### PR TITLE
fix(pdf-ui): code review fixes for PDF processing UI

### DIFF
--- a/apps/web/src/components/admin/knowledge-base/processing-metrics.tsx
+++ b/apps/web/src/components/admin/knowledge-base/processing-metrics.tsx
@@ -1,20 +1,10 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import {
-  ActivityIcon,
-  AlertTriangleIcon,
-  ClockIcon,
-  HashIcon,
-  RefreshCwIcon,
-} from 'lucide-react';
+import { ActivityIcon, AlertTriangleIcon, ClockIcon, HashIcon, RefreshCwIcon } from 'lucide-react';
 
 import { Button } from '@/components/ui/primitives/button';
-import { createAdminClient } from '@/lib/api/clients/adminClient';
-import { HttpClient } from '@/lib/api/core/httpClient';
-
-const httpClient = new HttpClient();
-const adminClient = createAdminClient({ httpClient });
+import { useApiClient } from '@/lib/api/context';
 
 interface StepAverages {
   step: string;
@@ -59,6 +49,7 @@ function barColor(seconds: number): string {
 }
 
 export function ProcessingMetrics() {
+  const apiClient = useApiClient();
   const {
     data: metrics,
     isLoading,
@@ -66,7 +57,7 @@ export function ProcessingMetrics() {
     isRefetching,
   } = useQuery({
     queryKey: ['admin', 'processing', 'metrics'],
-    queryFn: () => adminClient.getProcessingMetrics() as Promise<ProcessingMetrics | null>,
+    queryFn: () => apiClient.admin.getProcessingMetrics() as Promise<ProcessingMetrics | null>,
     staleTime: 60_000,
     refetchInterval: 60_000,
   });
@@ -77,7 +68,10 @@ export function ProcessingMetrics() {
         <div className="h-8 w-48 bg-white/40 dark:bg-zinc-800/40 rounded animate-pulse" />
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="h-48 bg-white/40 dark:bg-zinc-800/40 rounded-lg animate-pulse" />
+            <div
+              key={i}
+              className="h-48 bg-white/40 dark:bg-zinc-800/40 rounded-lg animate-pulse"
+            />
           ))}
         </div>
       </div>
@@ -87,13 +81,15 @@ export function ProcessingMetrics() {
   if (!metrics) {
     return (
       <div className="bg-white/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-xl p-6 border border-slate-200/50 dark:border-zinc-700/50">
-        <p className="text-sm text-slate-600 dark:text-zinc-400">No processing metrics available</p>
+        <p className="text-sm text-slate-600 dark:text-zinc-400">
+          Nessuna metrica di elaborazione disponibile
+        </p>
       </div>
     );
   }
 
   const stepNames = Object.keys(metrics.averages);
-  const allP95 = stepNames.map((s) => metrics.percentiles[s]?.p95 ?? 0);
+  const allP95 = stepNames.map(s => metrics.percentiles[s]?.p95 ?? 0);
   const maxP95 = Math.max(...allP95, 1);
   const bottleneckStep = stepNames[allP95.indexOf(maxP95)];
 
@@ -103,12 +99,16 @@ export function ProcessingMetrics() {
       <div className="flex items-center justify-between flex-wrap gap-4">
         <h2 className="font-quicksand text-xl font-bold text-slate-900 dark:text-zinc-100 flex items-center gap-2">
           <ActivityIcon className="h-5 w-5 text-blue-500" />
-          Processing Step Metrics
+          Metriche Elaborazione
         </h2>
         <div className="flex items-center gap-3">
-          <span className="text-xs text-slate-500 dark:text-zinc-500">
-            Updated {new Date(metrics.lastUpdated).toLocaleTimeString()}
-          </span>
+          <time
+            className="text-xs text-slate-500 dark:text-zinc-500"
+            dateTime={metrics.lastUpdated}
+            suppressHydrationWarning
+          >
+            Aggiornato {new Date(metrics.lastUpdated).toLocaleTimeString()}
+          </time>
           <Button
             variant="outline"
             size="sm"
@@ -117,14 +117,14 @@ export function ProcessingMetrics() {
             className="gap-2"
           >
             <RefreshCwIcon className={`h-4 w-4 ${isRefetching ? 'animate-spin' : ''}`} />
-            Refresh
+            Aggiorna
           </Button>
         </div>
       </div>
 
       {/* Step Cards */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {stepNames.map((stepName) => {
+        {stepNames.map(stepName => {
           const avg = metrics.averages[stepName];
           const pct = metrics.percentiles[stepName];
           const isBottleneck = stepName === bottleneckStep && (pct?.p95 ?? 0) > 0;
@@ -150,16 +150,28 @@ export function ProcessingMetrics() {
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b border-slate-200 dark:border-zinc-700">
-              <th className="text-left px-4 py-3 font-medium text-slate-600 dark:text-zinc-400">Step</th>
-              <th className="text-right px-4 py-3 font-medium text-slate-600 dark:text-zinc-400">Avg</th>
-              <th className="text-right px-4 py-3 font-medium text-slate-600 dark:text-zinc-400">P50</th>
-              <th className="text-right px-4 py-3 font-medium text-slate-600 dark:text-zinc-400">P95</th>
-              <th className="text-right px-4 py-3 font-medium text-slate-600 dark:text-zinc-400">P99</th>
-              <th className="text-right px-4 py-3 font-medium text-slate-600 dark:text-zinc-400">Samples</th>
+              <th className="text-left px-4 py-3 font-medium text-slate-600 dark:text-zinc-400">
+                Fase
+              </th>
+              <th className="text-right px-4 py-3 font-medium text-slate-600 dark:text-zinc-400">
+                Media
+              </th>
+              <th className="text-right px-4 py-3 font-medium text-slate-600 dark:text-zinc-400">
+                P50
+              </th>
+              <th className="text-right px-4 py-3 font-medium text-slate-600 dark:text-zinc-400">
+                P95
+              </th>
+              <th className="text-right px-4 py-3 font-medium text-slate-600 dark:text-zinc-400">
+                P99
+              </th>
+              <th className="text-right px-4 py-3 font-medium text-slate-600 dark:text-zinc-400">
+                Campioni
+              </th>
             </tr>
           </thead>
           <tbody>
-            {stepNames.map((stepName) => {
+            {stepNames.map(stepName => {
               const avg = metrics.averages[stepName];
               const pct = metrics.percentiles[stepName];
               const isBottleneck = stepName === bottleneckStep && (pct?.p95 ?? 0) > 0;
@@ -174,7 +186,9 @@ export function ProcessingMetrics() {
                     {isBottleneck && <AlertTriangleIcon className="h-3.5 w-3.5 text-amber-500" />}
                     {avg?.step ?? stepName}
                   </td>
-                  <td className={`text-right px-4 py-3 font-mono ${durationColor(avg?.avgDuration ?? 0)}`}>
+                  <td
+                    className={`text-right px-4 py-3 font-mono ${durationColor(avg?.avgDuration ?? 0)}`}
+                  >
                     {formatDuration(avg?.avgDuration ?? 0)}
                   </td>
                   <td className={`text-right px-4 py-3 font-mono ${durationColor(pct?.p50 ?? 0)}`}>
@@ -232,13 +246,13 @@ function StepMetricCard({
           {isBottleneck && (
             <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
               <AlertTriangleIcon className="h-3 w-3" />
-              Bottleneck
+              Collo di bottiglia
             </span>
           )}
         </div>
         <div className="flex items-center gap-1 text-xs text-slate-500 dark:text-zinc-500">
           <HashIcon className="h-3 w-3" />
-          {sampleSize} samples
+          {sampleSize} campioni
         </div>
       </div>
 

--- a/apps/web/src/components/admin/knowledge-base/processing-queue.tsx
+++ b/apps/web/src/components/admin/knowledge-base/processing-queue.tsx
@@ -14,6 +14,7 @@ import {
   WifiIcon,
   WifiOffIcon,
 } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { useQueueSSE } from '@/app/admin/(dashboard)/knowledge-base/queue/hooks/use-queue-sse';
 import {
@@ -29,35 +30,38 @@ import { Button } from '@/components/ui/button';
 
 // ── Status Config ──────────────────────────────────────────────────────
 
-const statusConfig: Record<JobStatus, {
-  icon: React.ComponentType<{ className?: string }>;
-  badge: string;
-  label: string;
-}> = {
+const statusConfig: Record<
+  JobStatus,
+  {
+    icon: React.ComponentType<{ className?: string }>;
+    badge: string;
+    label: string;
+  }
+> = {
   Queued: {
     icon: ClockIcon,
     badge: 'bg-slate-100 text-slate-900 dark:bg-slate-900/30 dark:text-slate-300',
-    label: 'Queued',
+    label: 'In coda',
   },
   Processing: {
     icon: LoaderIcon,
     badge: 'bg-blue-100 text-blue-900 dark:bg-blue-900/30 dark:text-blue-300',
-    label: 'Processing',
+    label: 'In elaborazione',
   },
   Completed: {
     icon: CheckCircleIcon,
     badge: 'bg-green-100 text-green-900 dark:bg-green-900/30 dark:text-green-300',
-    label: 'Completed',
+    label: 'Completato',
   },
   Failed: {
     icon: XCircleIcon,
     badge: 'bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-300',
-    label: 'Failed',
+    label: 'Errore',
   },
   Cancelled: {
     icon: BanIcon,
     badge: 'bg-gray-100 text-gray-900 dark:bg-gray-900/30 dark:text-gray-300',
-    label: 'Cancelled',
+    label: 'Annullato',
   },
 };
 
@@ -67,10 +71,7 @@ export function ProcessingQueue() {
   const { connectionState } = useQueueSSE(true);
   const sseConnected = connectionState === 'connected';
 
-  const { data, isLoading, error } = useQueueList(
-    { pageSize: 10 },
-    sseConnected
-  );
+  const { data, isLoading, error } = useQueueList({ pageSize: 10 }, sseConnected);
 
   const [actionLoading, setActionLoading] = useState<string | null>(null);
 
@@ -82,8 +83,9 @@ export function ProcessingQueue() {
       if (action === 'cancel') await cancelJob(jobId);
       if (action === 'retry') await retryJob(jobId);
       if (action === 'remove') await removeJob(jobId);
-    } catch {
-      // Actions will reflect in next SSE update
+    } catch (err) {
+      const message = err instanceof Error ? err.message : `Azione "${action}" fallita`;
+      toast.error(message);
     } finally {
       setActionLoading(null);
     }
@@ -93,7 +95,7 @@ export function ProcessingQueue() {
     <div className="bg-white/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-xl p-6 border border-slate-200/50 dark:border-zinc-700/50">
       <div className="flex items-center justify-between mb-4">
         <h2 className="font-quicksand text-xl font-bold text-slate-900 dark:text-zinc-100">
-          Processing Queue
+          Coda di Elaborazione
         </h2>
         <div className="flex items-center gap-1.5 text-xs">
           {sseConnected ? (
@@ -113,19 +115,19 @@ export function ProcessingQueue() {
       {isLoading && (
         <div className="flex items-center justify-center py-8 text-sm text-slate-500">
           <LoaderIcon className="w-4 h-4 animate-spin mr-2" />
-          Loading queue...
+          Caricamento coda...
         </div>
       )}
 
       {error && (
         <div className="py-4 text-sm text-red-500 text-center">
-          Failed to load queue. Retrying...
+          Errore nel caricamento della coda. Nuovo tentativo...
         </div>
       )}
 
       {!isLoading && !error && jobs.length === 0 && (
         <div className="py-8 text-sm text-slate-500 dark:text-zinc-400 text-center">
-          No jobs in queue. Upload a PDF to get started.
+          Nessun job in coda. Carica un PDF per iniziare.
         </div>
       )}
 
@@ -148,14 +150,16 @@ export function ProcessingQueue() {
                   </span>
                 </div>
                 <Badge variant="outline" className={config.badge}>
-                  <StatusIcon className={`w-3 h-3 mr-1 ${job.status === 'Processing' ? 'animate-spin' : ''}`} />
+                  <StatusIcon
+                    className={`w-3 h-3 mr-1 ${job.status === 'Processing' ? 'animate-spin' : ''}`}
+                  />
                   {config.label}
                 </Badge>
               </div>
 
               {job.currentStep && job.status === 'Processing' && (
                 <p className="text-xs text-blue-600 dark:text-blue-400 mb-1 ml-6">
-                  Step: {job.currentStep}
+                  Fase: {job.currentStep}
                 </p>
               )}
 
@@ -176,7 +180,7 @@ export function ProcessingQueue() {
                     onClick={() => handleAction(job.id, 'cancel')}
                   >
                     <BanIcon className="w-3 h-3 mr-1" />
-                    Cancel
+                    Annulla
                   </Button>
                 )}
                 {job.status === 'Failed' && job.canRetry && (
@@ -188,7 +192,7 @@ export function ProcessingQueue() {
                     onClick={() => handleAction(job.id, 'retry')}
                   >
                     <RotateCcwIcon className="w-3 h-3 mr-1" />
-                    Retry
+                    Riprova
                   </Button>
                 )}
                 {job.status === 'Queued' && (
@@ -200,12 +204,16 @@ export function ProcessingQueue() {
                     onClick={() => handleAction(job.id, 'remove')}
                   >
                     <TrashIcon className="w-3 h-3 mr-1" />
-                    Remove
+                    Rimuovi
                   </Button>
                 )}
-                <span className="text-xs text-slate-400 ml-auto">
+                <time
+                  className="text-xs text-slate-400 ml-auto"
+                  dateTime={job.createdAt}
+                  suppressHydrationWarning
+                >
                   {new Date(job.createdAt).toLocaleTimeString()}
-                </span>
+                </time>
               </div>
             </div>
           );
@@ -218,7 +226,7 @@ export function ProcessingQueue() {
             href="/admin/knowledge-base/queue"
             className="text-xs text-amber-600 hover:text-amber-700 dark:text-amber-400"
           >
-            View all {data.total} jobs →
+            Vedi tutti i {data.total} job →
           </a>
         </div>
       )}

--- a/apps/web/src/components/admin/knowledge-base/upload-zone.tsx
+++ b/apps/web/src/components/admin/knowledge-base/upload-zone.tsx
@@ -39,6 +39,7 @@ interface FileUploadState {
 const MAX_SINGLE_UPLOAD_SIZE = 10 * 1024 * 1024; // 10MB threshold for chunked upload
 const ACCEPTED_TYPES = ['application/pdf'];
 const MAX_FILE_SIZE = 500 * 1024 * 1024; // 500MB
+const MAX_CONCURRENT_UPLOADS = 3;
 
 // ── Component ──────────────────────────────────────────────────────────
 
@@ -194,18 +195,30 @@ export function UploadZone({ initialGameId }: { initialGameId?: string } = {}) {
       const startIndex = uploads.length;
       setUploads(prev => [...prev, ...validFiles]);
 
-      // Start uploads for valid files
-      for (let i = 0; i < validFiles.length; i++) {
-        if (validFiles[i].status === 'error') continue;
-        const file = validFiles[i].file;
-        const idx = startIndex + i;
+      // Upload files with concurrency limit
+      const uploadable = validFiles
+        .map((vf, i) => ({ vf, idx: startIndex + i }))
+        .filter(({ vf }) => vf.status !== 'error');
 
-        if (file.size > MAX_SINGLE_UPLOAD_SIZE) {
-          uploadChunkedFile(file, idx);
+      const queue = [...uploadable];
+      const runNext = async (): Promise<void> => {
+        const item = queue.shift();
+        if (!item) return;
+        const { vf, idx } = item;
+        if (vf.file.size > MAX_SINGLE_UPLOAD_SIZE) {
+          await uploadChunkedFile(vf.file, idx);
         } else {
-          uploadSingleFile(file, idx);
+          await uploadSingleFile(vf.file, idx);
         }
-      }
+        await runNext();
+      };
+
+      // Start up to MAX_CONCURRENT_UPLOADS workers
+      const workers = Array.from(
+        { length: Math.min(MAX_CONCURRENT_UPLOADS, uploadable.length) },
+        () => runNext()
+      );
+      await Promise.all(workers);
     },
     [selectedGame, uploads.length, validateFile, uploadSingleFile, uploadChunkedFile]
   );
@@ -266,13 +279,13 @@ export function UploadZone({ initialGameId }: { initialGameId?: string } = {}) {
       {/* Game Selector */}
       <div className="bg-white/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-xl p-4 border border-slate-200/50 dark:border-zinc-700/50">
         <label className="block text-sm font-medium text-slate-700 dark:text-zinc-300 mb-2">
-          Select Game <span className="text-red-500">*</span>
+          Seleziona Gioco <span className="text-red-500">*</span>
         </label>
         <div className="relative">
           <div className="relative">
             <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
             <Input
-              placeholder="Search games..."
+              placeholder="Cerca giochi..."
               value={gameQuery}
               onChange={e => {
                 setGameQuery(e.target.value);
@@ -288,7 +301,7 @@ export function UploadZone({ initialGameId }: { initialGameId?: string } = {}) {
                 className="absolute right-2 top-1/2 -translate-y-1/2 bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300"
               >
                 <CheckCircleIcon className="w-3 h-3 mr-1" />
-                Selected
+                Selezionato
               </Badge>
             )}
           </div>
@@ -298,10 +311,10 @@ export function UploadZone({ initialGameId }: { initialGameId?: string } = {}) {
               {isSearching ? (
                 <div className="p-3 text-sm text-slate-500 text-center">
                   <LoaderIcon className="w-4 h-4 animate-spin inline mr-2" />
-                  Searching...
+                  Ricerca...
                 </div>
               ) : gameResults.length === 0 ? (
-                <div className="p-3 text-sm text-slate-500 text-center">No games found</div>
+                <div className="p-3 text-sm text-slate-500 text-center">Nessun gioco trovato</div>
               ) : (
                 gameResults.map(game => (
                   <button
@@ -327,7 +340,7 @@ export function UploadZone({ initialGameId }: { initialGameId?: string } = {}) {
       <div className="bg-white/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-xl p-3 border border-slate-200/50 dark:border-zinc-700/50 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-slate-700 dark:text-zinc-300">
-            Processing Priority
+            Priorità Elaborazione
           </span>
           {urgentPriority && (
             <span className="text-xs text-amber-600 dark:text-amber-400">— in testa alla coda</span>
@@ -344,7 +357,7 @@ export function UploadZone({ initialGameId }: { initialGameId?: string } = {}) {
           }`}
         >
           {urgentPriority && <ZapIcon className="w-3.5 h-3.5" />}
-          {urgentPriority ? 'Urgent' : 'Normal'}
+          {urgentPriority ? 'Urgente' : 'Normale'}
         </button>
       </div>
 
@@ -377,7 +390,7 @@ export function UploadZone({ initialGameId }: { initialGameId?: string } = {}) {
           multiple
           onChange={handleFileChange}
           className="hidden"
-          aria-label="Select PDF files to upload"
+          aria-label="Seleziona file PDF da caricare"
         />
         <div className="flex flex-col items-center justify-center text-center">
           <div className="w-16 h-16 bg-amber-100 dark:bg-amber-900/30 rounded-full flex items-center justify-center mb-4">
@@ -385,18 +398,18 @@ export function UploadZone({ initialGameId }: { initialGameId?: string } = {}) {
           </div>
           <h3 className="font-quicksand text-lg font-bold text-slate-900 dark:text-zinc-100 mb-2">
             {selectedGame
-              ? 'Drop PDF files here or click to browse'
-              : 'Select a game above to start uploading'}
+              ? 'Trascina i PDF qui o clicca per sfogliare'
+              : 'Seleziona un gioco sopra per iniziare il caricamento'}
           </h3>
           <p className="text-sm text-slate-600 dark:text-zinc-400 mb-4">
             {selectedGame
-              ? `Uploading for: ${selectedGame.name} — Files > 10MB use chunked upload automatically`
-              : 'A game must be selected before uploading documents'}
+              ? `Caricamento per: ${selectedGame.name} — File > 10MB usano upload chunked automaticamente`
+              : 'Devi selezionare un gioco prima di caricare documenti'}
           </p>
           <div className="flex items-center gap-4 text-xs text-slate-500 dark:text-zinc-500">
             <div className="flex items-center gap-1">
               <FileTextIcon className="w-4 h-4" />
-              <span>PDF only</span>
+              <span>Solo PDF</span>
             </div>
             <span>Max 500MB per file</span>
           </div>
@@ -408,11 +421,11 @@ export function UploadZone({ initialGameId }: { initialGameId?: string } = {}) {
         <div className="bg-white/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-xl p-4 border border-slate-200/50 dark:border-zinc-700/50 space-y-3">
           <div className="flex items-center justify-between">
             <h3 className="font-quicksand font-bold text-sm text-slate-900 dark:text-zinc-100">
-              Uploads ({uploads.filter(u => u.status === 'completed').length}/{uploads.length})
+              Caricamenti ({uploads.filter(u => u.status === 'completed').length}/{uploads.length})
             </h3>
             {uploads.every(u => u.status === 'completed' || u.status === 'error') && (
               <Button variant="ghost" size="sm" onClick={() => setUploads([])}>
-                Clear all
+                Cancella tutto
               </Button>
             )}
           </div>
@@ -470,7 +483,7 @@ export function UploadZone({ initialGameId }: { initialGameId?: string } = {}) {
                     />
                   </div>
                   <div className="text-xs text-slate-500 text-right">
-                    {upload.status === 'processing' ? 'Processing...' : `${upload.progress}%`}
+                    {upload.status === 'processing' ? 'Elaborazione...' : `${upload.progress}%`}
                   </div>
                 </div>
               )}

--- a/apps/web/src/components/documents/KbCardStatusRow.tsx
+++ b/apps/web/src/components/documents/KbCardStatusRow.tsx
@@ -65,6 +65,8 @@ function mapProcessingState(state: string): DocumentIndexingStatus {
     case 'Embedding':
     case 'Indexing':
     case 'Uploading':
+    case 'Pending':
+    case 'Queued':
       return 'processing';
     default:
       return 'none';

--- a/apps/web/src/components/pdf/PdfProcessingProgressBar.tsx
+++ b/apps/web/src/components/pdf/PdfProcessingProgressBar.tsx
@@ -50,6 +50,8 @@ export interface PdfProcessingProgressBarProps {
   onError?: (error: string) => void;
   /** Callback when user cancels processing */
   onCancel?: () => void;
+  /** Callback when user requests processing retry (parent handles actual retry API call) */
+  onRetry?: (pdfId: string) => void;
   /** Additional CSS classes */
   className?: string;
 }
@@ -107,7 +109,7 @@ const STEP_CONFIG: Record<ProcessingStepValue, StepConfig> = {
   Failed: {
     icon: XCircle,
     label: 'Errore',
-    description: 'Si è verificato un errore durante l\'elaborazione.',
+    description: "Si è verificato un errore durante l'elaborazione.",
   },
 };
 
@@ -187,10 +189,8 @@ function StepIndicator({ step, currentStep, index }: StepIndicatorProps) {
       <div
         className={cn(
           'relative flex h-10 w-10 items-center justify-center rounded-full border-2 transition-all duration-300',
-          isCompleted &&
-            'border-green-500 bg-green-500/10 text-green-600 dark:text-green-400',
-          isActive &&
-            'border-primary bg-primary/10 text-primary animate-pulse',
+          isCompleted && 'border-green-500 bg-green-500/10 text-green-600 dark:text-green-400',
+          isActive && 'border-primary bg-primary/10 text-primary animate-pulse',
           isPending && 'border-muted-foreground/30 text-muted-foreground/50',
           isFailed && 'border-destructive bg-destructive/10 text-destructive'
         )}
@@ -201,11 +201,11 @@ function StepIndicator({ step, currentStep, index }: StepIndicatorProps) {
           <Icon className="h-5 w-5" />
         )}
 
-        {/* Connector Line (except for last step) */}
+        {/* Connector Line (except for last step, hidden on mobile) */}
         {index < PROCESSING_STEPS.length - 1 && (
           <div
             className={cn(
-              'absolute left-full top-1/2 h-0.5 w-8 -translate-y-1/2 transition-colors duration-300',
+              'absolute left-full top-1/2 hidden h-0.5 w-8 -translate-y-1/2 transition-colors duration-300 sm:block',
               isCompleted ? 'bg-green-500' : 'bg-muted-foreground/30'
             )}
           />
@@ -237,19 +237,17 @@ export function PdfProcessingProgressBar({
   onComplete,
   onError,
   onCancel,
+  onRetry,
   className,
 }: PdfProcessingProgressBarProps) {
   const [showCancelDialog, setShowCancelDialog] = useState(false);
   const [isCanceling, setIsCanceling] = useState(false);
 
-  const { progress, isLoading, error, refetch } = usePdfProcessingProgress(
-    pdfId,
-    {
-      pollingInterval: 500,
-      onComplete,
-      onError,
-    }
-  );
+  const { progress, isLoading, error, refetch } = usePdfProcessingProgress(pdfId, {
+    pollingInterval: 2000,
+    onComplete,
+    onError,
+  });
 
   const currentStep: ProcessingStepValue = progress?.currentStep ?? 'Uploading';
   const percentComplete = progress?.percentComplete ?? 0;
@@ -276,24 +274,22 @@ export function PdfProcessingProgressBar({
   }, [pdfId, onCancel]);
 
   const handleRetry = useCallback(() => {
+    if (onRetry) {
+      onRetry(pdfId);
+    }
     refetch();
-  }, [refetch]);
+  }, [onRetry, pdfId, refetch]);
 
   // Loading state
   if (isLoading && !progress) {
     return (
       <div
-        className={cn(
-          'rounded-lg border bg-card p-6',
-          className
-        )}
+        className={cn('rounded-lg border bg-card p-6', className)}
         data-testid="pdf-progress-loading"
       >
         <div className="flex items-center justify-center gap-3">
           <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-          <span className="text-sm text-muted-foreground">
-            Caricamento stato elaborazione...
-          </span>
+          <span className="text-sm text-muted-foreground">Caricamento stato elaborazione...</span>
         </div>
       </div>
     );
@@ -303,22 +299,15 @@ export function PdfProcessingProgressBar({
   if (error && !progress) {
     return (
       <div
-        className={cn(
-          'rounded-lg border border-destructive/50 bg-destructive/5 p-6',
-          className
-        )}
+        className={cn('rounded-lg border border-destructive/50 bg-destructive/5 p-6', className)}
         role="alert"
         data-testid="pdf-progress-error"
       >
         <div className="flex flex-col items-center gap-4">
           <AlertCircle className="h-10 w-10 text-destructive" />
           <div className="text-center">
-            <p className="font-medium text-destructive">
-              Errore di connessione
-            </p>
-            <p className="mt-1 text-sm text-muted-foreground">
-              {error.message}
-            </p>
+            <p className="font-medium text-destructive">Errore di connessione</p>
+            <p className="mt-1 text-sm text-muted-foreground">{error.message}</p>
           </div>
           <Button variant="outline" size="sm" onClick={handleRetry}>
             <RefreshCw className="mr-2 h-4 w-4" />
@@ -338,9 +327,7 @@ export function PdfProcessingProgressBar({
     >
       {/* Header */}
       <div className="mb-6 flex items-center justify-between">
-        <h3 className="text-lg font-semibold">
-          Elaborazione PDF
-        </h3>
+        <h3 className="text-lg font-semibold">Elaborazione PDF</h3>
         {isProcessing && (
           <Button
             variant="ghost"
@@ -361,16 +348,11 @@ export function PdfProcessingProgressBar({
 
       {/* Step Indicators */}
       <div
-        className="mb-6 flex items-center justify-between overflow-x-auto pb-2"
+        className="mb-6 flex items-center justify-between gap-1 overflow-x-auto pb-2 sm:gap-0"
         aria-label="Passaggi elaborazione"
       >
         {PROCESSING_STEPS.map((step, index) => (
-          <StepIndicator
-            key={step}
-            step={step}
-            currentStep={currentStep}
-            index={index}
-          />
+          <StepIndicator key={step} step={step} currentStep={currentStep} index={index} />
         ))}
       </div>
 
@@ -400,12 +382,8 @@ export function PdfProcessingProgressBar({
           className="flex items-center justify-between text-sm text-muted-foreground"
           aria-live="polite"
         >
-          <span>
-            Tempo trascorso: {formatTimeSpan(progress.elapsedTime)}
-          </span>
-          <span>
-            Tempo stimato: {formatTimeSpan(progress.estimatedTimeRemaining)}
-          </span>
+          <span>Tempo trascorso: {formatTimeSpan(progress.elapsedTime)}</span>
+          <span>Tempo stimato: {formatTimeSpan(progress.estimatedTimeRemaining)}</span>
         </div>
       )}
 
@@ -419,13 +397,9 @@ export function PdfProcessingProgressBar({
           <div className="flex items-start gap-3">
             <AlertCircle className="mt-0.5 h-5 w-5 shrink-0 text-destructive" />
             <div className="flex-1">
-              <p className="font-medium text-destructive">
-                Elaborazione fallita
-              </p>
+              <p className="font-medium text-destructive">Elaborazione fallita</p>
               {progress?.errorMessage && (
-                <p className="mt-1 text-sm text-muted-foreground">
-                  {progress.errorMessage}
-                </p>
+                <p className="mt-1 text-sm text-muted-foreground">{progress.errorMessage}</p>
               )}
             </div>
             <Button variant="outline" size="sm" onClick={handleRetry}>

--- a/apps/web/src/hooks/usePdfProcessingProgress.ts
+++ b/apps/web/src/hooks/usePdfProcessingProgress.ts
@@ -30,7 +30,7 @@ import { api, type ProcessingProgress } from '@/lib/api';
 // Constants
 // ============================================================================
 
-const DEFAULT_POLLING_INTERVAL_MS = 500;
+const DEFAULT_POLLING_INTERVAL_MS = 2000;
 const MAX_RETRY_ATTEMPTS = 3;
 const RETRY_DELAY_MS = 1000;
 
@@ -89,7 +89,6 @@ export function usePdfProcessingProgress(
 
   // Refs for cleanup and tracking
   const isMountedRef = useRef(true);
-  const abortControllerRef = useRef<AbortController | null>(null);
   const retryCountRef = useRef(0);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const hasNotifiedCompletionRef = useRef(false);
@@ -122,10 +121,6 @@ export function usePdfProcessingProgress(
     if (progressRef.current && isTerminalState(progressRef.current.currentStep)) {
       return;
     }
-
-    // Create new AbortController for this request
-    abortControllerRef.current?.abort();
-    abortControllerRef.current = new AbortController();
 
     try {
       setIsLoading(true);
@@ -161,11 +156,6 @@ export function usePdfProcessingProgress(
     } catch (err) {
       if (!isMountedRef.current) return;
 
-      // Check if it's an abort error (ignore these)
-      if (err instanceof Error && err.name === 'AbortError') {
-        return;
-      }
-
       // Retry logic
       if (retryCountRef.current < MAX_RETRY_ATTEMPTS) {
         retryCountRef.current += 1;
@@ -179,7 +169,8 @@ export function usePdfProcessingProgress(
       }
 
       // Max retries exceeded - set error state
-      const errorObj = err instanceof Error ? err : new Error('Failed to fetch processing progress');
+      const errorObj =
+        err instanceof Error ? err : new Error('Failed to fetch processing progress');
       setError(errorObj);
     } finally {
       if (isMountedRef.current) {
@@ -239,11 +230,6 @@ export function usePdfProcessingProgress(
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
         intervalRef.current = null;
-      }
-
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-        abortControllerRef.current = null;
       }
     };
   }, [enabled, pdfId, pollingInterval, fetchProgress]);

--- a/apps/web/src/types/pdf.ts
+++ b/apps/web/src/types/pdf.ts
@@ -20,6 +20,11 @@ export enum ProcessingStep {
 /**
  * Processing progress response from API
  */
+/**
+ * @deprecated Import `ProcessingProgress` from `@/lib/api` instead.
+ * This interface is stale — the authoritative type is the Zod schema
+ * in `lib/api/schemas/pdf.schemas.ts` (ProcessingProgressSchema).
+ */
 export interface ProcessingProgress {
   currentStep: ProcessingStep;
   percentComplete: number;
@@ -117,7 +122,7 @@ export function getPdfStateLabel(state: PdfState): string {
     ready: 'Ready',
     failed: 'Failed',
   };
-   
+
   return labels[state];
 }
 
@@ -142,6 +147,6 @@ export function getPdfStateOrder(state: PdfState): number {
     ready: 6,
     failed: 6,
   };
-   
+
   return order[state];
 }


### PR DESCRIPTION
## Summary
- **C1**: Add `onRetry` prop to `PdfProcessingProgressBar` (retry button was only re-polling status, not triggering actual retry)
- **C2**: Remove dead `AbortController` code from `usePdfProcessingProgress` (signal was never passed to fetch)
- **C3**: Mark stale `ProcessingProgress` interface in `types/pdf.ts` as `@deprecated`
- **M1**: Handle `Pending`/`Queued` states in `KbCardStatusRow` (were mapping to `'none'` instead of `'processing'`)
- **M2**: Add `MAX_CONCURRENT_UPLOADS=3` concurrency limiter in `upload-zone` (was firing all uploads simultaneously)
- **M3**: Standardize all UI labels to Italian across processing-queue, processing-metrics, upload-zone
- **M4**: Replace singleton `httpClient` with `useApiClient()` hook in `ProcessingMetrics` (was bypassing auth context)
- **m1**: Reduce polling interval from 500ms to 2000ms (less backend load)
- **m2**: Fix `toLocaleTimeString` hydration mismatch with `<time>` + `suppressHydrationWarning`
- **m3**: Hide step connectors on mobile, add gap for small screens
- **m4**: Show `toast.error` on failed queue actions instead of silently swallowing errors

## Test plan
- [ ] Upload a PDF as admin → verify Italian labels in upload zone
- [ ] Check processing queue shows Italian status badges
- [ ] Verify processing metrics dashboard renders with `useApiClient`
- [ ] Upload multiple PDFs (>3) → verify concurrency limit (max 3 simultaneous)
- [ ] Verify `KbCardStatusRow` shows processing badge for Pending documents
- [ ] Check mobile view of progress bar (no connector overflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)