### PR TITLE
fix(auth): widen SessionAuth catch + remove 500 from retry policy

### DIFF
--- a/apps/api/src/Api/Middleware/SessionAuthenticationMiddleware.cs
+++ b/apps/api/src/Api/Middleware/SessionAuthenticationMiddleware.cs
@@ -75,13 +75,17 @@ internal class SessionAuthenticationMiddleware
                     }
                 }
             }
-            catch (Exception ex) when (ex is InvalidOperationException or System.Security.SecurityException or FormatException)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 // MIDDLEWARE BOUNDARY PATTERN: Authentication middleware must not block requests on validation errors
                 // Rationale: This middleware validates session cookies but must not crash the request pipeline if
-                // validation fails (DB errors, crypto errors, malformed tokens). Failed authentication simply means
-                // the request proceeds as unauthenticated. We log the error for monitoring but allow the request.
-                // Context: Session validation involves DB queries and crypto operations that can fail
+                // validation fails (DB errors, crypto errors, malformed tokens, network timeouts). Failed
+                // authentication simply means the request proceeds as unauthenticated. We log the error for
+                // monitoring but allow the request through (fail-open pattern).
+                // Context: Session validation involves DB queries and crypto operations that can fail.
+                // Previous narrow catch (InvalidOperationException | SecurityException | FormatException) caused
+                // NpgsqlException / TimeoutException to propagate as HTTP 500 instead of returning 401.
+                // OperationCanceledException is excluded: client disconnects are expected and must not be logged.
                 _logger.LogWarning(ex, "Session cookie validation failed");
             }
         }

--- a/apps/web/src/lib/api/__tests__/httpClient-errors-retry.test.ts
+++ b/apps/web/src/lib/api/__tests__/httpClient-errors-retry.test.ts
@@ -24,9 +24,7 @@ describe('HttpClient - Error Handling', () => {
     it('should skip error logging when requested', async () => {
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation();
 
-      setup.mockFetch.mockResolvedValueOnce(
-        createErrorResponse(500, { error: 'Server error' })
-      );
+      setup.mockFetch.mockResolvedValueOnce(createErrorResponse(500, { error: 'Server error' }));
 
       await expect(
         setup.client.get('/api/v1/test', undefined, {
@@ -89,10 +87,25 @@ describe('HttpClient - Error Handling', () => {
       setup = setupTestEnvironment();
     });
 
-    it('should retry on 500 error and succeed', async () => {
-      // First call fails with 500, second call succeeds
+    it('should NOT retry on 500 error (application error)', async () => {
+      // 500 is not retryable — application bugs won't resolve with retries
+      setup.mockFetch.mockResolvedValueOnce(createErrorResponse(500, { error: 'Server error' }));
+
+      await expect(
+        setup.client.get('/api/v1/test', undefined, {
+          retry: {
+            retryConfig: { maxAttempts: 3, baseDelay: 10, maxDelay: 100, enabled: true, jitter: 0 },
+          },
+        })
+      ).rejects.toThrow(ServerError);
+
+      expect(setup.mockFetch).toHaveBeenCalledTimes(1); // No retries
+    });
+
+    it('should retry on 502 error and succeed', async () => {
+      // First call fails with 502 (gateway error), second call succeeds
       setup.mockFetch
-        .mockResolvedValueOnce(createErrorResponse(500, { error: 'Server error' }))
+        .mockResolvedValueOnce(createErrorResponse(502, { error: 'Bad Gateway' }))
         .mockResolvedValueOnce(createSuccessResponse({ data: 'success' }));
 
       const result = await setup.client.get('/api/v1/test', undefined, {
@@ -135,9 +148,7 @@ describe('HttpClient - Error Handling', () => {
     });
 
     it('should not retry on 401 error', async () => {
-      setup.mockFetch.mockResolvedValueOnce(
-        createErrorResponse(401, { error: 'Unauthorized' })
-      );
+      setup.mockFetch.mockResolvedValueOnce(createErrorResponse(401, { error: 'Unauthorized' }));
 
       const result = await setup.client.get('/api/v1/test', undefined, {
         retry: {
@@ -151,7 +162,7 @@ describe('HttpClient - Error Handling', () => {
     });
 
     it('should skip retry when skipRetry is true', async () => {
-      setup.mockFetch.mockResolvedValueOnce(createErrorResponse(500, { error: 'Server error' }));
+      setup.mockFetch.mockResolvedValueOnce(createErrorResponse(502, { error: 'Bad Gateway' }));
 
       await expect(
         setup.client.get('/api/v1/test', undefined, {
@@ -164,7 +175,7 @@ describe('HttpClient - Error Handling', () => {
 
     it('should record retry metrics', async () => {
       setup.mockFetch
-        .mockResolvedValueOnce(createErrorResponse(500, { error: 'Server error' }))
+        .mockResolvedValueOnce(createErrorResponse(502, { error: 'Bad Gateway' }))
         .mockResolvedValueOnce(createSuccessResponse({ data: 'success' }));
 
       await setup.client.get('/api/v1/test', undefined, {
@@ -180,7 +191,7 @@ describe('HttpClient - Error Handling', () => {
 
     it('should call onRetry callback', async () => {
       setup.mockFetch
-        .mockResolvedValueOnce(createErrorResponse(500, { error: 'Server error' }))
+        .mockResolvedValueOnce(createErrorResponse(502, { error: 'Bad Gateway' }))
         .mockResolvedValueOnce(createSuccessResponse({ data: 'success' }));
 
       const onRetry = vi.fn();
@@ -213,7 +224,7 @@ describe('HttpClient - Error Handling', () => {
 
     it('should work with DELETE requests', async () => {
       setup.mockFetch
-        .mockResolvedValueOnce(createErrorResponse(500, { error: 'Server error' }))
+        .mockResolvedValueOnce(createErrorResponse(503, { error: 'Service Unavailable' }))
         .mockResolvedValueOnce({
           ok: true,
           status: 204,
@@ -230,7 +241,7 @@ describe('HttpClient - Error Handling', () => {
     });
 
     it('should exhaust retries and throw last error', async () => {
-      setup.mockFetch.mockResolvedValue(createErrorResponse(500, { error: 'Server error' }));
+      setup.mockFetch.mockResolvedValue(createErrorResponse(502, { error: 'Bad Gateway' }));
 
       await expect(
         setup.client.get('/api/v1/test', undefined, {

--- a/apps/web/src/lib/api/core/__tests__/retryPolicy.test.ts
+++ b/apps/web/src/lib/api/core/__tests__/retryPolicy.test.ts
@@ -44,9 +44,9 @@ describe('retryPolicy', () => {
       expect(isRetryableError(error)).toBe(true);
     });
 
-    it('should identify 500 ServerError as retryable', () => {
+    it('should NOT retry 500 ServerError (application error)', () => {
       const error = new ServerError({ message: 'Internal error', statusCode: 500 });
-      expect(isRetryableError(error)).toBe(true);
+      expect(isRetryableError(error)).toBe(false);
     });
 
     it('should identify 502 ServerError as retryable', () => {
@@ -229,7 +229,7 @@ describe('retryPolicy', () => {
     });
 
     it('should throw after max attempts', async () => {
-      const error = new ServerError({ message: 'Server error', statusCode: 500 });
+      const error = new ServerError({ message: 'Server error', statusCode: 502 });
       const fn = vi.fn().mockRejectedValue(error);
 
       await expect(
@@ -269,7 +269,7 @@ describe('retryPolicy', () => {
     });
 
     it('should call onRetry callback', async () => {
-      const error = new ServerError({ message: 'Server error', statusCode: 500 });
+      const error = new ServerError({ message: 'Server error', statusCode: 502 });
       const fn = vi.fn().mockRejectedValueOnce(error).mockResolvedValueOnce('success');
 
       const onRetry = vi.fn();

--- a/apps/web/src/lib/api/core/retryPolicy.ts
+++ b/apps/web/src/lib/api/core/retryPolicy.ts
@@ -5,10 +5,12 @@
  * backoff and jitter to prevent thundering herd problems.
  *
  * Retryable errors:
- * - 500 Internal Server Error
- * - 502 Bad Gateway
- * - 503 Service Unavailable
+ * - 502 Bad Gateway (upstream/load-balancer transient)
+ * - 503 Service Unavailable (upstream/load-balancer transient)
  * - Network errors (fetch failures)
+ *
+ * Non-retryable server errors:
+ * - 500 Internal Server Error (application bug — retrying won't help)
  *
  * Non-retryable errors:
  * - 4xx client errors (except timeouts)
@@ -75,10 +77,12 @@ export function isRetryableError(error: unknown): boolean {
     return true;
   }
 
-  // Server errors (5xx) are retryable
+  // Gateway/infrastructure errors are retryable; application errors (500) are not.
+  // 500 = application bug — retrying won't help and causes console noise (e.g. /auth/me on page load).
+  // 502/503 = upstream/load-balancer transient issues — safe to retry.
   if (error instanceof ServerError) {
     const statusCode = error.statusCode;
-    return statusCode === 500 || statusCode === 502 || statusCode === 503;
+    return statusCode === 502 || statusCode === 503;
   }
 
   // Generic fetch errors are retryable


### PR DESCRIPTION
## Summary

Fixes 3× `GET /api/v1/auth/me 500` console errors on every page load.

**Root cause (backend)**: `SessionAuthenticationMiddleware` had a narrow exception filter (`InvalidOperationException | SecurityException | FormatException`). Any `NpgsqlException` or `TimeoutException` thrown by `UpdateLastSeenAsync` escaped the catch block and returned HTTP 500 instead of fail-open (unauthenticated).

**Amplifier (frontend)**: `retryPolicy.ts` treated HTTP 500 as retryable → each `/auth/me` 500 triggered 3 automatic retries with exponential backoff → 3× console noise per page load.

## Changes

- **`SessionAuthenticationMiddleware.cs`**: Broadened catch to `Exception when (ex is not OperationCanceledException)`. Consistent with `EmailVerificationMiddleware`, `SessionQuotaMiddleware`, `BggRateLimitMiddleware`. `OperationCanceledException` excluded to avoid logging expected client disconnects.
- **`retryPolicy.ts`**: Removed 500 from `isRetryableError`. Only 502/503 (transient gateway errors) remain retryable. 500 = application error, retrying won't help.
- **`retryPolicy.test.ts`** + **`httpClient-errors-retry.test.ts`**: Updated to assert 500 is NOT retried.

## Test plan

- [x] `retryPolicy.test.ts` — 31/31 ✅
- [x] `httpClient-errors-retry.test.ts` — 15/15 ✅
- [x] `dotnet build` — 0 errors ✅
- [ ] Deploy to staging → verify `/api/v1/auth/me` no longer returns 500 on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)