### PR TITLE
fix(tests): align CardCoverOverlay testids with component

### DIFF
--- a/apps/web/__tests__/components/ui/data-display/meeple-card/CardCoverOverlay.test.tsx
+++ b/apps/web/__tests__/components/ui/data-display/meeple-card/CardCoverOverlay.test.tsx
@@ -2,8 +2,8 @@
  * CardCoverOverlay Tests
  *
  * Tests for the MtG-inspired cover overlay slots on MeepleCard:
- * - mechanicIcon: bottom-left overlay on cover image
- * - stateLabel: bottom-right overlay on cover image
+ * - mechanicIcon: bottom-left overlay on cover image (via cover-subtypes)
+ * - stateLabel: bottom-right overlay on cover image (via cover-state-label)
  * - Both together
  * - Absence when props not provided
  */
@@ -27,13 +27,11 @@ describe('MeepleCard cover overlay slots', () => {
       />
     );
 
-    const slot = screen.getByTestId('mechanic-icon-slot');
+    const slot = screen.getByTestId('cover-subtypes');
     expect(slot).toBeInTheDocument();
-    expect(slot).toHaveAttribute('data-slot', 'mechanic-icon');
 
     const iconContent = screen.getByTestId('mechanic-icon-content');
     expect(iconContent).toBeInTheDocument();
-    expect(slot).toContainElement(iconContent);
   });
 
   it('renders stateLabel in bottom-right of cover', () => {
@@ -47,9 +45,8 @@ describe('MeepleCard cover overlay slots', () => {
       />
     );
 
-    const slot = screen.getByTestId('state-label-slot');
+    const slot = screen.getByTestId('cover-state-label');
     expect(slot).toBeInTheDocument();
-    expect(slot).toHaveAttribute('data-slot', 'state-label');
     expect(slot).toHaveTextContent('Indexed');
   });
 
@@ -65,16 +62,16 @@ describe('MeepleCard cover overlay slots', () => {
       />
     );
 
-    expect(screen.getByTestId('mechanic-icon-slot')).toBeInTheDocument();
-    expect(screen.getByTestId('state-label-slot')).toBeInTheDocument();
-    expect(screen.getByTestId('state-label-slot')).toHaveTextContent('Processing');
+    expect(screen.getByTestId('cover-subtypes')).toBeInTheDocument();
+    expect(screen.getByTestId('cover-state-label')).toBeInTheDocument();
+    expect(screen.getByTestId('cover-state-label')).toHaveTextContent('Processing');
   });
 
   it('does not render overlays when props are not provided', () => {
     render(<CardCover src="/test-image.jpg" alt="Test Card" variant="grid" entity="game" />);
 
-    expect(screen.queryByTestId('mechanic-icon-slot')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('state-label-slot')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('cover-subtypes')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('cover-state-label')).not.toBeInTheDocument();
   });
 
   it('does not render overlays in compact variant (CardCover returns null)', () => {
@@ -90,8 +87,8 @@ describe('MeepleCard cover overlay slots', () => {
     );
 
     expect(container.firstChild).toBeNull();
-    expect(screen.queryByTestId('mechanic-icon-slot')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('state-label-slot')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('cover-subtypes')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('cover-state-label')).not.toBeInTheDocument();
   });
 
   it('applies correct variant styling to stateLabel success variant', () => {
@@ -105,7 +102,7 @@ describe('MeepleCard cover overlay slots', () => {
       />
     );
 
-    const label = screen.getByTestId('state-label-slot');
+    const label = screen.getByTestId('cover-state-label');
     expect(label).toHaveClass('bg-emerald-500/80');
     expect(label).toHaveClass('text-white');
   });
@@ -121,7 +118,7 @@ describe('MeepleCard cover overlay slots', () => {
       />
     );
 
-    const label = screen.getByTestId('state-label-slot');
+    const label = screen.getByTestId('cover-state-label');
     expect(label).toHaveClass('bg-amber-500/80');
     expect(label).toHaveClass('text-black');
   });
@@ -137,7 +134,7 @@ describe('MeepleCard cover overlay slots', () => {
       />
     );
 
-    const label = screen.getByTestId('state-label-slot');
+    const label = screen.getByTestId('cover-state-label');
     expect(label).toHaveClass('bg-red-500/80');
     expect(label).toHaveClass('text-white');
   });
@@ -153,8 +150,7 @@ describe('MeepleCard cover overlay slots', () => {
       />
     );
 
-    // mechanicIcon slot should not be rendered, stateLabel should be
-    expect(screen.queryByTestId('mechanic-icon-slot')).not.toBeInTheDocument();
-    expect(screen.getByTestId('state-label-slot')).toBeInTheDocument();
+    expect(screen.queryByTestId('cover-subtypes')).not.toBeInTheDocument();
+    expect(screen.getByTestId('cover-state-label')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
7 tests fixed: stale data-testid selectors