### PR TITLE
refactor(meeple-card): Phase 4 batch 4 — navItems in 3 specialized adapters

### DIFF
--- a/apps/web/src/components/documents/MeepleKbCard.tsx
+++ b/apps/web/src/components/documents/MeepleKbCard.tsx
@@ -28,12 +28,15 @@
 
 'use client';
 
+import { useMemo } from 'react';
+
 import {
   MeepleCard,
   MeepleCardSkeleton,
   type MeepleCardAction,
   type MeepleCardVariant,
 } from '@/components/ui/data-display/meeple-card';
+import { buildKbNavItems } from '@/components/ui/data-display/meeple-card/nav-items';
 import type { PdfDocumentDto } from '@/lib/api/schemas/pdf.schemas';
 import { buildKbCardProps } from '@/lib/card-mappers';
 
@@ -160,6 +163,22 @@ export function MeepleKbCard({
     ? `${document.documentType.charAt(0).toUpperCase()}${document.documentType.slice(1)} — ${formatFileSize(document.fileSizeBytes)}`
     : formatFileSize(document.fileSizeBytes);
 
+  const navItems = useMemo(
+    () =>
+      buildKbNavItems(
+        { chunkCount: undefined }, // chunkCount not available on PdfDocumentDto
+        {
+          onChunksClick: undefined, // disabled in v1
+          onReindexClick: isAdmin && !isProcessing ? () => onReindex?.(document.id) : undefined,
+          onPreviewClick: () => {
+            window.location.href = `/documents/${document.id}`;
+          },
+          onDownloadClick: isEditorOrAdmin ? () => onDownload?.(document.id) : undefined,
+        }
+      ),
+    [isAdmin, isProcessing, isEditorOrAdmin, document.id, onReindex, onDownload]
+  );
+
   return (
     <MeepleCard
       entity="kb"
@@ -168,6 +187,7 @@ export function MeepleKbCard({
       subtitle={subtitle}
       badge={mapperProps.badge}
       metadata={mapperProps.metadata}
+      navItems={navItems}
       className={className}
       onClick={() => (window.location.href = `/documents/${document.id}`)}
       actions={actions.length > 0 ? actions : undefined}

--- a/apps/web/src/components/game-night/planning/MeepleGameNightCard.tsx
+++ b/apps/web/src/components/game-night/planning/MeepleGameNightCard.tsx
@@ -1,10 +1,13 @@
 'use client';
 
+import { useMemo } from 'react';
+
 import { Users, Gamepad2 } from 'lucide-react';
 import Link from 'next/link';
 
 import { MeepleCard } from '@/components/ui/data-display/meeple-card';
 import type { MeepleCardMetadata } from '@/components/ui/data-display/meeple-card';
+import { buildEventNavItems } from '@/components/ui/data-display/meeple-card/nav-items';
 import { cn } from '@/lib/utils';
 import type { GameNightSummary, GameNightStatus } from '@/stores/game-night';
 
@@ -34,6 +37,20 @@ export function MeepleGameNightCard({ night }: MeepleGameNightCardProps) {
     { icon: <Gamepad2 className="h-4 w-4" />, label: String(night.gameCount) },
   ];
 
+  const navItems = useMemo(
+    () =>
+      buildEventNavItems(
+        { participantCount: night.playerCount, gameCount: night.gameCount },
+        {
+          // Link-style: entire card navigates via <Link> wrapper, so inner clicks
+          // are intentionally no-ops to avoid double navigation.
+          onParticipantsClick: () => {},
+          onGamesClick: () => {},
+        }
+      ),
+    [night.playerCount, night.gameCount]
+  );
+
   return (
     <Link
       href={`/game-nights/${night.id}`}
@@ -46,6 +63,7 @@ export function MeepleGameNightCard({ night }: MeepleGameNightCardProps) {
         subtitle={subtitle}
         metadata={metadata}
         badge={STATUS_BADGE[night.status] ?? 'Sconosciuto'}
+        navItems={navItems}
         className="h-full"
         data-testid="game-night-card"
       />

--- a/apps/web/src/components/library/private-game-detail/MeeplePausedSessionCard.tsx
+++ b/apps/web/src/components/library/private-game-detail/MeeplePausedSessionCard.tsx
@@ -8,7 +8,7 @@
  * Preserves confirmation dialog for old sessions (>30 days).
  */
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { formatDistanceToNow } from 'date-fns';
 import { it } from 'date-fns/locale';
@@ -18,6 +18,7 @@ const PlayIcon = <Play className="h-4 w-4" />;
 const Trash2Icon = <Trash2 className="h-4 w-4" />;
 
 import { MeepleCard, type MeepleCardMetadata } from '@/components/ui/data-display/meeple-card';
+import { buildSessionNavItems } from '@/components/ui/data-display/meeple-card/nav-items';
 import { ConfirmationDialog } from '@/components/ui/overlays/confirmation-dialog';
 
 export interface PausedSession {
@@ -77,6 +78,25 @@ export function MeeplePausedSessionCard({
     }
   };
 
+  const navItems = useMemo(
+    () =>
+      buildSessionNavItems(
+        {
+          playerCount: session.participants.length,
+          hasNotes: session.hasNotes,
+          toolCount: 0,
+          photoCount: session.hasPhotos ? 1 : 0,
+        },
+        {
+          // Resume is the primary action; slot handlers no-op in this view
+          onPlayersClick: () => {},
+          onNotesClick: session.hasNotes ? () => {} : undefined,
+          onPhotosClick: session.hasPhotos ? () => {} : undefined,
+        }
+      ),
+    [session.participants.length, session.hasNotes, session.hasPhotos]
+  );
+
   return (
     <>
       <MeepleCard
@@ -86,6 +106,7 @@ export function MeeplePausedSessionCard({
         subtitle={subtitle}
         metadata={metadata}
         badge={isOld ? 'Vecchia' : undefined}
+        navItems={navItems}
         actions={[
           {
             icon: PlayIcon,


### PR DESCRIPTION
Wires navItems to MeepleKbCard (reindex/download/preview), MeepleGameNightCard (participants+games via buildEventNavItems), and MeeplePausedSessionCard (players/notes/photos via buildSessionNavItems). Phase 4 batch 4 of MeepleCard Consumers Completion epic.

## Files

- apps/web/src/components/documents/MeepleKbCard.tsx — KB document adapter
- apps/web/src/components/game-night/planning/MeepleGameNightCard.tsx — Game night planning card
- apps/web/src/components/library/private-game-detail/MeeplePausedSessionCard.tsx — Resume paused session

## Test Plan

- [x] pnpm typecheck passes
- [x] pnpm test nav-items still 39/39 passing
- [ ] Visit /library/games/{id} after deploy and verify PausedSession card shows nav-footer
- [ ] Visit /game-nights and verify GameNight cards show event nav-footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)