### PR TITLE
fix(ci): revert MaxPoolSize to 2 + ClearAllPools() in test teardown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,8 +314,8 @@ jobs:
           POSTGRES_DB: meepleai_test
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: testpass
-          # Fix: MaxPoolSize=1 — CI PostgreSQL max_connections=100, 33+ classes accumulate pools
-          ConnectionStrings__Postgres: Host=localhost;Port=5432;Database=meepleai_test;Username=postgres;Password=testpass;MaxPoolSize=1;Timeout=30;Command Timeout=60
+          # MaxPoolSize=2 + ClearAllPools() in teardown prevents accumulation within max_connections=100
+          ConnectionStrings__Postgres: Host=localhost;Port=5432;Database=meepleai_test;Username=postgres;Password=testpass;MaxPoolSize=2;Timeout=30;Command Timeout=60
           QDRANT_URL: http://localhost:6333
           REDIS_URL: localhost:6379,allowAdmin=true
           OPENROUTER_API_KEY: test-key
@@ -324,8 +324,8 @@ jobs:
           DISABLE_RATE_LIMITING: "true"
           # Issue #CI-Optimization: Pass external service URLs so SharedTestcontainersFixture
           # skips container startup and uses CI service containers directly
-          # Fix: MaxPoolSize=1 — matches SharedTestcontainersFixture + IntegrationTestBase
-          TEST_POSTGRES_CONNSTRING: Host=localhost;Port=5432;Database=meepleai_test;Username=postgres;Password=testpass;MaxPoolSize=1;Timeout=30;Command Timeout=60
+          # MaxPoolSize=2 + ClearAllPools() in test teardown — matches fixture code
+          TEST_POSTGRES_CONNSTRING: Host=localhost;Port=5432;Database=meepleai_test;Username=postgres;Password=testpass;MaxPoolSize=2;Timeout=30;Command Timeout=60
           TEST_REDIS_CONNSTRING: localhost:6379,allowAdmin=true
         run: |
           echo "🧪 Running integration tests - shard: ${{ matrix.shard.name }} (4 parallel threads)..."

--- a/apps/api/tests/Api.Tests/Infrastructure/IntegrationTestBase.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/IntegrationTestBase.cs
@@ -55,7 +55,7 @@ public abstract class IntegrationTestBase<TRepository> : IAsyncLifetime
                 KeepAlive = 10,
                 Pooling = true,
                 MinPoolSize = 0,
-                MaxPoolSize = 1, // CI: max_connections=100, 33+ classes accumulate pools
+                MaxPoolSize = 2, // CI: max_connections=100, ClearAllPools() in teardown prevents accumulation
                 ConnectionIdleLifetime = 5,
                 ConnectionPruningInterval = 3,
                 Timeout = 30,
@@ -116,6 +116,10 @@ public abstract class IntegrationTestBase<TRepository> : IAsyncLifetime
         {
             await DbContext.DisposeAsync();
         }
+
+        // Release all pooled connections back to PostgreSQL to prevent
+        // "too many clients" exhaustion across parallel test classes in CI.
+        NpgsqlConnection.ClearAllPools();
 
         if (_postgresContainer != null)
         {

--- a/apps/api/tests/Api.Tests/Infrastructure/SharedTestcontainersFixture.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/SharedTestcontainersFixture.cs
@@ -742,11 +742,10 @@ public sealed class SharedTestcontainersFixture : IAsyncLifetime
                 builder.Timeout = 60; // Increase timeout to 60s for long-running integration tests
                 builder.CommandTimeout = 60;
                 // CI: max_connections=100 (can't change in GH Actions service containers).
-                // 33+ test classes accumulate pools faster than xUnit releases them.
-                // MaxPoolSize=1 × 33 = 33 connections max. Local testcontainers: max_connections=500.
+                // MaxPoolSize=2 + ClearAllPools() in teardown prevents accumulation.
                 var isExternalPostgres = !string.IsNullOrWhiteSpace(
                     Environment.GetEnvironmentVariable(TestcontainersConfiguration.EnvPostgresConnectionString));
-                builder.MaxPoolSize = isExternalPostgres ? 1 : 5;
+                builder.MaxPoolSize = isExternalPostgres ? 2 : 5;
                 builder.MinPoolSize = 0;
                 builder.ConnectionIdleLifetime = isExternalPostgres ? 5 : 30;
                 builder.ConnectionPruningInterval = isExternalPostgres ? 3 : 10;
@@ -818,6 +817,10 @@ public sealed class SharedTestcontainersFixture : IAsyncLifetime
                     WHERE datname = '{databaseName}' AND pid <> pg_backend_pid();";
 #pragma warning restore CA2100
                 var terminatedCount = await terminateCmd.ExecuteNonQueryAsync();
+
+                // Clear all Npgsql connection pools to release connections back to PostgreSQL.
+                // Prevents "too many clients" exhaustion in CI (max_connections=100).
+                NpgsqlConnection.ClearAllPools();
 
                 // Issue #2706: Brief delay to allow terminated connections to fully close
                 // This prevents race conditions where drop runs before connections are fully terminated


### PR DESCRIPTION
MaxPoolSize=1 broke Core. New: MaxPoolSize=2 + NpgsqlConnection.ClearAllPools() in DropIsolatedDatabaseAsync() and IntegrationTestBase.DisposeAsync().