### PR TITLE
feat(meeple-card): dev page showcase + mobile preview + badge contrast

### DIFF
--- a/apps/web/src/app/(public)/dev/meeple-card/page.tsx
+++ b/apps/web/src/app/(public)/dev/meeple-card/page.tsx
@@ -9,7 +9,16 @@ export const dynamic = 'force-dynamic';
  * Accessible without authentication: /dev/meeple-card
  */
 
-import { MeepleCard, MeepleCardSkeleton } from '@/components/ui/data-display/meeple-card';
+import { useState, useMemo } from 'react';
+
+import {
+  MeepleCard,
+  MeepleCardSkeleton,
+  MobileCardLayout,
+  MobileDevicePreview,
+  MobileCardDrawer,
+} from '@/components/ui/data-display/meeple-card';
+import type { MeepleCardProps } from '@/components/ui/data-display/meeple-card';
 import {
   buildAgentNavItems,
   buildChatNavItems,
@@ -23,6 +32,67 @@ import {
 } from '@/components/ui/data-display/meeple-card/nav-items';
 
 const GAME_IMAGE = 'https://picsum.photos/seed/catan/400/300';
+
+const MOBILE_DEMO_CARDS: MeepleCardProps[] = [
+  {
+    entity: 'game',
+    id: 'mob-catan',
+    title: 'Catan',
+    subtitle: 'Klaus Teuber · 1995',
+    imageUrl: 'https://picsum.photos/seed/mobile-catan/400/300',
+    rating: 7.2,
+    ratingMax: 10,
+    badge: 'Owned',
+    status: 'owned',
+    metadata: [{ label: '3-4' }, { label: '60m' }],
+  },
+  {
+    entity: 'game',
+    id: 'mob-azul',
+    title: 'Azul',
+    subtitle: 'Michael Kiesling · 2017',
+    imageUrl: 'https://picsum.photos/seed/mobile-azul/400/300',
+    rating: 7.8,
+    ratingMax: 10,
+    badge: 'Top 10',
+    status: 'owned',
+    metadata: [{ label: '2-4' }, { label: '30m' }],
+  },
+  {
+    entity: 'agent',
+    id: 'mob-agent',
+    title: 'Azul Rules Expert',
+    subtitle: 'RAG · GPT-4o-mini',
+    status: 'active',
+    badge: 'v2',
+    metadata: [{ label: '342 invoc.' }],
+  },
+  {
+    entity: 'session',
+    id: 'mob-session',
+    title: 'Serata Azul',
+    subtitle: '4 giocatori · Casa di Marco',
+    status: 'inprogress',
+    badge: 'Live',
+    metadata: [{ label: '45 min' }],
+  },
+  {
+    entity: 'kb',
+    id: 'mob-kb',
+    title: 'azul_rulebook.pdf',
+    subtitle: 'Regolamento base · 12 pg',
+    status: 'indexed',
+    metadata: [{ label: '2.4 MB' }],
+  },
+  {
+    entity: 'chat',
+    id: 'mob-chat',
+    title: 'Come si gioca ad Azul?',
+    subtitle: 'Azul · 12 messaggi',
+    badge: '12 nuovi',
+    metadata: [{ label: '12 msg' }],
+  },
+];
 
 function Section({
   title,
@@ -778,6 +848,9 @@ export default function MeepleCardDevPage() {
           </div>
         </Section>
 
+        {/* Mobile Card Layout — match admin-mockups/mobile-card-layout-mockup.html */}
+        <MobilePreviewSection />
+
         {/* Skeleton */}
         <Section title="Skeleton" description="Stato di caricamento.">
           <CardRow>
@@ -788,5 +861,80 @@ export default function MeepleCardDevPage() {
         </Section>
       </div>
     </div>
+  );
+}
+
+/**
+ * Interactive mobile preview section.
+ *
+ * Separated as a component so it can use useState without making the
+ * entire page re-render on every state change.
+ */
+function MobilePreviewSection() {
+  const [drawerCard, setDrawerCard] = useState<MeepleCardProps | null>(null);
+
+  const interactiveCards = useMemo(
+    () =>
+      MOBILE_DEMO_CARDS.map(card => ({
+        ...card,
+        onClick: () => setDrawerCard(card),
+      })),
+    []
+  );
+
+  return (
+    <Section
+      title="Mobile Card Layout — Focus Mode"
+      description="Il componente MobileCardLayout con phone-frame da mobile-card-layout-mockup.html. Hand-stack a sinistra, FocusedCard centrale con swipe. Click sulla card apre il drawer con tab specifici per entity type."
+    >
+      <p className="text-xs text-amber-600 dark:text-amber-400 mb-3">
+        💡 Clicca sulla focused card (centro) per aprire il drawer con tab entity-specifici. Clicca
+        sulle card nella hand-stack (sinistra) per cambiare focus.
+      </p>
+      <div className="flex flex-col items-center gap-8 lg:flex-row lg:items-start lg:justify-center">
+        {/* Phone frame */}
+        <MobileDevicePreview>
+          {/* MobileCardLayout uses md:hidden — override with md:!flex for desktop */}
+          <MobileCardLayout className="md:!flex" cards={interactiveCards} />
+          {/* Drawer overlay — renders inside the phone frame */}
+          <MobileCardDrawer card={drawerCard} onClose={() => setDrawerCard(null)} />
+        </MobileDevicePreview>
+
+        {/* Sidebar notes */}
+        <div className="max-w-sm space-y-4 text-sm text-[var(--mc-text-secondary)]">
+          <h3 className="text-base font-bold text-[var(--mc-text-primary)]">
+            Componenti del Mockup
+          </h3>
+          <ul className="list-disc space-y-2 pl-5">
+            <li>
+              <strong>MobileDevicePreview</strong> — phone frame 390x720 con status bar, navbar
+              (logo MeepleAI + notifiche + avatar), search bar, action bar
+            </li>
+            <li>
+              <strong>HandSidebar</strong> — stack verticale a sinistra (44px) con le card come in
+              mano a un giocatore
+            </li>
+            <li>
+              <strong>FocusedCard</strong> — card centrale in focus con cover, entity badge, rating,
+              metadata e actions
+            </li>
+            <li>
+              <strong>SwipeGesture</strong> — swipe L/R per navigare tra card (o click su hand card)
+            </li>
+            <li>
+              <strong>MobileCardDrawer</strong> — drawer overlay con tabs entity-specifici. Si apre
+              cliccando sulla focused card. Tab diversi per ogni entity (game: Overview/AI/Sessioni/
+              Media/Scoreboard, agent: Overview/Config/Stats/Chat/Fonti, ecc.)
+            </li>
+          </ul>
+          <div className="rounded-lg border border-[var(--mc-border)] bg-[var(--mc-bg-muted)] p-3 text-xs">
+            <strong>Stato implementazione:</strong> MobileCardLayout e subcomponenti sono
+            implementati ed esportati da <code>meeple-card/index.ts</code>. Attualmente{' '}
+            <em>nessun consumer</em> li usa in produzione — il componente è <code>md:hidden</code>{' '}
+            (mobile-only). Override <code>md:!flex</code> usato qui per il rendering desktop.
+          </div>
+        </div>
+      </div>
+    </Section>
   );
 }

--- a/apps/web/src/app/(public)/dev/meeple-card/page.tsx
+++ b/apps/web/src/app/(public)/dev/meeple-card/page.tsx
@@ -65,7 +65,8 @@ export default function MeepleCardDevPage() {
         </p>
         <h1 className="text-3xl font-bold">MeepleCard Showcase</h1>
         <p className="text-muted-foreground mt-2 max-w-2xl">
-          Universal card component with 5 variants and 9 entity types.
+          Universal card component with 5 variants and 9 entity types. Tutte le feature dei mockup
+          in <code className="text-xs">admin-mockups/</code> sono dimostrate qui.
         </p>
       </div>
 
@@ -183,43 +184,381 @@ export default function MeepleCardDevPage() {
           />
 
           <Label>hero</Label>
-          <MeepleCard
-            entity="player"
-            variant="hero"
-            title="Alice Rossi"
-            subtitle="Giocatrice del mese"
-            metadata={[{ label: '42 partite' }, { label: '68% win rate' }]}
-          />
-        </Section>
-
-        {/* With Actions */}
-        <Section title="Con Azioni" description="MeepleCard con actions array.">
-          <CardRow>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <MeepleCard
               entity="game"
-              variant="grid"
-              title="Wingspan"
-              subtitle="Elizabeth Hargrave · 2019"
-              imageUrl="https://picsum.photos/seed/wingspan/400/300"
-              rating={4.8}
-              ratingMax={5}
-              metadata={[{ label: '1-5 giocatori' }]}
-              actions={[
-                { icon: '▶', label: 'Avvia partita', onClick: () => alert('Avvia!') },
-                { icon: '📖', label: 'Regolamento', onClick: () => alert('Regolamento') },
-                {
-                  icon: '🗑️',
-                  label: 'Rimuovi',
-                  onClick: () => alert('Rimuovi'),
-                  variant: 'danger',
-                },
-              ]}
+              variant="hero"
+              title="Game of the Month: Catan"
+              subtitle="The classic gateway game that started it all"
+              imageUrl="https://picsum.photos/seed/catan-hero/800/600"
+              rating={7.2}
+              ratingMax={10}
+              badge="Editor's Pick"
+              metadata={[{ label: 'Editor Pick' }, { label: '10K+ plays' }]}
             />
+            <MeepleCard
+              entity="player"
+              variant="hero"
+              title="Alice Rossi"
+              subtitle="Giocatrice del mese"
+              metadata={[{ label: '42 partite' }, { label: '68% win rate' }]}
+            />
+          </div>
+        </Section>
+
+        {/* Quick Actions — hover-reveal (fix showQuickActions prop) */}
+        <Section
+          title="Quick Actions (Hover)"
+          description="Le azioni rapide si rivelano al passaggio del mouse. Richiedono showQuickActions={true} AND actions.length > 0 (entrambe obbligatorie)."
+        >
+          <p className="text-xs text-amber-600 dark:text-amber-400 mb-3">
+            💡 Passa il mouse sopra ogni card per vedere i pulsanti delle azioni in alto a destra.
+          </p>
+          <CardRow>
+            <div>
+              <Label>game · 3 azioni</Label>
+              <MeepleCard
+                entity="game"
+                variant="grid"
+                title="Wingspan"
+                subtitle="Elizabeth Hargrave · 2019"
+                imageUrl="https://picsum.photos/seed/wingspan/400/300"
+                rating={4.8}
+                ratingMax={5}
+                metadata={[{ label: '1-5 giocatori' }]}
+                showQuickActions
+                actions={[
+                  { icon: '▶', label: 'Avvia partita', onClick: () => alert('Avvia!') },
+                  { icon: '📖', label: 'Regolamento', onClick: () => alert('Regolamento') },
+                  {
+                    icon: '🗑️',
+                    label: 'Rimuovi',
+                    onClick: () => alert('Rimuovi'),
+                    variant: 'danger',
+                  },
+                ]}
+              />
+            </div>
+            <div>
+              <Label>agent · 2 azioni</Label>
+              <MeepleCard
+                entity="agent"
+                variant="grid"
+                title="RulesBot Pro"
+                subtitle="RAG · GPT-4o-mini"
+                status="active"
+                metadata={[{ label: '342 invocazioni' }]}
+                showQuickActions
+                actions={[
+                  { icon: '💬', label: 'Chat', onClick: () => alert('Chat!') },
+                  { icon: '⚙️', label: 'Configura', onClick: () => alert('Config!') },
+                ]}
+              />
+            </div>
+            <div>
+              <Label>kb · disabled + danger</Label>
+              <MeepleCard
+                entity="kb"
+                variant="grid"
+                title="Manuale Catan"
+                subtitle="PDF · 48 pagine"
+                status="indexed"
+                metadata={[{ label: '124 chunks' }, { label: '2.4 MB' }]}
+                showQuickActions
+                actions={[
+                  { icon: '👁', label: 'Anteprima', onClick: () => alert('Preview') },
+                  {
+                    icon: '🔄',
+                    label: 'Reindex in corso',
+                    onClick: () => alert('Reindex'),
+                    disabled: true,
+                  },
+                  {
+                    icon: '🗑️',
+                    label: 'Elimina',
+                    onClick: () => alert('Elimina'),
+                    variant: 'danger',
+                  },
+                ]}
+              />
+            </div>
           </CardRow>
         </Section>
 
-        {/* Status badges */}
-        <Section title="Status Badges" description="Stato delle entità tramite CardStatus.">
+        {/* Showcase Completo — tutte le feature combinate (match mockup summary Section 2) */}
+        <Section
+          title="Showcase Completo — Tutte le Feature"
+          description="Una card per ogni entity con image + badge + rating + metadata + status + tags + navItems + quickActions combinati. Mirrors admin-mockups/meeple-card-summary-render.html Section 2."
+        >
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            <MeepleCard
+              entity="game"
+              variant="grid"
+              title="Catan"
+              subtitle="Klaus Teuber · 1995"
+              imageUrl="https://picsum.photos/seed/catan-full/400/300"
+              rating={7.2}
+              ratingMax={10}
+              badge="Bestseller"
+              status="owned"
+              tags={['Classic', 'Family', 'Strategy']}
+              metadata={[{ label: '3-4 giocatori' }, { label: '60-120 min' }]}
+              showQuickActions
+              actions={[
+                { icon: 'ℹ', label: 'Info', onClick: () => alert('Info') },
+                { icon: '📚', label: 'Library', onClick: () => alert('Library') },
+                { icon: '🤖', label: 'Crea agent', onClick: () => alert('Agent') },
+              ]}
+              navItems={buildGameNavItems(
+                { kbCount: 3, agentCount: 1, chatCount: 5, sessionCount: 12 },
+                {
+                  onKbClick: () => alert('KB'),
+                  onAgentClick: () => alert('Agent'),
+                  onChatClick: () => alert('Chat'),
+                  onSessionClick: () => alert('Session'),
+                }
+              )}
+            />
+            <MeepleCard
+              entity="player"
+              variant="grid"
+              title="Marco Rossi"
+              subtitle="@marco_games"
+              badge="Top 5%"
+              status="active"
+              metadata={[{ label: '142 plays' }, { label: '68% win' }]}
+              navItems={buildPlayerNavItems(
+                { totalWins: 96, totalSessions: 142 },
+                {
+                  onWinsClick: () => alert('Wins'),
+                  onSessionsClick: () => alert('Sessions'),
+                }
+              )}
+            />
+            <MeepleCard
+              entity="session"
+              variant="grid"
+              title="Serata Azul"
+              subtitle="Azul · Casa di Marco"
+              status="inprogress"
+              badge="Live"
+              metadata={[{ label: '4 giocatori' }, { label: '45 min' }]}
+              navItems={buildSessionNavItems(
+                { playerCount: 4, hasNotes: true, toolCount: 2, photoCount: 6 },
+                {
+                  onPlayersClick: () => alert('Players'),
+                  onNotesClick: () => alert('Notes'),
+                  onToolsClick: () => alert('Tools'),
+                  onPhotosClick: () => alert('Photos'),
+                }
+              )}
+            />
+            <MeepleCard
+              entity="agent"
+              variant="grid"
+              title="Azul Rules Expert"
+              subtitle="RAG Strategy · GPT-4o-mini"
+              status="active"
+              badge="v2"
+              metadata={[{ label: '342 invocazioni' }, { label: '12 fonti' }]}
+              showQuickActions
+              actions={[
+                { icon: '💬', label: 'Chat', onClick: () => alert('Chat') },
+                { icon: '⚙️', label: 'Config', onClick: () => alert('Config') },
+              ]}
+              navItems={buildAgentNavItems(
+                { chatCount: 18, kbCount: 12 },
+                {
+                  onChatClick: () => alert('Chat'),
+                  onKbClick: () => alert('KB'),
+                  onConfigClick: () => alert('Config'),
+                }
+              )}
+            />
+            <MeepleCard
+              entity="kb"
+              variant="grid"
+              title="azul_rulebook.pdf"
+              subtitle="Azul · Regolamento base"
+              status="indexed"
+              tags={['PDF', 'Base Rules']}
+              metadata={[{ label: '12 pagine' }, { label: '2.4 MB' }]}
+              showQuickActions
+              actions={[
+                { icon: '👁', label: 'Anteprima', onClick: () => alert('Preview') },
+                { icon: '⬇', label: 'Download', onClick: () => alert('Download') },
+              ]}
+              navItems={buildKbNavItems(
+                { chunkCount: 124 },
+                {
+                  onChunksClick: () => alert('Chunks'),
+                  onReindexClick: () => alert('Reindex'),
+                  onPreviewClick: () => alert('Preview'),
+                  onDownloadClick: () => alert('Download'),
+                }
+              )}
+            />
+            <MeepleCard
+              entity="chat"
+              variant="grid"
+              title="Come si gioca ad Azul?"
+              subtitle="Azul · Azul Rules Expert"
+              status="active"
+              badge="12 nuovi"
+              metadata={[{ label: '12 messaggi' }]}
+              navItems={buildChatNavItems(
+                { messageCount: 12 },
+                {
+                  onMessagesClick: () => alert('Messages'),
+                  onAgentLinkClick: () => alert('Agent'),
+                }
+              )}
+            />
+            <MeepleCard
+              entity="event"
+              variant="grid"
+              title="MeepleAI Tournament"
+              subtitle="Grand Finals · 15 Mar"
+              badge="Finals"
+              status="setup"
+              metadata={[{ label: '32 team' }, { label: '15 Mar' }]}
+              navItems={buildEventNavItems(
+                { participantCount: 32, gameCount: 4 },
+                {
+                  onParticipantsClick: () => alert('Participants'),
+                  onLocationClick: () => alert('Location'),
+                  onGamesClick: () => alert('Games'),
+                  onDateClick: () => alert('Date'),
+                }
+              )}
+            />
+            <MeepleCard
+              entity="toolkit"
+              variant="grid"
+              title="Catan Companion"
+              subtitle="Toolkit ufficiale · 6 strumenti"
+              badge="Ufficiale"
+              status="active"
+              tags={['Official', 'Stats', 'Dice']}
+              metadata={[{ label: '6 strumenti' }, { label: '124 uso' }]}
+              navItems={buildToolkitNavItems(
+                { toolCount: 6, deckCount: 2, phaseCount: 4, useCount: 124 },
+                {
+                  onToolsClick: () => alert('Tools'),
+                  onDecksClick: () => alert('Decks'),
+                  onPhasesClick: () => alert('Phases'),
+                  onHistoryClick: () => alert('History'),
+                }
+              )}
+            />
+            <MeepleCard
+              entity="tool"
+              variant="grid"
+              title="Dice Roller"
+              subtitle="Lancio dadi · 6d6"
+              badge="Beta"
+              metadata={[{ label: '18 uso' }]}
+              showQuickActions
+              actions={[
+                { icon: '🎲', label: 'Lancia', onClick: () => alert('Roll') },
+                { icon: '📋', label: 'Duplica', onClick: () => alert('Duplicate') },
+              ]}
+              navItems={buildToolNavItems({
+                onUseClick: () => alert('Use'),
+                onEditClick: () => alert('Edit'),
+                onDuplicateClick: () => alert('Duplicate'),
+                onHistoryClick: () => alert('History'),
+              })}
+            />
+          </div>
+        </Section>
+
+        {/* Tags showcase */}
+        <Section
+          title="Tags (TagStrip)"
+          description="Il prop tags produce una striscia verticale di tag sul bordo sinistro della cover. Supporta overflow con +N."
+        >
+          <CardRow>
+            <div>
+              <Label>3 tags</Label>
+              <MeepleCard
+                entity="game"
+                variant="grid"
+                title="Scythe"
+                subtitle="Jamey Stegmaier · 2016"
+                imageUrl="https://picsum.photos/seed/scythe/400/300"
+                rating={8.2}
+                ratingMax={10}
+                tags={['Heavy', 'Engine', 'Area Control']}
+                metadata={[{ label: '1-5' }, { label: '90-115m' }]}
+              />
+            </div>
+            <div>
+              <Label>overflow +2</Label>
+              <MeepleCard
+                entity="game"
+                variant="grid"
+                title="Gloomhaven"
+                subtitle="Isaac Childres · 2017"
+                imageUrl="https://picsum.photos/seed/gloomhaven/400/300"
+                rating={8.9}
+                ratingMax={10}
+                tags={['RPG', 'Campaign', 'Coop', 'Deckbuild', 'Legacy']}
+                metadata={[{ label: '1-4' }, { label: '60-120m' }]}
+              />
+            </div>
+            <div>
+              <Label>kb tags</Label>
+              <MeepleCard
+                entity="kb"
+                variant="grid"
+                title="rules_addendum.pdf"
+                subtitle="Scythe · FAQ ufficiali"
+                status="indexed"
+                tags={['FAQ', 'Errata']}
+                metadata={[{ label: '8 pagine' }]}
+              />
+            </div>
+          </CardRow>
+        </Section>
+
+        {/* Grid with Status Badges */}
+        <Section
+          title="Grid con Status Badge"
+          description="Lo status badge è mostrato sulla cover nei variant grid (oltre al rendering compact)."
+        >
+          <CardRow>
+            {(
+              [
+                { s: 'owned', t: 'Posseduto', e: 'game' },
+                { s: 'wishlist', t: 'Wishlist', e: 'game' },
+                { s: 'active', t: 'Attivo', e: 'agent' },
+                { s: 'indexed', t: 'Indicizzato', e: 'kb' },
+                { s: 'processing', t: 'Processing', e: 'kb' },
+                { s: 'failed', t: 'Fallito', e: 'kb' },
+                { s: 'inprogress', t: 'In corso', e: 'session' },
+                { s: 'completed', t: 'Completata', e: 'session' },
+              ] as const
+            ).map(({ s, t, e }) => (
+              <div key={s}>
+                <Label>{s}</Label>
+                <MeepleCard
+                  entity={e}
+                  variant="grid"
+                  title={t}
+                  subtitle={`status=${s}`}
+                  status={s}
+                />
+              </div>
+            ))}
+          </CardRow>
+        </Section>
+
+        {/* Status badges (compact) */}
+        <Section
+          title="Status Badges (compact)"
+          description="Tutti i 12 valori CardStatus nel variant compact."
+        >
           <CardRow>
             {(
               [

--- a/apps/web/src/components/ui/data-display/meeple-card/index.ts
+++ b/apps/web/src/components/ui/data-display/meeple-card/index.ts
@@ -13,6 +13,10 @@ export type {
   Carousel3DProps,
 } from './types';
 export { MobileCardLayout } from './mobile/MobileCardLayout';
+export { MobileDevicePreview } from './mobile/MobileDevicePreview';
+export { MobileCardDrawer } from './mobile/MobileCardDrawer';
+export { getDrawerTabs } from './mobile/drawerTabs';
+export type { CardDrawerTab } from './mobile/drawerTabs';
 export { FlipCard } from './features/FlipCard';
 export { HoverPreview } from './features/HoverPreview';
 export { Carousel3D } from './features/Carousel3D';

--- a/apps/web/src/components/ui/data-display/meeple-card/mobile/MobileCardDrawer.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/mobile/MobileCardDrawer.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { entityHsl, entityLabel } from '../tokens';
+import { getDrawerTabs } from './drawerTabs';
+
+import type { MeepleCardProps } from '../types';
+
+interface MobileCardDrawerProps {
+  /** Card currently shown in the drawer. When null, drawer is closed. */
+  card: MeepleCardProps | null;
+  /** Called when user dismisses the drawer (backdrop click, close button). */
+  onClose: () => void;
+  /**
+   * Optional bounds that constrain the drawer overlay.
+   * When the drawer is mounted inside a phone-frame preview, these bounds
+   * keep the drawer inside the phone instead of filling the full viewport.
+   */
+  containerClassName?: string;
+}
+
+/**
+ * Full-screen drawer overlay used in the mobile card layout.
+ *
+ * Opens when the focused card is clicked. Slides in from the top and shows
+ * entity-specific tabs (game, agent, session, kb, chat, event, player,
+ * toolkit, tool). Tab content is a placeholder that previews what the real
+ * ExtraMeepleCardDrawer would render in production.
+ */
+export function MobileCardDrawer({
+  card,
+  onClose,
+  containerClassName = '',
+}: MobileCardDrawerProps) {
+  const [activeTabId, setActiveTabId] = useState<string | null>(null);
+
+  // Reset active tab whenever the card changes, so drawer re-opens on a
+  // freshly-clicked card always start from the first tab.
+  useEffect(() => {
+    if (card) {
+      const tabs = getDrawerTabs(card.entity);
+      setActiveTabId(tabs[0]?.id ?? null);
+    } else {
+      setActiveTabId(null);
+    }
+  }, [card]);
+
+  if (!card) return null;
+
+  const tabs = getDrawerTabs(card.entity);
+  const activeTab = tabs.find(t => t.id === activeTabId) ?? tabs[0];
+  const accent = entityHsl(card.entity);
+
+  return (
+    <div
+      className={`absolute inset-0 z-30 flex flex-col ${containerClassName}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Dettagli ${card.title}`}
+    >
+      {/* Backdrop — tap to dismiss */}
+      <button
+        type="button"
+        aria-label="Chiudi drawer"
+        className="absolute inset-0 h-full w-full cursor-default bg-black/40 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Drawer content — slides from top */}
+      <div
+        className="relative mx-auto mt-10 flex w-[calc(100%-16px)] flex-1 flex-col overflow-hidden rounded-t-[20px] border border-[var(--mc-border)] bg-[var(--mc-bg-card)] shadow-[0_-8px_32px_rgba(0,0,0,0.15)] backdrop-blur-[16px]"
+        style={{ animation: 'meeplecard-drawer-slide 0.25s cubic-bezier(0.4,0,0.2,1)' }}
+      >
+        {/* Pull handle */}
+        <div className="flex justify-center py-2">
+          <div className="h-1 w-10 rounded-full bg-[var(--mc-border)]" />
+        </div>
+
+        {/* Header: entity ribbon + title + close */}
+        <div className="flex items-start gap-2 border-b border-[var(--mc-border)] px-4 pb-3">
+          <div
+            className="mt-0.5 h-9 w-9 flex-shrink-0 rounded-lg text-xs font-bold text-white flex items-center justify-center uppercase tracking-wide"
+            style={{ background: accent }}
+            aria-hidden
+          >
+            {entityLabel[card.entity].slice(0, 2)}
+          </div>
+          <div className="min-w-0 flex-1">
+            <h3 className="font-[var(--font-quicksand)] text-base font-bold leading-tight text-[var(--mc-text-primary)]">
+              {card.title}
+            </h3>
+            {card.subtitle && (
+              <p className="truncate text-xs text-[var(--mc-text-secondary)]">{card.subtitle}</p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Chiudi"
+            className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-[var(--mc-bg-muted)] text-sm text-[var(--mc-text-secondary)] transition-colors hover:bg-black/10 dark:hover:bg-white/15"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Tab bar — horizontal scroll */}
+        <div
+          role="tablist"
+          aria-label={`Tab di ${entityLabel[card.entity]}`}
+          className="flex gap-1 overflow-x-auto border-b border-[var(--mc-border)] px-2 py-1.5"
+          style={{ scrollbarWidth: 'none' }}
+        >
+          {tabs.map(tab => {
+            const isActive = tab.id === activeTab?.id;
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                aria-controls={`tab-panel-${tab.id}`}
+                id={`tab-${tab.id}`}
+                onClick={() => setActiveTabId(tab.id)}
+                className={`flex flex-shrink-0 items-center gap-1 rounded-full px-3 py-1.5 text-xs font-semibold transition-colors ${
+                  isActive
+                    ? 'text-white'
+                    : 'bg-[var(--mc-bg-muted)] text-[var(--mc-text-secondary)] hover:bg-black/10 dark:hover:bg-white/15'
+                }`}
+                style={isActive ? { background: accent } : undefined}
+              >
+                <span aria-hidden>{tab.icon}</span>
+                <span>{tab.label}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Tab content — placeholder with card data preview */}
+        <div
+          role="tabpanel"
+          id={activeTab ? `tab-panel-${activeTab.id}` : undefined}
+          aria-labelledby={activeTab ? `tab-${activeTab.id}` : undefined}
+          className="flex-1 overflow-y-auto px-4 py-3"
+        >
+          {activeTab ? (
+            <DrawerTabPlaceholder card={card} tabLabel={activeTab.label} tabIcon={activeTab.icon} />
+          ) : null}
+        </div>
+      </div>
+
+      <style jsx>{`
+        @keyframes meeplecard-drawer-slide {
+          from {
+            transform: translateY(-16px);
+            opacity: 0;
+          }
+          to {
+            transform: translateY(0);
+            opacity: 1;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+interface DrawerTabPlaceholderProps {
+  card: MeepleCardProps;
+  tabLabel: string;
+  tabIcon: string;
+}
+
+function DrawerTabPlaceholder({ card, tabLabel, tabIcon }: DrawerTabPlaceholderProps) {
+  const accent = entityHsl(card.entity);
+
+  return (
+    <div className="space-y-3">
+      <div
+        className="flex items-center gap-2 rounded-lg border px-3 py-2 text-xs"
+        style={{
+          background: entityHsl(card.entity, 0.08),
+          borderColor: entityHsl(card.entity, 0.25),
+          color: accent,
+        }}
+      >
+        <span aria-hidden className="text-base">
+          {tabIcon}
+        </span>
+        <span className="font-semibold uppercase tracking-wide">Tab: {tabLabel}</span>
+      </div>
+      <p className="text-xs text-[var(--mc-text-secondary)]">
+        Questa è una preview del tab <strong>{tabLabel}</strong> per entity type{' '}
+        <strong>{entityLabel[card.entity]}</strong>. In produzione, qui verrebbe caricato il
+        contenuto reale (es. ExtraMeepleCardDrawer tabs come Overview/AI/History/Media).
+      </p>
+      <dl className="grid grid-cols-[auto,1fr] gap-x-3 gap-y-1.5 text-xs">
+        {card.badge && (
+          <>
+            <dt className="font-semibold text-[var(--mc-text-secondary)]">Badge</dt>
+            <dd className="text-[var(--mc-text-primary)]">{card.badge}</dd>
+          </>
+        )}
+        {card.status && (
+          <>
+            <dt className="font-semibold text-[var(--mc-text-secondary)]">Status</dt>
+            <dd className="text-[var(--mc-text-primary)]">{card.status}</dd>
+          </>
+        )}
+        {card.rating !== undefined && (
+          <>
+            <dt className="font-semibold text-[var(--mc-text-secondary)]">Rating</dt>
+            <dd className="text-[var(--mc-text-primary)]">
+              {card.rating.toFixed(1)}
+              {card.ratingMax ? ` / ${card.ratingMax}` : ''}
+            </dd>
+          </>
+        )}
+        {card.metadata?.map((meta, i) => (
+          <div key={i} className="contents">
+            <dt className="font-semibold text-[var(--mc-text-secondary)]">
+              {meta.label.split(/[:·]/)[0] || 'Meta'}
+            </dt>
+            <dd className="text-[var(--mc-text-primary)]">{meta.label}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/data-display/meeple-card/mobile/MobileDevicePreview.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/mobile/MobileDevicePreview.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+interface MobileDevicePreviewProps {
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * Phone frame wrapper for the dev page showcase.
+ *
+ * Renders a 390×720 device frame matching the wireframe from
+ * `admin-mockups/mobile-card-layout-mockup.html`:
+ * - Status bar (time + icons)
+ * - Navbar (logo + notifications + avatar)
+ * - Search bar
+ * - Children slot (content area — typically MobileCardLayout)
+ * - Action bar at bottom
+ */
+export function MobileDevicePreview({ children, className = '' }: MobileDevicePreviewProps) {
+  return (
+    <div
+      className={`relative flex flex-col overflow-hidden rounded-[40px] border-[3px] border-[#c8c0b5] bg-[var(--mc-bg-card)] shadow-[0_30px_80px_rgba(0,0,0,0.15),0_8px_24px_rgba(0,0,0,0.1)] ${className}`}
+      style={{ width: 390, height: 720 }}
+    >
+      {/* Status bar */}
+      <div className="flex h-10 flex-shrink-0 items-end justify-between px-7 pb-1.5 text-xs font-semibold text-[var(--mc-text-primary)]">
+        <span className="font-bold">14:32</span>
+        <div className="flex items-center gap-1 text-[11px]">
+          <span>📶</span>
+          <span>🔋</span>
+        </div>
+      </div>
+
+      {/* Navbar */}
+      <div className="flex h-14 flex-shrink-0 items-center gap-3 border-b border-[var(--mc-border)] bg-[var(--mc-bg-card)] px-4 backdrop-blur-[12px] backdrop-saturate-[180%]">
+        <div className="flex items-center gap-1.5">
+          <div className="flex h-7 w-7 items-center justify-center rounded-md bg-[hsl(25,95%,45%)] text-sm font-bold text-white">
+            🎲
+          </div>
+          <span className="font-[var(--font-quicksand)] text-[1.1rem] font-extrabold text-[hsl(25,95%,45%)]">
+            MeepleAI
+          </span>
+        </div>
+        <div className="flex-1" />
+        <button
+          type="button"
+          className="flex h-9 w-9 items-center justify-center rounded-full bg-[var(--mc-bg-muted)] text-base text-[var(--mc-text-secondary)] transition-colors hover:bg-black/10 dark:hover:bg-white/15"
+        >
+          🔔
+        </button>
+        <div className="flex h-9 w-9 items-center justify-center rounded-full bg-[hsl(262,83%,58%)] text-xs font-bold text-white">
+          MR
+        </div>
+      </div>
+
+      {/* Search bar */}
+      <div className="flex-shrink-0 border-b border-[var(--mc-border)] px-4 py-2">
+        <div className="flex items-center gap-2 rounded-xl bg-[var(--mc-bg-muted)] px-3 py-2.5">
+          <span className="text-sm text-[var(--mc-text-secondary)]">🔍</span>
+          <span className="text-sm text-[var(--mc-text-muted)]">Cerca nella tua libreria...</span>
+        </div>
+      </div>
+
+      {/* Content area — fills remaining space */}
+      <div className="relative flex-1 overflow-hidden">{children}</div>
+
+      {/* Action bar */}
+      <div className="flex h-[72px] flex-shrink-0 items-center justify-around border-t border-[var(--mc-border)] bg-[var(--mc-bg-card)] px-4 backdrop-blur-[12px]">
+        {(['🏠 Home', '📚 Library', '🎲 Sessioni', '👤 Profilo'] as const).map(item => {
+          const [icon, label] = item.split(' ');
+          const isActive = label === 'Library';
+          return (
+            <button
+              key={label}
+              type="button"
+              className={`flex flex-col items-center gap-0.5 text-[10px] font-semibold transition-colors ${
+                isActive
+                  ? 'text-[hsl(25,95%,45%)]'
+                  : 'text-[var(--mc-text-secondary)] hover:text-[var(--mc-text-primary)]'
+              }`}
+            >
+              <span className="text-lg">{icon}</span>
+              <span>{label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/data-display/meeple-card/mobile/drawerTabs.ts
+++ b/apps/web/src/components/ui/data-display/meeple-card/mobile/drawerTabs.ts
@@ -1,0 +1,80 @@
+/**
+ * Entity-specific tab definitions for MobileCardDrawer.
+ *
+ * Each entity type exposes a set of tabs shown in the drawer when the user
+ * taps the focused card in the mobile layout. The tab IDs are stable and can
+ * be used by consumers to control active tab via props.
+ */
+
+import type { MeepleEntityType } from '../types';
+
+export interface CardDrawerTab {
+  id: string;
+  label: string;
+  icon: string;
+}
+
+export const entityDrawerTabs: Record<MeepleEntityType, CardDrawerTab[]> = {
+  game: [
+    { id: 'overview', label: 'Overview', icon: '📋' },
+    { id: 'ai', label: 'AI', icon: '🤖' },
+    { id: 'sessions', label: 'Sessioni', icon: '🎲' },
+    { id: 'media', label: 'Media', icon: '🖼' },
+    { id: 'scoreboard', label: 'Scoreboard', icon: '🏆' },
+  ],
+  player: [
+    { id: 'overview', label: 'Profilo', icon: '👤' },
+    { id: 'stats', label: 'Stats', icon: '📊' },
+    { id: 'history', label: 'Storico', icon: '📜' },
+    { id: 'achievements', label: 'Achievements', icon: '🏅' },
+  ],
+  session: [
+    { id: 'overview', label: 'Overview', icon: '📋' },
+    { id: 'players', label: 'Players', icon: '👥' },
+    { id: 'scoreboard', label: 'Scoreboard', icon: '🏆' },
+    { id: 'notes', label: 'Note', icon: '📝' },
+    { id: 'photos', label: 'Foto', icon: '📷' },
+  ],
+  agent: [
+    { id: 'overview', label: 'Overview', icon: '📋' },
+    { id: 'config', label: 'Config', icon: '⚙️' },
+    { id: 'stats', label: 'Stats', icon: '📊' },
+    { id: 'chat', label: 'Chat', icon: '💬' },
+    { id: 'sources', label: 'Fonti', icon: '📚' },
+  ],
+  kb: [
+    { id: 'overview', label: 'Overview', icon: '📋' },
+    { id: 'chunks', label: 'Chunks', icon: '🧩' },
+    { id: 'preview', label: 'Preview', icon: '👁' },
+    { id: 'metadata', label: 'Metadata', icon: '🏷' },
+  ],
+  chat: [
+    { id: 'messages', label: 'Messaggi', icon: '💬' },
+    { id: 'context', label: 'Contesto', icon: '🧠' },
+    { id: 'sources', label: 'Fonti', icon: '📚' },
+    { id: 'agent', label: 'Agent', icon: '🤖' },
+  ],
+  event: [
+    { id: 'overview', label: 'Overview', icon: '📋' },
+    { id: 'participants', label: 'Partecipanti', icon: '👥' },
+    { id: 'games', label: 'Giochi', icon: '🎲' },
+    { id: 'location', label: 'Luogo', icon: '📍' },
+  ],
+  toolkit: [
+    { id: 'overview', label: 'Overview', icon: '📋' },
+    { id: 'tools', label: 'Strumenti', icon: '🛠' },
+    { id: 'decks', label: 'Mazzi', icon: '🃏' },
+    { id: 'phases', label: 'Fasi', icon: '📖' },
+    { id: 'history', label: 'Storico', icon: '📜' },
+  ],
+  tool: [
+    { id: 'overview', label: 'Overview', icon: '📋' },
+    { id: 'use', label: 'Usa', icon: '▶' },
+    { id: 'history', label: 'Storico', icon: '📜' },
+    { id: 'config', label: 'Config', icon: '⚙️' },
+  ],
+};
+
+export function getDrawerTabs(entity: MeepleEntityType): CardDrawerTab[] {
+  return entityDrawerTabs[entity];
+}

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/CompactCard.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/CompactCard.tsx
@@ -26,7 +26,7 @@ export function CompactCard(props: MeepleCardProps) {
       </span>
       {badge && (
         <span
-          className="ml-auto shrink-0 rounded-full bg-[var(--mc-bg-muted)] px-1.5 py-0.5 text-[8px] font-semibold text-[var(--mc-text-secondary)]"
+          className="ml-auto shrink-0 rounded-full bg-black/10 px-1.5 py-0.5 text-[8px] font-bold text-[var(--mc-text-primary)] dark:bg-white/15"
           data-slot="badge"
         >
           {badge}

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/FeaturedCard.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/FeaturedCard.tsx
@@ -55,7 +55,7 @@ export function FeaturedCard(props: MeepleCardProps) {
           </h3>
           {badge && (
             <span
-              className="shrink-0 rounded-full border border-[var(--mc-border)] bg-[var(--mc-bg-muted)] px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[var(--mc-text-secondary)]"
+              className="shrink-0 rounded-full border border-[var(--mc-border)] bg-black/10 px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-[var(--mc-text-primary)] dark:bg-white/15"
               data-slot="badge"
             >
               {badge}

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/GridCard.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/GridCard.tsx
@@ -60,7 +60,7 @@ export function GridCard(props: MeepleCardProps) {
           </h3>
           {badge && (
             <span
-              className="shrink-0 rounded-full border border-[var(--mc-border)] bg-[var(--mc-bg-muted)] px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-[var(--mc-text-secondary)]"
+              className="shrink-0 rounded-full border border-[var(--mc-border)] bg-black/10 px-2 py-0.5 text-[9px] font-bold uppercase tracking-wide text-[var(--mc-text-primary)] dark:bg-white/15"
               data-slot="badge"
             >
               {badge}

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/ListCard.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/ListCard.tsx
@@ -55,7 +55,7 @@ export function ListCard(props: MeepleCardProps) {
           </h3>
           {badge && (
             <span
-              className="shrink-0 rounded-full border border-[var(--mc-border)] bg-[var(--mc-bg-muted)] px-1.5 py-0.5 text-[8px] font-semibold uppercase tracking-wide text-[var(--mc-text-secondary)]"
+              className="shrink-0 rounded-full border border-[var(--mc-border)] bg-black/10 px-1.5 py-0.5 text-[8px] font-bold uppercase tracking-wide text-[var(--mc-text-primary)] dark:bg-white/15"
               data-slot="badge"
             >
               {badge}


### PR DESCRIPTION
## Summary

- **Badge contrast fix**: Grid/List/Compact/Featured badge used `bg-[var(--mc-bg-muted)]` (cream 60% opacity) + `text-[var(--mc-text-secondary)]` (65% opacity) — below WCAG AA. Changed to `bg-black/10 dark:bg-white/15` + `text-[var(--mc-text-primary)]` (full opacity)
- **Dev page showcase restoration**: Adds Quick Actions (with `showQuickActions` fix), Showcase Completo (9 entities with all features), Tags/TagStrip demo, Grid with Status Badges, Game hero variant
- **Mobile device preview**: Phone frame (390x720) matching `admin-mockups/mobile-card-layout-mockup.html` wireframe — status bar, navbar, search, HandSidebar, FocusedCard, SwipeGesture, action bar
- **MobileCardDrawer**: Slide-in drawer with entity-specific tabs (9 entity types x 4-5 tabs each). Opens on focused card click
- **New components**: `MobileDevicePreview`, `MobileCardDrawer`, `drawerTabs.ts` — exported from `meeple-card/index.ts`

## Test plan

- [x] TypeScript typecheck passes
- [x] ESLint + Prettier pass (pre-commit hooks)
- [x] Backend build passes (pre-push hook)
- [ ] Visual verification on `/dev/meeple-card` page
- [ ] Badge contrast readable in both light/dark mode
- [ ] Mobile phone frame renders correctly on desktop
- [ ] Click focused card → drawer opens with entity tabs
- [ ] Click hand-stack cards → focus changes
- [ ] Drawer close on backdrop click / X button

🤖 Generated with [Claude Code](https://claude.com/claude-code)