### PR TITLE
chore(ci): bump deprecated GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/actions/setup-frontend/action.yml
+++ b/.github/actions/setup-frontend/action.yml
@@ -22,13 +22,13 @@ runs:
   using: 'composite'
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v5
       with:
         version: ${{ inputs.pnpm-version }}
         run_install: false
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         # Note: Built-in cache disabled because actions/setup-node doesn't include

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -207,7 +207,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Setup QEMU for ARM64 cross-compilation
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: arm64
 
@@ -250,7 +250,7 @@ jobs:
 
       - name: Build and Push API Image
         if: needs.detect-changes.outputs.deploy_api == 'true'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./apps/api
           file: ./apps/api/src/Api/Dockerfile
@@ -266,7 +266,7 @@ jobs:
 
       - name: Build and Push Web Image
         if: needs.detect-changes.outputs.deploy_web == 'true'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./apps/web
           file: ./apps/web/Dockerfile
@@ -689,6 +689,7 @@ jobs:
           name: staging-e2e-report
           path: apps/web/playwright-report/
           retention-days: 7
+          if-no-files-found: ignore
 
   notify-end:
     if: always()

--- a/.github/workflows/generate-operations-pdf.yml
+++ b/.github/workflows/generate-operations-pdf.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -84,7 +84,7 @@ jobs:
 
       # Frontend dependencies
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 


### PR DESCRIPTION
## Summary

- `pnpm/action-setup@v4` → `v5` (setup-frontend action + security-scan workflow)
- `actions/setup-node@v4` → `v6` (setup-frontend action + generate-operations-pdf workflow)
- `docker/setup-qemu-action@v3` → `v4` (deploy-staging workflow)
- `docker/build-push-action@v5` → `v6` (deploy-staging workflow)
- `if-no-files-found: ignore` aggiunto all'upload artifact per staging E2E report (fix warning quando i test passano senza generare HTML report)

## Motivazione

GitHub Actions forzerà Node.js 24 come default dal **2 giugno 2026** e rimuoverà Node.js 20 il **16 settembre 2026**. Le versioni aggiornate sono già compatibili con Node.js 24.

## Test plan

- [ ] CI passa su questo branch
- [ ] Deploy staging successivo non mostra più warning sulle azioni deprecate

🤖 Generated with [Claude Code](https://claude.com/claude-code)