### PR TITLE
fix(ci): prevent awk division by zero in baseline compare when error_rate=0

### DIFF
--- a/tests/k6/utils/deploy-baseline-compare.sh
+++ b/tests/k6/utils/deploy-baseline-compare.sh
@@ -24,7 +24,7 @@ THRESHOLD="${REGRESSION_THRESHOLD_PCT:-20}"
 
 # Portable float comparison using awk
 float_gt() { awk "BEGIN { exit !($1 > $2) }"; }
-float_pct_change() { awk "BEGIN { printf \"%.1f\", (($1 - $2) / $2) * 100 }"; }
+float_pct_change() { awk "BEGIN { if ($2 == 0) { printf \"0.0\" } else { printf \"%.1f\", (($1 - $2) / $2) * 100 } }"; }
 float_fmt() { awk "BEGIN { printf \"%.1f\", $1 }"; }
 
 # Extract metrics from K6 summary JSON
@@ -88,7 +88,7 @@ else
 
   compare_metric() {
     local name="$1" curr="$2" prev="$3" unit="$4"
-    if [ -z "$prev" ] || [ "$prev" = "null" ] || [ "$prev" = "0" ]; then
+    if [ -z "$prev" ] || [ "$prev" = "null" ] || awk "BEGIN { exit !($prev == 0) }"; then
       add "| $name | ${curr}${unit} | — | — | New |"
       return
     fi


### PR DESCRIPTION
## Bug

`Post-deploy Validation` fallisce con `awk: division by zero` quando il baseline precedente ha `error_rate: 0`.

### Root cause

1. Il baseline JSON contiene `"error_rate": 0`
2. Viene formattato come `"0.00"` tramite `awk printf "%.2f"`
3. Il guard in `compare_metric` controlla `[ "$prev" = "0" ]` → **FALSE** (`"0.00" != "0"` come stringa)
4. `float_pct_change "$curr" "0.00"` chiama awk con denominatore `0.00`
5. awk calcola `(x - 0) / 0` → **division by zero** → exit code 1

Riproducibile ogni volta che un deploy ha 0 errori HTTP (situazione normale).

## Fix

**`tests/k6/utils/deploy-baseline-compare.sh`** — 2 righe cambiate

**1. `float_pct_change` — guard diretto in awk (root cause):**
```bash
# Before
float_pct_change() { awk "BEGIN { printf \"%.1f\", (($1 - $2) / $2) * 100 }"; }
# After  
float_pct_change() { awk "BEGIN { if ($2 == 0) { printf \"0.0\" } else { printf \"%.1f\", (($1 - $2) / $2) * 100 } }"; }
```

**2. `compare_metric` — confronto numerico invece di stringa (difesa in profondità):**
```bash
# Before
if [ -z "$prev" ] || [ "$prev" = "null" ] || [ "$prev" = "0" ]; then
# After
if [ -z "$prev" ] || [ "$prev" = "null" ] || awk "BEGIN { exit !($prev == 0) }"; then
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)