### PR TITLE
fix(notifications): Slack notification system fixes — security hardening, semantic types, performance

### DIFF
--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationQueueItem.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationQueueItem.cs
@@ -203,13 +203,13 @@ internal sealed class NotificationQueueItem : AggregateRoot<Guid>
         var item = new NotificationQueueItem(
             id, channelType, recipientUserId, notificationType,
             payload, slackChannelTarget, slackTeamId, correlationId,
+            createdAt: createdAt,
             deepLinkPath: deepLinkPath);
         item.Status = status;
         item.RetryCount = retryCount;
         item.MaxRetries = maxRetries;
         item.NextRetryAt = nextRetryAt;
         item.LastError = lastError;
-        item.CreatedAt = createdAt;
         item.ProcessedAt = processedAt;
         return item;
     }

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationQueueItem.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationQueueItem.cs
@@ -31,6 +31,7 @@ internal sealed class NotificationQueueItem : AggregateRoot<Guid>
     public DateTime CreatedAt { get; private set; }
     public DateTime? ProcessedAt { get; private set; }
     public Guid CorrelationId { get; private set; }
+    public string? DeepLinkPath { get; private set; }
 
 #pragma warning disable CS8618
     private NotificationQueueItem() : base() { }
@@ -45,7 +46,8 @@ internal sealed class NotificationQueueItem : AggregateRoot<Guid>
         string? slackChannelTarget,
         string? slackTeamId,
         Guid correlationId,
-        DateTime? createdAt = null)
+        DateTime? createdAt = null,
+        string? deepLinkPath = null)
         : base(id)
     {
         ChannelType = channelType ?? throw new ArgumentNullException(nameof(channelType));
@@ -62,6 +64,7 @@ internal sealed class NotificationQueueItem : AggregateRoot<Guid>
         CreatedAt = createdAt ?? DateTime.UtcNow;
         ProcessedAt = null;
         CorrelationId = correlationId;
+        DeepLinkPath = deepLinkPath;
     }
 
     /// <summary>
@@ -75,7 +78,8 @@ internal sealed class NotificationQueueItem : AggregateRoot<Guid>
         string? slackChannelTarget = null,
         string? slackTeamId = null,
         Guid? correlationId = null,
-        DateTime? createdAt = null)
+        DateTime? createdAt = null,
+        string? deepLinkPath = null)
     {
         return new NotificationQueueItem(
             Guid.NewGuid(),
@@ -86,7 +90,8 @@ internal sealed class NotificationQueueItem : AggregateRoot<Guid>
             slackChannelTarget,
             slackTeamId,
             correlationId ?? Guid.NewGuid(),
-            createdAt);
+            createdAt,
+            deepLinkPath);
     }
 
     /// <summary>
@@ -192,11 +197,13 @@ internal sealed class NotificationQueueItem : AggregateRoot<Guid>
         string? lastError,
         DateTime createdAt,
         DateTime? processedAt,
-        Guid correlationId)
+        Guid correlationId,
+        string? deepLinkPath = null)
     {
         var item = new NotificationQueueItem(
             id, channelType, recipientUserId, notificationType,
-            payload, slackChannelTarget, slackTeamId, correlationId);
+            payload, slackChannelTarget, slackTeamId, correlationId,
+            deepLinkPath: deepLinkPath);
         item.Status = status;
         item.RetryCount = retryCount;
         item.MaxRetries = maxRetries;

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationQueueItem.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationQueueItem.cs
@@ -148,6 +148,21 @@ internal sealed class NotificationQueueItem : AggregateRoot<Guid>
     }
 
     /// <summary>
+    /// Marks the notification as temporarily unavailable due to API rate limiting.
+    /// Does NOT increment RetryCount — rate limit backpressure is not a delivery failure.
+    /// The item will be retried after the specified time.
+    /// </summary>
+    public void MarkAsRateLimited(DateTime retryAt)
+    {
+        if (!Status.IsProcessing)
+            throw new InvalidOperationException($"Cannot mark as rate-limited from status '{Status.Value}'");
+
+        Status = NotificationQueueStatus.Failed;
+        NextRetryAt = retryAt;
+        LastError = "rate limit — retry after backoff";
+    }
+
+    /// <summary>
     /// Moves the notification to dead letter queue.
     /// No further retry attempts will be made.
     /// </summary>

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Repositories/ISlackConnectionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Repositories/ISlackConnectionRepository.cs
@@ -9,5 +9,14 @@ internal interface ISlackConnectionRepository
     Task<SlackConnection?> GetByUserIdAsync(Guid userId, CancellationToken ct = default);
     Task<SlackConnection?> GetBySlackUserIdAsync(string slackUserId, CancellationToken ct = default);
     Task<SlackConnection?> GetActiveByUserIdAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Batch-fetches active Slack connections for multiple users.
+    /// Returns a dictionary keyed by UserId for O(1) lookup.
+    /// </summary>
+    Task<Dictionary<Guid, SlackConnection>> GetActiveByUserIdsAsync(
+        IEnumerable<Guid> userIds,
+        CancellationToken ct = default);
+
     Task<int> GetActiveConnectionCountAsync(CancellationToken ct = default);
 }

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/ValueObjects/NotificationPayloads.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/ValueObjects/NotificationPayloads.cs
@@ -22,7 +22,8 @@ public record GameNightPayload(
     Guid GameNightId,
     string Title,
     DateTime ScheduledAt,
-    string OrganizerName) : INotificationPayload;
+    string OrganizerName,
+    bool IsCancelled = false) : INotificationPayload;
 
 public record PdfProcessingPayload(
     Guid PdfId,

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/ValueObjects/NotificationPayloads.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/ValueObjects/NotificationPayloads.cs
@@ -15,7 +15,8 @@ public record ShareRequestPayload(
     Guid ShareRequestId,
     string RequesterName,
     string GameTitle,
-    string? GameImageUrl) : INotificationPayload;
+    string? GameImageUrl,
+    string Status = "created") : INotificationPayload;
 
 public record GameNightPayload(
     Guid GameNightId,

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/ValueObjects/NotificationType.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/ValueObjects/NotificationType.cs
@@ -88,6 +88,9 @@ internal sealed class NotificationType : ValueObject
     // GDPR Art. 7: AI consent updated
     public static readonly NotificationType GdprAiConsentUpdated = new("gdpr_ai_consent_updated");
 
+    // Slack connection forcibly revoked by workspace admin
+    public static readonly NotificationType SlackConnectionRevoked = new("slack_connection_revoked");
+
     private NotificationType(string value)
     {
         Value = value;
@@ -100,6 +103,7 @@ internal sealed class NotificationType : ValueObject
     public bool IsGameNightRsvpReceived => string.Equals(Value, GameNightRsvpReceived.Value, StringComparison.Ordinal);
     public bool IsGameNightReminder => string.Equals(Value, GameNightReminder.Value, StringComparison.Ordinal);
     public bool IsGameNightCancelled => string.Equals(Value, GameNightCancelled.Value, StringComparison.Ordinal);
+    public bool IsSlackConnectionRevoked => string.Equals(Value, SlackConnectionRevoked.Value, StringComparison.Ordinal);
 
     protected override IEnumerable<object?> GetEqualityComponents()
     {
@@ -153,6 +157,7 @@ internal sealed class NotificationType : ValueObject
             "admin_access_request_created" => AdminAccessRequestCreated,
             "admin_manual_notification" => AdminManualNotification,
             "admin_pdf_processing_started" => AdminPdfProcessingStarted,
+            "slack_connection_revoked" => SlackConnectionRevoked,
             // Legacy aliases — old type strings from DB or older clients map to new types
             "pdf_upload_completed" => DocumentReady,
             "processing_job_completed" => DocumentReady,

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationQueueRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationQueueRepository.cs
@@ -130,7 +130,8 @@ internal class NotificationQueueRepository : RepositoryBase, INotificationQueueR
             LastError = item.LastError,
             CreatedAt = item.CreatedAt,
             ProcessedAt = item.ProcessedAt,
-            CorrelationId = item.CorrelationId
+            CorrelationId = item.CorrelationId,
+            DeepLinkPath = item.DeepLinkPath
         };
     }
 
@@ -151,6 +152,7 @@ internal class NotificationQueueRepository : RepositoryBase, INotificationQueueR
             lastError: entity.LastError,
             createdAt: entity.CreatedAt,
             processedAt: entity.ProcessedAt,
-            correlationId: entity.CorrelationId);
+            correlationId: entity.CorrelationId,
+            deepLinkPath: entity.DeepLinkPath);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/SlackConnectionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/SlackConnectionRepository.cs
@@ -74,6 +74,22 @@ internal class SlackConnectionRepository : RepositoryBase, ISlackConnectionRepos
         return entity != null ? MapToDomain(entity) : null;
     }
 
+    public async Task<Dictionary<Guid, SlackConnection>> GetActiveByUserIdsAsync(
+        IEnumerable<Guid> userIds,
+        CancellationToken ct = default)
+    {
+        var ids = userIds.ToList();
+        if (ids.Count == 0)
+            return [];
+
+        var entities = await DbContext.Set<SlackConnectionEntity>()
+            .AsNoTracking()
+            .Where(e => ids.Contains(e.UserId) && e.IsActive)
+            .ToListAsync(ct).ConfigureAwait(false);
+
+        return entities.ToDictionary(e => e.UserId, MapToDomain);
+    }
+
     public async Task<int> GetActiveConnectionCountAsync(CancellationToken ct = default)
     {
         return await DbContext.Set<SlackConnectionEntity>()

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Scheduling/SlackNotificationProcessorJob.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Scheduling/SlackNotificationProcessorJob.cs
@@ -342,7 +342,7 @@ internal sealed class SlackNotificationProcessorJob : IJob
                 var notification = new Notification(
                     id: Guid.NewGuid(),
                     userId: item.RecipientUserId.Value,
-                    type: NotificationType.DocumentProcessingFailed,
+                    type: NotificationType.SlackConnectionRevoked,
                     severity: NotificationSeverity.Warning,
                     title: "Slack Disconnected",
                     message: "Your Slack workspace connection has been revoked. Please reconnect to continue receiving Slack notifications.",

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Scheduling/SlackNotificationProcessorJob.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Scheduling/SlackNotificationProcessorJob.cs
@@ -199,7 +199,7 @@ internal sealed class SlackNotificationProcessorJob : IJob
             ?? throw new InvalidOperationException($"Missing webhook URL for SlackTeam item {item.Id}");
 
         var builder = _builderFactory.GetBuilder(item.NotificationType);
-        var message = builder.BuildMessage(item.Payload, null);
+        var message = builder.BuildMessage(item.Payload, item.DeepLinkPath);
         var payload = JsonSerializer.Serialize(message);
 
         using var request = new HttpRequestMessage(HttpMethod.Post, webhookUrl)
@@ -245,7 +245,7 @@ internal sealed class SlackNotificationProcessorJob : IJob
             throw new InvalidOperationException($"No active bot token for item {item.Id}, user {item.RecipientUserId}");
 
         var builder = _builderFactory.GetBuilder(item.NotificationType);
-        var blockKitMessage = builder.BuildMessage(item.Payload, null);
+        var blockKitMessage = builder.BuildMessage(item.Payload, item.DeepLinkPath);
         // Merge channel into the Block Kit message by serializing and re-parsing
         var messageJson = JsonSerializer.Serialize(blockKitMessage);
         using var mergedDoc = JsonDocument.Parse(messageJson);

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Scheduling/SlackNotificationProcessorJob.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Scheduling/SlackNotificationProcessorJob.cs
@@ -71,6 +71,17 @@ internal sealed class SlackNotificationProcessorJob : IJob
 
             var allItems = slackUserItems.Concat(slackTeamItems).ToList();
 
+            // Batch-load bot tokens per tutti gli SlackUser items in una sola query
+            var userIds = allItems
+                .Where(i => i.ChannelType == NotificationChannelType.SlackUser && i.RecipientUserId.HasValue)
+                .Select(i => i.RecipientUserId!.Value)
+                .Distinct()
+                .ToList();
+
+            var connectionsByUserId = await _slackConnectionRepository
+                .GetActiveByUserIdsAsync(userIds, context.CancellationToken)
+                .ConfigureAwait(false);
+
             if (allItems.Count == 0)
             {
                 _logger.LogDebug("No pending Slack notifications to process");
@@ -109,7 +120,7 @@ internal sealed class SlackNotificationProcessorJob : IJob
                         await _queueRepository.UpdateAsync(item, context.CancellationToken).ConfigureAwait(false);
                         await _dbContext.SaveChangesAsync(context.CancellationToken).ConfigureAwait(false);
 
-                        await SendSlackMessageAsync(item, context.CancellationToken).ConfigureAwait(false);
+                        await SendSlackMessageAsync(item, connectionsByUserId, context.CancellationToken).ConfigureAwait(false);
 
                         item.MarkAsSent(DateTime.UtcNow);
                         await _queueRepository.UpdateAsync(item, context.CancellationToken).ConfigureAwait(false);
@@ -177,20 +188,17 @@ internal sealed class SlackNotificationProcessorJob : IJob
 #pragma warning restore CA1031
     }
 
-    private async Task SendSlackMessageAsync(NotificationQueueItem item, CancellationToken ct)
+    private async Task SendSlackMessageAsync(
+        NotificationQueueItem item,
+        IReadOnlyDictionary<Guid, SlackConnection> connectionCache,
+        CancellationToken ct)
     {
         using var client = _httpClientFactory.CreateClient("SlackApi");
 
         if (item.ChannelType == NotificationChannelType.SlackTeam)
-        {
-            // Webhook-based delivery for team channels
             await SendViaWebhookAsync(client, item, ct).ConfigureAwait(false);
-        }
         else
-        {
-            // Bot token-based delivery for DMs
-            await SendViaBotApiAsync(client, item, ct).ConfigureAwait(false);
-        }
+            await SendViaBotApiAsync(client, item, connectionCache, ct).ConfigureAwait(false);
     }
 
     private async Task SendViaWebhookAsync(HttpClient client, NotificationQueueItem item, CancellationToken ct)
@@ -226,20 +234,20 @@ internal sealed class SlackNotificationProcessorJob : IJob
         }
     }
 
-    private async Task SendViaBotApiAsync(HttpClient client, NotificationQueueItem item, CancellationToken ct)
+    private async Task SendViaBotApiAsync(
+        HttpClient client,
+        NotificationQueueItem item,
+        IReadOnlyDictionary<Guid, SlackConnection> connectionCache,
+        CancellationToken ct)
     {
         var channelId = item.SlackChannelTarget
             ?? throw new InvalidOperationException($"Missing channel ID for SlackUser item {item.Id}");
 
-        // Look up the bot token from the Slack connection
-        string? botToken = null;
-        if (item.RecipientUserId.HasValue)
-        {
-            var connection = await _slackConnectionRepository
-                .GetActiveByUserIdAsync(item.RecipientUserId.Value, ct)
-                .ConfigureAwait(false);
-            botToken = connection?.BotAccessToken;
-        }
+        // Use cache — avoids N+1 query per item
+        string? botToken = item.RecipientUserId.HasValue
+            && connectionCache.TryGetValue(item.RecipientUserId.Value, out var conn)
+            ? conn.BotAccessToken
+            : null;
 
         if (string.IsNullOrEmpty(botToken))
             throw new InvalidOperationException($"No active bot token for item {item.Id}, user {item.RecipientUserId}");
@@ -299,9 +307,7 @@ internal sealed class SlackNotificationProcessorJob : IJob
 
         try
         {
-            // Reset current item back to pending with retry time
-            currentItem.MarkAsFailed($"Rate limited, retry after {retryAfterSeconds}s");
-            currentItem.SetNextRetryAt(retryAt);
+            currentItem.MarkAsRateLimited(retryAt);   // FIX: era MarkAsFailed
             await _queueRepository.UpdateAsync(currentItem, ct).ConfigureAwait(false);
             await _dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
         }

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs
@@ -51,8 +51,8 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
             id: Guid.NewGuid(),
             userId: message.RecipientUserId,
             type: message.Type,
-            severity: NotificationSeverity.Info,
-            title: message.Payload.GetType().Name,
+            severity: ResolveSeverity(message.Type),
+            title: ResolveTitle(message.Type),
             message: message.Payload.ToString() ?? string.Empty,
             link: message.DeepLinkPath,
             metadata: metadataJson,
@@ -182,6 +182,76 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
     }
 
     /// <summary>
+    /// Maps notification type to display severity.
+    /// </summary>
+    private static NotificationSeverity ResolveSeverity(NotificationType type)
+    {
+        if (type == NotificationType.DocumentProcessingFailed
+            || type == NotificationType.AdminSystemHealthAlert
+            || type == NotificationType.AdminOpenRouterThresholdAlert)
+            return NotificationSeverity.Error;
+
+        if (type == NotificationType.SessionTerminated
+            || type == NotificationType.AdminReviewLockExpiring
+            || type == NotificationType.AdminStaleShareRequests
+            || type == NotificationType.RateLimitReached
+            || type == NotificationType.SlackConnectionRevoked)
+            return NotificationSeverity.Warning;
+
+        if (type == NotificationType.DocumentReady
+            || type == NotificationType.RuleSpecGenerated
+            || type == NotificationType.BadgeEarned
+            || type == NotificationType.AgentReady
+            || type == NotificationType.GdprDataExportReady)
+            return NotificationSeverity.Success;
+
+        return NotificationSeverity.Info;
+    }
+
+    /// <summary>
+    /// Returns a human-readable title for the notification type.
+    /// </summary>
+    private static string ResolveTitle(NotificationType type)
+    {
+        if (type == NotificationType.DocumentReady) return "Documento pronto";
+        if (type == NotificationType.RuleSpecGenerated) return "Specifiche generate";
+        if (type == NotificationType.DocumentProcessingFailed) return "Elaborazione fallita";
+        if (type == NotificationType.ShareRequestCreated) return "Nuova Share Request";
+        if (type == NotificationType.ShareRequestApproved) return "Share Request approvata";
+        if (type == NotificationType.ShareRequestRejected) return "Share Request rifiutata";
+        if (type == NotificationType.ShareRequestChangesRequested) return "Modifiche richieste";
+        if (type == NotificationType.BadgeEarned) return "Badge ottenuto";
+        if (type == NotificationType.GameNightInvitation) return "Invito Serata";
+        if (type == NotificationType.GameNightRsvpReceived) return "RSVP ricevuto";
+        if (type == NotificationType.GameNightReminder) return "Promemoria Serata";
+        if (type == NotificationType.GameNightCancelled) return "Serata annullata";
+        if (type == NotificationType.AgentReady) return "Agente pronto";
+        if (type == NotificationType.LoanReminder) return "Promemoria prestito";
+        if (type == NotificationType.RateLimitApproaching) return "Quota in avvicinamento";
+        if (type == NotificationType.RateLimitReached) return "Quota raggiunta";
+        if (type == NotificationType.SessionTerminated) return "Sessione terminata";
+        if (type == NotificationType.GdprDataExportReady) return "Export dati pronto";
+        if (type == NotificationType.GdprAccountDeleted) return "Account eliminato";
+        if (type == NotificationType.GdprAiConsentUpdated) return "Consenso AI aggiornato";
+        if (type == NotificationType.SlackConnectionRevoked) return "Slack disconnesso";
+
+        // Admin types
+        if (type == NotificationType.AdminNewShareRequest) return "[Admin] Nuova Share Request";
+        if (type == NotificationType.AdminStaleShareRequests) return "[Admin] Share Request in attesa";
+        if (type == NotificationType.AdminReviewLockExpiring) return "[Admin] Lock revisione in scadenza";
+        if (type == NotificationType.AdminSharedGameSubmitted) return "[Admin] Gioco condiviso inviato";
+        if (type == NotificationType.AdminOpenRouterThresholdAlert) return "[Admin] Soglia OpenRouter";
+        if (type == NotificationType.AdminOpenRouterDailySummary) return "[Admin] Digest giornaliero";
+        if (type == NotificationType.AdminSystemHealthAlert) return "[Admin] Alerta sistema";
+        if (type == NotificationType.AdminModelStatusChanged) return "[Admin] Stato modello cambiato";
+        if (type == NotificationType.AdminAccessRequestCreated) return "[Admin] Nuova richiesta accesso";
+        if (type == NotificationType.AdminManualNotification) return "[Admin] Notifica manuale";
+        if (type == NotificationType.AdminPdfProcessingStarted) return "[Admin] Elaborazione PDF avviata";
+
+        return "Notifica MeepleAI";
+    }
+
+    /// <summary>
     /// Checks if email delivery is enabled for a given notification type based on user preferences.
     /// </summary>
     private static bool IsEmailEnabledForType(NotificationPreferences prefs, NotificationType type)
@@ -201,9 +271,24 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
 
     /// <summary>
     /// Checks if Slack DM delivery is enabled for a given notification type based on user preferences.
+    /// Admin types are never delivered to individual users via Slack DM.
     /// </summary>
     private static bool IsSlackEnabledForType(NotificationPreferences prefs, NotificationType type)
     {
+        // Admin types are never sent to individual users via DM
+        if (type == NotificationType.AdminNewShareRequest
+            || type == NotificationType.AdminStaleShareRequests
+            || type == NotificationType.AdminReviewLockExpiring
+            || type == NotificationType.AdminSharedGameSubmitted
+            || type == NotificationType.AdminOpenRouterThresholdAlert
+            || type == NotificationType.AdminOpenRouterDailySummary
+            || type == NotificationType.AdminSystemHealthAlert
+            || type == NotificationType.AdminModelStatusChanged
+            || type == NotificationType.AdminAccessRequestCreated
+            || type == NotificationType.AdminManualNotification
+            || type == NotificationType.AdminPdfProcessingStarted)
+            return false;
+
         if (type == NotificationType.DocumentReady || type == NotificationType.RuleSpecGenerated)
             return prefs.SlackOnDocumentReady;
         if (type == NotificationType.DocumentProcessingFailed)

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs
@@ -89,7 +89,8 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
                     recipientUserId: message.RecipientUserId,
                     notificationType: message.Type,
                     payload: message.Payload,
-                    correlationId: correlationId);
+                    correlationId: correlationId,
+                    deepLinkPath: message.DeepLinkPath);
 
                 queueItems.Add(emailItem);
 
@@ -118,7 +119,8 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
                         payload: message.Payload,
                         slackChannelTarget: slackConnection.DmChannelId,
                         slackTeamId: slackConnection.SlackTeamId,
-                        correlationId: correlationId);
+                        correlationId: correlationId,
+                        deepLinkPath: message.DeepLinkPath);
 
                     queueItems.Add(slackItem);
 
@@ -150,7 +152,8 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
                         payload: message.Payload,
                         slackChannelTarget: settings.WebhookUrl,
                         slackTeamId: teamId,
-                        correlationId: correlationId);
+                        correlationId: correlationId,
+                        deepLinkPath: message.DeepLinkPath);
 
                     queueItems.Add(teamItem);
 

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Slack/AdminAlertSlackBuilder.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Slack/AdminAlertSlackBuilder.cs
@@ -10,6 +10,13 @@ namespace Api.BoundedContexts.UserNotifications.Infrastructure.Slack;
 /// </summary>
 internal sealed class AdminAlertSlackBuilder : ISlackMessageBuilder
 {
+    private readonly TimeProvider _timeProvider;
+
+    public AdminAlertSlackBuilder(TimeProvider timeProvider)
+    {
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+    }
+
     public bool CanHandle(NotificationType type)
     {
         // All admin notification types
@@ -51,7 +58,7 @@ internal sealed class AdminAlertSlackBuilder : ISlackMessageBuilder
                 type = "context",
                 elements = new object[]
                 {
-                    new { type = "mrkdwn", text = $"MeepleAI Monitoring | {DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture)} UTC" }
+                    new { type = "mrkdwn", text = $"MeepleAI Monitoring | {_timeProvider.GetUtcNow().ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture)} UTC" }
                 }
             }
         };

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Slack/GameNightSlackBuilder.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Slack/GameNightSlackBuilder.cs
@@ -31,9 +31,34 @@ internal sealed class GameNightSlackBuilder : ISlackMessageBuilder
             throw new ArgumentException($"Expected {nameof(GameNightPayload)} but received {payload.GetType().Name}", nameof(payload));
         }
 
+        var scheduledDate = gn.ScheduledAt.ToString("dddd d MMMM yyyy, HH:mm", CultureInfo.InvariantCulture);
+
+        if (gn.IsCancelled)
+        {
+            return new
+            {
+                blocks = new object[]
+                {
+                    new
+                    {
+                        type = "header",
+                        text = new { type = "plain_text", text = $"\u274c Annullata: {gn.Title}", emoji = true }
+                    },
+                    new
+                    {
+                        type = "section",
+                        text = new
+                        {
+                            type = "mrkdwn",
+                            text = $"\ud83d\udcc5 *Era prevista per*: {scheduledDate}\n\ud83d\udc64 *Organizzatore*: {gn.OrganizerName}\n\n_La serata è stata annullata._"
+                        }
+                    }
+                }
+            };
+        }
+
         var timestamp = _timeProvider.GetUtcNow().ToUnixTimeSeconds();
         var blockId = $"gn:{gn.GameNightId}:{timestamp}";
-        var scheduledDate = gn.ScheduledAt.ToString("dddd d MMMM yyyy, HH:mm", CultureInfo.InvariantCulture);
 
         var blocks = new List<object>
         {

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Slack/ShareRequestSlackBuilder.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Slack/ShareRequestSlackBuilder.cs
@@ -34,14 +34,13 @@ internal sealed class ShareRequestSlackBuilder : ISlackMessageBuilder
             throw new ArgumentException($"Expected {nameof(ShareRequestPayload)} but received {payload.GetType().Name}", nameof(payload));
         }
 
-        var isCreated = string.Equals(sr.Status, "created", StringComparison.OrdinalIgnoreCase);
-        var isApproved = string.Equals(sr.Status, "approved", StringComparison.OrdinalIgnoreCase);
-
-        var (headerEmoji, headerText) = (isCreated, isApproved) switch
+        var (headerEmoji, headerText) = sr.Status.ToLowerInvariant() switch
         {
-            (true, _)  => ("\ud83d\udce5", "Nuova Share Request"),
-            (_, true)  => ("\u2705", "Approvata"),
-            _          => ("\u274c", "Rifiutata")
+            "created"  => ("\ud83d\udce5", "Nuova Share Request"),
+            "approved" => ("\u2705", "Approvata"),
+            "rejected" => ("\u274c", "Rifiutata"),
+            var unknown => throw new ArgumentException(
+                $"Unrecognised ShareRequest status: '{unknown}'", nameof(payload))
         };
 
         var blocks = new List<object>
@@ -54,7 +53,7 @@ internal sealed class ShareRequestSlackBuilder : ISlackMessageBuilder
             BuildSectionBlock(sr)
         };
 
-        if (isCreated)
+        if (sr.Status.Equals("created", StringComparison.OrdinalIgnoreCase))
         {
             var timestamp = _timeProvider.GetUtcNow().ToUnixTimeSeconds();
             var blockId = $"sr:{sr.ShareRequestId}:{timestamp}";
@@ -100,7 +99,12 @@ internal sealed class ShareRequestSlackBuilder : ISlackMessageBuilder
 
     private static object BuildSectionBlock(ShareRequestPayload sr)
     {
-        var text = $"*{sr.RequesterName}* vuole condividere il regolamento di *{sr.GameTitle}* con te.";
+        var text = sr.Status.ToLowerInvariant() switch
+        {
+            "approved" => $"\u2705 La tua richiesta di condivisione per *{sr.GameTitle}* è stata approvata da {sr.RequesterName}.",
+            "rejected" => $"\u274c La tua richiesta di condivisione per *{sr.GameTitle}* è stata rifiutata da {sr.RequesterName}.",
+            _ => $"\ud83c\udfb2 *Gioco*: {sr.GameTitle}\n\ud83d\udc64 *Richiedente*: {sr.RequesterName}"
+        };
 
         if (!string.IsNullOrEmpty(sr.GameImageUrl))
         {

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Slack/ShareRequestSlackBuilder.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Slack/ShareRequestSlackBuilder.cs
@@ -34,19 +34,35 @@ internal sealed class ShareRequestSlackBuilder : ISlackMessageBuilder
             throw new ArgumentException($"Expected {nameof(ShareRequestPayload)} but received {payload.GetType().Name}", nameof(payload));
         }
 
-        var timestamp = _timeProvider.GetUtcNow().ToUnixTimeSeconds();
-        var blockId = $"sr:{sr.ShareRequestId}:{timestamp}";
-        var deepLink = $"{_frontendBaseUrl.TrimEnd('/')}/share-requests/{sr.ShareRequestId}";
+        var isCreated = string.Equals(sr.Status, "created", StringComparison.OrdinalIgnoreCase);
+        var isApproved = string.Equals(sr.Status, "approved", StringComparison.OrdinalIgnoreCase);
+
+        var (headerEmoji, headerText) = (isCreated, isApproved) switch
+        {
+            (true, _)  => ("\ud83d\udce5", "Nuova Share Request"),
+            (_, true)  => ("\u2705", "Approvata"),
+            _          => ("\u274c", "Rifiutata")
+        };
 
         var blocks = new List<object>
         {
             new
             {
                 type = "header",
-                text = new { type = "plain_text", text = "\ud83d\udce5 Nuova Share Request", emoji = true }
+                text = new { type = "plain_text", text = $"{headerEmoji} {headerText}", emoji = true }
             },
-            BuildSectionBlock(sr),
-            new
+            BuildSectionBlock(sr)
+        };
+
+        if (isCreated)
+        {
+            var timestamp = _timeProvider.GetUtcNow().ToUnixTimeSeconds();
+            var blockId = $"sr:{sr.ShareRequestId}:{timestamp}";
+            var deepLink = !string.IsNullOrEmpty(deepLinkPath)
+                ? $"{_frontendBaseUrl.TrimEnd('/')}{deepLinkPath}"
+                : $"{_frontendBaseUrl.TrimEnd('/')}/share-requests/{sr.ShareRequestId}";
+
+            blocks.Add(new
             {
                 type = "actions",
                 block_id = blockId,
@@ -76,8 +92,8 @@ internal sealed class ShareRequestSlackBuilder : ISlackMessageBuilder
                         url = deepLink
                     }
                 }
-            }
-        };
+            });
+        }
 
         return new { blocks };
     }

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Slack/SlackSignatureValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Slack/SlackSignatureValidator.cs
@@ -19,6 +19,8 @@ internal class SlackSignatureValidator
     {
         ArgumentNullException.ThrowIfNull(config);
         _signingSecret = config.Value.SigningSecret;
+        if (string.IsNullOrWhiteSpace(_signingSecret))
+            throw new ArgumentException("Slack signing secret must not be empty.", nameof(config));
         _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
     }
 
@@ -34,6 +36,7 @@ internal class SlackSignatureValidator
     {
         if (string.IsNullOrEmpty(timestamp) || string.IsNullOrEmpty(signature))
             return false;
+        body ??= string.Empty;
 
         if (!long.TryParse(timestamp, System.Globalization.CultureInfo.InvariantCulture, out var ts))
             return false;
@@ -48,8 +51,12 @@ internal class SlackSignatureValidator
         var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(baseString));
         var computed = "v0=" + Convert.ToHexString(hash).ToLowerInvariant();
 
-        return CryptographicOperations.FixedTimeEquals(
-            Encoding.UTF8.GetBytes(computed),
-            Encoding.UTF8.GetBytes(signature));
+        var computedBytes = Encoding.UTF8.GetBytes(computed);
+        var signatureBytes = Encoding.UTF8.GetBytes(signature);
+
+        if (computedBytes.Length != signatureBytes.Length)
+            return false;
+
+        return CryptographicOperations.FixedTimeEquals(computedBytes, signatureBytes);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Slack/SlackSignatureValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Slack/SlackSignatureValidator.cs
@@ -13,11 +13,13 @@ namespace Api.BoundedContexts.UserNotifications.Infrastructure.Slack;
 internal class SlackSignatureValidator
 {
     private readonly string _signingSecret;
+    private readonly TimeProvider _timeProvider;
 
-    public SlackSignatureValidator(IOptions<SlackNotificationConfiguration> config)
+    public SlackSignatureValidator(IOptions<SlackNotificationConfiguration> config, TimeProvider timeProvider)
     {
         ArgumentNullException.ThrowIfNull(config);
         _signingSecret = config.Value.SigningSecret;
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
     }
 
     /// <summary>
@@ -33,12 +35,11 @@ internal class SlackSignatureValidator
         if (string.IsNullOrEmpty(timestamp) || string.IsNullOrEmpty(signature))
             return false;
 
-        // Replay protection: reject requests older than 5 minutes
         if (!long.TryParse(timestamp, System.Globalization.CultureInfo.InvariantCulture, out var ts))
             return false;
 
         var requestTime = DateTimeOffset.FromUnixTimeSeconds(ts);
-        var now = DateTimeOffset.UtcNow;
+        var now = _timeProvider.GetUtcNow();
         if (Math.Abs((now - requestTime).TotalSeconds) > 300)
             return false;
 

--- a/apps/api/src/Api/Infrastructure/Entities/UserNotifications/NotificationQueueEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/UserNotifications/NotificationQueueEntity.cs
@@ -74,4 +74,8 @@ public class NotificationQueueEntity
     [Required]
     [Column("correlation_id")]
     public Guid CorrelationId { get; set; }
+
+    [MaxLength(500)]
+    [Column("deep_link_path")]
+    public string? DeepLinkPath { get; set; }
 }

--- a/apps/api/src/Api/Infrastructure/Migrations/20260406122729_AddDeepLinkPathToNotificationQueue.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260406122729_AddDeepLinkPathToNotificationQueue.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260406122729_AddDeepLinkPathToNotificationQueue")]
+    partial class AddDeepLinkPathToNotificationQueue
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260406122729_AddDeepLinkPathToNotificationQueue.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260406122729_AddDeepLinkPathToNotificationQueue.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDeepLinkPathToNotificationQueue : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "deep_link_path",
+                table: "notification_queue_items",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "deep_link_path",
+                table: "notification_queue_items");
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Application/Handlers/HandleSlackInteractionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Application/Handlers/HandleSlackInteractionCommandHandlerTests.cs
@@ -11,6 +11,7 @@ using Api.Tests.Constants;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
 using FluentAssertions;
@@ -32,18 +33,19 @@ public class HandleSlackInteractionCommandHandlerTests
 
     public HandleSlackInteractionCommandHandlerTests()
     {
+        _timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+
         var configMock = new Mock<IOptions<SlackNotificationConfiguration>>();
         configMock.Setup(c => c.Value).Returns(new SlackNotificationConfiguration
         {
             SigningSecret = SigningSecret
         });
-        _signatureValidator = new SlackSignatureValidator(configMock.Object);
+        _signatureValidator = new SlackSignatureValidator(configMock.Object, _timeProvider);
 
         _slackConnectionRepoMock = new Mock<ISlackConnectionRepository>();
         _mediatorMock = new Mock<IMediator>();
         _httpClientFactoryMock = new Mock<IHttpClientFactory>();
         _loggerMock = new Mock<ILogger<HandleSlackInteractionCommandHandler>>();
-        _timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
 
         _handler = new HandleSlackInteractionCommandHandler(
             _signatureValidator,

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationQueueItemTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationQueueItemTests.cs
@@ -18,7 +18,8 @@ public class NotificationQueueItemTests
         NotificationType? notificationType = null,
         INotificationPayload? payload = null,
         string? slackChannelTarget = null,
-        string? slackTeamId = null)
+        string? slackTeamId = null,
+        string? deepLinkPath = null)
     {
         return NotificationQueueItem.Create(
             channelType ?? NotificationChannelType.SlackUser,
@@ -26,7 +27,8 @@ public class NotificationQueueItemTests
             notificationType ?? NotificationType.DocumentReady,
             payload ?? new GenericPayload("Test", "Body"),
             slackChannelTarget,
-            slackTeamId);
+            slackTeamId,
+            deepLinkPath: deepLinkPath);
     }
 
     [Fact]
@@ -355,6 +357,20 @@ public class NotificationQueueItemTests
 
         item.RetryCount.Should().Be(0);
         item.Status.Should().Be(NotificationQueueStatus.Failed);
+    }
+
+    [Fact]
+    public void Create_WithDeepLinkPath_SetsProperty()
+    {
+        var item = CreateDefaultItem(deepLinkPath: "/library/documents/abc123");
+        item.DeepLinkPath.Should().Be("/library/documents/abc123");
+    }
+
+    [Fact]
+    public void Create_WithoutDeepLinkPath_PropertyIsNull()
+    {
+        var item = CreateDefaultItem();
+        item.DeepLinkPath.Should().BeNull();
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationQueueItemTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationQueueItemTests.cs
@@ -374,6 +374,37 @@ public class NotificationQueueItemTests
     }
 
     [Fact]
+    public void Reconstitute_WithDeepLinkPath_PreservesProperty()
+    {
+        // Arrange — simulate DB round-trip via Reconstitute
+        var id = Guid.NewGuid();
+        var expectedPath = "/library/documents/xyz789";
+
+        // Act
+        var item = NotificationQueueItem.Reconstitute(
+            id: id,
+            channelType: NotificationChannelType.SlackUser,
+            recipientUserId: DefaultRecipientUserId,
+            notificationType: NotificationType.DocumentReady,
+            payload: new GenericPayload("Test", "Body"),
+            slackChannelTarget: null,
+            slackTeamId: null,
+            status: NotificationQueueStatus.Pending,
+            retryCount: 0,
+            maxRetries: 3,
+            nextRetryAt: null,
+            lastError: null,
+            createdAt: new DateTime(2026, 3, 15, 12, 0, 0, DateTimeKind.Utc),
+            processedAt: null,
+            correlationId: Guid.NewGuid(),
+            deepLinkPath: expectedPath);
+
+        // Assert
+        item.DeepLinkPath.Should().Be(expectedPath);
+        item.Id.Should().Be(id);
+    }
+
+    [Fact]
     public void Create_SetsChannelTypeAndPayload()
     {
         // Arrange

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationQueueItemTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationQueueItemTests.cs
@@ -311,6 +311,53 @@ public class NotificationQueueItemTests
     }
 
     [Fact]
+    public void MarkAsRateLimited_FromProcessing_DoesNotIncrementRetryCount()
+    {
+        // Arrange
+        var item = CreateDefaultItem();
+        item.MarkAsProcessing();
+        var expectedRetryCount = item.RetryCount; // 0
+
+        // Act
+        var retryAt = new DateTime(2026, 3, 15, 12, 5, 0, DateTimeKind.Utc);
+        item.MarkAsRateLimited(retryAt);
+
+        // Assert
+        item.RetryCount.Should().Be(expectedRetryCount); // still 0
+        item.Status.Should().Be(NotificationQueueStatus.Failed);
+        item.NextRetryAt.Should().Be(retryAt);
+        item.LastError.Should().Contain("rate limit");
+    }
+
+    [Fact]
+    public void MarkAsRateLimited_FromPending_Throws()
+    {
+        // Arrange
+        var item = CreateDefaultItem();
+        var fixedRetryAt = new DateTime(2026, 3, 15, 12, 0, 30, DateTimeKind.Utc);
+
+        // Act & Assert
+        var act = () => item.MarkAsRateLimited(fixedRetryAt);
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void MarkAsRateLimited_MultipleTimes_NeverExceedsMaxRetries()
+    {
+        var item = CreateDefaultItem();
+        var fixedRetryAt = new DateTime(2026, 3, 15, 12, 0, 30, DateTimeKind.Utc);
+
+        for (int i = 0; i < 10; i++)
+        {
+            item.MarkAsProcessing();
+            item.MarkAsRateLimited(fixedRetryAt);
+        }
+
+        item.RetryCount.Should().Be(0);
+        item.Status.Should().Be(NotificationQueueStatus.Failed);
+    }
+
+    [Fact]
     public void Create_SetsChannelTypeAndPayload()
     {
         // Arrange

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Scheduling/SlackNotificationProcessorJobTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Scheduling/SlackNotificationProcessorJobTests.cs
@@ -170,7 +170,12 @@ public class SlackNotificationProcessorJobTests : IDisposable
         var slackConnection = SlackConnection.Create(
             userId, "U01ABC", "T01ABCDEF", "TestWorkspace", "xoxb-old-token", "D01ABCDEF");
 
-        // Return connection for both the bot API call and the revocation handler
+        // Batch lookup used during Execute for bot token resolution
+        _slackConnRepoMock.Setup(r => r.GetActiveByUserIdsAsync(
+                It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, SlackConnection> { { userId, slackConnection } });
+
+        // Single-item lookup used in HandleTokenRevocationAsync to deactivate the connection
         _slackConnRepoMock.Setup(r => r.GetActiveByUserIdAsync(userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(slackConnection);
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcherTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcherTests.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.UserNotifications.Domain.Repositories;
 using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
 using Api.BoundedContexts.UserNotifications.Infrastructure.Configuration;
 using Api.BoundedContexts.UserNotifications.Infrastructure.Services;
+using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -265,5 +266,126 @@ public class NotificationDispatcherTests
                     items.All(i => i.ChannelType != NotificationChannelType.SlackUser)),
                 It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Theory]
+    [InlineData("document_processing_failed", "error")]
+    [InlineData("admin_system_health_alert", "error")]
+    [InlineData("admin_openrouter_threshold_alert", "error")]
+    [InlineData("session_terminated", "warning")]
+    [InlineData("rate_limit_reached", "warning")]
+    [InlineData("slack_connection_revoked", "warning")]
+    [InlineData("document_ready", "success")]
+    [InlineData("badge_earned", "success")]
+    [InlineData("share_request_created", "info")]
+    public async Task DispatchAsync_MapsCorrectSeverityForType(string typeValue, string expectedSeverity)
+    {
+        // Arrange
+        var message = new NotificationMessage
+        {
+            Type = NotificationType.FromString(typeValue),
+            RecipientUserId = Guid.NewGuid(),
+            Payload = new GenericPayload("Title", "Body")
+        };
+
+        Notification? captured = null;
+        _notificationRepoMock
+            .Setup(r => r.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()))
+            .Callback<Notification, CancellationToken>((n, _) => captured = n)
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.DispatchAsync(message);
+
+        // Assert
+        captured.Should().NotBeNull();
+        captured!.Severity.Value.Should().Be(expectedSeverity);
+    }
+
+    [Theory]
+    [InlineData("document_ready", "Documento pronto")]
+    [InlineData("document_processing_failed", "Elaborazione fallita")]
+    [InlineData("badge_earned", "Badge ottenuto")]
+    [InlineData("share_request_created", "Nuova Share Request")]
+    [InlineData("game_night_invitation", "Invito Serata")]
+    public async Task DispatchAsync_UsesFriendlyTitleNotTypeName(string typeValue, string expectedTitleFragment)
+    {
+        // Arrange
+        var message = new NotificationMessage
+        {
+            Type = NotificationType.FromString(typeValue),
+            RecipientUserId = Guid.NewGuid(),
+            Payload = new GenericPayload("Title", "Body")
+        };
+
+        Notification? captured = null;
+        _notificationRepoMock
+            .Setup(r => r.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()))
+            .Callback<Notification, CancellationToken>((n, _) => captured = n)
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.DispatchAsync(message);
+
+        // Assert
+        captured.Should().NotBeNull();
+        captured!.Title.Should().Contain(expectedTitleFragment);
+        captured.Title.Should().NotContain("Payload"); // no C# type names
+    }
+
+    [Theory]
+    [InlineData("admin_new_share_request")]
+    [InlineData("admin_system_health_alert")]
+    [InlineData("admin_openrouter_threshold_alert")]
+    [InlineData("admin_model_status_changed")]
+    public async Task DispatchAsync_AdminTypes_NotSentViaSlackDm(string typeValue)
+    {
+        // Arrange: user has Slack enabled with active connection
+        var userId = Guid.NewGuid();
+        var prefs = new NotificationPreferences(userId);
+        prefs.UpdateSlackPreferences(
+            enabled: true,
+            onDocumentReady: true,
+            onDocumentFailed: true,
+            onRetryAvailable: false,
+            onGameNightInvitation: true,
+            onGameNightReminder: true,
+            onShareRequestCreated: true,
+            onShareRequestApproved: true,
+            onBadgeEarned: true);
+        _prefsRepoMock
+            .Setup(r => r.GetByUserIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(prefs);
+
+        var connection = SlackConnection.Create(userId, "U123", "T456", "TestTeam", "xoxb-token", "D789");
+        _slackConnRepoMock
+            .Setup(r => r.GetActiveByUserIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(connection);
+
+        var message = new NotificationMessage
+        {
+            Type = NotificationType.FromString(typeValue),
+            RecipientUserId = userId,
+            Payload = new GenericPayload("Admin Alert", "Details")
+        };
+
+        IEnumerable<NotificationQueueItem>? capturedItems = null;
+        _queueRepoMock
+            .Setup(r => r.AddRangeAsync(It.IsAny<IEnumerable<NotificationQueueItem>>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<NotificationQueueItem>, CancellationToken>((items, _) => capturedItems = items)
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.DispatchAsync(message);
+
+        // Assert — no SlackUser channel items for admin types
+        capturedItems?.Any(i => i.ChannelType == NotificationChannelType.SlackUser)
+            .Should().BeFalse($"admin type '{typeValue}' should not be delivered via Slack DM");
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Slack/AdminAlertSlackBuilderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Slack/AdminAlertSlackBuilderTests.cs
@@ -83,4 +83,53 @@ public sealed class AdminAlertSlackBuilderTests
         var act = () => CreateSut().BuildMessage(new BadgePayload(Guid.NewGuid(), "X", "Y"), null);
         act.Should().Throw<ArgumentException>().WithMessage("*GenericPayload*BadgePayload*");
     }
+
+    [Fact]
+    public void BuildMessage_InfoTitle_ProducesInfoAttachment()
+    {
+        var payload = new GenericPayload("Daily Summary", "No issues today.");
+
+        var result = CreateSut().BuildMessage(payload, null);
+        var json = JsonSerializer.Serialize(result);
+        var doc = JsonDocument.Parse(json);
+
+        // Default/info path uses "#1967d2" (informational blue)
+        var color = doc.RootElement.GetProperty("attachments")[0].GetProperty("color").GetString();
+        color.Should().Be("#1967d2");
+    }
+
+    [Theory]
+    [InlineData("CRITICAL issue detected")]
+    [InlineData("CIRCUIT BREAKER opened")]
+    [InlineData("Service DEGRADED")]
+    public void BuildMessage_CriticalKeywords_ProduceDangerAttachment(string title)
+    {
+        var payload = new GenericPayload(title, "Details here.");
+
+        var result = CreateSut().BuildMessage(payload, null);
+        var json = JsonSerializer.Serialize(result);
+        var doc = JsonDocument.Parse(json);
+
+        doc.RootElement.GetProperty("attachments")[0].GetProperty("color").GetString()
+            .Should().Be("danger");
+    }
+
+    [Theory]
+    [InlineData("WARNING: budget approaching")]
+    [InlineData("STALE share requests detected")]
+    [InlineData("Review lock EXPIRING soon")]
+    [InlineData("Model is DEPRECATED")]
+    [InlineData("BUDGET threshold reached")]
+    [InlineData("RPM quota near limit")]
+    public void BuildMessage_WarningKeywords_ProduceWarningAttachment(string title)
+    {
+        var payload = new GenericPayload(title, "Details here.");
+
+        var result = CreateSut().BuildMessage(payload, null);
+        var json = JsonSerializer.Serialize(result);
+        var doc = JsonDocument.Parse(json);
+
+        doc.RootElement.GetProperty("attachments")[0].GetProperty("color").GetString()
+            .Should().Be("warning");
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Slack/AdminAlertSlackBuilderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Slack/AdminAlertSlackBuilderTests.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+using Api.BoundedContexts.UserNotifications.Infrastructure.Slack;
+using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.UserNotifications.Infrastructure.Slack;
+
+[Trait("Category", "Unit")]
+public sealed class AdminAlertSlackBuilderTests
+{
+    private static readonly DateTimeOffset FixedTime = new(2026, 3, 15, 10, 30, 0, TimeSpan.Zero);
+
+    private static AdminAlertSlackBuilder CreateSut()
+        => new(new FakeTimeProvider(FixedTime));
+
+    [Theory]
+    [InlineData("admin_new_share_request")]
+    [InlineData("admin_stale_share_requests")]
+    [InlineData("admin_review_lock_expiring")]
+    [InlineData("admin_system_health_alert")]
+    [InlineData("admin_model_status_changed")]
+    [InlineData("admin_openrouter_threshold_alert")]
+    [InlineData("admin_openrouter_daily_summary")]
+    [InlineData("admin_shared_game_submitted")]
+    public void CanHandle_AdminTypes_ReturnsTrue(string typeValue)
+    {
+        CreateSut().CanHandle(NotificationType.FromString(typeValue)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanHandle_NonAdminType_ReturnsFalse()
+    {
+        CreateSut().CanHandle(NotificationType.BadgeEarned).Should().BeFalse();
+    }
+
+    [Fact]
+    public void BuildMessage_ContainsFixedTimestampInContextBlock()
+    {
+        var payload = new GenericPayload("Test Alert", "Something happened.");
+
+        var result = CreateSut().BuildMessage(payload, null);
+        var json = JsonSerializer.Serialize(result);
+        var doc = JsonDocument.Parse(json);
+
+        // AdminAlertSlackBuilder uses attachments
+        var blocks = doc.RootElement.GetProperty("attachments")[0].GetProperty("blocks");
+        var contextText = blocks[2].GetProperty("elements")[0].GetProperty("text").GetString();
+
+        contextText.Should().Contain("2026-03-15 10:30");
+    }
+
+    [Fact]
+    public void BuildMessage_CriticalTitle_ProducesDangerAttachment()
+    {
+        var payload = new GenericPayload("CRITICAL Circuit Breaker Open", "Service degraded.");
+
+        var result = CreateSut().BuildMessage(payload, null);
+        var json = JsonSerializer.Serialize(result);
+        var doc = JsonDocument.Parse(json);
+
+        doc.RootElement.GetProperty("attachments")[0].GetProperty("color").GetString()
+            .Should().Be("danger");
+    }
+
+    [Fact]
+    public void BuildMessage_WarningTitle_ProducesWarningAttachment()
+    {
+        var payload = new GenericPayload("WARNING Budget RPM approaching", "80% of quota used.");
+
+        var result = CreateSut().BuildMessage(payload, null);
+        var json = JsonSerializer.Serialize(result);
+        var doc = JsonDocument.Parse(json);
+
+        doc.RootElement.GetProperty("attachments")[0].GetProperty("color").GetString()
+            .Should().Be("warning");
+    }
+
+    [Fact]
+    public void BuildMessage_WithWrongPayloadType_ThrowsArgumentException()
+    {
+        var act = () => CreateSut().BuildMessage(new BadgePayload(Guid.NewGuid(), "X", "Y"), null);
+        act.Should().Throw<ArgumentException>().WithMessage("*GenericPayload*BadgePayload*");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Slack/GameNightSlackBuilderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Slack/GameNightSlackBuilderTests.cs
@@ -41,7 +41,7 @@ public sealed class GameNightSlackBuilderTests
     {
         // Arrange
         var gnId = Guid.Parse("11111111-2222-3333-4444-555555555555");
-        var payload = new GameNightPayload(gnId, "Friday Night Games", DateTime.UtcNow, "Alice");
+        var payload = new GameNightPayload(gnId, "Friday Night Games", new DateTime(2026, 5, 10, 20, 0, 0, DateTimeKind.Utc), "Alice");
 
         // Act
         var result = _sut.BuildMessage(payload, null);
@@ -65,7 +65,7 @@ public sealed class GameNightSlackBuilderTests
     {
         // Arrange
         var gnId = Guid.NewGuid();
-        var payload = new GameNightPayload(gnId, "Board Game Night", DateTime.UtcNow, "Bob");
+        var payload = new GameNightPayload(gnId, "Board Game Night", new DateTime(2026, 5, 10, 20, 0, 0, DateTimeKind.Utc), "Bob");
 
         // Act
         var result = _sut.BuildMessage(payload, null);
@@ -111,7 +111,7 @@ public sealed class GameNightSlackBuilderTests
     public void BuildMessage_HeaderContainsGameNightTitle()
     {
         // Arrange
-        var payload = new GameNightPayload(Guid.NewGuid(), "Epic Board Game Night", DateTime.UtcNow, "Host");
+        var payload = new GameNightPayload(Guid.NewGuid(), "Epic Board Game Night", new DateTime(2026, 5, 10, 20, 0, 0, DateTimeKind.Utc), "Host");
 
         // Act
         var result = _sut.BuildMessage(payload, null);

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Slack/GameNightSlackBuilderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Slack/GameNightSlackBuilderTests.cs
@@ -132,4 +132,59 @@ public sealed class GameNightSlackBuilderTests
         act.Should().Throw<ArgumentException>()
             .WithMessage("*GameNightPayload*GenericPayload*");
     }
+
+    [Fact]
+    public void BuildMessage_WhenIsCancelledTrue_ShowsCancellationLayoutWithoutRsvpButtons()
+    {
+        // Arrange
+        var payload = new GameNightPayload(
+            Guid.NewGuid(),
+            "Serata Catan",
+            new DateTime(2026, 5, 10, 20, 0, 0, DateTimeKind.Utc),
+            "Mario",
+            IsCancelled: true);
+
+        // Act
+        var result = _sut.BuildMessage(payload, null);
+        var json = JsonSerializer.Serialize(result);
+        var doc = JsonDocument.Parse(json);
+        var blocks = doc.RootElement.GetProperty("blocks");
+
+        // Assert — 2 blocks: header + section (no RSVP actions)
+        blocks.GetArrayLength().Should().Be(2);
+
+        var header = blocks[0];
+        header.GetProperty("text").GetProperty("text").GetString()
+            .Should().Contain("Annullata");
+
+        // No actions block
+        for (int i = 0; i < blocks.GetArrayLength(); i++)
+        {
+            blocks[i].GetProperty("type").GetString().Should().NotBe("actions");
+        }
+    }
+
+    [Fact]
+    public void BuildMessage_WhenIsCancelledFalse_ShowsRsvpButtons()
+    {
+        // Arrange
+        var payload = new GameNightPayload(
+            Guid.NewGuid(),
+            "Serata Catan",
+            new DateTime(2026, 5, 10, 20, 0, 0, DateTimeKind.Utc),
+            "Mario",
+            IsCancelled: false);
+
+        // Act
+        var result = _sut.BuildMessage(payload, null);
+        var json = JsonSerializer.Serialize(result);
+        var doc = JsonDocument.Parse(json);
+        var blocks = doc.RootElement.GetProperty("blocks");
+
+        // Assert — 3 blocks: header + section + actions
+        blocks.GetArrayLength().Should().Be(3);
+        blocks[2].GetProperty("type").GetString().Should().Be("actions");
+        var elements = blocks[2].GetProperty("elements");
+        elements[0].GetProperty("action_id").GetString().Should().Be("game_night_rsvp_yes");
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Slack/ShareRequestSlackBuilderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Slack/ShareRequestSlackBuilderTests.cs
@@ -166,4 +166,62 @@ public sealed class ShareRequestSlackBuilderTests
         act.Should().Throw<ArgumentException>()
             .WithMessage("*ShareRequestPayload*GenericPayload*");
     }
+
+    [Fact]
+    public void BuildMessage_WhenStatusIsCreated_ShowsApproveRejectButtons()
+    {
+        var payload = new ShareRequestPayload(
+            Guid.NewGuid(), "Mario", "Catan", null, Status: "created");
+
+        var result = _sut.BuildMessage(payload, null);
+        var json = JsonSerializer.Serialize(result);
+        var doc = JsonDocument.Parse(json);
+        var blocks = doc.RootElement.GetProperty("blocks");
+
+        // Header: "Nuova Share Request"
+        blocks[0].GetProperty("text").GetProperty("text").GetString()
+            .Should().Contain("Nuova Share Request");
+
+        // Actions block with 3 elements (Approve, Reject, Open)
+        blocks.GetArrayLength().Should().Be(3);
+        var elements = blocks[2].GetProperty("elements");
+        elements.GetArrayLength().Should().Be(3);
+        elements[0].GetProperty("action_id").GetString().Should().Be("share_request_approve");
+        elements[1].GetProperty("action_id").GetString().Should().Be("share_request_reject");
+    }
+
+    [Fact]
+    public void BuildMessage_WhenStatusIsApproved_ShowsConfirmationWithoutActionButtons()
+    {
+        var payload = new ShareRequestPayload(
+            Guid.NewGuid(), "Mario", "Catan", null, Status: "approved");
+
+        var result = _sut.BuildMessage(payload, null);
+        var json = JsonSerializer.Serialize(result);
+        var doc = JsonDocument.Parse(json);
+        var blocks = doc.RootElement.GetProperty("blocks");
+
+        // Header: "Approvata"
+        blocks[0].GetProperty("text").GetProperty("text").GetString()
+            .Should().Contain("Approvata");
+
+        // 2 blocks only: header + section (no actions)
+        blocks.GetArrayLength().Should().Be(2);
+    }
+
+    [Fact]
+    public void BuildMessage_WhenStatusIsRejected_ShowsRejectionWithoutActionButtons()
+    {
+        var payload = new ShareRequestPayload(
+            Guid.NewGuid(), "Mario", "Catan", null, Status: "rejected");
+
+        var result = _sut.BuildMessage(payload, null);
+        var json = JsonSerializer.Serialize(result);
+        var doc = JsonDocument.Parse(json);
+        var blocks = doc.RootElement.GetProperty("blocks");
+
+        blocks[0].GetProperty("text").GetProperty("text").GetString()
+            .Should().Contain("Rifiutata");
+        blocks.GetArrayLength().Should().Be(2);
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Slack/ShareRequestSlackBuilderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Slack/ShareRequestSlackBuilderTests.cs
@@ -207,6 +207,10 @@ public sealed class ShareRequestSlackBuilderTests
 
         // 2 blocks only: header + section (no actions)
         blocks.GetArrayLength().Should().Be(2);
+
+        var section = blocks[1];
+        section.GetProperty("text").GetProperty("text").GetString()
+            .Should().Contain("approvata");
     }
 
     [Fact]
@@ -223,5 +227,9 @@ public sealed class ShareRequestSlackBuilderTests
         blocks[0].GetProperty("text").GetProperty("text").GetString()
             .Should().Contain("Rifiutata");
         blocks.GetArrayLength().Should().Be(2);
+
+        var section = blocks[1];
+        section.GetProperty("text").GetProperty("text").GetString()
+            .Should().Contain("rifiutata");
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Slack/SlackMessageBuilderFactoryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Slack/SlackMessageBuilderFactoryTests.cs
@@ -96,7 +96,7 @@ public sealed class SlackMessageBuilderFactoryTests
     public void GetBuilder_AdminType_ReturnsAdminAlertBuilder()
     {
         // Arrange
-        var adminBuilder = new AdminAlertSlackBuilder();
+        var adminBuilder = new AdminAlertSlackBuilder(_timeProvider);
         var fallback = new GenericSlackBuilder(_config);
         var factory = new SlackMessageBuilderFactory(
             new ISlackMessageBuilder[] { adminBuilder },

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Slack/SlackSignatureValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Slack/SlackSignatureValidatorTests.cs
@@ -1,0 +1,92 @@
+using Api.BoundedContexts.UserNotifications.Infrastructure.Configuration;
+using Api.BoundedContexts.UserNotifications.Infrastructure.Slack;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using System.Security.Cryptography;
+using System.Text;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.UserNotifications.Infrastructure.Slack;
+
+[Trait("Category", "Unit")]
+public sealed class SlackSignatureValidatorTests
+{
+    private const string TestSigningSecret = "8f742231b10e8888abcd99baed85bc4ab719a2dv";
+
+    private static SlackSignatureValidator CreateSut(DateTimeOffset now)
+    {
+        var config = Options.Create(new SlackNotificationConfiguration
+        {
+            SigningSecret = TestSigningSecret,
+            ClientId = "client",
+            ClientSecret = "secret",
+            RedirectUri = "https://meepleai.app/slack/callback"
+        });
+        var timeProvider = new FakeTimeProvider(now);
+        return new SlackSignatureValidator(config, timeProvider);
+    }
+
+    private static string ComputeSignature(string timestamp, string body)
+    {
+        var baseString = $"v0:{timestamp}:{body}";
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(TestSigningSecret));
+        var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(baseString));
+        return "v0=" + Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    [Fact]
+    public void Validate_WithValidSignatureAndFreshTimestamp_ReturnsTrue()
+    {
+        var now = new DateTimeOffset(2026, 3, 15, 12, 0, 0, TimeSpan.Zero);
+        var timestamp = now.ToUnixTimeSeconds().ToString();
+        var body = "payload=%7B%22type%22%3A%22block_actions%22%7D";
+        var sig = ComputeSignature(timestamp, body);
+
+        var sut = CreateSut(now);
+        sut.Validate(timestamp, body, sig).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithExpiredTimestamp_ReturnsFalse()
+    {
+        var now = new DateTimeOffset(2026, 3, 15, 12, 0, 0, TimeSpan.Zero);
+        // Timestamp 6 minutes old — exceeds 5-minute window
+        var oldTimestamp = now.AddMinutes(-6).ToUnixTimeSeconds().ToString();
+        var body = "payload=test";
+        var sig = ComputeSignature(oldTimestamp, body);
+
+        var sut = CreateSut(now);
+        sut.Validate(oldTimestamp, body, sig).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_WithFutureTimestamp_ReturnsFalse()
+    {
+        var now = new DateTimeOffset(2026, 3, 15, 12, 0, 0, TimeSpan.Zero);
+        // Timestamp 6 minutes in the future (replay prevention)
+        var futureTimestamp = now.AddMinutes(6).ToUnixTimeSeconds().ToString();
+        var body = "payload=test";
+        var sig = ComputeSignature(futureTimestamp, body);
+
+        var sut = CreateSut(now);
+        sut.Validate(futureTimestamp, body, sig).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_WithWrongSignature_ReturnsFalse()
+    {
+        var now = new DateTimeOffset(2026, 3, 15, 12, 0, 0, TimeSpan.Zero);
+        var timestamp = now.ToUnixTimeSeconds().ToString();
+
+        var sut = CreateSut(now);
+        sut.Validate(timestamp, "payload=test", "v0=000wrongsignature").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_WithEmptyTimestamp_ReturnsFalse()
+    {
+        var sut = CreateSut(DateTimeOffset.UtcNow);
+        sut.Validate("", "body", "v0=sig").Should().BeFalse();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Slack/SlackSignatureValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Slack/SlackSignatureValidatorTests.cs
@@ -89,4 +89,64 @@ public sealed class SlackSignatureValidatorTests
         var sut = CreateSut(DateTimeOffset.UtcNow);
         sut.Validate("", "body", "v0=sig").Should().BeFalse();
     }
+
+    [Fact]
+    public void Validate_WithEmptySignature_ReturnsFalse()
+    {
+        var now = new DateTimeOffset(2026, 3, 15, 12, 0, 0, TimeSpan.Zero);
+        var timestamp = now.ToUnixTimeSeconds().ToString();
+
+        var sut = CreateSut(now);
+        sut.Validate(timestamp, "payload=test", "").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_WithNullBody_ReturnsFalse()
+    {
+        var now = new DateTimeOffset(2026, 3, 15, 12, 0, 0, TimeSpan.Zero);
+        var timestamp = now.ToUnixTimeSeconds().ToString();
+        var sig = ComputeSignature(timestamp, "");
+
+        var sut = CreateSut(now);
+        // null body should be treated as empty and validated — or return false for wrong sig
+        // With null body coerced to "" and valid sig for "", this should return true
+        sut.Validate(timestamp, null!, sig).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithTimestampAtExactBoundary_ReturnsTrue()
+    {
+        var now = new DateTimeOffset(2026, 3, 15, 12, 0, 0, TimeSpan.Zero);
+        // Exactly 300 seconds old — should still be accepted (boundary is > 300, not >= 300)
+        var boundaryTimestamp = now.AddSeconds(-300).ToUnixTimeSeconds().ToString();
+        var body = "payload=test";
+        var sig = ComputeSignature(boundaryTimestamp, body);
+
+        var sut = CreateSut(now);
+        sut.Validate(boundaryTimestamp, body, sig).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithSignatureOfDifferentLength_ReturnsFalse()
+    {
+        var now = new DateTimeOffset(2026, 3, 15, 12, 0, 0, TimeSpan.Zero);
+        var timestamp = now.ToUnixTimeSeconds().ToString();
+
+        var sut = CreateSut(now);
+        sut.Validate(timestamp, "payload=test", "v0=short").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Constructor_WithEmptySigningSecret_ThrowsArgumentException()
+    {
+        var config = Options.Create(new SlackNotificationConfiguration
+        {
+            SigningSecret = "",
+            ClientId = "client",
+            ClientSecret = "secret",
+            RedirectUri = "https://meepleai.app/slack/callback"
+        });
+        var act = () => new SlackSignatureValidator(config, new FakeTimeProvider(DateTimeOffset.UtcNow));
+        act.Should().Throw<ArgumentException>();
+    }
 }


### PR DESCRIPTION
## Summary

- **Task 1-2:** `ShareRequestSlackBuilder` context-aware per status (created/approved/rejected), `GameNightSlackBuilder` gestisce cancellazioni senza bottoni RSVP
- **Task 3:** `SlackSignatureValidator` hardening — `TimeProvider` injection, null body guard, validazione signing secret nel costruttore, length check prima di `FixedTimeEquals`
- **Task 4:** `AdminAlertSlackBuilder` — rimosso `DateTime.UtcNow`, iniettato `TimeProvider`
- **Task 5:** `NotificationQueueItem.MarkAsRateLimited()` — non incrementa `RetryCount` (rate limit backpressure ≠ delivery failure)
- **Task 6:** `DeepLinkPath` propagato da `NotificationMessage` → `NotificationQueueItem` → `NotificationQueueEntity` (migration) → `SlackNotificationProcessorJob`
- **Task 7:** Aggiunto `NotificationType.SlackConnectionRevoked` — fix semantico per `HandleTokenRevocationAsync` che usava `DocumentProcessingFailed`
- **Task 8:** `SlackNotificationProcessorJob` — N+1 token lookup → batch `GetActiveByUserIdsAsync`, `HandleRateLimitAsync` usa `MarkAsRateLimited`
- **Task 9:** `NotificationDispatcher` — `ResolveSeverity()` + `ResolveTitle()` sostituiscono `NotificationSeverity.Info` hardcoded e `GetType().Name`; tipi Admin esclusi da Slack DM
- **Task 10:** DI wiring verificato (nessuna modifica necessaria)

## Test plan

- [x] `dotnet build` — 0 errori, 0 warning
- [x] 15.933 test Unit — 0 failures
- [x] 102 test `BoundedContext=UserNotifications` — 0 failures
- [x] Nuovi test file: `SlackSignatureValidatorTests`, `AdminAlertSlackBuilderTests`, `NotificationDispatcherTests`
- [x] Test aggiornati: `ShareRequestSlackBuilderTests`, `GameNightSlackBuilderTests`, `NotificationQueueItemTests`
- [x] Frontend build verificato dal pre-push hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)