### PR TITLE
refactor(session): wire navItems in 2 session adapters

### DIFF
--- a/apps/web/src/components/session/MeepleResumeSessionCard.tsx
+++ b/apps/web/src/components/session/MeepleResumeSessionCard.tsx
@@ -7,11 +7,14 @@
  * Displays a paused session using the session entity variant.
  */
 
+import { useMemo } from 'react';
+
 import { formatDistanceToNow } from 'date-fns';
 import { it } from 'date-fns/locale';
 import Link from 'next/link';
 
 import { MeepleCard, type MeepleCardMetadata } from '@/components/ui/data-display/meeple-card';
+import { buildSessionNavItems } from '@/components/ui/data-display/meeple-card/nav-items';
 
 export interface MeepleResumeSessionCardProps {
   /** Session ID used to build the resume link. */
@@ -52,6 +55,24 @@ export function MeepleResumeSessionCard({
     ...(hasPhotos ? [{ label: `${photoCount} foto salvate` } as MeepleCardMetadata] : []),
   ];
 
+  const navItems = useMemo(
+    () =>
+      buildSessionNavItems(
+        {
+          playerCount,
+          hasNotes: false,
+          toolCount: 0,
+          photoCount: photoCount ?? 0,
+        },
+        {
+          // All nav slots are no-ops since the Link wraps the card.
+          onPlayersClick: () => {},
+          onPhotosClick: hasPhotos ? () => {} : undefined,
+        }
+      ),
+    [playerCount, photoCount, hasPhotos]
+  );
+
   return (
     <Link href={`/sessions/${sessionId}/scoreboard`}>
       <MeepleCard
@@ -62,6 +83,7 @@ export function MeepleResumeSessionCard({
         metadata={metadata}
         badge="In pausa"
         status="paused"
+        navItems={navItems}
       />
     </Link>
   );

--- a/apps/web/src/components/session/MeepleSessionCard.tsx
+++ b/apps/web/src/components/session/MeepleSessionCard.tsx
@@ -5,7 +5,10 @@
  * Issue #5003 — Session Card: azioni contestuali per stato e ruolo
  */
 
+import { useMemo } from 'react';
+
 import { MeepleCard, type MeepleCardVariant } from '@/components/ui/data-display/meeple-card';
+import { buildSessionNavItems } from '@/components/ui/data-display/meeple-card/nav-items';
 import type { GameSessionDto } from '@/lib/api/schemas/games.schemas';
 
 // ============================================================================
@@ -69,6 +72,22 @@ export function MeepleSessionCard({
           ? 'In pausa'
           : undefined;
 
+  const navItems = useMemo(
+    () =>
+      buildSessionNavItems(
+        {
+          playerCount: session.playerCount,
+          hasNotes: false, // session DTO doesn't expose notes flag
+          toolCount: 0,
+          photoCount: 0,
+        },
+        {
+          onPlayersClick: onClick ? () => onClick(session.id) : undefined,
+        }
+      ),
+    [session.playerCount, session.id, onClick]
+  );
+
   return (
     <MeepleCard
       id={session.id}
@@ -77,6 +96,7 @@ export function MeepleSessionCard({
       title={`Sessione #${session.id.slice(0, 8)}`}
       subtitle={subtitle}
       badge={statusBadge}
+      navItems={navItems}
       className={className}
       onClick={onClick ? () => onClick(session.id) : undefined}
       data-testid={`session-card-${session.id}`}


### PR DESCRIPTION
Phase 4 batch 5 — MeepleSessionCard and MeepleResumeSessionCard now expose buildSessionNavItems with player count mapped from their respective DTOs.

## Files
- apps/web/src/components/session/MeepleSessionCard.tsx
- apps/web/src/components/session/MeepleResumeSessionCard.tsx

## Test Plan
- [x] pnpm typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)