### PR TITLE
fix(integration): disable GSS encryption for Npgsql 10 on Windows

### DIFF
--- a/infra/scripts/integration-start.sh
+++ b/infra/scripts/integration-start.sh
@@ -90,7 +90,7 @@ start_api() {
     export Embedding__FallbackEnabled=false
 
     # Build connection string with SSL Mode=Disable (tunnel already encrypts)
-    export ConnectionStrings__Postgres="Host=localhost;Port=15432;Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};SSL Mode=Disable"
+    export ConnectionStrings__Postgres="Host=localhost;Port=15432;Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};SSL Mode=Disable;GssEncryptionMode=Disable"
 
     cd "$API_DIR"
     dotnet run &


### PR DESCRIPTION
## Summary

- Adds `GssEncryptionMode=Disable` to Npgsql connection string in `integration-start.sh`
- Fixes `28P01: password authentication failed` when connecting to staging postgres via SSH tunnel on Windows
- Synced from meepleAi-app/meepleai-monorepo#157

🤖 Generated with [Claude Code](https://claude.ai/claude-code)