### PR TITLE
fix(health): use factory registration for EmbeddingDimensionHealthCheck

### DIFF
--- a/apps/api/src/Api/Infrastructure/Health/Extensions/HealthCheckServiceExtensions.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Extensions/HealthCheckServiceExtensions.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.UserNotifications.Infrastructure.HealthChecks;
 using Api.Infrastructure.Health.Checks;
 using Api.Infrastructure.Health.Models;
+using Api.Services;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Api.Infrastructure.Health.Extensions;
@@ -38,13 +39,16 @@ public static class HealthCheckServiceExtensions
             timeout: TimeSpan.FromSeconds(5));
 
         // Embedding dimension validation — catches provider/schema mismatch at startup.
-        // Uses Degraded + NonCritical to match other AI health checks and avoid
-        // blocking dev/CI startup when embedding service is not running.
-        builder.AddCheck<EmbeddingDimensionHealthCheck>(
+        // Uses factory registration because IEmbeddingService is internal (CS0051 prevents
+        // a public constructor), and ActivatorUtilities does not resolve internal constructors.
+        builder.Add(new HealthCheckRegistration(
             "embedding-dimensions",
+            sp => new EmbeddingDimensionHealthCheck(
+                sp.GetRequiredService<IEmbeddingService>(),
+                sp.GetRequiredService<ILogger<EmbeddingDimensionHealthCheck>>()),
             HealthStatus.Degraded,
-            tags: new[] { HealthCheckTags.Ai, HealthCheckTags.NonCritical },
-            timeout: TimeSpan.FromSeconds(1));
+            new[] { HealthCheckTags.Ai, HealthCheckTags.NonCritical },
+            TimeSpan.FromSeconds(1)));
 
         builder.AddCheck<RerankerHealthCheck>(
             "reranker",


### PR DESCRIPTION
## Summary

- `EmbeddingDimensionHealthCheck` ha un costruttore `internal` perché `IEmbeddingService` è `internal` (CS0051 impedisce un costruttore `public`)
- `ActivatorUtilities` (usato da `AddCheck<T>()`) non risolve costruttori interni → `InvalidOperationException` al primo hit dell'endpoint `/health`
- Fix: sostituisce `AddCheck<EmbeddingDimensionHealthCheck>()` con una `HealthCheckRegistration` factory-based che instanzia direttamente la classe

## Test plan

- [x] Build senza errori (`dotnet build`)
- [x] `/health` risponde correttamente — `embedding-dimensions: Healthy (provider=768, schema=768)` verificato in integration su `main-staging`
- [ ] Eseguire integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)