### PR TITLE
fix(web): resolve ApiKeyCreationModal barrel import crash

### DIFF
--- a/apps/web/src/components/modals/ApiKeyCreationModal.tsx
+++ b/apps/web/src/components/modals/ApiKeyCreationModal.tsx
@@ -46,7 +46,8 @@ import { Button } from '@/components/ui/primitives/button';
 import { Input } from '@/components/ui/primitives/input';
 import { Label } from '@/components/ui/primitives/label';
 import { Textarea } from '@/components/ui/primitives/textarea';
-import { api, CreateApiKeyResponse } from '@/lib/api';
+import { api } from '@/lib/api';
+import type { CreateApiKeyResponse } from '@/lib/api/schemas/auth.schemas';
 import { createErrorContext } from '@/lib/errors';
 import { logger } from '@/lib/logger';
 

--- a/apps/web/src/components/modals/index.ts
+++ b/apps/web/src/components/modals/index.ts
@@ -1,5 +1,6 @@
 // Barrel exports for modals module
-export { ApiKeyCreationModal } from './ApiKeyCreationModal';
+// ApiKeyCreationModal temporarily excluded — Turbopack module resolution issue
+// export { ApiKeyCreationModal } from './ApiKeyCreationModal';
 export { BggSearchModal } from './BggSearchModal';
 export { ErrorModal } from './ErrorModal';
 export { SessionSetupModal } from './SessionSetupModal';


### PR DESCRIPTION
## Summary
- Fix circular import causing Turbopack module resolution failure
- Use direct schema import instead of barrel re-export for CreateApiKeyResponse
- Temporarily exclude ApiKeyCreationModal from modals barrel

🤖 Generated with [Claude Code](https://claude.com/claude-code)