### PR TITLE
fix(admin): use !== undefined guards for numeric query params

### DIFF
--- a/apps/web/src/lib/api/clients/admin/adminAiClient.ts
+++ b/apps/web/src/lib/api/clients/admin/adminAiClient.ts
@@ -780,13 +780,13 @@ export function createAdminAiClient(http: HttpClient) {
       dateTo?: string;
     }): Promise<RagExecutionListResult> {
       const searchParams = new URLSearchParams();
-      searchParams.set('skip', (params?.skip ?? 0).toString());
-      searchParams.set('take', (params?.take ?? 10).toString());
+      if (params?.skip !== undefined) searchParams.set('skip', params.skip.toString());
+      if (params?.take !== undefined) searchParams.set('take', params.take.toString());
       if (params?.strategy) searchParams.set('strategy', params.strategy);
       if (params?.status) searchParams.set('status', params.status);
-      if (params?.minLatencyMs) searchParams.set('minLatencyMs', params.minLatencyMs.toString());
-      if (params?.maxLatencyMs) searchParams.set('maxLatencyMs', params.maxLatencyMs.toString());
-      if (params?.minConfidence) searchParams.set('minConfidence', params.minConfidence.toString());
+      if (params?.minLatencyMs !== undefined) searchParams.set('minLatencyMs', params.minLatencyMs.toString());
+      if (params?.maxLatencyMs !== undefined) searchParams.set('maxLatencyMs', params.maxLatencyMs.toString());
+      if (params?.minConfidence !== undefined) searchParams.set('minConfidence', params.minConfidence.toString());
       if (params?.dateFrom) searchParams.set('dateFrom', params.dateFrom);
       if (params?.dateTo) searchParams.set('dateTo', params.dateTo);
       const qs = searchParams.toString();


### PR DESCRIPTION
## Summary
- Follow-up to #255 — addresses code review observations
- Use `!== undefined` guards instead of falsy checks for numeric query params
- Fixes latent bug: `minConfidence: 0` and `minLatencyMs: 0` were silently dropped
- Aligns `skip`/`take` handling with pattern used by other paginated clients

## Test plan
- [x] Backend already accepts nullable params (from #255)
- [x] `!== undefined` correctly sends `0` values while omitting `undefined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)