### PR TITLE
fix(ci): sparse checkout + exclude data/rulebook from git tracking

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -72,7 +72,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 2
+          fetch-depth: 0  # Full history needed to compare against github.event.before on merge commits
+          # sparse-checkout excludes data/ (1.3GB PDFs) — runner disk is limited
+          # PDFs are managed via S3 blob storage, not git
+          sparse-checkout: |
+            apps/
+            infra/
+            .github/
+            tests/
+            scripts/
+            packages/
+          sparse-checkout-cone-mode: true
 
       - uses: dorny/paths-filter@v4
         id: changes
@@ -119,6 +129,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # sparse-checkout excludes data/ (1.3GB PDFs) — runner disk is limited
+          sparse-checkout: |
+            apps/
+            .github/
+          sparse-checkout-cone-mode: true
 
       - name: Verify CI passed on this commit
         env:
@@ -185,6 +201,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # sparse-checkout excludes data/ (1.3GB PDFs) — runner disk is limited
+          sparse-checkout: |
+            apps/
+            .github/
+          sparse-checkout-cone-mode: true
 
       - name: Generate Version
         id: version
@@ -371,6 +393,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # sparse-checkout excludes data/ (1.3GB PDFs) — runner disk is limited
+          sparse-checkout: |
+            infra/
+            .github/
+          sparse-checkout-cone-mode: true
 
       # Option 1: SSH Deploy (VPS/Dedicated Server)
       - name: Deploy via SSH
@@ -460,6 +488,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # sparse-checkout excludes data/ (1.3GB PDFs) — runner disk is limited
+          sparse-checkout: |
+            tests/
+            apps/web/
+            .github/
+          sparse-checkout-cone-mode: true
 
       - name: Deep Health Check
         run: |
@@ -665,6 +700,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # sparse-checkout excludes data/ (1.3GB PDFs) — runner disk is limited
+          sparse-checkout: |
+            apps/web/
+            .github/
+          sparse-checkout-cone-mode: true
 
       - name: Setup Frontend
         uses: ./.github/actions/setup-frontend

--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,8 @@ tools/bgg-fetcher/logs/
 docs/pages/screenshots/
 docs/pages/dist/
 docs/pages/manifest.json
+
+# Rulebook PDFs — managed via S3/blob storage, not git
+# These are seed data for RAG embedding pipeline only
+data/rulebook/
+data/pdfDocs/


### PR DESCRIPTION
## Summary

- Adds sparse-checkout to all 6 CI jobs in `deploy-staging.yml` to exclude `data/` (1.3GB PDFs) from runner checkout
- Adds `data/rulebook/` and `data/pdfDocs/` to `.gitignore` to prevent future re-commits

## Context

The self-hosted runner was at 97% disk (75GB total) due to 126 rulebook PDFs (1.3GB) tracked in git. Docker image builds were failing with `No space left on device`. Sparse checkout reduces per-job checkout from ~1.5GB to ~100MB. PDFs are seed data for the RAG embedding pipeline only — managed via S3/blob storage at runtime, not needed in git.

## Changes

### `.github/workflows/deploy-staging.yml` — 6 jobs updated

| Job | Sparse-checkout paths |
|-----|----------------------|
| `detect-changes` | `apps/ infra/ .github/ tests/ scripts/ packages/` |
| `pre-deploy-check` | `apps/ .github/` |
| `build` | `apps/ .github/` |
| `deploy` | `infra/ .github/` |
| `validate` | `tests/ apps/web/ .github/` |
| `e2e-staging` | `apps/web/ .github/` |

### `.gitignore`
```
# Rulebook PDFs — managed via S3/blob storage, not git
data/rulebook/
data/pdfDocs/
```

## Verification

Already verified on `main-staging` (run #23858863304):
- `Build Images`: ✅ success (was ❌ disk full)
- `Deploy to Staging`: ✅ success  
- Runner disk: **77%** (was 97%)
- Checkout `_work`: **76MB** (was ~1.5GB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)