### PR TITLE
fix(integration): disable GSS encryption for Npgsql 10 on Windows

### DIFF
--- a/infra/scripts/integration-start.sh
+++ b/infra/scripts/integration-start.sh
@@ -90,7 +90,7 @@ start_api() {
     export Embedding__FallbackEnabled=false
 
     # Build connection string with SSL Mode=Disable (tunnel already encrypts)
-    export ConnectionStrings__Postgres="Host=localhost;Port=15432;Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};SSL Mode=Disable"
+    export ConnectionStrings__Postgres="Host=localhost;Port=15432;Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};SSL Mode=Disable;GssEncryptionMode=Disable"
 
     cd "$API_DIR"
     dotnet run &


### PR DESCRIPTION
## Summary

- Adds `GssEncryptionMode=Disable` to the Npgsql connection string in `integration-start.sh`
- Fixes `28P01: password authentication failed` errors when connecting to staging postgres through SSH tunnel on Windows

## Root cause

Npgsql 10 on Windows attempts GSSAPI/Kerberos negotiation before SCRAM-SHA-256 password authentication. When connecting through an SSH tunnel, this GSSAPI handshake fails silently, and Npgsql then sends a corrupted/empty password in the SCRAM exchange → `28P01`.

`psycopg2` (Python) connects fine because it skips GSSAPI and goes directly to SCRAM. `GssEncryptionMode=Disable` makes Npgsql do the same.

**Note**: `launchSettings.json` is gitignored (contains credentials) — the same fix must be applied locally to that file manually, which this PR documents.

## Test plan

- [x] API starts with `dotnet run --launch-profile Integration`
- [x] `postgres: Healthy` in `/health` response
- [x] `redis: Healthy` in `/health` response
- [x] Seeder reads/writes staging data successfully

🤖 Generated with [Claude Code](https://claude.ai/claude-code)