### PR TITLE
fix(tests): fix 18 UploadPdf NullRef — ITierEnforcementService mock guard

### DIFF
--- a/apps/api/tests/Api.Tests/Integration/UploadPdfIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/UploadPdfIntegrationTests.cs
@@ -241,7 +241,8 @@ public sealed class UploadPdfIntegrationTests : IAsyncLifetime
         }
 
         // Register ITierEnforcementService mock (required by UploadPdfCommandHandler)
-        if (!services.Any(s => s.ServiceType == typeof(ITierEnforcementService)))
+        // Always replace the bare Mock.Of<> from IntegrationServiceCollectionBuilder.CreateBase
+        // which has no setups (CanPerformAsync returns false, GetUsageAsync returns null → NullRef at handler line 97)
         {
             var tierMock = new Mock<ITierEnforcementService>();
             tierMock.Setup(t => t.CanPerformAsync(It.IsAny<Guid>(), It.IsAny<TierAction>(), It.IsAny<CancellationToken>()))


### PR DESCRIPTION
Remove if-exists guard so configured mock replaces bare Mock.Of<>().