### PR TITLE
fix(admin): fix overview approve/reject and schema errors

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/overview/PendingRequestsBanner.tsx
+++ b/apps/web/src/app/admin/(dashboard)/overview/PendingRequestsBanner.tsx
@@ -5,9 +5,10 @@ import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AlertTriangle, Check, Loader2, X } from 'lucide-react';
 import Link from 'next/link';
+import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/primitives/button';
-import { createApiClient } from '@/lib/api';
+import { api } from '@/lib/api';
 
 // ============================================================================
 // Types
@@ -34,12 +35,16 @@ export function PendingRequestsBanner({ requests, totalCount }: PendingRequestsB
   const [processing, setProcessing] = useState<Set<string>>(new Set());
 
   const approveMutation = useMutation({
-    mutationFn: async (id: string) => {
-      const api = createApiClient();
-      await api.accessRequests.approveAccessRequest(id);
-    },
+    mutationFn: (id: string) => api.accessRequests.approveAccessRequest(id),
     onMutate: (id: string) => {
       setProcessing(prev => new Set(prev).add(id));
+    },
+    onSuccess: () => {
+      toast.success('Richiesta di accesso approvata');
+      void queryClient.invalidateQueries({ queryKey: ['admin', 'overview'] });
+    },
+    onError: (err: unknown) => {
+      toast.error(err instanceof Error ? err.message : "Errore durante l'approvazione");
     },
     onSettled: (_data, _error, id: string) => {
       setProcessing(prev => {
@@ -47,17 +52,20 @@ export function PendingRequestsBanner({ requests, totalCount }: PendingRequestsB
         next.delete(id);
         return next;
       });
-      void queryClient.invalidateQueries({ queryKey: ['admin', 'overview'] });
     },
   });
 
   const rejectMutation = useMutation({
-    mutationFn: async (id: string) => {
-      const api = createApiClient();
-      await api.accessRequests.rejectAccessRequest(id);
-    },
+    mutationFn: (id: string) => api.accessRequests.rejectAccessRequest(id),
     onMutate: (id: string) => {
       setProcessing(prev => new Set(prev).add(id));
+    },
+    onSuccess: () => {
+      toast.success('Richiesta di accesso rifiutata');
+      void queryClient.invalidateQueries({ queryKey: ['admin', 'overview'] });
+    },
+    onError: (err: unknown) => {
+      toast.error(err instanceof Error ? err.message : 'Errore durante il rifiuto');
     },
     onSettled: (_data, _error, id: string) => {
       setProcessing(prev => {
@@ -65,7 +73,6 @@ export function PendingRequestsBanner({ requests, totalCount }: PendingRequestsB
         next.delete(id);
         return next;
       });
-      void queryClient.invalidateQueries({ queryKey: ['admin', 'overview'] });
     },
   });
 

--- a/apps/web/src/app/admin/(dashboard)/overview/__tests__/PendingRequestsBanner.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/overview/__tests__/PendingRequestsBanner.test.tsx
@@ -11,12 +11,12 @@ const mockApprove = vi.hoisted(() => vi.fn());
 const mockReject = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/api', () => ({
-  createApiClient: () => ({
+  api: {
     accessRequests: {
       approveAccessRequest: mockApprove,
       rejectAccessRequest: mockReject,
     },
-  }),
+  },
 }));
 
 import { PendingRequestsBanner } from '../PendingRequestsBanner';

--- a/apps/web/src/app/admin/(dashboard)/overview/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/overview/page.tsx
@@ -48,20 +48,40 @@ function toAccessRequest(dto: AccessRequestDto): AccessRequest {
   };
 }
 
+/**
+ * Lightweight fetch without Zod schema validation for overview summary data.
+ * Avoids SchemaValidationError noise when backend DTOs have extra/missing fields.
+ */
+async function fetchJson<T>(path: string, fallback: T): Promise<T> {
+  try {
+    const res = await fetch(path, { credentials: 'include' });
+    if (!res.ok) return fallback;
+    return (await res.json()) as T;
+  } catch {
+    return fallback;
+  }
+}
+
 async function fetchOverviewData(): Promise<OverviewData> {
   const [statsRes, pendingRes, gamesRes, usersRes, invitationsRes] = await Promise.all([
     api.admin.getOverviewStats().catch(() => null),
     api.accessRequests
       .getAccessRequests({ status: 'Pending', pageSize: 5 })
       .catch(() => ({ items: [] as AccessRequestDto[], totalCount: 0, page: 1, pageSize: 5 })),
-    api.sharedGames.getAll({ pageSize: 5, page: 1 }).catch(() => ({ items: [], total: 0 })),
-    api.admin.getAllUsers({ limit: 5 }).catch(() => []),
+    // Use lightweight fetch for summary data — avoids Zod schema mismatch errors
+    fetchJson<{ items?: Record<string, unknown>[]; total?: number }>(
+      '/api/v1/admin/shared-games?page=1&pageSize=5',
+      { items: [], total: 0 }
+    ),
+    fetchJson<{ items?: Record<string, unknown>[]; total?: number }>(
+      '/api/v1/admin/users?limit=5',
+      { items: [], total: 0 }
+    ),
     api.invitations
       .getInvitations({ status: 'Pending', pageSize: 5 })
       .catch(() => ({ items: [], totalCount: 0 })),
   ]);
 
-  const gamesResAny = gamesRes as { items?: unknown[] } | null;
   const invitationsResAny = invitationsRes as { items?: unknown[]; totalCount?: number } | null;
 
   return {
@@ -70,15 +90,12 @@ async function fetchOverviewData(): Promise<OverviewData> {
       items: (pendingRes.items ?? []).map(toAccessRequest),
       totalCount: pendingRes.totalCount ?? 0,
     },
-    recentGames: ((gamesResAny?.items ?? []) as Record<string, unknown>[]).map(g => ({
+    recentGames: ((gamesRes?.items ?? []) as Record<string, unknown>[]).map(g => ({
       id: String(g['id'] ?? ''),
       title: String(g['title'] ?? g['name'] ?? 'Untitled'),
       createdAt: String(g['createdAt'] ?? g['addedAt'] ?? new Date().toISOString()),
     })),
-    recentUsers: (Array.isArray(usersRes)
-      ? (usersRes as Record<string, unknown>[])
-      : (((usersRes as { items?: unknown[] } | null)?.items ?? []) as Record<string, unknown>[])
-    ).map(u => ({
+    recentUsers: ((usersRes?.items ?? []) as Record<string, unknown>[]).map(u => ({
       id: String(u['id'] ?? ''),
       displayName: u['displayName'] != null ? String(u['displayName']) : null,
       email: String(u['email'] ?? ''),


### PR DESCRIPTION
## Summary
- Fix approve/reject access requests on admin overview page (PendingRequestsBanner)
- Eliminate Zod SchemaValidationError console spam for shared-games and users summary data
- Add toast feedback for approve/reject actions

## Changes
- **PendingRequestsBanner**: Use `api` singleton instead of `createApiClient()`, add `onSuccess`/`onError` with toast notifications
- **Overview page**: Replace Zod-validated API calls with lightweight `fetchJson()` for summary endpoints that only need basic fields
- **Tests**: Update mock from `createApiClient` factory to `api` singleton

## Test plan
- [x] PendingRequestsBanner tests pass (8/8)
- [x] All overview component tests pass (44/45 - 1 pre-existing TechActionsBar failure)
- [x] TypeScript compiles cleanly
- [x] Frontend build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
