### PR TITLE
feat(ddd): Phase 6 — read-only User projections for BC isolation

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Domain/Entities/UserProfile.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Domain/Entities/UserProfile.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Api.BoundedContexts.Administration.Domain.Entities;
+
+/// <summary>
+/// Read-only projection of user profile data from the users table.
+/// Used by Administration BC queries to avoid loading the full User aggregate.
+/// Maps to the same "users" table via ToView() — EF treats it as read-only (no migrations).
+/// </summary>
+[SuppressMessage("SonarAnalyzer.CSharp", "S1144", Justification = "Private setters are required by EF Core for entity materialization")]
+public class UserProfile
+{
+    public Guid Id { get; private set; }
+    public string Email { get; private set; } = string.Empty;
+    public string? DisplayName { get; private set; }
+    public string? AvatarUrl { get; private set; }
+    public string? Bio { get; private set; }
+    public string Role { get; private set; } = "user";
+    public string Tier { get; private set; } = "free";
+    public string Status { get; private set; } = "Active";
+    public DateTime CreatedAt { get; private set; }
+    public int Level { get; private set; } = 1;
+    public int ExperiencePoints { get; private set; }
+    public bool EmailVerified { get; private set; }
+    public bool IsTwoFactorEnabled { get; private set; }
+    public bool IsSuspended { get; private set; }
+    public bool IsContributor { get; private set; }
+    public bool IsDemoAccount { get; private set; }
+
+    // EF Core requires a parameterless constructor for entity materialization
+    internal UserProfile() { }
+}

--- a/apps/api/src/Api/BoundedContexts/BusinessSimulations/Domain/Entities/UserBudget.cs
+++ b/apps/api/src/Api/BoundedContexts/BusinessSimulations/Domain/Entities/UserBudget.cs
@@ -1,0 +1,22 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Api.BoundedContexts.BusinessSimulations.Domain.Entities;
+
+/// <summary>
+/// Read-only projection of user budget/tier data from the users table.
+/// Used by BusinessSimulations BC queries for cost scenarios and resource forecasting
+/// without loading the full User aggregate.
+/// Maps to the same "users" table via ToView() — EF treats it as read-only (no migrations).
+/// </summary>
+[SuppressMessage("SonarAnalyzer.CSharp", "S1144", Justification = "Private setters are required by EF Core for entity materialization")]
+public class UserBudget
+{
+    public Guid Id { get; private set; }
+    public string Tier { get; private set; } = "free";
+    public int Level { get; private set; } = 1;
+    public int ExperiencePoints { get; private set; }
+    public bool IsContributor { get; private set; }
+
+    // EF Core requires a parameterless constructor for entity materialization
+    internal UserBudget() { }
+}

--- a/apps/api/src/Api/BoundedContexts/SystemConfiguration/Domain/Entities/UserPreferences.cs
+++ b/apps/api/src/Api/BoundedContexts/SystemConfiguration/Domain/Entities/UserPreferences.cs
@@ -1,0 +1,22 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Api.BoundedContexts.SystemConfiguration.Domain.Entities;
+
+/// <summary>
+/// Read-only projection of user preference data from the users table.
+/// Used by SystemConfiguration BC queries to read user settings
+/// without loading the full User aggregate.
+/// Maps to the same "users" table via ToView() — EF treats it as read-only (no migrations).
+/// </summary>
+[SuppressMessage("SonarAnalyzer.CSharp", "S1144", Justification = "Private setters are required by EF Core for entity materialization")]
+public class UserPreferences
+{
+    public Guid Id { get; private set; }
+    public string Language { get; private set; } = "en";
+    public bool EmailNotifications { get; private set; } = true;
+    public string Theme { get; private set; } = "system";
+    public int DataRetentionDays { get; private set; } = 90;
+
+    // EF Core requires a parameterless constructor for entity materialization
+    internal UserPreferences() { }
+}

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/Administration/UserProfileConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/Administration/UserProfileConfiguration.cs
@@ -1,0 +1,35 @@
+using Api.BoundedContexts.Administration.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations.Administration;
+
+/// <summary>
+/// EF Core configuration for UserProfile read-only projection.
+/// Uses ToView("users") to map to the existing users table without generating migrations.
+/// Phase 6: Entity Decomposition — Administration BC profile projection.
+/// </summary>
+internal class UserProfileConfiguration : IEntityTypeConfiguration<UserProfile>
+{
+    public void Configure(EntityTypeBuilder<UserProfile> builder)
+    {
+        builder.ToView("users");
+        builder.HasKey(u => u.Id);
+
+        builder.Property(u => u.Email).HasMaxLength(256);
+        builder.Property(u => u.DisplayName).HasMaxLength(128);
+        builder.Property(u => u.AvatarUrl).HasMaxLength(2048);
+        builder.Property(u => u.Bio).HasMaxLength(500);
+        builder.Property(u => u.Role).HasMaxLength(32);
+        builder.Property(u => u.Tier);
+        builder.Property(u => u.Status);
+        builder.Property(u => u.CreatedAt);
+        builder.Property(u => u.Level);
+        builder.Property(u => u.ExperiencePoints);
+        builder.Property(u => u.EmailVerified);
+        builder.Property(u => u.IsTwoFactorEnabled);
+        builder.Property(u => u.IsSuspended);
+        builder.Property(u => u.IsContributor);
+        builder.Property(u => u.IsDemoAccount);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/BusinessSimulations/UserBudgetConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/BusinessSimulations/UserBudgetConfiguration.cs
@@ -1,0 +1,24 @@
+using Api.BoundedContexts.BusinessSimulations.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations.BusinessSimulations;
+
+/// <summary>
+/// EF Core configuration for UserBudget read-only projection.
+/// Uses ToView("users") to map to the existing users table without generating migrations.
+/// Phase 6: Entity Decomposition — BusinessSimulations BC budget projection.
+/// </summary>
+internal class UserBudgetConfiguration : IEntityTypeConfiguration<UserBudget>
+{
+    public void Configure(EntityTypeBuilder<UserBudget> builder)
+    {
+        builder.ToView("users");
+        builder.HasKey(u => u.Id);
+
+        builder.Property(u => u.Tier);
+        builder.Property(u => u.Level);
+        builder.Property(u => u.ExperiencePoints);
+        builder.Property(u => u.IsContributor);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/SystemConfiguration/UserPreferencesConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/SystemConfiguration/UserPreferencesConfiguration.cs
@@ -1,0 +1,24 @@
+using Api.BoundedContexts.SystemConfiguration.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations.SystemConfiguration;
+
+/// <summary>
+/// EF Core configuration for UserPreferences read-only projection.
+/// Uses ToView("users") to map to the existing users table without generating migrations.
+/// Phase 6: Entity Decomposition — SystemConfiguration BC preferences projection.
+/// </summary>
+internal class UserPreferencesConfiguration : IEntityTypeConfiguration<UserPreferences>
+{
+    public void Configure(EntityTypeBuilder<UserPreferences> builder)
+    {
+        builder.ToView("users");
+        builder.HasKey(u => u.Id);
+
+        builder.Property(u => u.Language).HasMaxLength(10);
+        builder.Property(u => u.EmailNotifications);
+        builder.Property(u => u.Theme).HasMaxLength(20);
+        builder.Property(u => u.DataRetentionDays);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -81,6 +81,9 @@ public class MeepleAiDbContext : DbContext
     public DbSet<VectorDocumentEntity> VectorDocuments => Set<VectorDocumentEntity>();
     public DbSet<TextChunkEntity> TextChunks => Set<TextChunkEntity>(); // AI-14: Hybrid search
     public DbSet<BoundedContexts.Administration.Domain.Entities.UserAiConsent> UserAiConsents => Set<BoundedContexts.Administration.Domain.Entities.UserAiConsent>(); // ISSUE-5512: GDPR AI consent
+    public DbSet<BoundedContexts.Administration.Domain.Entities.UserProfile> UserProfiles => Set<BoundedContexts.Administration.Domain.Entities.UserProfile>(); // Phase 6: Admin user profile projection
+    public DbSet<BoundedContexts.BusinessSimulations.Domain.Entities.UserBudget> UserBudgets => Set<BoundedContexts.BusinessSimulations.Domain.Entities.UserBudget>(); // Phase 6: Budget/tier projection
+    public DbSet<BoundedContexts.SystemConfiguration.Domain.Entities.UserPreferences> UserPreferences => Set<BoundedContexts.SystemConfiguration.Domain.Entities.UserPreferences>(); // Phase 6: User preferences projection
     public DbSet<AuditLogEntity> AuditLogs => Set<AuditLogEntity>();
     public DbSet<AiRequestLogEntity> AiRequestLogs => Set<AiRequestLogEntity>();
     public DbSet<AgentFeedbackEntity> AgentFeedbacks => Set<AgentFeedbackEntity>();


### PR DESCRIPTION
## Summary

Phase 6 of backend-test-improvement plan: decompose the monolithic User entity into BC-specific read-only projections.

**3 new entities** mapped to the existing `users` table via `ToView()`:

| Entity | BC | Properties |
|--------|-----|-----------|
| `UserProfile` | Administration | Id, Email, DisplayName, AvatarUrl, Bio, Role, Tier, Status, Level, XP, EmailVerified, 2FA |
| `UserBudget` | BusinessSimulations | Id, Tier, Level, XP, IsContributor |
| `UserPreferences` | SystemConfiguration | Id, Language, EmailNotifications, Theme, DataRetentionDays |

**Architecture**: `ToView("users")` ensures EF treats these as read-only views — no migrations generated, no table modifications. Each BC can now query user data through its own projection without depending on the Authentication BC's User aggregate.

**No breaking changes** — existing code continues to work. Queries can be progressively migrated in follow-up PRs.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] No EF migrations generated
- [ ] `dotnet test` — full test suite
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)