### PR TITLE
fix(secrets): update stale subdirectory paths after flat secrets migration

### DIFF
--- a/data/SSH console.md
+++ b/data/SSH console.md
@@ -20,8 +20,8 @@ Poi sul server:
 
     sleep 10 && curl -sf http://localhost:8080/health | head -5
 
-Se dà errore su secret mancanti tipo oauth.secret, email.secret etc nella cartella secrets/staging/, creali vuoti:
+Se dà errore su secret mancanti tipo oauth.secret, email.secret etc nella cartella secrets/, creali vuoti:
 
-    touch secrets/staging/{oauth,email,n8n,storage,smoldocling,reranker-service,unstructured-service,bgg,slack}.secret
+    touch secrets/{oauth,email,n8n,storage,smoldocling,reranker-service,unstructured-service,bgg,slack}.secret
 
 E poi rilancia il docker compose up sopra.

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -58,7 +58,7 @@ cd apps/api/src/Api && dotnet run --launch-profile Integration
 cd apps/web && pnpm dev
 ```
 
-**Prerequisiti**: chiave SSH `~/.ssh/meepleai-staging`, secrets in `infra/secrets/integration/`.
+**Prerequisiti**: chiave SSH `~/.ssh/meepleai-staging`, secrets in `infra/secrets/`.
 
 Tunnel ports: PG `:15432`, Redis `:16379`, Qdrant `:16333`, Embedding `:18000`, Reranker `:18003`, Unstructured `:18001`, SmolDocling `:18002`, Ollama `:21434`.
 
@@ -76,9 +76,9 @@ Tunnel ports: PG `:15432`, Redis `:16379`, Qdrant `:16333`, Embedding `:18000`, 
 
 Compose files:
 - `docker-compose.yml` — base (no ports, no secrets)
-- `compose.dev.yml` — dev override (ports, `secrets/dev/`)
-- `compose.staging.yml` — staging (Traefik labels, `secrets/staging/`)
-- `compose.integration.yml` — integration (SSH tunnel, `secrets/integration/`)
+- `compose.dev.yml` — dev override (ports, `secrets/`)
+- `compose.staging.yml` — staging (Traefik labels, `secrets/`)
+- `compose.integration.yml` — integration (SSH tunnel, `secrets/`)
 - `compose.traefik.yml` — reverse proxy
 
 Dev override auto-loaded via `infra/.env`:
@@ -390,7 +390,7 @@ sudo ufw allow 22/tcp 80/tcp 443/tcp && sudo ufw enable
 | PDF upload 403 | Feature flag | Insert `Features.PdfUpload = true` in DB |
 | SuperAdmin 403 | Auth policy | Verificare che le policy includano `"SuperAdmin"` |
 | Endpoint duplicato | API crash on startup | Check `WithName()` unico per ogni endpoint |
-| Redis crash | `requirepass` config error | Verificare `secrets/dev/redis.secret` esiste |
+| Redis crash | `requirepass` config error | Verificare `secrets/redis.secret` esiste |
 | CORS errors | `CORS__AllowedOrigins` | Aggiornare env, restart |
 
 ### Health Checks

--- a/docs/testing/us-add-game-ownership-rag-chat-checklist.md
+++ b/docs/testing/us-add-game-ownership-rag-chat-checklist.md
@@ -11,7 +11,7 @@
 - [ ] `make dev` running from `infra/` (all services healthy)
 - [ ] Seed script eseguito: `bash infra/scripts/seed-test-game.sh <path-to-catan-rules.pdf>`
 - [ ] Annotare Game ID e PDF status dall'output del seed
-- [ ] OpenRouter API key configurata in `infra/secrets/dev/openrouter.secret`
+- [ ] OpenRouter API key configurata in `infra/secrets/openrouter.secret`
 
 ---
 
@@ -100,7 +100,7 @@
 | Gioco non trovato in /discover | `curl http://localhost:8080/api/v1/shared-games?searchTerm=Catan` |
 | PDF non Completed | `curl http://localhost:8080/api/v1/pdfs/{pdfId}/progress -b cookies.txt` (check `currentStep`=`Completed`) |
 | Nessuna risposta RAG | `pwsh -c "docker logs meepleai-embedding-service --tail=20"` |
-| Chat timeout | Verificare OpenRouter key: `cat infra/secrets/dev/openrouter.secret` |
+| Chat timeout | Verificare OpenRouter key: `cat infra/secrets/openrouter.secret` |
 | Agent creation fails | Possibile limite slot agente — verificare tier utente |
 | Bottone ownership mancante | Gioco potrebbe essere gia in stato "Owned" |
 | Features.PdfUpload disabled | Verificare: `SELECT * FROM system_configurations WHERE key='Features.PdfUpload'` |

--- a/tools/bgg-fetcher/BggFetchClient.cs
+++ b/tools/bgg-fetcher/BggFetchClient.cs
@@ -21,13 +21,13 @@ public sealed class BggFetchClient : IDisposable
 
     private static string? LoadTokenFromSecrets()
     {
-        // Walk up to repo root, look for infra/secrets/dev/bgg.secret
+        // Walk up to repo root, look for infra/secrets/bgg.secret
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
         while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, ".git")))
             dir = dir.Parent;
         if (dir == null) return null;
 
-        var secretFile = Path.Combine(dir.FullName, "infra", "secrets", "dev", "bgg.secret");
+        var secretFile = Path.Combine(dir.FullName, "infra", "secrets", "bgg.secret");
         if (!File.Exists(secretFile)) return null;
 
         foreach (var line in File.ReadAllLines(secretFile))


### PR DESCRIPTION
## Summary
- Replace all `secrets/dev/`, `secrets/integration/`, `secrets/staging/` references with flat `secrets/` path
- Fixes `launchSettings.json` Integration profile that was blocking API startup
- Updates `BggFetchClient.cs`, deployment docs, testing checklist, SSH console notes

## Files changed
- `apps/api/src/Api/Properties/launchSettings.json` — SECRETS_DIRECTORY fixed (was blocking API)
- `tools/bgg-fetcher/BggFetchClient.cs` — secret file path corrected
- `docs/deployment/README.md` — 4 references updated
- `docs/testing/us-add-game-ownership-rag-chat-checklist.md` — 2 references updated
- `data/SSH console.md` — staging path reference updated

## Test plan
- [x] API starts with `dotnet run --launch-profile Integration`
- [x] Frontend build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)