### PR TITLE
feat: default game toolkit drawer (dice, notes, diary, scoreboard)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/ToolkitMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/ToolkitMapper.cs
@@ -36,6 +36,9 @@ internal static class ToolkitMapper
             CounterTools: toolkit.CounterTools.Select(c => new CounterToolDto(
                 c.Name, c.MinValue, c.MaxValue, c.DefaultValue, c.IsPerPlayer, c.Icon, c.Color
             )).ToList(),
+            UserDicePresets: toolkit.UserDicePresets.Select(p => new UserDicePresetDto(
+                p.UserId, p.Name, p.Formula, p.CreatedAt
+            )).ToList(),
             ScoringTemplate: toolkit.ScoringTemplate != null
                 ? new ScoringTemplateDto(
                     toolkit.ScoringTemplate.Dimensions,

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/UserDicePresetCommandHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/UserDicePresetCommandHandlers.cs
@@ -1,0 +1,62 @@
+using Api.BoundedContexts.GameToolkit.Application.DTOs;
+using Api.BoundedContexts.GameToolkit.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Commands;
+
+internal class AddUserDicePresetCommandHandler : ICommandHandler<AddUserDicePresetCommand, GameToolkitDto>
+{
+    private readonly IGameToolkitRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public AddUserDicePresetCommandHandler(IGameToolkitRepository repository, IUnitOfWork unitOfWork)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task<GameToolkitDto> Handle(AddUserDicePresetCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var toolkit = await _repository.GetByIdAsync(command.ToolkitId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameToolkit", command.ToolkitId.ToString());
+
+        toolkit.AddUserDicePreset(command.UserId, command.Name, command.Formula);
+
+        await _repository.UpdateAsync(toolkit, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return ToolkitMapper.ToDto(toolkit);
+    }
+}
+
+internal class RemoveUserDicePresetCommandHandler : ICommandHandler<RemoveUserDicePresetCommand, GameToolkitDto>
+{
+    private readonly IGameToolkitRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public RemoveUserDicePresetCommandHandler(IGameToolkitRepository repository, IUnitOfWork unitOfWork)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task<GameToolkitDto> Handle(RemoveUserDicePresetCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var toolkit = await _repository.GetByIdAsync(command.ToolkitId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameToolkit", command.ToolkitId.ToString());
+
+        if (!toolkit.RemoveUserDicePreset(command.UserId, command.PresetName))
+            throw new NotFoundException("UserDicePreset", command.PresetName);
+
+        await _repository.UpdateAsync(toolkit, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return ToolkitMapper.ToDto(toolkit);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/UserDicePresetCommands.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/UserDicePresetCommands.cs
@@ -1,0 +1,18 @@
+#pragma warning disable MA0048 // File name must match type name - Contains related commands
+using Api.BoundedContexts.GameToolkit.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Commands;
+
+internal record AddUserDicePresetCommand(
+    Guid ToolkitId,
+    Guid UserId,
+    string Name,
+    string Formula
+) : ICommand<GameToolkitDto>;
+
+internal record RemoveUserDicePresetCommand(
+    Guid ToolkitId,
+    Guid UserId,
+    string PresetName
+) : ICommand<GameToolkitDto>;

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/DTOs/ToolkitDtos.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/DTOs/ToolkitDtos.cs
@@ -20,6 +20,7 @@ internal record GameToolkitDto(
     IReadOnlyList<CardToolDto> CardTools,
     IReadOnlyList<TimerToolDto> TimerTools,
     IReadOnlyList<CounterToolDto> CounterTools,
+    IReadOnlyList<UserDicePresetDto> UserDicePresets,
     ScoringTemplateDto? ScoringTemplate,
     TurnTemplateDto? TurnTemplate,
     StateTemplateDto? StateTemplate,
@@ -97,6 +98,18 @@ internal record StateTemplateDto(
     string? Description,
     TemplateCategory Category,
     string SchemaJson
+);
+
+internal record UserDicePresetDto(
+    Guid UserId,
+    string Name,
+    string Formula,
+    DateTime CreatedAt
+);
+
+internal record AddUserDicePresetRequest(
+    string Name,
+    string Formula
 );
 
 // Request DTOs

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetUserDicePresetsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetUserDicePresetsQuery.cs
@@ -1,0 +1,34 @@
+using Api.BoundedContexts.GameToolkit.Application.Commands;
+using Api.BoundedContexts.GameToolkit.Application.DTOs;
+using Api.BoundedContexts.GameToolkit.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries;
+
+internal record GetUserDicePresetsQuery(
+    Guid ToolkitId,
+    Guid UserId
+) : IQuery<IReadOnlyList<UserDicePresetDto>>;
+
+internal class GetUserDicePresetsQueryHandler : IQueryHandler<GetUserDicePresetsQuery, IReadOnlyList<UserDicePresetDto>>
+{
+    private readonly IGameToolkitRepository _repository;
+
+    public GetUserDicePresetsQueryHandler(IGameToolkitRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public async Task<IReadOnlyList<UserDicePresetDto>> Handle(GetUserDicePresetsQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var toolkit = await _repository.GetByIdAsync(query.ToolkitId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameToolkit", query.ToolkitId.ToString());
+
+        var presets = toolkit.GetUserDicePresets(query.UserId);
+
+        return presets.Select(p => new UserDicePresetDto(p.UserId, p.Name, p.Formula, p.CreatedAt)).ToList();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Entities/GameToolkit.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Entities/GameToolkit.cs
@@ -15,6 +15,7 @@ internal sealed class GameToolkit : AggregateRoot<Guid>
     private readonly List<CardToolConfig> _cardTools = new();
     private readonly List<TimerToolConfig> _timerTools = new();
     private readonly List<CounterToolConfig> _counterTools = new();
+    private readonly List<UserDicePreset> _userDicePresets = new();
 
     public Guid? GameId { get; private set; }
     public Guid? PrivateGameId { get; private set; }
@@ -35,6 +36,7 @@ internal sealed class GameToolkit : AggregateRoot<Guid>
     public IReadOnlyList<CardToolConfig> CardTools => _cardTools.AsReadOnly();
     public IReadOnlyList<TimerToolConfig> TimerTools => _timerTools.AsReadOnly();
     public IReadOnlyList<CounterToolConfig> CounterTools => _counterTools.AsReadOnly();
+    public IReadOnlyList<UserDicePreset> UserDicePresets => _userDicePresets.AsReadOnly();
 
     // Template configurations
     public ScoringTemplateConfig? ScoringTemplate { get; private set; }
@@ -234,6 +236,45 @@ internal sealed class GameToolkit : AggregateRoot<Guid>
         _counterTools.Remove(tool);
         UpdatedAt = DateTime.UtcNow;
         return true;
+    }
+
+    // ========================================================================
+    // User dice presets
+    // ========================================================================
+
+    public void AddUserDicePreset(Guid userId, string name, string formula)
+    {
+        if (userId == Guid.Empty)
+            throw new ArgumentException("UserId cannot be empty", nameof(userId));
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Preset name cannot be empty", nameof(name));
+        if (name.Length > 50)
+            throw new ArgumentException("Preset name cannot exceed 50 characters", nameof(name));
+        if (string.IsNullOrWhiteSpace(formula))
+            throw new ArgumentException("Formula cannot be empty", nameof(formula));
+        if (formula.Length > 100)
+            throw new ArgumentException("Formula cannot exceed 100 characters", nameof(formula));
+        if (_userDicePresets.Count >= 20)
+            throw new InvalidOperationException("Cannot add more than 20 user dice presets");
+
+        _userDicePresets.Add(new UserDicePreset(userId, name.Trim(), formula.Trim(), DateTime.UtcNow));
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    public bool RemoveUserDicePreset(Guid userId, string name)
+    {
+        var preset = _userDicePresets.Find(p =>
+            p.UserId == userId && string.Equals(p.Name, name, StringComparison.Ordinal));
+        if (preset == null) return false;
+
+        _userDicePresets.Remove(preset);
+        UpdatedAt = DateTime.UtcNow;
+        return true;
+    }
+
+    public IReadOnlyList<UserDicePreset> GetUserDicePresets(Guid userId)
+    {
+        return _userDicePresets.Where(p => p.UserId == userId).ToList().AsReadOnly();
     }
 
     // ========================================================================
@@ -494,6 +535,38 @@ internal sealed class CounterToolConfig
         IsPerPlayer = isPerPlayer;
         Icon = icon;
         Color = color;
+    }
+}
+
+// ============================================================================
+// User Dice Preset Value Object
+// ============================================================================
+
+/// <summary>User-specific dice preset (e.g. "Attack Roll" → "2d6+3").</summary>
+internal sealed class UserDicePreset
+{
+    public Guid UserId { get; }
+    public string Name { get; }
+    public string Formula { get; }
+    public DateTime CreatedAt { get; }
+
+    public UserDicePreset(Guid userId, string name, string formula, DateTime createdAt)
+    {
+        if (userId == Guid.Empty)
+            throw new ArgumentException("UserId cannot be empty", nameof(userId));
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Preset name cannot be empty", nameof(name));
+        if (name.Length > 50)
+            throw new ArgumentException("Preset name cannot exceed 50 characters", nameof(name));
+        if (string.IsNullOrWhiteSpace(formula))
+            throw new ArgumentException("Formula cannot be empty", nameof(formula));
+        if (formula.Length > 100)
+            throw new ArgumentException("Formula cannot exceed 100 characters", nameof(formula));
+
+        UserId = userId;
+        Name = name.Trim();
+        Formula = formula.Trim();
+        CreatedAt = createdAt;
     }
 }
 

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Infrastructure/Persistence/GameToolkitRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Infrastructure/Persistence/GameToolkitRepository.cs
@@ -192,6 +192,7 @@ internal class GameToolkitRepository : RepositoryBase, IGameToolkitRepository
         SetPrivateField(toolkit, "_cardTools", new List<CardToolConfig>());
         SetPrivateField(toolkit, "_timerTools", new List<TimerToolConfig>());
         SetPrivateField(toolkit, "_counterTools", new List<CounterToolConfig>());
+        SetPrivateField(toolkit, "_userDicePresets", new List<UserDicePreset>());
 
         // Deserialize JSONB tool configs directly into backing lists
         if (!string.IsNullOrEmpty(entity.DiceToolsJson))
@@ -243,6 +244,17 @@ internal class GameToolkitRepository : RepositoryBase, IGameToolkitRepository
                 var counterList = GetPrivateField<List<CounterToolConfig>>(toolkit, "_counterTools");
                 foreach (var c in counterConfigs)
                     counterList.Add(new CounterToolConfig(c.Name, c.MinValue, c.MaxValue, c.DefaultValue, c.IsPerPlayer, c.Icon, c.Color));
+            }
+        }
+
+        if (!string.IsNullOrEmpty(entity.UserDicePresetsJson))
+        {
+            var presetConfigs = JsonSerializer.Deserialize<List<UserDicePresetJsonModel>>(entity.UserDicePresetsJson, JsonOptions);
+            if (presetConfigs != null)
+            {
+                var presetList = GetPrivateField<List<UserDicePreset>>(toolkit, "_userDicePresets");
+                foreach (var p in presetConfigs)
+                    presetList.Add(new UserDicePreset(p.UserId, p.Name, p.Formula, p.CreatedAt));
             }
         }
 
@@ -348,6 +360,15 @@ internal class GameToolkitRepository : RepositoryBase, IGameToolkitRepository
                     IsPerPlayer = c.IsPerPlayer,
                     Icon = c.Icon,
                     Color = c.Color
+                }).ToList(), JsonOptions)
+                : null,
+            UserDicePresetsJson = toolkit.UserDicePresets.Count > 0
+                ? JsonSerializer.Serialize(toolkit.UserDicePresets.Select(p => new UserDicePresetJsonModel
+                {
+                    UserId = p.UserId,
+                    Name = p.Name,
+                    Formula = p.Formula,
+                    CreatedAt = p.CreatedAt
                 }).ToList(), JsonOptions)
                 : null,
             ScoringTemplateJson = toolkit.ScoringTemplate != null
@@ -469,6 +490,14 @@ internal class GameToolkitRepository : RepositoryBase, IGameToolkitRepository
         public bool IsPerPlayer { get; set; }
         public string? Icon { get; set; }
         public string? Color { get; set; }
+    }
+
+    private sealed class UserDicePresetJsonModel
+    {
+        public Guid UserId { get; set; }
+        public string Name { get; set; } = default!;
+        public string Formula { get; set; } = default!;
+        public DateTime CreatedAt { get; set; }
     }
 
     private sealed class ScoringTemplateJsonModel

--- a/apps/api/src/Api/Infrastructure/Entities/GameToolkit/GameToolkitEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameToolkit/GameToolkitEntity.cs
@@ -26,6 +26,7 @@ public class GameToolkitEntity
     public string? CardToolsJson { get; set; }
     public string? TimerToolsJson { get; set; }
     public string? CounterToolsJson { get; set; }
+    public string? UserDicePresetsJson { get; set; }
 
     // JSONB columns for templates
     public string? ScoringTemplateJson { get; set; }

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/GameToolkit/GameToolkitEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/GameToolkit/GameToolkitEntityConfiguration.cs
@@ -38,6 +38,7 @@ internal class GameToolkitEntityConfiguration : IEntityTypeConfiguration<GameToo
         builder.Property(e => e.CardToolsJson).HasColumnType("jsonb");
         builder.Property(e => e.TimerToolsJson).HasColumnType("jsonb");
         builder.Property(e => e.CounterToolsJson).HasColumnType("jsonb");
+        builder.Property(e => e.UserDicePresetsJson).HasColumnType("jsonb");
 
         // JSONB columns for templates
         builder.Property(e => e.ScoringTemplateJson).HasColumnType("jsonb");

--- a/apps/api/src/Api/Infrastructure/Migrations/20260408055234_AddUserDicePresetsJsonColumn.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260408055234_AddUserDicePresetsJsonColumn.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260408055234_AddUserDicePresetsJsonColumn")]
+    partial class AddUserDicePresetsJsonColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -3989,68 +3992,6 @@ namespace Api.Infrastructure.Migrations
                         .HasDatabaseName("IX_game_night_rsvps_event_user");
 
                     b.ToTable("game_night_rsvps", (string)null);
-                });
-
-            modelBuilder.Entity("Api.Infrastructure.Entities.GameManagement.GameNightSessionEntity", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid")
-                        .HasColumnName("id");
-
-                    b.Property<DateTimeOffset?>("CompletedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("completed_at");
-
-                    b.Property<Guid>("GameId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("game_id");
-
-                    b.Property<Guid>("GameNightEventId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("game_night_event_id");
-
-                    b.Property<string>("GameTitle")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)")
-                        .HasColumnName("game_title");
-
-                    b.Property<int>("PlayOrder")
-                        .HasColumnType("integer")
-                        .HasColumnName("play_order");
-
-                    b.Property<Guid>("SessionId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("session_id");
-
-                    b.Property<DateTimeOffset?>("StartedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("started_at");
-
-                    b.Property<string>("Status")
-                        .IsRequired()
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)")
-                        .HasColumnName("status");
-
-                    b.Property<Guid?>("WinnerId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("winner_id");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("GameId")
-                        .HasDatabaseName("IX_game_night_sessions_game_id");
-
-                    b.HasIndex("SessionId")
-                        .HasDatabaseName("IX_game_night_sessions_session_id");
-
-                    b.HasIndex("GameNightEventId", "PlayOrder")
-                        .IsUnique()
-                        .HasDatabaseName("IX_game_night_sessions_event_play_order");
-
-                    b.ToTable("game_night_sessions", (string)null);
                 });
 
             modelBuilder.Entity("Api.Infrastructure.Entities.GameManagement.GamePhaseTemplateEntity", b =>
@@ -8614,10 +8555,6 @@ namespace Api.Infrastructure.Migrations
                         .HasMaxLength(50)
                         .HasColumnType("character varying(50)");
 
-                    b.Property<Guid?>("GameNightId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("game_night_id");
-
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("boolean");
 
@@ -8637,8 +8574,6 @@ namespace Api.Infrastructure.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("CreatedBy");
-
-                    b.HasIndex("GameNightId");
 
                     b.HasIndex("SessionId", "EventType");
 
@@ -13068,17 +13003,6 @@ namespace Api.Infrastructure.Migrations
                     b.Navigation("Event");
                 });
 
-            modelBuilder.Entity("Api.Infrastructure.Entities.GameManagement.GameNightSessionEntity", b =>
-                {
-                    b.HasOne("Api.Infrastructure.Entities.GameManagement.GameNightEventEntity", "GameNightEvent")
-                        .WithMany("Sessions")
-                        .HasForeignKey("GameNightEventId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("GameNightEvent");
-                });
-
             modelBuilder.Entity("Api.Infrastructure.Entities.GameManagement.GamePhaseTemplateEntity", b =>
                 {
                     b.HasOne("Api.Infrastructure.Entities.GameEntity", "Game")
@@ -14472,8 +14396,6 @@ namespace Api.Infrastructure.Migrations
             modelBuilder.Entity("Api.Infrastructure.Entities.GameManagement.GameNightEventEntity", b =>
                 {
                     b.Navigation("Rsvps");
-
-                    b.Navigation("Sessions");
                 });
 
             modelBuilder.Entity("Api.Infrastructure.Entities.GameManagement.GameSessionStateEntity", b =>

--- a/apps/api/src/Api/Infrastructure/Migrations/20260408055234_AddUserDicePresetsJsonColumn.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260408055234_AddUserDicePresetsJsonColumn.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserDicePresetsJsonColumn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "UserDicePresetsJson",
+                table: "GameToolkits",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UserDicePresetsJson",
+                table: "GameToolkits");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/GameToolkitRoutes.cs
+++ b/apps/api/src/Api/Routing/GameToolkitRoutes.cs
@@ -194,6 +194,45 @@ internal static class GameToolkitRoutes
         .WithSummary("Remove a counter tool from the toolkit")
         .Produces<GameToolkitDto>(200);
 
+        // ---- User Dice Presets ----
+
+        toolkits.MapPost("/{id:guid}/user-dice-presets", async (Guid id, AddUserDicePresetRequest request, HttpContext ctx, IMediator m) =>
+        {
+            var userId = ctx.User.GetUserId();
+            if (userId == Guid.Empty)
+                return Results.Unauthorized();
+            var command = new AddUserDicePresetCommand(id, userId, request.Name, request.Formula);
+            var result = await m.Send(command).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .WithName("AddUserDicePreset")
+        .WithSummary("Add a user dice preset to the toolkit")
+        .Produces<GameToolkitDto>(200);
+
+        toolkits.MapGet("/{id:guid}/user-dice-presets", async (Guid id, HttpContext ctx, IMediator m) =>
+        {
+            var userId = ctx.User.GetUserId();
+            if (userId == Guid.Empty)
+                return Results.Unauthorized();
+            var result = await m.Send(new GetUserDicePresetsQuery(id, userId)).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .WithName("GetUserDicePresets")
+        .WithSummary("Get user dice presets for the current user")
+        .Produces<IReadOnlyList<UserDicePresetDto>>(200);
+
+        toolkits.MapDelete("/{id:guid}/user-dice-presets/{name}", async (Guid id, string name, HttpContext ctx, IMediator m) =>
+        {
+            var userId = ctx.User.GetUserId();
+            if (userId == Guid.Empty)
+                return Results.Unauthorized();
+            var result = await m.Send(new RemoveUserDicePresetCommand(id, userId, name)).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .WithName("RemoveUserDicePreset")
+        .WithSummary("Remove a user dice preset from the toolkit")
+        .Produces<GameToolkitDto>(200);
+
         // ---- Templates ----
 
         toolkits.MapPut("/{id:guid}/scoring-template", async (Guid id, SetScoringTemplateRequest request, IMediator m) =>

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Domain/UserDicePresetTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Domain/UserDicePresetTests.cs
@@ -1,0 +1,184 @@
+using Api.BoundedContexts.GameToolkit.Domain.Entities;
+using Api.Tests.Constants;
+using Xunit;
+using FluentAssertions;
+
+namespace Api.Tests.BoundedContexts.GameToolkit.Domain;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameToolkit")]
+public class UserDicePresetTests
+{
+    private static readonly Guid GameId = Guid.NewGuid();
+    private static readonly Guid UserId = Guid.NewGuid();
+
+    private static Api.BoundedContexts.GameToolkit.Domain.Entities.GameToolkit CreateToolkit()
+    {
+        return new Api.BoundedContexts.GameToolkit.Domain.Entities.GameToolkit(
+            Guid.NewGuid(), GameId, "Test Toolkit", UserId);
+    }
+
+    // ========================================================================
+    // AddUserDicePreset
+    // ========================================================================
+
+    [Fact]
+    public void AddUserDicePreset_WithValidParams_AddsPreset()
+    {
+        var toolkit = CreateToolkit();
+        var presetUserId = Guid.NewGuid();
+
+        toolkit.AddUserDicePreset(presetUserId, "Attack Roll", "2d6+3");
+
+        toolkit.UserDicePresets.Should().HaveCount(1);
+        var preset = toolkit.UserDicePresets[0];
+        preset.UserId.Should().Be(presetUserId);
+        preset.Name.Should().Be("Attack Roll");
+        preset.Formula.Should().Be("2d6+3");
+        preset.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public void AddUserDicePreset_Over20Limit_ThrowsInvalidOperationException()
+    {
+        var toolkit = CreateToolkit();
+        var presetUserId = Guid.NewGuid();
+
+        for (int i = 0; i < 20; i++)
+            toolkit.AddUserDicePreset(presetUserId, $"Preset {i}", $"{i + 1}d6");
+
+        var act = () => toolkit.AddUserDicePreset(presetUserId, "Preset 20", "1d20");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*20*");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AddUserDicePreset_WithEmptyName_ThrowsArgumentException(string name)
+    {
+        var toolkit = CreateToolkit();
+
+        var act = () => toolkit.AddUserDicePreset(Guid.NewGuid(), name, "2d6");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AddUserDicePreset_WithEmptyFormula_ThrowsArgumentException(string formula)
+    {
+        var toolkit = CreateToolkit();
+
+        var act = () => toolkit.AddUserDicePreset(Guid.NewGuid(), "Test", formula);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void AddUserDicePreset_WithEmptyUserId_ThrowsArgumentException()
+    {
+        var toolkit = CreateToolkit();
+
+        var act = () => toolkit.AddUserDicePreset(Guid.Empty, "Test", "2d6");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    // ========================================================================
+    // RemoveUserDicePreset
+    // ========================================================================
+
+    [Fact]
+    public void RemoveUserDicePreset_ExistingPreset_ReturnsTrue()
+    {
+        var toolkit = CreateToolkit();
+        var presetUserId = Guid.NewGuid();
+        toolkit.AddUserDicePreset(presetUserId, "Attack Roll", "2d6+3");
+
+        var result = toolkit.RemoveUserDicePreset(presetUserId, "Attack Roll");
+
+        result.Should().BeTrue();
+        toolkit.UserDicePresets.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RemoveUserDicePreset_WrongUser_ReturnsFalse()
+    {
+        var toolkit = CreateToolkit();
+        var presetUserId = Guid.NewGuid();
+        var otherUserId = Guid.NewGuid();
+        toolkit.AddUserDicePreset(presetUserId, "Attack Roll", "2d6+3");
+
+        var result = toolkit.RemoveUserDicePreset(otherUserId, "Attack Roll");
+
+        result.Should().BeFalse();
+        toolkit.UserDicePresets.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void RemoveUserDicePreset_NonExistentName_ReturnsFalse()
+    {
+        var toolkit = CreateToolkit();
+        var presetUserId = Guid.NewGuid();
+        toolkit.AddUserDicePreset(presetUserId, "Attack Roll", "2d6+3");
+
+        var result = toolkit.RemoveUserDicePreset(presetUserId, "NonExistent");
+
+        result.Should().BeFalse();
+        toolkit.UserDicePresets.Should().HaveCount(1);
+    }
+
+    // ========================================================================
+    // GetUserDicePresets
+    // ========================================================================
+
+    [Fact]
+    public void GetUserDicePresets_ReturnsOnlyPresetsForSpecificUser()
+    {
+        var toolkit = CreateToolkit();
+        var user1 = Guid.NewGuid();
+        var user2 = Guid.NewGuid();
+        toolkit.AddUserDicePreset(user1, "Attack Roll", "2d6+3");
+        toolkit.AddUserDicePreset(user2, "Damage Roll", "1d8+5");
+        toolkit.AddUserDicePreset(user1, "Save Roll", "1d20+2");
+
+        var user1Presets = toolkit.GetUserDicePresets(user1);
+
+        user1Presets.Should().HaveCount(2);
+        user1Presets.Should().OnlyContain(p => p.UserId == user1);
+    }
+
+    // ========================================================================
+    // UserDicePreset Value Object
+    // ========================================================================
+
+    [Fact]
+    public void UserDicePreset_TrimsNameAndFormula()
+    {
+        var preset = new UserDicePreset(Guid.NewGuid(), "  Attack Roll  ", "  2d6+3  ", DateTime.UtcNow);
+
+        preset.Name.Should().Be("Attack Roll");
+        preset.Formula.Should().Be("2d6+3");
+    }
+
+    [Fact]
+    public void UserDicePreset_NameExceeds50Chars_ThrowsArgumentException()
+    {
+        var act = () => new UserDicePreset(Guid.NewGuid(), new string('A', 51), "2d6", DateTime.UtcNow);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*50*");
+    }
+
+    [Fact]
+    public void UserDicePreset_FormulaExceeds100Chars_ThrowsArgumentException()
+    {
+        var act = () => new UserDicePreset(Guid.NewGuid(), "Test", new string('A', 101), DateTime.UtcNow);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*100*");
+    }
+}

--- a/apps/web/src/__tests__/stores/toolkit-local-store.test.ts
+++ b/apps/web/src/__tests__/stores/toolkit-local-store.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { createToolkitLocalStore } from '@/stores/toolkit-local-store';
+
+import type { DiaryEvent, LocalNote, LocalPlayer } from '@/components/toolkit-drawer/types';
+
+describe('ToolkitLocalStore', () => {
+  let store: ReturnType<typeof createToolkitLocalStore>;
+
+  const makePlayer = (id: string, name: string, color = '#E67E22'): LocalPlayer => ({
+    id,
+    name,
+    color,
+  });
+
+  beforeEach(() => {
+    store = createToolkitLocalStore('test-game-id');
+    store.getState().resetAll();
+  });
+
+  describe('Players', () => {
+    it('adds a player and initializes empty scores', () => {
+      store.getState().addPlayer(makePlayer('p1', 'Marco'));
+      const state = store.getState();
+      expect(state.players).toHaveLength(1);
+      expect(state.players[0].name).toBe('Marco');
+      expect(state.scores['p1']).toEqual({});
+    });
+
+    it('removes a player and cleans up their scores', () => {
+      store.getState().addPlayer(makePlayer('p1', 'Marco'));
+      store.getState().addPlayer(makePlayer('p2', 'Luca'));
+      store.getState().setScore('p1', 'PV', 10);
+
+      store.getState().removePlayer('p1');
+
+      const state = store.getState();
+      expect(state.players).toHaveLength(1);
+      expect(state.players[0].id).toBe('p2');
+      expect(state.scores['p1']).toBeUndefined();
+    });
+
+    it('advances turn cyclically', () => {
+      store.getState().addPlayer(makePlayer('p1', 'Marco'));
+      store.getState().addPlayer(makePlayer('p2', 'Luca'));
+
+      expect(store.getState().currentTurnIndex).toBe(0);
+      store.getState().advanceTurn();
+      expect(store.getState().currentTurnIndex).toBe(1);
+      store.getState().advanceTurn();
+      expect(store.getState().currentTurnIndex).toBe(0);
+    });
+
+    it('advanceRound increments round and resets turn', () => {
+      store.getState().addPlayer(makePlayer('p1', 'Marco'));
+      store.getState().addPlayer(makePlayer('p2', 'Luca'));
+      store.getState().advanceTurn();
+
+      store.getState().advanceRound();
+      expect(store.getState().currentRound).toBe(2);
+      expect(store.getState().currentTurnIndex).toBe(0);
+    });
+
+    it('reorderPlayers applies new order', () => {
+      store.getState().addPlayer(makePlayer('p1', 'Marco'));
+      store.getState().addPlayer(makePlayer('p2', 'Luca'));
+      store.getState().addPlayer(makePlayer('p3', 'Anna'));
+
+      store.getState().reorderPlayers(['p3', 'p1', 'p2']);
+
+      const names = store.getState().players.map(p => p.name);
+      expect(names).toEqual(['Anna', 'Marco', 'Luca']);
+    });
+  });
+
+  describe('Scores', () => {
+    beforeEach(() => {
+      store.getState().addPlayer(makePlayer('p1', 'Marco'));
+    });
+
+    it('setScore creates nested category entry', () => {
+      store.getState().addScoreCategory('PV');
+      store.getState().setScore('p1', 'PV', 12);
+
+      expect(store.getState().scores['p1']['PV']).toBe(12);
+    });
+
+    it('addScoreCategory is idempotent', () => {
+      store.getState().addScoreCategory('PV');
+      store.getState().addScoreCategory('PV');
+      expect(store.getState().scoreCategories).toEqual(['PV']);
+    });
+
+    it('removeScoreCategory removes from categories and all players', () => {
+      store.getState().addScoreCategory('PV');
+      store.getState().setScore('p1', 'PV', 10);
+
+      store.getState().removeScoreCategory('PV');
+
+      expect(store.getState().scoreCategories).toEqual([]);
+      expect(store.getState().scores['p1']['PV']).toBeUndefined();
+    });
+
+    it('resetScores empties all player score maps', () => {
+      store.getState().addScoreCategory('PV');
+      store.getState().setScore('p1', 'PV', 10);
+
+      store.getState().resetScores();
+
+      expect(store.getState().scores['p1']).toEqual({});
+    });
+  });
+
+  describe('Notes', () => {
+    const makeNote = (
+      id: string,
+      content: string,
+      type: 'shared' | 'private' = 'shared'
+    ): LocalNote => ({
+      id,
+      content,
+      type,
+      pinned: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    it('addNote appends to notes array', () => {
+      store.getState().addNote(makeNote('n1', 'Hello'));
+      expect(store.getState().notes).toHaveLength(1);
+      expect(store.getState().notes[0].content).toBe('Hello');
+    });
+
+    it('updateNote changes content and updatedAt', () => {
+      store.getState().addNote(makeNote('n1', 'Old'));
+      const originalUpdatedAt = store.getState().notes[0].updatedAt;
+
+      // Wait a tick to ensure timestamp differs
+      store.getState().updateNote('n1', 'New');
+
+      const updated = store.getState().notes[0];
+      expect(updated.content).toBe('New');
+      expect(updated.updatedAt).toBeGreaterThanOrEqual(originalUpdatedAt);
+    });
+
+    it('deleteNote removes by id', () => {
+      store.getState().addNote(makeNote('n1', 'First'));
+      store.getState().addNote(makeNote('n2', 'Second'));
+
+      store.getState().deleteNote('n1');
+
+      expect(store.getState().notes).toHaveLength(1);
+      expect(store.getState().notes[0].id).toBe('n2');
+    });
+
+    it('togglePin flips pinned state', () => {
+      store.getState().addNote(makeNote('n1', 'Test'));
+      expect(store.getState().notes[0].pinned).toBe(false);
+
+      store.getState().togglePin('n1');
+      expect(store.getState().notes[0].pinned).toBe(true);
+
+      store.getState().togglePin('n1');
+      expect(store.getState().notes[0].pinned).toBe(false);
+    });
+  });
+
+  describe('Diary', () => {
+    const makeEvent = (id: string, type: DiaryEvent['type'] = 'manual_entry'): DiaryEvent => ({
+      id,
+      type,
+      timestamp: Date.now(),
+      payload: {},
+    });
+
+    it('logEvent appends to diary', () => {
+      store.getState().logEvent(makeEvent('e1', 'dice_roll'));
+      store.getState().logEvent(makeEvent('e2', 'score_change'));
+
+      const diary = store.getState().diary;
+      expect(diary).toHaveLength(2);
+      expect(diary[0].type).toBe('dice_roll');
+      expect(diary[1].type).toBe('score_change');
+    });
+
+    it('clearDiary empties the diary', () => {
+      store.getState().logEvent(makeEvent('e1'));
+      store.getState().clearDiary();
+      expect(store.getState().diary).toEqual([]);
+    });
+  });
+
+  describe('Custom Dice Presets', () => {
+    it('addCustomPreset adds a new preset', () => {
+      store.getState().addCustomPreset({
+        name: 'Combat',
+        formula: '2d6+1d8',
+        source: 'custom',
+      });
+
+      expect(store.getState().customDicePresets).toHaveLength(1);
+      expect(store.getState().customDicePresets[0].name).toBe('Combat');
+    });
+
+    it('addCustomPreset prevents duplicates by name', () => {
+      store.getState().addCustomPreset({
+        name: 'Combat',
+        formula: '2d6',
+        source: 'custom',
+      });
+      store.getState().addCustomPreset({
+        name: 'Combat',
+        formula: '3d6',
+        source: 'custom',
+      });
+
+      expect(store.getState().customDicePresets).toHaveLength(1);
+    });
+
+    it('removeCustomPreset removes by name', () => {
+      store.getState().addCustomPreset({ name: 'A', formula: '1d6', source: 'custom' });
+      store.getState().addCustomPreset({ name: 'B', formula: '2d6', source: 'custom' });
+
+      store.getState().removeCustomPreset('A');
+
+      expect(store.getState().customDicePresets).toHaveLength(1);
+      expect(store.getState().customDicePresets[0].name).toBe('B');
+    });
+  });
+
+  describe('resetAll', () => {
+    it('resets the entire state to initial values', () => {
+      store.getState().addPlayer(makePlayer('p1', 'Marco'));
+      store.getState().addScoreCategory('PV');
+      store.getState().setScore('p1', 'PV', 10);
+      store.getState().advanceRound();
+
+      store.getState().resetAll();
+
+      const state = store.getState();
+      expect(state.players).toEqual([]);
+      expect(state.scores).toEqual({});
+      expect(state.scoreCategories).toEqual([]);
+      expect(state.currentRound).toBe(1);
+      expect(state.currentTurnIndex).toBe(0);
+    });
+  });
+});

--- a/apps/web/src/app/(public)/library/shared/[token]/page.tsx
+++ b/apps/web/src/app/(public)/library/shared/[token]/page.tsx
@@ -91,7 +91,7 @@ export default function SharedLibraryPage() {
     });
   };
 
-  const hasNotes = sharedLibrary.games.some(g => g.notes);
+  const _hasNotes = sharedLibrary.games.some(g => g.notes);
 
   return (
     <main className="min-h-screen bg-background">

--- a/apps/web/src/components/admin/knowledge-base/vector-game-card.tsx
+++ b/apps/web/src/components/admin/knowledge-base/vector-game-card.tsx
@@ -21,7 +21,7 @@ function healthLabel(healthPercent: number): string {
   return 'Error';
 }
 
-function healthVariant(healthPercent: number): 'success' | 'warning' | 'error' {
+function _healthVariant(healthPercent: number): 'success' | 'warning' | 'error' {
   if (healthPercent >= 90) return 'success';
   if (healthPercent >= 70) return 'warning';
   return 'error';

--- a/apps/web/src/components/admin/shared-games/game-catalog-grid.tsx
+++ b/apps/web/src/components/admin/shared-games/game-catalog-grid.tsx
@@ -99,7 +99,7 @@ function AdminGameCard({
   onPublish,
   onArchive,
   onDelete,
-  onOpenExtraCard,
+  onOpenExtraCard: _onOpenExtraCard,
 }: AdminGameCardProps) {
   const router = useRouter();
 

--- a/apps/web/src/components/library/MeepleLibraryGameCard.tsx
+++ b/apps/web/src/components/library/MeepleLibraryGameCard.tsx
@@ -92,10 +92,10 @@ function formatPlayCount(count: number): string {
 export function MeepleLibraryGameCard({
   game,
   variant = 'grid',
-  onConfigureAgent,
-  onUploadPdf,
-  onEditNotes,
-  onRemove,
+  onConfigureAgent: _onConfigureAgent,
+  onUploadPdf: _onUploadPdf,
+  onEditNotes: _onEditNotes,
+  onRemove: _onRemove,
   onAskAgent: _onAskAgent,
   onChangeState: _onChangeState,
   onShare: _onShare,
@@ -109,7 +109,7 @@ export function MeepleLibraryGameCard({
   const queryClient = useQueryClient();
   const [isTogglingFavorite, setIsTogglingFavorite] = useState(false);
   const [agentSheetOpen, setAgentSheetOpen] = useState(false);
-  const handleCreateAgent = useCallback(() => setAgentSheetOpen(true), []);
+  const _handleCreateAgent = useCallback(() => setAgentSheetOpen(true), []);
 
   const [wishlistDialogOpen, setWishlistDialogOpen] = useState(false);
   const [kbDrawerOpen, setKbDrawerOpen] = useState(false);
@@ -132,15 +132,18 @@ export function MeepleLibraryGameCard({
     staleTime: 2 * 60 * 1000,
   });
 
-  const modelDisplayName: Record<string, string> = {
-    'llama-3.3-70b-free': 'Llama Free',
-    'google-gemini-pro': 'Gemini Pro',
-    'deepseek-chat': 'DeepSeek',
-    'llama-3.3-70b': 'Llama Pro',
-    default: 'Default',
-  };
+  const modelDisplayName = useMemo<Record<string, string>>(
+    () => ({
+      'llama-3.3-70b-free': 'Llama Free',
+      'google-gemini-pro': 'Gemini Pro',
+      'deepseek-chat': 'DeepSeek',
+      'llama-3.3-70b': 'Llama Pro',
+      default: 'Default',
+    }),
+    []
+  );
 
-  const handleToggleFavorite = useCallback(async () => {
+  const _handleToggleFavorite = useCallback(async () => {
     if (isTogglingFavorite) return;
     setIsTogglingFavorite(true);
     try {

--- a/apps/web/src/components/play-records/PlayHistory.tsx
+++ b/apps/web/src/components/play-records/PlayHistory.tsx
@@ -101,7 +101,7 @@ export function PlayHistory({ userId: _userId }: PlayHistoryProps) {
     return duration;
   };
 
-  const getStatusColor = (status: string): string => {
+  const _getStatusColor = (status: string): string => {
     switch (status) {
       case 'Completed':
         return '120 100% 35%'; // Green

--- a/apps/web/src/components/showcase/stories/meeple-card.story.tsx
+++ b/apps/web/src/components/showcase/stories/meeple-card.story.tsx
@@ -31,10 +31,10 @@ export const meepleCardStory: ShowcaseStory<MeepleCardShowcaseProps> = {
     title,
     subtitle,
     rating,
-    showWishlist,
-    loading,
+    showWishlist: _showWishlist,
+    loading: _loading,
     badge,
-    selectable,
+    selectable: _selectable,
   }: MeepleCardShowcaseProps) {
     return (
       <div className="w-72">

--- a/apps/web/src/components/toolkit-drawer/ToolkitDrawer.tsx
+++ b/apps/web/src/components/toolkit-drawer/ToolkitDrawer.tsx
@@ -23,6 +23,9 @@ import { cn } from '@/lib/utils';
 
 import { PlayerBar } from './shared/PlayerBar';
 import { DiceRollerTab } from './tabs/DiceRollerTab';
+import { EventDiaryTab } from './tabs/EventDiaryTab';
+import { NotesTab } from './tabs/NotesTab';
+import { ScoreboardTab } from './tabs/ScoreboardTab';
 import { ToolkitDrawerProvider, useToolkitDrawer } from './ToolkitDrawerProvider';
 
 import type { ToolkitDrawerProps, ToolkitTab } from './types';
@@ -169,11 +172,11 @@ function TabContent({ tab }: { tab: ToolkitTab }) {
     case 'dice':
       return <DiceRollerTab />;
     case 'notes':
-      return <div data-testid="notes-tab-placeholder">Note</div>;
+      return <NotesTab />;
     case 'diary':
-      return <div data-testid="diary-tab-placeholder">Diario</div>;
+      return <EventDiaryTab />;
     case 'scores':
-      return <div data-testid="scores-tab-placeholder">Punti</div>;
+      return <ScoreboardTab />;
     default:
       return null;
   }

--- a/apps/web/src/components/toolkit-drawer/ToolkitDrawer.tsx
+++ b/apps/web/src/components/toolkit-drawer/ToolkitDrawer.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+/**
+ * ToolkitDrawer — Slide-down drawer for the Default Game Toolkit
+ *
+ * Follows the BottomSheet + ExtraMeepleCardDrawer animation patterns:
+ * - AnimatePresence + motion.div from framer-motion
+ * - Overlay with click-to-close
+ * - Escape key closes
+ * - Body scroll lock
+ * - Glassmorphism panel
+ * - Tab bar with toolkit green active color
+ *
+ * Tab content is placeholder until individual tab components are implemented.
+ */
+
+import React, { useCallback, useEffect } from 'react';
+
+import { AnimatePresence, motion } from 'framer-motion';
+
+import { lockScroll, unlockScroll } from '@/lib/scroll-lock';
+import { cn } from '@/lib/utils';
+
+import { ToolkitDrawerProvider, useToolkitDrawer } from './ToolkitDrawerProvider';
+
+import type { ToolkitDrawerProps, ToolkitTab } from './types';
+
+// ============================================================================
+// Tab Configuration
+// ============================================================================
+
+interface TabConfig {
+  key: ToolkitTab;
+  label: string;
+  icon: string;
+  testId: string;
+}
+
+const TABS: TabConfig[] = [
+  { key: 'dice', label: 'Dadi', icon: '\uD83C\uDFB2', testId: 'toolkit-tab-dice' },
+  { key: 'notes', label: 'Note', icon: '\uD83D\uDCDD', testId: 'toolkit-tab-notes' },
+  { key: 'diary', label: 'Diario', icon: '\uD83D\uDCD6', testId: 'toolkit-tab-diary' },
+  { key: 'scores', label: 'Punti', icon: '\uD83C\uDFC6', testId: 'toolkit-tab-scores' },
+];
+
+// ============================================================================
+// ToolkitDrawer (public entry point)
+// ============================================================================
+
+export function ToolkitDrawer({ gameId, sessionId, onClose, defaultTab }: ToolkitDrawerProps) {
+  return (
+    <ToolkitDrawerProvider gameId={gameId} sessionId={sessionId} defaultTab={defaultTab}>
+      <ToolkitDrawerInner onClose={onClose} />
+    </ToolkitDrawerProvider>
+  );
+}
+
+// ============================================================================
+// Inner Component (consumes context)
+// ============================================================================
+
+function ToolkitDrawerInner({ onClose }: { onClose: () => void }) {
+  const { activeTab, setActiveTab } = useToolkitDrawer();
+
+  // Escape key handler
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    },
+    [onClose]
+  );
+
+  // Escape key + scroll lock lifecycle
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown);
+    lockScroll();
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      unlockScroll();
+    };
+  }, [handleKeyDown]);
+
+  return (
+    <AnimatePresence>
+      {/* Overlay */}
+      <motion.div
+        data-testid="toolkit-drawer-overlay"
+        className="fixed inset-0 z-50 bg-black/30"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.2 }}
+        onClick={onClose}
+      />
+
+      {/* Panel — slides from top */}
+      <motion.div
+        data-testid="toolkit-drawer-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Game Toolkit"
+        className={cn(
+          'fixed inset-x-0 top-0 z-50 flex flex-col',
+          'max-h-[85vh]',
+          'bg-white/95 backdrop-blur-xl',
+          'rounded-b-2xl shadow-2xl'
+        )}
+        initial={{ y: '-100%' }}
+        animate={{ y: 0 }}
+        exit={{ y: '-100%' }}
+        transition={{ type: 'spring', damping: 30, stiffness: 300 }}
+      >
+        {/* Drag handle */}
+        <div className="flex justify-center pb-1 pt-3" data-testid="toolkit-drag-handle">
+          <div className="h-1 w-10 rounded-full bg-gray-300" />
+        </div>
+
+        {/* Tab bar */}
+        <div
+          className="flex shrink-0 border-b border-gray-200 px-2"
+          role="tablist"
+          aria-label="Toolkit tabs"
+        >
+          {TABS.map(tab => {
+            const isActive = activeTab === tab.key;
+            return (
+              <button
+                key={tab.key}
+                role="tab"
+                aria-selected={isActive}
+                data-testid={tab.testId}
+                onClick={() => setActiveTab(tab.key)}
+                className={cn(
+                  'flex flex-1 flex-col items-center gap-0.5 py-2.5 text-xs font-medium transition-colors',
+                  isActive
+                    ? 'border-b-2 text-[hsl(142,70%,45%)]'
+                    : 'text-gray-500 hover:text-gray-700'
+                )}
+                style={isActive ? { borderBottomColor: 'hsl(142, 70%, 45%)' } : undefined}
+              >
+                <span className="text-base">{tab.icon}</span>
+                <span>{tab.label}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Tab content */}
+        <div className="flex-1 overflow-y-auto px-4 pb-6 pt-4">
+          <TabContent tab={activeTab} />
+        </div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}
+
+// ============================================================================
+// Tab Content Placeholder
+// ============================================================================
+
+function TabContent({ tab }: { tab: ToolkitTab }) {
+  switch (tab) {
+    case 'dice':
+      return <div data-testid="dice-tab-placeholder">Dadi</div>;
+    case 'notes':
+      return <div data-testid="notes-tab-placeholder">Note</div>;
+    case 'diary':
+      return <div data-testid="diary-tab-placeholder">Diario</div>;
+    case 'scores':
+      return <div data-testid="scores-tab-placeholder">Punti</div>;
+    default:
+      return null;
+  }
+}

--- a/apps/web/src/components/toolkit-drawer/ToolkitDrawer.tsx
+++ b/apps/web/src/components/toolkit-drawer/ToolkitDrawer.tsx
@@ -21,6 +21,8 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { lockScroll, unlockScroll } from '@/lib/scroll-lock';
 import { cn } from '@/lib/utils';
 
+import { PlayerBar } from './shared/PlayerBar';
+import { DiceRollerTab } from './tabs/DiceRollerTab';
 import { ToolkitDrawerProvider, useToolkitDrawer } from './ToolkitDrawerProvider';
 
 import type { ToolkitDrawerProps, ToolkitTab } from './types';
@@ -147,9 +149,12 @@ function ToolkitDrawerInner({ onClose }: { onClose: () => void }) {
         </div>
 
         {/* Tab content */}
-        <div className="flex-1 overflow-y-auto px-4 pb-6 pt-4">
+        <div className="flex-1 overflow-y-auto px-4 pb-4 pt-4">
           <TabContent tab={activeTab} />
         </div>
+
+        {/* Player bar — always visible at bottom */}
+        <PlayerBar />
       </motion.div>
     </AnimatePresence>
   );
@@ -162,7 +167,7 @@ function ToolkitDrawerInner({ onClose }: { onClose: () => void }) {
 function TabContent({ tab }: { tab: ToolkitTab }) {
   switch (tab) {
     case 'dice':
-      return <div data-testid="dice-tab-placeholder">Dadi</div>;
+      return <DiceRollerTab />;
     case 'notes':
       return <div data-testid="notes-tab-placeholder">Note</div>;
     case 'diary':

--- a/apps/web/src/components/toolkit-drawer/ToolkitDrawerProvider.tsx
+++ b/apps/web/src/components/toolkit-drawer/ToolkitDrawerProvider.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+/**
+ * ToolkitDrawerProvider — React Context for the Toolkit Drawer
+ *
+ * Creates a per-game Zustand store and provides shared context
+ * (tab state, event logging) to all toolkit tab components.
+ */
+
+import React, { createContext, useCallback, useContext, useRef, useState } from 'react';
+
+import { createToolkitLocalStore, type ToolkitLocalStore } from '@/stores/toolkit-local-store';
+
+import type { DiaryEvent, DiaryEventType, ToolkitTab } from './types';
+import type { StoreApi, UseBoundStore } from 'zustand';
+
+// ============================================================================
+// Context Types
+// ============================================================================
+
+export interface ToolkitDrawerContextValue {
+  gameId: string;
+  sessionId: string | undefined;
+  store: UseBoundStore<StoreApi<ToolkitLocalStore>>;
+  /** Log a diary event to the local store (and POST to API when sessionId is present) */
+  logEvent: (
+    type: DiaryEventType,
+    payload: Record<string, unknown>,
+    extra?: { playerId?: string; playerName?: string; round?: number }
+  ) => void;
+  activeTab: ToolkitTab;
+  setActiveTab: (tab: ToolkitTab) => void;
+}
+
+const ToolkitDrawerContext = createContext<ToolkitDrawerContextValue | null>(null);
+
+// ============================================================================
+// Provider
+// ============================================================================
+
+export interface ToolkitDrawerProviderProps {
+  gameId: string;
+  sessionId?: string;
+  defaultTab?: ToolkitTab;
+  children: React.ReactNode;
+}
+
+export function ToolkitDrawerProvider({
+  gameId,
+  sessionId,
+  defaultTab = 'dice',
+  children,
+}: ToolkitDrawerProviderProps) {
+  const storeRef = useRef<UseBoundStore<StoreApi<ToolkitLocalStore>> | null>(null);
+
+  // Lazily create one store per gameId; recreate if gameId changes
+  if (!storeRef.current || storeRef.current.getState().players !== undefined) {
+    // Always create — the ref check ensures we only create once per mount
+  }
+  if (!storeRef.current) {
+    storeRef.current = createToolkitLocalStore(gameId);
+  }
+
+  const [activeTab, setActiveTab] = useState<ToolkitTab>(defaultTab);
+
+  const logEvent = useCallback(
+    (
+      type: DiaryEventType,
+      payload: Record<string, unknown>,
+      extra?: { playerId?: string; playerName?: string; round?: number }
+    ) => {
+      const event: DiaryEvent = {
+        id: crypto.randomUUID(),
+        type,
+        timestamp: Date.now(),
+        playerId: extra?.playerId,
+        playerName: extra?.playerName,
+        round: extra?.round,
+        payload,
+      };
+
+      // Write to local store
+      storeRef.current?.getState().logEvent(event);
+
+      // If we have a sessionId, POST to the backend (fire-and-forget)
+      if (sessionId) {
+        // Lazy import to avoid circular deps and keep the provider lightweight.
+        // The actual HTTP call is handled by the API client in the consuming layer.
+        // For now we just dispatch a custom event that a parent component can listen to.
+        window.dispatchEvent(
+          new CustomEvent('toolkit:session-event', {
+            detail: {
+              sessionId,
+              eventType: type,
+              payloadJson: JSON.stringify(payload),
+              participantId: extra?.playerId,
+              roundNumber: extra?.round,
+            },
+          })
+        );
+      }
+    },
+    [sessionId]
+  );
+
+  const value: ToolkitDrawerContextValue = {
+    gameId,
+    sessionId,
+    store: storeRef.current,
+    logEvent,
+    activeTab,
+    setActiveTab,
+  };
+
+  return <ToolkitDrawerContext.Provider value={value}>{children}</ToolkitDrawerContext.Provider>;
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+export function useToolkitDrawer(): ToolkitDrawerContextValue {
+  const ctx = useContext(ToolkitDrawerContext);
+  if (!ctx) {
+    throw new Error('useToolkitDrawer must be used within a ToolkitDrawerProvider');
+  }
+  return ctx;
+}

--- a/apps/web/src/components/toolkit-drawer/hooks/useDiceRoller.ts
+++ b/apps/web/src/components/toolkit-drawer/hooks/useDiceRoller.ts
@@ -1,0 +1,120 @@
+'use client';
+
+/**
+ * useDiceRoller — Custom hook for cryptographically random dice rolling.
+ *
+ * Parses formulas like "2d6+1d8+3" and rolls each die using
+ * crypto.getRandomValues() for fair randomness.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+
+import type { DiceResult } from '../types';
+
+interface ParsedDie {
+  count: number;
+  sides: number;
+}
+
+interface ParsedFormula {
+  dice: ParsedDie[];
+  modifier: number;
+}
+
+/**
+ * Parses a dice formula string into structured data.
+ *
+ * Supported formats:
+ *  - "2d6"         → 2 six-sided dice, modifier 0
+ *  - "2d6+1d8+3"  → 2d6 + 1d8, modifier +3
+ *  - "1d20-2"     → 1d20, modifier -2
+ */
+export function parseDiceFormula(formula: string): ParsedFormula {
+  const cleaned = formula.replace(/\s/g, '').toLowerCase();
+  const dice: ParsedDie[] = [];
+  let modifier = 0;
+
+  // Split on + or - while keeping the sign
+  const tokens = cleaned.split(/(?=[+-])/);
+
+  for (const token of tokens) {
+    const diceMatch = token.match(/^([+-]?)(\d*)d(\d+)$/);
+    if (diceMatch) {
+      const sign = diceMatch[1] === '-' ? -1 : 1;
+      const count = sign * (diceMatch[2] ? parseInt(diceMatch[2], 10) : 1);
+      const sides = parseInt(diceMatch[3], 10);
+      if (sides > 0) {
+        dice.push({ count, sides });
+      }
+    } else {
+      // Plain number modifier
+      const num = parseInt(token, 10);
+      if (!isNaN(num)) {
+        modifier += num;
+      }
+    }
+  }
+
+  return { dice, modifier };
+}
+
+/** Roll a single die with sides using crypto.getRandomValues(). */
+function rollSingleDie(sides: number): number {
+  const array = new Uint32Array(1);
+  crypto.getRandomValues(array);
+  return (array[0] % sides) + 1;
+}
+
+/** Execute a full dice roll from a formula string. */
+export function rollDiceFromFormula(formula: string): DiceResult {
+  const { dice, modifier } = parseDiceFormula(formula);
+  const rolls: number[] = [];
+
+  for (const { count, sides } of dice) {
+    const absCount = Math.abs(count);
+    const sign = count < 0 ? -1 : 1;
+    for (let i = 0; i < absCount; i++) {
+      rolls.push(sign * rollSingleDie(sides));
+    }
+  }
+
+  const total = rolls.reduce((sum, r) => sum + r, 0) + modifier;
+
+  return { formula, rolls, modifier, total };
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+export interface UseDiceRollerReturn {
+  roll: (formula: string) => DiceResult;
+  lastResult: DiceResult | null;
+  isRolling: boolean;
+}
+
+export function useDiceRoller(): UseDiceRollerReturn {
+  const [lastResult, setLastResult] = useState<DiceResult | null>(null);
+  const [isRolling, setIsRolling] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const roll = useCallback((formula: string): DiceResult => {
+    // Clear any pending animation timer
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+
+    setIsRolling(true);
+    const result = rollDiceFromFormula(formula);
+    setLastResult(result);
+
+    timerRef.current = setTimeout(() => {
+      setIsRolling(false);
+      timerRef.current = null;
+    }, 300);
+
+    return result;
+  }, []);
+
+  return { roll, lastResult, isRolling };
+}

--- a/apps/web/src/components/toolkit-drawer/index.ts
+++ b/apps/web/src/components/toolkit-drawer/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Toolkit Drawer — Public Exports
+ */
+
+export { ToolkitDrawer } from './ToolkitDrawer';
+export { ToolkitDrawerProvider, useToolkitDrawer } from './ToolkitDrawerProvider';
+export type { ToolkitDrawerProps, ToolkitTab } from './types';

--- a/apps/web/src/components/toolkit-drawer/shared/PlayerAvatar.tsx
+++ b/apps/web/src/components/toolkit-drawer/shared/PlayerAvatar.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+/**
+ * PlayerAvatar — Circular avatar showing player initial with their color.
+ */
+
+import { cn } from '@/lib/utils';
+
+export interface PlayerAvatarProps {
+  name: string;
+  color: string;
+  active?: boolean;
+  size?: 'sm' | 'md';
+  onClick?: () => void;
+}
+
+const SIZE_MAP = {
+  sm: 'h-7 w-7 text-xs',
+  md: 'h-9 w-9 text-sm',
+} as const;
+
+export function PlayerAvatar({ name, color, active, size = 'md', onClick }: PlayerAvatarProps) {
+  const initial = name.charAt(0).toUpperCase();
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={!onClick}
+      className={cn(
+        'flex shrink-0 items-center justify-center rounded-full font-bold text-white transition-shadow',
+        SIZE_MAP[size],
+        active && 'ring-2 ring-white ring-offset-2',
+        onClick ? 'cursor-pointer' : 'cursor-default'
+      )}
+      style={{ backgroundColor: color }}
+      aria-label={`${name}${active ? ' (turno attivo)' : ''}`}
+      data-testid={`player-avatar-${name}`}
+    >
+      {initial}
+    </button>
+  );
+}

--- a/apps/web/src/components/toolkit-drawer/shared/PlayerBar.tsx
+++ b/apps/web/src/components/toolkit-drawer/shared/PlayerBar.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+/**
+ * PlayerBar — Always-visible bottom bar showing player avatars and turn state.
+ *
+ * Tapping an avatar sets the current turn. A [+] button opens the
+ * PlayerSetupModal inline. The "Sessione" button is a placeholder for
+ * future session-upgrade flow.
+ */
+
+import React, { useState } from 'react';
+
+import { cn } from '@/lib/utils';
+
+import { useToolkitDrawer } from '../ToolkitDrawerProvider';
+import { PlayerAvatar } from './PlayerAvatar';
+import { PlayerSetupModal } from './PlayerSetupModal';
+
+export function PlayerBar() {
+  const { store, logEvent } = useToolkitDrawer();
+  const players = store(s => s.players);
+  const currentTurnIndex = store(s => s.currentTurnIndex);
+
+  const [showAddForm, setShowAddForm] = useState(false);
+
+  const handleSetTurn = (index: number) => {
+    const player = players[index];
+    if (!player) return;
+
+    store.getState().setTurn(index);
+    logEvent(
+      'turn_change',
+      { playerName: player.name, turnIndex: index },
+      {
+        playerId: player.id,
+        playerName: player.name,
+      }
+    );
+  };
+
+  return (
+    <div
+      className="shrink-0 border-t border-gray-200 bg-white/90 px-3 py-2"
+      data-testid="player-bar"
+    >
+      {/* Add player form (inline, above the bar) */}
+      {showAddForm && (
+        <div className="mb-2">
+          <PlayerSetupModal onClose={() => setShowAddForm(false)} />
+        </div>
+      )}
+
+      <div className="flex items-center gap-2">
+        {/* Scrollable avatar row */}
+        <div className="flex flex-1 items-center gap-2 overflow-x-auto">
+          {players.map((player, index) => {
+            const isActive = index === currentTurnIndex;
+            return (
+              <div key={player.id} className="relative flex flex-col items-center">
+                <PlayerAvatar
+                  name={player.name}
+                  color={player.color}
+                  active={isActive}
+                  size="sm"
+                  onClick={() => handleSetTurn(index)}
+                />
+                {/* Active turn dot */}
+                {isActive && (
+                  <span
+                    className="absolute -bottom-1 h-1.5 w-1.5 rounded-full bg-[hsl(142,70%,45%)]"
+                    data-testid="turn-indicator"
+                  />
+                )}
+              </div>
+            );
+          })}
+
+          {/* Add player button */}
+          <button
+            type="button"
+            onClick={() => setShowAddForm(prev => !prev)}
+            className={cn(
+              'flex h-7 w-7 shrink-0 items-center justify-center rounded-full border-2 border-dashed border-gray-300',
+              'text-gray-400 transition-colors hover:border-gray-400 hover:text-gray-500'
+            )}
+            aria-label="Aggiungi giocatore"
+            data-testid="add-player-btn"
+          >
+            +
+          </button>
+        </div>
+
+        {/* Session upgrade button (placeholder) */}
+        {players.length >= 2 && (
+          <button
+            type="button"
+            onClick={() => {
+              // Placeholder for session upgrade flow
+            }}
+            className="shrink-0 rounded-lg border border-gray-300 px-2 py-1 text-[10px] font-medium text-gray-600 transition-colors hover:bg-gray-100"
+            data-testid="session-upgrade-btn"
+          >
+            Sessione
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/toolkit-drawer/shared/PlayerSetupModal.tsx
+++ b/apps/web/src/components/toolkit-drawer/shared/PlayerSetupModal.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+/**
+ * PlayerSetupModal — Inline form for adding a new player.
+ *
+ * Auto-assigns a color from PLAYER_COLORS based on current player count,
+ * with optional color-swatch override.
+ */
+
+import React, { useState } from 'react';
+
+import { cn } from '@/lib/utils';
+
+import { useToolkitDrawer } from '../ToolkitDrawerProvider';
+import { PLAYER_COLORS } from '../types';
+
+import type { LocalPlayer } from '../types';
+
+export interface PlayerSetupModalProps {
+  onClose: () => void;
+}
+
+export function PlayerSetupModal({ onClose }: PlayerSetupModalProps) {
+  const { store, logEvent } = useToolkitDrawer();
+  const players = store(s => s.players);
+
+  const defaultColorIndex = players.length % PLAYER_COLORS.length;
+  const [name, setName] = useState('');
+  const [selectedColor, setSelectedColor] = useState<string>(PLAYER_COLORS[defaultColorIndex]);
+
+  const canConfirm = name.trim().length > 0;
+
+  const handleConfirm = () => {
+    if (!canConfirm) return;
+
+    const newPlayer: LocalPlayer = {
+      id: crypto.randomUUID(),
+      name: name.trim(),
+      color: selectedColor,
+    };
+
+    store.getState().addPlayer(newPlayer);
+
+    logEvent(
+      'player_joined',
+      { playerName: newPlayer.name, color: newPlayer.color },
+      {
+        playerId: newPlayer.id,
+        playerName: newPlayer.name,
+      }
+    );
+
+    onClose();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && canConfirm) handleConfirm();
+    if (e.key === 'Escape') onClose();
+  };
+
+  return (
+    <div
+      className="flex flex-col gap-3 rounded-xl border border-gray-200 bg-white p-3 shadow-sm"
+      data-testid="player-setup-form"
+    >
+      {/* Name input */}
+      <input
+        type="text"
+        placeholder="Nome giocatore"
+        value={name}
+        onChange={e => setName(e.target.value)}
+        onKeyDown={handleKeyDown}
+        autoFocus
+        className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm outline-none focus:border-[hsl(142,70%,45%)] focus:ring-1 focus:ring-[hsl(142,70%,45%)]"
+        data-testid="player-name-input"
+      />
+
+      {/* Color swatches */}
+      <div className="flex flex-wrap gap-1.5">
+        {PLAYER_COLORS.map(color => (
+          <button
+            key={color}
+            type="button"
+            onClick={() => setSelectedColor(color)}
+            className={cn(
+              'h-6 w-6 rounded-full transition-transform',
+              selectedColor === color && 'scale-110 ring-2 ring-gray-800 ring-offset-1'
+            )}
+            style={{ backgroundColor: color }}
+            aria-label={`Colore ${color}`}
+            data-testid={`color-swatch-${color}`}
+          />
+        ))}
+      </div>
+
+      {/* Actions */}
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-lg px-3 py-1 text-xs text-gray-500 hover:bg-gray-100"
+        >
+          Annulla
+        </button>
+        <button
+          type="button"
+          onClick={handleConfirm}
+          disabled={!canConfirm}
+          className={cn(
+            'rounded-lg px-3 py-1 text-xs font-medium text-white transition-colors',
+            canConfirm
+              ? 'bg-[hsl(142,70%,45%)] hover:bg-[hsl(142,70%,40%)]'
+              : 'cursor-not-allowed bg-gray-300'
+          )}
+          data-testid="player-confirm-btn"
+        >
+          Aggiungi
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/toolkit-drawer/tabs/DiaryEventRow.tsx
+++ b/apps/web/src/components/toolkit-drawer/tabs/DiaryEventRow.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+/**
+ * DiaryEventRow — Single diary event row with type-specific icon and formatting.
+ */
+
+import React from 'react';
+
+import type { DiaryEvent, DiaryEventType } from '../types';
+
+const EVENT_ICON: Record<DiaryEventType, string> = {
+  dice_roll: '🎲',
+  score_change: '🏆',
+  turn_change: '🔄',
+  note_added: '📝',
+  manual_entry: '✍️',
+  player_joined: '👤',
+  round_advance: '🔔',
+  score_reset: '♻️',
+};
+
+function formatTime(timestamp: number): string {
+  const d = new Date(timestamp);
+  const h = d.getHours().toString().padStart(2, '0');
+  const m = d.getMinutes().toString().padStart(2, '0');
+  return `${h}:${m}`;
+}
+
+function describeEvent(event: DiaryEvent): string {
+  const { type, payload, playerName } = event;
+  const who = playerName ? `${playerName} ` : '';
+
+  switch (type) {
+    case 'dice_roll': {
+      const formula = payload.formula as string | undefined;
+      const total = payload.total as number | undefined;
+      const rolls = payload.rolls as Array<{ value: number }> | undefined;
+      const results = rolls?.map(r => r.value).join(',');
+      return `${who}lancia ${formula ?? '?'} → [${results ?? '?'}] = ${total ?? '?'}`;
+    }
+    case 'score_change': {
+      const category = payload.category as string | undefined;
+      const delta = payload.delta as number | undefined;
+      const newTotal = payload.newTotal as number | undefined;
+      const deltaStr = typeof delta === 'number' ? (delta >= 0 ? `+${delta}` : `${delta}`) : '';
+      return `${who}${deltaStr} ${category ?? ''} (totale: ${newTotal ?? '?'})`;
+    }
+    case 'turn_change': {
+      const nextPlayer = payload.nextPlayerName as string | undefined;
+      return `Turno → ${nextPlayer ?? playerName ?? '?'}`;
+    }
+    case 'note_added': {
+      const preview = payload.preview as string | undefined;
+      return `${who}aggiunge nota${preview ? `: "${preview}"` : ''}`;
+    }
+    case 'manual_entry': {
+      const text = payload.text as string | undefined;
+      return text ? `${who}${text}` : who;
+    }
+    case 'player_joined': {
+      return `${who}si unisce alla partita`;
+    }
+    case 'round_advance': {
+      const round = payload.round as number | undefined;
+      return `Inizio Round ${round ?? '?'}`;
+    }
+    case 'score_reset': {
+      return 'Punteggi azzerati';
+    }
+    default:
+      return JSON.stringify(payload);
+  }
+}
+
+export interface DiaryEventRowProps {
+  event: DiaryEvent;
+}
+
+export function DiaryEventRow({ event }: DiaryEventRowProps) {
+  const icon = EVENT_ICON[event.type] ?? '•';
+  const time = formatTime(event.timestamp);
+  const desc = describeEvent(event);
+
+  return (
+    <div
+      className="flex items-start gap-2 py-1.5 text-xs text-gray-600"
+      data-testid={`diary-event-${event.id}`}
+    >
+      <span className="shrink-0 font-mono text-[10px] text-gray-400">{time}</span>
+      <span className="shrink-0">{icon}</span>
+      <span className="flex-1 leading-snug">{desc}</span>
+    </div>
+  );
+}

--- a/apps/web/src/components/toolkit-drawer/tabs/DiaryFilters.tsx
+++ b/apps/web/src/components/toolkit-drawer/tabs/DiaryFilters.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+/**
+ * DiaryFilters — Pill toggles for filtering diary events.
+ * Multi-select: active filters are OR-combined.
+ */
+
+import React from 'react';
+
+import { cn } from '@/lib/utils';
+
+import type { DiaryEventType } from '../types';
+
+export interface DiaryFilterOption {
+  type: DiaryEventType;
+  label: string;
+  icon: string;
+}
+
+export const DIARY_FILTER_OPTIONS: DiaryFilterOption[] = [
+  { type: 'dice_roll', label: 'Dadi', icon: '🎲' },
+  { type: 'score_change', label: 'Punti', icon: '🏆' },
+  { type: 'note_added', label: 'Note', icon: '📝' },
+  { type: 'turn_change', label: 'Turni', icon: '🔄' },
+  { type: 'manual_entry', label: 'Manual', icon: '✍️' },
+];
+
+export interface DiaryFiltersProps {
+  activeFilters: DiaryEventType[];
+  onToggle: (type: DiaryEventType) => void;
+  onReset: () => void;
+}
+
+export function DiaryFilters({ activeFilters, onToggle, onReset }: DiaryFiltersProps) {
+  const allActive = activeFilters.length === 0;
+
+  return (
+    <div className="flex flex-wrap gap-1.5" data-testid="diary-filters">
+      <button
+        type="button"
+        onClick={onReset}
+        className={cn(
+          'rounded-full px-2.5 py-1 text-[10px] font-semibold transition-colors',
+          allActive
+            ? 'bg-[hsl(142,70%,45%)] text-white'
+            : 'border border-gray-300 text-gray-600 hover:border-[hsl(142,70%,45%)]'
+        )}
+        data-testid="diary-filter-all"
+      >
+        Tutti
+      </button>
+      {DIARY_FILTER_OPTIONS.map(opt => {
+        const isActive = activeFilters.includes(opt.type);
+        return (
+          <button
+            key={opt.type}
+            type="button"
+            onClick={() => onToggle(opt.type)}
+            className={cn(
+              'flex items-center gap-1 rounded-full px-2.5 py-1 text-[10px] font-semibold transition-colors',
+              isActive
+                ? 'bg-[hsl(142,70%,45%)] text-white'
+                : 'border border-gray-300 text-gray-600 hover:border-[hsl(142,70%,45%)]'
+            )}
+            data-testid={`diary-filter-${opt.type}`}
+          >
+            <span>{opt.icon}</span>
+            <span>{opt.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/toolkit-drawer/tabs/DicePoolBuilder.tsx
+++ b/apps/web/src/components/toolkit-drawer/tabs/DicePoolBuilder.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+/**
+ * DicePoolBuilder — Interactive builder for composing a dice formula
+ * from individual die types with +/- steppers and a modifier.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+
+import { cn } from '@/lib/utils';
+
+// ============================================================================
+// Types & Constants
+// ============================================================================
+
+interface DieType {
+  sides: number;
+  label: string;
+}
+
+const DIE_TYPES: DieType[] = [
+  { sides: 4, label: 'd4' },
+  { sides: 6, label: 'd6' },
+  { sides: 8, label: 'd8' },
+  { sides: 10, label: 'd10' },
+  { sides: 12, label: 'd12' },
+  { sides: 20, label: 'd20' },
+];
+
+export interface DicePoolBuilderProps {
+  onRoll: (formula: string) => void;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function DicePoolBuilder({ onRoll }: DicePoolBuilderProps) {
+  const [pool, setPool] = useState<Record<number, number>>({});
+  const [modifier, setModifier] = useState(0);
+
+  const updateDie = useCallback((sides: number, delta: number) => {
+    setPool(prev => {
+      const current = prev[sides] ?? 0;
+      const next = Math.max(0, Math.min(20, current + delta));
+      if (next === 0) {
+        const { [sides]: _, ...rest } = prev;
+        return rest;
+      }
+      return { ...prev, [sides]: next };
+    });
+  }, []);
+
+  /** Build the formula string from the current pool. */
+  const formula = useMemo(() => {
+    const parts: string[] = [];
+    for (const die of DIE_TYPES) {
+      const count = pool[die.sides] ?? 0;
+      if (count > 0) {
+        parts.push(`${count}${die.label}`);
+      }
+    }
+    if (modifier > 0) parts.push(`+${modifier}`);
+    if (modifier < 0) parts.push(`${modifier}`);
+    return parts.join('+').replace(/\+\+/g, '+').replace(/\+-/g, '-') || '0';
+  }, [pool, modifier]);
+
+  const hasDice = Object.values(pool).some(c => c > 0);
+
+  const handleRoll = () => {
+    if (hasDice) onRoll(formula);
+  };
+
+  return (
+    <div className="flex flex-col gap-3" data-testid="dice-pool-builder">
+      {/* Die type grid */}
+      <div className="grid grid-cols-3 gap-2">
+        {DIE_TYPES.map(die => {
+          const count = pool[die.sides] ?? 0;
+          return (
+            <div
+              key={die.sides}
+              className="flex items-center justify-between rounded-lg border border-gray-200 px-2 py-1.5"
+              data-testid={`die-stepper-${die.label}`}
+            >
+              <span className="text-xs font-semibold text-gray-600">{die.label}</span>
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => updateDie(die.sides, -1)}
+                  disabled={count === 0}
+                  className={cn(
+                    'flex h-5 w-5 items-center justify-center rounded text-xs font-bold transition-colors',
+                    count === 0
+                      ? 'cursor-not-allowed text-gray-300'
+                      : 'text-gray-600 hover:bg-gray-100'
+                  )}
+                  aria-label={`Rimuovi ${die.label}`}
+                >
+                  -
+                </button>
+                <span className="w-4 text-center text-xs font-medium">{count}</span>
+                <button
+                  type="button"
+                  onClick={() => updateDie(die.sides, 1)}
+                  className="flex h-5 w-5 items-center justify-center rounded text-xs font-bold text-gray-600 transition-colors hover:bg-gray-100"
+                  aria-label={`Aggiungi ${die.label}`}
+                >
+                  +
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Modifier */}
+      <div className="flex items-center gap-2">
+        <span className="text-xs font-medium text-gray-500">Modificatore:</span>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => setModifier(m => m - 1)}
+            className="flex h-5 w-5 items-center justify-center rounded text-xs font-bold text-gray-600 hover:bg-gray-100"
+            aria-label="Riduci modificatore"
+          >
+            -
+          </button>
+          <span className="w-8 text-center text-sm font-medium">
+            {modifier >= 0 ? `+${modifier}` : modifier}
+          </span>
+          <button
+            type="button"
+            onClick={() => setModifier(m => m + 1)}
+            className="flex h-5 w-5 items-center justify-center rounded text-xs font-bold text-gray-600 hover:bg-gray-100"
+            aria-label="Aumenta modificatore"
+          >
+            +
+          </button>
+        </div>
+      </div>
+
+      {/* Current formula display */}
+      {hasDice && (
+        <div
+          className="text-center text-sm font-medium text-gray-700"
+          data-testid="dice-formula-display"
+        >
+          {formula}
+        </div>
+      )}
+
+      {/* Roll button */}
+      <button
+        type="button"
+        onClick={handleRoll}
+        disabled={!hasDice}
+        className={cn(
+          'rounded-xl py-2.5 text-sm font-bold transition-colors',
+          hasDice
+            ? 'bg-[hsl(142,70%,45%)] text-white hover:bg-[hsl(142,70%,40%)] active:scale-[0.98]'
+            : 'cursor-not-allowed bg-gray-200 text-gray-400'
+        )}
+        data-testid="dice-roll-btn"
+      >
+        LANCIA
+      </button>
+    </div>
+  );
+}
+
+/** Returns the current formula string from pool state (exported for save-preset). */
+export function buildFormula(pool: Record<number, number>, modifier: number): string {
+  const parts: string[] = [];
+  for (const die of DIE_TYPES) {
+    const count = pool[die.sides] ?? 0;
+    if (count > 0) {
+      parts.push(`${count}d${die.sides}`);
+    }
+  }
+  if (modifier > 0) parts.push(`+${modifier}`);
+  if (modifier < 0) parts.push(`${modifier}`);
+  return parts.join('+').replace(/\+\+/g, '+').replace(/\+-/g, '-') || '0';
+}

--- a/apps/web/src/components/toolkit-drawer/tabs/DicePresetRow.tsx
+++ b/apps/web/src/components/toolkit-drawer/tabs/DicePresetRow.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+/**
+ * DicePresetRow — Horizontal scrollable row of dice preset buttons.
+ */
+
+import { cn } from '@/lib/utils';
+
+import type { DicePreset } from '../types';
+
+export interface DicePresetRowProps {
+  presets: DicePreset[];
+  onRoll: (formula: string) => void;
+  variant: 'universal' | 'ai' | 'custom';
+}
+
+const VARIANT_STYLES = {
+  universal: 'border-gray-300 text-gray-700 hover:bg-gray-100',
+  ai: 'border-purple-300 text-purple-700 hover:bg-purple-50',
+  custom: 'border-[hsl(142,70%,45%)] text-[hsl(142,70%,35%)] hover:bg-green-50',
+} as const;
+
+export function DicePresetRow({ presets, onRoll, variant }: DicePresetRowProps) {
+  if (presets.length === 0) return null;
+
+  return (
+    <div className="flex gap-2 overflow-x-auto pb-1" data-testid={`dice-preset-row-${variant}`}>
+      {presets.map(preset => (
+        <button
+          key={preset.name}
+          type="button"
+          onClick={() => onRoll(preset.formula)}
+          className={cn(
+            'shrink-0 rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+            VARIANT_STYLES[variant]
+          )}
+          data-testid={`dice-preset-${preset.name}`}
+        >
+          {preset.icon ? `${preset.icon} ` : ''}
+          {preset.name}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/toolkit-drawer/tabs/DiceResultDisplay.tsx
+++ b/apps/web/src/components/toolkit-drawer/tabs/DiceResultDisplay.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+/**
+ * DiceResultDisplay — Shows the result of the last dice roll
+ * with individual die values and a prominent total.
+ */
+
+import { cn } from '@/lib/utils';
+
+import type { DiceResult } from '../types';
+
+export interface DiceResultDisplayProps {
+  result: DiceResult | null;
+  isRolling: boolean;
+}
+
+export function DiceResultDisplay({ result, isRolling }: DiceResultDisplayProps) {
+  if (!result) return null;
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center gap-2 rounded-xl bg-gray-50 p-4 transition-transform',
+        isRolling && 'animate-dice-shake'
+      )}
+      data-testid="dice-result-display"
+    >
+      {/* Individual rolls */}
+      <div className="flex flex-wrap justify-center gap-1.5">
+        {result.rolls.map((value, i) => (
+          <span
+            key={i}
+            className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-sm font-semibold text-gray-700"
+          >
+            {value}
+          </span>
+        ))}
+        {result.modifier !== 0 && (
+          <span className="flex h-8 items-center px-1 text-sm font-medium text-gray-500">
+            {result.modifier > 0 ? `+${result.modifier}` : result.modifier}
+          </span>
+        )}
+      </div>
+
+      {/* Total */}
+      <div className="text-3xl font-bold text-gray-900" data-testid="dice-result-total">
+        {result.total}
+      </div>
+
+      {/* Formula label */}
+      <div className="text-xs text-gray-400">{result.formula}</div>
+
+      {/* Inline keyframes for the shake animation */}
+      <style jsx>{`
+        @keyframes dice-shake {
+          0%,
+          100% {
+            transform: translateX(0);
+          }
+          10%,
+          50%,
+          90% {
+            transform: translateX(-2px) rotate(-1deg);
+          }
+          30%,
+          70% {
+            transform: translateX(2px) rotate(1deg);
+          }
+        }
+        :global(.animate-dice-shake) {
+          animation: dice-shake 0.3s ease-in-out;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/apps/web/src/components/toolkit-drawer/tabs/DiceRollerTab.tsx
+++ b/apps/web/src/components/toolkit-drawer/tabs/DiceRollerTab.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+/**
+ * DiceRollerTab — Main dice tab composing preset rows, pool builder,
+ * and result display. Logs every roll to the session diary.
+ */
+
+import React, { useCallback, useState } from 'react';
+
+import { cn } from '@/lib/utils';
+
+import { useDiceRoller } from '../hooks/useDiceRoller';
+import { useToolkitDrawer } from '../ToolkitDrawerProvider';
+import { UNIVERSAL_DICE_PRESETS } from '../types';
+import { DicePoolBuilder } from './DicePoolBuilder';
+import { DicePresetRow } from './DicePresetRow';
+import { DiceResultDisplay } from './DiceResultDisplay';
+
+import type { DicePreset, DiceResult } from '../types';
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function DiceRollerTab() {
+  const { store, logEvent } = useToolkitDrawer();
+  const customPresets = store(s => s.customDicePresets);
+  const { roll, lastResult, isRolling } = useDiceRoller();
+
+  // Collapsible sections
+  const [showAiPresets, setShowAiPresets] = useState(false);
+  const [showCustomPresets, setShowCustomPresets] = useState(true);
+
+  // Save-preset inline form
+  const [saveName, setSaveName] = useState('');
+  const [lastFormula, setLastFormula] = useState('');
+
+  // AI presets placeholder — will be populated from toolkit config in the future
+  const aiPresets: DicePreset[] = [];
+
+  const handleRoll = useCallback(
+    (formula: string) => {
+      const result: DiceResult = roll(formula);
+      setLastFormula(formula);
+
+      logEvent('dice_roll', {
+        formula: result.formula,
+        rolls: result.rolls,
+        modifier: result.modifier,
+        total: result.total,
+      });
+    },
+    [roll, logEvent]
+  );
+
+  const handleSavePreset = () => {
+    const name = saveName.trim();
+    if (!name || !lastFormula || lastFormula === '0') return;
+
+    store.getState().addCustomPreset({
+      name,
+      formula: lastFormula,
+      source: 'custom',
+    });
+    setSaveName('');
+  };
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="dice-roller-tab">
+      {/* Universal presets */}
+      <section>
+        <h3 className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-gray-400">
+          Preset
+        </h3>
+        <DicePresetRow presets={UNIVERSAL_DICE_PRESETS} onRoll={handleRoll} variant="universal" />
+      </section>
+
+      {/* AI presets (collapsible) */}
+      {aiPresets.length > 0 && (
+        <section>
+          <button
+            type="button"
+            onClick={() => setShowAiPresets(v => !v)}
+            className="mb-1.5 flex items-center gap-1 text-xs font-semibold uppercase tracking-wider text-purple-400"
+          >
+            <span className={cn('transition-transform', showAiPresets && 'rotate-90')}>
+              &#9654;
+            </span>
+            Suggeriti AI
+          </button>
+          {showAiPresets && <DicePresetRow presets={aiPresets} onRoll={handleRoll} variant="ai" />}
+        </section>
+      )}
+
+      {/* Custom presets (collapsible) */}
+      <section>
+        <button
+          type="button"
+          onClick={() => setShowCustomPresets(v => !v)}
+          className="mb-1.5 flex items-center gap-1 text-xs font-semibold uppercase tracking-wider text-[hsl(142,70%,40%)]"
+        >
+          <span className={cn('transition-transform', showCustomPresets && 'rotate-90')}>
+            &#9654;
+          </span>
+          I miei preset
+        </button>
+        {showCustomPresets && (
+          <>
+            <DicePresetRow presets={customPresets} onRoll={handleRoll} variant="custom" />
+
+            {/* Save preset form */}
+            {lastFormula && lastFormula !== '0' && (
+              <div className="mt-2 flex items-center gap-2">
+                <input
+                  type="text"
+                  placeholder="Nome preset"
+                  value={saveName}
+                  onChange={e => setSaveName(e.target.value)}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter') handleSavePreset();
+                  }}
+                  className="flex-1 rounded-lg border border-gray-300 px-2 py-1 text-xs outline-none focus:border-[hsl(142,70%,45%)]"
+                  data-testid="save-preset-input"
+                />
+                <button
+                  type="button"
+                  onClick={handleSavePreset}
+                  disabled={!saveName.trim()}
+                  className={cn(
+                    'rounded-lg px-2 py-1 text-xs font-medium transition-colors',
+                    saveName.trim()
+                      ? 'bg-[hsl(142,70%,45%)] text-white hover:bg-[hsl(142,70%,40%)]'
+                      : 'cursor-not-allowed bg-gray-200 text-gray-400'
+                  )}
+                  data-testid="save-preset-btn"
+                >
+                  Salva
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </section>
+
+      {/* Pool builder */}
+      <section>
+        <h3 className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-gray-400">
+          Pool dadi
+        </h3>
+        <DicePoolBuilder onRoll={handleRoll} />
+      </section>
+
+      {/* Result display */}
+      <DiceResultDisplay result={lastResult} isRolling={isRolling} />
+    </div>
+  );
+}

--- a/apps/web/src/components/toolkit-drawer/tabs/EventDiaryTab.tsx
+++ b/apps/web/src/components/toolkit-drawer/tabs/EventDiaryTab.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+/**
+ * EventDiaryTab — Chronological log of game events with filters and manual entries.
+ */
+
+import React, { useMemo, useState } from 'react';
+
+import { useToolkitDrawer } from '../ToolkitDrawerProvider';
+import { DiaryEventRow } from './DiaryEventRow';
+import { DiaryFilters } from './DiaryFilters';
+
+import type { DiaryEvent, DiaryEventType } from '../types';
+
+function groupByRound(events: DiaryEvent[]): Array<{ round: number | null; events: DiaryEvent[] }> {
+  const groups: Array<{ round: number | null; events: DiaryEvent[] }> = [];
+  let currentRound: number | null | undefined = undefined;
+  let currentGroup: DiaryEvent[] = [];
+
+  for (const evt of events) {
+    const round = evt.round ?? null;
+    if (round !== currentRound) {
+      if (currentGroup.length > 0) {
+        groups.push({ round: currentRound ?? null, events: currentGroup });
+      }
+      currentRound = round;
+      currentGroup = [];
+    }
+    currentGroup.push(evt);
+  }
+  if (currentGroup.length > 0) {
+    groups.push({ round: currentRound ?? null, events: currentGroup });
+  }
+  return groups;
+}
+
+export function EventDiaryTab() {
+  const { store, logEvent } = useToolkitDrawer();
+  const diary = store(s => s.diary);
+  const players = store(s => s.players);
+  const currentTurnIndex = store(s => s.currentTurnIndex);
+  const currentPlayer = players[currentTurnIndex];
+
+  const [activeFilters, setActiveFilters] = useState<DiaryEventType[]>([]);
+  const [manualText, setManualText] = useState('');
+
+  const filteredEvents = useMemo(() => {
+    // Sort by timestamp desc (most recent first)
+    const sorted = [...diary].sort((a, b) => b.timestamp - a.timestamp);
+    if (activeFilters.length === 0) return sorted;
+    return sorted.filter(e => activeFilters.includes(e.type));
+  }, [diary, activeFilters]);
+
+  const groups = useMemo(() => groupByRound(filteredEvents), [filteredEvents]);
+
+  const handleToggleFilter = (type: DiaryEventType) => {
+    setActiveFilters(prev =>
+      prev.includes(type) ? prev.filter(t => t !== type) : [...prev, type]
+    );
+  };
+
+  const handleReset = () => setActiveFilters([]);
+
+  const handleSubmitManual = () => {
+    const trimmed = manualText.trim();
+    if (!trimmed) return;
+    logEvent(
+      'manual_entry',
+      { text: trimmed },
+      {
+        playerId: currentPlayer?.id,
+        playerName: currentPlayer?.name,
+        round: store.getState().currentRound,
+      }
+    );
+    setManualText('');
+  };
+
+  return (
+    <div className="flex h-full flex-col gap-3" data-testid="event-diary-tab">
+      {/* Filters */}
+      <DiaryFilters
+        activeFilters={activeFilters}
+        onToggle={handleToggleFilter}
+        onReset={handleReset}
+      />
+
+      {/* Event list */}
+      <div className="flex-1 overflow-y-auto">
+        {groups.length === 0 ? (
+          <p className="py-4 text-center text-xs italic text-gray-400">Nessun evento nel diario</p>
+        ) : (
+          groups.map((group, idx) => (
+            <div key={idx} className="mb-2">
+              {group.round !== null && (
+                <div className="mb-1 mt-2 text-center text-[10px] font-bold uppercase tracking-wider text-gray-400">
+                  ── Round {group.round} ──
+                </div>
+              )}
+              {group.events.map(evt => (
+                <DiaryEventRow key={evt.id} event={evt} />
+              ))}
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* Manual entry input */}
+      <div className="flex items-center gap-2 border-t border-gray-200 pt-2">
+        <input
+          type="text"
+          value={manualText}
+          onChange={e => setManualText(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter') handleSubmitManual();
+          }}
+          placeholder="✍️ Aggiungi nota al diario"
+          className="flex-1 rounded-lg border border-gray-300 px-3 py-1.5 text-xs outline-none focus:border-[hsl(142,70%,45%)]"
+          data-testid="diary-manual-input"
+        />
+        <button
+          type="button"
+          onClick={handleSubmitManual}
+          disabled={!manualText.trim()}
+          className="rounded-lg bg-[hsl(142,70%,45%)] px-3 py-1.5 text-xs font-medium text-white disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400"
+          data-testid="diary-manual-submit"
+        >
+          +
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/toolkit-drawer/tabs/NoteCard.tsx
+++ b/apps/web/src/components/toolkit-drawer/tabs/NoteCard.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+/**
+ * NoteCard — Single note with inline edit, pin toggle, and delete.
+ */
+
+import React, { useState } from 'react';
+
+import { cn } from '@/lib/utils';
+
+import type { LocalNote } from '../types';
+
+export interface NoteCardProps {
+  note: LocalNote;
+  onUpdate: (noteId: string, content: string) => void;
+  onDelete: (noteId: string) => void;
+  onTogglePin: (noteId: string) => void;
+}
+
+function formatRelative(timestamp: number): string {
+  const diffMs = Date.now() - timestamp;
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return 'ora';
+  if (diffMin < 60) return `${diffMin}min fa`;
+  const diffH = Math.floor(diffMin / 60);
+  if (diffH < 24) return `${diffH}h fa`;
+  const d = new Date(timestamp);
+  return d.toLocaleDateString('it-IT', { day: 'numeric', month: 'short' });
+}
+
+export function NoteCard({ note, onUpdate, onDelete, onTogglePin }: NoteCardProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(note.content);
+
+  const handleSave = () => {
+    const trimmed = draft.trim();
+    if (trimmed && trimmed !== note.content) {
+      onUpdate(note.id, trimmed);
+    }
+    setEditing(false);
+  };
+
+  const handleCancel = () => {
+    setDraft(note.content);
+    setEditing(false);
+  };
+
+  const handleDelete = () => {
+    if (confirm('Eliminare questa nota?')) {
+      onDelete(note.id);
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        'rounded-xl border bg-white p-3 shadow-sm transition-all',
+        note.pinned ? 'border-[hsl(142,70%,45%)]/40 bg-[hsl(142,70%,45%)]/5' : 'border-gray-200'
+      )}
+      data-testid={`note-card-${note.id}`}
+    >
+      {editing ? (
+        <div className="flex flex-col gap-2">
+          <textarea
+            value={draft}
+            onChange={e => setDraft(e.target.value)}
+            autoFocus
+            rows={Math.max(2, draft.split('\n').length)}
+            className="w-full resize-none rounded-lg border border-gray-300 p-2 text-sm outline-none focus:border-[hsl(142,70%,45%)]"
+            data-testid={`note-edit-${note.id}`}
+          />
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="rounded-lg px-3 py-1 text-xs text-gray-500 hover:bg-gray-100"
+            >
+              Annulla
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              className="rounded-lg bg-[hsl(142,70%,45%)] px-3 py-1 text-xs font-medium text-white hover:bg-[hsl(142,70%,40%)]"
+            >
+              Salva
+            </button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="flex items-start justify-between gap-2">
+            <button
+              type="button"
+              onClick={() => setEditing(true)}
+              className="flex-1 text-left text-sm text-gray-800 whitespace-pre-wrap"
+              data-testid={`note-content-${note.id}`}
+            >
+              {note.pinned && <span className="mr-1">📌</span>}
+              {note.content}
+            </button>
+            <div className="flex shrink-0 items-center gap-1">
+              <button
+                type="button"
+                onClick={() => onTogglePin(note.id)}
+                className="rounded p-1 text-xs hover:bg-gray-100"
+                title={note.pinned ? 'Rimuovi pin' : 'Pinna'}
+                data-testid={`note-pin-${note.id}`}
+              >
+                {note.pinned ? '📌' : '📍'}
+              </button>
+              <button
+                type="button"
+                onClick={handleDelete}
+                className="rounded p-1 text-xs hover:bg-red-50"
+                title="Elimina"
+                data-testid={`note-delete-${note.id}`}
+              >
+                🗑️
+              </button>
+            </div>
+          </div>
+          <div className="mt-1 flex items-center gap-2 text-[10px] text-gray-400">
+            {note.playerName && <span>{note.playerName}</span>}
+            {note.playerName && <span>·</span>}
+            <span>{formatRelative(note.updatedAt)}</span>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/toolkit-drawer/tabs/NotesTab.tsx
+++ b/apps/web/src/components/toolkit-drawer/tabs/NotesTab.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+/**
+ * NotesTab — Notes tab with shared and private sections.
+ */
+
+import React, { useState } from 'react';
+
+import { useToolkitDrawer } from '../ToolkitDrawerProvider';
+import { NoteCard } from './NoteCard';
+
+import type { LocalNote } from '../types';
+
+// ============================================================================
+// Add Note inline form
+// ============================================================================
+
+interface AddNoteFormProps {
+  type: 'shared' | 'private';
+  onAdd: (content: string) => void;
+}
+
+function AddNoteForm({ type, onAdd }: AddNoteFormProps) {
+  const [content, setContent] = useState('');
+  const [open, setOpen] = useState(false);
+
+  const handleSubmit = () => {
+    const trimmed = content.trim();
+    if (!trimmed) return;
+    onAdd(trimmed);
+    setContent('');
+    setOpen(false);
+  };
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="mt-2 w-full rounded-lg border border-dashed border-gray-300 py-2 text-xs text-gray-500 hover:border-[hsl(142,70%,45%)] hover:text-[hsl(142,70%,45%)]"
+        data-testid={`add-note-${type}-btn`}
+      >
+        + Aggiungi nota {type === 'shared' ? 'condivisa' : 'privata'}
+      </button>
+    );
+  }
+
+  return (
+    <div className="mt-2 flex flex-col gap-2">
+      <textarea
+        value={content}
+        onChange={e => setContent(e.target.value)}
+        autoFocus
+        rows={2}
+        placeholder={type === 'shared' ? 'Nota visibile a tutti...' : 'Nota visibile solo a te...'}
+        className="w-full resize-none rounded-lg border border-gray-300 p-2 text-sm outline-none focus:border-[hsl(142,70%,45%)]"
+        data-testid={`add-note-${type}-input`}
+      />
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={() => {
+            setContent('');
+            setOpen(false);
+          }}
+          className="rounded-lg px-3 py-1 text-xs text-gray-500 hover:bg-gray-100"
+        >
+          Annulla
+        </button>
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={!content.trim()}
+          className="rounded-lg bg-[hsl(142,70%,45%)] px-3 py-1 text-xs font-medium text-white disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400"
+          data-testid={`add-note-${type}-submit`}
+        >
+          Aggiungi
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// NotesTab
+// ============================================================================
+
+function sortNotes(notes: LocalNote[]): LocalNote[] {
+  return [...notes].sort((a, b) => {
+    // Pinned first
+    if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+    // Then by updated time desc
+    return b.updatedAt - a.updatedAt;
+  });
+}
+
+export function NotesTab() {
+  const { store, logEvent } = useToolkitDrawer();
+
+  const notes = store(s => s.notes);
+  const players = store(s => s.players);
+  const currentTurnIndex = store(s => s.currentTurnIndex);
+  const currentPlayer = players[currentTurnIndex];
+
+  const sharedNotes = sortNotes(notes.filter(n => n.type === 'shared'));
+  const privateNotes = sortNotes(
+    notes.filter(n => n.type === 'private' && (!currentPlayer || n.playerId === currentPlayer.id))
+  );
+
+  const handleAdd = (type: 'shared' | 'private', content: string) => {
+    const note: LocalNote = {
+      id: crypto.randomUUID(),
+      content,
+      type,
+      playerId: currentPlayer?.id,
+      playerName: currentPlayer?.name,
+      pinned: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    store.getState().addNote(note);
+    logEvent(
+      'note_added',
+      { type, preview: content.slice(0, 80) },
+      {
+        playerId: currentPlayer?.id,
+        playerName: currentPlayer?.name,
+      }
+    );
+  };
+
+  const handleUpdate = (noteId: string, content: string) => {
+    store.getState().updateNote(noteId, content);
+  };
+
+  const handleDelete = (noteId: string) => {
+    store.getState().deleteNote(noteId);
+  };
+
+  const handleTogglePin = (noteId: string) => {
+    store.getState().togglePin(noteId);
+  };
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="notes-tab">
+      {/* Shared notes */}
+      <section>
+        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-400">
+          Condivise
+        </h3>
+        <div className="flex flex-col gap-2">
+          {sharedNotes.length === 0 ? (
+            <p className="text-xs italic text-gray-400">Nessuna nota condivisa</p>
+          ) : (
+            sharedNotes.map(note => (
+              <NoteCard
+                key={note.id}
+                note={note}
+                onUpdate={handleUpdate}
+                onDelete={handleDelete}
+                onTogglePin={handleTogglePin}
+              />
+            ))
+          )}
+          <AddNoteForm type="shared" onAdd={c => handleAdd('shared', c)} />
+        </div>
+      </section>
+
+      <hr className="border-gray-200" />
+
+      {/* Private notes */}
+      <section>
+        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-400">
+          🔒 Le mie note
+        </h3>
+        <div className="flex flex-col gap-2">
+          {privateNotes.length === 0 ? (
+            <p className="text-xs italic text-gray-400">Nessuna nota privata</p>
+          ) : (
+            privateNotes.map(note => (
+              <NoteCard
+                key={note.id}
+                note={note}
+                onUpdate={handleUpdate}
+                onDelete={handleDelete}
+                onTogglePin={handleTogglePin}
+              />
+            ))
+          )}
+          <AddNoteForm type="private" onAdd={c => handleAdd('private', c)} />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/components/toolkit-drawer/tabs/RankingBar.tsx
+++ b/apps/web/src/components/toolkit-drawer/tabs/RankingBar.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+/**
+ * RankingBar — Live ranking showing top players with medals.
+ */
+
+import React from 'react';
+
+export interface RankingEntry {
+  id: string;
+  name: string;
+  color: string;
+  total: number;
+}
+
+export interface RankingBarProps {
+  entries: RankingEntry[];
+}
+
+const MEDALS = ['🥇', '🥈', '🥉'];
+
+export function RankingBar({ entries }: RankingBarProps) {
+  if (entries.length === 0) return null;
+
+  const sorted = [...entries].sort((a, b) => b.total - a.total);
+
+  return (
+    <div
+      className="flex flex-wrap items-center justify-center gap-2 text-xs"
+      data-testid="ranking-bar"
+    >
+      {sorted.slice(0, 3).map((entry, idx) => (
+        <div key={entry.id} className="flex items-center gap-1">
+          <span>{MEDALS[idx]}</span>
+          <span className="font-medium" style={{ color: entry.color }}>
+            {entry.name}
+          </span>
+          <span className="font-bold text-gray-800">{entry.total}</span>
+          {idx < Math.min(2, sorted.length - 1) && <span className="ml-1 text-gray-300">·</span>}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/toolkit-drawer/tabs/RoundBreakdown.tsx
+++ b/apps/web/src/components/toolkit-drawer/tabs/RoundBreakdown.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+/**
+ * RoundBreakdown — Expandable per-round score breakdown (placeholder structure).
+ *
+ * Note: Since local scores are currently stored as totals (not per-round deltas),
+ * the breakdown only shows the current round totals. Full per-round tracking
+ * would require storing score history — future enhancement.
+ */
+
+import React, { useState } from 'react';
+
+import { cn } from '@/lib/utils';
+
+export interface RoundBreakdownProps {
+  currentRound: number;
+  onAdvanceRound: () => void;
+}
+
+export function RoundBreakdown({ currentRound, onAdvanceRound }: RoundBreakdownProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-gray-50" data-testid="round-breakdown">
+      <button
+        type="button"
+        onClick={() => setExpanded(v => !v)}
+        className="flex w-full items-center justify-between px-3 py-2 text-xs font-semibold text-gray-600 hover:bg-gray-100"
+        data-testid="round-breakdown-toggle"
+      >
+        <span className="flex items-center gap-1">
+          <span className={cn('transition-transform', expanded && 'rotate-90')}>&#9654;</span>
+          📊 Dettaglio round — R{currentRound}
+        </span>
+      </button>
+      {expanded && (
+        <div className="border-t border-gray-200 p-3">
+          <p className="mb-2 text-[11px] text-gray-500">
+            Round corrente: <strong>R{currentRound}</strong>
+          </p>
+          <button
+            type="button"
+            onClick={onAdvanceRound}
+            className="w-full rounded-lg bg-[hsl(142,70%,45%)] py-1.5 text-xs font-semibold text-white hover:bg-[hsl(142,70%,40%)]"
+            data-testid="advance-round-btn"
+          >
+            Nuovo Round → R{currentRound + 1}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/toolkit-drawer/tabs/ScoreCategoryHeader.tsx
+++ b/apps/web/src/components/toolkit-drawer/tabs/ScoreCategoryHeader.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+/**
+ * ScoreCategoryHeader — Column header for score category with remove action.
+ */
+
+import React from 'react';
+
+export interface ScoreCategoryHeaderProps {
+  category: string;
+  onRemove: () => void;
+}
+
+export function ScoreCategoryHeader({ category, onRemove }: ScoreCategoryHeaderProps) {
+  const handleRemove = () => {
+    if (confirm(`Rimuovere la categoria "${category}"? I punteggi rimarranno nel diario.`)) {
+      onRemove();
+    }
+  };
+
+  return (
+    <th className="min-w-[56px] border-b border-gray-200 px-1 pb-1 pt-1 text-center">
+      <div className="flex flex-col items-center gap-0.5">
+        <span className="max-w-[72px] truncate text-[10px] font-bold uppercase tracking-wider text-gray-600">
+          {category}
+        </span>
+        <button
+          type="button"
+          onClick={handleRemove}
+          className="text-[9px] text-gray-300 hover:text-red-500"
+          title="Rimuovi categoria"
+          data-testid={`remove-category-${category}`}
+        >
+          ×
+        </button>
+      </div>
+    </th>
+  );
+}

--- a/apps/web/src/components/toolkit-drawer/tabs/ScoreCell.tsx
+++ b/apps/web/src/components/toolkit-drawer/tabs/ScoreCell.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+/**
+ * ScoreCell — Editable score cell with tap-to-edit input and +/- stepper.
+ */
+
+import React, { useEffect, useRef, useState } from 'react';
+
+import { cn } from '@/lib/utils';
+
+export interface ScoreCellProps {
+  value: number;
+  onChange: (val: number) => void;
+  testId?: string;
+}
+
+export function ScoreCell({ value, onChange, testId }: ScoreCellProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(String(value));
+  const inputRef = useRef<HTMLInputElement>(null);
+  const holdTimerRef = useRef<number | null>(null);
+  const holdIntervalRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!editing) setDraft(String(value));
+  }, [value, editing]);
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editing]);
+
+  const commit = () => {
+    const parsed = parseInt(draft, 10);
+    if (!Number.isNaN(parsed)) {
+      onChange(parsed);
+    } else {
+      setDraft(String(value));
+    }
+    setEditing(false);
+  };
+
+  const cancel = () => {
+    setDraft(String(value));
+    setEditing(false);
+  };
+
+  const stopHold = () => {
+    if (holdTimerRef.current !== null) {
+      window.clearTimeout(holdTimerRef.current);
+      holdTimerRef.current = null;
+    }
+    if (holdIntervalRef.current !== null) {
+      window.clearInterval(holdIntervalRef.current);
+      holdIntervalRef.current = null;
+    }
+  };
+
+  const startHold = (delta: number) => {
+    onChange(value + delta);
+    holdTimerRef.current = window.setTimeout(() => {
+      let currentDelay = 200;
+      const tick = () => {
+        onChange(value + delta);
+        currentDelay = Math.max(50, currentDelay - 20);
+      };
+      holdIntervalRef.current = window.setInterval(tick, currentDelay);
+    }, 400);
+  };
+
+  useEffect(() => {
+    return () => stopHold();
+  }, []);
+
+  return (
+    <div className="flex flex-col items-center gap-0.5" data-testid={testId}>
+      {editing ? (
+        <input
+          ref={inputRef}
+          type="number"
+          value={draft}
+          onChange={e => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={e => {
+            if (e.key === 'Enter') commit();
+            if (e.key === 'Escape') cancel();
+          }}
+          className="w-12 rounded border border-[hsl(142,70%,45%)] px-1 text-center text-sm font-semibold outline-none"
+          data-testid={`${testId}-input`}
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={() => setEditing(true)}
+          className="w-12 rounded px-1 text-center text-sm font-semibold text-gray-800 hover:bg-gray-100"
+          data-testid={`${testId}-value`}
+        >
+          {value}
+        </button>
+      )}
+      <div className="flex items-center gap-0.5">
+        <button
+          type="button"
+          onPointerDown={e => {
+            e.preventDefault();
+            startHold(-1);
+          }}
+          onPointerUp={stopHold}
+          onPointerLeave={stopHold}
+          className={cn(
+            'h-5 w-5 rounded text-[10px] font-bold text-gray-500',
+            'bg-gray-100 hover:bg-gray-200 active:bg-gray-300'
+          )}
+          data-testid={`${testId}-dec`}
+        >
+          −
+        </button>
+        <button
+          type="button"
+          onPointerDown={e => {
+            e.preventDefault();
+            startHold(1);
+          }}
+          onPointerUp={stopHold}
+          onPointerLeave={stopHold}
+          className={cn(
+            'h-5 w-5 rounded text-[10px] font-bold text-gray-500',
+            'bg-gray-100 hover:bg-gray-200 active:bg-gray-300'
+          )}
+          data-testid={`${testId}-inc`}
+        >
+          +
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/toolkit-drawer/tabs/ScoreboardTab.tsx
+++ b/apps/web/src/components/toolkit-drawer/tabs/ScoreboardTab.tsx
@@ -1,0 +1,280 @@
+'use client';
+
+/**
+ * ScoreboardTab — Multi-dimension scoreboard with inline edit, stepper,
+ * row reorder, ranking, and round breakdown.
+ */
+
+import React, { useMemo, useState } from 'react';
+
+import { cn } from '@/lib/utils';
+
+import { useToolkitDrawer } from '../ToolkitDrawerProvider';
+import { RankingBar, type RankingEntry } from './RankingBar';
+import { RoundBreakdown } from './RoundBreakdown';
+import { ScoreCategoryHeader } from './ScoreCategoryHeader';
+import { ScoreCell } from './ScoreCell';
+
+// ============================================================================
+// Add category inline form
+// ============================================================================
+
+function AddCategoryButton({ onAdd }: { onAdd: (name: string) => void }) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+
+  const submit = () => {
+    const trimmed = name.trim();
+    if (trimmed) {
+      onAdd(trimmed);
+      setName('');
+      setOpen(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="rounded-lg border border-dashed border-gray-300 px-2 py-1 text-[10px] font-semibold text-gray-400 hover:border-[hsl(142,70%,45%)] hover:text-[hsl(142,70%,45%)]"
+        data-testid="add-category-btn"
+      >
+        + Aggiungi
+      </button>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-1">
+      <input
+        type="text"
+        value={name}
+        onChange={e => setName(e.target.value)}
+        autoFocus
+        onKeyDown={e => {
+          if (e.key === 'Enter') submit();
+          if (e.key === 'Escape') setOpen(false);
+        }}
+        placeholder="Nome"
+        className="w-20 rounded border border-[hsl(142,70%,45%)] px-1 text-[10px] outline-none"
+        data-testid="add-category-input"
+      />
+      <button
+        type="button"
+        onClick={submit}
+        className="text-[10px] text-[hsl(142,70%,45%)]"
+        data-testid="add-category-confirm"
+      >
+        ✓
+      </button>
+    </div>
+  );
+}
+
+// ============================================================================
+// ScoreboardTab
+// ============================================================================
+
+export function ScoreboardTab() {
+  const { store, logEvent } = useToolkitDrawer();
+  const players = store(s => s.players);
+  const scores = store(s => s.scores);
+  const scoreCategories = store(s => s.scoreCategories);
+  const currentTurnIndex = store(s => s.currentTurnIndex);
+  const currentRound = store(s => s.currentRound);
+
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+
+  const handleScoreChange = (
+    playerId: string,
+    playerName: string,
+    category: string,
+    newValue: number
+  ) => {
+    const prev = scores[playerId]?.[category] ?? 0;
+    const delta = newValue - prev;
+    if (delta === 0) return;
+
+    store.getState().setScore(playerId, category, newValue);
+    logEvent(
+      'score_change',
+      { category, delta, newTotal: newValue },
+      { playerId, playerName, round: currentRound }
+    );
+  };
+
+  const handleAddCategory = (name: string) => {
+    store.getState().addScoreCategory(name);
+  };
+
+  const handleRemoveCategory = (category: string) => {
+    store.getState().removeScoreCategory(category);
+  };
+
+  const handleReset = () => {
+    if (confirm('Azzerare tutti i punteggi? I valori attuali saranno persi.')) {
+      store.getState().resetScores();
+      logEvent('score_reset', {});
+    }
+  };
+
+  const handleAdvanceRound = () => {
+    store.getState().advanceRound();
+    logEvent('round_advance', { round: currentRound + 1 });
+  };
+
+  const handleSetTurn = (index: number, playerName: string) => {
+    const prevPlayer = players[currentTurnIndex];
+    const nextPlayer = players[index];
+    if (!nextPlayer || prevPlayer?.id === nextPlayer.id) return;
+
+    store.getState().setTurn(index);
+    logEvent(
+      'turn_change',
+      { nextPlayerName: playerName },
+      { playerId: nextPlayer.id, playerName: nextPlayer.name, round: currentRound }
+    );
+  };
+
+  // Row reorder via drag
+  const handleDragStart = (index: number) => setDragIndex(index);
+  const handleDragOver = (e: React.DragEvent) => e.preventDefault();
+  const handleDrop = (targetIndex: number) => {
+    if (dragIndex === null || dragIndex === targetIndex) {
+      setDragIndex(null);
+      return;
+    }
+    const reordered = [...players];
+    const [moved] = reordered.splice(dragIndex, 1);
+    reordered.splice(targetIndex, 0, moved);
+    store.getState().reorderPlayers(reordered.map(p => p.id));
+    setDragIndex(null);
+  };
+
+  // Compute totals and ranking
+  const rankingEntries: RankingEntry[] = useMemo(
+    () =>
+      players.map(p => ({
+        id: p.id,
+        name: p.name,
+        color: p.color,
+        total: Object.values(scores[p.id] ?? {}).reduce((a, b) => a + b, 0),
+      })),
+    [players, scores]
+  );
+
+  if (players.length === 0) {
+    return (
+      <div className="py-8 text-center" data-testid="scoreboard-tab">
+        <p className="text-sm italic text-gray-400">
+          Aggiungi giocatori dalla barra in basso per iniziare
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3" data-testid="scoreboard-tab">
+      {/* Categories row */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-400">Categorie</h3>
+        <AddCategoryButton onAdd={handleAddCategory} />
+      </div>
+
+      {/* Score table */}
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse">
+          <thead>
+            <tr>
+              <th className="border-b border-gray-200 px-1 pb-1 text-left text-[10px] font-bold uppercase tracking-wider text-gray-600">
+                Giocatore
+              </th>
+              {scoreCategories.map(cat => (
+                <ScoreCategoryHeader
+                  key={cat}
+                  category={cat}
+                  onRemove={() => handleRemoveCategory(cat)}
+                />
+              ))}
+              <th className="border-b border-gray-200 px-1 pb-1 text-center text-[10px] font-bold uppercase tracking-wider text-[hsl(142,70%,45%)]">
+                Totale
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {players.map((player, idx) => {
+              const isTurn = idx === currentTurnIndex;
+              const total = Object.values(scores[player.id] ?? {}).reduce((a, b) => a + b, 0);
+              return (
+                <tr
+                  key={player.id}
+                  draggable
+                  onDragStart={() => handleDragStart(idx)}
+                  onDragOver={handleDragOver}
+                  onDrop={() => handleDrop(idx)}
+                  className={cn('border-b border-gray-100', dragIndex === idx && 'opacity-50')}
+                  data-testid={`score-row-${player.id}`}
+                >
+                  <td className="py-1.5 pr-1">
+                    <div className="flex items-center gap-1.5">
+                      <span className="cursor-grab text-[10px] text-gray-300" title="Trascina">
+                        ⠿
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => handleSetTurn(idx, player.name)}
+                        className={cn(
+                          'flex items-center gap-1.5 rounded px-1 py-0.5 text-xs font-medium',
+                          isTurn && 'bg-[hsl(142,70%,45%)]/10'
+                        )}
+                        data-testid={`set-turn-${player.id}`}
+                      >
+                        {isTurn && <span className="text-[hsl(142,70%,45%)]">●</span>}
+                        <span
+                          className="h-3 w-3 rounded-full"
+                          style={{ backgroundColor: player.color }}
+                        />
+                        <span className="max-w-[72px] truncate text-gray-800">{player.name}</span>
+                      </button>
+                    </div>
+                  </td>
+                  {scoreCategories.map(cat => (
+                    <td key={cat} className="py-1.5 text-center">
+                      <ScoreCell
+                        value={scores[player.id]?.[cat] ?? 0}
+                        onChange={val => handleScoreChange(player.id, player.name, cat, val)}
+                        testId={`score-${player.id}-${cat}`}
+                      />
+                    </td>
+                  ))}
+                  <td className="py-1.5 text-center text-sm font-bold text-[hsl(142,70%,45%)]">
+                    {total}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Ranking */}
+      <RankingBar entries={rankingEntries} />
+
+      {/* Round breakdown */}
+      <RoundBreakdown currentRound={currentRound} onAdvanceRound={handleAdvanceRound} />
+
+      {/* Actions */}
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={handleReset}
+          className="rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-600 hover:border-red-400 hover:text-red-500"
+          data-testid="reset-scores-btn"
+        >
+          🔄 Reset
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/toolkit-drawer/types.ts
+++ b/apps/web/src/components/toolkit-drawer/types.ts
@@ -1,0 +1,120 @@
+/**
+ * Toolkit Drawer — Shared Types
+ *
+ * Type definitions and constants for the Default Game Toolkit drawer.
+ * Used across the store, API client, provider, and tab components.
+ */
+
+// ============================================================================
+// Tab Navigation
+// ============================================================================
+
+export type ToolkitTab = 'dice' | 'notes' | 'diary' | 'scores';
+
+// ============================================================================
+// Diary Event Types
+// ============================================================================
+
+export type DiaryEventType =
+  | 'dice_roll'
+  | 'score_change'
+  | 'turn_change'
+  | 'note_added'
+  | 'manual_entry'
+  | 'player_joined'
+  | 'round_advance'
+  | 'score_reset';
+
+// ============================================================================
+// Player
+// ============================================================================
+
+export interface LocalPlayer {
+  id: string;
+  name: string;
+  color: string;
+  avatarUrl?: string;
+}
+
+// ============================================================================
+// Diary
+// ============================================================================
+
+export interface DiaryEvent {
+  id: string;
+  type: DiaryEventType;
+  timestamp: number;
+  playerId?: string;
+  playerName?: string;
+  round?: number;
+  payload: Record<string, unknown>;
+}
+
+// ============================================================================
+// Dice
+// ============================================================================
+
+export interface DiceResult {
+  formula: string;
+  rolls: number[];
+  modifier: number;
+  total: number;
+}
+
+export interface DicePreset {
+  name: string;
+  formula: string;
+  source: 'universal' | 'ai' | 'custom';
+  icon?: string;
+}
+
+// ============================================================================
+// Notes
+// ============================================================================
+
+export interface LocalNote {
+  id: string;
+  content: string;
+  type: 'shared' | 'private';
+  playerId?: string;
+  playerName?: string;
+  pinned: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+// ============================================================================
+// Drawer Props
+// ============================================================================
+
+export interface ToolkitDrawerProps {
+  gameId: string;
+  sessionId?: string;
+  onClose: () => void;
+  defaultTab?: ToolkitTab;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** 8 distinct player colors for the toolkit */
+export const PLAYER_COLORS = [
+  '#E67E22', // orange
+  '#9B59B6', // purple
+  '#2ECC71', // green
+  '#3498DB', // blue
+  '#E74C3C', // red
+  '#F1C40F', // yellow
+  '#1ABC9C', // teal
+  '#E84393', // pink
+] as const;
+
+/** Built-in dice presets available to all users */
+export const UNIVERSAL_DICE_PRESETS: DicePreset[] = [
+  { name: '1d6', formula: '1d6', source: 'universal' },
+  { name: '2d6', formula: '2d6', source: 'universal' },
+  { name: '1d20', formula: '1d20', source: 'universal' },
+  { name: '3d6', formula: '3d6', source: 'universal' },
+  { name: '1d100', formula: '1d100', source: 'universal' },
+];

--- a/apps/web/src/lib/api/clients/index.ts
+++ b/apps/web/src/lib/api/clients/index.ts
@@ -54,3 +54,4 @@ export * from './contactClient'; // Public contact form
 export * from './agentMemoryClient'; // AgentMemory — groups, game memory, player stats
 export * from './agentDocumentsClient'; // User-scoped agent document selection
 export * from './infrastructureClient'; // AI Infrastructure Dashboard
+export * from './toolkit'; // Default Game Toolkit — session events & dice presets

--- a/apps/web/src/lib/api/clients/toolkit.ts
+++ b/apps/web/src/lib/api/clients/toolkit.ts
@@ -1,0 +1,121 @@
+/**
+ * Toolkit API Client
+ *
+ * Endpoints for the Default Game Toolkit (session events and dice presets).
+ *
+ * Endpoints:
+ * - POST   /api/v1/session-events                       — Add session event
+ * - GET    /api/v1/session-events/by-session/{sessionId} — List session events
+ * - GET    /api/v1/game-toolkits/{toolkitId}/dice-presets — Get user dice presets
+ * - POST   /api/v1/game-toolkits/{toolkitId}/dice-presets — Add dice preset
+ * - DELETE  /api/v1/game-toolkits/{toolkitId}/dice-presets/{name} — Remove dice preset
+ */
+
+import type { HttpClient } from '../core/httpClient';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface AddSessionEventRequest {
+  eventType: string;
+  payloadJson: string;
+  participantId?: string;
+  roundNumber?: number;
+}
+
+export interface SessionEventDto {
+  id: string;
+  sessionId: string;
+  eventType: string;
+  payloadJson: string;
+  participantId?: string;
+  roundNumber?: number;
+  createdAt: string;
+}
+
+export interface GetSessionEventsParams {
+  type?: string;
+  round?: number;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface UserDicePresetDto {
+  name: string;
+  formula: string;
+}
+
+// ============================================================================
+// Client Interface
+// ============================================================================
+
+export interface ToolkitClient {
+  /** Add a session event (dice roll, score change, etc.) */
+  addSessionEvent(sessionId: string, request: AddSessionEventRequest): Promise<SessionEventDto>;
+
+  /** Get session events with optional filters */
+  getSessionEvents(sessionId: string, params?: GetSessionEventsParams): Promise<SessionEventDto[]>;
+
+  /** Get user dice presets for a toolkit */
+  getUserDicePresets(toolkitId: string): Promise<UserDicePresetDto[]>;
+
+  /** Add a custom dice preset */
+  addUserDicePreset(
+    toolkitId: string,
+    preset: { name: string; formula: string }
+  ): Promise<UserDicePresetDto>;
+
+  /** Remove a custom dice preset by name */
+  removeUserDicePreset(toolkitId: string, presetName: string): Promise<void>;
+}
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+export function createToolkitClient({ httpClient }: { httpClient: HttpClient }): ToolkitClient {
+  return {
+    async addSessionEvent(sessionId, request) {
+      const response = await httpClient.post<SessionEventDto>(`/api/v1/session-events`, {
+        sessionId,
+        ...request,
+      });
+      return response;
+    },
+
+    async getSessionEvents(sessionId, params) {
+      const searchParams = new URLSearchParams();
+      if (params?.type) searchParams.set('type', params.type);
+      if (params?.round != null) searchParams.set('round', String(params.round));
+      if (params?.limit != null) searchParams.set('limit', String(params.limit));
+      if (params?.cursor) searchParams.set('cursor', params.cursor);
+
+      const qs = searchParams.toString();
+      const path = `/api/v1/session-events/by-session/${sessionId}${qs ? `?${qs}` : ''}`;
+      const response = await httpClient.get<SessionEventDto[]>(path);
+      return response ?? [];
+    },
+
+    async getUserDicePresets(toolkitId) {
+      const response = await httpClient.get<UserDicePresetDto[]>(
+        `/api/v1/game-toolkits/${toolkitId}/dice-presets`
+      );
+      return response ?? [];
+    },
+
+    async addUserDicePreset(toolkitId, preset) {
+      const response = await httpClient.post<UserDicePresetDto>(
+        `/api/v1/game-toolkits/${toolkitId}/dice-presets`,
+        preset
+      );
+      return response;
+    },
+
+    async removeUserDicePreset(toolkitId, presetName) {
+      await httpClient.delete(
+        `/api/v1/game-toolkits/${toolkitId}/dice-presets/${encodeURIComponent(presetName)}`
+      );
+    },
+  };
+}

--- a/apps/web/src/lib/api/clients/toolkit.ts
+++ b/apps/web/src/lib/api/clients/toolkit.ts
@@ -87,8 +87,10 @@ export function createToolkitClient({ httpClient }: { httpClient: HttpClient }):
     async getSessionEvents(sessionId, params) {
       const searchParams = new URLSearchParams();
       if (params?.type) searchParams.set('type', params.type);
-      if (params?.round != null) searchParams.set('round', String(params.round));
-      if (params?.limit != null) searchParams.set('limit', String(params.limit));
+      if (params?.round !== undefined && params.round !== null)
+        searchParams.set('round', String(params.round));
+      if (params?.limit !== undefined && params.limit !== null)
+        searchParams.set('limit', String(params.limit));
       if (params?.cursor) searchParams.set('cursor', params.cursor);
 
       const qs = searchParams.toString();

--- a/apps/web/src/stores/toolkit-local-store.ts
+++ b/apps/web/src/stores/toolkit-local-store.ts
@@ -1,0 +1,305 @@
+'use client';
+
+/**
+ * Toolkit Local Store
+ *
+ * Per-game local Zustand store for the Default Game Toolkit.
+ * Persists player state, scores, notes, diary, and custom dice presets
+ * to localStorage using the standard MeepleAI middleware stack:
+ * devtools + persist + immer.
+ *
+ * Factory pattern: `createToolkitLocalStore(gameId)` produces a unique
+ * store keyed to `meepleai-toolkit-${gameId}`.
+ */
+
+import { create } from 'zustand';
+import { createJSONStorage, devtools, persist } from 'zustand/middleware';
+import { immer } from 'zustand/middleware/immer';
+
+import type {
+  DicePreset,
+  DiaryEvent,
+  LocalNote,
+  LocalPlayer,
+} from '@/components/toolkit-drawer/types';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ToolkitLocalState {
+  // Player management
+  players: LocalPlayer[];
+  currentTurnIndex: number;
+  currentRound: number;
+
+  // Scores
+  scores: Record<string, Record<string, number>>; // playerId → category → value
+  scoreCategories: string[];
+
+  // Notes
+  notes: LocalNote[];
+
+  // Diary
+  diary: DiaryEvent[];
+
+  // Custom dice presets
+  customDicePresets: DicePreset[];
+}
+
+export interface ToolkitLocalActions {
+  // Player actions
+  addPlayer: (player: LocalPlayer) => void;
+  removePlayer: (playerId: string) => void;
+  reorderPlayers: (playerIds: string[]) => void;
+  setTurn: (index: number) => void;
+  advanceTurn: () => void;
+  advanceRound: () => void;
+
+  // Score actions
+  setScore: (playerId: string, category: string, value: number) => void;
+  addScoreCategory: (category: string) => void;
+  removeScoreCategory: (category: string) => void;
+  resetScores: () => void;
+
+  // Note actions
+  addNote: (note: LocalNote) => void;
+  updateNote: (noteId: string, content: string) => void;
+  deleteNote: (noteId: string) => void;
+  togglePin: (noteId: string) => void;
+
+  // Diary actions
+  logEvent: (event: DiaryEvent) => void;
+  clearDiary: () => void;
+
+  // Dice preset actions
+  addCustomPreset: (preset: DicePreset) => void;
+  removeCustomPreset: (presetName: string) => void;
+
+  // Reset
+  resetAll: () => void;
+}
+
+export type ToolkitLocalStore = ToolkitLocalState & ToolkitLocalActions;
+
+// ============================================================================
+// Initial State
+// ============================================================================
+
+const INITIAL_STATE: ToolkitLocalState = {
+  players: [],
+  currentTurnIndex: 0,
+  currentRound: 1,
+  scores: {},
+  scoreCategories: [],
+  notes: [],
+  diary: [],
+  customDicePresets: [],
+};
+
+// ============================================================================
+// Store Factory
+// ============================================================================
+
+/**
+ * Creates a per-game toolkit store persisted under `meepleai-toolkit-${gameId}`.
+ *
+ * Each store instance is independent — opening toolkits for different games
+ * will not interfere with each other.
+ */
+export function createToolkitLocalStore(gameId: string) {
+  const storageKey = `meepleai-toolkit-${gameId}`;
+
+  return create<ToolkitLocalStore>()(
+    devtools(
+      persist(
+        immer(set => ({
+          // ─── Initial State ─────────────────────────────
+          ...INITIAL_STATE,
+
+          // ─── Player Actions ────────────────────────────
+
+          addPlayer: player => {
+            set(state => {
+              state.players.push(player);
+              state.scores[player.id] = {};
+            });
+          },
+
+          removePlayer: playerId => {
+            set(state => {
+              state.players = state.players.filter(p => p.id !== playerId);
+              delete state.scores[playerId];
+              // Adjust turn index if needed
+              if (state.currentTurnIndex >= state.players.length) {
+                state.currentTurnIndex = Math.max(0, state.players.length - 1);
+              }
+            });
+          },
+
+          reorderPlayers: playerIds => {
+            set(state => {
+              const indexed = new Map(state.players.map(p => [p.id, p]));
+              state.players = playerIds
+                .map(id => indexed.get(id))
+                .filter((p): p is LocalPlayer => p !== undefined);
+            });
+          },
+
+          setTurn: index => {
+            set(state => {
+              state.currentTurnIndex = index;
+            });
+          },
+
+          advanceTurn: () => {
+            set(state => {
+              if (state.players.length === 0) return;
+              state.currentTurnIndex = (state.currentTurnIndex + 1) % state.players.length;
+            });
+          },
+
+          advanceRound: () => {
+            set(state => {
+              state.currentRound += 1;
+              state.currentTurnIndex = 0;
+            });
+          },
+
+          // ─── Score Actions ─────────────────────────────
+
+          setScore: (playerId, category, value) => {
+            set(state => {
+              if (!state.scores[playerId]) {
+                state.scores[playerId] = {};
+              }
+              state.scores[playerId][category] = value;
+            });
+          },
+
+          addScoreCategory: category => {
+            set(state => {
+              if (!state.scoreCategories.includes(category)) {
+                state.scoreCategories.push(category);
+              }
+            });
+          },
+
+          removeScoreCategory: category => {
+            set(state => {
+              state.scoreCategories = state.scoreCategories.filter(c => c !== category);
+              // Remove the category from all players' scores
+              for (const playerId of Object.keys(state.scores)) {
+                delete state.scores[playerId][category];
+              }
+            });
+          },
+
+          resetScores: () => {
+            set(state => {
+              for (const playerId of Object.keys(state.scores)) {
+                state.scores[playerId] = {};
+              }
+            });
+          },
+
+          // ─── Note Actions ──────────────────────────────
+
+          addNote: note => {
+            set(state => {
+              state.notes.push(note);
+            });
+          },
+
+          updateNote: (noteId, content) => {
+            set(state => {
+              const note = state.notes.find(n => n.id === noteId);
+              if (note) {
+                note.content = content;
+                note.updatedAt = Date.now();
+              }
+            });
+          },
+
+          deleteNote: noteId => {
+            set(state => {
+              state.notes = state.notes.filter(n => n.id !== noteId);
+            });
+          },
+
+          togglePin: noteId => {
+            set(state => {
+              const note = state.notes.find(n => n.id === noteId);
+              if (note) {
+                note.pinned = !note.pinned;
+              }
+            });
+          },
+
+          // ─── Diary Actions ─────────────────────────────
+
+          logEvent: event => {
+            set(state => {
+              state.diary.push(event);
+            });
+          },
+
+          clearDiary: () => {
+            set(state => {
+              state.diary = [];
+            });
+          },
+
+          // ─── Dice Preset Actions ───────────────────────
+
+          addCustomPreset: preset => {
+            set(state => {
+              // Prevent duplicates by name
+              if (!state.customDicePresets.some(p => p.name === preset.name)) {
+                state.customDicePresets.push(preset);
+              }
+            });
+          },
+
+          removeCustomPreset: presetName => {
+            set(state => {
+              state.customDicePresets = state.customDicePresets.filter(p => p.name !== presetName);
+            });
+          },
+
+          // ─── Reset ─────────────────────────────────────
+
+          resetAll: () => {
+            set(() => ({ ...INITIAL_STATE }));
+          },
+        })),
+        {
+          name: storageKey,
+          storage: createJSONStorage(() =>
+            typeof window !== 'undefined'
+              ? localStorage
+              : {
+                  getItem: () => null,
+                  setItem: () => {},
+                  removeItem: () => {},
+                }
+          ),
+          // Only persist state values, not action functions
+          partialize: state => ({
+            players: state.players,
+            currentTurnIndex: state.currentTurnIndex,
+            currentRound: state.currentRound,
+            scores: state.scores,
+            scoreCategories: state.scoreCategories,
+            notes: state.notes,
+            diary: state.diary,
+            customDicePresets: state.customDicePresets,
+          }),
+        }
+      ),
+      {
+        name: `ToolkitLocalStore(${gameId})`,
+      }
+    )
+  );
+}

--- a/docs/superpowers/plans/2026-04-08-default-game-toolkit.md
+++ b/docs/superpowers/plans/2026-04-08-default-game-toolkit.md
@@ -1,0 +1,2209 @@
+# Default Game Toolkit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a 4-tab ToolkitDrawer (dice, notes, diary, scoreboard) accessible from MeepleCard NavFooter, with local-first state and optional SessionTracking sync.
+
+**Architecture:** GameToolkit BC provides config/presets (read), SessionTracking BC persists runtime data (read/write). Frontend Zustand store handles local mode; promotion flow migrates to session. The drawer follows ExtraMeepleCardDrawer pattern with tabs.
+
+**Tech Stack:** .NET 9 (MediatR, FluentValidation, EF Core, PostgreSQL) | Next.js (React 19, Zustand, TanStack Query, Tailwind, Framer Motion)
+
+**Spec:** `docs/superpowers/specs/2026-04-08-default-game-toolkit-design.md`
+
+---
+
+## File Structure
+
+### Backend (New Files)
+
+```
+apps/api/src/Api/BoundedContexts/
+├── SessionTracking/
+│   ├── Domain/
+│   │   ├── Entities/SessionEvent.cs
+│   │   └── Repositories/ISessionEventRepository.cs
+│   ├── Application/
+│   │   ├── Commands/AddSessionEventCommand.cs
+│   │   ├── Commands/AddSessionEventCommandHandler.cs
+│   │   ├── Commands/AddSessionEventCommandValidator.cs
+│   │   ├── Queries/GetSessionEventsQuery.cs
+│   │   ├── Queries/GetSessionEventsQueryHandler.cs
+│   │   └── DTOs/SessionEventDtos.cs
+│   └── Infrastructure/
+│       ├── Persistence/SessionEventRepository.cs
+│       └── Persistence/Configurations/SessionEventConfiguration.cs
+│
+└── GameToolkit/
+    ├── Domain/Entities/GameToolkit.cs              ← MODIFY (add UserDicePreset)
+    ├── Application/
+    │   ├── Commands/UserDicePresetCommands.cs       ← NEW
+    │   ├── Commands/UserDicePresetCommandHandlers.cs← NEW
+    │   ├── Queries/GetUserDicePresetsQuery.cs       ← NEW
+    │   └── DTOs/ToolkitDtos.cs                      ← MODIFY (add UserDicePresetDto)
+    └── Infrastructure/
+        └── Persistence/GameToolkitRepository.cs     ← MODIFY (serialize presets)
+```
+
+### Backend (Modified Files)
+
+```
+apps/api/src/Api/
+├── Routing/SessionTrackingRoutes.cs                 ← ADD event endpoints
+├── Routing/GameToolkitRoutes.cs                     ← ADD preset endpoints
+├── BoundedContexts/SessionTracking/Infrastructure/DependencyInjection/
+│   └── SessionTrackingServiceExtensions.cs          ← REGISTER SessionEventRepository
+└── Infrastructure/Persistence/Migrations/
+    └── {timestamp}_AddSessionEventsAndUserDicePresets.cs ← NEW migration
+```
+
+### Frontend (New Files)
+
+```
+apps/web/src/
+├── components/toolkit-drawer/
+│   ├── ToolkitDrawer.tsx
+│   ├── ToolkitDrawerProvider.tsx
+│   ├── index.ts
+│   ├── types.ts
+│   ├── tabs/
+│   │   ├── DiceRollerTab.tsx
+│   │   ├── DicePresetRow.tsx
+│   │   ├── DicePoolBuilder.tsx
+│   │   ├── DiceResultDisplay.tsx
+│   │   ├── NotesTab.tsx
+│   │   ├── NoteCard.tsx
+│   │   ├── EventDiaryTab.tsx
+│   │   ├── DiaryEventRow.tsx
+│   │   ├── DiaryFilters.tsx
+│   │   ├── ScoreboardTab.tsx
+│   │   ├── ScoreCell.tsx
+│   │   ├── ScoreCategoryHeader.tsx
+│   │   ├── RankingBar.tsx
+│   │   └── RoundBreakdown.tsx
+│   ├── shared/
+│   │   ├── PlayerBar.tsx
+│   │   ├── PlayerAvatar.tsx
+│   │   ├── PlayerSetupModal.tsx
+│   │   └── PromoteSessionModal.tsx
+│   └── hooks/
+│       ├── useToolkitConfig.ts
+│       ├── usePlayerContext.ts
+│       ├── useDiceRoller.ts
+│       ├── useScoreboard.ts
+│       ├── useNotes.ts
+│       ├── useDiary.ts
+│       └── useToolkitSession.ts
+├── stores/toolkit-local-store.ts
+└── lib/api/clients/toolkit.ts
+```
+
+---
+
+## Task 1: SessionEvent Domain Entity
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/SessionEvent.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Repositories/ISessionEventRepository.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/SessionEventTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Domain;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SessionTracking")]
+public class SessionEventTests
+{
+    [Fact]
+    public void Create_WithValidParameters_ShouldSucceed()
+    {
+        var sessionId = Guid.NewGuid();
+        var participantId = Guid.NewGuid();
+
+        var evt = SessionEvent.Create(
+            sessionId, "dice_roll",
+            """{"formula":"2d6","results":[3,5],"total":8}""",
+            participantId, roundNumber: 2);
+
+        evt.Should().NotBeNull();
+        evt.Id.Should().NotBe(Guid.Empty);
+        evt.SessionId.Should().Be(sessionId);
+        evt.EventType.Should().Be("dice_roll");
+        evt.ParticipantId.Should().Be(participantId);
+        evt.RoundNumber.Should().Be(2);
+        evt.PayloadJson.Should().Contain("formula");
+        evt.Timestamp.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public void Create_WithEmptySessionId_ShouldThrow()
+    {
+        var act = () => SessionEvent.Create(Guid.Empty, "dice_roll", "{}");
+        act.Should().Throw<ArgumentException>().WithMessage("*sessionId*");
+    }
+
+    [Fact]
+    public void Create_WithEmptyEventType_ShouldThrow()
+    {
+        var act = () => SessionEvent.Create(Guid.NewGuid(), "", "{}");
+        act.Should().Throw<ArgumentException>().WithMessage("*eventType*");
+    }
+
+    [Fact]
+    public void Create_WithNullPayload_ShouldThrow()
+    {
+        var act = () => SessionEvent.Create(Guid.NewGuid(), "dice_roll", null!);
+        act.Should().Throw<ArgumentException>().WithMessage("*payloadJson*");
+    }
+
+    [Fact]
+    public void Create_WithNoParticipant_ShouldSucceed()
+    {
+        var evt = SessionEvent.Create(Guid.NewGuid(), "round_advance", """{"round":3}""");
+        evt.ParticipantId.Should().BeNull();
+        evt.RoundNumber.Should().BeNull();
+    }
+
+    [Fact]
+    public void Create_EventType_ShouldBeTrimmedLowercase()
+    {
+        var evt = SessionEvent.Create(Guid.NewGuid(), "  Dice_Roll  ", "{}");
+        evt.EventType.Should().Be("dice_roll");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && dotnet test --filter "FullyQualifiedName~SessionEventTests" -v minimal`
+Expected: FAIL — `SessionEvent` class does not exist.
+
+- [ ] **Step 3: Write the domain entity**
+
+```csharp
+// SessionEvent.cs
+using System.ComponentModel.DataAnnotations;
+
+namespace Api.BoundedContexts.SessionTracking.Domain.Entities;
+
+public class SessionEvent
+{
+    public Guid Id { get; private set; }
+    public Guid SessionId { get; private set; }
+    public Guid? ParticipantId { get; private set; }
+
+    [MaxLength(50)]
+    public string EventType { get; private set; } = string.Empty;
+
+    public int? RoundNumber { get; private set; }
+    public string PayloadJson { get; private set; } = string.Empty;
+    public DateTime Timestamp { get; private set; }
+
+    private SessionEvent() { } // EF Core
+
+    public static SessionEvent Create(
+        Guid sessionId,
+        string eventType,
+        string payloadJson,
+        Guid? participantId = null,
+        int? roundNumber = null)
+    {
+        if (sessionId == Guid.Empty)
+            throw new ArgumentException("Session ID is required.", nameof(sessionId));
+        if (string.IsNullOrWhiteSpace(eventType))
+            throw new ArgumentException("Event type is required.", nameof(eventType));
+        ArgumentNullException.ThrowIfNull(payloadJson, nameof(payloadJson));
+
+        return new SessionEvent
+        {
+            Id = Guid.NewGuid(),
+            SessionId = sessionId,
+            EventType = eventType.Trim().ToLowerInvariant(),
+            PayloadJson = payloadJson,
+            ParticipantId = participantId,
+            RoundNumber = roundNumber,
+            Timestamp = DateTime.UtcNow
+        };
+    }
+}
+```
+
+- [ ] **Step 4: Write the repository interface**
+
+```csharp
+// ISessionEventRepository.cs
+namespace Api.BoundedContexts.SessionTracking.Domain.Repositories;
+
+public interface ISessionEventRepository
+{
+    Task<SessionEvent?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<List<SessionEvent>> GetBySessionIdAsync(
+        Guid sessionId,
+        string? eventType = null,
+        int? roundNumber = null,
+        int limit = 50,
+        DateTime? cursor = null,
+        CancellationToken ct = default);
+    Task AddAsync(SessionEvent sessionEvent, CancellationToken ct = default);
+    Task SaveChangesAsync(CancellationToken ct = default);
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd apps/api && dotnet test --filter "FullyQualifiedName~SessionEventTests" -v minimal`
+Expected: All 6 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/SessionEvent.cs \
+       apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Repositories/ISessionEventRepository.cs \
+       apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/SessionEventTests.cs
+git commit -m "feat(session-tracking): add SessionEvent domain entity and repository interface"
+```
+
+---
+
+## Task 2: SessionEvent Infrastructure (Repository + Config)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionEventRepository.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/Configurations/SessionEventConfiguration.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/DependencyInjection/SessionTrackingServiceExtensions.cs`
+- Modify: `apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs` (add DbSet)
+
+- [ ] **Step 1: Write the entity configuration**
+
+```csharp
+// SessionEventConfiguration.cs
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.BoundedContexts.SessionTracking.Infrastructure.Persistence.Configurations;
+
+public class SessionEventConfiguration : IEntityTypeConfiguration<Api.BoundedContexts.SessionTracking.Domain.Entities.SessionEvent>
+{
+    public void Configure(EntityTypeBuilder<Api.BoundedContexts.SessionTracking.Domain.Entities.SessionEvent> builder)
+    {
+        builder.ToTable("session_tracking_session_events");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id)
+            .HasColumnName("id")
+            .ValueGeneratedNever();
+
+        builder.Property(e => e.SessionId)
+            .HasColumnName("session_id")
+            .IsRequired();
+
+        builder.Property(e => e.ParticipantId)
+            .HasColumnName("participant_id");
+
+        builder.Property(e => e.EventType)
+            .HasColumnName("event_type")
+            .HasMaxLength(50)
+            .IsRequired();
+
+        builder.Property(e => e.RoundNumber)
+            .HasColumnName("round_number");
+
+        builder.Property(e => e.PayloadJson)
+            .HasColumnName("payload_json")
+            .HasColumnType("jsonb")
+            .IsRequired();
+
+        builder.Property(e => e.Timestamp)
+            .HasColumnName("timestamp")
+            .IsRequired();
+
+        builder.HasIndex(e => new { e.SessionId, e.Timestamp })
+            .HasDatabaseName("idx_session_events_session_timestamp")
+            .IsDescending(false, true);
+
+        builder.HasIndex(e => new { e.SessionId, e.EventType })
+            .HasDatabaseName("idx_session_events_session_type");
+
+        builder.HasIndex(e => new { e.SessionId, e.RoundNumber })
+            .HasDatabaseName("idx_session_events_session_round");
+    }
+}
+```
+
+- [ ] **Step 2: Write the repository implementation**
+
+```csharp
+// SessionEventRepository.cs
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SessionTracking.Infrastructure.Persistence;
+
+public class SessionEventRepository : ISessionEventRepository
+{
+    private readonly MeepleAiDbContext _context;
+
+    public SessionEventRepository(MeepleAiDbContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public async Task<SessionEvent?> GetByIdAsync(Guid id, CancellationToken ct = default)
+    {
+        return await _context.Set<SessionEvent>()
+            .FirstOrDefaultAsync(e => e.Id == id, ct)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<List<SessionEvent>> GetBySessionIdAsync(
+        Guid sessionId,
+        string? eventType = null,
+        int? roundNumber = null,
+        int limit = 50,
+        DateTime? cursor = null,
+        CancellationToken ct = default)
+    {
+        var query = _context.Set<SessionEvent>()
+            .Where(e => e.SessionId == sessionId);
+
+        if (!string.IsNullOrWhiteSpace(eventType))
+            query = query.Where(e => e.EventType == eventType.Trim().ToLowerInvariant());
+
+        if (roundNumber.HasValue)
+            query = query.Where(e => e.RoundNumber == roundNumber.Value);
+
+        if (cursor.HasValue)
+            query = query.Where(e => e.Timestamp < cursor.Value);
+
+        return await query
+            .OrderByDescending(e => e.Timestamp)
+            .Take(limit)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+    }
+
+    public async Task AddAsync(SessionEvent sessionEvent, CancellationToken ct = default)
+    {
+        await _context.Set<SessionEvent>().AddAsync(sessionEvent, ct).ConfigureAwait(false);
+    }
+
+    public async Task SaveChangesAsync(CancellationToken ct = default)
+    {
+        await _context.SaveChangesAsync(ct).ConfigureAwait(false);
+    }
+}
+```
+
+- [ ] **Step 3: Add DbSet to MeepleAiDbContext**
+
+Find the `MeepleAiDbContext` class and add:
+
+```csharp
+public DbSet<Api.BoundedContexts.SessionTracking.Domain.Entities.SessionEvent> SessionTrackingSessionEvents => Set<Api.BoundedContexts.SessionTracking.Domain.Entities.SessionEvent>();
+```
+
+- [ ] **Step 4: Register in DI**
+
+In `SessionTrackingServiceExtensions.cs`, add inside `AddSessionTrackingContext()`:
+
+```csharp
+services.AddScoped<ISessionEventRepository, SessionEventRepository>();
+```
+
+Add the using:
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Infrastructure.Persistence;
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/ \
+       apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+git commit -m "feat(session-tracking): add SessionEvent repository, EF config, and DI registration"
+```
+
+---
+
+## Task 3: SessionEvent Application Layer (Commands + Queries + DTOs)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/DTOs/SessionEventDtos.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/AddSessionEventCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/AddSessionEventCommandHandler.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/AddSessionEventCommandValidator.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetSessionEventsQuery.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetSessionEventsQueryHandler.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/AddSessionEventCommandHandlerTests.cs`
+
+- [ ] **Step 1: Write DTOs**
+
+```csharp
+// SessionEventDtos.cs
+namespace Api.BoundedContexts.SessionTracking.Application.DTOs;
+
+public record SessionEventDto
+{
+    public Guid Id { get; init; }
+    public Guid SessionId { get; init; }
+    public Guid? ParticipantId { get; init; }
+    public string EventType { get; init; } = string.Empty;
+    public int? RoundNumber { get; init; }
+    public string PayloadJson { get; init; } = string.Empty;
+    public DateTime Timestamp { get; init; }
+}
+
+public record AddSessionEventRequest(
+    string EventType,
+    string PayloadJson,
+    Guid? ParticipantId = null,
+    int? RoundNumber = null);
+
+public record GetSessionEventsResponse(
+    Guid SessionId,
+    IReadOnlyList<SessionEventDto> Events,
+    DateTime? NextCursor);
+```
+
+- [ ] **Step 2: Write command + result**
+
+```csharp
+// AddSessionEventCommand.cs
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+public record AddSessionEventCommand(
+    Guid SessionId,
+    string EventType,
+    string PayloadJson,
+    Guid? ParticipantId = null,
+    int? RoundNumber = null
+) : IRequest<AddSessionEventResult>;
+
+public record AddSessionEventResult(Guid EventId, DateTime Timestamp);
+```
+
+- [ ] **Step 3: Write validator**
+
+```csharp
+// AddSessionEventCommandValidator.cs
+using FluentValidation;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+public class AddSessionEventCommandValidator : AbstractValidator<AddSessionEventCommand>
+{
+    private static readonly HashSet<string> ValidEventTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "dice_roll", "score_change", "turn_change", "note_added",
+        "manual_entry", "player_joined", "round_advance", "score_reset"
+    };
+
+    public AddSessionEventCommandValidator()
+    {
+        RuleFor(x => x.SessionId)
+            .NotEmpty()
+            .WithMessage("Session ID is required.");
+
+        RuleFor(x => x.EventType)
+            .NotEmpty()
+            .WithMessage("Event type is required.")
+            .MaximumLength(50)
+            .WithMessage("Event type cannot exceed 50 characters.")
+            .Must(type => ValidEventTypes.Contains(type?.Trim() ?? ""))
+            .WithMessage("Invalid event type. Valid types: dice_roll, score_change, turn_change, note_added, manual_entry, player_joined, round_advance, score_reset.");
+
+        RuleFor(x => x.PayloadJson)
+            .NotEmpty()
+            .WithMessage("Payload JSON is required.");
+
+        RuleFor(x => x.RoundNumber)
+            .GreaterThan(0)
+            .WithMessage("Round number must be positive.")
+            .When(x => x.RoundNumber.HasValue);
+    }
+}
+```
+
+- [ ] **Step 4: Write the failing handler test**
+
+```csharp
+// AddSessionEventCommandHandlerTests.cs
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Handlers;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SessionTracking")]
+public class AddSessionEventCommandHandlerTests
+{
+    private readonly Mock<ISessionRepository> _sessionRepoMock = new();
+    private readonly Mock<ISessionEventRepository> _eventRepoMock = new();
+    private readonly AddSessionEventCommandHandler _handler;
+
+    public AddSessionEventCommandHandlerTests()
+    {
+        _handler = new AddSessionEventCommandHandler(
+            _sessionRepoMock.Object,
+            _eventRepoMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ValidCommand_CreatesEventAndReturnsResult()
+    {
+        var sessionId = Guid.NewGuid();
+        var participantId = Guid.NewGuid();
+        var session = Session.Create(Guid.NewGuid(), sessionId, SessionType.Generic);
+
+        _sessionRepoMock.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var command = new AddSessionEventCommand(
+            sessionId, "dice_roll",
+            """{"formula":"2d6","results":[3,5],"total":8}""",
+            participantId, 1);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.NotEqual(Guid.Empty, result.EventId);
+        _eventRepoMock.Verify(r => r.AddAsync(
+            It.Is<SessionEvent>(e => e.EventType == "dice_roll" && e.SessionId == sessionId),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _eventRepoMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_SessionNotFound_ThrowsNotFoundException()
+    {
+        var sessionId = Guid.NewGuid();
+        _sessionRepoMock.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Session?)null);
+
+        var command = new AddSessionEventCommand(sessionId, "dice_roll", "{}");
+
+        await Assert.ThrowsAsync<NotFoundException>(
+            () => _handler.Handle(command, CancellationToken.None));
+    }
+}
+```
+
+- [ ] **Step 5: Run test to verify it fails**
+
+Run: `cd apps/api && dotnet test --filter "FullyQualifiedName~AddSessionEventCommandHandlerTests" -v minimal`
+Expected: FAIL — handler does not exist.
+
+- [ ] **Step 6: Write the command handler**
+
+```csharp
+// AddSessionEventCommandHandler.cs
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+public class AddSessionEventCommandHandler : IRequestHandler<AddSessionEventCommand, AddSessionEventResult>
+{
+    private readonly ISessionRepository _sessionRepository;
+    private readonly ISessionEventRepository _eventRepository;
+
+    public AddSessionEventCommandHandler(
+        ISessionRepository sessionRepository,
+        ISessionEventRepository eventRepository)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _eventRepository = eventRepository ?? throw new ArgumentNullException(nameof(eventRepository));
+    }
+
+    public async Task<AddSessionEventResult> Handle(
+        AddSessionEventCommand request, CancellationToken cancellationToken)
+    {
+        var session = await _sessionRepository
+            .GetByIdAsync(request.SessionId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {request.SessionId} not found");
+
+        var sessionEvent = SessionEvent.Create(
+            request.SessionId,
+            request.EventType,
+            request.PayloadJson,
+            request.ParticipantId,
+            request.RoundNumber);
+
+        await _eventRepository.AddAsync(sessionEvent, cancellationToken).ConfigureAwait(false);
+        await _eventRepository.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return new AddSessionEventResult(sessionEvent.Id, sessionEvent.Timestamp);
+    }
+}
+```
+
+- [ ] **Step 7: Write the query + handler**
+
+```csharp
+// GetSessionEventsQuery.cs
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+public record GetSessionEventsQuery(
+    Guid SessionId,
+    string? EventType = null,
+    int? RoundNumber = null,
+    int Limit = 50,
+    DateTime? Cursor = null
+) : IRequest<Api.BoundedContexts.SessionTracking.Application.DTOs.GetSessionEventsResponse>;
+```
+
+```csharp
+// GetSessionEventsQueryHandler.cs
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+public class GetSessionEventsQueryHandler
+    : IRequestHandler<GetSessionEventsQuery, GetSessionEventsResponse>
+{
+    private readonly ISessionEventRepository _repository;
+
+    public GetSessionEventsQueryHandler(ISessionEventRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public async Task<GetSessionEventsResponse> Handle(
+        GetSessionEventsQuery request, CancellationToken cancellationToken)
+    {
+        var events = await _repository.GetBySessionIdAsync(
+            request.SessionId,
+            request.EventType,
+            request.RoundNumber,
+            request.Limit,
+            request.Cursor,
+            cancellationToken).ConfigureAwait(false);
+
+        var dtos = events.Select(e => new SessionEventDto
+        {
+            Id = e.Id,
+            SessionId = e.SessionId,
+            ParticipantId = e.ParticipantId,
+            EventType = e.EventType,
+            RoundNumber = e.RoundNumber,
+            PayloadJson = e.PayloadJson,
+            Timestamp = e.Timestamp
+        }).ToList();
+
+        var nextCursor = dtos.Count == request.Limit
+            ? dtos[^1].Timestamp
+            : (DateTime?)null;
+
+        return new GetSessionEventsResponse(request.SessionId, dtos, nextCursor);
+    }
+}
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `cd apps/api && dotnet test --filter "FullyQualifiedName~AddSessionEventCommandHandlerTests" -v minimal`
+Expected: All tests PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SessionTracking/Application/ \
+       apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/AddSessionEventCommandHandlerTests.cs
+git commit -m "feat(session-tracking): add SessionEvent commands, queries, DTOs, and handler"
+```
+
+---
+
+## Task 4: SessionEvent API Endpoints
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/SessionTrackingRoutes.cs` (or the appropriate endpoint file for SessionTracking)
+
+- [ ] **Step 1: Add event endpoints to the routing file**
+
+Find the SessionTracking routing file. Add inside the route group:
+
+```csharp
+// Session Events
+group.MapPost("/game-sessions/{sessionId:guid}/events", async (
+    Guid sessionId,
+    Api.BoundedContexts.SessionTracking.Application.DTOs.AddSessionEventRequest request,
+    IMediator mediator,
+    CancellationToken ct) =>
+{
+    var command = new Api.BoundedContexts.SessionTracking.Application.Commands.AddSessionEventCommand(
+        sessionId, request.EventType, request.PayloadJson,
+        request.ParticipantId, request.RoundNumber);
+    var result = await mediator.Send(command, ct).ConfigureAwait(false);
+    return Results.Created($"/api/v1/game-sessions/{sessionId}/events/{result.EventId}", result);
+})
+.RequireAuthenticatedUser()
+.WithName("AddSessionEvent")
+.WithTags("SessionTracking")
+.WithSummary("Log an event to the session diary")
+.Produces(201)
+.Produces(400)
+.Produces(404);
+
+group.MapGet("/game-sessions/{sessionId:guid}/events", async (
+    Guid sessionId,
+    string? type,
+    int? round,
+    int? limit,
+    DateTime? cursor,
+    IMediator mediator,
+    CancellationToken ct) =>
+{
+    var query = new Api.BoundedContexts.SessionTracking.Application.Queries.GetSessionEventsQuery(
+        sessionId, type, round, limit ?? 50, cursor);
+    var result = await mediator.Send(query, ct).ConfigureAwait(false);
+    return Results.Ok(result);
+})
+.RequireAuthenticatedUser()
+.WithName("GetSessionEvents")
+.WithTags("SessionTracking")
+.WithSummary("Get session diary events with optional filters")
+.Produces<Api.BoundedContexts.SessionTracking.Application.DTOs.GetSessionEventsResponse>(200);
+```
+
+- [ ] **Step 2: Build to verify compilation**
+
+Run: `cd apps/api/src/Api && dotnet build`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/
+git commit -m "feat(session-tracking): add session event API endpoints (POST + GET)"
+```
+
+---
+
+## Task 5: UserDicePreset in GameToolkit BC
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Entities/GameToolkit.cs`
+- Create: `apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/UserDicePresetCommands.cs`
+- Create: `apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/UserDicePresetCommandHandlers.cs`
+- Create: `apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetUserDicePresetsQuery.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/GameToolkit/Application/DTOs/ToolkitDtos.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/GameToolkit/Infrastructure/Persistence/GameToolkitRepository.cs`
+- Modify: `apps/api/src/Api/Routing/GameToolkitRoutes.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Domain/UserDicePresetTests.cs`
+
+- [ ] **Step 1: Write the failing domain test**
+
+```csharp
+// UserDicePresetTests.cs
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameToolkit.Domain;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "GameToolkit")]
+public class UserDicePresetTests
+{
+    [Fact]
+    public void AddUserDicePreset_WithValidParams_ShouldSucceed()
+    {
+        var toolkit = CreateTestToolkit();
+        var userId = Guid.NewGuid();
+
+        toolkit.AddUserDicePreset(userId, "Combat Roll", "2d6+1d8");
+
+        toolkit.UserDicePresets.Should().HaveCount(1);
+        toolkit.UserDicePresets[0].Name.Should().Be("Combat Roll");
+        toolkit.UserDicePresets[0].Formula.Should().Be("2d6+1d8");
+        toolkit.UserDicePresets[0].UserId.Should().Be(userId);
+    }
+
+    [Fact]
+    public void AddUserDicePreset_OverLimit_ShouldThrow()
+    {
+        var toolkit = CreateTestToolkit();
+        var userId = Guid.NewGuid();
+
+        for (int i = 0; i < 20; i++)
+            toolkit.AddUserDicePreset(userId, $"Preset {i}", $"{i + 1}d6");
+
+        var act = () => toolkit.AddUserDicePreset(userId, "One more", "1d6");
+        act.Should().Throw<InvalidOperationException>().WithMessage("*20*");
+    }
+
+    [Fact]
+    public void RemoveUserDicePreset_Existing_ShouldSucceed()
+    {
+        var toolkit = CreateTestToolkit();
+        var userId = Guid.NewGuid();
+        toolkit.AddUserDicePreset(userId, "Test", "1d6");
+
+        var result = toolkit.RemoveUserDicePreset(userId, "Test");
+
+        result.Should().BeTrue();
+        toolkit.UserDicePresets.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RemoveUserDicePreset_WrongUser_ShouldReturnFalse()
+    {
+        var toolkit = CreateTestToolkit();
+        toolkit.AddUserDicePreset(Guid.NewGuid(), "Test", "1d6");
+
+        var result = toolkit.RemoveUserDicePreset(Guid.NewGuid(), "Test");
+        result.Should().BeFalse();
+    }
+
+    private static Api.BoundedContexts.GameToolkit.Domain.Entities.GameToolkit CreateTestToolkit()
+    {
+        return Api.BoundedContexts.GameToolkit.Domain.Entities.GameToolkit.Create(
+            name: "Test Toolkit",
+            gameId: Guid.NewGuid(),
+            createdByUserId: Guid.NewGuid());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && dotnet test --filter "FullyQualifiedName~UserDicePresetTests" -v minimal`
+Expected: FAIL — `AddUserDicePreset` method does not exist.
+
+- [ ] **Step 3: Add UserDicePreset value object and methods to GameToolkit aggregate**
+
+In `GameToolkit.cs`, add the value object class (inside or after the existing value objects):
+
+```csharp
+internal sealed class UserDicePreset
+{
+    public Guid UserId { get; }
+    public string Name { get; }
+    public string Formula { get; }
+    public DateTime CreatedAt { get; }
+
+    public UserDicePreset(Guid userId, string name, string formula)
+    {
+        if (userId == Guid.Empty)
+            throw new ArgumentException("User ID is required.", nameof(userId));
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Name is required.", nameof(name));
+        if (name.Length > 50)
+            throw new ArgumentException("Name cannot exceed 50 characters.", nameof(name));
+        if (string.IsNullOrWhiteSpace(formula))
+            throw new ArgumentException("Formula is required.", nameof(formula));
+        if (formula.Length > 100)
+            throw new ArgumentException("Formula cannot exceed 100 characters.", nameof(formula));
+
+        UserId = userId;
+        Name = name.Trim();
+        Formula = formula.Trim();
+        CreatedAt = DateTime.UtcNow;
+    }
+}
+```
+
+Add backing field and accessor to the GameToolkit class:
+
+```csharp
+private readonly List<UserDicePreset> _userDicePresets = new();
+public IReadOnlyList<UserDicePreset> UserDicePresets => _userDicePresets.AsReadOnly();
+```
+
+Add mutation methods:
+
+```csharp
+public void AddUserDicePreset(Guid userId, string name, string formula)
+{
+    if (_userDicePresets.Count >= 20)
+        throw new InvalidOperationException("Cannot add more than 20 user dice presets");
+
+    _userDicePresets.Add(new UserDicePreset(userId, name, formula));
+    UpdatedAt = DateTime.UtcNow;
+}
+
+public bool RemoveUserDicePreset(Guid userId, string name)
+{
+    var preset = _userDicePresets.Find(p =>
+        p.UserId == userId &&
+        string.Equals(p.Name, name, StringComparison.Ordinal));
+    if (preset == null) return false;
+
+    _userDicePresets.Remove(preset);
+    UpdatedAt = DateTime.UtcNow;
+    return true;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/api && dotnet test --filter "FullyQualifiedName~UserDicePresetTests" -v minimal`
+Expected: All 4 tests PASS.
+
+- [ ] **Step 5: Add DTOs, commands, handlers, query, and routes**
+
+Add to `ToolkitDtos.cs`:
+
+```csharp
+internal record UserDicePresetDto(
+    Guid UserId,
+    string Name,
+    string Formula,
+    DateTime CreatedAt);
+
+internal record AddUserDicePresetRequest(
+    string Name,
+    string Formula);
+```
+
+Create `UserDicePresetCommands.cs`:
+
+```csharp
+using MediatR;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Commands;
+
+internal record AddUserDicePresetCommand(
+    Guid ToolkitId,
+    Guid UserId,
+    string Name,
+    string Formula
+) : IRequest<UserDicePresetDto>;
+
+internal record RemoveUserDicePresetCommand(
+    Guid ToolkitId,
+    Guid UserId,
+    string PresetName
+) : IRequest<Unit>;
+```
+
+Create `UserDicePresetCommandHandlers.cs`:
+
+```csharp
+using Api.BoundedContexts.GameToolkit.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using MediatR;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Commands;
+
+internal class AddUserDicePresetCommandHandler
+    : IRequestHandler<AddUserDicePresetCommand, UserDicePresetDto>
+{
+    private readonly IGameToolkitRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public AddUserDicePresetCommandHandler(
+        IGameToolkitRepository repository, IUnitOfWork unitOfWork)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task<UserDicePresetDto> Handle(
+        AddUserDicePresetCommand command, CancellationToken cancellationToken)
+    {
+        var toolkit = await _repository
+            .GetByIdAsync(command.ToolkitId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException("GameToolkit", command.ToolkitId.ToString());
+
+        toolkit.AddUserDicePreset(command.UserId, command.Name, command.Formula);
+
+        await _repository.UpdateAsync(toolkit, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        var preset = toolkit.UserDicePresets.Last();
+        return new UserDicePresetDto(preset.UserId, preset.Name, preset.Formula, preset.CreatedAt);
+    }
+}
+
+internal class RemoveUserDicePresetCommandHandler
+    : IRequestHandler<RemoveUserDicePresetCommand, Unit>
+{
+    private readonly IGameToolkitRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public RemoveUserDicePresetCommandHandler(
+        IGameToolkitRepository repository, IUnitOfWork unitOfWork)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task<Unit> Handle(
+        RemoveUserDicePresetCommand command, CancellationToken cancellationToken)
+    {
+        var toolkit = await _repository
+            .GetByIdAsync(command.ToolkitId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException("GameToolkit", command.ToolkitId.ToString());
+
+        var removed = toolkit.RemoveUserDicePreset(command.UserId, command.PresetName);
+        if (!removed)
+            throw new NotFoundException($"Preset '{command.PresetName}' not found for user");
+
+        await _repository.UpdateAsync(toolkit, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Unit.Value;
+    }
+}
+```
+
+Create `GetUserDicePresetsQuery.cs`:
+
+```csharp
+using Api.BoundedContexts.GameToolkit.Application.DTOs;
+using Api.BoundedContexts.GameToolkit.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using MediatR;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries;
+
+internal record GetUserDicePresetsQuery(
+    Guid ToolkitId,
+    Guid UserId
+) : IRequest<List<UserDicePresetDto>>;
+
+internal class GetUserDicePresetsQueryHandler
+    : IRequestHandler<GetUserDicePresetsQuery, List<UserDicePresetDto>>
+{
+    private readonly IGameToolkitRepository _repository;
+
+    public GetUserDicePresetsQueryHandler(IGameToolkitRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public async Task<List<UserDicePresetDto>> Handle(
+        GetUserDicePresetsQuery request, CancellationToken cancellationToken)
+    {
+        var toolkit = await _repository
+            .GetByIdAsync(request.ToolkitId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException("GameToolkit", request.ToolkitId.ToString());
+
+        return toolkit.UserDicePresets
+            .Where(p => p.UserId == request.UserId)
+            .Select(p => new UserDicePresetDto(p.UserId, p.Name, p.Formula, p.CreatedAt))
+            .ToList();
+    }
+}
+```
+
+Add routes to `GameToolkitRoutes.cs`:
+
+```csharp
+// User Dice Presets
+toolkits.MapPost("/{id:guid}/user-dice-presets", async (
+    Guid id,
+    AddUserDicePresetRequest request,
+    HttpContext httpContext,
+    IMediator m) =>
+{
+    var userId = httpContext.User.GetUserId();
+    var command = new AddUserDicePresetCommand(id, userId, request.Name, request.Formula);
+    var result = await m.Send(command).ConfigureAwait(false);
+    return Results.Created($"/api/v1/game-toolkits/{id}/user-dice-presets", result);
+})
+.RequireAuthenticatedUser()
+.WithName("AddUserDicePreset")
+.WithSummary("Save a custom dice preset for the current user")
+.Produces<UserDicePresetDto>(201);
+
+toolkits.MapGet("/{id:guid}/user-dice-presets", async (
+    Guid id,
+    HttpContext httpContext,
+    IMediator m) =>
+{
+    var userId = httpContext.User.GetUserId();
+    var result = await m.Send(new GetUserDicePresetsQuery(id, userId)).ConfigureAwait(false);
+    return Results.Ok(result);
+})
+.RequireAuthenticatedUser()
+.WithName("GetUserDicePresets")
+.WithSummary("Get custom dice presets for the current user")
+.Produces<List<UserDicePresetDto>>(200);
+
+toolkits.MapDelete("/{id:guid}/user-dice-presets/{presetName}", async (
+    Guid id,
+    string presetName,
+    HttpContext httpContext,
+    IMediator m) =>
+{
+    var userId = httpContext.User.GetUserId();
+    await m.Send(new RemoveUserDicePresetCommand(id, userId, presetName)).ConfigureAwait(false);
+    return Results.NoContent();
+})
+.RequireAuthenticatedUser()
+.WithName("RemoveUserDicePreset")
+.WithSummary("Remove a custom dice preset")
+.Produces(204);
+```
+
+- [ ] **Step 6: Update GameToolkitRepository to serialize/deserialize UserDicePresets**
+
+In `GameToolkitRepository.cs`, add JSON serialization for `_userDicePresets` following the same pattern as `DiceToolConfig` serialization. Add a `UserDicePresetJsonModel` record and serialize/deserialize alongside the existing tool configs.
+
+- [ ] **Step 7: Build to verify compilation**
+
+Run: `cd apps/api/src/Api && dotnet build`
+Expected: Build succeeds.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameToolkit/ apps/api/src/Api/Routing/GameToolkitRoutes.cs \
+       apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/
+git commit -m "feat(game-toolkit): add UserDicePreset with CRUD commands, query, and API endpoints"
+```
+
+---
+
+## Task 6: Database Migration
+
+**Files:**
+- Create: EF Core migration
+
+- [ ] **Step 1: Create migration**
+
+```bash
+cd apps/api/src/Api
+dotnet ef migrations add AddSessionEventsAndUserDicePresets
+```
+
+- [ ] **Step 2: Review generated migration SQL**
+
+Read the generated migration file. Verify:
+- Table `session_tracking_session_events` with correct columns and indexes
+- `UserDicePresetsJson` column (JSONB) added to GameToolkit entity table (if stored as JSON column)
+- All column names are snake_case
+- Indexes match the configuration
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Persistence/Migrations/
+git commit -m "feat(db): add migration for SessionEvent table and UserDicePreset JSON column"
+```
+
+---
+
+## Task 7: Frontend — Types and Zustand Local Store
+
+**Files:**
+- Create: `apps/web/src/components/toolkit-drawer/types.ts`
+- Create: `apps/web/src/stores/toolkit-local-store.ts`
+
+- [ ] **Step 1: Write shared types**
+
+```typescript
+// types.ts
+import type { ReactNode } from 'react';
+
+export type ToolkitTab = 'dice' | 'notes' | 'diary' | 'scores';
+
+export type DiaryEventType =
+  | 'dice_roll'
+  | 'score_change'
+  | 'turn_change'
+  | 'note_added'
+  | 'manual_entry'
+  | 'player_joined'
+  | 'round_advance'
+  | 'score_reset';
+
+export interface LocalPlayer {
+  id: string;
+  name: string;
+  color: string;
+  avatarUrl?: string;
+}
+
+export interface DiaryEvent {
+  id: string;
+  type: DiaryEventType;
+  timestamp: Date;
+  playerId?: string;
+  playerName?: string;
+  round?: number;
+  payload: Record<string, unknown>;
+}
+
+export interface DiceResult {
+  formula: string;
+  rolls: { dieType: string; value: number }[];
+  modifier: number;
+  total: number;
+}
+
+export interface DicePreset {
+  name: string;
+  formula: string;
+  source: 'universal' | 'ai' | 'custom';
+  icon?: string;
+}
+
+export interface LocalNote {
+  id: string;
+  content: string;
+  type: 'shared' | 'private';
+  playerId?: string;
+  playerName?: string;
+  pinned: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface ToolkitDrawerProps {
+  gameId: string;
+  sessionId?: string;
+  onClose: () => void;
+  defaultTab?: ToolkitTab;
+}
+
+export const PLAYER_COLORS = [
+  '#E67E22', '#9B59B6', '#2ECC71', '#3498DB',
+  '#E74C3C', '#F1C40F', '#1ABC9C', '#E84393',
+] as const;
+
+export const UNIVERSAL_DICE_PRESETS: DicePreset[] = [
+  { name: '1d6', formula: '1d6', source: 'universal' },
+  { name: '2d6', formula: '2d6', source: 'universal' },
+  { name: '1d20', formula: '1d20', source: 'universal' },
+  { name: '3d6', formula: '3d6', source: 'universal' },
+  { name: '1d100', formula: '1d100', source: 'universal' },
+];
+```
+
+- [ ] **Step 2: Write Zustand store**
+
+```typescript
+// toolkit-local-store.ts
+'use client';
+
+import { create } from 'zustand';
+import { devtools, persist } from 'zustand/middleware';
+import { immer } from 'zustand/middleware/immer';
+import { createJSONStorage } from 'zustand/middleware';
+
+import type {
+  LocalPlayer,
+  DiaryEvent,
+  LocalNote,
+  DicePreset,
+} from '@/components/toolkit-drawer/types';
+import { PLAYER_COLORS } from '@/components/toolkit-drawer/types';
+
+// ==== State ====
+
+export interface ToolkitLocalState {
+  players: LocalPlayer[];
+  currentTurnIndex: number;
+  currentRound: number;
+  scores: Record<string, Record<string, number>>; // playerId → category → value
+  scoreCategories: string[];
+  notes: LocalNote[];
+  diary: DiaryEvent[];
+  customDicePresets: DicePreset[];
+}
+
+// ==== Actions ====
+
+export interface ToolkitLocalActions {
+  // Players
+  addPlayer: (name: string) => void;
+  removePlayer: (id: string) => void;
+  reorderPlayers: (orderedIds: string[]) => void;
+  setTurn: (playerId: string) => void;
+  advanceTurn: () => void;
+  advanceRound: () => void;
+
+  // Scores
+  setScore: (playerId: string, category: string, value: number) => void;
+  addScoreCategory: (category: string) => void;
+  removeScoreCategory: (category: string) => void;
+  resetScores: () => void;
+
+  // Notes
+  addNote: (content: string, type: 'shared' | 'private', playerId?: string, playerName?: string) => void;
+  updateNote: (noteId: string, content: string) => void;
+  deleteNote: (noteId: string) => void;
+  togglePin: (noteId: string) => void;
+
+  // Diary
+  logEvent: (event: Omit<DiaryEvent, 'id'>) => void;
+  clearDiary: () => void;
+
+  // Dice presets
+  addCustomPreset: (name: string, formula: string) => void;
+  removeCustomPreset: (name: string) => void;
+
+  // Reset
+  resetAll: () => void;
+}
+
+export type ToolkitLocalStore = ToolkitLocalState & ToolkitLocalActions;
+
+// ==== Initial State ====
+
+const initialState: ToolkitLocalState = {
+  players: [],
+  currentTurnIndex: 0,
+  currentRound: 1,
+  scores: {},
+  scoreCategories: [],
+  notes: [],
+  diary: [],
+  customDicePresets: [],
+};
+
+// ==== Store Factory ====
+
+export function createToolkitLocalStore(gameId: string) {
+  return create<ToolkitLocalStore>()(
+    devtools(
+      persist(
+        immer((set, get) => ({
+          ...initialState,
+
+          // ---- Players ----
+
+          addPlayer: (name: string) => {
+            set((state) => {
+              const color = PLAYER_COLORS[state.players.length % PLAYER_COLORS.length];
+              const id = `local_${Date.now()}_${Math.random().toString(36).substring(7)}`;
+              state.players.push({ id, name, color });
+              state.scores[id] = {};
+            });
+          },
+
+          removePlayer: (id: string) => {
+            set((state) => {
+              state.players = state.players.filter((p) => p.id !== id);
+              delete state.scores[id];
+              if (state.currentTurnIndex >= state.players.length) {
+                state.currentTurnIndex = 0;
+              }
+            });
+          },
+
+          reorderPlayers: (orderedIds: string[]) => {
+            set((state) => {
+              const mapped = orderedIds
+                .map((id) => state.players.find((p) => p.id === id))
+                .filter(Boolean) as LocalPlayer[];
+              state.players = mapped;
+            });
+          },
+
+          setTurn: (playerId: string) => {
+            set((state) => {
+              const index = state.players.findIndex((p) => p.id === playerId);
+              if (index >= 0) state.currentTurnIndex = index;
+            });
+          },
+
+          advanceTurn: () => {
+            set((state) => {
+              if (state.players.length === 0) return;
+              state.currentTurnIndex =
+                (state.currentTurnIndex + 1) % state.players.length;
+            });
+          },
+
+          advanceRound: () => {
+            set((state) => {
+              state.currentRound += 1;
+              state.currentTurnIndex = 0;
+            });
+          },
+
+          // ---- Scores ----
+
+          setScore: (playerId: string, category: string, value: number) => {
+            set((state) => {
+              if (!state.scores[playerId]) state.scores[playerId] = {};
+              state.scores[playerId][category] = value;
+            });
+          },
+
+          addScoreCategory: (category: string) => {
+            set((state) => {
+              if (!state.scoreCategories.includes(category)) {
+                state.scoreCategories.push(category);
+              }
+            });
+          },
+
+          removeScoreCategory: (category: string) => {
+            set((state) => {
+              state.scoreCategories = state.scoreCategories.filter((c) => c !== category);
+              for (const playerId of Object.keys(state.scores)) {
+                delete state.scores[playerId][category];
+              }
+            });
+          },
+
+          resetScores: () => {
+            set((state) => {
+              for (const playerId of Object.keys(state.scores)) {
+                state.scores[playerId] = {};
+              }
+            });
+          },
+
+          // ---- Notes ----
+
+          addNote: (content, type, playerId, playerName) => {
+            set((state) => {
+              const id = `note_${Date.now()}_${Math.random().toString(36).substring(7)}`;
+              const now = new Date();
+              state.notes.push({
+                id, content, type, playerId, playerName,
+                pinned: false, createdAt: now, updatedAt: now,
+              });
+            });
+          },
+
+          updateNote: (noteId: string, content: string) => {
+            set((state) => {
+              const note = state.notes.find((n) => n.id === noteId);
+              if (note) {
+                note.content = content;
+                note.updatedAt = new Date();
+              }
+            });
+          },
+
+          deleteNote: (noteId: string) => {
+            set((state) => {
+              state.notes = state.notes.filter((n) => n.id !== noteId);
+            });
+          },
+
+          togglePin: (noteId: string) => {
+            set((state) => {
+              const note = state.notes.find((n) => n.id === noteId);
+              if (note) note.pinned = !note.pinned;
+            });
+          },
+
+          // ---- Diary ----
+
+          logEvent: (event) => {
+            set((state) => {
+              const id = `evt_${Date.now()}_${Math.random().toString(36).substring(7)}`;
+              state.diary.unshift({ ...event, id });
+            });
+          },
+
+          clearDiary: () => {
+            set((state) => {
+              state.diary = [];
+            });
+          },
+
+          // ---- Dice Presets ----
+
+          addCustomPreset: (name: string, formula: string) => {
+            set((state) => {
+              state.customDicePresets.push({ name, formula, source: 'custom' });
+            });
+          },
+
+          removeCustomPreset: (name: string) => {
+            set((state) => {
+              state.customDicePresets = state.customDicePresets.filter(
+                (p) => p.name !== name
+              );
+            });
+          },
+
+          // ---- Reset ----
+
+          resetAll: () => {
+            set(() => ({ ...initialState }));
+          },
+        })),
+        {
+          name: `meepleai-toolkit-${gameId}`,
+          storage: createJSONStorage(() =>
+            typeof window !== 'undefined'
+              ? localStorage
+              : {
+                  getItem: () => null,
+                  setItem: () => {},
+                  removeItem: () => {},
+                }
+          ),
+          partialize: (state) => ({
+            players: state.players,
+            currentTurnIndex: state.currentTurnIndex,
+            currentRound: state.currentRound,
+            scores: state.scores,
+            scoreCategories: state.scoreCategories,
+            notes: state.notes,
+            diary: state.diary,
+            customDicePresets: state.customDicePresets,
+          }),
+        }
+      ),
+      {
+        name: `ToolkitLocalStore-${gameId}`,
+        enabled: process.env.NODE_ENV === 'development',
+      }
+    )
+  );
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/toolkit-drawer/types.ts \
+       apps/web/src/stores/toolkit-local-store.ts
+git commit -m "feat(toolkit): add shared types and Zustand local store with localStorage persistence"
+```
+
+---
+
+## Task 8: Frontend — API Client
+
+**Files:**
+- Create: `apps/web/src/lib/api/clients/toolkit.ts`
+
+- [ ] **Step 1: Write the API client**
+
+```typescript
+// toolkit.ts
+import type { HttpClient } from '../http-client';
+
+// ==== Types ====
+
+export interface SessionEventDto {
+  id: string;
+  sessionId: string;
+  participantId?: string;
+  eventType: string;
+  roundNumber?: number;
+  payloadJson: string;
+  timestamp: string;
+}
+
+export interface GetSessionEventsResponse {
+  sessionId: string;
+  events: SessionEventDto[];
+  nextCursor?: string;
+}
+
+export interface UserDicePresetDto {
+  userId: string;
+  name: string;
+  formula: string;
+  createdAt: string;
+}
+
+// ==== Client ====
+
+export interface CreateToolkitClientParams {
+  httpClient: HttpClient;
+}
+
+export interface ToolkitClient {
+  // Session Events
+  addSessionEvent(sessionId: string, event: {
+    eventType: string;
+    payloadJson: string;
+    participantId?: string;
+    roundNumber?: number;
+  }): Promise<{ eventId: string; timestamp: string }>;
+
+  getSessionEvents(sessionId: string, params?: {
+    type?: string;
+    round?: number;
+    limit?: number;
+    cursor?: string;
+  }): Promise<GetSessionEventsResponse>;
+
+  // User Dice Presets
+  getUserDicePresets(toolkitId: string): Promise<UserDicePresetDto[]>;
+
+  addUserDicePreset(toolkitId: string, preset: {
+    name: string;
+    formula: string;
+  }): Promise<UserDicePresetDto>;
+
+  removeUserDicePreset(toolkitId: string, presetName: string): Promise<void>;
+}
+
+export function createToolkitClient({ httpClient }: CreateToolkitClientParams): ToolkitClient {
+  return {
+    async addSessionEvent(sessionId, event) {
+      return await httpClient.post(
+        `/api/v1/game-sessions/${encodeURIComponent(sessionId)}/events`,
+        event
+      );
+    },
+
+    async getSessionEvents(sessionId, params = {}) {
+      const searchParams = new URLSearchParams();
+      if (params.type) searchParams.set('type', params.type);
+      if (params.round) searchParams.set('round', String(params.round));
+      if (params.limit) searchParams.set('limit', String(params.limit));
+      if (params.cursor) searchParams.set('cursor', params.cursor);
+
+      const qs = searchParams.toString();
+      const url = `/api/v1/game-sessions/${encodeURIComponent(sessionId)}/events${qs ? `?${qs}` : ''}`;
+      return await httpClient.get(url);
+    },
+
+    async getUserDicePresets(toolkitId) {
+      const data = await httpClient.get<UserDicePresetDto[]>(
+        `/api/v1/game-toolkits/${encodeURIComponent(toolkitId)}/user-dice-presets`
+      );
+      return data ?? [];
+    },
+
+    async addUserDicePreset(toolkitId, preset) {
+      return await httpClient.post(
+        `/api/v1/game-toolkits/${encodeURIComponent(toolkitId)}/user-dice-presets`,
+        preset
+      );
+    },
+
+    async removeUserDicePreset(toolkitId, presetName) {
+      await httpClient.delete(
+        `/api/v1/game-toolkits/${encodeURIComponent(toolkitId)}/user-dice-presets/${encodeURIComponent(presetName)}`
+      );
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/web/src/lib/api/clients/toolkit.ts
+git commit -m "feat(toolkit): add toolkit API client for session events and user dice presets"
+```
+
+---
+
+## Task 9: Frontend — ToolkitDrawer Container + Provider
+
+**Files:**
+- Create: `apps/web/src/components/toolkit-drawer/ToolkitDrawerProvider.tsx`
+- Create: `apps/web/src/components/toolkit-drawer/ToolkitDrawer.tsx`
+- Create: `apps/web/src/components/toolkit-drawer/index.ts`
+
+- [ ] **Step 1: Write the Provider (context for all tabs)**
+
+```typescript
+// ToolkitDrawerProvider.tsx
+'use client';
+
+import React, { createContext, useContext, useMemo, useRef } from 'react';
+
+import { createToolkitLocalStore, type ToolkitLocalStore } from '@/stores/toolkit-local-store';
+
+import type { DiaryEvent, ToolkitTab } from './types';
+
+interface ToolkitDrawerContextValue {
+  gameId: string;
+  sessionId?: string;
+  mode: 'local' | 'session';
+  store: ReturnType<typeof createToolkitLocalStore>;
+  logEvent: (event: Omit<DiaryEvent, 'id'>) => void;
+  activeTab: ToolkitTab;
+  setActiveTab: (tab: ToolkitTab) => void;
+}
+
+const ToolkitDrawerContext = createContext<ToolkitDrawerContextValue | null>(null);
+
+export function useToolkitDrawer() {
+  const ctx = useContext(ToolkitDrawerContext);
+  if (!ctx) throw new Error('useToolkitDrawer must be used within ToolkitDrawerProvider');
+  return ctx;
+}
+
+interface ToolkitDrawerProviderProps {
+  gameId: string;
+  sessionId?: string;
+  defaultTab?: ToolkitTab;
+  children: React.ReactNode;
+}
+
+export function ToolkitDrawerProvider({
+  gameId,
+  sessionId,
+  defaultTab = 'dice',
+  children,
+}: ToolkitDrawerProviderProps) {
+  const storeRef = useRef<ReturnType<typeof createToolkitLocalStore>>();
+  if (!storeRef.current) {
+    storeRef.current = createToolkitLocalStore(gameId);
+  }
+
+  const [activeTab, setActiveTab] = React.useState<ToolkitTab>(defaultTab);
+
+  const mode = sessionId ? 'session' : 'local';
+
+  const logEvent = React.useCallback(
+    (event: Omit<DiaryEvent, 'id'>) => {
+      storeRef.current?.getState().logEvent(event);
+      // TODO: if session mode, POST to /sessions/{id}/events in background
+    },
+    []
+  );
+
+  const value = useMemo<ToolkitDrawerContextValue>(
+    () => ({
+      gameId,
+      sessionId,
+      mode,
+      store: storeRef.current!,
+      logEvent,
+      activeTab,
+      setActiveTab,
+    }),
+    [gameId, sessionId, mode, logEvent, activeTab]
+  );
+
+  return (
+    <ToolkitDrawerContext.Provider value={value}>
+      {children}
+    </ToolkitDrawerContext.Provider>
+  );
+}
+```
+
+- [ ] **Step 2: Write the Drawer container**
+
+```typescript
+// ToolkitDrawer.tsx
+'use client';
+
+import React, { useCallback, useEffect } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+
+import { cn } from '@/lib/utils';
+
+import { ToolkitDrawerProvider, useToolkitDrawer } from './ToolkitDrawerProvider';
+import type { ToolkitDrawerProps, ToolkitTab } from './types';
+
+const TAB_CONFIG: { key: ToolkitTab; icon: string; label: string }[] = [
+  { key: 'dice', icon: '🎲', label: 'Dadi' },
+  { key: 'notes', icon: '📝', label: 'Note' },
+  { key: 'diary', icon: '📖', label: 'Diario' },
+  { key: 'scores', icon: '🏆', label: 'Punti' },
+];
+
+function DrawerContent({ onClose }: { onClose: () => void }) {
+  const { activeTab, setActiveTab } = useToolkitDrawer();
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    },
+    [onClose]
+  );
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown);
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = '';
+    };
+  }, [handleKeyDown]);
+
+  return (
+    <>
+      {/* Overlay */}
+      <motion.div
+        data-testid="toolkit-drawer-overlay"
+        className="fixed inset-0 z-50 bg-black/30"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.2 }}
+        onClick={onClose}
+      />
+
+      {/* Panel */}
+      <motion.div
+        data-testid="toolkit-drawer-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Game Toolkit"
+        className={cn(
+          'fixed inset-x-0 top-16 bottom-0 z-50',
+          'flex flex-col overflow-hidden',
+          'bg-white/95 backdrop-blur-xl saturate-[1.8]',
+          'border-t border-gray-200',
+          'shadow-[0_-8px_32px_rgba(0,0,0,0.12)]',
+          'rounded-t-2xl'
+        )}
+        initial={{ y: '-100%' }}
+        animate={{ y: 0 }}
+        exit={{ y: '-100%' }}
+        transition={{ type: 'spring', damping: 30, stiffness: 300 }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Drag Handle */}
+        <div className="flex justify-center py-2.5">
+          <div className="h-1 w-9 rounded-full bg-gray-300" />
+        </div>
+
+        {/* Tabs */}
+        <div className="flex border-b border-gray-200 px-3 gap-0.5">
+          {TAB_CONFIG.map((tab) => (
+            <button
+              key={tab.key}
+              data-testid={`toolkit-tab-${tab.key}`}
+              className={cn(
+                'px-2.5 py-2 text-[11px] font-bold font-[Quicksand,sans-serif]',
+                'border-b-2 transition-colors duration-200',
+                'bg-transparent border-t-0 border-l-0 border-r-0 cursor-pointer',
+                activeTab === tab.key
+                  ? 'text-[hsl(142,70%,45%)] border-b-[hsl(142,70%,45%)]'
+                  : 'text-gray-400 border-b-transparent hover:text-gray-700'
+              )}
+              onClick={() => setActiveTab(tab.key)}
+            >
+              {tab.icon} {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto px-4 py-3">
+          <TabContent tab={activeTab} />
+        </div>
+
+        {/* PlayerBar will go here */}
+      </motion.div>
+    </>
+  );
+}
+
+function TabContent({ tab }: { tab: ToolkitTab }) {
+  switch (tab) {
+    case 'dice':
+      return <div data-testid="dice-tab-placeholder">Dice Roller Tab</div>;
+    case 'notes':
+      return <div data-testid="notes-tab-placeholder">Notes Tab</div>;
+    case 'diary':
+      return <div data-testid="diary-tab-placeholder">Event Diary Tab</div>;
+    case 'scores':
+      return <div data-testid="scores-tab-placeholder">Scoreboard Tab</div>;
+    default:
+      return null;
+  }
+}
+
+export function ToolkitDrawer({
+  gameId,
+  sessionId,
+  onClose,
+  defaultTab,
+}: ToolkitDrawerProps) {
+  return (
+    <AnimatePresence>
+      <ToolkitDrawerProvider
+        gameId={gameId}
+        sessionId={sessionId}
+        defaultTab={defaultTab}
+      >
+        <DrawerContent onClose={onClose} />
+      </ToolkitDrawerProvider>
+    </AnimatePresence>
+  );
+}
+```
+
+- [ ] **Step 3: Write index.ts**
+
+```typescript
+// index.ts
+export { ToolkitDrawer } from './ToolkitDrawer';
+export type { ToolkitDrawerProps, ToolkitTab } from './types';
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/toolkit-drawer/
+git commit -m "feat(toolkit): add ToolkitDrawer container with tabs, provider, and glassmorphism panel"
+```
+
+---
+
+## Tasks 10-15: Remaining Frontend Components
+
+> **Note:** Tasks 10-15 follow the same pattern. Each task creates one tab component or shared component with its hook. The detailed implementation for each tab follows the spec sections 4-7. For brevity, these tasks are described at a higher level — the implementing engineer should reference the spec for exact layouts and interactions.
+
+### Task 10: PlayerBar + PlayerAvatar + PlayerSetupModal
+- Create `shared/PlayerBar.tsx`, `shared/PlayerAvatar.tsx`, `shared/PlayerSetupModal.tsx`
+- PlayerBar reads from Zustand store, renders color dots with initials, turn indicator, add button, promote button
+- Wire `advanceTurn`, `addPlayer`, `removePlayer` actions
+
+### Task 11: DiceRollerTab + sub-components
+- Create `tabs/DiceRollerTab.tsx`, `tabs/DicePresetRow.tsx`, `tabs/DicePoolBuilder.tsx`, `tabs/DiceResultDisplay.tsx`
+- Create `hooks/useDiceRoller.ts` with formula parsing and `crypto.getRandomValues()` client-side rolling
+- Create `hooks/useToolkitConfig.ts` with React Query to fetch GameToolkit config (AI presets)
+- Wire preset rows (universal, AI, custom), pool builder steppers, roll button, result display with shake animation
+- Log `dice_roll` events to diary on each roll
+
+### Task 12: NotesTab + NoteCard
+- Create `tabs/NotesTab.tsx`, `tabs/NoteCard.tsx`
+- Create `hooks/useNotes.ts` for local/session mode CRUD
+- Grouped display: shared notes, then private notes
+- Inline edit on tap, swipe-to-delete, pin toggle
+
+### Task 13: EventDiaryTab + sub-components
+- Create `tabs/EventDiaryTab.tsx`, `tabs/DiaryEventRow.tsx`, `tabs/DiaryFilters.tsx`
+- Create `hooks/useDiary.ts` for local/session mode reading + manual entry
+- Pill filter toggles, round grouping, manual entry input at bottom
+- Event icons by type, timestamp formatting
+
+### Task 14: ScoreboardTab + sub-components
+- Create `tabs/ScoreboardTab.tsx`, `tabs/ScoreCell.tsx`, `tabs/ScoreCategoryHeader.tsx`, `tabs/RankingBar.tsx`, `tabs/RoundBreakdown.tsx`
+- Create `hooks/useScoreboard.ts` for local/session mode CRUD
+- Multi-dimension table with inline edit + stepper
+- Drag handle for row reorder, ranking bar with medals
+- Category add/remove, round breakdown expandable, reset with diary event
+
+### Task 15: Integration + PromoteSessionModal
+- Create `shared/PromoteSessionModal.tsx`
+- Create `hooks/useToolkitSession.ts` for promotion flow (create session + bulk migrate)
+- Modify consumer pages to add 🧰 Toolkit NavFooterItem on game MeepleCards
+- Render `<ToolkitDrawer>` conditionally on drawer open state
+
+---
+
+## Task 16: Frontend Tests
+
+**Files:**
+- Create: `apps/web/src/__tests__/components/toolkit-drawer/ToolkitDrawer.test.tsx`
+- Create: `apps/web/src/__tests__/stores/toolkit-local-store.test.ts`
+
+- [ ] **Step 1: Write store tests**
+
+```typescript
+// toolkit-local-store.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createToolkitLocalStore } from '@/stores/toolkit-local-store';
+
+describe('ToolkitLocalStore', () => {
+  let store: ReturnType<typeof createToolkitLocalStore>;
+
+  beforeEach(() => {
+    store = createToolkitLocalStore('test-game-id');
+    store.getState().resetAll();
+  });
+
+  describe('Players', () => {
+    it('adds a player with auto-assigned color', () => {
+      store.getState().addPlayer('Marco');
+      const { players } = store.getState();
+      expect(players).toHaveLength(1);
+      expect(players[0].name).toBe('Marco');
+      expect(players[0].color).toBe('#E67E22');
+    });
+
+    it('advances turn cyclically', () => {
+      store.getState().addPlayer('Marco');
+      store.getState().addPlayer('Luca');
+      expect(store.getState().currentTurnIndex).toBe(0);
+
+      store.getState().advanceTurn();
+      expect(store.getState().currentTurnIndex).toBe(1);
+
+      store.getState().advanceTurn();
+      expect(store.getState().currentTurnIndex).toBe(0);
+    });
+
+    it('advances round and resets turn', () => {
+      store.getState().addPlayer('Marco');
+      store.getState().addPlayer('Luca');
+      store.getState().advanceTurn();
+
+      store.getState().advanceRound();
+      expect(store.getState().currentRound).toBe(2);
+      expect(store.getState().currentTurnIndex).toBe(0);
+    });
+  });
+
+  describe('Scores', () => {
+    it('sets score for player and category', () => {
+      store.getState().addPlayer('Marco');
+      const playerId = store.getState().players[0].id;
+
+      store.getState().addScoreCategory('PV');
+      store.getState().setScore(playerId, 'PV', 12);
+
+      expect(store.getState().scores[playerId]['PV']).toBe(12);
+    });
+
+    it('resets all scores to empty', () => {
+      store.getState().addPlayer('Marco');
+      const playerId = store.getState().players[0].id;
+      store.getState().setScore(playerId, 'PV', 12);
+
+      store.getState().resetScores();
+      expect(store.getState().scores[playerId]).toEqual({});
+    });
+  });
+
+  describe('Diary', () => {
+    it('logs events in reverse chronological order', () => {
+      store.getState().logEvent({
+        type: 'dice_roll',
+        timestamp: new Date(),
+        payload: { formula: '2d6', total: 8 },
+      });
+      store.getState().logEvent({
+        type: 'score_change',
+        timestamp: new Date(),
+        payload: { category: 'PV', delta: 3 },
+      });
+
+      const { diary } = store.getState();
+      expect(diary).toHaveLength(2);
+      expect(diary[0].type).toBe('score_change');
+      expect(diary[1].type).toBe('dice_roll');
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Write drawer component test**
+
+```typescript
+// ToolkitDrawer.test.tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ToolkitDrawer } from '@/components/toolkit-drawer';
+
+// Mock framer-motion to avoid animation issues in tests
+vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: {
+    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  },
+}));
+
+describe('ToolkitDrawer', () => {
+  const defaultProps = {
+    gameId: 'test-game-id',
+    onClose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders all 4 tab buttons', () => {
+    render(<ToolkitDrawer {...defaultProps} />);
+    expect(screen.getByTestId('toolkit-tab-dice')).toBeInTheDocument();
+    expect(screen.getByTestId('toolkit-tab-notes')).toBeInTheDocument();
+    expect(screen.getByTestId('toolkit-tab-diary')).toBeInTheDocument();
+    expect(screen.getByTestId('toolkit-tab-scores')).toBeInTheDocument();
+  });
+
+  it('shows dice tab by default', () => {
+    render(<ToolkitDrawer {...defaultProps} />);
+    expect(screen.getByTestId('dice-tab-placeholder')).toBeInTheDocument();
+  });
+
+  it('switches tabs on click', async () => {
+    const user = userEvent.setup();
+    render(<ToolkitDrawer {...defaultProps} />);
+
+    await user.click(screen.getByTestId('toolkit-tab-scores'));
+    expect(screen.getByTestId('scores-tab-placeholder')).toBeInTheDocument();
+  });
+
+  it('calls onClose when overlay is clicked', async () => {
+    const user = userEvent.setup();
+    render(<ToolkitDrawer {...defaultProps} />);
+
+    await user.click(screen.getByTestId('toolkit-drawer-overlay'));
+    expect(defaultProps.onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose on Escape key', async () => {
+    const user = userEvent.setup();
+    render(<ToolkitDrawer {...defaultProps} />);
+
+    await user.keyboard('{Escape}');
+    expect(defaultProps.onClose).toHaveBeenCalledOnce();
+  });
+
+  it('accepts defaultTab prop', () => {
+    render(<ToolkitDrawer {...defaultProps} defaultTab="scores" />);
+    expect(screen.getByTestId('scores-tab-placeholder')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd apps/web && pnpm test -- --run --reporter=verbose toolkit-drawer toolkit-local-store`
+Expected: All tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/__tests__/
+git commit -m "test(toolkit): add unit tests for ToolkitDrawer component and Zustand local store"
+```
+
+---
+
+## Summary
+
+| Task | Description | Backend/Frontend | Files |
+|------|-------------|-----------------|-------|
+| 1 | SessionEvent domain entity | Backend | 3 |
+| 2 | SessionEvent infrastructure | Backend | 4 |
+| 3 | SessionEvent application layer | Backend | 8 |
+| 4 | SessionEvent API endpoints | Backend | 1 |
+| 5 | UserDicePreset in GameToolkit | Backend | 8 |
+| 6 | Database migration | Backend | 1 |
+| 7 | Types + Zustand store | Frontend | 2 |
+| 8 | API client | Frontend | 1 |
+| 9 | ToolkitDrawer container | Frontend | 3 |
+| 10 | PlayerBar + shared | Frontend | 3 |
+| 11 | DiceRollerTab + hooks | Frontend | 6 |
+| 12 | NotesTab | Frontend | 3 |
+| 13 | EventDiaryTab | Frontend | 4 |
+| 14 | ScoreboardTab | Frontend | 6 |
+| 15 | Integration + promotion | Frontend | 3 |
+| 16 | Frontend tests | Frontend | 2 |
+| **Total** | | | **~58** |

--- a/docs/superpowers/specs/2026-04-08-default-game-toolkit-design.md
+++ b/docs/superpowers/specs/2026-04-08-default-game-toolkit-design.md
@@ -1,0 +1,691 @@
+# Default Game Toolkit — Design Specification
+
+**Date**: 2026-04-08
+**Status**: Approved
+**Scope**: Frontend feature + minimal backend additions
+**Bounded Contexts**: GameToolkit (config), SessionTracking (data)
+
+---
+
+## 1. Overview
+
+Every MeepleCard with `entity="game"` displays a 🧰 Toolkit ManaPip in the NavFooter. Tapping it opens a **ToolkitDrawer** — a slide-down panel following the ExtraMeepleCardDrawer pattern — containing 4 tabbed tools for real-time game support.
+
+The same ManaPip can appear on `session`, `player`, and other MeepleCard entity types, always linking to the toolkit of the associated game.
+
+### Goals
+
+- Provide a universal game companion (dice, notes, diary, scores) accessible from any game card
+- Reuse existing backend infrastructure (GameToolkit config + SessionTracking data)
+- Support both casual use (no session, local state) and full session tracking
+- Enable AI-generated presets from game rulebooks via existing KB pipeline
+
+### Non-Goals
+
+- Real-time multiplayer sync (WebSocket/SSE between players) — future scope
+- Custom tool plugins — only the 4 built-in tabs
+- Mobile-native features (haptics, gyroscope dice) — web-only
+
+---
+
+## 2. Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│                   FRONTEND                       │
+│                                                  │
+│  MeepleCard (game/session/...)                   │
+│    └─ NavFooter ManaPip 🧰                       │
+│         └─ onClick → open ToolkitDrawer          │
+│                                                  │
+│  ToolkitDrawer                                   │
+│    ├─ Tab: 🎲 DiceRoller                         │
+│    ├─ Tab: 📝 Notes                              │
+│    ├─ Tab: 📖 EventDiary                         │
+│    └─ Tab: 🏆 Scoreboard                         │
+│                                                  │
+│  PlayerContext (hook)                             │
+│    ├─ source: "session" → SessionTracking API    │
+│    └─ source: "local" → Zustand store            │
+│         └─ promoteToSession() → creates Session  │
+├─────────────────────────────────────────────────┤
+│                   BACKEND                        │
+│                                                  │
+│  GameToolkit BC (CONFIG — read-only from FE)     │
+│    ├─ Toolkit aggregate (widget config)          │
+│    ├─ AI preset generation (KB-based)            │
+│    ├─ Default auto-creation on game add          │
+│    └─ NEW: UserDicePreset child entity           │
+│                                                  │
+│  SessionTracking BC (DATA — read/write from FE)  │
+│    ├─ DiceRoll (formula, results, history)       │
+│    ├─ ScoreEntry (multi-dimension, categories)   │
+│    ├─ PlayerNote (private/shared)                │
+│    ├─ Participant (name, color, role, turn)      │
+│    └─ NEW: SessionEvent entity (diary log)       │
+└─────────────────────────────────────────────────┘
+```
+
+### Data Flow
+
+| Data | Source BC | Persistence |
+|------|----------|-------------|
+| Tool config, AI dice presets | GameToolkit | Server (per game) |
+| User custom dice presets | GameToolkit | Server (per user per game) |
+| Score entries | SessionTracking | Server (if session) or localStorage |
+| Player notes | SessionTracking | Server (if session) or localStorage |
+| Diary events | SessionTracking | Server (if session) or localStorage |
+| Dice roll results | SessionTracking | Volatile — logged in diary only |
+| Player list, turn, round | SessionTracking | Server (if session) or localStorage |
+
+---
+
+## 3. ToolkitDrawer Component
+
+### Activation
+
+The drawer is opened via a `NavFooterItem` with `entity: "toolkit"` on any MeepleCard. The consumer page (not MeepleCard itself) manages the drawer state:
+
+```typescript
+interface ToolkitDrawerProps {
+  gameId: string;
+  sessionId?: string;        // If present, sync from SessionTracking
+  onClose: () => void;
+  defaultTab?: 'dice' | 'notes' | 'diary' | 'scores';
+}
+```
+
+### Visual Structure
+
+- **Overlay**: semi-transparent backdrop (`rgba(0,0,0,0.3)`)
+- **Panel**: slides down from below navbar, glassmorphism (`backdrop-filter: blur(16px) saturate(180%)`)
+- **Drag handle**: 36px bar at top for gesture close
+- **Tabs**: `🎲 Dadi | 📝 Note | 📖 Diario | 🏆 Punti` — Quicksand 11px bold, entity color underline (toolkit green h:142)
+- **Content area**: scrollable, `padding: 12px 16px`
+- **PlayerBar**: fixed at bottom, always visible across all tabs
+
+### Animation
+
+- Open: `transform: translateY(-105%) → translateY(0)`, 400ms `cubic-bezier(0.4, 0, 0.2, 1)`
+- Close: reverse, or swipe-up gesture on drag handle
+
+---
+
+## 4. Tab: 🎲 Dice Roller
+
+### Layout
+
+```
+PRESET RAPIDI (horizontal scroll)
+[1d6] [2d6] [1d20] [3d6] [1d100]
+
+★ Da Regolamento (collapsible — AI presets)
+  ⚔️ Combattimento  2d6+1d8
+  🎯 Skill check     1d20
+
+⭐ I Miei Preset (collapsible — user custom)
+  🏠 Casa rule       3d6
+  [+ Salva combo corrente]
+
+POOL BUILDER
+  d4[0] d6[2] d8[1] d10[0] d12[0] d20[0]  +[3]
+  [ 🎲 LANCIA ]
+
+RISULTATO
+  ⚄ ⚂ + ⬡3 = 12
+  2d6: [5,3]  1d8: [3]  +3
+```
+
+### Preset Sources
+
+| Source | Origin | API |
+|--------|--------|-----|
+| Universal | Hardcoded frontend | None — `[1d6, 2d6, 1d20, 3d6, 1d100]` |
+| AI (from rulebook) | GameToolkit BC | `GET /game-toolkits/by-game/{gameId}` → `diceTools[]` |
+| User custom | GameToolkit BC | `GET /game-toolkits/{id}/user-dice-presets` |
+
+### Roll Logic
+
+- **With session**: `POST /sessions/{id}/dice-rolls` — server-side cryptographic RNG, persisted
+- **Without session**: client-side `crypto.getRandomValues()`, result volatile
+
+### Result Display
+
+- Shake animation: 300ms on dice icons
+- Reveal: individual die results with type-specific icons + total
+- Auto-log: result pushed to EventDiary as `dice_roll` event
+
+### Backend: UserDicePreset (NEW)
+
+New child entity on `GameToolkit` aggregate:
+
+```csharp
+public class UserDicePreset : Entity
+{
+    public Guid GameToolkitId { get; private set; }
+    public Guid UserId { get; private set; }
+    public string Name { get; private set; }        // max 50
+    public string Formula { get; private set; }     // max 100, e.g. "2d6+1d8+3"
+    public DateTime CreatedAt { get; private set; }
+}
+```
+
+Endpoints:
+
+```
+POST   /api/v1/game-toolkits/{id}/user-dice-presets   → UserDicePresetDto
+GET    /api/v1/game-toolkits/{id}/user-dice-presets    → List<UserDicePresetDto>
+DELETE /api/v1/game-toolkits/{id}/user-dice-presets/{presetId} → 204
+```
+
+---
+
+## 5. Tab: 📝 Notes
+
+### Layout
+
+```
+CONDIVISE
+  📌 Regole casa
+     "Niente alleanze prima del round 3"
+     Marco · 2min fa
+
+  📝 Setup reminder
+     "Mescolare carte evento dopo ogni era"
+     Luca · 5min fa
+
+  [ + Aggiungi nota condivisa ]
+
+────────────────────
+
+🔒 LE MIE NOTE (private)
+  🤫 Obiettivo segreto:
+     "Conquistare 3 città costiere"
+     ora · ✏️ 🗑️
+
+  [ + Aggiungi nota privata ]
+```
+
+### Data Mapping
+
+Maps directly to `PlayerNote` in SessionTracking:
+
+| UI Element | Backend Field |
+|------------|---------------|
+| Shared notes | `NoteType = Shared` |
+| Private notes | `NoteType = Private` |
+| Pin status | `TemplateKey = "pinned"` |
+| Author | `CreatedBy` → `Participant.DisplayName` |
+
+### Interactions
+
+- Tap note → expand to edit mode (autosize textarea)
+- Swipe left → delete with confirmation
+- Long press → pin/unpin (moves to top)
+- Light markdown: bold, italic, lists
+
+### Without Session
+
+Notes stored in Zustand local store. No owner distinction (no auth). On promotion to session → bulk `POST /sessions/{id}/notes`.
+
+### With Session
+
+- Create: `POST /sessions/{id}/notes` with `{ content, noteType, participantId }`
+- Read: `GET /sessions/{id}/notes` with visibility filter for current user
+- Real-time: `NoteAddedEvent` SSE (already exists)
+
+### Backend Changes
+
+None. `PlayerNote` entity covers all cases.
+
+---
+
+## 6. Tab: 📖 Event Diary
+
+### Layout
+
+```
+FILTRI
+[Tutti] [🎲 Dadi] [🏆 Punti] [📝 Note] [🔄 Turni] [✍️ Manual]
+
+── Oggi ────────────────────
+14:32  🎲  Marco lancia 2d6+1d8 → [5,3]+[7] = 15
+14:31  🏆  Luca +3 Punti Vittoria (totale: 12)
+14:28  🔄  Turno → Marco (R.3)
+14:25  ✍️  Anna: "Luca sospetto alleanza con Marco"
+14:20  📝  Marco aggiunge nota condivisa
+
+── Round 2 ────────────────
+14:15  🎲  Anna lancia 1d20 → [17] critico!
+...
+
+┌──────────────────────────┐
+│ ✍️ Aggiungi nota al diario │
+└──────────────────────────┘
+```
+
+### Event Types
+
+| Type | Icon | Source | Auto-trigger |
+|------|------|--------|-------------|
+| `dice_roll` | 🎲 | DiceRoller tab | After every roll |
+| `score_change` | 🏆 | Scoreboard tab | After score edit |
+| `turn_change` | 🔄 | PlayerBar | On turn change tap |
+| `note_added` | 📝 | Notes tab | On note create/pin |
+| `manual_entry` | ✍️ | Diary input | User writes |
+| `player_joined` | 👤 | PlayerBar | New player added |
+| `round_advance` | 🔔 | Scoreboard/PlayerBar | On round change |
+
+### Event Schema
+
+```typescript
+interface DiaryEvent {
+  id: string;
+  type: DiaryEventType;
+  timestamp: Date;
+  playerId?: string;
+  playerName?: string;
+  round?: number;
+  payload: Record<string, unknown>;
+}
+```
+
+Payload examples:
+- `dice_roll`: `{ formula: "2d6+1d8", results: [5,3,7], total: 15 }`
+- `score_change`: `{ category: "Punti Vittoria", delta: +3, newTotal: 12 }`
+- `manual_entry`: `{ text: "Luca sospetto alleanza con Marco" }`
+
+### Auto-Event Generation
+
+The `ToolkitDrawerProvider` exposes a `logEvent(event)` function. Each tab calls it after actions:
+1. Adds to local diary array (immediate UI update)
+2. If session exists: `POST /sessions/{id}/events` in background (fire-and-forget)
+
+### Grouping
+
+Events grouped by `Round N` separators when round tracking is active, otherwise by date (Today/Yesterday). Infinite scroll downward (older events).
+
+### Filters
+
+Pill toggles — multi-select. Active filters are OR-combined. "Tutti" resets all filters.
+
+### Backend: SessionEvent (NEW)
+
+New entity in SessionTracking BC:
+
+```csharp
+public class SessionEvent : Entity
+{
+    public Guid SessionId { get; private set; }
+    public Guid? ParticipantId { get; private set; }
+    public string EventType { get; private set; }     // max 50
+    public int? RoundNumber { get; private set; }
+    public string PayloadJson { get; private set; }    // JSONB
+    public DateTime Timestamp { get; private set; }
+
+    public static SessionEvent Create(
+        Guid sessionId, string eventType,
+        string payloadJson, Guid? participantId = null,
+        int? roundNumber = null) { ... }
+}
+```
+
+Table: `session_tracking.session_events`
+
+Indexes:
+- `(SessionId, Timestamp DESC)` — primary query pattern
+- `(SessionId, EventType)` — filter by type
+- `(SessionId, RoundNumber)` — filter by round
+
+Endpoints:
+
+```
+POST /api/v1/sessions/{id}/events
+     Body: { eventType, payloadJson, participantId?, roundNumber? }
+     Returns: SessionEventDto
+
+GET  /api/v1/sessions/{id}/events?type=&round=&limit=50&cursor=
+     Returns: PagedResult<SessionEventDto>
+```
+
+---
+
+## 7. Tab: 🏆 Scoreboard
+
+### Layout
+
+```
+CATEGORIE: [+ Aggiungi]
+┌─────┬──────┬──────┬──────┬────────┐
+│     │  PV  │ Oro  │ Terr.│ TOTALE │
+├─────┼──────┼──────┼──────┼────────┤
+│⠿ ●  │      │      │      │        │
+│Marco│ [12] │  [8] │  [3] │   23   │
+│ −[+]│ −[+] │ −[+] │ −[+] │        │
+├─────┼──────┼──────┼──────┼────────┤
+│⠿   │      │      │      │        │
+│Luca │  [9] │ [11] │  [5] │   25   │
+│ −[+]│ −[+] │ −[+] │ −[+] │        │
+├─────┼──────┼──────┼──────┼────────┤
+│⠿   │      │      │      │        │
+│Anna │  [7] │  [6] │  [9] │   22   │
+│ −[+]│ −[+] │ −[+] │ −[+] │        │
+└─────┴──────┴──────┴──────┴────────┘
+
+🥇 Luca 25 · 🥈 Marco 23 · 🥉 Anna 22
+
+[ 🔄 Reset ] [ 📊 Dettaglio round ]
+```
+
+### Interactions
+
+| Action | Gesture | Result |
+|--------|---------|--------|
+| Edit score | Tap cell → numeric input | Overwrites value, recalculates total |
+| Quick increment | Tap +/− below cell | +1/-1 (long press: accelerating repeat) |
+| Mark turn | Tap player avatar/name | Moves ● indicator, logs `turn_change` |
+| Reorder rows | Drag handle ⠿ | Drag row up/down, persistent order |
+| Add category | Tap [+ Aggiungi] in header | Name input, new column added |
+| Remove category | Long press column header → confirm | Removes column (scores kept in diary) |
+| Reset scores | Tap 🔄 → confirm | Zeros all, logs `score_reset` event |
+| Round breakdown | Tap 📊 | Expand per-round breakdown below table |
+
+### Round Breakdown (expandable)
+
+```
+📊 Breakdown per Round
+  R1:  Marco +5  Luca +3  Anna +4
+  R2:  Marco +4  Luca +8  Anna +2
+  R3:  Marco +3  Luca +2  Anna +5  ← current
+
+  [ Nuovo Round → R4 ]
+```
+
+Advancing round increments `currentRound` in PlayerContext and logs `round_advance` event.
+
+### Data Mapping
+
+```
+Column "PV"  → ScoreEntry { Category = "PV" }
+Each cell    → ScoreEntry { ParticipantId, Category, ScoreValue, RoundNumber? }
+Total        → Calculated frontend: sum(entries per participant)
+Ranking      → Calculated frontend: sort by total desc
+```
+
+### Predefined Categories from AI
+
+If GameToolkit has a `ScoringTemplate` generated from KB (e.g., rulebook says "Victory Points, Resources, Territories"), categories are pre-populated. User can always add/remove.
+
+### API (existing)
+
+| Operation | With session | Without session |
+|-----------|-------------|----------------|
+| Read scores | `GET /sessions/{id}/scoreboard` | Zustand store |
+| Update score | `PUT /sessions/{id}/scores` | Zustand store |
+| Ranking | `GetScoreboardQuery` (exists) | Local calculation |
+
+### Backend Changes
+
+None. `ScoreEntry` with `Category` and `RoundNumber` already covers all cases. `GetScoreboardQuery` already returns breakdown by round and category.
+
+---
+
+## 8. PlayerContext & Session Promotion
+
+### Unified Hook
+
+```typescript
+interface PlayerContextValue {
+  // State
+  mode: 'local' | 'session';
+  players: Player[];
+  currentTurnIndex: number;
+  currentRound: number;
+
+  // Player actions
+  addPlayer: (name: string, color: string) => void;
+  removePlayer: (id: string) => void;
+  reorderPlayers: (orderedIds: string[]) => void;
+  setTurn: (playerId: string) => void;
+  advanceTurn: () => void;
+  advanceRound: () => void;
+
+  // Data actions (delegates to correct backend)
+  rollDice: (formula: string) => DiceResult;
+  addScore: (playerId: string, category: string, value: number) => void;
+  addNote: (content: string, type: 'shared' | 'private') => void;
+  logEvent: (event: DiaryEvent) => void;
+
+  // Promotion
+  canPromote: boolean;
+  promote: () => Promise<void>;
+  sessionId?: string;
+}
+```
+
+### Mode Resolution
+
+- `sessionId` prop provided → **session mode** (all data via SessionTracking API)
+- No `sessionId` → **local mode** (Zustand store persisted to `localStorage` keyed by `toolkit:${gameId}`)
+
+### Promotion Flow (local → session)
+
+```
+1. User taps "Salva come sessione" in PlayerBar
+2. POST /sessions { gameId, participants: players[] }
+3. Response: { sessionId, sessionCode, participants[] }
+4. Migrate data (parallel):
+   ├─ POST /sessions/{id}/scores      ← bulk score entries
+   ├─ POST /sessions/{id}/notes       ← bulk player notes
+   └─ POST /sessions/{id}/events      ← bulk diary events
+5. Switch mode: 'local' → 'session'
+   - Zustand store cleared for this gameId
+   - All calls now go to SessionTracking APIs
+   - SessionCode displayed for inviting other players
+```
+
+### PlayerBar (always visible)
+
+```
+🟠Marco  🟣Luca  🟢Anna  [+]    [⬆ Sessione]
+ ●turno
+```
+
+Tap player → context menu: Mark turn / Edit / Change color / Remove
+
+### Player Colors
+
+8-color high-contrast palette, auto-assigned in order:
+
+```typescript
+const PLAYER_COLORS = [
+  '#E67E22', '#9B59B6', '#2ECC71', '#3498DB',
+  '#E74C3C', '#F1C40F', '#1ABC9C', '#E84393',
+];
+```
+
+### Local Store
+
+```typescript
+interface ToolkitLocalStore {
+  players: LocalPlayer[];
+  currentTurnIndex: number;
+  currentRound: number;
+  scores: Record<string, Record<string, number>>;  // playerId → category → value
+  notes: LocalNote[];
+  diary: DiaryEvent[];
+  customDicePresets: DicePreset[];
+  scoreCategories: string[];
+}
+// Persisted in localStorage keyed by `toolkit:${gameId}`
+```
+
+### Persistence Rules
+
+| Data | Persists across drawer close/reopen | Persists across page reload |
+|------|-------------------------------------|-----------------------------|
+| Players, turn, round | Yes | Yes (localStorage or session) |
+| Scores | Yes | Yes |
+| Notes | Yes | Yes |
+| Diary events | Yes | Yes |
+| Dice roll results | No (volatile) | No — logged in diary only |
+| Custom dice presets | Yes | Yes (server-side via GameToolkit) |
+
+---
+
+## 9. Backend Changes Summary
+
+### New: SessionEvent entity (SessionTracking BC)
+
+```
+SessionTracking/
+├── Domain/Entities/SessionEvent.cs              ← NEW
+├── Application/
+│   ├── Commands/AddSessionEventCommand.cs       ← NEW
+│   ├── Queries/GetSessionEventsQuery.cs         ← NEW
+│   └── DTOs/SessionEventDtos.cs                 ← NEW
+├── Infrastructure/Persistence/
+│   └── Configurations/SessionEventEntityConfiguration.cs ← NEW
+└── Domain/Repositories/ (extend or new ISessionEventRepository)
+```
+
+Endpoints: 2 new (POST + GET with filters)
+
+### New: UserDicePreset entity (GameToolkit BC)
+
+```
+GameToolkit/
+├── Domain/Entities/GameToolkit.cs               ← MODIFY (add _userDicePresets)
+│   └── UserDicePreset.cs                        ← NEW child entity
+├── Application/
+│   ├── Commands/AddUserDicePresetCommand.cs      ← NEW
+│   ├── Commands/RemoveUserDicePresetCommand.cs   ← NEW
+│   └── Queries/GetUserDicePresetsQuery.cs        ← NEW
+└── Infrastructure/Persistence/
+    └── Configurations/UserDicePresetEntityConfiguration.cs ← NEW
+```
+
+Endpoints: 3 new (POST + GET + DELETE)
+
+### Migrations
+
+- 1 migration: `session_tracking.session_events` table
+- 1 migration: `game_toolkit.user_dice_presets` table
+
+### Impact Summary
+
+| Area | New files | Modified files | Breaking changes |
+|------|-----------|---------------|-----------------|
+| SessionTracking BC | ~6 | ~1 | 0 |
+| GameToolkit BC | ~5 | ~2 | 0 |
+| Migrations | 2 | 0 | 0 |
+| Routing | 0 | 2 | 0 |
+| **Backend total** | **~13** | **~5** | **0** |
+
+### Unchanged (already supports all requirements)
+
+- `DiceRoll` — formulas, cryptographic RNG, d4-d100
+- `ScoreEntry` — multi-category, round-based
+- `PlayerNote` — Private/Shared/Template visibility
+- `Session` + `Participant` — roles, turns, ready state
+- `Toolkit` widget config — RandomGenerator, ScoreTracker, NoteManager
+- `ScoringTemplate` — AI-generated categories from KB
+- `DiceToolConfig` — AI-generated dice presets
+- `GetScoreboardQuery` — ranking, round/category breakdown
+
+---
+
+## 10. Frontend File Structure
+
+```
+apps/web/src/
+├── components/
+│   └── toolkit-drawer/
+│       ├── ToolkitDrawer.tsx
+│       ├── ToolkitDrawerProvider.tsx
+│       ├── index.ts
+│       │
+│       ├── tabs/
+│       │   ├── DiceRollerTab.tsx
+│       │   ├── DicePresetRow.tsx
+│       │   ├── DicePoolBuilder.tsx
+│       │   ├── DiceResultDisplay.tsx
+│       │   ├── NotesTab.tsx
+│       │   ├── NoteCard.tsx
+│       │   ├── EventDiaryTab.tsx
+│       │   ├── DiaryEventRow.tsx
+│       │   ├── DiaryFilters.tsx
+│       │   ├── ScoreboardTab.tsx
+│       │   ├── ScoreCell.tsx
+│       │   ├── ScoreCategoryHeader.tsx
+│       │   ├── RankingBar.tsx
+│       │   └── RoundBreakdown.tsx
+│       │
+│       ├── shared/
+│       │   ├── PlayerBar.tsx
+│       │   ├── PlayerAvatar.tsx
+│       │   ├── PlayerSetupModal.tsx
+│       │   └── PromoteSessionModal.tsx
+│       │
+│       └── hooks/
+│           ├── useToolkitConfig.ts
+│           ├── usePlayerContext.ts
+│           ├── useDiceRoller.ts
+│           ├── useScoreboard.ts
+│           ├── useNotes.ts
+│           ├── useDiary.ts
+│           └── useToolkitSession.ts
+│
+├── stores/
+│   └── toolkit-local-store.ts
+│
+└── lib/api/
+    └── toolkit-api.ts
+```
+
+### Integration Point
+
+MeepleCard itself is NOT modified. Consumer pages add the navItem and render the drawer:
+
+```typescript
+<MeepleCard
+  entity="game"
+  title={game.title}
+  navItems={[
+    {
+      icon: '🧰', label: 'Toolkit', entity: 'toolkit',
+      onClick: () => openToolkitDrawer(game.id),
+    },
+  ]}
+/>
+
+{drawerOpen && (
+  <ToolkitDrawer
+    gameId={drawerGameId}
+    sessionId={activeSession?.id}
+    onClose={closeDrawer}
+  />
+)}
+```
+
+### File Count
+
+| Area | New | Modified |
+|------|-----|----------|
+| `toolkit-drawer/` components | 22 | 0 |
+| `stores/` | 1 | 0 |
+| `lib/api/` | 1 | 0 |
+| Consumer pages | 0 | 2-3 |
+| MeepleCard | 0 | 0 |
+| **Frontend total** | **24** | **2-3** |
+
+---
+
+## 11. Grand Total
+
+| Layer | New files | Modified | Breaking changes |
+|-------|-----------|----------|-----------------|
+| Backend | ~13 | ~5 | 0 |
+| Frontend | ~24 | ~3 | 0 |
+| Migrations | 2 | 0 | 0 |
+| **Total** | **~39** | **~8** | **0** |


### PR DESCRIPTION
## Summary

Default Game Toolkit: 4-tab drawer (🎲 Dadi, 📝 Note, 📖 Diario, 🏆 Punti) accessible from MeepleCard NavFooter 🧰 ManaPips. Local-first with optional SessionTracking sync.

**Backend** (~13 new files): UserDicePreset value object on GameToolkit BC, 3 CRUD endpoints, JSON serialization, migration, 14 unit tests. SessionEvent infrastructure was already present.

**Frontend** (~24 new files):
- Zustand store factory with `devtools(persist(immer(...)))` — per-game localStorage persistence
- ToolkitDrawer container with glassmorphism panel, slide-from-top animation, tab bar
- DiceRollerTab: preset rows + pool builder + crypto RNG + result display
- NotesTab: shared/private sections with pin/edit/delete
- EventDiaryTab: filtered log with auto-events and manual entries
- ScoreboardTab: multi-dim table with inline edit + long-press stepper + row reorder + ranking
- PlayerBar: always-visible player management with turn indicator
- 19 store unit tests

**Architecture**: GameToolkit BC provides config (read), SessionTracking BC persists data (when session active). No breaking changes.

## Test plan

- [x] Backend: `dotnet test --filter UserDicePresetTests` — 14/14 pass
- [x] Backend: `dotnet test --filter SessionEventTests` — 18/18 pass
- [x] Frontend: `pnpm test toolkit-local-store` — 19/19 pass
- [x] Frontend: `pnpm typecheck` — clean
- [x] Migration generated and reviewed (nullable JSONB column)
- [ ] Manual: Open drawer from a game MeepleCard, test all 4 tabs
- [ ] Manual: Verify localStorage persistence across browser reload
- [ ] Manual: Apply migration on dev DB

## Spec & Plan

- Spec: `docs/superpowers/specs/2026-04-08-default-game-toolkit-design.md`
- Plan: `docs/superpowers/plans/2026-04-08-default-game-toolkit.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
