### PR TITLE
fix(auth): superadmin redirect + centralized isAdminRole helper

### DIFF
--- a/apps/web/src/__tests__/lib/utils/roles.test.ts
+++ b/apps/web/src/__tests__/lib/utils/roles.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAdminRole } from '@/lib/utils/roles';
+
+describe('isAdminRole', () => {
+  it('returns true for "Admin"', () => {
+    expect(isAdminRole('Admin')).toBe(true);
+  });
+
+  it('returns true for "admin" (lowercase)', () => {
+    expect(isAdminRole('admin')).toBe(true);
+  });
+
+  it('returns true for "superadmin"', () => {
+    expect(isAdminRole('superadmin')).toBe(true);
+  });
+
+  it('returns true for "SuperAdmin" (mixed case)', () => {
+    expect(isAdminRole('SuperAdmin')).toBe(true);
+  });
+
+  it('returns false for "User"', () => {
+    expect(isAdminRole('User')).toBe(false);
+  });
+
+  it('returns false for "Editor"', () => {
+    expect(isAdminRole('Editor')).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isAdminRole(undefined)).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isAdminRole(null)).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isAdminRole('')).toBe(false);
+  });
+});

--- a/apps/web/src/components/auth/AuthModal.tsx
+++ b/apps/web/src/components/auth/AuthModal.tsx
@@ -22,6 +22,7 @@ import { Button } from '@/components/ui/primitives/button';
 import { useAuth, type AuthUser } from '@/hooks/useAuth';
 import { api } from '@/lib/api';
 import { logger } from '@/lib/logger';
+import { isAdminRole } from '@/lib/utils/roles';
 
 import { LoginForm, LoginFormData } from './LoginForm';
 import OAuthButtons from './OAuthButtons';
@@ -104,7 +105,7 @@ export function AuthModal({
           onSuccess?.(response.user);
           onClose();
           // Redirect admins to admin dashboard, others to specified redirect or default dashboard
-          const targetUrl = response.user.role?.toLowerCase() === 'admin' ? '/admin' : redirectTo;
+          const targetUrl = isAdminRole(response.user.role) ? '/admin' : redirectTo;
 
           // Small delay to ensure session cookie is persisted before navigation
           // This prevents race condition with middleware session validation
@@ -152,7 +153,7 @@ export function AuthModal({
         onSuccess?.(user);
         onClose();
         // Redirect admins to admin dashboard, others to specified redirect or default dashboard
-        const targetUrl = user.role?.toLowerCase() === 'admin' ? '/admin' : redirectTo;
+        const targetUrl = isAdminRole(user.role) ? '/admin' : redirectTo;
 
         // Small delay to ensure session cookie is persisted before navigation
         await new Promise(resolve => setTimeout(resolve, 100));

--- a/apps/web/src/lib/utils/roles.ts
+++ b/apps/web/src/lib/utils/roles.ts
@@ -1,0 +1,11 @@
+/**
+ * Centralized admin role check.
+ * Returns true for 'admin' and 'superadmin' roles (case-insensitive).
+ *
+ * Usage sites: AuthModal redirect, proxy.ts middleware, RequireRole component.
+ */
+export function isAdminRole(role: string | null | undefined): boolean {
+  if (!role) return false;
+  const normalized = role.toLowerCase();
+  return normalized === 'admin' || normalized === 'superadmin';
+}

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -28,6 +28,7 @@
 import { NextResponse } from 'next/server';
 
 import * as metrics from '@/lib/metrics/session-cache-metrics';
+import { isAdminRole } from '@/lib/utils/roles';
 
 import type { NextRequest } from 'next/server';
 
@@ -340,7 +341,7 @@ export async function proxy(request: NextRequest) {
   // Check user role (only trusted when we know the session is valid)
   const userRoleCookie = request.cookies.get(USER_ROLE_COOKIE);
   const userRole = isAuthenticated ? userRoleCookie?.value || 'user' : 'user';
-  const isAdmin = isAuthenticated && (userRole === 'admin' || userRole === 'superadmin');
+  const isAdmin = isAuthenticated && isAdminRole(userRole);
 
   // Check if the current route is protected or public auth route
   const isProtectedRoute = PROTECTED_ROUTES.some(route => pathname.startsWith(route));


### PR DESCRIPTION
## Summary
- Fix AuthModal redirect: superadmin users now correctly redirect to `/admin` after login (was going to `/dashboard`)
- Add `isAdminRole()` helper in `lib/utils/roles.ts` to centralize admin/superadmin role checks (case-insensitive)
- Adopt helper in `proxy.ts` for consistency

## Bug Details
- **BUG-2**: `AuthModal.tsx:107,155` only checked `role === 'admin'`, missing `superadmin`
- **Staging impact**: superadmin login → dashboard instead of admin panel

## Changes
| File | Change |
|------|--------|
| `lib/utils/roles.ts` | New `isAdminRole()` helper |
| `__tests__/lib/utils/roles.test.ts` | 9 unit tests |
| `AuthModal.tsx` | Use `isAdminRole()` for login + 2FA redirects |
| `proxy.ts` | Use `isAdminRole()` instead of inline check |

## Test plan
- [x] `pnpm vitest run src/__tests__/lib/utils/roles.test.ts` — 9/9 pass
- [x] `pnpm tsc --noEmit` — no type errors
- [x] Frontend build passes (pre-push hook)
- [ ] Manual: login as superadmin → redirects to `/admin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
