### PR TITLE
perf(ci): migrate 7 workflows to ubuntu-latest, unblock self-hosted runner

### DIFF
--- a/.github/workflows/auto-branch-policy.yml
+++ b/.github/workflows/auto-branch-policy.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   validate-source-branch:
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     steps:
       - name: Validate PR source branch
         env:

--- a/.github/workflows/auto-dependabot.yml
+++ b/.github/workflows/auto-dependabot.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   auto-merge:
     name: Auto-merge Dependabot PRs
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     # Only run for Dependabot PRs with automerge label
     if: |
       github.actor == 'dependabot[bot]' &&

--- a/.github/workflows/auto-validate.yml
+++ b/.github/workflows/auto-validate.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   validate-workflow-patterns:
     name: Validate pnpm Cache Patterns
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/generate-diagrams.yml
+++ b/.github/workflows/generate-diagrams.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   generate-svgs:
     name: Generate SVG Diagrams
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/security-pentest.yml
+++ b/.github/workflows/security-pentest.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   check-trigger:
     name: Check Security Test Trigger
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
     steps:
@@ -63,7 +63,7 @@ jobs:
   # Detect if authentication/security files changed
   changes:
     name: Detect Security Changes
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     outputs:
       security: ${{ steps.filter.outputs.security }}
@@ -90,7 +90,7 @@ jobs:
   security-penetration-tests:
     name: 2FA Security Penetration Tests (OWASP)
     needs: [check-trigger, changes]
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     # Run if: manual/schedule trigger OR (PR with 'security' label OR security files changed)
     if: |
       needs.check-trigger.outputs.should_run == 'true' ||

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   create-reminder-issue:
     name: Create Quarterly Security Review Issue
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     permissions:
       issues: write
       contents: read

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -58,7 +58,7 @@ jobs:
   # Dependency scanning
   dependencies:
     name: Dependency Vulnerabilities
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -118,7 +118,7 @@ jobs:
   # Secrets scanning with Semgrep
   secrets:
     name: Secrets Detection
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
Self-hosted runner bottleneck: 15/18 workflows competed for 1 ARM64 runner.
Migrated 7 lightweight workflows to ubuntu-latest (10 runs-on lines changed).

Reduces self-hosted queue from ~10 jobs/push to ~3 jobs/push.

## Test plan
- [x] Workflows validated locally (`node scripts/validate-workflows.js`)
- [ ] CI passes on this PR (meta: this PR itself tests the migration)

🤖 Generated with [Claude Code](https://claude.ai/code)