### PR TITLE
feat(dashboard): simplify and improve desktop dashboard

### DIFF
--- a/apps/web/src/app/(authenticated)/dashboard/dashboard-client.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/dashboard-client.tsx
@@ -15,6 +15,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 import { ErrorBoundary } from '@/components/errors/ErrorBoundary';
+import { useAuthUser } from '@/hooks/useAuthUser';
 import type { SessionSummaryDto, TrendingGameDto, UserGameDto } from '@/lib/api/dashboard-client';
 import { useDashboardStore } from '@/lib/stores/dashboard-store';
 import { cn } from '@/lib/utils';
@@ -605,9 +606,44 @@ function TrendingWidget({ games, isLoading }: { games: TrendingGameDto[]; isLoad
   );
 }
 
+// ─── Greeting Widget (12×1) ──────────────────────────────────────────────────
+
+function getGreeting(): string {
+  const h = new Date().getHours();
+  if (h < 12) return 'Buongiorno';
+  if (h < 18) return 'Buon pomeriggio';
+  return 'Buonasera';
+}
+
+function GreetingWidget({ displayName }: { displayName?: string | null }) {
+  const greeting = getGreeting();
+  const name = displayName ?? '';
+  const today = new Date().toLocaleDateString('it-IT', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+  });
+
+  return (
+    <BentoWidget
+      colSpan={12}
+      rowSpan={1}
+      className="flex items-center justify-between"
+      data-testid="widget-greeting"
+    >
+      <p className="font-quicksand font-extrabold text-base leading-none truncate">
+        {greeting}
+        {name ? `, ${name}` : ''}! 👋
+      </p>
+      <p className="text-[11px] text-muted-foreground shrink-0 capitalize">{today}</p>
+    </BentoWidget>
+  );
+}
+
 // ─── Dashboard Client ─────────────────────────────────────────────────────────
 
 export function DashboardClient() {
+  const { user } = useAuthUser();
   const {
     stats,
     isLoadingStats,
@@ -647,6 +683,9 @@ export function DashboardClient() {
           className="grid grid-cols-6 lg:grid-cols-12"
           style={{ gridAutoRows: '60px', gap: '8px' }}
         >
+          {/* Row 0: Greeting (12×1) */}
+          <GreetingWidget displayName={user?.displayName} />
+
           {/* Row 1-2: Live Session (8×2) + Partite (4×2) */}
           <LiveSessionWidget
             session={latestSession}


### PR DESCRIPTION
## Summary

- **Rimuove** `BentoDashboardSidebar` ridondante (duplicava la nav di `UnifiedShell`, 80 righe di dead code)
- **Sostituisce** `ChatPreviewWidget` (conversazione fake hardcoded) con `QuickActionsWidget` — 4 CTA reali (Nuova Partita, Chat AI, Aggiungi Gioco, Storico)
- **Aggiunge** `GreetingWidget` (12×1) come prima riga: saluto contestuale al momento della giornata + data corrente + nome utente personalizzato
- **Aggiunge** `ErrorBoundary` attorno al bento grid e surface `sessionsError` in `LiveSessionWidget`
- **Migra** colori hardcoded (`#22c55e`, `#3b82f6`) a token CSS di design system (`--gaming-accent-success`, `--gaming-accent-info`)
- **Corregge** font size (`text-[8px]`/`text-[9px]`/`text-[10px]` → `text-[11px]` per leggibilità)
- **Aggiunge** `data-testid` su tutti i widget Bento per testabilità
- **Sostituisce** tag `<img>` raw con `next/image` (3 widget)
- **Chiarisce** etichette: "Classifica Gruppo · basata sulle ultime partite" e "Popolari su MeepleAI · 7 giorni"

## Test Plan

- [ ] Verifica visiva dashboard desktop: greeting row, quick actions, live session, library, KPIs, leaderboard, trending
- [ ] Verifica saluto ora-dipendente (Buongiorno/pomeriggio/Buonasera)
- [ ] Verifica nome utente personalizzato nel greeting (o vuoto se non disponibile)
- [ ] Verifica `data-testid` presenti sui widget (`widget-live-session`, `widget-library`, etc.)
- [ ] Verifica ErrorBoundary non rompe rendering in condizioni normali
- [ ] `pnpm typecheck` ✅ | `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)