### PR TITLE
feat(library): refactor public catalog tab UI

### DIFF
--- a/apps/web/src/components/library/PublicLibraryPage.tsx
+++ b/apps/web/src/components/library/PublicLibraryPage.tsx
@@ -168,6 +168,8 @@ export function PublicLibraryPage({ className }: PublicLibraryPageProps) {
     return mechanicsData?.map(m => m.slug) ?? [];
   }, [mechanicsData]);
 
+  const selectedMechanicsSet = useMemo(() => new Set(selectedMechanics), [selectedMechanics]);
+
   // ------------------------------------------------------------------
   // Handlers
   // ------------------------------------------------------------------
@@ -356,7 +358,7 @@ export function PublicLibraryPage({ className }: PublicLibraryPageProps) {
               {/* Mechanic list */}
               <div className="max-h-64 overflow-y-auto p-2">
                 {availableMechanicSlugs.map(mechanic => {
-                  const isChecked = selectedMechanics.includes(mechanic);
+                  const isChecked = selectedMechanicsSet.has(mechanic);
                   return (
                     <label
                       key={mechanic}
@@ -371,7 +373,6 @@ export function PublicLibraryPage({ className }: PublicLibraryPageProps) {
                         checked={isChecked}
                         onChange={() => handleMechanicToggle(mechanic)}
                         className="h-3.5 w-3.5 rounded accent-[#f0a030]"
-                        aria-label={MECHANIC_LABELS[mechanic] ?? mechanic}
                       />
                       <MechanicIcon mechanic={mechanic} size={14} />
                       <span className="text-sm">{MECHANIC_LABELS[mechanic] ?? mechanic}</span>

--- a/apps/web/src/components/library/__tests__/PublicLibraryPage.test.tsx
+++ b/apps/web/src/components/library/__tests__/PublicLibraryPage.test.tsx
@@ -55,11 +55,17 @@ const MOCK_CATALOG = { items: MOCK_GAMES, total: 2, page: 1, pageSize: 18 };
 const MOCK_LIBRARY = { items: [{ gameId: 'g1' }], totalCount: 1 };
 const MOCK_ADD_MUTATE = vi.fn();
 
+const MOCK_MECHANICS = [
+  { id: 'm1', slug: 'deck-building', name: 'Deck Building' },
+  { id: 'm2', slug: 'cooperative', name: 'Cooperative' },
+];
+
 function setupMocks(
   overrides: Partial<{
     catalogError: boolean;
     trendingError: boolean;
     catalogEmpty: boolean;
+    withMechanics: boolean;
   }> = {}
 ) {
   (useSharedGames as Mock).mockReturnValue(
@@ -69,7 +75,9 @@ function setupMocks(
         ? { data: { items: [], total: 0, page: 1, pageSize: 18 }, isLoading: false, isError: false }
         : { data: MOCK_CATALOG, isLoading: false, isError: false }
   );
-  (useGameMechanics as Mock).mockReturnValue({ data: [] });
+  (useGameMechanics as Mock).mockReturnValue({
+    data: overrides.withMechanics ? MOCK_MECHANICS : [],
+  });
   (useCatalogTrending as Mock).mockReturnValue(
     overrides.trendingError
       ? { data: undefined, isLoading: false, isError: true }
@@ -154,5 +162,58 @@ describe('PublicLibraryPage', () => {
     expect(addButtons.length).toBeGreaterThan(0);
     await user.click(addButtons[0]);
     expect(MOCK_ADD_MUTATE).toHaveBeenCalled();
+  });
+
+  describe('Mechanic filter Popover', () => {
+    beforeEach(() => setupMocks({ withMechanics: true }));
+
+    it('mostra il bottone Meccaniche quando ci sono meccaniche disponibili', async () => {
+      renderWithQuery(<PublicLibraryPage />);
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /filtra per meccanica/i })).toBeInTheDocument();
+      });
+    });
+
+    it('apre il popover e mostra le checkbox delle meccaniche', async () => {
+      const user = userEvent.setup();
+      renderWithQuery(<PublicLibraryPage />);
+      await waitFor(() => screen.getByRole('button', { name: /filtra per meccanica/i }));
+      await user.click(screen.getByRole('button', { name: /filtra per meccanica/i }));
+      await waitFor(() => {
+        expect(screen.getByText('Deck Building')).toBeInTheDocument();
+        expect(screen.getByText('Cooperativo')).toBeInTheDocument();
+      });
+    });
+
+    it('selezionare una meccanica aggiunge un chip attivo dismissibile', async () => {
+      const user = userEvent.setup();
+      renderWithQuery(<PublicLibraryPage />);
+      await waitFor(() => screen.getByRole('button', { name: /filtra per meccanica/i }));
+      await user.click(screen.getByRole('button', { name: /filtra per meccanica/i }));
+      await waitFor(() => screen.getByText('Deck Building'));
+      const [firstCheckbox] = screen.getAllByRole('checkbox', { hidden: true });
+      await user.click(firstCheckbox);
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /rimuovi filtro/i })).toBeInTheDocument();
+      });
+    });
+
+    it('clicking il chip dismissibile rimuove il filtro', async () => {
+      const user = userEvent.setup();
+      renderWithQuery(<PublicLibraryPage />);
+      await waitFor(() => screen.getByRole('button', { name: /filtra per meccanica/i }));
+      // Apri e seleziona
+      await user.click(screen.getByRole('button', { name: /filtra per meccanica/i }));
+      await waitFor(() => screen.getByText('Deck Building'));
+      const [firstCheckbox] = screen.getAllByRole('checkbox', { hidden: true });
+      await user.click(firstCheckbox);
+      // Verifica chip
+      await waitFor(() => screen.getByRole('button', { name: /rimuovi filtro/i }));
+      // Rimuovi cliccando il chip
+      await user.click(screen.getByRole('button', { name: /rimuovi filtro/i }));
+      await waitFor(() => {
+        expect(screen.queryByRole('button', { name: /rimuovi filtro/i })).not.toBeInTheDocument();
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Replace `ShelfCard` in trending section with `MeepleCard variant="grid"` inside `ShelfRow` — visual consistency with the game grid below
- Replace `MechanicFilter` chip row (cluttered with many labels) with a compact **Popover button + checkbox list** + dismissible active-filter chips
- Move mechanic filter outside `SectionBlock` to a standalone filter bar between trending and grid
- Responsive grid breakpoints: `cols-2 / sm:cols-3 / lg:cols-4 / xl:cols-5`

## Test plan
- [ ] `/library?tab=public` carica correttamente trending con MeepleCard
- [ ] Click su carta trending naviga a `/library/games/{id}`
- [ ] Bottone "Meccaniche" apre popover con lista checkbox
- [ ] Selezionare meccanica filtra la griglia
- [ ] Chip attivi appaiono accanto al bottone e sono dismissibili con X
- [ ] "Pulisci tutto" nel popover resetta tutti i filtri
- [ ] Grid responsive su mobile / tablet / desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)