### PR TITLE
feat(logs): hybrid log viewer — Container Errors tab via Loki proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ infra/secrets/prod/*.pfx
 logs/
 # Exception: Allow admin monitor logs page
 !apps/web/src/app/admin/*/monitor/logs/
+# Exception: Allow Next.js API route for logs
+!apps/web/src/app/api/logs/
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/DependencyInjection/AdministrationServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/DependencyInjection/AdministrationServiceExtensions.cs
@@ -99,7 +99,7 @@ internal static class AdministrationServiceExtensions
         services.AddHttpClient<ISeqQueryClient, SeqQueryClient>((sp, client) =>
         {
             var options = sp.GetRequiredService<IOptions<SeqOptions>>().Value;
-            client.BaseAddress = new Uri(options.ServerUrl);
+            client.BaseAddress = new Uri(options.QueryUrl);
             if (!string.IsNullOrEmpty(options.ApiKey))
                 client.DefaultRequestHeaders.Add("X-Seq-ApiKey", options.ApiKey);
             client.Timeout = TimeSpan.FromSeconds(15);

--- a/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/External/SeqOptions.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/External/SeqOptions.cs
@@ -5,6 +5,8 @@ public sealed class SeqOptions
     public const string SectionName = "Seq";
 
     public string ServerUrl { get; set; } = "http://seq:5341";
+    /// <summary>Query URL for Seq REST API (port 80); differs from ingestion port 5341.</summary>
+    public string QueryUrl { get; set; } = "http://seq:80";
     public string? ApiKey { get; set; }
     public int RetentionDays { get; set; } = 7;
 }

--- a/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/External/SeqQueryClient.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/External/SeqQueryClient.cs
@@ -48,6 +48,8 @@ public sealed class SeqQueryClient : ISeqQueryClient
         if (!string.IsNullOrWhiteSpace(afterId))
             queryParams.Add($"afterId={afterId}");
 
+        // render=true asks Seq to include RenderedMessage in the response
+        queryParams.Add("render=true");
         var url = $"/api/events?{string.Join("&", queryParams)}";
 
         try
@@ -83,11 +85,13 @@ public sealed class SeqQueryClient : ISeqQueryClient
     private static ApplicationLogDto ParseEvent(JsonElement evt)
     {
         var properties = new Dictionary<string, string>(StringComparer.Ordinal);
-        if (evt.TryGetProperty("Properties", out var props))
+        // Seq REST API returns Properties as an array of {Name, Value} objects
+        if (evt.TryGetProperty("Properties", out var props) && props.ValueKind == JsonValueKind.Array)
         {
-            foreach (var prop in props.EnumerateObject())
+            foreach (var prop in props.EnumerateArray())
             {
-                properties[prop.Name] = prop.Value.ToString();
+                if (prop.TryGetProperty("Name", out var name) && prop.TryGetProperty("Value", out var value))
+                    properties[name.GetString() ?? ""] = value.ToString();
             }
         }
 

--- a/apps/api/src/Api/appsettings.json
+++ b/apps/api/src/Api/appsettings.json
@@ -542,6 +542,7 @@
   },
   "Seq": {
     "ServerUrl": "http://seq:5341",
+    "QueryUrl": "http://seq:80",
     "ApiKey": "",
     "MinimumLevel": "Information",
     "RetentionDays": 7

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/DI/OrchestratorDICircularDependencyTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/DI/OrchestratorDICircularDependencyTests.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.DocumentProcessing.Application.Services;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.DependencyInjection;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+using Api.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -40,6 +41,9 @@ public class OrchestratorDICircularDependencyTests
         // Register IConfiguration for domain services
         services.AddSingleton<IConfiguration>(configuration);
 
+        // Register shared services required by EnhancedPdfProcessingOrchestrator
+        services.AddScoped<ITextChunkingService, TextChunkingService>();
+
         // Act - Should not throw InvalidOperationException (circular dependency)
         services.AddDocumentProcessingContext(configuration);
         var serviceProvider = services.BuildServiceProvider();
@@ -70,6 +74,9 @@ public class OrchestratorDICircularDependencyTests
             .Build();
 
         services.AddSingleton<IConfiguration>(configuration);
+
+        // Register shared services required by EnhancedPdfProcessingOrchestrator
+        services.AddScoped<ITextChunkingService, TextChunkingService>();
 
         // Act
         services.AddDocumentProcessingContext(configuration);

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Infrastructure/EmbeddingProviders/EmbeddingServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Infrastructure/EmbeddingProviders/EmbeddingServiceTests.cs
@@ -390,6 +390,7 @@ public class EmbeddingServiceTests
         _primaryProviderMock
             .Setup(x => x.GenerateBatchEmbeddingsAsync(
                 It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<string>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(EmbeddingProviderResult.CreateSuccess(expectedEmbeddings, "test-model"));
 
@@ -416,6 +417,7 @@ public class EmbeddingServiceTests
         _primaryProviderMock
             .Setup(x => x.GenerateBatchEmbeddingsAsync(
                 It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<string>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(EmbeddingProviderResult.CreateSuccess(expectedEmbeddings, "test-model"));
 
@@ -444,6 +446,7 @@ public class EmbeddingServiceTests
         _primaryProviderMock
             .Setup(x => x.GenerateBatchEmbeddingsAsync(
                 It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<string>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(EmbeddingProviderResult.CreateSuccess(expectedEmbeddings, "test-model"));
 

--- a/apps/web/src/app/admin/(dashboard)/monitor/logs/LokiErrorViewer.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/logs/LokiErrorViewer.tsx
@@ -61,7 +61,7 @@ export function LokiErrorViewer() {
     );
   }
 
-  if (isError) {
+  if (isError && !data) {
     return (
       <div
         className="flex items-center gap-2 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/30 dark:text-red-400"

--- a/apps/web/src/app/admin/(dashboard)/monitor/logs/LokiErrorViewer.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/logs/LokiErrorViewer.tsx
@@ -110,6 +110,17 @@ export function LokiErrorViewer() {
         </Button>
       </div>
 
+      {/* Stale data warning */}
+      {isError && data && (
+        <div
+          className="flex items-center gap-2 border-b border-amber-200 bg-amber-50 px-4 py-2 text-xs text-amber-700 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-400"
+          data-testid="loki-refresh-error"
+        >
+          <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+          Could not refresh logs. Showing last known data.
+        </div>
+      )}
+
       {entries.length === 0 ? (
         <div className="py-12 text-center text-sm text-muted-foreground" data-testid="loki-empty">
           No errors or warnings in the last 24 hours.
@@ -126,9 +137,9 @@ export function LokiErrorViewer() {
               </tr>
             </thead>
             <tbody>
-              {entries.map(entry => (
+              {entries.map((entry, index) => (
                 <tr
-                  key={entry.id}
+                  key={`${entry.id}-${index}`}
                   className="border-b transition-colors hover:bg-muted/40"
                   data-testid={`loki-row-${entry.id}`}
                 >

--- a/apps/web/src/app/admin/(dashboard)/monitor/logs/LokiErrorViewer.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/logs/LokiErrorViewer.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { useCallback } from 'react';
+
+import { useQuery } from '@tanstack/react-query';
+import { AlertCircle, RefreshCw } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/primitives/button';
+import type { LokiLogEntry, LogsApiResponse } from '@/lib/loki/types';
+
+function levelBadgeClass(level: LokiLogEntry['level']): string {
+  switch (level) {
+    case 'error':
+      return 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300';
+    case 'warning':
+      return 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300';
+    case 'info':
+      return 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300';
+    default:
+      return 'bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400';
+  }
+}
+
+function formatTimestamp(ts: string): string {
+  try {
+    return new Date(ts).toLocaleTimeString(undefined, {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    });
+  } catch {
+    return ts;
+  }
+}
+
+async function fetchLokiLogs(): Promise<LogsApiResponse> {
+  const res = await fetch('/api/logs');
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json() as Promise<LogsApiResponse>;
+}
+
+export function LokiErrorViewer() {
+  const { data, isFetching, isError, refetch } = useQuery({
+    queryKey: ['admin', 'loki-errors'],
+    queryFn: fetchLokiLogs,
+    staleTime: 60_000,
+    refetchInterval: 120_000,
+  });
+
+  const handleRefresh = useCallback(() => {
+    void refetch();
+  }, [refetch]);
+
+  if (isFetching && !data) {
+    return (
+      <div className="flex items-center justify-center py-12" data-testid="loki-loading">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div
+        className="flex items-center gap-2 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/30 dark:text-red-400"
+        data-testid="loki-error"
+      >
+        <AlertCircle className="h-4 w-4 shrink-0" />
+        Unable to load container logs. Check your connection and try again.
+      </div>
+    );
+  }
+
+  if (data?.lokiUnavailable) {
+    return (
+      <div
+        className="rounded-xl border bg-muted/30 p-6 text-center text-sm text-muted-foreground"
+        data-testid="loki-unavailable"
+      >
+        <p className="font-medium">Loki log aggregation not available</p>
+        <p className="mt-1 text-xs">
+          Start the logging stack with <code className="rounded bg-muted px-1">make logging</code>{' '}
+          on the staging server to enable container log collection.
+        </p>
+      </div>
+    );
+  }
+
+  const entries = data?.entries ?? [];
+
+  return (
+    <div
+      className="rounded-xl border bg-white/70 backdrop-blur-md dark:bg-zinc-900/70"
+      data-testid="loki-viewer"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <span className="text-xs text-muted-foreground">Last 100 errors/warnings · last 24h</span>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={handleRefresh}
+          disabled={isFetching}
+          data-testid="loki-refresh-btn"
+        >
+          <RefreshCw className={`mr-1.5 h-3.5 w-3.5 ${isFetching ? 'animate-spin' : ''}`} />
+          Refresh
+        </Button>
+      </div>
+
+      {entries.length === 0 ? (
+        <div className="py-12 text-center text-sm text-muted-foreground" data-testid="loki-empty">
+          No errors or warnings in the last 24 hours.
+        </div>
+      ) : (
+        <div className="overflow-auto">
+          <table className="w-full text-sm" data-testid="loki-table">
+            <thead>
+              <tr className="border-b bg-muted/30 text-left font-mono text-xs text-muted-foreground">
+                <th className="px-2 py-2">Time</th>
+                <th className="px-2 py-2">Level</th>
+                <th className="px-2 py-2">Container</th>
+                <th className="px-2 py-2">Message</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map(entry => (
+                <tr
+                  key={entry.id}
+                  className="border-b transition-colors hover:bg-muted/40"
+                  data-testid={`loki-row-${entry.id}`}
+                >
+                  <td className="whitespace-nowrap px-2 py-1.5 font-mono text-xs tabular-nums text-muted-foreground">
+                    {formatTimestamp(entry.timestamp)}
+                  </td>
+                  <td className="px-2 py-1.5">
+                    <Badge className={`text-[10px] font-medium ${levelBadgeClass(entry.level)}`}>
+                      {entry.level}
+                    </Badge>
+                  </td>
+                  <td className="whitespace-nowrap px-2 py-1.5 font-mono text-xs text-muted-foreground">
+                    {entry.container}
+                  </td>
+                  <td className="max-w-xs truncate px-2 py-1.5 font-mono text-xs lg:max-w-lg xl:max-w-2xl">
+                    {entry.message}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/logs/__tests__/LokiErrorViewer.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/logs/__tests__/LokiErrorViewer.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { LokiErrorViewer } from '../LokiErrorViewer';
+import type { LogsApiResponse } from '@/lib/loki/types';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('LokiErrorViewer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows loading state initially', () => {
+    mockFetch.mockImplementation(() => new Promise(() => {}));
+    render(<LokiErrorViewer />, { wrapper });
+    expect(screen.getByTestId('loki-loading')).toBeInTheDocument();
+  });
+
+  it('shows unavailable message when Loki is not configured', async () => {
+    const body: LogsApiResponse = { entries: [], lokiUnavailable: true };
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => body });
+    render(<LokiErrorViewer />, { wrapper });
+    await waitFor(() => expect(screen.getByTestId('loki-unavailable')).toBeInTheDocument());
+  });
+
+  it('shows empty state when no errors found', async () => {
+    const body: LogsApiResponse = { entries: [] };
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => body });
+    render(<LokiErrorViewer />, { wrapper });
+    await waitFor(() => expect(screen.getByTestId('loki-empty')).toBeInTheDocument());
+  });
+
+  it('renders log entries with container and message', async () => {
+    const body: LogsApiResponse = {
+      entries: [
+        {
+          id: '0-0',
+          timestamp: new Date().toISOString(),
+          container: 'meepleai-api',
+          message: 'ERROR: database connection failed',
+          level: 'error',
+        },
+      ],
+    };
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => body });
+    render(<LokiErrorViewer />, { wrapper });
+    await waitFor(() => {
+      expect(screen.getByTestId('loki-table')).toBeInTheDocument();
+      expect(screen.getByText('meepleai-api')).toBeInTheDocument();
+      expect(screen.getByText(/database connection failed/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows error state when fetch fails', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+    render(<LokiErrorViewer />, { wrapper });
+    await waitFor(() => expect(screen.getByTestId('loki-error')).toBeInTheDocument());
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/monitor/logs/__tests__/LokiErrorViewer.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/logs/__tests__/LokiErrorViewer.test.tsx
@@ -6,7 +6,11 @@ import { LokiErrorViewer } from '../LokiErrorViewer';
 import type { LogsApiResponse } from '@/lib/loki/types';
 
 function wrapper({ children }: { children: React.ReactNode }) {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const qc = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchInterval: false, gcTime: 0 },
+    },
+  });
   return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
 }
 

--- a/apps/web/src/app/admin/(dashboard)/monitor/logs/__tests__/page.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/logs/__tests__/page.test.tsx
@@ -1,10 +1,11 @@
 /**
  * LogViewerPage Tests
  * Issue #142 — Log Viewer page-level test
+ * Issue #3367 — LokiErrorViewer tab integration
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 // Mock child components that use React Query internally
 vi.mock('../AppLogViewer', () => ({
@@ -13,6 +14,10 @@ vi.mock('../AppLogViewer', () => ({
 
 vi.mock('../LogViewer', () => ({
   LogViewer: () => <div data-testid="container-log-viewer">Container Log Viewer</div>,
+}));
+
+vi.mock('../LokiErrorViewer', () => ({
+  LokiErrorViewer: () => <div data-testid="mock-loki-viewer" />,
 }));
 
 vi.mock('@/hooks/useSetNavConfig', () => ({
@@ -35,5 +40,21 @@ describe('LogViewerPage', () => {
   it('renders page description', () => {
     render(<LogViewerPage />);
     expect(screen.getByText(/Application and container log monitoring/)).toBeInTheDocument();
+  });
+
+  it('shows Container Errors tab', () => {
+    render(<LogViewerPage />);
+    expect(screen.getByRole('button', { name: /container errors/i })).toBeInTheDocument();
+  });
+
+  it('shows LokiErrorViewer when Container Errors tab is active', () => {
+    render(<LogViewerPage />);
+    fireEvent.click(screen.getByRole('button', { name: /container errors/i }));
+    expect(screen.getByTestId('mock-loki-viewer')).toBeInTheDocument();
+  });
+
+  it('renders without crashing regardless of NEXT_PUBLIC_GRAFANA_URL', () => {
+    render(<LogViewerPage />);
+    expect(screen.getByTestId('logs-page')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/admin/(dashboard)/monitor/logs/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/logs/page.tsx
@@ -1,25 +1,53 @@
 'use client';
 
 /**
- * Log Viewer Page — Application + Container logs
- * Issue #141 / #1.8
+ * Log Viewer Page — Application + Container logs + Container Errors (Loki)
+ * Issue #141 / #1.8 + #3367 (Hybrid Solution C)
  */
 
 import { useState } from 'react';
 
+import { ExternalLink } from 'lucide-react';
+
 import { AppLogViewer } from './AppLogViewer';
 import { LogViewer } from './LogViewer';
+import { LokiErrorViewer } from './LokiErrorViewer';
 
-type LogTab = 'app' | 'container';
+type LogTab = 'app' | 'container' | 'loki';
+
+const GRAFANA_URL = process.env.NEXT_PUBLIC_GRAFANA_URL;
+
+// Build Grafana Explore URL with correctly URL-encoded JSON
+function buildGrafanaExploreUrl(baseUrl: string): string {
+  const state = JSON.stringify({
+    datasource: 'loki',
+    queries: [{ refId: 'A', expr: '{container_name=~"meepleai-.*"}' }],
+  });
+  return `${baseUrl}/explore?left=${encodeURIComponent(state)}`;
+}
 
 export default function LogViewerPage() {
   const [activeTab, setActiveTab] = useState<LogTab>('app');
 
   return (
     <div data-testid="logs-page" className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight">Log Viewer</h1>
-        <p className="text-muted-foreground">Application and container log monitoring</p>
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Log Viewer</h1>
+          <p className="text-muted-foreground">Application and container log monitoring</p>
+        </div>
+        {GRAFANA_URL && (
+          <a
+            href={buildGrafanaExploreUrl(GRAFANA_URL)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            data-testid="grafana-link"
+          >
+            <ExternalLink className="h-3.5 w-3.5" />
+            Open in Grafana
+          </a>
+        )}
       </div>
 
       <div className="flex gap-1 border-b">
@@ -43,10 +71,21 @@ export default function LogViewerPage() {
         >
           Container Logs
         </button>
+        <button
+          onClick={() => setActiveTab('loki')}
+          className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+            activeTab === 'loki'
+              ? 'border-primary text-primary'
+              : 'border-transparent text-muted-foreground hover:text-foreground'
+          }`}
+        >
+          Container Errors
+        </button>
       </div>
 
       {activeTab === 'app' && <AppLogViewer />}
       {activeTab === 'container' && <LogViewer />}
+      {activeTab === 'loki' && <LokiErrorViewer />}
     </div>
   );
 }

--- a/apps/web/src/app/api/logs/__tests__/route.test.ts
+++ b/apps/web/src/app/api/logs/__tests__/route.test.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock global fetch
 const mockFetch = vi.fn();
@@ -11,6 +11,11 @@ vi.stubEnv('LOKI_URL', 'http://loki:3100');
 describe('GET /api/logs', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('LOKI_URL', 'http://loki:3100');
   });
 
   it('returns 401 when meepleai_user_role cookie is missing', async () => {
@@ -37,11 +42,10 @@ describe('GET /api/logs', () => {
       headers: { cookie: 'meepleai_user_role=admin' },
     });
     const res = await GET(req);
-    const body = await res.json() as { lokiUnavailable: boolean; entries: unknown[] };
+    const body = (await res.json()) as { lokiUnavailable: boolean; entries: unknown[] };
     expect(res.status).toBe(200);
     expect(body.lokiUnavailable).toBe(true);
     expect(body.entries).toHaveLength(0);
-    vi.stubEnv('LOKI_URL', 'http://loki:3100');
   });
 
   it('returns lokiUnavailable when Loki fetch fails', async () => {
@@ -52,7 +56,7 @@ describe('GET /api/logs', () => {
       headers: { cookie: 'meepleai_user_role=admin' },
     });
     const res = await GET(req);
-    const body = await res.json() as { lokiUnavailable: boolean };
+    const body = (await res.json()) as { lokiUnavailable: boolean };
     expect(res.status).toBe(200);
     expect(body.lokiUnavailable).toBe(true);
   });
@@ -86,7 +90,7 @@ describe('GET /api/logs', () => {
     });
     const res = await GET(req);
     expect(res.status).toBe(200);
-    const body = await res.json() as { entries: Array<{ container: string; level: string }> };
+    const body = (await res.json()) as { entries: Array<{ container: string; level: string }> };
     expect(body.entries).toHaveLength(2);
     expect(body.entries[0].container).toBe('meepleai-api');
     // Sort descending: WARNING (più recente) è entries[0], ERROR (più vecchio) è entries[1]

--- a/apps/web/src/app/api/logs/__tests__/route.test.ts
+++ b/apps/web/src/app/api/logs/__tests__/route.test.ts
@@ -1,0 +1,110 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+// Mock process.env
+vi.stubEnv('LOKI_URL', 'http://loki:3100');
+
+describe('GET /api/logs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when meepleai_user_role cookie is missing', async () => {
+    const { GET } = await import('../route');
+    const req = new NextRequest('http://localhost/api/logs');
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when role is not admin', async () => {
+    const { GET } = await import('../route');
+    const req = new NextRequest('http://localhost/api/logs', {
+      headers: { cookie: 'meepleai_user_role=user' },
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns lokiUnavailable when LOKI_URL is not configured', async () => {
+    vi.stubEnv('LOKI_URL', '');
+    vi.resetModules();
+    const { GET } = await import('../route');
+    const req = new NextRequest('http://localhost/api/logs', {
+      headers: { cookie: 'meepleai_user_role=admin' },
+    });
+    const res = await GET(req);
+    const body = await res.json() as { lokiUnavailable: boolean; entries: unknown[] };
+    expect(res.status).toBe(200);
+    expect(body.lokiUnavailable).toBe(true);
+    expect(body.entries).toHaveLength(0);
+    vi.stubEnv('LOKI_URL', 'http://loki:3100');
+  });
+
+  it('returns lokiUnavailable when Loki fetch fails', async () => {
+    vi.resetModules();
+    const { GET } = await import('../route');
+    mockFetch.mockRejectedValueOnce(new Error('connect ECONNREFUSED'));
+    const req = new NextRequest('http://localhost/api/logs', {
+      headers: { cookie: 'meepleai_user_role=admin' },
+    });
+    const res = await GET(req);
+    const body = await res.json() as { lokiUnavailable: boolean };
+    expect(res.status).toBe(200);
+    expect(body.lokiUnavailable).toBe(true);
+  });
+
+  it('returns normalized entries sorted descending by timestamp', async () => {
+    vi.resetModules();
+    const { GET } = await import('../route');
+    const lokiResponse = {
+      status: 'success',
+      data: {
+        resultType: 'streams',
+        result: [
+          {
+            stream: { container_name: 'meepleai-api' },
+            values: [
+              // timestamp più vecchio → ERROR
+              ['1712300000000000000', 'ERROR: database connection failed'],
+              // timestamp più recente → WARNING (sarà entries[0] dopo sort desc)
+              ['1712300001000000000', 'WARNING: high memory usage'],
+            ],
+          },
+        ],
+      },
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => lokiResponse,
+    });
+    const req = new NextRequest('http://localhost/api/logs', {
+      headers: { cookie: 'meepleai_user_role=admin' },
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { entries: Array<{ container: string; level: string }> };
+    expect(body.entries).toHaveLength(2);
+    expect(body.entries[0].container).toBe('meepleai-api');
+    // Sort descending: WARNING (più recente) è entries[0], ERROR (più vecchio) è entries[1]
+    expect(body.entries[0].level).toBe('warning');
+    expect(body.entries[1].level).toBe('error');
+  });
+
+  it('returns 200 when role is superadmin', async () => {
+    vi.resetModules();
+    const { GET } = await import('../route');
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: 'success', data: { resultType: 'streams', result: [] } }),
+    });
+    const req = new NextRequest('http://localhost/api/logs', {
+      headers: { cookie: 'meepleai_user_role=superadmin' },
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/web/src/app/api/logs/route.ts
+++ b/apps/web/src/app/api/logs/route.ts
@@ -1,22 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import type { LokiLogEntry, LokiQueryRangeResponse, LogsApiResponse } from '@/lib/loki/types';
+import { isAdminRole } from '@/lib/utils/roles';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
-const ADMIN_ROLES = new Set(['admin', 'superadmin']);
 // container_name=~"meepleai-.*" scopea ai soli container MeepleAI (Fluent-bit label standard)
 const LOKI_QUERY = '{container_name=~"meepleai-.*"} |~ "(?i)(error|warn|fatal)"';
 const LIMIT = 100;
 const LOOK_BACK_HOURS = 24;
-
-function isAdminCookie(cookieHeader: string | null): boolean {
-  if (!cookieHeader) return false;
-  const match = cookieHeader.match(/meepleai_user_role=([^;]+)/);
-  if (!match) return false;
-  return ADMIN_ROLES.has(match[1].toLowerCase());
-}
 
 function detectLevel(line: string): LokiLogEntry['level'] {
   const lower = line.toLowerCase();
@@ -33,8 +26,8 @@ function nsToIso(ns: string): string {
 }
 
 export async function GET(request: NextRequest): Promise<NextResponse<LogsApiResponse>> {
-  const cookieHeader = request.headers.get('cookie');
-  if (!isAdminCookie(cookieHeader)) {
+  const userRole = request.cookies.get('meepleai_user_role')?.value ?? null;
+  if (!isAdminRole(userRole)) {
     return NextResponse.json({ entries: [] }, { status: 401 });
   }
 

--- a/apps/web/src/app/api/logs/route.ts
+++ b/apps/web/src/app/api/logs/route.ts
@@ -21,7 +21,8 @@ function detectLevel(line: string): LokiLogEntry['level'] {
 }
 
 function nsToIso(ns: string): string {
-  const ms = Math.floor(Number(ns) / 1_000_000);
+  // Loki timestamps are nanoseconds since epoch — use BigInt to avoid precision loss
+  const ms = Number(BigInt(ns) / BigInt(1_000_000));
   return new Date(ms).toISOString();
 }
 

--- a/apps/web/src/app/api/logs/route.ts
+++ b/apps/web/src/app/api/logs/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import type { LokiLogEntry, LokiQueryRangeResponse, LogsApiResponse } from '@/lib/loki/types';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const ADMIN_ROLES = new Set(['admin', 'superadmin']);
+// container_name=~"meepleai-.*" scopea ai soli container MeepleAI (Fluent-bit label standard)
+const LOKI_QUERY = '{container_name=~"meepleai-.*"} |~ "(?i)(error|warn|fatal)"';
+const LIMIT = 100;
+const LOOK_BACK_HOURS = 24;
+
+function isAdminCookie(cookieHeader: string | null): boolean {
+  if (!cookieHeader) return false;
+  const match = cookieHeader.match(/meepleai_user_role=([^;]+)/);
+  if (!match) return false;
+  return ADMIN_ROLES.has(match[1].toLowerCase());
+}
+
+function detectLevel(line: string): LokiLogEntry['level'] {
+  const lower = line.toLowerCase();
+  if (lower.includes('fatal') || lower.includes('"level":"fatal"')) return 'error';
+  if (lower.includes('error') || lower.includes('"level":"error"')) return 'error';
+  if (lower.includes('warn') || lower.includes('"level":"warn"')) return 'warning';
+  if (lower.includes('info') || lower.includes('"level":"info"')) return 'info';
+  return 'unknown';
+}
+
+function nsToIso(ns: string): string {
+  const ms = Math.floor(Number(ns) / 1_000_000);
+  return new Date(ms).toISOString();
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse<LogsApiResponse>> {
+  const cookieHeader = request.headers.get('cookie');
+  if (!isAdminCookie(cookieHeader)) {
+    return NextResponse.json({ entries: [] }, { status: 401 });
+  }
+
+  const lokiUrl = process.env.LOKI_URL;
+  if (!lokiUrl) {
+    return NextResponse.json({ entries: [], lokiUnavailable: true });
+  }
+
+  const now = Date.now();
+  const start = now - LOOK_BACK_HOURS * 60 * 60 * 1000;
+  const params = new URLSearchParams({
+    query: LOKI_QUERY,
+    start: String(start * 1_000_000),
+    end: String(now * 1_000_000),
+    limit: String(LIMIT),
+    direction: 'backward',
+  });
+
+  let lokiData: LokiQueryRangeResponse;
+  try {
+    const response = await fetch(`${lokiUrl}/loki/api/v1/query_range?${params.toString()}`, {
+      headers: { 'Content-Type': 'application/json' },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) {
+      return NextResponse.json({ entries: [], lokiUnavailable: true });
+    }
+    lokiData = (await response.json()) as LokiQueryRangeResponse;
+  } catch {
+    return NextResponse.json({ entries: [], lokiUnavailable: true });
+  }
+
+  const entries: LokiLogEntry[] = [];
+  const result = lokiData.data?.result ?? [];
+  for (let si = 0; si < result.length; si++) {
+    const stream = result[si];
+    const container =
+      stream.stream['container_name'] ??
+      stream.stream['container'] ??
+      stream.stream['job'] ??
+      'unknown';
+    for (let vi = 0; vi < (stream.values?.length ?? 0); vi++) {
+      const [ts, line] = stream.values[vi];
+      entries.push({
+        id: `${si}-${vi}`,
+        timestamp: nsToIso(ts),
+        container,
+        message: line,
+        level: detectLevel(line),
+      });
+    }
+  }
+
+  entries.sort((a, b) => (a.timestamp > b.timestamp ? -1 : 1));
+
+  return NextResponse.json({ entries });
+}

--- a/apps/web/src/lib/loki/types.ts
+++ b/apps/web/src/lib/loki/types.ts
@@ -1,0 +1,34 @@
+/** Risposta grezza dell'API Loki query_range */
+export interface LokiQueryRangeResponse {
+  status: 'success' | 'error';
+  data: {
+    resultType: 'streams';
+    result: LokiStream[];
+  };
+}
+
+export interface LokiStream {
+  stream: Record<string, string>;
+  /** Array di [nanosecond-timestamp-string, log-line] */
+  values: [string, string][];
+}
+
+/** Entry normalizzata per il frontend */
+export interface LokiLogEntry {
+  /** ID sintetico: `${streamIndex}-${valueIndex}` */
+  id: string;
+  /** ISO 8601 */
+  timestamp: string;
+  /** Nome container, es. "meepleai-api" */
+  container: string;
+  /** Linea di log grezza */
+  message: string;
+  level: 'error' | 'warning' | 'info' | 'unknown';
+}
+
+/** Risposta della Next.js API route /api/logs */
+export interface LogsApiResponse {
+  entries: LokiLogEntry[];
+  /** Indica se Loki è configurato ma non disponibile */
+  lokiUnavailable?: boolean;
+}

--- a/docs/deployment/monitoring/log-aggregation-guide.md
+++ b/docs/deployment/monitoring/log-aggregation-guide.md
@@ -1,0 +1,89 @@
+# Log Aggregation Guide
+
+Stack di log aggregation per MeepleAI: Fluent-bit → Loki → Grafana.
+
+## Accesso Rapido
+
+**Grafana (staging)**: https://meepleai.app/grafana
+- Credenziali: vedi `infra/secrets/monitoring.secret`
+- Dashboard diretta: https://meepleai.app/grafana/d/meepleai-log-explorer
+
+## Avvio Stack
+
+```bash
+cd infra
+
+# Avvia log aggregation (staging)
+make logging
+
+# Ferma log aggregation
+make logging-down
+
+# URL Grafana
+make logs-ui
+```
+
+## Architettura
+
+```
+[Docker Containers]
+    → [Fluent-bit :24224] (raccoglie da /var/lib/docker/containers)
+    → [Loki :3100]        (storage, retention 30gg)
+    → [Grafana :3000]     (UI, su /grafana via Traefik)
+```
+
+## Config Files
+
+| File | Scopo |
+|------|-------|
+| `infra/compose.logging.yml` | Servizi Loki + Fluent-bit |
+| `infra/monitoring/loki/loki-config.yml` | Config Loki (retention, storage) |
+| `infra/monitoring/fluent-bit/fluent-bit.conf` | Input/Output Fluent-bit |
+| `infra/monitoring/fluent-bit/parsers.conf` | Parser .NET (Serilog) e Python JSON |
+| `infra/grafana-datasources.yml` | Datasource Prometheus + Loki |
+| `infra/dashboards/log-explorer.json` | Dashboard log explorer |
+
+## Query LogQL Utili
+
+```logql
+# Tutti i log di un servizio
+{container_name="meepleai-api"}
+
+# Solo errori da tutti i servizi MeepleAI
+{container_name=~"meepleai-.*"} | json | level = "error"
+
+# Log API degli ultimi 10 minuti con parola chiave
+{container_name="meepleai-api"} |= "migration" | json
+
+# Error rate per servizio (ultimi 5 min)
+sum by (container_name) (count_over_time({container_name=~"meepleai-.*"} | json | level="error" [5m]))
+```
+
+## Deployment su Staging
+
+Il profilo `logging` va aggiunto al comando di deploy staging:
+
+```bash
+# Deploy completo con logging
+docker compose \
+  -f docker-compose.yml \
+  -f compose.staging.yml \
+  -f compose.traefik.yml \
+  -f compose.logging.yml \
+  --profile ai --profile monitoring --profile logging --profile proxy \
+  up -d
+```
+
+## Troubleshooting
+
+| Problema | Verifica |
+|----------|----------|
+| Datasource Loki "Data source connected but no labels received" | Fluent-bit è avviato? `docker logs meepleai-fluent-bit` |
+| Nessun log in Explore | Seleziona time range → Last 1h. Verifica label `container_name` |
+| Loki non si avvia | Verifica permessi su volume: `docker inspect meepleai-loki` |
+| Grafana non mostra dashboard | Attendi 10s per provisioning automatico |
+
+## Retention
+
+- **Loki**: 30 giorni (720h) — configurato in `loki-config.yml`
+- **Compactor**: ogni 10 minuti, ottimizza storage

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -113,6 +113,16 @@ alpha-down: ## Stop Alpha Zero environment
 logs: ## Tail logs for a service (usage: make logs s=api)
 	$(COMPOSE) logs -f $(s)
 
+logging: ## Start log aggregation stack on staging (loki + fluent-bit)
+	$(COMPOSE) -f compose.staging.yml -f compose.logging.yml --profile logging up -d
+
+logging-down: ## Stop log aggregation stack
+	$(COMPOSE) -f compose.logging.yml --profile logging down
+
+logs-ui: ## Open Grafana log explorer in browser (staging)
+	@echo "Grafana Logs: https://meepleai.app/grafana"
+	@echo "  Explore → Loki → {container_name=~\"meepleai-.*\"}"
+
 ps: ## Show running containers
 	$(COMPOSE) ps
 

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -232,6 +232,6 @@ validate-workflows: ## Validate GitHub Actions workflows — mirrors auto-valida
         alpha alpha-core alpha-down \
         secrets-setup secrets-sync \
         snapshot restore-staging restore-local seed-games \
-        logs ps build clean help \
+        logs logging logging-down logs-ui ps build clean help \
         ci ci-fe ci-be-unit ci-be-integration ci-be-e2e ci-all \
         sec-scan sec-pentest test-e2e test-visual test-perf validate-workflows

--- a/infra/compose.logging.yml
+++ b/infra/compose.logging.yml
@@ -40,6 +40,8 @@ services:
       loki:
         condition: service_healthy
     user: root
+    environment:
+      ENVIRONMENT: ${ENVIRONMENT:-staging}
     volumes:
       - ./monitoring/fluent-bit/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro
       - ./monitoring/fluent-bit/parsers.conf:/fluent-bit/etc/parsers.conf:ro

--- a/infra/compose.logging.yml
+++ b/infra/compose.logging.yml
@@ -43,6 +43,7 @@ services:
     volumes:
       - ./monitoring/fluent-bit/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro
       - ./monitoring/fluent-bit/parsers.conf:/fluent-bit/etc/parsers.conf:ro
+      - ./monitoring/fluent-bit/docker_name.lua:/fluent-bit/etc/docker_name.lua:ro
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:

--- a/infra/compose.logging.yml
+++ b/infra/compose.logging.yml
@@ -58,3 +58,7 @@ services:
 
 volumes:
   loki_data:
+
+networks:
+  meepleai:
+    external: true

--- a/infra/compose.logging.yml
+++ b/infra/compose.logging.yml
@@ -1,0 +1,60 @@
+# Log aggregation stack — Linux only (staging/prod servers)
+# Dev on Windows: use 'make logs s=<service>' for local log viewing.
+#
+# Usage (with staging):
+#   docker compose -f docker-compose.yml -f compose.staging.yml -f compose.traefik.yml -f compose.logging.yml \
+#     --profile ai --profile monitoring --profile logging --profile proxy up -d
+
+services:
+  loki:
+    image: grafana/loki:3.4.1
+    container_name: meepleai-loki
+    restart: unless-stopped
+    profiles: [logging]
+    command: -config.file=/etc/loki/loki-config.yml
+    volumes:
+      - ./monitoring/loki/loki-config.yml:/etc/loki/loki-config.yml:ro
+      - loki_data:/loki
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://localhost:3100/ready || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - meepleai
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 256M
+
+  fluent-bit:
+    image: fluent/fluent-bit:3.2
+    container_name: meepleai-fluent-bit
+    restart: unless-stopped
+    profiles: [logging]
+    depends_on:
+      loki:
+        condition: service_healthy
+    user: root
+    volumes:
+      - ./monitoring/fluent-bit/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro
+      - ./monitoring/fluent-bit/parsers.conf:/fluent-bit/etc/parsers.conf:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - meepleai
+    deploy:
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 128M
+        reservations:
+          cpus: '0.1'
+          memory: 64M
+
+volumes:
+  loki_data:

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -88,11 +88,14 @@ services:
       args:
         NEXT_PUBLIC_API_BASE: "https://meepleai.app"
         NEXT_PUBLIC_APP_URL: "https://meepleai.app"
+        NEXT_PUBLIC_GRAFANA_URL: /grafana
     environment:
       NODE_ENV: production
       NEXT_PUBLIC_API_BASE: "https://meepleai.app"
       NEXT_PUBLIC_APP_URL: "https://meepleai.app"
       API_BASE_URL: http://api:8080
+      LOKI_URL: http://loki:3100
+      NEXT_PUBLIC_GRAFANA_URL: /grafana
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.web.rule=Host(`meepleai.app`)"

--- a/infra/dashboards/log-explorer.json
+++ b/infra/dashboards/log-explorer.json
@@ -1,0 +1,341 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 20,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{container_name=~\"meepleai-${service}\"} | json",
+          "refId": "A"
+        }
+      ],
+      "title": "Log Stream",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum by (container_name) (count_over_time({container_name=~\"meepleai-${service}\"} | json | level=\"error\" [5m]))",
+          "legendFormat": "{{container_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Rate (5m window)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Errors"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Warnings"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({container_name=~\"meepleai-.*\"} | json | level=\"error\" [24h]))",
+          "legendFormat": "Errors",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({container_name=~\"meepleai-.*\"} | json | level=\"warn\" [24h]))",
+          "legendFormat": "Warnings",
+          "refId": "B"
+        }
+      ],
+      "title": "Errors / Warnings (24h)",
+      "type": "stat"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "logs",
+    "loki",
+    "meepleai"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "hide": 0,
+        "includeAll": true,
+        "label": "Service",
+        "multi": true,
+        "name": "service",
+        "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": false,
+            "text": "api",
+            "value": "api"
+          },
+          {
+            "selected": false,
+            "text": "web",
+            "value": "web"
+          },
+          {
+            "selected": false,
+            "text": "embedding",
+            "value": "embedding"
+          },
+          {
+            "selected": false,
+            "text": "reranker",
+            "value": "reranker"
+          },
+          {
+            "selected": false,
+            "text": "smoldocling",
+            "value": "smoldocling"
+          },
+          {
+            "selected": false,
+            "text": "unstructured",
+            "value": "unstructured"
+          },
+          {
+            "selected": false,
+            "text": "postgres",
+            "value": "postgres"
+          },
+          {
+            "selected": false,
+            "text": "redis",
+            "value": "redis"
+          }
+        ],
+        "query": "api,web,embedding,reranker,smoldocling,unstructured,postgres,redis",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "MeepleAI Log Explorer",
+  "uid": "meepleai-log-explorer",
+  "version": 1
+}

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -617,6 +617,7 @@ volumes:
   alertmanager_data:
   seq_data:
   mailpit_data:
+  loki_data:
 
 # =============================================================================
 # Networks

--- a/infra/grafana-datasources.yml
+++ b/infra/grafana-datasources.yml
@@ -20,6 +20,7 @@ datasources:
 
   # Loki datasource for log aggregation (Issue #3367)
   - name: Loki
+    uid: loki
     type: loki
     access: proxy
     url: http://loki:3100

--- a/infra/grafana-datasources.yml
+++ b/infra/grafana-datasources.yml
@@ -1,5 +1,5 @@
 # OPS-02: Grafana Datasources Configuration
-# Auto-provisions Prometheus data source
+# Auto-provisions Prometheus and Loki data sources
 # Jaeger datasource removed (Issue #1564) - using Prometheus for metrics only
 
 apiVersion: 1
@@ -18,3 +18,14 @@ datasources:
       httpMethod: 'POST'
     version: 1
 
+  # Loki datasource for log aggregation (Issue #3367)
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false
+    editable: false
+    jsonData:
+      timeout: 60
+      maxLines: 1000
+    version: 1

--- a/infra/monitoring/fluent-bit/docker_name.lua
+++ b/infra/monitoring/fluent-bit/docker_name.lua
@@ -1,0 +1,41 @@
+-- docker_name.lua
+-- Reads the Docker container name from config.v2.json on the filesystem.
+-- Called by the [FILTER] lua block in fluent-bit.conf.
+--
+-- Tag format for tail input with Path /var/lib/docker/containers/*/*.log:
+--   docker.var.lib.docker.containers.<container-id>.<container-id>-json.log
+-- We extract the container ID from the trailing segment before "-json.log".
+
+local name_cache = {}
+
+local function read_container_name(container_id)
+    if name_cache[container_id] then
+        return name_cache[container_id]
+    end
+
+    local config_path = "/var/lib/docker/containers/" .. container_id .. "/config.v2.json"
+    local f = io.open(config_path, "r")
+    if not f then
+        name_cache[container_id] = container_id
+        return container_id
+    end
+
+    local content = f:read("*all")
+    f:close()
+
+    -- Docker stores the name as "Name":"/meepleai-api" (with leading slash)
+    local name = content:match('"Name":"/([^"]+)"')
+    local result = name or container_id
+    name_cache[container_id] = result
+    return result
+end
+
+function add_container_name(tag, timestamp, record)
+    -- Extract container ID: last segment before "-json.log" in the dot-encoded path
+    -- e.g. docker.var.lib.docker.containers.abc123.abc123-json.log -> abc123
+    local container_id = tag:match("%.([a-f0-9]+)-json%.log$")
+    if container_id then
+        record["container_name"] = read_container_name(container_id)
+    end
+    return 1, timestamp, record
+end

--- a/infra/monitoring/fluent-bit/fluent-bit.conf
+++ b/infra/monitoring/fluent-bit/fluent-bit.conf
@@ -1,5 +1,9 @@
 # Fluent Bit Configuration for MeepleAI
 # Issue #3367: Collect logs from all Docker containers and forward to Loki
+#
+# Input: tail reads Docker json-file log files (preserves `docker logs` functionality)
+# Enrichment: Lua filter adds container_name from Docker config.v2.json
+# Output: Loki with container_name label for query filtering
 
 [SERVICE]
     Flush        5
@@ -8,21 +12,16 @@
     Parsers_File parsers.conf
 
 # ====================================
-# INPUTS - Docker Container Logs
+# INPUT - Docker Container Logs
+# Reads json-file logs directly from the filesystem.
+# Preserves `docker logs` command functionality (unlike fluentd driver).
+# Tag contains the full path with / replaced by . so we can extract container ID.
 # ====================================
 
 [INPUT]
-    Name              forward
-    Listen            0.0.0.0
-    Port              24224
-    Buffer_Chunk_Size 1M
-    Buffer_Max_Size   6M
-
-# Collect from all Docker containers
-[INPUT]
-    Name                docker
+    Name                tail
     Tag                 docker.*
-    Path                /var/lib/docker/containers
+    Path                /var/lib/docker/containers/*/*.log
     Parser              docker
     Docker_Mode         On
     DB                  /var/log/flb-docker.db
@@ -31,57 +30,42 @@
     Refresh_Interval    10
 
 # ====================================
-# FILTERS - Parsing & Enrichment
+# FILTERS - Container name enrichment
 # ====================================
 
-# Parse .NET structured logs (JSON)
+# Enrich each record with container_name read from Docker's config.v2.json.
+# The Lua script extracts the container ID from the tag (path-based) and
+# reads /var/lib/docker/containers/<id>/config.v2.json for the name.
+[FILTER]
+    Name                lua
+    Match               docker.*
+    Script              /fluent-bit/etc/docker_name.lua
+    Call                add_container_name
+
+# Only forward MeepleAI containers to Loki (filter out infra noise)
+[FILTER]
+    Name                grep
+    Match               docker.*
+    Regex               container_name meepleai-
+
+# Parse .NET structured logs (JSON format from Serilog)
 [FILTER]
     Name                parser
-    Match               docker.meepleai-api*
+    Match               docker.*
     Key_Name            log
     Parser              dotnet-json
     Reserve_Data        True
     Preserve_Key        True
 
-# Parse Python service logs (JSON)
+# Add environment metadata
 [FILTER]
-    Name                parser
-    Match               docker.meepleai-embedding*
-    Key_Name            log
-    Parser              python-json
-    Reserve_Data        True
-
-[FILTER]
-    Name                parser
-    Match               docker.meepleai-smoldocling*
-    Key_Name            log
-    Parser              python-json
-    Reserve_Data        True
-
-[FILTER]
-    Name                parser
-    Match               docker.meepleai-unstructured*
-    Key_Name            log
-    Parser              python-json
-    Reserve_Data        True
-
-# Add container metadata (service name, image, labels)
-[FILTER]
-    Name                modify
+    Name                record_modifier
     Match               docker.*
-    Add                 environment ${ENVIRONMENT:-development}
-    Add                 cluster meepleai
-
-# Kubernetes-style labels for Loki
-[FILTER]
-    Name                nest
-    Match               docker.*
-    Operation           lift
-    Nested_under        container
-    Add_prefix          container_
+    Record              environment ${ENVIRONMENT:-staging}
+    Record              cluster     meepleai
 
 # ====================================
-# OUTPUTS - Forward to Loki
+# OUTPUT - Forward to Loki
 # ====================================
 
 [OUTPUT]
@@ -89,8 +73,8 @@
     Match               docker.*
     Host                loki
     Port                3100
-    Labels              job=fluentbit, environment=${ENVIRONMENT:-development}
-    Label_keys          container_name,container_image
+    Labels              job=fluentbit, environment=${ENVIRONMENT:-staging}
+    Label_keys          container_name
     Line_format         json
     Remove_keys         container_id,source
     Auto_kubernetes_labels Off

--- a/infra/monitoring/fluent-bit/fluent-bit.conf
+++ b/infra/monitoring/fluent-bit/fluent-bit.conf
@@ -61,7 +61,7 @@
 [FILTER]
     Name                record_modifier
     Match               docker.*
-    Record              environment ${ENVIRONMENT:-staging}
+    Record              environment ${ENVIRONMENT}
     Record              cluster     meepleai
 
 # ====================================
@@ -73,8 +73,8 @@
     Match               docker.*
     Host                loki
     Port                3100
-    Labels              job=fluentbit, environment=${ENVIRONMENT:-staging}
-    Label_keys          container_name
+    Labels              job=fluentbit, environment=${ENVIRONMENT}
+    Label_keys          $container_name
     Line_format         json
     Remove_keys         container_id,source
     Auto_kubernetes_labels Off

--- a/infra/monitoring/loki/loki-config.yml
+++ b/infra/monitoring/loki/loki-config.yml
@@ -59,3 +59,4 @@ compactor:
   retention_enabled: true
   retention_delete_delay: 2h
   retention_delete_worker_count: 150
+  delete_request_store: filesystem

--- a/infra/monitoring/loki/loki-config.yml
+++ b/infra/monitoring/loki/loki-config.yml
@@ -52,11 +52,6 @@ limits_config:
   max_streams_per_user: 10000
   max_global_streams_per_user: 50000
 
-# Table manager for retention enforcement
-table_manager:
-  retention_deletes_enabled: true
-  retention_period: 720h
-
 # Compactor for storage optimization
 compactor:
   working_directory: /loki/compactor

--- a/infra/secrets/monitoring.secret.example
+++ b/infra/secrets/monitoring.secret.example
@@ -2,7 +2,14 @@
 # OPTIONAL - Info logged if missing (monitoring dashboards use defaults)
 # Copy this file to infra/secrets/monitoring.secret and fill in values
 
+# Grafana admin credentials (used by GF_SECURITY_* env vars in containers)
+GF_SECURITY_ADMIN_USER=admin
+GF_SECURITY_ADMIN_PASSWORD=change_me_grafana_admin_password
+GF_AUTH_ANONYMOUS_ENABLED=false
+
+# Legacy variable (kept for backward compatibility, not recommended)
 GRAFANA_ADMIN_PASSWORD=change_me_grafana_admin_password
+
 PROMETHEUS_PASSWORD=change_me_prometheus_password
 
 # Slack webhook for alertmanager notifications (optional)


### PR DESCRIPTION
## Summary

Hybrid log viewer at `/admin/monitor/logs` with three tabs:
- **Application Logs** — queries Seq via new `SeqQueryClient` (backend)
- **Container Logs** — lists running containers via Docker Socket Proxy + streams live logs
- **Container Errors** — queries Loki for `error|warn|fatal` across all `meepleai-*` containers

### Backend Bug Fixes (SeqQueryClient)
- Fixed port: Seq internal port is **80**, not 5341 — caused 0 results
- Fixed `Properties` array parsing: Seq returns an **array** not an object
- Added `render=true` to query params so `RenderedMessage` is populated

### Infra: Log Aggregation Stack (Loki + Fluent Bit)
- `compose.logging.yml`: new `--profile logging` stack (Loki 3.4.1 + Fluent Bit 3.2)
- `fluent-bit.conf`: `tail` input reads `/var/lib/docker/containers/*/*.log` (json-file driver, preserves `docker logs`)
- `docker_name.lua`: Lua filter reads `config.v2.json` to enrich logs with `container_name`
- `loki-config.yml`: 30-day retention, TSDB v13 schema, filesystem storage

### Staging Fixes (found during staging test)
- `loki-config.yml`: added `delete_request_store: filesystem` (required by Loki 3.4.1 when retention enabled)
- `fluent-bit.conf`: replaced bash-style `${VAR:-default}` with `${VAR}` (Fluent Bit 3.x does not support bash default syntax)
- `fluent-bit.conf`: prefixed `Label_keys` with `$` as required by Fluent Bit Loki output plugin
- `compose.logging.yml`: added `ENVIRONMENT` env var to fluent-bit service so Docker resolves the default

## Staging Verification

Tested on `https://meepleai.app` with feature branch web build:
- **Container Logs tab**: 23 containers returned via `meepleai-socket-proxy` ✅
- **Container Errors tab**: 100 log entries from Loki (warn/error from 12 meepleai-* containers) ✅
- **Loki labels**: `container_name`, `environment`, `job` confirmed in Loki ✅

## Test Plan

- [x] `/api/logs` returns 401 for non-admin, `lokiUnavailable: true` when `LOKI_URL` not set
- [x] Container Errors tab renders `LokiErrorViewer` on click
- [x] **Application Logs tab shows real entries** (verified locally — 50+ log entries from Seq)
- [x] **Staging: Container Logs tab** — 23 containers from socket proxy
- [x] **Staging: Container Errors tab** — 100 Loki entries from 12 meepleai-* containers
- [ ] Verify Grafana link opens Explore with correct LogQL query at `/grafana/explore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
