### PR TITLE
fix(ci): MaxPoolSize=1 + aggressive pruning to fix 108 integration test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,9 +314,8 @@ jobs:
           POSTGRES_DB: meepleai_test
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: testpass
-          # Fix: Reduced MaxPoolSize from 20 to 5 to prevent "too many clients" (default max_connections=100)
-          # 4 threads × ~10 concurrent test classes × 5 pool = 200 potential, but pools don't all max out
-          ConnectionStrings__Postgres: Host=localhost;Port=5432;Database=meepleai_test;Username=postgres;Password=testpass;MaxPoolSize=5;Timeout=30;Command Timeout=60
+          # Fix: MaxPoolSize=1 — CI PostgreSQL max_connections=100, 33+ classes accumulate pools
+          ConnectionStrings__Postgres: Host=localhost;Port=5432;Database=meepleai_test;Username=postgres;Password=testpass;MaxPoolSize=1;Timeout=30;Command Timeout=60
           QDRANT_URL: http://localhost:6333
           REDIS_URL: localhost:6379,allowAdmin=true
           OPENROUTER_API_KEY: test-key
@@ -325,8 +324,8 @@ jobs:
           DISABLE_RATE_LIMITING: "true"
           # Issue #CI-Optimization: Pass external service URLs so SharedTestcontainersFixture
           # skips container startup and uses CI service containers directly
-          # Fix: Reduced MaxPoolSize from 20 to 5 — matches SharedTestcontainersFixture.cs:749
-          TEST_POSTGRES_CONNSTRING: Host=localhost;Port=5432;Database=meepleai_test;Username=postgres;Password=testpass;MaxPoolSize=5;Timeout=30;Command Timeout=60
+          # Fix: MaxPoolSize=1 — matches SharedTestcontainersFixture + IntegrationTestBase
+          TEST_POSTGRES_CONNSTRING: Host=localhost;Port=5432;Database=meepleai_test;Username=postgres;Password=testpass;MaxPoolSize=1;Timeout=30;Command Timeout=60
           TEST_REDIS_CONNSTRING: localhost:6379,allowAdmin=true
         run: |
           echo "🧪 Running integration tests - shard: ${{ matrix.shard.name }} (4 parallel threads)..."

--- a/apps/api/tests/Api.Tests/Infrastructure/IntegrationTestBase.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/IntegrationTestBase.cs
@@ -54,10 +54,10 @@ public abstract class IntegrationTestBase<TRepository> : IAsyncLifetime
                 SslMode = SslMode.Disable,
                 KeepAlive = 10,
                 Pooling = true,
-                MinPoolSize = 1,
-                MaxPoolSize = 2, // CI service containers have max_connections=100 (default)
-                ConnectionIdleLifetime = 30,
-                ConnectionPruningInterval = 5,
+                MinPoolSize = 0,
+                MaxPoolSize = 1, // CI: max_connections=100, 33+ classes accumulate pools
+                ConnectionIdleLifetime = 5,
+                ConnectionPruningInterval = 3,
                 Timeout = 30,
                 CommandTimeout = 60
             };

--- a/apps/api/tests/Api.Tests/Infrastructure/SharedTestcontainersFixture.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/SharedTestcontainersFixture.cs
@@ -741,13 +741,15 @@ public sealed class SharedTestcontainersFixture : IAsyncLifetime
                 builder.Database = databaseName;
                 builder.Timeout = 60; // Increase timeout to 60s for long-running integration tests
                 builder.CommandTimeout = 60;
-                // CI service containers use default max_connections=100 (can't be changed),
-                // while testcontainers set max_connections=500.
-                // MaxPoolSize=2 keeps us within 100: 4 threads × ~10 concurrent classes × 2 pool = 80 connections
+                // CI: max_connections=100 (can't change in GH Actions service containers).
+                // 33+ test classes accumulate pools faster than xUnit releases them.
+                // MaxPoolSize=1 × 33 = 33 connections max. Local testcontainers: max_connections=500.
                 var isExternalPostgres = !string.IsNullOrWhiteSpace(
                     Environment.GetEnvironmentVariable(TestcontainersConfiguration.EnvPostgresConnectionString));
-                builder.MaxPoolSize = isExternalPostgres ? 2 : 5;
-                builder.MinPoolSize = 1;
+                builder.MaxPoolSize = isExternalPostgres ? 1 : 5;
+                builder.MinPoolSize = 0;
+                builder.ConnectionIdleLifetime = isExternalPostgres ? 5 : 30;
+                builder.ConnectionPruningInterval = isExternalPostgres ? 3 : 10;
 
                 // Issue #2577: Log successful database creation with timing
                 var duration = (DateTime.UtcNow - startTime).TotalSeconds;


### PR DESCRIPTION
Connection pool exhaustion: 33 classes × MaxPoolSize=2 > PostgreSQL max_connections=100. Reduced to 1 with aggressive pruning.