### PR TITLE
fix(security): remove hardcoded seed passwords, add staging demo

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedE2ETestUsersCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedE2ETestUsersCommand.cs
@@ -8,7 +8,7 @@ namespace Api.BoundedContexts.Administration.Application.Commands;
 ///
 /// Users created:
 /// - Admin: email from INITIAL_ADMIN_EMAIL secret, password from ADMIN_PASSWORD secret (Admin role)
-/// - editor@meepleai.dev / Demo123! (Editor role)
-/// - user@meepleai.dev / Demo123! (User role)
+/// - editor@meepleai.dev / password from SEED_TEST_PASSWORD secret (Editor role)
+/// - user@meepleai.dev / password from SEED_TEST_PASSWORD secret (User role)
 /// </summary>
 public sealed record SeedE2ETestUsersCommand : ICommand;

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedE2ETestUsersCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedE2ETestUsersCommandHandler.cs
@@ -1,4 +1,3 @@
-using Api.BoundedContexts.Administration.Application.Commands;
 using Api.BoundedContexts.Authentication.Domain.Entities;
 using Api.SharedKernel.Domain.ValueObjects;
 using Api.BoundedContexts.Authentication.Domain.ValueObjects;
@@ -14,13 +13,11 @@ namespace Api.BoundedContexts.Administration.Application.Commands;
 
 /// <summary>
 /// Handler for SeedE2ETestUsersCommand.
-/// Creates E2E test users for Playwright tests with predictable credentials.
+/// Creates E2E test users for Playwright tests with credentials from secrets.
 /// Idempotent: Skips users that already exist.
 /// </summary>
 internal sealed class SeedE2ETestUsersCommandHandler : ICommandHandler<SeedE2ETestUsersCommand>
 {
-    private const string TestPassword = "Demo123!";
-
     private static readonly (string Email, string DisplayName, Role Role)[] NonAdminTestUsers =
     [
         ("editor@meepleai.dev", "E2E Editor User", Role.Editor),
@@ -48,10 +45,21 @@ internal sealed class SeedE2ETestUsersCommandHandler : ICommandHandler<SeedE2ETe
     {
         ArgumentNullException.ThrowIfNull(command);
 
+        var testPassword = SecretsHelper.GetSeedTestPassword(_configuration, _logger);
+        if (string.IsNullOrWhiteSpace(testPassword))
+        {
+            _logger.LogWarning("SEED_TEST_PASSWORD not configured — skipping E2E test user seed");
+            return;
+        }
+        if (testPassword.Length < 8)
+        {
+            _logger.LogWarning("SEED_TEST_PASSWORD is too short (min 8 chars) — skipping E2E user seed");
+            return;
+        }
+
         var usersCreated = 0;
 
-        // Admin E2E user: use email/password from secret (same source as SeedAdminUserCommandHandler)
-        // This avoids creating a second admin with a different email than the one in admin.secret.
+        // Admin E2E user
         var adminEmail = _configuration["INITIAL_ADMIN_EMAIL"]
             ?? Environment.GetEnvironmentVariable("INITIAL_ADMIN_EMAIL")
             ?? _configuration["ADMIN_EMAIL"]
@@ -70,7 +78,7 @@ internal sealed class SeedE2ETestUsersCommandHandler : ICommandHandler<SeedE2ETe
             {
                 var adminPassword = SecretsHelper.GetSecretOrValue(_configuration, "ADMIN_PASSWORD", _logger, required: false)
                     ?? Environment.GetEnvironmentVariable("ADMIN_PASSWORD")
-                    ?? TestPassword;
+                    ?? testPassword;
 
                 var adminUser = new User(
                     id: Guid.NewGuid(),
@@ -90,7 +98,7 @@ internal sealed class SeedE2ETestUsersCommandHandler : ICommandHandler<SeedE2ETe
             _logger.LogWarning("INITIAL_ADMIN_EMAIL not configured — skipping E2E admin user seed");
         }
 
-        // Non-admin E2E users: hardcoded emails and password
+        // Non-admin E2E users
         foreach (var (emailStr, displayName, role) in NonAdminTestUsers)
         {
             var email = new Email(emailStr);
@@ -106,7 +114,7 @@ internal sealed class SeedE2ETestUsersCommandHandler : ICommandHandler<SeedE2ETe
                 id: Guid.NewGuid(),
                 email: email,
                 displayName: displayName,
-                passwordHash: PasswordHash.Create(TestPassword),
+                passwordHash: PasswordHash.Create(testPassword),
                 role: role
             );
 

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedStagingDemoUserCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedStagingDemoUserCommand.cs
@@ -1,0 +1,10 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Administration.Application.Commands;
+
+/// <summary>
+/// Command to seed a staging demo user for external testing/demos.
+/// Only executes when ASPNETCORE_ENVIRONMENT=Staging.
+/// Email from STAGING_DEMO_EMAIL, password from STAGING_DEMO_PASSWORD secret.
+/// </summary>
+public sealed record SeedStagingDemoUserCommand : ICommand;

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedStagingDemoUserCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedStagingDemoUserCommandHandler.cs
@@ -1,0 +1,85 @@
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.BoundedContexts.Authentication.Domain.ValueObjects;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Security;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.Administration.Application.Commands;
+
+/// <summary>
+/// Creates a demo user on staging for external testing/demos.
+/// Only runs in Staging environment. Idempotent.
+/// </summary>
+internal sealed class SeedStagingDemoUserCommandHandler : ICommandHandler<SeedStagingDemoUserCommand>
+{
+    private const string DefaultDisplayName = "Demo User";
+
+    private readonly IUserRepository _userRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IConfiguration _configuration;
+    private readonly IHostEnvironment _hostEnvironment;
+    private readonly ILogger<SeedStagingDemoUserCommandHandler> _logger;
+
+    public SeedStagingDemoUserCommandHandler(
+        IUserRepository userRepository,
+        IUnitOfWork unitOfWork,
+        IConfiguration configuration,
+        IHostEnvironment hostEnvironment,
+        ILogger<SeedStagingDemoUserCommandHandler> logger)
+    {
+        _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _hostEnvironment = hostEnvironment ?? throw new ArgumentNullException(nameof(hostEnvironment));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(SeedStagingDemoUserCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (!_hostEnvironment.IsStaging())
+        {
+            _logger.LogDebug("Skipping staging demo user seed — not in Staging environment");
+            return;
+        }
+
+        var demoEmail = _configuration["STAGING_DEMO_EMAIL"]
+            ?? Environment.GetEnvironmentVariable("STAGING_DEMO_EMAIL");
+        var demoPassword = SecretsHelper.GetSecretOrValue(_configuration, "STAGING_DEMO_PASSWORD", _logger, required: false)
+            ?? Environment.GetEnvironmentVariable("STAGING_DEMO_PASSWORD");
+
+        if (string.IsNullOrWhiteSpace(demoEmail) || string.IsNullOrWhiteSpace(demoPassword))
+        {
+            _logger.LogWarning("STAGING_DEMO_EMAIL or STAGING_DEMO_PASSWORD not configured — skipping");
+            return;
+        }
+
+        var email = new Email(demoEmail);
+        var existingUser = await _userRepository.GetByEmailAsync(email, cancellationToken).ConfigureAwait(false);
+        if (existingUser != null)
+        {
+            _logger.LogInformation("Staging demo user already exists: {Email}. Skipping.", DataMasking.MaskEmail(demoEmail));
+            return;
+        }
+
+        var demoUser = new User(
+            id: Guid.NewGuid(),
+            email: email,
+            displayName: DefaultDisplayName,
+            passwordHash: PasswordHash.Create(demoPassword),
+            role: Role.User
+        );
+        demoUser.VerifyEmail();
+
+        await _userRepository.AddAsync(demoUser, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        _logger.LogInformation("Staging demo user seeded: {Email}", DataMasking.MaskEmail(demoEmail));
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedTestUserCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedTestUserCommand.cs
@@ -4,6 +4,6 @@ namespace Api.BoundedContexts.Administration.Application.Commands;
 
 /// <summary>
 /// Command to seed a demo test user for development/testing purposes.
-/// Creates Test@meepleai.com / Demo123! with User role.
+/// Creates Test@meepleai.com with password from SEED_TEST_PASSWORD secret.
 /// </summary>
 public sealed record SeedTestUserCommand : ICommand;

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedTestUserCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedTestUserCommandHandler.cs
@@ -1,37 +1,40 @@
-using Api.BoundedContexts.Administration.Application.Commands;
 using Api.BoundedContexts.Authentication.Domain.Entities;
 using Api.SharedKernel.Domain.ValueObjects;
 using Api.BoundedContexts.Authentication.Domain.ValueObjects;
 using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.Infrastructure;
 using Api.Infrastructure.Security;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.Administration.Application.Commands;
 
 /// <summary>
 /// Handler for SeedTestUserCommand.
-/// Creates demo test user (Test@meepleai.com / Demo123!).
+/// Creates demo test user (Test@meepleai.com) with password from SEED_TEST_PASSWORD secret.
 /// Idempotent: Only executes if test user doesn't exist.
 /// </summary>
 internal sealed class SeedTestUserCommandHandler : ICommandHandler<SeedTestUserCommand>
 {
     private const string TestEmail = "Test@meepleai.com";
-    private const string TestPassword = "Demo123!";
     private const string TestDisplayName = "Test User";
 
     private readonly IUserRepository _userRepository;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IConfiguration _configuration;
     private readonly ILogger<SeedTestUserCommandHandler> _logger;
 
     public SeedTestUserCommandHandler(
         IUserRepository userRepository,
         IUnitOfWork unitOfWork,
+        IConfiguration configuration,
         ILogger<SeedTestUserCommandHandler> logger)
     {
         _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -39,34 +42,36 @@ internal sealed class SeedTestUserCommandHandler : ICommandHandler<SeedTestUserC
     {
         ArgumentNullException.ThrowIfNull(command);
 
-        // Check idempotency: Skip if test user already exists
+        var testPassword = SecretsHelper.GetSeedTestPassword(_configuration, _logger);
+        if (string.IsNullOrWhiteSpace(testPassword))
+        {
+            _logger.LogWarning("SEED_TEST_PASSWORD not configured — skipping test user seed");
+            return;
+        }
+        if (testPassword.Length < 8)
+        {
+            _logger.LogWarning("SEED_TEST_PASSWORD is too short (min 8 chars) — skipping test user seed");
+            return;
+        }
+
         var testEmailValue = new Email(TestEmail);
         var existingUser = await _userRepository.GetByEmailAsync(testEmailValue, cancellationToken).ConfigureAwait(false);
-
         if (existingUser != null)
         {
             _logger.LogInformation("Test user already exists. Skipping seed.");
             return;
         }
 
-        // Create domain objects
-        var email = new Email(TestEmail);
-        var passwordHash = PasswordHash.Create(TestPassword);
-        var role = Role.User;
-
-        // Create test user
         var testUser = new User(
             id: Guid.NewGuid(),
-            email: email,
+            email: new Email(TestEmail),
             displayName: TestDisplayName,
-            passwordHash: passwordHash,
-            role: role
+            passwordHash: PasswordHash.Create(testPassword),
+            role: Role.User
         );
 
-        // Persist
         await _userRepository.AddAsync(testUser, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-
         _logger.LogInformation("Test user seeded successfully: {Email}", DataMasking.MaskEmail(TestEmail));
     }
 }

--- a/apps/api/src/Api/Infrastructure/SecretsHelper.cs
+++ b/apps/api/src/Api/Infrastructure/SecretsHelper.cs
@@ -107,6 +107,16 @@ internal static class SecretsHelper
     }
 
     /// <summary>
+    /// Resolve seed test password from SEED_TEST_PASSWORD secret or env var.
+    /// Shared by SeedTestUserCommandHandler and SeedE2ETestUsersCommandHandler.
+    /// </summary>
+    public static string? GetSeedTestPassword(IConfiguration config, ILogger? logger = null)
+    {
+        return GetSecretOrValue(config, "SEED_TEST_PASSWORD", logger, required: false)
+            ?? Environment.GetEnvironmentVariable("SEED_TEST_PASSWORD");
+    }
+
+    /// <summary>
     /// Builds a PostgreSQL connection string using password from secret file or config.
     /// </summary>
     /// <param name="config">Configuration instance</param>

--- a/apps/api/src/Api/Infrastructure/Seeders/Core/CoreSeedLayer.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Core/CoreSeedLayer.cs
@@ -26,6 +26,14 @@ internal sealed class CoreSeedLayer : ISeedLayer
         logger.LogInformation("[Core] Seeding admin user...");
         await mediator.Send(new SeedAdminUserCommand(), cancellationToken).ConfigureAwait(false);
 
+        // Non-fatal: test user (requires SEED_TEST_PASSWORD secret)
+        await SafeExecute("test user",
+            () => mediator.Send(new SeedTestUserCommand(), cancellationToken), logger).ConfigureAwait(false);
+
+        // Non-fatal: staging demo user (only runs in Staging environment)
+        await SafeExecute("staging demo user",
+            () => mediator.Send(new SeedStagingDemoUserCommand(), cancellationToken), logger).ConfigureAwait(false);
+
         // Non-fatal: log + continue on failure
         await SafeExecute("AI models",
             () => mediator.Send(new SeedAiModelsCommand(), cancellationToken), logger).ConfigureAwait(false);

--- a/apps/api/tests/Api.Tests/Administration/SeedTestUserCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/Administration/SeedTestUserCommandHandlerTests.cs
@@ -1,12 +1,11 @@
 using Api.BoundedContexts.Administration.Application.Commands;
-using Api.BoundedContexts.Administration.Application.Commands;
-using Api.BoundedContexts.Administration.Application.Queries;
 using Api.BoundedContexts.Authentication.Domain.Entities;
 using Api.SharedKernel.Domain.ValueObjects;
 using Api.BoundedContexts.Authentication.Domain.ValueObjects;
 using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
 using Api.SharedKernel.Infrastructure.Persistence;
 using FluentAssertions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -15,11 +14,13 @@ using Api.Tests.Constants;
 namespace Api.Tests.Administration.AutoConfiguration;
 
 [Trait("Category", TestCategories.Unit)]
-
 public sealed class SeedTestUserCommandHandlerTests
 {
+    private const string TestPassword = "TestSeed2026!xK";
+
     private readonly Mock<IUserRepository> _userRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IConfiguration> _configurationMock;
     private readonly Mock<ILogger<SeedTestUserCommandHandler>> _loggerMock;
     private readonly SeedTestUserCommandHandler _handler;
 
@@ -28,10 +29,13 @@ public sealed class SeedTestUserCommandHandlerTests
         _userRepositoryMock = new Mock<IUserRepository>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _loggerMock = new Mock<ILogger<SeedTestUserCommandHandler>>();
+        _configurationMock = new Mock<IConfiguration>();
+        _configurationMock.Setup(c => c["SEED_TEST_PASSWORD"]).Returns(TestPassword);
 
         _handler = new SeedTestUserCommandHandler(
             _userRepositoryMock.Object,
             _unitOfWorkMock.Object,
+            _configurationMock.Object,
             _loggerMock.Object
         );
     }
@@ -39,46 +43,25 @@ public sealed class SeedTestUserCommandHandlerTests
     [Fact]
     public async Task Handle_WhenTestUserExists_ShouldSkipSeed()
     {
-        // Arrange
-        var testEmail = new Email("Test@meepleai.com");
-        var existingUser = CreateTestUser();
-
         _userRepositoryMock
-            .Setup(x => x.GetByEmailAsync(It.Is<Email>(e => e.Value == testEmail.Value), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(existingUser);
+            .Setup(x => x.GetByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateTestUser());
 
-        var command = new SeedTestUserCommand();
+        await _handler.Handle(new SeedTestUserCommand(), CancellationToken.None);
 
-        // Act
-        await _handler.Handle(command, CancellationToken.None);
-
-        // Assert
-        _userRepositoryMock.Verify(
-            x => x.AddAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()),
-            Times.Never
-        );
-
-        _unitOfWorkMock.Verify(
-            x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
-            Times.Never
-        );
+        _userRepositoryMock.Verify(x => x.AddAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Never);
+        _unitOfWorkMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
     public async Task Handle_WhenNoTestUserExists_ShouldCreateTestUser()
     {
-        // Arrange
         _userRepositoryMock
             .Setup(x => x.GetByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((User?)null);
 
-        var command = new SeedTestUserCommand();
+        await _handler.Handle(new SeedTestUserCommand(), CancellationToken.None);
 
-        // Act
-        await _handler.Handle(command, CancellationToken.None);
-
-        // Assert
-        // Note: Email value object normalizes to lowercase
         _userRepositoryMock.Verify(
             x => x.AddAsync(It.Is<User>(u =>
                 u.Email.Value == "test@meepleai.com" &&
@@ -87,23 +70,52 @@ public sealed class SeedTestUserCommandHandlerTests
             ), It.IsAny<CancellationToken>()),
             Times.Once
         );
+        _unitOfWorkMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
 
-        _unitOfWorkMock.Verify(
-            x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
-            Times.Once
+    [Fact]
+    public async Task Handle_WhenPasswordNotConfigured_ShouldSkipSeed()
+    {
+        var configMock = new Mock<IConfiguration>();
+        configMock.Setup(c => c["SEED_TEST_PASSWORD"]).Returns((string?)null);
+
+        var handler = new SeedTestUserCommandHandler(
+            _userRepositoryMock.Object,
+            _unitOfWorkMock.Object,
+            configMock.Object,
+            _loggerMock.Object
         );
+
+        await handler.Handle(new SeedTestUserCommand(), CancellationToken.None);
+
+        _userRepositoryMock.Verify(x => x.AddAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenPasswordTooShort_ShouldSkipSeed()
+    {
+        var configMock = new Mock<IConfiguration>();
+        configMock.Setup(c => c["SEED_TEST_PASSWORD"]).Returns("short");
+
+        var handler = new SeedTestUserCommandHandler(
+            _userRepositoryMock.Object,
+            _unitOfWorkMock.Object,
+            configMock.Object,
+            _loggerMock.Object
+        );
+
+        await handler.Handle(new SeedTestUserCommand(), CancellationToken.None);
+
+        _userRepositoryMock.Verify(x => x.AddAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     private static User CreateTestUser()
     {
-        var testEmail = new Email("Test@meepleai.com");
-        var passwordHash = PasswordHash.Create("Demo123!");
-
         return new User(
             Guid.NewGuid(),
-            testEmail,
+            new Email("Test@meepleai.com"),
             "Test User",
-            passwordHash,
+            PasswordHash.Create(TestPassword),
             Role.User
         );
     }

--- a/infra/secrets/admin.secret.example
+++ b/infra/secrets/admin.secret.example
@@ -10,3 +10,11 @@ ADMIN_PASSWORD=change_me_min_8_chars_with_uppercase_and_digit
 # For seed command (SeedAdminUserCommandHandler)
 INITIAL_ADMIN_EMAIL=admin@meepleai.app
 INITIAL_ADMIN_DISPLAY_NAME=System Administrator
+
+# Seed test/E2E user password (used by SeedTestUser + SeedE2ETestUsers)
+# IMPORTANT: Never hardcode in source code — always read from this secret
+SEED_TEST_PASSWORD=change_me_min_8_chars_with_uppercase_and_digit
+
+# Staging demo user (seeded only when ASPNETCORE_ENVIRONMENT=Staging)
+STAGING_DEMO_EMAIL=demo@meepleai.app
+STAGING_DEMO_PASSWORD=change_me_min_8_chars_with_uppercase_and_digit


### PR DESCRIPTION
## Summary

- Remove hardcoded `"Demo123!"` password from `SeedTestUserCommandHandler` and `SeedE2ETestUsersCommandHandler`
- All seed passwords now read from `SEED_TEST_PASSWORD` secret (same pattern as `ADMIN_PASSWORD`)
- Add new `SeedStagingDemoUserCommand` — creates `demo@meepleai.app` User account only in Staging environment
- Add `SEED_TEST_PASSWORD`, `STAGING_DEMO_EMAIL`, `STAGING_DEMO_PASSWORD` to `admin.secret.example` template

## Behavior by environment

| Environment | Test User | E2E Users | Staging Demo |
|-------------|-----------|-----------|-------------|
| Dev | From secret | From secret | Skipped (env guard) |
| CI | From env var | From env var | Skipped |
| Staging | From secret | From secret | Created (demo@meepleai.app) |
| Prod | Skipped (no secret) | Skipped | Skipped |

## Test plan

- [x] Backend builds (0 errors)
- [ ] Verify dev seeding works with `SEED_TEST_PASSWORD` in `admin.secret`
- [ ] Verify staging demo user created only in Staging env

🤖 Generated with [Claude Code](https://claude.com/claude-code)
