### PR TITLE
fix(auth): restore DomainException message propagation lost in release merge

### DIFF
--- a/apps/api/src/Api/Middleware/ApiExceptionHandlerMiddleware.cs
+++ b/apps/api/src/Api/Middleware/ApiExceptionHandlerMiddleware.cs
@@ -233,10 +233,10 @@ internal class ApiExceptionHandlerMiddleware
                 "validation_error",
                 validationEx.Message
             ),
-            DomainException => (
+            DomainException domainEx => (
                 StatusCodes.Status400BadRequest,
                 "domain_error",
-                "The request could not be processed"
+                domainEx.Message
             ),
 
             // ASP.NET request binding exceptions (e.g., invalid JSON body)


### PR DESCRIPTION
## Summary

- **Regression fix**: The release merge PR #227 resolved a conflict in `ApiExceptionHandlerMiddleware.cs` by keeping main-staging's old version, reverting the auth error message fix from PR #222
- **Impact**: Auth errors (account locked, account suspended, invalid credentials) were returning `"The request could not be processed"` instead of the actual error message — breaking the login UX
- **Fix**: Restores `DomainException domainEx => ... domainEx.Message` (the behavior already verified correct in PR #222)
- **Test**: `InvokeAsync_DomainException_PropagatesAllLoginMessages` (already in main from PR #222) was failing due to this regression — will pass again

## Root Cause

The promotion chain merge (main-dev → main-staging → main) was done while main-staging was behind main-dev on the middleware file. The merge conflict in PR #227 was resolved in favor of main-staging's stale code, silently reverting PR #222's fix.

## Test Plan
- [ ] CI Backend Unit Tests pass (specifically `InvokeAsync_DomainException_PropagatesAllLoginMessages`)
- [ ] Login with locked account returns the lockout message instead of generic error

🤖 Generated with [Claude Code](https://claude.com/claude-code)