### PR TITLE
feat(web): desktop UX redesign phase 1 — shell foundation

### DIFF
--- a/apps/web/.env.development.example
+++ b/apps/web/.env.development.example
@@ -1,0 +1,2 @@
+# Desktop UX redesign (Phase 1-5) — toggle new shell/dashboard/library/chat
+NEXT_PUBLIC_UX_REDESIGN=false

--- a/apps/web/src/components/layout/UserShell/UserShellClient.tsx
+++ b/apps/web/src/components/layout/UserShell/UserShellClient.tsx
@@ -5,12 +5,28 @@ import { Suspense, type ReactNode } from 'react';
 import { DashboardEngineProvider } from '@/components/dashboard';
 import { AppNavbar } from '@/components/layout/AppNavbar';
 import { BackToSessionFAB } from '@/components/session/BackToSessionFAB';
+import { isUxRedesignEnabled } from '@/lib/feature-flags';
+
+import { DesktopShell } from './v2';
 
 interface UserShellClientProps {
   children: ReactNode;
 }
 
 export function UserShellClient({ children }: UserShellClientProps) {
+  const useNewShell = isUxRedesignEnabled();
+
+  if (useNewShell) {
+    return (
+      <DesktopShell>
+        <DashboardEngineProvider>{children}</DashboardEngineProvider>
+        <Suspense>
+          <BackToSessionFAB />
+        </Suspense>
+      </DesktopShell>
+    );
+  }
+
   return (
     <div className="min-h-dvh bg-background">
       <AppNavbar />

--- a/apps/web/src/components/layout/UserShell/__tests__/UserShellClient.flag.test.tsx
+++ b/apps/web/src/components/layout/UserShell/__tests__/UserShellClient.flag.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}));
+
+vi.mock('@/stores/use-card-hand', () => {
+  const state = {
+    cards: [],
+    pinnedIds: new Set(),
+    pinCard: vi.fn(),
+    unpinCard: vi.fn(),
+  };
+  return {
+    useCardHand: (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state),
+  };
+});
+
+vi.mock('@/components/notifications', () => ({
+  NotificationBell: () => <button aria-label="Notifications">🔔</button>,
+}));
+
+vi.mock('@/components/layout/UserMenuDropdown', () => ({
+  UserMenuDropdown: () => <button aria-label="User menu">MR</button>,
+}));
+
+vi.mock('@/components/layout/AppNavbar', () => ({
+  AppNavbar: () => <nav data-testid="legacy-navbar">Legacy Navbar</nav>,
+}));
+
+vi.mock('@/components/dashboard', () => ({
+  DashboardEngineProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/session/BackToSessionFAB', () => ({
+  BackToSessionFAB: () => null,
+}));
+
+const originalEnv = process.env.NEXT_PUBLIC_UX_REDESIGN;
+
+describe('UserShellClient feature flag', () => {
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.NEXT_PUBLIC_UX_REDESIGN;
+    else process.env.NEXT_PUBLIC_UX_REDESIGN = originalEnv;
+    vi.resetModules();
+  });
+
+  it('renders legacy AppNavbar when flag is off', async () => {
+    process.env.NEXT_PUBLIC_UX_REDESIGN = 'false';
+    const { UserShellClient } = await import('../UserShellClient');
+    render(
+      <UserShellClient>
+        <div>child</div>
+      </UserShellClient>
+    );
+    expect(screen.getByTestId('legacy-navbar')).toBeInTheDocument();
+    expect(screen.queryByTestId('top-bar-64')).not.toBeInTheDocument();
+  });
+
+  it('renders DesktopShell when flag is on', async () => {
+    process.env.NEXT_PUBLIC_UX_REDESIGN = 'true';
+    vi.resetModules();
+    const { UserShellClient } = await import('../UserShellClient');
+    render(
+      <UserShellClient>
+        <div>child</div>
+      </UserShellClient>
+    );
+    expect(screen.getByTestId('top-bar-64')).toBeInTheDocument();
+    expect(screen.queryByTestId('legacy-navbar')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/layout/UserShell/v2/DesktopHandRail.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/DesktopHandRail.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useState } from 'react';
+
+import { usePathname } from 'next/navigation';
+
+import { useCardHand } from '@/stores/use-card-hand';
+
+import { HandRailItem } from './HandRailItem';
+import { HandRailToolbar } from './HandRailToolbar';
+
+/**
+ * DesktopHandRail — persistent left rail reading from useCardHand store.
+ * Replaces the hardcoded NAV_ITEMS behavior of the legacy CardRack.
+ *
+ * Active state is computed from the current pathname: the card whose
+ * href matches the pathname (exact or prefix for game/session ids) is active.
+ */
+export function DesktopHandRail() {
+  const cards = useCardHand(s => s.cards);
+  const pinnedIds = useCardHand(s => s.pinnedIds);
+  const pinCard = useCardHand(s => s.pinCard);
+  const unpinCard = useCardHand(s => s.unpinCard);
+  const pathname = usePathname() ?? '';
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const isCardActive = (href: string) => {
+    if (href === '/') return pathname === '/';
+    return pathname === href || pathname.startsWith(href + '/');
+  };
+
+  const activeCard = cards.find(c => isCardActive(c.href));
+  const isActivePinned = activeCard ? pinnedIds.has(activeCard.id) : false;
+
+  const handleTogglePin = () => {
+    if (!activeCard) return;
+    if (isActivePinned) unpinCard(activeCard.id);
+    else pinCard(activeCard.id);
+  };
+
+  return (
+    <aside
+      data-testid="desktop-hand-rail"
+      aria-label="Cards in hand"
+      className="hidden md:flex flex-col w-[76px] shrink-0 border-r border-[var(--nh-border-default)] py-3.5 pb-3 gap-2"
+      style={{
+        background: 'linear-gradient(180deg, rgba(255,252,248,0.6), rgba(255,252,248,0.2))',
+      }}
+    >
+      <span
+        className="text-[9px] font-extrabold font-[var(--font-quicksand)] uppercase tracking-[0.12em] text-[var(--nh-text-muted)] pb-2 self-center"
+        style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}
+      >
+        La tua mano
+      </span>
+      <div className="flex-1 flex flex-col items-center gap-2.5 w-full overflow-y-auto pt-1 px-1">
+        {cards.map(card => (
+          <HandRailItem key={card.id} card={card} isActive={isCardActive(card.href)} />
+        ))}
+      </div>
+      <HandRailToolbar
+        onTogglePin={handleTogglePin}
+        onToggleExpand={() => setIsExpanded(!isExpanded)}
+        isPinned={isActivePinned}
+        isExpanded={isExpanded}
+      />
+    </aside>
+  );
+}

--- a/apps/web/src/components/layout/UserShell/v2/DesktopShell.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/DesktopShell.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { DesktopHandRail } from './DesktopHandRail';
+import { MiniNavSlot } from './MiniNavSlot';
+import { TopBar64 } from './TopBar64';
+
+interface DesktopShellProps {
+  children: ReactNode;
+}
+
+/**
+ * DesktopShell — new Phase 1 layout composition.
+ *
+ * Layout:
+ *   ┌───────────────────────────────┐
+ *   │ TopBar64 (64px sticky)        │
+ *   ├───────────────────────────────┤
+ *   │ MiniNavSlot (48px, optional)  │
+ *   ├────┬──────────────────────────┤
+ *   │ HR │ main                     │
+ *   │ 76 │                          │
+ *   └────┴──────────────────────────┘
+ */
+export function DesktopShell({ children }: DesktopShellProps) {
+  return (
+    <div className="min-h-dvh flex flex-col bg-[var(--nh-bg-base)]">
+      <TopBar64 />
+      <MiniNavSlot />
+      <div className="flex-1 flex min-h-0">
+        <DesktopHandRail />
+        <main className="flex-1 min-w-0 overflow-y-auto">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/UserShell/v2/HandRailItem.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/HandRailItem.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import Link from 'next/link';
+
+import { cn } from '@/lib/utils';
+import type { HandCard } from '@/stores/use-card-hand';
+
+interface HandRailItemProps {
+  card: HandCard;
+  isActive: boolean;
+}
+
+const ENTITY_GRADIENTS: Record<string, string> = {
+  game: 'linear-gradient(135deg, hsl(25 75% 78%), hsl(25 80% 55%))',
+  session: 'linear-gradient(135deg, hsl(240 55% 75%), hsl(240 60% 55%))',
+  chat: 'linear-gradient(135deg, hsl(220 72% 78%), hsl(220 80% 58%))',
+  player: 'linear-gradient(135deg, hsl(262 78% 78%), hsl(262 83% 60%))',
+  agent: 'linear-gradient(135deg, hsl(38 85% 75%), hsl(38 92% 55%))',
+  kb: 'linear-gradient(135deg, hsl(210 55% 78%), hsl(210 40% 55%))',
+  event: 'linear-gradient(135deg, hsl(350 75% 78%), hsl(350 89% 60%))',
+  toolkit: 'linear-gradient(135deg, hsl(142 60% 78%), hsl(142 70% 45%))',
+  tool: 'linear-gradient(135deg, hsl(195 70% 78%), hsl(195 80% 50%))',
+};
+
+const ENTITY_ACCENTS: Record<string, string> = {
+  game: 'hsl(25 95% 45%)',
+  session: 'hsl(240 60% 55%)',
+  chat: 'hsl(220 80% 55%)',
+  player: 'hsl(262 83% 58%)',
+  agent: 'hsl(38 92% 50%)',
+  kb: 'hsl(210 40% 55%)',
+  event: 'hsl(350 89% 60%)',
+  toolkit: 'hsl(142 70% 45%)',
+  tool: 'hsl(195 80% 50%)',
+};
+
+const ENTITY_ICONS: Record<string, string> = {
+  game: '🎲',
+  session: '🎯',
+  chat: '💬',
+  player: '👤',
+  agent: '🤖',
+  kb: '📚',
+  event: '📅',
+  toolkit: '🧰',
+  tool: '🔧',
+};
+
+export function HandRailItem({ card, isActive }: HandRailItemProps) {
+  const gradient = ENTITY_GRADIENTS[card.entity] ?? ENTITY_GRADIENTS.game;
+  const accent = ENTITY_ACCENTS[card.entity] ?? ENTITY_ACCENTS.game;
+  const icon = ENTITY_ICONS[card.entity] ?? '🎲';
+
+  return (
+    <Link
+      href={card.href}
+      data-entity={card.entity}
+      data-active={isActive}
+      title={card.title}
+      className={cn(
+        'relative block w-[52px] h-[72px] rounded-[10px] bg-[var(--nh-bg-elevated)] border border-[var(--nh-border-default)] overflow-hidden shrink-0 transition-all duration-300 ease-out',
+        'shadow-[var(--shadow-warm-sm)]',
+        'hover:translate-x-[3px] hover:scale-105 hover:shadow-[var(--shadow-warm-md)]',
+        isActive && 'translate-x-[6px] scale-110 shadow-[var(--shadow-warm-lg)]'
+      )}
+      style={isActive ? { outline: `2px solid ${accent}`, outlineOffset: '2px' } : undefined}
+    >
+      <span
+        aria-hidden
+        className="absolute left-0 top-0 bottom-0 w-[3px]"
+        style={{ background: accent }}
+      />
+      <div
+        className="w-full h-[42px] flex items-center justify-center text-lg"
+        style={{ background: gradient }}
+        aria-hidden
+      >
+        {card.imageUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={card.imageUrl} alt="" className="w-full h-full object-cover" />
+        ) : (
+          icon
+        )}
+      </div>
+      <span className="absolute bottom-[3px] left-[4px] right-[4px] text-[7px] font-bold font-[var(--font-quicksand)] leading-[1.1] text-[var(--nh-text-primary)] whitespace-nowrap overflow-hidden text-ellipsis text-center">
+        {card.title}
+      </span>
+    </Link>
+  );
+}

--- a/apps/web/src/components/layout/UserShell/v2/HandRailToolbar.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/HandRailToolbar.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+interface HandRailToolbarProps {
+  onTogglePin: () => void;
+  onToggleExpand: () => void;
+  isPinned?: boolean;
+  isExpanded?: boolean;
+}
+
+export function HandRailToolbar({
+  onTogglePin,
+  onToggleExpand,
+  isPinned = false,
+  isExpanded = false,
+}: HandRailToolbarProps) {
+  return (
+    <div className="w-full border-t border-[var(--nh-border-default)] pt-2.5 mt-1.5 flex flex-col items-center gap-1.5">
+      <button
+        type="button"
+        aria-label={isPinned ? 'Unpin current card' : 'Pin current card'}
+        onClick={onTogglePin}
+        className="flex h-[34px] w-[34px] items-center justify-center rounded-lg border border-[var(--nh-border-default)] bg-[var(--nh-bg-surface)] text-[13px] hover:bg-white hover:shadow-[var(--shadow-warm-sm)] transition-all"
+      >
+        📌
+      </button>
+      <button
+        type="button"
+        aria-label={isExpanded ? 'Collapse rail' : 'Expand rail'}
+        onClick={onToggleExpand}
+        className="flex h-[34px] w-[34px] items-center justify-center rounded-lg border border-[var(--nh-border-default)] bg-[var(--nh-bg-surface)] text-[13px] hover:bg-white hover:shadow-[var(--shadow-warm-sm)] transition-all"
+      >
+        ⇔
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/UserShell/v2/MiniNavSlot.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/MiniNavSlot.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import Link from 'next/link';
+
+import { useMiniNavConfigStore } from '@/lib/stores/mini-nav-config-store';
+import { cn } from '@/lib/utils';
+
+/**
+ * MiniNavSlot — renders the mini-nav registered by the current page.
+ * Hidden when no config is set.
+ */
+export function MiniNavSlot() {
+  const config = useMiniNavConfigStore(s => s.config);
+  if (!config) return null;
+
+  return (
+    <div
+      data-testid="mini-nav-slot"
+      className="h-12 flex items-center gap-1 px-7 pl-[104px] border-b border-[var(--nh-border-default)] bg-[var(--nh-bg-base)]"
+    >
+      <div className="text-xs font-semibold text-[var(--nh-text-muted)] mr-5">
+        <span aria-hidden>›</span> {config.breadcrumb}
+      </div>
+      {config.tabs.map(tab => {
+        const active = tab.id === config.activeTabId;
+        return (
+          <Link
+            key={tab.id}
+            href={tab.href}
+            aria-current={active ? 'page' : undefined}
+            className={cn(
+              'relative px-3.5 py-2 rounded-lg text-[0.78rem] font-bold flex items-center gap-1.5 transition-colors',
+              active
+                ? 'text-[var(--nh-text-primary)]'
+                : 'text-[var(--nh-text-secondary)] hover:bg-[var(--nh-bg-surface)]'
+            )}
+          >
+            {tab.label}
+            {tab.count !== undefined && (
+              <span className="px-1.5 py-0.5 rounded text-[10px] font-extrabold bg-[rgba(160,120,60,0.1)] text-[var(--nh-text-secondary)]">
+                {tab.count}
+              </span>
+            )}
+            {active && (
+              <span
+                aria-hidden
+                className="absolute bottom-[-12px] left-3.5 right-3.5 h-0.5 rounded-t"
+                style={{ background: 'hsl(25 95% 45%)' }}
+              />
+            )}
+          </Link>
+        );
+      })}
+      <div className="flex-1" />
+      {config.primaryAction && (
+        <button
+          type="button"
+          onClick={config.primaryAction.onClick}
+          className="px-3.5 py-2 rounded-[10px] text-[0.78rem] font-bold text-white border-none cursor-pointer flex items-center gap-1.5 transition-all hover:-translate-y-px"
+          style={{
+            background: 'linear-gradient(135deg, hsl(25 95% 48%), hsl(25 95% 40%))',
+            boxShadow: '0 2px 6px hsla(25, 95%, 45%, 0.3)',
+          }}
+        >
+          {config.primaryAction.label}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/UserShell/v2/TopBar64.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/TopBar64.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { UserMenuDropdown } from '@/components/layout/UserMenuDropdown';
+import { NotificationBell } from '@/components/notifications';
+
+import { TopBarChatButton } from './TopBarChatButton';
+import { TopBarLogo } from './TopBarLogo';
+import { TopBarNavLinks } from './TopBarNavLinks';
+import { TopBarSearchPill } from './TopBarSearchPill';
+
+interface TopBar64Props {
+  onOpenChat?: () => void;
+  onOpenSearch?: () => void;
+}
+
+/**
+ * New 64px top bar for the UX redesign (Phase 1).
+ * Composes: Logo + NavLinks + SearchPill + ChatButton + Notifications + UserMenu
+ * Sticky positioning, backdrop-blur, border-bottom.
+ */
+export function TopBar64({ onOpenChat, onOpenSearch }: TopBar64Props) {
+  return (
+    <header
+      data-testid="top-bar-64"
+      className="sticky top-0 z-40 h-16 flex items-center gap-4 px-6 border-b border-[var(--nh-border-default)] backdrop-blur-md"
+      style={{
+        background: 'rgba(255, 252, 248, 0.85)',
+      }}
+    >
+      <TopBarLogo />
+      <TopBarNavLinks />
+      <TopBarSearchPill onOpen={onOpenSearch} />
+      <div className="flex items-center gap-2.5 shrink-0">
+        <TopBarChatButton onOpen={onOpenChat} />
+        <NotificationBell />
+        <UserMenuDropdown />
+      </div>
+    </header>
+  );
+}

--- a/apps/web/src/components/layout/UserShell/v2/TopBarChatButton.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/TopBarChatButton.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+interface TopBarChatButtonProps {
+  onOpen?: () => void;
+  hasUnread?: boolean;
+}
+
+export function TopBarChatButton({ onOpen, hasUnread = false }: TopBarChatButtonProps) {
+  const handleClick = () => {
+    if (onOpen) {
+      onOpen();
+      return;
+    }
+    // Phase 1: chat panel not wired yet — Phase 4 will provide onOpen
+
+    console.warn(
+      '[TopBarChatButton] onOpen handler not provided — chat panel not wired yet (Phase 4)'
+    );
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label="Chat agente"
+      onClick={handleClick}
+      className="relative flex h-10 w-10 items-center justify-center rounded-[10px] border border-[var(--nh-border-default)] bg-[var(--nh-bg-surface)] text-base shrink-0 hover:bg-white hover:shadow-[var(--shadow-warm-sm)] hover:-translate-y-px transition-all"
+    >
+      <span aria-hidden>💬</span>
+      {hasUnread && (
+        <span
+          data-testid="chat-unread-dot"
+          aria-label="Unread messages"
+          className="absolute top-[7px] right-[7px] h-2 w-2 rounded-full"
+          style={{
+            background: 'hsl(350 89% 58%)',
+            boxShadow: '0 0 0 2px var(--nh-bg-surface)',
+          }}
+        />
+      )}
+    </button>
+  );
+}

--- a/apps/web/src/components/layout/UserShell/v2/TopBarLogo.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/TopBarLogo.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import Link from 'next/link';
+
+export function TopBarLogo() {
+  return (
+    <Link
+      href="/"
+      aria-label="MeepleAi home"
+      className="flex items-center gap-2.5 font-[var(--font-quicksand)] font-extrabold text-[1.05rem] shrink-0"
+    >
+      <span
+        aria-hidden
+        className="flex h-8 w-8 items-center justify-center rounded-[10px] text-white font-extrabold text-sm"
+        style={{
+          background: 'linear-gradient(135deg, hsl(25 95% 52%), hsl(38 92% 55%))',
+          boxShadow: '0 2px 8px hsla(25, 95%, 45%, 0.35)',
+        }}
+      >
+        ◆
+      </span>
+      <span className="text-[var(--nh-text-primary)]">Meeple</span>
+      <span className="-ml-2.5" style={{ color: 'hsl(25 95% 42%)' }}>
+        Ai
+      </span>
+    </Link>
+  );
+}

--- a/apps/web/src/components/layout/UserShell/v2/TopBarNavLinks.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/TopBarNavLinks.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+import { cn } from '@/lib/utils';
+
+interface NavLink {
+  href: string;
+  label: string;
+  isActive: (pathname: string) => boolean;
+}
+
+const LINKS: NavLink[] = [
+  {
+    href: '/',
+    label: 'Home',
+    isActive: p => p === '/' || p === '/dashboard' || p?.startsWith('/dashboard') || false,
+  },
+  {
+    href: '/library',
+    label: 'Libreria',
+    isActive: p => p?.startsWith('/library') || false,
+  },
+  {
+    href: '/sessions',
+    label: 'Sessioni',
+    isActive: p => p?.startsWith('/sessions') || false,
+  },
+];
+
+export function TopBarNavLinks() {
+  const pathname = usePathname() ?? '';
+
+  return (
+    <nav className="flex items-center gap-1 ml-3 shrink-0" aria-label="Primary">
+      {LINKS.map(link => {
+        const active = link.isActive(pathname);
+        return (
+          <Link
+            key={link.href}
+            href={link.href}
+            aria-current={active ? 'page' : undefined}
+            className={cn(
+              'px-3.5 py-2 rounded-[10px] font-[var(--font-nunito)] font-bold text-[0.82rem] transition-colors',
+              active
+                ? 'text-[hsl(25_95%_38%)] shadow-[inset_0_0_0_1px_hsla(25,95%,45%,0.25)]'
+                : 'text-[var(--nh-text-secondary)] hover:bg-[var(--nh-bg-surface)] hover:text-[var(--nh-text-primary)]'
+            )}
+            style={active ? { background: 'hsla(25, 95%, 45%, 0.1)' } : undefined}
+          >
+            {link.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/web/src/components/layout/UserShell/v2/TopBarSearchPill.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/TopBarSearchPill.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect } from 'react';
+
+interface TopBarSearchPillProps {
+  /** Called when the pill is clicked or ⌘K/Ctrl+K is pressed */
+  onOpen?: () => void;
+  placeholder?: string;
+}
+
+export function TopBarSearchPill({
+  onOpen,
+  placeholder = 'Cerca giochi, sessioni, regole, giocatori…',
+}: TopBarSearchPillProps) {
+  useEffect(() => {
+    if (!onOpen) return;
+
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        onOpen();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onOpen]);
+
+  return (
+    <div className="flex-1 min-w-0 px-2 max-w-[420px]">
+      <button
+        type="button"
+        aria-label="Search"
+        onClick={() => onOpen?.()}
+        className="w-full flex items-center gap-3 px-5 py-[11px] rounded-xl border border-[var(--nh-border-default)] bg-[var(--nh-bg-surface)] text-left text-[0.82rem] text-[var(--nh-text-muted)] hover:bg-white hover:border-[rgba(160,120,60,0.2)] hover:shadow-[var(--shadow-warm-sm)] transition-all"
+      >
+        <span className="shrink-0 text-sm" aria-hidden>
+          🔍
+        </span>
+        <span className="flex-1 truncate">{placeholder}</span>
+        <span
+          className="shrink-0 px-2 py-0.5 rounded-[5px] border border-[var(--nh-border-default)] bg-[rgba(160,120,60,0.08)] text-[10px] font-mono font-bold text-[var(--nh-text-secondary)]"
+          aria-hidden
+        >
+          ⌘K
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/UserShell/v2/__tests__/DesktopHandRail.test.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/__tests__/DesktopHandRail.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/stores/use-card-hand', () => {
+  const cards = [
+    { id: 'azul', entity: 'game', title: 'Azul', href: '/library/azul' },
+    { id: 'wings', entity: 'game', title: 'Wingspan', href: '/library/wings' },
+    { id: 'ses', entity: 'session', title: 'Serata', href: '/sessions/live/123' },
+  ];
+  const state = {
+    cards,
+    pinnedIds: new Set<string>(),
+    pinCard: vi.fn(),
+    unpinCard: vi.fn(),
+  };
+  return {
+    useCardHand: (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state),
+  };
+});
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/library/azul',
+}));
+
+import { DesktopHandRail } from '../DesktopHandRail';
+
+describe('DesktopHandRail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders hand label', () => {
+    render(<DesktopHandRail />);
+    expect(screen.getByText(/la tua mano/i)).toBeInTheDocument();
+  });
+
+  it('renders all cards from useCardHand', () => {
+    render(<DesktopHandRail />);
+    expect(screen.getByText('Azul')).toBeInTheDocument();
+    expect(screen.getByText('Wingspan')).toBeInTheDocument();
+    expect(screen.getByText('Serata')).toBeInTheDocument();
+  });
+
+  it('marks the card matching the current pathname as active', () => {
+    render(<DesktopHandRail />);
+    const azul = screen.getByText('Azul').closest('a');
+    expect(azul).toHaveAttribute('data-active', 'true');
+  });
+
+  it('renders the toolbar with pin/expand buttons', () => {
+    render(<DesktopHandRail />);
+    expect(screen.getByRole('button', { name: /pin/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /expand/i })).toBeInTheDocument();
+  });
+
+  it('is 76px wide by default', () => {
+    const { container } = render(<DesktopHandRail />);
+    const rail = container.querySelector('[data-testid="desktop-hand-rail"]');
+    expect(rail).toHaveClass('w-[76px]');
+  });
+});

--- a/apps/web/src/components/layout/UserShell/v2/__tests__/DesktopShell.test.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/__tests__/DesktopShell.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}));
+
+vi.mock('@/stores/use-card-hand', () => {
+  const state = {
+    cards: [],
+    pinnedIds: new Set<string>(),
+    pinCard: vi.fn(),
+    unpinCard: vi.fn(),
+  };
+  return {
+    useCardHand: (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state),
+  };
+});
+
+vi.mock('@/components/notifications', () => ({
+  NotificationBell: () => <button aria-label="Notifications">🔔</button>,
+}));
+
+vi.mock('@/components/layout/UserMenuDropdown', () => ({
+  UserMenuDropdown: () => <button aria-label="User menu">MR</button>,
+}));
+
+import { DesktopShell } from '../DesktopShell';
+
+describe('DesktopShell', () => {
+  it('renders top bar, mini-nav slot, hand rail and children', () => {
+    render(
+      <DesktopShell>
+        <div data-testid="content">hello</div>
+      </DesktopShell>
+    );
+    expect(screen.getByTestId('top-bar-64')).toBeInTheDocument();
+    expect(screen.getByTestId('desktop-hand-rail')).toBeInTheDocument();
+    expect(screen.getByTestId('content')).toBeInTheDocument();
+  });
+
+  it('wraps children in a main landmark', () => {
+    render(
+      <DesktopShell>
+        <div>child</div>
+      </DesktopShell>
+    );
+    expect(screen.getByRole('main')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/layout/UserShell/v2/__tests__/HandRailItem.test.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/__tests__/HandRailItem.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { HandRailItem } from '../HandRailItem';
+
+describe('HandRailItem', () => {
+  const baseCard = {
+    id: 'azul',
+    entity: 'game' as const,
+    title: 'Azul',
+    href: '/library/azul',
+  };
+
+  it('renders title in the card body', () => {
+    render(<HandRailItem card={baseCard} isActive={false} />);
+    expect(screen.getByText('Azul')).toBeInTheDocument();
+  });
+
+  it('renders as a link to card.href', () => {
+    render(<HandRailItem card={baseCard} isActive={false} />);
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/library/azul');
+  });
+
+  it('applies active state when isActive is true', () => {
+    render(<HandRailItem card={baseCard} isActive />);
+    expect(screen.getByRole('link')).toHaveAttribute('data-active', 'true');
+  });
+
+  it('uses entity data attribute for styling', () => {
+    render(<HandRailItem card={baseCard} isActive={false} />);
+    expect(screen.getByRole('link')).toHaveAttribute('data-entity', 'game');
+  });
+
+  it('applies different entity for session', () => {
+    render(<HandRailItem card={{ ...baseCard, entity: 'session' }} isActive={false} />);
+    expect(screen.getByRole('link')).toHaveAttribute('data-entity', 'session');
+  });
+});

--- a/apps/web/src/components/layout/UserShell/v2/__tests__/HandRailToolbar.test.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/__tests__/HandRailToolbar.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+
+import { HandRailToolbar } from '../HandRailToolbar';
+
+describe('HandRailToolbar', () => {
+  it('renders pin and expand buttons', () => {
+    render(<HandRailToolbar onTogglePin={() => {}} onToggleExpand={() => {}} />);
+    expect(screen.getByRole('button', { name: /pin/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /expand/i })).toBeInTheDocument();
+  });
+
+  it('calls onTogglePin when pin clicked', async () => {
+    const onTogglePin = vi.fn();
+    const user = userEvent.setup();
+    render(<HandRailToolbar onTogglePin={onTogglePin} onToggleExpand={() => {}} />);
+    await user.click(screen.getByRole('button', { name: /pin/i }));
+    expect(onTogglePin).toHaveBeenCalledOnce();
+  });
+
+  it('calls onToggleExpand when expand clicked', async () => {
+    const onToggleExpand = vi.fn();
+    const user = userEvent.setup();
+    render(<HandRailToolbar onTogglePin={() => {}} onToggleExpand={onToggleExpand} />);
+    await user.click(screen.getByRole('button', { name: /expand/i }));
+    expect(onToggleExpand).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/components/layout/UserShell/v2/__tests__/MiniNavSlot.test.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/__tests__/MiniNavSlot.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { useMiniNavConfigStore } from '@/lib/stores/mini-nav-config-store';
+
+import { MiniNavSlot } from '../MiniNavSlot';
+
+describe('MiniNavSlot', () => {
+  beforeEach(() => {
+    useMiniNavConfigStore.getState().clear();
+  });
+
+  it('renders nothing when config is null', () => {
+    const { container } = render(<MiniNavSlot />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders breadcrumb and tabs when config is set', () => {
+    useMiniNavConfigStore.getState().setConfig({
+      breadcrumb: 'Libreria · Hub',
+      tabs: [
+        { id: 'hub', label: 'Hub', href: '/library' },
+        { id: 'personal', label: 'Personal', href: '/library?tab=personal', count: 47 },
+      ],
+      activeTabId: 'hub',
+    });
+    render(<MiniNavSlot />);
+    expect(screen.getByText(/Libreria/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Hub/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Personal/i })).toBeInTheDocument();
+    expect(screen.getByText('47')).toBeInTheDocument();
+  });
+
+  it('marks active tab with aria-current', () => {
+    useMiniNavConfigStore.getState().setConfig({
+      breadcrumb: 'Libreria',
+      tabs: [
+        { id: 'hub', label: 'Hub', href: '/library' },
+        { id: 'personal', label: 'Personal', href: '/library?tab=personal' },
+      ],
+      activeTabId: 'personal',
+    });
+    render(<MiniNavSlot />);
+    expect(screen.getByRole('link', { name: /Personal/i })).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('renders primary action button when provided', () => {
+    useMiniNavConfigStore.getState().setConfig({
+      breadcrumb: 'Home',
+      tabs: [{ id: 'a', label: 'A', href: '/' }],
+      activeTabId: 'a',
+      primaryAction: { label: '＋ Nuova partita', onClick: () => {} },
+    });
+    render(<MiniNavSlot />);
+    expect(screen.getByRole('button', { name: /Nuova partita/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/layout/UserShell/v2/__tests__/TopBar64.test.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/__tests__/TopBar64.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { TopBar64 } from '../TopBar64';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}));
+
+// Mock the notification bell (existing component with runtime deps)
+vi.mock('@/components/notifications', () => ({
+  NotificationBell: () => <button aria-label="Notifications">🔔</button>,
+}));
+
+vi.mock('@/components/layout/UserMenuDropdown', () => ({
+  UserMenuDropdown: () => <button aria-label="User menu">MR</button>,
+}));
+
+describe('TopBar64', () => {
+  it('renders logo, nav links, search, chat button, and user menu', () => {
+    render(<TopBar64 />);
+    expect(screen.getByRole('link', { name: /meepleai home/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Home' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /search/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /chat agente/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /notifications/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /user menu/i })).toBeInTheDocument();
+  });
+
+  it('is 64px tall and sticky', () => {
+    const { container } = render(<TopBar64 />);
+    const header = container.querySelector('header');
+    expect(header).toHaveClass('h-16');
+    expect(header).toHaveClass('sticky');
+  });
+});

--- a/apps/web/src/components/layout/UserShell/v2/__tests__/TopBarChatButton.test.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/__tests__/TopBarChatButton.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { TopBarChatButton } from '../TopBarChatButton';
+
+describe('TopBarChatButton', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('renders with accessible label', () => {
+    render(<TopBarChatButton />);
+    expect(screen.getByRole('button', { name: /chat agente/i })).toBeInTheDocument();
+  });
+
+  it('shows notification dot when hasUnread is true', () => {
+    render(<TopBarChatButton hasUnread />);
+    expect(screen.getByTestId('chat-unread-dot')).toBeInTheDocument();
+  });
+
+  it('hides notification dot when hasUnread is false', () => {
+    render(<TopBarChatButton hasUnread={false} />);
+    expect(screen.queryByTestId('chat-unread-dot')).not.toBeInTheDocument();
+  });
+
+  it('calls onOpen when clicked', async () => {
+    const onOpen = vi.fn();
+    const user = userEvent.setup();
+    render(<TopBarChatButton onOpen={onOpen} />);
+    await user.click(screen.getByRole('button', { name: /chat agente/i }));
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+
+  it('warns if clicked without onOpen (Phase 1 stub)', async () => {
+    const user = userEvent.setup();
+    render(<TopBarChatButton />);
+    await user.click(screen.getByRole('button', { name: /chat agente/i }));
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('TopBarChatButton'));
+  });
+});

--- a/apps/web/src/components/layout/UserShell/v2/__tests__/TopBarLogo.test.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/__tests__/TopBarLogo.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { TopBarLogo } from '../TopBarLogo';
+
+describe('TopBarLogo', () => {
+  it('renders the wordmark', () => {
+    render(<TopBarLogo />);
+    expect(screen.getByText('Meeple')).toBeInTheDocument();
+    expect(screen.getByText('Ai')).toBeInTheDocument();
+  });
+
+  it('has accessible label', () => {
+    render(<TopBarLogo />);
+    expect(screen.getByRole('link', { name: /meepleai home/i })).toBeInTheDocument();
+  });
+
+  it('links to /', () => {
+    render(<TopBarLogo />);
+    const link = screen.getByRole('link', { name: /meepleai home/i });
+    expect(link).toHaveAttribute('href', '/');
+  });
+});

--- a/apps/web/src/components/layout/UserShell/v2/__tests__/TopBarNavLinks.test.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/__tests__/TopBarNavLinks.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { TopBarNavLinks } from '../TopBarNavLinks';
+
+vi.mock('next/navigation', () => ({
+  usePathname: vi.fn(),
+}));
+
+import { usePathname } from 'next/navigation';
+
+const mockUsePathname = usePathname as unknown as ReturnType<typeof vi.fn>;
+
+describe('TopBarNavLinks', () => {
+  it('renders all 3 links', () => {
+    mockUsePathname.mockReturnValue('/');
+    render(<TopBarNavLinks />);
+    expect(screen.getByRole('link', { name: 'Home' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Libreria' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Sessioni' })).toBeInTheDocument();
+  });
+
+  it('marks Home active when pathname is /', () => {
+    mockUsePathname.mockReturnValue('/');
+    render(<TopBarNavLinks />);
+    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('marks Home active when pathname is /dashboard', () => {
+    mockUsePathname.mockReturnValue('/dashboard');
+    render(<TopBarNavLinks />);
+    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('marks Libreria active when pathname starts with /library', () => {
+    mockUsePathname.mockReturnValue('/library?tab=personal');
+    render(<TopBarNavLinks />);
+    expect(screen.getByRole('link', { name: 'Libreria' })).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('marks Sessioni active when pathname starts with /sessions', () => {
+    mockUsePathname.mockReturnValue('/sessions/live/abc');
+    render(<TopBarNavLinks />);
+    expect(screen.getByRole('link', { name: 'Sessioni' })).toHaveAttribute('aria-current', 'page');
+  });
+});

--- a/apps/web/src/components/layout/UserShell/v2/__tests__/TopBarSearchPill.test.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/__tests__/TopBarSearchPill.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+
+import { TopBarSearchPill } from '../TopBarSearchPill';
+
+describe('TopBarSearchPill', () => {
+  it('shows placeholder text and ⌘K hint', () => {
+    render(<TopBarSearchPill />);
+    expect(screen.getByText(/cerca giochi/i)).toBeInTheDocument();
+    expect(screen.getByText('⌘K')).toBeInTheDocument();
+  });
+
+  it('invokes onOpen when clicked', async () => {
+    const onOpen = vi.fn();
+    const user = userEvent.setup();
+    render(<TopBarSearchPill onOpen={onOpen} />);
+    await user.click(screen.getByRole('button', { name: /search/i }));
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+
+  it('invokes onOpen on ⌘K keyboard shortcut', async () => {
+    const onOpen = vi.fn();
+    render(<TopBarSearchPill onOpen={onOpen} />);
+    // Simulate Cmd+K
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true }));
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+
+  it('invokes onOpen on Ctrl+K keyboard shortcut', async () => {
+    const onOpen = vi.fn();
+    render(<TopBarSearchPill onOpen={onOpen} />);
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }));
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/components/layout/UserShell/v2/index.ts
+++ b/apps/web/src/components/layout/UserShell/v2/index.ts
@@ -1,0 +1,10 @@
+export { DesktopShell } from './DesktopShell';
+export { TopBar64 } from './TopBar64';
+export { TopBarLogo } from './TopBarLogo';
+export { TopBarNavLinks } from './TopBarNavLinks';
+export { TopBarSearchPill } from './TopBarSearchPill';
+export { TopBarChatButton } from './TopBarChatButton';
+export { MiniNavSlot } from './MiniNavSlot';
+export { DesktopHandRail } from './DesktopHandRail';
+export { HandRailItem } from './HandRailItem';
+export { HandRailToolbar } from './HandRailToolbar';

--- a/apps/web/src/hooks/__tests__/useMiniNavConfig.test.tsx
+++ b/apps/web/src/hooks/__tests__/useMiniNavConfig.test.tsx
@@ -1,0 +1,54 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { useMiniNavConfigStore } from '@/lib/stores/mini-nav-config-store';
+
+import { useMiniNavConfig } from '../useMiniNavConfig';
+
+describe('useMiniNavConfig', () => {
+  beforeEach(() => {
+    useMiniNavConfigStore.getState().clear();
+  });
+
+  it('sets config on mount', () => {
+    renderHook(() =>
+      useMiniNavConfig({
+        breadcrumb: 'Home',
+        tabs: [{ id: 'a', label: 'A', href: '/' }],
+        activeTabId: 'a',
+      })
+    );
+    expect(useMiniNavConfigStore.getState().config?.breadcrumb).toBe('Home');
+  });
+
+  it('clears config on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useMiniNavConfig({
+        breadcrumb: 'Home',
+        tabs: [{ id: 'a', label: 'A', href: '/' }],
+        activeTabId: 'a',
+      })
+    );
+    expect(useMiniNavConfigStore.getState().config).not.toBeNull();
+    unmount();
+    expect(useMiniNavConfigStore.getState().config).toBeNull();
+  });
+
+  it('updates config when props change', () => {
+    const { rerender } = renderHook(
+      ({ activeTabId }: { activeTabId: string }) =>
+        useMiniNavConfig({
+          breadcrumb: 'Home',
+          tabs: [
+            { id: 'a', label: 'A', href: '/a' },
+            { id: 'b', label: 'B', href: '/b' },
+          ],
+          activeTabId,
+        }),
+      { initialProps: { activeTabId: 'a' } }
+    );
+    expect(useMiniNavConfigStore.getState().config?.activeTabId).toBe('a');
+    rerender({ activeTabId: 'b' });
+    expect(useMiniNavConfigStore.getState().config?.activeTabId).toBe('b');
+  });
+});

--- a/apps/web/src/hooks/useMiniNavConfig.ts
+++ b/apps/web/src/hooks/useMiniNavConfig.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { useMiniNavConfigStore, type MiniNavConfig } from '@/lib/stores/mini-nav-config-store';
+
+/**
+ * Pages call this hook to register their mini-nav config with the global shell.
+ * The shell reads the store and renders MiniNavSlot automatically.
+ * Config is cleared on unmount (so navigating away hides the mini-nav).
+ */
+export function useMiniNavConfig(config: MiniNavConfig): void {
+  const setConfig = useMiniNavConfigStore(s => s.setConfig);
+  const clear = useMiniNavConfigStore(s => s.clear);
+
+  useEffect(() => {
+    setConfig(config);
+    return () => clear();
+  }, [config, setConfig, clear]);
+}

--- a/apps/web/src/lib/__tests__/feature-flags.test.ts
+++ b/apps/web/src/lib/__tests__/feature-flags.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, afterEach } from 'vitest';
+
+import { isUxRedesignEnabled } from '../feature-flags';
+
+describe('feature-flags', () => {
+  const originalEnv = process.env.NEXT_PUBLIC_UX_REDESIGN;
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.NEXT_PUBLIC_UX_REDESIGN;
+    else process.env.NEXT_PUBLIC_UX_REDESIGN = originalEnv;
+  });
+
+  describe('isUxRedesignEnabled', () => {
+    it('returns false when env var is undefined', () => {
+      delete process.env.NEXT_PUBLIC_UX_REDESIGN;
+      expect(isUxRedesignEnabled()).toBe(false);
+    });
+
+    it('returns false when env var is "false"', () => {
+      process.env.NEXT_PUBLIC_UX_REDESIGN = 'false';
+      expect(isUxRedesignEnabled()).toBe(false);
+    });
+
+    it('returns true when env var is "true"', () => {
+      process.env.NEXT_PUBLIC_UX_REDESIGN = 'true';
+      expect(isUxRedesignEnabled()).toBe(true);
+    });
+
+    it('returns false for any other value', () => {
+      process.env.NEXT_PUBLIC_UX_REDESIGN = '1';
+      expect(isUxRedesignEnabled()).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/lib/feature-flags.ts
+++ b/apps/web/src/lib/feature-flags.ts
@@ -1,0 +1,16 @@
+/**
+ * Feature flag helpers.
+ *
+ * All flags read from build-time `NEXT_PUBLIC_*` env vars.
+ * Changing a flag requires a rebuild (not a restart).
+ */
+
+/**
+ * Desktop UX redesign (Phase 1 — shell, Phase 2 — dashboard, Phase 3 — library hub, Phase 4 — chat panel).
+ *
+ * Controlled by `NEXT_PUBLIC_UX_REDESIGN=true`. Defaults to false.
+ * See: `docs/superpowers/specs/2026-04-08-desktop-ux-redesign-design.md`
+ */
+export function isUxRedesignEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_UX_REDESIGN === 'true';
+}

--- a/apps/web/src/lib/stores/__tests__/mini-nav-config-store.test.ts
+++ b/apps/web/src/lib/stores/__tests__/mini-nav-config-store.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { useMiniNavConfigStore, type MiniNavConfig } from '../mini-nav-config-store';
+
+describe('mini-nav-config-store', () => {
+  beforeEach(() => {
+    useMiniNavConfigStore.getState().clear();
+  });
+
+  it('starts with null config', () => {
+    expect(useMiniNavConfigStore.getState().config).toBeNull();
+  });
+
+  it('setConfig stores the payload', () => {
+    const config: MiniNavConfig = {
+      breadcrumb: 'Libreria · Hub',
+      tabs: [
+        { id: 'hub', label: 'Hub', href: '/library' },
+        { id: 'personal', label: 'Personal', href: '/library?tab=personal', count: 47 },
+      ],
+      activeTabId: 'hub',
+    };
+    useMiniNavConfigStore.getState().setConfig(config);
+    expect(useMiniNavConfigStore.getState().config).toEqual(config);
+  });
+
+  it('clear resets to null', () => {
+    useMiniNavConfigStore.getState().setConfig({
+      breadcrumb: 'x',
+      tabs: [{ id: 'a', label: 'A', href: '/a' }],
+      activeTabId: 'a',
+    });
+    useMiniNavConfigStore.getState().clear();
+    expect(useMiniNavConfigStore.getState().config).toBeNull();
+  });
+
+  it('supports optional primary action', () => {
+    useMiniNavConfigStore.getState().setConfig({
+      breadcrumb: 'Home',
+      tabs: [{ id: 'a', label: 'A', href: '/' }],
+      activeTabId: 'a',
+      primaryAction: { label: '＋ Nuova partita', onClick: () => {} },
+    });
+    expect(useMiniNavConfigStore.getState().config?.primaryAction?.label).toBe('＋ Nuova partita');
+  });
+});

--- a/apps/web/src/lib/stores/mini-nav-config-store.ts
+++ b/apps/web/src/lib/stores/mini-nav-config-store.ts
@@ -1,0 +1,48 @@
+/**
+ * Mini-nav config store.
+ *
+ * Holds the current page's mini-nav configuration (breadcrumb, tabs,
+ * active tab id, optional primary action) so the global DesktopShell
+ * can render it via MiniNavSlot.
+ *
+ * Pages register their config via the `useMiniNavConfig` hook
+ * (Task 3 — `apps/web/src/hooks/useMiniNavConfig.ts`).
+ * The config is rendered by `MiniNavSlot` (Task 9 — `DesktopShell/v2/MiniNavSlot.tsx`).
+ *
+ * The store is framework-agnostic — do NOT add a `'use client'` directive here.
+ * Client boundaries live on the consumers (hook + slot).
+ */
+
+import { create } from 'zustand';
+
+export interface MiniNavTab {
+  id: string;
+  label: string;
+  href: string;
+  count?: number;
+}
+
+export interface MiniNavPrimaryAction {
+  label: string;
+  onClick: () => void;
+  icon?: string;
+}
+
+export interface MiniNavConfig {
+  breadcrumb: string;
+  tabs: MiniNavTab[];
+  activeTabId: string;
+  primaryAction?: MiniNavPrimaryAction;
+}
+
+interface MiniNavConfigState {
+  config: MiniNavConfig | null;
+  setConfig: (config: MiniNavConfig) => void;
+  clear: () => void;
+}
+
+export const useMiniNavConfigStore = create<MiniNavConfigState>(set => ({
+  config: null,
+  setConfig: config => set({ config }),
+  clear: () => set({ config: null }),
+}));

--- a/docs/superpowers/plans/2026-04-08-desktop-ux-redesign-phase-1-shell.md
+++ b/docs/superpowers/plans/2026-04-08-desktop-ux-redesign-phase-1-shell.md
@@ -1,0 +1,2080 @@
+# Desktop UX Redesign — Phase 1: Shell Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the new desktop shell (top bar 64px + contextual mini-nav 48px + persistent hand rail 76px) behind a feature flag, reusing existing infrastructure (`AppNavbar`, `CardRack`, `ContextMiniNav`, `useCardHand`, `ContextBarRegistrar`) and laying the foundation for the following phases (Dashboard, Library Hub, Chat panel).
+
+**Architecture:** This phase **evolves** the existing shell, it does not replace it. A new `DesktopShell` component wraps the new layout (new `TopBar64`, new `DesktopHandRail` built on `CardRack`, and a global `ContextMiniNavSlot` driven by a new `useMiniNavConfig` hook + Zustand store). A `NEXT_PUBLIC_UX_REDESIGN` feature flag in `UserShellClient.tsx` toggles between the legacy `AppNavbar` layout and the new `DesktopShell`. No existing component is deleted in Phase 1.
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript, Tailwind 4, Zustand, Vitest + Testing Library, Playwright (for E2E in Phase 5 only). All design tokens reused from `apps/web/src/styles/design-tokens.css`.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-08-desktop-ux-redesign-design.md` §4 (Shell Architecture)
+
+---
+
+## File Structure
+
+### New files
+
+| Path | Responsibility |
+|---|---|
+| `apps/web/src/lib/feature-flags.ts` | Central flag helper (`isUxRedesignEnabled()`) reading `NEXT_PUBLIC_UX_REDESIGN` at build time |
+| `apps/web/src/lib/stores/mini-nav-config-store.ts` | Zustand store holding the current page's mini-nav config (tabs, active id, breadcrumb, primary action) |
+| `apps/web/src/hooks/useMiniNavConfig.ts` | React hook for pages to register their mini-nav config; `{ setConfig, clear }` |
+| `apps/web/src/components/layout/UserShell/v2/DesktopShell.tsx` | New shell composition: `<TopBar64>` + `<MiniNavSlot>` + `<DesktopHandRail>` + main content slot |
+| `apps/web/src/components/layout/UserShell/v2/TopBar64.tsx` | New 64px top bar: logo + 3 nav links + search pill + chat icon + notification + avatar |
+| `apps/web/src/components/layout/UserShell/v2/TopBarLogo.tsx` | Hex gradient logo "MeepleAi" wordmark, 32px hex + Quicksand wordmark |
+| `apps/web/src/components/layout/UserShell/v2/TopBarNavLinks.tsx` | 3-link pill nav (Home / Libreria / Sessioni) with active state by pathname |
+| `apps/web/src/components/layout/UserShell/v2/TopBarSearchPill.tsx` | Global search pill with ⌘K kbd + expand-on-focus behavior |
+| `apps/web/src/components/layout/UserShell/v2/TopBarChatButton.tsx` | Chat trigger icon button (dispatches `openChatPanel()` — Phase 4; Phase 1 stub no-op + console.warn) |
+| `apps/web/src/components/layout/UserShell/v2/MiniNavSlot.tsx` | Renders the current mini-nav from the `mini-nav-config-store`, hidden when empty |
+| `apps/web/src/components/layout/UserShell/v2/DesktopHandRail.tsx` | New desktop hand rail (76px collapsed, 240px hover) that reads from `useCardHand` instead of hardcoded `NAV_ITEMS` |
+| `apps/web/src/components/layout/UserShell/v2/HandRailItem.tsx` | Single hand card item 52×72 with accent edge, cover gradient, title, active/pinned state |
+| `apps/web/src/components/layout/UserShell/v2/HandRailToolbar.tsx` | Bottom toolbar of the rail with Pin/Unpin and Expand buttons |
+| `apps/web/src/components/layout/UserShell/v2/index.ts` | Public barrel exporting the above components |
+| `apps/web/src/components/layout/UserShell/v2/__tests__/TopBar64.test.tsx` | Vitest tests for TopBar64 composition + nav link active state |
+| `apps/web/src/components/layout/UserShell/v2/__tests__/DesktopHandRail.test.tsx` | Vitest tests for rail render from `useCardHand`, click nav, active state |
+| `apps/web/src/components/layout/UserShell/v2/__tests__/MiniNavSlot.test.tsx` | Vitest tests for slot visibility based on store content |
+| `apps/web/src/components/layout/UserShell/v2/__tests__/DesktopShell.test.tsx` | Vitest integration test: shell mounts, renders children, flag on/off |
+| `apps/web/src/lib/__tests__/feature-flags.test.ts` | Vitest test for feature flag helper |
+| `apps/web/src/lib/stores/__tests__/mini-nav-config-store.test.ts` | Vitest test for Zustand store set/clear |
+
+### Modified files
+
+| Path | Change |
+|---|---|
+| `apps/web/src/components/layout/UserShell/UserShellClient.tsx` | Add feature flag branch: if `isUxRedesignEnabled()` render `<DesktopShell>`, else legacy `<AppNavbar>` |
+| `apps/web/.env.development.example` | Add `NEXT_PUBLIC_UX_REDESIGN=false` (commented default) |
+| `apps/web/src/app/(authenticated)/layout.tsx` (if exists — else no change) | Ensure it uses `UserShell`, not directly `AppNavbar` |
+
+### NOT touched in Phase 1
+
+- `AppNavbar.tsx` — legacy path, unchanged
+- `CardRack.tsx` — legacy path, unchanged (new rail is a separate file in `v2/`)
+- `ContextMiniNav.tsx` — kept for pages that import it directly; new `MiniNavSlot` coexists
+- `useCardHand` store — reused as-is, no changes
+- Dashboard, Library, Chat pages — Phase 2-4
+
+---
+
+## Task 1: Feature flag helper
+
+**Files:**
+- Create: `apps/web/src/lib/feature-flags.ts`
+- Test: `apps/web/src/lib/__tests__/feature-flags.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/lib/__tests__/feature-flags.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { isUxRedesignEnabled } from '../feature-flags';
+
+describe('feature-flags', () => {
+  const originalEnv = process.env.NEXT_PUBLIC_UX_REDESIGN;
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.NEXT_PUBLIC_UX_REDESIGN;
+    else process.env.NEXT_PUBLIC_UX_REDESIGN = originalEnv;
+  });
+
+  describe('isUxRedesignEnabled', () => {
+    it('returns false when env var is undefined', () => {
+      delete process.env.NEXT_PUBLIC_UX_REDESIGN;
+      expect(isUxRedesignEnabled()).toBe(false);
+    });
+
+    it('returns false when env var is "false"', () => {
+      process.env.NEXT_PUBLIC_UX_REDESIGN = 'false';
+      expect(isUxRedesignEnabled()).toBe(false);
+    });
+
+    it('returns true when env var is "true"', () => {
+      process.env.NEXT_PUBLIC_UX_REDESIGN = 'true';
+      expect(isUxRedesignEnabled()).toBe(true);
+    });
+
+    it('returns false for any other value', () => {
+      process.env.NEXT_PUBLIC_UX_REDESIGN = '1';
+      expect(isUxRedesignEnabled()).toBe(false);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/lib/__tests__/feature-flags.test.ts`
+Expected: FAIL — cannot resolve `../feature-flags`
+
+- [ ] **Step 3: Create the feature flag helper**
+
+Create `apps/web/src/lib/feature-flags.ts`:
+
+```typescript
+/**
+ * Feature flag helpers.
+ *
+ * All flags read from build-time `NEXT_PUBLIC_*` env vars.
+ * Changing a flag requires a rebuild (not a restart).
+ */
+
+/**
+ * Desktop UX redesign (Phase 1 — shell, Phase 2 — dashboard, Phase 3 — library hub, Phase 4 — chat panel).
+ *
+ * Controlled by `NEXT_PUBLIC_UX_REDESIGN=true`. Defaults to false.
+ * See: `docs/superpowers/specs/2026-04-08-desktop-ux-redesign-design.md`
+ */
+export function isUxRedesignEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_UX_REDESIGN === 'true';
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/lib/__tests__/feature-flags.test.ts`
+Expected: PASS — 4 tests passing
+
+- [ ] **Step 5: Add env var to example**
+
+Append to `apps/web/.env.development.example`:
+
+```
+# Desktop UX redesign (Phase 1-5) — toggle new shell/dashboard/library/chat
+NEXT_PUBLIC_UX_REDESIGN=false
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd D:/Repositories/meepleai-monorepo-dev
+git add apps/web/src/lib/feature-flags.ts apps/web/src/lib/__tests__/feature-flags.test.ts apps/web/.env.development.example
+git commit -m "feat(web): add isUxRedesignEnabled feature flag"
+```
+
+---
+
+## Task 2: Mini-nav config Zustand store
+
+**Files:**
+- Create: `apps/web/src/lib/stores/mini-nav-config-store.ts`
+- Test: `apps/web/src/lib/stores/__tests__/mini-nav-config-store.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/lib/stores/__tests__/mini-nav-config-store.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { useMiniNavConfigStore, type MiniNavConfig } from '../mini-nav-config-store';
+
+describe('mini-nav-config-store', () => {
+  beforeEach(() => {
+    useMiniNavConfigStore.getState().clear();
+  });
+
+  it('starts with null config', () => {
+    expect(useMiniNavConfigStore.getState().config).toBeNull();
+  });
+
+  it('setConfig stores the payload', () => {
+    const config: MiniNavConfig = {
+      breadcrumb: 'Libreria · Hub',
+      tabs: [
+        { id: 'hub', label: 'Hub', href: '/library' },
+        { id: 'personal', label: 'Personal', href: '/library?tab=personal', count: 47 },
+      ],
+      activeTabId: 'hub',
+    };
+    useMiniNavConfigStore.getState().setConfig(config);
+    expect(useMiniNavConfigStore.getState().config).toEqual(config);
+  });
+
+  it('clear resets to null', () => {
+    useMiniNavConfigStore.getState().setConfig({
+      breadcrumb: 'x',
+      tabs: [{ id: 'a', label: 'A', href: '/a' }],
+      activeTabId: 'a',
+    });
+    useMiniNavConfigStore.getState().clear();
+    expect(useMiniNavConfigStore.getState().config).toBeNull();
+  });
+
+  it('supports optional primary action', () => {
+    useMiniNavConfigStore.getState().setConfig({
+      breadcrumb: 'Home',
+      tabs: [{ id: 'a', label: 'A', href: '/' }],
+      activeTabId: 'a',
+      primaryAction: { label: '＋ Nuova partita', onClick: () => {} },
+    });
+    expect(useMiniNavConfigStore.getState().config?.primaryAction?.label).toBe('＋ Nuova partita');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/lib/stores/__tests__/mini-nav-config-store.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement the store**
+
+Create `apps/web/src/lib/stores/mini-nav-config-store.ts`:
+
+```typescript
+'use client';
+
+import { create } from 'zustand';
+
+export interface MiniNavTab {
+  id: string;
+  label: string;
+  href: string;
+  count?: number;
+}
+
+export interface MiniNavPrimaryAction {
+  label: string;
+  onClick: () => void;
+  icon?: string;
+}
+
+export interface MiniNavConfig {
+  breadcrumb: string;
+  tabs: MiniNavTab[];
+  activeTabId: string;
+  primaryAction?: MiniNavPrimaryAction;
+}
+
+interface MiniNavConfigState {
+  config: MiniNavConfig | null;
+  setConfig: (config: MiniNavConfig) => void;
+  clear: () => void;
+}
+
+export const useMiniNavConfigStore = create<MiniNavConfigState>(set => ({
+  config: null,
+  setConfig: config => set({ config }),
+  clear: () => set({ config: null }),
+}));
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/lib/stores/__tests__/mini-nav-config-store.test.ts`
+Expected: PASS — 4 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/stores/mini-nav-config-store.ts apps/web/src/lib/stores/__tests__/mini-nav-config-store.test.ts
+git commit -m "feat(web): add mini-nav-config Zustand store"
+```
+
+---
+
+## Task 3: useMiniNavConfig hook (page registration)
+
+**Files:**
+- Create: `apps/web/src/hooks/useMiniNavConfig.ts`
+- Test: `apps/web/src/hooks/__tests__/useMiniNavConfig.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/hooks/__tests__/useMiniNavConfig.test.tsx`:
+
+```typescript
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { useMiniNavConfigStore } from '@/lib/stores/mini-nav-config-store';
+
+import { useMiniNavConfig } from '../useMiniNavConfig';
+
+describe('useMiniNavConfig', () => {
+  beforeEach(() => {
+    useMiniNavConfigStore.getState().clear();
+  });
+
+  it('sets config on mount', () => {
+    renderHook(() =>
+      useMiniNavConfig({
+        breadcrumb: 'Home',
+        tabs: [{ id: 'a', label: 'A', href: '/' }],
+        activeTabId: 'a',
+      })
+    );
+    expect(useMiniNavConfigStore.getState().config?.breadcrumb).toBe('Home');
+  });
+
+  it('clears config on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useMiniNavConfig({
+        breadcrumb: 'Home',
+        tabs: [{ id: 'a', label: 'A', href: '/' }],
+        activeTabId: 'a',
+      })
+    );
+    expect(useMiniNavConfigStore.getState().config).not.toBeNull();
+    unmount();
+    expect(useMiniNavConfigStore.getState().config).toBeNull();
+  });
+
+  it('updates config when props change', () => {
+    const { rerender } = renderHook(
+      ({ activeTabId }: { activeTabId: string }) =>
+        useMiniNavConfig({
+          breadcrumb: 'Home',
+          tabs: [
+            { id: 'a', label: 'A', href: '/a' },
+            { id: 'b', label: 'B', href: '/b' },
+          ],
+          activeTabId,
+        }),
+      { initialProps: { activeTabId: 'a' } }
+    );
+    expect(useMiniNavConfigStore.getState().config?.activeTabId).toBe('a');
+    rerender({ activeTabId: 'b' });
+    expect(useMiniNavConfigStore.getState().config?.activeTabId).toBe('b');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/hooks/__tests__/useMiniNavConfig.test.tsx`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement the hook**
+
+Create `apps/web/src/hooks/useMiniNavConfig.ts`:
+
+```typescript
+'use client';
+
+import { useEffect } from 'react';
+
+import { useMiniNavConfigStore, type MiniNavConfig } from '@/lib/stores/mini-nav-config-store';
+
+/**
+ * Pages call this hook to register their mini-nav config with the global shell.
+ * The shell reads the store and renders MiniNavSlot automatically.
+ * Config is cleared on unmount (so navigating away hides the mini-nav).
+ */
+export function useMiniNavConfig(config: MiniNavConfig): void {
+  const setConfig = useMiniNavConfigStore(s => s.setConfig);
+  const clear = useMiniNavConfigStore(s => s.clear);
+
+  useEffect(() => {
+    setConfig(config);
+    return () => clear();
+  }, [config, setConfig, clear]);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/hooks/__tests__/useMiniNavConfig.test.tsx`
+Expected: PASS — 3 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/hooks/useMiniNavConfig.ts apps/web/src/hooks/__tests__/useMiniNavConfig.test.tsx
+git commit -m "feat(web): add useMiniNavConfig hook for page registration"
+```
+
+---
+
+## Task 4: TopBarLogo component
+
+**Files:**
+- Create: `apps/web/src/components/layout/UserShell/v2/TopBarLogo.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/layout/UserShell/v2/__tests__/TopBarLogo.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { TopBarLogo } from '../TopBarLogo';
+
+describe('TopBarLogo', () => {
+  it('renders the wordmark', () => {
+    render(<TopBarLogo />);
+    expect(screen.getByText('Meeple')).toBeInTheDocument();
+    expect(screen.getByText('Ai')).toBeInTheDocument();
+  });
+
+  it('has accessible label', () => {
+    render(<TopBarLogo />);
+    expect(screen.getByRole('link', { name: /meepleai home/i })).toBeInTheDocument();
+  });
+
+  it('links to /', () => {
+    render(<TopBarLogo />);
+    const link = screen.getByRole('link', { name: /meepleai home/i });
+    expect(link).toHaveAttribute('href', '/');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/v2/__tests__/TopBarLogo.test.tsx`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement TopBarLogo**
+
+Create `apps/web/src/components/layout/UserShell/v2/TopBarLogo.tsx`:
+
+```typescript
+'use client';
+
+import Link from 'next/link';
+
+export function TopBarLogo() {
+  return (
+    <Link
+      href="/"
+      aria-label="MeepleAi home"
+      className="flex items-center gap-2.5 font-[var(--font-quicksand)] font-extrabold text-[1.05rem] shrink-0"
+    >
+      <span
+        aria-hidden
+        className="flex h-8 w-8 items-center justify-center rounded-[10px] text-white font-extrabold text-sm"
+        style={{
+          background:
+            'linear-gradient(135deg, hsl(25 95% 52%), hsl(38 92% 55%))',
+          boxShadow: '0 2px 8px hsla(25, 95%, 45%, 0.35)',
+        }}
+      >
+        ◆
+      </span>
+      <span className="text-[var(--nh-text-primary)]">Meeple</span>
+      <span className="-ml-2.5" style={{ color: 'hsl(25 95% 42%)' }}>
+        Ai
+      </span>
+    </Link>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/v2/__tests__/TopBarLogo.test.tsx`
+Expected: PASS — 3 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/layout/UserShell/v2/TopBarLogo.tsx apps/web/src/components/layout/UserShell/v2/__tests__/TopBarLogo.test.tsx
+git commit -m "feat(web): add TopBarLogo component"
+```
+
+---
+
+## Task 5: TopBarNavLinks component
+
+**Files:**
+- Create: `apps/web/src/components/layout/UserShell/v2/TopBarNavLinks.tsx`
+- Test: `apps/web/src/components/layout/UserShell/v2/__tests__/TopBarNavLinks.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/layout/UserShell/v2/__tests__/TopBarNavLinks.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { TopBarNavLinks } from '../TopBarNavLinks';
+
+vi.mock('next/navigation', () => ({
+  usePathname: vi.fn(),
+}));
+
+import { usePathname } from 'next/navigation';
+
+const mockUsePathname = usePathname as unknown as ReturnType<typeof vi.fn>;
+
+describe('TopBarNavLinks', () => {
+  it('renders all 3 links', () => {
+    mockUsePathname.mockReturnValue('/');
+    render(<TopBarNavLinks />);
+    expect(screen.getByRole('link', { name: 'Home' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Libreria' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Sessioni' })).toBeInTheDocument();
+  });
+
+  it('marks Home active when pathname is /', () => {
+    mockUsePathname.mockReturnValue('/');
+    render(<TopBarNavLinks />);
+    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+
+  it('marks Home active when pathname is /dashboard', () => {
+    mockUsePathname.mockReturnValue('/dashboard');
+    render(<TopBarNavLinks />);
+    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+
+  it('marks Libreria active when pathname starts with /library', () => {
+    mockUsePathname.mockReturnValue('/library?tab=personal');
+    render(<TopBarNavLinks />);
+    expect(screen.getByRole('link', { name: 'Libreria' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+
+  it('marks Sessioni active when pathname starts with /sessions', () => {
+    mockUsePathname.mockReturnValue('/sessions/live/abc');
+    render(<TopBarNavLinks />);
+    expect(screen.getByRole('link', { name: 'Sessioni' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/v2/__tests__/TopBarNavLinks.test.tsx`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement TopBarNavLinks**
+
+Create `apps/web/src/components/layout/UserShell/v2/TopBarNavLinks.tsx`:
+
+```typescript
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+import { cn } from '@/lib/utils';
+
+interface NavLink {
+  href: string;
+  label: string;
+  isActive: (pathname: string) => boolean;
+}
+
+const LINKS: NavLink[] = [
+  {
+    href: '/',
+    label: 'Home',
+    isActive: p => p === '/' || p === '/dashboard' || p?.startsWith('/dashboard') || false,
+  },
+  {
+    href: '/library',
+    label: 'Libreria',
+    isActive: p => p?.startsWith('/library') || false,
+  },
+  {
+    href: '/sessions',
+    label: 'Sessioni',
+    isActive: p => p?.startsWith('/sessions') || false,
+  },
+];
+
+export function TopBarNavLinks() {
+  const pathname = usePathname() ?? '';
+
+  return (
+    <nav className="flex items-center gap-1 ml-3 shrink-0" aria-label="Primary">
+      {LINKS.map(link => {
+        const active = link.isActive(pathname);
+        return (
+          <Link
+            key={link.href}
+            href={link.href}
+            aria-current={active ? 'page' : undefined}
+            className={cn(
+              'px-3.5 py-2 rounded-[10px] font-[var(--font-nunito)] font-bold text-[0.82rem] transition-colors',
+              active
+                ? 'text-[hsl(25_95%_38%)] shadow-[inset_0_0_0_1px_hsla(25,95%,45%,0.25)]'
+                : 'text-[var(--nh-text-secondary)] hover:bg-[var(--nh-bg-surface)] hover:text-[var(--nh-text-primary)]'
+            )}
+            style={active ? { background: 'hsla(25, 95%, 45%, 0.1)' } : undefined}
+          >
+            {link.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/v2/__tests__/TopBarNavLinks.test.tsx`
+Expected: PASS — 5 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/layout/UserShell/v2/TopBarNavLinks.tsx apps/web/src/components/layout/UserShell/v2/__tests__/TopBarNavLinks.test.tsx
+git commit -m "feat(web): add TopBarNavLinks with pathname-based active state"
+```
+
+---
+
+## Task 6: TopBarSearchPill component
+
+**Files:**
+- Create: `apps/web/src/components/layout/UserShell/v2/TopBarSearchPill.tsx`
+- Test: `apps/web/src/components/layout/UserShell/v2/__tests__/TopBarSearchPill.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/layout/UserShell/v2/__tests__/TopBarSearchPill.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+
+import { TopBarSearchPill } from '../TopBarSearchPill';
+
+describe('TopBarSearchPill', () => {
+  it('shows placeholder text and ⌘K hint', () => {
+    render(<TopBarSearchPill />);
+    expect(screen.getByText(/cerca giochi/i)).toBeInTheDocument();
+    expect(screen.getByText('⌘K')).toBeInTheDocument();
+  });
+
+  it('invokes onOpen when clicked', async () => {
+    const onOpen = vi.fn();
+    const user = userEvent.setup();
+    render(<TopBarSearchPill onOpen={onOpen} />);
+    await user.click(screen.getByRole('button', { name: /search/i }));
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+
+  it('invokes onOpen on ⌘K keyboard shortcut', async () => {
+    const onOpen = vi.fn();
+    render(<TopBarSearchPill onOpen={onOpen} />);
+    // Simulate Cmd+K
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true })
+    );
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+
+  it('invokes onOpen on Ctrl+K keyboard shortcut', async () => {
+    const onOpen = vi.fn();
+    render(<TopBarSearchPill onOpen={onOpen} />);
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true })
+    );
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/v2/__tests__/TopBarSearchPill.test.tsx`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement TopBarSearchPill**
+
+Create `apps/web/src/components/layout/UserShell/v2/TopBarSearchPill.tsx`:
+
+```typescript
+'use client';
+
+import { useEffect } from 'react';
+
+interface TopBarSearchPillProps {
+  /** Called when the pill is clicked or ⌘K/Ctrl+K is pressed */
+  onOpen?: () => void;
+  placeholder?: string;
+}
+
+export function TopBarSearchPill({
+  onOpen,
+  placeholder = 'Cerca giochi, sessioni, regole, giocatori…',
+}: TopBarSearchPillProps) {
+  useEffect(() => {
+    if (!onOpen) return;
+
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        onOpen();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onOpen]);
+
+  return (
+    <div className="flex-1 min-w-0 px-2 max-w-[420px]">
+      <button
+        type="button"
+        aria-label="Search"
+        onClick={() => onOpen?.()}
+        className="w-full flex items-center gap-3 px-5 py-[11px] rounded-xl border border-[var(--nh-border-default)] bg-[var(--nh-bg-surface)] text-left text-[0.82rem] text-[var(--nh-text-muted)] hover:bg-white hover:border-[rgba(160,120,60,0.2)] hover:shadow-[var(--shadow-warm-sm)] transition-all"
+      >
+        <span className="shrink-0 text-sm" aria-hidden>
+          🔍
+        </span>
+        <span className="flex-1 truncate">{placeholder}</span>
+        <span
+          className="shrink-0 px-2 py-0.5 rounded-[5px] border border-[var(--nh-border-default)] bg-[rgba(160,120,60,0.08)] text-[10px] font-mono font-bold text-[var(--nh-text-secondary)]"
+          aria-hidden
+        >
+          ⌘K
+        </span>
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/v2/__tests__/TopBarSearchPill.test.tsx`
+Expected: PASS — 4 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/layout/UserShell/v2/TopBarSearchPill.tsx apps/web/src/components/layout/UserShell/v2/__tests__/TopBarSearchPill.test.tsx
+git commit -m "feat(web): add TopBarSearchPill with ⌘K shortcut"
+```
+
+---
+
+## Task 7: TopBarChatButton (stub)
+
+**Files:**
+- Create: `apps/web/src/components/layout/UserShell/v2/TopBarChatButton.tsx`
+- Test: `apps/web/src/components/layout/UserShell/v2/__tests__/TopBarChatButton.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/layout/UserShell/v2/__tests__/TopBarChatButton.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { TopBarChatButton } from '../TopBarChatButton';
+
+describe('TopBarChatButton', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('renders with accessible label', () => {
+    render(<TopBarChatButton />);
+    expect(screen.getByRole('button', { name: /chat agente/i })).toBeInTheDocument();
+  });
+
+  it('shows notification dot when hasUnread is true', () => {
+    render(<TopBarChatButton hasUnread />);
+    expect(screen.getByTestId('chat-unread-dot')).toBeInTheDocument();
+  });
+
+  it('hides notification dot when hasUnread is false', () => {
+    render(<TopBarChatButton hasUnread={false} />);
+    expect(screen.queryByTestId('chat-unread-dot')).not.toBeInTheDocument();
+  });
+
+  it('calls onOpen when clicked', async () => {
+    const onOpen = vi.fn();
+    const user = userEvent.setup();
+    render(<TopBarChatButton onOpen={onOpen} />);
+    await user.click(screen.getByRole('button', { name: /chat agente/i }));
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+
+  it('warns if clicked without onOpen (Phase 1 stub)', async () => {
+    const user = userEvent.setup();
+    render(<TopBarChatButton />);
+    await user.click(screen.getByRole('button', { name: /chat agente/i }));
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('TopBarChatButton')
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/v2/__tests__/TopBarChatButton.test.tsx`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement TopBarChatButton**
+
+Create `apps/web/src/components/layout/UserShell/v2/TopBarChatButton.tsx`:
+
+```typescript
+'use client';
+
+interface TopBarChatButtonProps {
+  onOpen?: () => void;
+  hasUnread?: boolean;
+}
+
+export function TopBarChatButton({ onOpen, hasUnread = false }: TopBarChatButtonProps) {
+  const handleClick = () => {
+    if (onOpen) {
+      onOpen();
+      return;
+    }
+    // Phase 1: chat panel not wired yet — Phase 4 will provide onOpen
+    // eslint-disable-next-line no-console
+    console.warn('[TopBarChatButton] onOpen handler not provided — chat panel not wired yet (Phase 4)');
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label="Chat agente"
+      onClick={handleClick}
+      className="relative flex h-10 w-10 items-center justify-center rounded-[10px] border border-[var(--nh-border-default)] bg-[var(--nh-bg-surface)] text-base shrink-0 hover:bg-white hover:shadow-[var(--shadow-warm-sm)] hover:-translate-y-px transition-all"
+    >
+      <span aria-hidden>💬</span>
+      {hasUnread && (
+        <span
+          data-testid="chat-unread-dot"
+          aria-label="Unread messages"
+          className="absolute top-[7px] right-[7px] h-2 w-2 rounded-full"
+          style={{
+            background: 'hsl(350 89% 58%)',
+            boxShadow: '0 0 0 2px var(--nh-bg-surface)',
+          }}
+        />
+      )}
+    </button>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/v2/__tests__/TopBarChatButton.test.tsx`
+Expected: PASS — 5 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/layout/UserShell/v2/TopBarChatButton.tsx apps/web/src/components/layout/UserShell/v2/__tests__/TopBarChatButton.test.tsx
+git commit -m "feat(web): add TopBarChatButton stub (Phase 4 will wire onOpen)"
+```
+
+---
+
+## Task 8: TopBar64 composition
+
+**Files:**
+- Create: `apps/web/src/components/layout/UserShell/v2/TopBar64.tsx`
+- Test: `apps/web/src/components/layout/UserShell/v2/__tests__/TopBar64.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/layout/UserShell/v2/__tests__/TopBar64.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { TopBar64 } from '../TopBar64';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}));
+
+// Mock the notification bell (existing component with runtime deps)
+vi.mock('@/components/notifications', () => ({
+  NotificationBell: () => <button aria-label="Notifications">🔔</button>,
+}));
+
+vi.mock('@/components/layout/UserMenuDropdown', () => ({
+  UserMenuDropdown: () => <button aria-label="User menu">MR</button>,
+}));
+
+describe('TopBar64', () => {
+  it('renders logo, nav links, search, chat button, and user menu', () => {
+    render(<TopBar64 />);
+    expect(screen.getByRole('link', { name: /meepleai home/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Home' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /search/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /chat agente/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /notifications/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /user menu/i })).toBeInTheDocument();
+  });
+
+  it('is 64px tall and sticky', () => {
+    const { container } = render(<TopBar64 />);
+    const header = container.querySelector('header');
+    expect(header).toHaveClass('h-16');
+    expect(header).toHaveClass('sticky');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/v2/__tests__/TopBar64.test.tsx`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement TopBar64**
+
+Create `apps/web/src/components/layout/UserShell/v2/TopBar64.tsx`:
+
+```typescript
+'use client';
+
+import { NotificationBell } from '@/components/notifications';
+
+import { TopBarChatButton } from './TopBarChatButton';
+import { TopBarLogo } from './TopBarLogo';
+import { TopBarNavLinks } from './TopBarNavLinks';
+import { TopBarSearchPill } from './TopBarSearchPill';
+import { UserMenuDropdown } from '../../UserMenuDropdown';
+
+interface TopBar64Props {
+  onOpenChat?: () => void;
+  onOpenSearch?: () => void;
+}
+
+/**
+ * New 64px top bar for the UX redesign (Phase 1).
+ * Composes: Logo + NavLinks + SearchPill + ChatButton + Notifications + UserMenu
+ * Sticky positioning, backdrop-blur, border-bottom.
+ */
+export function TopBar64({ onOpenChat, onOpenSearch }: TopBar64Props) {
+  return (
+    <header
+      data-testid="top-bar-64"
+      className="sticky top-0 z-40 h-16 flex items-center gap-4 px-6 border-b border-[var(--nh-border-default)] backdrop-blur-md"
+      style={{
+        background: 'rgba(255, 252, 248, 0.85)',
+      }}
+    >
+      <TopBarLogo />
+      <TopBarNavLinks />
+      <TopBarSearchPill onOpen={onOpenSearch} />
+      <div className="flex items-center gap-2.5 shrink-0">
+        <TopBarChatButton onOpen={onOpenChat} />
+        <NotificationBell />
+        <UserMenuDropdown />
+      </div>
+    </header>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/v2/__tests__/TopBar64.test.tsx`
+Expected: PASS — 2 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/layout/UserShell/v2/TopBar64.tsx apps/web/src/components/layout/UserShell/v2/__tests__/TopBar64.test.tsx
+git commit -m "feat(web): add TopBar64 composition"
+```
+
+---
+
+## Task 9: MiniNavSlot (reads from store)
+
+**Files:**
+- Create: `apps/web/src/components/layout/UserShell/v2/MiniNavSlot.tsx`
+- Test: `apps/web/src/components/layout/UserShell/v2/__tests__/MiniNavSlot.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/layout/UserShell/v2/__tests__/MiniNavSlot.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { useMiniNavConfigStore } from '@/lib/stores/mini-nav-config-store';
+
+import { MiniNavSlot } from '../MiniNavSlot';
+
+describe('MiniNavSlot', () => {
+  beforeEach(() => {
+    useMiniNavConfigStore.getState().clear();
+  });
+
+  it('renders nothing when config is null', () => {
+    const { container } = render(<MiniNavSlot />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders breadcrumb and tabs when config is set', () => {
+    useMiniNavConfigStore.getState().setConfig({
+      breadcrumb: 'Libreria · Hub',
+      tabs: [
+        { id: 'hub', label: 'Hub', href: '/library' },
+        { id: 'personal', label: 'Personal', href: '/library?tab=personal', count: 47 },
+      ],
+      activeTabId: 'hub',
+    });
+    render(<MiniNavSlot />);
+    expect(screen.getByText(/Libreria/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Hub/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Personal/i })).toBeInTheDocument();
+    expect(screen.getByText('47')).toBeInTheDocument();
+  });
+
+  it('marks active tab with aria-current', () => {
+    useMiniNavConfigStore.getState().setConfig({
+      breadcrumb: 'Libreria',
+      tabs: [
+        { id: 'hub', label: 'Hub', href: '/library' },
+        { id: 'personal', label: 'Personal', href: '/library?tab=personal' },
+      ],
+      activeTabId: 'personal',
+    });
+    render(<MiniNavSlot />);
+    expect(screen.getByRole('link', { name: /Personal/i })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+
+  it('renders primary action button when provided', () => {
+    useMiniNavConfigStore.getState().setConfig({
+      breadcrumb: 'Home',
+      tabs: [{ id: 'a', label: 'A', href: '/' }],
+      activeTabId: 'a',
+      primaryAction: { label: '＋ Nuova partita', onClick: () => {} },
+    });
+    render(<MiniNavSlot />);
+    expect(
+      screen.getByRole('button', { name: /Nuova partita/i })
+    ).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/v2/__tests__/MiniNavSlot.test.tsx`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement MiniNavSlot**
+
+Create `apps/web/src/components/layout/UserShell/v2/MiniNavSlot.tsx`:
+
+```typescript
+'use client';
+
+import Link from 'next/link';
+
+import { useMiniNavConfigStore } from '@/lib/stores/mini-nav-config-store';
+import { cn } from '@/lib/utils';
+
+/**
+ * MiniNavSlot — renders the mini-nav registered by the current page.
+ * Hidden when no config is set.
+ */
+export function MiniNavSlot() {
+  const config = useMiniNavConfigStore(s => s.config);
+  if (!config) return null;
+
+  return (
+    <div
+      data-testid="mini-nav-slot"
+      className="h-12 flex items-center gap-1 px-7 pl-[104px] border-b border-[var(--nh-border-default)] bg-[var(--nh-bg-base)]"
+    >
+      <div className="text-xs font-semibold text-[var(--nh-text-muted)] mr-5">
+        <span aria-hidden>›</span> {config.breadcrumb}
+      </div>
+      {config.tabs.map(tab => {
+        const active = tab.id === config.activeTabId;
+        return (
+          <Link
+            key={tab.id}
+            href={tab.href}
+            aria-current={active ? 'page' : undefined}
+            className={cn(
+              'relative px-3.5 py-2 rounded-lg text-[0.78rem] font-bold flex items-center gap-1.5 transition-colors',
+              active
+                ? 'text-[var(--nh-text-primary)]'
+                : 'text-[var(--nh-text-secondary)] hover:bg-[var(--nh-bg-surface)]'
+            )}
+          >
+            {tab.label}
+            {tab.count !== undefined && (
+              <span className="px-1.5 py-0.5 rounded text-[10px] font-extrabold bg-[rgba(160,120,60,0.1)] text-[var(--nh-text-secondary)]">
+                {tab.count}
+              </span>
+            )}
+            {active && (
+              <span
+                aria-hidden
+                className="absolute bottom-[-12px] left-3.5 right-3.5 h-0.5 rounded-t"
+                style={{ background: 'hsl(25 95% 45%)' }}
+              />
+            )}
+          </Link>
+        );
+      })}
+      <div className="flex-1" />
+      {config.primaryAction && (
+        <button
+          type="button"
+          onClick={config.primaryAction.onClick}
+          className="px-3.5 py-2 rounded-[10px] text-[0.78rem] font-bold text-white border-none cursor-pointer flex items-center gap-1.5 transition-all hover:-translate-y-px"
+          style={{
+            background: 'linear-gradient(135deg, hsl(25 95% 48%), hsl(25 95% 40%))',
+            boxShadow: '0 2px 6px hsla(25, 95%, 45%, 0.3)',
+          }}
+        >
+          {config.primaryAction.label}
+        </button>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/v2/__tests__/MiniNavSlot.test.tsx`
+Expected: PASS — 4 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/layout/UserShell/v2/MiniNavSlot.tsx apps/web/src/components/layout/UserShell/v2/__tests__/MiniNavSlot.test.tsx
+git commit -m "feat(web): add MiniNavSlot reading from mini-nav-config-store"
+```
+
+---
+
+## Task 10: HandRailItem component
+
+**Files:**
+- Create: `apps/web/src/components/layout/UserShell/v2/HandRailItem.tsx`
+- Test: `apps/web/src/components/layout/UserShell/v2/__tests__/HandRailItem.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/layout/UserShell/v2/__tests__/HandRailItem.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { HandRailItem } from '../HandRailItem';
+
+describe('HandRailItem', () => {
+  const baseCard = {
+    id: 'azul',
+    entity: 'game' as const,
+    title: 'Azul',
+    href: '/library/azul',
+  };
+
+  it('renders title in the card body', () => {
+    render(<HandRailItem card={baseCard} isActive={false} />);
+    expect(screen.getByText('Azul')).toBeInTheDocument();
+  });
+
+  it('renders as a link to card.href', () => {
+    render(<HandRailItem card={baseCard} isActive={false} />);
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/library/azul');
+  });
+
+  it('applies active state when isActive is true', () => {
+    render(<HandRailItem card={baseCard} isActive />);
+    expect(screen.getByRole('link')).toHaveAttribute('data-active', 'true');
+  });
+
+  it('uses entity data attribute for styling', () => {
+    render(<HandRailItem card={baseCard} isActive={false} />);
+    expect(screen.getByRole('link')).toHaveAttribute('data-entity', 'game');
+  });
+
+  it('applies different entity for session', () => {
+    render(
+      <HandRailItem
+        card={{ ...baseCard, entity: 'session' }}
+        isActive={false}
+      />
+    );
+    expect(screen.getByRole('link')).toHaveAttribute('data-entity', 'session');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/v2/__tests__/HandRailItem.test.tsx`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement HandRailItem**
+
+Create `apps/web/src/components/layout/UserShell/v2/HandRailItem.tsx`:
+
+```typescript
+'use client';
+
+import Link from 'next/link';
+
+import type { HandCard } from '@/stores/use-card-hand';
+
+import { cn } from '@/lib/utils';
+
+interface HandRailItemProps {
+  card: HandCard;
+  isActive: boolean;
+}
+
+const ENTITY_GRADIENTS: Record<string, string> = {
+  game: 'linear-gradient(135deg, hsl(25 75% 78%), hsl(25 80% 55%))',
+  session: 'linear-gradient(135deg, hsl(240 55% 75%), hsl(240 60% 55%))',
+  chat: 'linear-gradient(135deg, hsl(220 72% 78%), hsl(220 80% 58%))',
+  player: 'linear-gradient(135deg, hsl(262 78% 78%), hsl(262 83% 60%))',
+  agent: 'linear-gradient(135deg, hsl(38 85% 75%), hsl(38 92% 55%))',
+  kb: 'linear-gradient(135deg, hsl(210 55% 78%), hsl(210 40% 55%))',
+  event: 'linear-gradient(135deg, hsl(350 75% 78%), hsl(350 89% 60%))',
+  toolkit: 'linear-gradient(135deg, hsl(142 60% 78%), hsl(142 70% 45%))',
+  tool: 'linear-gradient(135deg, hsl(195 70% 78%), hsl(195 80% 50%))',
+};
+
+const ENTITY_ACCENTS: Record<string, string> = {
+  game: 'hsl(25 95% 45%)',
+  session: 'hsl(240 60% 55%)',
+  chat: 'hsl(220 80% 55%)',
+  player: 'hsl(262 83% 58%)',
+  agent: 'hsl(38 92% 50%)',
+  kb: 'hsl(210 40% 55%)',
+  event: 'hsl(350 89% 60%)',
+  toolkit: 'hsl(142 70% 45%)',
+  tool: 'hsl(195 80% 50%)',
+};
+
+const ENTITY_ICONS: Record<string, string> = {
+  game: '🎲',
+  session: '🎯',
+  chat: '💬',
+  player: '👤',
+  agent: '🤖',
+  kb: '📚',
+  event: '📅',
+  toolkit: '🧰',
+  tool: '🔧',
+};
+
+export function HandRailItem({ card, isActive }: HandRailItemProps) {
+  const gradient = ENTITY_GRADIENTS[card.entity] ?? ENTITY_GRADIENTS.game;
+  const accent = ENTITY_ACCENTS[card.entity] ?? ENTITY_ACCENTS.game;
+  const icon = ENTITY_ICONS[card.entity] ?? '🎲';
+
+  return (
+    <Link
+      href={card.href}
+      data-entity={card.entity}
+      data-active={isActive}
+      title={card.title}
+      className={cn(
+        'relative block w-[52px] h-[72px] rounded-[10px] bg-[var(--nh-bg-elevated)] border border-[var(--nh-border-default)] overflow-hidden shrink-0 transition-all duration-300 ease-out',
+        'shadow-[var(--shadow-warm-sm)]',
+        'hover:translate-x-[3px] hover:scale-105 hover:shadow-[var(--shadow-warm-md)]',
+        isActive &&
+          'translate-x-[6px] scale-110 shadow-[var(--shadow-warm-lg)]'
+      )}
+      style={
+        isActive
+          ? { outline: `2px solid ${accent}`, outlineOffset: '2px' }
+          : undefined
+      }
+    >
+      <span
+        aria-hidden
+        className="absolute left-0 top-0 bottom-0 w-[3px]"
+        style={{ background: accent }}
+      />
+      <div
+        className="w-full h-[42px] flex items-center justify-center text-lg"
+        style={{ background: gradient }}
+        aria-hidden
+      >
+        {card.imageUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={card.imageUrl}
+            alt=""
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          icon
+        )}
+      </div>
+      <span className="absolute bottom-[3px] left-[4px] right-[4px] text-[7px] font-bold font-[var(--font-quicksand)] leading-[1.1] text-[var(--nh-text-primary)] whitespace-nowrap overflow-hidden text-ellipsis text-center">
+        {card.title}
+      </span>
+    </Link>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/v2/__tests__/HandRailItem.test.tsx`
+Expected: PASS — 5 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/layout/UserShell/v2/HandRailItem.tsx apps/web/src/components/layout/UserShell/v2/__tests__/HandRailItem.test.tsx
+git commit -m "feat(web): add HandRailItem with entity-aware styling"
+```
+
+---
+
+## Task 11: HandRailToolbar component
+
+**Files:**
+- Create: `apps/web/src/components/layout/UserShell/v2/HandRailToolbar.tsx`
+- Test: `apps/web/src/components/layout/UserShell/v2/__tests__/HandRailToolbar.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/layout/UserShell/v2/__tests__/HandRailToolbar.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+
+import { HandRailToolbar } from '../HandRailToolbar';
+
+describe('HandRailToolbar', () => {
+  it('renders pin and expand buttons', () => {
+    render(<HandRailToolbar onTogglePin={() => {}} onToggleExpand={() => {}} />);
+    expect(screen.getByRole('button', { name: /pin/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /expand/i })).toBeInTheDocument();
+  });
+
+  it('calls onTogglePin when pin clicked', async () => {
+    const onTogglePin = vi.fn();
+    const user = userEvent.setup();
+    render(<HandRailToolbar onTogglePin={onTogglePin} onToggleExpand={() => {}} />);
+    await user.click(screen.getByRole('button', { name: /pin/i }));
+    expect(onTogglePin).toHaveBeenCalledOnce();
+  });
+
+  it('calls onToggleExpand when expand clicked', async () => {
+    const onToggleExpand = vi.fn();
+    const user = userEvent.setup();
+    render(<HandRailToolbar onTogglePin={() => {}} onToggleExpand={onToggleExpand} />);
+    await user.click(screen.getByRole('button', { name: /expand/i }));
+    expect(onToggleExpand).toHaveBeenCalledOnce();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/v2/__tests__/HandRailToolbar.test.tsx`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement HandRailToolbar**
+
+Create `apps/web/src/components/layout/UserShell/v2/HandRailToolbar.tsx`:
+
+```typescript
+'use client';
+
+interface HandRailToolbarProps {
+  onTogglePin: () => void;
+  onToggleExpand: () => void;
+  isPinned?: boolean;
+  isExpanded?: boolean;
+}
+
+export function HandRailToolbar({
+  onTogglePin,
+  onToggleExpand,
+  isPinned = false,
+  isExpanded = false,
+}: HandRailToolbarProps) {
+  return (
+    <div className="w-full border-t border-[var(--nh-border-default)] pt-2.5 mt-1.5 flex flex-col items-center gap-1.5">
+      <button
+        type="button"
+        aria-label={isPinned ? 'Unpin current card' : 'Pin current card'}
+        onClick={onTogglePin}
+        className="flex h-[34px] w-[34px] items-center justify-center rounded-lg border border-[var(--nh-border-default)] bg-[var(--nh-bg-surface)] text-[13px] hover:bg-white hover:shadow-[var(--shadow-warm-sm)] transition-all"
+      >
+        📌
+      </button>
+      <button
+        type="button"
+        aria-label={isExpanded ? 'Collapse rail' : 'Expand rail'}
+        onClick={onToggleExpand}
+        className="flex h-[34px] w-[34px] items-center justify-center rounded-lg border border-[var(--nh-border-default)] bg-[var(--nh-bg-surface)] text-[13px] hover:bg-white hover:shadow-[var(--shadow-warm-sm)] transition-all"
+      >
+        ⇔
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/v2/__tests__/HandRailToolbar.test.tsx`
+Expected: PASS — 3 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/layout/UserShell/v2/HandRailToolbar.tsx apps/web/src/components/layout/UserShell/v2/__tests__/HandRailToolbar.test.tsx
+git commit -m "feat(web): add HandRailToolbar with pin/expand buttons"
+```
+
+---
+
+## Task 12: DesktopHandRail (reads from useCardHand)
+
+**Files:**
+- Create: `apps/web/src/components/layout/UserShell/v2/DesktopHandRail.tsx`
+- Test: `apps/web/src/components/layout/UserShell/v2/__tests__/DesktopHandRail.test.tsx`
+
+- [ ] **Step 1: Confirm useCardHand store API**
+
+The store `apps/web/src/stores/use-card-hand.ts` exposes (verified):
+- State: `cards: HandCard[]`, `pinnedIds: Set<string>`, `focusedIdx: number`, etc.
+- Actions: `drawCard`, `discardCard`, `focusCard`, `focusByHref`, `pinCard(id)`, `unpinCard(id)` (separate, NOT `togglePin`), `clear`
+- Usage: `useCardHand()` returns the full state, or with selector `useCardHand(s => s.cards)`
+- `isPinned(id)` is NOT a helper — derive from `pinnedIds.has(id)`
+
+- [ ] **Step 2: Write the failing test**
+
+Create `apps/web/src/components/layout/UserShell/v2/__tests__/DesktopHandRail.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/stores/use-card-hand', () => {
+  const cards = [
+    { id: 'azul', entity: 'game', title: 'Azul', href: '/library/azul' },
+    { id: 'wings', entity: 'game', title: 'Wingspan', href: '/library/wings' },
+    { id: 'ses', entity: 'session', title: 'Serata', href: '/sessions/live/123' },
+  ];
+  const state = {
+    cards,
+    pinnedIds: new Set<string>(),
+    pinCard: vi.fn(),
+    unpinCard: vi.fn(),
+  };
+  return {
+    useCardHand: (selector?: (s: typeof state) => unknown) =>
+      selector ? selector(state) : state,
+  };
+});
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/library/azul',
+}));
+
+import { DesktopHandRail } from '../DesktopHandRail';
+
+describe('DesktopHandRail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders hand label', () => {
+    render(<DesktopHandRail />);
+    expect(screen.getByText(/la tua mano/i)).toBeInTheDocument();
+  });
+
+  it('renders all cards from useCardHand', () => {
+    render(<DesktopHandRail />);
+    expect(screen.getByText('Azul')).toBeInTheDocument();
+    expect(screen.getByText('Wingspan')).toBeInTheDocument();
+    expect(screen.getByText('Serata')).toBeInTheDocument();
+  });
+
+  it('marks the card matching the current pathname as active', () => {
+    render(<DesktopHandRail />);
+    const azul = screen.getByText('Azul').closest('a');
+    expect(azul).toHaveAttribute('data-active', 'true');
+  });
+
+  it('renders the toolbar with pin/expand buttons', () => {
+    render(<DesktopHandRail />);
+    expect(screen.getByRole('button', { name: /pin/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /expand/i })).toBeInTheDocument();
+  });
+
+  it('is 76px wide by default', () => {
+    const { container } = render(<DesktopHandRail />);
+    const rail = container.querySelector('[data-testid="desktop-hand-rail"]');
+    expect(rail).toHaveClass('w-[76px]');
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/v2/__tests__/DesktopHandRail.test.tsx`
+Expected: FAIL — module not found
+
+- [ ] **Step 4: Implement DesktopHandRail**
+
+Create `apps/web/src/components/layout/UserShell/v2/DesktopHandRail.tsx`:
+
+```typescript
+'use client';
+
+import { useState } from 'react';
+
+import { usePathname } from 'next/navigation';
+
+import { useCardHand } from '@/stores/use-card-hand';
+
+import { HandRailItem } from './HandRailItem';
+import { HandRailToolbar } from './HandRailToolbar';
+
+/**
+ * DesktopHandRail — persistent left rail reading from useCardHand store.
+ * Replaces the hardcoded NAV_ITEMS behavior of the legacy CardRack.
+ *
+ * Active state is computed from the current pathname: the card whose
+ * href matches the pathname (exact or prefix for game/session ids) is active.
+ */
+export function DesktopHandRail() {
+  const cards = useCardHand(s => s.cards);
+  const pinnedIds = useCardHand(s => s.pinnedIds);
+  const pinCard = useCardHand(s => s.pinCard);
+  const unpinCard = useCardHand(s => s.unpinCard);
+  const pathname = usePathname() ?? '';
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const isCardActive = (href: string) => {
+    if (href === '/') return pathname === '/';
+    return pathname === href || pathname.startsWith(href + '/');
+  };
+
+  const activeCard = cards.find(c => isCardActive(c.href));
+  const isActivePinned = activeCard ? pinnedIds.has(activeCard.id) : false;
+
+  const handleTogglePin = () => {
+    if (!activeCard) return;
+    if (isActivePinned) unpinCard(activeCard.id);
+    else pinCard(activeCard.id);
+  };
+
+  return (
+    <aside
+      data-testid="desktop-hand-rail"
+      aria-label="Cards in hand"
+      className="hidden md:flex flex-col w-[76px] shrink-0 border-r border-[var(--nh-border-default)] py-3.5 pb-3 gap-2"
+      style={{
+        background:
+          'linear-gradient(180deg, rgba(255,252,248,0.6), rgba(255,252,248,0.2))',
+      }}
+    >
+      <span
+        className="text-[9px] font-extrabold font-[var(--font-quicksand)] uppercase tracking-[0.12em] text-[var(--nh-text-muted)] pb-2 self-center"
+        style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}
+      >
+        La tua mano
+      </span>
+      <div className="flex-1 flex flex-col items-center gap-2.5 w-full overflow-y-auto pt-1 px-1">
+        {cards.map(card => (
+          <HandRailItem
+            key={card.id}
+            card={card}
+            isActive={isCardActive(card.href)}
+          />
+        ))}
+      </div>
+      <HandRailToolbar
+        onTogglePin={handleTogglePin}
+        onToggleExpand={() => setIsExpanded(!isExpanded)}
+        isPinned={isActivePinned}
+        isExpanded={isExpanded}
+      />
+    </aside>
+  );
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/v2/__tests__/DesktopHandRail.test.tsx`
+Expected: PASS — 5 tests passing
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/layout/UserShell/v2/DesktopHandRail.tsx apps/web/src/components/layout/UserShell/v2/__tests__/DesktopHandRail.test.tsx
+git commit -m "feat(web): add DesktopHandRail reading from useCardHand"
+```
+
+---
+
+## Task 13: DesktopShell composition
+
+**Files:**
+- Create: `apps/web/src/components/layout/UserShell/v2/DesktopShell.tsx`
+- Test: `apps/web/src/components/layout/UserShell/v2/__tests__/DesktopShell.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/layout/UserShell/v2/__tests__/DesktopShell.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}));
+
+vi.mock('@/stores/use-card-hand', () => ({
+  useCardHand: () => ({ cards: [], togglePin: vi.fn(), isPinned: () => false }),
+}));
+
+vi.mock('@/components/notifications', () => ({
+  NotificationBell: () => <button aria-label="Notifications">🔔</button>,
+}));
+
+vi.mock('@/components/layout/UserMenuDropdown', () => ({
+  UserMenuDropdown: () => <button aria-label="User menu">MR</button>,
+}));
+
+import { DesktopShell } from '../DesktopShell';
+
+describe('DesktopShell', () => {
+  it('renders top bar, mini-nav slot, hand rail and children', () => {
+    render(
+      <DesktopShell>
+        <div data-testid="content">hello</div>
+      </DesktopShell>
+    );
+    expect(screen.getByTestId('top-bar-64')).toBeInTheDocument();
+    expect(screen.getByTestId('desktop-hand-rail')).toBeInTheDocument();
+    expect(screen.getByTestId('content')).toBeInTheDocument();
+  });
+
+  it('wraps children in a main landmark', () => {
+    render(
+      <DesktopShell>
+        <div>child</div>
+      </DesktopShell>
+    );
+    expect(screen.getByRole('main')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/v2/__tests__/DesktopShell.test.tsx`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement DesktopShell**
+
+Create `apps/web/src/components/layout/UserShell/v2/DesktopShell.tsx`:
+
+```typescript
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { DesktopHandRail } from './DesktopHandRail';
+import { MiniNavSlot } from './MiniNavSlot';
+import { TopBar64 } from './TopBar64';
+
+interface DesktopShellProps {
+  children: ReactNode;
+}
+
+/**
+ * DesktopShell — new Phase 1 layout composition.
+ *
+ * Layout:
+ *   ┌───────────────────────────────┐
+ *   │ TopBar64 (64px sticky)        │
+ *   ├───────────────────────────────┤
+ *   │ MiniNavSlot (48px, optional)  │
+ *   ├────┬──────────────────────────┤
+ *   │ HR │ main                     │
+ *   │ 76 │                          │
+ *   └────┴──────────────────────────┘
+ */
+export function DesktopShell({ children }: DesktopShellProps) {
+  return (
+    <div className="min-h-dvh flex flex-col bg-[var(--nh-bg-base)]">
+      <TopBar64 />
+      <MiniNavSlot />
+      <div className="flex-1 flex min-h-0">
+        <DesktopHandRail />
+        <main className="flex-1 min-w-0 overflow-y-auto">{children}</main>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/v2/__tests__/DesktopShell.test.tsx`
+Expected: PASS — 2 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/layout/UserShell/v2/DesktopShell.tsx apps/web/src/components/layout/UserShell/v2/__tests__/DesktopShell.test.tsx
+git commit -m "feat(web): add DesktopShell composition (TopBar + MiniNav + HandRail + main)"
+```
+
+---
+
+## Task 14: Barrel export for v2
+
+**Files:**
+- Create: `apps/web/src/components/layout/UserShell/v2/index.ts`
+
+- [ ] **Step 1: Create the barrel**
+
+Create `apps/web/src/components/layout/UserShell/v2/index.ts`:
+
+```typescript
+export { DesktopShell } from './DesktopShell';
+export { TopBar64 } from './TopBar64';
+export { TopBarLogo } from './TopBarLogo';
+export { TopBarNavLinks } from './TopBarNavLinks';
+export { TopBarSearchPill } from './TopBarSearchPill';
+export { TopBarChatButton } from './TopBarChatButton';
+export { MiniNavSlot } from './MiniNavSlot';
+export { DesktopHandRail } from './DesktopHandRail';
+export { HandRailItem } from './HandRailItem';
+export { HandRailToolbar } from './HandRailToolbar';
+```
+
+- [ ] **Step 2: Verify imports resolve**
+
+Run: `cd apps/web && pnpm typecheck`
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/layout/UserShell/v2/index.ts
+git commit -m "feat(web): add v2 barrel export"
+```
+
+---
+
+## Task 15: Wire DesktopShell into UserShellClient behind flag
+
+**Files:**
+- Modify: `apps/web/src/components/layout/UserShell/UserShellClient.tsx`
+
+- [ ] **Step 1: Read the current file**
+
+Run: `cd apps/web && cat src/components/layout/UserShell/UserShellClient.tsx`
+
+- [ ] **Step 2: Write an integration test**
+
+Create `apps/web/src/components/layout/UserShell/__tests__/UserShellClient.flag.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}));
+
+vi.mock('@/stores/use-card-hand', () => ({
+  useCardHand: () => ({ cards: [], togglePin: vi.fn(), isPinned: () => false }),
+}));
+
+vi.mock('@/components/notifications', () => ({
+  NotificationBell: () => <button aria-label="Notifications">🔔</button>,
+}));
+
+vi.mock('@/components/layout/UserMenuDropdown', () => ({
+  UserMenuDropdown: () => <button aria-label="User menu">MR</button>,
+}));
+
+vi.mock('@/components/layout/AppNavbar', () => ({
+  AppNavbar: () => <nav data-testid="legacy-navbar">Legacy Navbar</nav>,
+}));
+
+vi.mock('@/components/dashboard', () => ({
+  DashboardEngineProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock('@/components/session/BackToSessionFAB', () => ({
+  BackToSessionFAB: () => null,
+}));
+
+const originalEnv = process.env.NEXT_PUBLIC_UX_REDESIGN;
+
+describe('UserShellClient feature flag', () => {
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.NEXT_PUBLIC_UX_REDESIGN;
+    else process.env.NEXT_PUBLIC_UX_REDESIGN = originalEnv;
+    vi.resetModules();
+  });
+
+  it('renders legacy AppNavbar when flag is off', async () => {
+    process.env.NEXT_PUBLIC_UX_REDESIGN = 'false';
+    const { UserShellClient } = await import('../UserShellClient');
+    render(
+      <UserShellClient>
+        <div>child</div>
+      </UserShellClient>
+    );
+    expect(screen.getByTestId('legacy-navbar')).toBeInTheDocument();
+    expect(screen.queryByTestId('top-bar-64')).not.toBeInTheDocument();
+  });
+
+  it('renders DesktopShell when flag is on', async () => {
+    process.env.NEXT_PUBLIC_UX_REDESIGN = 'true';
+    vi.resetModules();
+    const { UserShellClient } = await import('../UserShellClient');
+    render(
+      <UserShellClient>
+        <div>child</div>
+      </UserShellClient>
+    );
+    expect(screen.getByTestId('top-bar-64')).toBeInTheDocument();
+    expect(screen.queryByTestId('legacy-navbar')).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/__tests__/UserShellClient.flag.test.tsx`
+Expected: FAIL — the flag branch doesn't exist yet
+
+- [ ] **Step 4: Update UserShellClient to branch on the flag**
+
+Replace the contents of `apps/web/src/components/layout/UserShell/UserShellClient.tsx` with:
+
+```typescript
+'use client';
+
+import { Suspense, type ReactNode } from 'react';
+
+import { DashboardEngineProvider } from '@/components/dashboard';
+import { AppNavbar } from '@/components/layout/AppNavbar';
+import { BackToSessionFAB } from '@/components/session/BackToSessionFAB';
+import { isUxRedesignEnabled } from '@/lib/feature-flags';
+
+import { DesktopShell } from './v2';
+
+interface UserShellClientProps {
+  children: ReactNode;
+}
+
+export function UserShellClient({ children }: UserShellClientProps) {
+  const useNewShell = isUxRedesignEnabled();
+
+  if (useNewShell) {
+    return (
+      <DesktopShell>
+        <DashboardEngineProvider>{children}</DashboardEngineProvider>
+        <Suspense>
+          <BackToSessionFAB />
+        </Suspense>
+      </DesktopShell>
+    );
+  }
+
+  return (
+    <div className="min-h-dvh bg-background">
+      <AppNavbar />
+      <main className="flex-1 min-w-0">
+        <DashboardEngineProvider>{children}</DashboardEngineProvider>
+      </main>
+      <Suspense>
+        <BackToSessionFAB />
+      </Suspense>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Run the test again**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/__tests__/UserShellClient.flag.test.tsx`
+Expected: PASS — 2 tests passing
+
+- [ ] **Step 6: Run the full UserShell test suite for regressions**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell`
+Expected: all existing tests still pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/layout/UserShell/UserShellClient.tsx apps/web/src/components/layout/UserShell/__tests__/UserShellClient.flag.test.tsx
+git commit -m "feat(web): wire DesktopShell into UserShellClient behind feature flag"
+```
+
+---
+
+## Task 16: Manual smoke test of the new shell
+
+**Files:** none (manual QA)
+
+- [ ] **Step 1: Start dev server with the flag on**
+
+Run in Git Bash (NOT PowerShell):
+
+```bash
+cd D:/Repositories/meepleai-monorepo-dev/apps/web
+NEXT_PUBLIC_UX_REDESIGN=true pnpm dev
+```
+
+Expected: dev server starts on `http://localhost:3000` without errors
+
+- [ ] **Step 2: Visit the homepage**
+
+Open `http://localhost:3000/` in browser.
+Expected:
+- New 64px top bar visible: MeepleAi logo + Home/Libreria/Sessioni links + search pill + chat button + notification + user menu
+- No mini-nav visible (no page registered one yet)
+- Empty hand rail on the left (76px, hand label vertical, no cards since store is empty)
+- Main content area renders the current dashboard/landing
+
+- [ ] **Step 3: Navigate to /library**
+
+Expected:
+- Libreria link in top bar is highlighted (orange tint + aria-current=page)
+- Main area shows the current library page (unchanged)
+
+- [ ] **Step 4: Click the chat button**
+
+Expected: console warn message: `[TopBarChatButton] onOpen handler not provided — chat panel not wired yet (Phase 4)`. No crash.
+
+- [ ] **Step 5: Disable the flag and verify rollback**
+
+Stop dev server. Restart without the flag:
+
+```bash
+pnpm dev
+```
+
+Expected: legacy `AppNavbar` layout restored, no visual regression from pre-task state.
+
+- [ ] **Step 6: Commit any findings**
+
+If issues are found during manual smoke, file follow-up tasks in the plan before continuing. If all green, document the smoke test result in the next commit message.
+
+```bash
+# No code changes — just a marker commit with empty allow if needed, OR skip this step
+git commit --allow-empty -m "chore(web): phase 1 shell manual smoke test passed"
+```
+
+---
+
+## Task 17: Typecheck + lint + full test sweep
+
+**Files:** none
+
+- [ ] **Step 1: Typecheck**
+
+Run: `cd apps/web && pnpm typecheck`
+Expected: no errors
+
+- [ ] **Step 2: Lint**
+
+Run: `cd apps/web && pnpm lint`
+Expected: no errors (warnings OK)
+
+- [ ] **Step 3: Full unit test suite**
+
+Run: `cd apps/web && pnpm test`
+Expected: all tests pass, new tests included in count
+
+- [ ] **Step 4: If anything fails**
+
+Fix issues inline. Do NOT mark Phase 1 complete until all green.
+
+- [ ] **Step 5: Final Phase 1 commit marker**
+
+```bash
+git commit --allow-empty -m "chore(web): phase 1 shell foundation complete
+
+New desktop shell (TopBar64 + MiniNavSlot + DesktopHandRail) behind
+NEXT_PUBLIC_UX_REDESIGN flag. All unit tests passing. Legacy shell
+unchanged. Phase 2 (Dashboard restyle) to follow in a separate plan."
+```
+
+---
+
+## Self-Review Checklist (run before marking Phase 1 complete)
+
+- [ ] All 17 tasks marked complete with green tests
+- [ ] `apps/web/src/lib/feature-flags.ts` exists and is imported in `UserShellClient`
+- [ ] `.env.development.example` has the `NEXT_PUBLIC_UX_REDESIGN=false` line
+- [ ] No `TODO` or `FIXME` comments left in new files
+- [ ] All new components have at least one unit test
+- [ ] `pnpm typecheck`, `pnpm lint`, `pnpm test` all pass
+- [ ] Manual smoke test passed with flag on AND off
+- [ ] Spec §4 (Shell Architecture) requirements covered:
+  - [x] Top bar 64px with logo / 3 links / search / chat icon / notifications / avatar
+  - [x] Mini-nav slot 48px driven by a store
+  - [x] Hand rail 76px reading from `useCardHand`
+  - [x] Feature flag for rollback
+
+---
+
+## Next Phases (separate plans, NOT in this plan)
+
+Each subsequent phase will get its own plan file following the same TDD pattern:
+
+| Phase | Scope | Plan file (TBD) |
+|---|---|---|
+| Phase 2 | Dashboard Gaming Hub restyle (widgets → MeepleCard variants) | `2026-XX-XX-desktop-ux-redesign-phase-2-dashboard.md` |
+| Phase 3 | Library Hub (carousels, header, filter bar, wire tab routing) | `2026-XX-XX-desktop-ux-redesign-phase-3-library.md` |
+| Phase 4 | Chat slide-over panel (panel, sidebar, ctx switcher, URL state) | `2026-XX-XX-desktop-ux-redesign-phase-4-chat.md` |
+| Phase 5 | Cleanup (remove flag, delete legacy, add Playwright E2E, redirects) | `2026-XX-XX-desktop-ux-redesign-phase-5-cleanup.md` |
+
+Each phase depends on the previous. Phase 2+ must not start until Phase 1 ships and smoke-test passes.
+
+---
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-04-08-desktop-ux-redesign-design.md`
+- Mockups: `.superpowers/brainstorm/598863-1775669036/content/*.html` (shell-overview, dashboard-gaming-hub, library-hub, chat-panel)
+- Design tokens: `apps/web/src/styles/design-tokens.css`
+- Existing shell: `apps/web/src/components/layout/UserShell/`
+- Existing hand store: `apps/web/src/stores/use-card-hand.ts`
+- Existing mini-nav: `apps/web/src/components/layout/ContextMiniNav.tsx`

--- a/docs/superpowers/plans/2026-04-08-desktop-ux-redesign-phase-2-dashboard.md
+++ b/docs/superpowers/plans/2026-04-08-desktop-ux-redesign-phase-2-dashboard.md
@@ -1,0 +1,1709 @@
+# Desktop UX Redesign — Phase 2: Dashboard Gaming Hub Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restyle the Dashboard Gaming Hub with the new MeepleCard design language (greeting + hero LiveSession + KPI strip + "Continua a giocare" carousel + recent chats + friends), gated by the Phase 1 `NEXT_PUBLIC_UX_REDESIGN` flag. Also fixes the 4 carry-forward items from Phase 1 code review (M1/M3/M4/M6).
+
+**Architecture:** The existing `dashboard-client.tsx` (Bento grid) is kept intact as the legacy path. A new `DashboardClientV2` component is mounted when the flag is on (internal branch inside the existing `DashboardClient`). The v2 layout reuses the existing data layer (`useDashboardStore`, `useAuth`, `StatsRow`, `WelcomeHero`) but replaces the Bento grid with vertical sections composed of `MeepleCard` variants (GridCard for games, HeroCard for live session, CompactCard for friends, StatCard for KPI).
+
+**Tech Stack:** Next.js 16, React 19, TypeScript, Tailwind 4, Zustand, Vitest + Testing Library. All design tokens reused from `apps/web/src/styles/design-tokens.css`. No new tokens.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-08-desktop-ux-redesign-design.md` §5.1 (Dashboard)
+
+**Prior phase:** Phase 1 (shell foundation) — see PR #296.
+
+---
+
+## Prerequisite: Phase 1 carry-forward fixes
+
+Before touching the dashboard, we fix 4 items flagged during the Phase 1 code review. These are bundled into the first 3 tasks of this plan so that Phase 2 pages consuming the hook can do so safely.
+
+## File Structure
+
+### New files
+
+| Path | Responsibility |
+|---|---|
+| `apps/web/src/app/(authenticated)/dashboard/v2/DashboardClientV2.tsx` | New Phase 2 dashboard layout: greeting + hero + KPI + carousel + chat + friends |
+| `apps/web/src/app/(authenticated)/dashboard/v2/sections/GreetingRow.tsx` | "Ciao {name}" row with gradient wordmark + quick stats |
+| `apps/web/src/app/(authenticated)/dashboard/v2/sections/HeroLiveSession.tsx` | Full-width HeroCard variant showing active session (replaced by "Start a game" card if no active session) |
+| `apps/web/src/app/(authenticated)/dashboard/v2/sections/KpiStrip.tsx` | 4-column StatCard strip (games / sessions / friends / chats) |
+| `apps/web/src/app/(authenticated)/dashboard/v2/sections/ContinueCarousel.tsx` | Horizontal scroll carousel of "continue playing" games as GridCard |
+| `apps/web/src/app/(authenticated)/dashboard/v2/sections/ChatRecentCards.tsx` | 3 compact chat preview cards with ConfidenceBadge |
+| `apps/web/src/app/(authenticated)/dashboard/v2/sections/FriendsRow.tsx` | 4 CompactCard variants for active friends with online dot |
+| `apps/web/src/app/(authenticated)/dashboard/v2/index.ts` | Barrel export |
+| `apps/web/src/app/(authenticated)/dashboard/v2/__tests__/GreetingRow.test.tsx` | unit test |
+| `apps/web/src/app/(authenticated)/dashboard/v2/__tests__/HeroLiveSession.test.tsx` | unit test |
+| `apps/web/src/app/(authenticated)/dashboard/v2/__tests__/KpiStrip.test.tsx` | unit test |
+| `apps/web/src/app/(authenticated)/dashboard/v2/__tests__/ContinueCarousel.test.tsx` | unit test |
+| `apps/web/src/app/(authenticated)/dashboard/v2/__tests__/ChatRecentCards.test.tsx` | unit test |
+| `apps/web/src/app/(authenticated)/dashboard/v2/__tests__/FriendsRow.test.tsx` | unit test |
+| `apps/web/src/app/(authenticated)/dashboard/v2/__tests__/DashboardClientV2.test.tsx` | integration test |
+
+### Modified files
+
+| Path | Change |
+|---|---|
+| `apps/web/src/hooks/useMiniNavConfig.ts` | **M3 fix** — stabilize config reference with shallow equality (no infinite re-registration on inline objects) |
+| `apps/web/src/lib/stores/mini-nav-config-store.ts` | **M4 fix** — tighten `MiniNavPrimaryAction.icon` type to `string` emoji with JSDoc clarification |
+| `apps/web/src/components/layout/UserShell/v2/DesktopHandRail.tsx` | **M6 fix** — add TODO comment on `isExpanded` explaining Phase 2 width wiring; wire expand transition with `w-[var(--card-rack-hover-width)]` |
+| `apps/web/src/components/layout/UserShell/v2/TopBarLogo.tsx` | **M1 fix** — `font-[var(--font-quicksand)]` → `font-quicksand` |
+| `apps/web/src/components/layout/UserShell/v2/TopBarNavLinks.tsx` | **M1 fix** — font utility cleanup |
+| `apps/web/src/components/layout/UserShell/v2/DesktopHandRail.tsx` | **M1 fix** — font utility cleanup (in the same commit as M6) |
+| `apps/web/src/components/layout/UserShell/v2/HandRailItem.tsx` | **M1 fix** — font utility cleanup |
+| `apps/web/src/app/(authenticated)/dashboard/dashboard-client.tsx` | Internal flag branch: `isUxRedesignEnabled() ? <DashboardClientV2 /> : <legacy bento grid />` |
+
+### Not touched in Phase 2
+
+- `apps/web/src/app/(authenticated)/dashboard/dashboard-mobile.tsx` — mobile path unchanged
+- Existing widgets under `dashboard/widgets/` — kept for legacy path, not modified
+- `useDashboardStore` store and API — reused as-is
+
+---
+
+## Task 1: M1 — Font utility cleanup in v2 shell files
+
+**Files:**
+- Modify: `apps/web/src/components/layout/UserShell/v2/TopBarLogo.tsx`
+- Modify: `apps/web/src/components/layout/UserShell/v2/TopBarNavLinks.tsx`
+- Modify: `apps/web/src/components/layout/UserShell/v2/DesktopHandRail.tsx`
+- Modify: `apps/web/src/components/layout/UserShell/v2/HandRailItem.tsx`
+
+- [ ] **Step 1: Find all occurrences**
+
+Run: `grep -rn "font-\[var(--font-" apps/web/src/components/layout/UserShell/v2/`
+Expected occurrences: 4 files, ~6-8 lines total.
+
+- [ ] **Step 2: Replace arbitrary-value syntax with Tailwind utilities**
+
+In each file, replace:
+- `font-[var(--font-quicksand)]` → `font-quicksand`
+- `font-[var(--font-nunito)]` → `font-nunito`
+
+These utilities are already registered in `apps/web/tailwind.config.js`.
+
+- [ ] **Step 3: Run existing tests to confirm no regression**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/v2`
+Expected: all existing v2 tests pass (no behavior change, pure style refactor).
+
+- [ ] **Step 4: Typecheck**
+
+Run: `cd apps/web && pnpm typecheck`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd D:/Repositories/meepleai-monorepo-dev
+git add apps/web/src/components/layout/UserShell/v2/TopBarLogo.tsx apps/web/src/components/layout/UserShell/v2/TopBarNavLinks.tsx apps/web/src/components/layout/UserShell/v2/DesktopHandRail.tsx apps/web/src/components/layout/UserShell/v2/HandRailItem.tsx
+git commit -m "refactor(web): use font-quicksand/nunito utilities (M1 from phase 1 review)"
+```
+
+---
+
+## Task 2: M3 — Stabilize useMiniNavConfig with shallow equality
+
+**Files:**
+- Modify: `apps/web/src/hooks/useMiniNavConfig.ts`
+- Modify: `apps/web/src/hooks/__tests__/useMiniNavConfig.test.tsx` (add regression test)
+
+- [ ] **Step 1: Write failing regression test**
+
+Add a new test to `apps/web/src/hooks/__tests__/useMiniNavConfig.test.tsx` at the end of the describe block, BEFORE modifying the hook:
+
+```typescript
+  it('does not re-trigger setConfig when rerendered with equivalent inline config', () => {
+    const setConfigSpy = vi.spyOn(useMiniNavConfigStore.getState(), 'setConfig');
+
+    const { rerender } = renderHook(() =>
+      useMiniNavConfig({
+        breadcrumb: 'Home',
+        tabs: [{ id: 'a', label: 'A', href: '/' }],
+        activeTabId: 'a',
+      })
+    );
+
+    const initialCallCount = setConfigSpy.mock.calls.length;
+    // Simulate a page re-render with a new inline object that has equivalent content
+    rerender();
+    const finalCallCount = setConfigSpy.mock.calls.length;
+
+    // setConfig should NOT be called on the equivalent rerender
+    expect(finalCallCount).toBe(initialCallCount);
+    setConfigSpy.mockRestore();
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/hooks/__tests__/useMiniNavConfig.test.tsx`
+Expected: the new test FAILS — `setConfig` is called twice (initial mount + rerender).
+
+- [ ] **Step 3: Fix the hook with shallow-compare stability**
+
+Replace the contents of `apps/web/src/hooks/useMiniNavConfig.ts` with:
+
+```typescript
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+import { useMiniNavConfigStore, type MiniNavConfig } from '@/lib/stores/mini-nav-config-store';
+
+/**
+ * Pages call this hook to register their mini-nav config with the global shell.
+ * The shell reads the store and renders MiniNavSlot automatically.
+ * Config is cleared on unmount (so navigating away hides the mini-nav).
+ *
+ * Shallow equality check on the config primitive fields prevents
+ * re-registration loops when consumers pass inline object literals.
+ * (Carry-forward fix M3 from Phase 1 code review.)
+ */
+export function useMiniNavConfig(config: MiniNavConfig): void {
+  const setConfig = useMiniNavConfigStore(s => s.setConfig);
+  const clear = useMiniNavConfigStore(s => s.clear);
+  const previousKeyRef = useRef<string | null>(null);
+
+  // Build a stable structural key from the config's observable fields.
+  // Tabs and primaryAction are part of the identity; onClick is excluded
+  // because function references change between renders but rarely carry
+  // meaning independent of the breadcrumb/activeTabId.
+  const key = JSON.stringify({
+    breadcrumb: config.breadcrumb,
+    activeTabId: config.activeTabId,
+    tabs: config.tabs,
+    primaryActionLabel: config.primaryAction?.label ?? null,
+    primaryActionIcon: config.primaryAction?.icon ?? null,
+  });
+
+  useEffect(() => {
+    if (previousKeyRef.current === key) return; // shallow equality: skip redundant updates
+    previousKeyRef.current = key;
+    setConfig(config);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, setConfig]);
+
+  // Separate effect for unmount cleanup — runs once, clears on teardown.
+  useEffect(() => {
+    return () => {
+      clear();
+      previousKeyRef.current = null;
+    };
+  }, [clear]);
+}
+```
+
+- [ ] **Step 4: Run tests to verify all pass**
+
+Run: `cd apps/web && pnpm vitest run src/hooks/__tests__/useMiniNavConfig.test.tsx`
+Expected: all 4 tests pass (3 original + 1 new regression test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/hooks/useMiniNavConfig.ts apps/web/src/hooks/__tests__/useMiniNavConfig.test.tsx
+git commit -m "fix(web): stabilize useMiniNavConfig with shallow equality (M3 from phase 1 review)"
+```
+
+---
+
+## Task 3: M4 — Tighten MiniNavPrimaryAction.icon type + M6 hand rail expand wiring
+
+**Files:**
+- Modify: `apps/web/src/lib/stores/mini-nav-config-store.ts`
+- Modify: `apps/web/src/components/layout/UserShell/v2/MiniNavSlot.tsx`
+- Modify: `apps/web/src/components/layout/UserShell/v2/DesktopHandRail.tsx`
+
+- [ ] **Step 1: Update the store type**
+
+Edit `apps/web/src/lib/stores/mini-nav-config-store.ts` — update the `MiniNavPrimaryAction` interface:
+
+```typescript
+export interface MiniNavPrimaryAction {
+  label: string;
+  onClick: () => void;
+  /**
+   * Optional emoji or icon character prepended to the label.
+   * Keep it short — single emoji or ASCII symbol (e.g. '＋', '🎲', '▶').
+   * For complex icons, render them in the label text itself.
+   */
+  icon?: string;
+}
+```
+
+- [ ] **Step 2: Render the icon in MiniNavSlot**
+
+Edit `apps/web/src/components/layout/UserShell/v2/MiniNavSlot.tsx` — update the primary action button to render the icon:
+
+```typescript
+{config.primaryAction && (
+  <button
+    type="button"
+    onClick={config.primaryAction.onClick}
+    className="px-3.5 py-2 rounded-[10px] text-[0.78rem] font-bold text-white border-none cursor-pointer flex items-center gap-1.5 transition-all hover:-translate-y-px"
+    style={{
+      background: 'linear-gradient(135deg, hsl(25 95% 48%), hsl(25 95% 40%))',
+      boxShadow: '0 2px 6px hsla(25, 95%, 45%, 0.3)',
+    }}
+  >
+    {config.primaryAction.icon && <span aria-hidden>{config.primaryAction.icon}</span>}
+    {config.primaryAction.label}
+  </button>
+)}
+```
+
+- [ ] **Step 3: Wire isExpanded in DesktopHandRail**
+
+Edit `apps/web/src/components/layout/UserShell/v2/DesktopHandRail.tsx` — replace the hardcoded `w-[76px]` with a conditional and add a TODO-removal note:
+
+Find:
+```tsx
+<aside
+  data-testid="desktop-hand-rail"
+  aria-label="Cards in hand"
+  className="hidden md:flex flex-col w-[76px] shrink-0 border-r border-[var(--nh-border-default)] py-3.5 pb-3 gap-2"
+```
+
+Replace with:
+```tsx
+<aside
+  data-testid="desktop-hand-rail"
+  aria-label="Cards in hand"
+  data-expanded={isExpanded}
+  className={cn(
+    'hidden md:flex flex-col shrink-0 border-r border-[var(--nh-border-default)] py-3.5 pb-3 gap-2 transition-[width] duration-200 ease-out',
+    isExpanded ? 'w-[220px]' : 'w-[76px]'
+  )}
+```
+
+Add `import { cn } from '@/lib/utils';` to the imports if not already present.
+
+- [ ] **Step 4: Update existing DesktopHandRail test**
+
+Edit `apps/web/src/components/layout/UserShell/v2/__tests__/DesktopHandRail.test.tsx` — keep the `w-[76px]` default test but relax it to accept either class OR add a new test for expanded state. Replace the existing "is 76px wide by default" test with:
+
+```typescript
+  it('is 76px wide when collapsed (default)', () => {
+    const { container } = render(<DesktopHandRail />);
+    const rail = container.querySelector('[data-testid="desktop-hand-rail"]');
+    expect(rail).toHaveClass('w-[76px]');
+    expect(rail).toHaveAttribute('data-expanded', 'false');
+  });
+```
+
+Add a new test after it:
+
+```typescript
+  it('expands to 220px when toggle is clicked', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<DesktopHandRail />);
+    const expandBtn = screen.getByRole('button', { name: /expand/i });
+    await user.click(expandBtn);
+    const rail = container.querySelector('[data-testid="desktop-hand-rail"]');
+    expect(rail).toHaveClass('w-[220px]');
+    expect(rail).toHaveAttribute('data-expanded', 'true');
+  });
+```
+
+Add imports if missing:
+```typescript
+import userEvent from '@testing-library/user-event';
+import { screen } from '@testing-library/react';
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/v2/__tests__/DesktopHandRail.test.tsx src/components/layout/UserShell/v2/__tests__/MiniNavSlot.test.tsx`
+Expected: all tests pass.
+
+- [ ] **Step 6: Typecheck**
+
+Run: `cd apps/web && pnpm typecheck`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/lib/stores/mini-nav-config-store.ts apps/web/src/components/layout/UserShell/v2/MiniNavSlot.tsx apps/web/src/components/layout/UserShell/v2/DesktopHandRail.tsx apps/web/src/components/layout/UserShell/v2/__tests__/DesktopHandRail.test.tsx
+git commit -m "feat(web): wire hand rail expand + clarify primary action icon (M4, M6 from phase 1 review)"
+```
+
+---
+
+## Task 4: GreetingRow section
+
+**Files:**
+- Create: `apps/web/src/app/(authenticated)/dashboard/v2/sections/GreetingRow.tsx`
+- Test: `apps/web/src/app/(authenticated)/dashboard/v2/__tests__/GreetingRow.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/app/(authenticated)/dashboard/v2/__tests__/GreetingRow.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { GreetingRow } from '../sections/GreetingRow';
+
+describe('GreetingRow', () => {
+  it('renders the greeting with user display name', () => {
+    render(
+      <GreetingRow
+        displayName="Marco"
+        subtitle="Hai una partita in corso"
+        stats={[
+          { label: 'Partite mese', value: '24' },
+          { label: 'Win rate', value: '68%' },
+          { label: 'Tempo gioco', value: '42h' },
+        ]}
+      />
+    );
+    expect(screen.getByText(/Ciao/)).toBeInTheDocument();
+    expect(screen.getByText('Marco')).toBeInTheDocument();
+    expect(screen.getByText('Hai una partita in corso')).toBeInTheDocument();
+  });
+
+  it('renders all provided quick stats', () => {
+    render(
+      <GreetingRow
+        displayName="Anna"
+        subtitle="subtitle"
+        stats={[
+          { label: 'Partite mese', value: '24' },
+          { label: 'Win rate', value: '68%' },
+        ]}
+      />
+    );
+    expect(screen.getByText('24')).toBeInTheDocument();
+    expect(screen.getByText('Partite mese')).toBeInTheDocument();
+    expect(screen.getByText('68%')).toBeInTheDocument();
+    expect(screen.getByText('Win rate')).toBeInTheDocument();
+  });
+
+  it('omits the stats cluster when no stats provided', () => {
+    const { container } = render(
+      <GreetingRow displayName="X" subtitle="Y" stats={[]} />
+    );
+    expect(container.querySelector('[data-testid="greet-stats"]')).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/app/(authenticated)/dashboard/v2/__tests__/GreetingRow.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement GreetingRow**
+
+Create `apps/web/src/app/(authenticated)/dashboard/v2/sections/GreetingRow.tsx`:
+
+```typescript
+'use client';
+
+export interface GreetingStat {
+  label: string;
+  value: string;
+}
+
+interface GreetingRowProps {
+  displayName: string;
+  subtitle: string;
+  stats: GreetingStat[];
+}
+
+/**
+ * Phase 2 dashboard greeting row: "Ciao {name}" with gradient wordmark on the name,
+ * subtitle underneath, and a right-aligned cluster of quick stats.
+ */
+export function GreetingRow({ displayName, subtitle, stats }: GreetingRowProps) {
+  return (
+    <div className="mb-6 flex items-end justify-between gap-6">
+      <div>
+        <h1 className="font-quicksand text-[1.8rem] font-extrabold leading-tight text-[var(--nh-text-primary)]">
+          Ciao{' '}
+          <span
+            className="bg-clip-text text-transparent"
+            style={{
+              backgroundImage:
+                'linear-gradient(135deg, hsl(25 95% 48%), hsl(38 92% 55%))',
+            }}
+          >
+            {displayName}
+          </span>{' '}
+          <span aria-hidden>👋</span>
+        </h1>
+        <p className="mt-1 text-sm text-[var(--nh-text-muted)]">{subtitle}</p>
+      </div>
+      {stats.length > 0 && (
+        <div data-testid="greet-stats" className="flex gap-5">
+          {stats.map(stat => (
+            <div key={stat.label} className="text-right">
+              <div className="font-quicksand text-[1.35rem] font-extrabold leading-none text-[var(--nh-text-primary)]">
+                {stat.value}
+              </div>
+              <div className="mt-1 text-[0.68rem] font-bold uppercase tracking-wider text-[var(--nh-text-muted)]">
+                {stat.label}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/app/(authenticated)/dashboard/v2/__tests__/GreetingRow.test.tsx`
+Expected: PASS — 3 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/\(authenticated\)/dashboard/v2/sections/GreetingRow.tsx apps/web/src/app/\(authenticated\)/dashboard/v2/__tests__/GreetingRow.test.tsx
+git commit -m "feat(web): add Phase 2 dashboard GreetingRow section"
+```
+
+---
+
+## Task 5: KpiStrip section (using existing StatCard showcase component)
+
+**Files:**
+- Create: `apps/web/src/app/(authenticated)/dashboard/v2/sections/KpiStrip.tsx`
+- Test: `apps/web/src/app/(authenticated)/dashboard/v2/__tests__/KpiStrip.test.tsx`
+
+- [ ] **Step 1: Verify StatCard component location**
+
+Run: `find apps/web/src/components -name "stat-card*" -o -name "StatCard*"`
+Expected: find the existing StatCard component path (likely `apps/web/src/components/ui/data-display/stat-card.tsx` or similar). If found, import from there. If not found, STOP and report NEEDS_CONTEXT.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `apps/web/src/app/(authenticated)/dashboard/v2/__tests__/KpiStrip.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { KpiStrip } from '../sections/KpiStrip';
+
+describe('KpiStrip', () => {
+  const kpis = {
+    games: 47,
+    sessions: 128,
+    friends: 8,
+    chats: 36,
+  };
+
+  it('renders all 4 KPI values', () => {
+    render(<KpiStrip kpis={kpis} />);
+    expect(screen.getByText('47')).toBeInTheDocument();
+    expect(screen.getByText('128')).toBeInTheDocument();
+    expect(screen.getByText('8')).toBeInTheDocument();
+    expect(screen.getByText('36')).toBeInTheDocument();
+  });
+
+  it('renders all 4 KPI labels', () => {
+    render(<KpiStrip kpis={kpis} />);
+    expect(screen.getByText(/libreria/i)).toBeInTheDocument();
+    expect(screen.getByText(/sessioni/i)).toBeInTheDocument();
+    expect(screen.getByText(/amici/i)).toBeInTheDocument();
+    expect(screen.getByText(/chat/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/app/(authenticated)/dashboard/v2/__tests__/KpiStrip.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 4: Implement KpiStrip**
+
+Create `apps/web/src/app/(authenticated)/dashboard/v2/sections/KpiStrip.tsx`:
+
+```typescript
+'use client';
+
+export interface KpiValues {
+  games: number;
+  sessions: number;
+  friends: number;
+  chats: number;
+}
+
+interface KpiStripProps {
+  kpis: KpiValues;
+}
+
+interface KpiCardData {
+  key: keyof KpiValues;
+  label: string;
+  icon: string;
+  entity: 'game' | 'session' | 'player' | 'chat';
+}
+
+const CARDS: KpiCardData[] = [
+  { key: 'games', label: 'Giochi in libreria', icon: '🎲', entity: 'game' },
+  { key: 'sessions', label: 'Sessioni totali', icon: '🎯', entity: 'session' },
+  { key: 'friends', label: 'Amici preferiti', icon: '👥', entity: 'player' },
+  { key: 'chats', label: 'Chat con agente', icon: '💬', entity: 'chat' },
+];
+
+const ENTITY_BG: Record<KpiCardData['entity'], string> = {
+  game: 'hsla(25, 95%, 45%, 0.12)',
+  session: 'hsla(240, 60%, 55%, 0.12)',
+  player: 'hsla(262, 83%, 58%, 0.12)',
+  chat: 'hsla(220, 80%, 55%, 0.12)',
+};
+const ENTITY_FG: Record<KpiCardData['entity'], string> = {
+  game: 'hsl(25 95% 38%)',
+  session: 'hsl(240 60% 45%)',
+  player: 'hsl(262 83% 50%)',
+  chat: 'hsl(220 80% 45%)',
+};
+
+export function KpiStrip({ kpis }: KpiStripProps) {
+  return (
+    <div className="mb-7 grid grid-cols-4 gap-3.5">
+      {CARDS.map(card => (
+        <div
+          key={card.key}
+          className="relative overflow-hidden rounded-2xl border border-[var(--nh-border-default)] bg-[var(--nh-bg-elevated)] p-5 shadow-[var(--shadow-warm-sm)] transition-all duration-300 hover:-translate-y-0.5 hover:shadow-[var(--shadow-warm-md)]"
+        >
+          <div
+            className="mb-3 flex h-10 w-10 items-center justify-center rounded-xl text-lg"
+            style={{ background: ENTITY_BG[card.entity], color: ENTITY_FG[card.entity] }}
+            aria-hidden
+          >
+            {card.icon}
+          </div>
+          <div className="text-[0.7rem] font-bold uppercase tracking-wider text-[var(--nh-text-muted)]">
+            {card.label}
+          </div>
+          <div className="mt-1 font-quicksand text-2xl font-extrabold leading-none text-[var(--nh-text-primary)]">
+            {kpis[card.key]}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/app/(authenticated)/dashboard/v2/__tests__/KpiStrip.test.tsx`
+Expected: PASS — 2 tests passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/app/\(authenticated\)/dashboard/v2/sections/KpiStrip.tsx apps/web/src/app/\(authenticated\)/dashboard/v2/__tests__/KpiStrip.test.tsx
+git commit -m "feat(web): add Phase 2 dashboard KpiStrip section"
+```
+
+---
+
+## Task 6: HeroLiveSession section
+
+**Files:**
+- Create: `apps/web/src/app/(authenticated)/dashboard/v2/sections/HeroLiveSession.tsx`
+- Test: `apps/web/src/app/(authenticated)/dashboard/v2/__tests__/HeroLiveSession.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/app/(authenticated)/dashboard/v2/__tests__/HeroLiveSession.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+
+import { HeroLiveSession } from '../sections/HeroLiveSession';
+
+describe('HeroLiveSession', () => {
+  const baseSession = {
+    id: 'ses-1',
+    gameName: 'Azul',
+    locationName: 'Casa di Marco',
+    playerCount: 3,
+    roundCurrent: 4,
+    roundTotal: 6,
+    startedMinutesAgo: 38,
+  };
+
+  it('renders the session title and meta when a session is active', () => {
+    render(<HeroLiveSession session={baseSession} onContinue={() => {}} />);
+    expect(screen.getByText(/Serata Azul/)).toBeInTheDocument();
+    expect(screen.getByText(/Casa di Marco/)).toBeInTheDocument();
+    expect(screen.getByText(/In corso/i)).toBeInTheDocument();
+  });
+
+  it('calls onContinue when the primary action is clicked', async () => {
+    const onContinue = vi.fn();
+    const user = userEvent.setup();
+    render(<HeroLiveSession session={baseSession} onContinue={onContinue} />);
+    await user.click(screen.getByRole('button', { name: /Continua/i }));
+    expect(onContinue).toHaveBeenCalledOnce();
+  });
+
+  it('renders the empty state when no active session', () => {
+    render(<HeroLiveSession session={null} onContinue={() => {}} />);
+    expect(screen.getByText(/Nessuna partita/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Inizia nuova partita/i })).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/app/(authenticated)/dashboard/v2/__tests__/HeroLiveSession.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement HeroLiveSession**
+
+Create `apps/web/src/app/(authenticated)/dashboard/v2/sections/HeroLiveSession.tsx`:
+
+```typescript
+'use client';
+
+export interface LiveSessionPreview {
+  id: string;
+  gameName: string;
+  locationName: string;
+  playerCount: number;
+  roundCurrent: number;
+  roundTotal: number;
+  startedMinutesAgo: number;
+}
+
+interface HeroLiveSessionProps {
+  session: LiveSessionPreview | null;
+  onContinue: () => void;
+}
+
+export function HeroLiveSession({ session, onContinue }: HeroLiveSessionProps) {
+  if (!session) {
+    return (
+      <div
+        className="mb-6 flex min-h-[180px] items-center justify-between gap-6 overflow-hidden rounded-3xl border border-[var(--nh-border-default)] bg-[var(--nh-bg-elevated)] p-8 shadow-[var(--shadow-warm-sm)]"
+      >
+        <div>
+          <h2 className="font-quicksand text-xl font-extrabold text-[var(--nh-text-primary)]">
+            Nessuna partita in corso
+          </h2>
+          <p className="mt-1 text-sm text-[var(--nh-text-muted)]">
+            Pronto per una nuova serata di gioco?
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onContinue}
+          className="rounded-xl px-5 py-3 font-nunito text-sm font-bold text-white transition-all hover:-translate-y-0.5"
+          style={{
+            background: 'linear-gradient(135deg, hsl(25 95% 48%), hsl(25 95% 40%))',
+            boxShadow: '0 2px 8px hsla(25, 95%, 45%, 0.35)',
+          }}
+        >
+          ▶ Inizia nuova partita
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="group relative mb-6 flex min-h-[220px] cursor-pointer gap-0 overflow-hidden rounded-3xl border border-[var(--nh-border-default)] shadow-[var(--shadow-warm-md)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[var(--shadow-warm-xl)]"
+      style={{
+        background:
+          'linear-gradient(135deg, hsla(240,60%,55%,0.12), hsla(262,83%,58%,0.08)), var(--nh-bg-elevated)',
+      }}
+      onClick={onContinue}
+      role="button"
+      tabIndex={0}
+      onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onContinue();
+        }
+      }}
+    >
+      <div
+        aria-hidden
+        className="absolute left-0 top-0 bottom-0 w-[5px] z-10"
+        style={{ background: 'hsl(240 60% 55%)' }}
+      />
+      <div
+        className="relative hidden md:flex w-[300px] shrink-0 items-center justify-center text-[80px] overflow-hidden"
+        style={{
+          background: 'linear-gradient(135deg, hsl(240 55% 65%), hsl(262 80% 55%))',
+        }}
+        aria-hidden
+      >
+        🎯
+      </div>
+      <div className="relative z-[2] flex flex-1 flex-col justify-between p-7 md:p-8">
+        <div>
+          <span
+            className="mb-2.5 inline-flex w-fit items-center gap-1.5 rounded-md px-2.5 py-1 font-quicksand text-[10px] font-extrabold uppercase tracking-wider text-white"
+            style={{ background: 'hsl(240 60% 55%)' }}
+          >
+            🎯 Session
+          </span>
+          <h2 className="mb-1.5 font-quicksand text-[1.75rem] font-extrabold leading-tight text-[var(--nh-text-primary)]">
+            Serata {session.gameName} · {session.locationName}
+          </h2>
+          <p className="mb-3.5 text-[0.92rem] text-[var(--nh-text-secondary)]">
+            {session.playerCount} giocatori · round {session.roundCurrent} di {session.roundTotal} · iniziata {session.startedMinutesAgo} min fa
+          </p>
+        </div>
+        <div className="flex gap-2.5">
+          <button
+            type="button"
+            onClick={e => {
+              e.stopPropagation();
+              onContinue();
+            }}
+            className="rounded-xl px-5 py-2.5 font-nunito text-[0.82rem] font-bold text-white transition-all hover:-translate-y-0.5"
+            style={{
+              background: 'linear-gradient(135deg, hsl(240 60% 55%), hsl(240 60% 42%))',
+              boxShadow: '0 2px 8px hsla(240, 60%, 55%, 0.35)',
+            }}
+          >
+            ▶ Continua partita
+          </button>
+        </div>
+      </div>
+      <div
+        className="absolute right-7 top-6 flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-nunito text-[0.7rem] font-extrabold uppercase tracking-wider"
+        style={{
+          background: 'hsla(140, 60%, 45%, 0.12)',
+          borderColor: 'hsla(140, 60%, 45%, 0.25)',
+          color: 'hsl(140 60% 30%)',
+        }}
+      >
+        <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full" style={{ background: 'hsl(140 60% 45%)' }} />
+        In corso
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/app/(authenticated)/dashboard/v2/__tests__/HeroLiveSession.test.tsx`
+Expected: PASS — 3 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/\(authenticated\)/dashboard/v2/sections/HeroLiveSession.tsx apps/web/src/app/\(authenticated\)/dashboard/v2/__tests__/HeroLiveSession.test.tsx
+git commit -m "feat(web): add Phase 2 dashboard HeroLiveSession section"
+```
+
+---
+
+## Task 7: ContinueCarousel section
+
+**Files:**
+- Create: `apps/web/src/app/(authenticated)/dashboard/v2/sections/ContinueCarousel.tsx`
+- Test: `apps/web/src/app/(authenticated)/dashboard/v2/__tests__/ContinueCarousel.test.tsx`
+
+- [ ] **Step 1: Check MeepleCard export location**
+
+Run: `find apps/web/src/components/ui/data-display/meeple-card -name "index.ts" -maxdepth 2`
+Confirm the public `MeepleCard` export exists, plus `GridCard` variant. The barrel is at `apps/web/src/components/ui/data-display/meeple-card/index.ts`. Verify by running `cat apps/web/src/components/ui/data-display/meeple-card/index.ts`.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `apps/web/src/app/(authenticated)/dashboard/v2/__tests__/ContinueCarousel.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { ContinueCarousel } from '../sections/ContinueCarousel';
+
+describe('ContinueCarousel', () => {
+  const games = [
+    {
+      id: 'g1',
+      title: 'Azul',
+      subtitle: 'Plan B Games',
+      imageUrl: 'https://example.com/azul.jpg',
+      rating: 7.8,
+      players: '2–4',
+      duration: '45m',
+    },
+    {
+      id: 'g2',
+      title: 'Wingspan',
+      subtitle: 'Stonemaier',
+      rating: 8.1,
+      players: '1–5',
+      duration: '70m',
+    },
+  ];
+
+  it('renders the section header and see-all link', () => {
+    render(<ContinueCarousel games={games} />);
+    expect(screen.getByText(/Continua a giocare/i)).toBeInTheDocument();
+    expect(screen.getByText(/Vedi tutto/i)).toBeInTheDocument();
+  });
+
+  it('renders all provided games as cards', () => {
+    render(<ContinueCarousel games={games} />);
+    expect(screen.getByText('Azul')).toBeInTheDocument();
+    expect(screen.getByText('Wingspan')).toBeInTheDocument();
+  });
+
+  it('renders nothing (empty message) when no games', () => {
+    render(<ContinueCarousel games={[]} />);
+    expect(screen.queryByText(/Continua a giocare/i)).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/app/(authenticated)/dashboard/v2/__tests__/ContinueCarousel.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 4: Implement ContinueCarousel**
+
+Create `apps/web/src/app/(authenticated)/dashboard/v2/sections/ContinueCarousel.tsx`:
+
+```typescript
+'use client';
+
+import Link from 'next/link';
+
+import { MeepleCard } from '@/components/ui/data-display/meeple-card';
+
+export interface ContinueCarouselGame {
+  id: string;
+  title: string;
+  subtitle?: string;
+  imageUrl?: string;
+  rating?: number;
+  players?: string;
+  duration?: string;
+}
+
+interface ContinueCarouselProps {
+  games: ContinueCarouselGame[];
+}
+
+export function ContinueCarousel({ games }: ContinueCarouselProps) {
+  if (games.length === 0) return null;
+
+  return (
+    <section className="mb-7">
+      <div className="mb-3.5 flex items-center justify-between">
+        <h3 className="flex items-center gap-3 font-quicksand text-[1.1rem] font-extrabold">
+          <span
+            aria-hidden
+            className="inline-block h-[18px] w-1 rounded-sm"
+            style={{ background: 'hsl(25 95% 45%)' }}
+          />
+          Continua a giocare
+        </h3>
+        <Link
+          href="/library"
+          className="rounded-lg px-3 py-1.5 text-[0.78rem] font-bold text-[hsl(25_95%_40%)] transition-colors hover:bg-[hsla(25,95%,45%,0.08)]"
+        >
+          Vedi tutto →
+        </Link>
+      </div>
+      <div className="grid grid-cols-5 gap-4">
+        {games.slice(0, 5).map(game => (
+          <MeepleCard
+            key={game.id}
+            variant="grid"
+            entity="game"
+            title={game.title}
+            subtitle={game.subtitle}
+            imageUrl={game.imageUrl}
+            rating={game.rating}
+            metadata={[
+              ...(game.players ? [{ icon: '👥' as const, label: game.players }] : []),
+              ...(game.duration ? [{ icon: '⏱' as const, label: game.duration }] : []),
+            ]}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+```
+
+**Note on MeepleCard props:** The real `MeepleCard` component's `metadata` prop shape may differ. If the test fails because of mismatched types, consult `apps/web/src/components/ui/data-display/meeple-card/types.ts` and align the `metadata` entry shape. Fall back to omitting `metadata` and rendering chips inline if the type is incompatible.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/app/(authenticated)/dashboard/v2/__tests__/ContinueCarousel.test.tsx`
+Expected: PASS — 3 tests passing.
+
+If the test FAILS due to `MeepleCard` prop mismatch, STOP and report NEEDS_CONTEXT with the actual `MeepleCardProps` type.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/app/\(authenticated\)/dashboard/v2/sections/ContinueCarousel.tsx apps/web/src/app/\(authenticated\)/dashboard/v2/__tests__/ContinueCarousel.test.tsx
+git commit -m "feat(web): add Phase 2 dashboard ContinueCarousel section"
+```
+
+---
+
+## Task 8: ChatRecentCards section
+
+**Files:**
+- Create: `apps/web/src/app/(authenticated)/dashboard/v2/sections/ChatRecentCards.tsx`
+- Test: `apps/web/src/app/(authenticated)/dashboard/v2/__tests__/ChatRecentCards.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/app/(authenticated)/dashboard/v2/__tests__/ChatRecentCards.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { ChatRecentCards } from '../sections/ChatRecentCards';
+
+describe('ChatRecentCards', () => {
+  const chats = [
+    {
+      id: 'c1',
+      gameName: 'Azul',
+      topic: 'Regola turno finale',
+      snippet: 'Il turno finale inizia quando un giocatore completa una riga orizzontale.',
+      confidence: 0.94,
+      timestamp: 'Oggi, 14:32',
+    },
+    {
+      id: 'c2',
+      gameName: 'Wingspan',
+      topic: 'Carte bonus a fine partita',
+      snippet: 'Le carte bonus vengono rivelate solo alla fine della partita.',
+      confidence: 0.98,
+      timestamp: 'Ieri, 21:15',
+    },
+  ];
+
+  it('renders the section header', () => {
+    render(<ChatRecentCards chats={chats} />);
+    expect(screen.getByText(/Chat recenti/i)).toBeInTheDocument();
+  });
+
+  it('renders all chat cards with titles and snippets', () => {
+    render(<ChatRecentCards chats={chats} />);
+    expect(screen.getByText('Azul · Regola turno finale')).toBeInTheDocument();
+    expect(screen.getByText('Wingspan · Carte bonus a fine partita')).toBeInTheDocument();
+    expect(screen.getAllByText(/accurata/i)).toHaveLength(2);
+  });
+
+  it('renders nothing when no chats', () => {
+    const { container } = render(<ChatRecentCards chats={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/app/(authenticated)/dashboard/v2/__tests__/ChatRecentCards.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement ChatRecentCards**
+
+Create `apps/web/src/app/(authenticated)/dashboard/v2/sections/ChatRecentCards.tsx`:
+
+```typescript
+'use client';
+
+import Link from 'next/link';
+
+export interface ChatRecentPreview {
+  id: string;
+  gameName: string;
+  topic: string;
+  snippet: string;
+  confidence: number;
+  timestamp: string;
+}
+
+interface ChatRecentCardsProps {
+  chats: ChatRecentPreview[];
+}
+
+function formatConfidence(score: number): string {
+  return `✓ ${Math.round(score * 100)}% accurata`;
+}
+
+export function ChatRecentCards({ chats }: ChatRecentCardsProps) {
+  if (chats.length === 0) return null;
+
+  return (
+    <section className="mb-7">
+      <div className="mb-3.5 flex items-center justify-between">
+        <h3 className="flex items-center gap-3 font-quicksand text-[1.1rem] font-extrabold">
+          <span
+            aria-hidden
+            className="inline-block h-[18px] w-1 rounded-sm"
+            style={{ background: 'hsl(220 80% 55%)' }}
+          />
+          Chat recenti con l'agente
+        </h3>
+        <Link
+          href="/chat"
+          className="rounded-lg px-3 py-1.5 text-[0.78rem] font-bold text-[hsl(25_95%_40%)] transition-colors hover:bg-[hsla(25,95%,45%,0.08)]"
+        >
+          Vedi tutto →
+        </Link>
+      </div>
+      <div className="grid grid-cols-3 gap-4">
+        {chats.slice(0, 3).map(chat => (
+          <div
+            key={chat.id}
+            className="relative flex min-h-[140px] cursor-pointer flex-col gap-3 overflow-hidden rounded-[20px] border border-[var(--nh-border-default)] bg-[var(--nh-bg-elevated)] p-5 shadow-[var(--shadow-warm-sm)] transition-all duration-300 hover:-translate-y-0.5 hover:shadow-[var(--shadow-warm-md)]"
+          >
+            <span
+              aria-hidden
+              className="absolute left-0 top-0 bottom-0 w-1"
+              style={{ background: 'hsl(220 80% 55%)' }}
+            />
+            <div className="flex items-center gap-2.5">
+              <div
+                className="flex h-[38px] w-[38px] items-center justify-center rounded-[10px] text-lg"
+                style={{ background: 'linear-gradient(135deg, hsl(220 72% 72%), hsl(220 80% 55%))' }}
+                aria-hidden
+              >
+                💬
+              </div>
+              <div className="font-quicksand text-[0.88rem] font-extrabold leading-tight">
+                {chat.gameName} · {chat.topic}
+              </div>
+            </div>
+            <p className="line-clamp-2 text-[0.78rem] text-[var(--nh-text-secondary)]">
+              {chat.snippet}
+            </p>
+            <div className="mt-auto flex items-center justify-between">
+              <span
+                className="inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 font-nunito text-[0.68rem] font-extrabold uppercase tracking-wider"
+                style={{
+                  background: 'hsla(140, 60%, 45%, 0.12)',
+                  color: 'hsl(140 60% 30%)',
+                }}
+              >
+                {formatConfidence(chat.confidence)}
+              </span>
+              <span className="text-[0.7rem] font-semibold text-[var(--nh-text-muted)]">
+                {chat.timestamp}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/app/(authenticated)/dashboard/v2/__tests__/ChatRecentCards.test.tsx`
+Expected: PASS — 3 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/\(authenticated\)/dashboard/v2/sections/ChatRecentCards.tsx apps/web/src/app/\(authenticated\)/dashboard/v2/__tests__/ChatRecentCards.test.tsx
+git commit -m "feat(web): add Phase 2 dashboard ChatRecentCards section"
+```
+
+---
+
+## Task 9: FriendsRow section
+
+**Files:**
+- Create: `apps/web/src/app/(authenticated)/dashboard/v2/sections/FriendsRow.tsx`
+- Test: `apps/web/src/app/(authenticated)/dashboard/v2/__tests__/FriendsRow.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/app/(authenticated)/dashboard/v2/__tests__/FriendsRow.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { FriendsRow } from '../sections/FriendsRow';
+
+describe('FriendsRow', () => {
+  const friends = [
+    { id: 'f1', name: 'Luca Marconi', status: 'Sta giocando Azul', presence: 'online' as const },
+    { id: 'f2', name: 'Sara Vitali', status: 'Online · 12 giochi', presence: 'online' as const },
+    { id: 'f3', name: 'Giulia Bianchi', status: 'Inattiva da 2 ore', presence: 'idle' as const },
+    { id: 'f4', name: 'Alessandro Rossi', status: 'Offline · ieri', presence: 'offline' as const },
+  ];
+
+  it('renders the section header', () => {
+    render(<FriendsRow friends={friends} />);
+    expect(screen.getByText(/Amici attivi/i)).toBeInTheDocument();
+  });
+
+  it('renders all 4 friends', () => {
+    render(<FriendsRow friends={friends} />);
+    expect(screen.getByText('Luca Marconi')).toBeInTheDocument();
+    expect(screen.getByText('Sara Vitali')).toBeInTheDocument();
+    expect(screen.getByText('Giulia Bianchi')).toBeInTheDocument();
+    expect(screen.getByText('Alessandro Rossi')).toBeInTheDocument();
+  });
+
+  it('renders initials from the name', () => {
+    render(<FriendsRow friends={[friends[0]]} />);
+    expect(screen.getByText('LM')).toBeInTheDocument();
+  });
+
+  it('renders nothing when empty', () => {
+    const { container } = render(<FriendsRow friends={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/app/(authenticated)/dashboard/v2/__tests__/FriendsRow.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement FriendsRow**
+
+Create `apps/web/src/app/(authenticated)/dashboard/v2/sections/FriendsRow.tsx`:
+
+```typescript
+'use client';
+
+import Link from 'next/link';
+
+export interface FriendPreview {
+  id: string;
+  name: string;
+  status: string;
+  presence: 'online' | 'idle' | 'offline';
+}
+
+interface FriendsRowProps {
+  friends: FriendPreview[];
+}
+
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .map(part => part[0] ?? '')
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+const PRESENCE_BG: Record<FriendPreview['presence'], string> = {
+  online: 'hsl(140 60% 45%)',
+  idle: 'hsl(38 92% 55%)',
+  offline: '#cbd5e1',
+};
+
+export function FriendsRow({ friends }: FriendsRowProps) {
+  if (friends.length === 0) return null;
+
+  return (
+    <section className="mb-7">
+      <div className="mb-3.5 flex items-center justify-between">
+        <h3 className="flex items-center gap-3 font-quicksand text-[1.1rem] font-extrabold">
+          <span
+            aria-hidden
+            className="inline-block h-[18px] w-1 rounded-sm"
+            style={{ background: 'hsl(262 83% 58%)' }}
+          />
+          Amici attivi
+        </h3>
+        <Link
+          href="/players"
+          className="rounded-lg px-3 py-1.5 text-[0.78rem] font-bold text-[hsl(25_95%_40%)] transition-colors hover:bg-[hsla(25,95%,45%,0.08)]"
+        >
+          Vedi tutto →
+        </Link>
+      </div>
+      <div className="grid grid-cols-4 gap-3">
+        {friends.slice(0, 4).map(friend => (
+          <div
+            key={friend.id}
+            className="relative flex cursor-pointer items-center gap-2.5 rounded-xl border border-[var(--nh-border-default)] bg-[rgba(255,252,248,0.8)] px-3.5 py-2.5 transition-all duration-200 hover:translate-x-0.5 hover:bg-white hover:shadow-[var(--shadow-warm-sm)]"
+          >
+            <span
+              aria-hidden
+              className="absolute left-0 top-1/2 h-[60%] w-[3px] -translate-y-1/2 rounded-full"
+              style={{ background: 'hsl(262 83% 58%)' }}
+            />
+            <div
+              aria-hidden
+              className="flex h-[42px] w-[42px] shrink-0 items-center justify-center rounded-[10px] font-quicksand text-sm font-extrabold text-white"
+              style={{ background: 'linear-gradient(135deg, hsl(262 78% 75%), hsl(262 83% 55%))' }}
+            >
+              {initials(friend.name)}
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="font-quicksand text-[0.82rem] font-extrabold text-[var(--nh-text-primary)]">
+                {friend.name}
+              </div>
+              <div className="truncate text-[0.7rem] text-[var(--nh-text-muted)]">
+                {friend.status}
+              </div>
+            </div>
+            <span
+              aria-label={`Presence: ${friend.presence}`}
+              className="h-2 w-2 shrink-0 rounded-full"
+              style={{
+                background: PRESENCE_BG[friend.presence],
+                boxShadow: '0 0 0 2px rgba(255,255,255,0.9)',
+              }}
+            />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/app/(authenticated)/dashboard/v2/__tests__/FriendsRow.test.tsx`
+Expected: PASS — 4 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/\(authenticated\)/dashboard/v2/sections/FriendsRow.tsx apps/web/src/app/\(authenticated\)/dashboard/v2/__tests__/FriendsRow.test.tsx
+git commit -m "feat(web): add Phase 2 dashboard FriendsRow section"
+```
+
+---
+
+## Task 10: DashboardClientV2 composition + mini-nav registration
+
+**Files:**
+- Create: `apps/web/src/app/(authenticated)/dashboard/v2/DashboardClientV2.tsx`
+- Create: `apps/web/src/app/(authenticated)/dashboard/v2/index.ts`
+- Test: `apps/web/src/app/(authenticated)/dashboard/v2/__tests__/DashboardClientV2.test.tsx`
+
+- [ ] **Step 1: Inspect the existing dashboard data layer**
+
+Run: `cat apps/web/src/lib/stores/dashboard-store.ts | head -80` and `cat apps/web/src/app/(authenticated)/dashboard/dashboard-client.tsx | head -120`. Identify the data shape used by the existing dashboard (`SessionSummaryDto`, `TrendingGameDto`, `UserGameDto`, KPIs, live session).
+
+- [ ] **Step 2: Write the failing integration test**
+
+Create `apps/web/src/app/(authenticated)/dashboard/v2/__tests__/DashboardClientV2.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/dashboard',
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('@/components/auth/AuthProvider', () => ({
+  useAuth: () => ({
+    user: { id: 'u1', displayName: 'Marco' },
+  }),
+}));
+
+vi.mock('@/lib/stores/dashboard-store', () => ({
+  useDashboardStore: () => ({
+    totalGames: 47,
+    totalSessions: 128,
+    friendsCount: 8,
+    chatCount: 36,
+    activeLiveSession: null,
+    continuePlayingGames: [
+      { id: 'g1', title: 'Azul', subtitle: 'Plan B', rating: 7.8, players: '2–4', duration: '45m' },
+      { id: 'g2', title: 'Wingspan', subtitle: 'Stonemaier', rating: 8.1, players: '1–5', duration: '70m' },
+    ],
+    recentChats: [],
+    activeFriends: [],
+    loading: false,
+  }),
+}));
+
+vi.mock('@/stores/use-card-hand', () => {
+  const state = {
+    cards: [],
+    pinnedIds: new Set(),
+    drawCard: vi.fn(),
+    pinCard: vi.fn(),
+    unpinCard: vi.fn(),
+  };
+  return {
+    useCardHand: (selector?: (s: typeof state) => unknown) =>
+      selector ? selector(state) : state,
+  };
+});
+
+import { DashboardClientV2 } from '../DashboardClientV2';
+
+describe('DashboardClientV2', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the greeting with the user name', () => {
+    render(<DashboardClientV2 />);
+    expect(screen.getByText('Marco')).toBeInTheDocument();
+  });
+
+  it('renders the KPI strip with store values', () => {
+    render(<DashboardClientV2 />);
+    expect(screen.getByText('47')).toBeInTheDocument();
+    expect(screen.getByText('128')).toBeInTheDocument();
+    expect(screen.getByText('8')).toBeInTheDocument();
+    expect(screen.getByText('36')).toBeInTheDocument();
+  });
+
+  it('renders the continue carousel when games are present', () => {
+    render(<DashboardClientV2 />);
+    expect(screen.getByText('Azul')).toBeInTheDocument();
+    expect(screen.getByText('Wingspan')).toBeInTheDocument();
+  });
+
+  it('renders the empty state when no live session', () => {
+    render(<DashboardClientV2 />);
+    expect(screen.getByText(/Nessuna partita in corso/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/app/(authenticated)/dashboard/v2/__tests__/DashboardClientV2.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 4: Implement DashboardClientV2**
+
+Create `apps/web/src/app/(authenticated)/dashboard/v2/DashboardClientV2.tsx`:
+
+```typescript
+'use client';
+
+import { useEffect } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import { useAuth } from '@/components/auth/AuthProvider';
+import { useMiniNavConfig } from '@/hooks/useMiniNavConfig';
+import { useDashboardStore } from '@/lib/stores/dashboard-store';
+import { useCardHand } from '@/stores/use-card-hand';
+
+import { ChatRecentCards } from './sections/ChatRecentCards';
+import { ContinueCarousel } from './sections/ContinueCarousel';
+import { FriendsRow } from './sections/FriendsRow';
+import { GreetingRow } from './sections/GreetingRow';
+import { HeroLiveSession } from './sections/HeroLiveSession';
+import { KpiStrip } from './sections/KpiStrip';
+
+/**
+ * Phase 2 dashboard client — new layout with greeting, hero, KPI, carousel,
+ * chat cards, and friends row. Reads data from the existing useDashboardStore.
+ */
+export function DashboardClientV2() {
+  const { user } = useAuth();
+  const router = useRouter();
+  const drawCard = useCardHand(s => s.drawCard);
+  const store = useDashboardStore();
+
+  // Register mini-nav config with the global shell
+  useMiniNavConfig({
+    breadcrumb: 'Home · Gaming Hub',
+    tabs: [
+      { id: 'overview', label: 'Panoramica', href: '/dashboard' },
+    ],
+    activeTabId: 'overview',
+    primaryAction: {
+      label: 'Nuova partita',
+      icon: '＋',
+      onClick: () => router.push('/sessions/new'),
+    },
+  });
+
+  // Draw this page as a hand card for cross-page context memory
+  useEffect(() => {
+    drawCard({
+      id: 'section-dashboard',
+      entity: 'game',
+      title: 'Home',
+      href: '/dashboard',
+    });
+  }, [drawCard]);
+
+  const handleContinueSession = () => {
+    if (store.activeLiveSession) {
+      router.push(`/sessions/live/${store.activeLiveSession.id}`);
+    } else {
+      router.push('/sessions/new');
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-[1440px] p-7 pb-12">
+      <GreetingRow
+        displayName={user?.displayName ?? 'giocatore'}
+        subtitle="Ecco cosa succede nella tua tavola oggi"
+        stats={[
+          { label: 'Partite mese', value: String(store.totalSessions ?? 0) },
+          { label: 'Giochi', value: String(store.totalGames ?? 0) },
+        ]}
+      />
+
+      <HeroLiveSession
+        session={store.activeLiveSession ?? null}
+        onContinue={handleContinueSession}
+      />
+
+      <KpiStrip
+        kpis={{
+          games: store.totalGames ?? 0,
+          sessions: store.totalSessions ?? 0,
+          friends: store.friendsCount ?? 0,
+          chats: store.chatCount ?? 0,
+        }}
+      />
+
+      <ContinueCarousel games={store.continuePlayingGames ?? []} />
+      <ChatRecentCards chats={store.recentChats ?? []} />
+      <FriendsRow friends={store.activeFriends ?? []} />
+    </div>
+  );
+}
+```
+
+**Note on `useDashboardStore` shape:** The new fields used here (`friendsCount`, `chatCount`, `activeLiveSession`, `continuePlayingGames`, `recentChats`, `activeFriends`) may not match the existing store shape. When running Task 10, if the store doesn't expose these fields, the implementer must either:
+- (a) Extend `useDashboardStore` to compute them from the existing data, OR
+- (b) Stub them with hardcoded empty arrays / zeros for Phase 2 (mark as TODO for Phase 3)
+If the divergence is too wide, STOP and report NEEDS_CONTEXT.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/app/(authenticated)/dashboard/v2/__tests__/DashboardClientV2.test.tsx`
+Expected: PASS — 4 tests passing.
+
+- [ ] **Step 6: Create the barrel**
+
+Create `apps/web/src/app/(authenticated)/dashboard/v2/index.ts`:
+
+```typescript
+export { DashboardClientV2 } from './DashboardClientV2';
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/app/\(authenticated\)/dashboard/v2/
+git commit -m "feat(web): add Phase 2 DashboardClientV2 composition"
+```
+
+---
+
+## Task 11: Wire DashboardClientV2 into dashboard-client.tsx behind flag
+
+**Files:**
+- Modify: `apps/web/src/app/(authenticated)/dashboard/dashboard-client.tsx`
+
+- [ ] **Step 1: Read the current file**
+
+Run: `cat apps/web/src/app/\(authenticated\)/dashboard/dashboard-client.tsx | head -40`
+
+- [ ] **Step 2: Add feature flag branch at the top of the exported function**
+
+At the top of the `DashboardClient` function component, add:
+
+```typescript
+import { isUxRedesignEnabled } from '@/lib/feature-flags';
+import { DashboardClientV2 } from './v2';
+```
+
+And inside the component, as the first statement:
+
+```typescript
+if (isUxRedesignEnabled()) {
+  return <DashboardClientV2 />;
+}
+```
+
+The rest of the legacy bento grid stays untouched after this early return.
+
+- [ ] **Step 3: Write an integration test for the branch**
+
+Create (or extend) `apps/web/src/app/(authenticated)/dashboard/__tests__/dashboard-client.flag.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// Minimal mocks — the real DashboardClientV2 has its own mocks in its test file
+vi.mock('./v2', () => ({
+  DashboardClientV2: () => <div data-testid="dashboard-v2">V2 Dashboard</div>,
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('@/components/auth/AuthProvider', () => ({
+  useAuth: () => ({ user: { id: 'u1', displayName: 'Marco' } }),
+}));
+
+vi.mock('@/lib/stores/dashboard-store', () => ({
+  useDashboardStore: () => ({
+    totalGames: 0,
+    totalSessions: 0,
+    loading: false,
+  }),
+}));
+
+// ... add any other mocks required by the legacy DashboardClient
+
+const originalEnv = process.env.NEXT_PUBLIC_UX_REDESIGN;
+
+describe('DashboardClient feature flag branch', () => {
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.NEXT_PUBLIC_UX_REDESIGN;
+    else process.env.NEXT_PUBLIC_UX_REDESIGN = originalEnv;
+    vi.resetModules();
+  });
+
+  it('renders DashboardClientV2 when flag is on', async () => {
+    process.env.NEXT_PUBLIC_UX_REDESIGN = 'true';
+    vi.resetModules();
+    const mod = await import('../dashboard-client');
+    const DashboardClient = mod.DashboardClient;
+    render(<DashboardClient />);
+    expect(screen.getByTestId('dashboard-v2')).toBeInTheDocument();
+  });
+
+  it('renders legacy bento grid when flag is off', async () => {
+    process.env.NEXT_PUBLIC_UX_REDESIGN = 'false';
+    vi.resetModules();
+    const mod = await import('../dashboard-client');
+    const DashboardClient = mod.DashboardClient;
+    render(<DashboardClient />);
+    expect(screen.queryByTestId('dashboard-v2')).not.toBeInTheDocument();
+    // Legacy path should have rendered something (first render = empty/loading OK)
+  });
+});
+```
+
+**Note:** the legacy `DashboardClient` has many dependencies (many store fields, providers, etc.). If adding mocks for all of them is too fragile, the legacy-off test can simply assert that `data-testid="dashboard-v2"` is NOT present and leave the full legacy render exercise to its existing tests. Don't duplicate the legacy test coverage.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd apps/web && pnpm vitest run src/app/(authenticated)/dashboard`
+Expected: all tests pass (new flag test + existing dashboard widget tests unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/\(authenticated\)/dashboard/dashboard-client.tsx apps/web/src/app/\(authenticated\)/dashboard/__tests__/dashboard-client.flag.test.tsx
+git commit -m "feat(web): wire DashboardClientV2 into DashboardClient behind feature flag"
+```
+
+---
+
+## Task 12: Phase 2 quality gate
+
+**Files:** none (just commands)
+
+- [ ] **Step 1: Typecheck**
+
+Run: `cd apps/web && pnpm typecheck`
+Expected: no errors.
+
+- [ ] **Step 2: Lint**
+
+Run: `cd apps/web && pnpm lint`
+Expected: 0 errors. Pre-existing warnings OK. ZERO new warnings in `dashboard/v2/` files.
+
+- [ ] **Step 3: Full unit test suite**
+
+Run: `cd apps/web && pnpm test`
+Expected: all tests pass (Phase 1 tests + new Phase 2 tests).
+
+- [ ] **Step 4: Production build (flag ON)**
+
+```bash
+cd apps/web
+NEXT_PUBLIC_UX_REDESIGN=true pnpm build
+```
+Expected: build succeeds.
+
+- [ ] **Step 5: Production build (flag OFF)**
+
+```bash
+cd apps/web
+pnpm build
+```
+Expected: build succeeds with the same output as Phase 1 baseline.
+
+- [ ] **Step 6: Final Phase 2 marker commit**
+
+```bash
+git commit --allow-empty -m "chore(web): phase 2 dashboard gaming hub complete
+
+New dashboard layout (GreetingRow + HeroLiveSession + KpiStrip +
+ContinueCarousel + ChatRecentCards + FriendsRow) behind the
+NEXT_PUBLIC_UX_REDESIGN flag. Phase 1 shell foundation extended
+with: mini-nav registration via useMiniNavConfig, hand rail expand
+wiring (M6), stable hook ref (M3), icon type (M4), font utilities (M1).
+Legacy bento grid unchanged. Phase 3 (Library Hub) to follow."
+```
+
+---
+
+## Self-Review Checklist (run before marking Phase 2 complete)
+
+- [ ] All 12 tasks marked complete
+- [ ] M1 font utility cleanup applied (`grep -r "font-\[var" apps/web/src/components/layout/UserShell/v2` returns nothing)
+- [ ] M3 useMiniNavConfig stable — regression test asserts no re-registration on equivalent rerenders
+- [ ] M4 `MiniNavPrimaryAction.icon` documented with JSDoc, rendered in `MiniNavSlot`
+- [ ] M6 DesktopHandRail expand transition wired, test covers expanded state
+- [ ] All new v2 dashboard sections have ≥3 tests each
+- [ ] DashboardClientV2 integration test passes flag-on branch
+- [ ] Legacy bento grid renders untouched when flag is off
+- [ ] `pnpm typecheck`, `pnpm lint`, `pnpm test`, both `pnpm build` flag states succeed
+- [ ] Manual smoke: with `NEXT_PUBLIC_UX_REDESIGN=true`, `/dashboard` shows the new layout with mini-nav "Home · Gaming Hub" + "＋ Nuova partita" action visible in shell
+
+---
+
+## Next Phases (future plans)
+
+- **Phase 3** — Library Hub (carousels for Continua / Personal / Catalogo / Wishlist + filter bar)
+- **Phase 4** — Chat slide-over panel (global panel wired to `TopBarChatButton`)
+- **Phase 5** — Cleanup (remove feature flag, delete legacy bento/AppNavbar/CardRack, add Playwright visual regression, deprecate old routes)
+
+---
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-04-08-desktop-ux-redesign-design.md` §5.1
+- Phase 1 plan: `docs/superpowers/plans/2026-04-08-desktop-ux-redesign-phase-1-shell.md`
+- Phase 1 PR: meepleAi-app/meepleai-monorepo#296
+- Mockup (committed in `.superpowers/brainstorm/`): `dashboard-gaming-hub.html`
+- Design tokens: `apps/web/src/styles/design-tokens.css`
+- Existing dashboard data layer: `apps/web/src/lib/stores/dashboard-store.ts`
+- Existing dashboard page: `apps/web/src/app/(authenticated)/dashboard/dashboard-client.tsx`

--- a/docs/superpowers/specs/2026-04-08-desktop-ux-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-08-desktop-ux-redesign-design.md
@@ -1,0 +1,453 @@
+# Desktop User UX Redesign — Design Spec
+
+**Date:** 2026-04-08
+**Status:** Proposed
+**Scope:** User-facing desktop experience (Dashboard, Library, Chat with Agent) + global navigation
+**Out of scope:** Mobile (already has `carte-in-mano-nav` shipped), Admin pages, Sessions deep-dive pages, Game detail pages
+**Related specs:** `2026-03-28-user-pages-redesign`, `2026-03-30-layout-nav-redesign`, `2026-03-25-library-visual-redesign`
+
+---
+
+## 1. Context & Goals
+
+### Context
+
+The desktop user experience currently has three friction points that drive this redesign:
+
+1. **Dashboard drift.** `/dashboard` (Gaming Hub) exists with a widget system (`KpiWidget`, `LeaderboardWidget`, `LibraryWidget`, `LiveSessionWidget`, `TrendingWidget`, `ChatPreviewWidget`) but visually inconsistent with the MeepleCard design language shipped in recent sprints.
+2. **Library information architecture.** `/library` uses searchParam-based tabs (`?tab=catalogo`, `?tab=wishlist`, default → personal). Shared catalog and personal collection feel disconnected. Users don't have a quick overview of "what's going on" in their library.
+3. **Chat entry points fragmented.** Chat with agent lives contextually under `/library/games/[gameId]/agent` and `/sessions/live/[sessionId]/agent`. There is no quick access from elsewhere. Users who want "ask the agent about X" must navigate to a game first.
+
+The redesign must **reuse existing infrastructure** (MeepleCard component library, `useCardHand` Zustand store, NavFooter, GridCard/HeroCard/CompactCard/ListCard variants, design tokens in `apps/web/src/styles/design-tokens.css`) — not introduce a parallel design system.
+
+### Goals
+
+- **Unify visual language** across Dashboard, Library, Chat with the MeepleCard design system (`--nh-*` palette, warm shadows, Quicksand/Nunito, entity HSL colors, 24px radius cards).
+- **Clarify IA** with a 3-link top navigation (Home / Libreria / Sessioni) + contextual mini-nav + contextual hand stack.
+- **Give Chat a first-class entry point** via a global slide-over panel accessible from the top bar, while preserving contextual entry from games and sessions.
+- **Reuse the "carte in mano" (cards-in-hand) concept** on desktop — cross-page context memory of recently/pinned entities, already implemented for mobile in `stores/use-card-hand.ts`.
+- **Build a Library Hub** (Netflix-style carousel landing) that shows "Continua a giocare", "La tua libreria", "Dal catalogo community", "Wishlist" as horizontal caroselli, with detail tabs for deep-dive.
+
+### Non-goals
+
+- Changing the backend or the Alpha Mode scope of Bounded Contexts.
+- Redesigning mobile layouts.
+- Changing the onboarding or landing pages (`(public)/*`, `(auth)/*`).
+- Redesigning deep-dive pages (`/library/[gameId]`, `/sessions/live/[sessionId]/*`, `/play-records/*`).
+- Adding new features (all work is layout/UI/UX restructuring over existing data).
+
+---
+
+## 2. Decisions Confirmed During Brainstorming
+
+| Question | Decision | Reasoning |
+|---|---|---|
+| Dashboard concept | **Gaming Hub widgets** — keep widget logic, restyle with MeepleCard tokens | Existing widgets (`HeroBanner`, `KpiWidget`, `LibraryWidget`, `LiveSessionWidget`, `ChatPreviewWidget`) represent real user value; user wants to keep them, only restyle |
+| Library organization | **Hub + detail model** — one `/library` page is a landing with carousel sections (Continua / Personal / Catalogo / Wishlist), plus dedicated tab detail views | Netflix/Spotify pattern; lets users scan everything at a glance while preserving deep-dive views for power users |
+| Chat entry point | **Contextual + global slide-over** — no dedicated nav link. Entry from MeepleCard quick actions, game page, session live; global access via `💬` icon in top bar (slide-over panel) | Keeps the nav minimal while making chat always 1-click away. Slide-over remembers the game context from the hand stack |
+| Navigation paradigm | **Top bar + contextual mini-nav + hand stack** (option 4). Reuse the "carte in mano" concept | Combines discoverability (top bar 3 links) with contextual depth (mini-nav tabs) and persistent memory of active entities (hand stack). Already has infrastructure in `useCardHand` store |
+| Visual style | **MeepleCard light warm palette** (`--nh-bg-base #faf8f5`, warm shadows, Quicksand/Nunito, entity HSL) — NOT the dark v0app navy theme | User explicitly requested "usa proprio i token e i componenti UI nel frontend". The frontend design system already has MeepleCard tokens shipped and tested |
+
+---
+
+## 3. Visual Identity (Design Tokens — reuse only)
+
+All tokens below **already exist** in `apps/web/src/styles/design-tokens.css`. No new tokens introduced.
+
+**Palette (Hybrid Warm-Modern, spec 2026-03-25):**
+```
+--nh-bg-base:        #faf8f5   /* page bg */
+--nh-bg-surface:     #fffcf8   /* cards bg */
+--nh-bg-elevated:    #fffcf8
+--nh-border-default: rgba(160,120,60,0.08)
+--nh-text-primary:   #1a1a1a
+--nh-text-secondary: #5a4a35
+--nh-text-muted:     #8a7a65
+```
+
+**Shadows (warm-brown, not neutral):**
+```
+--shadow-warm-sm / md / lg / xl / 2xl
+```
+
+**Typography:**
+```
+--font-heading: Quicksand 500-800
+--font-body:    Nunito 400-800
+```
+
+**Entity HSL colors** (from `meeple-card/tokens.ts`, used for accent edges, badges, glow):
+```
+game     → hsl(25 95% 45%)   Orange
+player   → hsl(262 83% 58%)  Purple
+session  → hsl(240 60% 55%)  Indigo
+agent    → hsl(38 92% 50%)   Amber
+kb       → hsl(210 40% 55%)  Slate
+chat     → hsl(220 80% 55%)  Blue
+event    → hsl(350 89% 60%)  Rose
+toolkit  → hsl(142 70% 45%)  Green
+```
+
+**Radius:** `--radius-xl` (1rem) for small/medium surfaces, `rounded-2xl` (1.5rem / 24px) for MeepleCard, `--radius-lg` (0.75rem) for buttons/pills.
+
+**Layout constants:**
+```
+--top-bar-height:          64px (increased from current 52px for breathing room)
+--card-rack-width:         76px (expanded from 64px mobile to give desktop more presence)
+--card-rack-hover-width:   240px (unchanged)
+--mini-nav-height:         48px (new)
+```
+
+---
+
+## 4. Shell Architecture (global layout)
+
+Desktop layout is composed of four persistent regions:
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│  TOP BAR 64px                                                  │
+│  [logo] [Home Libreria Sessioni] [search ⌘K] [💬 🔔 avatar]    │
+├────────────────────────────────────────────────────────────────┤
+│  MINI-NAV 48px                                                 │
+│  ›section · tab1 tab2 tab3               [primary action]     │
+├────┬───────────────────────────────────────────────────────────┤
+│ H  │                                                           │
+│ A  │                                                           │
+│ N  │                   MAIN CONTENT                            │
+│ D  │                                                           │
+│    │                                                           │
+│ 76 │                   (scrollable)                            │
+│    │                                                           │
+└────┴───────────────────────────────────────────────────────────┘
+```
+
+### 4.1 Top Bar (64px, sticky)
+
+**Left:** Logo (hex gradient orange→amber, `Meeple**Ai**` wordmark with `.ai` in entity-game orange).
+**Center-left:** 3 nav links (Home / Libreria / Sessioni) as pill buttons with entity-game tint for active state.
+**Center:** Search pill (`⌘K`) — expandable global search across games/sessions/rules/players. Padding `11px 20px`, min-width 340px, radius 12px, warm hover state.
+**Right:** Icon button `💬` (chat panel trigger) with notification dot, icon button `🔔` (notifications), user avatar 40px circle with purple border (entity-player color).
+
+**Behavior:**
+- Sticky position, backdrop-blur on scroll.
+- Active top-level link determined by pathname segment (`/`, `/library`, `/sessions`).
+- `💬` icon toggles the global Chat slide-over panel (§6.3).
+- `⌘K` opens command palette / global search (future enhancement — MVP can be simple search input).
+
+### 4.2 Mini-nav contestuale (48px)
+
+**Left:** Breadcrumb `section · **current**` + contextual tabs (e.g., `Panoramica | Attività | Statistiche` on dashboard; `Hub | Personal | Catalogo | Wishlist | Collezioni` on library).
+**Right:** Primary page action button (`＋ Aggiungi gioco` on library, `＋ Nuova partita` on dashboard, etc.), warm orange gradient.
+
+**Behavior:**
+- Rendered via `useNavConfig` hook (already exists) — each page registers its mini-nav config.
+- Active tab has a 2px underline in `entity-game` orange.
+- Primary action button is optional (shown only when the page declares one).
+
+### 4.3 Hand Stack (76px, persistent left rail)
+
+Reuses the `useCardHand` Zustand store (`apps/web/src/stores/use-card-hand.ts`) already shipped for mobile.
+
+**Content:** Mini cards (52×72px) of the user's current "in hand" context — recently opened games, sessions, chats, agents. Pinnable cards persist across pages (localStorage). Non-pinned cards are LRU-evicted (max 10).
+
+**Per-card layout:**
+- Cover (42px height) with entity-gradient background
+- 3px left accent edge in entity color
+- Title (7px Quicksand, bottom)
+- Active state: `translateX(6px) scale(1.1)`, warm-lg shadow, 2px outline in entity color
+- Hover: `translateX(3px) scale(1.05)`, warm-md shadow
+
+**Bottom toolbar (40px section):**
+- 📌 Pin / unpin current focus
+- ⇔ Expand rail to 240px (shows card title + metadata)
+
+**Behavior:**
+- Cards are drawn automatically when entering a page (`drawCard({ id, entity, title, href })`).
+- Clicking a card navigates to its `href`.
+- Pin state stored in `localStorage` under `meeple-card-pins`.
+- Collapsed/expanded state under `meeple-hand-collapsed`.
+
+---
+
+## 5. Page-by-Page Specs
+
+### 5.1 Dashboard — Gaming Hub (`/` or `/dashboard`)
+
+Purpose: personalized landing after login showing "what's going on" and driving action.
+
+**Mini-nav:** `Home · Gaming Hub | Panoramica · Attività · Statistiche · Trending` + action `＋ Nuova partita`.
+
+**Sections (vertical scroll):**
+
+1. **Greeting row** — `h1` "Ciao Marco 👋" with gradient orange-amber on name. Subtitle "Ecco cosa succede nella tua tavola oggi". Right side: 3 quick stats inline (Partite mese / Win rate / Tempo gioco).
+
+2. **Hero Live Session widget** — full-width `HeroCard` variant of MeepleCard. Entity=session. Shows `hc-cover` (300px) + accent bar indigo + entity badge + title/subtitle/chips + action row (`Continua partita` primary, `Scoreboard` + `Chiedi regola` ghost) + `In corso` pulse badge top-right. Hidden if no active session — replaced by "last session" card.
+
+3. **KPI strip** — 4 `StatCard` components (existing showcase component). Entities: game, session, player, chat. Each card: icon box tinted in entity color, label, value, trend chip (up/down with %).
+
+4. **Continua a giocare** carousel — 4-5 `MeepleCard` (GridCard variant). Each card with progress bar overlay if there's an active session for that game. Quick actions hover: `▶ Continua` + `💬 Chat`.
+
+5. **Chat recenti con l'agente** — 3 compact chat cards (custom layout, chat entity accent). Each shows icon box + title (`Azul · Turno finale`) + snippet (2-line clamp) + ConfidenceBadge + timestamp. Click opens chat panel with that conversation.
+
+6. **Amici attivi** — 4 `CompactCard` Player variant. Thumb avatar with entity-player gradient + name + status line + online dot.
+
+**Component reuse:**
+- `HeroCard` variant of MeepleCard → hero live session
+- `GridCard` variant of MeepleCard → game cards in carousel
+- `CompactCard` variant → friends
+- `StatCard` (showcase) → KPI strip
+- `ConfidenceBadge` (showcase) → chat cards
+- Existing widgets `HeroBanner`, `KpiWidget`, `LibraryWidget`, `LiveSessionWidget`, `ChatPreviewWidget` will be **restyled** (not rewritten) to use the above components internally.
+
+### 5.2 Library Hub (`/library`)
+
+Purpose: single entry point for personal library + shared catalog + wishlist, with deep-dive tabs.
+
+**Mini-nav:** `Libreria · Hub | **Hub** · Personal 47 · Catalogo 230 · Wishlist 8 · Collezioni` + action `＋ Aggiungi gioco`.
+
+**Tab routing:** keep existing searchParam pattern. Default (no tab) → Hub mode with carousels. `?tab=personal` → grid view. `?tab=catalogo` → catalog grid. `?tab=wishlist` → wishlist grid. `?tab=collezioni` → future.
+
+**Hub mode layout (default tab):**
+
+1. **Library header** — h1 "La tua libreria" with orange accent bar + subtitle. Right side: 3 stat cards (Tuoi giochi / Catalogo / Wishlist) — colored by entity (game / session / wishlist amber).
+
+2. **Filter bar** — horizontal pill filters (Tutti, Strategici, Familiari, Cooperativi, Party, 👥 2–4, ⏱ <60m) + sort dropdown + view toggle (caroselli / griglia / lista). Filters apply to ALL sections below.
+
+3. **Carousel "Continua a giocare"** — 4+ `MeepleCard` (GridCard), session accent. Each card has progress bar if in-progress session + "last played X days ago" footer.
+
+4. **Carousel "La tua libreria personale"** — 5+ `MeepleCard` + "Add new game" ghost card (dashed border, ＋ icon) at the end. See-all → `?tab=personal`.
+
+5. **Carousel "Dal catalogo community"** — 5+ `MeepleCard` with status badge `Catalog` (frosted pill, not-in-lib state). Quick actions: `➕` add to library, `⭐` add to wishlist. See-all → `?tab=catalogo`.
+
+6. **Carousel "La tua wishlist"** — 4+ `MeepleCard` with status `★ Wishlist` amber. Quick actions: `✕` remove, `➕` add to library. See-all → `?tab=wishlist`.
+
+**Detail tab views (`?tab=personal | catalogo | wishlist`):**
+- Full grid (5-col desktop, existing `PersonalLibraryPage`, `PublicLibraryPageClient`, `WishlistPageClient`).
+- Filter bar remains at top.
+- Hand stack unchanged.
+
+**Component reuse:**
+- `GridCard` variant → all game cards
+- `EntityListView` (showcase) → detail tab grids
+- `GameCarousel` or custom horizontal carousel → hub caroselli (preference: extend existing carousel pattern used in other pages)
+- Existing `PersonalLibraryPage`, `PublicLibraryPageClient`, `WishlistPageClient` → detail tabs (already shipped, visually refined only)
+
+**Carousel scroll behavior:** horizontal `overflow-x-auto` with `scroll-snap-type: x mandatory`, snap points on each card. Nav buttons ‹ › in the section header scroll by ±1 page. See-all link navigates to the respective tab.
+
+### 5.3 Chat Slide-Over Panel (global)
+
+Purpose: first-class chat entry accessible from anywhere, context-aware.
+
+**Trigger:** `💬` icon in top bar (any page). Also opens from MeepleCard `💬` quick action, from game page "Chiedi all'agente" CTA, from live session `Chiedi regola` button.
+
+**Layout (overlay from right):**
+- Panel width: `760px`, `max-width: 60%` of viewport
+- Animates in with `translateX(30px) → 0` + fade over 350ms
+- Backdrop behind: `rgba(40,28,14,0.28)` + subtle `blur(2px)` on underlying page
+- Top bar remains visible; `💬` icon shows highlighted (blue tint + ring)
+
+**Internal structure:**
+
+```
+┌ panel-header ─────────────────────────────┐
+│ [💬 icon box] Chat con l'agente      [✕] │
+│              KB aggiornata 2 giorni fa   │
+├ ctx-bar ───────────────────────────────── │
+│ Contesto: [Azul pill ▾]    [📜 Storia] [⚙]│
+├ panel-body ─────────────────────────────── │
+│ ┌── chat-side (220px) ──┬── chat-main ──┐ │
+│ │ [+ Nuova chat]        │   messages    │ │
+│ │                        │               │ │
+│ │ ▾ Chat recenti        │   ...         │ │
+│ │ • Azul Turno finale ● │               │ │
+│ │ • Wingspan bonus      │   [input bar] │ │
+│ │ • Everdell eventi     │               │ │
+│ │                        │               │ │
+│ │ ▾ Giochi con KB       │               │ │
+│ │ • Azul    ● ready     │               │ │
+│ │ • Wings   ● ready     │               │ │
+│ │ • Everd   ● indexing  │               │ │
+│ └───────────────────────┴───────────────┘ │
+└───────────────────────────────────────────┘
+```
+
+**Context switcher (ctx-bar):**
+- Current game pill: mini-cover + name + meta (year · N PDF · KB status) + chevron dropdown
+- Dropdown opens game picker (searchable list of games with KB ready)
+- On open, auto-selects the currently focused card from the hand stack if it's a game
+
+**Chat sidebar (220px):**
+- `＋ Nuova chat` button (blue gradient, entity-chat color)
+- "Chat recenti" section: list of recent chats, each with game emoji, 2-line title, timestamp. Active chat has blue accent + tinted background.
+- "Giochi con KB" section: list of games with KB, mini-thumb + name + status dot (ready green / indexing amber pulsing).
+- Sidebar is collapsible (optional, future) — MVP always visible.
+
+**Chat main area:**
+- Messages list (scrollable). Each message = `ChatMessage` showcase component:
+  - User: right-aligned bubble, amber tinted (`hsl(25 95% 94%)` bg + `hsla(25,95%,45%,0.2)` border), avatar with user initials on entity-player purple gradient.
+  - Assistant: left-aligned bubble, elevated surface, avatar `🎲` on orange-amber gradient. Supports markdown (h4, strong, ul, p).
+- **Citation RuleSourceCard** embedded below assistant messages: doc icon (entity-kb slate) + doc name + page badge(s) + italic excerpt + "Apri regolamento →" link.
+- **Confidence badge** (high 90%+ green, med 70-90% amber, low red) + feedback buttons (👍 👎 📋 ↗) below each assistant message.
+- **Suggested questions**: row of pill chips appearing after assistant messages or as empty state.
+
+**Input bar:**
+- Textarea input (resizable, rounded 16px, focus ring blue)
+- Icon buttons: `📎` allega PDF, `🎤` dettatura, `➤ send` (blue gradient)
+- Keyboard hints below: `Enter` send, `⇧ Enter` newline, `Esc` close
+- Disclaimer: "✦ Risposte basate solo sulla KB caricata"
+
+**Close behavior:**
+- `Esc` key closes the panel (restores scroll lock on body)
+- Click on backdrop closes
+- Close button `✕` in header
+- State persisted in URL via `?chat=open&gameId=X` (so refresh reopens)
+
+**Component reuse:**
+- `ChatMessage` (showcase) → message bubbles
+- `RuleSourceCard` (showcase) → citations
+- `ConfidenceBadge` (showcase) → confidence score
+- `Sheet` primitive (existing UI overlays) → slide-over panel
+- Existing chat services / API calls → no backend changes
+
+---
+
+## 6. Information Architecture
+
+```
+(authenticated)
+├── / or /dashboard         → Dashboard (Gaming Hub) — restyled
+├── /library                → Library Hub (default Hub mode)
+│   ├── ?tab=personal      → personal grid (existing, restyled)
+│   ├── ?tab=catalogo      → catalog grid (existing, restyled)
+│   ├── ?tab=wishlist      → wishlist grid (existing, restyled)
+│   └── ?tab=collezioni    → future, shell in place
+├── /library/[gameId]       → game detail (existing, not in scope)
+├── /library/private/[id]   → private game detail (existing, not in scope)
+├── /sessions               → sessions list (existing, not in scope)
+├── /sessions/live/[id]/*   → live session (existing, not in scope)
+└── /play-records/*         → play records (existing, not in scope)
+```
+
+Chat has no dedicated route — it's a global overlay driven by `?chat=open` URL param.
+
+**Routes REMOVED or MOVED:**
+- `/library/games/[gameId]/agent` → replaced by chat slide-over opened with `?chat=open&gameId=X`
+- `/knowledge-base` — stays for Editor/Admin, not in user IA
+- `/editor/*`, `/n8n`, `/pipeline-builder` — not in user IA (admin/editor only)
+
+---
+
+## 7. Component Map (what to build / reuse)
+
+### Reused as-is (0 changes)
+- `MeepleCard` (all variants: `GridCard`, `HeroCard`, `CompactCard`, `ListCard`, `FeaturedCard`)
+- `AccentBorder`, `Cover`, `EntityBadge`, `MetaChips`, `NavFooter`, `QuickActions`, `Rating`, `StatusBadge`, `TagStrip`
+- `ChatMessage`, `RuleSourceCard`, `ConfidenceBadge`, `StatCard`, `CollectionProgress` (all from showcase)
+- `Sheet`, `Dialog`, `Tooltip`, `Popover` (UI overlays)
+- `useCardHand` store
+- `useNavConfig` hook (mini-nav config)
+- `PersonalLibraryPage`, `PublicLibraryPageClient`, `WishlistPageClient` (tab detail views)
+
+### New components to build
+- `LibraryHubCarousel` — horizontal carousel with scroll-snap, section header with count badge + nav buttons + see-all link. Wraps `MeepleCard` children. Accepts `entity` prop for accent color.
+- `LibraryHubHeader` — `h1` with accent bar + subtitle + 3 stat cards row.
+- `FilterBar` — horizontal pill filters + sort + view toggle. Extend or replace existing filter bar in library.
+- `ChatSlideOverPanel` — the global slide-over panel (header + ctx-bar + 2-col body + input bar). Uses existing `Sheet` primitive for overlay mechanics.
+- `ChatContextSwitcher` — the `ctx-pill` with game picker dropdown.
+- `ChatSidebar` — 220px sidebar with new-chat button, chat history, KB games list.
+- `DesktopHandStack` — desktop-specific variant of the mobile `HandSidebar`. Reuses `useCardHand` store, renders 52×72 mini cards vertically with `hand-toolbar` at bottom. The mobile component lives at `components/ui/data-display/meeple-card/mobile/HandSidebar.tsx` — extract shared logic into `shared/` and add `desktop/HandRail.tsx`.
+- `TopBar` — desktop version replacing existing top-level nav. 64px, logo + 3 nav links + search pill + chat icon + notification icon + avatar.
+- `MiniNav` — desktop contextual mini-nav (48px) driven by `useNavConfig`. May already exist as `NavContextTabs` — verify and extend.
+
+### Restyled (keep structure, update visuals)
+- `DashboardClient` and all widgets in `apps/web/src/app/(authenticated)/dashboard/widgets/` — replace internal card markup with MeepleCard variants.
+- `UnifiedShell` / `HybridSidebar` — evolve into the new top bar + mini-nav + hand stack architecture. May be renamed/refactored.
+- `FloatingActionPill` — may be removed or repurposed; its role is absorbed by the mini-nav primary action button on desktop (still needed for mobile).
+
+---
+
+## 8. Interaction Patterns
+
+**Hand stack draw:** Every page mounts an effect that calls `drawCard({ id, entity, title, href, imageUrl })` with the current page's subject entity. The card stays in hand for the session; pinning makes it persist across sessions.
+
+**Chat open from MeepleCard:** Quick action `💬` on a game MeepleCard dispatches `openChatPanel({ gameId })`. The panel opens, context switcher pre-selects the game, sidebar highlights the last chat for that game (if any), messages load.
+
+**Chat open from top bar:** `💬` icon dispatches `openChatPanel()` with no gameId. The context switcher defaults to the currently focused card in the hand stack if it's a game; otherwise shows "seleziona gioco" prompt.
+
+**Chat URL state:** Opening the panel sets `?chat=open&gameId=X&chatId=Y` (replace, not push). Closing removes these params. Refresh restores the state.
+
+**Carousel keyboard nav:** `← →` arrows scroll the carousel by one card when focused. Tab moves focus to next card.
+
+**Mini-nav sync:** Active tab is derived from URL. Clicking a tab updates URL (push). Breadcrumb is static per page.
+
+**Search (⌘K):** MVP is a simple expandable input that navigates to `/library?q=...`. Future: command palette with entity jumps.
+
+---
+
+## 9. Responsive Considerations
+
+**Desktop ≥1280px:** full layout as specified.
+**Desktop 1024-1279px:** hand stack collapses to 60px width, search pill shrinks to 280px.
+**Tablet 768-1023px:** hand stack hidden by default, accessible via toggle button in mini-nav. Top bar compressed (logo + hamburger + search + chat + avatar).
+**Mobile <768px:** Not in scope. `carte-in-mano-nav` mobile experience already shipped and unchanged.
+
+The existing `LibraryMobile`, `DashboardMobile` components remain untouched; the redesign only affects the `hidden md:block` desktop paths.
+
+---
+
+## 10. Migration Strategy
+
+Incremental: ship shell first, then page by page. Feature-flag via `NEXT_PUBLIC_UX_REDESIGN=true` to allow A/B or gradual rollout.
+
+1. **Phase 1 — Shell:** New `TopBar`, `MiniNav`, `DesktopHandStack`. Replace `UnifiedShell` contents behind flag. Dashboard and Library still render old widgets inside new shell.
+2. **Phase 2 — Dashboard:** Restyle widgets to use MeepleCard variants. No structural change.
+3. **Phase 3 — Library Hub:** Build `LibraryHubCarousel`, `LibraryHubHeader`, new filter bar. Wire default `?tab=` (no param) to hub mode. Existing tab detail views unchanged.
+4. **Phase 4 — Chat slide-over:** Build `ChatSlideOverPanel`, wire top bar trigger + MeepleCard quick action. Deprecate `/library/games/[gameId]/agent` route (keep as redirect).
+5. **Phase 5 — Cleanup:** Remove feature flag, delete old shell components, update tests.
+
+Each phase is independently mergeable and shippable.
+
+---
+
+## 11. Open Questions & Risks
+
+| # | Question / Risk | Impact | Mitigation |
+|---|---|---|---|
+| Q1 | Should `/dashboard` route remain or be promoted to `/`? | Low | Keep `/dashboard` for now; map `/` via redirect middleware. Decide in Phase 2. |
+| Q2 | `NavContextTabs` component — does it match the new `MiniNav` spec, or needs refactor? | Med | Verify in Phase 1 during shell build. If mismatch, extend existing component. |
+| Q3 | Carousel component — build new or extend `GameCarousel` from showcase? | Med | Review `GameCarousel` story first. If it supports custom cards + horizontal snap, extend it; otherwise build `LibraryHubCarousel` as a wrapper. |
+| Q4 | Search behavior (⌘K) — simple input or command palette? | Low | MVP is simple input. Command palette is a follow-up spec. |
+| R1 | Chat panel URL state may conflict with existing `?action=add` drawer state on library | Med | Namespace params: library uses `?action=add`, chat uses `?chat=open`. Verify no collision. |
+| R2 | `useCardHand` store currently caps at 10 cards — enough for desktop? | Low | Yes, matches UX expectation. Revisit if users report scrolling fatigue. |
+| R3 | Feature flag rollout may produce visual inconsistency during transition | Med | Ship Phase 1 (shell) fully before starting Phase 2. Flag toggles the whole desktop path at once. |
+| R4 | `carte-in-mano-nav` mobile and new desktop hand stack share store — need to verify mobile behavior doesn't regress | High | Add integration tests for `useCardHand` covering both desktop and mobile mount scenarios in Phase 1. |
+
+---
+
+## 12. References
+
+**Mockups (interactive, in `.superpowers/brainstorm/`):**
+- `shell-overview-v2.html` — global shell architecture
+- `dashboard-gaming-hub.html` — full Dashboard Gaming Hub
+- `library-hub.html` — Library Hub with caroselli
+- `chat-panel.html` — Chat slide-over panel
+
+**Frontend source:**
+- `apps/web/src/styles/design-tokens.css` — all design tokens (reuse)
+- `apps/web/src/components/ui/data-display/meeple-card/` — MeepleCard component system (reuse)
+- `apps/web/src/stores/use-card-hand.ts` — hand stack store (reuse)
+- `apps/web/src/components/showcase/` — showcase components inventory
+- `apps/web/src/app/(authenticated)/dashboard/` — current dashboard to restyle
+- `apps/web/src/app/(authenticated)/library/_content.tsx` — current library tab routing
+
+**Wireframe reference:**
+- `v0app/` — wireframe layout reference (top bar + library + chat IA)
+- `admin-mockups/meeple-card-real-app-render.html` — MeepleCard visual reference
+- `admin-mockups/mobile-card-layout-mockup.html` — "carte in mano" concept reference
+
+**Related specs (context):**
+- `2026-03-25-library-visual-redesign` — Hybrid Warm-Modern palette spec
+- `2026-03-28-user-pages-redesign` — prior user-pages pass
+- `2026-03-30-layout-nav-redesign` — shell evolution prior context
+- `2026-04-01-meeple-logo-redesign` — logo source of truth


### PR DESCRIPTION
## Summary

Phase 1 of the Desktop UX Redesign: new desktop shell (TopBar 64px + MiniNav 48px + persistent HandRail 76px) behind the `NEXT_PUBLIC_UX_REDESIGN` feature flag. Legacy shell path kept intact for seamless rollback.

**Reference:**
- Design spec: `docs/superpowers/specs/2026-04-08-desktop-ux-redesign-design.md`
- Implementation plan: `docs/superpowers/plans/2026-04-08-desktop-ux-redesign-phase-1-shell.md`

## What's new

**Infrastructure:**
- `isUxRedesignEnabled()` feature flag helper reading `NEXT_PUBLIC_UX_REDESIGN`
- `useMiniNavConfigStore` Zustand store (breadcrumb + tabs + activeTabId + optional primaryAction)
- `useMiniNavConfig` React hook for pages to register their mini-nav config with auto-cleanup

**New `v2/` shell components** under `apps/web/src/components/layout/UserShell/v2/`:
- `TopBarLogo` — hex gradient logo + wordmark
- `TopBarNavLinks` — 3-link pill nav (Home / Libreria / Sessioni) with pathname-based active state
- `TopBarSearchPill` — search button with ⌘K / Ctrl+K keyboard shortcut
- `TopBarChatButton` — stub with console.warn (Phase 4 will wire the slide-over panel)
- `TopBar64` — 64px sticky top bar composition
- `MiniNavSlot` — 48px contextual mini-nav, hidden when no config is registered
- `HandRailItem` — 52×72px mini card with entity-aware styling (9 entity types)
- `HandRailToolbar` — pin/expand buttons
- `DesktopHandRail` — 76px persistent left rail reading from `useCardHand` store
- `DesktopShell` — full composition (TopBar64 + MiniNavSlot + HandRail + main)

**Integration:**
- `UserShellClient.tsx` modified with feature-flag branch: `DesktopShell` when flag is on, legacy `AppNavbar` path preserved when off

## Quality gate

- ✅ `pnpm typecheck`: clean
- ✅ `pnpm lint`: 0 errors (pre-existing warnings unchanged)
- ✅ `pnpm test`: **13,688 tests passing** (1013 test files)
- ✅ `pnpm build` flag OFF: 15.4s, 132 pages
- ✅ `pnpm build` flag ON: 14.6s, 132 pages
- ✅ Final code review (opus): **APPROVE for merge**

## Test plan

- [x] Unit tests: 29 new test cases across 14 test files (TDD red → green per task)
- [x] Integration test: `UserShellClient.flag.test.tsx` verifies both branches (flag on / off) render correctly
- [x] Backward compatibility: legacy `UserShell` suite (73 tests) passes with zero regressions
- [x] Production build: succeeds on both flag states
- [ ] **Manual smoke test** (reviewer): start dev server with `NEXT_PUBLIC_UX_REDESIGN=true pnpm dev` and verify the new shell renders at `http://localhost:3000`

## Known carry-forward to Phase 2 (non-blocking)

1. **M3** — `useMiniNavConfig` dep array will trigger re-registration on every render when consumers pass inline config objects. Fix before first Phase 2 consumer (dashboard/library page).
2. **M4** — `MiniNavPrimaryAction.icon?: string` is loosely typed. Clarify before Phase 2.
3. **M1** — Font utilities use arbitrary value syntax (`font-[var(--font-quicksand)]`) instead of `font-quicksand`. Batch cleanup in first Phase 2 commit.
4. **M6** — `isExpanded` state in `DesktopHandRail` is wired but has no visual effect yet (rail width hardcoded). Phase 2 will wire the width transition.
5. **AO#4** — Verify `DesktopHandRail` stickiness behavior against spec §4 before Phase 2.

## Out of scope

- Dashboard restyle (Phase 2)
- Library Hub carousels (Phase 3)
- Chat slide-over panel (Phase 4)
- Cleanup / flag removal (Phase 5)

Task 16 (manual dev server smoke test) was skipped in subagent execution and compensated by automated build checks on both flag states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)