### PR TITLE
fix(web): show SuperAdmin role on admin users page

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/users/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/users/page.tsx
@@ -39,7 +39,7 @@ import { useDebounce } from '@/hooks/useDebounce';
 import { api } from '@/lib/api';
 
 const PAGE_SIZE = 20;
-const ROLE_OPTIONS = ['all', 'User', 'Editor', 'Admin'] as const;
+const ROLE_OPTIONS = ['all', 'User', 'Editor', 'Admin', 'SuperAdmin'] as const;
 
 export default function AdminUsersPage() {
   const queryClient = useQueryClient();

--- a/apps/web/src/components/admin/users/InlineRoleSelect.tsx
+++ b/apps/web/src/components/admin/users/InlineRoleSelect.tsx
@@ -24,7 +24,7 @@ import {
 } from '@/components/ui/overlays/select';
 import { api } from '@/lib/api';
 
-const AVAILABLE_ROLES = ['User', 'Editor', 'Admin'] as const;
+const ASSIGNABLE_ROLES = ['User', 'Editor', 'Admin'] as const;
 
 interface InlineRoleSelectProps {
   userId: string;
@@ -41,6 +41,7 @@ export function InlineRoleSelect({
 }: InlineRoleSelectProps) {
   const queryClient = useQueryClient();
   const [pendingRole, setPendingRole] = useState<string | null>(null);
+  const isSuperAdmin = currentRole === 'SuperAdmin';
 
   const mutation = useMutation({
     mutationFn: (newRole: string) => api.admin.changeUserRole(userId, newRole),
@@ -67,6 +68,14 @@ export function InlineRoleSelect({
     }
   }
 
+  if (isSuperAdmin) {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-md bg-amber-100 px-2.5 py-0.5 text-xs font-semibold text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
+        SuperAdmin
+      </span>
+    );
+  }
+
   return (
     <>
       <Select value={currentRole} onValueChange={handleSelect} disabled={mutation.isPending}>
@@ -74,7 +83,7 @@ export function InlineRoleSelect({
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
-          {AVAILABLE_ROLES.map(role => (
+          {ASSIGNABLE_ROLES.map(role => (
             <SelectItem key={role} value={role}>
               {role}
             </SelectItem>

--- a/apps/web/src/components/ui/data-display/user-role-badge.tsx
+++ b/apps/web/src/components/ui/data-display/user-role-badge.tsx
@@ -1,17 +1,18 @@
 import * as React from 'react';
 
 import { cva, type VariantProps } from 'class-variance-authority';
-import { Shield, Edit, User } from 'lucide-react';
+import { Crown, Shield, Edit, User } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
-export type UserRole = 'Admin' | 'Editor' | 'User';
+export type UserRole = 'SuperAdmin' | 'Admin' | 'Editor' | 'User';
 
 const userRoleBadgeVariants = cva(
   'inline-flex items-center gap-1.5 rounded-md px-2.5 py-0.5 text-xs font-semibold transition-colors',
   {
     variants: {
       role: {
+        SuperAdmin: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300',
         Admin: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
         Editor: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300',
         User: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
@@ -24,6 +25,7 @@ const userRoleBadgeVariants = cva(
 );
 
 const roleIconMap: Record<UserRole, React.ComponentType<{ className?: string }>> = {
+  SuperAdmin: Crown,
   Admin: Shield,
   Editor: Edit,
   User: User,


### PR DESCRIPTION
## Summary
- **SuperAdmin users** now display an amber badge instead of a blank/broken dropdown on `/admin/users`
- Added `SuperAdmin` to the role filter dropdown so admins can filter by SuperAdmin
- Updated `UserRoleBadge` component with SuperAdmin variant (amber + Crown icon)
- SuperAdmin role is **non-editable** via the inline dropdown to prevent accidental demotion

## Root Cause
`InlineRoleSelect` and `UserRoleBadge` only defined 3 roles (`User`, `Editor`, `Admin`). When the backend returned `SuperAdmin`, the `<Select>` had no matching `<SelectItem>` and displayed blank.

## Files Changed
- `apps/web/src/components/admin/users/InlineRoleSelect.tsx` — render static badge for SuperAdmin
- `apps/web/src/app/admin/(dashboard)/users/page.tsx` — add SuperAdmin to filter
- `apps/web/src/components/ui/data-display/user-role-badge.tsx` — add SuperAdmin variant

## Test plan
- [ ] Open `/admin/users` — verify SuperAdmin user shows amber "SuperAdmin" badge
- [ ] Verify SuperAdmin badge is not a dropdown (no role change possible)
- [ ] Verify role filter includes "SuperAdmin" option
- [ ] Verify other users (User/Editor/Admin) still have working role dropdowns
- [ ] TypeScript compiles clean (`pnpm typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)