### PR TITLE
fix(tests): resolve 7 failing CardCoverOverlay frontend tests

### DIFF
--- a/apps/web/__tests__/components/ui/data-display/meeple-card/CardCoverOverlay.test.tsx
+++ b/apps/web/__tests__/components/ui/data-display/meeple-card/CardCoverOverlay.test.tsx
@@ -1,8 +1,8 @@
 /**
  * CardCoverOverlay Tests
  *
- * Tests for the MtG-inspired cover overlay slots on MeepleCard:
- * - mechanicIcon: bottom-left overlay on cover image
+ * Tests for the 4-corner cover overlay system on MeepleCard:
+ * - subtypeIcons: bottom-left overlay on cover image
  * - stateLabel: bottom-right overlay on cover image
  * - Both together
  * - Absence when props not provided
@@ -16,22 +16,23 @@ import { describe, it, expect } from 'vitest';
 import { CardCover } from '@/components/ui/data-display/meeple-card/parts/CardCover';
 
 describe('MeepleCard cover overlay slots', () => {
-  it('renders mechanicIcon in bottom-left of cover', () => {
+  it('renders subtypeIcons in bottom-left of cover', () => {
     render(
       <CardCover
         src="/test-image.jpg"
         alt="Test Card"
         variant="grid"
         entity="game"
-        mechanicIcon={<span data-testid="mechanic-icon-content">dice</span>}
+        subtypeIcons={[
+          { icon: <span data-testid="subtype-icon-content">dice</span>, tooltip: 'Dice' },
+        ]}
       />
     );
 
-    const slot = screen.getByTestId('mechanic-icon-slot');
+    const slot = screen.getByTestId('cover-subtypes');
     expect(slot).toBeInTheDocument();
-    expect(slot).toHaveAttribute('data-slot', 'mechanic-icon');
 
-    const iconContent = screen.getByTestId('mechanic-icon-content');
+    const iconContent = screen.getByTestId('subtype-icon-content');
     expect(iconContent).toBeInTheDocument();
     expect(slot).toContainElement(iconContent);
   });
@@ -47,9 +48,8 @@ describe('MeepleCard cover overlay slots', () => {
       />
     );
 
-    const slot = screen.getByTestId('state-label-slot');
+    const slot = screen.getByTestId('cover-state-label');
     expect(slot).toBeInTheDocument();
-    expect(slot).toHaveAttribute('data-slot', 'state-label');
     expect(slot).toHaveTextContent('Indexed');
   });
 
@@ -60,21 +60,26 @@ describe('MeepleCard cover overlay slots', () => {
         alt="Test Card"
         variant="featured"
         entity="game"
-        mechanicIcon={<span data-testid="mechanic-icon-content">area-control</span>}
+        subtypeIcons={[
+          {
+            icon: <span data-testid="subtype-icon-content">area-control</span>,
+            tooltip: 'Area Control',
+          },
+        ]}
         stateLabel={{ text: 'Processing', variant: 'warning' }}
       />
     );
 
-    expect(screen.getByTestId('mechanic-icon-slot')).toBeInTheDocument();
-    expect(screen.getByTestId('state-label-slot')).toBeInTheDocument();
-    expect(screen.getByTestId('state-label-slot')).toHaveTextContent('Processing');
+    expect(screen.getByTestId('cover-subtypes')).toBeInTheDocument();
+    expect(screen.getByTestId('cover-state-label')).toBeInTheDocument();
+    expect(screen.getByTestId('cover-state-label')).toHaveTextContent('Processing');
   });
 
   it('does not render overlays when props are not provided', () => {
     render(<CardCover src="/test-image.jpg" alt="Test Card" variant="grid" entity="game" />);
 
-    expect(screen.queryByTestId('mechanic-icon-slot')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('state-label-slot')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('cover-subtypes')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('cover-state-label')).not.toBeInTheDocument();
   });
 
   it('does not render overlays in compact variant (CardCover returns null)', () => {
@@ -84,14 +89,16 @@ describe('MeepleCard cover overlay slots', () => {
         alt="Test Card"
         variant="compact"
         entity="game"
-        mechanicIcon={<span data-testid="mechanic-icon-content">dice</span>}
+        subtypeIcons={[
+          { icon: <span data-testid="subtype-icon-content">dice</span>, tooltip: 'Dice' },
+        ]}
         stateLabel={{ text: 'Active', variant: 'info' }}
       />
     );
 
     expect(container.firstChild).toBeNull();
-    expect(screen.queryByTestId('mechanic-icon-slot')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('state-label-slot')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('cover-subtypes')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('cover-state-label')).not.toBeInTheDocument();
   });
 
   it('applies correct variant styling to stateLabel success variant', () => {
@@ -105,7 +112,7 @@ describe('MeepleCard cover overlay slots', () => {
       />
     );
 
-    const label = screen.getByTestId('state-label-slot');
+    const label = screen.getByTestId('cover-state-label');
     expect(label).toHaveClass('bg-emerald-500/80');
     expect(label).toHaveClass('text-white');
   });
@@ -121,7 +128,7 @@ describe('MeepleCard cover overlay slots', () => {
       />
     );
 
-    const label = screen.getByTestId('state-label-slot');
+    const label = screen.getByTestId('cover-state-label');
     expect(label).toHaveClass('bg-amber-500/80');
     expect(label).toHaveClass('text-black');
   });
@@ -137,12 +144,12 @@ describe('MeepleCard cover overlay slots', () => {
       />
     );
 
-    const label = screen.getByTestId('state-label-slot');
+    const label = screen.getByTestId('cover-state-label');
     expect(label).toHaveClass('bg-red-500/80');
     expect(label).toHaveClass('text-white');
   });
 
-  it('renders empty spacer div when only stateLabel is provided (no mechanicIcon)', () => {
+  it('renders empty spacer div when only stateLabel is provided (no subtypeIcons)', () => {
     render(
       <CardCover
         src="/test-image.jpg"
@@ -153,8 +160,8 @@ describe('MeepleCard cover overlay slots', () => {
       />
     );
 
-    // mechanicIcon slot should not be rendered, stateLabel should be
-    expect(screen.queryByTestId('mechanic-icon-slot')).not.toBeInTheDocument();
-    expect(screen.getByTestId('state-label-slot')).toBeInTheDocument();
+    // subtypeIcons slot should not be rendered, stateLabel should be
+    expect(screen.queryByTestId('cover-subtypes')).not.toBeInTheDocument();
+    expect(screen.getByTestId('cover-state-label')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Fixed 7 failing `CardCoverOverlay` tests that were stale after component refactoring
- Root cause: `CardCover` was refactored from `mechanicIcon` slot to `subtypeIcons` system, tests not updated

## Changes

| Before (stale) | After (current) |
|----------------|-----------------|
| `mechanicIcon` prop (ReactNode) | `subtypeIcons` prop ({icon, tooltip}[]) |
| `data-testid="mechanic-icon-slot"` | `data-testid="cover-subtypes"` |
| `data-testid="state-label-slot"` | `data-testid="cover-state-label"` |

## Test plan

- [x] 7 CardCoverOverlay tests pass
- [x] All 25 meeple-card tests pass
- [x] `pnpm build` succeeds
- [x] No new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)