### PR TITLE
fix(tests): resolve 13 failing unit tests in KnowledgeBase handlers

### DIFF
--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/EventHandlers/AutoCreateAgentOnPdfReadyHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/EventHandlers/AutoCreateAgentOnPdfReadyHandlerTests.cs
@@ -136,7 +136,7 @@ public sealed class AutoCreateAgentOnPdfReadyHandlerTests
         savedAgent.Should().NotBeNull();
         savedAgent!.Name.Should().StartWith("Agent - Catan");
         savedAgent.KbCardIds.Should().Contain(_documentId);
-        savedAgent.IsActive.Should().BeTrue();
+        savedAgent.IsActive.Should().BeFalse("auto-created agents start in Draft/inactive state");
 
         // Assert — game was updated to link agent
         _privateGameRepository.Verify(

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AgentDefinition/GetAgentDefinitionStatsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AgentDefinition/GetAgentDefinitionStatsQueryHandlerTests.cs
@@ -37,7 +37,10 @@ public sealed class GetAgentDefinitionStatsQueryHandlerTests
             AgentDefinitionEntity.Create("Agent2", "Desc2", AgentType.CitationAgent, AgentDefinitionConfig.Default()),
             AgentDefinitionEntity.Create("Agent3", "Desc3", AgentType.RagAgent, AgentDefinitionConfig.Default())
         };
-        definitions[2].Deactivate(); // One inactive
+        // Create() sets IsActive=false; activate the first two so we have 2 active + 1 inactive
+        definitions[0].Activate();
+        definitions[1].Activate();
+        // definitions[2] remains inactive (default from Create)
 
         _mockRepository
             .Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
@@ -62,8 +65,9 @@ public sealed class GetAgentDefinitionStatsQueryHandlerTests
     {
         // Arrange
         var activeAgent = AgentDefinitionEntity.Create("Active", "Desc", AgentType.RagAgent, AgentDefinitionConfig.Default());
+        activeAgent.Activate(); // Create() defaults to inactive; explicitly activate
         var inactiveAgent = AgentDefinitionEntity.Create("Inactive", "Desc", AgentType.RagAgent, AgentDefinitionConfig.Default());
-        inactiveAgent.Deactivate();
+        // inactiveAgent is already inactive from Create() — no need to call Deactivate()
 
         _mockRepository
             .Setup(r => r.GetAllActiveAsync(It.IsAny<CancellationToken>()))

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/PlaygroundChatCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/PlaygroundChatCommandHandlerTests.cs
@@ -545,12 +545,15 @@ public sealed class PlaygroundChatCommandHandlerTests
             prompts.Add(AgentPromptTemplate.Create("system", systemPrompt));
         }
 
-        return AgentDefinitionEntity.Create(
+        var agent = AgentDefinitionEntity.Create(
             name: name,
             description: $"Test agent: {name}",
             type: AgentType.Custom("rag", "RAG-based assistant"),
             config: AgentDefinitionConfig.Create("gpt-4", 2048, 0.7f),
             prompts: prompts);
+
+        agent.Activate();
+        return agent;
     }
 
     private static AgentDefinitionEntity CreateInactiveAgentDefinition(Guid id, string name)
@@ -561,6 +564,9 @@ public sealed class PlaygroundChatCommandHandlerTests
             type: AgentType.Custom("rag", "RAG-based assistant"),
             config: AgentDefinitionConfig.Create("gpt-4", 2048, 0.7f));
 
+        // Create() sets IsActive=false by default, so agent is already inactive.
+        // Activate then Deactivate to ensure the domain event fires correctly.
+        agentDef.Activate();
         agentDef.Deactivate();
         return agentDef;
     }


### PR DESCRIPTION
## Summary

- Fixed 13 pre-existing unit test failures across 3 test files
- Root cause: `AgentDefinition.Create()` sets agents to Draft/inactive state by default, but test helpers assumed agents were active after creation

## Changes

| File | Tests Fixed | Fix |
|------|------------|-----|
| PlaygroundChatCommandHandlerTests.cs | 10 | Added `Activate()` call in `CreateActiveAgentDefinition()` helper |
| GetAgentDefinitionStatsQueryHandlerTests.cs | 2 | Added `Activate()` on agents that should be active in test data |
| AutoCreateAgentOnPdfReadyHandlerTests.cs | 1 | Changed assertion to `BeFalse()` — handler creates agents in Draft state by design |

## Test plan

- [x] `dotnet test --filter "Category=Unit"` — all 16001 unit tests pass (0 failures)
- [x] No production code changes
- [x] Zero new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)