### PR TITLE
fix(admin): fix pagination and filters on shared-games/all page

### DIFF
--- a/apps/web/src/components/admin/shared-games/game-catalog-grid.tsx
+++ b/apps/web/src/components/admin/shared-games/game-catalog-grid.tsx
@@ -196,53 +196,50 @@ export function GameCatalogGrid({
   const [page, setPage] = useState(1);
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
 
+  // Map filter values to backend enum names
+  const STATUS_MAP: Record<string, string> = {
+    published: 'Published',
+    pending: 'PendingApproval',
+    draft: 'Draft',
+    archived: 'Archived',
+  };
+
+  const apiStatus = statusFilter !== 'all' ? STATUS_MAP[statusFilter] : undefined;
+
   const { data, isLoading } = useQuery({
-    queryKey: [...sharedGamesKeys.all, 'admin-list', page, PAGE_SIZE],
-    queryFn: () => api.sharedGames.getAll({ page, pageSize: PAGE_SIZE }),
+    queryKey: [...sharedGamesKeys.all, 'admin-list', page, PAGE_SIZE, searchQuery, apiStatus],
+    queryFn: () =>
+      api.sharedGames.getAll({
+        page,
+        pageSize: PAGE_SIZE,
+        status: apiStatus,
+        search: searchQuery || undefined,
+      }),
     staleTime: 2 * 60 * 1000,
   });
   const allGames = data?.items ?? [];
   const total = data?.total ?? 0;
 
-  // Client-side filtering
-  const games = allGames.filter(game => {
-    // Search filter (title, description)
-    if (searchQuery) {
-      const q = searchQuery.toLowerCase();
-      const titleMatch = game.title?.toLowerCase().includes(q);
-      const descMatch = game.description?.toLowerCase().includes(q);
-      if (!titleMatch && !descMatch) return false;
-    }
-
-    // Status filter
-    if (statusFilter !== 'all') {
-      const statusMap: Record<string, string> = {
-        published: 'Published',
-        pending: 'PendingApproval',
-        draft: 'Draft',
-        archived: 'Archived',
-      };
-      if (game.status !== statusMap[statusFilter]) return false;
-    }
-
-    // Players filter
-    if (playersFilter !== 'all') {
-      const min = game.minPlayers ?? 0;
-      const max = game.maxPlayers ?? 99;
-      if (playersFilter === '1-2' && min > 2) return false;
-      if (playersFilter === '3-4' && (max < 3 || min > 4)) return false;
-      if (playersFilter === '5+' && max < 5) return false;
-    }
-
-    return true;
-  });
+  // Client-side filtering only for players (not supported server-side)
+  const games =
+    playersFilter === 'all'
+      ? allGames
+      : allGames.filter(game => {
+          const min = game.minPlayers ?? 0;
+          const max = game.maxPlayers ?? 99;
+          if (playersFilter === '1-2' && min > 2) return false;
+          if (playersFilter === '3-4' && (max < 3 || min > 4)) return false;
+          if (playersFilter === '5+' && max < 5) return false;
+          return true;
+        });
   const totalPages = Math.ceil(total / PAGE_SIZE);
 
   // Selection state for bulk actions
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
-  // Clear selection when filters change to avoid bulk actions on hidden games
+  // Reset page and selection when filters change
   useEffect(() => {
+    setPage(1);
     setSelectedIds(new Set());
   }, [searchQuery, categoryFilter, statusFilter, playersFilter]);
 

--- a/apps/web/src/lib/api/clients/sharedGamesClient.ts
+++ b/apps/web/src/lib/api/clients/sharedGamesClient.ts
@@ -250,12 +250,13 @@ export function createSharedGamesClient({ httpClient }: CreateSharedGamesClientP
      * @returns Paginated list of shared games (all statuses)
      */
     async getAll(
-      params: { status?: number; page?: number; pageSize?: number } = {}
+      params: { status?: string; search?: string; page?: number; pageSize?: number } = {}
     ): Promise<PagedSharedGames> {
       const queryParams = new URLSearchParams();
 
-      if (params.status !== undefined) queryParams.set('status', params.status.toString());
-      if (params.page !== undefined) queryParams.set('page', params.page.toString());
+      if (params.status !== undefined) queryParams.set('status', params.status);
+      if (params.search) queryParams.set('search', params.search);
+      if (params.page !== undefined) queryParams.set('pageNumber', params.page.toString());
       if (params.pageSize !== undefined) queryParams.set('pageSize', params.pageSize.toString());
 
       const queryString = queryParams.toString();

--- a/apps/web/src/stores/admin-games/hooks.ts
+++ b/apps/web/src/stores/admin-games/hooks.ts
@@ -79,10 +79,12 @@ export function useAdminGamesData() {
       if (filters.mechanicIds) params.mechanicIds = filters.mechanicIds;
 
       // Use admin endpoint to get all statuses
+      const statusNames = ['Draft', 'PendingApproval', 'Published', 'Archived'] as const;
+      const statusStr = filters.status !== null ? statusNames[filters.status] : undefined;
       const result = await sharedGames.getAll({
         page,
         pageSize,
-        status: filters.status ?? undefined,
+        status: statusStr,
       });
 
       setGames(result);


### PR DESCRIPTION
## Summary
- **Pagination broken**: API client sent `?page=` but backend expects `?pageNumber=` — only page 1 ever loaded
- **Filters client-side only**: Status and search filters were applied on just 30 items from page 1 instead of being passed to the backend (which already supports them)
- **Status type mismatch**: `getAll()` expected `status: number` but backend expects string enum (`"Published"`, `"Draft"`, etc.)

## Changes
- `sharedGamesClient.ts`: Fixed `page` → `pageNumber` param, changed `status` from `number` to `string`, added `search` param
- `game-catalog-grid.tsx`: Pass status/search to API server-side, keep only players filter client-side, reset page on filter change
- `hooks.ts`: Convert numeric status to string enum name before API call

## Test plan
- [x] TypeScript compiles cleanly
- [x] game-catalog-grid tests pass (6/6)
- [x] admin-games store tests pass (39/39)
- [ ] Manual: verify all games load and pagination works beyond page 1
- [ ] Manual: verify status filter (Draft/Published/etc.) returns correct results
- [ ] Manual: verify search filter works across all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)