### PR TITLE
fix(migration): use system role for seed user

### DIFF
--- a/apps/api/src/Api/Infrastructure/Migrations/20260320092808_SeedTop143BggGames.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260320092808_SeedTop143BggGames.cs
@@ -47,7 +47,7 @@ namespace Api.Infrastructure.Migrations
                     "FailedLoginAttempts", "IsContributor", "OnboardingCompleted", "OnboardingSkipped"
                 )
                 VALUES (
-                    gen_random_uuid(), 'system-seed@meepleai.app', 'System Seed Admin', NULL, 'admin', 'free',
+                    gen_random_uuid(), 'system-seed@meepleai.app', 'System Seed Admin', NULL, 'system', 'free',
                     NOW(), false, 'en', false,
                     'system', 90, false, true,
                     false, 'Active', 1, 0,


### PR DESCRIPTION
Prevents seed user (role=admin) from blocking the real admin seeder. Changed to role=system.