### PR TITLE
fix(smoldocling): fix Docker build and startup issues

### DIFF
--- a/apps/smoldocling-service/Dockerfile
+++ b/apps/smoldocling-service/Dockerfile
@@ -60,6 +60,10 @@ RUN groupadd -r smoldocling && useradd -r -g smoldocling -m -d /home/smoldocling
 
 # Copy the pre-built virtual environment from builder
 COPY --from=builder /opt/venv /opt/venv
+# Fix venv shebang: builder uses /opt/venv/bin/python but runtime has python3.11 elsewhere
+RUN ln -sf /usr/bin/python3.11 /opt/venv/bin/python && \
+    ln -sf /usr/bin/python3.11 /opt/venv/bin/python3 && \
+    ln -sf /usr/bin/python3.11 /opt/venv/bin/python3.11
 ENV PATH="/opt/venv/bin:$PATH"
 
 # Copy pre-downloaded model weights from builder and set ownership

--- a/apps/smoldocling-service/requirements.txt
+++ b/apps/smoldocling-service/requirements.txt
@@ -1,6 +1,6 @@
 # Core VLM inference
 torch>=2.0.0
-transformers>=4.40.0
+transformers>=4.45.0,<5.0
 pillow>=10.0.0
 pdf2image>=1.16.0
 

--- a/apps/smoldocling-service/src/config/settings.py
+++ b/apps/smoldocling-service/src/config/settings.py
@@ -15,7 +15,9 @@ class Settings(BaseSettings):
     max_pages_per_request: int = 20  # Prevent excessive GPU/CPU usage
     timeout: int = 60  # seconds (longer than Unstructured due to VLM inference)
     temp_dir: Path = Path("/tmp/pdf-processing")
-    model_cache_dir: Path = Path("/root/.cache/huggingface")
+    model_cache_dir: Path = Path(
+        __import__("os").environ.get("HF_HOME", "/home/smoldocling/.cache/huggingface")
+    )
 
     # SmolDocling VLM Configuration
     device: Literal["cuda", "cpu", "auto"] = "auto"  # auto = use CUDA if available

--- a/infra/compose.dev.yml
+++ b/infra/compose.dev.yml
@@ -86,6 +86,8 @@ services:
 
   smoldocling-service:
     ports: ["127.0.0.1:8002:8002"]
+    environment:
+      ENABLE_MODEL_WARMUP: "false"
 
   reranker-service:
     ports: ["127.0.0.1:8003:8003"]


### PR DESCRIPTION
## Summary

- Pin `transformers<5.0` — v5.x breaks SmolDocling `Idefics3ImageProcessor` loading
- Fix venv Python symlink — builder uses Python 3.11 but NVIDIA runtime image needs explicit symlink
- Fix `model_cache_dir` to use `HF_HOME` env var instead of hardcoded `/root/.cache`
- Disable warmup in dev — CPU VLM inference too slow for container startup

## Test plan

- [x] Docker build succeeds (was failing on model download)
- [x] Container starts and responds to `/health`
- [x] Model loads on first request (lazy loading)

🤖 Generated with [Claude Code](https://claude.com/claude-code)