### PR TITLE
fix(admin): resolve API 400 errors on /admin/agents Mission Control

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetAgentMetricsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetAgentMetricsQueryHandler.cs
@@ -33,8 +33,8 @@ internal sealed class GetAgentMetricsQueryHandler : IRequestHandler<GetAgentMetr
         var endDate = request.EndDate ?? DateOnly.FromDateTime(DateTime.UtcNow);
         var startDate = request.StartDate ?? endDate.AddDays(-30);
 
-        var from = startDate.ToDateTime(TimeOnly.MinValue);
-        var to = endDate.ToDateTime(TimeOnly.MaxValue);
+        var from = startDate.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+        var to = endDate.ToDateTime(TimeOnly.MaxValue, DateTimeKind.Utc);
 
         _logger.LogInformation(
             "Fetching agent metrics from {From} to {To}, TypologyId: {TypologyId}, Strategy: {Strategy}",

--- a/apps/api/src/Api/Routing/AdminRagExecutionEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminRagExecutionEndpoints.cs
@@ -18,8 +18,8 @@ internal static class AdminRagExecutionEndpoints
             .AddEndpointFilter<RequireAdminSessionFilter>();
 
         group.MapGet("/", async (
-            [FromQuery] int skip,
-            [FromQuery] int take,
+            [FromQuery] int? skip,
+            [FromQuery] int? take,
             [FromQuery] string? strategy,
             [FromQuery] string? status,
             [FromQuery] int? minLatencyMs,
@@ -31,8 +31,8 @@ internal static class AdminRagExecutionEndpoints
             CancellationToken ct) =>
         {
             var query = new GetRagExecutionsQuery(
-                Skip: Math.Max(0, skip),
-                Take: Math.Clamp(take, 1, 100),
+                Skip: Math.Max(0, skip ?? 0),
+                Take: Math.Clamp(take ?? 10, 1, 100),
                 Strategy: strategy,
                 Status: status,
                 MinLatencyMs: minLatencyMs,

--- a/apps/web/src/lib/api/clients/admin/adminAiClient.ts
+++ b/apps/web/src/lib/api/clients/admin/adminAiClient.ts
@@ -780,8 +780,8 @@ export function createAdminAiClient(http: HttpClient) {
       dateTo?: string;
     }): Promise<RagExecutionListResult> {
       const searchParams = new URLSearchParams();
-      if (params?.skip) searchParams.set('skip', params.skip.toString());
-      if (params?.take) searchParams.set('take', params.take.toString());
+      searchParams.set('skip', (params?.skip ?? 0).toString());
+      searchParams.set('take', (params?.take ?? 10).toString());
       if (params?.strategy) searchParams.set('strategy', params.strategy);
       if (params?.status) searchParams.set('status', params.status);
       if (params?.minLatencyMs) searchParams.set('minLatencyMs', params.minLatencyMs.toString());


### PR DESCRIPTION
## Summary
- Fix 3 API errors causing 21 console errors on `/admin/agents` Mission Control page
- `GET /admin/rag-executions` returned 400 because `skip` parameter was required but frontend didn't send it
- `GET /admin/agents/metrics` returned 400 due to Npgsql `DateTimeKind.Unspecified` → `timestamptz` conversion failure
- Frontend `getRagExecutions()` had falsy check on `skip=0` that prevented sending the parameter

## Changes
| File | Fix |
|------|-----|
| `AdminRagExecutionEndpoints.cs` | `int skip` → `int? skip` with default 0 |
| `GetAgentMetricsQueryHandler.cs` | Added `DateTimeKind.Utc` to `ToDateTime()` |
| `adminAiClient.ts` | Always send `skip`/`take` with defaults |

## Test plan
- [x] Verified both endpoints return 200 via curl with session cookie
- [x] Verified via Playwright: console errors dropped from 21 → 0 (API)
- [x] Remaining 19 errors are axe-core accessibility warnings → #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)