### PR TITLE
feat(seed): R2 blob migration — 159 games indexed in staging

### DIFF
--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml
@@ -9252,6 +9252,8 @@ catalog:
     pdfBlobKey: rulebooks/v1/skytear_rulebook.pdf
     pdfSha256: 2f316d16c5001b55097b9966c7c697bbde6a50e7e5c9b1c3df336ff5c3775960
     pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Skytear%3A%20Arena%20of%20Legends
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Skytear%3A%20Arena%20of%20Legends
   - title: Terra Mystica
     bggId: 120677
     language: en
@@ -10913,6 +10915,8 @@ catalog:
     pdfBlobKey: rulebooks/v1/great-western-trail-argentina_rulebook.pdf
     pdfSha256: 88be4a0b83dda037566941e46d1e936ec6280c37e9860c0405a58a9bd412c2fa
     pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Great%20Western%20Trail%3A%20Argentina
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Great%20Western%20Trail%3A%20Argentina
   - title: Agricola (Revised Edition)
     bggId: 200680
     language: en
@@ -11454,6 +11458,8 @@ catalog:
     pdfBlobKey: rulebooks/v1/voidfall_rulebook.pdf
     pdfSha256: 29847a547dcec0deac860cfb658cd3ea694dcaab319258fcf286c27161243157
     pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Voidfall
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Voidfall
   - title: 'Wingspan: Asia'
     bggId: 366161
     language: en

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml
@@ -4,22 +4,37 @@ catalog:
   - title: Catan
     bggId: 13
     language: en
-    pdf: catan_en_rulebook.pdf
     fallbackImageUrl: https://cf.geekdo-images.com/W3Bsga_uLP9kO91gZ7H8yw__original/img/IwRwEpu1I6YfkyYjFIekCh80ntc=/0x0/filters:format(jpeg)/pic2419375.jpg
     fallbackThumbnailUrl: https://cf.geekdo-images.com/W3Bsga_uLP9kO91gZ7H8yw__small/img/7a0LOL48K-2lC3IG0HyYT3XxJBs=/fit-in/200x150/filters:strip_icc()/pic2419375.jpg
     bggEnhanced: true
-    description: >+
-      In CATAN (formerly The Settlers of Catan), players try to be the dominant force on the island of Catan by building settlements, cities and roads. On each turn dice are rolled to determine which resources the island produces. Players build structures by 'spending' resources (sheep, wheat, wood, brick and ore) which are represented by the relevant resource cards; each land type, with the exception of the unproductive desert, produces a specific resource: hills produce brick, forests produce wood, mountains produce ore, fields produce wheat, and pastures produce sheep.
+    description: 'In CATAN (formerly The Settlers of Catan), players try to be the dominant force on the island of Catan by
+      building settlements, cities and roads. On each turn dice are rolled to determine which resources the island produces.
+      Players build structures by ''spending'' resources (sheep, wheat, wood, brick and ore) which are represented by the
+      relevant resource cards; each land type, with the exception of the unproductive desert, produces a specific resource:
+      hills produce brick, forests produce wood, mountains produce ore, fields produce wheat, and pastures produce sheep.
 
 
-      Set-up includes randomly placing large hexagonal tiles (each depicting one of the five resource-producing terrain types--or the desert) in a honeycomb shape and surrounding them with water tiles, some of which contain ports of exchange. A number disk, the value of which will correspond to the roll of two 6-sided dice, are placed on each terrain tile. Each player is given two settlements (think: houses) and roads (sticks) which are placed on intersections and borders of the terrain tiles. Players collect a hand of resource cards based on which terrain tiles their last-placed settlement is adjacent to. A robber pawn is placed on the desert tile.
+      Set-up includes randomly placing large hexagonal tiles (each depicting one of the five resource-producing terrain types--or
+      the desert) in a honeycomb shape and surrounding them with water tiles, some of which contain ports of exchange. A number
+      disk, the value of which will correspond to the roll of two 6-sided dice, are placed on each terrain tile. Each player
+      is given two settlements (think: houses) and roads (sticks) which are placed on intersections and borders of the terrain
+      tiles. Players collect a hand of resource cards based on which terrain tiles their last-placed settlement is adjacent
+      to. A robber pawn is placed on the desert tile.
 
 
-      A turn consists of rolling the dice, collecting resource cards based on this dice roll and the position of settlements (or upgraded cities&mdash;think: hotels), turning in resource cards (if possible and desired) for improvements, trading cards at a port, possibly playing a development card, or trading resource cards with other players. If the dice roll is a 7, the active player moves the robber to a new terrain tile and steals a resource card from another player who has a settlement adjacent to that tile.
+      A turn consists of rolling the dice, collecting resource cards based on this dice roll and the position of settlements
+      (or upgraded cities&mdash;think: hotels), turning in resource cards (if possible and desired) for improvements, trading
+      cards at a port, possibly playing a development card, or trading resource cards with other players. If the dice roll
+      is a 7, the active player moves the robber to a new terrain tile and steals a resource card from another player who
+      has a settlement adjacent to that tile.
 
 
-      Points are accumulated by building settlements and cities, having the longest road or the largest army (from some of the development cards), and gathering certain development cards that simply award victory points. When a player has gathered 10 points (some of which may be held in secret), s/he announces this and claims the win.
+      Points are accumulated by building settlements and cities, having the longest road or the largest army (from some of
+      the development cards), and gathering certain development cards that simply award victory points. When a player has
+      gathered 10 points (some of which may be held in secret), s/he announces this and claims the win.
 
+
+      '
     yearPublished: 1995
     minPlayers: 3
     maxPlayers: 4
@@ -104,33 +119,24 @@ catalog:
     - Top Toys
     - TRY SOFT
     - Vennerød Forlag AS
+    pdfBlobKey: rulebooks/v1/catan_en_rulebook.pdf
+    pdfSha256: 0d81a40c1d4eb5eb438a62f80d71cdaab5f00404722c3cfa0b106d79b635ebc6
+    pdfVersion: '1.0'
   - title: Wingspan
     bggId: 266192
     language: en
-    pdf: wingspan_en_rulebook.pdf
     fallbackImageUrl: https://cf.geekdo-images.com/yLZJCVLlIx4c7eJEWUNJ7w__original/img/cI782Zis9cT66j2MjSHKJGnFPNw=/0x0/filters:format(jpeg)/pic4458123.jpg
     fallbackThumbnailUrl: https://cf.geekdo-images.com/yLZJCVLlIx4c7eJEWUNJ7w__small/img/VNToqgS2-pOGU6MuvIkMPKn_y-s=/fit-in/200x150/filters:strip_icc()/pic4458123.jpg
     bggEnhanced: true
-    description: >+
-      Wingspan is&nbsp;a competitive, medium-weight, card-driven, engine-building board game from Stonemaier Games. It's designed by Elizabeth Hargrave and features 180 birds illustrated by Natalia Rojas and Ana Maria Martinez.
-
-
-      You are bird enthusiasts&mdash;researchers, bird watchers, ornithologists, and collectors&mdash;seeking to discover and attract the best birds to your network of wildlife preserves. Each bird extends a chain of powerful combinations in one of your habitats (actions). These habitats  focus on several key aspects of growth:
-
-
-           Gain food tokens via custom dice in a birdfeeder dice tower
-           Lay eggs using egg miniatures in a variety of colors
-           Draw from hundreds of unique bird cards and play them
-
-
-      The winner is the player with the most points after 4 rounds.
-
-
-      &mdash;description from the publisher
-
-
-      From the 7th printing on, the base game box includes Wingspan: Swift-Start Promo Pack.
-
+    description: "Wingspan is&nbsp;a competitive, medium-weight, card-driven, engine-building board game from Stonemaier Games.\
+      \ It's designed by Elizabeth Hargrave and features 180 birds illustrated by Natalia Rojas and Ana Maria Martinez.\n\n\
+      You are bird enthusiasts&mdash;researchers, bird watchers, ornithologists, and collectors&mdash;seeking to discover\
+      \ and attract the best birds to your network of wildlife preserves. Each bird extends a chain of powerful combinations\
+      \ in one of your habitats (actions). These habitats  focus on several key aspects of growth:\n\n\n     Gain food tokens\
+      \ via custom dice in a birdfeeder dice tower\n     Lay eggs using egg miniatures in a variety of colors\n     Draw from\
+      \ hundreds of unique bird cards and play them\n\n\nThe winner is the player with the most points after 4 rounds.\n\n\
+      &mdash;description from the publisher\n\nFrom the 7th printing on, the base game box includes Wingspan: Swift-Start\
+      \ Promo Pack.\n\n"
     yearPublished: 2019
     minPlayers: 1
     maxPlayers: 5
@@ -186,19 +192,29 @@ catalog:
     - Siam Board Games
     - Surfin' Meeple China
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/wingspan_en_rulebook.pdf
+    pdfSha256: eb6b55b5224dcc6619d1145f4055cd3ed1be7f5bc301ff3953b94277ebd93e51
+    pdfVersion: '1.0'
   - title: Azul
     bggId: 230802
     language: en
-    pdf: azul_rulebook.pdf
     fallbackImageUrl: https://cf.geekdo-images.com/aPSHJO0d0XOpQR5X-wJonw__original/img/AkbtYVc6xXJF3c9EUrakklcclKw=/0x0/filters:format(png)/pic6973671.png
     fallbackThumbnailUrl: https://cf.geekdo-images.com/aPSHJO0d0XOpQR5X-wJonw__small/img/ccsXKrdGJw-YSClWwzVUwk5Nh9Y=/fit-in/200x150/filters:strip_icc()/pic6973671.png
     bggEnhanced: true
-    description: >+
-      Introduced by the Moors, azulejos (originally white and blue ceramic tiles) were fully embraced by the Portuguese when their king Manuel I, on a visit to the Alhambra palace in Southern Spain, was mesmerized by the stunning beauty of the Moorish decorative tiles. The king, awestruck by the interior beauty of the Alhambra, immediately ordered that his own palace in Portugal be decorated with similar wall tiles. As a tile-laying artist, you have been challenged to embellish the walls of the Royal Palace of Evora.
+    description: 'Introduced by the Moors, azulejos (originally white and blue ceramic tiles) were fully embraced by the Portuguese
+      when their king Manuel I, on a visit to the Alhambra palace in Southern Spain, was mesmerized by the stunning beauty
+      of the Moorish decorative tiles. The king, awestruck by the interior beauty of the Alhambra, immediately ordered that
+      his own palace in Portugal be decorated with similar wall tiles. As a tile-laying artist, you have been challenged to
+      embellish the walls of the Royal Palace of Evora.
 
 
-      In the game Azul, players take turns drafting colored tiles from suppliers to their player board. Later in the round, players score points based on how they've placed their tiles to decorate the palace. Extra points are scored for specific patterns and completing sets; wasted supplies harm the player's score. The player with the most points at the end of the game wins.
+      In the game Azul, players take turns drafting colored tiles from suppliers to their player board. Later in the round,
+      players score points based on how they''ve placed their tiles to decorate the palace. Extra points are scored for specific
+      patterns and completing sets; wasted supplies harm the player''s score. The player with the most points at the end of
+      the game wins.
 
+
+      '
     yearPublished: 2017
     minPlayers: 2
     maxPlayers: 4
@@ -249,34 +265,31 @@ catalog:
     - Tower Tactic Games
     - TWOPLUS Games
     - Zvezda
+    pdfBlobKey: rulebooks/v1/azul_rulebook.pdf
+    pdfSha256: 407a5ae91d219a72dfad0fd600fd9bf4ee2f9690e9726ae74fb7240d9a1a6911
+    pdfVersion: '1.0'
   - title: 'Descent: Journeys in the Dark (Second Edition)'
     bggId: 104162
     language: en
-    pdf: descent_rulebook.pdf
     fallbackImageUrl: https://cf.geekdo-images.com/ZTkiJEPvz2O3vmMJWfjrbw__original/img/GZJIjJPJKk1a4Bx-rM-3KL6O4hk=/0x0/filters:format(jpeg)/pic1180640.jpg
     fallbackThumbnailUrl: https://cf.geekdo-images.com/ZTkiJEPvz2O3vmMJWfjrbw__small/img/cO_2QvC_2BCb-Smd0xp4a5G2n-s=/fit-in/200x150/filters:strip_icc()/pic1180640.jpg
     bggEnhanced: true
-    description: >+
-      In Descent: Journeys in the Dark (Second Edition), one player takes on the role of the treacherous overlord, and up to four other players take on the roles of courageous heroes. During each game, the heroes embark on quests and venture into dangerous caves, ancient ruins, dark dungeons, and cursed forests to battle monsters, earn riches, and attempt to stop the overlord from carrying out his vile plot. Featuring double-sided modular board pieces, countless hero and skill combinations, and an immersive story-driven campaign, Descent: Journeys in the Dark (Second Edition) transports heroes to a vibrant fantasy realm where they must stand together against an ancient evil.
-
-
-      With danger lurking in every shadow, combat is a necessity. For such times, Descent: Journeys in the Dark (Second Edition) uses a unique dice-based system. Players build their dice pools according to their character's abilities and weapons, and each die in the pool contributes to an attack in different ways. Surges, special symbols that appear on most dice, also let you trigger special effects to make the most of your attacks. And with the horrors awaiting you beneath the surface, you'll need every advantage you can take...
-
-
-      Compared to the first edition of Descent: Journeys in the Dark, this game features:
-
-
-           Simpler rules for determining line of sight 
-           Faster setup of each encounter
-           Defense dice to mitigate the tendency to "math out" attacks
-           Shorter quests with plenty of natural stopping points
-           Cards that list necessary statistics, conditions, and effects
-           A new mechanism for controlling the overlord powers
-           Enhanced hero selection and creation process
-           Experience system to allow for hero growth and development
-           Out-of-the-box campaign system
-
-
+    description: "In Descent: Journeys in the Dark (Second Edition), one player takes on the role of the treacherous overlord,\
+      \ and up to four other players take on the roles of courageous heroes. During each game, the heroes embark on quests\
+      \ and venture into dangerous caves, ancient ruins, dark dungeons, and cursed forests to battle monsters, earn riches,\
+      \ and attempt to stop the overlord from carrying out his vile plot. Featuring double-sided modular board pieces, countless\
+      \ hero and skill combinations, and an immersive story-driven campaign, Descent: Journeys in the Dark (Second Edition)\
+      \ transports heroes to a vibrant fantasy realm where they must stand together against an ancient evil.\n\nWith danger\
+      \ lurking in every shadow, combat is a necessity. For such times, Descent: Journeys in the Dark (Second Edition) uses\
+      \ a unique dice-based system. Players build their dice pools according to their character's abilities and weapons, and\
+      \ each die in the pool contributes to an attack in different ways. Surges, special symbols that appear on most dice,\
+      \ also let you trigger special effects to make the most of your attacks. And with the horrors awaiting you beneath the\
+      \ surface, you'll need every advantage you can take...\n\nCompared to the first edition of Descent: Journeys in the\
+      \ Dark, this game features:\n\n\n     Simpler rules for determining line of sight \n     Faster setup of each encounter\n\
+      \     Defense dice to mitigate the tendency to \"math out\" attacks\n     Shorter quests with plenty of natural stopping\
+      \ points\n     Cards that list necessary statistics, conditions, and effects\n     A new mechanism for controlling the\
+      \ overlord powers\n     Enhanced hero selection and creation process\n     Experience system to allow for hero growth\
+      \ and development\n     Out-of-the-box campaign system\n\n\n"
     yearPublished: 2012
     minPlayers: 1
     maxPlayers: 5
@@ -325,20 +338,31 @@ catalog:
     - Heidelberger Spieleverlag
     - Hobby World
     - Wargames Club Publishing
+    pdfBlobKey: rulebooks/v1/descent_rulebook.pdf
+    pdfSha256: 8ae7fd3d1887aad1c1f8aeb10881526dbf7431fd1099b3bcb486748ea0c4a4aa
+    pdfVersion: '1.0'
   - title: Codenames
     bggId: 178900
     language: en
-    pdf: codenames_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Two rival spymasters know the secret identities of 25 agents. Their teammates know the agents only by their codenames &mdash; single-word labels like "disease", "Germany", and "carrot". Yes, carrot. It's a legitimate codename. Each spymaster wants their team to identify their agents first...without uncovering the assassin by mistake.
+    description: 'Two rival spymasters know the secret identities of 25 agents. Their teammates know the agents only by their
+      codenames &mdash; single-word labels like "disease", "Germany", and "carrot". Yes, carrot. It''s a legitimate codename.
+      Each spymaster wants their team to identify their agents first...without uncovering the assassin by mistake.
 
 
-      In Codenames, two teams compete to see who can make contact with all of their agents first. Lay out 25 cards, each bearing a single word. The spymasters look at a card showing the identity of each card, then take turns clueing their teammates. A clue consists of a single word and a number, with the number suggesting how many cards in play have some association to the given clue word. The teammates then identify one agent they think is on their team; if they're correct, they can keep guessing up to one more than the stated number of times; if the agent belongs to the opposing team or is an innocent bystander, the team's turn ends; and if they fingered the assassin, they lose the game.
+      In Codenames, two teams compete to see who can make contact with all of their agents first. Lay out 25 cards, each bearing
+      a single word. The spymasters look at a card showing the identity of each card, then take turns clueing their teammates.
+      A clue consists of a single word and a number, with the number suggesting how many cards in play have some association
+      to the given clue word. The teammates then identify one agent they think is on their team; if they''re correct, they
+      can keep guessing up to one more than the stated number of times; if the agent belongs to the opposing team or is an
+      innocent bystander, the team''s turn ends; and if they fingered the assassin, they lose the game.
 
 
-      Spymasters continue giving clues until one team has identified all of their agents or the assassin has removed one team from play.
+      Spymasters continue giving clues until one team has identified all of their agents or the assassin has removed one team
+      from play.
 
+
+      '
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 8
@@ -403,32 +427,52 @@ catalog:
     - SuperHeated Neurons
     - TWOPLUS Games
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/codenames_rulebook.pdf
+    pdfSha256: bf6ae8c47ede4e824587cd3506c4ab1fb81f51c96514a0a19df86a5c92441f11
+    pdfVersion: '1.0'
   - title: Terraforming Mars
     bggId: 167791
     language: en
-    pdf: terraforming-mars_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In the 2400s, mankind begins to terraform the planet Mars. Giant corporations, sponsored by the World Government on Earth, initiate huge projects to raise the temperature, the oxygen level, and the ocean coverage until the environment is habitable. In Terraforming Mars, you play one of those corporations and work together in the terraforming process, but compete for getting victory points that are awarded not only for your contribution to the terraforming, but also for advancing human infrastructure throughout the solar system, and doing other commendable things.
+    description: 'In the 2400s, mankind begins to terraform the planet Mars. Giant corporations, sponsored by the World Government
+      on Earth, initiate huge projects to raise the temperature, the oxygen level, and the ocean coverage until the environment
+      is habitable. In Terraforming Mars, you play one of those corporations and work together in the terraforming process,
+      but compete for getting victory points that are awarded not only for your contribution to the terraforming, but also
+      for advancing human infrastructure throughout the solar system, and doing other commendable things.
 
 
-      As a player, you acquire unique project cards (from over two hundred different ones) by buying them to your hand. The cards can give you immediate bonuses, as well as increasing your production of different resources. Many cards also have requirements and they become playable when the temperature, oxygen, or ocean coverage increases enough. Buying cards is costly, so there is a balance between buying cards and actually playing them. Standard Projects are always available to complement your hand of cards. Your basic income, as well as your basic score, are based on your Terraform Rating. However, your income is boosted by your production, and VPs are also gained from many other sources.
+      As a player, you acquire unique project cards (from over two hundred different ones) by buying them to your hand. The
+      cards can give you immediate bonuses, as well as increasing your production of different resources. Many cards also
+      have requirements and they become playable when the temperature, oxygen, or ocean coverage increases enough. Buying
+      cards is costly, so there is a balance between buying cards and actually playing them. Standard Projects are always
+      available to complement your hand of cards. Your basic income, as well as your basic score, are based on your Terraform
+      Rating. However, your income is boosted by your production, and VPs are also gained from many other sources.
 
 
-      You keep track of your production and resources on your player board.  The game uses six types of resources: MegaCredits, Steel, Titanium, Plants, Energy, and Heat. On the game board, you compete for the best places for your city tiles, ocean tiles, and greenery tiles. You also compete for different Milestones and Awards worth many VPs. Each round is called a generation and consists of the following phases:
+      You keep track of your production and resources on your player board.  The game uses six types of resources: MegaCredits,
+      Steel, Titanium, Plants, Energy, and Heat. On the game board, you compete for the best places for your city tiles, ocean
+      tiles, and greenery tiles. You also compete for different Milestones and Awards worth many VPs. Each round is called
+      a generation and consists of the following phases:
 
 
       1) Player order shifts clockwise.
 
       2) Research phase: All players buy cards from four privately drawn.
 
-      3) Action phase: Players take turns doing 1-2 actions from these options: Playing a card, claiming a Milestone, funding an Award, using a Standard project, converting plant into greenery tiles (and raising oxygen), converting heat into a temperature raise, and using the action of a card in play. The turn continues around the table (sometimes several laps) until all players have passed.
+      3) Action phase: Players take turns doing 1-2 actions from these options: Playing a card, claiming a Milestone, funding
+      an Award, using a Standard project, converting plant into greenery tiles (and raising oxygen), converting heat into
+      a temperature raise, and using the action of a card in play. The turn continues around the table (sometimes several
+      laps) until all players have passed.
 
       4) Production phase: Players get resources according to their terraform rating and production parameters.
 
 
-      When the three global parameters (temperature, oxygen, ocean) have all reached their required levels, the terraforming is complete, and the game ends after that generation. Combine your Terraform Rating and other VPs to determine the winning corporation!
+      When the three global parameters (temperature, oxygen, ocean) have all reached their required levels, the terraforming
+      is complete, and the game ends after that generation. Combine your Terraform Rating and other VPs to determine the winning
+      corporation!
 
+
+      '
     yearPublished: 2016
     minPlayers: 1
     maxPlayers: 5
@@ -492,23 +536,38 @@ catalog:
     - Stronghold Games
     - SuperHeated Neurons
     - Surfin' Meeple China
+    pdfBlobKey: rulebooks/v1/terraforming-mars_rulebook.pdf
+    pdfSha256: 97d5923d4e05c8b492c6f6b8937a9226936c6e39f8627dddeac81d5b6927aabe
+    pdfVersion: '1.0'
   - title: 7 Wonders
     bggId: 68448
     language: en
-    pdf: 7-wonders_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      You are the leader of one of the 7 great cities of the Ancient World. Gather resources, develop commercial routes, and affirm your military supremacy. Build your city and erect an architectural wonder which will transcend future times.
+    description: 'You are the leader of one of the 7 great cities of the Ancient World. Gather resources, develop commercial
+      routes, and affirm your military supremacy. Build your city and erect an architectural wonder which will transcend future
+      times.
 
 
-      7 Wonders lasts three ages. In each age, players receive seven cards from a particular deck, choose one of those cards, then pass the remainder to an adjacent player. Players reveal their cards simultaneously, paying resources if needed or collecting resources or interacting with other players in various ways. (Players have individual boards with special powers on which to organize their cards, and the boards are double-sided). Each player then chooses another card from the deck they were passed, and the process repeats until players have six cards in play from that age. After three ages, the game ends.
+      7 Wonders lasts three ages. In each age, players receive seven cards from a particular deck, choose one of those cards,
+      then pass the remainder to an adjacent player. Players reveal their cards simultaneously, paying resources if needed
+      or collecting resources or interacting with other players in various ways. (Players have individual boards with special
+      powers on which to organize their cards, and the boards are double-sided). Each player then chooses another card from
+      the deck they were passed, and the process repeats until players have six cards in play from that age. After three ages,
+      the game ends.
 
 
-      In essence, 7 Wonders is a card development game. Some cards have immediate effects, while others provide bonuses or upgrades later in the game. Some cards provide discounts on future purchases. Some provide military strength to overpower your neighbors and others give nothing but victory points. Each card is played immediately after being drafted, so you'll know which cards your neighbor is receiving and how her choices might affect what you've already built up. Cards are passed left-right-left over the three ages, so you need to keep an eye on the neighbors in both directions.
+      In essence, 7 Wonders is a card development game. Some cards have immediate effects, while others provide bonuses or
+      upgrades later in the game. Some cards provide discounts on future purchases. Some provide military strength to overpower
+      your neighbors and others give nothing but victory points. Each card is played immediately after being drafted, so you''ll
+      know which cards your neighbor is receiving and how her choices might affect what you''ve already built up. Cards are
+      passed left-right-left over the three ages, so you need to keep an eye on the neighbors in both directions.
 
 
-      Though the box of earlier editions is listed as being for 3&ndash;7 players, there is an official 2-player variant included in the instructions.
+      Though the box of earlier editions is listed as being for 3&ndash;7 players, there is an official 2-player variant included
+      in the instructions.
 
+
+      '
     yearPublished: 2010
     minPlayers: 2
     maxPlayers: 7
@@ -557,26 +616,38 @@ catalog:
     - NeoTroy Games
     - Rebel Sp. z o.o.
     - Siam Board Games
+    pdfBlobKey: rulebooks/v1/7-wonders_rulebook.pdf
+    pdfSha256: 5b719f677c830066b0493cd6ea5f2808e512ce9cbf72fa0fe80aa09127182849
+    pdfVersion: '1.0'
   - title: Ticket to Ride
     bggId: 9209
     language: en
-    pdf: ticket-to-ride_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      With elegantly simple gameplay, Ticket to Ride can be learned in under 15 minutes. Players collect cards of various types of train cars they then use to claim railway routes in North America. The longer the routes, the more points they earn. Additional points come to those who fulfill Destination Tickets &ndash; goal cards that connect distant cities; and to the player who builds the longest continuous route.
+    description: 'With elegantly simple gameplay, Ticket to Ride can be learned in under 15 minutes. Players collect cards
+      of various types of train cars they then use to claim railway routes in North America. The longer the routes, the more
+      points they earn. Additional points come to those who fulfill Destination Tickets &ndash; goal cards that connect distant
+      cities; and to the player who builds the longest continuous route.
 
 
-      "The rules are simple enough to write on a train ticket &ndash; each turn you either draw more cards, claim a route, or get additional Destination Tickets," says Ticket to Ride author, Alan R. Moon. "The tension comes from being forced to balance greed &ndash; adding more cards to your hand, and fear &ndash; losing a critical route to a competitor."
+      "The rules are simple enough to write on a train ticket &ndash; each turn you either draw more cards, claim a route,
+      or get additional Destination Tickets," says Ticket to Ride author, Alan R. Moon. "The tension comes from being forced
+      to balance greed &ndash; adding more cards to your hand, and fear &ndash; losing a critical route to a competitor."
 
 
-      Ticket to Ride continues in the tradition of Days of Wonder's big format board games featuring high-quality illustrations and components including: an oversize board map of North America, 225 custom-molded train cars, 144 illustrated cards, and wooden scoring markers.
+      Ticket to Ride continues in the tradition of Days of Wonder''s big format board games featuring high-quality illustrations
+      and components including: an oversize board map of North America, 225 custom-molded train cars, 144 illustrated cards,
+      and wooden scoring markers.
 
 
-      Since its introduction and numerous subsequent awards, Ticket to Ride has become the BoardGameGeek epitome of a "gateway game" -- simple enough to be taught in a few minutes, and with enough action and tension to keep new players involved and in the game for the duration.
+      Since its introduction and numerous subsequent awards, Ticket to Ride has become the BoardGameGeek epitome of a "gateway
+      game" -- simple enough to be taught in a few minutes, and with enough action and tension to keep new players involved
+      and in the game for the duration.
 
 
       Part of the Ticket to Ride series.
 
+
+      '
     yearPublished: 2004
     minPlayers: 2
     maxPlayers: 5
@@ -621,20 +692,31 @@ catalog:
     - Rebel Sp. z o.o.
     - Siam Board Games
     - Swan Panasia Co., Ltd.
+    pdfBlobKey: rulebooks/v1/ticket-to-ride_rulebook.pdf
+    pdfSha256: fac2dfc144c7709aadcb9be1423c7ba1ffe72f427e3eab5ebc0c03cada7f91ff
+    pdfVersion: '1.0'
   - title: Splendor
     bggId: 148228
     language: en
-    pdf: splendor_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Splendor is a game of chip-collecting and card development. Players are merchants of the Renaissance trying to buy gem mines, means of transportation, shops&mdash;all in order to acquire the most prestige points. If you're wealthy enough, you might even receive a visit from a noble at some point, which of course will further increase your prestige.
+    description: 'Splendor is a game of chip-collecting and card development. Players are merchants of the Renaissance trying
+      to buy gem mines, means of transportation, shops&mdash;all in order to acquire the most prestige points. If you''re
+      wealthy enough, you might even receive a visit from a noble at some point, which of course will further increase your
+      prestige.
 
 
-      On your turn, you may (1) collect chips (gems), or (2) buy and build a card, or (3) reserve one card. If you collect chips, you take either three different kinds of chips or two chips of the same kind. If you buy a card, you pay its price in chips and add it to your playing area. To reserve a card&mdash;in order to make sure you get it, or, why not, your opponents don't get it&mdash;you place it in front of you face down for later building; this costs you a round, but you also get gold in the form of a joker chip, which you can use as any gem.
+      On your turn, you may (1) collect chips (gems), or (2) buy and build a card, or (3) reserve one card. If you collect
+      chips, you take either three different kinds of chips or two chips of the same kind. If you buy a card, you pay its
+      price in chips and add it to your playing area. To reserve a card&mdash;in order to make sure you get it, or, why not,
+      your opponents don''t get it&mdash;you place it in front of you face down for later building; this costs you a round,
+      but you also get gold in the form of a joker chip, which you can use as any gem.
 
 
-      All of the cards you buy increase your wealth as they give you a permanent gem bonus for later buys; some of the cards also give you prestige points. In order to win the game, you must reach 15 prestige points before your opponents do.
+      All of the cards you buy increase your wealth as they give you a permanent gem bonus for later buys; some of the cards
+      also give you prestige points. In order to win the game, you must reach 15 prestige points before your opponents do.
 
+
+      '
     yearPublished: 2014
     minPlayers: 2
     maxPlayers: 4
@@ -686,19 +768,28 @@ catalog:
     - Rebel Sp. z o.o.
     - Siam Board Games
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/splendor_rulebook.pdf
+    pdfSha256: f4423dfde0c9bf7bb71d3ab1a5f87823f8c90857b84b83541bc9cd43727dc6a1
+    pdfVersion: '1.0'
   - title: 'Ticket to Ride: Europe'
     bggId: 14996
     language: en
-    pdf: ticket-to-ride-europe_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Ticket to Ride: Europe takes you on a new train adventure across Europe. From Edinburgh to Constantinople and from Lisbon to Moscow, you'll visit great cities of turn-of-the-century Europe. Like the original Ticket to Ride, the game remains elegantly simple, can be learned in 5 minutes, and appeals to both families and experienced gamers. Ticket to Ride: Europe is a complete, new game and does not require the original version.
+    description: 'Ticket to Ride: Europe takes you on a new train adventure across Europe. From Edinburgh to Constantinople
+      and from Lisbon to Moscow, you''ll visit great cities of turn-of-the-century Europe. Like the original Ticket to Ride,
+      the game remains elegantly simple, can be learned in 5 minutes, and appeals to both families and experienced gamers.
+      Ticket to Ride: Europe is a complete, new game and does not require the original version.
 
 
-      More than just a new map, Ticket to Ride: Europe features brand new gameplay elements. Tunnels may require you to pay extra cards to build on them, Ferries require locomotive cards in order to claim them, and Stations allow you to sacrifice a few points in order to use an opponent's route to connect yours. The game also includes larger format cards and Train Station game pieces.
+      More than just a new map, Ticket to Ride: Europe features brand new gameplay elements. Tunnels may require you to pay
+      extra cards to build on them, Ferries require locomotive cards in order to claim them, and Stations allow you to sacrifice
+      a few points in order to use an opponent''s route to connect yours. The game also includes larger format cards and Train
+      Station game pieces.
 
 
-      The overall goal remains the same: collect and play train cards in order to place your pieces on the board, attempting to connect cities on your ticket cards. Points are earned both from placing trains and completing tickets but uncompleted tickets lose you points. The player who has the most points at the end of the game wins.
+      The overall goal remains the same: collect and play train cards in order to place your pieces on the board, attempting
+      to connect cities on your ticket cards. Points are earned both from placing trains and completing tickets but uncompleted
+      tickets lose you points. The player who has the most points at the end of the game wins.
 
 
       Copyright 2002-2014 Days of Wonder, inc.
@@ -706,6 +797,8 @@ catalog:
 
       Part of the Ticket to Ride series.
 
+
+      '
     yearPublished: 2005
     minPlayers: 2
     maxPlayers: 5
@@ -757,25 +850,38 @@ catalog:
     - Runadrake
     - Smart Ltd
     - Well Designed Game
+    pdfBlobKey: rulebooks/v1/ticket-to-ride-europe_rulebook.pdf
+    pdfSha256: 9dc1f4210477d61dcd9b1baed990f4080fe372b657f6531f6e57c98197487fae
+    pdfVersion: '1.0'
   - title: Dominion
     bggId: 36218
     language: en
-    pdf: dominion_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      "You are a monarch, like your parents before you, a ruler of a small pleasant kingdom of rivers and evergreens. Unlike your parents, however, you have hopes and dreams! You want a bigger and more pleasant kingdom, with more rivers and a wider variety of trees. You want a Dominion! In all directions lie fiefs, freeholds, and feodums. All are small bits of land, controlled by petty lords and verging on anarchy. You will bring civilization to these people, uniting them under your banner.
+    description: '"You are a monarch, like your parents before you, a ruler of a small pleasant kingdom of rivers and evergreens.
+      Unlike your parents, however, you have hopes and dreams! You want a bigger and more pleasant kingdom, with more rivers
+      and a wider variety of trees. You want a Dominion! In all directions lie fiefs, freeholds, and feodums. All are small
+      bits of land, controlled by petty lords and verging on anarchy. You will bring civilization to these people, uniting
+      them under your banner.
 
 
-      But wait! It must be something in the air; several other monarchs have had the exact same idea. You must race to get as much of the unclaimed land as possible, fending them off along the way. To do this you will hire minions, construct buildings, spruce up your castle, and fill the coffers of your treasury. Your parents wouldn't be proud, but your grandparents, on your mother's side, would be delighted."
+      But wait! It must be something in the air; several other monarchs have had the exact same idea. You must race to get
+      as much of the unclaimed land as possible, fending them off along the way. To do this you will hire minions, construct
+      buildings, spruce up your castle, and fill the coffers of your treasury. Your parents wouldn''t be proud, but your grandparents,
+      on your mother''s side, would be delighted."
 
 
       &mdash;description from the back of the box
 
 
-      In Dominion, each player starts with an identical, very small deck of cards.  In the center of the table is a selection of other cards the players can "buy" as they can afford them.  Through their selection of cards to buy, and how they play their hands as they draw them, the players construct their deck on the fly, striving for the most efficient path to the precious victory points by game end.
+      In Dominion, each player starts with an identical, very small deck of cards.  In the center of the table is a selection
+      of other cards the players can "buy" as they can afford them.  Through their selection of cards to buy, and how they
+      play their hands as they draw them, the players construct their deck on the fly, striving for the most efficient path
+      to the precious victory points by game end.
 
 
-      Dominion is not a Collectible Card Game (CCG), but the play of the game is similar to the construction and play of a CCG deck. The game comes with 500 cards. You select 10 of the 25 Kingdom card types to include in any given play&mdash;leading to immense variety.
+      Dominion is not a Collectible Card Game (CCG), but the play of the game is similar to the construction and play of a
+      CCG deck. The game comes with 500 cards. You select 10 of the 25 Kingdom card types to include in any given play&mdash;leading
+      to immense variety.
 
 
       &mdash;user summary
@@ -783,6 +889,8 @@ catalog:
 
       Part of the Dominion series.
 
+
+      '
     yearPublished: 2008
     minPlayers: 2
     maxPlayers: 4
@@ -830,23 +938,43 @@ catalog:
     - Swan Panasia Co., Ltd.
     - Vennerød Forlag AS
     - Ystari Games
+    pdfBlobKey: rulebooks/v1/dominion_rulebook.pdf
+    pdfSha256: ea9e3fbef0064e6773c8772bbb234ac7d06c71a478422b45143432a29aa64273
+    pdfVersion: '1.0'
   - title: Scythe
     bggId: 169786
     language: en
-    pdf: scythe_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      It is a time of unrest in 1920s Europa. The ashes from the first great war still darken the snow. The capitalistic city-state known simply as &ldquo;The Factory&rdquo;, which fueled the war with heavily armored mechs, has closed its doors, drawing the attention of several nearby countries.
+    description: 'It is a time of unrest in 1920s Europa. The ashes from the first great war still darken the snow. The capitalistic
+      city-state known simply as &ldquo;The Factory&rdquo;, which fueled the war with heavily armored mechs, has closed its
+      doors, drawing the attention of several nearby countries.
 
 
-      Scythe is an engine-building game set in a 1920s era, alternate-history. It is a time of farming and war, broken hearts and rusted gears, innovation and valor. In Scythe, each player controls one of five factions of Eastern Europe, all of which are attempting to earn their fortunes and claim their stakes in the land around the mysterious Factory. Players conquer territory, enlist new recruits, reap resources, gain villagers, build structures, and activate monstrous mechs.
+      Scythe is an engine-building game set in a 1920s era, alternate-history. It is a time of farming and war, broken hearts
+      and rusted gears, innovation and valor. In Scythe, each player controls one of five factions of Eastern Europe, all
+      of which are attempting to earn their fortunes and claim their stakes in the land around the mysterious Factory. Players
+      conquer territory, enlist new recruits, reap resources, gain villagers, build structures, and activate monstrous mechs.
 
 
-      Each player begins the game with different resources (power, coins, combat acumen, and popularity), a different starting location, and a hidden goal. Starting positions are specially calibrated to contribute to each faction&rsquo;s uniqueness and the asymmetrical nature of the game (each faction always starts in the same place). Scythe uses a streamlined action-selection mechanism (no rounds or phases) to keep gameplay moving at a brisk pace and reduce downtime between turns. While there is plenty of direct conflict for players who seek it, there is no player elimination.
+      Each player begins the game with different resources (power, coins, combat acumen, and popularity), a different starting
+      location, and a hidden goal. Starting positions are specially calibrated to contribute to each faction&rsquo;s uniqueness
+      and the asymmetrical nature of the game (each faction always starts in the same place). Scythe uses a streamlined action-selection
+      mechanism (no rounds or phases) to keep gameplay moving at a brisk pace and reduce downtime between turns. While there
+      is plenty of direct conflict for players who seek it, there is no player elimination.
 
 
-      Scythe gives players almost complete control over their fate. Other than each player&rsquo;s individual hidden objective card, the only elements of luck or variability are &ldquo;encounter&rdquo; cards that players will draw as they interact with the citizens of newly explored lands. Each encounter card provides the player with several options, allowing them to mitigate the luck of the draw through their selection. Combat is also driven by choices, not luck or randomness. Every part of Scythe has an aspect of engine-building to it. Players can upgrade actions to become more efficient, build structures that improve their position on the map, enlist new recruits to enhance character abilities, activate mechs to deter opponents from invading, and expand their borders to reap greater types and quantities of resources. These engine-building aspects create a sense of momentum and progress throughout the game. The order in which players improve their engines adds to the unique feel of each game, even if having played one faction multiple times.
+      Scythe gives players almost complete control over their fate. Other than each player&rsquo;s individual hidden objective
+      card, the only elements of luck or variability are &ldquo;encounter&rdquo; cards that players will draw as they interact
+      with the citizens of newly explored lands. Each encounter card provides the player with several options, allowing them
+      to mitigate the luck of the draw through their selection. Combat is also driven by choices, not luck or randomness.
+      Every part of Scythe has an aspect of engine-building to it. Players can upgrade actions to become more efficient, build
+      structures that improve their position on the map, enlist new recruits to enhance character abilities, activate mechs
+      to deter opponents from invading, and expand their borders to reap greater types and quantities of resources. These
+      engine-building aspects create a sense of momentum and progress throughout the game. The order in which players improve
+      their engines adds to the unique feel of each game, even if having played one faction multiple times.
 
+
+      '
     yearPublished: 2016
     minPlayers: 1
     maxPlayers: 5
@@ -904,29 +1032,50 @@ catalog:
     - Planeta Igor
     - Playfun Games
     - Surfin' Meeple China
+    pdfBlobKey: rulebooks/v1/scythe_rulebook.pdf
+    pdfSha256: 3a27021231ff6ceb6401878eb27912ca7ce9455c6d2e7393e29248a80939f606
+    pdfVersion: '1.0'
   - title: Patchwork
     bggId: 163412
     language: en
-    pdf: patchwork_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Patchwork, two players compete to build the most aesthetic (and high-scoring) patchwork quilt on a personal 9x9 game board. To start play, lay out all of the patches at random in a circle and place a marker directly clockwise of the 2-1 patch. Each player takes five buttons &mdash; the currency/points in the game &mdash; and someone is chosen as the start player.
+    description: 'In Patchwork, two players compete to build the most aesthetic (and high-scoring) patchwork quilt on a personal
+      9x9 game board. To start play, lay out all of the patches at random in a circle and place a marker directly clockwise
+      of the 2-1 patch. Each player takes five buttons &mdash; the currency/points in the game &mdash; and someone is chosen
+      as the start player.
 
 
-      On a turn, a player either purchases one of the three patches standing clockwise of the spool or passes. To purchase a patch, you pay the cost in buttons shown on the patch, move the spool to that patch's location in the circle, add the patch to your game board, then advance your time token on the time track a number of spaces equal to the time shown on the patch. You're free to place the patch anywhere on your board that doesn't overlap other patches, but you probably want to fit things together as tightly as possible. If your time token is behind or on top of the other player's time token, then you take another turn; otherwise the opponent now goes. Instead of purchasing a patch, you can choose to pass; to do this, you move your time token to the space immediately in front of the opponent's time token, then take one button from the bank for each space you moved.
+      On a turn, a player either purchases one of the three patches standing clockwise of the spool or passes. To purchase
+      a patch, you pay the cost in buttons shown on the patch, move the spool to that patch''s location in the circle, add
+      the patch to your game board, then advance your time token on the time track a number of spaces equal to the time shown
+      on the patch. You''re free to place the patch anywhere on your board that doesn''t overlap other patches, but you probably
+      want to fit things together as tightly as possible. If your time token is behind or on top of the other player''s time
+      token, then you take another turn; otherwise the opponent now goes. Instead of purchasing a patch, you can choose to
+      pass; to do this, you move your time token to the space immediately in front of the opponent''s time token, then take
+      one button from the bank for each space you moved.
 
 
-      In addition to a button cost and time cost, each patch also features 0-3 buttons, and when you move your time token past a button on the time track, you earn "button income": sum the number of buttons depicted on your personal game board, then take this many buttons from the bank.
+      In addition to a button cost and time cost, each patch also features 0-3 buttons, and when you move your time token
+      past a button on the time track, you earn "button income": sum the number of buttons depicted on your personal game
+      board, then take this many buttons from the bank.
 
 
-      What's more, the time track depicts five 1x1 patches on it, and during set-up you place five actual 1x1 patches on these spaces. Whoever first passes a patch on the time track claims this patch and immediately places it on his game board.
+      What''s more, the time track depicts five 1x1 patches on it, and during set-up you place five actual 1x1 patches on
+      these spaces. Whoever first passes a patch on the time track claims this patch and immediately places it on his game
+      board.
 
 
-      Additionally, the first player to completely fill in a 7x7 square on his game board earns a bonus tile worth 7 extra points at the end of the game. (Of course, this doesn't happen in every game.)
+      Additionally, the first player to completely fill in a 7x7 square on his game board earns a bonus tile worth 7 extra
+      points at the end of the game. (Of course, this doesn''t happen in every game.)
 
 
-      When a player takes an action that moves his time token to the central square of the time track, he takes one final button income from the bank. Once both players are in the center, the game ends and scoring takes place. Each player scores one point per button in his possession, then loses two points for each empty square on his game board. Scores can be negative. The player with the most points wins.
+      When a player takes an action that moves his time token to the central square of the time track, he takes one final
+      button income from the bank. Once both players are in the center, the game ends and scoring takes place. Each player
+      scores one point per button in his possession, then loses two points for each empty square on his game board. Scores
+      can be negative. The player with the most points wins.
 
+
+      '
     yearPublished: 2014
     minPlayers: 2
     maxPlayers: 2
@@ -984,20 +1133,29 @@ catalog:
     - Tower Tactic Games
     - uplay.it edizioni
     - Нескучные игры
+    pdfBlobKey: rulebooks/v1/patchwork_rulebook.pdf
+    pdfSha256: 045325d8717e566f2cdb85196c6ee2ced1c7d484a67e9fc109b042b853b98874
+    pdfVersion: '1.0'
   - title: Love Letter
     bggId: 129622
     language: en
-    pdf: love-letter_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      All of the eligible young men (and many of the not-so-young) seek to woo the princess of Tempest. Unfortunately, she has locked herself in the palace, and you must rely on others to take your romantic letters to her. Will yours reach her first?
+    description: 'All of the eligible young men (and many of the not-so-young) seek to woo the princess of Tempest. Unfortunately,
+      she has locked herself in the palace, and you must rely on others to take your romantic letters to her. Will yours reach
+      her first?
 
 
-      Love Letter is a game of risk, deduction, and luck for 2&ndash;4 players. Your goal is to get your love letter into Princess Annette's hands while deflecting the letters from competing suitors. From a deck with only sixteen cards, each player starts with only one card in hand; one card is removed from play. On a turn, you draw one card, and play one card, trying to expose others and knock them from the game. Powerful cards lead to early gains, but make you a target. Rely on weaker cards for too long, however, and your letter may be tossed in the fire!
+      Love Letter is a game of risk, deduction, and luck for 2&ndash;4 players. Your goal is to get your love letter into
+      Princess Annette''s hands while deflecting the letters from competing suitors. From a deck with only sixteen cards,
+      each player starts with only one card in hand; one card is removed from play. On a turn, you draw one card, and play
+      one card, trying to expose others and knock them from the game. Powerful cards lead to early gains, but make you a target.
+      Rely on weaker cards for too long, however, and your letter may be tossed in the fire!
 
 
       Number 4 in the Setting: Tempest Shared World Game Series
 
+
+      '
     yearPublished: 2012
     minPlayers: 2
     maxPlayers: 4
@@ -1053,29 +1211,39 @@ catalog:
     - Swan Panasia Co., Ltd.
     - uplay.it edizioni
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/love-letter_rulebook.pdf
+    pdfSha256: e6b14614ffa5da73d995eaceefd7ca99e20ea8687b873da9b67ce6f3a5e69655
+    pdfVersion: '1.0'
   - title: King of Tokyo
     bggId: 70323
     language: en
-    pdf: king-of-tokyo_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In King of Tokyo, you play mutant monsters, gigantic robots, and strange aliens&mdash;all of whom are destroying Tokyo and whacking each other in order to become the one and only King of Tokyo.
+    description: 'In King of Tokyo, you play mutant monsters, gigantic robots, and strange aliens&mdash;all of whom are destroying
+      Tokyo and whacking each other in order to become the one and only King of Tokyo.
 
 
-      At the start of each turn, you roll six dice, which show the following six symbols: 1, 2, or 3 Victory Points, Energy, Heal, and Attack. Over three successive throws, choose whether to keep or discard each die in order to win victory points, gain energy, restore health, or attack other players into understanding that Tokyo is YOUR territory.
+      At the start of each turn, you roll six dice, which show the following six symbols: 1, 2, or 3 Victory Points, Energy,
+      Heal, and Attack. Over three successive throws, choose whether to keep or discard each die in order to win victory points,
+      gain energy, restore health, or attack other players into understanding that Tokyo is YOUR territory.
 
 
-      The fiercest player will occupy Tokyo, and earn extra victory points, but that player can't heal and must face all the other monsters alone!
+      The fiercest player will occupy Tokyo, and earn extra victory points, but that player can''t heal and must face all
+      the other monsters alone!
 
 
-      Top this off with special cards purchased with energy that have a permanent or temporary effect, such as the growing of a second head which grants you an additional die, body armor, nova death ray, and more.... and it's one of the most explosive games of the year!
+      Top this off with special cards purchased with energy that have a permanent or temporary effect, such as the growing
+      of a second head which grants you an additional die, body armor, nova death ray, and more.... and it''s one of the most
+      explosive games of the year!
 
 
-      In order to win the game, one must either destroy Tokyo by accumulating 20 victory points, or be the only surviving monster once the fighting has ended.
+      In order to win the game, one must either destroy Tokyo by accumulating 20 victory points, or be the only surviving
+      monster once the fighting has ended.
 
 
       First Game in the King of Tokyo series
 
+
+      '
     yearPublished: 2011
     minPlayers: 2
     maxPlayers: 6
@@ -1140,23 +1308,33 @@ catalog:
     - uplay.it edizioni
     - Vennerød Forlag AS
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/king-of-tokyo_rulebook.pdf
+    pdfSha256: 8ad8bba7f868b3925bb82ba206bd5cc8eab9a1c5d08e2b36fccad615af57e5fe
+    pdfVersion: '1.0'
   - title: Dixit
     bggId: 39856
     language: en
-    pdf: dixit_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Each turn in Dixit, one player is the storyteller who chooses one of the six cards in their hand, then expresses an idea, with sounds or words, that is reflected on that card's image, and places the card face down on the playing surface. Each other player then selects the card that best matches that expression, and passes the selected card to the storyteller, face down.
+    description: 'Each turn in Dixit, one player is the storyteller who chooses one of the six cards in their hand, then expresses
+      an idea, with sounds or words, that is reflected on that card''s image, and places the card face down on the playing
+      surface. Each other player then selects the card that best matches that expression, and passes the selected card to
+      the storyteller, face down.
 
 
-      The storyteller shuffles all the cards together, then turns them over to reveal them. Each player other than the storyteller then secretly guesses which card belongs to the storyteller. If nobody or everybody guesses the correct card, the storyteller scores 0 points, and each other player scores 2 points. Otherwise, the storyteller and whoever found the correct answer score 3 points. Additionally, the non-storyteller players score 1 point for every vote received by their card.
+      The storyteller shuffles all the cards together, then turns them over to reveal them. Each player other than the storyteller
+      then secretly guesses which card belongs to the storyteller. If nobody or everybody guesses the correct card, the storyteller
+      scores 0 points, and each other player scores 2 points. Otherwise, the storyteller and whoever found the correct answer
+      score 3 points. Additionally, the non-storyteller players score 1 point for every vote received by their card.
 
 
-      The game ends when the deck is empty or if a player has scored at least 30 points. In either case, the player with the most points wins.
+      The game ends when the deck is empty or if a player has scored at least 30 points. In either case, the player with the
+      most points wins.
 
 
       The Dixit base game and each expansion contain 84 cards, and the cards can be mixed together as desired.
 
+
+      '
     yearPublished: 2008
     minPlayers: 3
     maxPlayers: 6
@@ -1202,17 +1380,27 @@ catalog:
     - Rebel Sp. z o.o.
     - Swan Panasia Co., Ltd.
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/dixit_rulebook.pdf
+    pdfSha256: 26365f602d44493cb38f63459a904d653c31ac93eb5543f899ca0da20cfd51b7
+    pdfVersion: '1.0'
   - title: Gloomhaven
     bggId: 174430
     language: en
-    pdf: gloomhaven_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Gloomhaven  is a game of Euro-inspired tactical combat in a persistent world of shifting motives. Players will take on the roles of wandering adventurers with their own special sets of skills and their own reasons for traveling to this dark corner of the world. Players must work together out of necessity to clear out menacing dungeons and forgotten ruins. In the process, they will enhance their abilities with experience and loot, discover new locations to explore and plunder, and expand an ever-branching story fueled by the decisions they make.
-       This is a game with a persistent and changing world that is ideally played over many game sessions. After a scenario, players will make decisions about what to do next, which will determine how the story continues, kind of like a &ldquo;Choose Your Own Adventure&rdquo; book. Playing through a scenario is a co-operative affair where players will fight against automated monsters using an innovative card system to determine the order of play and what a player does on their turn.
-
-      Each turn, a player chooses two cards to play out of their hand. The number on the top card determines their initiative for the round. Each card also has a top and bottom power, and when it is a player&rsquo;s turn in the initiative order, they determine whether to use the top power of one card and the bottom power of the other, or vice-versa. Players must be careful, though, because over time they will permanently lose cards from their hands. If they take too long to clear a dungeon, they may end u exhausted and be forced to retreat.
-
+    description: "Gloomhaven  is a game of Euro-inspired tactical combat in a persistent world of shifting motives. Players\
+      \ will take on the roles of wandering adventurers with their own special sets of skills and their own reasons for traveling\
+      \ to this dark corner of the world. Players must work together out of necessity to clear out menacing dungeons and forgotten\
+      \ ruins. In the process, they will enhance their abilities with experience and loot, discover new locations to explore\
+      \ and plunder, and expand an ever-branching story fueled by the decisions they make.\n This is a game with a persistent\
+      \ and changing world that is ideally played over many game sessions. After a scenario, players will make decisions about\
+      \ what to do next, which will determine how the story continues, kind of like a &ldquo;Choose Your Own Adventure&rdquo;\
+      \ book. Playing through a scenario is a co-operative affair where players will fight against automated monsters using\
+      \ an innovative card system to determine the order of play and what a player does on their turn.\n\nEach turn, a player\
+      \ chooses two cards to play out of their hand. The number on the top card determines their initiative for the round.\
+      \ Each card also has a top and bottom power, and when it is a player&rsquo;s turn in the initiative order, they determine\
+      \ whether to use the top power of one card and the bottom power of the other, or vice-versa. Players must be careful,\
+      \ though, because over time they will permanently lose cards from their hands. If they take too long to clear a dungeon,\
+      \ they may end u exhausted and be forced to retreat.\n\n"
     yearPublished: 2017
     minPlayers: 1
     maxPlayers: 4
@@ -1269,29 +1457,41 @@ catalog:
     - Hobby World
     - Korea Boardgames
     - MYBG Co., Ltd.
+    pdfBlobKey: rulebooks/v1/gloomhaven_rulebook.pdf
+    pdfSha256: a8bb3b2e3d875f325d12da48ca4c6fd7807876b3b0353bf4052a74678d339f27
+    pdfVersion: '1.0'
   - title: Small World
     bggId: 40692
     language: en
-    pdf: small-world_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Small World, players vie for conquest and control of a world that is simply too small to accommodate them all.
+    description: 'In Small World, players vie for conquest and control of a world that is simply too small to accommodate
+      them all.
 
 
-      Designed by Philippe Keyaerts as a fantasy follow-up to his award-winning Vinci, Small World is inhabited by a zany cast of characters such as dwarves, wizards, amazons, giants, orcs, and even humans, who use their troops to occupy territory and conquer adjacent lands in order to push the other races off the face of the earth.
+      Designed by Philippe Keyaerts as a fantasy follow-up to his award-winning Vinci, Small World is inhabited by a zany
+      cast of characters such as dwarves, wizards, amazons, giants, orcs, and even humans, who use their troops to occupy
+      territory and conquer adjacent lands in order to push the other races off the face of the earth.
 
 
-      Picking the right combination from the 14 different fantasy races and 20 unique special powers, players rush to expand their empires - often at the expense of weaker neighbors. Yet they must also know when to push their own over-extended civilization into decline and ride a new one to victory!
+      Picking the right combination from the 14 different fantasy races and 20 unique special powers, players rush to expand
+      their empires - often at the expense of weaker neighbors. Yet they must also know when to push their own over-extended
+      civilization into decline and ride a new one to victory!
 
 
-      On each turn, you either use the multiple tiles of your chosen race (type of creatures) to occupy adjacent (normally) territories - possibly defeating weaker enemy races along the way, or you give up on your race letting it go "into decline". A race in decline is designated by flipping the tiles over to their black-and-white side.
+      On each turn, you either use the multiple tiles of your chosen race (type of creatures) to occupy adjacent (normally)
+      territories - possibly defeating weaker enemy races along the way, or you give up on your race letting it go "into decline".
+      A race in decline is designated by flipping the tiles over to their black-and-white side.
 
 
-      At the end of your turn, you score one point (coin) for each territory your races occupy. You may have one active race and one race in decline on the board at the same time. Your occupation total can vary depending on the special abilities of your race and the territories they occupy. After the final round, the player with the most coins wins.
+      At the end of your turn, you score one point (coin) for each territory your races occupy. You may have one active race
+      and one race in decline on the board at the same time. Your occupation total can vary depending on the special abilities
+      of your race and the territories they occupy. After the final round, the player with the most coins wins.
 
 
       Clarifications: available in a pinned forum post.
 
+
+      '
     yearPublished: 2009
     minPlayers: 2
     maxPlayers: 5
@@ -1333,13 +1533,19 @@ catalog:
     - Rebel Sp. z o.o.
     - Siam Board Games
     - Stratelibri
+    pdfBlobKey: rulebooks/v1/small-world_rulebook.pdf
+    pdfSha256: 9accfbeafcd1d650d39746eb79da373f9e9fe1c92f6f3322983d2e30b94b1c2a
+    pdfVersion: '1.0'
   - title: Everdell
     bggId: 199792
     language: en
-    pdf: everdell_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Within the charming valley of Everdell, beneath the boughs of towering trees, among meandering streams and mossy hollows, a civilization of forest critters is thriving and expanding. From Everfrost to Bellsong, many a year have come and gone, but the time has come for new territories to be settled and new cities established. You will be the leader of a group of critters intent on just such a task. There are buildings to construct, lively characters to meet, events to host&mdash;you have a busy year ahead of yourself. Will the sun shine brightest on your city before the winter moon rises?
+    description: 'Within the charming valley of Everdell, beneath the boughs of towering trees, among meandering streams and
+      mossy hollows, a civilization of forest critters is thriving and expanding. From Everfrost to Bellsong, many a year
+      have come and gone, but the time has come for new territories to be settled and new cities established. You will be
+      the leader of a group of critters intent on just such a task. There are buildings to construct, lively characters to
+      meet, events to host&mdash;you have a busy year ahead of yourself. Will the sun shine brightest on your city before
+      the winter moon rises?
 
 
       Everdell is a game of dynamic tableau building and worker placement.
@@ -1348,14 +1554,23 @@ catalog:
       On their turn a player can take one of three actions:
 
 
-      a) Place a Worker: Each player has a collection of Worker pieces. These are placed on the board locations, events, and on Destination cards. Workers perform various actions to further the development of a player's tableau: gathering resources, drawing cards, and taking other special actions.
+      a) Place a Worker: Each player has a collection of Worker pieces. These are placed on the board locations, events, and
+      on Destination cards. Workers perform various actions to further the development of a player''s tableau: gathering resources,
+      drawing cards, and taking other special actions.
 
 
-      b) Play a Card: Each player is building and populating a city; a tableau of up to 15 Construction and Critter cards. There are five types of cards: Travelers, Production, Destination, Governance, and Prosperity. Cards generate resources (twigs, resin, pebbles, and berries), grant abilities, and ultimately score points. The interactions of the cards reveal numerous strategies and a near infinite variety of working cities.
+      b) Play a Card: Each player is building and populating a city; a tableau of up to 15 Construction and Critter cards.
+      There are five types of cards: Travelers, Production, Destination, Governance, and Prosperity. Cards generate resources
+      (twigs, resin, pebbles, and berries), grant abilities, and ultimately score points. The interactions of the cards reveal
+      numerous strategies and a near infinite variety of working cities.
 
 
-      c) Prepare for the next Season: Workers are returned to the players supply and new workers are added. The game is played from Winter through to the onset of the following winter, at which point the player with the city with the most points wins.
+      c) Prepare for the next Season: Workers are returned to the players supply and new workers are added. The game is played
+      from Winter through to the onset of the following winter, at which point the player with the city with the most points
+      wins.
 
+
+      '
     yearPublished: 2018
     minPlayers: 1
     maxPlayers: 4
@@ -1409,80 +1624,41 @@ catalog:
     - White Goblin Games
     - YOKA Games
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/everdell_rulebook.pdf
+    pdfSha256: df74d35f64e90f0f94ed0077140c1ad18a4901cdd54a24c019257a5da671b74b
+    pdfVersion: '1.0'
   - title: Munchkin
     bggId: 1927
     language: en
-    pdf: munchkin_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      				
-      				
-      					Publisher's DescriptionGo down in the dungeon. Kill everything you meet. Backstab your friends and steal their stuff. Grab the treasure and run.
-
-      Admit it. You love it.
-
-
-      This award-winning card game, designed by Steve Jackson, captures the essence of the dungeon experience... with none of that stupid roleplaying stuff. You and your friends compete to kill monsters and grab magic items. And what magic items! Don the Horny Helmet and the Boots of Butt-Kicking. Wield the Staff of Napalm... or maybe the Chainsaw of Bloody Dismemberment. Start by slaughtering the Potted Plant and the Drooling Slime, and work your way up to the Plutonium Dragon...
-
-
-      And it's illustrated by John Kovalic! Fast-playing and silly, Munchkin can reduce any roleplaying group to hysteria. And, while they're laughing, you can steal their stuff.
-
-      				
-      				
-      					OtherPart of the Munchkin series.
-
-      Munchkin is a satirical card game based on the clich&eacute;s and oddities of Dungeons and Dragons and other role-playing games. Each player starts at level 1 and the winner is the first player to reach level 10. Players can acquire familiar D&D style character classes during the game which determine to some extent the cards they can play.
-
-
-      There are two types of cards - treasure and encounters. Each turn the current players 'kicks down the door' - drawing an encounter card from the deck. Usually this will involve battling a monster. Monsters have their own levels and players must try and overcome it using the levels, weapons and powers they have acquired during the game or run away. Other players can chose to help the player or hinder by adding extra monsters to the encounter. Defeating a monster will usually result in drawing treasure cards and acquiring levels.  Being defeated by a monster results in "bad stuff" which usually involves losing levels and treasure.
-
-
-      In May 2010, Steve Jackson Games made the "big announcement." Many rules and cards were changed. See The Great 2010 Munchkin Changeover for details. Of note to Munchkin fans, the Kneepads of Allure card, which had been removed in the 14th printing, was added back to the game but modified to be less powerful.
-
-      				
-      				
-      					Sequels:
-          The Good, the Bad, and the Munchkin
-          Munchkin Apocalypse
-          Munchkin Axe Cop
-          Munchkin Bites!
-          Munchkin Booty
-          Munchkin Conan
-          Munchkin Cthulhu
-          Munchkin Fu
-          Munchkin Impossible
-          Munchkin Legends
-          Munchkin Pathfinder
-          Munchkin Zombies
-          Star Munchkin
-          Super Munchkin
-
-
-      				
-      				
-      					Related Board Games
-          Munchkin Quest
-
-
-      				
-      				
-      					Online play
-           Vassal does not support Munchkin anymore. Former link: Vassal Module
-
-
-      				
-      				
-      					Pegasus Expansions
-          Munchkin Sammlerbox
-          Munchkin Sammlerkoffer
-          Munchkin Promotional Bookmarks
-          Munchkin Weihnachtsedition - The same as Munchkin, but with a promotional button that grants the wearer extra treasure (when worn in December). 
-
-
-      				
-      				
-      					Online PlaythroughThere's a great YouTube playthrough with Will Wheaton and Steve Jackson (yes, the Steve Jackson) found here LINK
-
+    description: "\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tPublisher's DescriptionGo down in the dungeon. Kill everything you meet. Backstab\
+      \ your friends and steal their stuff. Grab the treasure and run.\n\nAdmit it. You love it.\n\nThis award-winning card\
+      \ game, designed by Steve Jackson, captures the essence of the dungeon experience... with none of that stupid roleplaying\
+      \ stuff. You and your friends compete to kill monsters and grab magic items. And what magic items! Don the Horny Helmet\
+      \ and the Boots of Butt-Kicking. Wield the Staff of Napalm... or maybe the Chainsaw of Bloody Dismemberment. Start by\
+      \ slaughtering the Potted Plant and the Drooling Slime, and work your way up to the Plutonium Dragon...\n\nAnd it's\
+      \ illustrated by John Kovalic! Fast-playing and silly, Munchkin can reduce any roleplaying group to hysteria. And, while\
+      \ they're laughing, you can steal their stuff.\n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tOtherPart of the Munchkin series.\n\n\
+      Munchkin is a satirical card game based on the clich&eacute;s and oddities of Dungeons and Dragons and other role-playing\
+      \ games. Each player starts at level 1 and the winner is the first player to reach level 10. Players can acquire familiar\
+      \ D&D style character classes during the game which determine to some extent the cards they can play.\n\nThere are two\
+      \ types of cards - treasure and encounters. Each turn the current players 'kicks down the door' - drawing an encounter\
+      \ card from the deck. Usually this will involve battling a monster. Monsters have their own levels and players must\
+      \ try and overcome it using the levels, weapons and powers they have acquired during the game or run away. Other players\
+      \ can chose to help the player or hinder by adding extra monsters to the encounter. Defeating a monster will usually\
+      \ result in drawing treasure cards and acquiring levels.  Being defeated by a monster results in \"bad stuff\" which\
+      \ usually involves losing levels and treasure.\n\nIn May 2010, Steve Jackson Games made the \"big announcement.\" Many\
+      \ rules and cards were changed. See The Great 2010 Munchkin Changeover for details. Of note to Munchkin fans, the Kneepads\
+      \ of Allure card, which had been removed in the 14th printing, was added back to the game but modified to be less powerful.\n\
+      \n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tSequels:\n    The Good, the Bad, and the Munchkin\n    Munchkin Apocalypse\n    Munchkin\
+      \ Axe Cop\n    Munchkin Bites!\n    Munchkin Booty\n    Munchkin Conan\n    Munchkin Cthulhu\n    Munchkin Fu\n    Munchkin\
+      \ Impossible\n    Munchkin Legends\n    Munchkin Pathfinder\n    Munchkin Zombies\n    Star Munchkin\n    Super Munchkin\n\
+      \n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tRelated Board Games\n    Munchkin Quest\n\n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tOnline\
+      \ play\n     Vassal does not support Munchkin anymore. Former link: Vassal Module\n\n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\t\
+      Pegasus Expansions\n    Munchkin Sammlerbox\n    Munchkin Sammlerkoffer\n    Munchkin Promotional Bookmarks\n    Munchkin\
+      \ Weihnachtsedition - The same as Munchkin, but with a promotional button that grants the wearer extra treasure (when\
+      \ worn in December). \n\n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tOnline PlaythroughThere's a great YouTube playthrough with\
+      \ Will Wheaton and Steve Jackson (yes, the Steve Jackson) found here LINK\n\n"
     yearPublished: 2001
     minPlayers: 3
     maxPlayers: 6
@@ -1537,26 +1713,33 @@ catalog:
     - Ubik
     - Wargames Club Publishing
     - ТРЕТЯ ПЛАНЕТА
+    pdfBlobKey: rulebooks/v1/munchkin_rulebook.pdf
+    pdfSha256: a68e64aa104b6d1746194835ecfaa2bc22324e642a02cadb4be81371bad62e1a
+    pdfVersion: '1.0'
   - title: Forbidden Island
     bggId: 65244
     language: en
-    pdf: forbidden-island_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Forbidden Island is a visually stunning cooperative board game. Instead of winning by competing with other players like most games, everyone must work together to win the game. Players take turns moving their pawns around the 'island', which is built by arranging the many beautifully screen-printed tiles before play begins. As the game progresses, more and more island tiles sink, becoming unavailable, and the pace increases. Players use strategies to keep the island from sinking, while trying to collect treasures and items. As the water level rises, it gets more difficult- sacrifices must be made.
-
-
-      What causes this game to truly stand out among co-op and competitive games alike is the extreme detail that has been paid to the physical components of the game. It comes in a sturdy and organized tin of good shelf storage size. The plastic treasure pieces and wooden pawns are well crafted and they fit just right into the box. The cards are durable, well printed, and easy to understand. The island tiles are the real gem: they are screen-printed with vibrant colors, each with a unique and pleasing image.
-
-
-      With multiple levels of difficulty, different characters to choose from (each with a special ability of their own), many optional island formats and game variations available, Forbidden Island has huge replay value. The game can be played by as few as two players and up to four (though it can accommodate five). More players translates into a faster and more difficult game, though the extra help can make all the difference. This is a fun game, tricky for players of almost any age. Selling for under twenty dollars, oddly, Forbidden Island is a rare game of both quality and affordable price.
-       For those who enjoy Forbidden Island, a follow-up project by Gamewright titled Forbidden Desert was released in 2013.
-
-      From the publisher's website:
-
-
-      Dare to discover Forbidden Island! Join a team of fearless adventurers on a do-or-die mission to capture four sacred treasures from the ruins of this perilous paradise. Your team will have to work together and make some pulse-pounding maneuvers, as the island will sink beneath every step! Race to collect the treasures and make a triumphant escape before you are swallowed into the watery abyss!
-
+    description: "Forbidden Island is a visually stunning cooperative board game. Instead of winning by competing with other\
+      \ players like most games, everyone must work together to win the game. Players take turns moving their pawns around\
+      \ the 'island', which is built by arranging the many beautifully screen-printed tiles before play begins. As the game\
+      \ progresses, more and more island tiles sink, becoming unavailable, and the pace increases. Players use strategies\
+      \ to keep the island from sinking, while trying to collect treasures and items. As the water level rises, it gets more\
+      \ difficult- sacrifices must be made.\n\nWhat causes this game to truly stand out among co-op and competitive games\
+      \ alike is the extreme detail that has been paid to the physical components of the game. It comes in a sturdy and organized\
+      \ tin of good shelf storage size. The plastic treasure pieces and wooden pawns are well crafted and they fit just right\
+      \ into the box. The cards are durable, well printed, and easy to understand. The island tiles are the real gem: they\
+      \ are screen-printed with vibrant colors, each with a unique and pleasing image.\n\nWith multiple levels of difficulty,\
+      \ different characters to choose from (each with a special ability of their own), many optional island formats and game\
+      \ variations available, Forbidden Island has huge replay value. The game can be played by as few as two players and\
+      \ up to four (though it can accommodate five). More players translates into a faster and more difficult game, though\
+      \ the extra help can make all the difference. This is a fun game, tricky for players of almost any age. Selling for\
+      \ under twenty dollars, oddly, Forbidden Island is a rare game of both quality and affordable price.\n For those who\
+      \ enjoy Forbidden Island, a follow-up project by Gamewright titled Forbidden Desert was released in 2013.\n\nFrom the\
+      \ publisher's website:\n\nDare to discover Forbidden Island! Join a team of fearless adventurers on a do-or-die mission\
+      \ to capture four sacred treasures from the ruins of this perilous paradise. Your team will have to work together and\
+      \ make some pulse-pounding maneuvers, as the island will sink beneath every step! Race to collect the treasures and\
+      \ make a triumphant escape before you are swallowed into the watery abyss!\n\n"
     yearPublished: 2010
     minPlayers: 2
     maxPlayers: 4
@@ -1609,26 +1792,39 @@ catalog:
     - Spilbræt.dk
     - uplay.it edizioni
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/forbidden-island_rulebook.pdf
+    pdfSha256: b007c6b6a9385f4e27e74499f5e4623f3360ab7f8301853a4a3df01c6fa71c39
+    pdfVersion: '1.0'
   - title: Root
     bggId: 237182
     language: en
-    pdf: root_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Root is a game of adventure and war in which 2 to 4 (1 to 6 with the 'Riverfolk' expansion, 2-6 with the 'Underworld', or 'Marauder' expansions) players battle for control of a vast wilderness. Like Vast: The Crystal Caverns, each player in Root has unique capabilities and a different victory condition. Now, with the aid of gorgeous, multi-use cards, a truly asymmetric design has never been more accessible.
+    description: 'Root is a game of adventure and war in which 2 to 4 (1 to 6 with the ''Riverfolk'' expansion, 2-6 with the
+      ''Underworld'', or ''Marauder'' expansions) players battle for control of a vast wilderness. Like Vast: The Crystal
+      Caverns, each player in Root has unique capabilities and a different victory condition. Now, with the aid of gorgeous,
+      multi-use cards, a truly asymmetric design has never been more accessible.
 
 
-      The nefarious Marquise de Cat has seized the great woodland, intent on harvesting its riches. Under her rule, the many creatures of the forest have banded together. This Alliance will seek to strengthen its resources and subvert the rule of Cats. In this effort, the Alliance may enlist the help of the wandering Vagabonds who are able to move through the more dangerous woodland paths. Though some may sympathize with the Alliance&rsquo;s hopes and dreams, these wanderers are old enough to remember the great birds of prey who once controlled the woods.
+      The nefarious Marquise de Cat has seized the great woodland, intent on harvesting its riches. Under her rule, the many
+      creatures of the forest have banded together. This Alliance will seek to strengthen its resources and subvert the rule
+      of Cats. In this effort, the Alliance may enlist the help of the wandering Vagabonds who are able to move through the
+      more dangerous woodland paths. Though some may sympathize with the Alliance&rsquo;s hopes and dreams, these wanderers
+      are old enough to remember the great birds of prey who once controlled the woods.
 
 
-      Meanwhile, at the edge of the region, the proud, squabbling Eyrie have found a new commander who they hope will lead their faction to resume their ancient birthright. The stage is set for a contest that will decide the fate of the great woodland. It is up to the players to decide which group will ultimately take root.
+      Meanwhile, at the edge of the region, the proud, squabbling Eyrie have found a new commander who they hope will lead
+      their faction to resume their ancient birthright. The stage is set for a contest that will decide the fate of the great
+      woodland. It is up to the players to decide which group will ultimately take root.
 
 
-      In Root, players drive the narrative, and the differences between each role create an unparalleled level of interaction and replayability. Leder Games invites you and your family to explore the fantastic world of Root!
+      In Root, players drive the narrative, and the differences between each role create an unparalleled level of interaction
+      and replayability. Leder Games invites you and your family to explore the fantastic world of Root!
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2018
     minPlayers: 2
     maxPlayers: 4
@@ -1681,17 +1877,29 @@ catalog:
     - Spielworxx
     - Tower Tactic Games
     - YOKA Games
+    pdfBlobKey: rulebooks/v1/root_rulebook.pdf
+    pdfSha256: e79ca615f78f3f41a20b080f212eaf1da2e91f52af21c41f176c8a09bc5c8328
+    pdfVersion: '1.0'
   - title: Sushi Go!
     bggId: 133473
     language: en
-    pdf: sushi-go_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In the super-fast sushi card game Sushi Go!, you are eating at a sushi restaurant and trying to grab the best combination of sushi dishes as they whiz by. Score points for collecting the most sushi rolls or making a full set of sashimi. Dip your favorite nigiri in wasabi to triple its value! And once you've eaten it all, finish your meal with all the pudding you've got! But be careful which sushi you allow your friends to take; it might be just what they need to beat you!
+    description: 'In the super-fast sushi card game Sushi Go!, you are eating at a sushi restaurant and trying to grab the
+      best combination of sushi dishes as they whiz by. Score points for collecting the most sushi rolls or making a full
+      set of sashimi. Dip your favorite nigiri in wasabi to triple its value! And once you''ve eaten it all, finish your meal
+      with all the pudding you''ve got! But be careful which sushi you allow your friends to take; it might be just what they
+      need to beat you!
 
 
-      Sushi Go! takes the card-drafting mechanism of Fairy Tale and 7 Wonders and distills it into a twenty-minute game that anyone can play. The dynamics of "draft and pass" are brought to the fore, while keeping the rules to a minimum. As you see the first few hands of cards, you must quickly assess the make-up of the round and decide which type of sushi you'll go for. Then, each turn you'll need to weigh which cards to keep and which to pass on. The different scoring combinations allow for some clever plays and nasty blocks. Round to round, you must also keep your eye on the goal of having the most pudding cards at the end of the game!
+      Sushi Go! takes the card-drafting mechanism of Fairy Tale and 7 Wonders and distills it into a twenty-minute game that
+      anyone can play. The dynamics of "draft and pass" are brought to the fore, while keeping the rules to a minimum. As
+      you see the first few hands of cards, you must quickly assess the make-up of the round and decide which type of sushi
+      you''ll go for. Then, each turn you''ll need to weigh which cards to keep and which to pass on. The different scoring
+      combinations allow for some clever plays and nasty blocks. Round to round, you must also keep your eye on the goal of
+      having the most pudding cards at the end of the game!
 
+
+      '
     yearPublished: 2013
     minPlayers: 2
     maxPlayers: 5
@@ -1741,26 +1949,49 @@ catalog:
     - uplay.it edizioni
     - White Goblin Games
     - Zoch Verlag
+    pdfBlobKey: rulebooks/v1/sushi-go_rulebook.pdf
+    pdfSha256: 9c876c63af4e976927e0cf29c366409e6913d5b9e3b558300ad0712b971f3f99
+    pdfVersion: '1.0'
   - title: Spirit Island
     bggId: 162886
     language: en
-    pdf: spirit-island_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In the most distant reaches of the world, magic still exists, embodied by spirits of the land, of the sky, and of every natural thing. As the great powers of Europe stretch their colonial empires further and further, they will inevitably lay claim to a place where spirits still hold power - and when they do, the land itself will fight back alongside the islanders who live there.
+    description: 'In the most distant reaches of the world, magic still exists, embodied by spirits of the land, of the sky,
+      and of every natural thing. As the great powers of Europe stretch their colonial empires further and further, they will
+      inevitably lay claim to a place where spirits still hold power - and when they do, the land itself will fight back alongside
+      the islanders who live there.
 
 
-      Spirit Island is a complex and thematic co-operative game about defending your island home from colonizing Invaders. Players are different spirits of the land, each with its own unique elemental powers. Every turn, players simultaneously choose which of their power cards to play, paying energy to do so. Using combinations of power cards that match a spirit's elemental affinities can grant free bonus effects. Faster powers take effect immediately, before the Invaders spread and ravage, but other magics are slower, requiring forethought and planning to use effectively. In the Spirit phase, spirits gain energy, and choose how / whether to Grow: to reclaim used power cards, to seek new power, or to spread their presence into new areas of the island.
+      Spirit Island is a complex and thematic co-operative game about defending your island home from colonizing Invaders.
+      Players are different spirits of the land, each with its own unique elemental powers. Every turn, players simultaneously
+      choose which of their power cards to play, paying energy to do so. Using combinations of power cards that match a spirit''s
+      elemental affinities can grant free bonus effects. Faster powers take effect immediately, before the Invaders spread
+      and ravage, but other magics are slower, requiring forethought and planning to use effectively. In the Spirit phase,
+      spirits gain energy, and choose how / whether to Grow: to reclaim used power cards, to seek new power, or to spread
+      their presence into new areas of the island.
 
 
-      The Invaders expand across the island map in a semi-predictable fashion. Each turn they explore into some lands (portions of the island); the next turn, they build in those lands, forming towns and cities. The turn after that, they ravage there, bringing blight to the land and attacking any native islanders present. The islanders fight back against the Invaders when attacked, and lend the spirits some other aid, but may not always do so exactly as you'd hoped. Some Powers work through the islanders, helping them, for example, to drive out the Invaders or clean the land of blight.
+      The Invaders expand across the island map in a semi-predictable fashion. Each turn they explore into some lands (portions
+      of the island); the next turn, they build in those lands, forming towns and cities. The turn after that, they ravage
+      there, bringing blight to the land and attacking any native islanders present. The islanders fight back against the
+      Invaders when attacked, and lend the spirits some other aid, but may not always do so exactly as you''d hoped. Some
+      Powers work through the islanders, helping them, for example, to drive out the Invaders or clean the land of blight.
 
 
-      The game escalates as it progresses: spirits spread their presence to new parts of the island and seek out new and more potent powers, while the Invaders step up their colonization efforts. Each turn represents 1-3 years of alternate history. At game start, winning requires destroying every last explorer, town and city on the board - but as you frighten the Invaders more and more, victory becomes easier: they'll run away even if explorers or even towns and cities remain. Defeat comes if any spirit is destroyed, if the island is overrun by blight, or if the Invader deck is depleted before achieving victory.
+      The game escalates as it progresses: spirits spread their presence to new parts of the island and seek out new and more
+      potent powers, while the Invaders step up their colonization efforts. Each turn represents 1-3 years of alternate history.
+      At game start, winning requires destroying every last explorer, town and city on the board - but as you frighten the
+      Invaders more and more, victory becomes easier: they''ll run away even if explorers or even towns and cities remain.
+      Defeat comes if any spirit is destroyed, if the island is overrun by blight, or if the Invader deck is depleted before
+      achieving victory.
 
 
-      The game includes different adversaries to fight against (eg., a Swedish Mining Colony, or a Remote British Colony). Each changes play in different ways, and offers a different path of difficulty boosts to keep the game challenging as you gain skill.
+      The game includes different adversaries to fight against (eg., a Swedish Mining Colony, or a Remote British Colony).
+      Each changes play in different ways, and offers a different path of difficulty boosts to keep the game challenging as
+      you gain skill.
 
+
+      '
     yearPublished: 2017
     minPlayers: 1
     maxPlayers: 4
@@ -1813,23 +2044,35 @@ catalog:
     - Portal Games
     - REXhry
     - Siam Board Games
+    pdfBlobKey: rulebooks/v1/spirit-island_rulebook.pdf
+    pdfSha256: 64012c21460d3aee0f5c2c0d1048811a4dd4b4aebd03284ee4706a6a1f8e630e
+    pdfVersion: '1.0'
   - title: Jaipur
     bggId: 54043
     language: en
-    pdf: jaipur_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      You are one of the two most powerful traders in the city of Jaipur, the capital of Rajasthan, but that's not enough for you because only the merchant with two "seals of excellence" will have the privilege of being invited to the Maharaja's court. You are therefore going to have to do better than your direct competitor by buying, exchanging, and selling at better prices, all while keeping an eye on both your camel herds.
+    description: 'You are one of the two most powerful traders in the city of Jaipur, the capital of Rajasthan, but that''s
+      not enough for you because only the merchant with two "seals of excellence" will have the privilege of being invited
+      to the Maharaja''s court. You are therefore going to have to do better than your direct competitor by buying, exchanging,
+      and selling at better prices, all while keeping an eye on both your camel herds.
 
 
-      Jaipur is a fast-paced card game, a blend of tactics, risk and luck. On your turn, you can either take or sell cards. If you take cards, you have to choose between taking all the camels, taking one card from the market, or swapping 2-5 cards between the market and your cards.
+      Jaipur is a fast-paced card game, a blend of tactics, risk and luck. On your turn, you can either take or sell cards.
+      If you take cards, you have to choose between taking all the camels, taking one card from the market, or swapping 2-5
+      cards between the market and your cards.
 
 
-      If you sell cards, you get to sell only one type of good, and you receive as many chips for that good as the number of cards you sold. The chips' values decrease as the game progresses, so you'd better hurry! On the other hand, you receive increasingly high rewards for selling three, four, or five cards of the same good at a time, so you'd better wait!
+      If you sell cards, you get to sell only one type of good, and you receive as many chips for that good as the number
+      of cards you sold. The chips'' values decrease as the game progresses, so you''d better hurry! On the other hand, you
+      receive increasingly high rewards for selling three, four, or five cards of the same good at a time, so you''d better
+      wait!
 
 
-      You can't sell camels, but they're paramount for trading and they're also worth a little something at the end of the round, enough sometimes to secure the win, so you have to use them smartly.
+      You can''t sell camels, but they''re paramount for trading and they''re also worth a little something at the end of
+      the round, enough sometimes to secure the win, so you have to use them smartly.
 
+
+      '
     yearPublished: 2009
     minPlayers: 2
     maxPlayers: 2
@@ -1876,20 +2119,30 @@ catalog:
     - Rebel Sp. z o.o.
     - Siam Board Games
     - Yes Papa Games
+    pdfBlobKey: rulebooks/v1/jaipur_rulebook.pdf
+    pdfSha256: 4eca03a489d0436236cc501d861c7b555d1cad17dd3f91fecafe61bf23b9b31b
+    pdfVersion: '1.0'
   - title: The Quacks of Quedlinburg
     bggId: 244521
     language: en
-    pdf: quacks-of-quedlinburg_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Quacks, which was first released as The Quacks of Quedlinburg, players are charlatans &mdash; or quack doctors &mdash; each making their own secret brew by adding ingredients one at a time. Take care with what you add, though, for a pinch too much of this or that will spoil the whole mixture!
+    description: 'In Quacks, which was first released as The Quacks of Quedlinburg, players are charlatans &mdash; or quack
+      doctors &mdash; each making their own secret brew by adding ingredients one at a time. Take care with what you add,
+      though, for a pinch too much of this or that will spoil the whole mixture!
 
 
-      Each player has their own bag of ingredient chips. During each round, they simultaneously draw chips from their bags and add them to their pots. The higher the face value of the drawn chip, the further it is placed in the pot's swirling pattern, increasing how much the potion will be worth. Push your luck as far as you can, but if you add too many cherry bombs, your pot will explode!
+      Each player has their own bag of ingredient chips. During each round, they simultaneously draw chips from their bags
+      and add them to their pots. The higher the face value of the drawn chip, the further it is placed in the pot''s swirling
+      pattern, increasing how much the potion will be worth. Push your luck as far as you can, but if you add too many cherry
+      bombs, your pot will explode!
 
 
-      At the end of each round, players gain victory points and coins to spend on new ingredients, depending on how well they managed to fill up their pots. But players whose pots have exploded must choose points or coins &mdash; not both! The player with the most victory points at the end of nine rounds wins the game.
+      At the end of each round, players gain victory points and coins to spend on new ingredients, depending on how well they
+      managed to fill up their pots. But players whose pots have exploded must choose points or coins &mdash; not both! The
+      player with the most victory points at the end of nine rounds wins the game.
 
+
+      '
     yearPublished: 2018
     minPlayers: 2
     maxPlayers: 4
@@ -1939,16 +2192,22 @@ catalog:
     - North Star Games, LLC
     - Swan Panasia Co., Ltd.
     - YellowBOX
+    pdfBlobKey: rulebooks/v1/quacks-of-quedlinburg_rulebook.pdf
+    pdfSha256: f8fe7eb1cc25a229db9be200201941d2de28a23b3b810417a2b9ac792e3e4d16
+    pdfVersion: '1.0'
   - title: 'The Crew: Quest for Planet Nine'
     bggId: 284083
     language: en
-    pdf: the-crew_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In the co-operative trick-taking game The Crew: The Quest for Planet Nine, the players set out as astronauts on an uncertain space adventure. What are the rumors regarding the unknown planet about? The eventful journey through space extends over 50 exciting missions. But this game can only be defeated by meeting common individual tasks of each player. In order to meet the varied challenges communication is essential in the team. But this is more difficult than expected in space.
+    description: 'In the co-operative trick-taking game The Crew: The Quest for Planet Nine, the players set out as astronauts
+      on an uncertain space adventure. What are the rumors regarding the unknown planet about? The eventful journey through
+      space extends over 50 exciting missions. But this game can only be defeated by meeting common individual tasks of each
+      player. In order to meet the varied challenges communication is essential in the team. But this is more difficult than
+      expected in space.
 
 
-      With each mission the game becomes more difficult. After each mission the game can be paused and continued later. During each mission it is not the number of tricks but the right tricks at the right time that count.
+      With each mission the game becomes more difficult. After each mission the game can be paused and continued later. During
+      each mission it is not the number of tricks but the right tricks at the right time that count.
 
 
       The team completes a mission only if every single player is successful in fulfilling their tasks.
@@ -1956,6 +2215,8 @@ catalog:
 
       The game comes with 50 missions, with three additional missions published in spielbox 2/2020.
 
+
+      '
     yearPublished: 2019
     minPlayers: 2
     maxPlayers: 5
@@ -2003,51 +2264,41 @@ catalog:
     - Swan Panasia Co., Ltd.
     - Thames & Kosmos
     - Zvezda
+    pdfBlobKey: rulebooks/v1/the-crew_rulebook.pdf
+    pdfSha256: 12aded82732014978dfd8a744c6775e75ba9e719b7241e2bab7de42680a8db2f
+    pdfVersion: '1.0'
   - title: Coup
     bggId: 131357
     language: en
-    pdf: coup_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      You are head of a family in an Italian city-state, a city run by a weak and corrupt court. You need to manipulate, bluff and bribe your way to power. Your object is to destroy the influence of all the other families, forcing them into exile. Only one family will survive...
-
-
-      In Coup, you want to be the last player with influence in the game, with influence being represented by face-down character cards in your playing area.
-
-
-      Each player starts the game with two coins and two influence &ndash; i.e., two face-down character cards; the fifteen card deck consists of three copies of five different characters, each with a unique set of powers:
-
-
-           Duke: Take three coins from the treasury. Block someone from taking foreign aid.
-           Assassin: Pay three coins and try to assassinate another player's character.
-           Contessa: Block an assassination attempt against yourself.
-           Captain: Take two coins from another player, or block someone from stealing coins from you.
-           Ambassador: Draw two character cards from the Court (the deck), choose which (if any) to exchange with your face-down characters, then return two. Block someone from stealing coins from you.
-
-
-      On your turn, you can take any of the actions listed above, regardless of which characters you actually have in front of you, or you can take one of three other actions:
-
-
-           Income: Take one coin from the treasury.
-           Foreign aid: Take two coins from the treasury.
-           Coup: Pay seven coins and launch a coup against an opponent, forcing that player to lose an influence. (If you have ten coins or more, you must take this action.)
-
-
-      When you take one of the character actions &ndash; whether actively on your turn, or defensively in response to someone else's action &ndash; that character's action automatically succeeds unless an opponent challenges you. In this case, if you can't (or don't) reveal the appropriate character, you lose an influence, turning one of your characters face-up. Face-up characters cannot be used, and if both of your characters are face-up, you're out of the game.
-
-
-      If you do have the character in question and choose to reveal it, the opponent loses an influence, then you shuffle that character into the deck and draw a new one, perhaps getting the same character again and perhaps not.
-
-
-      The last player to still have influence &ndash; that is, a face-down character &ndash; wins the game!
-
-
-      A new & optional character called the Inquisitor has been added (currently, the only English edition with the Inquisitor included is the Kickstarter Version from Indie Boards & Cards. Copies in stores may not be the Kickstarter versions and may only be the base game). The Inquisitor character cards may be used to replace the Ambassador cards.
-
-
-           Inquisitor: Draw one character card from the Court deck and choose whether or not to exchange it with one of your face-down characters. OR Force an opponent to show you one of their character cards (their choice which). If you wish it, you may then force them to draw a new card from the Court deck. They then shuffle the old card into the Court deck. Block someone from stealing coins from you.
-
-
+    description: "You are head of a family in an Italian city-state, a city run by a weak and corrupt court. You need to manipulate,\
+      \ bluff and bribe your way to power. Your object is to destroy the influence of all the other families, forcing them\
+      \ into exile. Only one family will survive...\n\nIn Coup, you want to be the last player with influence in the game,\
+      \ with influence being represented by face-down character cards in your playing area.\n\nEach player starts the game\
+      \ with two coins and two influence &ndash; i.e., two face-down character cards; the fifteen card deck consists of three\
+      \ copies of five different characters, each with a unique set of powers:\n\n\n     Duke: Take three coins from the treasury.\
+      \ Block someone from taking foreign aid.\n     Assassin: Pay three coins and try to assassinate another player's character.\n\
+      \     Contessa: Block an assassination attempt against yourself.\n     Captain: Take two coins from another player,\
+      \ or block someone from stealing coins from you.\n     Ambassador: Draw two character cards from the Court (the deck),\
+      \ choose which (if any) to exchange with your face-down characters, then return two. Block someone from stealing coins\
+      \ from you.\n\n\nOn your turn, you can take any of the actions listed above, regardless of which characters you actually\
+      \ have in front of you, or you can take one of three other actions:\n\n\n     Income: Take one coin from the treasury.\n\
+      \     Foreign aid: Take two coins from the treasury.\n     Coup: Pay seven coins and launch a coup against an opponent,\
+      \ forcing that player to lose an influence. (If you have ten coins or more, you must take this action.)\n\n\nWhen you\
+      \ take one of the character actions &ndash; whether actively on your turn, or defensively in response to someone else's\
+      \ action &ndash; that character's action automatically succeeds unless an opponent challenges you. In this case, if\
+      \ you can't (or don't) reveal the appropriate character, you lose an influence, turning one of your characters face-up.\
+      \ Face-up characters cannot be used, and if both of your characters are face-up, you're out of the game.\n\nIf you do\
+      \ have the character in question and choose to reveal it, the opponent loses an influence, then you shuffle that character\
+      \ into the deck and draw a new one, perhaps getting the same character again and perhaps not.\n\nThe last player to\
+      \ still have influence &ndash; that is, a face-down character &ndash; wins the game!\n\nA new & optional character called\
+      \ the Inquisitor has been added (currently, the only English edition with the Inquisitor included is the Kickstarter\
+      \ Version from Indie Boards & Cards. Copies in stores may not be the Kickstarter versions and may only be the base game).\
+      \ The Inquisitor character cards may be used to replace the Ambassador cards.\n\n\n     Inquisitor: Draw one character\
+      \ card from the Court deck and choose whether or not to exchange it with one of your face-down characters. OR Force\
+      \ an opponent to show you one of their character cards (their choice which). If you wish it, you may then force them\
+      \ to draw a new card from the Court deck. They then shuffle the old card into the Court deck. Block someone from stealing\
+      \ coins from you.\n\n\n"
     yearPublished: 2012
     minPlayers: 2
     maxPlayers: 6
@@ -2105,17 +2356,23 @@ catalog:
     - テンデイズゲームズ (TendaysGames)
     - Zacatrus
     - 狗吠火車
+    pdfBlobKey: rulebooks/v1/coup_rulebook.pdf
+    pdfSha256: ca1e7851b438c494c27b613921dfa428a6205775939885a5a740624ac0cba46a
+    pdfVersion: '1.0'
   - title: Exploding Kittens
     bggId: 172225
     language: en
-    pdf: exploding-kittens_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Exploding Kittens is a kitty-powered version of Russian Roulette. Players take turns drawing cards until someone draws an exploding kitten and loses the game. The deck is made up of cards that let you avoid exploding by peeking at cards before you draw, forcing your opponent to draw multiple cards, or shuffling the deck.
+    description: 'Exploding Kittens is a kitty-powered version of Russian Roulette. Players take turns drawing cards until
+      someone draws an exploding kitten and loses the game. The deck is made up of cards that let you avoid exploding by peeking
+      at cards before you draw, forcing your opponent to draw multiple cards, or shuffling the deck.
 
 
-      The game gets more and more intense with each card you draw because fewer cards left in the deck means a greater chance of drawing the kitten and exploding in a fiery ball of feline hyperbole.
+      The game gets more and more intense with each card you draw because fewer cards left in the deck means a greater chance
+      of drawing the kitten and exploding in a fiery ball of feline hyperbole.
 
+
+      '
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 5
@@ -2166,19 +2423,33 @@ catalog:
     - Rozum
     - Siam Board Games
     - Super Impulse
+    pdfBlobKey: rulebooks/v1/exploding-kittens_rulebook.pdf
+    pdfSha256: 1585eb968604bd7652b3e8f276e5a7409c5bfca8fc1217ca75792ae3b44b654c
+    pdfVersion: '1.0'
   - title: Agricola
     bggId: 31260
     language: en
-    pdf: agricola_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Agricola, you're a farmer in a wooden shack with your spouse and little else. At first, on a turn, your family gets to take only two actions, one for you and one for your spouse, as might be found among all the possibilities on a farm: plowing fields; collecting materials; building fences, and so on. There are numerous choices available, and while the game progresses you'll have more and more, as each round a new action card is flipped over, offering one more possible action. You might think about having kids in order to get more work accomplished but first you'll need to expand your house to make room - and what are you going to feed all the little rug rats?
+    description: 'In Agricola, you''re a farmer in a wooden shack with your spouse and little else. At first, on a turn, your
+      family gets to take only two actions, one for you and one for your spouse, as might be found among all the possibilities
+      on a farm: plowing fields; collecting materials; building fences, and so on. There are numerous choices available, and
+      while the game progresses you''ll have more and more, as each round a new action card is flipped over, offering one
+      more possible action. You might think about having kids in order to get more work accomplished but first you''ll need
+      to expand your house to make room - and what are you going to feed all the little rug rats?
 
 
-      The game supports many levels of complexity, mainly through the distribution of cards which represent Minor Improvements and Occupations. In the beginner's version (called the Family Variant in the U.S. release) these cards are not used at all. For advanced play, the U.S. release includes three levels of both types of cards; Basic (E-deck), Interactive (I-deck), and Complex (K-deck), and the rulebook encourages players to experiment with the various decks and mixtures thereof. Aftermarket decks such as the Z-Deck and the L-Deck also exist. Each player starts with a hand of 7 Occupation cards (of more than 160 total) and 7 Minor Improvement cards (of more than 140 total) that he/she may use during the game if they fit into his/her strategy.
+      The game supports many levels of complexity, mainly through the distribution of cards which represent Minor Improvements
+      and Occupations. In the beginner''s version (called the Family Variant in the U.S. release) these cards are not used
+      at all. For advanced play, the U.S. release includes three levels of both types of cards; Basic (E-deck), Interactive
+      (I-deck), and Complex (K-deck), and the rulebook encourages players to experiment with the various decks and mixtures
+      thereof. Aftermarket decks such as the Z-Deck and the L-Deck also exist. Each player starts with a hand of 7 Occupation
+      cards (of more than 160 total) and 7 Minor Improvement cards (of more than 140 total) that he/she may use during the
+      game if they fit into his/her strategy.
 
 
-      Agricola is a turn-based game, and the problem to be overcome is that each available action can be taken by only one player each round so it's important to be careful about your choices.  There are countless strategies, some of which depend on your hand of cards.
+      Agricola is a turn-based game, and the problem to be overcome is that each available action can be taken by only one
+      player each round so it''s important to be careful about your choices.  There are countless strategies, some of which
+      depend on your hand of cards.
 
 
       The winner is the player with the most Victory Points from the Improvements made on his farm.
@@ -2186,6 +2457,8 @@ catalog:
 
       -description originally from BoardgameNews
 
+
+      '
     yearPublished: 2007
     minPlayers: 1
     maxPlayers: 5
@@ -2230,17 +2503,26 @@ catalog:
     - Swan Panasia Co., Ltd.
     - Ystari Games
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/agricola_rulebook.pdf
+    pdfSha256: 76fbd30f440c34b109be0b1f20d4ad188b602c382fe0b33860c800cb20d11d75
+    pdfVersion: '1.0'
   - title: Kingdomino
     bggId: 204583
     language: en
-    pdf: kingdomino_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Kingdomino, you are a lord seeking new lands in which to expand your kingdom. You must explore all the lands, including wheat fields, lakes, and mountains, in order to spot the best plots, while competing with other lords to acquire them first.
+    description: 'In Kingdomino, you are a lord seeking new lands in which to expand your kingdom. You must explore all the
+      lands, including wheat fields, lakes, and mountains, in order to spot the best plots, while competing with other lords
+      to acquire them first.
 
 
-      The game uses tiles with two sections, similar to Dominoes. Each turn, each player will select a new domino to connect to their existing kingdom, making sure at least one of its sides connects to a matching terrain type already in play. The order of who picks first depends on which tile was previously chosen, with better tiles forcing players to pick later in the next round. The game ends when each player has completed a 5x5 grid (or failed to do so), and points are counted based on number of connecting tiles and valuable crown symbols.
+      The game uses tiles with two sections, similar to Dominoes. Each turn, each player will select a new domino to connect
+      to their existing kingdom, making sure at least one of its sides connects to a matching terrain type already in play.
+      The order of who picks first depends on which tile was previously chosen, with better tiles forcing players to pick
+      later in the next round. The game ends when each player has completed a 5x5 grid (or failed to do so), and points are
+      counted based on number of connecting tiles and valuable crown symbols.
 
+
+      '
     yearPublished: 2016
     minPlayers: 2
     maxPlayers: 4
@@ -2293,16 +2575,23 @@ catalog:
     - Swan Panasia Co., Ltd.
     - テンデイズゲームズ (TendaysGames)
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/kingdomino_rulebook.pdf
+    pdfSha256: 25787aa1e0d3c70d292b7de68534b4c6b05ef75720ba6a535720d782c51d1cb2
+    pdfVersion: '1.0'
   - title: Hanabi
     bggId: 98778
     language: en
-    pdf: hanabi_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Hanabi&mdash;named for the Japanese word for "fireworks"&mdash;is a cooperative game in which players try to create the perfect fireworks show by placing the cards on the table in the right order. (In Japanese, hanabi is written as 花火; these are the ideograms flower and fire, respectively.)
+    description: 'Hanabi&mdash;named for the Japanese word for "fireworks"&mdash;is a cooperative game in which players try
+      to create the perfect fireworks show by placing the cards on the table in the right order. (In Japanese, hanabi is written
+      as 花火; these are the ideograms flower and fire, respectively.)
 
 
-      The card deck consists of five different colors of cards, numbered 1&ndash;5 in each color. For each color, the players try to place a row in the correct order from 1&ndash;5. Sounds easy, right? Well, not quite, as in this game you hold your cards so that they're visible only to other players. To assist other players in playing a card, you must give them hints regarding the numbers or the colors of their cards. Players must act as a team to avoid errors and to finish the fireworks display before they run out of cards.
+      The card deck consists of five different colors of cards, numbered 1&ndash;5 in each color. For each color, the players
+      try to place a row in the correct order from 1&ndash;5. Sounds easy, right? Well, not quite, as in this game you hold
+      your cards so that they''re visible only to other players. To assist other players in playing a card, you must give
+      them hints regarding the numbers or the colors of their cards. Players must act as a team to avoid errors and to finish
+      the fireworks display before they run out of cards.
 
 
       An extra suit of cards, rainbow colored, is also provided for advanced or variant play.
@@ -2310,6 +2599,8 @@ catalog:
 
       Hanabi was originally published as part of Hanabi & Ikebana.
 
+
+      '
     yearPublished: 2010
     minPlayers: 2
     maxPlayers: 5
@@ -2361,29 +2652,45 @@ catalog:
     - REXhry
     - Spin Master Ltd.
     - Swan Panasia Co., Ltd.
+    pdfBlobKey: rulebooks/v1/hanabi_rulebook.pdf
+    pdfSha256: f23df0ceaa2715e6b46444018fb8bfad6afb021d76fc2c2ee802fdfb4c2dc472
+    pdfVersion: '1.0'
   - title: 'Pandemic Legacy: Season 1'
     bggId: 161936
     language: en
-    pdf: pandemic-legacy-s1_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Pandemic Legacy is a co-operative campaign game, with an overarching story arc played through 12-24 sessions, depending on how well your group does at the game. At the beginning, the game starts in a very similar fashion as basic Pandemic, in which your team of disease-fighting specialists races against the clock to travel around the world, treating disease hot spots while researching cures for each of four plagues before they get out of hand.
+    description: 'Pandemic Legacy is a co-operative campaign game, with an overarching story arc played through 12-24 sessions,
+      depending on how well your group does at the game. At the beginning, the game starts in a very similar fashion as basic
+      Pandemic, in which your team of disease-fighting specialists races against the clock to travel around the world, treating
+      disease hot spots while researching cures for each of four plagues before they get out of hand.
 
 
-      During a player's turn, they have four actions available, with which they may travel around in the world in various ways (sometimes needing to discard a card), build structures like research stations, treat diseases (removing one cube from the board; if all cubes of a color have been removed, the disease has been eradicated), trade cards with other players, or find a cure for a disease (requiring five cards of the same color to be discarded while at a research station). Each player has a unique role with special abilities to help them at these actions.
+      During a player''s turn, they have four actions available, with which they may travel around in the world in various
+      ways (sometimes needing to discard a card), build structures like research stations, treat diseases (removing one cube
+      from the board; if all cubes of a color have been removed, the disease has been eradicated), trade cards with other
+      players, or find a cure for a disease (requiring five cards of the same color to be discarded while at a research station).
+      Each player has a unique role with special abilities to help them at these actions.
 
 
-      After a player has taken their actions, they draw two cards. These cards can include epidemic cards, which will place new disease cubes on the board, and can lead to an outbreak, spreading disease cubes even further. Outbreaks additionally increase the panic level of a city, making that city more expensive to travel to.
+      After a player has taken their actions, they draw two cards. These cards can include epidemic cards, which will place
+      new disease cubes on the board, and can lead to an outbreak, spreading disease cubes even further. Outbreaks additionally
+      increase the panic level of a city, making that city more expensive to travel to.
 
 
-      Each month in the game, you have two chances to achieve that month's objectives. If you succeed, you win and immediately move on to the next month. If you fail, you have a second chance, with more funding for beneficial event cards.
+      Each month in the game, you have two chances to achieve that month''s objectives. If you succeed, you win and immediately
+      move on to the next month. If you fail, you have a second chance, with more funding for beneficial event cards.
 
 
-      During the campaign, new rules and components will be introduced. These will sometimes require you to permanently alter the components of the game; this includes writing on cards, ripping up cards, and placing permanent stickers on components. Your characters can gain new skills, or detrimental effects. A character can even be lost entirely, at which point it's no longer available for play.
+      During the campaign, new rules and components will be introduced. These will sometimes require you to permanently alter
+      the components of the game; this includes writing on cards, ripping up cards, and placing permanent stickers on components.
+      Your characters can gain new skills, or detrimental effects. A character can even be lost entirely, at which point it''s
+      no longer available for play.
 
 
       Part of the Pandemic series
 
+
+      '
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 4
@@ -2426,20 +2733,35 @@ catalog:
     - Lifestyle Boardgames Ltd
     - MINDOK
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/pandemic-legacy-s1_rulebook.pdf
+    pdfSha256: 9198abfbd116b96446294b8db1bf2f98c44a1444a727d27ec861c0ad6e1f93d5
+    pdfVersion: '1.0'
   - title: Cascadia
     bggId: 295947
     language: en
-    pdf: cascadia_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Cascadia is a puzzly tile-laying and token-drafting game featuring the habitats and wildlife of the Pacific Northwest.
+    description: 'Cascadia is a puzzly tile-laying and token-drafting game featuring the habitats and wildlife of the Pacific
+      Northwest.
 
 
-      In the game, you take turns building out your own terrain area and populating it with wildlife. You start with three hexagonal habitat tiles (with the five types of habitat in the game), and on a turn you choose a new habitat tile that's paired with a wildlife token, then place that tile next to your other ones and place the wildlife token on an appropriate habitat. (Each tile depicts 1-3 types of wildlife from the five types in the game, and you can place at most one token on a habitat.) Four tiles are on display, with each tile being paired at random with a wildlife token, so you must make the best of what's available &mdash; unless you have a nature token to spend so that you can pick your choice of each item.
+      In the game, you take turns building out your own terrain area and populating it with wildlife. You start with three
+      hexagonal habitat tiles (with the five types of habitat in the game), and on a turn you choose a new habitat tile that''s
+      paired with a wildlife token, then place that tile next to your other ones and place the wildlife token on an appropriate
+      habitat. (Each tile depicts 1-3 types of wildlife from the five types in the game, and you can place at most one token
+      on a habitat.) Four tiles are on display, with each tile being paired at random with a wildlife token, so you must make
+      the best of what''s available &mdash; unless you have a nature token to spend so that you can pick your choice of each
+      item.
 
 
-      Ideally you can place habitat tiles to create matching terrain that reduces fragmentation and creates wildlife corridors, mostly because you score for the largest area of each type of habitat at game's end, with a bonus if your group is larger than each other player's. At the same time, you want to place wildlife tokens so that you can maximize the number of points scored by them, with the wildlife goals being determined at random by one of the four scoring cards for each type of wildlife. Maybe hawks want to be separate from other hawks, while foxes want lots of different animals surrounding them and bears want to be in pairs. Can you make it happen?
+      Ideally you can place habitat tiles to create matching terrain that reduces fragmentation and creates wildlife corridors,
+      mostly because you score for the largest area of each type of habitat at game''s end, with a bonus if your group is
+      larger than each other player''s. At the same time, you want to place wildlife tokens so that you can maximize the number
+      of points scored by them, with the wildlife goals being determined at random by one of the four scoring cards for each
+      type of wildlife. Maybe hawks want to be separate from other hawks, while foxes want lots of different animals surrounding
+      them and bears want to be in pairs. Can you make it happen?
 
+
+      '
     yearPublished: 2021
     minPlayers: 1
     maxPlayers: 4
@@ -2490,20 +2812,32 @@ catalog:
     - Tower Tactic Games
     - White Goblin Games
     - 株式会社ケンビル (KenBill)
+    pdfBlobKey: rulebooks/v1/cascadia_rulebook.pdf
+    pdfSha256: 94c7313aef8e161527844fbfc4296419ad5999ec9027e4aede905ac83b510a80
+    pdfVersion: '1.0'
   - title: 'Gloomhaven: Jaws of the Lion'
     bggId: 291457
     language: en
-    pdf: gloomhaven-jaws-of-the-lion_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Gloomhaven: Jaws of the Lion is a standalone game that takes place before the events of Gloomhaven. The game includes four new characters &mdash; Valrath Red Guard (tank, crowd control), Inox Hatchet (ranged damage), Human Voidwarden (support, mind control), and Quatryl Demolitionist (melee damage, obstacle manipulation) &mdash; that can also be used in the original Gloomhaven game.
+    description: 'Gloomhaven: Jaws of the Lion is a standalone game that takes place before the events of Gloomhaven. The
+      game includes four new characters &mdash; Valrath Red Guard (tank, crowd control), Inox Hatchet (ranged damage), Human
+      Voidwarden (support, mind control), and Quatryl Demolitionist (melee damage, obstacle manipulation) &mdash; that can
+      also be used in the original Gloomhaven game.
 
 
-      The game also includes 16 monster types (including seven new standard monsters and three new bosses) and a new campaign with 25 scenarios that invites the heroes to investigate a case of mysterious disappearances within the city. Is it the work of Vermlings, or is something far more sinister going on?
+      The game also includes 16 monster types (including seven new standard monsters and three new bosses) and a new campaign
+      with 25 scenarios that invites the heroes to investigate a case of mysterious disappearances within the city. Is it
+      the work of Vermlings, or is something far more sinister going on?
 
 
-      Gloomhaven: Jaws of the Lion is aimed at a more casual audience to get people into the gameplay more quickly. All of the hard-to-organize cardboard map tiles have been removed, and instead players will play on the scenario book itself, which features new artwork unique to each scenario. The last barrier to entry &mdash; i.e., learning the game &mdash; has also been lowered through a simplified rule set and a five-scenario tutorial that will ease new players into the experience.
+      Gloomhaven: Jaws of the Lion is aimed at a more casual audience to get people into the gameplay more quickly. All of
+      the hard-to-organize cardboard map tiles have been removed, and instead players will play on the scenario book itself,
+      which features new artwork unique to each scenario. The last barrier to entry &mdash; i.e., learning the game &mdash;
+      has also been lowered through a simplified rule set and a five-scenario tutorial that will ease new players into the
+      experience.
 
+
+      '
     yearPublished: 2020
     minPlayers: 1
     maxPlayers: 4
@@ -2558,26 +2892,39 @@ catalog:
     - Lord of Boards
     - Meanbook Games
     - Siam Board Games
+    pdfBlobKey: rulebooks/v1/gloomhaven-jaws-of-the-lion_rulebook.pdf
+    pdfSha256: 5ece90b8054527a29ba56600d99a9b88c02fb567ee8334aac9bf9f70978f8fcb
+    pdfVersion: '1.0'
   - title: Power Grid
     bggId: 2651
     language: en
-    pdf: power-grid_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Power Grid is the updated release of the Friedemann Friese crayon game Funkenschlag. It removes the crayon aspect from network building in the original edition, while retaining the fluctuating commodities market like Crude: The Oil Game and an auction round intensity reminiscent of The Princes of Florence.
+    description: 'Power Grid is the updated release of the Friedemann Friese crayon game Funkenschlag. It removes the crayon
+      aspect from network building in the original edition, while retaining the fluctuating commodities market like Crude:
+      The Oil Game and an auction round intensity reminiscent of The Princes of Florence.
 
 
-      The objective of Power Grid is to supply the most cities with power when someone's network gains a predetermined size.  In this new edition, players mark pre-existing routes between cities for connection, and then bid against each other to purchase the power plants that they use to power their cities.
+      The objective of Power Grid is to supply the most cities with power when someone''s network gains a predetermined size.  In
+      this new edition, players mark pre-existing routes between cities for connection, and then bid against each other to
+      purchase the power plants that they use to power their cities.
 
 
-      However, as plants are purchased, newer, more efficient plants become available, so by merely purchasing, you're potentially allowing others access to superior equipment.
+      However, as plants are purchased, newer, more efficient plants become available, so by merely purchasing, you''re potentially
+      allowing others access to superior equipment.
 
 
-      Additionally, players must acquire the raw materials (coal, oil, garbage, and uranium) needed to power said plants (except for the 'renewable' windfarm/ solar plants, which require no fuel), making it a constant struggle to upgrade your plants for maximum efficiency while still retaining enough wealth to quickly expand your network to get the cheapest routes.
+      Additionally, players must acquire the raw materials (coal, oil, garbage, and uranium) needed to power said plants (except
+      for the ''renewable'' windfarm/ solar plants, which require no fuel), making it a constant struggle to upgrade your
+      plants for maximum efficiency while still retaining enough wealth to quickly expand your network to get the cheapest
+      routes.
 
 
-      ☛ Power Grid FAQ - Please read this before posting a rules question!  Many questions are asked over and over in the forums... If you have a question about a specific expansion, please check the rules forum or FAQ for that particular expansion.
+      ☛ Power Grid FAQ - Please read this before posting a rules question!  Many questions are asked over and over in the
+      forums... If you have a question about a specific expansion, please check the rules forum or FAQ for that particular
+      expansion.
 
+
+      '
     yearPublished: 2004
     minPlayers: 2
     maxPlayers: 6
@@ -2628,26 +2975,36 @@ catalog:
     - Smart Ltd
     - Stratelibri
     - Swan Panasia Co., Ltd.
+    pdfBlobKey: rulebooks/v1/power-grid_rulebook.pdf
+    pdfSha256: e90d321d233b3fbffac8a1900d6a5cb96ffccd29b1a215e2889c5eacb995e73f
+    pdfVersion: '1.0'
   - title: Betrayal at House on the Hill
     bggId: 10547
     language: en
-    pdf: betrayal-at-house-on-the-hill_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Betrayal at House on the Hill quickly builds suspense and excitement as players explore a haunted mansion of their own 'design', encountering spirits and frightening omens that foretell their fate. With an estimated one hour playing time, Betrayal at House on the Hill is ideal for parties, family gatherings or casual fun with friends.
+    description: 'Betrayal at House on the Hill quickly builds suspense and excitement as players explore a haunted mansion
+      of their own ''design'', encountering spirits and frightening omens that foretell their fate. With an estimated one
+      hour playing time, Betrayal at House on the Hill is ideal for parties, family gatherings or casual fun with friends.
 
 
-      Betrayal at House on the Hill is a tile game that allows players to lay out the haunted house room by room, tile by tile, creating a new thrilling game board every time. The game is designed for three to six people, each of whom plays one of six possible characters.
+      Betrayal at House on the Hill is a tile game that allows players to lay out the haunted house room by room, tile by
+      tile, creating a new thrilling game board every time. The game is designed for three to six people, each of whom plays
+      one of six possible characters.
 
 
-      Secretly, one of the characters betrays the rest of the party, and the innocent members of the party must defeat the traitor in their midst before it&rsquo;s too late! Betrayal at House on the Hill will appeal to any game player who enjoys a fun, suspenseful, and strategic game.
+      Secretly, one of the characters betrays the rest of the party, and the innocent members of the party must defeat the
+      traitor in their midst before it&rsquo;s too late! Betrayal at House on the Hill will appeal to any game player who
+      enjoys a fun, suspenseful, and strategic game.
 
 
-      Betrayal at House on the Hill includes detailed game pieces, including character cards, pre-painted plastic figures, and special tokens, all of which help create a spooky atmosphere and streamline game play.
+      Betrayal at House on the Hill includes detailed game pieces, including character cards, pre-painted plastic figures,
+      and special tokens, all of which help create a spooky atmosphere and streamline game play.
 
 
       An updated reprint of Betrayal at House on the Hill was released on October 5, 2010.
 
+
+      '
     yearPublished: 2004
     minPlayers: 3
     maxPlayers: 6
@@ -2684,30 +3041,24 @@ catalog:
     - Wizards of the Coast
     - asmodee
     - Hasbro
+    pdfBlobKey: rulebooks/v1/betrayal-at-house-on-the-hill_rulebook.pdf
+    pdfSha256: 806700be2b34ee26d0dee42c4b600bc57b0d1c4c520ddfeaf9db171441ba9f9e
+    pdfVersion: '1.0'
   - title: Ark Nova
     bggId: 342942
     language: en
-    pdf: ark-nova_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Ark Nova, you will plan and design a modern, scientifically managed zoo. With the ultimate goal of owning the most successful zoological establishment, you will build enclosures, accommodate animals, and support conservation projects all over the world. Specialists and unique buildings will help you in achieving this goal.
-
-
-      Each player has a set of five action cards to manage their gameplay, and the power of an action is determined by the slot the card currently occupies. The cards in question are:
-
-
-          CARDS: Allows you to gain new zoo cards (animals, sponsors, and conservation project cards).
-          BUILD: Allows you to build standard or special enclosures, kiosks, and pavilions.
-          ANIMALS: Allows you to accommodate animals in your zoo.
-          ASSOCIATION: Allows your association workers to carry out different tasks.
-          SPONSORS: Allows you to play a sponsor card in your zoo or to raise money.
-
-
-      255 cards featuring animals, specialists, special enclosures, and conservation projects, each with a special ability, are at the heart of Ark Nova. Use them to increase the appeal and scientific reputation of your zoo and collect conservation points.
-
-
-      &mdash;description from the publisher
-
+    description: "In Ark Nova, you will plan and design a modern, scientifically managed zoo. With the ultimate goal of owning\
+      \ the most successful zoological establishment, you will build enclosures, accommodate animals, and support conservation\
+      \ projects all over the world. Specialists and unique buildings will help you in achieving this goal.\n\nEach player\
+      \ has a set of five action cards to manage their gameplay, and the power of an action is determined by the slot the\
+      \ card currently occupies. The cards in question are:\n\n\n    CARDS: Allows you to gain new zoo cards (animals, sponsors,\
+      \ and conservation project cards).\n    BUILD: Allows you to build standard or special enclosures, kiosks, and pavilions.\n\
+      \    ANIMALS: Allows you to accommodate animals in your zoo.\n    ASSOCIATION: Allows your association workers to carry\
+      \ out different tasks.\n    SPONSORS: Allows you to play a sponsor card in your zoo or to raise money.\n\n\n255 cards\
+      \ featuring animals, specialists, special enclosures, and conservation projects, each with a special ability, are at\
+      \ the heart of Ark Nova. Use them to increase the appeal and scientific reputation of your zoo and collect conservation\
+      \ points.\n\n&mdash;description from the publisher\n\n"
     yearPublished: 2021
     minPlayers: 1
     maxPlayers: 4
@@ -2764,32 +3115,53 @@ catalog:
     - テンデイズゲームズ (TendaysGames)
     - Tower Tactic Games
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/ark-nova_rulebook.pdf
+    pdfSha256: f6b4eedc68e993f61b4c5cb5d99bb4af399da0be3de4781321bcba1ba44516f6
+    pdfVersion: '1.0'
   - title: Puerto Rico
     bggId: 3076
     language: en
-    pdf: puerto-rico_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Puerto Rico, players assume the roles of colonial governors on the island of Puerto Rico. The aim of the game is to amass victory points by shipping goods to Europe or by constructing buildings.
+    description: 'In Puerto Rico, players assume the roles of colonial governors on the island of Puerto Rico. The aim of
+      the game is to amass victory points by shipping goods to Europe or by constructing buildings.
 
 
-      Each player uses a separate small board with spaces for city buildings, plantations, and resources. Shared between the players are three ships, a trading house, and a supply of resources and doubloons.
+      Each player uses a separate small board with spaces for city buildings, plantations, and resources. Shared between the
+      players are three ships, a trading house, and a supply of resources and doubloons.
 
 
-      The resource cycle of the game is that players grow crops which they exchange for points or doubloons. Doubloons can then be used to buy buildings, which allow players to produce more crops or give them other abilities. Buildings and plantations do not work unless they are manned by colonists.
+      The resource cycle of the game is that players grow crops which they exchange for points or doubloons. Doubloons can
+      then be used to buy buildings, which allow players to produce more crops or give them other abilities. Buildings and
+      plantations do not work unless they are manned by colonists.
 
 
-      During each round, players take turns selecting a role card from those on the table (such as "Trader" or "Builder"). When a role is chosen, every player gets to take the action appropriate to that role. The player that selected the role also receives a small privilege for doing so - for example, choosing the "Builder" role allows all players to construct a building, but the player who chose the role may do so at a discount on that turn. Unused roles gain a doubloon bonus at the end of each turn, so the next player who chooses that role gets to keep any doubloon bonus associated with it. This encourages players to make use of all the roles throughout a typical course of a game.
+      During each round, players take turns selecting a role card from those on the table (such as "Trader" or "Builder").
+      When a role is chosen, every player gets to take the action appropriate to that role. The player that selected the role
+      also receives a small privilege for doing so - for example, choosing the "Builder" role allows all players to construct
+      a building, but the player who chose the role may do so at a discount on that turn. Unused roles gain a doubloon bonus
+      at the end of each turn, so the next player who chooses that role gets to keep any doubloon bonus associated with it.
+      This encourages players to make use of all the roles throughout a typical course of a game.
 
 
-      Puerto Rico uses a variable phase order mechanism in which a "governor" token is passed clockwise to the next player at the conclusion of a turn. The player with the token begins the round by choosing a role and taking the first action.
+      Puerto Rico uses a variable phase order mechanism in which a "governor" token is passed clockwise to the next player
+      at the conclusion of a turn. The player with the token begins the round by choosing a role and taking the first action.
 
 
-      Players earn victory points for owning buildings, for shipping goods, and for manned "large buildings." Each player's accumulated shipping chips are kept face down and come in denominations of one or five. This prevents other players from being able to determine the exact score of another player. Goods and doubloons are placed in clear view of other players and the totals of each can always be requested by a player. As the game enters its later stages, the unknown quantity of shipping tokens and its denominations require players to consider their options before choosing a role that can end the game.
+      Players earn victory points for owning buildings, for shipping goods, and for manned "large buildings." Each player''s
+      accumulated shipping chips are kept face down and come in denominations of one or five. This prevents other players
+      from being able to determine the exact score of another player. Goods and doubloons are placed in clear view of other
+      players and the totals of each can always be requested by a player. As the game enters its later stages, the unknown
+      quantity of shipping tokens and its denominations require players to consider their options before choosing a role that
+      can end the game.
 
 
-      In 2011 and mostly afterwards, Puerto Rico was published to include both Puerto Rico: Expansion I &ndash; New Buildings and Puerto Rico: Expansion II &ndash; The Nobles. These versions are included in the other game entry Puerto Rico, not this regular game entry for Puerto Rico. Some editions of Puerto Rico list the player count as 2-5 instead of 3-5, and they include variant rules for games with only two players.
+      In 2011 and mostly afterwards, Puerto Rico was published to include both Puerto Rico: Expansion I &ndash; New Buildings
+      and Puerto Rico: Expansion II &ndash; The Nobles. These versions are included in the other game entry Puerto Rico, not
+      this regular game entry for Puerto Rico. Some editions of Puerto Rico list the player count as 2-5 instead of 3-5, and
+      they include variant rules for games with only two players.
 
+
+      '
     yearPublished: 2002
     minPlayers: 3
     maxPlayers: 5
@@ -2829,19 +3201,29 @@ catalog:
     - Swan Panasia Co., Ltd.
     - Tilsit
     - VAKKO
+    pdfBlobKey: rulebooks/v1/puerto-rico_rulebook.pdf
+    pdfSha256: d55058bde864f4216eecd14e2d3fabd244955972f3176e1b3bf64e5ed7afa697
+    pdfVersion: '1.0'
   - title: Lost Ruins of Arnak
     bggId: 312484
     language: en
-    pdf: lost-ruins-of-arnak_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      On an uninhabited island in uncharted seas, explorers have found traces of a great civilization. Now you will lead an expedition to explore the island, find lost artifacts, and face fearsome guardians, all in a quest to learn the island's secrets.
+    description: 'On an uninhabited island in uncharted seas, explorers have found traces of a great civilization. Now you
+      will lead an expedition to explore the island, find lost artifacts, and face fearsome guardians, all in a quest to learn
+      the island''s secrets.
 
 
-      Lost Ruins of Arnak combines deck-building and worker placement in a game of exploration, resource management, and discovery. In addition to traditional deck-builder effects, cards can also be used to place workers, and new worker actions become available as players explore the island. Some of these actions require resources instead of workers, so building a solid resource base will be essential. You are limited to only one action per turn, so make your choice carefully... what action will benefit you most now? And what can you afford to do later... assuming someone else doesn't take the action first!?
+      Lost Ruins of Arnak combines deck-building and worker placement in a game of exploration, resource management, and discovery.
+      In addition to traditional deck-builder effects, cards can also be used to place workers, and new worker actions become
+      available as players explore the island. Some of these actions require resources instead of workers, so building a solid
+      resource base will be essential. You are limited to only one action per turn, so make your choice carefully... what
+      action will benefit you most now? And what can you afford to do later... assuming someone else doesn''t take the action
+      first!?
 
 
-      Decks are small, and randomness in the game is heavily mitigated by the wealth of tactical decisions offered on the game board. With a variety of worker actions, artifacts, and equipment cards, the set-up for each game will be unique, encouraging players to explore new strategies to meet the challenge.
+      Decks are small, and randomness in the game is heavily mitigated by the wealth of tactical decisions offered on the
+      game board. With a variety of worker actions, artifacts, and equipment cards, the set-up for each game will be unique,
+      encouraging players to explore new strategies to meet the challenge.
 
 
       Discover the Lost Ruins of Arnak!
@@ -2849,6 +3231,8 @@ catalog:
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2020
     minPlayers: 1
     maxPlayers: 4
@@ -2907,34 +3291,30 @@ catalog:
     - Rebel Sp. z o.o.
     - Spilbræt.dk
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/lost-ruins-of-arnak_rulebook.pdf
+    pdfSha256: d697b0612bbab7b16d183bdaee061d17fea25d6be485329e0c98bc90a1af11c1
+    pdfVersion: '1.0'
   - title: The Castles of Burgundy
     bggId: 84876
     language: en
-    pdf: castles-of-burgundy_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      The game is set in the Burgundy region of High Medieval France. Each player takes on the role of an aristocrat, originally controlling a small princedom. While playing they aim to build settlements and powerful castles, practice trade along the river, exploit silver mines, and use the knowledge of travelers. The game is about players taking settlement tiles from the game board and placing them into their princedom which is represented by the player board. Every tile has a function that starts when the tile is placed in the princedom. The princedom itself consists of several regions, each of which demands its own type of settlement tile.
-
-
-      The game is played in five phases, each consisting of five rounds.  Each phase begins with the game board stocked with settlement tiles and goods tiles.  At the beginning of each round all players roll their two dice, and the player who is currently first in turn order rolls a goods placement die.  A goods tile is made available on the game board according to the roll of the goods die.
-
-
-      During each round, a player may perform any two of the four possible types of actions:
-
-          take a settlement tile and place it in the staging area on their player board
-          take a settlement tile from the staging area and place in the corresponding region for the type of tile and adjacent to a previously placed settlement tile, 
-          deliver goods with a number matching one of their dice
-          take worker tokens which allow the player to adjust the roll of their dice.  
-
-
-      In addition to these actions a player may buy a settlement tile and place it in the staging area on their player board.
-
-
-      The game ends after the fifth phase is played to completion.  Victory points are awarded for unused money and workers, and undelivered goods.  Bonus victory points from certain settlement tiles are awarded at the end of the game. The player with the most victory points wins.
-
-
-      The rules include basic and advanced versions.
-
+    description: "The game is set in the Burgundy region of High Medieval France. Each player takes on the role of an aristocrat,\
+      \ originally controlling a small princedom. While playing they aim to build settlements and powerful castles, practice\
+      \ trade along the river, exploit silver mines, and use the knowledge of travelers. The game is about players taking\
+      \ settlement tiles from the game board and placing them into their princedom which is represented by the player board.\
+      \ Every tile has a function that starts when the tile is placed in the princedom. The princedom itself consists of several\
+      \ regions, each of which demands its own type of settlement tile.\n\nThe game is played in five phases, each consisting\
+      \ of five rounds.  Each phase begins with the game board stocked with settlement tiles and goods tiles.  At the beginning\
+      \ of each round all players roll their two dice, and the player who is currently first in turn order rolls a goods placement\
+      \ die.  A goods tile is made available on the game board according to the roll of the goods die.\n\nDuring each round,\
+      \ a player may perform any two of the four possible types of actions:\n\n    take a settlement tile and place it in\
+      \ the staging area on their player board\n    take a settlement tile from the staging area and place in the corresponding\
+      \ region for the type of tile and adjacent to a previously placed settlement tile, \n    deliver goods with a number\
+      \ matching one of their dice\n    take worker tokens which allow the player to adjust the roll of their dice.  \n\n\n\
+      In addition to these actions a player may buy a settlement tile and place it in the staging area on their player board.\n\
+      \nThe game ends after the fifth phase is played to completion.  Victory points are awarded for unused money and workers,\
+      \ and undelivered goods.  Bonus victory points from certain settlement tiles are awarded at the end of the game. The\
+      \ player with the most victory points wins.\n\nThe rules include basic and advanced versions.\n\n"
     yearPublished: 2011
     minPlayers: 2
     maxPlayers: 4
@@ -2975,26 +3355,43 @@ catalog:
     - Hobby World
     - Maldito Games
     - Rebel Sp. z o.o.
+    pdfBlobKey: rulebooks/v1/castles-of-burgundy_rulebook.pdf
+    pdfSha256: 6fb4eb68f7fc788d9c68f325e310648def996faf16016aa81140c6f3dc798b1c
+    pdfVersion: '1.0'
   - title: 'Arkham Horror: The Card Game'
     bggId: 205637
     language: en
-    pdf: arkham-horror-tcg_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Something evil stirs in Arkham, and only you can stop it. Blurring the traditional lines between role-playing and card game experiences, Arkham Horror: The Card Game is a Living Card Game of Lovecraftian mystery, monsters, and madness!
+    description: 'Something evil stirs in Arkham, and only you can stop it. Blurring the traditional lines between role-playing
+      and card game experiences, Arkham Horror: The Card Game is a Living Card Game of Lovecraftian mystery, monsters, and
+      madness!
 
 
-      In the game, you, alone or with a friend (or up to three friends with two Core Sets), become investigators within the quiet New England town of Arkham. You have your talents, sure, but you also have your flaws. Perhaps you've dabbled a little too much in the writings of the Necronomicon, and its words continue to haunt you. Perhaps you feel compelled to cover up any signs of otherworldly evils, hampering your own investigations in order to protect the quiet confidence of the greater population. Perhaps you'll be scarred by your encounters with a ghoulish cult.
+      In the game, you, alone or with a friend (or up to three friends with two Core Sets), become investigators within the
+      quiet New England town of Arkham. You have your talents, sure, but you also have your flaws. Perhaps you''ve dabbled
+      a little too much in the writings of the Necronomicon, and its words continue to haunt you. Perhaps you feel compelled
+      to cover up any signs of otherworldly evils, hampering your own investigations in order to protect the quiet confidence
+      of the greater population. Perhaps you''ll be scarred by your encounters with a ghoulish cult.
 
 
-      No matter what compels you, no matter what haunts you, you'll find both your strengths and weaknesses reflected in your custom deck of cards, and these cards will be your resources as you work with your friends to unravel the world's most terrifying mysteries.
+      No matter what compels you, no matter what haunts you, you''ll find both your strengths and weaknesses reflected in
+      your custom deck of cards, and these cards will be your resources as you work with your friends to unravel the world''s
+      most terrifying mysteries.
 
 
-      Each of your adventures in Arkham Horror LCG carries you deeper into mystery. You'll find cultists and foul rituals. You'll find haunted houses and strange creatures. And you may find signs of the Ancient Ones straining against the barriers to our world...
+      Each of your adventures in Arkham Horror LCG carries you deeper into mystery. You''ll find cultists and foul rituals.
+      You''ll find haunted houses and strange creatures. And you may find signs of the Ancient Ones straining against the
+      barriers to our world...
 
 
-      The basic mode of play in Arkham LCG is not the adventure, but the campaign. You might be scarred by your adventures, your sanity may be strained, and you may alter Arkham's landscape, burning buildings to the ground. All your choices and actions have consequences that reach far beyond the immediate resolution of the scenario at hand&mdash;and your actions may earn you valuable experience with which you can better prepare yourself for the adventures that still lie before you.
+      The basic mode of play in Arkham LCG is not the adventure, but the campaign. You might be scarred by your adventures,
+      your sanity may be strained, and you may alter Arkham''s landscape, burning buildings to the ground. All your choices
+      and actions have consequences that reach far beyond the immediate resolution of the scenario at hand&mdash;and your
+      actions may earn you valuable experience with which you can better prepare yourself for the adventures that still lie
+      before you.
 
+
+      '
     yearPublished: 2016
     minPlayers: 1
     maxPlayers: 2
@@ -3046,35 +3443,63 @@ catalog:
     - Korea Boardgames
     - Tower Tactic Games
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/arkham-horror-tcg_rulebook.pdf
+    pdfSha256: 28c88deaa538b6132f212cb3107bebea294c6240caef651088d4a39c277e95f6
+    pdfVersion: '1.0'
   - title: Mysterium
     bggId: 181304
     language: en
-    pdf: mysterium_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In the 1920s, Mr. MacDowell, a gifted astrologer, immediately detected a supernatural being upon entering his new house in Scotland. He gathered eminent mediums of his time for an extraordinary s&eacute;ance, and they have seven hours to make contact with the ghost and investigate any clues that it can provide to unlock an old mystery.
+    description: 'In the 1920s, Mr. MacDowell, a gifted astrologer, immediately detected a supernatural being upon entering
+      his new house in Scotland. He gathered eminent mediums of his time for an extraordinary s&eacute;ance, and they have
+      seven hours to make contact with the ghost and investigate any clues that it can provide to unlock an old mystery.
 
 
-      Unable to talk, the amnesiac ghost communicates with the mediums through visions, which are represented in the game by illustrated cards. The mediums must decipher the images to help the ghost remember how he was murdered: Who did the crime? Where did it take place? Which weapon caused the death? The more the mediums cooperate and guess well, the easier it is to catch the right culprit.
+      Unable to talk, the amnesiac ghost communicates with the mediums through visions, which are represented in the game
+      by illustrated cards. The mediums must decipher the images to help the ghost remember how he was murdered: Who did the
+      crime? Where did it take place? Which weapon caused the death? The more the mediums cooperate and guess well, the easier
+      it is to catch the right culprit.
 
 
-      In Mysterium, a reworking of the game system present in Tajemnicze Domostwo, one player takes the role of ghost while everyone else represents a medium. To solve the crime, the ghost must first recall (with the aid of the mediums) all of the suspects present on the night of the murder. A number of suspect, location and murder weapon cards are placed on the table, and the ghost randomly assigns one of each of these in secret to a medium.
+      In Mysterium, a reworking of the game system present in Tajemnicze Domostwo, one player takes the role of ghost while
+      everyone else represents a medium. To solve the crime, the ghost must first recall (with the aid of the mediums) all
+      of the suspects present on the night of the murder. A number of suspect, location and murder weapon cards are placed
+      on the table, and the ghost randomly assigns one of each of these in secret to a medium.
 
 
-      Each hour (i.e., game turn), the ghost hands one or more vision cards face up to each medium, refilling their hand to seven each time they share vision cards. These vision cards present dreamlike images to the mediums, with each medium first needing to deduce which suspect corresponds to the vision cards received. Once the ghost has handed cards to the final medium, they start a two-minute sandtimer. Once a medium has placed their token on a suspect, they may also place clairvoyancy tokens on the guesses made by other mediums to show whether they agree or disagree with those guesses.
+      Each hour (i.e., game turn), the ghost hands one or more vision cards face up to each medium, refilling their hand to
+      seven each time they share vision cards. These vision cards present dreamlike images to the mediums, with each medium
+      first needing to deduce which suspect corresponds to the vision cards received. Once the ghost has handed cards to the
+      final medium, they start a two-minute sandtimer. Once a medium has placed their token on a suspect, they may also place
+      clairvoyancy tokens on the guesses made by other mediums to show whether they agree or disagree with those guesses.
 
 
-      After time runs out, the ghost reveals to each medium whether the guesses were correct or not. Mediums who guessed correctly move on to guess the location of the crime (and then the murder weapon), while those who didn't keep their vision cards and receive new ones next hour corresponding to the same suspect. Once a medium has correctly guessed the suspect, location and weapon, they move their token to the epilogue board and receive one clairvoyancy point for each hour remaining on the clock. They can still use their remaining clairvoyancy tokens to score additional points.
+      After time runs out, the ghost reveals to each medium whether the guesses were correct or not. Mediums who guessed correctly
+      move on to guess the location of the crime (and then the murder weapon), while those who didn''t keep their vision cards
+      and receive new ones next hour corresponding to the same suspect. Once a medium has correctly guessed the suspect, location
+      and weapon, they move their token to the epilogue board and receive one clairvoyancy point for each hour remaining on
+      the clock. They can still use their remaining clairvoyancy tokens to score additional points.
 
 
-      If one or more mediums fail to identify their proper suspect, location and weapon before the end of the seventh hour, then the ghost has failed and dissipates, leaving the mystery unsolved. If, however, they have all succeeded, then the ghost has recovered enough of its memory to identify the culprit.
+      If one or more mediums fail to identify their proper suspect, location and weapon before the end of the seventh hour,
+      then the ghost has failed and dissipates, leaving the mystery unsolved. If, however, they have all succeeded, then the
+      ghost has recovered enough of its memory to identify the culprit.
 
 
-      Mediums then group their suspect, location and weapon cards on the table and place a number by each group. The ghost then selects one group, places the matching culprit number face down on the epilogue board, picks three vision cards &mdash; one for the suspect, one for the location, and one for the weapon &mdash; then shuffles these cards. Players who have achieved few clairvoyancy points flip over one vision card at random, then secretly vote on which suspect they think is guilty; players with more points then flip over a second vision card and vote; then those with the most points see the final card and vote.
+      Mediums then group their suspect, location and weapon cards on the table and place a number by each group. The ghost
+      then selects one group, places the matching culprit number face down on the epilogue board, picks three vision cards
+      &mdash; one for the suspect, one for the location, and one for the weapon &mdash; then shuffles these cards. Players
+      who have achieved few clairvoyancy points flip over one vision card at random, then secretly vote on which suspect they
+      think is guilty; players with more points then flip over a second vision card and vote; then those with the most points
+      see the final card and vote.
 
 
-      If a majority of the mediums have identified the proper suspect, with ties being broken by the vote of the most clairvoyant medium, then the killer has been identified and the ghost can now rest peacefully. If not, well, perhaps you can try again...
+      If a majority of the mediums have identified the proper suspect, with ties being broken by the vote of the most clairvoyant
+      medium, then the killer has been identified and the ghost can now rest peacefully. If not, well, perhaps you can try
+      again...
 
+
+      '
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 7
@@ -3119,22 +3544,25 @@ catalog:
     - Morapiaf
     - Rebel Sp. z o.o.
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/mysterium_rulebook.pdf
+    pdfSha256: 030485b917f8b98ade40b48fbe12501dd5c490426e57c6466dfa63a6a6a84692
+    pdfVersion: '1.0'
   - title: 'Dominion: Prosperity'
     bggId: 66690
     language: en
-    pdf: dominion-prosperity_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Released in late 2010, Prosperity is the 4th addition to the Dominion game family. It adds 25 new Kingdom cards to Dominion, plus 2 new Basic cards that let players keep building up past Gold and Province. The central theme is wealth; there are treasures with abilities, cards that interact with treasures, and powerful expensive cards. (Source: http://www.riograndegames.com/games.html?id=361 )
-
-
-      From the back of the box: "Ah, money. There's nothing like the sound of coins clinking in your hands. You vastly prefer it to the sound of coins clinking in someone else's hands, or the sound of coins just sitting there in a pile that no-one can quite reach without getting up. Getting up, that's all behind you now. Life has been good to you. Just ten years ago, you were tilling your own fields in a simple straw hat. Today, your kingdom stretches from sea to sea, and your straw hat is the largest the world has ever known. You also have the world's smallest dog, and a life-sized statue of yourself made out of baklava. Sure, money can't buy happiness, but it can buy envy, anger, and also this kind of blank feeling. You still have problems - troublesome neighbours that must be conquered. 
-
-      But this time, you'll conquer them in style."
-
-
-      Part of the Dominion series.
-
+    description: "Released in late 2010, Prosperity is the 4th addition to the Dominion game family. It adds 25 new Kingdom\
+      \ cards to Dominion, plus 2 new Basic cards that let players keep building up past Gold and Province. The central theme\
+      \ is wealth; there are treasures with abilities, cards that interact with treasures, and powerful expensive cards. (Source:\
+      \ http://www.riograndegames.com/games.html?id=361 )\n\nFrom the back of the box: \"Ah, money. There's nothing like the\
+      \ sound of coins clinking in your hands. You vastly prefer it to the sound of coins clinking in someone else's hands,\
+      \ or the sound of coins just sitting there in a pile that no-one can quite reach without getting up. Getting up, that's\
+      \ all behind you now. Life has been good to you. Just ten years ago, you were tilling your own fields in a simple straw\
+      \ hat. Today, your kingdom stretches from sea to sea, and your straw hat is the largest the world has ever known. You\
+      \ also have the world's smallest dog, and a life-sized statue of yourself made out of baklava. Sure, money can't buy\
+      \ happiness, but it can buy envy, anger, and also this kind of blank feeling. You still have problems - troublesome\
+      \ neighbours that must be conquered. \nBut this time, you'll conquer them in style.\"\n\nPart of the Dominion series.\n\
+      \n"
     yearPublished: 2010
     minPlayers: 2
     maxPlayers: 4
@@ -3171,23 +3599,20 @@ catalog:
     - Lautapelit.fi
     - Stupor Mundi
     - Ystari Games
+    pdfBlobKey: rulebooks/v1/dominion-prosperity_rulebook.pdf
+    pdfSha256: b8879173187beb0f78c60043607b26aa5ef1b84814645d682d075a8f1492c82d
+    pdfVersion: '1.0'
   - title: 'Century: Spice Road'
     bggId: 209685
     language: en
-    pdf: century-spice-road_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Century: Spice Road is the first in a series of games that explores the history of each century with spice-trading as the theme for the first installment.  In Century: Spice Road, players are caravan leaders who travel the famed silk road to deliver spices to the far reaches of the continent for fame and glory. Each turn, players perform one of four actions:
-
-
-           Establish a trade route (by taking a market card)
-           Make a trade or harvest spices (by playing a card from hand)
-           Fulfill a demand (by meeting a victory point card's requirements and claiming it)
-           Rest (by taking back into your hand all of the cards you've played)
-
-
-      The last round is triggered once a player has claimed their fifth victory point card, then whoever has the most victory points wins.
-
+    description: "Century: Spice Road is the first in a series of games that explores the history of each century with spice-trading\
+      \ as the theme for the first installment.  In Century: Spice Road, players are caravan leaders who travel the famed\
+      \ silk road to deliver spices to the far reaches of the continent for fame and glory. Each turn, players perform one\
+      \ of four actions:\n\n\n     Establish a trade route (by taking a market card)\n     Make a trade or harvest spices\
+      \ (by playing a card from hand)\n     Fulfill a demand (by meeting a victory point card's requirements and claiming\
+      \ it)\n     Rest (by taking back into your hand all of the cards you've played)\n\n\nThe last round is triggered once\
+      \ a player has claimed their fifth victory point card, then whoever has the most victory points wins.\n\n"
     yearPublished: 2017
     minPlayers: 2
     maxPlayers: 5
@@ -3232,20 +3657,34 @@ catalog:
     - Mandoo Games
     - Ninive Games
     - Piatnik Distribution
+    pdfBlobKey: rulebooks/v1/century-spice-road_rulebook.pdf
+    pdfSha256: c80bd5921916f5ea6e72ffa5c8d9c23710e286ddef509f0b9531df3f57acb5ef
+    pdfVersion: '1.0'
   - title: Gloom
     bggId: 12692
     language: en
-    pdf: gloom_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      The world of Gloom is a sad and benighted place. The sky is gray, the tea is cold, and a new tragedy lies around every corner. Debt, disease, heartache, and packs of rabid flesh-eating mice&mdash;just when it seems like things can't get any worse, they do. But some say that one's reward in the afterlife is based on the misery endured in life. If so, there may yet be hope&mdash;if not in this world, then in the peace that lies beyond.
+    description: 'The world of Gloom is a sad and benighted place. The sky is gray, the tea is cold, and a new tragedy lies
+      around every corner. Debt, disease, heartache, and packs of rabid flesh-eating mice&mdash;just when it seems like things
+      can''t get any worse, they do. But some say that one''s reward in the afterlife is based on the misery endured in life.
+      If so, there may yet be hope&mdash;if not in this world, then in the peace that lies beyond.
 
 
-      In the Gloom card game, you assume control of the fate of an eccentric family of misfits and misanthropes. The goal of the game is sad, but simple: you want your characters to suffer the greatest tragedies possible before passing on to the well-deserved respite of death. You'll play horrible mishaps like Pursued by Poodles or Mocked by Midgets on your own characters to lower their Self-Worth scores, while trying to cheer your opponents' characters with marriages and other happy occasions that pile on positive points. The player with the lowest total Family Value wins.
+      In the Gloom card game, you assume control of the fate of an eccentric family of misfits and misanthropes. The goal
+      of the game is sad, but simple: you want your characters to suffer the greatest tragedies possible before passing on
+      to the well-deserved respite of death. You''ll play horrible mishaps like Pursued by Poodles or Mocked by Midgets on
+      your own characters to lower their Self-Worth scores, while trying to cheer your opponents'' characters with marriages
+      and other happy occasions that pile on positive points. The player with the lowest total Family Value wins.
 
 
-      Printed on transparent plastic cards, Gloom features an innovative design by noted RPG author Keith Baker. Multiple modifier cards can be played on top of the same character card; since the cards are transparent, elements from previously played modifier cards either show through or are obscured by those played above them. You'll immediately and easily know the worth of every character, no matter how many modifiers they have. You've got to see (through) this game to believe it!
+      Printed on transparent plastic cards, Gloom features an innovative design by noted RPG author Keith Baker. Multiple
+      modifier cards can be played on top of the same character card; since the cards are transparent, elements from previously
+      played modifier cards either show through or are obscured by those played above them. You''ll immediately and easily
+      know the worth of every character, no matter how many modifiers they have. You''ve got to see (through) this game to
+      believe it!
 
+
+      '
     yearPublished: 2005
     minPlayers: 2
     maxPlayers: 5
@@ -3275,17 +3714,27 @@ catalog:
     - Calamity Games
     - Edge Entertainment
     - uplay.it edizioni
+    pdfBlobKey: rulebooks/v1/gloom_rulebook.pdf
+    pdfSha256: 5256839f16a3ad69a54abc350d455e3dc190d073131c46462bfd3bb21da0c048
+    pdfVersion: '1.0'
   - title: Hive Pocket
     bggId: 154597
     language: en
-    pdf: hive-pocket_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Hive is a strategic game for two players that is not restricted by a board and can be played anywhere on any flat surface. The base game of Hive is made up of twenty two pieces, eleven black and eleven white, resembling a variety of creatures each with a unique way of moving. Hive Carbon and Hive Pocket include the Mosquito and Ladybug expansions, for a total of 26 pieces.
+    description: 'Hive is a strategic game for two players that is not restricted by a board and can be played anywhere on
+      any flat surface. The base game of Hive is made up of twenty two pieces, eleven black and eleven white, resembling a
+      variety of creatures each with a unique way of moving. Hive Carbon and Hive Pocket include the Mosquito and Ladybug
+      expansions, for a total of 26 pieces.
 
 
-      With no setting up to do, the game begins when the first piece is placed down. As the subsequent pieces are placed this forms a pattern that becomes the playing surface. (The pieces themselves become the board.) Unlike other such games, the pieces are never eliminated and not all have to be played. The object of the game is to totally surround your opponent's queen, while at the same time trying to block your opponent from doing likewise to your queen. The first player to totally surround the opponent's queen wins the game.
+      With no setting up to do, the game begins when the first piece is placed down. As the subsequent pieces are placed this
+      forms a pattern that becomes the playing surface. (The pieces themselves become the board.) Unlike other such games,
+      the pieces are never eliminated and not all have to be played. The object of the game is to totally surround your opponent''s
+      queen, while at the same time trying to block your opponent from doing likewise to your queen. The first player to totally
+      surround the opponent''s queen wins the game.
 
+
+      '
     yearPublished: 2010
     minPlayers: 2
     maxPlayers: 2
@@ -3335,27 +3784,30 @@ catalog:
     - Vendetta
     - Zhiyanjia
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/hive-pocket_rulebook.pdf
+    pdfSha256: d5dc5809bc293ef53f13b4aa92bbf833d6f7d95852b14bf491a4e2713478d1d5
+    pdfVersion: '1.0'
   - title: Raiders of the North Sea
     bggId: 170042
     language: en
-    pdf: raiders-of-the-north-sea_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Raiders of the North Sea is set in the central years of the Viking Age. As Viking warriors, players seek to impress the Chieftain by raiding unsuspecting settlements. To do so, players need to assemble a crew, collect provisions, and journey north to plunder gold, iron and livestock. Glory can be found in battle, even at the hands of the Valkyrie, so gather your warriors because it's raiding season!
-
-
-      To impress the Chieftain, you need victory points (VPs), with those being acquired primarily by raiding settlements, taking plunder, and making offerings to the Chieftain. How you use your plunder is also vital to your success. Players take turns in clockwise order, and on a turn you place a worker and resolve its action, then pick up a different worker and resolve its action. Broadly speaking, those actions fall in one of two categories:
-
-
-           Work: Having a good crew and enough provisions are vital to successful raiding, so before making any raids, players need to do some work to prepare their crew and collect supplies. This is all done in the village at the bottom of the game board, with eight buildings offering various actions. You must first place your worker in an available building where no other worker is present, then pick up a different worker from a different building.
-
-
-
-           Raid: Once players have hired enough crew and collected provisions, you may choose to raid on your turn. To raid a settlement &mdash; whether a harbor, outpost, monastery or fortress &mdash; you need to meet three requirements: Having a large enough crew, having enough provisions (along with gold for monasteries and fortresses, and having a worker of the right color. Raiding offers various ways of scoring, such as military strength, plunder, and Valkyries, which is how grey and white workers enter the game.
-
-
-      The game ends when only one fortress raid remains, all Valkyrie have been removed, or all offerings have been made, then players tally their scores.
-
+    description: "Raiders of the North Sea is set in the central years of the Viking Age. As Viking warriors, players seek\
+      \ to impress the Chieftain by raiding unsuspecting settlements. To do so, players need to assemble a crew, collect provisions,\
+      \ and journey north to plunder gold, iron and livestock. Glory can be found in battle, even at the hands of the Valkyrie,\
+      \ so gather your warriors because it's raiding season!\n\nTo impress the Chieftain, you need victory points (VPs), with\
+      \ those being acquired primarily by raiding settlements, taking plunder, and making offerings to the Chieftain. How\
+      \ you use your plunder is also vital to your success. Players take turns in clockwise order, and on a turn you place\
+      \ a worker and resolve its action, then pick up a different worker and resolve its action. Broadly speaking, those actions\
+      \ fall in one of two categories:\n\n\n     Work: Having a good crew and enough provisions are vital to successful raiding,\
+      \ so before making any raids, players need to do some work to prepare their crew and collect supplies. This is all done\
+      \ in the village at the bottom of the game board, with eight buildings offering various actions. You must first place\
+      \ your worker in an available building where no other worker is present, then pick up a different worker from a different\
+      \ building.\n\n\n\n     Raid: Once players have hired enough crew and collected provisions, you may choose to raid on\
+      \ your turn. To raid a settlement &mdash; whether a harbor, outpost, monastery or fortress &mdash; you need to meet\
+      \ three requirements: Having a large enough crew, having enough provisions (along with gold for monasteries and fortresses,\
+      \ and having a worker of the right color. Raiding offers various ways of scoring, such as military strength, plunder,\
+      \ and Valkyries, which is how grey and white workers enter the game.\n\n\nThe game ends when only one fortress raid\
+      \ remains, all Valkyrie have been removed, or all offerings have been made, then players tally their scores.\n\n"
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 4
@@ -3396,35 +3848,43 @@ catalog:
     - Schwerkraft-Verlag
     - White Goblin Games
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/raiders-of-the-north-sea_rulebook.pdf
+    pdfSha256: 2bd3601c5709698becc198584d3d7c8c321640a05a56ae3399af757ae88afa20
+    pdfVersion: '1.0'
   - title: 'Pandemic Legacy: Season 2'
     bggId: 221107
     language: en
-    pdf: pandemic-legacy-s2_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Description from the publisher:
+    description: 'Description from the publisher:
 
 
       The world almost ended 71 years ago...
 
 
-      The plague came out of nowhere and ravaged the world. Most died within a week. Nothing could stop it. The world did its best. It wasn't good enough.
+      The plague came out of nowhere and ravaged the world. Most died within a week. Nothing could stop it. The world did
+      its best. It wasn''t good enough.
 
 
-      For three generations, we, the last fragments of humanity have lived on the seas, on floating stations called "havens." Far from the plague, we are able to provide supplies to the mainland to keep them (and us) from succumbing completely.
+      For three generations, we, the last fragments of humanity have lived on the seas, on floating stations called "havens."
+      Far from the plague, we are able to provide supplies to the mainland to keep them (and us) from succumbing completely.
 
 
-      We've managed to keep a network of the largest known cities in the world alive. Things have been tough the past few years. Cities far away from the havens have fallen off our grid...
+      We''ve managed to keep a network of the largest known cities in the world alive. Things have been tough the past few
+      years. Cities far away from the havens have fallen off our grid...
 
 
-      Tomorrow, a small group of us head out into what's left of the world. We don't know what we'll find.
+      Tomorrow, a small group of us head out into what''s left of the world. We don''t know what we''ll find.
 
 
-      Pandemic Legacy: Season 2 is an epic cooperative game for 2 to 4 players. Unlike most other games, this one is working against you. What's more, some of the actions you take in Pandemic Legacy will carry over to future games. No two worlds will ever be alike!
+      Pandemic Legacy: Season 2 is an epic cooperative game for 2 to 4 players. Unlike most other games, this one is working
+      against you. What''s more, some of the actions you take in Pandemic Legacy will carry over to future games. No two worlds
+      will ever be alike!
 
 
       Part of the Pandemic series.
 
+
+      '
     yearPublished: 2017
     minPlayers: 2
     maxPlayers: 4
@@ -3465,20 +3925,30 @@ catalog:
     - Korea Boardgames
     - Lacerta
     - Lifestyle Boardgames Ltd
+    pdfBlobKey: rulebooks/v1/pandemic-legacy-s2_rulebook.pdf
+    pdfSha256: 6ba4c2623e00eac786b5f6c3a65d1aa99927163870551d2ea3f8f4744c334e51
+    pdfVersion: '1.0'
   - title: Imperial Settlers
     bggId: 154203
     language: en
-    pdf: imperial-settlers_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Settlers from four major powers of the world have discovered new lands, with new resources and opportunities. Romans, Barbarians, Egyptians and Japanese all at once move there to expand the boundaries of their empires. They build new buildings to strengthen their economy, they found mines and fields to gather resources, and they build barracks and training grounds to train soldiers. Soon after they discover that this land is far too small for everybody, then the war begins...
+    description: 'Settlers from four major powers of the world have discovered new lands, with new resources and opportunities.
+      Romans, Barbarians, Egyptians and Japanese all at once move there to expand the boundaries of their empires. They build
+      new buildings to strengthen their economy, they found mines and fields to gather resources, and they build barracks
+      and training grounds to train soldiers. Soon after they discover that this land is far too small for everybody, then
+      the war begins...
 
 
-      Imperial Settlers is a card game that lets players lead one of the four factions and build empires by placing buildings, then sending workers to those buildings to acquire new resources and abilities. The game is played over five rounds during which players take various actions in order to explore new lands, build buildings, trade resources, conquer enemies, and thus score victory points.
+      Imperial Settlers is a card game that lets players lead one of the four factions and build empires by placing buildings,
+      then sending workers to those buildings to acquire new resources and abilities. The game is played over five rounds
+      during which players take various actions in order to explore new lands, build buildings, trade resources, conquer enemies,
+      and thus score victory points.
 
 
-      The core mechanism of Imperial Settlers is based on concepts from the author's card game 51st State.
+      The core mechanism of Imperial Settlers is based on concepts from the author''s card game 51st State.
 
+
+      '
     yearPublished: 2014
     minPlayers: 1
     maxPlayers: 4
@@ -3521,14 +3991,22 @@ catalog:
     - REXhry
     - White Goblin Games
     - Zvezda
+    pdfBlobKey: rulebooks/v1/imperial-settlers_rulebook.pdf
+    pdfSha256: 98c7e716c460934f725a9fbbf55445e39807b4c9241dccfface50f98cf283574
+    pdfVersion: '1.0'
   - title: Guillotine
     bggId: 116
     language: en
-    pdf: guillotine_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      The French Revolution is famous in part for the use of the guillotine to put nobles to death, and this is the macabre subject of this light card game.  As executioners pandering to the masses, the players are trying to behead the most popular nobles.  Each day the nobles are lined up and players take turns killing the ones at the front of the line until all the nobles are gone.  However, players are given cards which will manipulate the line order right before 'harvesting' heads, which is what makes the game interesting.  After three days of chopping, the highest total carries the day.
+    description: 'The French Revolution is famous in part for the use of the guillotine to put nobles to death, and this is
+      the macabre subject of this light card game.  As executioners pandering to the masses, the players are trying to behead
+      the most popular nobles.  Each day the nobles are lined up and players take turns killing the ones at the front of the
+      line until all the nobles are gone.  However, players are given cards which will manipulate the line order right before
+      ''harvesting'' heads, which is what makes the game interesting.  After three days of chopping, the highest total carries
+      the day.
 
+
+      '
     yearPublished: 1998
     minPlayers: 2
     maxPlayers: 5
@@ -3560,29 +4038,46 @@ catalog:
     - Hasbro
     - Play Factory
     - PS-Games
+    pdfBlobKey: rulebooks/v1/guillotine_rulebook.pdf
+    pdfSha256: 6272d65910f05a2a9ada9aa79d1247b3d015cc3b2b402d465f32894ef0928b76
+    pdfVersion: '1.0'
   - title: Harmonies
     bggId: 414317
     language: en
-    pdf: harmonies_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Harmonies, build landscapes by placing colored tokens and create habitats for your animals. To earn the most points and win the game, incorporate the habitats in your landscapes wisely and have as many animals as you can settle there.
+    description: 'In Harmonies, build landscapes by placing colored tokens and create habitats for your animals. To earn the
+      most points and win the game, incorporate the habitats in your landscapes wisely and have as many animals as you can
+      settle there.
 
 
-      Starting with the first player and proceeding clockwise, each player will choose a set of 3 terrain tokens from the central area to place on their personal board. They may optionally choose an Animal card from the 5 displayed and/or place an Animal cube from their Animal card(s) on any completed patterns on their board that match their personal Animal cards. There is a 4-card limit per player. After their turn, refill with a new set of 3 tokens and a new Animal card if needed.
+      Starting with the first player and proceeding clockwise, each player will choose a set of 3 terrain tokens from the
+      central area to place on their personal board. They may optionally choose an Animal card from the 5 displayed and/or
+      place an Animal cube from their Animal card(s) on any completed patterns on their board that match their personal Animal
+      cards. There is a 4-card limit per player. After their turn, refill with a new set of 3 tokens and a new Animal card
+      if needed.
 
 
-      Placement of the terrain tokens will depend on the personal Animal card goals, and scoring rules for the various terrain types (mountain, field, forest, etc). For example, mountain tiles score based on how high they are (1 tile scores 1, while 3 tiles stacked score 7), but the mountain scores zero if it is not adjacent to at least one other mountain. If all the cubes on a given Animal card have been placed, the card is set aside and a new card can be drawn. The cards are scored at game end based on the highest number that isn't covered by a cube.
+      Placement of the terrain tokens will depend on the personal Animal card goals, and scoring rules for the various terrain
+      types (mountain, field, forest, etc). For example, mountain tiles score based on how high they are (1 tile scores 1,
+      while 3 tiles stacked score 7), but the mountain scores zero if it is not adjacent to at least one other mountain. If
+      all the cubes on a given Animal card have been placed, the card is set aside and a new card can be drawn. The cards
+      are scored at game end based on the highest number that isn''t covered by a cube.
 
 
-      The games ends when there are no tokens left in the bag to refill the central area, or at least one players has 2 or fewer empty spaces on their player board. Play continues until all players have had an equal turn that round. The player with the highest points is the winner.
+      The games ends when there are no tokens left in the bag to refill the central area, or at least one players has 2 or
+      fewer empty spaces on their player board. Play continues until all players have had an equal turn that round. The player
+      with the highest points is the winner.
 
 
-      Optionally, you can use Nature's Spirit cards for richer gameplay. During setup, each player chooses 1 of 2 spirit cards and places a Spirit cube on the card. They follow the same placement rules as Animal cards, but tend to have an ongoing effect once completed. The spirit card does count towards the 4-card hand limit.
+      Optionally, you can use Nature''s Spirit cards for richer gameplay. During setup, each player chooses 1 of 2 spirit
+      cards and places a Spirit cube on the card. They follow the same placement rules as Animal cards, but tend to have an
+      ongoing effect once completed. The spirit card does count towards the 4-card hand limit.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2024
     minPlayers: 1
     maxPlayers: 4
@@ -3623,27 +4118,28 @@ catalog:
     - Korea Boardgames
     - Rebel Sp. z o.o.
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/harmonies_rulebook.pdf
+    pdfSha256: 5ed98481b5a6580d15ee92c2c744a33027481fb17ec75fb22fa0e05d9a0ae6c7
+    pdfVersion: '1.0'
   - title: 'Dixit: Odyssey'
     bggId: 92828
     language: en
-    pdf: dixit-odyssey_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Dixit Odyssey is both a standalone game and an expansion (Dixit: Odyssey (expansion)) for Jean-Louis Roubira's Dixit, which won Germany's Spiel des Jahres award in 2010.
-
-
-      Game play in Dixit Odyssey matches that of Dixit: Each turn one player is the storyteller. This player secretly chooses one card in his hand, then gives a word or sentence to describe this card&mdash;but not too obviously. Each other player chooses a card in hand that matches this word/sentence and gives it to the storyteller. The storyteller then lays out the cards, and all other players vote on which card belongs to the storyteller. If no one or everyone guesses the storyteller's card, the storyteller receives no points and all players receive two; otherwise the storyteller and the correct guesser(s) each receive three points. Players score one point for each vote their image receives. Players refill their hands, and the next player becomes the storyteller. When the deck runs out, the player with the most points wins.
-
-
-      Dixit Odyssey contains 84 new cards, each with a unique image drawn by Pier&ocirc; and colored by Marie Cardouat, artist of Dixit and Dixit 2. The stand alone version also includes a folding game board, 6 new rabbit scoring tokens (12 total), and a box large enough to hold all the Dixit cards released to date. The stand alone version of Dixit Odyssey includes enough components for up to twelve players and also has variant rules for team play and for new ways to play with the cards.
-
-
-      Expansion versus standalone versions of the game.
-
-           Standalone version is in a square box (released in 2011 but may still be available).
-           Expansion version is in a rectangular box (available from 2013 onwards): Dixit: Odyssey (expansion)
-
-
+    description: "Dixit Odyssey is both a standalone game and an expansion (Dixit: Odyssey (expansion)) for Jean-Louis Roubira's\
+      \ Dixit, which won Germany's Spiel des Jahres award in 2010.\n\nGame play in Dixit Odyssey matches that of Dixit: Each\
+      \ turn one player is the storyteller. This player secretly chooses one card in his hand, then gives a word or sentence\
+      \ to describe this card&mdash;but not too obviously. Each other player chooses a card in hand that matches this word/sentence\
+      \ and gives it to the storyteller. The storyteller then lays out the cards, and all other players vote on which card\
+      \ belongs to the storyteller. If no one or everyone guesses the storyteller's card, the storyteller receives no points\
+      \ and all players receive two; otherwise the storyteller and the correct guesser(s) each receive three points. Players\
+      \ score one point for each vote their image receives. Players refill their hands, and the next player becomes the storyteller.\
+      \ When the deck runs out, the player with the most points wins.\n\nDixit Odyssey contains 84 new cards, each with a\
+      \ unique image drawn by Pier&ocirc; and colored by Marie Cardouat, artist of Dixit and Dixit 2. The stand alone version\
+      \ also includes a folding game board, 6 new rabbit scoring tokens (12 total), and a box large enough to hold all the\
+      \ Dixit cards released to date. The stand alone version of Dixit Odyssey includes enough components for up to twelve\
+      \ players and also has variant rules for team play and for new ways to play with the cards.\n\nExpansion versus standalone\
+      \ versions of the game.\n\n     Standalone version is in a square box (released in 2011 but may still be available).\n\
+      \     Expansion version is in a rectangular box (available from 2013 onwards): Dixit: Odyssey (expansion)\n\n\n"
     yearPublished: 2011
     minPlayers: 3
     maxPlayers: 12
@@ -3681,16 +4177,21 @@ catalog:
     - Rebel Sp. z o.o.
     - Swan Panasia Co., Ltd.
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/dixit-odyssey_rulebook.pdf
+    pdfSha256: a3d0b2c61420c8ad04147a323143bf5885b26b92040cf2bc83d9e9211265a4db
+    pdfVersion: '1.0'
   - title: Hanamikoji
     bggId: 158600
     language: en
-    pdf: hanamikoji_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Welcome to the most famed Geisha street in the old capital, Hanamikoji. Geishas are elegant and graceful women who are skilled in art, music, dance, and a variety of performances and ceremonies. Greatly respected and adored, Geishas are masters of entertainment.
+    description: 'Welcome to the most famed Geisha street in the old capital, Hanamikoji. Geishas are elegant and graceful
+      women who are skilled in art, music, dance, and a variety of performances and ceremonies. Greatly respected and adored,
+      Geishas are masters of entertainment.
 
 
-      In Hanamikoji, two players compete to earn the favor of seven illustrious Geishas by collecting each Geisha&rsquo;s preferred performance item. With careful speculation and a few bold moves, can you outsmart your opponent to win the favor of the most Geishas?
+      In Hanamikoji, two players compete to earn the favor of seven illustrious Geishas by collecting each Geisha&rsquo;s
+      preferred performance item. With careful speculation and a few bold moves, can you outsmart your opponent to win the
+      favor of the most Geishas?
 
 
       Jixia Academy features the same gameplay as Hanamikoji, but with different artwork.
@@ -3698,6 +4199,8 @@ catalog:
 
       Hanamikoji FAQ
 
+
+      '
     yearPublished: 2013
     minPlayers: 2
     maxPlayers: 2
@@ -3745,25 +4248,36 @@ catalog:
     - Taiwan Boardgame Design
     - White Goblin Games
     - Zvezda
+    pdfBlobKey: rulebooks/v1/hanamikoji_rulebook.pdf
+    pdfSha256: 662765d0f77dd24235ec59f6c00b629ac69078a62e7fbd044a803bb7458326a2
+    pdfVersion: '1.0'
   - title: Sleeping Gods
     bggId: 255984
     language: en
-    pdf: sleeping-gods_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      "Are the stars unfamiliar here?" she asked, and the sky grew suddenly dark, the star's patterns alien and exotic. "This is the Wandering Sea. The gods have brought you here, and you must wake them if you wish to return home."
+    description: '"Are the stars unfamiliar here?" she asked, and the sky grew suddenly dark, the star''s patterns alien and
+      exotic. "This is the Wandering Sea. The gods have brought you here, and you must wake them if you wish to return home."
 
 
-      In Sleeping Gods, you and up to 3 friends become Captain Sofi Odessa and her crew, lost in a strange world in 1929 on your steamship, the Manticore. You must work together to survive, exploring exotic islands, meeting new characters, and seeking out the totems of the gods so that you can return home.
+      In Sleeping Gods, you and up to 3 friends become Captain Sofi Odessa and her crew, lost in a strange world in 1929 on
+      your steamship, the Manticore. You must work together to survive, exploring exotic islands, meeting new characters,
+      and seeking out the totems of the gods so that you can return home.
 
 
-      Sleeping Gods is a campaign game. Each session can last as long as you want. When you are ready to take a break, you mark your progress on a journey log sheet, making it easy to return to the same place in the game the next time you play. You can play solo or with friends throughout your campaign. It's easy to swap players in and out at will. Your goal is to find at least fourteen totems hidden throughout the world. Like reading a book, you'll complete this journey one or two hours at a time, discovering new lands, stories, and challenges along the way.
+      Sleeping Gods is a campaign game. Each session can last as long as you want. When you are ready to take a break, you
+      mark your progress on a journey log sheet, making it easy to return to the same place in the game the next time you
+      play. You can play solo or with friends throughout your campaign. It''s easy to swap players in and out at will. Your
+      goal is to find at least fourteen totems hidden throughout the world. Like reading a book, you''ll complete this journey
+      one or two hours at a time, discovering new lands, stories, and challenges along the way.
 
 
-      Sleeping Gods is an atlas game. Each page of the atlas represents only a small portion of the world you can explore. When you reach the edge of a page and you want to continue in the same direction, you simply turn to a new page and sail onward.
+      Sleeping Gods is an atlas game. Each page of the atlas represents only a small portion of the world you can explore.
+      When you reach the edge of a page and you want to continue in the same direction, you simply turn to a new page and
+      sail onward.
 
 
-      Sleeping Gods is a storybook game. Each new location holds wild adventure, hidden treasures, and vivid characters. Your choices affect the characters and the plot of the game, and may help or hinder your chances of getting home!
+      Sleeping Gods is a storybook game. Each new location holds wild adventure, hidden treasures, and vivid characters. Your
+      choices affect the characters and the plot of the game, and may help or hinder your chances of getting home!
 
 
       Welcome to a vast world. Your journey starts now.
@@ -3771,6 +4285,8 @@ catalog:
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2021
     minPlayers: 1
     maxPlayers: 4
@@ -3815,22 +4331,40 @@ catalog:
     - REXhry
     - リゴレ (rigoler)
     - Schwerkraft-Verlag
+    pdfBlobKey: rulebooks/v1/sleeping-gods_rulebook.pdf
+    pdfSha256: 07fe81f40884134f92b5b50720fa2348501b9b33c3f5dff774fda5ad12e2807c
+    pdfVersion: '1.0'
   - title: Jenga
     bggId: 2452
     language: en
     bggEnhanced: true
-    description: >+
-      Jenga is tower building game played with 54 wooden blocks; each block is 3 times as long as it is wide, and slightly smaller in height than in width. The blocks are stacked in a tower formation; each story is three blocks placed adjacent to each other along their long side, and each story is placed perpendicular to the previous (so, for example, if the blocks in the first story are pointing north-south, the second story blocks will point east-west). There are therefore 18 stories to the Jenga tower. Since stacking the blocks neatly can be tedious, a plastic loading tray is included.
+    description: 'Jenga is tower building game played with 54 wooden blocks; each block is 3 times as long as it is wide,
+      and slightly smaller in height than in width. The blocks are stacked in a tower formation; each story is three blocks
+      placed adjacent to each other along their long side, and each story is placed perpendicular to the previous (so, for
+      example, if the blocks in the first story are pointing north-south, the second story blocks will point east-west). There
+      are therefore 18 stories to the Jenga tower. Since stacking the blocks neatly can be tedious, a plastic loading tray
+      is included.
 
 
-      Once the tower is built, the person who built the tower moves first. Moving in Jenga consists of taking one and only one block from any story except the completed top story of the tower at the time of the turn, and placing it on the topmost story in order to complete it. Only one hand at a time may be used to remove a block; both hands can be used, but only one hand may be on the tower at a time. Blocks may be bumped to find a loose block that will not disturb the rest of the tower. Any block that is moved out of place may be left out of place if it is determined that it will knock the tower over if it is removed. The turn ends when the next person to move touches the tower, although he or she can wait 10 seconds before moving for the previous turn to end if they believe the tower will fall in that time.
+      Once the tower is built, the person who built the tower moves first. Moving in Jenga consists of taking one and only
+      one block from any story except the completed top story of the tower at the time of the turn, and placing it on the
+      topmost story in order to complete it. Only one hand at a time may be used to remove a block; both hands can be used,
+      but only one hand may be on the tower at a time. Blocks may be bumped to find a loose block that will not disturb the
+      rest of the tower. Any block that is moved out of place may be left out of place if it is determined that it will knock
+      the tower over if it is removed. The turn ends when the next person to move touches the tower, although he or she can
+      wait 10 seconds before moving for the previous turn to end if they believe the tower will fall in that time.
 
 
-      The game ends when the tower falls in any significant way -- in other words, any piece falls from the tower, other than the piece being knocked out to move to the top. The loser is the person who made the tower fall (i.e. whose turn it was when the tower fell); the winner is the person who moved before the loser.
+      The game ends when the tower falls in any significant way -- in other words, any piece falls from the tower, other than
+      the piece being knocked out to move to the top. The loser is the person who made the tower fall (i.e. whose turn it
+      was when the tower fell); the winner is the person who moved before the loser.
 
 
-      The same game concept was published in 1984 by Fagus under the name "Hoppla - eins zuviel!" According to the designer, the game was developed from Takoradi blocks/bricks. "Jenga" is Swahili for "build".
+      The same game concept was published in 1984 by Fagus under the name "Hoppla - eins zuviel!" According to the designer,
+      the game was developed from Takoradi blocks/bricks. "Jenga" is Swahili for "build".
 
+
+      '
     yearPublished: 1983
     minPlayers: 1
     maxPlayers: 8
@@ -3926,20 +4460,32 @@ catalog:
   - title: El Grande
     bggId: 93
     language: en
-    pdf: el-grande_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In this award-winning game, players take on the roles of Grandes in medieval Spain.  The king's power is flagging, and these powerful lords are vying for control of the various regions.  To that end, you draft caballeros (knights) into your court and subsequently move them onto the board to help seize control of regions.  After every third round, the regions are scored, and after the ninth round, the player with the most points is the winner.
+    description: 'In this award-winning game, players take on the roles of Grandes in medieval Spain.  The king''s power is
+      flagging, and these powerful lords are vying for control of the various regions.  To that end, you draft caballeros
+      (knights) into your court and subsequently move them onto the board to help seize control of regions.  After every third
+      round, the regions are scored, and after the ninth round, the player with the most points is the winner.
 
 
-      In each of the nine rounds, you select one of your 13 power cards to determine turn order as well as the number of caballeros you get to move from the provinces (general supply) into your court (personal supply).
+      In each of the nine rounds, you select one of your 13 power cards to determine turn order as well as the number of caballeros
+      you get to move from the provinces (general supply) into your court (personal supply).
 
 
-      A turn then consists of selecting one of five action cards which allow variations to the rules and additional scoring opportunities in addition to determining how many caballeros to move from your court to one or more of the regions on the board (or into the castillo - a secretive tower). Normally, you may only place your caballeros into regions adjacent to the one containing the king. The one hard and fast rule in El Grande is that nothing may move into or out of the king's region. One of the five action cards that is always available each round allows you to move the king to a new region. The other four action cards vary from round to round.
+      A turn then consists of selecting one of five action cards which allow variations to the rules and additional scoring
+      opportunities in addition to determining how many caballeros to move from your court to one or more of the regions on
+      the board (or into the castillo - a secretive tower). Normally, you may only place your caballeros into regions adjacent
+      to the one containing the king. The one hard and fast rule in El Grande is that nothing may move into or out of the
+      king''s region. One of the five action cards that is always available each round allows you to move the king to a new
+      region. The other four action cards vary from round to round.
 
 
-      The goal is to have a caballero majority in as many regions (and the castillo) as possible during a scoring round. Following the scoring of the castillo, you place any cubes you had there into the region you secretly indicated on your region dial. Each region is then scored individually according to a table printed in that region. Two-point bonuses are awarded for having sole majority in the region containing your Grande and in the region containing the king.
+      The goal is to have a caballero majority in as many regions (and the castillo) as possible during a scoring round. Following
+      the scoring of the castillo, you place any cubes you had there into the region you secretly indicated on your region
+      dial. Each region is then scored individually according to a table printed in that region. Two-point bonuses are awarded
+      for having sole majority in the region containing your Grande and in the region containing the king.
 
+
+      '
     yearPublished: 1995
     minPlayers: 2
     maxPlayers: 5
@@ -3983,17 +4529,26 @@ catalog:
     - MINDOK
     - Möbius Games
     - Rio Grande Games
+    pdfBlobKey: rulebooks/v1/el-grande_rulebook.pdf
+    pdfSha256: 414db220f71e3ab7e8735ee71945f960ea36e36f0a348ef91a55558d4f2097a3
+    pdfVersion: '1.0'
   - title: Aeon's End
     bggId: 191189
     language: en
-    pdf: aeons-end_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      The survivors of a long-ago invasion have taken refuge in the forgotten underground city of Gravehold. There, the desperate remnants of society have learned that the energy of the very breaches the beings use to attack them can be repurposed through various gems, transforming the malign energies within into beneficial spells and weapons to aid their last line of defense: the breach mages.
+    description: 'The survivors of a long-ago invasion have taken refuge in the forgotten underground city of Gravehold. There,
+      the desperate remnants of society have learned that the energy of the very breaches the beings use to attack them can
+      be repurposed through various gems, transforming the malign energies within into beneficial spells and weapons to aid
+      their last line of defense: the breach mages.
 
 
-      Aeon's End is a cooperative game that explores the deckbuilding genre with a number of innovative mechanisms, including a variable turn order system that simulates the chaos of an attack, and deck management rules that require careful planning with every discarded card. Players will struggle to defend Gravehold from The Nameless and their hordes using unique abilities, powerful spells, and, most importantly of all, their collective wits.
+      Aeon''s End is a cooperative game that explores the deckbuilding genre with a number of innovative mechanisms, including
+      a variable turn order system that simulates the chaos of an attack, and deck management rules that require careful planning
+      with every discarded card. Players will struggle to defend Gravehold from The Nameless and their hordes using unique
+      abilities, powerful spells, and, most importantly of all, their collective wits.
 
+
+      '
     yearPublished: 2016
     minPlayers: 1
     maxPlayers: 4
@@ -4042,30 +4597,24 @@ catalog:
     - REXhry
     - SD Games
     - Surfin' Meeple China
+    pdfBlobKey: rulebooks/v1/aeons-end_rulebook.pdf
+    pdfSha256: d4496bf1b1a69d52d59a1bfb544f1b220465ffbfcc453d1fb2834706d7cf423b
+    pdfVersion: '1.0'
   - title: Res Arcana
     bggId: 262712
     language: en
-    pdf: res-arcana_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Prepare Your Place of Power!
-
-
-      In a high tower, an Alchemist prepares potions, using vials filled with otherworldly fluids. In a sacred grove, a Druid grinds herbs for a mystical ritual. In the catacombs, a Necromancer summons a bone dragon... Welcome to the world of Res Arcana!
-
-
-      In it, Life, Death, Elan, Calm, and Gold are the essences that fuel the art of magic. Choose your mage, gather essences, craft unique artifacts, and use them to summon dragons, conquer places of power, and achieve victory!
-
-
-      A game typically lasts 4-6 rounds. In each round, players do these steps:
-
-
-          Collect essences: performs  any Collect abilities, and may take essences from components.
-          Do actions, 1 per turn, clockwise from the First Player: place an artifact, claim a monument or Place of Power, discard a card for 1 Gold or any 2 other essences, use a power on a straightened component, or pass: exchange magic items and draw 1 card. Play continues until all players have passed.
-          Pass procedure: If you are first to pass, take the First Player token, swap your magic item for a different magic item, draw 1 card.
-          Check victory points (10+ VPs). If no one has won: straighten all turned components, and begin the next round.
-
-
+    description: "Prepare Your Place of Power!\n\nIn a high tower, an Alchemist prepares potions, using vials filled with\
+      \ otherworldly fluids. In a sacred grove, a Druid grinds herbs for a mystical ritual. In the catacombs, a Necromancer\
+      \ summons a bone dragon... Welcome to the world of Res Arcana!\n\nIn it, Life, Death, Elan, Calm, and Gold are the essences\
+      \ that fuel the art of magic. Choose your mage, gather essences, craft unique artifacts, and use them to summon dragons,\
+      \ conquer places of power, and achieve victory!\n\nA game typically lasts 4-6 rounds. In each round, players do these\
+      \ steps:\n\n\n    Collect essences: performs  any Collect abilities, and may take essences from components.\n    Do\
+      \ actions, 1 per turn, clockwise from the First Player: place an artifact, claim a monument or Place of Power, discard\
+      \ a card for 1 Gold or any 2 other essences, use a power on a straightened component, or pass: exchange magic items\
+      \ and draw 1 card. Play continues until all players have passed.\n    Pass procedure: If you are first to pass, take\
+      \ the First Player token, swap your magic item for a different magic item, draw 1 card.\n    Check victory points (10+\
+      \ VPs). If no one has won: straighten all turned components, and begin the next round.\n\n\n"
     yearPublished: 2019
     minPlayers: 2
     maxPlayers: 4
@@ -4103,20 +4652,32 @@ catalog:
     - Rebel Sp. z o.o.
     - sternenschimmermeer
     - テンデイズゲームズ (TendaysGames)
+    pdfBlobKey: rulebooks/v1/res-arcana_rulebook.pdf
+    pdfSha256: 79eca4421a36e2b547b06132f32cdc31fbfbd417ac4f73a5eb6130db472d9886
+    pdfVersion: '1.0'
   - title: Hero Realms
     bggId: 198994
     language: en
-    pdf: hero-realms_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Hero Realms is a fantasy-themed deck-building game that is an adaptation of the award-winning Star Realms game. The game includes basic rules for two-player games, along with rules for multiplayer formats such as Free-For-All, Hunter, and Hydra.
+    description: 'Hero Realms is a fantasy-themed deck-building game that is an adaptation of the award-winning Star Realms
+      game. The game includes basic rules for two-player games, along with rules for multiplayer formats such as Free-For-All,
+      Hunter, and Hydra.
 
 
-      Each player starts the game with a ten-card personal deck containing gold (for buying) and weapons (for combat). You start each turn with a new hand of five cards from your personal deck. When your deck runs out of cards, you shuffle your discard pile into your new deck. An 80-card Market deck is shared by all players, with five cards being revealed from that deck to create the Market Row. As you play, you use gold to buy champion cards and action cards from the Market. These champions and actions can generate large amounts of gold, combat, or other powerful effects. You use combat to attack your opponent and their champions. When you reduce your opponent's score (called health) to zero, you win!
+      Each player starts the game with a ten-card personal deck containing gold (for buying) and weapons (for combat). You
+      start each turn with a new hand of five cards from your personal deck. When your deck runs out of cards, you shuffle
+      your discard pile into your new deck. An 80-card Market deck is shared by all players, with five cards being revealed
+      from that deck to create the Market Row. As you play, you use gold to buy champion cards and action cards from the Market.
+      These champions and actions can generate large amounts of gold, combat, or other powerful effects. You use combat to
+      attack your opponent and their champions. When you reduce your opponent''s score (called health) to zero, you win!
 
 
-      Multiple expansions are available for Hero Realms that allow players to start as a particular character (Cleric, Fighter, Ranger, Thief, or Wizard) and fight cooperatively against a Boss, fight Boss decks against one another, or compete in a campaign mode that has you gain experience to work through different levels of missions.
+      Multiple expansions are available for Hero Realms that allow players to start as a particular character (Cleric, Fighter,
+      Ranger, Thief, or Wizard) and fight cooperatively against a Boss, fight Boss decks against one another, or compete in
+      a campaign mode that has you gain experience to work through different levels of missions.
 
+
+      '
     yearPublished: 2016
     minPlayers: 2
     maxPlayers: 4
@@ -4155,17 +4716,26 @@ catalog:
     - Lord of Boards
     - MIPL
     - Rawstone
+    pdfBlobKey: rulebooks/v1/hero-realms_rulebook.pdf
+    pdfSha256: 5e9f80ac096cd880ce21bbebaf83a789e1b671d0f6f2746b1707565108ca79f8
+    pdfVersion: '1.0'
   - title: Roll Player
     bggId: 169426
     language: en
-    pdf: roll-player_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Mighty heroes don&rsquo;t just appear out of thin air -- you must create them! Race, class, alignment, skills, traits, and equipment are all elements of the perfect hero, who is ready to take on all opposition in the quest for glory and riches.
+    description: 'Mighty heroes don&rsquo;t just appear out of thin air -- you must create them! Race, class, alignment, skills,
+      traits, and equipment are all elements of the perfect hero, who is ready to take on all opposition in the quest for
+      glory and riches.
 
 
-      In Roll Player, you will compete to create the greatest fantasy adventurer who has ever lived, preparing your character to embark on an epic quest. Roll and draft dice to build up your character&rsquo;s attributes. Purchase weapons and armor to outfit your hero. Train to gain skills and discover your hero&rsquo;s traits to prepare them for their journey. Earn Reputation Stars by constructing the perfect character. The player with the greatest Reputation wins the game and will surely triumph over whatever nefarious plot lies ahead!
+      In Roll Player, you will compete to create the greatest fantasy adventurer who has ever lived, preparing your character
+      to embark on an epic quest. Roll and draft dice to build up your character&rsquo;s attributes. Purchase weapons and
+      armor to outfit your hero. Train to gain skills and discover your hero&rsquo;s traits to prepare them for their journey.
+      Earn Reputation Stars by constructing the perfect character. The player with the greatest Reputation wins the game and
+      will surely triumph over whatever nefarious plot lies ahead!
 
+
+      '
     yearPublished: 2016
     minPlayers: 1
     maxPlayers: 4
@@ -4203,22 +4773,32 @@ catalog:
     - Pegasus Spiele
     - Raven Distribution
     - REXhry
+    pdfBlobKey: rulebooks/v1/roll-player_rulebook.pdf
+    pdfSha256: 0ae1cee918d58e165308cdef58b731e89a916652e919e7b61dbe74cb29e5240b
+    pdfVersion: '1.0'
   - title: Yahtzee
     bggId: 2243
     language: en
     bggEnhanced: true
-    description: >+
-      Yahtzee is a classic dice game played with 5 dice.  Each player's turn consists of rolling the dice up to 3 times in hope of making 1 of 13 categories.  Examples of categories are 3 of a kind, 4 of a kind, straight, full house, etc.  Each player tries to fill in a score for each category, but this is not always possible.  When all players have entered a score or a zero for all 13 categories, the game ends and total scores are compared.
+    description: 'Yahtzee is a classic dice game played with 5 dice.  Each player''s turn consists of rolling the dice up
+      to 3 times in hope of making 1 of 13 categories.  Examples of categories are 3 of a kind, 4 of a kind, straight, full
+      house, etc.  Each player tries to fill in a score for each category, but this is not always possible.  When all players
+      have entered a score or a zero for all 13 categories, the game ends and total scores are compared.
 
 
       The traditional (public domain) game Yacht predates the trademarked game, and has slightly different scoring.
 
 
-      There are four basic scoring difference between the tradition game Yacht and Yahtzee.  They are:  1) Yacht has no Three of a Kind category, 2) there are no bonuses in Yacht, 3) there are no Joker rules in Yacht, and 4) the Full House category is scored as the sum of the dice.  The other scoring rules are identical between the two games.
+      There are four basic scoring difference between the tradition game Yacht and Yahtzee.  They are:  1) Yacht has no Three
+      of a Kind category, 2) there are no bonuses in Yacht, 3) there are no Joker rules in Yacht, and 4) the Full House category
+      is scored as the sum of the dice.  The other scoring rules are identical between the two games.
 
 
-      Travel versions of the game use a device that keeps the dice captured within compartments of a plastic box and allows players to "lock" a particular die between rolls.
+      Travel versions of the game use a device that keeps the dice captured within compartments of a plastic box and allows
+      players to "lock" a particular die between rolls.
 
+
+      '
     yearPublished: 1956
     minPlayers: 2
     maxPlayers: 10
@@ -4317,8 +4897,10 @@ catalog:
     bggId: 2223
     language: en
     bggEnhanced: true
-    description: >+
-      Players race to empty their hands and catch opposing players with cards left in theirs, which score points. In turns, players attempt to play a card by matching its color, number, or word to the topmost card on the discard pile. If unable to play, players draw a card from the draw pile, and if still unable to play, they pass their turn. Wild and special cards spice things up a bit.
+    description: 'Players race to empty their hands and catch opposing players with cards left in theirs, which score points.
+      In turns, players attempt to play a card by matching its color, number, or word to the topmost card on the discard pile.
+      If unable to play, players draw a card from the draw pile, and if still unable to play, they pass their turn. Wild and
+      special cards spice things up a bit.
 
 
       UNO is a commercial version of Crazy Eights, a public domain card game played with a standard deck of playing cards.
@@ -4326,6 +4908,8 @@ catalog:
 
       This entry includes all themed versions of UNO that do not include new cards.
 
+
+      '
     yearPublished: 1971
     minPlayers: 2
     maxPlayers: 10
@@ -4382,17 +4966,25 @@ catalog:
   - title: Carcassonne
     bggId: 822
     language: en
-    pdf: carcassone_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Carcassonne is a tile placement game in which the players draw and place a tile with a piece of southern French landscape represented on it. The tile might feature a city, a road, a cloister, grassland or some combination thereof, and it must be placed adjacent to tiles that have already been played, in such a way that cities are connected to cities, roads to roads, et cetera. Having placed a tile, the player can then decide to place one of their meeples in one of the areas on it: in the city as a knight, on the road as a robber, in the cloister as a monk, or in the field as a farmer. When that area is complete that meeple scores points for its owner.
+    description: 'Carcassonne is a tile placement game in which the players draw and place a tile with a piece of southern
+      French landscape represented on it. The tile might feature a city, a road, a cloister, grassland or some combination
+      thereof, and it must be placed adjacent to tiles that have already been played, in such a way that cities are connected
+      to cities, roads to roads, et cetera. Having placed a tile, the player can then decide to place one of their meeples
+      in one of the areas on it: in the city as a knight, on the road as a robber, in the cloister as a monk, or in the field
+      as a farmer. When that area is complete that meeple scores points for its owner.
 
 
-      During a game of Carcassonne, players are faced with decisions like: "Is it really worth putting my last meeple there?" or "Should I use this tile to expand my city, or should I place it near my opponent instead, thus making it a harder for them to complete it and score points?" Since players place only one tile and have the option to place one meeple on it, turns proceed quickly even if it is a game full of options and possibilities.
+      During a game of Carcassonne, players are faced with decisions like: "Is it really worth putting my last meeple there?"
+      or "Should I use this tile to expand my city, or should I place it near my opponent instead, thus making it a harder
+      for them to complete it and score points?" Since players place only one tile and have the option to place one meeple
+      on it, turns proceed quickly even if it is a game full of options and possibilities.
 
 
       First game in the Carcassonne series.
 
+
+      '
     yearPublished: 2000
     minPlayers: 2
     maxPlayers: 5
@@ -4458,22 +5050,28 @@ catalog:
     - Venice Connection
     - Ventura Games
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/carcassone_rulebook.pdf
+    pdfSha256: 762a1ca8cc547ef6c5a6899b0043ecd1ef6f448dc51cfcc6906827452d90253e
+    pdfVersion: '1.0'
   - title: Risk
     bggId: 181
     language: en
     bggEnhanced: true
-    description: >+
-      Possibly the most popular, mass market war game.  The goal is conquest of the world.
+    description: 'Possibly the most popular, mass market war game.  The goal is conquest of the world.
 
 
-      Each player's turn consists of:
+      Each player''s turn consists of:
 
-      - gaining reinforcements through number of territories held, control of every territory on each continent, and turning sets of bonus cards.
+      - gaining reinforcements through number of territories held, control of every territory on each continent, and turning
+      sets of bonus cards.
 
-      -  Attacking other players using a simple combat rule of comparing the highest dice rolled for each side.  Players may attack as often as desired.  If one enemy territory is successfully taken, the player is awarded with a  bonus card.
+      -  Attacking other players using a simple combat rule of comparing the highest dice rolled for each side.  Players may
+      attack as often as desired.  If one enemy territory is successfully taken, the player is awarded with a  bonus card.
 
       -  Moving a group of armies to another adjacent territory.
 
+
+      '
     yearPublished: 1959
     minPlayers: 2
     maxPlayers: 6
@@ -4532,17 +5130,31 @@ catalog:
   - title: Chess
     bggId: 171
     language: en
-    pdf: scacchi-fide_2017_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Chess is a two-player, abstract strategy board game that represents medieval warfare on an 8x8 board with alternating light and dark squares. Opposing pieces, traditionally designated White and Black, are initially lined up on either side of the board. Each type of piece has a unique form of movement and capturing occurs when a piece, via its movement, occupies the square of an opposing piece. Players take turns moving one of their pieces in an attempt to capture, attack, defend, or develop their positions. Chess games can end in checkmate (when the king cannot escape from the opponent's pieces), resignation (when one player recognizes that defeat is inevitable and ends the game), or one of several types of draws.
+    description: 'Chess is a two-player, abstract strategy board game that represents medieval warfare on an 8x8 board with
+      alternating light and dark squares. Opposing pieces, traditionally designated White and Black, are initially lined up
+      on either side of the board. Each type of piece has a unique form of movement and capturing occurs when a piece, via
+      its movement, occupies the square of an opposing piece. Players take turns moving one of their pieces in an attempt
+      to capture, attack, defend, or develop their positions. Chess games can end in checkmate (when the king cannot escape
+      from the opponent''s pieces), resignation (when one player recognizes that defeat is inevitable and ends the game),
+      or one of several types of draws.
 
 
-      Chess is one of the most popular games in the world, played by millions of people worldwide at home, in clubs, online, by correspondence, and in tournaments. Between two highly skilled players, chess can be a beautiful thing to watch, and a game can provide great entertainment even for novices. The 2020 Netflix series, The Queen's Gambit was enjoyed by both chess players and non-players alike. There is also a large literature of books and periodicals about chess, typically featuring games and commentary by chess masters. Chess is so well known and highly regarded that it is often used as a metaphor in journalism, poetry, fiction, and film.
+      Chess is one of the most popular games in the world, played by millions of people worldwide at home, in clubs, online,
+      by correspondence, and in tournaments. Between two highly skilled players, chess can be a beautiful thing to watch,
+      and a game can provide great entertainment even for novices. The 2020 Netflix series, The Queen''s Gambit was enjoyed
+      by both chess players and non-players alike. There is also a large literature of books and periodicals about chess,
+      typically featuring games and commentary by chess masters. Chess is so well known and highly regarded that it is often
+      used as a metaphor in journalism, poetry, fiction, and film.
 
 
-      Chess evolved from the ancient Indian game Chaturanga, which became Shatranj when introduced to the Persians. The current form of the game emerged in the second half of the 15th century when the Persians brought Shatranj to Southern Europe. The tradition of organized competitive chess began in the 16th century. The first official World Chess Champion, Wilhelm Steinitz, claimed his title in 1886. Chess is also a recognized sport of the International Olympic Committee.
+      Chess evolved from the ancient Indian game Chaturanga, which became Shatranj when introduced to the Persians. The current
+      form of the game emerged in the second half of the 15th century when the Persians brought Shatranj to Southern Europe.
+      The tradition of organized competitive chess began in the 16th century. The first official World Chess Champion, Wilhelm
+      Steinitz, claimed his title in 1886. Chess is also a recognized sport of the International Olympic Committee.
 
+
+      '
     yearPublished: 1475
     minPlayers: 2
     maxPlayers: 2
@@ -4772,20 +5384,23 @@ catalog:
     - Xinliye
     - Οδύσσεια
     - Киевпластмасс
+    pdfBlobKey: rulebooks/v1/scacchi-fide_2017_rulebook.pdf
+    pdfSha256: dcd7496d22fb8efd3af35646ac38e8b07250acf0670772133d7983d9c82c0542
+    pdfVersion: '1.0'
   - title: Checkers
     bggId: 2083
     language: en
     bggEnhanced: true
-    description: >+
-      Abstract strategy game where players move disc-shaped pieces across an 8 by 8 cross-hatched ("checker") board. 
-
-      Pieces only move diagonally, and only one space at a time.  If a player can move one of his pieces so that it jumps over an adjacent piece of their opponent and into an empty space, that player captures the opponent's disc.  Jumping moves must be taken when possible, thereby creating a strategy game where players offer up jumps in exchange for setting up the board so that they jump even more pieces on their turn.  A player wins by removing all of his opponent's pieces from the board or by blocking the opponent so that he has no more moves.
-
-      This game, also known as Draughts, is part of the Checkers family.
-
-
-      The Official Checker Board to be used in tournaments and official matches of associations like international WCDF, ACF, and APCA usually shall be colored of green and off-white (buff). Board squares shall be not less than 2 inches nor more than 2&frac12; inches wide. Tournament pieces are Red and White, but called Black and White in game related literature.
-
+    description: "Abstract strategy game where players move disc-shaped pieces across an 8 by 8 cross-hatched (\"checker\"\
+      ) board. \nPieces only move diagonally, and only one space at a time.  If a player can move one of his pieces so that\
+      \ it jumps over an adjacent piece of their opponent and into an empty space, that player captures the opponent's disc.\
+      \  Jumping moves must be taken when possible, thereby creating a strategy game where players offer up jumps in exchange\
+      \ for setting up the board so that they jump even more pieces on their turn.  A player wins by removing all of his opponent's\
+      \ pieces from the board or by blocking the opponent so that he has no more moves.\nThis game, also known as Draughts,\
+      \ is part of the Checkers family.\n\nThe Official Checker Board to be used in tournaments and official matches of associations\
+      \ like international WCDF, ACF, and APCA usually shall be colored of green and off-white (buff). Board squares shall\
+      \ be not less than 2 inches nor more than 2&frac12; inches wide. Tournament pieces are Red and White, but called Black\
+      \ and White in game related literature.\n\n"
     yearPublished: 1150
     minPlayers: 2
     maxPlayers: 2
@@ -4967,23 +5582,34 @@ catalog:
   - title: Pandemic
     bggId: 30549
     language: en
-    pdf: pandemic_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Pandemic, several virulent diseases have broken out simultaneously all over the world! The players are disease-fighting specialists whose mission is to treat disease hotspots while researching cures for each of four plagues before they get out of hand.
+    description: 'In Pandemic, several virulent diseases have broken out simultaneously all over the world! The players are
+      disease-fighting specialists whose mission is to treat disease hotspots while researching cures for each of four plagues
+      before they get out of hand.
 
 
-      The game board depicts several major population centers on Earth. On each turn, a player can use up to four actions to travel between cities, treat infected populaces, discover a cure, or build a research station. A deck of cards provides the players with these abilities, but sprinkled throughout this deck are Epidemic! cards that accelerate and intensify the diseases' activity. A second, separate deck of cards controls the "normal" spread of the infections.
+      The game board depicts several major population centers on Earth. On each turn, a player can use up to four actions
+      to travel between cities, treat infected populaces, discover a cure, or build a research station. A deck of cards provides
+      the players with these abilities, but sprinkled throughout this deck are Epidemic! cards that accelerate and intensify
+      the diseases'' activity. A second, separate deck of cards controls the "normal" spread of the infections.
 
 
-      Taking a unique role within the team, players must plan their strategy to mesh with their specialists' strengths in order to conquer the diseases. For example, the Operations Expert can build research stations which are needed to find cures for the diseases and which allow for greater mobility between cities; the Scientist needs only four cards of a particular disease to cure it instead of the normal five&mdash;but the diseases are spreading quickly and time is running out. If one or more diseases spreads beyond recovery or if too much time elapses, the players all lose. If they cure the four diseases, they all win!
+      Taking a unique role within the team, players must plan their strategy to mesh with their specialists'' strengths in
+      order to conquer the diseases. For example, the Operations Expert can build research stations which are needed to find
+      cures for the diseases and which allow for greater mobility between cities; the Scientist needs only four cards of a
+      particular disease to cure it instead of the normal five&mdash;but the diseases are spreading quickly and time is running
+      out. If one or more diseases spreads beyond recovery or if too much time elapses, the players all lose. If they cure
+      the four diseases, they all win!
 
 
-      The 2013 edition of Pandemic includes two new characters&mdash;the Contingency Planner and the Quarantine Specialist&mdash;not available in earlier editions of the game.
+      The 2013 edition of Pandemic includes two new characters&mdash;the Contingency Planner and the Quarantine Specialist&mdash;not
+      available in earlier editions of the game.
 
 
       Pandemic is the first game in the Pandemic series.
 
+
+      '
     yearPublished: 2008
     minPlayers: 2
     maxPlayers: 4
@@ -5054,30 +5680,52 @@ catalog:
     - Zhiyanjia
     - Взрослые дети
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/pandemic_rulebook.pdf
+    pdfSha256: 6634e5cdbcc73afdb03ae788b096e6f1c251eeca39d1c66960f51f8ed1e38e02
+    pdfVersion: '1.0'
   - title: Monopoly
     bggId: 1406
     language: en
     bggEnhanced: true
-    description: >+
-      Theme
+    description: 'Theme
 
-      Players take the part of land owners, attempting to buy and then develop their land. Income is gained by other players visiting their properties and money is spent when they visit properties belonging to other players. When times get tough, players may have to mortgage their properties to raise cash for fines, taxes and other misfortunes.
+      Players take the part of land owners, attempting to buy and then develop their land. Income is gained by other players
+      visiting their properties and money is spent when they visit properties belonging to other players. When times get tough,
+      players may have to mortgage their properties to raise cash for fines, taxes and other misfortunes.
 
 
       Gameplay
 
-      On their turn, a player rolls two dice and moves that number of spaces around the board. If the player lands on an as-yet-unowned property, they has the opportunity to buy it or auction it to the highest bidder. If a player owns all the spaces within a color group, they may then build houses and hotels on these spaces, generating even more income from opponents who land there. If they lands on a property owned by another player, they must pay that player rent according to the value of the land and any buildings on it. There are other places on the board which can not be bought, but instead require the player to draw a card and perform the action on the card, pay taxes, collect income, or even go to jail.
+      On their turn, a player rolls two dice and moves that number of spaces around the board. If the player lands on an as-yet-unowned
+      property, they has the opportunity to buy it or auction it to the highest bidder. If a player owns all the spaces within
+      a color group, they may then build houses and hotels on these spaces, generating even more income from opponents who
+      land there. If they lands on a property owned by another player, they must pay that player rent according to the value
+      of the land and any buildings on it. There are other places on the board which can not be bought, but instead require
+      the player to draw a card and perform the action on the card, pay taxes, collect income, or even go to jail.
 
 
       Goal
 
-      The goal of the game is to be the last player remaining with any money. (though some editions end the game when the first player goes bankrupt)
+      The goal of the game is to be the last player remaining with any money. (though some editions end the game when the
+      first player goes bankrupt)
 
 
       Cultural impact on rules
 
-      Monopoly is unusual in that the game has official, printed rules, but most players learn how to play from others, never actually learning the correct way to play. This has led to the canonization of a number of house rules that make the game more palatable to children (and sore losers) but harm the gameplay by preventing players from going bankrupt or slowing down the rate of property acquisition. One common house rule has players put any money paid to the bank in the center of the board, which jackpot a player may earn by landing on Free Parking. This prevents the game from removing money from play, and since players collect $200 each time they pass Go, this results in ever-increasing bankrolls and players surviving rents that should have bankrupted them. Another house rule allows players to take "loans" from the bank instead of going bankrupt, which means the game will never end. Some house rules arise out of ignorance rather than attempts to improve the game. For instance, many players don't know that properties landed on but left unbought go up for auction, and even some that know to auction don't know that the bidding starts at $1, meaning a player may pay well below the listed price for an auctioned property.
+      Monopoly is unusual in that the game has official, printed rules, but most players learn how to play from others, never
+      actually learning the correct way to play. This has led to the canonization of a number of house rules that make the
+      game more palatable to children (and sore losers) but harm the gameplay by preventing players from going bankrupt or
+      slowing down the rate of property acquisition. One common house rule has players put any money paid to the bank in the
+      center of the board, which jackpot a player may earn by landing on Free Parking. This prevents the game from removing
+      money from play, and since players collect $200 each time they pass Go, this results in ever-increasing bankrolls and
+      players surviving rents that should have bankrupted them. Another house rule allows players to take "loans" from the
+      bank instead of going bankrupt, which means the game will never end. Some house rules arise out of ignorance rather
+      than attempts to improve the game. For instance, many players don''t know that properties landed on but left unbought
+      go up for auction, and even some that know to auction don''t know that the bidding starts at $1, meaning a player may
+      pay well below the listed price for an auctioned property.
 
+
+      '
     yearPublished: 1935
     minPlayers: 2
     maxPlayers: 8
@@ -5174,12 +5822,19 @@ catalog:
     bggId: 320
     language: en
     bggEnhanced: true
-    description: >+
-      In this classic word game, players use their seven drawn letter-tiles to form words on the gameboard. Each word laid out earns points based on the commonality of the letters used, with certain board spaces giving bonuses.  But a word can only be played if it uses at least one already-played tile or adds to an already-played word.  This leads to slightly tactical play, as potential words are rejected because they would give an opponent too much access to the better bonus spaces.
+    description: 'In this classic word game, players use their seven drawn letter-tiles to form words on the gameboard. Each
+      word laid out earns points based on the commonality of the letters used, with certain board spaces giving bonuses.  But
+      a word can only be played if it uses at least one already-played tile or adds to an already-played word.  This leads
+      to slightly tactical play, as potential words are rejected because they would give an opponent too much access to the
+      better bonus spaces.
 
 
-      Skip-a-cross was licensed by Selchow & Righter and manufactured by Cadaco. Both games have identical rules but Skip-a-cross has tiles and racks made of cardboard instead of wood. The game was also published because not enough Scrabble games were manufactured to meet the demand.
+      Skip-a-cross was licensed by Selchow & Righter and manufactured by Cadaco. Both games have identical rules but Skip-a-cross
+      has tiles and racks made of cardboard instead of wood. The game was also published because not enough Scrabble games
+      were manufactured to meet the demand.
 
+
+      '
     yearPublished: 1948
     minPlayers: 2
     maxPlayers: 4
@@ -5265,21 +5920,29 @@ catalog:
     bggId: 2394
     language: en
     bggEnhanced: true
-    description: >+
-      A traditional tile game played in many different cultures around the world.  This entry is for Western Dominoes; the standard set being the 28 "Double Six" tiles.  Chinese Dominoes use a 32 tile set with different distributions.
+    description: 'A traditional tile game played in many different cultures around the world.  This entry is for Western Dominoes;
+      the standard set being the 28 "Double Six" tiles.  Chinese Dominoes use a 32 tile set with different distributions.
 
 
-      Dominoes is a family of games using the "Western" style tiles.  The standard set of tiles is based on the 21 different combinations made with a roll of two six-sided dice.  Seven (7) additional "Blank" combination tiles combine with the 21 to form the standard 28 "Double-Six" set. "Double-Nine" (with 55 tiles) and "Double-Twelve" (with 91 tiles) are also popular. "Double-Fifteen" sets with 136 tiles also exist.
+      Dominoes is a family of games using the "Western" style tiles.  The standard set of tiles is based on the 21 different
+      combinations made with a roll of two six-sided dice.  Seven (7) additional "Blank" combination tiles combine with the
+      21 to form the standard 28 "Double-Six" set. "Double-Nine" (with 55 tiles) and "Double-Twelve" (with 91 tiles) are also
+      popular. "Double-Fifteen" sets with 136 tiles also exist.
 
 
-      There are many different games played with Dominoes.  The standard game is known as the Block game.  Forms of this game are known in many different areas of the world with similar rules.  Puerto Rican Dominoes, Latin Dominoes, and Cuban Dominoes are all forms of the Block game.
+      There are many different games played with Dominoes.  The standard game is known as the Block game.  Forms of this game
+      are known in many different areas of the world with similar rules.  Puerto Rican Dominoes, Latin Dominoes, and Cuban
+      Dominoes are all forms of the Block game.
 
 
-      Another main variety of Dominoes games are based on the "Fives Family".  Five-up, All Fives, Sniff, and Muggins are all part of this family.  This variation adds the ends of the dominoes to make a multiple of five for scoring.
+      Another main variety of Dominoes games are based on the "Fives Family".  Five-up, All Fives, Sniff, and Muggins are
+      all part of this family.  This variation adds the ends of the dominoes to make a multiple of five for scoring.
 
 
       Other popular Dominoes games include 42, ChickenFoot, and Mexican Train.
 
+
+      '
     yearPublished: 1500
     minPlayers: 2
     maxPlayers: 10
@@ -5480,15 +6143,22 @@ catalog:
     bggId: 188
     language: en
     bggEnhanced: true
-    description: >+
-      In Go, players alternately place stones on the empty intersections of a 19x19 grid. The goal: to enclose territory behind stone perimeters and, secondarily, to tightly surround and capture enemy stones. After both players pass, they add up their territory and deduct the number of captives lost, higher score wins.
+    description: 'In Go, players alternately place stones on the empty intersections of a 19x19 grid. The goal: to enclose
+      territory behind stone perimeters and, secondarily, to tightly surround and capture enemy stones. After both players
+      pass, they add up their territory and deduct the number of captives lost, higher score wins.
 
 
-      As you see, the concept is simple, yet the challenge can enrich a lifetime. In truth many lifetimes, for Go has been played for thousands of years. With that long of a lineage and a worldwide following, it has come to be known by different names (Weiqi, Igo, Baduk) and to be played by slightly differing rules, but those differences seldom affect play.
+      As you see, the concept is simple, yet the challenge can enrich a lifetime. In truth many lifetimes, for Go has been
+      played for thousands of years. With that long of a lineage and a worldwide following, it has come to be known by different
+      names (Weiqi, Igo, Baduk) and to be played by slightly differing rules, but those differences seldom affect play.
 
 
-      So welcome to this masterpiece that is the game of Go, the race for geographical control of an unclaimed land. Experience running battles and swift reversals, bold invasions and painful sacrifices, each sally, each setback playing out to the dulcet tap of stone on wood.
+      So welcome to this masterpiece that is the game of Go, the race for geographical control of an unclaimed land. Experience
+      running battles and swift reversals, bold invasions and painful sacrifices, each sally, each setback playing out to
+      the dulcet tap of stone on wood.
 
+
+      '
     yearPublished: -2200
     minPlayers: 2
     maxPlayers: 2
@@ -5594,18 +6264,35 @@ catalog:
     bggId: 2397
     language: en
     bggEnhanced: true
-    description: >+
-      Backgammon is a classic abstract strategy game dating back thousands of years. Each player has a set of 15 checkers (or stones) that must be moved from their starting positions, around, and then off the board. Dice are thrown each turn, and each player must decide which of their checkers to move based on the outcome of the roll. Players can capture each other's checkers, forcing the captured checkers to restart their journey around the board. The winner is the first player to get all 15 checkers off the board. A more recent addition to the game is the "doubling cube", which allows players to up the stakes of the game. Although the game relies on dice to determine movement, there is a large degree of strategy in deciding how to make the most effective moves given each dice roll and measuring the risk in terms of possible rolls the opponent may get.
+    description: 'Backgammon is a classic abstract strategy game dating back thousands of years. Each player has a set of
+      15 checkers (or stones) that must be moved from their starting positions, around, and then off the board. Dice are thrown
+      each turn, and each player must decide which of their checkers to move based on the outcome of the roll. Players can
+      capture each other''s checkers, forcing the captured checkers to restart their journey around the board. The winner
+      is the first player to get all 15 checkers off the board. A more recent addition to the game is the "doubling cube",
+      which allows players to up the stakes of the game. Although the game relies on dice to determine movement, there is
+      a large degree of strategy in deciding how to make the most effective moves given each dice roll and measuring the risk
+      in terms of possible rolls the opponent may get.
 
 
-      Backgammon may be the first game to be mentioned in written history, going back 5,000 years to the Sumerians of ancient Mesopotamia. During the 1920s, archaeologists unearthed five boards from a cemetery in the ancient town of Ur. At another location, pieces and dice were also found along with the board. Boards from ancient Egypt have also been recovered from the tomb of Tutankhamun, including a mechanical dice box, no doubt intended to stop cheaters.
+      Backgammon may be the first game to be mentioned in written history, going back 5,000 years to the Sumerians of ancient
+      Mesopotamia. During the 1920s, archaeologists unearthed five boards from a cemetery in the ancient town of Ur. At another
+      location, pieces and dice were also found along with the board. Boards from ancient Egypt have also been recovered from
+      the tomb of Tutankhamun, including a mechanical dice box, no doubt intended to stop cheaters.
 
 
-      The names of the game were many. In Persia, Takhteh Nard which means "Battle on Wood". In Egypt, Tau, which may be the ancestor of Senat. In Rome, Ludus Duodecim Scriptorum ("game of twelve marks"), later, Tabula ("table"), and by the sixth century, Alea ("dice"). In ancient China, T-shu-p-u and later in Japan, Sugoroko. The English name may derive from "Bac gamen" meaning "Back Game", referring to re-entry of taken stones back to the board. It was often enjoyed by the upper classes and is sometimes called "The Aristocratic Game". The Roman Emperor Claudius was known to be such a fan of Tabula that he had a set built into his coach so he could play as he traveled (the world's first travel edition?).
+      The names of the game were many. In Persia, Takhteh Nard which means "Battle on Wood". In Egypt, Tau, which may be the
+      ancestor of Senat. In Rome, Ludus Duodecim Scriptorum ("game of twelve marks"), later, Tabula ("table"), and by the
+      sixth century, Alea ("dice"). In ancient China, T-shu-p-u and later in Japan, Sugoroko. The English name may derive
+      from "Bac gamen" meaning "Back Game", referring to re-entry of taken stones back to the board. It was often enjoyed
+      by the upper classes and is sometimes called "The Aristocratic Game". The Roman Emperor Claudius was known to be such
+      a fan of Tabula that he had a set built into his coach so he could play as he traveled (the world''s first travel edition?).
 
 
-      The rules in English were standardized in 1743 by Edmond Hoyle. These remained popular until the American innovations of the 1930s.
+      The rules in English were standardized in 1743 by Edmond Hoyle. These remained popular until the American innovations
+      of the 1930s.
 
+
+      '
     yearPublished: -3000
     minPlayers: 2
     maxPlayers: 2
@@ -5806,18 +6493,28 @@ catalog:
     bggId: 1294
     language: en
     bggEnhanced: true
-    description: >+
-      For versions of Clue that feature the new character Dr. Orchid, please use this Clue page.
+    description: 'For versions of Clue that feature the new character Dr. Orchid, please use this Clue page.
 
 
       The classic detective game!   A game for those who enjoy reasoning and thinking things out.
 
 
-      In Clue, players move from room to room in a mansion to solve the mystery of: who done it, with what, and where?  Players are dealt character, weapon, and location cards after the top card from each card type is secretly placed in the confidential file in the middle of the board.  Players must move to a room and then make a suggestion against a character saying they did it in that room with a specific weapon.  The player to the left must show one of any cards mentioned if in that player's hand.  Through deductive reasoning each player must figure out which character, weapon, and location are in the secret file.  To do this, each player must uncover what cards are in other players hands by making more and more suggestions.  Once a player knows what cards the other players are holding, they will know what cards are in the secret file, and then make an accusation. If correct, the player wins, but if incorrect, the player must return the cards to the file without revealing them and may no longer make suggestions or accusations.
+      In Clue, players move from room to room in a mansion to solve the mystery of: who done it, with what, and where?  Players
+      are dealt character, weapon, and location cards after the top card from each card type is secretly placed in the confidential
+      file in the middle of the board.  Players must move to a room and then make a suggestion against a character saying
+      they did it in that room with a specific weapon.  The player to the left must show one of any cards mentioned if in
+      that player''s hand.  Through deductive reasoning each player must figure out which character, weapon, and location
+      are in the secret file.  To do this, each player must uncover what cards are in other players hands by making more and
+      more suggestions.  Once a player knows what cards the other players are holding, they will know what cards are in the
+      secret file, and then make an accusation. If correct, the player wins, but if incorrect, the player must return the
+      cards to the file without revealing them and may no longer make suggestions or accusations.
 
 
-      Note: There are some early versions of Clue which are labeled as 2-6 players. Recent and current issues of the game state 3-6 players.
+      Note: There are some early versions of Clue which are labeled as 2-6 players. Recent and current issues of the game
+      state 3-6 players.
 
+
+      '
     yearPublished: 1949
     minPlayers: 2
     maxPlayers: 6
@@ -5894,15 +6591,22 @@ catalog:
     bggId: 74
     language: en
     bggEnhanced: true
-    description: >+
-      The party game Apples to Apples consists of two decks of cards: Things and Descriptions. Each round, the active player draws a Description card (which features an adjective like "Hairy" or "Smarmy") from the deck, then the other players each secretly choose the Thing card in hand that best matches that description and plays it face-down on the table. The active player then reveals these cards and chooses the Thing card that, in his opinion, best matches the Description card, which he awards to whoever played that Thing card. This player becomes the new active player for the next round.
+    description: 'The party game Apples to Apples consists of two decks of cards: Things and Descriptions. Each round, the
+      active player draws a Description card (which features an adjective like "Hairy" or "Smarmy") from the deck, then the
+      other players each secretly choose the Thing card in hand that best matches that description and plays it face-down
+      on the table. The active player then reveals these cards and chooses the Thing card that, in his opinion, best matches
+      the Description card, which he awards to whoever played that Thing card. This player becomes the new active player for
+      the next round.
 
 
       Once a player has won a pre-determined number of Description cards, that player wins.
 
 
-      Note: "Party Box" editions include all cards from Apples to Apples: Expansion Set #1 and Apples to Apples: Expansion Set #2
+      Note: "Party Box" editions include all cards from Apples to Apples: Expansion Set #1 and Apples to Apples: Expansion
+      Set #2
 
+
+      '
     yearPublished: 1999
     minPlayers: 4
     maxPlayers: 10
@@ -5939,31 +6643,16 @@ catalog:
     bggId: 163
     language: en
     bggEnhanced: true
-    description: >+
-      A clever repackaging of the parlor game Dictionary, Balderdash contains several cards with real words nobody has heard of.  After one of those words has been read aloud, players try to come up with definitions that at least sound plausible, because points are later awarded for every opposing player who guessed that your definition was the correct one.
-
-
-      Versions of the game as a parlor game go back at least as far as 1970, although Balderdash itself was not published until 1984.
-
-
-      Mattel, Inc. republished Balderdash in 2006 in a form that derives its gameplay from the sequel Beyond Balderdash.
-
-
-      Re-implemented by:
-
-          Beyond Balderdash / Absolute Balderdash
-          Kokkelimonke Jubileum
-
-
-      Re-implements:
-
-          Beyond Balderdash*
-
-
-
-          In a peculiar situation, this game was reimplemented by Beyond/Absolute Balderdash and then combined back into the original title (Balderdash) but with the rules and cards from Beyond/Absolute; while Tactic re-published their version of Beyond/Absolute combined with the original Balderdash and called it Kokkelimonke Jubileum.
-
-
+    description: "A clever repackaging of the parlor game Dictionary, Balderdash contains several cards with real words nobody\
+      \ has heard of.  After one of those words has been read aloud, players try to come up with definitions that at least\
+      \ sound plausible, because points are later awarded for every opposing player who guessed that your definition was the\
+      \ correct one.\n\nVersions of the game as a parlor game go back at least as far as 1970, although Balderdash itself\
+      \ was not published until 1984.\n\nMattel, Inc. republished Balderdash in 2006 in a form that derives its gameplay from\
+      \ the sequel Beyond Balderdash.\n\nRe-implemented by:\n\n    Beyond Balderdash / Absolute Balderdash\n    Kokkelimonke\
+      \ Jubileum\n\n\nRe-implements:\n\n    Beyond Balderdash*\n\n\n\n    In a peculiar situation, this game was reimplemented\
+      \ by Beyond/Absolute Balderdash and then combined back into the original title (Balderdash) but with the rules and cards\
+      \ from Beyond/Absolute; while Tactic re-published their version of Beyond/Absolute combined with the original Balderdash\
+      \ and called it Kokkelimonke Jubileum.\n\n\n"
     yearPublished: 1984
     minPlayers: 2
     maxPlayers: 6
@@ -6007,18 +6696,23 @@ catalog:
     bggId: 1293
     language: en
     bggEnhanced: true
-    description: >+
-      Boggle is a timed word game in which players have 3 minutes to find as many connected words as possible from the face up letters resting in a 16 cube grid.  When the timer runs out, players compare their lists of words and remove any words found by multiple players.  Points are then awarded for remaining words, depending on how many letters are in the word.  (In the original Boggle, all words must contain 3 or more letters to score points.)
+    description: 'Boggle is a timed word game in which players have 3 minutes to find as many connected words as possible
+      from the face up letters resting in a 16 cube grid.  When the timer runs out, players compare their lists of words and
+      remove any words found by multiple players.  Points are then awarded for remaining words, depending on how many letters
+      are in the word.  (In the original Boggle, all words must contain 3 or more letters to score points.)
 
 
       An example grid given in the French Canadian rules (of Deluxe Boggle) holds an amazing 459 words!
 
 
-      A number of variants have been produced by Parker Brothers over time, including Big Boggle (which uses a 5&times;5 grid of letters and forces players to search for longer words).
+      A number of variants have been produced by Parker Brothers over time, including Big Boggle (which uses a 5&times;5 grid
+      of letters and forces players to search for longer words).
 
 
       Boggle is a word dice game.
 
+
+      '
     yearPublished: 1972
     minPlayers: 1
     maxPlayers: 8
@@ -6065,18 +6759,11 @@ catalog:
     bggId: 2381
     language: en
     bggEnhanced: true
-    description: >+
-      In "The Game of Scattergories," published in 1988 by Milton Bradley, each player fills out a category list with answers that begin with the same letter. If no other player matches your answers, you score points. The game is played in rounds. After 3 rounds a winner is declared, and a new game can be begun.
-
-
-      Scattergories is a commercial version of an old parlour game known as Categories or Guggenheim.
-
-
-      Similar to:
-
-          Facts in Five
-
-
+    description: "In \"The Game of Scattergories,\" published in 1988 by Milton Bradley, each player fills out a category\
+      \ list with answers that begin with the same letter. If no other player matches your answers, you score points. The\
+      \ game is played in rounds. After 3 rounds a winner is declared, and a new game can be begun.\n\nScattergories is a\
+      \ commercial version of an old parlour game known as Categories or Guggenheim.\n\nSimilar to:\n\n    Facts in Five\n\
+      \n\n"
     yearPublished: 1988
     minPlayers: 2
     maxPlayers: 6
@@ -6113,15 +6800,22 @@ catalog:
     bggId: 27225
     language: en
     bggEnhanced: true
-    description: >+
-      Bananagrams is a fast and fun word game that requires no pencil, paper or board, and the tiles come in a fabric banana-shaped carrying pouch. One hand can be played in as little as five minutes. Much like Pick Two!, but without the letter values.
+    description: 'Bananagrams is a fast and fun word game that requires no pencil, paper or board, and the tiles come in a
+      fabric banana-shaped carrying pouch. One hand can be played in as little as five minutes. Much like Pick Two!, but without
+      the letter values.
 
 
-      Using a selection of 144 plastic letter tiles in the English edition, each player works independently to create their own 'crossword' faster than one's opponents. When a player uses up all their letters, all players take a new tile from the pool. The object of the game is to be the first to complete a word grid after the "bunch" of tiles has been depleted.
+      Using a selection of 144 plastic letter tiles in the English edition, each player works independently to create their
+      own ''crossword'' faster than one''s opponents. When a player uses up all their letters, all players take a new tile
+      from the pool. The object of the game is to be the first to complete a word grid after the "bunch" of tiles has been
+      depleted.
 
 
-      There are variants included in the instructions, such as Banana Smoothie and Banana Cafe for limited set skills or space-deprived places, and the game is suitable for solo play.
+      There are variants included in the instructions, such as Banana Smoothie and Banana Cafe for limited set skills or space-deprived
+      places, and the game is suitable for solo play.
 
+
+      '
     yearPublished: 2006
     minPlayers: 1
     maxPlayers: 8
@@ -6164,23 +6858,31 @@ catalog:
   - title: 'Survive: Escape from Atlantis!'
     bggId: 2653
     language: en
-    pdf: survive-escape-from-atlantis_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Survive is a cutthroat game where players seek to evacuate their pieces from an island that is breaking up, while remembering where their highest-valued pieces are located to maximize their score.
+    description: 'Survive is a cutthroat game where players seek to evacuate their pieces from an island that is breaking
+      up, while remembering where their highest-valued pieces are located to maximize their score.
 
 
-      An island made up of 40 hex-tiles is slowly sinking into the ocean (as the tiles are removed from the board). Each player controls ten people (valued from 1 to 6) that they try and move towards the safety of the surrounding islands before the main island finally blows up. Players can either swim or use boats to travel but must avoid sea serpents, whales and sharks on their way to safety.
+      An island made up of 40 hex-tiles is slowly sinking into the ocean (as the tiles are removed from the board). Each player
+      controls ten people (valued from 1 to 6) that they try and move towards the safety of the surrounding islands before
+      the main island finally blows up. Players can either swim or use boats to travel but must avoid sea serpents, whales
+      and sharks on their way to safety.
 
 
       Survive is very similar to Escape from Atlantis with some key differences.
 
 
-      Survive was reprinted as "Survive: Escape from Atlantis!" by publisher Stronghold Games and hit store shelves in February, 2011.   The reprint contains the game Survive, as well as all the extra pieces needed in order to play the game as "Escape from Atlantis" and is actually found here: Survive: Escape from Atlantis! because it came with the dolphins and dive dice which were removed from the anniversary edition which was released a couple of years later (though they were later made available by themselves for owners of that version).
+      Survive was reprinted as "Survive: Escape from Atlantis!" by publisher Stronghold Games and hit store shelves in February,
+      2011.   The reprint contains the game Survive, as well as all the extra pieces needed in order to play the game as "Escape
+      from Atlantis" and is actually found here: Survive: Escape from Atlantis! because it came with the dolphins and dive
+      dice which were removed from the anniversary edition which was released a couple of years later (though they were later
+      made available by themselves for owners of that version).
 
 
       "Survive: Escape from Atlantis!" is game #2 in the Stronghold Games "Survive Line".
 
+
+      '
     yearPublished: 1982
     minPlayers: 2
     maxPlayers: 4
@@ -6228,19 +6930,26 @@ catalog:
     - Vennerød Forlag AS
     - Waddingtons
     - Zygomatic
+    pdfBlobKey: rulebooks/v1/survive-escape-from-atlantis_rulebook.pdf
+    pdfSha256: f38dbcab30df17928d2e1102c5cfa0e8d3a1b0f8672f9ad39f616820f03c6c7c
+    pdfVersion: '1.0'
   - title: Spot it!
     bggId: 63268
     language: en
-    pdf: spot-it_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Spot it!, a.k.a. Dobble, is a simple pattern recognition game in which players try to find an image shown on two cards.
+    description: 'Spot it!, a.k.a. Dobble, is a simple pattern recognition game in which players try to find an image shown
+      on two cards.
 
 
-      Each card in original Spot it! features eight different symbols, with the symbols varying in size from one card to the next. Any two cards have exactly one symbol in common. For the basic Spot it! game, reveal one card, then another. Whoever spots the symbol in common on both cards claims the first card, then another card is revealed for players to search, and so on. Whoever has collected the most cards when the 55-card deck runs out wins!
+      Each card in original Spot it! features eight different symbols, with the symbols varying in size from one card to the
+      next. Any two cards have exactly one symbol in common. For the basic Spot it! game, reveal one card, then another. Whoever
+      spots the symbol in common on both cards claims the first card, then another card is revealed for players to search,
+      and so on. Whoever has collected the most cards when the 55-card deck runs out wins!
 
 
-      Rules for different games &ndash; each an observation game with a speed element &ndash; are included with Spot it!, with the first player to find a match either gaining or getting rid of a card. Multiple versions of Spot it! have been published, with images in each version ranging from Halloween to hockey to baseball to San Francisco.
+      Rules for different games &ndash; each an observation game with a speed element &ndash; are included with Spot it!,
+      with the first player to find a match either gaining or getting rid of a card. Multiple versions of Spot it! have been
+      published, with images in each version ranging from Halloween to hockey to baseball to San Francisco.
 
 
       The game is sold as Spot it! in the USA and Dobble in Europe, with slight differences between the two editions.
@@ -6248,6 +6957,8 @@ catalog:
 
       Note: some versions have fewer cards and fewer symbols per card. (E.g. 30 cards with 6 symbols each.): Spot it! 1,2,3
 
+
+      '
     yearPublished: 2009
     minPlayers: 2
     maxPlayers: 8
@@ -6316,19 +7027,26 @@ catalog:
     - Super Impulse
     - Top Toys
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/spot-it_rulebook.pdf
+    pdfSha256: f8fa9d62aa27a4070d9a632713c1fd22a904c1f735b74229c838b81225e3fcdd
+    pdfVersion: '1.0'
   - title: Connect Four
     bggId: 2719
     language: en
     bggEnhanced: true
-    description: >+
-      Connect 4 is a well known vertical game played with "checkers" game pieces, although it is more akin to Tic-Tac-Toe or Go Moku.
+    description: 'Connect 4 is a well known vertical game played with "checkers" game pieces, although it is more akin to
+      Tic-Tac-Toe or Go Moku.
 
 
-      The board is placed in the stand to hold it vertically and the players drop game pieces into one of the seven slots, each of which holds up to six game pieces, until one player succeeds in getting four in a row, whether horizontally, vertically, or diagonally.
+      The board is placed in the stand to hold it vertically and the players drop game pieces into one of the seven slots,
+      each of which holds up to six game pieces, until one player succeeds in getting four in a row, whether horizontally,
+      vertically, or diagonally.
 
 
-      The game is non-proprietary.  More elegant, wooden versions can be found under the name The Captain's Mistress.
+      The game is non-proprietary.  More elegant, wooden versions can be found under the name The Captain''s Mistress.
 
+
+      '
     yearPublished: 1974
     minPlayers: 2
     maxPlayers: 2
@@ -6448,9 +7166,12 @@ catalog:
     bggId: 4143
     language: en
     bggEnhanced: true
-    description: >+
-      The mystery face game where you flip over a collection of faces with different color hair, eye color, hair, hats, glasses etc.  to deduce who the secret person is that your opponent has chosen. You flip over the hooked tiles as you narrow your choices by asking characteristic questions.
+    description: 'The mystery face game where you flip over a collection of faces with different color hair, eye color, hair,
+      hats, glasses etc.  to deduce who the secret person is that your opponent has chosen. You flip over the hooked tiles
+      as you narrow your choices by asking characteristic questions.
 
+
+      '
     yearPublished: 1979
     minPlayers: 2
     maxPlayers: 2
@@ -6517,9 +7238,12 @@ catalog:
     bggId: 5432
     language: en
     bggEnhanced: true
-    description: >+
-      Traditional game from ancient India was brought to the UK in 1892 and first commercially published in the USA by Milton Bradley in 1943 (as Chutes and Ladders).  Players travel along the squares sometimes using ladders, which represent good acts, that allow the player to come closer to nirvana while the snakes were slides into evil.
+    description: 'Traditional game from ancient India was brought to the UK in 1892 and first commercially published in the
+      USA by Milton Bradley in 1943 (as Chutes and Ladders).  Players travel along the squares sometimes using ladders, which
+      represent good acts, that allow the player to come closer to nirvana while the snakes were slides into evil.
 
+
+      '
     yearPublished: -200
     minPlayers: 2
     maxPlayers: 6
@@ -6694,21 +7418,33 @@ catalog:
     bggId: 2407
     language: en
     bggEnhanced: true
-    description: >+
-      Slide Pursuit Game
+    description: 'Slide Pursuit Game
 
 
-      Race your four game pieces from Start around the board to your Home in this Pachisi type game. By turning over a card from the draw deck and following its instructions, players move their pieces around the game board, switch places with players, and knock opponents' pieces off the track and back to their Start position.
+      Race your four game pieces from Start around the board to your Home in this Pachisi type game. By turning over a card
+      from the draw deck and following its instructions, players move their pieces around the game board, switch places with
+      players, and knock opponents'' pieces off the track and back to their Start position.
 
 
-      Slides are located at various places around the game board. When a player's piece lands at the beginning of one of these slides not of its own color, it automatically advances to the end, removing any piece on the slide and sending it back to Start.
+      Slides are located at various places around the game board. When a player''s piece lands at the beginning of one of
+      these slides not of its own color, it automatically advances to the end, removing any piece on the slide and sending
+      it back to Start.
 
 
-      Game moves are directed exclusively by cards from the play-action deck.  If one plays the normal version in which one card is drawn from the deck each turn, the outcome has a huge element of luck.  Sorry can be made more of a strategic game (and more appealing to adults) by dealing five cards to each player at the start of the game and allowing the player to choose which card he/she will play each turn.  In this version, at the end of each turn, a new card is drawn from the deck to replace the card that was played, so that each player is always working from five cards.
+      Game moves are directed exclusively by cards from the play-action deck.  If one plays the normal version in which one
+      card is drawn from the deck each turn, the outcome has a huge element of luck.  Sorry can be made more of a strategic
+      game (and more appealing to adults) by dealing five cards to each player at the start of the game and allowing the player
+      to choose which card he/she will play each turn.  In this version, at the end of each turn, a new card is drawn from
+      the deck to replace the card that was played, so that each player is always working from five cards.
 
 
-      A player's fortunes can change dramatically in one or two rounds of play through the use of Sorry cards, the "11" cards (which give the player the option of trading places with an opponent's piece on the track), and the fact that it is possible to move from Start to Home without circumnavigating the full board by making judicious use of the "backward 4" cards.
+      A player''s fortunes can change dramatically in one or two rounds of play through the use of Sorry cards, the "11" cards
+      (which give the player the option of trading places with an opponent''s piece on the track), and the fact that it is
+      possible to move from Start to Home without circumnavigating the full board by making judicious use of the "backward
+      4" cards.
 
+
+      '
     yearPublished: 1929
     minPlayers: 2
     maxPlayers: 4
@@ -6759,16 +7495,20 @@ catalog:
   - title: 'Brass: Birmingham'
     bggId: 224517
     language: en
-    pdf: brass-birmingham_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Brass: Birmingham is an economic strategy game sequel to Martin Wallace's 2007 masterpiece, Brass. Brass: Birmingham tells the story of competing entrepreneurs in Birmingham during the industrial revolution between the years of 1770 and 1870.
+    description: 'Brass: Birmingham is an economic strategy game sequel to Martin Wallace''s 2007 masterpiece, Brass. Brass:
+      Birmingham tells the story of competing entrepreneurs in Birmingham during the industrial revolution between the years
+      of 1770 and 1870.
 
 
-      It offers a very different story arc and experience from its predecessor. As in its predecessor, you must develop, build and establish your industries and network in an effort to exploit low or high market demands. The game is played over two halves: the canal era (years 1770-1830) and the rail era (years 1830-1870). To win the game, score the most VPs. VPs are counted at the end of each half for the canals, rails and established (flipped) industry tiles.
+      It offers a very different story arc and experience from its predecessor. As in its predecessor, you must develop, build
+      and establish your industries and network in an effort to exploit low or high market demands. The game is played over
+      two halves: the canal era (years 1770-1830) and the rail era (years 1830-1870). To win the game, score the most VPs.
+      VPs are counted at the end of each half for the canals, rails and established (flipped) industry tiles.
 
 
-      Each round, players take turns according to the turn order track, receiving two actions to perform any of the following actions (found in the original game):
+      Each round, players take turns according to the turn order track, receiving two actions to perform any of the following
+      actions (found in the original game):
 
 
       1) Build - Pay required resources and place an industry tile.
@@ -6785,8 +7525,11 @@ catalog:
       Brass: Birmingham also features a new sixth action:
 
 
-      6) Scout - Discard three cards and take a wild location and wild industry card. (This action replaces Double Action Build in original Brass.)
+      6) Scout - Discard three cards and take a wild location and wild industry card. (This action replaces Double Action
+      Build in original Brass.)
 
+
+      '
     yearPublished: 2018
     minPlayers: 2
     maxPlayers: 4
@@ -6846,29 +7589,45 @@ catalog:
     - TLAMA games
     - White Goblin Games
     - 盒拍工作室 Hepa Studio
+    pdfBlobKey: rulebooks/v1/brass-birmingham_rulebook.pdf
+    pdfSha256: 71916357bca0b51d26e646348f21f98715390b0a8d5772fe0b3f5fdfd63aeffc
+    pdfVersion: '1.0'
   - title: 'Dune: Imperium'
     bggId: 316554
     language: en
-    pdf: dune-imperium_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Dune: Imperium is a game that uses deck building to add a hidden information angle to traditional worker placement. It finds inspiration in elements and characters from the Dune legacy, both the new film from Legendary Pictures and the seminal literary series from Frank Herbert, Brian Herbert, and Kevin J. Anderson.
+    description: 'Dune: Imperium is a game that uses deck building to add a hidden information angle to traditional worker
+      placement. It finds inspiration in elements and characters from the Dune legacy, both the new film from Legendary Pictures
+      and the seminal literary series from Frank Herbert, Brian Herbert, and Kevin J. Anderson.
 
 
-      As a leader of one of the Great Houses of the Landsraad, raise your banner and marshal your forces and spies. War is coming, and at the center of the conflict is Arrakis &ndash; Dune, the desert planet.
+      As a leader of one of the Great Houses of the Landsraad, raise your banner and marshal your forces and spies. War is
+      coming, and at the center of the conflict is Arrakis &ndash; Dune, the desert planet.
 
 
-      You start with a unique leader card, as well as a deck identical to those of your opponents.  As you acquire cards and build your deck, your choices will define your strengths and weaknesses. Cards allow you to send your Agents to certain spaces on the game board, so how your deck evolves affects your strategy. You might become more powerful militarily, able to deploy more troops than your opponents. Or you might acquire cards that give you an edge with the four political factions represented in the game: the Emperor, the Spacing Guild, the Bene Gesserit, and the Fremen.
+      You start with a unique leader card, as well as a deck identical to those of your opponents.  As you acquire cards and
+      build your deck, your choices will define your strengths and weaknesses. Cards allow you to send your Agents to certain
+      spaces on the game board, so how your deck evolves affects your strategy. You might become more powerful militarily,
+      able to deploy more troops than your opponents. Or you might acquire cards that give you an edge with the four political
+      factions represented in the game: the Emperor, the Spacing Guild, the Bene Gesserit, and the Fremen.
 
 
-      Unlike many deck building games, you don&rsquo;t play your entire hand in one turn. Instead, you draw a hand of cards at the start of every round and alternate with other players, taking one Agent turn at a time (playing one card to send one of your Agents to the game board). When it&rsquo;s your turn and you have no more Agents to place, you&rsquo;ll take a Reveal turn, revealing the rest of your cards, which will provide Persuasion and Swords. Persuasion is used to acquire more cards, and Swords help your troops fight for the current round&rsquo;s rewards as shown on the revealed Conflict card.
+      Unlike many deck building games, you don&rsquo;t play your entire hand in one turn. Instead, you draw a hand of cards
+      at the start of every round and alternate with other players, taking one Agent turn at a time (playing one card to send
+      one of your Agents to the game board). When it&rsquo;s your turn and you have no more Agents to place, you&rsquo;ll
+      take a Reveal turn, revealing the rest of your cards, which will provide Persuasion and Swords. Persuasion is used to
+      acquire more cards, and Swords help your troops fight for the current round&rsquo;s rewards as shown on the revealed
+      Conflict card.
 
 
-      Defeat your rivals in combat, shrewdly navigate the political factions, and acquire precious cards. The Spice must flow to lead your House to victory!
+      Defeat your rivals in combat, shrewdly navigate the political factions, and acquire precious cards. The Spice must flow
+      to lead your House to victory!
 
 
       Some important links: The Official FAQ, the Unofficial FAQ, and an Automa (solo and 2p) Overview
 
+
+      '
     yearPublished: 2020
     minPlayers: 1
     maxPlayers: 4
@@ -6917,26 +7676,50 @@ catalog:
     - sternenschimmermeer
     - Tabletop KZ
     - YingDi (旅法师营地)
+    pdfBlobKey: rulebooks/v1/dune-imperium_rulebook.pdf
+    pdfSha256: 0472bf7bfc04b7f3a07fd1454b8a472b65b3d5bfea8bad881b3c7b725a04f862
+    pdfVersion: '1.0'
   - title: 'Twilight Imperium: Fourth Edition'
     bggId: 233078
     language: en
-    pdf: twilight-imperium-4e_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Twilight Imperium (Fourth Edition) is a game of galactic conquest in which three to six players each take on the role of one of seventeen factions vying for galactic domination through military might, political maneuvering, and economic bargaining. Every faction offers a completely different play experience, from the wormhole-hopping Ghosts of Creuss to the Emirates of Hacan, masters of trade and economics. These seventeen races are offered many paths to victory, but only one may sit upon the throne of Mecatol Rex as the new masters of the galaxy.
+    description: 'Twilight Imperium (Fourth Edition) is a game of galactic conquest in which three to six players each take
+      on the role of one of seventeen factions vying for galactic domination through military might, political maneuvering,
+      and economic bargaining. Every faction offers a completely different play experience, from the wormhole-hopping Ghosts
+      of Creuss to the Emirates of Hacan, masters of trade and economics. These seventeen races are offered many paths to
+      victory, but only one may sit upon the throne of Mecatol Rex as the new masters of the galaxy.
 
 
-      No two games of Twilight Imperium are ever identical. At the start of each galactic age, the game board is uniquely and strategically constructed from among 51 galaxy tiles that feature everything from lush new planets and supernovas to asteroid fields and gravity rifts. Players are dealt a hand of these tiles and take turns creating the galaxy around Mecatol Rex, the capital planet seated in the center of the board. An ion storm may block your race from progressing through the galaxy while a fortuitously placed gravity rift may protect you from your closest foes. The galaxy is yours to both craft and dominate.
+      No two games of Twilight Imperium are ever identical. At the start of each galactic age, the game board is uniquely
+      and strategically constructed from among 51 galaxy tiles that feature everything from lush new planets and supernovas
+      to asteroid fields and gravity rifts. Players are dealt a hand of these tiles and take turns creating the galaxy around
+      Mecatol Rex, the capital planet seated in the center of the board. An ion storm may block your race from progressing
+      through the galaxy while a fortuitously placed gravity rift may protect you from your closest foes. The galaxy is yours
+      to both craft and dominate.
 
 
-      A round of Twilight Imperium begins with players selecting one of eight strategy cards that both determine player order and give their owner a unique strategic action for that round. These may do anything from providing additional command tokens to allowing a player to control trade throughout the galaxy. After these strategies are selected, players take turns moving their fleets from system to system, claiming new planets for their empires, and engaging in warfare and trade with other factions. At the end of a turn, players gather in a grand council to pass new laws and agendas, shaking up the game in unpredictable ways.
+      A round of Twilight Imperium begins with players selecting one of eight strategy cards that both determine player order
+      and give their owner a unique strategic action for that round. These may do anything from providing additional command
+      tokens to allowing a player to control trade throughout the galaxy. After these strategies are selected, players take
+      turns moving their fleets from system to system, claiming new planets for their empires, and engaging in warfare and
+      trade with other factions. At the end of a turn, players gather in a grand council to pass new laws and agendas, shaking
+      up the game in unpredictable ways.
 
 
-      After every player has passed their turn, players move up the victory track by checking to see whether they have completed any objectives throughout the turn and scoring them. Objectives are determined by setting up ten public objective cards at the start of each game, then gradually revealing them over the course of the game. Each player also chooses between two random secret objectives at the start of the game, achievement of which provides victory points--only for the holder of that objective. These objectives can be anything from researching new technologies to taking your neighbor's home system. At the end of every turn, a player can claim one public objective and one secret objective. As play continues, more of these objectives are revealed and more secret objectives are dealt out, giving players dynamically changing goals throughout the game. Play continues until a player reaches ten victory points.
+      After every player has passed their turn, players move up the victory track by checking to see whether they have completed
+      any objectives throughout the turn and scoring them. Objectives are determined by setting up ten public objective cards
+      at the start of each game, then gradually revealing them over the course of the game. Each player also chooses between
+      two random secret objectives at the start of the game, achievement of which provides victory points--only for the holder
+      of that objective. These objectives can be anything from researching new technologies to taking your neighbor''s home
+      system. At the end of every turn, a player can claim one public objective and one secret objective. As play continues,
+      more of these objectives are revealed and more secret objectives are dealt out, giving players dynamically changing
+      goals throughout the game. Play continues until a player reaches ten victory points.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2017
     minPlayers: 3
     maxPlayers: 6
@@ -6993,23 +7776,31 @@ catalog:
     - Hobby World
     - Playfun Games
     - sternenschimmermeer
+    pdfBlobKey: rulebooks/v1/twilight-imperium-4e_rulebook.pdf
+    pdfSha256: 3111c1857435c8fc8726814c18fab3296d05a6cc5f3b92da10e4cfed114890dc
+    pdfVersion: '1.0'
   - title: 'Dune: Imperium - Uprising'
     bggId: 397598
     language: en
-    pdf: dune-imperium-uprising_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Dune: Imperium Uprising, you want to continue to balance military might with political intrigue, wielding new tools in pursuit of victory. Spies will shore up your plans, vital contracts will expand your resources, or you can learn the ways of the Fremen and ride mighty sandworms into battle!
+    description: 'In Dune: Imperium Uprising, you want to continue to balance military might with political intrigue, wielding
+      new tools in pursuit of victory. Spies will shore up your plans, vital contracts will expand your resources, or you
+      can learn the ways of the Fremen and ride mighty sandworms into battle!
 
 
-      Dune: Imperium Uprising is a standalone spinoff to Dune: Imperium that expands on that game's blend of deck-building and worker placement, while introducing a new six-player mode that pits two teams against one other in the biggest struggle yet.
+      Dune: Imperium Uprising is a standalone spinoff to Dune: Imperium that expands on that game''s blend of deck-building
+      and worker placement, while introducing a new six-player mode that pits two teams against one other in the biggest struggle
+      yet.
 
 
-      The Dune: Imperium expansions Rise of Ix and Immortality work with Uprising, as do almost all of the cards from the base game, and elements of Uprising can be used with Dune: Imperium.
+      The Dune: Imperium expansions Rise of Ix and Immortality work with Uprising, as do almost all of the cards from the
+      base game, and elements of Uprising can be used with Dune: Imperium.
 
 
       The choices are yours. The Imperium awaits!
 
+
+      '
     yearPublished: 2023
     minPlayers: 1
     maxPlayers: 6
@@ -7055,23 +7846,40 @@ catalog:
     - Regatul Jocurilor
     - REXhry
     - Tabletop KZ
+    pdfBlobKey: rulebooks/v1/dune-imperium-uprising_rulebook.pdf
+    pdfSha256: 0a8daa36f73c09316143d05bbd5d845183d1ae6f56ce211d93c59b360074f7db
+    pdfVersion: '1.0'
   - title: 'War of the Ring: Second Edition'
     bggId: 115746
     language: en
-    pdf: war-of-the-ring_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In War of the Ring, one player takes control of the Free Peoples (FP) while the other player controls Shadow Armies (SA). Initially, the Free People Nations are reluctant to take arms against Sauron, so they must be attacked by Sauron or persuaded by Gandalf or other Companions before they start to fight in earnest: this is represented by the Political Track which shows if a Nation is ready to fight in the War of the Ring or not.
+    description: 'In War of the Ring, one player takes control of the Free Peoples (FP) while the other player controls Shadow
+      Armies (SA). Initially, the Free People Nations are reluctant to take arms against Sauron, so they must be attacked
+      by Sauron or persuaded by Gandalf or other Companions before they start to fight in earnest: this is represented by
+      the Political Track which shows if a Nation is ready to fight in the War of the Ring or not.
 
 
-      The game can be won by a military victory if Sauron conquers a certain number of Free People cities and strongholds, or vice versa. But the true hope of the Free Peoples lies with the quest of the Ring bearer: while the armies clash across Middle-earth, the Fellowship of the Ring is trying to get secretly to Mount Doom to destroy the One Ring. Sauron is not aware of the real intention of his enemies but is looking across Middle-earth for the precious Ring, so that the Fellowship is going to face numerous dangers, represented by the rules of The Hunt for the Ring. But the Companions can spur the Free Peoples to the fight against Sauron, so the Free People player must balance the need to protect the Ring bearer from harm with an attempt to raise a proper defense against the armies of the Shadow so that they do not overrun Middle-earth before the Ringbearer completes his quest.
+      The game can be won by a military victory if Sauron conquers a certain number of Free People cities and strongholds,
+      or vice versa. But the true hope of the Free Peoples lies with the quest of the Ring bearer: while the armies clash
+      across Middle-earth, the Fellowship of the Ring is trying to get secretly to Mount Doom to destroy the One Ring. Sauron
+      is not aware of the real intention of his enemies but is looking across Middle-earth for the precious Ring, so that
+      the Fellowship is going to face numerous dangers, represented by the rules of The Hunt for the Ring. But the Companions
+      can spur the Free Peoples to the fight against Sauron, so the Free People player must balance the need to protect the
+      Ring bearer from harm with an attempt to raise a proper defense against the armies of the Shadow so that they do not
+      overrun Middle-earth before the Ringbearer completes his quest.
 
 
-      Each game turn revolves around the roll of Action Dice: each die corresponds to an action that a player can perform during a turn. Depending on the face rolled on each die, different actions are possible (moving armies or characters, recruiting troops, advancing a Political Track).
+      Each game turn revolves around the roll of Action Dice: each die corresponds to an action that a player can perform
+      during a turn. Depending on the face rolled on each die, different actions are possible (moving armies or characters,
+      recruiting troops, advancing a Political Track).
 
 
-      Action Dice can also be used to draw or play Event Cards. Event Cards are played to represent specific events from the story (or events that could possibly have happened) that cannot be portrayed through normal game-play. Each Event Card can also create an unexpected turn in the game, allowing special actions or altering the course of a battle.
+      Action Dice can also be used to draw or play Event Cards. Event Cards are played to represent specific events from the
+      story (or events that could possibly have happened) that cannot be portrayed through normal game-play. Each Event Card
+      can also create an unexpected turn in the game, allowing special actions or altering the course of a battle.
 
+
+      '
     yearPublished: 2011
     minPlayers: 2
     maxPlayers: 4
@@ -7120,26 +7928,35 @@ catalog:
     - Schwerkraft-Verlag
     - Sophisticated Games
     - Zhiyanjia
+    pdfBlobKey: rulebooks/v1/war-of-the-ring_rulebook.pdf
+    pdfSha256: 645d2c3df8d67a4d85fb059d00ef68880f27f8c51ffb832e911ea3acb8b90f75
+    pdfVersion: '1.0'
   - title: 'Star Wars: Rebellion'
     bggId: 187645
     language: en
-    pdf: star-wars-rebellion_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Star Wars: Rebellion is a board game of epic conflict between the Galactic Empire and Rebel Alliance for two to four players.
-
-
-      Experience the Galactic Civil War like never before. In Rebellion, you control the entire Galactic Empire or the fledgling Rebel Alliance. You must command starships, account for troop movements, and rally systems to your cause. Given the differences between the Empire and Rebel Alliance, each side has different win conditions, and you'll need to adjust your play style depending on who you represent:
-
-           As the Imperial player, you can command legions of Stormtroopers, swarms of TIEs, Star Destroyers, and even the Death Star. You rule the galaxy by fear, relying on the power of your massive military to enforce your will. To win the game, you need to snuff out the budding Rebel Alliance by finding its base and obliterating it. Along the way, you can subjugate worlds or even destroy them.
-           As the Rebel player, you can command dozens of troopers, T-47 airspeeders, Corellian corvettes, and fighter squadrons. However, these forces are no match for the Imperial military. In terms of raw strength, you'll find yourself clearly overmatched from the very outset, so you'll need to rally the planets to join your cause and execute targeted military strikes to sabotage Imperial build yards and steal valuable intelligence. To win the Galactic Civil War, you'll need to sway the galaxy's citizens to your cause. If you survive long enough and strengthen your reputation, you inspire the galaxy to a full-scale revolt, and you win.
-
-
-      Featuring more than 150 plastic miniatures and two game boards that account for thirty-two of the Star Wars galaxy's most notable systems, Rebellion features a scope that is as large and sweeping as any Star Wars game before it.
-
-
-      Yet for all its grandiosity, Rebellion remains intensely personal, cinematic, and heroic. As much as your success depends upon the strength of your starships, vehicles, and troops, it depends upon the individual efforts of such notable characters as Leia Organa, Mon Mothma, Grand Moff Tarkin, and Emperor Palpatine. As civil war spreads throughout the galaxy, these leaders are invaluable to your efforts, and the secret missions they attempt will evoke many of the most inspiring moments from the classic trilogy. You might send Luke Skywalker to receive Jedi training on Dagobah or have Darth Vader spring a trap that freezes Han Solo in carbonite!
-
+    description: "Star Wars: Rebellion is a board game of epic conflict between the Galactic Empire and Rebel Alliance for\
+      \ two to four players.\n\nExperience the Galactic Civil War like never before. In Rebellion, you control the entire\
+      \ Galactic Empire or the fledgling Rebel Alliance. You must command starships, account for troop movements, and rally\
+      \ systems to your cause. Given the differences between the Empire and Rebel Alliance, each side has different win conditions,\
+      \ and you'll need to adjust your play style depending on who you represent:\n\n     As the Imperial player, you can\
+      \ command legions of Stormtroopers, swarms of TIEs, Star Destroyers, and even the Death Star. You rule the galaxy by\
+      \ fear, relying on the power of your massive military to enforce your will. To win the game, you need to snuff out the\
+      \ budding Rebel Alliance by finding its base and obliterating it. Along the way, you can subjugate worlds or even destroy\
+      \ them.\n     As the Rebel player, you can command dozens of troopers, T-47 airspeeders, Corellian corvettes, and fighter\
+      \ squadrons. However, these forces are no match for the Imperial military. In terms of raw strength, you'll find yourself\
+      \ clearly overmatched from the very outset, so you'll need to rally the planets to join your cause and execute targeted\
+      \ military strikes to sabotage Imperial build yards and steal valuable intelligence. To win the Galactic Civil War,\
+      \ you'll need to sway the galaxy's citizens to your cause. If you survive long enough and strengthen your reputation,\
+      \ you inspire the galaxy to a full-scale revolt, and you win.\n\n\nFeaturing more than 150 plastic miniatures and two\
+      \ game boards that account for thirty-two of the Star Wars galaxy's most notable systems, Rebellion features a scope\
+      \ that is as large and sweeping as any Star Wars game before it.\n\nYet for all its grandiosity, Rebellion remains intensely\
+      \ personal, cinematic, and heroic. As much as your success depends upon the strength of your starships, vehicles, and\
+      \ troops, it depends upon the individual efforts of such notable characters as Leia Organa, Mon Mothma, Grand Moff Tarkin,\
+      \ and Emperor Palpatine. As civil war spreads throughout the galaxy, these leaders are invaluable to your efforts, and\
+      \ the secret missions they attempt will evoke many of the most inspiring moments from the classic trilogy. You might\
+      \ send Luke Skywalker to receive Jedi training on Dagobah or have Darth Vader spring a trap that freezes Han Solo in\
+      \ carbonite!\n\n"
     yearPublished: 2016
     minPlayers: 2
     maxPlayers: 4
@@ -7191,23 +8008,33 @@ catalog:
     - Hobby World
     - Korea Boardgames
     - Rooster Games
+    pdfBlobKey: rulebooks/v1/star-wars-rebellion_rulebook.pdf
+    pdfSha256: 0b5af3a28bc4bc29a16f84456ed3a6543bf4d6a141461971e6fb170c6afba35a
+    pdfVersion: '1.0'
   - title: Gaia Project
     bggId: 220308
     language: en
-    pdf: gaia-project_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Gaia Project is a new game in the line of Terra Mystica. As in the original Terra Mystica, fourteen different factions live on seven different kinds of planets, and factions are bound to their own home planets, so to develop and grow, they must terraform neighboring planets into their home environments in competition with the other groups. In addition, Gaia planets can be used by all factions for colonization, and Transdimensional planets can be changed into Gaia planets.
+    description: 'Gaia Project is a new game in the line of Terra Mystica. As in the original Terra Mystica, fourteen different
+      factions live on seven different kinds of planets, and factions are bound to their own home planets, so to develop and
+      grow, they must terraform neighboring planets into their home environments in competition with the other groups. In
+      addition, Gaia planets can be used by all factions for colonization, and Transdimensional planets can be changed into
+      Gaia planets.
 
 
-      All factions can improve their skills in six different areas of development: Terraforming, Navigation, Artificial Intelligence, Gaiaforming, Economy, Research; leading to advanced technology and special bonuses. To do all of that, each group has special skills and abilities.
+      All factions can improve their skills in six different areas of development: Terraforming, Navigation, Artificial Intelligence,
+      Gaiaforming, Economy, Research; leading to advanced technology and special bonuses. To do all of that, each group has
+      special skills and abilities.
 
 
-      The playing area is made of ten sectors, allowing a variable set-up and thus an even bigger replay value than its predecessor Terra Mystica. A two-player game is hosted on seven sectors.
+      The playing area is made of ten sectors, allowing a variable set-up and thus an even bigger replay value than its predecessor
+      Terra Mystica. A two-player game is hosted on seven sectors.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2017
     minPlayers: 1
     maxPlayers: 4
@@ -7261,22 +8088,39 @@ catalog:
     - TLAMA games
     - White Goblin Games
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/gaia-project_rulebook.pdf
+    pdfSha256: 23331c7527cf3364de847ef5ca7de563f0fbbd906d0cd1932e54783cb6c24043
+    pdfVersion: '1.0'
   - title: Twilight Struggle
     bggId: 12333
     language: en
-    pdf: twilight-struggle_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Now the trumpet summons us again, not as a call to bear arms, though arms we need; not as a call to battle, though embattled we are &ndash; but a call to bear the burden of a long twilight struggle. &ndash; John F. Kennedy
+    description: 'Now the trumpet summons us again, not as a call to bear arms, though arms we need; not as a call to battle,
+      though embattled we are &ndash; but a call to bear the burden of a long twilight struggle. &ndash; John F. Kennedy
 
 
-      In 1945, unlikely allies toppled Hitler's war machine, while humanity's most devastating weapons forced the Japanese Empire to its knees in a storm of fire. Where once there stood many great powers, there then stood only two. The world had scant months to sigh its collective relief before a new conflict threatened. Unlike the titanic struggles of the preceding decades, this conflict would be waged not primarily by soldiers and tanks, but by spies and politicians, scientists and intellectuals, artists and traitors.
+      In 1945, unlikely allies toppled Hitler''s war machine, while humanity''s most devastating weapons forced the Japanese
+      Empire to its knees in a storm of fire. Where once there stood many great powers, there then stood only two. The world
+      had scant months to sigh its collective relief before a new conflict threatened. Unlike the titanic struggles of the
+      preceding decades, this conflict would be waged not primarily by soldiers and tanks, but by spies and politicians, scientists
+      and intellectuals, artists and traitors.
 
 
-      Twilight Struggle is a two-player game simulating the forty-five year dance of intrigue, prestige, and occasional flares of warfare between the Soviet Union and the United States. The entire world is the stage on which these two titans fight to make the world safe for their own ideologies and ways of life. The game begins amidst the ruins of Europe as the two new "superpowers" scramble over the wreckage of the Second World War, and ends in 1989, when only the United States remained standing.
+      Twilight Struggle is a two-player game simulating the forty-five year dance of intrigue, prestige, and occasional flares
+      of warfare between the Soviet Union and the United States. The entire world is the stage on which these two titans fight
+      to make the world safe for their own ideologies and ways of life. The game begins amidst the ruins of Europe as the
+      two new "superpowers" scramble over the wreckage of the Second World War, and ends in 1989, when only the United States
+      remained standing.
 
 
-      Twilight Struggle inherits its fundamental systems from the card-driven classics We the People and Hannibal: Rome vs. Carthage. It is a quick-playing, low-complexity game in that tradition. The game map is a world map of the period, whereon players move units and exert influence in attempts to gain allies and control for their superpower. As with GMT's other card-driven games, decision-making is a challenge; how to best use one's cards and units given consistently limited resources? Event cards add detail and flavor to the game. They cover a vast array of historical happenings, from the Arab-Israeli conflicts of 1948 and 1967, to Vietnam and the U.S. peace movement, to the Cuban Missile Crisis and other such incidents that brought the world to the brink of nuclear annihilation. Subsystems capture the prestige-laden Space Race as well as nuclear tensions, with the possibility of game-ending nuclear war.
+      Twilight Struggle inherits its fundamental systems from the card-driven classics We the People and Hannibal: Rome vs.
+      Carthage. It is a quick-playing, low-complexity game in that tradition. The game map is a world map of the period, whereon
+      players move units and exert influence in attempts to gain allies and control for their superpower. As with GMT''s other
+      card-driven games, decision-making is a challenge; how to best use one''s cards and units given consistently limited
+      resources? Event cards add detail and flavor to the game. They cover a vast array of historical happenings, from the
+      Arab-Israeli conflicts of 1948 and 1967, to Vietnam and the U.S. peace movement, to the Cuban Missile Crisis and other
+      such incidents that brought the world to the brink of nuclear annihilation. Subsystems capture the prestige-laden Space
+      Race as well as nuclear tensions, with the possibility of game-ending nuclear war.
 
 
       TIME SCALE:     approx. 3-5 years per turn
@@ -7285,6 +8129,8 @@ catalog:
 
       UNIT SCALE:     Influence markers
 
+
+      '
     yearPublished: 2005
     minPlayers: 2
     maxPlayers: 2
@@ -7331,23 +8177,37 @@ catalog:
     - Pixie Games
     - Udo Grebe Gamedesign
     - Wargames Club Publishing
+    pdfBlobKey: rulebooks/v1/twilight-struggle_rulebook.pdf
+    pdfSha256: cecc32db372d4c8e1822114f4f7a651e5c18e89048abfd2b7005fe8dd8e93a0d
+    pdfVersion: '1.0'
   - title: 'Through the Ages: A New Story of Civilization'
     bggId: 182028
     language: en
-    pdf: through-the-ages_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Through the Ages: A New Story of Civilization is the new edition of Through the Ages: A Story of Civilization, with many changes small and large to the game's cards over its three ages and extensive changes to how military works.
+    description: 'Through the Ages: A New Story of Civilization is the new edition of Through the Ages: A Story of Civilization,
+      with many changes small and large to the game''s cards over its three ages and extensive changes to how military works.
 
 
-      Through the Ages (TTA) is a civilization building game. Each player attempts to build the best civilization through careful resource management, and by: discovering new technologies, electing competent leaders, building wonders and maintaining a strong military. Weakness in any area can be exploited by your opponents. The game takes place throughout the ages, beginning in the age of antiquity and ending in the modern age.
+      Through the Ages (TTA) is a civilization building game. Each player attempts to build the best civilization through
+      careful resource management, and by: discovering new technologies, electing competent leaders, building wonders and
+      maintaining a strong military. Weakness in any area can be exploited by your opponents. The game takes place throughout
+      the ages, beginning in the age of antiquity and ending in the modern age.
 
 
-      One of the primary mechanisms in TTA is card drafting. Technologies, wonders, and leaders come into play and become easier to draft the longer they are in play. In order to use a technology you will need enough science to discover it, enough food to create a population to man it and enough resources (ore) to build the building to use it. While balancing the resources needed to advance your technology you also need to build a military. Military is 'built' in the same manner as civilian buildings. Players that have a weak military will be preyed upon by other players. There is no map in the game so you cannot lose territory, but players with a stronger military will steal resources, science, kill leaders, take population or culture. It is very difficult to win with a strong military, but it is very easy to lose because of a weak one.
+      One of the primary mechanisms in TTA is card drafting. Technologies, wonders, and leaders come into play and become
+      easier to draft the longer they are in play. In order to use a technology you will need enough science to discover it,
+      enough food to create a population to man it and enough resources (ore) to build the building to use it. While balancing
+      the resources needed to advance your technology you also need to build a military. Military is ''built'' in the same
+      manner as civilian buildings. Players that have a weak military will be preyed upon by other players. There is no map
+      in the game so you cannot lose territory, but players with a stronger military will steal resources, science, kill leaders,
+      take population or culture. It is very difficult to win with a strong military, but it is very easy to lose because
+      of a weak one.
 
 
       Victory is achieved by the player whose nation has the most culture at the end of the modern age.
 
+
+      '
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 4
@@ -7392,20 +8252,29 @@ catalog:
     - New Games Order, LLC
     - One Moment Games
     - Rebel Sp. z o.o.
+    pdfBlobKey: rulebooks/v1/through-the-ages_rulebook.pdf
+    pdfSha256: 8159de133667a4ea467629787a18b7c5d73c5f313aaf3f668f1ceb27d03c193e
+    pdfVersion: '1.0'
   - title: Great Western Trail
     bggId: 193738
     language: en
-    pdf: great-western-trail_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      America in the 19th century: You are a rancher and repeatedly herd your cattle from Texas to Kansas City, where you send them off by train. This earns you money and victory points. Needless to say, each time you arrive in Kansas City, you want to have your most valuable cattle in tow. However, the "Great Western Trail" not only requires that you keep your herd in good shape, but also that you wisely use the various buildings along the trail. Also, it might be a good idea to hire capable staff: cowboys to improve your herd, craftsmen to build your very own buildings, or engineers for the important railroad line.
+    description: 'America in the 19th century: You are a rancher and repeatedly herd your cattle from Texas to Kansas City,
+      where you send them off by train. This earns you money and victory points. Needless to say, each time you arrive in
+      Kansas City, you want to have your most valuable cattle in tow. However, the "Great Western Trail" not only requires
+      that you keep your herd in good shape, but also that you wisely use the various buildings along the trail. Also, it
+      might be a good idea to hire capable staff: cowboys to improve your herd, craftsmen to build your very own buildings,
+      or engineers for the important railroad line.
 
 
-      If you cleverly manage your herd and navigate the opportunities and pitfalls of Great Western Trail, you surely will gain the most victory points and win the game.
+      If you cleverly manage your herd and navigate the opportunities and pitfalls of Great Western Trail, you surely will
+      gain the most victory points and win the game.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2016
     minPlayers: 2
     maxPlayers: 4
@@ -7448,29 +8317,47 @@ catalog:
     - uplay.it edizioni
     - YOKA Games
     - Zvezda
+    pdfBlobKey: rulebooks/v1/great-western-trail_rulebook.pdf
+    pdfSha256: 72b01b97b3bbf12661fbdfa513873bc9efd694b9c4bd1d7765c4da1727df7f79
+    pdfVersion: '1.0'
   - title: 'SETI: Search for Extraterrestrial Intelligence'
     bggId: 418059
     language: en
-    pdf: seti_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In SETI: Search for Extraterrestrial Intelligence, you lead a scientific institution tasked with searching for traces of life beyond planet Earth. The game draws inspiration from current or emerging technologies and efforts in space exploration. Players will explore nearby planets and their moons by launching probes from Earth while taking advantage of ever-shifting planetary positions. Decide whether to land on their surfaces to collect valuable samples or stay in orbit for a broader survey. Additionally, by directing your telescopes to gaze into distant star systems, you may detect traces of alien signals or undiscovered exoplanets, and collect promising data to examine and study back home.
+    description: 'In SETI: Search for Extraterrestrial Intelligence, you lead a scientific institution tasked with searching
+      for traces of life beyond planet Earth. The game draws inspiration from current or emerging technologies and efforts
+      in space exploration. Players will explore nearby planets and their moons by launching probes from Earth while taking
+      advantage of ever-shifting planetary positions. Decide whether to land on their surfaces to collect valuable samples
+      or stay in orbit for a broader survey. Additionally, by directing your telescopes to gaze into distant star systems,
+      you may detect traces of alien signals or undiscovered exoplanets, and collect promising data to examine and study back
+      home.
 
 
-      Back on Earth, you can invest in upgrading your equipment so you can analyze incoming data more efficiently, boost your telescope signal capacity, or increase your supply of resources&mdash;all to expand the scope of your search that could lead to a discovery of extraterrestrial life forms. Finding traces of extraterrestrial life is only a matter of time&mdash;utilize the resources you have at your disposal strategically and you may well end up being the one to make the biggest scientific contribution towards advancing our understanding of alien life within our galaxy.
+      Back on Earth, you can invest in upgrading your equipment so you can analyze incoming data more efficiently, boost your
+      telescope signal capacity, or increase your supply of resources&mdash;all to expand the scope of your search that could
+      lead to a discovery of extraterrestrial life forms. Finding traces of extraterrestrial life is only a matter of time&mdash;utilize
+      the resources you have at your disposal strategically and you may well end up being the one to make the biggest scientific
+      contribution towards advancing our understanding of alien life within our galaxy.
 
 
-      You will also make use of over 200 cards to aid your efforts or focus your research in a particular direction for additional bonuses and rewards. Each card has unique effects and illustrations and depicts real-life technologies, projects, and discoveries (like the ISS, Large Hadron Collider, Perseverance rover, Voyager probe, and many more).
+      You will also make use of over 200 cards to aid your efforts or focus your research in a particular direction for additional
+      bonuses and rewards. Each card has unique effects and illustrations and depicts real-life technologies, projects, and
+      discoveries (like the ISS, Large Hadron Collider, Perseverance rover, Voyager probe, and many more).
 
 
-      The game is played in five rounds. The player with the starting player marker takes the first turn of the round. Players take turns in clockwise order, skipping any players who have already passed for the round. At the end of round 5, the final score is calculated and the player with the most points wins.
+      The game is played in five rounds. The player with the starting player marker takes the first turn of the round. Players
+      take turns in clockwise order, skipping any players who have already passed for the round. At the end of round 5, the
+      final score is calculated and the player with the most points wins.
 
 
-      SETI: Search for Extraterrestrial Intelligence pays homage to space and planetary exploration, astronomy, the ongoing search for signs of life in the vastness of space, and efforts to understand the nature of life in the universe.
+      SETI: Search for Extraterrestrial Intelligence pays homage to space and planetary exploration, astronomy, the ongoing
+      search for signs of life in the vastness of space, and efforts to understand the nature of life in the universe.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2024
     minPlayers: 1
     maxPlayers: 4
@@ -7511,26 +8398,42 @@ catalog:
     - MINDOK
     - MIPL
     - Rebel Sp. z o.o.
+    pdfBlobKey: rulebooks/v1/seti_rulebook.pdf
+    pdfSha256: b241d2ace42c1199254bde456ddac09d7ce1ca5ba036596f545b5d3aadcc083a
+    pdfVersion: '1.0'
   - title: Frosthaven
     bggId: 295770
     language: en
-    pdf: frosthaven_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Frosthaven is the story of a small outpost far to the north of the capital city of White Oak.  It's an outpost barely surviving the harsh weather let alone invasions from forces both known and unknown. However, a group of mercenaries, at the end of their rope, will help bring this settlement back from the edge of destruction. Not only will they have to deal with the harsh elements, but with other, far more dangerous threats out in the unforgiving cold, as well. There are: Algox, the bigger, more yeti-like cousins of the Inox, attacking from the mountains; Lurkers flooding in from the northern sea; and rumors have it that there are machines that wander the frozen wastes of their own free will. The party of mercenaries must face all of these perils, and perhaps in doing so, make peace with these new races so they can work together against even more sinister forces.
+    description: 'Frosthaven is the story of a small outpost far to the north of the capital city of White Oak.  It''s an
+      outpost barely surviving the harsh weather let alone invasions from forces both known and unknown. However, a group
+      of mercenaries, at the end of their rope, will help bring this settlement back from the edge of destruction. Not only
+      will they have to deal with the harsh elements, but with other, far more dangerous threats out in the unforgiving cold,
+      as well. There are: Algox, the bigger, more yeti-like cousins of the Inox, attacking from the mountains; Lurkers flooding
+      in from the northern sea; and rumors have it that there are machines that wander the frozen wastes of their own free
+      will. The party of mercenaries must face all of these perils, and perhaps in doing so, make peace with these new races
+      so they can work together against even more sinister forces.
 
 
-      Frosthaven is a standalone adventure from the designer and publisher of Gloomhaven that features sixteen new characters, three new races, more than twenty new enemies, more than one hundred new items, and a new, 100-scenario campaign.  Characters and items from Gloomhaven will be usable in Frosthaven, and vice versa.
+      Frosthaven is a standalone adventure from the designer and publisher of Gloomhaven that features sixteen new characters,
+      three new races, more than twenty new enemies, more than one hundred new items, and a new, 100-scenario campaign.  Characters
+      and items from Gloomhaven will be usable in Frosthaven, and vice versa.
 
 
-      In addition to using the well-known combat mechanisms of Gloomhaven, Frosthaven features other elements, such as mysteries to solve, a seasonal event system to live through, and player control over how the ramshackle village expands, with each new building offering new ways to progress.
+      In addition to using the well-known combat mechanisms of Gloomhaven, Frosthaven features other elements, such as mysteries
+      to solve, a seasonal event system to live through, and player control over how the ramshackle village expands, with
+      each new building offering new ways to progress.
 
 
-      Frosthaven has a whole new set of items but there is a mechanism for bringing items over from 'Gloomhaven'. However, as Frosthaven's outpost is a remote location, these products may be imported but are not present as standard items. Resources are much more valuable and you have to build items through a crafting system rather than just buying them.
+      Frosthaven has a whole new set of items but there is a mechanism for bringing items over from ''Gloomhaven''. However,
+      as Frosthaven''s outpost is a remote location, these products may be imported but are not present as standard items.
+      Resources are much more valuable and you have to build items through a crafting system rather than just buying them.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2022
     minPlayers: 1
     maxPlayers: 4
@@ -7578,26 +8481,21 @@ catalog:
     - Galápagos Jogos
     - GoKids 玩樂小子
     - Korea Boardgames
+    pdfBlobKey: rulebooks/v1/frosthaven_rulebook.pdf
+    pdfSha256: bf53b8260cd1a567d6d9f9db37b9237179e236c8b59d31f6149787292bbc7008
+    pdfVersion: '1.0'
   - title: 'Eclipse: Second Dawn for the Galaxy'
     bggId: 246900
     language: en
-    pdf: eclipse-second-dawn_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      A game of Eclipse places you in control of a vast interstellar civilization, competing for success with its rivals. You explore new star systems, research technologies, and build spaceships with which to wage war. There are many potential paths to victory, so you need to plan your strategy according to the strengths and weaknesses of your species, while paying attention to the other civilizations' endeavors.
-
-
-      Eclipse: Second Dawn for the Galaxy is a revised and upgraded version of the Eclipse base game that debuted in 2011 that features:
-
-
-          New graphic design, while maintaining the acclaimed symbology of the first edition 
-          A full line of Ship Pack 1 miniatures
-          New miniatures for ancients, GCDS, orbitals, and more
-          Custom plastic inlays
-          Custom combat dice
-          Fine-tuned gameplay
-
-
+    description: "A game of Eclipse places you in control of a vast interstellar civilization, competing for success with\
+      \ its rivals. You explore new star systems, research technologies, and build spaceships with which to wage war. There\
+      \ are many potential paths to victory, so you need to plan your strategy according to the strengths and weaknesses of\
+      \ your species, while paying attention to the other civilizations' endeavors.\n\nEclipse: Second Dawn for the Galaxy\
+      \ is a revised and upgraded version of the Eclipse base game that debuted in 2011 that features:\n\n\n    New graphic\
+      \ design, while maintaining the acclaimed symbology of the first edition \n    A full line of Ship Pack 1 miniatures\n\
+      \    New miniatures for ancients, GCDS, orbitals, and more\n    Custom plastic inlays\n    Custom combat dice\n    Fine-tuned\
+      \ gameplay\n\n\n"
     yearPublished: 2020
     minPlayers: 2
     maxPlayers: 6
@@ -7644,23 +8542,32 @@ catalog:
     - Surfin' Meeple China
     - TLAMA games
     - uplay.it edizioni
+    pdfBlobKey: rulebooks/v1/eclipse-second-dawn_rulebook.pdf
+    pdfSha256: 11853e30ee828569946a7c7b18ee0d968dc4de0d4de9728e685636dfba058548
+    pdfVersion: '1.0'
   - title: 'Slay the Spire: The Board Game'
     bggId: 338960
     language: en
-    pdf: slay-the-spire_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Slay the Spire: The Board Game is a co-operative deck-building, dungeon-crawling adventure. Craft a unique deck, encounter bizarre creatures, discover relics of immense power, and finally become strong enough to slay the Spire!
+    description: 'Slay the Spire: The Board Game is a co-operative deck-building, dungeon-crawling adventure. Craft a unique
+      deck, encounter bizarre creatures, discover relics of immense power, and finally become strong enough to slay the Spire!
 
 
-      Each player starts with a character with unique abilities and a simple deck of cards that they can improve by adding and removing cards during the game. Slay the Spire is also a rogue-like. That means that when you die (and you will die!), start over from the beginning. Take the lessons you learned and try again!
+      Each player starts with a character with unique abilities and a simple deck of cards that they can improve by adding
+      and removing cards during the game. Slay the Spire is also a rogue-like. That means that when you die (and you will
+      die!), start over from the beginning. Take the lessons you learned and try again!
 
 
-      The game is divided into Acts. At the end of an Act you can continue, stop and end the adventure there, or save and continue another time!
+      The game is divided into Acts. At the end of an Act you can continue, stop and end the adventure there, or save and
+      continue another time!
 
 
-      If players defeat the final Boss, they win the game! Which Boss you consider to be final depends on how many Acts you want to play. You can stop playing at the end of any Act! When a player&rsquo;s HP is reduced to 0, they are dead and the party loses the game.
+      If players defeat the final Boss, they win the game! Which Boss you consider to be final depends on how many Acts you
+      want to play. You can stop playing at the end of any Act! When a player&rsquo;s HP is reduced to 0, they are dead and
+      the party loses the game.
 
+
+      '
     yearPublished: 2024
     minPlayers: 1
     maxPlayers: 4
@@ -7702,40 +8609,38 @@ catalog:
     - Yayoi The Dreamer
     - YOKA Games
     - 株式会社ケンビル (KenBill)
+    pdfBlobKey: rulebooks/v1/slay-the-spire_rulebook.pdf
+    pdfSha256: 4507546fcb8e72eb7228cf9aabaff443f696b76df1b5f04c0c01ee1a8228ce50
+    pdfVersion: '1.0'
   - title: 'Brass: Lancashire'
     bggId: 28720
     language: en
-    pdf: brass-lancashire_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Brass: Lancashire &mdash; first published as Brass &mdash; is an economic strategy game that tells the story of competing cotton entrepreneurs in Lancashire during the industrial revolution. You must develop, build and establish your industries and network so that you can capitalize on demand for iron, coal and cotton. The game is played over two halves: the canal phase and the rail phase. To win the game, score the most victory points (VPs), which are counted at the end of each phase. VPs are gained from your canals, rails, and established (flipped) industry tiles. Each round, players take turns according to the turn order track, receiving two actions to perform any of the following:
-
-
-          Build an industry tile
-          Build a rail or canal
-          Develop an industry
-          Sell cotton
-          Take a loan
-
-
-      At the end of your turn, you replace the two cards you played with two more from the deck. Turn order is determined by how much money a player spent on the previous turn, the lowest spender going first. This turn order mechanism opens some strategic options for players going later in the turn order, allowing for the possibility of back-to-back turns.
-
-
-      After all the cards have been played the first time (with the deck size being adjusted for the number of players), the canal phase ends and a scoring round commences. After scoring, all canals and all of the lowest level industries are removed from the game, after which new cards are dealt and the rail phase begins. During this phase, players may now occupy more than one location in a city and double-connection builds (though expensive) are possible. At the end of the rail phase, another scoring round takes place, then a winner is crowned.
-
-
-      The cards limit where you can build your industries, sell cotton or build connections (though any card can be used to 'develop'). This leads to a strategic timing/storing of cards. Resources are common so that if you build a rail line (which requires coal) you have to use the coal from the nearest source, which may be an opponent's coal mine, which in turn gets that coal mine closer to scoring (i.e., being utilized).
-
-
-      Brass: Lancashire, the 2018 edition from Roxley Games, reboots the original Warfrog Games edition of Brass with new artwork and components, as well as a few rules changes:
-
-
-           The virtual link rules between Birkenhead have been made optional.
-           The three-player experience has been brought closer to the ideal experience of four players by shortening each half of the game by one round and tuning the deck and distant market tiles slightly to ensure a consistent experience.
-           Two-player rules have been created and are playable without the need of an alternate board.
-           The level 1 cotton mill is now worth 5 VP to make it slightly less terrible.
-
-
+    description: "Brass: Lancashire &mdash; first published as Brass &mdash; is an economic strategy game that tells the story\
+      \ of competing cotton entrepreneurs in Lancashire during the industrial revolution. You must develop, build and establish\
+      \ your industries and network so that you can capitalize on demand for iron, coal and cotton. The game is played over\
+      \ two halves: the canal phase and the rail phase. To win the game, score the most victory points (VPs), which are counted\
+      \ at the end of each phase. VPs are gained from your canals, rails, and established (flipped) industry tiles. Each round,\
+      \ players take turns according to the turn order track, receiving two actions to perform any of the following:\n\n\n\
+      \    Build an industry tile\n    Build a rail or canal\n    Develop an industry\n    Sell cotton\n    Take a loan\n\n\
+      \nAt the end of your turn, you replace the two cards you played with two more from the deck. Turn order is determined\
+      \ by how much money a player spent on the previous turn, the lowest spender going first. This turn order mechanism opens\
+      \ some strategic options for players going later in the turn order, allowing for the possibility of back-to-back turns.\n\
+      \nAfter all the cards have been played the first time (with the deck size being adjusted for the number of players),\
+      \ the canal phase ends and a scoring round commences. After scoring, all canals and all of the lowest level industries\
+      \ are removed from the game, after which new cards are dealt and the rail phase begins. During this phase, players may\
+      \ now occupy more than one location in a city and double-connection builds (though expensive) are possible. At the end\
+      \ of the rail phase, another scoring round takes place, then a winner is crowned.\n\nThe cards limit where you can build\
+      \ your industries, sell cotton or build connections (though any card can be used to 'develop'). This leads to a strategic\
+      \ timing/storing of cards. Resources are common so that if you build a rail line (which requires coal) you have to use\
+      \ the coal from the nearest source, which may be an opponent's coal mine, which in turn gets that coal mine closer to\
+      \ scoring (i.e., being utilized).\n\nBrass: Lancashire, the 2018 edition from Roxley Games, reboots the original Warfrog\
+      \ Games edition of Brass with new artwork and components, as well as a few rules changes:\n\n\n     The virtual link\
+      \ rules between Birkenhead have been made optional.\n     The three-player experience has been brought closer to the\
+      \ ideal experience of four players by shortening each half of the game by one round and tuning the deck and distant\
+      \ market tiles slightly to ensure a consistent experience.\n     Two-player rules have been created and are playable\
+      \ without the need of an alternate board.\n     The level 1 cotton mill is now worth 5 VP to make it slightly less terrible.\n\
+      \n\n"
     yearPublished: 2007
     minPlayers: 2
     maxPlayers: 4
@@ -7790,23 +8695,39 @@ catalog:
     - Rebel Sp. z o.o.
     - Wargames Club Publishing
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/brass-lancashire_rulebook.pdf
+    pdfSha256: dde82526c26edec98ef036d3f52e7c3dee66fbd546281286c1280298e4182c15
+    pdfVersion: '1.0'
   - title: 7 Wonders Duel
     bggId: 173346
     language: en
-    pdf: 7-wonders-duel_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In many ways 7 Wonders Duel resembles its parent game 7 Wonders. Over three ages, players acquire cards that provide resources or advance their military or scientific development in order to develop a civilization and complete wonders. What's different about 7 Wonders Duel is that, as the title suggests, the game is solely for two players.
+    description: 'In many ways 7 Wonders Duel resembles its parent game 7 Wonders. Over three ages, players acquire cards
+      that provide resources or advance their military or scientific development in order to develop a civilization and complete
+      wonders. What''s different about 7 Wonders Duel is that, as the title suggests, the game is solely for two players.
 
 
-      Players do not draft cards simultaneously from decks of cards, but from a display of face-down and face-up cards arranged at the start of a round. A player can take a card only if it's not covered by any others, so timing comes into play, as it can with bonus moves that allow the player to take a second card immediately. As in the original game, each acquired card can be built, discarded for coins, or used to construct a wonder. Each player also starts with four wonder cards, and the construction of a wonder provides its owner with a special ability. Only seven wonders can be built, though, so one player will end up short.
+      Players do not draft cards simultaneously from decks of cards, but from a display of face-down and face-up cards arranged
+      at the start of a round. A player can take a card only if it''s not covered by any others, so timing comes into play,
+      as it can with bonus moves that allow the player to take a second card immediately. As in the original game, each acquired
+      card can be built, discarded for coins, or used to construct a wonder. Each player also starts with four wonder cards,
+      and the construction of a wonder provides its owner with a special ability. Only seven wonders can be built, though,
+      so one player will end up short.
 
 
-      Players can purchase resources at any time from the bank, or they can gain cards during the game that provide them with resources for future building; as they are acquired, the cost for those resources increases for the opponent, representing the owner's dominance in this area.
+      Players can purchase resources at any time from the bank, or they can gain cards during the game that provide them with
+      resources for future building; as they are acquired, the cost for those resources increases for the opponent, representing
+      the owner''s dominance in this area.
 
 
-      You can win 7 Wonders Duel in one of three ways: each time you acquire a military card, you advance the military marker toward your opponent's capital (also giving you a bonus at certain positions). If you reach the opponent's capital, you win the game immediately. Or if you acquire six of seven different scientific symbols, you achieve scientific dominance and win immediately. If none of these situations occurs, then the player with the most points at the end of the game wins.
+      You can win 7 Wonders Duel in one of three ways: each time you acquire a military card, you advance the military marker
+      toward your opponent''s capital (also giving you a bonus at certain positions). If you reach the opponent''s capital,
+      you win the game immediately. Or if you acquire six of seven different scientific symbols, you achieve scientific dominance
+      and win immediately. If none of these situations occurs, then the player with the most points at the end of the game
+      wins.
 
+
+      '
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 2
@@ -7865,20 +8786,34 @@ catalog:
     - Siam Board Games
     - Sombreros Production
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/7-wonders-duel_rulebook.pdf
+    pdfSha256: 09b2939823df80444da078e0713d0cc400da95d2f1e96edb86dc023c4dc956f2
+    pdfVersion: '1.0'
   - title: Nemesis
     bggId: 167355
     language: en
-    pdf: nemesis_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Playing Nemesis will take you into the heart of sci-fi survival horror in all its terror. A soldier fires blindly down a corridor, trying to stop the alien advance. A scientist races to find a solution in his makeshift lab. A traitor steals the last escape pod in the very last moment. Intruders you meet on the ship are not only reacting to the noise you make but also evolve as the time goes by. The longer the game takes, the stronger they become. During the game, you control one of the crew members with a unique set of skills, personal deck of cards, and individual starting equipment. These heroes cover all your basic SF horror needs. For example, the scientist is great with computers and research, but will have a hard time in combat. The soldier, on the other hand...
+    description: 'Playing Nemesis will take you into the heart of sci-fi survival horror in all its terror. A soldier fires
+      blindly down a corridor, trying to stop the alien advance. A scientist races to find a solution in his makeshift lab.
+      A traitor steals the last escape pod in the very last moment. Intruders you meet on the ship are not only reacting to
+      the noise you make but also evolve as the time goes by. The longer the game takes, the stronger they become. During
+      the game, you control one of the crew members with a unique set of skills, personal deck of cards, and individual starting
+      equipment. These heroes cover all your basic SF horror needs. For example, the scientist is great with computers and
+      research, but will have a hard time in combat. The soldier, on the other hand...
 
 
-      Nemesis is a semi-cooperative game in which you and your crewmates must survive on a ship infested with hostile organisms. To win the game, you have to complete one of the two objectives dealt to you at the start of the game and get back to Earth in one piece. You will find many obstacles on your way: swarms of Intruders (the name given to the alien organisms by the ship AI), the poor physical condition of the ship, agendas held by your fellow players, and sometimes just cruel fate.
+      Nemesis is a semi-cooperative game in which you and your crewmates must survive on a ship infested with hostile organisms.
+      To win the game, you have to complete one of the two objectives dealt to you at the start of the game and get back to
+      Earth in one piece. You will find many obstacles on your way: swarms of Intruders (the name given to the alien organisms
+      by the ship AI), the poor physical condition of the ship, agendas held by your fellow players, and sometimes just cruel
+      fate.
 
 
-      The gameplay of Nemesis is designed to be full of climactic moments which, hopefully, you will find rewarding even when your best plans are ruined and your character meets a terrible fate.
+      The gameplay of Nemesis is designed to be full of climactic moments which, hopefully, you will find rewarding even when
+      your best plans are ruined and your character meets a terrible fate.
 
+
+      '
     yearPublished: 2018
     minPlayers: 1
     maxPlayers: 5
@@ -7925,39 +8860,62 @@ catalog:
     - Korea Boardgames
     - MINDOK
     - Rebel Studio
+    pdfBlobKey: rulebooks/v1/nemesis_rulebook.pdf
+    pdfSha256: 361b7df733bd97f40df76ff002063433724fb0d96a3307de0171cdbb00f84ae2
+    pdfVersion: '1.0'
   - title: A Feast for Odin
     bggId: 177736
     language: en
-    pdf: a-feast-for-odin_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      A Feast for Odin is a saga in the form of a board game. You are reliving the cultural achievements, mercantile expeditions, and pillages of those tribes we know as Viking today &mdash; a term that was used quite differently towards the end of the first millennium.
+    description: 'A Feast for Odin is a saga in the form of a board game. You are reliving the cultural achievements, mercantile
+      expeditions, and pillages of those tribes we know as Viking today &mdash; a term that was used quite differently towards
+      the end of the first millennium.
 
 
-      When the northerners went out for a raid, they used to say they headed out for a viking. Their Scandinavian ancestors, however, were much more than just pirates. They were explorers and founders of states. Leif Eriksson is said to be the first European in America, long before Columbus.
+      When the northerners went out for a raid, they used to say they headed out for a viking. Their Scandinavian ancestors,
+      however, were much more than just pirates. They were explorers and founders of states. Leif Eriksson is said to be the
+      first European in America, long before Columbus.
 
-      In what is known today as Normandy, the intruders were not called Vikings but Normans. One of them is the famous William the Conqueror who invaded England in 1066. He managed to do what the king of Norway failed to do only a few years prior: conquer the Throne of England. The reason the people of these times became such strong seafarers was their unfortunate agricultural situation: crop shortfalls caused great distress.
-
-
-      In this game, you will raid and explore new territories. You will also engage in the day-to-day activity of collecting goods with which to achieve a financially secure position in society. In the end, the player whose possessions bear the greatest value will be declared the winner.
-
-
-      --gameplay description from @StoryBoardGamer's review:
-
-      A Feast for Odin is a points-driven game, with a plethora of pathways to victory, with a range of risks balanced against rewards. A significant portion of this is your central hall, which has a whopping -86 points of squares and a major part of your game is attempting to cover these up with various tiles. Likewise, long halls and island colonies can also offer large rewards, but they will have penalties of their own.
+      In what is known today as Normandy, the intruders were not called Vikings but Normans. One of them is the famous William
+      the Conqueror who invaded England in 1066. He managed to do what the king of Norway failed to do only a few years prior:
+      conquer the Throne of England. The reason the people of these times became such strong seafarers was their unfortunate
+      agricultural situation: crop shortfalls caused great distress.
 
 
-      Each year follows a familiar pattern of preparation, worker placement, and then meeting the requirements of your feast. The main phase of each year is a worker placement affair. You start with a selection of Vikings, and a large action board with a whopping 61 different options to choose from. Each of these will be arranged from left to right in one of four columns. Each column requires an additional Viking to activate, but they are proportionally more powerful.
+      In this game, you will raid and explore new territories. You will also engage in the day-to-day activity of collecting
+      goods with which to achieve a financially secure position in society. In the end, the player whose possessions bear
+      the greatest value will be declared the winner.
 
 
-      At the end of each round, you will need to fill a feast table with food, alternating between plants and vegetable matter. You will also have a chance to lay the valuable green and blue tiles into your main hall. The configuration of these tiles must follow certain requirements, but your main goal is to both cover up a line of coin icons to increase your income, while otherwise encircling certain printed icons to generate those.
+      --gameplay description from @StoryBoardGamer''s review:
+
+      A Feast for Odin is a points-driven game, with a plethora of pathways to victory, with a range of risks balanced against
+      rewards. A significant portion of this is your central hall, which has a whopping -86 points of squares and a major
+      part of your game is attempting to cover these up with various tiles. Likewise, long halls and island colonies can also
+      offer large rewards, but they will have penalties of their own.
 
 
-      You will build your engine over time, following an alternating pattern of outward expansion and hunting against development and cultivation. It all comes down to how much you&rsquo;re willing to take on at any one time, and what risks you&rsquo;re willing to set yourself up with for their rewards.
+      Each year follows a familiar pattern of preparation, worker placement, and then meeting the requirements of your feast.
+      The main phase of each year is a worker placement affair. You start with a selection of Vikings, and a large action
+      board with a whopping 61 different options to choose from. Each of these will be arranged from left to right in one
+      of four columns. Each column requires an additional Viking to activate, but they are proportionally more powerful.
+
+
+      At the end of each round, you will need to fill a feast table with food, alternating between plants and vegetable matter.
+      You will also have a chance to lay the valuable green and blue tiles into your main hall. The configuration of these
+      tiles must follow certain requirements, but your main goal is to both cover up a line of coin icons to increase your
+      income, while otherwise encircling certain printed icons to generate those.
+
+
+      You will build your engine over time, following an alternating pattern of outward expansion and hunting against development
+      and cultivation. It all comes down to how much you&rsquo;re willing to take on at any one time, and what risks you&rsquo;re
+      willing to set yourself up with for their rewards.
 
 
       UPC 681706716909
 
+
+      '
     yearPublished: 2016
     minPlayers: 1
     maxPlayers: 4
@@ -8010,46 +8968,34 @@ catalog:
     - TLAMA games
     - White Goblin Games
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/a-feast-for-odin_rulebook.pdf
+    pdfSha256: e1280d095d2df7da6cb1cfd9cd7c0b7befcce2d8c495e3a541bc9ef64c2d9e36
+    pdfVersion: '1.0'
   - title: 'The Lord of the Rings: The Card Game'
     bggId: 421006
     language: en
-    pdf: lotr-card-game_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      A dark rumour rises from Mordor. The Eye turns to Middle-earth. The hour has come. The Fellowship is reunited. The Heroes prepare for battle. Will you play as the Fellowship of the Ring to defend the free races and destroy the One Ring? Or will you play as Sauron and pursue Frodo and Sam while deploying your hordes to the gates of the enemy cities? The destiny of Middle-earth is in your hands!
-
-
-      A game plays over 3 successive chapters that unfold similarly.
-
-      On your turn, strengthen your Skills, hoard your treasure, stretch your presence across Middle-earth, rally Races to your cause, or advance the Quest of the Ring.
-
-      				
-      				
-      					Turn OverviewIn each chapter players take cards from a display of face-down and face-up cards arranged at the start of a round. A player can take a card only if it's available, that is not partially covered by any other cards. Players can either play the card, paying its cost and placing it in their play area, obtaining its benefit, or discard the card and take as many coins from the reserve as the current chapter.
-
-      Players can also take a Landmark tile from one of the faceup tiles, paying its cost placing it in their play area. They will be able to immediately place a Fortress pawn on the corresponding region of the central board and benefit from its other effects.
-
-      				
-      				
-      					Victory ConditionsImmediately win the game by fulfilling one of the 3 victory conditions:
-
-      				
-      				
-      					Quest of the Ring
-           For the Fellowship: If Frodo and Sam reach Mount Doom, they destroy the One Ring and you immediately win the game.
-           For Sauron: If the Nazg&ucirc;l catch Frodo and Sam, they seize the One Ring and you immediately win the game.
-
-
-      				
-      				
-      					Support of the RacesIf any player gathers 6 different Race symbols on their Green cards, they rally the support of the Races of Middle-earth and immediately win the game
-
-      				
-      				
-      					Conquering Middle-earthIf a player is present in all 7 regions (with a Fortress and/or at least 1 Unit), they dominate Middle-earth and immediately win the game.
-
-      If none of these three victory conditions are achieved by the end of chapter 3, the player who is present in the most regions of Middle-earth (with a Fortress and/or at least 1 Unit) wins the game. In case of tie, share the victory.
-
+    description: "A dark rumour rises from Mordor. The Eye turns to Middle-earth. The hour has come. The Fellowship is reunited.\
+      \ The Heroes prepare for battle. Will you play as the Fellowship of the Ring to defend the free races and destroy the\
+      \ One Ring? Or will you play as Sauron and pursue Frodo and Sam while deploying your hordes to the gates of the enemy\
+      \ cities? The destiny of Middle-earth is in your hands!\n\nA game plays over 3 successive chapters that unfold similarly.\n\
+      On your turn, strengthen your Skills, hoard your treasure, stretch your presence across Middle-earth, rally Races to\
+      \ your cause, or advance the Quest of the Ring.\n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tTurn OverviewIn each chapter players\
+      \ take cards from a display of face-down and face-up cards arranged at the start of a round. A player can take a card\
+      \ only if it's available, that is not partially covered by any other cards. Players can either play the card, paying\
+      \ its cost and placing it in their play area, obtaining its benefit, or discard the card and take as many coins from\
+      \ the reserve as the current chapter.\n\nPlayers can also take a Landmark tile from one of the faceup tiles, paying\
+      \ its cost placing it in their play area. They will be able to immediately place a Fortress pawn on the corresponding\
+      \ region of the central board and benefit from its other effects.\n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tVictory ConditionsImmediately\
+      \ win the game by fulfilling one of the 3 victory conditions:\n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tQuest of the Ring\n \
+      \    For the Fellowship: If Frodo and Sam reach Mount Doom, they destroy the One Ring and you immediately win the game.\n\
+      \     For Sauron: If the Nazg&ucirc;l catch Frodo and Sam, they seize the One Ring and you immediately win the game.\n\
+      \n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tSupport of the RacesIf any player gathers 6 different Race symbols on their Green\
+      \ cards, they rally the support of the Races of Middle-earth and immediately win the game\n\n\t\t\t\t\n\t\t\t\t\n\t\t\
+      \t\t\tConquering Middle-earthIf a player is present in all 7 regions (with a Fortress and/or at least 1 Unit), they\
+      \ dominate Middle-earth and immediately win the game.\n\nIf none of these three victory conditions are achieved by the\
+      \ end of chapter 3, the player who is present in the most regions of Middle-earth (with a Fortress and/or at least 1\
+      \ Unit) wins the game. In case of tie, share the victory.\n\n"
     yearPublished: 2024
     minPlayers: 2
     maxPlayers: 2
@@ -8101,17 +9047,24 @@ catalog:
     - Ponva d.o.o.
     - Rebel Sp. z o.o.
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/lotr-card-game_rulebook.pdf
+    pdfSha256: ef604fe7a639dfcb59e1b63538c77cb39bfbbda512ba0e9d2756ade92ef084ee
+    pdfVersion: '1.0'
   - title: 'Clank! Legacy: Acquisitions Incorporated'
     bggId: 266507
     language: en
-    pdf: clank-legacy_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Clank! Legacy: Acquisitions Incorporated extends the deck-building fun of Clank! with legacy-style gameplay! Found your own franchise of the legendary adventuring company, Acquisitions Incorporated, and shepherd your fledgling treasure-hunters to immortal corporate glory over the course of multiple games. Your game board, your deck, and your world change as you play to create a unique campaign tailored to your adventuring party. Be cunning, be bold, and most importantly, be ready...
+    description: 'Clank! Legacy: Acquisitions Incorporated extends the deck-building fun of Clank! with legacy-style gameplay!
+      Found your own franchise of the legendary adventuring company, Acquisitions Incorporated, and shepherd your fledgling
+      treasure-hunters to immortal corporate glory over the course of multiple games. Your game board, your deck, and your
+      world change as you play to create a unique campaign tailored to your adventuring party. Be cunning, be bold, and most
+      importantly, be ready...
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2019
     minPlayers: 2
     maxPlayers: 4
@@ -8158,24 +9111,29 @@ catalog:
     - Lucrum Games
     - Origames
     - Schwerkraft-Verlag
+    pdfBlobKey: rulebooks/v1/clank-legacy_rulebook.pdf
+    pdfSha256: 56885abb8944aef298c305f26a145882c0318acc56a78ffd0876fedb3be6a2bd
+    pdfVersion: '1.0'
   - title: Concordia
     bggId: 124361
     language: en
-    pdf: concordia_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Two thousand years ago, the Roman Empire ruled the lands around the Mediterranean Sea. With peace at the borders, harmony inside the provinces, uniform law, and a common currency, the economy thrived and gave rise to mighty Roman dynasties as they expanded throughout the numerous cities. Guide one of these dynasties and send colonists to the remote realms of the Empire; develop your trade network; and appease the ancient gods for their favor &mdash; all to gain the chance to emerge victorious!
-
-
-      Concordia is a peaceful, strategy game of economic development in Roman times for 2-5 players aged 13 and up. Instead of looking to the luck of dice or cards, players must rely on their strategic abilities. Be sure to watch your rivals to determine which goals they are pursuing and where you can outpace them! In the game, colonists are sent out from Rome to settle down in cities that produce bricks, food, tools, wine, and cloth. Each player starts with an identical set of playing cards and acquires more cards during the game. These cards serve two purposes:
-
-
-          They allow a player to choose actions during the game.
-          They are worth victory points (VPs) at the end of the game. 
-
-
-      Concordia is a strategy game that requires advanced planning and consideration of your opponent's moves. Every game is different, not only because of the sequence of new cards on sale but also due to the modular layout of cities. (One side of the game board shows the entire Roman Empire with 30 cities for 3-5 players, while the other shows Roman Italy with 25 cities for 2-4 players.) When all cards have been sold or after the first player builds their 15th house, the game ends. The player with the most VPs from the gods (Jupiter, Saturnus, Mercurius, Minerva, Vesta, etc.) wins the game.
-
+    description: "Two thousand years ago, the Roman Empire ruled the lands around the Mediterranean Sea. With peace at the\
+      \ borders, harmony inside the provinces, uniform law, and a common currency, the economy thrived and gave rise to mighty\
+      \ Roman dynasties as they expanded throughout the numerous cities. Guide one of these dynasties and send colonists to\
+      \ the remote realms of the Empire; develop your trade network; and appease the ancient gods for their favor &mdash;\
+      \ all to gain the chance to emerge victorious!\n\nConcordia is a peaceful, strategy game of economic development in\
+      \ Roman times for 2-5 players aged 13 and up. Instead of looking to the luck of dice or cards, players must rely on\
+      \ their strategic abilities. Be sure to watch your rivals to determine which goals they are pursuing and where you can\
+      \ outpace them! In the game, colonists are sent out from Rome to settle down in cities that produce bricks, food, tools,\
+      \ wine, and cloth. Each player starts with an identical set of playing cards and acquires more cards during the game.\
+      \ These cards serve two purposes:\n\n\n    They allow a player to choose actions during the game.\n    They are worth\
+      \ victory points (VPs) at the end of the game. \n\n\nConcordia is a strategy game that requires advanced planning and\
+      \ consideration of your opponent's moves. Every game is different, not only because of the sequence of new cards on\
+      \ sale but also due to the modular layout of cities. (One side of the game board shows the entire Roman Empire with\
+      \ 30 cities for 3-5 players, while the other shows Roman Italy with 25 cities for 2-4 players.) When all cards have\
+      \ been sold or after the first player builds their 15th house, the game ends. The player with the most VPs from the\
+      \ gods (Jupiter, Saturnus, Mercurius, Minerva, Vesta, etc.) wins the game.\n\n"
     yearPublished: 2013
     minPlayers: 2
     maxPlayers: 5
@@ -8224,42 +9182,30 @@ catalog:
     - Playfun Games
     - Rio Grande Games
     - Ystari Games
+    pdfBlobKey: rulebooks/v1/concordia_rulebook.pdf
+    pdfSha256: 90dbdaa9dd1467777dfc9f7f9f2e57dc17d5ac8a538feebc1644480d663a0703
+    pdfVersion: '1.0'
   - title: 'Great Western Trail: New Zealand'
     bggId: 341169
     language: en
     bggEnhanced: true
-    description: >+
-      America in the 19th century: You are a rancher and repeatedly herd your cattle from Texas to Kansas City, where you send them off by train. This earns you money and victory points. Needless to say, each time you arrive in Kansas City, you want to have your most valuable cattle in tow. However, the "Great Western Trail" not only requires that you keep your herd in good shape, but also that you wisely use the various buildings along the trail. Also, it might be a good idea to hire capable staff: cowboys to improve your herd, craftsmen to build your very own buildings, or engineers for the important railroad line.
-
-
-      If you cleverly manage your herd and navigate the opportunities and pitfalls of Great Western Trail, you surely will gain the most victory points and win the game.
-
-
-      The second edition of Great Western Trail includes solitaire rules, making for a player count of 1-4.
-
-
-      Second Edition:
-
-      Remember the old days in the West? Well, the times they are a-changing&rsquo;! From new solo opponent to incredible landscapes, you won't know where to start. And there is a new herd of cows for you to sell!
-
-
-      Great Western Trail is the critically acclaimed game of cattle ranching by Alexander Pfister. Players attempt to wrangle their herd across the Midwest prairie and deliver it to Kansas City. But beware! Other cowboys are sharing the trail with you. We invite you to saddle up!
-
-
-      The changes in the Second edition:
-
-
-           Brand New Artwork by Chris Quilliams
-           Solo Mode: A New Challenger in the West
-           Dual-Layered Player Boards
-           Addition of a new breed of cows: The Simmental breed
-           Two new reversible buildings (#11 & 12)
-           Twelve Exchange Tokens, First introduced in the Rails of North Expansion, for more interaction with other players
-           Four new Master Tiles added for more strategy, replayability, and challenges
-
-
-      &mdash;description from the publisher
-
+    description: "America in the 19th century: You are a rancher and repeatedly herd your cattle from Texas to Kansas City,\
+      \ where you send them off by train. This earns you money and victory points. Needless to say, each time you arrive in\
+      \ Kansas City, you want to have your most valuable cattle in tow. However, the \"Great Western Trail\" not only requires\
+      \ that you keep your herd in good shape, but also that you wisely use the various buildings along the trail. Also, it\
+      \ might be a good idea to hire capable staff: cowboys to improve your herd, craftsmen to build your very own buildings,\
+      \ or engineers for the important railroad line.\n\nIf you cleverly manage your herd and navigate the opportunities and\
+      \ pitfalls of Great Western Trail, you surely will gain the most victory points and win the game.\n\nThe second edition\
+      \ of Great Western Trail includes solitaire rules, making for a player count of 1-4.\n\nSecond Edition:\nRemember the\
+      \ old days in the West? Well, the times they are a-changing&rsquo;! From new solo opponent to incredible landscapes,\
+      \ you won't know where to start. And there is a new herd of cows for you to sell!\n\nGreat Western Trail is the critically\
+      \ acclaimed game of cattle ranching by Alexander Pfister. Players attempt to wrangle their herd across the Midwest prairie\
+      \ and deliver it to Kansas City. But beware! Other cowboys are sharing the trail with you. We invite you to saddle up!\n\
+      \nThe changes in the Second edition:\n\n\n     Brand New Artwork by Chris Quilliams\n     Solo Mode: A New Challenger\
+      \ in the West\n     Dual-Layered Player Boards\n     Addition of a new breed of cows: The Simmental breed\n     Two\
+      \ new reversible buildings (#11 & 12)\n     Twelve Exchange Tokens, First introduced in the Rails of North Expansion,\
+      \ for more interaction with other players\n     Four new Master Tiles added for more strategy, replayability, and challenges\n\
+      \n\n&mdash;description from the publisher\n\n"
     yearPublished: 2021
     minPlayers: 1
     maxPlayers: 4
@@ -8302,23 +9248,29 @@ catalog:
   - title: 'Skytear: Arena of Legends'
     bggId: 373106
     language: en
-    pdf: skytear_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Sky Team is a co-operative game, exclusively for two players, in which you play a pilot and co-pilot at the controls of an airliner. Your goal is to work together as a team to land your airplane in different airports around the world.
+    description: 'Sky Team is a co-operative game, exclusively for two players, in which you play a pilot and co-pilot at
+      the controls of an airliner. Your goal is to work together as a team to land your airplane in different airports around
+      the world.
 
 
-      To land your plane, you need to silently assign your dice to the correct spaces in your cockpit to balance the axis of your plane, control its speed, deploy the flaps, extend the landing gear, contact the control tower to clear your path, and even have a little coffee to improve your concentration enough to change the value of your dice.
+      To land your plane, you need to silently assign your dice to the correct spaces in your cockpit to balance the axis
+      of your plane, control its speed, deploy the flaps, extend the landing gear, contact the control tower to clear your
+      path, and even have a little coffee to improve your concentration enough to change the value of your dice.
 
 
-      If the aircraft tilts too much and stalls, overshoots the airport, or collides with another aircraft, you lose the game...and your pilot's license...and probably your life.
+      If the aircraft tilts too much and stalls, overshoots the airport, or collides with another aircraft, you lose the game...and
+      your pilot''s license...and probably your life.
 
 
-      From Montreal to Tokyo, each airport offers its own set of challenges. Watch out for the turbulence as this could end up being a bumpy ride!
+      From Montreal to Tokyo, each airport offers its own set of challenges. Watch out for the turbulence as this could end
+      up being a bumpy ride!
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2023
     minPlayers: 2
     maxPlayers: 2
@@ -8366,35 +9318,29 @@ catalog:
     - Sugorokuya
     - Tabletop KZ
     - YOKA Games
+    pdfBlobKey: rulebooks/v1/skytear_rulebook.pdf
+    pdfSha256: 2f316d16c5001b55097b9966c7c697bbde6a50e7e5c9b1c3df336ff5c3775960
+    pdfVersion: '1.0'
   - title: Terra Mystica
     bggId: 120677
     language: en
-    pdf: terra-mystica_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In the land of Terra Mystica dwell 14 different peoples in seven landscapes, and each group is bound to its own home environment, so to develop and grow, they must terraform neighboring landscapes into their home environments in competition with the other groups.
-
-
-      Terra Mystica is a full information game, without any luck, that rewards strategic planning. Each player governs one of the 14 groups. With subtlety and craft, the player must attempt to rule as great an area as possible and to develop that group's skills. There are also four religious cults in which you can progress. To do all that, each group has special skills and abilities.
-
-
-      Taking turns, the players execute their actions on the resources they have at their disposal. Different buildings allow players to develop different resources. Dwellings allow for more workers. Trading houses allow players to make money. Strongholds unlock a group's special ability, and temples allow you to develop religion and your terraforming and seafaring skills. Buildings can be upgraded: Dwellings can be developed into trading houses; trading houses can be developed into strongholds or temples; one temple can be upgraded to become a sanctuary. Each group must also develop its terraforming skill and its skill with boats to use the rivers. The groups in question, along with their home landscape, are:
-
-
-          Desert (Fakirs, Nomads)
-          Plains (Halflings, Cultists)
-          Swamp (Alchemists, Darklings)
-          Lake (Mermaids, Swarmlings)
-          Forest (Witches, Auren)
-          Mountain (Dwarves, Engineers)
-          Wasteland (Giants, Chaos Magicians)
-
-
-      Proximity to other groups is a double-edged sword in Terra Mystica. Being close to other groups gives you extra power, but it also means that expanding is more difficult...
-
-
-      Terra Mystica FAQ
-
+    description: "In the land of Terra Mystica dwell 14 different peoples in seven landscapes, and each group is bound to\
+      \ its own home environment, so to develop and grow, they must terraform neighboring landscapes into their home environments\
+      \ in competition with the other groups.\n\nTerra Mystica is a full information game, without any luck, that rewards\
+      \ strategic planning. Each player governs one of the 14 groups. With subtlety and craft, the player must attempt to\
+      \ rule as great an area as possible and to develop that group's skills. There are also four religious cults in which\
+      \ you can progress. To do all that, each group has special skills and abilities.\n\nTaking turns, the players execute\
+      \ their actions on the resources they have at their disposal. Different buildings allow players to develop different\
+      \ resources. Dwellings allow for more workers. Trading houses allow players to make money. Strongholds unlock a group's\
+      \ special ability, and temples allow you to develop religion and your terraforming and seafaring skills. Buildings can\
+      \ be upgraded: Dwellings can be developed into trading houses; trading houses can be developed into strongholds or temples;\
+      \ one temple can be upgraded to become a sanctuary. Each group must also develop its terraforming skill and its skill\
+      \ with boats to use the rivers. The groups in question, along with their home landscape, are:\n\n\n    Desert (Fakirs,\
+      \ Nomads)\n    Plains (Halflings, Cultists)\n    Swamp (Alchemists, Darklings)\n    Lake (Mermaids, Swarmlings)\n  \
+      \  Forest (Witches, Auren)\n    Mountain (Dwarves, Engineers)\n    Wasteland (Giants, Chaos Magicians)\n\n\nProximity\
+      \ to other groups is a double-edged sword in Terra Mystica. Being close to other groups gives you extra power, but it\
+      \ also means that expanding is more difficult...\n\nTerra Mystica FAQ\n\n"
     yearPublished: 2012
     minPlayers: 2
     maxPlayers: 5
@@ -8443,17 +9389,29 @@ catalog:
     - White Goblin Games
     - Z-Man Games
     - Zvezda
+    pdfBlobKey: rulebooks/v1/terra-mystica_rulebook.pdf
+    pdfSha256: 9fc6eee922e6b73248ef8ca718d0edab29329ed9751ef9754a72d09beea6a9da
+    pdfVersion: '1.0'
   - title: Too Many Bones
     bggId: 192135
     language: en
-    pdf: too-many-bones_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Too Many Bones comes loaded for bear by breaking into a new genre: the dice-builder RPG. This game takes everything you think you know about dice-rolling and turns it on its head. Dripping with strategy, this fantasy-based RPG puts you in the skin of a new race and takes you on an adventure to the northern territories to root out and defeat growing enemy forces and of course the infamous "baddie" responsible.
+    description: 'Too Many Bones comes loaded for bear by breaking into a new genre: the dice-builder RPG. This game takes
+      everything you think you know about dice-rolling and turns it on its head. Dripping with strategy, this fantasy-based
+      RPG puts you in the skin of a new race and takes you on an adventure to the northern territories to root out and defeat
+      growing enemy forces and of course the infamous "baddie" responsible.
 
 
-      Team up or go it alone in a 1-4 player Coop or Solo play campaign. With over 100+ unique skill dice and 4-7 classes to choose from, every battle is its own mini challenge to figure out. Your adventure will consist of 8-12 battles before you reach your final destination and face off against one of a number of possible kingpins in order to win. Along the way, you will be faced with storyline decisions that will quickly have you weighing risk/reward, odds, and logic - with dice woven into every aspect! Your party will also be faced with other decisions: when to rest, when to explore, or even which fights to pursue! The Encounter cards offer fun plot twists and some comic relief, all while setting the stage for your next battle.
+      Team up or go it alone in a 1-4 player Coop or Solo play campaign. With over 100+ unique skill dice and 4-7 classes
+      to choose from, every battle is its own mini challenge to figure out. Your adventure will consist of 8-12 battles before
+      you reach your final destination and face off against one of a number of possible kingpins in order to win. Along the
+      way, you will be faced with storyline decisions that will quickly have you weighing risk/reward, odds, and logic - with
+      dice woven into every aspect! Your party will also be faced with other decisions: when to rest, when to explore, or
+      even which fights to pursue! The Encounter cards offer fun plot twists and some comic relief, all while setting the
+      stage for your next battle.
 
+
+      '
     yearPublished: 2017
     minPlayers: 1
     maxPlayers: 4
@@ -8500,20 +9458,29 @@ catalog:
     - Portal Games
     - Reflexshop
     - SD Games
+    pdfBlobKey: rulebooks/v1/too-many-bones_rulebook.pdf
+    pdfSha256: d1ffb9613ac5c460a37d91a69a7b19f6368bca8038f015e2c2ba5f26fb87620c
+    pdfVersion: '1.0'
   - title: Orleans
     bggId: 164928
     language: en
-    pdf: orleans_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      During the medieval goings-on around Orl&eacute;ans, you must assemble a following of farmers, merchants, knights, monks, etc. to gain supremacy through trade, construction and science in medieval France.
+    description: 'During the medieval goings-on around Orl&eacute;ans, you must assemble a following of farmers, merchants,
+      knights, monks, etc. to gain supremacy through trade, construction and science in medieval France.
 
 
-      In Orl&eacute;ans, you will recruit followers and put them to work to make use of their abilities. Farmers and Boatmen supply you with money and goods; Knights expand your scope of action and secure your mercantile expeditions; Craftsmen build trading stations and tools to facilitate work; Scholars make progress in science; Traders open up new locations for you to use your followers; and last but not least, it cannot hurt to get active in monasteries since with Monks on your side you are much less likely to fall prey to fate.
+      In Orl&eacute;ans, you will recruit followers and put them to work to make use of their abilities. Farmers and Boatmen
+      supply you with money and goods; Knights expand your scope of action and secure your mercantile expeditions; Craftsmen
+      build trading stations and tools to facilitate work; Scholars make progress in science; Traders open up new locations
+      for you to use your followers; and last but not least, it cannot hurt to get active in monasteries since with Monks
+      on your side you are much less likely to fall prey to fate.
 
 
-      You will always want to take more actions than possible, and there are many paths to victory. The challenge is to combine all elements as best as possible with regard to your strategy.
+      You will always want to take more actions than possible, and there are many paths to victory. The challenge is to combine
+      all elements as best as possible with regard to your strategy.
 
+
+      '
     yearPublished: 2014
     minPlayers: 2
     maxPlayers: 5
@@ -8562,17 +9529,26 @@ catalog:
     - Swan Panasia Co., Ltd.
     - Tasty Minstrel Games
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/orleans_rulebook.pdf
+    pdfSha256: 267ac223f04cba34b686f4dcdcb47460af3c9813a8f644b7ba46950f94750fad
+    pdfVersion: '1.0'
   - title: Mage Knight Board Game
     bggId: 96848
     language: en
-    pdf: mage-knight_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      The Mage Knight board game puts you in control of one of four powerful Mage Knights as you explore (and conquer) a corner of the Mage Knight universe under the control of the Atlantean Empire. Build your army, fill your deck with powerful spells and actions, explore caves and dungeons, and eventually conquer powerful cities controlled by this once-great faction!  In competitive scenarios, opposing players may be powerful allies, but only one will be able to claim the land as their own.  In cooperative scenarios, the players win or lose as a group.  Solo rules are also included.
+    description: 'The Mage Knight board game puts you in control of one of four powerful Mage Knights as you explore (and
+      conquer) a corner of the Mage Knight universe under the control of the Atlantean Empire. Build your army, fill your
+      deck with powerful spells and actions, explore caves and dungeons, and eventually conquer powerful cities controlled
+      by this once-great faction!  In competitive scenarios, opposing players may be powerful allies, but only one will be
+      able to claim the land as their own.  In cooperative scenarios, the players win or lose as a group.  Solo rules are
+      also included.
 
 
-      Combining elements of RPGs, deck-building, and traditional board games the Mage Knight board game captures the rich history of the Mage Knight universe in a self-contained gaming experience.
+      Combining elements of RPGs, deck-building, and traditional board games the Mage Knight board game captures the rich
+      history of the Mage Knight universe in a self-contained gaming experience.
 
+
+      '
     yearPublished: 2011
     minPlayers: 1
     maxPlayers: 4
@@ -8617,23 +9593,34 @@ catalog:
     - NECA
     - Pegasus Spiele
     - REXhry
+    pdfBlobKey: rulebooks/v1/mage-knight_rulebook.pdf
+    pdfSha256: 664ab0e5405d821be665178f2e325205cfbccbc3d1723b07fe3ff261f6c835bd
+    pdfVersion: '1.0'
   - title: Barrage
     bggId: 251247
     language: en
-    pdf: barrage_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In the dystopic 1930s, the industrial revolution pushed the exploitation of fossil-based resources to the limit, and now the only thing powerful enough to quench the thirst for power of the massive machines and of the unstoppable engineering progress is the unlimited hydroelectric energy provided by the rivers.
+    description: 'In the dystopic 1930s, the industrial revolution pushed the exploitation of fossil-based resources to the
+      limit, and now the only thing powerful enough to quench the thirst for power of the massive machines and of the unstoppable
+      engineering progress is the unlimited hydroelectric energy provided by the rivers.
 
 
-      Barrage is a resource management strategic game in which players compete to build their majestic dams, raise them to increase their storing capacity, and deliver all the potential power through pressure tunnels connected to the energy turbines of their powerhouses.
+      Barrage is a resource management strategic game in which players compete to build their majestic dams, raise them to
+      increase their storing capacity, and deliver all the potential power through pressure tunnels connected to the energy
+      turbines of their powerhouses.
 
 
-      Each player represents one of the four international companies who are gathering machinery, innovative patents and brilliant engineers to claim the best locations to collect and exploit the water of a contested Alpine region crossed by rivers.
+      Each player represents one of the four international companies who are gathering machinery, innovative patents and brilliant
+      engineers to claim the best locations to collect and exploit the water of a contested Alpine region crossed by rivers.
 
 
-      Over five rounds, the players must fulfill power requirements represented by a common competitive power track and meet specific requests of personal contracts. At the same time, by placing a limited number of engineers, they attempt to enhance their machinery to acquire new and more efficient construction actions and to build and activate special unique-effect buildings to forward their own developing strategy.
+      Over five rounds, the players must fulfill power requirements represented by a common competitive power track and meet
+      specific requests of personal contracts. At the same time, by placing a limited number of engineers, they attempt to
+      enhance their machinery to acquire new and more efficient construction actions and to build and activate special unique-effect
+      buildings to forward their own developing strategy.
 
+
+      '
     yearPublished: 2019
     minPlayers: 1
     maxPlayers: 4
@@ -8678,33 +9665,51 @@ catalog:
     - テンデイズゲームズ (TendaysGames)
     - TLAMA games
     - WoodCat
+    pdfBlobKey: rulebooks/v1/barrage_rulebook.pdf
+    pdfSha256: 2c68f1c8d57f4d3f4c3bb083c94738a9dbea054a6aa8cb4ff19a4708fe5bc709
+    pdfVersion: '1.0'
   - title: 'Hegemony: Lead Your Class to Victory'
     bggId: 321608
     language: en
-    pdf: hegemony_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Extended edition includes Crisis & Control expansion.
+    description: 'Extended edition includes Crisis & Control expansion.
 
 
 
-      The Nation is in disarray and a war is waging between the classes. The working class faces a dismantled welfare system, the capitalists are losing their hard-earned profits, the middle class is gradually fading and the state is sinking into a deep deficit. Amidst all this chaos, the only person who can provide guidance is... you. Will you take the side of the working class and fight for social reforms? Or will you stand with the corporations and the free market? Will you help the government try to keep it all together, or will you try to enforce your agenda no matter the cost to the country?
+      The Nation is in disarray and a war is waging between the classes. The working class faces a dismantled welfare system,
+      the capitalists are losing their hard-earned profits, the middle class is gradually fading and the state is sinking
+      into a deep deficit. Amidst all this chaos, the only person who can provide guidance is... you. Will you take the side
+      of the working class and fight for social reforms? Or will you stand with the corporations and the free market? Will
+      you help the government try to keep it all together, or will you try to enforce your agenda no matter the cost to the
+      country?
 
 
-      Hegemony is an asymmetric politico-economic card-driven board game for 2-4 players that puts you in the role of one of the socio-economic groups in a fictional state: The Working Class, the Middle Class, the Capitalist Class and the State itself.
+      Hegemony is an asymmetric politico-economic card-driven board game for 2-4 players that puts you in the role of one
+      of the socio-economic groups in a fictional state: The Working Class, the Middle Class, the Capitalist Class and the
+      State itself.
 
 
-      The Working class controls the workers. The Capitalist class controls the companies. The Middle class combines elements from both the Working class and the Capitalist. It has workers who can work in the Capitalist's companies but it can also build companies of its own, yet smaller. Finally the State is trying to keep everyone happy, providing benefits and subsidies when needed but trying also to maintain a steady income through taxes to avoid going into debt.
+      The Working class controls the workers. The Capitalist class controls the companies. The Middle class combines elements
+      from both the Working class and the Capitalist. It has workers who can work in the Capitalist''s companies but it can
+      also build companies of its own, yet smaller. Finally the State is trying to keep everyone happy, providing benefits
+      and subsidies when needed but trying also to maintain a steady income through taxes to avoid going into debt.
 
 
-      While players have their own separate goals, they are all limited by a series of policies that affect most of their actions, like Taxation, Labor Market, Foreign Trade etc. Voting on those policies and using their influence to change them is also very important. Through careful planning, strategic actions and political maneuvering, you will do your best to increase the power of your class and carry out your agenda. Will you be the one to lead your class to victory?
+      While players have their own separate goals, they are all limited by a series of policies that affect most of their
+      actions, like Taxation, Labor Market, Foreign Trade etc. Voting on those policies and using their influence to change
+      them is also very important. Through careful planning, strategic actions and political maneuvering, you will do your
+      best to increase the power of your class and carry out your agenda. Will you be the one to lead your class to victory?
 
 
-      Hegemony is heavily based on actual academic principles such as Social-Democracy, Neoliberalism, Nationalism and Globalism, and allows players to see their real world applications through engaging gameplay. There are many ways to achieve hegemony- which one will you take?
+      Hegemony is heavily based on actual academic principles such as Social-Democracy, Neoliberalism, Nationalism and Globalism,
+      and allows players to see their real world applications through engaging gameplay. There are many ways to achieve hegemony-
+      which one will you take?
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2023
     minPlayers: 2
     maxPlayers: 4
@@ -8739,23 +9744,36 @@ catalog:
     - Lavka Games
     - MYBG Co., Ltd.
     - Portal Games
+    pdfBlobKey: rulebooks/v1/hegemony_rulebook.pdf
+    pdfSha256: 95d89918c65189836d92e1b1fde7b7abad83b902cf53332299c11cd2bbfd478a
+    pdfVersion: '1.0'
   - title: Viticulture Essential Edition
     bggId: 183394
     language: en
-    pdf: viticulture_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Viticulture, the players find themselves in the roles of people in rustic, pre-modern Tuscany who have inherited meagre vineyards. They have a few plots of land, an old crush pad, a tiny cellar, and three workers. They each have a dream of being the first to call their winery a true success.
+    description: 'In Viticulture, the players find themselves in the roles of people in rustic, pre-modern Tuscany who have
+      inherited meagre vineyards. They have a few plots of land, an old crush pad, a tiny cellar, and three workers. They
+      each have a dream of being the first to call their winery a true success.
 
 
-      The players are in the position of determining how they want to allocate their workers throughout the year. Every season is different on a vineyard, so the workers have different tasks they can take care of in the summer and winter. There's competition over those tasks, and often the first worker to get to the job has an advantage over subsequent workers.
+      The players are in the position of determining how they want to allocate their workers throughout the year. Every season
+      is different on a vineyard, so the workers have different tasks they can take care of in the summer and winter. There''s
+      competition over those tasks, and often the first worker to get to the job has an advantage over subsequent workers.
 
 
-      Fortunately for the vineyard owners, people love to visit wineries, and it just so happens that many of those visitors are willing to help out around the vineyard when they visit as long as you assign a worker to take care of them. Their visits (in the form of cards) are brief but can be very helpful. Using those workers and visitors, the vineyard owners can expand their vineyards by building structures, planting vines, and filling wine orders, working towards the goal of running the most successful winery in Tuscany.
+      Fortunately for the vineyard owners, people love to visit wineries, and it just so happens that many of those visitors
+      are willing to help out around the vineyard when they visit as long as you assign a worker to take care of them. Their
+      visits (in the form of cards) are brief but can be very helpful. Using those workers and visitors, the vineyard owners
+      can expand their vineyards by building structures, planting vines, and filling wine orders, working towards the goal
+      of running the most successful winery in Tuscany.
 
 
-      Viticulture Essential Edition includes the base game of Viticulture and a few of the most popular modules from the original Tuscany expansion, including Mamas & Papas, Fields (previously known as Properties), expanded and revised Visitors, and Automa cards for a solo variant, along with a few minor rule changes.
+      Viticulture Essential Edition includes the base game of Viticulture and a few of the most popular modules from the original
+      Tuscany expansion, including Mamas & Papas, Fields (previously known as Properties), expanded and revised Visitors,
+      and Automa cards for a solo variant, along with a few minor rule changes.
 
+
+      '
     yearPublished: 2015
     minPlayers: 1
     maxPlayers: 6
@@ -8801,25 +9819,41 @@ catalog:
     - Regatul Jocurilor
     - Surfin' Meeple China
     - Tower Tactic Games
+    pdfBlobKey: rulebooks/v1/viticulture_rulebook.pdf
+    pdfSha256: bca0937ac513b49bceef44c4fe65acc0aacc8a444774894fe62bde10836f613a
+    pdfVersion: '1.0'
   - title: Crokinole
     bggId: 521
     language: en
     bggEnhanced: true
-    description: >+
-      Crokinole is a traditional two- or four-player dexterity game, played on a circular wooden board, with 3 rings and an inner recessed 'bullseye'. A ring of posts is set around the inner circle, which functions as an obstacle to reach this area. Playing pieces are wooden circular disks similar to checkers pieces.  Players take turns shooting disks across the board by flicking them with their fingers in an effort to land them in the highest scoring ring on the board, the highest score (20 points) achieved by shooting a disk into the centre, recessed hole. From the outside in, rings are worth 5, 10, 15 points.
+    description: 'Crokinole is a traditional two- or four-player dexterity game, played on a circular wooden board, with 3
+      rings and an inner recessed ''bullseye''. A ring of posts is set around the inner circle, which functions as an obstacle
+      to reach this area. Playing pieces are wooden circular disks similar to checkers pieces.  Players take turns shooting
+      disks across the board by flicking them with their fingers in an effort to land them in the highest scoring ring on
+      the board, the highest score (20 points) achieved by shooting a disk into the centre, recessed hole. From the outside
+      in, rings are worth 5, 10, 15 points.
 
 
-      As a traditional game, there are often many variations played, but the following method is based on the National Crokinole Association's rules which also govern the World Crokinole Championship.
+      As a traditional game, there are often many variations played, but the following method is based on the National Crokinole
+      Association''s rules which also govern the World Crokinole Championship.
 
 
-      Each disk to be shot must be placed on the outer boundary and within the shooting player's quadrant. If there are no opponent's disks on the board, the shot disk must land in the inner ring or it is removed. If there is an opponent's disk on the board, the shot disk must hit an opponent's piece, either directly, or by bumping another disk into it.  Disks landing in the centre hole are removed and scored at the end of the round. Disks that lie outside--or are touching--the outer boundary after each shot are removed from play for the round.
+      Each disk to be shot must be placed on the outer boundary and within the shooting player''s quadrant. If there are no
+      opponent''s disks on the board, the shot disk must land in the inner ring or it is removed. If there is an opponent''s
+      disk on the board, the shot disk must hit an opponent''s piece, either directly, or by bumping another disk into it.  Disks
+      landing in the centre hole are removed and scored at the end of the round. Disks that lie outside--or are touching--the
+      outer boundary after each shot are removed from play for the round.
 
 
-      The player to score the most points wins the round and scores 2 points, and if a tie, each player scores 1 point. A "game" is usually played to four rounds. The number of "games" in a match is set by the tournament.
+      The player to score the most points wins the round and scores 2 points, and if a tie, each player scores 1 point. A
+      "game" is usually played to four rounds. The number of "games" in a match is set by the tournament.
 
 
-      Alternatively, play is to a set score, usually the first player or team to 100, and each round is scored by cancellation. For example if Player One scores 250, and Player Two scores 225, then Player One will add 25 to his/her game score.
+      Alternatively, play is to a set score, usually the first player or team to 100, and each round is scored by cancellation.
+      For example if Player One scores 250, and Player Two scores 225, then Player One will add 25 to his/her game score.
 
+
+      '
     yearPublished: 1876
     minPlayers: 2
     maxPlayers: 4
@@ -8870,17 +9904,23 @@ catalog:
   - title: 'Heat: Pedal to the Metal'
     bggId: 366013
     language: en
-    pdf: heat_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Based on simple and intuitive hand management, Heat: Pedal to the Metal puts players in the driver's seat of intense car races, jockeying for position to cross the finish line first, while managing their car's speed if they don't want to overheat. Selecting the right upgrades for their car will help them hug the curves and keep their engine cool enough to maintain top speeds. Ultimately, their driving skills will be the key to victory!
+    description: 'Based on simple and intuitive hand management, Heat: Pedal to the Metal puts players in the driver''s seat
+      of intense car races, jockeying for position to cross the finish line first, while managing their car''s speed if they
+      don''t want to overheat. Selecting the right upgrades for their car will help them hug the curves and keep their engine
+      cool enough to maintain top speeds. Ultimately, their driving skills will be the key to victory!
 
 
-      Drivers can compete in a single race or use the "Championship System" to play a whole season in one game night, customizing their car before each race to claim the top spot of the podium. They have to be careful as the weather, road conditions, and events will change every race to spice up their championship. Players can also enjoy a solo mode with the Legends Module or add automated drivers as additional opponents in multiplayer games.
+      Drivers can compete in a single race or use the "Championship System" to play a whole season in one game night, customizing
+      their car before each race to claim the top spot of the podium. They have to be careful as the weather, road conditions,
+      and events will change every race to spice up their championship. Players can also enjoy a solo mode with the Legends
+      Module or add automated drivers as additional opponents in multiplayer games.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2022
     minPlayers: 1
     maxPlayers: 6
@@ -8922,22 +9962,35 @@ catalog:
     - Kaissa Chess & Games
     - Korea Boardgames
     - Lord of Boards
+    pdfBlobKey: rulebooks/v1/heat_rulebook.pdf
+    pdfSha256: 03515036dff608ec23a69ca0f7a538f06ec5612809950df1650d4d3d57586f81
+    pdfVersion: '1.0'
   - title: Kanban EV
     bggId: 284378
     language: en
-    pdf: kanban-ev_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Electric vehicles (EVs) have become more common since 2014 and are the future of the automobile industry. They are superior vehicles due to them being more efficient, easier to maintain, cleaner, and cheaper to run. They are computerized machines that use AI to improve safety and in the near future will provide autonomous driving. They receive software upgrades during their lifetime and are constantly improving, unlike their traditional combustion-engine counterparts, which start to become obsolete as soon as you start using them.
+    description: 'Electric vehicles (EVs) have become more common since 2014 and are the future of the automobile industry.
+      They are superior vehicles due to them being more efficient, easier to maintain, cleaner, and cheaper to run. They are
+      computerized machines that use AI to improve safety and in the near future will provide autonomous driving. They receive
+      software upgrades during their lifetime and are constantly improving, unlike their traditional combustion-engine counterparts,
+      which start to become obsolete as soon as you start using them.
 
 
-      You will be overseeing the production of these vehicles in Kanban EV, with "kanban" (看板) being the name for a scheduling system that supports an efficient assembly line, just-in-time production, and a smooth workflow process. Over the course of the game, players take on the role of rookie employees who are trying to secure their career. You need to manage suppliers and supplies, improve and innovate automobile parts, and get your hands greasy on the assembly line in order to boost production and impress the factory manager.
+      You will be overseeing the production of these vehicles in Kanban EV, with "kanban" (看板) being the name for a scheduling
+      system that supports an efficient assembly line, just-in-time production, and a smooth workflow process. Over the course
+      of the game, players take on the role of rookie employees who are trying to secure their career. You need to manage
+      suppliers and supplies, improve and innovate automobile parts, and get your hands greasy on the assembly line in order
+      to boost production and impress the factory manager.
 
 
-      You must make shrewd use of the recycling facilities and the limited factory supplies in order to appropriate parts when the suppliers come up short. Because the factory must run at optimum efficiency, production doesn't wait for you or for mistakes. Sandra, the factory manager, will review your performance and keep the factory on tempo.
+      You must make shrewd use of the recycling facilities and the limited factory supplies in order to appropriate parts
+      when the suppliers come up short. Because the factory must run at optimum efficiency, production doesn''t wait for you
+      or for mistakes. Sandra, the factory manager, will review your performance and keep the factory on tempo.
 
 
-      Kanban EV is a game that focuses on resource and time management that puts you in the driver's seat of an entire production facility, racing for factory goals and the highest level of promotion. You earn production points (PP) for performing various actions in the game, and the player with the most PP at the end of the game wins.
+      Kanban EV is a game that focuses on resource and time management that puts you in the driver''s seat of an entire production
+      facility, racing for factory goals and the highest level of promotion. You earn production points (PP) for performing
+      various actions in the game, and the player with the most PP at the end of the game wins.
 
 
       &mdash;description from publisher
@@ -8945,6 +9998,8 @@ catalog:
 
       Includes solo mode by D&aacute;vid Turczi
 
+
+      '
     yearPublished: 2020
     minPlayers: 1
     maxPlayers: 4
@@ -8980,26 +10035,21 @@ catalog:
     - Skellig Games
     - TLAMA games
     - YOKA Games
+    pdfBlobKey: rulebooks/v1/kanban-ev_rulebook.pdf
+    pdfSha256: d09cdca785107379277fd8a8bd8da5daa6b7cdc2247dc6f0b650a28320cc584c
+    pdfVersion: '1.0'
   - title: 'Marvel Champions: The Card Game'
     bggId: 285774
     language: en
-    pdf: marvel-champions_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      "With great power, there must also come great responsibility."
-         &ndash;Stan Lee, Amazing Fantasy #15
-
-      Iron Man and Black Panther team up to stop Rhino from rampaging through the streets of New York. Captain Marvel and Spider-Man battle Ultron as he threatens global annihilation. Do you have what it takes to join the ranks of these legendary heroes and become a champion?
-
-
-      Jump into the Marvel Universe with Marvel Champions: The Card Game, a cooperative Living Card Game for one to four players!
-
-
-      Marvel Champions: The Card Game invites players to embody iconic heroes from the Marvel Universe as they battle to stop infamous villains from enacting their devious schemes. As a Living Card Game, Marvel Champions is supported with regular releases of new product, including new heroes and scenarios.
-
-
-      &mdash;description from the publisher
-
+    description: "\"With great power, there must also come great responsibility.\"\n   &ndash;Stan Lee, Amazing Fantasy #15\n\
+      \nIron Man and Black Panther team up to stop Rhino from rampaging through the streets of New York. Captain Marvel and\
+      \ Spider-Man battle Ultron as he threatens global annihilation. Do you have what it takes to join the ranks of these\
+      \ legendary heroes and become a champion?\n\nJump into the Marvel Universe with Marvel Champions: The Card Game, a cooperative\
+      \ Living Card Game for one to four players!\n\nMarvel Champions: The Card Game invites players to embody iconic heroes\
+      \ from the Marvel Universe as they battle to stop infamous villains from enacting their devious schemes. As a Living\
+      \ Card Game, Marvel Champions is supported with regular releases of new product, including new heroes and scenarios.\n\
+      \n&mdash;description from the publisher\n\n"
     yearPublished: 2019
     minPlayers: 1
     maxPlayers: 4
@@ -9038,20 +10088,33 @@ catalog:
     - Kilogames
     - Korea Boardgames
     - NeoTroy Games
+    pdfBlobKey: rulebooks/v1/marvel-champions_rulebook.pdf
+    pdfSha256: 357c9be2010723dd3e8831e81eb140567d0d93f83b803a9040dcad2b8f2730b9
+    pdfVersion: '1.0'
   - title: Underwater Cities
     bggId: 247763
     language: en
-    pdf: underwater-cities_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Underwater Cities, which takes about 30-45 minutes per player, players represent the most powerful brains in the world, brains nominated due to the overpopulation of Earth to establish the best and most livable underwater areas possible.
+    description: 'In Underwater Cities, which takes about 30-45 minutes per player, players represent the most powerful brains
+      in the world, brains nominated due to the overpopulation of Earth to establish the best and most livable underwater
+      areas possible.
 
 
-      The main principle of the game is card placement. Three colored cards are placed along the edge of the main board  into 3 x 5 slots, which are also colored. Ideally players can place cards into slots of the same color. Then they can take both actions and advantages: the action depicted in the slot on the main board and also the advantage of the card. Actions and advantages can allow players to intake raw materials; to build and upgrade city domes, tunnels and production buildings such as farms, desalination devices and laboratories in their personal underwater area; to move their marker on the initiative track (which is important for player order in the next turn); to activate the player's "A-cards"; and to collect cards, both special ones and basic ones that allow for better decision possibilities during gameplay.
+      The main principle of the game is card placement. Three colored cards are placed along the edge of the main board  into
+      3 x 5 slots, which are also colored. Ideally players can place cards into slots of the same color. Then they can take
+      both actions and advantages: the action depicted in the slot on the main board and also the advantage of the card. Actions
+      and advantages can allow players to intake raw materials; to build and upgrade city domes, tunnels and production buildings
+      such as farms, desalination devices and laboratories in their personal underwater area; to move their marker on the
+      initiative track (which is important for player order in the next turn); to activate the player''s "A-cards"; and to
+      collect cards, both special ones and basic ones that allow for better decision possibilities during gameplay.
 
 
-      All of the nearly 220 cards &mdash; whether special or basic &mdash; are divided into five types according to the way and time of use. Underwater areas are planned to be double-sided, giving players many opportunities to achieve VPs and finally win.
+      All of the nearly 220 cards &mdash; whether special or basic &mdash; are divided into five types according to the way
+      and time of use. Underwater areas are planned to be double-sided, giving players many opportunities to achieve VPs and
+      finally win.
 
+
+      '
     yearPublished: 2018
     minPlayers: 1
     maxPlayers: 4
@@ -9097,29 +10160,50 @@ catalog:
     - Rio Grande Games
     - sternenschimmermeer
     - 数寄ゲームズ (Suki Games)
+    pdfBlobKey: rulebooks/v1/underwater-cities_rulebook.pdf
+    pdfSha256: 09a932ae6a3c5adfe07d0efeda8071a8ba225b9c66a766d08576075b2e7a2c9c
+    pdfVersion: '1.0'
   - title: Food Chain Magnate
     bggId: 175914
     language: en
-    pdf: food-chain-magnate_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      "Lemonade? They want lemonade? What is the world coming to? I want commercials for burgers on all channels, every 15 minutes. We are the Home of the Original Burger, not a hippie health haven. And place a billboard next to that new house on the corner. I want them craving beer every second they sit in their posh new garden." The new management trainee trembles in front of the CEO and tries to politely point out that... "How do you mean, we don't have enough staff? The HR director reports to you. Hire more people! Train them! But whatever you do, don't pay them any real wages. I did not go into business to become poor. And fire that discount manager, she is only costing me money. From now on, we'll sell gourmet burgers. Same crap, double the price. Get my marketing director in here!"
+    description: '"Lemonade? They want lemonade? What is the world coming to? I want commercials for burgers on all channels,
+      every 15 minutes. We are the Home of the Original Burger, not a hippie health haven. And place a billboard next to that
+      new house on the corner. I want them craving beer every second they sit in their posh new garden." The new management
+      trainee trembles in front of the CEO and tries to politely point out that... "How do you mean, we don''t have enough
+      staff? The HR director reports to you. Hire more people! Train them! But whatever you do, don''t pay them any real wages.
+      I did not go into business to become poor. And fire that discount manager, she is only costing me money. From now on,
+      we''ll sell gourmet burgers. Same crap, double the price. Get my marketing director in here!"
 
 
-      Food Chain Magnate is a heavy strategy game about building a fast food chain. The focus is on building your company using a card-driven (human) resource management system. Players compete on a variable city map through purchasing, marketing and sales, and on a job market for key staff members. The game can be played by 2-5 serious gamers in 2-4 hours.
+      Food Chain Magnate is a heavy strategy game about building a fast food chain. The focus is on building your company
+      using a card-driven (human) resource management system. Players compete on a variable city map through purchasing, marketing
+      and sales, and on a job market for key staff members. The game can be played by 2-5 serious gamers in 2-4 hours.
 
 
       German:
 
 
-      "Limonade? Sie wollen Limonade? Was ist mit der Welt los? Ich will Werbung f&uuml;r Burger auf allen Kan&auml;len, alle 15 Minuten. Wir sind die Heimat des Original-Burgers, kein Hippie-Gesundheitsparadies. Und stellen Sie eine Werbetafel neben das neue Haus an der Ecke. Ich will, dass sie jede Sekunde, in der sie in ihrem schicken neuen Garten sitzen, nach Bier lechzen." Der neue Management-Trainee zittert vor dem CEO und versucht, h&ouml;flich darauf hinzuweisen, dass... "Wie meinen Sie das, wir haben nicht genug Personal? Der Personaldirektor berichtet an Sie. Stellen Sie mehr Leute ein! Bilden Sie sie aus! Aber was auch immer Sie tun, zahlen Sie ihnen keine echten L&ouml;hne. Ich bin nicht ins Gesch&auml;ft eingestiegen, um arm zu werden. Und feuere diese Discount-Managerin, sie kostet mich nur Geld. Von nun an werden wir Gourmet-Burger verkaufen. Derselbe Mist, nur doppelt so teuer. Holen Sie meinen Marketingdirektor her!"
+      "Limonade? Sie wollen Limonade? Was ist mit der Welt los? Ich will Werbung f&uuml;r Burger auf allen Kan&auml;len, alle
+      15 Minuten. Wir sind die Heimat des Original-Burgers, kein Hippie-Gesundheitsparadies. Und stellen Sie eine Werbetafel
+      neben das neue Haus an der Ecke. Ich will, dass sie jede Sekunde, in der sie in ihrem schicken neuen Garten sitzen,
+      nach Bier lechzen." Der neue Management-Trainee zittert vor dem CEO und versucht, h&ouml;flich darauf hinzuweisen, dass...
+      "Wie meinen Sie das, wir haben nicht genug Personal? Der Personaldirektor berichtet an Sie. Stellen Sie mehr Leute ein!
+      Bilden Sie sie aus! Aber was auch immer Sie tun, zahlen Sie ihnen keine echten L&ouml;hne. Ich bin nicht ins Gesch&auml;ft
+      eingestiegen, um arm zu werden. Und feuere diese Discount-Managerin, sie kostet mich nur Geld. Von nun an werden wir
+      Gourmet-Burger verkaufen. Derselbe Mist, nur doppelt so teuer. Holen Sie meinen Marketingdirektor her!"
 
 
-      Food Chain Magnate ist ein schweres Strategiespiel &uuml;ber den Aufbau einer Fast-Food-Kette. Der Schwerpunkt liegt auf dem Aufbau des eigenen Unternehmens mit Hilfe eines kartengesteuerten (Personal-)Managementsystems. Die Spieler konkurrieren auf einer variablen Stadtkarte durch Einkauf, Marketing und Verkauf sowie auf einem Stellenmarkt f&uuml;r wichtige Mitarbeiter.
+      Food Chain Magnate ist ein schweres Strategiespiel &uuml;ber den Aufbau einer Fast-Food-Kette. Der Schwerpunkt liegt
+      auf dem Aufbau des eigenen Unternehmens mit Hilfe eines kartengesteuerten (Personal-)Managementsystems. Die Spieler
+      konkurrieren auf einer variablen Stadtkarte durch Einkauf, Marketing und Verkauf sowie auf einem Stellenmarkt f&uuml;r
+      wichtige Mitarbeiter.
 
 
       Das Spiel kann von 2-5 ernsthaften Spielern in 2-4 Stunden gespielt werden.
 
+
+      '
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 5
@@ -9158,23 +10242,40 @@ catalog:
     - New Games Order, LLC
     - One Moment Games
     - Portal Games
+    pdfBlobKey: rulebooks/v1/food-chain-magnate_rulebook.pdf
+    pdfSha256: f228049fcadc5d674049cb10a419e13d7e6d270bfcdf8a8e8ef33ddb7482f4a3
+    pdfVersion: '1.0'
   - title: 'Pax Pamir: Second Edition'
     bggId: 256960
     language: en
-    pdf: pax-pamir_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Pax Pamir, players assume the role of nineteenth century Afghan leaders attempting to forge a new state after the collapse of the Durrani Empire. Western histories often call this period "The Great Game" because of the role played by the Europeans who attempted to use central Asia as a theater for their own rivalries. In this game, those empires are viewed strictly from the perspective of the Afghans who sought to manipulate the interloping ferengi (foreigners) for their own purposes.
+    description: 'In Pax Pamir, players assume the role of nineteenth century Afghan leaders attempting to forge a new state
+      after the collapse of the Durrani Empire. Western histories often call this period "The Great Game" because of the role
+      played by the Europeans who attempted to use central Asia as a theater for their own rivalries. In this game, those
+      empires are viewed strictly from the perspective of the Afghans who sought to manipulate the interloping ferengi (foreigners)
+      for their own purposes.
 
 
-      In terms of game play, Pax Pamir is a pretty straightforward tableau builder. Players spend most of their turns purchasing cards from a central market, then playing those cards in front of them in a single row called a court. Playing cards adds units to the game's map and grants access to additional actions that can be taken to disrupt other players and influence the course of the game. That last point is worth emphasizing. Though everyone is building their own row of cards, the game offers many ways for players to interfere with each other directly and indirectly.
+      In terms of game play, Pax Pamir is a pretty straightforward tableau builder. Players spend most of their turns purchasing
+      cards from a central market, then playing those cards in front of them in a single row called a court. Playing cards
+      adds units to the game''s map and grants access to additional actions that can be taken to disrupt other players and
+      influence the course of the game. That last point is worth emphasizing. Though everyone is building their own row of
+      cards, the game offers many ways for players to interfere with each other directly and indirectly.
 
 
-      To survive, players will organize into coalitions. Throughout the game, the dominance of the different coalitions will be evaluated by the players when a special card, called a "Dominance Check", is resolved. If a single coalition has a commanding lead during one of these checks, those players loyal to that coalition will receive victory points based on their influence in their coalition. However, if Afghanistan remains fragmented during one of these checks, players instead will receive victory points based on their personal power base.
+      To survive, players will organize into coalitions. Throughout the game, the dominance of the different coalitions will
+      be evaluated by the players when a special card, called a "Dominance Check", is resolved. If a single coalition has
+      a commanding lead during one of these checks, those players loyal to that coalition will receive victory points based
+      on their influence in their coalition. However, if Afghanistan remains fragmented during one of these checks, players
+      instead will receive victory points based on their personal power base.
 
 
-      After each Dominance Check, victory is checked and the game will be partially reset, offering players a fresh attempt to realize their ambitions. The game ends when a single player is able to achieve a lead of four or more victory points  or after the fourth and final Dominance Check is resolved.
+      After each Dominance Check, victory is checked and the game will be partially reset, offering players a fresh attempt
+      to realize their ambitions. The game ends when a single player is able to achieve a lead of four or more victory points  or
+      after the fourth and final Dominance Check is resolved.
 
+
+      '
     yearPublished: 2019
     minPlayers: 1
     maxPlayers: 5
@@ -9222,20 +10323,29 @@ catalog:
     - Spielworxx
     - テンデイズゲームズ (TendaysGames)
     - YOKA Games
+    pdfBlobKey: rulebooks/v1/pax-pamir_rulebook.pdf
+    pdfSha256: 63b77858c8013806355dc52b7620044478fe545c12b495dbf16843c6242c009b
+    pdfVersion: '1.0'
   - title: 'Cthulhu: Death May Die'
     bggId: 253344
     language: en
-    pdf: cthulhu-death-may-die_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Cthulhu: Death May Die, inspired by the writings of H.P. Lovecraft, you and your fellow players represent investigators in the 1920s who instead of trying to stop the coming of Elder Gods, want to summon those otherworldly beings so that you can put a stop to them permanently. You start the game insane, and while your long-term goal is to shoot Cthulhu in the face, so to speak, at some point during the game you'll probably fail to mitigate your dice rolls properly and your insanity will cause you to do something terrible &mdash; or maybe advantageous. Hard to know for sure.
+    description: 'In Cthulhu: Death May Die, inspired by the writings of H.P. Lovecraft, you and your fellow players represent
+      investigators in the 1920s who instead of trying to stop the coming of Elder Gods, want to summon those otherworldly
+      beings so that you can put a stop to them permanently. You start the game insane, and while your long-term goal is to
+      shoot Cthulhu in the face, so to speak, at some point during the game you''ll probably fail to mitigate your dice rolls
+      properly and your insanity will cause you to do something terrible &mdash; or maybe advantageous. Hard to know for sure.
 
 
-      The game has multiple episodes, and each of them has a similar structure of two acts, those being before and after you summon whatever it is you happen to be summoning. If any character dies prior to the summoning, then the game ends and you lose; once the Elder One is on the board, as long as one of you is still alive, you still have a chance to win.
+      The game has multiple episodes, and each of them has a similar structure of two acts, those being before and after you
+      summon whatever it is you happen to be summoning. If any character dies prior to the summoning, then the game ends and
+      you lose; once the Elder One is on the board, as long as one of you is still alive, you still have a chance to win.
 
 
       The episodes are all standalone and not contingent on being played in a certain order or with the same players.
 
+
+      '
     yearPublished: 2019
     minPlayers: 1
     maxPlayers: 5
@@ -9279,26 +10389,35 @@ catalog:
     - Portal Games
     - REXhry
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/cthulhu-death-may-die_rulebook.pdf
+    pdfSha256: bd68232abefd9f2b2904bf5a3b5c1e3db59b29f4567838c4b799d0e7b6468b11
+    pdfVersion: '1.0'
   - title: Age of Innovation
     bggId: 383179
     language: en
-    pdf: age-of-innovation_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Age of Innovation is a standalone game set in the world of Terra Mystica.
+    description: 'Age of Innovation is a standalone game set in the world of Terra Mystica.
 
 
-      Twelve factions, each with unique characteristics, populate this world of varying terrains. Here you will compete to erect buildings and merge them into cities. Each game allows you to create new combinations of factions, homelands, and abilities so that each game isn't the same as another.
+      Twelve factions, each with unique characteristics, populate this world of varying terrains. Here you will compete to
+      erect buildings and merge them into cities. Each game allows you to create new combinations of factions, homelands,
+      and abilities so that each game isn''t the same as another.
 
 
-      You control one of these factions and will terraform the game map's terrain into your homelands where you can erect your buildings. Proximity to other factions may limit your expansion, but it also gains you significant advantages in the game. This tension adds to the appeal of the Terra Mystica series.
+      You control one of these factions and will terraform the game map''s terrain into your homelands where you can erect
+      your buildings. Proximity to other factions may limit your expansion, but it also gains you significant advantages in
+      the game. This tension adds to the appeal of the Terra Mystica series.
 
 
-      Upgrade your buildings to gain valuable resources such as tools, scholars, money, and power. Build schools to advance in different sciences and collect books, which you can use to make innovations. Build your palace to gain a powerful new ability or build workshops, guilds, and universities to complete your culture.
+      Upgrade your buildings to gain valuable resources such as tools, scholars, money, and power. Build schools to advance
+      in different sciences and collect books, which you can use to make innovations. Build your palace to gain a powerful
+      new ability or build workshops, guilds, and universities to complete your culture.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2023
     minPlayers: 1
     maxPlayers: 5
@@ -9344,32 +10463,29 @@ catalog:
     - Swan Panasia Co., Ltd.
     - テンデイズゲームズ (TendaysGames)
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/age-of-innovation_rulebook.pdf
+    pdfSha256: 8f1150d295498a2df9ac6da4de3e73eb7efb2e8da8298aa6377afb1af6dc65e5
+    pdfVersion: '1.0'
   - title: 'Clank!: A Deck-Building Adventure'
     bggId: 201808
     language: en
-    pdf: clank_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Burgle your way to adventure in the deck-building board game Clank! Sneak into an angry dragon's mountain lair to steal precious artifacts. Delve deeper to find more valuable loot. Acquire cards for your deck and watch your thievish abilities grow. Be quick and be quiet. One false step and CLANK! Each careless sound draws the attention of the dragon, and each artifact stolen increases its rage. You can enjoy your plunder only if you make it out of the depths alive!
-
-
-      Clank! is a deck-building game. Each player has their own deck, and building yours up is part of playing the game. You start each of your turns with five cards in your hand, and you'll play them all in any order you choose. Most cards will generate resources, of which there are three different kinds:
-
-
-          Skill, which is used to acquire new cards for your deck.
-          Swords, which are used to fight the monsters that infest the dungeon.
-          Boots, which are used to move around the board.
-
-
-      Every time you acquire a new card, you put it face up in your discard pile. Whenever you need to draw a card and find your deck empty, you shuffle your discard pile and turn it face down to form a new deck. With each shuffle, your newest cards become part of a bigger and better deck! Each player starts with the same cards in their deck, but they&rsquo;ll acquire different cards during their turns. Because cards can do many different things, each player&rsquo;s deck (and strategy) will become more and more different as the game unfolds.
-
-
-      During the game, you have two goals:
-
-          Retrieve an Artifact token and escape the dragon by returning to the place you started, outside of the dungeon.
-          Accumulate enough points with your Artifact and other loot to beat out your opponents and earn the title of Greatest Thief in the Realm!
-
-
+    description: "Burgle your way to adventure in the deck-building board game Clank! Sneak into an angry dragon's mountain\
+      \ lair to steal precious artifacts. Delve deeper to find more valuable loot. Acquire cards for your deck and watch your\
+      \ thievish abilities grow. Be quick and be quiet. One false step and CLANK! Each careless sound draws the attention\
+      \ of the dragon, and each artifact stolen increases its rage. You can enjoy your plunder only if you make it out of\
+      \ the depths alive!\n\nClank! is a deck-building game. Each player has their own deck, and building yours up is part\
+      \ of playing the game. You start each of your turns with five cards in your hand, and you'll play them all in any order\
+      \ you choose. Most cards will generate resources, of which there are three different kinds:\n\n\n    Skill, which is\
+      \ used to acquire new cards for your deck.\n    Swords, which are used to fight the monsters that infest the dungeon.\n\
+      \    Boots, which are used to move around the board.\n\n\nEvery time you acquire a new card, you put it face up in your\
+      \ discard pile. Whenever you need to draw a card and find your deck empty, you shuffle your discard pile and turn it\
+      \ face down to form a new deck. With each shuffle, your newest cards become part of a bigger and better deck! Each player\
+      \ starts with the same cards in their deck, but they&rsquo;ll acquire different cards during their turns. Because cards\
+      \ can do many different things, each player&rsquo;s deck (and strategy) will become more and more different as the game\
+      \ unfolds.\n\nDuring the game, you have two goals:\n\n    Retrieve an Artifact token and escape the dragon by returning\
+      \ to the place you started, outside of the dungeon.\n    Accumulate enough points with your Artifact and other loot\
+      \ to beat out your opponents and earn the title of Greatest Thief in the Realm!\n\n\n"
     yearPublished: 2016
     minPlayers: 2
     maxPlayers: 4
@@ -9411,29 +10527,51 @@ catalog:
     - REXhry
     - Schwerkraft-Verlag
     - Tabletop KZ
+    pdfBlobKey: rulebooks/v1/clank_rulebook.pdf
+    pdfSha256: 3bac57806508832c3ecbff7ba1095fc8570f5a9229d00073aa78683acadcca1d
+    pdfVersion: '1.0'
   - title: The White Castle
     bggId: 371942
     language: en
-    pdf: the-white-castle_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      The heron flies over the Himeji sky while the Daimyo, from the top of the castle, watches his servants move. Gardeners tend the pond, where the koi carp live, warriors stand guard on the walls, and courtiers crowd the gates, pining for an audience that brings them closer to the innermost circles of the court. When night falls, the lanterns are lit and the workers return to their clan.
+    description: 'The heron flies over the Himeji sky while the Daimyo, from the top of the castle, watches his servants move.
+      Gardeners tend the pond, where the koi carp live, warriors stand guard on the walls, and courtiers crowd the gates,
+      pining for an audience that brings them closer to the innermost circles of the court. When night falls, the lanterns
+      are lit and the workers return to their clan.
 
 
-      In The White Castle, players will control one of these clans in order to score more victory points than the rest. To do so, they must amass influence in the court, manage resources boldly, and place their workers in the right place at the right time. The authors are Sheila Santos and Israel Cendrero, the duo known as Llama Dice who also designed the successful The Red Cathedral with Devir. In this case, we leave the Moscow of Ivan the Terrible behind to explore the most imposing fortress in modern Japan, Himeji Castle, where the banner of the Sakai clan flies under the orders of Daimyo Sakai Tadakiyo.
+      In The White Castle, players will control one of these clans in order to score more victory points than the rest. To
+      do so, they must amass influence in the court, manage resources boldly, and place their workers in the right place at
+      the right time. The authors are Sheila Santos and Israel Cendrero, the duo known as Llama Dice who also designed the
+      successful The Red Cathedral with Devir. In this case, we leave the Moscow of Ivan the Terrible behind to explore the
+      most imposing fortress in modern Japan, Himeji Castle, where the banner of the Sakai clan flies under the orders of
+      Daimyo Sakai Tadakiyo.
 
 
-      The White Castle is a Euro type game with mechanics of resource management, worker placement and dice placement to carry out actions. During the game, over three rounds, players will send members of their clan to tend the gardens, defend the castle or progress up the social ladder of the nobility. At the end of the match, these will award players victory points in a variety of ways.
+      The White Castle is a Euro type game with mechanics of resource management, worker placement and dice placement to carry
+      out actions. During the game, over three rounds, players will send members of their clan to tend the gardens, defend
+      the castle or progress up the social ladder of the nobility. At the end of the match, these will award players victory
+      points in a variety of ways.
 
 
-      The central panel shows Himeji Castle in all its splendor, divided into several zones. The largest is inside the castle, with the Room of the Thousand Carpets, where the courtiers must ascend socially until they reach the circle closest to the Daimyo to enjoy his favor. There is also the pond and the gardens, patiently tended by the gardeners where everyone can relax and contemplate its beauty without restriction. Another important area is the wall and the outside of the castle, where the warriors patrol and stand guard. Finally, we find the area of the three bridges, where the three types of dice that can be used to carry out actions are accumulated, and the personal domain of each player, where they will keep track of their resources and where they will have the reserve of workers.
+      The central panel shows Himeji Castle in all its splendor, divided into several zones. The largest is inside the castle,
+      with the Room of the Thousand Carpets, where the courtiers must ascend socially until they reach the circle closest
+      to the Daimyo to enjoy his favor. There is also the pond and the gardens, patiently tended by the gardeners where everyone
+      can relax and contemplate its beauty without restriction. Another important area is the wall and the outside of the
+      castle, where the warriors patrol and stand guard. Finally, we find the area of the three bridges, where the three types
+      of dice that can be used to carry out actions are accumulated, and the personal domain of each player, where they will
+      keep track of their resources and where they will have the reserve of workers.
 
 
-      With accessible rules and a very careful setting, The White Castle is a very versatile title that will fit in with different gaming groups. As is tradition with Llama Dice titles, its sleek and simple design belies a great deal of strategic depth within the grasp of players.
+      With accessible rules and a very careful setting, The White Castle is a very versatile title that will fit in with different
+      gaming groups. As is tradition with Llama Dice titles, its sleek and simple design belies a great deal of strategic
+      depth within the grasp of players.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2023
     minPlayers: 1
     maxPlayers: 4
@@ -9481,20 +10619,32 @@ catalog:
     - Portal Games
     - Reflexshop
     - TLAMA games
+    pdfBlobKey: rulebooks/v1/the-white-castle_rulebook.pdf
+    pdfSha256: dd14099d0194afad2402875e6eb6a27e0b8fbdc631713b16eca1026ad4b225b2
+    pdfVersion: '1.0'
   - title: Paladins of the West Kingdom
     bggId: 266810
     language: en
-    pdf: paladins-of-the-west-kingdom_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Paladins of the West Kingdom is set at a turbulent time of West Francia's story, circa 900 AD. Despite recent efforts to develop the city, outlying townships are still under threat from outsiders. Saracens scout the borders, while Vikings plunder wealth and livestock. Even the Byzantines from the east have shown their darker side. As noble men and women, players must gather workers from the city to defend against enemies, build fortifications and spread faith throughout the land. Fortunately you are not alone. In his great wisdom, the King has sent his finest knights to help aid in our efforts. So ready the horses and sharpen the swords. The Paladins are approaching.
+    description: 'Paladins of the West Kingdom is set at a turbulent time of West Francia''s story, circa 900 AD. Despite
+      recent efforts to develop the city, outlying townships are still under threat from outsiders. Saracens scout the borders,
+      while Vikings plunder wealth and livestock. Even the Byzantines from the east have shown their darker side. As noble
+      men and women, players must gather workers from the city to defend against enemies, build fortifications and spread
+      faith throughout the land. Fortunately you are not alone. In his great wisdom, the King has sent his finest knights
+      to help aid in our efforts. So ready the horses and sharpen the swords. The Paladins are approaching.
 
 
-      The aim of Paladins of the West Kingdom is to be the player with the most victory points (VP) at game's end. Points are gained by building outposts and fortifications, commissioning monks and confronting outsiders. Each round, players will enlist the help of a specific Paladin and gather workers to carry out tasks. As the game progresses, players will slowly increase their faith, strength and influence. Not only will these affect their final score, but they will also determine the significance of their actions. The game is concluded at the end of the seventh round.
+      The aim of Paladins of the West Kingdom is to be the player with the most victory points (VP) at game''s end. Points
+      are gained by building outposts and fortifications, commissioning monks and confronting outsiders. Each round, players
+      will enlist the help of a specific Paladin and gather workers to carry out tasks. As the game progresses, players will
+      slowly increase their faith, strength and influence. Not only will these affect their final score, but they will also
+      determine the significance of their actions. The game is concluded at the end of the seventh round.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2019
     minPlayers: 1
     maxPlayers: 4
@@ -9537,17 +10687,28 @@ catalog:
     - TLAMA games
     - White Goblin Games
     - 株式会社ケンビル (KenBill)
+    pdfBlobKey: rulebooks/v1/paladins-of-the-west-kingdom_rulebook.pdf
+    pdfSha256: 97df1e8977704b8ab3618199ab3951affce87740aa1da04a03c2692c42e7b81e
+    pdfVersion: '1.0'
   - title: Le Havre
     bggId: 35677
     language: en
-    pdf: le-havre_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Le Havre, a player's turn consists of two parts: First, distribute newly supplied goods onto the offer spaces; then take an action. As an action, players may choose either to take all goods of one type from an offer space or to use one of the available buildings. Building actions allow players to upgrade goods, sell them or use them to build their own buildings and ships. Buildings are both an investment opportunity and a revenue stream, as players must pay an entry fee to use buildings that they do not own. Ships, on the other hand, are primarily used to provide the food that is needed to feed the workers.
+    description: 'In Le Havre, a player''s turn consists of two parts: First, distribute newly supplied goods onto the offer
+      spaces; then take an action. As an action, players may choose either to take all goods of one type from an offer space
+      or to use one of the available buildings. Building actions allow players to upgrade goods, sell them or use them to
+      build their own buildings and ships. Buildings are both an investment opportunity and a revenue stream, as players must
+      pay an entry fee to use buildings that they do not own. Ships, on the other hand, are primarily used to provide the
+      food that is needed to feed the workers.
 
 
-      After every seven turns, the round ends: players' cattle and grain may multiply through a Harvest, and players must feed their workers. After a fixed number of rounds, each player may carry out one final action, and then the game ends. Players add the value of their buildings and ships to their cash reserves. The player who has amassed the largest fortune is the winner.
+      After every seven turns, the round ends: players'' cattle and grain may multiply through a Harvest, and players must
+      feed their workers. After a fixed number of rounds, each player may carry out one final action, and then the game ends.
+      Players add the value of their buildings and ships to their cash reserves. The player who has amassed the largest fortune
+      is the winner.
 
+
+      '
     yearPublished: 2008
     minPlayers: 1
     maxPlayers: 5
@@ -9593,29 +10754,22 @@ catalog:
     - uplay.it edizioni
     - Ystari Games
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/le-havre_rulebook.pdf
+    pdfSha256: 060b2f6f9a32af213b6d39ed6698d1fe94d339abfb8d3b1954a952228e0f3be3
+    pdfVersion: '1.0'
   - title: The Gallerist
     bggId: 125153
     language: en
-    pdf: the-gallerist_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      This age of art and capitalism has created a need for a new occupation - The Gallerist.
-
-
-      Combining the elements of an Art dealer, museum curator, and Artists&rsquo; manager, you are about to take on that job! You will promote and nurture Artists; buy, display, and sell their Art; and build and exert your international reputation. As a result, you will achieve the respect needed to draw visitors to your Gallery from all over the world.
-
-
-      There's a lot of work to be done, but don't worry, you can hire assistants to help you achieve your goals. Build your fortune by running the most lucrative Gallery and secure your reputation as a world-class Gallerist!
-
-
-      Maximize your money and thus win the game by: 
-
-           having visitors in your gallery; 
-           exhibiting and selling works of art;
-           investing in artists&rsquo; promotion to increase art value;
-           achieving trends and reputation as well as curator and dealer goals.
-
-
+    description: "This age of art and capitalism has created a need for a new occupation - The Gallerist.\n\nCombining the\
+      \ elements of an Art dealer, museum curator, and Artists&rsquo; manager, you are about to take on that job! You will\
+      \ promote and nurture Artists; buy, display, and sell their Art; and build and exert your international reputation.\
+      \ As a result, you will achieve the respect needed to draw visitors to your Gallery from all over the world.\n\nThere's\
+      \ a lot of work to be done, but don't worry, you can hire assistants to help you achieve your goals. Build your fortune\
+      \ by running the most lucrative Gallery and secure your reputation as a world-class Gallerist!\n\nMaximize your money\
+      \ and thus win the game by: \n\n     having visitors in your gallery; \n     exhibiting and selling works of art;\n\
+      \     investing in artists&rsquo; promotion to increase art value;\n     achieving trends and reputation as well as\
+      \ curator and dealer goals.\n\n\n"
     yearPublished: 2015
     minPlayers: 1
     maxPlayers: 4
@@ -9654,29 +10808,49 @@ catalog:
     - Maldito Games
     - sternenschimmermeer
     - YOKA Games
+    pdfBlobKey: rulebooks/v1/the-gallerist_rulebook.pdf
+    pdfSha256: 4c1cc0f09c85177e05e890208a2377ab229a8563976b88e7c5d6f38d7e690dea
+    pdfVersion: '1.0'
   - title: 'Android: Netrunner'
     bggId: 124742
     language: en
-    pdf: android-netrunner_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Welcome to New Angeles, home of the Beanstalk. From our branch offices in this monument of human achievement, NBN proudly broadcasts all your favorite media programming. We offer fully comprehensive streaming in music and threedee, news and sitcoms, classic movies and sensies. We cover it all. Ours is a brave new age, and as humanity hurtles into space and the future with an astonishing series of new advances every day, NBN and our affiliates are keeping pace, bringing you all the vid that's fit to view.
+    description: 'Welcome to New Angeles, home of the Beanstalk. From our branch offices in this monument of human achievement,
+      NBN proudly broadcasts all your favorite media programming. We offer fully comprehensive streaming in music and threedee,
+      news and sitcoms, classic movies and sensies. We cover it all. Ours is a brave new age, and as humanity hurtles into
+      space and the future with an astonishing series of new advances every day, NBN and our affiliates are keeping pace,
+      bringing you all the vid that''s fit to view.
 
 
-      Android: Netrunner is an asymmetrical Living Card Game for two players. Set in the cyberpunk future of Android and Infiltration, the game pits a megacorporation and its massive resources against the subversive talents of lone runners.
+      Android: Netrunner is an asymmetrical Living Card Game for two players. Set in the cyberpunk future of Android and Infiltration,
+      the game pits a megacorporation and its massive resources against the subversive talents of lone runners.
 
 
-      Corporations seek to score agendas by advancing them. Doing so takes time and credits. To buy the time and earn the credits they need, they must secure their servers and data forts with "ice". These security programs come in different varieties, from simple barriers, to code gates and aggressive sentries. They serve as the corporation's virtual eyes, ears, and machine guns on the sprawling information superhighways of the network.
+      Corporations seek to score agendas by advancing them. Doing so takes time and credits. To buy the time and earn the
+      credits they need, they must secure their servers and data forts with "ice". These security programs come in different
+      varieties, from simple barriers, to code gates and aggressive sentries. They serve as the corporation''s virtual eyes,
+      ears, and machine guns on the sprawling information superhighways of the network.
 
 
-      In turn, runners need to spend their time and credits acquiring a sufficient wealth of resources, purchasing the necessary hardware, and developing suitably powerful ice-breaker programs to hack past corporate security measures. Their jobs are always a little desperate, driven by tight timelines, and shrouded in mystery. When a runner jacks-in and starts a run at a corporate server, he risks having his best programs trashed or being caught by a trace program and left vulnerable to corporate countermeasures. It's not uncommon for an unprepared runner to fail to bypass a nasty sentry and suffer massive brain damage as a result. Even if a runner gets through a data fort's defenses, there's no telling what it holds. Sometimes, the runner finds something of value. Sometimes, the best he can do is work to trash whatever the corporation was developing.
+      In turn, runners need to spend their time and credits acquiring a sufficient wealth of resources, purchasing the necessary
+      hardware, and developing suitably powerful ice-breaker programs to hack past corporate security measures. Their jobs
+      are always a little desperate, driven by tight timelines, and shrouded in mystery. When a runner jacks-in and starts
+      a run at a corporate server, he risks having his best programs trashed or being caught by a trace program and left vulnerable
+      to corporate countermeasures. It''s not uncommon for an unprepared runner to fail to bypass a nasty sentry and suffer
+      massive brain damage as a result. Even if a runner gets through a data fort''s defenses, there''s no telling what it
+      holds. Sometimes, the runner finds something of value. Sometimes, the best he can do is work to trash whatever the corporation
+      was developing.
 
 
       The first player to seven points wins the game, but not likely before he suffers some brain damage or bad publicity.
 
 
-      The Revised Core Set for Android: Netrunner released in late 2017 includes cards from the original Core Set released in 2012 as well as cards from the Genesis Cycle and Spin Cycle series of Data Packs. While the cards in this set have been released previously, the art on some of them is new.
+      The Revised Core Set for Android: Netrunner released in late 2017 includes cards from the original Core Set released
+      in 2012 as well as cards from the Genesis Cycle and Spin Cycle series of Data Packs. While the cards in this set have
+      been released previously, the art on some of them is new.
 
+
+      '
     yearPublished: 2012
     minPlayers: 2
     maxPlayers: 2
@@ -9713,29 +10887,49 @@ catalog:
     - Giochi Uniti
     - Heidelberger Spieleverlag
     - Korea Boardgames
+    pdfBlobKey: rulebooks/v1/android-netrunner_rulebook.pdf
+    pdfSha256: e07e9076e7e7da7c90f079ae5e7f5e695d49f93b457d9a069a69077d7f8393f1
+    pdfVersion: '1.0'
   - title: 'Star Wars: Imperial Assault'
     bggId: 164153
     language: en
-    pdf: star-wars-imperial-assault_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Star Wars: Imperial Assault is a strategy board game of tactical combat and missions for two to five players, offering two distinct games of battle and adventure in the Star Wars universe!
+    description: 'Star Wars: Imperial Assault is a strategy board game of tactical combat and missions for two to five players,
+      offering two distinct games of battle and adventure in the Star Wars universe!
 
 
-      Imperial Assault puts you in the midst of the Galactic Civil War between the Rebel Alliance and the Galactic Empire after the destruction of the Death Star over Yavin 4. In this game, you and your friends can participate in two separate games. The campaign game pits the limitless troops and resources of the Galactic Empire against a crack team of elite Rebel operatives as they strive to break the Empire&rsquo;s hold on the galaxy, while the skirmish game invites you and a friend to muster strike teams and battle head-to-head over conflicting objectives.
+      Imperial Assault puts you in the midst of the Galactic Civil War between the Rebel Alliance and the Galactic Empire
+      after the destruction of the Death Star over Yavin 4. In this game, you and your friends can participate in two separate
+      games. The campaign game pits the limitless troops and resources of the Galactic Empire against a crack team of elite
+      Rebel operatives as they strive to break the Empire&rsquo;s hold on the galaxy, while the skirmish game invites you
+      and a friend to muster strike teams and battle head-to-head over conflicting objectives.
 
 
-      In the campaign game, Imperial Assault invites you to play through a cinematic tale set in the Star Wars universe. One player commands the seemingly limitless armies of the Galactic Empire, threatening to extinguish the flame of the Rebellion forever. Up to four other players become heroes of the Rebel Alliance, engaging in covert operations to undermine the Empire&rsquo;s schemes. Over the course of the campaign, both the Imperial player and the Rebel heroes gain new experience and skills, allowing characters to evolve as the story unfolds.
+      In the campaign game, Imperial Assault invites you to play through a cinematic tale set in the Star Wars universe. One
+      player commands the seemingly limitless armies of the Galactic Empire, threatening to extinguish the flame of the Rebellion
+      forever. Up to four other players become heroes of the Rebel Alliance, engaging in covert operations to undermine the
+      Empire&rsquo;s schemes. Over the course of the campaign, both the Imperial player and the Rebel heroes gain new experience
+      and skills, allowing characters to evolve as the story unfolds.
 
 
-      Imperial Assault offers a different game experience in the skirmish game. In skirmish missions, you and a friend compete in head-to-head, tactical combat. You&rsquo;ll gather your own strike force of Imperials, Rebels, and Mercenaries and build a deck of command cards to gain an unexpected advantage in the heat of battle. Whether you recover lost holocrons or battle to defeat a raiding party, you&rsquo;ll find danger and tactical choices in every skirmish.
+      Imperial Assault offers a different game experience in the skirmish game. In skirmish missions, you and a friend compete
+      in head-to-head, tactical combat. You&rsquo;ll gather your own strike force of Imperials, Rebels, and Mercenaries and
+      build a deck of command cards to gain an unexpected advantage in the heat of battle. Whether you recover lost holocrons
+      or battle to defeat a raiding party, you&rsquo;ll find danger and tactical choices in every skirmish.
 
 
-      As an additional benefit, the Luke Skywalker Ally Pack and the Darth Vader Villain Pack are included within the Imperial Assault Core Set. These figure packs offer sculpted plastic figures alongside additional campaign and skirmish missions that highlight both Luke Skywalker and Darth Vader within Imperial Assault.
+      As an additional benefit, the Luke Skywalker Ally Pack and the Darth Vader Villain Pack are included within the Imperial
+      Assault Core Set. These figure packs offer sculpted plastic figures alongside additional campaign and skirmish missions
+      that highlight both Luke Skywalker and Darth Vader within Imperial Assault.
 
 
-      With these Imperial Assault and other Figure Packs, you'll find even more missions that allow your heroes to fight alongside iconic characters from the Star Wars saga. Boxed expansions add more heroes, imperial and mercenary groups, and totally new campaigns (see IA Community Wiki for a list), and the free Star Wars: Imperial Assault – Legends of the Alliance app provides you with additional content to play in solo or co-op mode.
+      With these Imperial Assault and other Figure Packs, you''ll find even more missions that allow your heroes to fight
+      alongside iconic characters from the Star Wars saga. Boxed expansions add more heroes, imperial and mercenary groups,
+      and totally new campaigns (see IA Community Wiki for a list), and the free Star Wars: Imperial Assault – Legends of
+      the Alliance app provides you with additional content to play in solo or co-op mode.
 
+
+      '
     yearPublished: 2014
     minPlayers: 2
     maxPlayers: 5
@@ -9778,26 +10972,37 @@ catalog:
     - Galakta
     - Heidelberger Spieleverlag
     - Hobby World
+    pdfBlobKey: rulebooks/v1/star-wars-imperial-assault_rulebook.pdf
+    pdfSha256: 31e496fdc97b9df7a8f38ccbd36561dc16265c142ff1cc3597fe6217f4707cc9
+    pdfVersion: '1.0'
   - title: 'Great Western Trail: Argentina'
     bggId: 380607
     language: en
-    pdf: great-western-trail-argentina_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Kia ora, and welcome to Great Western Trail New Zealand!
+    description: 'Kia ora, and welcome to Great Western Trail New Zealand!
 
 
-      Towards the end of the 19th century, you established yourself as a runholder (owner of a sheep station) on the South Island of New Zealand. Recent years have seen your family farm prosper by diversifying your breeds of sheep and increasing the value of your wool.
+      Towards the end of the 19th century, you established yourself as a runholder (owner of a sheep station) on the South
+      Island of New Zealand. Recent years have seen your family farm prosper by diversifying your breeds of sheep and increasing
+      the value of your wool.
 
 
-      With the dawn of the new century, difficult challenges have arisen. You must acquire improved and valuable breeds of sheep to ensure the prosperity of your family business and the labourers who work for you. Decide whether to focus on your past strengths or to diversify into new ventures. Will the beginning of the 20th century be as rewarding as earlier years, or will the efforts of others surpass your strategy? Good luck, and kia kaha!
+      With the dawn of the new century, difficult challenges have arisen. You must acquire improved and valuable breeds of
+      sheep to ensure the prosperity of your family business and the labourers who work for you. Decide whether to focus on
+      your past strengths or to diversify into new ventures. Will the beginning of the 20th century be as rewarding as earlier
+      years, or will the efforts of others surpass your strategy? Good luck, and kia kaha!
 
 
-      In Great Western Trail New Zealand, you move your runholder along a trail that winds and forks from the lower left corner of the game board to Wellington in the upper right. Along your path, you perform actions that provide you with various ways to earn victory points.
+      In Great Western Trail New Zealand, you move your runholder along a trail that winds and forks from the lower left corner
+      of the game board to Wellington in the upper right. Along your path, you perform actions that provide you with various
+      ways to earn victory points.
 
 
-      Each time your runholder reaches Wellington, you deliver sheep to a local or foreign trading post, which may also be worth victory points. Afterwards, your runholder continues its movement again.
+      Each time your runholder reaches Wellington, you deliver sheep to a local or foreign trading post, which may also be
+      worth victory points. Afterwards, your runholder continues its movement again.
 
+
+      '
     yearPublished: 2023
     minPlayers: 1
     maxPlayers: 4
@@ -9831,19 +11036,21 @@ catalog:
     - Rebel Sp. z o.o.
     - Yayoi The Dreamer
     - Zvezda
+    pdfBlobKey: rulebooks/v1/great-western-trail-argentina_rulebook.pdf
+    pdfSha256: 88be4a0b83dda037566941e46d1e936ec6280c37e9860c0405a58a9bd412c2fa
+    pdfVersion: '1.0'
   - title: Agricola (Revised Edition)
     bggId: 200680
     language: en
-    pdf: agricola-revised_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Updated and streamlined for a new generation of players, Agricola, the award-winning and highly acclaimed game by Uwe Rosenberg, features a revised rulebook and gameplay, wood pieces and components, and a card selection from the base game as well as its expansions, revised and updated for this edition.
-
-
-      The 17th century was not an easy time to be a farmer. 
-
-      Players begin the game with two family members and can grow their families over the course of the game. This allows them more actions but remember you have to grow more food to feed your family as it grows! Feeding your family is a special kind of challenge and players will plant grain and vegetables while supplementing their food supply with sheep, wild boar and cattle. Guide your family to wealth, health and prosperity and you will win the game.
-
+    description: "Updated and streamlined for a new generation of players, Agricola, the award-winning and highly acclaimed\
+      \ game by Uwe Rosenberg, features a revised rulebook and gameplay, wood pieces and components, and a card selection\
+      \ from the base game as well as its expansions, revised and updated for this edition.\n\nThe 17th century was not an\
+      \ easy time to be a farmer. \nPlayers begin the game with two family members and can grow their families over the course\
+      \ of the game. This allows them more actions but remember you have to grow more food to feed your family as it grows!\
+      \ Feeding your family is a special kind of challenge and players will plant grain and vegetables while supplementing\
+      \ their food supply with sheep, wild boar and cattle. Guide your family to wealth, health and prosperity and you will\
+      \ win the game.\n\n"
     yearPublished: 2016
     minPlayers: 1
     maxPlayers: 4
@@ -9892,24 +11099,33 @@ catalog:
     - Rebel Sp. z o.o.
     - Swan Panasia Co., Ltd.
     - uplay.it edizioni
+    pdfBlobKey: rulebooks/v1/agricola-revised_rulebook.pdf
+    pdfSha256: 1aa612ed43bdde109a0bfff900cf9322bae02e5b53f4ee3fe9f37d264ca8bc70
+    pdfVersion: '1.0'
   - title: Maracaibo
     bggId: 276025
     language: en
-    pdf: maracaibo_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Maracaibo, a strategy game for 1-4 players by Alexander Pfister, is set in the Caribbean during the 17th century. The players try to increase their influence in three nations in four rounds with a play time of 40 minutes per player.
+    description: 'Maracaibo, a strategy game for 1-4 players by Alexander Pfister, is set in the Caribbean during the 17th
+      century. The players try to increase their influence in three nations in four rounds with a play time of 40 minutes
+      per player.
 
 
-      The players sail on a round course through the Caribbean, e.g., you have city tiles where you are able to perform various&nbsp;actions or deliver goods to. One special feature is an implemented quest mode over more and various tiles, which tells the player, who chase after it, a little story.
+      The players sail on a round course through the Caribbean, e.g., you have city tiles where you are able to perform various&nbsp;actions
+      or deliver goods to. One special feature is an implemented quest mode over more and various tiles, which tells the player,
+      who chase after it, a little story.
 
 
-      As a player, you move with your ship around the course, managing it by using cards like in other games from Alexander Pfister.
+      As a player, you move with your ship around the course, managing it by using cards like in other games from Alexander
+      Pfister.
 
 
 
-      NOTE: The Spanish and Portuguese editions of Maracaibo contain La Armada mini-expansion packaged inside the base game's box.
+      NOTE: The Spanish and Portuguese editions of Maracaibo contain La Armada mini-expansion packaged inside the base game''s
+      box.
 
+
+      '
     yearPublished: 2019
     minPlayers: 1
     maxPlayers: 4
@@ -9959,17 +11175,24 @@ catalog:
     - テンデイズゲームズ (TendaysGames)
     - uplay.it edizioni
     - YOKA Games
+    pdfBlobKey: rulebooks/v1/maracaibo_rulebook.pdf
+    pdfSha256: a2b92b6924b916c0a5119427350ce62aca25121253784b1089137073feac4306
+    pdfVersion: '1.0'
   - title: Mechs vs. Minions
     bggId: 209010
     language: en
-    pdf: mechs-vs-minions_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Mechs vs. Minions is a cooperative tabletop campaign for 2-4 players. Set in the world of Runeterra, players take on the roles of four intrepid Yordles: Corki, Tristana, Heimerdinger, and Ziggs, who must join forces and pilot their newly-crafted mechs against an army of marauding minions. With modular boards, programmatic command lines, and a story-driven campaign, each mission will be unique, putting your teamwork, programming, and piloting skills to the test.
+    description: 'Mechs vs. Minions is a cooperative tabletop campaign for 2-4 players. Set in the world of Runeterra, players
+      take on the roles of four intrepid Yordles: Corki, Tristana, Heimerdinger, and Ziggs, who must join forces and pilot
+      their newly-crafted mechs against an army of marauding minions. With modular boards, programmatic command lines, and
+      a story-driven campaign, each mission will be unique, putting your teamwork, programming, and piloting skills to the
+      test.
 
 
       There are ten missions in total, and each individual mission will take about 60-90 minutes.
 
+
+      '
     yearPublished: 2016
     minPlayers: 2
     maxPlayers: 4
@@ -10004,36 +11227,56 @@ catalog:
     - Nathan Tiras
     publishers:
     - Riot Games
+    pdfBlobKey: rulebooks/v1/mechs-vs-minions_rulebook.pdf
+    pdfSha256: 9a342ef39b2efa6dd51aa94d892947a5d656a139c1c7906f76fdd4380854bd33
+    pdfVersion: '1.0'
   - title: 'Kingdom Death: Monster'
     bggId: 55690
     language: en
     bggEnhanced: true
-    description: >+
-      Kingdom Death: Monster is a fully cooperative tabletop hobby game experience.  Set in a unique nightmarish world devoid of most natural resources, you control a settlement at the dawn of its existence. Fight monsters, craft weapons and gear, and develop your settlement to ensure your survival from generation to generation.
+    description: 'Kingdom Death: Monster is a fully cooperative tabletop hobby game experience.  Set in a unique nightmarish
+      world devoid of most natural resources, you control a settlement at the dawn of its existence. Fight monsters, craft
+      weapons and gear, and develop your settlement to ensure your survival from generation to generation.
 
 
       Campaign System
 
-      Embark alone or with up to 3 friends (5 with game variant) on a 5-30-lantern-year campaign, with each year consisting of a cycle of hunt, showdown, and settlement phases. The settlement phase is an intricate civilization building game in which you spend very limited resources to build buildings, research new technologies, train your warriors, and set up your strategy for survival.  During the hunt, you'll encounter a series of stories in a "choose your own adventure" style journey through various events and encounters.  Finally, when you meet the monster you're pursuing, you'll engage it in an a massive arena-style battle where only one party is going to survive.  If your party lives, you'll be able to bring the spoils back home to use in expanding your settlement.
+      Embark alone or with up to 3 friends (5 with game variant) on a 5-30-lantern-year campaign, with each year consisting
+      of a cycle of hunt, showdown, and settlement phases. The settlement phase is an intricate civilization building game
+      in which you spend very limited resources to build buildings, research new technologies, train your warriors, and set
+      up your strategy for survival.  During the hunt, you''ll encounter a series of stories in a "choose your own adventure"
+      style journey through various events and encounters.  Finally, when you meet the monster you''re pursuing, you''ll engage
+      it in an a massive arena-style battle where only one party is going to survive.  If your party lives, you''ll be able
+      to bring the spoils back home to use in expanding your settlement.
 
 
       Monster AI System
 
-      Each of the 7 monsters included are controlled by their own pair of decks that scale to 3 levels of difficulty (except for the final encounter, which has only 1 level and it's HARD!). Every encounter, even with the same monster, is highly variable and no two showdowns will resolve the same way. Players will have to plan their gear and keep their minds sharp to prevail.
+      Each of the 7 monsters included are controlled by their own pair of decks that scale to 3 levels of difficulty (except
+      for the final encounter, which has only 1 level and it''s HARD!). Every encounter, even with the same monster, is highly
+      variable and no two showdowns will resolve the same way. Players will have to plan their gear and keep their minds sharp
+      to prevail.
 
 
       Gear System
 
-      In Kingdom Death: Monster, survivors will craft gear from resources earned from defeating monsters or found on their hunt. Each survivor has a 3x3 gear grid. Selection and arrangement of your gear cards is critical, as many provided bonuses and activate special rules when aligned correctly.
+      In Kingdom Death: Monster, survivors will craft gear from resources earned from defeating monsters or found on their
+      hunt. Each survivor has a 3x3 gear grid. Selection and arrangement of your gear cards is critical, as many provided
+      bonuses and activate special rules when aligned correctly.
 
 
       Story Event System
 
-      40+ Story Events plus over 100 hunt encounters will shape and guide your campaign. Story Events detail important evolutions in your civilization, introduce new monsters, and provide rich detail for your campaign.  Some will trigger automatically as you progress through the campaign, but most will be entirely based on choices players make.
+      40+ Story Events plus over 100 hunt encounters will shape and guide your campaign. Story Events detail important evolutions
+      in your civilization, introduce new monsters, and provide rich detail for your campaign.  Some will trigger automatically
+      as you progress through the campaign, but most will be entirely based on choices players make.
 
 
-      Story Events cover everything from setting up and fighting a monster to key events that happen within the overall story. Some are triggered directly from the timeline and others from choices you make in game.
+      Story Events cover everything from setting up and fighting a monster to key events that happen within the overall story.
+      Some are triggered directly from the timeline and others from choices you make in game.
 
+
+      '
     yearPublished: 2015
     minPlayers: 1
     maxPlayers: 4
@@ -10076,20 +11319,31 @@ catalog:
   - title: Darwin's Journey
     bggId: 322289
     language: en
-    pdf: darwins-journey_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      When all you can identify in the horizon for many long days is the line that detaches the sea from the sky, the glimpse of a distant shore appearing before you will make you shiver at the understanding that the adventure is about to begin.
+    description: 'When all you can identify in the horizon for many long days is the line that detaches the sea from the sky,
+      the glimpse of a distant shore appearing before you will make you shiver at the understanding that the adventure is
+      about to begin.
 
 
-      You find yourself astonished, landing on the shore that will be the origin of an extensive exploration through the Galapagos, a magic place of inconceivable beauty and endless biodiversity. There, you will gather repertoires and expand your knowledge of the natural sciences. Your eyes will learn how to detect the hidden species in the tropical forest, gazing at the countless colors and textures of nature. After inspiring hours spent studying and getting to enlightening conclusions, you will rest under a sparkling sky, admiring the stunning complexity of the animal realm.
+      You find yourself astonished, landing on the shore that will be the origin of an extensive exploration through the Galapagos,
+      a magic place of inconceivable beauty and endless biodiversity. There, you will gather repertoires and expand your knowledge
+      of the natural sciences. Your eyes will learn how to detect the hidden species in the tropical forest, gazing at the
+      countless colors and textures of nature. After inspiring hours spent studying and getting to enlightening conclusions,
+      you will rest under a sparkling sky, admiring the stunning complexity of the animal realm.
 
 
-      Darwin's Journey is a worker-placement Eurogame in which players recall Charles Darwin's memories of his adventure through the Galapagos islands, which contributed to the development of his theory of evolution.
+      Darwin''s Journey is a worker-placement Eurogame in which players recall Charles Darwin''s memories of his adventure
+      through the Galapagos islands, which contributed to the development of his theory of evolution.
 
 
-      With the game's innovative worker progression system, each worker will have to study the disciplines that are a prerequisite to perform several actions in the game, such as exploration, correspondence, gathering, and dispatch of repertoires found on the island to museums in order to contribute to the human knowledge of biology. The game lasts five rounds, and thanks to several short- and long-term objectives, every action you take will grant victory points in different ways.
+      With the game''s innovative worker progression system, each worker will have to study the disciplines that are a prerequisite
+      to perform several actions in the game, such as exploration, correspondence, gathering, and dispatch of repertoires
+      found on the island to museums in order to contribute to the human knowledge of biology. The game lasts five rounds,
+      and thanks to several short- and long-term objectives, every action you take will grant victory points in different
+      ways.
 
+
+      '
     yearPublished: 2023
     minPlayers: 1
     maxPlayers: 4
@@ -10134,33 +11388,27 @@ catalog:
     - TCG Factory
     - 株式会社ケンビル (KenBill)
     - 黑城堡桌游 Black Castle Games
+    pdfBlobKey: rulebooks/v1/darwins-journey_rulebook.pdf
+    pdfSha256: c37ef3550858530943766ef49878ec91fe105a4f0f9171ef4c804e942be49bf8
+    pdfVersion: '1.0'
   - title: Revive
     bggId: 332772
     language: en
-    pdf: revive_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Revive civilization, 5000 years after everything was destroyed. Lead your tribe and explore the frozen earth. Harness its resources. Recruit surface survivors to your cause. Build factories with powerful machines. And populate ancient sites to relearn your tribe's forgotten technologies.
-
-      --
-
-      Revive is a game for 1-4 players with asymmetric player powers, highly variable setup, and no fighting or direct conflict. Playing through the 5-part campaign unlocks additional contents, and once all contents have been unlocked, the game can be replayed indefinitely.
-
-
-      At the beginning of the game, each player gets a set of citizen cards, a tribe board, as well as a huge dual-layer player board. The tribe board shows your unique tribe ability and the ancient technologies that you may relearn during the game. The dual-layer player board is where you place your custom machines and upgrade your card slots.
-
-
-      A main goal of the game is to reach and populate the large ancient sites. These ancient locations are randomized, and as they are important sources of victory points, they will shape your strategy differently each game. The game ends when all artifacts have been taken, and the player with the most points wins.
-
-
-      On your turn you take two actions: 
-
-           Play a card (its effect is determined by which card slot you use)
-           Explore (reveal an area tile and recruit a new citizen card)
-           Populate (populate an ancient location to learn a new technology)
-           Build factory (the adjacent terrains determine which machine tracks you advance)
-
-
+    description: "Revive civilization, 5000 years after everything was destroyed. Lead your tribe and explore the frozen earth.\
+      \ Harness its resources. Recruit surface survivors to your cause. Build factories with powerful machines. And populate\
+      \ ancient sites to relearn your tribe's forgotten technologies.\n--\nRevive is a game for 1-4 players with asymmetric\
+      \ player powers, highly variable setup, and no fighting or direct conflict. Playing through the 5-part campaign unlocks\
+      \ additional contents, and once all contents have been unlocked, the game can be replayed indefinitely.\n\nAt the beginning\
+      \ of the game, each player gets a set of citizen cards, a tribe board, as well as a huge dual-layer player board. The\
+      \ tribe board shows your unique tribe ability and the ancient technologies that you may relearn during the game. The\
+      \ dual-layer player board is where you place your custom machines and upgrade your card slots.\n\nA main goal of the\
+      \ game is to reach and populate the large ancient sites. These ancient locations are randomized, and as they are important\
+      \ sources of victory points, they will shape your strategy differently each game. The game ends when all artifacts have\
+      \ been taken, and the player with the most points wins.\n\nOn your turn you take two actions: \n\n     Play a card (its\
+      \ effect is determined by which card slot you use)\n     Explore (reveal an area tile and recruit a new citizen card)\n\
+      \     Populate (populate an ancient location to learn a new technology)\n     Build factory (the adjacent terrains determine\
+      \ which machine tracks you advance)\n\n\n"
     yearPublished: 2022
     minPlayers: 1
     maxPlayers: 4
@@ -10207,30 +11455,42 @@ catalog:
     - Pegasus Spiele
     - Rebel Sp. z o.o.
     - Surfin' Meeple China
+    pdfBlobKey: rulebooks/v1/revive_rulebook.pdf
+    pdfSha256: ab5631c96bc4cf81e79358d77060cbdc85a8ff4c657caf13f4b05e8cbcf72e80
+    pdfVersion: '1.0'
   - title: Race for the Galaxy
     bggId: 28143
     language: en
-    pdf: race-for-the-galaxy_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Race for the Galaxy, players build galactic civilizations by playing cards representing worlds or technical and social developments.
+    description: 'In Race for the Galaxy, players build galactic civilizations by playing cards representing worlds or technical
+      and social developments.
 
 
-      Each round, players secretly and simultaneously select an action card corresponding to one phase of a round. These phases let players draw cards, play cards, add goods to worlds, or consume goods for VP chips. Only the phases chosen will occur that round. Every player may act in a phase that occurs, but the players who chose that phase get a bonus.
+      Each round, players secretly and simultaneously select an action card corresponding to one phase of a round. These phases
+      let players draw cards, play cards, add goods to worlds, or consume goods for VP chips. Only the phases chosen will
+      occur that round. Every player may act in a phase that occurs, but the players who chose that phase get a bonus.
 
 
-      Game end is triggered either when a player has built a civilization of 12 cards or when the pool of VP chips is exhausted. Each player then totals the victory points in their tableau plus any VP chips earned during play.
+      Game end is triggered either when a player has built a civilization of 12 cards or when the pool of VP chips is exhausted.
+      Each player then totals the victory points in their tableau plus any VP chips earned during play.
 
 
       Detailed Overview
 
-      Race for the Galaxy tells a story of galactic discovery and expansion through a single deck of cards. Every card in the deck represents either a world that you might settle or a development that you might implement. Cards placed into your tableau represent your current achievements -- worlds you have colonized, technology you now wield -- while cards in your hand represent the options currently available to you.
+      Race for the Galaxy tells a story of galactic discovery and expansion through a single deck of cards. Every card in
+      the deck represents either a world that you might settle or a development that you might implement. Cards placed into
+      your tableau represent your current achievements -- worlds you have colonized, technology you now wield -- while cards
+      in your hand represent the options currently available to you.
 
 
-      To play a card, discard the number of cards equal to its cost, representing other opportunities you must forgo to concentrate on your current course. Once in your tableau, a card provides special powers during the game and, at the end, its listed number of victory points. Many worlds, once placed, also produce goods that can be traded for more cards or consumed for VP chips.
+      To play a card, discard the number of cards equal to its cost, representing other opportunities you must forgo to concentrate
+      on your current course. Once in your tableau, a card provides special powers during the game and, at the end, its listed
+      number of victory points. Many worlds, once placed, also produce goods that can be traded for more cards or consumed
+      for VP chips.
 
 
-      Race for the Galaxy is played in rounds. In each round, you and your opponents secretly select an action phase for the upcoming turn. You can choose to:
+      Race for the Galaxy is played in rounds. In each round, you and your opponents secretly select an action phase for the
+      upcoming turn. You can choose to:
 
       &bull; Place a world in your tableau with settle or a development with develop.
 
@@ -10241,19 +11501,25 @@ catalog:
       &bull; Add cards to your hand with explore or by trading a good.
 
 
-      Each round, only those phases that are selected will occur -- but they'll occur for everyone. Selecting a phase both ensures that it occurs that round and gains the selecting player a bonus.
+      Each round, only those phases that are selected will occur -- but they''ll occur for everyone. Selecting a phase both
+      ensures that it occurs that round and gains the selecting player a bonus.
 
 
-      Round follows round until someone builds their tableau to twelve cards, or until the last VP chip is claimed. The victor is the player with the most VPs.
+      Round follows round until someone builds their tableau to twelve cards, or until the last VP chip is claimed. The victor
+      is the player with the most VPs.
 
 
       2018 UPDATE
 
-      The second edition of the game is improved for CVD (color blindness) and includes 5 revised cards from the original version and 6 New Worlds promo homeworlds. The promo homeworlds and first edition compatible Revised Cards are both available for purchase through the BGG store.
+      The second edition of the game is improved for CVD (color blindness) and includes 5 revised cards from the original
+      version and 6 New Worlds promo homeworlds. The promo homeworlds and first edition compatible Revised Cards are both
+      available for purchase through the BGG store.
 
 
       UPC 655132003018
 
+
+      '
     yearPublished: 2007
     minPlayers: 2
     maxPlayers: 4
@@ -10304,26 +11570,36 @@ catalog:
     - Wargames Club Publishing
     - YOKA Games
     - Ystari Games
+    pdfBlobKey: rulebooks/v1/race-for-the-galaxy_rulebook.pdf
+    pdfSha256: a43d7ee00276e963ea7afd327711cd52cee609712a8128e0f4a164290c2754d4
+    pdfVersion: '1.0'
   - title: Voidfall
     bggId: 338111
     language: en
-    pdf: voidfall_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      A trick-taking card game with cards featuring photos of contemporary United States Navy aircraft, surface ships, and submarines.
+    description: 'A trick-taking card game with cards featuring photos of contemporary United States Navy aircraft, surface
+      ships, and submarines.
 
 
-      The cards are marked with letters from A to Z and some of the cards are numbered as well (i.e. A1, A2, A3, A4). At the start of the game, each player is dealt seven cards. The goal is to capture the most Navy equipment by winning tricks. The highest card played wins the trick, with A being the highest and Z being the lowest. In addition, among the numbered cards with the same letter, the highest number wins (so B4 beats B2).
+      The cards are marked with letters from A to Z and some of the cards are numbered as well (i.e. A1, A2, A3, A4). At the
+      start of the game, each player is dealt seven cards. The goal is to capture the most Navy equipment by winning tricks.
+      The highest card played wins the trick, with A being the highest and Z being the lowest. In addition, among the numbered
+      cards with the same letter, the highest number wins (so B4 beats B2).
 
 
-      At the end of the game a player receives 10 points for each card having a number and 5 points for each card that only has a letter. A player can score a bonus 100 points during the game if the cards in the player's hand spell out N-A-V-Y, J-E-T, or S-H-I-P. The first player to reach 1000 points wins the game.
+      At the end of the game a player receives 10 points for each card having a number and 5 points for each card that only
+      has a letter. A player can score a bonus 100 points during the game if the cards in the player''s hand spell out N-A-V-Y,
+      J-E-T, or S-H-I-P. The first player to reach 1000 points wins the game.
 
 
-      The contents include the rules folder, 54 cards, a score pad, and a small cardboard box-insert tray. The rules folder provides a description of each photo used on the cards.
+      The contents include the rules folder, 54 cards, a score pad, and a small cardboard box-insert tray. The rules folder
+      provides a description of each photo used on the cards.
 
 
       &mdash;user summary
 
+
+      '
     yearPublished: 1957
     minPlayers: 2
     maxPlayers: 6
@@ -10348,21 +11624,19 @@ catalog:
     - (Uncredited)
     publishers:
     - Exclusive Playing Card Company
+    pdfBlobKey: rulebooks/v1/voidfall_rulebook.pdf
+    pdfSha256: 29847a547dcec0deac860cfb658cd3ea694dcaab319258fcf286c27161243157
+    pdfVersion: '1.0'
   - title: 'Wingspan: Asia'
     bggId: 366161
     language: en
-    pdf: wingspan-asia_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Wingspan: Asia introduces the diverse and vibrant birds of the Asian continent. As always, the objective is to earn the most points by playing birds, achieving objectives, and laying eggs across your habitats. This release serves multiple roles within the Wingspan universe!
-
-
-      Wingspan: Asia is several different things:
-        - a stand-alone game for 1 or 2 players 
-        - a new Duet mode for 2 players that can be combined with the base game or other expansions
-        - For 1-5 players, new bird and bonus cards to add to the original Wingspan and its other expansions
-        - For 6-7 players, a new Flock mode (which also requires the components of the base game).
-
+    description: "Wingspan: Asia introduces the diverse and vibrant birds of the Asian continent. As always, the objective\
+      \ is to earn the most points by playing birds, achieving objectives, and laying eggs across your habitats. This release\
+      \ serves multiple roles within the Wingspan universe!\n\nWingspan: Asia is several different things:\n  - a stand-alone\
+      \ game for 1 or 2 players \n  - a new Duet mode for 2 players that can be combined with the base game or other expansions\n\
+      \  - For 1-5 players, new bird and bonus cards to add to the original Wingspan and its other expansions\n  - For 6-7\
+      \ players, a new Flock mode (which also requires the components of the base game).\n\n"
     yearPublished: 2022
     minPlayers: 1
     maxPlayers: 2
@@ -10409,20 +11683,33 @@ catalog:
     - Regatul Jocurilor
     - Siam Board Games
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/wingspan-asia_rulebook.pdf
+    pdfSha256: a3bef7f481236d2a6bd57a184b07b3001c6fa171602935c42885a1c0f2cf8f26
+    pdfVersion: '1.0'
   - title: Five Tribes
     bggId: 157354
     language: en
-    pdf: five-tribes_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Crossing into the Land of 1001 Nights, your caravan arrives at the fabled Sultanate of Naqala. The old sultan just died and control of Naqala is up for grabs! The oracles foretold of strangers who would maneuver the Five Tribes to gain influence over the legendary city-state. Will you fulfill the prophecy? Invoke the old Djinns and move the Tribes into position at the right time, and the Sultanate may become yours!
+    description: 'Crossing into the Land of 1001 Nights, your caravan arrives at the fabled Sultanate of Naqala. The old sultan
+      just died and control of Naqala is up for grabs! The oracles foretold of strangers who would maneuver the Five Tribes
+      to gain influence over the legendary city-state. Will you fulfill the prophecy? Invoke the old Djinns and move the Tribes
+      into position at the right time, and the Sultanate may become yours!
 
 
-      Designed by Bruno Cathala, Five Tribes builds on a long tradition of German-style games that feature wooden meeples. Here, in a unique twist on the now-standard "worker placement" genre, the game begins with the meeples already in place &ndash; and players must cleverly maneuver them over the villages, markets, oases, and sacred places tiles that make up Naqala. How, when, and where you dis-place these Five Tribes of Assassins, Elders, Builders, Merchants, and Viziers determine your victory or failure.
+      Designed by Bruno Cathala, Five Tribes builds on a long tradition of German-style games that feature wooden meeples.
+      Here, in a unique twist on the now-standard "worker placement" genre, the game begins with the meeples already in place
+      &ndash; and players must cleverly maneuver them over the villages, markets, oases, and sacred places tiles that make
+      up Naqala. How, when, and where you dis-place these Five Tribes of Assassins, Elders, Builders, Merchants, and Viziers
+      determine your victory or failure.
 
 
-      As befitting a Days of Wonder game, the rules are straightforward and easy to learn. But devising a winning strategy will take a more calculated approach than our standard fare. You need to carefully consider what moves can score you well and put your opponents at a disadvantage. You need to weigh many different pathways to victory, including the summoning of powerful Djinns that may help your cause as you attempt to control this legendary Sultanate.
+      As befitting a Days of Wonder game, the rules are straightforward and easy to learn. But devising a winning strategy
+      will take a more calculated approach than our standard fare. You need to carefully consider what moves can score you
+      well and put your opponents at a disadvantage. You need to weigh many different pathways to victory, including the summoning
+      of powerful Djinns that may help your cause as you attempt to control this legendary Sultanate.
 
+
+      '
     yearPublished: 2014
     minPlayers: 2
     maxPlayers: 4
@@ -10465,26 +11752,38 @@ catalog:
     - Lord of Boards
     - Maldito Games
     - Rebel Sp. z o.o.
+    pdfBlobKey: rulebooks/v1/five-tribes_rulebook.pdf
+    pdfSha256: 0175a44d57b48636164db12a54458641cd0c9064205b9cb70de184af769512d8
+    pdfVersion: '1.0'
   - title: Final Girl
     bggId: 277659
     language: en
-    pdf: final-girl_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Playing on a famous horror movie trope, Final Girl is a solitaire-only game that puts the player in the shoes of a female protagonist who must kill the slasher if she wants to survive.
+    description: 'Playing on a famous horror movie trope, Final Girl is a solitaire-only game that puts the player in the
+      shoes of a female protagonist who must kill the slasher if she wants to survive.
 
 
-      The Core Box, when combined with one of our Feature Film Boxes, has everything you need to play the game. Each Feature Film Box features a unique Killer and and iconic Location, and the more Feature Films you have, the more killer/location combinations you can experience!
+      The Core Box, when combined with one of our Feature Film Boxes, has everything you need to play the game. Each Feature
+      Film Box features a unique Killer and and iconic Location, and the more Feature Films you have, the more killer/location
+      combinations you can experience!
 
 
-      In game terms, Final Girl shares similarities with Hostage Negotiator, but with some key differences that change it up, including a game board to track locations and character movement. You can choose from multiple characters when picking someone to play and multiple killers when picking someone to play against. Killers and locations each have their own specific terror cards that will be shuffled together to create a unique experience with various combinations of scenarios for you to play!
+      In game terms, Final Girl shares similarities with Hostage Negotiator, but with some key differences that change it
+      up, including a game board to track locations and character movement. You can choose from multiple characters when picking
+      someone to play and multiple killers when picking someone to play against. Killers and locations each have their own
+      specific terror cards that will be shuffled together to create a unique experience with various combinations of scenarios
+      for you to play!
 
 
-      NOTE: The 2022 Kickstarter for Final Girl: Season 2 included a 13 card Final Girl: First Printing Correction Pack of corrected cards for the first printing of Final Girl: Series 1. The cards mostly fix typos and are not required to play the game. The cards were corrected for the second printing of Final Girl: Series 1.
+      NOTE: The 2022 Kickstarter for Final Girl: Season 2 included a 13 card Final Girl: First Printing Correction Pack of
+      corrected cards for the first printing of Final Girl: Series 1. The cards mostly fix typos and are not required to play
+      the game. The cards were corrected for the second printing of Final Girl: Series 1.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2021
     minPlayers: 1
     maxPlayers: 1
@@ -10520,34 +11819,56 @@ catalog:
     - Ludofun
     - Raven Distribution
     - REXhry
+    pdfBlobKey: rulebooks/v1/final-girl_rulebook.pdf
+    pdfSha256: df546c716dbdb555ed98d12ca896e57ffb82213cbb0e8f5ecc2603a8b076d15d
+    pdfVersion: '1.0'
   - title: Fields of Arle
     bggId: 159675
     language: en
-    pdf: fields-of-arle_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Welcome to Arle
+    description: 'Welcome to Arle
 
-      In Fields of Arle, created by Uwe Rosenberg, one to two players live as farmers in the small and peaceful town of Arle in East Frisia. The flax grown in the land surrounding the village makes it a profitable place to work and live. Fields of Arle takes players through four and a half years of this era of prosperity, with different opportunities available as the seasons change. Farm the land to capitalize on the demand for flax, or find other ways to make the most of the small town&rsquo;s prosperity.
+      In Fields of Arle, created by Uwe Rosenberg, one to two players live as farmers in the small and peaceful town of Arle
+      in East Frisia. The flax grown in the land surrounding the village makes it a profitable place to work and live. Fields
+      of Arle takes players through four and a half years of this era of prosperity, with different opportunities available
+      as the seasons change. Farm the land to capitalize on the demand for flax, or find other ways to make the most of the
+      small town&rsquo;s prosperity.
 
 
       Work the Land
 
-      Whether you delve into flax farming or leverage other areas of expertise, always make sure that you have the land to build up your village. Construct dikes to keep the waters at bay and expand your fields. Dry out bogs to harvest peat and then clear the land for cultivation. Create more fields for your livestock, buildings, or future crops; after that, you can decide whether to house animals or cultivate a forest for timber. Perhaps you&rsquo;d like to take up some flax farming for yourself, or diversify and try out a little bit of everything.
+      Whether you delve into flax farming or leverage other areas of expertise, always make sure that you have the land to
+      build up your village. Construct dikes to keep the waters at bay and expand your fields. Dry out bogs to harvest peat
+      and then clear the land for cultivation. Create more fields for your livestock, buildings, or future crops; after that,
+      you can decide whether to house animals or cultivate a forest for timber. Perhaps you&rsquo;d like to take up some flax
+      farming for yourself, or diversify and try out a little bit of everything.
 
 
       Tools of the Trade
 
-      At the outset of each half year, you&rsquo;ll choose how you&rsquo;d like to spend that time working. There are many ways to build your fortune. Use the Master space to increase the tools at your disposal, focus on the Cattle Trainer to make the most of your livestock, or build up your fleet of vehicles and ship out goods. Taking stock of your progress differs depending on the season. You may milk your existing livestock or care for a bunch of newborn animals. You could harvest your flax in the fall, and shear your sheep in spring. At the end of each half year, you&rsquo;ll need to take stock of your progress by unloading your vehicles and feeding your family and animals, so keep an eye on the season and do your best to keep the farm growing and everyone well fed!
+      At the outset of each half year, you&rsquo;ll choose how you&rsquo;d like to spend that time working. There are many
+      ways to build your fortune. Use the Master space to increase the tools at your disposal, focus on the Cattle Trainer
+      to make the most of your livestock, or build up your fleet of vehicles and ship out goods. Taking stock of your progress
+      differs depending on the season. You may milk your existing livestock or care for a bunch of newborn animals. You could
+      harvest your flax in the fall, and shear your sheep in spring. At the end of each half year, you&rsquo;ll need to take
+      stock of your progress by unloading your vehicles and feeding your family and animals, so keep an eye on the season
+      and do your best to keep the farm growing and everyone well fed!
 
 
       Travel and Prosper
 
-      Once you&rsquo;ve made headway in clearing fields and stocking up goods, it's time to make your products available to potential buyers. The more vehicles you have, the more goods you can ship. Send things into the wide world to increase your Travel Experience and grant you points over the course of the four and a half years of the game. Build up your farm and your vehicles and get your goods out into the world to make the most of every season. There are many roads to success in Fields of Arle, so pick your path, work the land, and enjoy the friendly competition as you strive to make your fortune!
+      Once you&rsquo;ve made headway in clearing fields and stocking up goods, it''s time to make your products available
+      to potential buyers. The more vehicles you have, the more goods you can ship. Send things into the wide world to increase
+      your Travel Experience and grant you points over the course of the four and a half years of the game. Build up your
+      farm and your vehicles and get your goods out into the world to make the most of every season. There are many roads
+      to success in Fields of Arle, so pick your path, work the land, and enjoy the friendly competition as you strive to
+      make your fortune!
 
 
-      - from the publisher's website
+      - from the publisher''s website
 
+
+      '
     yearPublished: 2014
     minPlayers: 1
     maxPlayers: 2
@@ -10583,20 +11904,32 @@ catalog:
     - Mandala Jogos
     - テンデイズゲームズ (TendaysGames)
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/fields-of-arle_rulebook.pdf
+    pdfSha256: a7d44d5d0f033a0a32b55da417a1031fcda41a45cfdc834ffca174056b0753ca
+    pdfVersion: '1.0'
   - title: 'Eclipse: New Dawn for the Galaxy'
     bggId: 72125
     language: en
-    pdf: eclipse_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      The galaxy has been a peaceful place for many years. After the ruthless Terran&ndash;Hegemony War (30.027&ndash;33.364), much effort has been employed by all major spacefaring species to prevent the terrifying events from repeating themselves. The Galactic Council was formed to enforce precious peace, and it has taken many courageous efforts to prevent the escalation of malicious acts. Nevertheless, tension and discord are growing among the seven major species and in the Council itself. Old alliances are shattering, and hasty diplomatic treaties are made in secrecy. A confrontation of the superpowers seems inevitable &ndash; only the outcome of the galactic conflict remains to be seen. Which faction will emerge victorious and lead the galaxy under its rule?
+    description: 'The galaxy has been a peaceful place for many years. After the ruthless Terran&ndash;Hegemony War (30.027&ndash;33.364),
+      much effort has been employed by all major spacefaring species to prevent the terrifying events from repeating themselves.
+      The Galactic Council was formed to enforce precious peace, and it has taken many courageous efforts to prevent the escalation
+      of malicious acts. Nevertheless, tension and discord are growing among the seven major species and in the Council itself.
+      Old alliances are shattering, and hasty diplomatic treaties are made in secrecy. A confrontation of the superpowers
+      seems inevitable &ndash; only the outcome of the galactic conflict remains to be seen. Which faction will emerge victorious
+      and lead the galaxy under its rule?
 
 
-      A game of Eclipse places you in control of a vast interstellar civilization, competing for success with its rivals. You will explore new star systems, research technologies, and build spaceships with which to wage war. There are many potential paths to victory, so you need to plan your strategy according to the strengths and weaknesses of your species, while paying attention to the other civilizations' endeavors.
+      A game of Eclipse places you in control of a vast interstellar civilization, competing for success with its rivals.
+      You will explore new star systems, research technologies, and build spaceships with which to wage war. There are many
+      potential paths to victory, so you need to plan your strategy according to the strengths and weaknesses of your species,
+      while paying attention to the other civilizations'' endeavors.
 
 
       The shadows of the great civilizations are about to eclipse the galaxy. Lead your people to victory!
 
+
+      '
     yearPublished: 2011
     minPlayers: 2
     maxPlayers: 6
@@ -10635,6 +11968,9 @@ catalog:
     - Korea Boardgames
     - Rebel Sp. z o.o.
     - Ystari Games
+    pdfBlobKey: rulebooks/v1/eclipse_rulebook.pdf
+    pdfSha256: bd13229470079df4df34fb2c6b1126172985b89b856984f5fb9f46a160370b79
+    pdfVersion: '1.0'
   defaultAgent:
     name: MeepleAssistant POC
     model: anthropic/claude-3-haiku

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml
@@ -9248,76 +9248,7 @@ catalog:
   - title: 'Skytear: Arena of Legends'
     bggId: 373106
     language: en
-    bggEnhanced: true
-    description: 'Sky Team is a co-operative game, exclusively for two players, in which you play a pilot and co-pilot at
-      the controls of an airliner. Your goal is to work together as a team to land your airplane in different airports around
-      the world.
-
-
-      To land your plane, you need to silently assign your dice to the correct spaces in your cockpit to balance the axis
-      of your plane, control its speed, deploy the flaps, extend the landing gear, contact the control tower to clear your
-      path, and even have a little coffee to improve your concentration enough to change the value of your dice.
-
-
-      If the aircraft tilts too much and stalls, overshoots the airport, or collides with another aircraft, you lose the game...and
-      your pilot''s license...and probably your life.
-
-
-      From Montreal to Tokyo, each airport offers its own set of challenges. Watch out for the turbulence as this could end
-      up being a bumpy ride!
-
-
-      &mdash;description from the publisher
-
-
-      '
-    yearPublished: 2023
-    minPlayers: 2
-    maxPlayers: 2
-    playingTime: 20
-    minAge: 10
-    averageRating: 8.12
-    averageWeight: 2.04
-    imageUrl: https://cf.geekdo-images.com/uXMeQzNenHb3zK7Hoa6b2w__original/img/mWOQnkpyYBorh_Y1-0Y2o-ew17k=/0x0/filters:format(jpeg)/pic7398904.jpg
-    thumbnailUrl: https://cf.geekdo-images.com/uXMeQzNenHb3zK7Hoa6b2w__small/img/WyPClajMWU9lV5BdCXiZnqdZgmU=/fit-in/200x150/filters:strip_icc()/pic7398904.jpg
-    fallbackImageUrl: https://cf.geekdo-images.com/uXMeQzNenHb3zK7Hoa6b2w__original/img/mWOQnkpyYBorh_Y1-0Y2o-ew17k=/0x0/filters:format(jpeg)/pic7398904.jpg
-    fallbackThumbnailUrl: https://cf.geekdo-images.com/uXMeQzNenHb3zK7Hoa6b2w__small/img/WyPClajMWU9lV5BdCXiZnqdZgmU=/fit-in/200x150/filters:strip_icc()/pic7398904.jpg
-    categories:
-    - Aviation / Flight
-    - Dice
-    mechanics:
-    - Communication Limits
-    - Cooperative Game
-    - Dice Rolling
-    - Scenario / Mission / Campaign Game
-    - 'Turn Order: Progressive'
-    - Variable Player Powers
-    - Variable Set-up
-    - Worker Placement with Dice Workers
-    designers:
-    - Luc Rémond
-    publishers:
-    - Scorpion Masqué
-    - 999 Games
-    - ADC Blackfire Entertainment
-    - asmodee
-    - Brädspel.se
-    - Galápagos Jogos
-    - Games4you
-    - Geekach LLC
-    - Hachette Boardgames USA
-    - Kaissa Chess & Games
-    - KOSMOS
-    - Lautapelit.fi
-    - Lavka Games
-    - Lucky Duck Games
-    - Reflexshop
-    - Regatul Jocurilor
-    - Salta da Caixa
-    - Spilbræt.dk
-    - Sugorokuya
-    - Tabletop KZ
-    - YOKA Games
+    bggEnhanced: false
     pdfBlobKey: rulebooks/v1/skytear_rulebook.pdf
     pdfSha256: 2f316d16c5001b55097b9966c7c697bbde6a50e7e5c9b1c3df336ff5c3775960
     pdfVersion: '1.0'
@@ -10978,64 +10909,7 @@ catalog:
   - title: 'Great Western Trail: Argentina'
     bggId: 380607
     language: en
-    bggEnhanced: true
-    description: 'Kia ora, and welcome to Great Western Trail New Zealand!
-
-
-      Towards the end of the 19th century, you established yourself as a runholder (owner of a sheep station) on the South
-      Island of New Zealand. Recent years have seen your family farm prosper by diversifying your breeds of sheep and increasing
-      the value of your wool.
-
-
-      With the dawn of the new century, difficult challenges have arisen. You must acquire improved and valuable breeds of
-      sheep to ensure the prosperity of your family business and the labourers who work for you. Decide whether to focus on
-      your past strengths or to diversify into new ventures. Will the beginning of the 20th century be as rewarding as earlier
-      years, or will the efforts of others surpass your strategy? Good luck, and kia kaha!
-
-
-      In Great Western Trail New Zealand, you move your runholder along a trail that winds and forks from the lower left corner
-      of the game board to Wellington in the upper right. Along your path, you perform actions that provide you with various
-      ways to earn victory points.
-
-
-      Each time your runholder reaches Wellington, you deliver sheep to a local or foreign trading post, which may also be
-      worth victory points. Afterwards, your runholder continues its movement again.
-
-
-      '
-    yearPublished: 2023
-    minPlayers: 1
-    maxPlayers: 4
-    playingTime: 150
-    minAge: 12
-    averageRating: 8.47
-    averageWeight: 4.01
-    imageUrl: https://cf.geekdo-images.com/X4KaD6ADLW1ohOznNay7xg__original/img/HhxsLMIsz6Te567qXEbRBen4Sm8=/0x0/filters:format(png)/pic7350809.png
-    thumbnailUrl: https://cf.geekdo-images.com/X4KaD6ADLW1ohOznNay7xg__small/img/iCWpe4ydO3Rtu6yBjn01eQ97xLc=/fit-in/200x150/filters:strip_icc()/pic7350809.png
-    fallbackImageUrl: https://cf.geekdo-images.com/X4KaD6ADLW1ohOznNay7xg__original/img/HhxsLMIsz6Te567qXEbRBen4Sm8=/0x0/filters:format(png)/pic7350809.png
-    fallbackThumbnailUrl: https://cf.geekdo-images.com/X4KaD6ADLW1ohOznNay7xg__small/img/iCWpe4ydO3Rtu6yBjn01eQ97xLc=/fit-in/200x150/filters:strip_icc()/pic7350809.png
-    categories:
-    - Animals
-    mechanics:
-    - Deck, Bag, and Pool Building
-    - Hand Management
-    - Ownership
-    - Set Collection
-    - Solo / Solitaire Game
-    - Track Movement
-    - Variable Set-up
-    designers:
-    - Alexander Pfister
-    publishers:
-    - eggertspiele
-    - Arclight Games
-    - Delta Vision Publishing
-    - Ediciones MasQueOca
-    - Galápagos Jogos
-    - Ghenos Games
-    - Rebel Sp. z o.o.
-    - Yayoi The Dreamer
-    - Zvezda
+    bggEnhanced: false
     pdfBlobKey: rulebooks/v1/great-western-trail-argentina_rulebook.pdf
     pdfSha256: 88be4a0b83dda037566941e46d1e936ec6280c37e9860c0405a58a9bd412c2fa
     pdfVersion: '1.0'
@@ -11576,54 +11450,7 @@ catalog:
   - title: Voidfall
     bggId: 338111
     language: en
-    bggEnhanced: true
-    description: 'A trick-taking card game with cards featuring photos of contemporary United States Navy aircraft, surface
-      ships, and submarines.
-
-
-      The cards are marked with letters from A to Z and some of the cards are numbered as well (i.e. A1, A2, A3, A4). At the
-      start of the game, each player is dealt seven cards. The goal is to capture the most Navy equipment by winning tricks.
-      The highest card played wins the trick, with A being the highest and Z being the lowest. In addition, among the numbered
-      cards with the same letter, the highest number wins (so B4 beats B2).
-
-
-      At the end of the game a player receives 10 points for each card having a number and 5 points for each card that only
-      has a letter. A player can score a bonus 100 points during the game if the cards in the player''s hand spell out N-A-V-Y,
-      J-E-T, or S-H-I-P. The first player to reach 1000 points wins the game.
-
-
-      The contents include the rules folder, 54 cards, a score pad, and a small cardboard box-insert tray. The rules folder
-      provides a description of each photo used on the cards.
-
-
-      &mdash;user summary
-
-
-      '
-    yearPublished: 1957
-    minPlayers: 2
-    maxPlayers: 6
-    playingTime: 45
-    minAge: 9
-    averageRating: 0
-    averageWeight: 0
-    imageUrl: https://cf.geekdo-images.com/NSNqLPStIevgazzFvDjBXg__original/img/IBBihaLB4Gf7bfMVbyrWiyHFzrQ=/0x0/filters:format(jpeg)/pic6166941.jpg
-    thumbnailUrl: https://cf.geekdo-images.com/NSNqLPStIevgazzFvDjBXg__small/img/wGkH7Z1C44mG3xCZ1NyOgpbWge8=/fit-in/200x150/filters:strip_icc()/pic6166941.jpg
-    fallbackImageUrl: https://cf.geekdo-images.com/NSNqLPStIevgazzFvDjBXg__original/img/IBBihaLB4Gf7bfMVbyrWiyHFzrQ=/0x0/filters:format(jpeg)/pic6166941.jpg
-    fallbackThumbnailUrl: https://cf.geekdo-images.com/NSNqLPStIevgazzFvDjBXg__small/img/wGkH7Z1C44mG3xCZ1NyOgpbWge8=/fit-in/200x150/filters:strip_icc()/pic6166941.jpg
-    categories:
-    - Aviation / Flight
-    - Card Game
-    - Modern Warfare
-    - Nautical
-    mechanics:
-    - Race
-    - Set Collection
-    - Trick-taking
-    designers:
-    - (Uncredited)
-    publishers:
-    - Exclusive Playing Card Company
+    bggEnhanced: false
     pdfBlobKey: rulebooks/v1/voidfall_rulebook.pdf
     pdfSha256: 29847a547dcec0deac860cfb658cd3ea694dcaab319258fcf286c27161243157
     pdfVersion: '1.0'

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/prod.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/prod.yml
@@ -9254,76 +9254,7 @@ catalog:
   - title: 'Skytear: Arena of Legends'
     bggId: 373106
     language: en
-    bggEnhanced: true
-    description: 'Sky Team is a co-operative game, exclusively for two players, in which you play a pilot and co-pilot at
-      the controls of an airliner. Your goal is to work together as a team to land your airplane in different airports around
-      the world.
-
-
-      To land your plane, you need to silently assign your dice to the correct spaces in your cockpit to balance the axis
-      of your plane, control its speed, deploy the flaps, extend the landing gear, contact the control tower to clear your
-      path, and even have a little coffee to improve your concentration enough to change the value of your dice.
-
-
-      If the aircraft tilts too much and stalls, overshoots the airport, or collides with another aircraft, you lose the game...and
-      your pilot''s license...and probably your life.
-
-
-      From Montreal to Tokyo, each airport offers its own set of challenges. Watch out for the turbulence as this could end
-      up being a bumpy ride!
-
-
-      &mdash;description from the publisher
-
-
-      '
-    yearPublished: 2023
-    minPlayers: 2
-    maxPlayers: 2
-    playingTime: 20
-    minAge: 10
-    averageRating: 8.12
-    averageWeight: 2.04
-    imageUrl: https://cf.geekdo-images.com/uXMeQzNenHb3zK7Hoa6b2w__original/img/mWOQnkpyYBorh_Y1-0Y2o-ew17k=/0x0/filters:format(jpeg)/pic7398904.jpg
-    thumbnailUrl: https://cf.geekdo-images.com/uXMeQzNenHb3zK7Hoa6b2w__small/img/WyPClajMWU9lV5BdCXiZnqdZgmU=/fit-in/200x150/filters:strip_icc()/pic7398904.jpg
-    fallbackImageUrl: https://cf.geekdo-images.com/uXMeQzNenHb3zK7Hoa6b2w__original/img/mWOQnkpyYBorh_Y1-0Y2o-ew17k=/0x0/filters:format(jpeg)/pic7398904.jpg
-    fallbackThumbnailUrl: https://cf.geekdo-images.com/uXMeQzNenHb3zK7Hoa6b2w__small/img/WyPClajMWU9lV5BdCXiZnqdZgmU=/fit-in/200x150/filters:strip_icc()/pic7398904.jpg
-    categories:
-    - Aviation / Flight
-    - Dice
-    mechanics:
-    - Communication Limits
-    - Cooperative Game
-    - Dice Rolling
-    - Scenario / Mission / Campaign Game
-    - 'Turn Order: Progressive'
-    - Variable Player Powers
-    - Variable Set-up
-    - Worker Placement with Dice Workers
-    designers:
-    - Luc Rémond
-    publishers:
-    - Scorpion Masqué
-    - 999 Games
-    - ADC Blackfire Entertainment
-    - asmodee
-    - Brädspel.se
-    - Galápagos Jogos
-    - Games4you
-    - Geekach LLC
-    - Hachette Boardgames USA
-    - Kaissa Chess & Games
-    - KOSMOS
-    - Lautapelit.fi
-    - Lavka Games
-    - Lucky Duck Games
-    - Reflexshop
-    - Regatul Jocurilor
-    - Salta da Caixa
-    - Spilbræt.dk
-    - Sugorokuya
-    - Tabletop KZ
-    - YOKA Games
+    bggEnhanced: false
     pdfBlobKey: rulebooks/v1/skytear_rulebook.pdf
     pdfSha256: 2f316d16c5001b55097b9966c7c697bbde6a50e7e5c9b1c3df336ff5c3775960
     pdfVersion: '1.0'
@@ -10984,64 +10915,7 @@ catalog:
   - title: 'Great Western Trail: Argentina'
     bggId: 380607
     language: en
-    bggEnhanced: true
-    description: 'Kia ora, and welcome to Great Western Trail New Zealand!
-
-
-      Towards the end of the 19th century, you established yourself as a runholder (owner of a sheep station) on the South
-      Island of New Zealand. Recent years have seen your family farm prosper by diversifying your breeds of sheep and increasing
-      the value of your wool.
-
-
-      With the dawn of the new century, difficult challenges have arisen. You must acquire improved and valuable breeds of
-      sheep to ensure the prosperity of your family business and the labourers who work for you. Decide whether to focus on
-      your past strengths or to diversify into new ventures. Will the beginning of the 20th century be as rewarding as earlier
-      years, or will the efforts of others surpass your strategy? Good luck, and kia kaha!
-
-
-      In Great Western Trail New Zealand, you move your runholder along a trail that winds and forks from the lower left corner
-      of the game board to Wellington in the upper right. Along your path, you perform actions that provide you with various
-      ways to earn victory points.
-
-
-      Each time your runholder reaches Wellington, you deliver sheep to a local or foreign trading post, which may also be
-      worth victory points. Afterwards, your runholder continues its movement again.
-
-
-      '
-    yearPublished: 2023
-    minPlayers: 1
-    maxPlayers: 4
-    playingTime: 150
-    minAge: 12
-    averageRating: 8.47
-    averageWeight: 4.01
-    imageUrl: https://cf.geekdo-images.com/X4KaD6ADLW1ohOznNay7xg__original/img/HhxsLMIsz6Te567qXEbRBen4Sm8=/0x0/filters:format(png)/pic7350809.png
-    thumbnailUrl: https://cf.geekdo-images.com/X4KaD6ADLW1ohOznNay7xg__small/img/iCWpe4ydO3Rtu6yBjn01eQ97xLc=/fit-in/200x150/filters:strip_icc()/pic7350809.png
-    fallbackImageUrl: https://cf.geekdo-images.com/X4KaD6ADLW1ohOznNay7xg__original/img/HhxsLMIsz6Te567qXEbRBen4Sm8=/0x0/filters:format(png)/pic7350809.png
-    fallbackThumbnailUrl: https://cf.geekdo-images.com/X4KaD6ADLW1ohOznNay7xg__small/img/iCWpe4ydO3Rtu6yBjn01eQ97xLc=/fit-in/200x150/filters:strip_icc()/pic7350809.png
-    categories:
-    - Animals
-    mechanics:
-    - Deck, Bag, and Pool Building
-    - Hand Management
-    - Ownership
-    - Set Collection
-    - Solo / Solitaire Game
-    - Track Movement
-    - Variable Set-up
-    designers:
-    - Alexander Pfister
-    publishers:
-    - eggertspiele
-    - Arclight Games
-    - Delta Vision Publishing
-    - Ediciones MasQueOca
-    - Galápagos Jogos
-    - Ghenos Games
-    - Rebel Sp. z o.o.
-    - Yayoi The Dreamer
-    - Zvezda
+    bggEnhanced: false
     pdfBlobKey: rulebooks/v1/great-western-trail-argentina_rulebook.pdf
     pdfSha256: 88be4a0b83dda037566941e46d1e936ec6280c37e9860c0405a58a9bd412c2fa
     pdfVersion: '1.0'
@@ -11582,54 +11456,7 @@ catalog:
   - title: Voidfall
     bggId: 338111
     language: en
-    bggEnhanced: true
-    description: 'A trick-taking card game with cards featuring photos of contemporary United States Navy aircraft, surface
-      ships, and submarines.
-
-
-      The cards are marked with letters from A to Z and some of the cards are numbered as well (i.e. A1, A2, A3, A4). At the
-      start of the game, each player is dealt seven cards. The goal is to capture the most Navy equipment by winning tricks.
-      The highest card played wins the trick, with A being the highest and Z being the lowest. In addition, among the numbered
-      cards with the same letter, the highest number wins (so B4 beats B2).
-
-
-      At the end of the game a player receives 10 points for each card having a number and 5 points for each card that only
-      has a letter. A player can score a bonus 100 points during the game if the cards in the player''s hand spell out N-A-V-Y,
-      J-E-T, or S-H-I-P. The first player to reach 1000 points wins the game.
-
-
-      The contents include the rules folder, 54 cards, a score pad, and a small cardboard box-insert tray. The rules folder
-      provides a description of each photo used on the cards.
-
-
-      &mdash;user summary
-
-
-      '
-    yearPublished: 1957
-    minPlayers: 2
-    maxPlayers: 6
-    playingTime: 45
-    minAge: 9
-    averageRating: 0
-    averageWeight: 0
-    imageUrl: https://cf.geekdo-images.com/NSNqLPStIevgazzFvDjBXg__original/img/IBBihaLB4Gf7bfMVbyrWiyHFzrQ=/0x0/filters:format(jpeg)/pic6166941.jpg
-    thumbnailUrl: https://cf.geekdo-images.com/NSNqLPStIevgazzFvDjBXg__small/img/wGkH7Z1C44mG3xCZ1NyOgpbWge8=/fit-in/200x150/filters:strip_icc()/pic6166941.jpg
-    fallbackImageUrl: https://cf.geekdo-images.com/NSNqLPStIevgazzFvDjBXg__original/img/IBBihaLB4Gf7bfMVbyrWiyHFzrQ=/0x0/filters:format(jpeg)/pic6166941.jpg
-    fallbackThumbnailUrl: https://cf.geekdo-images.com/NSNqLPStIevgazzFvDjBXg__small/img/wGkH7Z1C44mG3xCZ1NyOgpbWge8=/fit-in/200x150/filters:strip_icc()/pic6166941.jpg
-    categories:
-    - Aviation / Flight
-    - Card Game
-    - Modern Warfare
-    - Nautical
-    mechanics:
-    - Race
-    - Set Collection
-    - Trick-taking
-    designers:
-    - (Uncredited)
-    publishers:
-    - Exclusive Playing Card Company
+    bggEnhanced: false
     pdfBlobKey: rulebooks/v1/voidfall_rulebook.pdf
     pdfSha256: 29847a547dcec0deac860cfb658cd3ea694dcaab319258fcf286c27161243157
     pdfVersion: '1.0'

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/prod.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/prod.yml
@@ -4,23 +4,38 @@ catalog:
   - title: Catan
     bggId: 13
     language: en
-    pdf: catan_en_rulebook.pdf
     seedAgent: true
     fallbackImageUrl: https://cf.geekdo-images.com/W3Bsga_uLP9kO91gZ7H8yw__original/img/IwRwEpu1I6YfkyYjFIekCh80ntc=/0x0/filters:format(jpeg)/pic2419375.jpg
     fallbackThumbnailUrl: https://cf.geekdo-images.com/W3Bsga_uLP9kO91gZ7H8yw__small/img/7a0LOL48K-2lC3IG0HyYT3XxJBs=/fit-in/200x150/filters:strip_icc()/pic2419375.jpg
     bggEnhanced: true
-    description: >+
-      In CATAN (formerly The Settlers of Catan), players try to be the dominant force on the island of Catan by building settlements, cities and roads. On each turn dice are rolled to determine which resources the island produces. Players build structures by 'spending' resources (sheep, wheat, wood, brick and ore) which are represented by the relevant resource cards; each land type, with the exception of the unproductive desert, produces a specific resource: hills produce brick, forests produce wood, mountains produce ore, fields produce wheat, and pastures produce sheep.
+    description: 'In CATAN (formerly The Settlers of Catan), players try to be the dominant force on the island of Catan by
+      building settlements, cities and roads. On each turn dice are rolled to determine which resources the island produces.
+      Players build structures by ''spending'' resources (sheep, wheat, wood, brick and ore) which are represented by the
+      relevant resource cards; each land type, with the exception of the unproductive desert, produces a specific resource:
+      hills produce brick, forests produce wood, mountains produce ore, fields produce wheat, and pastures produce sheep.
 
 
-      Set-up includes randomly placing large hexagonal tiles (each depicting one of the five resource-producing terrain types--or the desert) in a honeycomb shape and surrounding them with water tiles, some of which contain ports of exchange. A number disk, the value of which will correspond to the roll of two 6-sided dice, are placed on each terrain tile. Each player is given two settlements (think: houses) and roads (sticks) which are placed on intersections and borders of the terrain tiles. Players collect a hand of resource cards based on which terrain tiles their last-placed settlement is adjacent to. A robber pawn is placed on the desert tile.
+      Set-up includes randomly placing large hexagonal tiles (each depicting one of the five resource-producing terrain types--or
+      the desert) in a honeycomb shape and surrounding them with water tiles, some of which contain ports of exchange. A number
+      disk, the value of which will correspond to the roll of two 6-sided dice, are placed on each terrain tile. Each player
+      is given two settlements (think: houses) and roads (sticks) which are placed on intersections and borders of the terrain
+      tiles. Players collect a hand of resource cards based on which terrain tiles their last-placed settlement is adjacent
+      to. A robber pawn is placed on the desert tile.
 
 
-      A turn consists of rolling the dice, collecting resource cards based on this dice roll and the position of settlements (or upgraded cities&mdash;think: hotels), turning in resource cards (if possible and desired) for improvements, trading cards at a port, possibly playing a development card, or trading resource cards with other players. If the dice roll is a 7, the active player moves the robber to a new terrain tile and steals a resource card from another player who has a settlement adjacent to that tile.
+      A turn consists of rolling the dice, collecting resource cards based on this dice roll and the position of settlements
+      (or upgraded cities&mdash;think: hotels), turning in resource cards (if possible and desired) for improvements, trading
+      cards at a port, possibly playing a development card, or trading resource cards with other players. If the dice roll
+      is a 7, the active player moves the robber to a new terrain tile and steals a resource card from another player who
+      has a settlement adjacent to that tile.
 
 
-      Points are accumulated by building settlements and cities, having the longest road or the largest army (from some of the development cards), and gathering certain development cards that simply award victory points. When a player has gathered 10 points (some of which may be held in secret), s/he announces this and claims the win.
+      Points are accumulated by building settlements and cities, having the longest road or the largest army (from some of
+      the development cards), and gathering certain development cards that simply award victory points. When a player has
+      gathered 10 points (some of which may be held in secret), s/he announces this and claims the win.
 
+
+      '
     yearPublished: 1995
     minPlayers: 3
     maxPlayers: 4
@@ -105,33 +120,24 @@ catalog:
     - Top Toys
     - TRY SOFT
     - Vennerød Forlag AS
+    pdfBlobKey: rulebooks/v1/catan_en_rulebook.pdf
+    pdfSha256: 0d81a40c1d4eb5eb438a62f80d71cdaab5f00404722c3cfa0b106d79b635ebc6
+    pdfVersion: '1.0'
   - title: Wingspan
     bggId: 266192
     language: en
-    pdf: wingspan_en_rulebook.pdf
     fallbackImageUrl: https://cf.geekdo-images.com/yLZJCVLlIx4c7eJEWUNJ7w__original/img/cI782Zis9cT66j2MjSHKJGnFPNw=/0x0/filters:format(jpeg)/pic4458123.jpg
     fallbackThumbnailUrl: https://cf.geekdo-images.com/yLZJCVLlIx4c7eJEWUNJ7w__small/img/VNToqgS2-pOGU6MuvIkMPKn_y-s=/fit-in/200x150/filters:strip_icc()/pic4458123.jpg
     bggEnhanced: true
-    description: >+
-      Wingspan is&nbsp;a competitive, medium-weight, card-driven, engine-building board game from Stonemaier Games. It's designed by Elizabeth Hargrave and features 180 birds illustrated by Natalia Rojas and Ana Maria Martinez.
-
-
-      You are bird enthusiasts&mdash;researchers, bird watchers, ornithologists, and collectors&mdash;seeking to discover and attract the best birds to your network of wildlife preserves. Each bird extends a chain of powerful combinations in one of your habitats (actions). These habitats  focus on several key aspects of growth:
-
-
-           Gain food tokens via custom dice in a birdfeeder dice tower
-           Lay eggs using egg miniatures in a variety of colors
-           Draw from hundreds of unique bird cards and play them
-
-
-      The winner is the player with the most points after 4 rounds.
-
-
-      &mdash;description from the publisher
-
-
-      From the 7th printing on, the base game box includes Wingspan: Swift-Start Promo Pack.
-
+    description: "Wingspan is&nbsp;a competitive, medium-weight, card-driven, engine-building board game from Stonemaier Games.\
+      \ It's designed by Elizabeth Hargrave and features 180 birds illustrated by Natalia Rojas and Ana Maria Martinez.\n\n\
+      You are bird enthusiasts&mdash;researchers, bird watchers, ornithologists, and collectors&mdash;seeking to discover\
+      \ and attract the best birds to your network of wildlife preserves. Each bird extends a chain of powerful combinations\
+      \ in one of your habitats (actions). These habitats  focus on several key aspects of growth:\n\n\n     Gain food tokens\
+      \ via custom dice in a birdfeeder dice tower\n     Lay eggs using egg miniatures in a variety of colors\n     Draw from\
+      \ hundreds of unique bird cards and play them\n\n\nThe winner is the player with the most points after 4 rounds.\n\n\
+      &mdash;description from the publisher\n\nFrom the 7th printing on, the base game box includes Wingspan: Swift-Start\
+      \ Promo Pack.\n\n"
     yearPublished: 2019
     minPlayers: 1
     maxPlayers: 5
@@ -187,19 +193,29 @@ catalog:
     - Siam Board Games
     - Surfin' Meeple China
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/wingspan_en_rulebook.pdf
+    pdfSha256: eb6b55b5224dcc6619d1145f4055cd3ed1be7f5bc301ff3953b94277ebd93e51
+    pdfVersion: '1.0'
   - title: Azul
     bggId: 230802
     language: en
-    pdf: azul_rulebook.pdf
     fallbackImageUrl: https://cf.geekdo-images.com/aPSHJO0d0XOpQR5X-wJonw__original/img/AkbtYVc6xXJF3c9EUrakklcclKw=/0x0/filters:format(png)/pic6973671.png
     fallbackThumbnailUrl: https://cf.geekdo-images.com/aPSHJO0d0XOpQR5X-wJonw__small/img/ccsXKrdGJw-YSClWwzVUwk5Nh9Y=/fit-in/200x150/filters:strip_icc()/pic6973671.png
     bggEnhanced: true
-    description: >+
-      Introduced by the Moors, azulejos (originally white and blue ceramic tiles) were fully embraced by the Portuguese when their king Manuel I, on a visit to the Alhambra palace in Southern Spain, was mesmerized by the stunning beauty of the Moorish decorative tiles. The king, awestruck by the interior beauty of the Alhambra, immediately ordered that his own palace in Portugal be decorated with similar wall tiles. As a tile-laying artist, you have been challenged to embellish the walls of the Royal Palace of Evora.
+    description: 'Introduced by the Moors, azulejos (originally white and blue ceramic tiles) were fully embraced by the Portuguese
+      when their king Manuel I, on a visit to the Alhambra palace in Southern Spain, was mesmerized by the stunning beauty
+      of the Moorish decorative tiles. The king, awestruck by the interior beauty of the Alhambra, immediately ordered that
+      his own palace in Portugal be decorated with similar wall tiles. As a tile-laying artist, you have been challenged to
+      embellish the walls of the Royal Palace of Evora.
 
 
-      In the game Azul, players take turns drafting colored tiles from suppliers to their player board. Later in the round, players score points based on how they've placed their tiles to decorate the palace. Extra points are scored for specific patterns and completing sets; wasted supplies harm the player's score. The player with the most points at the end of the game wins.
+      In the game Azul, players take turns drafting colored tiles from suppliers to their player board. Later in the round,
+      players score points based on how they''ve placed their tiles to decorate the palace. Extra points are scored for specific
+      patterns and completing sets; wasted supplies harm the player''s score. The player with the most points at the end of
+      the game wins.
 
+
+      '
     yearPublished: 2017
     minPlayers: 2
     maxPlayers: 4
@@ -250,35 +266,32 @@ catalog:
     - Tower Tactic Games
     - TWOPLUS Games
     - Zvezda
+    pdfBlobKey: rulebooks/v1/azul_rulebook.pdf
+    pdfSha256: 407a5ae91d219a72dfad0fd600fd9bf4ee2f9690e9726ae74fb7240d9a1a6911
+    pdfVersion: '1.0'
   - title: 'Descent: Journeys in the Dark (Second Edition)'
     bggId: 104162
     language: en
-    pdf: descent_rulebook.pdf
     seedAgent: true
     fallbackImageUrl: https://cf.geekdo-images.com/ZTkiJEPvz2O3vmMJWfjrbw__original/img/GZJIjJPJKk1a4Bx-rM-3KL6O4hk=/0x0/filters:format(jpeg)/pic1180640.jpg
     fallbackThumbnailUrl: https://cf.geekdo-images.com/ZTkiJEPvz2O3vmMJWfjrbw__small/img/cO_2QvC_2BCb-Smd0xp4a5G2n-s=/fit-in/200x150/filters:strip_icc()/pic1180640.jpg
     bggEnhanced: true
-    description: >+
-      In Descent: Journeys in the Dark (Second Edition), one player takes on the role of the treacherous overlord, and up to four other players take on the roles of courageous heroes. During each game, the heroes embark on quests and venture into dangerous caves, ancient ruins, dark dungeons, and cursed forests to battle monsters, earn riches, and attempt to stop the overlord from carrying out his vile plot. Featuring double-sided modular board pieces, countless hero and skill combinations, and an immersive story-driven campaign, Descent: Journeys in the Dark (Second Edition) transports heroes to a vibrant fantasy realm where they must stand together against an ancient evil.
-
-
-      With danger lurking in every shadow, combat is a necessity. For such times, Descent: Journeys in the Dark (Second Edition) uses a unique dice-based system. Players build their dice pools according to their character's abilities and weapons, and each die in the pool contributes to an attack in different ways. Surges, special symbols that appear on most dice, also let you trigger special effects to make the most of your attacks. And with the horrors awaiting you beneath the surface, you'll need every advantage you can take...
-
-
-      Compared to the first edition of Descent: Journeys in the Dark, this game features:
-
-
-           Simpler rules for determining line of sight 
-           Faster setup of each encounter
-           Defense dice to mitigate the tendency to "math out" attacks
-           Shorter quests with plenty of natural stopping points
-           Cards that list necessary statistics, conditions, and effects
-           A new mechanism for controlling the overlord powers
-           Enhanced hero selection and creation process
-           Experience system to allow for hero growth and development
-           Out-of-the-box campaign system
-
-
+    description: "In Descent: Journeys in the Dark (Second Edition), one player takes on the role of the treacherous overlord,\
+      \ and up to four other players take on the roles of courageous heroes. During each game, the heroes embark on quests\
+      \ and venture into dangerous caves, ancient ruins, dark dungeons, and cursed forests to battle monsters, earn riches,\
+      \ and attempt to stop the overlord from carrying out his vile plot. Featuring double-sided modular board pieces, countless\
+      \ hero and skill combinations, and an immersive story-driven campaign, Descent: Journeys in the Dark (Second Edition)\
+      \ transports heroes to a vibrant fantasy realm where they must stand together against an ancient evil.\n\nWith danger\
+      \ lurking in every shadow, combat is a necessity. For such times, Descent: Journeys in the Dark (Second Edition) uses\
+      \ a unique dice-based system. Players build their dice pools according to their character's abilities and weapons, and\
+      \ each die in the pool contributes to an attack in different ways. Surges, special symbols that appear on most dice,\
+      \ also let you trigger special effects to make the most of your attacks. And with the horrors awaiting you beneath the\
+      \ surface, you'll need every advantage you can take...\n\nCompared to the first edition of Descent: Journeys in the\
+      \ Dark, this game features:\n\n\n     Simpler rules for determining line of sight \n     Faster setup of each encounter\n\
+      \     Defense dice to mitigate the tendency to \"math out\" attacks\n     Shorter quests with plenty of natural stopping\
+      \ points\n     Cards that list necessary statistics, conditions, and effects\n     A new mechanism for controlling the\
+      \ overlord powers\n     Enhanced hero selection and creation process\n     Experience system to allow for hero growth\
+      \ and development\n     Out-of-the-box campaign system\n\n\n"
     yearPublished: 2012
     minPlayers: 1
     maxPlayers: 5
@@ -327,20 +340,31 @@ catalog:
     - Heidelberger Spieleverlag
     - Hobby World
     - Wargames Club Publishing
+    pdfBlobKey: rulebooks/v1/descent_rulebook.pdf
+    pdfSha256: 8ae7fd3d1887aad1c1f8aeb10881526dbf7431fd1099b3bcb486748ea0c4a4aa
+    pdfVersion: '1.0'
   - title: Codenames
     bggId: 178900
     language: en
-    pdf: codenames_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Two rival spymasters know the secret identities of 25 agents. Their teammates know the agents only by their codenames &mdash; single-word labels like "disease", "Germany", and "carrot". Yes, carrot. It's a legitimate codename. Each spymaster wants their team to identify their agents first...without uncovering the assassin by mistake.
+    description: 'Two rival spymasters know the secret identities of 25 agents. Their teammates know the agents only by their
+      codenames &mdash; single-word labels like "disease", "Germany", and "carrot". Yes, carrot. It''s a legitimate codename.
+      Each spymaster wants their team to identify their agents first...without uncovering the assassin by mistake.
 
 
-      In Codenames, two teams compete to see who can make contact with all of their agents first. Lay out 25 cards, each bearing a single word. The spymasters look at a card showing the identity of each card, then take turns clueing their teammates. A clue consists of a single word and a number, with the number suggesting how many cards in play have some association to the given clue word. The teammates then identify one agent they think is on their team; if they're correct, they can keep guessing up to one more than the stated number of times; if the agent belongs to the opposing team or is an innocent bystander, the team's turn ends; and if they fingered the assassin, they lose the game.
+      In Codenames, two teams compete to see who can make contact with all of their agents first. Lay out 25 cards, each bearing
+      a single word. The spymasters look at a card showing the identity of each card, then take turns clueing their teammates.
+      A clue consists of a single word and a number, with the number suggesting how many cards in play have some association
+      to the given clue word. The teammates then identify one agent they think is on their team; if they''re correct, they
+      can keep guessing up to one more than the stated number of times; if the agent belongs to the opposing team or is an
+      innocent bystander, the team''s turn ends; and if they fingered the assassin, they lose the game.
 
 
-      Spymasters continue giving clues until one team has identified all of their agents or the assassin has removed one team from play.
+      Spymasters continue giving clues until one team has identified all of their agents or the assassin has removed one team
+      from play.
 
+
+      '
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 8
@@ -405,32 +429,52 @@ catalog:
     - SuperHeated Neurons
     - TWOPLUS Games
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/codenames_rulebook.pdf
+    pdfSha256: bf6ae8c47ede4e824587cd3506c4ab1fb81f51c96514a0a19df86a5c92441f11
+    pdfVersion: '1.0'
   - title: Terraforming Mars
     bggId: 167791
     language: en
-    pdf: terraforming-mars_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In the 2400s, mankind begins to terraform the planet Mars. Giant corporations, sponsored by the World Government on Earth, initiate huge projects to raise the temperature, the oxygen level, and the ocean coverage until the environment is habitable. In Terraforming Mars, you play one of those corporations and work together in the terraforming process, but compete for getting victory points that are awarded not only for your contribution to the terraforming, but also for advancing human infrastructure throughout the solar system, and doing other commendable things.
+    description: 'In the 2400s, mankind begins to terraform the planet Mars. Giant corporations, sponsored by the World Government
+      on Earth, initiate huge projects to raise the temperature, the oxygen level, and the ocean coverage until the environment
+      is habitable. In Terraforming Mars, you play one of those corporations and work together in the terraforming process,
+      but compete for getting victory points that are awarded not only for your contribution to the terraforming, but also
+      for advancing human infrastructure throughout the solar system, and doing other commendable things.
 
 
-      As a player, you acquire unique project cards (from over two hundred different ones) by buying them to your hand. The cards can give you immediate bonuses, as well as increasing your production of different resources. Many cards also have requirements and they become playable when the temperature, oxygen, or ocean coverage increases enough. Buying cards is costly, so there is a balance between buying cards and actually playing them. Standard Projects are always available to complement your hand of cards. Your basic income, as well as your basic score, are based on your Terraform Rating. However, your income is boosted by your production, and VPs are also gained from many other sources.
+      As a player, you acquire unique project cards (from over two hundred different ones) by buying them to your hand. The
+      cards can give you immediate bonuses, as well as increasing your production of different resources. Many cards also
+      have requirements and they become playable when the temperature, oxygen, or ocean coverage increases enough. Buying
+      cards is costly, so there is a balance between buying cards and actually playing them. Standard Projects are always
+      available to complement your hand of cards. Your basic income, as well as your basic score, are based on your Terraform
+      Rating. However, your income is boosted by your production, and VPs are also gained from many other sources.
 
 
-      You keep track of your production and resources on your player board.  The game uses six types of resources: MegaCredits, Steel, Titanium, Plants, Energy, and Heat. On the game board, you compete for the best places for your city tiles, ocean tiles, and greenery tiles. You also compete for different Milestones and Awards worth many VPs. Each round is called a generation and consists of the following phases:
+      You keep track of your production and resources on your player board.  The game uses six types of resources: MegaCredits,
+      Steel, Titanium, Plants, Energy, and Heat. On the game board, you compete for the best places for your city tiles, ocean
+      tiles, and greenery tiles. You also compete for different Milestones and Awards worth many VPs. Each round is called
+      a generation and consists of the following phases:
 
 
       1) Player order shifts clockwise.
 
       2) Research phase: All players buy cards from four privately drawn.
 
-      3) Action phase: Players take turns doing 1-2 actions from these options: Playing a card, claiming a Milestone, funding an Award, using a Standard project, converting plant into greenery tiles (and raising oxygen), converting heat into a temperature raise, and using the action of a card in play. The turn continues around the table (sometimes several laps) until all players have passed.
+      3) Action phase: Players take turns doing 1-2 actions from these options: Playing a card, claiming a Milestone, funding
+      an Award, using a Standard project, converting plant into greenery tiles (and raising oxygen), converting heat into
+      a temperature raise, and using the action of a card in play. The turn continues around the table (sometimes several
+      laps) until all players have passed.
 
       4) Production phase: Players get resources according to their terraform rating and production parameters.
 
 
-      When the three global parameters (temperature, oxygen, ocean) have all reached their required levels, the terraforming is complete, and the game ends after that generation. Combine your Terraform Rating and other VPs to determine the winning corporation!
+      When the three global parameters (temperature, oxygen, ocean) have all reached their required levels, the terraforming
+      is complete, and the game ends after that generation. Combine your Terraform Rating and other VPs to determine the winning
+      corporation!
 
+
+      '
     yearPublished: 2016
     minPlayers: 1
     maxPlayers: 5
@@ -494,23 +538,38 @@ catalog:
     - Stronghold Games
     - SuperHeated Neurons
     - Surfin' Meeple China
+    pdfBlobKey: rulebooks/v1/terraforming-mars_rulebook.pdf
+    pdfSha256: 97d5923d4e05c8b492c6f6b8937a9226936c6e39f8627dddeac81d5b6927aabe
+    pdfVersion: '1.0'
   - title: 7 Wonders
     bggId: 68448
     language: en
-    pdf: 7-wonders_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      You are the leader of one of the 7 great cities of the Ancient World. Gather resources, develop commercial routes, and affirm your military supremacy. Build your city and erect an architectural wonder which will transcend future times.
+    description: 'You are the leader of one of the 7 great cities of the Ancient World. Gather resources, develop commercial
+      routes, and affirm your military supremacy. Build your city and erect an architectural wonder which will transcend future
+      times.
 
 
-      7 Wonders lasts three ages. In each age, players receive seven cards from a particular deck, choose one of those cards, then pass the remainder to an adjacent player. Players reveal their cards simultaneously, paying resources if needed or collecting resources or interacting with other players in various ways. (Players have individual boards with special powers on which to organize their cards, and the boards are double-sided). Each player then chooses another card from the deck they were passed, and the process repeats until players have six cards in play from that age. After three ages, the game ends.
+      7 Wonders lasts three ages. In each age, players receive seven cards from a particular deck, choose one of those cards,
+      then pass the remainder to an adjacent player. Players reveal their cards simultaneously, paying resources if needed
+      or collecting resources or interacting with other players in various ways. (Players have individual boards with special
+      powers on which to organize their cards, and the boards are double-sided). Each player then chooses another card from
+      the deck they were passed, and the process repeats until players have six cards in play from that age. After three ages,
+      the game ends.
 
 
-      In essence, 7 Wonders is a card development game. Some cards have immediate effects, while others provide bonuses or upgrades later in the game. Some cards provide discounts on future purchases. Some provide military strength to overpower your neighbors and others give nothing but victory points. Each card is played immediately after being drafted, so you'll know which cards your neighbor is receiving and how her choices might affect what you've already built up. Cards are passed left-right-left over the three ages, so you need to keep an eye on the neighbors in both directions.
+      In essence, 7 Wonders is a card development game. Some cards have immediate effects, while others provide bonuses or
+      upgrades later in the game. Some cards provide discounts on future purchases. Some provide military strength to overpower
+      your neighbors and others give nothing but victory points. Each card is played immediately after being drafted, so you''ll
+      know which cards your neighbor is receiving and how her choices might affect what you''ve already built up. Cards are
+      passed left-right-left over the three ages, so you need to keep an eye on the neighbors in both directions.
 
 
-      Though the box of earlier editions is listed as being for 3&ndash;7 players, there is an official 2-player variant included in the instructions.
+      Though the box of earlier editions is listed as being for 3&ndash;7 players, there is an official 2-player variant included
+      in the instructions.
 
+
+      '
     yearPublished: 2010
     minPlayers: 2
     maxPlayers: 7
@@ -559,27 +618,39 @@ catalog:
     - NeoTroy Games
     - Rebel Sp. z o.o.
     - Siam Board Games
+    pdfBlobKey: rulebooks/v1/7-wonders_rulebook.pdf
+    pdfSha256: 5b719f677c830066b0493cd6ea5f2808e512ce9cbf72fa0fe80aa09127182849
+    pdfVersion: '1.0'
   - title: Ticket to Ride
     bggId: 9209
     language: en
-    pdf: ticket-to-ride_rulebook.pdf
     seedAgent: true
     bggEnhanced: true
-    description: >+
-      With elegantly simple gameplay, Ticket to Ride can be learned in under 15 minutes. Players collect cards of various types of train cars they then use to claim railway routes in North America. The longer the routes, the more points they earn. Additional points come to those who fulfill Destination Tickets &ndash; goal cards that connect distant cities; and to the player who builds the longest continuous route.
+    description: 'With elegantly simple gameplay, Ticket to Ride can be learned in under 15 minutes. Players collect cards
+      of various types of train cars they then use to claim railway routes in North America. The longer the routes, the more
+      points they earn. Additional points come to those who fulfill Destination Tickets &ndash; goal cards that connect distant
+      cities; and to the player who builds the longest continuous route.
 
 
-      "The rules are simple enough to write on a train ticket &ndash; each turn you either draw more cards, claim a route, or get additional Destination Tickets," says Ticket to Ride author, Alan R. Moon. "The tension comes from being forced to balance greed &ndash; adding more cards to your hand, and fear &ndash; losing a critical route to a competitor."
+      "The rules are simple enough to write on a train ticket &ndash; each turn you either draw more cards, claim a route,
+      or get additional Destination Tickets," says Ticket to Ride author, Alan R. Moon. "The tension comes from being forced
+      to balance greed &ndash; adding more cards to your hand, and fear &ndash; losing a critical route to a competitor."
 
 
-      Ticket to Ride continues in the tradition of Days of Wonder's big format board games featuring high-quality illustrations and components including: an oversize board map of North America, 225 custom-molded train cars, 144 illustrated cards, and wooden scoring markers.
+      Ticket to Ride continues in the tradition of Days of Wonder''s big format board games featuring high-quality illustrations
+      and components including: an oversize board map of North America, 225 custom-molded train cars, 144 illustrated cards,
+      and wooden scoring markers.
 
 
-      Since its introduction and numerous subsequent awards, Ticket to Ride has become the BoardGameGeek epitome of a "gateway game" -- simple enough to be taught in a few minutes, and with enough action and tension to keep new players involved and in the game for the duration.
+      Since its introduction and numerous subsequent awards, Ticket to Ride has become the BoardGameGeek epitome of a "gateway
+      game" -- simple enough to be taught in a few minutes, and with enough action and tension to keep new players involved
+      and in the game for the duration.
 
 
       Part of the Ticket to Ride series.
 
+
+      '
     yearPublished: 2004
     minPlayers: 2
     maxPlayers: 5
@@ -624,21 +695,32 @@ catalog:
     - Rebel Sp. z o.o.
     - Siam Board Games
     - Swan Panasia Co., Ltd.
+    pdfBlobKey: rulebooks/v1/ticket-to-ride_rulebook.pdf
+    pdfSha256: fac2dfc144c7709aadcb9be1423c7ba1ffe72f427e3eab5ebc0c03cada7f91ff
+    pdfVersion: '1.0'
   - title: Splendor
     bggId: 148228
     language: en
-    pdf: splendor_rulebook.pdf
     seedAgent: true
     bggEnhanced: true
-    description: >+
-      Splendor is a game of chip-collecting and card development. Players are merchants of the Renaissance trying to buy gem mines, means of transportation, shops&mdash;all in order to acquire the most prestige points. If you're wealthy enough, you might even receive a visit from a noble at some point, which of course will further increase your prestige.
+    description: 'Splendor is a game of chip-collecting and card development. Players are merchants of the Renaissance trying
+      to buy gem mines, means of transportation, shops&mdash;all in order to acquire the most prestige points. If you''re
+      wealthy enough, you might even receive a visit from a noble at some point, which of course will further increase your
+      prestige.
 
 
-      On your turn, you may (1) collect chips (gems), or (2) buy and build a card, or (3) reserve one card. If you collect chips, you take either three different kinds of chips or two chips of the same kind. If you buy a card, you pay its price in chips and add it to your playing area. To reserve a card&mdash;in order to make sure you get it, or, why not, your opponents don't get it&mdash;you place it in front of you face down for later building; this costs you a round, but you also get gold in the form of a joker chip, which you can use as any gem.
+      On your turn, you may (1) collect chips (gems), or (2) buy and build a card, or (3) reserve one card. If you collect
+      chips, you take either three different kinds of chips or two chips of the same kind. If you buy a card, you pay its
+      price in chips and add it to your playing area. To reserve a card&mdash;in order to make sure you get it, or, why not,
+      your opponents don''t get it&mdash;you place it in front of you face down for later building; this costs you a round,
+      but you also get gold in the form of a joker chip, which you can use as any gem.
 
 
-      All of the cards you buy increase your wealth as they give you a permanent gem bonus for later buys; some of the cards also give you prestige points. In order to win the game, you must reach 15 prestige points before your opponents do.
+      All of the cards you buy increase your wealth as they give you a permanent gem bonus for later buys; some of the cards
+      also give you prestige points. In order to win the game, you must reach 15 prestige points before your opponents do.
 
+
+      '
     yearPublished: 2014
     minPlayers: 2
     maxPlayers: 4
@@ -690,19 +772,28 @@ catalog:
     - Rebel Sp. z o.o.
     - Siam Board Games
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/splendor_rulebook.pdf
+    pdfSha256: f4423dfde0c9bf7bb71d3ab1a5f87823f8c90857b84b83541bc9cd43727dc6a1
+    pdfVersion: '1.0'
   - title: 'Ticket to Ride: Europe'
     bggId: 14996
     language: en
-    pdf: ticket-to-ride-europe_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Ticket to Ride: Europe takes you on a new train adventure across Europe. From Edinburgh to Constantinople and from Lisbon to Moscow, you'll visit great cities of turn-of-the-century Europe. Like the original Ticket to Ride, the game remains elegantly simple, can be learned in 5 minutes, and appeals to both families and experienced gamers. Ticket to Ride: Europe is a complete, new game and does not require the original version.
+    description: 'Ticket to Ride: Europe takes you on a new train adventure across Europe. From Edinburgh to Constantinople
+      and from Lisbon to Moscow, you''ll visit great cities of turn-of-the-century Europe. Like the original Ticket to Ride,
+      the game remains elegantly simple, can be learned in 5 minutes, and appeals to both families and experienced gamers.
+      Ticket to Ride: Europe is a complete, new game and does not require the original version.
 
 
-      More than just a new map, Ticket to Ride: Europe features brand new gameplay elements. Tunnels may require you to pay extra cards to build on them, Ferries require locomotive cards in order to claim them, and Stations allow you to sacrifice a few points in order to use an opponent's route to connect yours. The game also includes larger format cards and Train Station game pieces.
+      More than just a new map, Ticket to Ride: Europe features brand new gameplay elements. Tunnels may require you to pay
+      extra cards to build on them, Ferries require locomotive cards in order to claim them, and Stations allow you to sacrifice
+      a few points in order to use an opponent''s route to connect yours. The game also includes larger format cards and Train
+      Station game pieces.
 
 
-      The overall goal remains the same: collect and play train cards in order to place your pieces on the board, attempting to connect cities on your ticket cards. Points are earned both from placing trains and completing tickets but uncompleted tickets lose you points. The player who has the most points at the end of the game wins.
+      The overall goal remains the same: collect and play train cards in order to place your pieces on the board, attempting
+      to connect cities on your ticket cards. Points are earned both from placing trains and completing tickets but uncompleted
+      tickets lose you points. The player who has the most points at the end of the game wins.
 
 
       Copyright 2002-2014 Days of Wonder, inc.
@@ -710,6 +801,8 @@ catalog:
 
       Part of the Ticket to Ride series.
 
+
+      '
     yearPublished: 2005
     minPlayers: 2
     maxPlayers: 5
@@ -761,25 +854,38 @@ catalog:
     - Runadrake
     - Smart Ltd
     - Well Designed Game
+    pdfBlobKey: rulebooks/v1/ticket-to-ride-europe_rulebook.pdf
+    pdfSha256: 9dc1f4210477d61dcd9b1baed990f4080fe372b657f6531f6e57c98197487fae
+    pdfVersion: '1.0'
   - title: Dominion
     bggId: 36218
     language: en
-    pdf: dominion_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      "You are a monarch, like your parents before you, a ruler of a small pleasant kingdom of rivers and evergreens. Unlike your parents, however, you have hopes and dreams! You want a bigger and more pleasant kingdom, with more rivers and a wider variety of trees. You want a Dominion! In all directions lie fiefs, freeholds, and feodums. All are small bits of land, controlled by petty lords and verging on anarchy. You will bring civilization to these people, uniting them under your banner.
+    description: '"You are a monarch, like your parents before you, a ruler of a small pleasant kingdom of rivers and evergreens.
+      Unlike your parents, however, you have hopes and dreams! You want a bigger and more pleasant kingdom, with more rivers
+      and a wider variety of trees. You want a Dominion! In all directions lie fiefs, freeholds, and feodums. All are small
+      bits of land, controlled by petty lords and verging on anarchy. You will bring civilization to these people, uniting
+      them under your banner.
 
 
-      But wait! It must be something in the air; several other monarchs have had the exact same idea. You must race to get as much of the unclaimed land as possible, fending them off along the way. To do this you will hire minions, construct buildings, spruce up your castle, and fill the coffers of your treasury. Your parents wouldn't be proud, but your grandparents, on your mother's side, would be delighted."
+      But wait! It must be something in the air; several other monarchs have had the exact same idea. You must race to get
+      as much of the unclaimed land as possible, fending them off along the way. To do this you will hire minions, construct
+      buildings, spruce up your castle, and fill the coffers of your treasury. Your parents wouldn''t be proud, but your grandparents,
+      on your mother''s side, would be delighted."
 
 
       &mdash;description from the back of the box
 
 
-      In Dominion, each player starts with an identical, very small deck of cards.  In the center of the table is a selection of other cards the players can "buy" as they can afford them.  Through their selection of cards to buy, and how they play their hands as they draw them, the players construct their deck on the fly, striving for the most efficient path to the precious victory points by game end.
+      In Dominion, each player starts with an identical, very small deck of cards.  In the center of the table is a selection
+      of other cards the players can "buy" as they can afford them.  Through their selection of cards to buy, and how they
+      play their hands as they draw them, the players construct their deck on the fly, striving for the most efficient path
+      to the precious victory points by game end.
 
 
-      Dominion is not a Collectible Card Game (CCG), but the play of the game is similar to the construction and play of a CCG deck. The game comes with 500 cards. You select 10 of the 25 Kingdom card types to include in any given play&mdash;leading to immense variety.
+      Dominion is not a Collectible Card Game (CCG), but the play of the game is similar to the construction and play of a
+      CCG deck. The game comes with 500 cards. You select 10 of the 25 Kingdom card types to include in any given play&mdash;leading
+      to immense variety.
 
 
       &mdash;user summary
@@ -787,6 +893,8 @@ catalog:
 
       Part of the Dominion series.
 
+
+      '
     yearPublished: 2008
     minPlayers: 2
     maxPlayers: 4
@@ -834,23 +942,43 @@ catalog:
     - Swan Panasia Co., Ltd.
     - Vennerød Forlag AS
     - Ystari Games
+    pdfBlobKey: rulebooks/v1/dominion_rulebook.pdf
+    pdfSha256: ea9e3fbef0064e6773c8772bbb234ac7d06c71a478422b45143432a29aa64273
+    pdfVersion: '1.0'
   - title: Scythe
     bggId: 169786
     language: en
-    pdf: scythe_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      It is a time of unrest in 1920s Europa. The ashes from the first great war still darken the snow. The capitalistic city-state known simply as &ldquo;The Factory&rdquo;, which fueled the war with heavily armored mechs, has closed its doors, drawing the attention of several nearby countries.
+    description: 'It is a time of unrest in 1920s Europa. The ashes from the first great war still darken the snow. The capitalistic
+      city-state known simply as &ldquo;The Factory&rdquo;, which fueled the war with heavily armored mechs, has closed its
+      doors, drawing the attention of several nearby countries.
 
 
-      Scythe is an engine-building game set in a 1920s era, alternate-history. It is a time of farming and war, broken hearts and rusted gears, innovation and valor. In Scythe, each player controls one of five factions of Eastern Europe, all of which are attempting to earn their fortunes and claim their stakes in the land around the mysterious Factory. Players conquer territory, enlist new recruits, reap resources, gain villagers, build structures, and activate monstrous mechs.
+      Scythe is an engine-building game set in a 1920s era, alternate-history. It is a time of farming and war, broken hearts
+      and rusted gears, innovation and valor. In Scythe, each player controls one of five factions of Eastern Europe, all
+      of which are attempting to earn their fortunes and claim their stakes in the land around the mysterious Factory. Players
+      conquer territory, enlist new recruits, reap resources, gain villagers, build structures, and activate monstrous mechs.
 
 
-      Each player begins the game with different resources (power, coins, combat acumen, and popularity), a different starting location, and a hidden goal. Starting positions are specially calibrated to contribute to each faction&rsquo;s uniqueness and the asymmetrical nature of the game (each faction always starts in the same place). Scythe uses a streamlined action-selection mechanism (no rounds or phases) to keep gameplay moving at a brisk pace and reduce downtime between turns. While there is plenty of direct conflict for players who seek it, there is no player elimination.
+      Each player begins the game with different resources (power, coins, combat acumen, and popularity), a different starting
+      location, and a hidden goal. Starting positions are specially calibrated to contribute to each faction&rsquo;s uniqueness
+      and the asymmetrical nature of the game (each faction always starts in the same place). Scythe uses a streamlined action-selection
+      mechanism (no rounds or phases) to keep gameplay moving at a brisk pace and reduce downtime between turns. While there
+      is plenty of direct conflict for players who seek it, there is no player elimination.
 
 
-      Scythe gives players almost complete control over their fate. Other than each player&rsquo;s individual hidden objective card, the only elements of luck or variability are &ldquo;encounter&rdquo; cards that players will draw as they interact with the citizens of newly explored lands. Each encounter card provides the player with several options, allowing them to mitigate the luck of the draw through their selection. Combat is also driven by choices, not luck or randomness. Every part of Scythe has an aspect of engine-building to it. Players can upgrade actions to become more efficient, build structures that improve their position on the map, enlist new recruits to enhance character abilities, activate mechs to deter opponents from invading, and expand their borders to reap greater types and quantities of resources. These engine-building aspects create a sense of momentum and progress throughout the game. The order in which players improve their engines adds to the unique feel of each game, even if having played one faction multiple times.
+      Scythe gives players almost complete control over their fate. Other than each player&rsquo;s individual hidden objective
+      card, the only elements of luck or variability are &ldquo;encounter&rdquo; cards that players will draw as they interact
+      with the citizens of newly explored lands. Each encounter card provides the player with several options, allowing them
+      to mitigate the luck of the draw through their selection. Combat is also driven by choices, not luck or randomness.
+      Every part of Scythe has an aspect of engine-building to it. Players can upgrade actions to become more efficient, build
+      structures that improve their position on the map, enlist new recruits to enhance character abilities, activate mechs
+      to deter opponents from invading, and expand their borders to reap greater types and quantities of resources. These
+      engine-building aspects create a sense of momentum and progress throughout the game. The order in which players improve
+      their engines adds to the unique feel of each game, even if having played one faction multiple times.
 
+
+      '
     yearPublished: 2016
     minPlayers: 1
     maxPlayers: 5
@@ -908,29 +1036,50 @@ catalog:
     - Planeta Igor
     - Playfun Games
     - Surfin' Meeple China
+    pdfBlobKey: rulebooks/v1/scythe_rulebook.pdf
+    pdfSha256: 3a27021231ff6ceb6401878eb27912ca7ce9455c6d2e7393e29248a80939f606
+    pdfVersion: '1.0'
   - title: Patchwork
     bggId: 163412
     language: en
-    pdf: patchwork_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Patchwork, two players compete to build the most aesthetic (and high-scoring) patchwork quilt on a personal 9x9 game board. To start play, lay out all of the patches at random in a circle and place a marker directly clockwise of the 2-1 patch. Each player takes five buttons &mdash; the currency/points in the game &mdash; and someone is chosen as the start player.
+    description: 'In Patchwork, two players compete to build the most aesthetic (and high-scoring) patchwork quilt on a personal
+      9x9 game board. To start play, lay out all of the patches at random in a circle and place a marker directly clockwise
+      of the 2-1 patch. Each player takes five buttons &mdash; the currency/points in the game &mdash; and someone is chosen
+      as the start player.
 
 
-      On a turn, a player either purchases one of the three patches standing clockwise of the spool or passes. To purchase a patch, you pay the cost in buttons shown on the patch, move the spool to that patch's location in the circle, add the patch to your game board, then advance your time token on the time track a number of spaces equal to the time shown on the patch. You're free to place the patch anywhere on your board that doesn't overlap other patches, but you probably want to fit things together as tightly as possible. If your time token is behind or on top of the other player's time token, then you take another turn; otherwise the opponent now goes. Instead of purchasing a patch, you can choose to pass; to do this, you move your time token to the space immediately in front of the opponent's time token, then take one button from the bank for each space you moved.
+      On a turn, a player either purchases one of the three patches standing clockwise of the spool or passes. To purchase
+      a patch, you pay the cost in buttons shown on the patch, move the spool to that patch''s location in the circle, add
+      the patch to your game board, then advance your time token on the time track a number of spaces equal to the time shown
+      on the patch. You''re free to place the patch anywhere on your board that doesn''t overlap other patches, but you probably
+      want to fit things together as tightly as possible. If your time token is behind or on top of the other player''s time
+      token, then you take another turn; otherwise the opponent now goes. Instead of purchasing a patch, you can choose to
+      pass; to do this, you move your time token to the space immediately in front of the opponent''s time token, then take
+      one button from the bank for each space you moved.
 
 
-      In addition to a button cost and time cost, each patch also features 0-3 buttons, and when you move your time token past a button on the time track, you earn "button income": sum the number of buttons depicted on your personal game board, then take this many buttons from the bank.
+      In addition to a button cost and time cost, each patch also features 0-3 buttons, and when you move your time token
+      past a button on the time track, you earn "button income": sum the number of buttons depicted on your personal game
+      board, then take this many buttons from the bank.
 
 
-      What's more, the time track depicts five 1x1 patches on it, and during set-up you place five actual 1x1 patches on these spaces. Whoever first passes a patch on the time track claims this patch and immediately places it on his game board.
+      What''s more, the time track depicts five 1x1 patches on it, and during set-up you place five actual 1x1 patches on
+      these spaces. Whoever first passes a patch on the time track claims this patch and immediately places it on his game
+      board.
 
 
-      Additionally, the first player to completely fill in a 7x7 square on his game board earns a bonus tile worth 7 extra points at the end of the game. (Of course, this doesn't happen in every game.)
+      Additionally, the first player to completely fill in a 7x7 square on his game board earns a bonus tile worth 7 extra
+      points at the end of the game. (Of course, this doesn''t happen in every game.)
 
 
-      When a player takes an action that moves his time token to the central square of the time track, he takes one final button income from the bank. Once both players are in the center, the game ends and scoring takes place. Each player scores one point per button in his possession, then loses two points for each empty square on his game board. Scores can be negative. The player with the most points wins.
+      When a player takes an action that moves his time token to the central square of the time track, he takes one final
+      button income from the bank. Once both players are in the center, the game ends and scoring takes place. Each player
+      scores one point per button in his possession, then loses two points for each empty square on his game board. Scores
+      can be negative. The player with the most points wins.
 
+
+      '
     yearPublished: 2014
     minPlayers: 2
     maxPlayers: 2
@@ -988,20 +1137,29 @@ catalog:
     - Tower Tactic Games
     - uplay.it edizioni
     - Нескучные игры
+    pdfBlobKey: rulebooks/v1/patchwork_rulebook.pdf
+    pdfSha256: 045325d8717e566f2cdb85196c6ee2ced1c7d484a67e9fc109b042b853b98874
+    pdfVersion: '1.0'
   - title: Love Letter
     bggId: 129622
     language: en
-    pdf: love-letter_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      All of the eligible young men (and many of the not-so-young) seek to woo the princess of Tempest. Unfortunately, she has locked herself in the palace, and you must rely on others to take your romantic letters to her. Will yours reach her first?
+    description: 'All of the eligible young men (and many of the not-so-young) seek to woo the princess of Tempest. Unfortunately,
+      she has locked herself in the palace, and you must rely on others to take your romantic letters to her. Will yours reach
+      her first?
 
 
-      Love Letter is a game of risk, deduction, and luck for 2&ndash;4 players. Your goal is to get your love letter into Princess Annette's hands while deflecting the letters from competing suitors. From a deck with only sixteen cards, each player starts with only one card in hand; one card is removed from play. On a turn, you draw one card, and play one card, trying to expose others and knock them from the game. Powerful cards lead to early gains, but make you a target. Rely on weaker cards for too long, however, and your letter may be tossed in the fire!
+      Love Letter is a game of risk, deduction, and luck for 2&ndash;4 players. Your goal is to get your love letter into
+      Princess Annette''s hands while deflecting the letters from competing suitors. From a deck with only sixteen cards,
+      each player starts with only one card in hand; one card is removed from play. On a turn, you draw one card, and play
+      one card, trying to expose others and knock them from the game. Powerful cards lead to early gains, but make you a target.
+      Rely on weaker cards for too long, however, and your letter may be tossed in the fire!
 
 
       Number 4 in the Setting: Tempest Shared World Game Series
 
+
+      '
     yearPublished: 2012
     minPlayers: 2
     maxPlayers: 4
@@ -1057,29 +1215,39 @@ catalog:
     - Swan Panasia Co., Ltd.
     - uplay.it edizioni
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/love-letter_rulebook.pdf
+    pdfSha256: e6b14614ffa5da73d995eaceefd7ca99e20ea8687b873da9b67ce6f3a5e69655
+    pdfVersion: '1.0'
   - title: King of Tokyo
     bggId: 70323
     language: en
-    pdf: king-of-tokyo_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In King of Tokyo, you play mutant monsters, gigantic robots, and strange aliens&mdash;all of whom are destroying Tokyo and whacking each other in order to become the one and only King of Tokyo.
+    description: 'In King of Tokyo, you play mutant monsters, gigantic robots, and strange aliens&mdash;all of whom are destroying
+      Tokyo and whacking each other in order to become the one and only King of Tokyo.
 
 
-      At the start of each turn, you roll six dice, which show the following six symbols: 1, 2, or 3 Victory Points, Energy, Heal, and Attack. Over three successive throws, choose whether to keep or discard each die in order to win victory points, gain energy, restore health, or attack other players into understanding that Tokyo is YOUR territory.
+      At the start of each turn, you roll six dice, which show the following six symbols: 1, 2, or 3 Victory Points, Energy,
+      Heal, and Attack. Over three successive throws, choose whether to keep or discard each die in order to win victory points,
+      gain energy, restore health, or attack other players into understanding that Tokyo is YOUR territory.
 
 
-      The fiercest player will occupy Tokyo, and earn extra victory points, but that player can't heal and must face all the other monsters alone!
+      The fiercest player will occupy Tokyo, and earn extra victory points, but that player can''t heal and must face all
+      the other monsters alone!
 
 
-      Top this off with special cards purchased with energy that have a permanent or temporary effect, such as the growing of a second head which grants you an additional die, body armor, nova death ray, and more.... and it's one of the most explosive games of the year!
+      Top this off with special cards purchased with energy that have a permanent or temporary effect, such as the growing
+      of a second head which grants you an additional die, body armor, nova death ray, and more.... and it''s one of the most
+      explosive games of the year!
 
 
-      In order to win the game, one must either destroy Tokyo by accumulating 20 victory points, or be the only surviving monster once the fighting has ended.
+      In order to win the game, one must either destroy Tokyo by accumulating 20 victory points, or be the only surviving
+      monster once the fighting has ended.
 
 
       First Game in the King of Tokyo series
 
+
+      '
     yearPublished: 2011
     minPlayers: 2
     maxPlayers: 6
@@ -1144,23 +1312,33 @@ catalog:
     - uplay.it edizioni
     - Vennerød Forlag AS
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/king-of-tokyo_rulebook.pdf
+    pdfSha256: 8ad8bba7f868b3925bb82ba206bd5cc8eab9a1c5d08e2b36fccad615af57e5fe
+    pdfVersion: '1.0'
   - title: Dixit
     bggId: 39856
     language: en
-    pdf: dixit_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Each turn in Dixit, one player is the storyteller who chooses one of the six cards in their hand, then expresses an idea, with sounds or words, that is reflected on that card's image, and places the card face down on the playing surface. Each other player then selects the card that best matches that expression, and passes the selected card to the storyteller, face down.
+    description: 'Each turn in Dixit, one player is the storyteller who chooses one of the six cards in their hand, then expresses
+      an idea, with sounds or words, that is reflected on that card''s image, and places the card face down on the playing
+      surface. Each other player then selects the card that best matches that expression, and passes the selected card to
+      the storyteller, face down.
 
 
-      The storyteller shuffles all the cards together, then turns them over to reveal them. Each player other than the storyteller then secretly guesses which card belongs to the storyteller. If nobody or everybody guesses the correct card, the storyteller scores 0 points, and each other player scores 2 points. Otherwise, the storyteller and whoever found the correct answer score 3 points. Additionally, the non-storyteller players score 1 point for every vote received by their card.
+      The storyteller shuffles all the cards together, then turns them over to reveal them. Each player other than the storyteller
+      then secretly guesses which card belongs to the storyteller. If nobody or everybody guesses the correct card, the storyteller
+      scores 0 points, and each other player scores 2 points. Otherwise, the storyteller and whoever found the correct answer
+      score 3 points. Additionally, the non-storyteller players score 1 point for every vote received by their card.
 
 
-      The game ends when the deck is empty or if a player has scored at least 30 points. In either case, the player with the most points wins.
+      The game ends when the deck is empty or if a player has scored at least 30 points. In either case, the player with the
+      most points wins.
 
 
       The Dixit base game and each expansion contain 84 cards, and the cards can be mixed together as desired.
 
+
+      '
     yearPublished: 2008
     minPlayers: 3
     maxPlayers: 6
@@ -1206,17 +1384,27 @@ catalog:
     - Rebel Sp. z o.o.
     - Swan Panasia Co., Ltd.
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/dixit_rulebook.pdf
+    pdfSha256: 26365f602d44493cb38f63459a904d653c31ac93eb5543f899ca0da20cfd51b7
+    pdfVersion: '1.0'
   - title: Gloomhaven
     bggId: 174430
     language: en
-    pdf: gloomhaven_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Gloomhaven  is a game of Euro-inspired tactical combat in a persistent world of shifting motives. Players will take on the roles of wandering adventurers with their own special sets of skills and their own reasons for traveling to this dark corner of the world. Players must work together out of necessity to clear out menacing dungeons and forgotten ruins. In the process, they will enhance their abilities with experience and loot, discover new locations to explore and plunder, and expand an ever-branching story fueled by the decisions they make.
-       This is a game with a persistent and changing world that is ideally played over many game sessions. After a scenario, players will make decisions about what to do next, which will determine how the story continues, kind of like a &ldquo;Choose Your Own Adventure&rdquo; book. Playing through a scenario is a co-operative affair where players will fight against automated monsters using an innovative card system to determine the order of play and what a player does on their turn.
-
-      Each turn, a player chooses two cards to play out of their hand. The number on the top card determines their initiative for the round. Each card also has a top and bottom power, and when it is a player&rsquo;s turn in the initiative order, they determine whether to use the top power of one card and the bottom power of the other, or vice-versa. Players must be careful, though, because over time they will permanently lose cards from their hands. If they take too long to clear a dungeon, they may end u exhausted and be forced to retreat.
-
+    description: "Gloomhaven  is a game of Euro-inspired tactical combat in a persistent world of shifting motives. Players\
+      \ will take on the roles of wandering adventurers with their own special sets of skills and their own reasons for traveling\
+      \ to this dark corner of the world. Players must work together out of necessity to clear out menacing dungeons and forgotten\
+      \ ruins. In the process, they will enhance their abilities with experience and loot, discover new locations to explore\
+      \ and plunder, and expand an ever-branching story fueled by the decisions they make.\n This is a game with a persistent\
+      \ and changing world that is ideally played over many game sessions. After a scenario, players will make decisions about\
+      \ what to do next, which will determine how the story continues, kind of like a &ldquo;Choose Your Own Adventure&rdquo;\
+      \ book. Playing through a scenario is a co-operative affair where players will fight against automated monsters using\
+      \ an innovative card system to determine the order of play and what a player does on their turn.\n\nEach turn, a player\
+      \ chooses two cards to play out of their hand. The number on the top card determines their initiative for the round.\
+      \ Each card also has a top and bottom power, and when it is a player&rsquo;s turn in the initiative order, they determine\
+      \ whether to use the top power of one card and the bottom power of the other, or vice-versa. Players must be careful,\
+      \ though, because over time they will permanently lose cards from their hands. If they take too long to clear a dungeon,\
+      \ they may end u exhausted and be forced to retreat.\n\n"
     yearPublished: 2017
     minPlayers: 1
     maxPlayers: 4
@@ -1273,29 +1461,41 @@ catalog:
     - Hobby World
     - Korea Boardgames
     - MYBG Co., Ltd.
+    pdfBlobKey: rulebooks/v1/gloomhaven_rulebook.pdf
+    pdfSha256: a8bb3b2e3d875f325d12da48ca4c6fd7807876b3b0353bf4052a74678d339f27
+    pdfVersion: '1.0'
   - title: Small World
     bggId: 40692
     language: en
-    pdf: small-world_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Small World, players vie for conquest and control of a world that is simply too small to accommodate them all.
+    description: 'In Small World, players vie for conquest and control of a world that is simply too small to accommodate
+      them all.
 
 
-      Designed by Philippe Keyaerts as a fantasy follow-up to his award-winning Vinci, Small World is inhabited by a zany cast of characters such as dwarves, wizards, amazons, giants, orcs, and even humans, who use their troops to occupy territory and conquer adjacent lands in order to push the other races off the face of the earth.
+      Designed by Philippe Keyaerts as a fantasy follow-up to his award-winning Vinci, Small World is inhabited by a zany
+      cast of characters such as dwarves, wizards, amazons, giants, orcs, and even humans, who use their troops to occupy
+      territory and conquer adjacent lands in order to push the other races off the face of the earth.
 
 
-      Picking the right combination from the 14 different fantasy races and 20 unique special powers, players rush to expand their empires - often at the expense of weaker neighbors. Yet they must also know when to push their own over-extended civilization into decline and ride a new one to victory!
+      Picking the right combination from the 14 different fantasy races and 20 unique special powers, players rush to expand
+      their empires - often at the expense of weaker neighbors. Yet they must also know when to push their own over-extended
+      civilization into decline and ride a new one to victory!
 
 
-      On each turn, you either use the multiple tiles of your chosen race (type of creatures) to occupy adjacent (normally) territories - possibly defeating weaker enemy races along the way, or you give up on your race letting it go "into decline". A race in decline is designated by flipping the tiles over to their black-and-white side.
+      On each turn, you either use the multiple tiles of your chosen race (type of creatures) to occupy adjacent (normally)
+      territories - possibly defeating weaker enemy races along the way, or you give up on your race letting it go "into decline".
+      A race in decline is designated by flipping the tiles over to their black-and-white side.
 
 
-      At the end of your turn, you score one point (coin) for each territory your races occupy. You may have one active race and one race in decline on the board at the same time. Your occupation total can vary depending on the special abilities of your race and the territories they occupy. After the final round, the player with the most coins wins.
+      At the end of your turn, you score one point (coin) for each territory your races occupy. You may have one active race
+      and one race in decline on the board at the same time. Your occupation total can vary depending on the special abilities
+      of your race and the territories they occupy. After the final round, the player with the most coins wins.
 
 
       Clarifications: available in a pinned forum post.
 
+
+      '
     yearPublished: 2009
     minPlayers: 2
     maxPlayers: 5
@@ -1337,13 +1537,19 @@ catalog:
     - Rebel Sp. z o.o.
     - Siam Board Games
     - Stratelibri
+    pdfBlobKey: rulebooks/v1/small-world_rulebook.pdf
+    pdfSha256: 9accfbeafcd1d650d39746eb79da373f9e9fe1c92f6f3322983d2e30b94b1c2a
+    pdfVersion: '1.0'
   - title: Everdell
     bggId: 199792
     language: en
-    pdf: everdell_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Within the charming valley of Everdell, beneath the boughs of towering trees, among meandering streams and mossy hollows, a civilization of forest critters is thriving and expanding. From Everfrost to Bellsong, many a year have come and gone, but the time has come for new territories to be settled and new cities established. You will be the leader of a group of critters intent on just such a task. There are buildings to construct, lively characters to meet, events to host&mdash;you have a busy year ahead of yourself. Will the sun shine brightest on your city before the winter moon rises?
+    description: 'Within the charming valley of Everdell, beneath the boughs of towering trees, among meandering streams and
+      mossy hollows, a civilization of forest critters is thriving and expanding. From Everfrost to Bellsong, many a year
+      have come and gone, but the time has come for new territories to be settled and new cities established. You will be
+      the leader of a group of critters intent on just such a task. There are buildings to construct, lively characters to
+      meet, events to host&mdash;you have a busy year ahead of yourself. Will the sun shine brightest on your city before
+      the winter moon rises?
 
 
       Everdell is a game of dynamic tableau building and worker placement.
@@ -1352,14 +1558,23 @@ catalog:
       On their turn a player can take one of three actions:
 
 
-      a) Place a Worker: Each player has a collection of Worker pieces. These are placed on the board locations, events, and on Destination cards. Workers perform various actions to further the development of a player's tableau: gathering resources, drawing cards, and taking other special actions.
+      a) Place a Worker: Each player has a collection of Worker pieces. These are placed on the board locations, events, and
+      on Destination cards. Workers perform various actions to further the development of a player''s tableau: gathering resources,
+      drawing cards, and taking other special actions.
 
 
-      b) Play a Card: Each player is building and populating a city; a tableau of up to 15 Construction and Critter cards. There are five types of cards: Travelers, Production, Destination, Governance, and Prosperity. Cards generate resources (twigs, resin, pebbles, and berries), grant abilities, and ultimately score points. The interactions of the cards reveal numerous strategies and a near infinite variety of working cities.
+      b) Play a Card: Each player is building and populating a city; a tableau of up to 15 Construction and Critter cards.
+      There are five types of cards: Travelers, Production, Destination, Governance, and Prosperity. Cards generate resources
+      (twigs, resin, pebbles, and berries), grant abilities, and ultimately score points. The interactions of the cards reveal
+      numerous strategies and a near infinite variety of working cities.
 
 
-      c) Prepare for the next Season: Workers are returned to the players supply and new workers are added. The game is played from Winter through to the onset of the following winter, at which point the player with the city with the most points wins.
+      c) Prepare for the next Season: Workers are returned to the players supply and new workers are added. The game is played
+      from Winter through to the onset of the following winter, at which point the player with the city with the most points
+      wins.
 
+
+      '
     yearPublished: 2018
     minPlayers: 1
     maxPlayers: 4
@@ -1413,80 +1628,41 @@ catalog:
     - White Goblin Games
     - YOKA Games
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/everdell_rulebook.pdf
+    pdfSha256: df74d35f64e90f0f94ed0077140c1ad18a4901cdd54a24c019257a5da671b74b
+    pdfVersion: '1.0'
   - title: Munchkin
     bggId: 1927
     language: en
-    pdf: munchkin_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      				
-      				
-      					Publisher's DescriptionGo down in the dungeon. Kill everything you meet. Backstab your friends and steal their stuff. Grab the treasure and run.
-
-      Admit it. You love it.
-
-
-      This award-winning card game, designed by Steve Jackson, captures the essence of the dungeon experience... with none of that stupid roleplaying stuff. You and your friends compete to kill monsters and grab magic items. And what magic items! Don the Horny Helmet and the Boots of Butt-Kicking. Wield the Staff of Napalm... or maybe the Chainsaw of Bloody Dismemberment. Start by slaughtering the Potted Plant and the Drooling Slime, and work your way up to the Plutonium Dragon...
-
-
-      And it's illustrated by John Kovalic! Fast-playing and silly, Munchkin can reduce any roleplaying group to hysteria. And, while they're laughing, you can steal their stuff.
-
-      				
-      				
-      					OtherPart of the Munchkin series.
-
-      Munchkin is a satirical card game based on the clich&eacute;s and oddities of Dungeons and Dragons and other role-playing games. Each player starts at level 1 and the winner is the first player to reach level 10. Players can acquire familiar D&D style character classes during the game which determine to some extent the cards they can play.
-
-
-      There are two types of cards - treasure and encounters. Each turn the current players 'kicks down the door' - drawing an encounter card from the deck. Usually this will involve battling a monster. Monsters have their own levels and players must try and overcome it using the levels, weapons and powers they have acquired during the game or run away. Other players can chose to help the player or hinder by adding extra monsters to the encounter. Defeating a monster will usually result in drawing treasure cards and acquiring levels.  Being defeated by a monster results in "bad stuff" which usually involves losing levels and treasure.
-
-
-      In May 2010, Steve Jackson Games made the "big announcement." Many rules and cards were changed. See The Great 2010 Munchkin Changeover for details. Of note to Munchkin fans, the Kneepads of Allure card, which had been removed in the 14th printing, was added back to the game but modified to be less powerful.
-
-      				
-      				
-      					Sequels:
-          The Good, the Bad, and the Munchkin
-          Munchkin Apocalypse
-          Munchkin Axe Cop
-          Munchkin Bites!
-          Munchkin Booty
-          Munchkin Conan
-          Munchkin Cthulhu
-          Munchkin Fu
-          Munchkin Impossible
-          Munchkin Legends
-          Munchkin Pathfinder
-          Munchkin Zombies
-          Star Munchkin
-          Super Munchkin
-
-
-      				
-      				
-      					Related Board Games
-          Munchkin Quest
-
-
-      				
-      				
-      					Online play
-           Vassal does not support Munchkin anymore. Former link: Vassal Module
-
-
-      				
-      				
-      					Pegasus Expansions
-          Munchkin Sammlerbox
-          Munchkin Sammlerkoffer
-          Munchkin Promotional Bookmarks
-          Munchkin Weihnachtsedition - The same as Munchkin, but with a promotional button that grants the wearer extra treasure (when worn in December). 
-
-
-      				
-      				
-      					Online PlaythroughThere's a great YouTube playthrough with Will Wheaton and Steve Jackson (yes, the Steve Jackson) found here LINK
-
+    description: "\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tPublisher's DescriptionGo down in the dungeon. Kill everything you meet. Backstab\
+      \ your friends and steal their stuff. Grab the treasure and run.\n\nAdmit it. You love it.\n\nThis award-winning card\
+      \ game, designed by Steve Jackson, captures the essence of the dungeon experience... with none of that stupid roleplaying\
+      \ stuff. You and your friends compete to kill monsters and grab magic items. And what magic items! Don the Horny Helmet\
+      \ and the Boots of Butt-Kicking. Wield the Staff of Napalm... or maybe the Chainsaw of Bloody Dismemberment. Start by\
+      \ slaughtering the Potted Plant and the Drooling Slime, and work your way up to the Plutonium Dragon...\n\nAnd it's\
+      \ illustrated by John Kovalic! Fast-playing and silly, Munchkin can reduce any roleplaying group to hysteria. And, while\
+      \ they're laughing, you can steal their stuff.\n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tOtherPart of the Munchkin series.\n\n\
+      Munchkin is a satirical card game based on the clich&eacute;s and oddities of Dungeons and Dragons and other role-playing\
+      \ games. Each player starts at level 1 and the winner is the first player to reach level 10. Players can acquire familiar\
+      \ D&D style character classes during the game which determine to some extent the cards they can play.\n\nThere are two\
+      \ types of cards - treasure and encounters. Each turn the current players 'kicks down the door' - drawing an encounter\
+      \ card from the deck. Usually this will involve battling a monster. Monsters have their own levels and players must\
+      \ try and overcome it using the levels, weapons and powers they have acquired during the game or run away. Other players\
+      \ can chose to help the player or hinder by adding extra monsters to the encounter. Defeating a monster will usually\
+      \ result in drawing treasure cards and acquiring levels.  Being defeated by a monster results in \"bad stuff\" which\
+      \ usually involves losing levels and treasure.\n\nIn May 2010, Steve Jackson Games made the \"big announcement.\" Many\
+      \ rules and cards were changed. See The Great 2010 Munchkin Changeover for details. Of note to Munchkin fans, the Kneepads\
+      \ of Allure card, which had been removed in the 14th printing, was added back to the game but modified to be less powerful.\n\
+      \n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tSequels:\n    The Good, the Bad, and the Munchkin\n    Munchkin Apocalypse\n    Munchkin\
+      \ Axe Cop\n    Munchkin Bites!\n    Munchkin Booty\n    Munchkin Conan\n    Munchkin Cthulhu\n    Munchkin Fu\n    Munchkin\
+      \ Impossible\n    Munchkin Legends\n    Munchkin Pathfinder\n    Munchkin Zombies\n    Star Munchkin\n    Super Munchkin\n\
+      \n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tRelated Board Games\n    Munchkin Quest\n\n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tOnline\
+      \ play\n     Vassal does not support Munchkin anymore. Former link: Vassal Module\n\n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\t\
+      Pegasus Expansions\n    Munchkin Sammlerbox\n    Munchkin Sammlerkoffer\n    Munchkin Promotional Bookmarks\n    Munchkin\
+      \ Weihnachtsedition - The same as Munchkin, but with a promotional button that grants the wearer extra treasure (when\
+      \ worn in December). \n\n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tOnline PlaythroughThere's a great YouTube playthrough with\
+      \ Will Wheaton and Steve Jackson (yes, the Steve Jackson) found here LINK\n\n"
     yearPublished: 2001
     minPlayers: 3
     maxPlayers: 6
@@ -1541,26 +1717,33 @@ catalog:
     - Ubik
     - Wargames Club Publishing
     - ТРЕТЯ ПЛАНЕТА
+    pdfBlobKey: rulebooks/v1/munchkin_rulebook.pdf
+    pdfSha256: a68e64aa104b6d1746194835ecfaa2bc22324e642a02cadb4be81371bad62e1a
+    pdfVersion: '1.0'
   - title: Forbidden Island
     bggId: 65244
     language: en
-    pdf: forbidden-island_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Forbidden Island is a visually stunning cooperative board game. Instead of winning by competing with other players like most games, everyone must work together to win the game. Players take turns moving their pawns around the 'island', which is built by arranging the many beautifully screen-printed tiles before play begins. As the game progresses, more and more island tiles sink, becoming unavailable, and the pace increases. Players use strategies to keep the island from sinking, while trying to collect treasures and items. As the water level rises, it gets more difficult- sacrifices must be made.
-
-
-      What causes this game to truly stand out among co-op and competitive games alike is the extreme detail that has been paid to the physical components of the game. It comes in a sturdy and organized tin of good shelf storage size. The plastic treasure pieces and wooden pawns are well crafted and they fit just right into the box. The cards are durable, well printed, and easy to understand. The island tiles are the real gem: they are screen-printed with vibrant colors, each with a unique and pleasing image.
-
-
-      With multiple levels of difficulty, different characters to choose from (each with a special ability of their own), many optional island formats and game variations available, Forbidden Island has huge replay value. The game can be played by as few as two players and up to four (though it can accommodate five). More players translates into a faster and more difficult game, though the extra help can make all the difference. This is a fun game, tricky for players of almost any age. Selling for under twenty dollars, oddly, Forbidden Island is a rare game of both quality and affordable price.
-       For those who enjoy Forbidden Island, a follow-up project by Gamewright titled Forbidden Desert was released in 2013.
-
-      From the publisher's website:
-
-
-      Dare to discover Forbidden Island! Join a team of fearless adventurers on a do-or-die mission to capture four sacred treasures from the ruins of this perilous paradise. Your team will have to work together and make some pulse-pounding maneuvers, as the island will sink beneath every step! Race to collect the treasures and make a triumphant escape before you are swallowed into the watery abyss!
-
+    description: "Forbidden Island is a visually stunning cooperative board game. Instead of winning by competing with other\
+      \ players like most games, everyone must work together to win the game. Players take turns moving their pawns around\
+      \ the 'island', which is built by arranging the many beautifully screen-printed tiles before play begins. As the game\
+      \ progresses, more and more island tiles sink, becoming unavailable, and the pace increases. Players use strategies\
+      \ to keep the island from sinking, while trying to collect treasures and items. As the water level rises, it gets more\
+      \ difficult- sacrifices must be made.\n\nWhat causes this game to truly stand out among co-op and competitive games\
+      \ alike is the extreme detail that has been paid to the physical components of the game. It comes in a sturdy and organized\
+      \ tin of good shelf storage size. The plastic treasure pieces and wooden pawns are well crafted and they fit just right\
+      \ into the box. The cards are durable, well printed, and easy to understand. The island tiles are the real gem: they\
+      \ are screen-printed with vibrant colors, each with a unique and pleasing image.\n\nWith multiple levels of difficulty,\
+      \ different characters to choose from (each with a special ability of their own), many optional island formats and game\
+      \ variations available, Forbidden Island has huge replay value. The game can be played by as few as two players and\
+      \ up to four (though it can accommodate five). More players translates into a faster and more difficult game, though\
+      \ the extra help can make all the difference. This is a fun game, tricky for players of almost any age. Selling for\
+      \ under twenty dollars, oddly, Forbidden Island is a rare game of both quality and affordable price.\n For those who\
+      \ enjoy Forbidden Island, a follow-up project by Gamewright titled Forbidden Desert was released in 2013.\n\nFrom the\
+      \ publisher's website:\n\nDare to discover Forbidden Island! Join a team of fearless adventurers on a do-or-die mission\
+      \ to capture four sacred treasures from the ruins of this perilous paradise. Your team will have to work together and\
+      \ make some pulse-pounding maneuvers, as the island will sink beneath every step! Race to collect the treasures and\
+      \ make a triumphant escape before you are swallowed into the watery abyss!\n\n"
     yearPublished: 2010
     minPlayers: 2
     maxPlayers: 4
@@ -1613,26 +1796,39 @@ catalog:
     - Spilbræt.dk
     - uplay.it edizioni
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/forbidden-island_rulebook.pdf
+    pdfSha256: b007c6b6a9385f4e27e74499f5e4623f3360ab7f8301853a4a3df01c6fa71c39
+    pdfVersion: '1.0'
   - title: Root
     bggId: 237182
     language: en
-    pdf: root_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Root is a game of adventure and war in which 2 to 4 (1 to 6 with the 'Riverfolk' expansion, 2-6 with the 'Underworld', or 'Marauder' expansions) players battle for control of a vast wilderness. Like Vast: The Crystal Caverns, each player in Root has unique capabilities and a different victory condition. Now, with the aid of gorgeous, multi-use cards, a truly asymmetric design has never been more accessible.
+    description: 'Root is a game of adventure and war in which 2 to 4 (1 to 6 with the ''Riverfolk'' expansion, 2-6 with the
+      ''Underworld'', or ''Marauder'' expansions) players battle for control of a vast wilderness. Like Vast: The Crystal
+      Caverns, each player in Root has unique capabilities and a different victory condition. Now, with the aid of gorgeous,
+      multi-use cards, a truly asymmetric design has never been more accessible.
 
 
-      The nefarious Marquise de Cat has seized the great woodland, intent on harvesting its riches. Under her rule, the many creatures of the forest have banded together. This Alliance will seek to strengthen its resources and subvert the rule of Cats. In this effort, the Alliance may enlist the help of the wandering Vagabonds who are able to move through the more dangerous woodland paths. Though some may sympathize with the Alliance&rsquo;s hopes and dreams, these wanderers are old enough to remember the great birds of prey who once controlled the woods.
+      The nefarious Marquise de Cat has seized the great woodland, intent on harvesting its riches. Under her rule, the many
+      creatures of the forest have banded together. This Alliance will seek to strengthen its resources and subvert the rule
+      of Cats. In this effort, the Alliance may enlist the help of the wandering Vagabonds who are able to move through the
+      more dangerous woodland paths. Though some may sympathize with the Alliance&rsquo;s hopes and dreams, these wanderers
+      are old enough to remember the great birds of prey who once controlled the woods.
 
 
-      Meanwhile, at the edge of the region, the proud, squabbling Eyrie have found a new commander who they hope will lead their faction to resume their ancient birthright. The stage is set for a contest that will decide the fate of the great woodland. It is up to the players to decide which group will ultimately take root.
+      Meanwhile, at the edge of the region, the proud, squabbling Eyrie have found a new commander who they hope will lead
+      their faction to resume their ancient birthright. The stage is set for a contest that will decide the fate of the great
+      woodland. It is up to the players to decide which group will ultimately take root.
 
 
-      In Root, players drive the narrative, and the differences between each role create an unparalleled level of interaction and replayability. Leder Games invites you and your family to explore the fantastic world of Root!
+      In Root, players drive the narrative, and the differences between each role create an unparalleled level of interaction
+      and replayability. Leder Games invites you and your family to explore the fantastic world of Root!
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2018
     minPlayers: 2
     maxPlayers: 4
@@ -1685,17 +1881,29 @@ catalog:
     - Spielworxx
     - Tower Tactic Games
     - YOKA Games
+    pdfBlobKey: rulebooks/v1/root_rulebook.pdf
+    pdfSha256: e79ca615f78f3f41a20b080f212eaf1da2e91f52af21c41f176c8a09bc5c8328
+    pdfVersion: '1.0'
   - title: Sushi Go!
     bggId: 133473
     language: en
-    pdf: sushi-go_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In the super-fast sushi card game Sushi Go!, you are eating at a sushi restaurant and trying to grab the best combination of sushi dishes as they whiz by. Score points for collecting the most sushi rolls or making a full set of sashimi. Dip your favorite nigiri in wasabi to triple its value! And once you've eaten it all, finish your meal with all the pudding you've got! But be careful which sushi you allow your friends to take; it might be just what they need to beat you!
+    description: 'In the super-fast sushi card game Sushi Go!, you are eating at a sushi restaurant and trying to grab the
+      best combination of sushi dishes as they whiz by. Score points for collecting the most sushi rolls or making a full
+      set of sashimi. Dip your favorite nigiri in wasabi to triple its value! And once you''ve eaten it all, finish your meal
+      with all the pudding you''ve got! But be careful which sushi you allow your friends to take; it might be just what they
+      need to beat you!
 
 
-      Sushi Go! takes the card-drafting mechanism of Fairy Tale and 7 Wonders and distills it into a twenty-minute game that anyone can play. The dynamics of "draft and pass" are brought to the fore, while keeping the rules to a minimum. As you see the first few hands of cards, you must quickly assess the make-up of the round and decide which type of sushi you'll go for. Then, each turn you'll need to weigh which cards to keep and which to pass on. The different scoring combinations allow for some clever plays and nasty blocks. Round to round, you must also keep your eye on the goal of having the most pudding cards at the end of the game!
+      Sushi Go! takes the card-drafting mechanism of Fairy Tale and 7 Wonders and distills it into a twenty-minute game that
+      anyone can play. The dynamics of "draft and pass" are brought to the fore, while keeping the rules to a minimum. As
+      you see the first few hands of cards, you must quickly assess the make-up of the round and decide which type of sushi
+      you''ll go for. Then, each turn you''ll need to weigh which cards to keep and which to pass on. The different scoring
+      combinations allow for some clever plays and nasty blocks. Round to round, you must also keep your eye on the goal of
+      having the most pudding cards at the end of the game!
 
+
+      '
     yearPublished: 2013
     minPlayers: 2
     maxPlayers: 5
@@ -1745,26 +1953,49 @@ catalog:
     - uplay.it edizioni
     - White Goblin Games
     - Zoch Verlag
+    pdfBlobKey: rulebooks/v1/sushi-go_rulebook.pdf
+    pdfSha256: 9c876c63af4e976927e0cf29c366409e6913d5b9e3b558300ad0712b971f3f99
+    pdfVersion: '1.0'
   - title: Spirit Island
     bggId: 162886
     language: en
-    pdf: spirit-island_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In the most distant reaches of the world, magic still exists, embodied by spirits of the land, of the sky, and of every natural thing. As the great powers of Europe stretch their colonial empires further and further, they will inevitably lay claim to a place where spirits still hold power - and when they do, the land itself will fight back alongside the islanders who live there.
+    description: 'In the most distant reaches of the world, magic still exists, embodied by spirits of the land, of the sky,
+      and of every natural thing. As the great powers of Europe stretch their colonial empires further and further, they will
+      inevitably lay claim to a place where spirits still hold power - and when they do, the land itself will fight back alongside
+      the islanders who live there.
 
 
-      Spirit Island is a complex and thematic co-operative game about defending your island home from colonizing Invaders. Players are different spirits of the land, each with its own unique elemental powers. Every turn, players simultaneously choose which of their power cards to play, paying energy to do so. Using combinations of power cards that match a spirit's elemental affinities can grant free bonus effects. Faster powers take effect immediately, before the Invaders spread and ravage, but other magics are slower, requiring forethought and planning to use effectively. In the Spirit phase, spirits gain energy, and choose how / whether to Grow: to reclaim used power cards, to seek new power, or to spread their presence into new areas of the island.
+      Spirit Island is a complex and thematic co-operative game about defending your island home from colonizing Invaders.
+      Players are different spirits of the land, each with its own unique elemental powers. Every turn, players simultaneously
+      choose which of their power cards to play, paying energy to do so. Using combinations of power cards that match a spirit''s
+      elemental affinities can grant free bonus effects. Faster powers take effect immediately, before the Invaders spread
+      and ravage, but other magics are slower, requiring forethought and planning to use effectively. In the Spirit phase,
+      spirits gain energy, and choose how / whether to Grow: to reclaim used power cards, to seek new power, or to spread
+      their presence into new areas of the island.
 
 
-      The Invaders expand across the island map in a semi-predictable fashion. Each turn they explore into some lands (portions of the island); the next turn, they build in those lands, forming towns and cities. The turn after that, they ravage there, bringing blight to the land and attacking any native islanders present. The islanders fight back against the Invaders when attacked, and lend the spirits some other aid, but may not always do so exactly as you'd hoped. Some Powers work through the islanders, helping them, for example, to drive out the Invaders or clean the land of blight.
+      The Invaders expand across the island map in a semi-predictable fashion. Each turn they explore into some lands (portions
+      of the island); the next turn, they build in those lands, forming towns and cities. The turn after that, they ravage
+      there, bringing blight to the land and attacking any native islanders present. The islanders fight back against the
+      Invaders when attacked, and lend the spirits some other aid, but may not always do so exactly as you''d hoped. Some
+      Powers work through the islanders, helping them, for example, to drive out the Invaders or clean the land of blight.
 
 
-      The game escalates as it progresses: spirits spread their presence to new parts of the island and seek out new and more potent powers, while the Invaders step up their colonization efforts. Each turn represents 1-3 years of alternate history. At game start, winning requires destroying every last explorer, town and city on the board - but as you frighten the Invaders more and more, victory becomes easier: they'll run away even if explorers or even towns and cities remain. Defeat comes if any spirit is destroyed, if the island is overrun by blight, or if the Invader deck is depleted before achieving victory.
+      The game escalates as it progresses: spirits spread their presence to new parts of the island and seek out new and more
+      potent powers, while the Invaders step up their colonization efforts. Each turn represents 1-3 years of alternate history.
+      At game start, winning requires destroying every last explorer, town and city on the board - but as you frighten the
+      Invaders more and more, victory becomes easier: they''ll run away even if explorers or even towns and cities remain.
+      Defeat comes if any spirit is destroyed, if the island is overrun by blight, or if the Invader deck is depleted before
+      achieving victory.
 
 
-      The game includes different adversaries to fight against (eg., a Swedish Mining Colony, or a Remote British Colony). Each changes play in different ways, and offers a different path of difficulty boosts to keep the game challenging as you gain skill.
+      The game includes different adversaries to fight against (eg., a Swedish Mining Colony, or a Remote British Colony).
+      Each changes play in different ways, and offers a different path of difficulty boosts to keep the game challenging as
+      you gain skill.
 
+
+      '
     yearPublished: 2017
     minPlayers: 1
     maxPlayers: 4
@@ -1817,23 +2048,35 @@ catalog:
     - Portal Games
     - REXhry
     - Siam Board Games
+    pdfBlobKey: rulebooks/v1/spirit-island_rulebook.pdf
+    pdfSha256: 64012c21460d3aee0f5c2c0d1048811a4dd4b4aebd03284ee4706a6a1f8e630e
+    pdfVersion: '1.0'
   - title: Jaipur
     bggId: 54043
     language: en
-    pdf: jaipur_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      You are one of the two most powerful traders in the city of Jaipur, the capital of Rajasthan, but that's not enough for you because only the merchant with two "seals of excellence" will have the privilege of being invited to the Maharaja's court. You are therefore going to have to do better than your direct competitor by buying, exchanging, and selling at better prices, all while keeping an eye on both your camel herds.
+    description: 'You are one of the two most powerful traders in the city of Jaipur, the capital of Rajasthan, but that''s
+      not enough for you because only the merchant with two "seals of excellence" will have the privilege of being invited
+      to the Maharaja''s court. You are therefore going to have to do better than your direct competitor by buying, exchanging,
+      and selling at better prices, all while keeping an eye on both your camel herds.
 
 
-      Jaipur is a fast-paced card game, a blend of tactics, risk and luck. On your turn, you can either take or sell cards. If you take cards, you have to choose between taking all the camels, taking one card from the market, or swapping 2-5 cards between the market and your cards.
+      Jaipur is a fast-paced card game, a blend of tactics, risk and luck. On your turn, you can either take or sell cards.
+      If you take cards, you have to choose between taking all the camels, taking one card from the market, or swapping 2-5
+      cards between the market and your cards.
 
 
-      If you sell cards, you get to sell only one type of good, and you receive as many chips for that good as the number of cards you sold. The chips' values decrease as the game progresses, so you'd better hurry! On the other hand, you receive increasingly high rewards for selling three, four, or five cards of the same good at a time, so you'd better wait!
+      If you sell cards, you get to sell only one type of good, and you receive as many chips for that good as the number
+      of cards you sold. The chips'' values decrease as the game progresses, so you''d better hurry! On the other hand, you
+      receive increasingly high rewards for selling three, four, or five cards of the same good at a time, so you''d better
+      wait!
 
 
-      You can't sell camels, but they're paramount for trading and they're also worth a little something at the end of the round, enough sometimes to secure the win, so you have to use them smartly.
+      You can''t sell camels, but they''re paramount for trading and they''re also worth a little something at the end of
+      the round, enough sometimes to secure the win, so you have to use them smartly.
 
+
+      '
     yearPublished: 2009
     minPlayers: 2
     maxPlayers: 2
@@ -1880,20 +2123,30 @@ catalog:
     - Rebel Sp. z o.o.
     - Siam Board Games
     - Yes Papa Games
+    pdfBlobKey: rulebooks/v1/jaipur_rulebook.pdf
+    pdfSha256: 4eca03a489d0436236cc501d861c7b555d1cad17dd3f91fecafe61bf23b9b31b
+    pdfVersion: '1.0'
   - title: The Quacks of Quedlinburg
     bggId: 244521
     language: en
-    pdf: quacks-of-quedlinburg_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Quacks, which was first released as The Quacks of Quedlinburg, players are charlatans &mdash; or quack doctors &mdash; each making their own secret brew by adding ingredients one at a time. Take care with what you add, though, for a pinch too much of this or that will spoil the whole mixture!
+    description: 'In Quacks, which was first released as The Quacks of Quedlinburg, players are charlatans &mdash; or quack
+      doctors &mdash; each making their own secret brew by adding ingredients one at a time. Take care with what you add,
+      though, for a pinch too much of this or that will spoil the whole mixture!
 
 
-      Each player has their own bag of ingredient chips. During each round, they simultaneously draw chips from their bags and add them to their pots. The higher the face value of the drawn chip, the further it is placed in the pot's swirling pattern, increasing how much the potion will be worth. Push your luck as far as you can, but if you add too many cherry bombs, your pot will explode!
+      Each player has their own bag of ingredient chips. During each round, they simultaneously draw chips from their bags
+      and add them to their pots. The higher the face value of the drawn chip, the further it is placed in the pot''s swirling
+      pattern, increasing how much the potion will be worth. Push your luck as far as you can, but if you add too many cherry
+      bombs, your pot will explode!
 
 
-      At the end of each round, players gain victory points and coins to spend on new ingredients, depending on how well they managed to fill up their pots. But players whose pots have exploded must choose points or coins &mdash; not both! The player with the most victory points at the end of nine rounds wins the game.
+      At the end of each round, players gain victory points and coins to spend on new ingredients, depending on how well they
+      managed to fill up their pots. But players whose pots have exploded must choose points or coins &mdash; not both! The
+      player with the most victory points at the end of nine rounds wins the game.
 
+
+      '
     yearPublished: 2018
     minPlayers: 2
     maxPlayers: 4
@@ -1943,16 +2196,22 @@ catalog:
     - North Star Games, LLC
     - Swan Panasia Co., Ltd.
     - YellowBOX
+    pdfBlobKey: rulebooks/v1/quacks-of-quedlinburg_rulebook.pdf
+    pdfSha256: f8fe7eb1cc25a229db9be200201941d2de28a23b3b810417a2b9ac792e3e4d16
+    pdfVersion: '1.0'
   - title: 'The Crew: Quest for Planet Nine'
     bggId: 284083
     language: en
-    pdf: the-crew_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In the co-operative trick-taking game The Crew: The Quest for Planet Nine, the players set out as astronauts on an uncertain space adventure. What are the rumors regarding the unknown planet about? The eventful journey through space extends over 50 exciting missions. But this game can only be defeated by meeting common individual tasks of each player. In order to meet the varied challenges communication is essential in the team. But this is more difficult than expected in space.
+    description: 'In the co-operative trick-taking game The Crew: The Quest for Planet Nine, the players set out as astronauts
+      on an uncertain space adventure. What are the rumors regarding the unknown planet about? The eventful journey through
+      space extends over 50 exciting missions. But this game can only be defeated by meeting common individual tasks of each
+      player. In order to meet the varied challenges communication is essential in the team. But this is more difficult than
+      expected in space.
 
 
-      With each mission the game becomes more difficult. After each mission the game can be paused and continued later. During each mission it is not the number of tricks but the right tricks at the right time that count.
+      With each mission the game becomes more difficult. After each mission the game can be paused and continued later. During
+      each mission it is not the number of tricks but the right tricks at the right time that count.
 
 
       The team completes a mission only if every single player is successful in fulfilling their tasks.
@@ -1960,6 +2219,8 @@ catalog:
 
       The game comes with 50 missions, with three additional missions published in spielbox 2/2020.
 
+
+      '
     yearPublished: 2019
     minPlayers: 2
     maxPlayers: 5
@@ -2007,51 +2268,41 @@ catalog:
     - Swan Panasia Co., Ltd.
     - Thames & Kosmos
     - Zvezda
+    pdfBlobKey: rulebooks/v1/the-crew_rulebook.pdf
+    pdfSha256: 12aded82732014978dfd8a744c6775e75ba9e719b7241e2bab7de42680a8db2f
+    pdfVersion: '1.0'
   - title: Coup
     bggId: 131357
     language: en
-    pdf: coup_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      You are head of a family in an Italian city-state, a city run by a weak and corrupt court. You need to manipulate, bluff and bribe your way to power. Your object is to destroy the influence of all the other families, forcing them into exile. Only one family will survive...
-
-
-      In Coup, you want to be the last player with influence in the game, with influence being represented by face-down character cards in your playing area.
-
-
-      Each player starts the game with two coins and two influence &ndash; i.e., two face-down character cards; the fifteen card deck consists of three copies of five different characters, each with a unique set of powers:
-
-
-           Duke: Take three coins from the treasury. Block someone from taking foreign aid.
-           Assassin: Pay three coins and try to assassinate another player's character.
-           Contessa: Block an assassination attempt against yourself.
-           Captain: Take two coins from another player, or block someone from stealing coins from you.
-           Ambassador: Draw two character cards from the Court (the deck), choose which (if any) to exchange with your face-down characters, then return two. Block someone from stealing coins from you.
-
-
-      On your turn, you can take any of the actions listed above, regardless of which characters you actually have in front of you, or you can take one of three other actions:
-
-
-           Income: Take one coin from the treasury.
-           Foreign aid: Take two coins from the treasury.
-           Coup: Pay seven coins and launch a coup against an opponent, forcing that player to lose an influence. (If you have ten coins or more, you must take this action.)
-
-
-      When you take one of the character actions &ndash; whether actively on your turn, or defensively in response to someone else's action &ndash; that character's action automatically succeeds unless an opponent challenges you. In this case, if you can't (or don't) reveal the appropriate character, you lose an influence, turning one of your characters face-up. Face-up characters cannot be used, and if both of your characters are face-up, you're out of the game.
-
-
-      If you do have the character in question and choose to reveal it, the opponent loses an influence, then you shuffle that character into the deck and draw a new one, perhaps getting the same character again and perhaps not.
-
-
-      The last player to still have influence &ndash; that is, a face-down character &ndash; wins the game!
-
-
-      A new & optional character called the Inquisitor has been added (currently, the only English edition with the Inquisitor included is the Kickstarter Version from Indie Boards & Cards. Copies in stores may not be the Kickstarter versions and may only be the base game). The Inquisitor character cards may be used to replace the Ambassador cards.
-
-
-           Inquisitor: Draw one character card from the Court deck and choose whether or not to exchange it with one of your face-down characters. OR Force an opponent to show you one of their character cards (their choice which). If you wish it, you may then force them to draw a new card from the Court deck. They then shuffle the old card into the Court deck. Block someone from stealing coins from you.
-
-
+    description: "You are head of a family in an Italian city-state, a city run by a weak and corrupt court. You need to manipulate,\
+      \ bluff and bribe your way to power. Your object is to destroy the influence of all the other families, forcing them\
+      \ into exile. Only one family will survive...\n\nIn Coup, you want to be the last player with influence in the game,\
+      \ with influence being represented by face-down character cards in your playing area.\n\nEach player starts the game\
+      \ with two coins and two influence &ndash; i.e., two face-down character cards; the fifteen card deck consists of three\
+      \ copies of five different characters, each with a unique set of powers:\n\n\n     Duke: Take three coins from the treasury.\
+      \ Block someone from taking foreign aid.\n     Assassin: Pay three coins and try to assassinate another player's character.\n\
+      \     Contessa: Block an assassination attempt against yourself.\n     Captain: Take two coins from another player,\
+      \ or block someone from stealing coins from you.\n     Ambassador: Draw two character cards from the Court (the deck),\
+      \ choose which (if any) to exchange with your face-down characters, then return two. Block someone from stealing coins\
+      \ from you.\n\n\nOn your turn, you can take any of the actions listed above, regardless of which characters you actually\
+      \ have in front of you, or you can take one of three other actions:\n\n\n     Income: Take one coin from the treasury.\n\
+      \     Foreign aid: Take two coins from the treasury.\n     Coup: Pay seven coins and launch a coup against an opponent,\
+      \ forcing that player to lose an influence. (If you have ten coins or more, you must take this action.)\n\n\nWhen you\
+      \ take one of the character actions &ndash; whether actively on your turn, or defensively in response to someone else's\
+      \ action &ndash; that character's action automatically succeeds unless an opponent challenges you. In this case, if\
+      \ you can't (or don't) reveal the appropriate character, you lose an influence, turning one of your characters face-up.\
+      \ Face-up characters cannot be used, and if both of your characters are face-up, you're out of the game.\n\nIf you do\
+      \ have the character in question and choose to reveal it, the opponent loses an influence, then you shuffle that character\
+      \ into the deck and draw a new one, perhaps getting the same character again and perhaps not.\n\nThe last player to\
+      \ still have influence &ndash; that is, a face-down character &ndash; wins the game!\n\nA new & optional character called\
+      \ the Inquisitor has been added (currently, the only English edition with the Inquisitor included is the Kickstarter\
+      \ Version from Indie Boards & Cards. Copies in stores may not be the Kickstarter versions and may only be the base game).\
+      \ The Inquisitor character cards may be used to replace the Ambassador cards.\n\n\n     Inquisitor: Draw one character\
+      \ card from the Court deck and choose whether or not to exchange it with one of your face-down characters. OR Force\
+      \ an opponent to show you one of their character cards (their choice which). If you wish it, you may then force them\
+      \ to draw a new card from the Court deck. They then shuffle the old card into the Court deck. Block someone from stealing\
+      \ coins from you.\n\n\n"
     yearPublished: 2012
     minPlayers: 2
     maxPlayers: 6
@@ -2109,17 +2360,23 @@ catalog:
     - テンデイズゲームズ (TendaysGames)
     - Zacatrus
     - 狗吠火車
+    pdfBlobKey: rulebooks/v1/coup_rulebook.pdf
+    pdfSha256: ca1e7851b438c494c27b613921dfa428a6205775939885a5a740624ac0cba46a
+    pdfVersion: '1.0'
   - title: Exploding Kittens
     bggId: 172225
     language: en
-    pdf: exploding-kittens_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Exploding Kittens is a kitty-powered version of Russian Roulette. Players take turns drawing cards until someone draws an exploding kitten and loses the game. The deck is made up of cards that let you avoid exploding by peeking at cards before you draw, forcing your opponent to draw multiple cards, or shuffling the deck.
+    description: 'Exploding Kittens is a kitty-powered version of Russian Roulette. Players take turns drawing cards until
+      someone draws an exploding kitten and loses the game. The deck is made up of cards that let you avoid exploding by peeking
+      at cards before you draw, forcing your opponent to draw multiple cards, or shuffling the deck.
 
 
-      The game gets more and more intense with each card you draw because fewer cards left in the deck means a greater chance of drawing the kitten and exploding in a fiery ball of feline hyperbole.
+      The game gets more and more intense with each card you draw because fewer cards left in the deck means a greater chance
+      of drawing the kitten and exploding in a fiery ball of feline hyperbole.
 
+
+      '
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 5
@@ -2170,19 +2427,33 @@ catalog:
     - Rozum
     - Siam Board Games
     - Super Impulse
+    pdfBlobKey: rulebooks/v1/exploding-kittens_rulebook.pdf
+    pdfSha256: 1585eb968604bd7652b3e8f276e5a7409c5bfca8fc1217ca75792ae3b44b654c
+    pdfVersion: '1.0'
   - title: Agricola
     bggId: 31260
     language: en
-    pdf: agricola_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Agricola, you're a farmer in a wooden shack with your spouse and little else. At first, on a turn, your family gets to take only two actions, one for you and one for your spouse, as might be found among all the possibilities on a farm: plowing fields; collecting materials; building fences, and so on. There are numerous choices available, and while the game progresses you'll have more and more, as each round a new action card is flipped over, offering one more possible action. You might think about having kids in order to get more work accomplished but first you'll need to expand your house to make room - and what are you going to feed all the little rug rats?
+    description: 'In Agricola, you''re a farmer in a wooden shack with your spouse and little else. At first, on a turn, your
+      family gets to take only two actions, one for you and one for your spouse, as might be found among all the possibilities
+      on a farm: plowing fields; collecting materials; building fences, and so on. There are numerous choices available, and
+      while the game progresses you''ll have more and more, as each round a new action card is flipped over, offering one
+      more possible action. You might think about having kids in order to get more work accomplished but first you''ll need
+      to expand your house to make room - and what are you going to feed all the little rug rats?
 
 
-      The game supports many levels of complexity, mainly through the distribution of cards which represent Minor Improvements and Occupations. In the beginner's version (called the Family Variant in the U.S. release) these cards are not used at all. For advanced play, the U.S. release includes three levels of both types of cards; Basic (E-deck), Interactive (I-deck), and Complex (K-deck), and the rulebook encourages players to experiment with the various decks and mixtures thereof. Aftermarket decks such as the Z-Deck and the L-Deck also exist. Each player starts with a hand of 7 Occupation cards (of more than 160 total) and 7 Minor Improvement cards (of more than 140 total) that he/she may use during the game if they fit into his/her strategy.
+      The game supports many levels of complexity, mainly through the distribution of cards which represent Minor Improvements
+      and Occupations. In the beginner''s version (called the Family Variant in the U.S. release) these cards are not used
+      at all. For advanced play, the U.S. release includes three levels of both types of cards; Basic (E-deck), Interactive
+      (I-deck), and Complex (K-deck), and the rulebook encourages players to experiment with the various decks and mixtures
+      thereof. Aftermarket decks such as the Z-Deck and the L-Deck also exist. Each player starts with a hand of 7 Occupation
+      cards (of more than 160 total) and 7 Minor Improvement cards (of more than 140 total) that he/she may use during the
+      game if they fit into his/her strategy.
 
 
-      Agricola is a turn-based game, and the problem to be overcome is that each available action can be taken by only one player each round so it's important to be careful about your choices.  There are countless strategies, some of which depend on your hand of cards.
+      Agricola is a turn-based game, and the problem to be overcome is that each available action can be taken by only one
+      player each round so it''s important to be careful about your choices.  There are countless strategies, some of which
+      depend on your hand of cards.
 
 
       The winner is the player with the most Victory Points from the Improvements made on his farm.
@@ -2190,6 +2461,8 @@ catalog:
 
       -description originally from BoardgameNews
 
+
+      '
     yearPublished: 2007
     minPlayers: 1
     maxPlayers: 5
@@ -2234,17 +2507,26 @@ catalog:
     - Swan Panasia Co., Ltd.
     - Ystari Games
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/agricola_rulebook.pdf
+    pdfSha256: 76fbd30f440c34b109be0b1f20d4ad188b602c382fe0b33860c800cb20d11d75
+    pdfVersion: '1.0'
   - title: Kingdomino
     bggId: 204583
     language: en
-    pdf: kingdomino_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Kingdomino, you are a lord seeking new lands in which to expand your kingdom. You must explore all the lands, including wheat fields, lakes, and mountains, in order to spot the best plots, while competing with other lords to acquire them first.
+    description: 'In Kingdomino, you are a lord seeking new lands in which to expand your kingdom. You must explore all the
+      lands, including wheat fields, lakes, and mountains, in order to spot the best plots, while competing with other lords
+      to acquire them first.
 
 
-      The game uses tiles with two sections, similar to Dominoes. Each turn, each player will select a new domino to connect to their existing kingdom, making sure at least one of its sides connects to a matching terrain type already in play. The order of who picks first depends on which tile was previously chosen, with better tiles forcing players to pick later in the next round. The game ends when each player has completed a 5x5 grid (or failed to do so), and points are counted based on number of connecting tiles and valuable crown symbols.
+      The game uses tiles with two sections, similar to Dominoes. Each turn, each player will select a new domino to connect
+      to their existing kingdom, making sure at least one of its sides connects to a matching terrain type already in play.
+      The order of who picks first depends on which tile was previously chosen, with better tiles forcing players to pick
+      later in the next round. The game ends when each player has completed a 5x5 grid (or failed to do so), and points are
+      counted based on number of connecting tiles and valuable crown symbols.
 
+
+      '
     yearPublished: 2016
     minPlayers: 2
     maxPlayers: 4
@@ -2297,16 +2579,23 @@ catalog:
     - Swan Panasia Co., Ltd.
     - テンデイズゲームズ (TendaysGames)
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/kingdomino_rulebook.pdf
+    pdfSha256: 25787aa1e0d3c70d292b7de68534b4c6b05ef75720ba6a535720d782c51d1cb2
+    pdfVersion: '1.0'
   - title: Hanabi
     bggId: 98778
     language: en
-    pdf: hanabi_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Hanabi&mdash;named for the Japanese word for "fireworks"&mdash;is a cooperative game in which players try to create the perfect fireworks show by placing the cards on the table in the right order. (In Japanese, hanabi is written as 花火; these are the ideograms flower and fire, respectively.)
+    description: 'Hanabi&mdash;named for the Japanese word for "fireworks"&mdash;is a cooperative game in which players try
+      to create the perfect fireworks show by placing the cards on the table in the right order. (In Japanese, hanabi is written
+      as 花火; these are the ideograms flower and fire, respectively.)
 
 
-      The card deck consists of five different colors of cards, numbered 1&ndash;5 in each color. For each color, the players try to place a row in the correct order from 1&ndash;5. Sounds easy, right? Well, not quite, as in this game you hold your cards so that they're visible only to other players. To assist other players in playing a card, you must give them hints regarding the numbers or the colors of their cards. Players must act as a team to avoid errors and to finish the fireworks display before they run out of cards.
+      The card deck consists of five different colors of cards, numbered 1&ndash;5 in each color. For each color, the players
+      try to place a row in the correct order from 1&ndash;5. Sounds easy, right? Well, not quite, as in this game you hold
+      your cards so that they''re visible only to other players. To assist other players in playing a card, you must give
+      them hints regarding the numbers or the colors of their cards. Players must act as a team to avoid errors and to finish
+      the fireworks display before they run out of cards.
 
 
       An extra suit of cards, rainbow colored, is also provided for advanced or variant play.
@@ -2314,6 +2603,8 @@ catalog:
 
       Hanabi was originally published as part of Hanabi & Ikebana.
 
+
+      '
     yearPublished: 2010
     minPlayers: 2
     maxPlayers: 5
@@ -2365,29 +2656,45 @@ catalog:
     - REXhry
     - Spin Master Ltd.
     - Swan Panasia Co., Ltd.
+    pdfBlobKey: rulebooks/v1/hanabi_rulebook.pdf
+    pdfSha256: f23df0ceaa2715e6b46444018fb8bfad6afb021d76fc2c2ee802fdfb4c2dc472
+    pdfVersion: '1.0'
   - title: 'Pandemic Legacy: Season 1'
     bggId: 161936
     language: en
-    pdf: pandemic-legacy-s1_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Pandemic Legacy is a co-operative campaign game, with an overarching story arc played through 12-24 sessions, depending on how well your group does at the game. At the beginning, the game starts in a very similar fashion as basic Pandemic, in which your team of disease-fighting specialists races against the clock to travel around the world, treating disease hot spots while researching cures for each of four plagues before they get out of hand.
+    description: 'Pandemic Legacy is a co-operative campaign game, with an overarching story arc played through 12-24 sessions,
+      depending on how well your group does at the game. At the beginning, the game starts in a very similar fashion as basic
+      Pandemic, in which your team of disease-fighting specialists races against the clock to travel around the world, treating
+      disease hot spots while researching cures for each of four plagues before they get out of hand.
 
 
-      During a player's turn, they have four actions available, with which they may travel around in the world in various ways (sometimes needing to discard a card), build structures like research stations, treat diseases (removing one cube from the board; if all cubes of a color have been removed, the disease has been eradicated), trade cards with other players, or find a cure for a disease (requiring five cards of the same color to be discarded while at a research station). Each player has a unique role with special abilities to help them at these actions.
+      During a player''s turn, they have four actions available, with which they may travel around in the world in various
+      ways (sometimes needing to discard a card), build structures like research stations, treat diseases (removing one cube
+      from the board; if all cubes of a color have been removed, the disease has been eradicated), trade cards with other
+      players, or find a cure for a disease (requiring five cards of the same color to be discarded while at a research station).
+      Each player has a unique role with special abilities to help them at these actions.
 
 
-      After a player has taken their actions, they draw two cards. These cards can include epidemic cards, which will place new disease cubes on the board, and can lead to an outbreak, spreading disease cubes even further. Outbreaks additionally increase the panic level of a city, making that city more expensive to travel to.
+      After a player has taken their actions, they draw two cards. These cards can include epidemic cards, which will place
+      new disease cubes on the board, and can lead to an outbreak, spreading disease cubes even further. Outbreaks additionally
+      increase the panic level of a city, making that city more expensive to travel to.
 
 
-      Each month in the game, you have two chances to achieve that month's objectives. If you succeed, you win and immediately move on to the next month. If you fail, you have a second chance, with more funding for beneficial event cards.
+      Each month in the game, you have two chances to achieve that month''s objectives. If you succeed, you win and immediately
+      move on to the next month. If you fail, you have a second chance, with more funding for beneficial event cards.
 
 
-      During the campaign, new rules and components will be introduced. These will sometimes require you to permanently alter the components of the game; this includes writing on cards, ripping up cards, and placing permanent stickers on components. Your characters can gain new skills, or detrimental effects. A character can even be lost entirely, at which point it's no longer available for play.
+      During the campaign, new rules and components will be introduced. These will sometimes require you to permanently alter
+      the components of the game; this includes writing on cards, ripping up cards, and placing permanent stickers on components.
+      Your characters can gain new skills, or detrimental effects. A character can even be lost entirely, at which point it''s
+      no longer available for play.
 
 
       Part of the Pandemic series
 
+
+      '
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 4
@@ -2430,20 +2737,35 @@ catalog:
     - Lifestyle Boardgames Ltd
     - MINDOK
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/pandemic-legacy-s1_rulebook.pdf
+    pdfSha256: 9198abfbd116b96446294b8db1bf2f98c44a1444a727d27ec861c0ad6e1f93d5
+    pdfVersion: '1.0'
   - title: Cascadia
     bggId: 295947
     language: en
-    pdf: cascadia_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Cascadia is a puzzly tile-laying and token-drafting game featuring the habitats and wildlife of the Pacific Northwest.
+    description: 'Cascadia is a puzzly tile-laying and token-drafting game featuring the habitats and wildlife of the Pacific
+      Northwest.
 
 
-      In the game, you take turns building out your own terrain area and populating it with wildlife. You start with three hexagonal habitat tiles (with the five types of habitat in the game), and on a turn you choose a new habitat tile that's paired with a wildlife token, then place that tile next to your other ones and place the wildlife token on an appropriate habitat. (Each tile depicts 1-3 types of wildlife from the five types in the game, and you can place at most one token on a habitat.) Four tiles are on display, with each tile being paired at random with a wildlife token, so you must make the best of what's available &mdash; unless you have a nature token to spend so that you can pick your choice of each item.
+      In the game, you take turns building out your own terrain area and populating it with wildlife. You start with three
+      hexagonal habitat tiles (with the five types of habitat in the game), and on a turn you choose a new habitat tile that''s
+      paired with a wildlife token, then place that tile next to your other ones and place the wildlife token on an appropriate
+      habitat. (Each tile depicts 1-3 types of wildlife from the five types in the game, and you can place at most one token
+      on a habitat.) Four tiles are on display, with each tile being paired at random with a wildlife token, so you must make
+      the best of what''s available &mdash; unless you have a nature token to spend so that you can pick your choice of each
+      item.
 
 
-      Ideally you can place habitat tiles to create matching terrain that reduces fragmentation and creates wildlife corridors, mostly because you score for the largest area of each type of habitat at game's end, with a bonus if your group is larger than each other player's. At the same time, you want to place wildlife tokens so that you can maximize the number of points scored by them, with the wildlife goals being determined at random by one of the four scoring cards for each type of wildlife. Maybe hawks want to be separate from other hawks, while foxes want lots of different animals surrounding them and bears want to be in pairs. Can you make it happen?
+      Ideally you can place habitat tiles to create matching terrain that reduces fragmentation and creates wildlife corridors,
+      mostly because you score for the largest area of each type of habitat at game''s end, with a bonus if your group is
+      larger than each other player''s. At the same time, you want to place wildlife tokens so that you can maximize the number
+      of points scored by them, with the wildlife goals being determined at random by one of the four scoring cards for each
+      type of wildlife. Maybe hawks want to be separate from other hawks, while foxes want lots of different animals surrounding
+      them and bears want to be in pairs. Can you make it happen?
 
+
+      '
     yearPublished: 2021
     minPlayers: 1
     maxPlayers: 4
@@ -2494,20 +2816,32 @@ catalog:
     - Tower Tactic Games
     - White Goblin Games
     - 株式会社ケンビル (KenBill)
+    pdfBlobKey: rulebooks/v1/cascadia_rulebook.pdf
+    pdfSha256: 94c7313aef8e161527844fbfc4296419ad5999ec9027e4aede905ac83b510a80
+    pdfVersion: '1.0'
   - title: 'Gloomhaven: Jaws of the Lion'
     bggId: 291457
     language: en
-    pdf: gloomhaven-jaws-of-the-lion_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Gloomhaven: Jaws of the Lion is a standalone game that takes place before the events of Gloomhaven. The game includes four new characters &mdash; Valrath Red Guard (tank, crowd control), Inox Hatchet (ranged damage), Human Voidwarden (support, mind control), and Quatryl Demolitionist (melee damage, obstacle manipulation) &mdash; that can also be used in the original Gloomhaven game.
+    description: 'Gloomhaven: Jaws of the Lion is a standalone game that takes place before the events of Gloomhaven. The
+      game includes four new characters &mdash; Valrath Red Guard (tank, crowd control), Inox Hatchet (ranged damage), Human
+      Voidwarden (support, mind control), and Quatryl Demolitionist (melee damage, obstacle manipulation) &mdash; that can
+      also be used in the original Gloomhaven game.
 
 
-      The game also includes 16 monster types (including seven new standard monsters and three new bosses) and a new campaign with 25 scenarios that invites the heroes to investigate a case of mysterious disappearances within the city. Is it the work of Vermlings, or is something far more sinister going on?
+      The game also includes 16 monster types (including seven new standard monsters and three new bosses) and a new campaign
+      with 25 scenarios that invites the heroes to investigate a case of mysterious disappearances within the city. Is it
+      the work of Vermlings, or is something far more sinister going on?
 
 
-      Gloomhaven: Jaws of the Lion is aimed at a more casual audience to get people into the gameplay more quickly. All of the hard-to-organize cardboard map tiles have been removed, and instead players will play on the scenario book itself, which features new artwork unique to each scenario. The last barrier to entry &mdash; i.e., learning the game &mdash; has also been lowered through a simplified rule set and a five-scenario tutorial that will ease new players into the experience.
+      Gloomhaven: Jaws of the Lion is aimed at a more casual audience to get people into the gameplay more quickly. All of
+      the hard-to-organize cardboard map tiles have been removed, and instead players will play on the scenario book itself,
+      which features new artwork unique to each scenario. The last barrier to entry &mdash; i.e., learning the game &mdash;
+      has also been lowered through a simplified rule set and a five-scenario tutorial that will ease new players into the
+      experience.
 
+
+      '
     yearPublished: 2020
     minPlayers: 1
     maxPlayers: 4
@@ -2562,26 +2896,39 @@ catalog:
     - Lord of Boards
     - Meanbook Games
     - Siam Board Games
+    pdfBlobKey: rulebooks/v1/gloomhaven-jaws-of-the-lion_rulebook.pdf
+    pdfSha256: 5ece90b8054527a29ba56600d99a9b88c02fb567ee8334aac9bf9f70978f8fcb
+    pdfVersion: '1.0'
   - title: Power Grid
     bggId: 2651
     language: en
-    pdf: power-grid_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Power Grid is the updated release of the Friedemann Friese crayon game Funkenschlag. It removes the crayon aspect from network building in the original edition, while retaining the fluctuating commodities market like Crude: The Oil Game and an auction round intensity reminiscent of The Princes of Florence.
+    description: 'Power Grid is the updated release of the Friedemann Friese crayon game Funkenschlag. It removes the crayon
+      aspect from network building in the original edition, while retaining the fluctuating commodities market like Crude:
+      The Oil Game and an auction round intensity reminiscent of The Princes of Florence.
 
 
-      The objective of Power Grid is to supply the most cities with power when someone's network gains a predetermined size.  In this new edition, players mark pre-existing routes between cities for connection, and then bid against each other to purchase the power plants that they use to power their cities.
+      The objective of Power Grid is to supply the most cities with power when someone''s network gains a predetermined size.  In
+      this new edition, players mark pre-existing routes between cities for connection, and then bid against each other to
+      purchase the power plants that they use to power their cities.
 
 
-      However, as plants are purchased, newer, more efficient plants become available, so by merely purchasing, you're potentially allowing others access to superior equipment.
+      However, as plants are purchased, newer, more efficient plants become available, so by merely purchasing, you''re potentially
+      allowing others access to superior equipment.
 
 
-      Additionally, players must acquire the raw materials (coal, oil, garbage, and uranium) needed to power said plants (except for the 'renewable' windfarm/ solar plants, which require no fuel), making it a constant struggle to upgrade your plants for maximum efficiency while still retaining enough wealth to quickly expand your network to get the cheapest routes.
+      Additionally, players must acquire the raw materials (coal, oil, garbage, and uranium) needed to power said plants (except
+      for the ''renewable'' windfarm/ solar plants, which require no fuel), making it a constant struggle to upgrade your
+      plants for maximum efficiency while still retaining enough wealth to quickly expand your network to get the cheapest
+      routes.
 
 
-      ☛ Power Grid FAQ - Please read this before posting a rules question!  Many questions are asked over and over in the forums... If you have a question about a specific expansion, please check the rules forum or FAQ for that particular expansion.
+      ☛ Power Grid FAQ - Please read this before posting a rules question!  Many questions are asked over and over in the
+      forums... If you have a question about a specific expansion, please check the rules forum or FAQ for that particular
+      expansion.
 
+
+      '
     yearPublished: 2004
     minPlayers: 2
     maxPlayers: 6
@@ -2632,26 +2979,36 @@ catalog:
     - Smart Ltd
     - Stratelibri
     - Swan Panasia Co., Ltd.
+    pdfBlobKey: rulebooks/v1/power-grid_rulebook.pdf
+    pdfSha256: e90d321d233b3fbffac8a1900d6a5cb96ffccd29b1a215e2889c5eacb995e73f
+    pdfVersion: '1.0'
   - title: Betrayal at House on the Hill
     bggId: 10547
     language: en
-    pdf: betrayal-at-house-on-the-hill_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Betrayal at House on the Hill quickly builds suspense and excitement as players explore a haunted mansion of their own 'design', encountering spirits and frightening omens that foretell their fate. With an estimated one hour playing time, Betrayal at House on the Hill is ideal for parties, family gatherings or casual fun with friends.
+    description: 'Betrayal at House on the Hill quickly builds suspense and excitement as players explore a haunted mansion
+      of their own ''design'', encountering spirits and frightening omens that foretell their fate. With an estimated one
+      hour playing time, Betrayal at House on the Hill is ideal for parties, family gatherings or casual fun with friends.
 
 
-      Betrayal at House on the Hill is a tile game that allows players to lay out the haunted house room by room, tile by tile, creating a new thrilling game board every time. The game is designed for three to six people, each of whom plays one of six possible characters.
+      Betrayal at House on the Hill is a tile game that allows players to lay out the haunted house room by room, tile by
+      tile, creating a new thrilling game board every time. The game is designed for three to six people, each of whom plays
+      one of six possible characters.
 
 
-      Secretly, one of the characters betrays the rest of the party, and the innocent members of the party must defeat the traitor in their midst before it&rsquo;s too late! Betrayal at House on the Hill will appeal to any game player who enjoys a fun, suspenseful, and strategic game.
+      Secretly, one of the characters betrays the rest of the party, and the innocent members of the party must defeat the
+      traitor in their midst before it&rsquo;s too late! Betrayal at House on the Hill will appeal to any game player who
+      enjoys a fun, suspenseful, and strategic game.
 
 
-      Betrayal at House on the Hill includes detailed game pieces, including character cards, pre-painted plastic figures, and special tokens, all of which help create a spooky atmosphere and streamline game play.
+      Betrayal at House on the Hill includes detailed game pieces, including character cards, pre-painted plastic figures,
+      and special tokens, all of which help create a spooky atmosphere and streamline game play.
 
 
       An updated reprint of Betrayal at House on the Hill was released on October 5, 2010.
 
+
+      '
     yearPublished: 2004
     minPlayers: 3
     maxPlayers: 6
@@ -2688,30 +3045,24 @@ catalog:
     - Wizards of the Coast
     - asmodee
     - Hasbro
+    pdfBlobKey: rulebooks/v1/betrayal-at-house-on-the-hill_rulebook.pdf
+    pdfSha256: 806700be2b34ee26d0dee42c4b600bc57b0d1c4c520ddfeaf9db171441ba9f9e
+    pdfVersion: '1.0'
   - title: Ark Nova
     bggId: 342942
     language: en
-    pdf: ark-nova_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Ark Nova, you will plan and design a modern, scientifically managed zoo. With the ultimate goal of owning the most successful zoological establishment, you will build enclosures, accommodate animals, and support conservation projects all over the world. Specialists and unique buildings will help you in achieving this goal.
-
-
-      Each player has a set of five action cards to manage their gameplay, and the power of an action is determined by the slot the card currently occupies. The cards in question are:
-
-
-          CARDS: Allows you to gain new zoo cards (animals, sponsors, and conservation project cards).
-          BUILD: Allows you to build standard or special enclosures, kiosks, and pavilions.
-          ANIMALS: Allows you to accommodate animals in your zoo.
-          ASSOCIATION: Allows your association workers to carry out different tasks.
-          SPONSORS: Allows you to play a sponsor card in your zoo or to raise money.
-
-
-      255 cards featuring animals, specialists, special enclosures, and conservation projects, each with a special ability, are at the heart of Ark Nova. Use them to increase the appeal and scientific reputation of your zoo and collect conservation points.
-
-
-      &mdash;description from the publisher
-
+    description: "In Ark Nova, you will plan and design a modern, scientifically managed zoo. With the ultimate goal of owning\
+      \ the most successful zoological establishment, you will build enclosures, accommodate animals, and support conservation\
+      \ projects all over the world. Specialists and unique buildings will help you in achieving this goal.\n\nEach player\
+      \ has a set of five action cards to manage their gameplay, and the power of an action is determined by the slot the\
+      \ card currently occupies. The cards in question are:\n\n\n    CARDS: Allows you to gain new zoo cards (animals, sponsors,\
+      \ and conservation project cards).\n    BUILD: Allows you to build standard or special enclosures, kiosks, and pavilions.\n\
+      \    ANIMALS: Allows you to accommodate animals in your zoo.\n    ASSOCIATION: Allows your association workers to carry\
+      \ out different tasks.\n    SPONSORS: Allows you to play a sponsor card in your zoo or to raise money.\n\n\n255 cards\
+      \ featuring animals, specialists, special enclosures, and conservation projects, each with a special ability, are at\
+      \ the heart of Ark Nova. Use them to increase the appeal and scientific reputation of your zoo and collect conservation\
+      \ points.\n\n&mdash;description from the publisher\n\n"
     yearPublished: 2021
     minPlayers: 1
     maxPlayers: 4
@@ -2768,32 +3119,53 @@ catalog:
     - テンデイズゲームズ (TendaysGames)
     - Tower Tactic Games
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/ark-nova_rulebook.pdf
+    pdfSha256: f6b4eedc68e993f61b4c5cb5d99bb4af399da0be3de4781321bcba1ba44516f6
+    pdfVersion: '1.0'
   - title: Puerto Rico
     bggId: 3076
     language: en
-    pdf: puerto-rico_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Puerto Rico, players assume the roles of colonial governors on the island of Puerto Rico. The aim of the game is to amass victory points by shipping goods to Europe or by constructing buildings.
+    description: 'In Puerto Rico, players assume the roles of colonial governors on the island of Puerto Rico. The aim of
+      the game is to amass victory points by shipping goods to Europe or by constructing buildings.
 
 
-      Each player uses a separate small board with spaces for city buildings, plantations, and resources. Shared between the players are three ships, a trading house, and a supply of resources and doubloons.
+      Each player uses a separate small board with spaces for city buildings, plantations, and resources. Shared between the
+      players are three ships, a trading house, and a supply of resources and doubloons.
 
 
-      The resource cycle of the game is that players grow crops which they exchange for points or doubloons. Doubloons can then be used to buy buildings, which allow players to produce more crops or give them other abilities. Buildings and plantations do not work unless they are manned by colonists.
+      The resource cycle of the game is that players grow crops which they exchange for points or doubloons. Doubloons can
+      then be used to buy buildings, which allow players to produce more crops or give them other abilities. Buildings and
+      plantations do not work unless they are manned by colonists.
 
 
-      During each round, players take turns selecting a role card from those on the table (such as "Trader" or "Builder"). When a role is chosen, every player gets to take the action appropriate to that role. The player that selected the role also receives a small privilege for doing so - for example, choosing the "Builder" role allows all players to construct a building, but the player who chose the role may do so at a discount on that turn. Unused roles gain a doubloon bonus at the end of each turn, so the next player who chooses that role gets to keep any doubloon bonus associated with it. This encourages players to make use of all the roles throughout a typical course of a game.
+      During each round, players take turns selecting a role card from those on the table (such as "Trader" or "Builder").
+      When a role is chosen, every player gets to take the action appropriate to that role. The player that selected the role
+      also receives a small privilege for doing so - for example, choosing the "Builder" role allows all players to construct
+      a building, but the player who chose the role may do so at a discount on that turn. Unused roles gain a doubloon bonus
+      at the end of each turn, so the next player who chooses that role gets to keep any doubloon bonus associated with it.
+      This encourages players to make use of all the roles throughout a typical course of a game.
 
 
-      Puerto Rico uses a variable phase order mechanism in which a "governor" token is passed clockwise to the next player at the conclusion of a turn. The player with the token begins the round by choosing a role and taking the first action.
+      Puerto Rico uses a variable phase order mechanism in which a "governor" token is passed clockwise to the next player
+      at the conclusion of a turn. The player with the token begins the round by choosing a role and taking the first action.
 
 
-      Players earn victory points for owning buildings, for shipping goods, and for manned "large buildings." Each player's accumulated shipping chips are kept face down and come in denominations of one or five. This prevents other players from being able to determine the exact score of another player. Goods and doubloons are placed in clear view of other players and the totals of each can always be requested by a player. As the game enters its later stages, the unknown quantity of shipping tokens and its denominations require players to consider their options before choosing a role that can end the game.
+      Players earn victory points for owning buildings, for shipping goods, and for manned "large buildings." Each player''s
+      accumulated shipping chips are kept face down and come in denominations of one or five. This prevents other players
+      from being able to determine the exact score of another player. Goods and doubloons are placed in clear view of other
+      players and the totals of each can always be requested by a player. As the game enters its later stages, the unknown
+      quantity of shipping tokens and its denominations require players to consider their options before choosing a role that
+      can end the game.
 
 
-      In 2011 and mostly afterwards, Puerto Rico was published to include both Puerto Rico: Expansion I &ndash; New Buildings and Puerto Rico: Expansion II &ndash; The Nobles. These versions are included in the other game entry Puerto Rico, not this regular game entry for Puerto Rico. Some editions of Puerto Rico list the player count as 2-5 instead of 3-5, and they include variant rules for games with only two players.
+      In 2011 and mostly afterwards, Puerto Rico was published to include both Puerto Rico: Expansion I &ndash; New Buildings
+      and Puerto Rico: Expansion II &ndash; The Nobles. These versions are included in the other game entry Puerto Rico, not
+      this regular game entry for Puerto Rico. Some editions of Puerto Rico list the player count as 2-5 instead of 3-5, and
+      they include variant rules for games with only two players.
 
+
+      '
     yearPublished: 2002
     minPlayers: 3
     maxPlayers: 5
@@ -2833,19 +3205,29 @@ catalog:
     - Swan Panasia Co., Ltd.
     - Tilsit
     - VAKKO
+    pdfBlobKey: rulebooks/v1/puerto-rico_rulebook.pdf
+    pdfSha256: d55058bde864f4216eecd14e2d3fabd244955972f3176e1b3bf64e5ed7afa697
+    pdfVersion: '1.0'
   - title: Lost Ruins of Arnak
     bggId: 312484
     language: en
-    pdf: lost-ruins-of-arnak_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      On an uninhabited island in uncharted seas, explorers have found traces of a great civilization. Now you will lead an expedition to explore the island, find lost artifacts, and face fearsome guardians, all in a quest to learn the island's secrets.
+    description: 'On an uninhabited island in uncharted seas, explorers have found traces of a great civilization. Now you
+      will lead an expedition to explore the island, find lost artifacts, and face fearsome guardians, all in a quest to learn
+      the island''s secrets.
 
 
-      Lost Ruins of Arnak combines deck-building and worker placement in a game of exploration, resource management, and discovery. In addition to traditional deck-builder effects, cards can also be used to place workers, and new worker actions become available as players explore the island. Some of these actions require resources instead of workers, so building a solid resource base will be essential. You are limited to only one action per turn, so make your choice carefully... what action will benefit you most now? And what can you afford to do later... assuming someone else doesn't take the action first!?
+      Lost Ruins of Arnak combines deck-building and worker placement in a game of exploration, resource management, and discovery.
+      In addition to traditional deck-builder effects, cards can also be used to place workers, and new worker actions become
+      available as players explore the island. Some of these actions require resources instead of workers, so building a solid
+      resource base will be essential. You are limited to only one action per turn, so make your choice carefully... what
+      action will benefit you most now? And what can you afford to do later... assuming someone else doesn''t take the action
+      first!?
 
 
-      Decks are small, and randomness in the game is heavily mitigated by the wealth of tactical decisions offered on the game board. With a variety of worker actions, artifacts, and equipment cards, the set-up for each game will be unique, encouraging players to explore new strategies to meet the challenge.
+      Decks are small, and randomness in the game is heavily mitigated by the wealth of tactical decisions offered on the
+      game board. With a variety of worker actions, artifacts, and equipment cards, the set-up for each game will be unique,
+      encouraging players to explore new strategies to meet the challenge.
 
 
       Discover the Lost Ruins of Arnak!
@@ -2853,6 +3235,8 @@ catalog:
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2020
     minPlayers: 1
     maxPlayers: 4
@@ -2911,34 +3295,30 @@ catalog:
     - Rebel Sp. z o.o.
     - Spilbræt.dk
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/lost-ruins-of-arnak_rulebook.pdf
+    pdfSha256: d697b0612bbab7b16d183bdaee061d17fea25d6be485329e0c98bc90a1af11c1
+    pdfVersion: '1.0'
   - title: The Castles of Burgundy
     bggId: 84876
     language: en
-    pdf: castles-of-burgundy_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      The game is set in the Burgundy region of High Medieval France. Each player takes on the role of an aristocrat, originally controlling a small princedom. While playing they aim to build settlements and powerful castles, practice trade along the river, exploit silver mines, and use the knowledge of travelers. The game is about players taking settlement tiles from the game board and placing them into their princedom which is represented by the player board. Every tile has a function that starts when the tile is placed in the princedom. The princedom itself consists of several regions, each of which demands its own type of settlement tile.
-
-
-      The game is played in five phases, each consisting of five rounds.  Each phase begins with the game board stocked with settlement tiles and goods tiles.  At the beginning of each round all players roll their two dice, and the player who is currently first in turn order rolls a goods placement die.  A goods tile is made available on the game board according to the roll of the goods die.
-
-
-      During each round, a player may perform any two of the four possible types of actions:
-
-          take a settlement tile and place it in the staging area on their player board
-          take a settlement tile from the staging area and place in the corresponding region for the type of tile and adjacent to a previously placed settlement tile, 
-          deliver goods with a number matching one of their dice
-          take worker tokens which allow the player to adjust the roll of their dice.  
-
-
-      In addition to these actions a player may buy a settlement tile and place it in the staging area on their player board.
-
-
-      The game ends after the fifth phase is played to completion.  Victory points are awarded for unused money and workers, and undelivered goods.  Bonus victory points from certain settlement tiles are awarded at the end of the game. The player with the most victory points wins.
-
-
-      The rules include basic and advanced versions.
-
+    description: "The game is set in the Burgundy region of High Medieval France. Each player takes on the role of an aristocrat,\
+      \ originally controlling a small princedom. While playing they aim to build settlements and powerful castles, practice\
+      \ trade along the river, exploit silver mines, and use the knowledge of travelers. The game is about players taking\
+      \ settlement tiles from the game board and placing them into their princedom which is represented by the player board.\
+      \ Every tile has a function that starts when the tile is placed in the princedom. The princedom itself consists of several\
+      \ regions, each of which demands its own type of settlement tile.\n\nThe game is played in five phases, each consisting\
+      \ of five rounds.  Each phase begins with the game board stocked with settlement tiles and goods tiles.  At the beginning\
+      \ of each round all players roll their two dice, and the player who is currently first in turn order rolls a goods placement\
+      \ die.  A goods tile is made available on the game board according to the roll of the goods die.\n\nDuring each round,\
+      \ a player may perform any two of the four possible types of actions:\n\n    take a settlement tile and place it in\
+      \ the staging area on their player board\n    take a settlement tile from the staging area and place in the corresponding\
+      \ region for the type of tile and adjacent to a previously placed settlement tile, \n    deliver goods with a number\
+      \ matching one of their dice\n    take worker tokens which allow the player to adjust the roll of their dice.  \n\n\n\
+      In addition to these actions a player may buy a settlement tile and place it in the staging area on their player board.\n\
+      \nThe game ends after the fifth phase is played to completion.  Victory points are awarded for unused money and workers,\
+      \ and undelivered goods.  Bonus victory points from certain settlement tiles are awarded at the end of the game. The\
+      \ player with the most victory points wins.\n\nThe rules include basic and advanced versions.\n\n"
     yearPublished: 2011
     minPlayers: 2
     maxPlayers: 4
@@ -2979,26 +3359,43 @@ catalog:
     - Hobby World
     - Maldito Games
     - Rebel Sp. z o.o.
+    pdfBlobKey: rulebooks/v1/castles-of-burgundy_rulebook.pdf
+    pdfSha256: 6fb4eb68f7fc788d9c68f325e310648def996faf16016aa81140c6f3dc798b1c
+    pdfVersion: '1.0'
   - title: 'Arkham Horror: The Card Game'
     bggId: 205637
     language: en
-    pdf: arkham-horror-tcg_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Something evil stirs in Arkham, and only you can stop it. Blurring the traditional lines between role-playing and card game experiences, Arkham Horror: The Card Game is a Living Card Game of Lovecraftian mystery, monsters, and madness!
+    description: 'Something evil stirs in Arkham, and only you can stop it. Blurring the traditional lines between role-playing
+      and card game experiences, Arkham Horror: The Card Game is a Living Card Game of Lovecraftian mystery, monsters, and
+      madness!
 
 
-      In the game, you, alone or with a friend (or up to three friends with two Core Sets), become investigators within the quiet New England town of Arkham. You have your talents, sure, but you also have your flaws. Perhaps you've dabbled a little too much in the writings of the Necronomicon, and its words continue to haunt you. Perhaps you feel compelled to cover up any signs of otherworldly evils, hampering your own investigations in order to protect the quiet confidence of the greater population. Perhaps you'll be scarred by your encounters with a ghoulish cult.
+      In the game, you, alone or with a friend (or up to three friends with two Core Sets), become investigators within the
+      quiet New England town of Arkham. You have your talents, sure, but you also have your flaws. Perhaps you''ve dabbled
+      a little too much in the writings of the Necronomicon, and its words continue to haunt you. Perhaps you feel compelled
+      to cover up any signs of otherworldly evils, hampering your own investigations in order to protect the quiet confidence
+      of the greater population. Perhaps you''ll be scarred by your encounters with a ghoulish cult.
 
 
-      No matter what compels you, no matter what haunts you, you'll find both your strengths and weaknesses reflected in your custom deck of cards, and these cards will be your resources as you work with your friends to unravel the world's most terrifying mysteries.
+      No matter what compels you, no matter what haunts you, you''ll find both your strengths and weaknesses reflected in
+      your custom deck of cards, and these cards will be your resources as you work with your friends to unravel the world''s
+      most terrifying mysteries.
 
 
-      Each of your adventures in Arkham Horror LCG carries you deeper into mystery. You'll find cultists and foul rituals. You'll find haunted houses and strange creatures. And you may find signs of the Ancient Ones straining against the barriers to our world...
+      Each of your adventures in Arkham Horror LCG carries you deeper into mystery. You''ll find cultists and foul rituals.
+      You''ll find haunted houses and strange creatures. And you may find signs of the Ancient Ones straining against the
+      barriers to our world...
 
 
-      The basic mode of play in Arkham LCG is not the adventure, but the campaign. You might be scarred by your adventures, your sanity may be strained, and you may alter Arkham's landscape, burning buildings to the ground. All your choices and actions have consequences that reach far beyond the immediate resolution of the scenario at hand&mdash;and your actions may earn you valuable experience with which you can better prepare yourself for the adventures that still lie before you.
+      The basic mode of play in Arkham LCG is not the adventure, but the campaign. You might be scarred by your adventures,
+      your sanity may be strained, and you may alter Arkham''s landscape, burning buildings to the ground. All your choices
+      and actions have consequences that reach far beyond the immediate resolution of the scenario at hand&mdash;and your
+      actions may earn you valuable experience with which you can better prepare yourself for the adventures that still lie
+      before you.
 
+
+      '
     yearPublished: 2016
     minPlayers: 1
     maxPlayers: 2
@@ -3050,35 +3447,63 @@ catalog:
     - Korea Boardgames
     - Tower Tactic Games
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/arkham-horror-tcg_rulebook.pdf
+    pdfSha256: 28c88deaa538b6132f212cb3107bebea294c6240caef651088d4a39c277e95f6
+    pdfVersion: '1.0'
   - title: Mysterium
     bggId: 181304
     language: en
-    pdf: mysterium_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In the 1920s, Mr. MacDowell, a gifted astrologer, immediately detected a supernatural being upon entering his new house in Scotland. He gathered eminent mediums of his time for an extraordinary s&eacute;ance, and they have seven hours to make contact with the ghost and investigate any clues that it can provide to unlock an old mystery.
+    description: 'In the 1920s, Mr. MacDowell, a gifted astrologer, immediately detected a supernatural being upon entering
+      his new house in Scotland. He gathered eminent mediums of his time for an extraordinary s&eacute;ance, and they have
+      seven hours to make contact with the ghost and investigate any clues that it can provide to unlock an old mystery.
 
 
-      Unable to talk, the amnesiac ghost communicates with the mediums through visions, which are represented in the game by illustrated cards. The mediums must decipher the images to help the ghost remember how he was murdered: Who did the crime? Where did it take place? Which weapon caused the death? The more the mediums cooperate and guess well, the easier it is to catch the right culprit.
+      Unable to talk, the amnesiac ghost communicates with the mediums through visions, which are represented in the game
+      by illustrated cards. The mediums must decipher the images to help the ghost remember how he was murdered: Who did the
+      crime? Where did it take place? Which weapon caused the death? The more the mediums cooperate and guess well, the easier
+      it is to catch the right culprit.
 
 
-      In Mysterium, a reworking of the game system present in Tajemnicze Domostwo, one player takes the role of ghost while everyone else represents a medium. To solve the crime, the ghost must first recall (with the aid of the mediums) all of the suspects present on the night of the murder. A number of suspect, location and murder weapon cards are placed on the table, and the ghost randomly assigns one of each of these in secret to a medium.
+      In Mysterium, a reworking of the game system present in Tajemnicze Domostwo, one player takes the role of ghost while
+      everyone else represents a medium. To solve the crime, the ghost must first recall (with the aid of the mediums) all
+      of the suspects present on the night of the murder. A number of suspect, location and murder weapon cards are placed
+      on the table, and the ghost randomly assigns one of each of these in secret to a medium.
 
 
-      Each hour (i.e., game turn), the ghost hands one or more vision cards face up to each medium, refilling their hand to seven each time they share vision cards. These vision cards present dreamlike images to the mediums, with each medium first needing to deduce which suspect corresponds to the vision cards received. Once the ghost has handed cards to the final medium, they start a two-minute sandtimer. Once a medium has placed their token on a suspect, they may also place clairvoyancy tokens on the guesses made by other mediums to show whether they agree or disagree with those guesses.
+      Each hour (i.e., game turn), the ghost hands one or more vision cards face up to each medium, refilling their hand to
+      seven each time they share vision cards. These vision cards present dreamlike images to the mediums, with each medium
+      first needing to deduce which suspect corresponds to the vision cards received. Once the ghost has handed cards to the
+      final medium, they start a two-minute sandtimer. Once a medium has placed their token on a suspect, they may also place
+      clairvoyancy tokens on the guesses made by other mediums to show whether they agree or disagree with those guesses.
 
 
-      After time runs out, the ghost reveals to each medium whether the guesses were correct or not. Mediums who guessed correctly move on to guess the location of the crime (and then the murder weapon), while those who didn't keep their vision cards and receive new ones next hour corresponding to the same suspect. Once a medium has correctly guessed the suspect, location and weapon, they move their token to the epilogue board and receive one clairvoyancy point for each hour remaining on the clock. They can still use their remaining clairvoyancy tokens to score additional points.
+      After time runs out, the ghost reveals to each medium whether the guesses were correct or not. Mediums who guessed correctly
+      move on to guess the location of the crime (and then the murder weapon), while those who didn''t keep their vision cards
+      and receive new ones next hour corresponding to the same suspect. Once a medium has correctly guessed the suspect, location
+      and weapon, they move their token to the epilogue board and receive one clairvoyancy point for each hour remaining on
+      the clock. They can still use their remaining clairvoyancy tokens to score additional points.
 
 
-      If one or more mediums fail to identify their proper suspect, location and weapon before the end of the seventh hour, then the ghost has failed and dissipates, leaving the mystery unsolved. If, however, they have all succeeded, then the ghost has recovered enough of its memory to identify the culprit.
+      If one or more mediums fail to identify their proper suspect, location and weapon before the end of the seventh hour,
+      then the ghost has failed and dissipates, leaving the mystery unsolved. If, however, they have all succeeded, then the
+      ghost has recovered enough of its memory to identify the culprit.
 
 
-      Mediums then group their suspect, location and weapon cards on the table and place a number by each group. The ghost then selects one group, places the matching culprit number face down on the epilogue board, picks three vision cards &mdash; one for the suspect, one for the location, and one for the weapon &mdash; then shuffles these cards. Players who have achieved few clairvoyancy points flip over one vision card at random, then secretly vote on which suspect they think is guilty; players with more points then flip over a second vision card and vote; then those with the most points see the final card and vote.
+      Mediums then group their suspect, location and weapon cards on the table and place a number by each group. The ghost
+      then selects one group, places the matching culprit number face down on the epilogue board, picks three vision cards
+      &mdash; one for the suspect, one for the location, and one for the weapon &mdash; then shuffles these cards. Players
+      who have achieved few clairvoyancy points flip over one vision card at random, then secretly vote on which suspect they
+      think is guilty; players with more points then flip over a second vision card and vote; then those with the most points
+      see the final card and vote.
 
 
-      If a majority of the mediums have identified the proper suspect, with ties being broken by the vote of the most clairvoyant medium, then the killer has been identified and the ghost can now rest peacefully. If not, well, perhaps you can try again...
+      If a majority of the mediums have identified the proper suspect, with ties being broken by the vote of the most clairvoyant
+      medium, then the killer has been identified and the ghost can now rest peacefully. If not, well, perhaps you can try
+      again...
 
+
+      '
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 7
@@ -3123,22 +3548,25 @@ catalog:
     - Morapiaf
     - Rebel Sp. z o.o.
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/mysterium_rulebook.pdf
+    pdfSha256: 030485b917f8b98ade40b48fbe12501dd5c490426e57c6466dfa63a6a6a84692
+    pdfVersion: '1.0'
   - title: 'Dominion: Prosperity'
     bggId: 66690
     language: en
-    pdf: dominion-prosperity_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Released in late 2010, Prosperity is the 4th addition to the Dominion game family. It adds 25 new Kingdom cards to Dominion, plus 2 new Basic cards that let players keep building up past Gold and Province. The central theme is wealth; there are treasures with abilities, cards that interact with treasures, and powerful expensive cards. (Source: http://www.riograndegames.com/games.html?id=361 )
-
-
-      From the back of the box: "Ah, money. There's nothing like the sound of coins clinking in your hands. You vastly prefer it to the sound of coins clinking in someone else's hands, or the sound of coins just sitting there in a pile that no-one can quite reach without getting up. Getting up, that's all behind you now. Life has been good to you. Just ten years ago, you were tilling your own fields in a simple straw hat. Today, your kingdom stretches from sea to sea, and your straw hat is the largest the world has ever known. You also have the world's smallest dog, and a life-sized statue of yourself made out of baklava. Sure, money can't buy happiness, but it can buy envy, anger, and also this kind of blank feeling. You still have problems - troublesome neighbours that must be conquered. 
-
-      But this time, you'll conquer them in style."
-
-
-      Part of the Dominion series.
-
+    description: "Released in late 2010, Prosperity is the 4th addition to the Dominion game family. It adds 25 new Kingdom\
+      \ cards to Dominion, plus 2 new Basic cards that let players keep building up past Gold and Province. The central theme\
+      \ is wealth; there are treasures with abilities, cards that interact with treasures, and powerful expensive cards. (Source:\
+      \ http://www.riograndegames.com/games.html?id=361 )\n\nFrom the back of the box: \"Ah, money. There's nothing like the\
+      \ sound of coins clinking in your hands. You vastly prefer it to the sound of coins clinking in someone else's hands,\
+      \ or the sound of coins just sitting there in a pile that no-one can quite reach without getting up. Getting up, that's\
+      \ all behind you now. Life has been good to you. Just ten years ago, you were tilling your own fields in a simple straw\
+      \ hat. Today, your kingdom stretches from sea to sea, and your straw hat is the largest the world has ever known. You\
+      \ also have the world's smallest dog, and a life-sized statue of yourself made out of baklava. Sure, money can't buy\
+      \ happiness, but it can buy envy, anger, and also this kind of blank feeling. You still have problems - troublesome\
+      \ neighbours that must be conquered. \nBut this time, you'll conquer them in style.\"\n\nPart of the Dominion series.\n\
+      \n"
     yearPublished: 2010
     minPlayers: 2
     maxPlayers: 4
@@ -3175,23 +3603,20 @@ catalog:
     - Lautapelit.fi
     - Stupor Mundi
     - Ystari Games
+    pdfBlobKey: rulebooks/v1/dominion-prosperity_rulebook.pdf
+    pdfSha256: b8879173187beb0f78c60043607b26aa5ef1b84814645d682d075a8f1492c82d
+    pdfVersion: '1.0'
   - title: 'Century: Spice Road'
     bggId: 209685
     language: en
-    pdf: century-spice-road_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Century: Spice Road is the first in a series of games that explores the history of each century with spice-trading as the theme for the first installment.  In Century: Spice Road, players are caravan leaders who travel the famed silk road to deliver spices to the far reaches of the continent for fame and glory. Each turn, players perform one of four actions:
-
-
-           Establish a trade route (by taking a market card)
-           Make a trade or harvest spices (by playing a card from hand)
-           Fulfill a demand (by meeting a victory point card's requirements and claiming it)
-           Rest (by taking back into your hand all of the cards you've played)
-
-
-      The last round is triggered once a player has claimed their fifth victory point card, then whoever has the most victory points wins.
-
+    description: "Century: Spice Road is the first in a series of games that explores the history of each century with spice-trading\
+      \ as the theme for the first installment.  In Century: Spice Road, players are caravan leaders who travel the famed\
+      \ silk road to deliver spices to the far reaches of the continent for fame and glory. Each turn, players perform one\
+      \ of four actions:\n\n\n     Establish a trade route (by taking a market card)\n     Make a trade or harvest spices\
+      \ (by playing a card from hand)\n     Fulfill a demand (by meeting a victory point card's requirements and claiming\
+      \ it)\n     Rest (by taking back into your hand all of the cards you've played)\n\n\nThe last round is triggered once\
+      \ a player has claimed their fifth victory point card, then whoever has the most victory points wins.\n\n"
     yearPublished: 2017
     minPlayers: 2
     maxPlayers: 5
@@ -3236,20 +3661,34 @@ catalog:
     - Mandoo Games
     - Ninive Games
     - Piatnik Distribution
+    pdfBlobKey: rulebooks/v1/century-spice-road_rulebook.pdf
+    pdfSha256: c80bd5921916f5ea6e72ffa5c8d9c23710e286ddef509f0b9531df3f57acb5ef
+    pdfVersion: '1.0'
   - title: Gloom
     bggId: 12692
     language: en
-    pdf: gloom_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      The world of Gloom is a sad and benighted place. The sky is gray, the tea is cold, and a new tragedy lies around every corner. Debt, disease, heartache, and packs of rabid flesh-eating mice&mdash;just when it seems like things can't get any worse, they do. But some say that one's reward in the afterlife is based on the misery endured in life. If so, there may yet be hope&mdash;if not in this world, then in the peace that lies beyond.
+    description: 'The world of Gloom is a sad and benighted place. The sky is gray, the tea is cold, and a new tragedy lies
+      around every corner. Debt, disease, heartache, and packs of rabid flesh-eating mice&mdash;just when it seems like things
+      can''t get any worse, they do. But some say that one''s reward in the afterlife is based on the misery endured in life.
+      If so, there may yet be hope&mdash;if not in this world, then in the peace that lies beyond.
 
 
-      In the Gloom card game, you assume control of the fate of an eccentric family of misfits and misanthropes. The goal of the game is sad, but simple: you want your characters to suffer the greatest tragedies possible before passing on to the well-deserved respite of death. You'll play horrible mishaps like Pursued by Poodles or Mocked by Midgets on your own characters to lower their Self-Worth scores, while trying to cheer your opponents' characters with marriages and other happy occasions that pile on positive points. The player with the lowest total Family Value wins.
+      In the Gloom card game, you assume control of the fate of an eccentric family of misfits and misanthropes. The goal
+      of the game is sad, but simple: you want your characters to suffer the greatest tragedies possible before passing on
+      to the well-deserved respite of death. You''ll play horrible mishaps like Pursued by Poodles or Mocked by Midgets on
+      your own characters to lower their Self-Worth scores, while trying to cheer your opponents'' characters with marriages
+      and other happy occasions that pile on positive points. The player with the lowest total Family Value wins.
 
 
-      Printed on transparent plastic cards, Gloom features an innovative design by noted RPG author Keith Baker. Multiple modifier cards can be played on top of the same character card; since the cards are transparent, elements from previously played modifier cards either show through or are obscured by those played above them. You'll immediately and easily know the worth of every character, no matter how many modifiers they have. You've got to see (through) this game to believe it!
+      Printed on transparent plastic cards, Gloom features an innovative design by noted RPG author Keith Baker. Multiple
+      modifier cards can be played on top of the same character card; since the cards are transparent, elements from previously
+      played modifier cards either show through or are obscured by those played above them. You''ll immediately and easily
+      know the worth of every character, no matter how many modifiers they have. You''ve got to see (through) this game to
+      believe it!
 
+
+      '
     yearPublished: 2005
     minPlayers: 2
     maxPlayers: 5
@@ -3279,17 +3718,27 @@ catalog:
     - Calamity Games
     - Edge Entertainment
     - uplay.it edizioni
+    pdfBlobKey: rulebooks/v1/gloom_rulebook.pdf
+    pdfSha256: 5256839f16a3ad69a54abc350d455e3dc190d073131c46462bfd3bb21da0c048
+    pdfVersion: '1.0'
   - title: Hive Pocket
     bggId: 154597
     language: en
-    pdf: hive-pocket_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Hive is a strategic game for two players that is not restricted by a board and can be played anywhere on any flat surface. The base game of Hive is made up of twenty two pieces, eleven black and eleven white, resembling a variety of creatures each with a unique way of moving. Hive Carbon and Hive Pocket include the Mosquito and Ladybug expansions, for a total of 26 pieces.
+    description: 'Hive is a strategic game for two players that is not restricted by a board and can be played anywhere on
+      any flat surface. The base game of Hive is made up of twenty two pieces, eleven black and eleven white, resembling a
+      variety of creatures each with a unique way of moving. Hive Carbon and Hive Pocket include the Mosquito and Ladybug
+      expansions, for a total of 26 pieces.
 
 
-      With no setting up to do, the game begins when the first piece is placed down. As the subsequent pieces are placed this forms a pattern that becomes the playing surface. (The pieces themselves become the board.) Unlike other such games, the pieces are never eliminated and not all have to be played. The object of the game is to totally surround your opponent's queen, while at the same time trying to block your opponent from doing likewise to your queen. The first player to totally surround the opponent's queen wins the game.
+      With no setting up to do, the game begins when the first piece is placed down. As the subsequent pieces are placed this
+      forms a pattern that becomes the playing surface. (The pieces themselves become the board.) Unlike other such games,
+      the pieces are never eliminated and not all have to be played. The object of the game is to totally surround your opponent''s
+      queen, while at the same time trying to block your opponent from doing likewise to your queen. The first player to totally
+      surround the opponent''s queen wins the game.
 
+
+      '
     yearPublished: 2010
     minPlayers: 2
     maxPlayers: 2
@@ -3339,27 +3788,30 @@ catalog:
     - Vendetta
     - Zhiyanjia
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/hive-pocket_rulebook.pdf
+    pdfSha256: d5dc5809bc293ef53f13b4aa92bbf833d6f7d95852b14bf491a4e2713478d1d5
+    pdfVersion: '1.0'
   - title: Raiders of the North Sea
     bggId: 170042
     language: en
-    pdf: raiders-of-the-north-sea_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Raiders of the North Sea is set in the central years of the Viking Age. As Viking warriors, players seek to impress the Chieftain by raiding unsuspecting settlements. To do so, players need to assemble a crew, collect provisions, and journey north to plunder gold, iron and livestock. Glory can be found in battle, even at the hands of the Valkyrie, so gather your warriors because it's raiding season!
-
-
-      To impress the Chieftain, you need victory points (VPs), with those being acquired primarily by raiding settlements, taking plunder, and making offerings to the Chieftain. How you use your plunder is also vital to your success. Players take turns in clockwise order, and on a turn you place a worker and resolve its action, then pick up a different worker and resolve its action. Broadly speaking, those actions fall in one of two categories:
-
-
-           Work: Having a good crew and enough provisions are vital to successful raiding, so before making any raids, players need to do some work to prepare their crew and collect supplies. This is all done in the village at the bottom of the game board, with eight buildings offering various actions. You must first place your worker in an available building where no other worker is present, then pick up a different worker from a different building.
-
-
-
-           Raid: Once players have hired enough crew and collected provisions, you may choose to raid on your turn. To raid a settlement &mdash; whether a harbor, outpost, monastery or fortress &mdash; you need to meet three requirements: Having a large enough crew, having enough provisions (along with gold for monasteries and fortresses, and having a worker of the right color. Raiding offers various ways of scoring, such as military strength, plunder, and Valkyries, which is how grey and white workers enter the game.
-
-
-      The game ends when only one fortress raid remains, all Valkyrie have been removed, or all offerings have been made, then players tally their scores.
-
+    description: "Raiders of the North Sea is set in the central years of the Viking Age. As Viking warriors, players seek\
+      \ to impress the Chieftain by raiding unsuspecting settlements. To do so, players need to assemble a crew, collect provisions,\
+      \ and journey north to plunder gold, iron and livestock. Glory can be found in battle, even at the hands of the Valkyrie,\
+      \ so gather your warriors because it's raiding season!\n\nTo impress the Chieftain, you need victory points (VPs), with\
+      \ those being acquired primarily by raiding settlements, taking plunder, and making offerings to the Chieftain. How\
+      \ you use your plunder is also vital to your success. Players take turns in clockwise order, and on a turn you place\
+      \ a worker and resolve its action, then pick up a different worker and resolve its action. Broadly speaking, those actions\
+      \ fall in one of two categories:\n\n\n     Work: Having a good crew and enough provisions are vital to successful raiding,\
+      \ so before making any raids, players need to do some work to prepare their crew and collect supplies. This is all done\
+      \ in the village at the bottom of the game board, with eight buildings offering various actions. You must first place\
+      \ your worker in an available building where no other worker is present, then pick up a different worker from a different\
+      \ building.\n\n\n\n     Raid: Once players have hired enough crew and collected provisions, you may choose to raid on\
+      \ your turn. To raid a settlement &mdash; whether a harbor, outpost, monastery or fortress &mdash; you need to meet\
+      \ three requirements: Having a large enough crew, having enough provisions (along with gold for monasteries and fortresses,\
+      \ and having a worker of the right color. Raiding offers various ways of scoring, such as military strength, plunder,\
+      \ and Valkyries, which is how grey and white workers enter the game.\n\n\nThe game ends when only one fortress raid\
+      \ remains, all Valkyrie have been removed, or all offerings have been made, then players tally their scores.\n\n"
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 4
@@ -3400,35 +3852,43 @@ catalog:
     - Schwerkraft-Verlag
     - White Goblin Games
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/raiders-of-the-north-sea_rulebook.pdf
+    pdfSha256: 2bd3601c5709698becc198584d3d7c8c321640a05a56ae3399af757ae88afa20
+    pdfVersion: '1.0'
   - title: 'Pandemic Legacy: Season 2'
     bggId: 221107
     language: en
-    pdf: pandemic-legacy-s2_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Description from the publisher:
+    description: 'Description from the publisher:
 
 
       The world almost ended 71 years ago...
 
 
-      The plague came out of nowhere and ravaged the world. Most died within a week. Nothing could stop it. The world did its best. It wasn't good enough.
+      The plague came out of nowhere and ravaged the world. Most died within a week. Nothing could stop it. The world did
+      its best. It wasn''t good enough.
 
 
-      For three generations, we, the last fragments of humanity have lived on the seas, on floating stations called "havens." Far from the plague, we are able to provide supplies to the mainland to keep them (and us) from succumbing completely.
+      For three generations, we, the last fragments of humanity have lived on the seas, on floating stations called "havens."
+      Far from the plague, we are able to provide supplies to the mainland to keep them (and us) from succumbing completely.
 
 
-      We've managed to keep a network of the largest known cities in the world alive. Things have been tough the past few years. Cities far away from the havens have fallen off our grid...
+      We''ve managed to keep a network of the largest known cities in the world alive. Things have been tough the past few
+      years. Cities far away from the havens have fallen off our grid...
 
 
-      Tomorrow, a small group of us head out into what's left of the world. We don't know what we'll find.
+      Tomorrow, a small group of us head out into what''s left of the world. We don''t know what we''ll find.
 
 
-      Pandemic Legacy: Season 2 is an epic cooperative game for 2 to 4 players. Unlike most other games, this one is working against you. What's more, some of the actions you take in Pandemic Legacy will carry over to future games. No two worlds will ever be alike!
+      Pandemic Legacy: Season 2 is an epic cooperative game for 2 to 4 players. Unlike most other games, this one is working
+      against you. What''s more, some of the actions you take in Pandemic Legacy will carry over to future games. No two worlds
+      will ever be alike!
 
 
       Part of the Pandemic series.
 
+
+      '
     yearPublished: 2017
     minPlayers: 2
     maxPlayers: 4
@@ -3469,20 +3929,30 @@ catalog:
     - Korea Boardgames
     - Lacerta
     - Lifestyle Boardgames Ltd
+    pdfBlobKey: rulebooks/v1/pandemic-legacy-s2_rulebook.pdf
+    pdfSha256: 6ba4c2623e00eac786b5f6c3a65d1aa99927163870551d2ea3f8f4744c334e51
+    pdfVersion: '1.0'
   - title: Imperial Settlers
     bggId: 154203
     language: en
-    pdf: imperial-settlers_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Settlers from four major powers of the world have discovered new lands, with new resources and opportunities. Romans, Barbarians, Egyptians and Japanese all at once move there to expand the boundaries of their empires. They build new buildings to strengthen their economy, they found mines and fields to gather resources, and they build barracks and training grounds to train soldiers. Soon after they discover that this land is far too small for everybody, then the war begins...
+    description: 'Settlers from four major powers of the world have discovered new lands, with new resources and opportunities.
+      Romans, Barbarians, Egyptians and Japanese all at once move there to expand the boundaries of their empires. They build
+      new buildings to strengthen their economy, they found mines and fields to gather resources, and they build barracks
+      and training grounds to train soldiers. Soon after they discover that this land is far too small for everybody, then
+      the war begins...
 
 
-      Imperial Settlers is a card game that lets players lead one of the four factions and build empires by placing buildings, then sending workers to those buildings to acquire new resources and abilities. The game is played over five rounds during which players take various actions in order to explore new lands, build buildings, trade resources, conquer enemies, and thus score victory points.
+      Imperial Settlers is a card game that lets players lead one of the four factions and build empires by placing buildings,
+      then sending workers to those buildings to acquire new resources and abilities. The game is played over five rounds
+      during which players take various actions in order to explore new lands, build buildings, trade resources, conquer enemies,
+      and thus score victory points.
 
 
-      The core mechanism of Imperial Settlers is based on concepts from the author's card game 51st State.
+      The core mechanism of Imperial Settlers is based on concepts from the author''s card game 51st State.
 
+
+      '
     yearPublished: 2014
     minPlayers: 1
     maxPlayers: 4
@@ -3525,14 +3995,22 @@ catalog:
     - REXhry
     - White Goblin Games
     - Zvezda
+    pdfBlobKey: rulebooks/v1/imperial-settlers_rulebook.pdf
+    pdfSha256: 98c7e716c460934f725a9fbbf55445e39807b4c9241dccfface50f98cf283574
+    pdfVersion: '1.0'
   - title: Guillotine
     bggId: 116
     language: en
-    pdf: guillotine_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      The French Revolution is famous in part for the use of the guillotine to put nobles to death, and this is the macabre subject of this light card game.  As executioners pandering to the masses, the players are trying to behead the most popular nobles.  Each day the nobles are lined up and players take turns killing the ones at the front of the line until all the nobles are gone.  However, players are given cards which will manipulate the line order right before 'harvesting' heads, which is what makes the game interesting.  After three days of chopping, the highest total carries the day.
+    description: 'The French Revolution is famous in part for the use of the guillotine to put nobles to death, and this is
+      the macabre subject of this light card game.  As executioners pandering to the masses, the players are trying to behead
+      the most popular nobles.  Each day the nobles are lined up and players take turns killing the ones at the front of the
+      line until all the nobles are gone.  However, players are given cards which will manipulate the line order right before
+      ''harvesting'' heads, which is what makes the game interesting.  After three days of chopping, the highest total carries
+      the day.
 
+
+      '
     yearPublished: 1998
     minPlayers: 2
     maxPlayers: 5
@@ -3564,29 +4042,46 @@ catalog:
     - Hasbro
     - Play Factory
     - PS-Games
+    pdfBlobKey: rulebooks/v1/guillotine_rulebook.pdf
+    pdfSha256: 6272d65910f05a2a9ada9aa79d1247b3d015cc3b2b402d465f32894ef0928b76
+    pdfVersion: '1.0'
   - title: Harmonies
     bggId: 414317
     language: en
-    pdf: harmonies_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Harmonies, build landscapes by placing colored tokens and create habitats for your animals. To earn the most points and win the game, incorporate the habitats in your landscapes wisely and have as many animals as you can settle there.
+    description: 'In Harmonies, build landscapes by placing colored tokens and create habitats for your animals. To earn the
+      most points and win the game, incorporate the habitats in your landscapes wisely and have as many animals as you can
+      settle there.
 
 
-      Starting with the first player and proceeding clockwise, each player will choose a set of 3 terrain tokens from the central area to place on their personal board. They may optionally choose an Animal card from the 5 displayed and/or place an Animal cube from their Animal card(s) on any completed patterns on their board that match their personal Animal cards. There is a 4-card limit per player. After their turn, refill with a new set of 3 tokens and a new Animal card if needed.
+      Starting with the first player and proceeding clockwise, each player will choose a set of 3 terrain tokens from the
+      central area to place on their personal board. They may optionally choose an Animal card from the 5 displayed and/or
+      place an Animal cube from their Animal card(s) on any completed patterns on their board that match their personal Animal
+      cards. There is a 4-card limit per player. After their turn, refill with a new set of 3 tokens and a new Animal card
+      if needed.
 
 
-      Placement of the terrain tokens will depend on the personal Animal card goals, and scoring rules for the various terrain types (mountain, field, forest, etc). For example, mountain tiles score based on how high they are (1 tile scores 1, while 3 tiles stacked score 7), but the mountain scores zero if it is not adjacent to at least one other mountain. If all the cubes on a given Animal card have been placed, the card is set aside and a new card can be drawn. The cards are scored at game end based on the highest number that isn't covered by a cube.
+      Placement of the terrain tokens will depend on the personal Animal card goals, and scoring rules for the various terrain
+      types (mountain, field, forest, etc). For example, mountain tiles score based on how high they are (1 tile scores 1,
+      while 3 tiles stacked score 7), but the mountain scores zero if it is not adjacent to at least one other mountain. If
+      all the cubes on a given Animal card have been placed, the card is set aside and a new card can be drawn. The cards
+      are scored at game end based on the highest number that isn''t covered by a cube.
 
 
-      The games ends when there are no tokens left in the bag to refill the central area, or at least one players has 2 or fewer empty spaces on their player board. Play continues until all players have had an equal turn that round. The player with the highest points is the winner.
+      The games ends when there are no tokens left in the bag to refill the central area, or at least one players has 2 or
+      fewer empty spaces on their player board. Play continues until all players have had an equal turn that round. The player
+      with the highest points is the winner.
 
 
-      Optionally, you can use Nature's Spirit cards for richer gameplay. During setup, each player chooses 1 of 2 spirit cards and places a Spirit cube on the card. They follow the same placement rules as Animal cards, but tend to have an ongoing effect once completed. The spirit card does count towards the 4-card hand limit.
+      Optionally, you can use Nature''s Spirit cards for richer gameplay. During setup, each player chooses 1 of 2 spirit
+      cards and places a Spirit cube on the card. They follow the same placement rules as Animal cards, but tend to have an
+      ongoing effect once completed. The spirit card does count towards the 4-card hand limit.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2024
     minPlayers: 1
     maxPlayers: 4
@@ -3627,27 +4122,28 @@ catalog:
     - Korea Boardgames
     - Rebel Sp. z o.o.
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/harmonies_rulebook.pdf
+    pdfSha256: 5ed98481b5a6580d15ee92c2c744a33027481fb17ec75fb22fa0e05d9a0ae6c7
+    pdfVersion: '1.0'
   - title: 'Dixit: Odyssey'
     bggId: 92828
     language: en
-    pdf: dixit-odyssey_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Dixit Odyssey is both a standalone game and an expansion (Dixit: Odyssey (expansion)) for Jean-Louis Roubira's Dixit, which won Germany's Spiel des Jahres award in 2010.
-
-
-      Game play in Dixit Odyssey matches that of Dixit: Each turn one player is the storyteller. This player secretly chooses one card in his hand, then gives a word or sentence to describe this card&mdash;but not too obviously. Each other player chooses a card in hand that matches this word/sentence and gives it to the storyteller. The storyteller then lays out the cards, and all other players vote on which card belongs to the storyteller. If no one or everyone guesses the storyteller's card, the storyteller receives no points and all players receive two; otherwise the storyteller and the correct guesser(s) each receive three points. Players score one point for each vote their image receives. Players refill their hands, and the next player becomes the storyteller. When the deck runs out, the player with the most points wins.
-
-
-      Dixit Odyssey contains 84 new cards, each with a unique image drawn by Pier&ocirc; and colored by Marie Cardouat, artist of Dixit and Dixit 2. The stand alone version also includes a folding game board, 6 new rabbit scoring tokens (12 total), and a box large enough to hold all the Dixit cards released to date. The stand alone version of Dixit Odyssey includes enough components for up to twelve players and also has variant rules for team play and for new ways to play with the cards.
-
-
-      Expansion versus standalone versions of the game.
-
-           Standalone version is in a square box (released in 2011 but may still be available).
-           Expansion version is in a rectangular box (available from 2013 onwards): Dixit: Odyssey (expansion)
-
-
+    description: "Dixit Odyssey is both a standalone game and an expansion (Dixit: Odyssey (expansion)) for Jean-Louis Roubira's\
+      \ Dixit, which won Germany's Spiel des Jahres award in 2010.\n\nGame play in Dixit Odyssey matches that of Dixit: Each\
+      \ turn one player is the storyteller. This player secretly chooses one card in his hand, then gives a word or sentence\
+      \ to describe this card&mdash;but not too obviously. Each other player chooses a card in hand that matches this word/sentence\
+      \ and gives it to the storyteller. The storyteller then lays out the cards, and all other players vote on which card\
+      \ belongs to the storyteller. If no one or everyone guesses the storyteller's card, the storyteller receives no points\
+      \ and all players receive two; otherwise the storyteller and the correct guesser(s) each receive three points. Players\
+      \ score one point for each vote their image receives. Players refill their hands, and the next player becomes the storyteller.\
+      \ When the deck runs out, the player with the most points wins.\n\nDixit Odyssey contains 84 new cards, each with a\
+      \ unique image drawn by Pier&ocirc; and colored by Marie Cardouat, artist of Dixit and Dixit 2. The stand alone version\
+      \ also includes a folding game board, 6 new rabbit scoring tokens (12 total), and a box large enough to hold all the\
+      \ Dixit cards released to date. The stand alone version of Dixit Odyssey includes enough components for up to twelve\
+      \ players and also has variant rules for team play and for new ways to play with the cards.\n\nExpansion versus standalone\
+      \ versions of the game.\n\n     Standalone version is in a square box (released in 2011 but may still be available).\n\
+      \     Expansion version is in a rectangular box (available from 2013 onwards): Dixit: Odyssey (expansion)\n\n\n"
     yearPublished: 2011
     minPlayers: 3
     maxPlayers: 12
@@ -3685,16 +4181,21 @@ catalog:
     - Rebel Sp. z o.o.
     - Swan Panasia Co., Ltd.
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/dixit-odyssey_rulebook.pdf
+    pdfSha256: a3d0b2c61420c8ad04147a323143bf5885b26b92040cf2bc83d9e9211265a4db
+    pdfVersion: '1.0'
   - title: Hanamikoji
     bggId: 158600
     language: en
-    pdf: hanamikoji_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Welcome to the most famed Geisha street in the old capital, Hanamikoji. Geishas are elegant and graceful women who are skilled in art, music, dance, and a variety of performances and ceremonies. Greatly respected and adored, Geishas are masters of entertainment.
+    description: 'Welcome to the most famed Geisha street in the old capital, Hanamikoji. Geishas are elegant and graceful
+      women who are skilled in art, music, dance, and a variety of performances and ceremonies. Greatly respected and adored,
+      Geishas are masters of entertainment.
 
 
-      In Hanamikoji, two players compete to earn the favor of seven illustrious Geishas by collecting each Geisha&rsquo;s preferred performance item. With careful speculation and a few bold moves, can you outsmart your opponent to win the favor of the most Geishas?
+      In Hanamikoji, two players compete to earn the favor of seven illustrious Geishas by collecting each Geisha&rsquo;s
+      preferred performance item. With careful speculation and a few bold moves, can you outsmart your opponent to win the
+      favor of the most Geishas?
 
 
       Jixia Academy features the same gameplay as Hanamikoji, but with different artwork.
@@ -3702,6 +4203,8 @@ catalog:
 
       Hanamikoji FAQ
 
+
+      '
     yearPublished: 2013
     minPlayers: 2
     maxPlayers: 2
@@ -3749,25 +4252,36 @@ catalog:
     - Taiwan Boardgame Design
     - White Goblin Games
     - Zvezda
+    pdfBlobKey: rulebooks/v1/hanamikoji_rulebook.pdf
+    pdfSha256: 662765d0f77dd24235ec59f6c00b629ac69078a62e7fbd044a803bb7458326a2
+    pdfVersion: '1.0'
   - title: Sleeping Gods
     bggId: 255984
     language: en
-    pdf: sleeping-gods_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      "Are the stars unfamiliar here?" she asked, and the sky grew suddenly dark, the star's patterns alien and exotic. "This is the Wandering Sea. The gods have brought you here, and you must wake them if you wish to return home."
+    description: '"Are the stars unfamiliar here?" she asked, and the sky grew suddenly dark, the star''s patterns alien and
+      exotic. "This is the Wandering Sea. The gods have brought you here, and you must wake them if you wish to return home."
 
 
-      In Sleeping Gods, you and up to 3 friends become Captain Sofi Odessa and her crew, lost in a strange world in 1929 on your steamship, the Manticore. You must work together to survive, exploring exotic islands, meeting new characters, and seeking out the totems of the gods so that you can return home.
+      In Sleeping Gods, you and up to 3 friends become Captain Sofi Odessa and her crew, lost in a strange world in 1929 on
+      your steamship, the Manticore. You must work together to survive, exploring exotic islands, meeting new characters,
+      and seeking out the totems of the gods so that you can return home.
 
 
-      Sleeping Gods is a campaign game. Each session can last as long as you want. When you are ready to take a break, you mark your progress on a journey log sheet, making it easy to return to the same place in the game the next time you play. You can play solo or with friends throughout your campaign. It's easy to swap players in and out at will. Your goal is to find at least fourteen totems hidden throughout the world. Like reading a book, you'll complete this journey one or two hours at a time, discovering new lands, stories, and challenges along the way.
+      Sleeping Gods is a campaign game. Each session can last as long as you want. When you are ready to take a break, you
+      mark your progress on a journey log sheet, making it easy to return to the same place in the game the next time you
+      play. You can play solo or with friends throughout your campaign. It''s easy to swap players in and out at will. Your
+      goal is to find at least fourteen totems hidden throughout the world. Like reading a book, you''ll complete this journey
+      one or two hours at a time, discovering new lands, stories, and challenges along the way.
 
 
-      Sleeping Gods is an atlas game. Each page of the atlas represents only a small portion of the world you can explore. When you reach the edge of a page and you want to continue in the same direction, you simply turn to a new page and sail onward.
+      Sleeping Gods is an atlas game. Each page of the atlas represents only a small portion of the world you can explore.
+      When you reach the edge of a page and you want to continue in the same direction, you simply turn to a new page and
+      sail onward.
 
 
-      Sleeping Gods is a storybook game. Each new location holds wild adventure, hidden treasures, and vivid characters. Your choices affect the characters and the plot of the game, and may help or hinder your chances of getting home!
+      Sleeping Gods is a storybook game. Each new location holds wild adventure, hidden treasures, and vivid characters. Your
+      choices affect the characters and the plot of the game, and may help or hinder your chances of getting home!
 
 
       Welcome to a vast world. Your journey starts now.
@@ -3775,6 +4289,8 @@ catalog:
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2021
     minPlayers: 1
     maxPlayers: 4
@@ -3819,22 +4335,40 @@ catalog:
     - REXhry
     - リゴレ (rigoler)
     - Schwerkraft-Verlag
+    pdfBlobKey: rulebooks/v1/sleeping-gods_rulebook.pdf
+    pdfSha256: 07fe81f40884134f92b5b50720fa2348501b9b33c3f5dff774fda5ad12e2807c
+    pdfVersion: '1.0'
   - title: Jenga
     bggId: 2452
     language: en
     bggEnhanced: true
-    description: >+
-      Jenga is tower building game played with 54 wooden blocks; each block is 3 times as long as it is wide, and slightly smaller in height than in width. The blocks are stacked in a tower formation; each story is three blocks placed adjacent to each other along their long side, and each story is placed perpendicular to the previous (so, for example, if the blocks in the first story are pointing north-south, the second story blocks will point east-west). There are therefore 18 stories to the Jenga tower. Since stacking the blocks neatly can be tedious, a plastic loading tray is included.
+    description: 'Jenga is tower building game played with 54 wooden blocks; each block is 3 times as long as it is wide,
+      and slightly smaller in height than in width. The blocks are stacked in a tower formation; each story is three blocks
+      placed adjacent to each other along their long side, and each story is placed perpendicular to the previous (so, for
+      example, if the blocks in the first story are pointing north-south, the second story blocks will point east-west). There
+      are therefore 18 stories to the Jenga tower. Since stacking the blocks neatly can be tedious, a plastic loading tray
+      is included.
 
 
-      Once the tower is built, the person who built the tower moves first. Moving in Jenga consists of taking one and only one block from any story except the completed top story of the tower at the time of the turn, and placing it on the topmost story in order to complete it. Only one hand at a time may be used to remove a block; both hands can be used, but only one hand may be on the tower at a time. Blocks may be bumped to find a loose block that will not disturb the rest of the tower. Any block that is moved out of place may be left out of place if it is determined that it will knock the tower over if it is removed. The turn ends when the next person to move touches the tower, although he or she can wait 10 seconds before moving for the previous turn to end if they believe the tower will fall in that time.
+      Once the tower is built, the person who built the tower moves first. Moving in Jenga consists of taking one and only
+      one block from any story except the completed top story of the tower at the time of the turn, and placing it on the
+      topmost story in order to complete it. Only one hand at a time may be used to remove a block; both hands can be used,
+      but only one hand may be on the tower at a time. Blocks may be bumped to find a loose block that will not disturb the
+      rest of the tower. Any block that is moved out of place may be left out of place if it is determined that it will knock
+      the tower over if it is removed. The turn ends when the next person to move touches the tower, although he or she can
+      wait 10 seconds before moving for the previous turn to end if they believe the tower will fall in that time.
 
 
-      The game ends when the tower falls in any significant way -- in other words, any piece falls from the tower, other than the piece being knocked out to move to the top. The loser is the person who made the tower fall (i.e. whose turn it was when the tower fell); the winner is the person who moved before the loser.
+      The game ends when the tower falls in any significant way -- in other words, any piece falls from the tower, other than
+      the piece being knocked out to move to the top. The loser is the person who made the tower fall (i.e. whose turn it
+      was when the tower fell); the winner is the person who moved before the loser.
 
 
-      The same game concept was published in 1984 by Fagus under the name "Hoppla - eins zuviel!" According to the designer, the game was developed from Takoradi blocks/bricks. "Jenga" is Swahili for "build".
+      The same game concept was published in 1984 by Fagus under the name "Hoppla - eins zuviel!" According to the designer,
+      the game was developed from Takoradi blocks/bricks. "Jenga" is Swahili for "build".
 
+
+      '
     yearPublished: 1983
     minPlayers: 1
     maxPlayers: 8
@@ -3930,20 +4464,32 @@ catalog:
   - title: El Grande
     bggId: 93
     language: en
-    pdf: el-grande_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In this award-winning game, players take on the roles of Grandes in medieval Spain.  The king's power is flagging, and these powerful lords are vying for control of the various regions.  To that end, you draft caballeros (knights) into your court and subsequently move them onto the board to help seize control of regions.  After every third round, the regions are scored, and after the ninth round, the player with the most points is the winner.
+    description: 'In this award-winning game, players take on the roles of Grandes in medieval Spain.  The king''s power is
+      flagging, and these powerful lords are vying for control of the various regions.  To that end, you draft caballeros
+      (knights) into your court and subsequently move them onto the board to help seize control of regions.  After every third
+      round, the regions are scored, and after the ninth round, the player with the most points is the winner.
 
 
-      In each of the nine rounds, you select one of your 13 power cards to determine turn order as well as the number of caballeros you get to move from the provinces (general supply) into your court (personal supply).
+      In each of the nine rounds, you select one of your 13 power cards to determine turn order as well as the number of caballeros
+      you get to move from the provinces (general supply) into your court (personal supply).
 
 
-      A turn then consists of selecting one of five action cards which allow variations to the rules and additional scoring opportunities in addition to determining how many caballeros to move from your court to one or more of the regions on the board (or into the castillo - a secretive tower). Normally, you may only place your caballeros into regions adjacent to the one containing the king. The one hard and fast rule in El Grande is that nothing may move into or out of the king's region. One of the five action cards that is always available each round allows you to move the king to a new region. The other four action cards vary from round to round.
+      A turn then consists of selecting one of five action cards which allow variations to the rules and additional scoring
+      opportunities in addition to determining how many caballeros to move from your court to one or more of the regions on
+      the board (or into the castillo - a secretive tower). Normally, you may only place your caballeros into regions adjacent
+      to the one containing the king. The one hard and fast rule in El Grande is that nothing may move into or out of the
+      king''s region. One of the five action cards that is always available each round allows you to move the king to a new
+      region. The other four action cards vary from round to round.
 
 
-      The goal is to have a caballero majority in as many regions (and the castillo) as possible during a scoring round. Following the scoring of the castillo, you place any cubes you had there into the region you secretly indicated on your region dial. Each region is then scored individually according to a table printed in that region. Two-point bonuses are awarded for having sole majority in the region containing your Grande and in the region containing the king.
+      The goal is to have a caballero majority in as many regions (and the castillo) as possible during a scoring round. Following
+      the scoring of the castillo, you place any cubes you had there into the region you secretly indicated on your region
+      dial. Each region is then scored individually according to a table printed in that region. Two-point bonuses are awarded
+      for having sole majority in the region containing your Grande and in the region containing the king.
 
+
+      '
     yearPublished: 1995
     minPlayers: 2
     maxPlayers: 5
@@ -3987,17 +4533,26 @@ catalog:
     - MINDOK
     - Möbius Games
     - Rio Grande Games
+    pdfBlobKey: rulebooks/v1/el-grande_rulebook.pdf
+    pdfSha256: 414db220f71e3ab7e8735ee71945f960ea36e36f0a348ef91a55558d4f2097a3
+    pdfVersion: '1.0'
   - title: Aeon's End
     bggId: 191189
     language: en
-    pdf: aeons-end_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      The survivors of a long-ago invasion have taken refuge in the forgotten underground city of Gravehold. There, the desperate remnants of society have learned that the energy of the very breaches the beings use to attack them can be repurposed through various gems, transforming the malign energies within into beneficial spells and weapons to aid their last line of defense: the breach mages.
+    description: 'The survivors of a long-ago invasion have taken refuge in the forgotten underground city of Gravehold. There,
+      the desperate remnants of society have learned that the energy of the very breaches the beings use to attack them can
+      be repurposed through various gems, transforming the malign energies within into beneficial spells and weapons to aid
+      their last line of defense: the breach mages.
 
 
-      Aeon's End is a cooperative game that explores the deckbuilding genre with a number of innovative mechanisms, including a variable turn order system that simulates the chaos of an attack, and deck management rules that require careful planning with every discarded card. Players will struggle to defend Gravehold from The Nameless and their hordes using unique abilities, powerful spells, and, most importantly of all, their collective wits.
+      Aeon''s End is a cooperative game that explores the deckbuilding genre with a number of innovative mechanisms, including
+      a variable turn order system that simulates the chaos of an attack, and deck management rules that require careful planning
+      with every discarded card. Players will struggle to defend Gravehold from The Nameless and their hordes using unique
+      abilities, powerful spells, and, most importantly of all, their collective wits.
 
+
+      '
     yearPublished: 2016
     minPlayers: 1
     maxPlayers: 4
@@ -4046,30 +4601,24 @@ catalog:
     - REXhry
     - SD Games
     - Surfin' Meeple China
+    pdfBlobKey: rulebooks/v1/aeons-end_rulebook.pdf
+    pdfSha256: d4496bf1b1a69d52d59a1bfb544f1b220465ffbfcc453d1fb2834706d7cf423b
+    pdfVersion: '1.0'
   - title: Res Arcana
     bggId: 262712
     language: en
-    pdf: res-arcana_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Prepare Your Place of Power!
-
-
-      In a high tower, an Alchemist prepares potions, using vials filled with otherworldly fluids. In a sacred grove, a Druid grinds herbs for a mystical ritual. In the catacombs, a Necromancer summons a bone dragon... Welcome to the world of Res Arcana!
-
-
-      In it, Life, Death, Elan, Calm, and Gold are the essences that fuel the art of magic. Choose your mage, gather essences, craft unique artifacts, and use them to summon dragons, conquer places of power, and achieve victory!
-
-
-      A game typically lasts 4-6 rounds. In each round, players do these steps:
-
-
-          Collect essences: performs  any Collect abilities, and may take essences from components.
-          Do actions, 1 per turn, clockwise from the First Player: place an artifact, claim a monument or Place of Power, discard a card for 1 Gold or any 2 other essences, use a power on a straightened component, or pass: exchange magic items and draw 1 card. Play continues until all players have passed.
-          Pass procedure: If you are first to pass, take the First Player token, swap your magic item for a different magic item, draw 1 card.
-          Check victory points (10+ VPs). If no one has won: straighten all turned components, and begin the next round.
-
-
+    description: "Prepare Your Place of Power!\n\nIn a high tower, an Alchemist prepares potions, using vials filled with\
+      \ otherworldly fluids. In a sacred grove, a Druid grinds herbs for a mystical ritual. In the catacombs, a Necromancer\
+      \ summons a bone dragon... Welcome to the world of Res Arcana!\n\nIn it, Life, Death, Elan, Calm, and Gold are the essences\
+      \ that fuel the art of magic. Choose your mage, gather essences, craft unique artifacts, and use them to summon dragons,\
+      \ conquer places of power, and achieve victory!\n\nA game typically lasts 4-6 rounds. In each round, players do these\
+      \ steps:\n\n\n    Collect essences: performs  any Collect abilities, and may take essences from components.\n    Do\
+      \ actions, 1 per turn, clockwise from the First Player: place an artifact, claim a monument or Place of Power, discard\
+      \ a card for 1 Gold or any 2 other essences, use a power on a straightened component, or pass: exchange magic items\
+      \ and draw 1 card. Play continues until all players have passed.\n    Pass procedure: If you are first to pass, take\
+      \ the First Player token, swap your magic item for a different magic item, draw 1 card.\n    Check victory points (10+\
+      \ VPs). If no one has won: straighten all turned components, and begin the next round.\n\n\n"
     yearPublished: 2019
     minPlayers: 2
     maxPlayers: 4
@@ -4107,20 +4656,32 @@ catalog:
     - Rebel Sp. z o.o.
     - sternenschimmermeer
     - テンデイズゲームズ (TendaysGames)
+    pdfBlobKey: rulebooks/v1/res-arcana_rulebook.pdf
+    pdfSha256: 79eca4421a36e2b547b06132f32cdc31fbfbd417ac4f73a5eb6130db472d9886
+    pdfVersion: '1.0'
   - title: Hero Realms
     bggId: 198994
     language: en
-    pdf: hero-realms_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Hero Realms is a fantasy-themed deck-building game that is an adaptation of the award-winning Star Realms game. The game includes basic rules for two-player games, along with rules for multiplayer formats such as Free-For-All, Hunter, and Hydra.
+    description: 'Hero Realms is a fantasy-themed deck-building game that is an adaptation of the award-winning Star Realms
+      game. The game includes basic rules for two-player games, along with rules for multiplayer formats such as Free-For-All,
+      Hunter, and Hydra.
 
 
-      Each player starts the game with a ten-card personal deck containing gold (for buying) and weapons (for combat). You start each turn with a new hand of five cards from your personal deck. When your deck runs out of cards, you shuffle your discard pile into your new deck. An 80-card Market deck is shared by all players, with five cards being revealed from that deck to create the Market Row. As you play, you use gold to buy champion cards and action cards from the Market. These champions and actions can generate large amounts of gold, combat, or other powerful effects. You use combat to attack your opponent and their champions. When you reduce your opponent's score (called health) to zero, you win!
+      Each player starts the game with a ten-card personal deck containing gold (for buying) and weapons (for combat). You
+      start each turn with a new hand of five cards from your personal deck. When your deck runs out of cards, you shuffle
+      your discard pile into your new deck. An 80-card Market deck is shared by all players, with five cards being revealed
+      from that deck to create the Market Row. As you play, you use gold to buy champion cards and action cards from the Market.
+      These champions and actions can generate large amounts of gold, combat, or other powerful effects. You use combat to
+      attack your opponent and their champions. When you reduce your opponent''s score (called health) to zero, you win!
 
 
-      Multiple expansions are available for Hero Realms that allow players to start as a particular character (Cleric, Fighter, Ranger, Thief, or Wizard) and fight cooperatively against a Boss, fight Boss decks against one another, or compete in a campaign mode that has you gain experience to work through different levels of missions.
+      Multiple expansions are available for Hero Realms that allow players to start as a particular character (Cleric, Fighter,
+      Ranger, Thief, or Wizard) and fight cooperatively against a Boss, fight Boss decks against one another, or compete in
+      a campaign mode that has you gain experience to work through different levels of missions.
 
+
+      '
     yearPublished: 2016
     minPlayers: 2
     maxPlayers: 4
@@ -4159,17 +4720,26 @@ catalog:
     - Lord of Boards
     - MIPL
     - Rawstone
+    pdfBlobKey: rulebooks/v1/hero-realms_rulebook.pdf
+    pdfSha256: 5e9f80ac096cd880ce21bbebaf83a789e1b671d0f6f2746b1707565108ca79f8
+    pdfVersion: '1.0'
   - title: Roll Player
     bggId: 169426
     language: en
-    pdf: roll-player_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Mighty heroes don&rsquo;t just appear out of thin air -- you must create them! Race, class, alignment, skills, traits, and equipment are all elements of the perfect hero, who is ready to take on all opposition in the quest for glory and riches.
+    description: 'Mighty heroes don&rsquo;t just appear out of thin air -- you must create them! Race, class, alignment, skills,
+      traits, and equipment are all elements of the perfect hero, who is ready to take on all opposition in the quest for
+      glory and riches.
 
 
-      In Roll Player, you will compete to create the greatest fantasy adventurer who has ever lived, preparing your character to embark on an epic quest. Roll and draft dice to build up your character&rsquo;s attributes. Purchase weapons and armor to outfit your hero. Train to gain skills and discover your hero&rsquo;s traits to prepare them for their journey. Earn Reputation Stars by constructing the perfect character. The player with the greatest Reputation wins the game and will surely triumph over whatever nefarious plot lies ahead!
+      In Roll Player, you will compete to create the greatest fantasy adventurer who has ever lived, preparing your character
+      to embark on an epic quest. Roll and draft dice to build up your character&rsquo;s attributes. Purchase weapons and
+      armor to outfit your hero. Train to gain skills and discover your hero&rsquo;s traits to prepare them for their journey.
+      Earn Reputation Stars by constructing the perfect character. The player with the greatest Reputation wins the game and
+      will surely triumph over whatever nefarious plot lies ahead!
 
+
+      '
     yearPublished: 2016
     minPlayers: 1
     maxPlayers: 4
@@ -4207,22 +4777,32 @@ catalog:
     - Pegasus Spiele
     - Raven Distribution
     - REXhry
+    pdfBlobKey: rulebooks/v1/roll-player_rulebook.pdf
+    pdfSha256: 0ae1cee918d58e165308cdef58b731e89a916652e919e7b61dbe74cb29e5240b
+    pdfVersion: '1.0'
   - title: Yahtzee
     bggId: 2243
     language: en
     bggEnhanced: true
-    description: >+
-      Yahtzee is a classic dice game played with 5 dice.  Each player's turn consists of rolling the dice up to 3 times in hope of making 1 of 13 categories.  Examples of categories are 3 of a kind, 4 of a kind, straight, full house, etc.  Each player tries to fill in a score for each category, but this is not always possible.  When all players have entered a score or a zero for all 13 categories, the game ends and total scores are compared.
+    description: 'Yahtzee is a classic dice game played with 5 dice.  Each player''s turn consists of rolling the dice up
+      to 3 times in hope of making 1 of 13 categories.  Examples of categories are 3 of a kind, 4 of a kind, straight, full
+      house, etc.  Each player tries to fill in a score for each category, but this is not always possible.  When all players
+      have entered a score or a zero for all 13 categories, the game ends and total scores are compared.
 
 
       The traditional (public domain) game Yacht predates the trademarked game, and has slightly different scoring.
 
 
-      There are four basic scoring difference between the tradition game Yacht and Yahtzee.  They are:  1) Yacht has no Three of a Kind category, 2) there are no bonuses in Yacht, 3) there are no Joker rules in Yacht, and 4) the Full House category is scored as the sum of the dice.  The other scoring rules are identical between the two games.
+      There are four basic scoring difference between the tradition game Yacht and Yahtzee.  They are:  1) Yacht has no Three
+      of a Kind category, 2) there are no bonuses in Yacht, 3) there are no Joker rules in Yacht, and 4) the Full House category
+      is scored as the sum of the dice.  The other scoring rules are identical between the two games.
 
 
-      Travel versions of the game use a device that keeps the dice captured within compartments of a plastic box and allows players to "lock" a particular die between rolls.
+      Travel versions of the game use a device that keeps the dice captured within compartments of a plastic box and allows
+      players to "lock" a particular die between rolls.
 
+
+      '
     yearPublished: 1956
     minPlayers: 2
     maxPlayers: 10
@@ -4321,8 +4901,10 @@ catalog:
     bggId: 2223
     language: en
     bggEnhanced: true
-    description: >+
-      Players race to empty their hands and catch opposing players with cards left in theirs, which score points. In turns, players attempt to play a card by matching its color, number, or word to the topmost card on the discard pile. If unable to play, players draw a card from the draw pile, and if still unable to play, they pass their turn. Wild and special cards spice things up a bit.
+    description: 'Players race to empty their hands and catch opposing players with cards left in theirs, which score points.
+      In turns, players attempt to play a card by matching its color, number, or word to the topmost card on the discard pile.
+      If unable to play, players draw a card from the draw pile, and if still unable to play, they pass their turn. Wild and
+      special cards spice things up a bit.
 
 
       UNO is a commercial version of Crazy Eights, a public domain card game played with a standard deck of playing cards.
@@ -4330,6 +4912,8 @@ catalog:
 
       This entry includes all themed versions of UNO that do not include new cards.
 
+
+      '
     yearPublished: 1971
     minPlayers: 2
     maxPlayers: 10
@@ -4386,18 +4970,26 @@ catalog:
   - title: Carcassonne
     bggId: 822
     language: en
-    pdf: carcassone_rulebook.pdf
     seedAgent: true
     bggEnhanced: true
-    description: >+
-      Carcassonne is a tile placement game in which the players draw and place a tile with a piece of southern French landscape represented on it. The tile might feature a city, a road, a cloister, grassland or some combination thereof, and it must be placed adjacent to tiles that have already been played, in such a way that cities are connected to cities, roads to roads, et cetera. Having placed a tile, the player can then decide to place one of their meeples in one of the areas on it: in the city as a knight, on the road as a robber, in the cloister as a monk, or in the field as a farmer. When that area is complete that meeple scores points for its owner.
+    description: 'Carcassonne is a tile placement game in which the players draw and place a tile with a piece of southern
+      French landscape represented on it. The tile might feature a city, a road, a cloister, grassland or some combination
+      thereof, and it must be placed adjacent to tiles that have already been played, in such a way that cities are connected
+      to cities, roads to roads, et cetera. Having placed a tile, the player can then decide to place one of their meeples
+      in one of the areas on it: in the city as a knight, on the road as a robber, in the cloister as a monk, or in the field
+      as a farmer. When that area is complete that meeple scores points for its owner.
 
 
-      During a game of Carcassonne, players are faced with decisions like: "Is it really worth putting my last meeple there?" or "Should I use this tile to expand my city, or should I place it near my opponent instead, thus making it a harder for them to complete it and score points?" Since players place only one tile and have the option to place one meeple on it, turns proceed quickly even if it is a game full of options and possibilities.
+      During a game of Carcassonne, players are faced with decisions like: "Is it really worth putting my last meeple there?"
+      or "Should I use this tile to expand my city, or should I place it near my opponent instead, thus making it a harder
+      for them to complete it and score points?" Since players place only one tile and have the option to place one meeple
+      on it, turns proceed quickly even if it is a game full of options and possibilities.
 
 
       First game in the Carcassonne series.
 
+
+      '
     yearPublished: 2000
     minPlayers: 2
     maxPlayers: 5
@@ -4463,22 +5055,28 @@ catalog:
     - Venice Connection
     - Ventura Games
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/carcassone_rulebook.pdf
+    pdfSha256: 762a1ca8cc547ef6c5a6899b0043ecd1ef6f448dc51cfcc6906827452d90253e
+    pdfVersion: '1.0'
   - title: Risk
     bggId: 181
     language: en
     bggEnhanced: true
-    description: >+
-      Possibly the most popular, mass market war game.  The goal is conquest of the world.
+    description: 'Possibly the most popular, mass market war game.  The goal is conquest of the world.
 
 
-      Each player's turn consists of:
+      Each player''s turn consists of:
 
-      - gaining reinforcements through number of territories held, control of every territory on each continent, and turning sets of bonus cards.
+      - gaining reinforcements through number of territories held, control of every territory on each continent, and turning
+      sets of bonus cards.
 
-      -  Attacking other players using a simple combat rule of comparing the highest dice rolled for each side.  Players may attack as often as desired.  If one enemy territory is successfully taken, the player is awarded with a  bonus card.
+      -  Attacking other players using a simple combat rule of comparing the highest dice rolled for each side.  Players may
+      attack as often as desired.  If one enemy territory is successfully taken, the player is awarded with a  bonus card.
 
       -  Moving a group of armies to another adjacent territory.
 
+
+      '
     yearPublished: 1959
     minPlayers: 2
     maxPlayers: 6
@@ -4537,17 +5135,31 @@ catalog:
   - title: Chess
     bggId: 171
     language: en
-    pdf: scacchi-fide_2017_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Chess is a two-player, abstract strategy board game that represents medieval warfare on an 8x8 board with alternating light and dark squares. Opposing pieces, traditionally designated White and Black, are initially lined up on either side of the board. Each type of piece has a unique form of movement and capturing occurs when a piece, via its movement, occupies the square of an opposing piece. Players take turns moving one of their pieces in an attempt to capture, attack, defend, or develop their positions. Chess games can end in checkmate (when the king cannot escape from the opponent's pieces), resignation (when one player recognizes that defeat is inevitable and ends the game), or one of several types of draws.
+    description: 'Chess is a two-player, abstract strategy board game that represents medieval warfare on an 8x8 board with
+      alternating light and dark squares. Opposing pieces, traditionally designated White and Black, are initially lined up
+      on either side of the board. Each type of piece has a unique form of movement and capturing occurs when a piece, via
+      its movement, occupies the square of an opposing piece. Players take turns moving one of their pieces in an attempt
+      to capture, attack, defend, or develop their positions. Chess games can end in checkmate (when the king cannot escape
+      from the opponent''s pieces), resignation (when one player recognizes that defeat is inevitable and ends the game),
+      or one of several types of draws.
 
 
-      Chess is one of the most popular games in the world, played by millions of people worldwide at home, in clubs, online, by correspondence, and in tournaments. Between two highly skilled players, chess can be a beautiful thing to watch, and a game can provide great entertainment even for novices. The 2020 Netflix series, The Queen's Gambit was enjoyed by both chess players and non-players alike. There is also a large literature of books and periodicals about chess, typically featuring games and commentary by chess masters. Chess is so well known and highly regarded that it is often used as a metaphor in journalism, poetry, fiction, and film.
+      Chess is one of the most popular games in the world, played by millions of people worldwide at home, in clubs, online,
+      by correspondence, and in tournaments. Between two highly skilled players, chess can be a beautiful thing to watch,
+      and a game can provide great entertainment even for novices. The 2020 Netflix series, The Queen''s Gambit was enjoyed
+      by both chess players and non-players alike. There is also a large literature of books and periodicals about chess,
+      typically featuring games and commentary by chess masters. Chess is so well known and highly regarded that it is often
+      used as a metaphor in journalism, poetry, fiction, and film.
 
 
-      Chess evolved from the ancient Indian game Chaturanga, which became Shatranj when introduced to the Persians. The current form of the game emerged in the second half of the 15th century when the Persians brought Shatranj to Southern Europe. The tradition of organized competitive chess began in the 16th century. The first official World Chess Champion, Wilhelm Steinitz, claimed his title in 1886. Chess is also a recognized sport of the International Olympic Committee.
+      Chess evolved from the ancient Indian game Chaturanga, which became Shatranj when introduced to the Persians. The current
+      form of the game emerged in the second half of the 15th century when the Persians brought Shatranj to Southern Europe.
+      The tradition of organized competitive chess began in the 16th century. The first official World Chess Champion, Wilhelm
+      Steinitz, claimed his title in 1886. Chess is also a recognized sport of the International Olympic Committee.
 
+
+      '
     yearPublished: 1475
     minPlayers: 2
     maxPlayers: 2
@@ -4777,20 +5389,23 @@ catalog:
     - Xinliye
     - Οδύσσεια
     - Киевпластмасс
+    pdfBlobKey: rulebooks/v1/scacchi-fide_2017_rulebook.pdf
+    pdfSha256: dcd7496d22fb8efd3af35646ac38e8b07250acf0670772133d7983d9c82c0542
+    pdfVersion: '1.0'
   - title: Checkers
     bggId: 2083
     language: en
     bggEnhanced: true
-    description: >+
-      Abstract strategy game where players move disc-shaped pieces across an 8 by 8 cross-hatched ("checker") board. 
-
-      Pieces only move diagonally, and only one space at a time.  If a player can move one of his pieces so that it jumps over an adjacent piece of their opponent and into an empty space, that player captures the opponent's disc.  Jumping moves must be taken when possible, thereby creating a strategy game where players offer up jumps in exchange for setting up the board so that they jump even more pieces on their turn.  A player wins by removing all of his opponent's pieces from the board or by blocking the opponent so that he has no more moves.
-
-      This game, also known as Draughts, is part of the Checkers family.
-
-
-      The Official Checker Board to be used in tournaments and official matches of associations like international WCDF, ACF, and APCA usually shall be colored of green and off-white (buff). Board squares shall be not less than 2 inches nor more than 2&frac12; inches wide. Tournament pieces are Red and White, but called Black and White in game related literature.
-
+    description: "Abstract strategy game where players move disc-shaped pieces across an 8 by 8 cross-hatched (\"checker\"\
+      ) board. \nPieces only move diagonally, and only one space at a time.  If a player can move one of his pieces so that\
+      \ it jumps over an adjacent piece of their opponent and into an empty space, that player captures the opponent's disc.\
+      \  Jumping moves must be taken when possible, thereby creating a strategy game where players offer up jumps in exchange\
+      \ for setting up the board so that they jump even more pieces on their turn.  A player wins by removing all of his opponent's\
+      \ pieces from the board or by blocking the opponent so that he has no more moves.\nThis game, also known as Draughts,\
+      \ is part of the Checkers family.\n\nThe Official Checker Board to be used in tournaments and official matches of associations\
+      \ like international WCDF, ACF, and APCA usually shall be colored of green and off-white (buff). Board squares shall\
+      \ be not less than 2 inches nor more than 2&frac12; inches wide. Tournament pieces are Red and White, but called Black\
+      \ and White in game related literature.\n\n"
     yearPublished: 1150
     minPlayers: 2
     maxPlayers: 2
@@ -4972,24 +5587,35 @@ catalog:
   - title: Pandemic
     bggId: 30549
     language: en
-    pdf: pandemic_rulebook.pdf
     seedAgent: true
     bggEnhanced: true
-    description: >+
-      In Pandemic, several virulent diseases have broken out simultaneously all over the world! The players are disease-fighting specialists whose mission is to treat disease hotspots while researching cures for each of four plagues before they get out of hand.
+    description: 'In Pandemic, several virulent diseases have broken out simultaneously all over the world! The players are
+      disease-fighting specialists whose mission is to treat disease hotspots while researching cures for each of four plagues
+      before they get out of hand.
 
 
-      The game board depicts several major population centers on Earth. On each turn, a player can use up to four actions to travel between cities, treat infected populaces, discover a cure, or build a research station. A deck of cards provides the players with these abilities, but sprinkled throughout this deck are Epidemic! cards that accelerate and intensify the diseases' activity. A second, separate deck of cards controls the "normal" spread of the infections.
+      The game board depicts several major population centers on Earth. On each turn, a player can use up to four actions
+      to travel between cities, treat infected populaces, discover a cure, or build a research station. A deck of cards provides
+      the players with these abilities, but sprinkled throughout this deck are Epidemic! cards that accelerate and intensify
+      the diseases'' activity. A second, separate deck of cards controls the "normal" spread of the infections.
 
 
-      Taking a unique role within the team, players must plan their strategy to mesh with their specialists' strengths in order to conquer the diseases. For example, the Operations Expert can build research stations which are needed to find cures for the diseases and which allow for greater mobility between cities; the Scientist needs only four cards of a particular disease to cure it instead of the normal five&mdash;but the diseases are spreading quickly and time is running out. If one or more diseases spreads beyond recovery or if too much time elapses, the players all lose. If they cure the four diseases, they all win!
+      Taking a unique role within the team, players must plan their strategy to mesh with their specialists'' strengths in
+      order to conquer the diseases. For example, the Operations Expert can build research stations which are needed to find
+      cures for the diseases and which allow for greater mobility between cities; the Scientist needs only four cards of a
+      particular disease to cure it instead of the normal five&mdash;but the diseases are spreading quickly and time is running
+      out. If one or more diseases spreads beyond recovery or if too much time elapses, the players all lose. If they cure
+      the four diseases, they all win!
 
 
-      The 2013 edition of Pandemic includes two new characters&mdash;the Contingency Planner and the Quarantine Specialist&mdash;not available in earlier editions of the game.
+      The 2013 edition of Pandemic includes two new characters&mdash;the Contingency Planner and the Quarantine Specialist&mdash;not
+      available in earlier editions of the game.
 
 
       Pandemic is the first game in the Pandemic series.
 
+
+      '
     yearPublished: 2008
     minPlayers: 2
     maxPlayers: 4
@@ -5060,30 +5686,52 @@ catalog:
     - Zhiyanjia
     - Взрослые дети
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/pandemic_rulebook.pdf
+    pdfSha256: 6634e5cdbcc73afdb03ae788b096e6f1c251eeca39d1c66960f51f8ed1e38e02
+    pdfVersion: '1.0'
   - title: Monopoly
     bggId: 1406
     language: en
     bggEnhanced: true
-    description: >+
-      Theme
+    description: 'Theme
 
-      Players take the part of land owners, attempting to buy and then develop their land. Income is gained by other players visiting their properties and money is spent when they visit properties belonging to other players. When times get tough, players may have to mortgage their properties to raise cash for fines, taxes and other misfortunes.
+      Players take the part of land owners, attempting to buy and then develop their land. Income is gained by other players
+      visiting their properties and money is spent when they visit properties belonging to other players. When times get tough,
+      players may have to mortgage their properties to raise cash for fines, taxes and other misfortunes.
 
 
       Gameplay
 
-      On their turn, a player rolls two dice and moves that number of spaces around the board. If the player lands on an as-yet-unowned property, they has the opportunity to buy it or auction it to the highest bidder. If a player owns all the spaces within a color group, they may then build houses and hotels on these spaces, generating even more income from opponents who land there. If they lands on a property owned by another player, they must pay that player rent according to the value of the land and any buildings on it. There are other places on the board which can not be bought, but instead require the player to draw a card and perform the action on the card, pay taxes, collect income, or even go to jail.
+      On their turn, a player rolls two dice and moves that number of spaces around the board. If the player lands on an as-yet-unowned
+      property, they has the opportunity to buy it or auction it to the highest bidder. If a player owns all the spaces within
+      a color group, they may then build houses and hotels on these spaces, generating even more income from opponents who
+      land there. If they lands on a property owned by another player, they must pay that player rent according to the value
+      of the land and any buildings on it. There are other places on the board which can not be bought, but instead require
+      the player to draw a card and perform the action on the card, pay taxes, collect income, or even go to jail.
 
 
       Goal
 
-      The goal of the game is to be the last player remaining with any money. (though some editions end the game when the first player goes bankrupt)
+      The goal of the game is to be the last player remaining with any money. (though some editions end the game when the
+      first player goes bankrupt)
 
 
       Cultural impact on rules
 
-      Monopoly is unusual in that the game has official, printed rules, but most players learn how to play from others, never actually learning the correct way to play. This has led to the canonization of a number of house rules that make the game more palatable to children (and sore losers) but harm the gameplay by preventing players from going bankrupt or slowing down the rate of property acquisition. One common house rule has players put any money paid to the bank in the center of the board, which jackpot a player may earn by landing on Free Parking. This prevents the game from removing money from play, and since players collect $200 each time they pass Go, this results in ever-increasing bankrolls and players surviving rents that should have bankrupted them. Another house rule allows players to take "loans" from the bank instead of going bankrupt, which means the game will never end. Some house rules arise out of ignorance rather than attempts to improve the game. For instance, many players don't know that properties landed on but left unbought go up for auction, and even some that know to auction don't know that the bidding starts at $1, meaning a player may pay well below the listed price for an auctioned property.
+      Monopoly is unusual in that the game has official, printed rules, but most players learn how to play from others, never
+      actually learning the correct way to play. This has led to the canonization of a number of house rules that make the
+      game more palatable to children (and sore losers) but harm the gameplay by preventing players from going bankrupt or
+      slowing down the rate of property acquisition. One common house rule has players put any money paid to the bank in the
+      center of the board, which jackpot a player may earn by landing on Free Parking. This prevents the game from removing
+      money from play, and since players collect $200 each time they pass Go, this results in ever-increasing bankrolls and
+      players surviving rents that should have bankrupted them. Another house rule allows players to take "loans" from the
+      bank instead of going bankrupt, which means the game will never end. Some house rules arise out of ignorance rather
+      than attempts to improve the game. For instance, many players don''t know that properties landed on but left unbought
+      go up for auction, and even some that know to auction don''t know that the bidding starts at $1, meaning a player may
+      pay well below the listed price for an auctioned property.
 
+
+      '
     yearPublished: 1935
     minPlayers: 2
     maxPlayers: 8
@@ -5180,12 +5828,19 @@ catalog:
     bggId: 320
     language: en
     bggEnhanced: true
-    description: >+
-      In this classic word game, players use their seven drawn letter-tiles to form words on the gameboard. Each word laid out earns points based on the commonality of the letters used, with certain board spaces giving bonuses.  But a word can only be played if it uses at least one already-played tile or adds to an already-played word.  This leads to slightly tactical play, as potential words are rejected because they would give an opponent too much access to the better bonus spaces.
+    description: 'In this classic word game, players use their seven drawn letter-tiles to form words on the gameboard. Each
+      word laid out earns points based on the commonality of the letters used, with certain board spaces giving bonuses.  But
+      a word can only be played if it uses at least one already-played tile or adds to an already-played word.  This leads
+      to slightly tactical play, as potential words are rejected because they would give an opponent too much access to the
+      better bonus spaces.
 
 
-      Skip-a-cross was licensed by Selchow & Righter and manufactured by Cadaco. Both games have identical rules but Skip-a-cross has tiles and racks made of cardboard instead of wood. The game was also published because not enough Scrabble games were manufactured to meet the demand.
+      Skip-a-cross was licensed by Selchow & Righter and manufactured by Cadaco. Both games have identical rules but Skip-a-cross
+      has tiles and racks made of cardboard instead of wood. The game was also published because not enough Scrabble games
+      were manufactured to meet the demand.
 
+
+      '
     yearPublished: 1948
     minPlayers: 2
     maxPlayers: 4
@@ -5271,21 +5926,29 @@ catalog:
     bggId: 2394
     language: en
     bggEnhanced: true
-    description: >+
-      A traditional tile game played in many different cultures around the world.  This entry is for Western Dominoes; the standard set being the 28 "Double Six" tiles.  Chinese Dominoes use a 32 tile set with different distributions.
+    description: 'A traditional tile game played in many different cultures around the world.  This entry is for Western Dominoes;
+      the standard set being the 28 "Double Six" tiles.  Chinese Dominoes use a 32 tile set with different distributions.
 
 
-      Dominoes is a family of games using the "Western" style tiles.  The standard set of tiles is based on the 21 different combinations made with a roll of two six-sided dice.  Seven (7) additional "Blank" combination tiles combine with the 21 to form the standard 28 "Double-Six" set. "Double-Nine" (with 55 tiles) and "Double-Twelve" (with 91 tiles) are also popular. "Double-Fifteen" sets with 136 tiles also exist.
+      Dominoes is a family of games using the "Western" style tiles.  The standard set of tiles is based on the 21 different
+      combinations made with a roll of two six-sided dice.  Seven (7) additional "Blank" combination tiles combine with the
+      21 to form the standard 28 "Double-Six" set. "Double-Nine" (with 55 tiles) and "Double-Twelve" (with 91 tiles) are also
+      popular. "Double-Fifteen" sets with 136 tiles also exist.
 
 
-      There are many different games played with Dominoes.  The standard game is known as the Block game.  Forms of this game are known in many different areas of the world with similar rules.  Puerto Rican Dominoes, Latin Dominoes, and Cuban Dominoes are all forms of the Block game.
+      There are many different games played with Dominoes.  The standard game is known as the Block game.  Forms of this game
+      are known in many different areas of the world with similar rules.  Puerto Rican Dominoes, Latin Dominoes, and Cuban
+      Dominoes are all forms of the Block game.
 
 
-      Another main variety of Dominoes games are based on the "Fives Family".  Five-up, All Fives, Sniff, and Muggins are all part of this family.  This variation adds the ends of the dominoes to make a multiple of five for scoring.
+      Another main variety of Dominoes games are based on the "Fives Family".  Five-up, All Fives, Sniff, and Muggins are
+      all part of this family.  This variation adds the ends of the dominoes to make a multiple of five for scoring.
 
 
       Other popular Dominoes games include 42, ChickenFoot, and Mexican Train.
 
+
+      '
     yearPublished: 1500
     minPlayers: 2
     maxPlayers: 10
@@ -5486,15 +6149,22 @@ catalog:
     bggId: 188
     language: en
     bggEnhanced: true
-    description: >+
-      In Go, players alternately place stones on the empty intersections of a 19x19 grid. The goal: to enclose territory behind stone perimeters and, secondarily, to tightly surround and capture enemy stones. After both players pass, they add up their territory and deduct the number of captives lost, higher score wins.
+    description: 'In Go, players alternately place stones on the empty intersections of a 19x19 grid. The goal: to enclose
+      territory behind stone perimeters and, secondarily, to tightly surround and capture enemy stones. After both players
+      pass, they add up their territory and deduct the number of captives lost, higher score wins.
 
 
-      As you see, the concept is simple, yet the challenge can enrich a lifetime. In truth many lifetimes, for Go has been played for thousands of years. With that long of a lineage and a worldwide following, it has come to be known by different names (Weiqi, Igo, Baduk) and to be played by slightly differing rules, but those differences seldom affect play.
+      As you see, the concept is simple, yet the challenge can enrich a lifetime. In truth many lifetimes, for Go has been
+      played for thousands of years. With that long of a lineage and a worldwide following, it has come to be known by different
+      names (Weiqi, Igo, Baduk) and to be played by slightly differing rules, but those differences seldom affect play.
 
 
-      So welcome to this masterpiece that is the game of Go, the race for geographical control of an unclaimed land. Experience running battles and swift reversals, bold invasions and painful sacrifices, each sally, each setback playing out to the dulcet tap of stone on wood.
+      So welcome to this masterpiece that is the game of Go, the race for geographical control of an unclaimed land. Experience
+      running battles and swift reversals, bold invasions and painful sacrifices, each sally, each setback playing out to
+      the dulcet tap of stone on wood.
 
+
+      '
     yearPublished: -2200
     minPlayers: 2
     maxPlayers: 2
@@ -5600,18 +6270,35 @@ catalog:
     bggId: 2397
     language: en
     bggEnhanced: true
-    description: >+
-      Backgammon is a classic abstract strategy game dating back thousands of years. Each player has a set of 15 checkers (or stones) that must be moved from their starting positions, around, and then off the board. Dice are thrown each turn, and each player must decide which of their checkers to move based on the outcome of the roll. Players can capture each other's checkers, forcing the captured checkers to restart their journey around the board. The winner is the first player to get all 15 checkers off the board. A more recent addition to the game is the "doubling cube", which allows players to up the stakes of the game. Although the game relies on dice to determine movement, there is a large degree of strategy in deciding how to make the most effective moves given each dice roll and measuring the risk in terms of possible rolls the opponent may get.
+    description: 'Backgammon is a classic abstract strategy game dating back thousands of years. Each player has a set of
+      15 checkers (or stones) that must be moved from their starting positions, around, and then off the board. Dice are thrown
+      each turn, and each player must decide which of their checkers to move based on the outcome of the roll. Players can
+      capture each other''s checkers, forcing the captured checkers to restart their journey around the board. The winner
+      is the first player to get all 15 checkers off the board. A more recent addition to the game is the "doubling cube",
+      which allows players to up the stakes of the game. Although the game relies on dice to determine movement, there is
+      a large degree of strategy in deciding how to make the most effective moves given each dice roll and measuring the risk
+      in terms of possible rolls the opponent may get.
 
 
-      Backgammon may be the first game to be mentioned in written history, going back 5,000 years to the Sumerians of ancient Mesopotamia. During the 1920s, archaeologists unearthed five boards from a cemetery in the ancient town of Ur. At another location, pieces and dice were also found along with the board. Boards from ancient Egypt have also been recovered from the tomb of Tutankhamun, including a mechanical dice box, no doubt intended to stop cheaters.
+      Backgammon may be the first game to be mentioned in written history, going back 5,000 years to the Sumerians of ancient
+      Mesopotamia. During the 1920s, archaeologists unearthed five boards from a cemetery in the ancient town of Ur. At another
+      location, pieces and dice were also found along with the board. Boards from ancient Egypt have also been recovered from
+      the tomb of Tutankhamun, including a mechanical dice box, no doubt intended to stop cheaters.
 
 
-      The names of the game were many. In Persia, Takhteh Nard which means "Battle on Wood". In Egypt, Tau, which may be the ancestor of Senat. In Rome, Ludus Duodecim Scriptorum ("game of twelve marks"), later, Tabula ("table"), and by the sixth century, Alea ("dice"). In ancient China, T-shu-p-u and later in Japan, Sugoroko. The English name may derive from "Bac gamen" meaning "Back Game", referring to re-entry of taken stones back to the board. It was often enjoyed by the upper classes and is sometimes called "The Aristocratic Game". The Roman Emperor Claudius was known to be such a fan of Tabula that he had a set built into his coach so he could play as he traveled (the world's first travel edition?).
+      The names of the game were many. In Persia, Takhteh Nard which means "Battle on Wood". In Egypt, Tau, which may be the
+      ancestor of Senat. In Rome, Ludus Duodecim Scriptorum ("game of twelve marks"), later, Tabula ("table"), and by the
+      sixth century, Alea ("dice"). In ancient China, T-shu-p-u and later in Japan, Sugoroko. The English name may derive
+      from "Bac gamen" meaning "Back Game", referring to re-entry of taken stones back to the board. It was often enjoyed
+      by the upper classes and is sometimes called "The Aristocratic Game". The Roman Emperor Claudius was known to be such
+      a fan of Tabula that he had a set built into his coach so he could play as he traveled (the world''s first travel edition?).
 
 
-      The rules in English were standardized in 1743 by Edmond Hoyle. These remained popular until the American innovations of the 1930s.
+      The rules in English were standardized in 1743 by Edmond Hoyle. These remained popular until the American innovations
+      of the 1930s.
 
+
+      '
     yearPublished: -3000
     minPlayers: 2
     maxPlayers: 2
@@ -5812,18 +6499,28 @@ catalog:
     bggId: 1294
     language: en
     bggEnhanced: true
-    description: >+
-      For versions of Clue that feature the new character Dr. Orchid, please use this Clue page.
+    description: 'For versions of Clue that feature the new character Dr. Orchid, please use this Clue page.
 
 
       The classic detective game!   A game for those who enjoy reasoning and thinking things out.
 
 
-      In Clue, players move from room to room in a mansion to solve the mystery of: who done it, with what, and where?  Players are dealt character, weapon, and location cards after the top card from each card type is secretly placed in the confidential file in the middle of the board.  Players must move to a room and then make a suggestion against a character saying they did it in that room with a specific weapon.  The player to the left must show one of any cards mentioned if in that player's hand.  Through deductive reasoning each player must figure out which character, weapon, and location are in the secret file.  To do this, each player must uncover what cards are in other players hands by making more and more suggestions.  Once a player knows what cards the other players are holding, they will know what cards are in the secret file, and then make an accusation. If correct, the player wins, but if incorrect, the player must return the cards to the file without revealing them and may no longer make suggestions or accusations.
+      In Clue, players move from room to room in a mansion to solve the mystery of: who done it, with what, and where?  Players
+      are dealt character, weapon, and location cards after the top card from each card type is secretly placed in the confidential
+      file in the middle of the board.  Players must move to a room and then make a suggestion against a character saying
+      they did it in that room with a specific weapon.  The player to the left must show one of any cards mentioned if in
+      that player''s hand.  Through deductive reasoning each player must figure out which character, weapon, and location
+      are in the secret file.  To do this, each player must uncover what cards are in other players hands by making more and
+      more suggestions.  Once a player knows what cards the other players are holding, they will know what cards are in the
+      secret file, and then make an accusation. If correct, the player wins, but if incorrect, the player must return the
+      cards to the file without revealing them and may no longer make suggestions or accusations.
 
 
-      Note: There are some early versions of Clue which are labeled as 2-6 players. Recent and current issues of the game state 3-6 players.
+      Note: There are some early versions of Clue which are labeled as 2-6 players. Recent and current issues of the game
+      state 3-6 players.
 
+
+      '
     yearPublished: 1949
     minPlayers: 2
     maxPlayers: 6
@@ -5900,15 +6597,22 @@ catalog:
     bggId: 74
     language: en
     bggEnhanced: true
-    description: >+
-      The party game Apples to Apples consists of two decks of cards: Things and Descriptions. Each round, the active player draws a Description card (which features an adjective like "Hairy" or "Smarmy") from the deck, then the other players each secretly choose the Thing card in hand that best matches that description and plays it face-down on the table. The active player then reveals these cards and chooses the Thing card that, in his opinion, best matches the Description card, which he awards to whoever played that Thing card. This player becomes the new active player for the next round.
+    description: 'The party game Apples to Apples consists of two decks of cards: Things and Descriptions. Each round, the
+      active player draws a Description card (which features an adjective like "Hairy" or "Smarmy") from the deck, then the
+      other players each secretly choose the Thing card in hand that best matches that description and plays it face-down
+      on the table. The active player then reveals these cards and chooses the Thing card that, in his opinion, best matches
+      the Description card, which he awards to whoever played that Thing card. This player becomes the new active player for
+      the next round.
 
 
       Once a player has won a pre-determined number of Description cards, that player wins.
 
 
-      Note: "Party Box" editions include all cards from Apples to Apples: Expansion Set #1 and Apples to Apples: Expansion Set #2
+      Note: "Party Box" editions include all cards from Apples to Apples: Expansion Set #1 and Apples to Apples: Expansion
+      Set #2
 
+
+      '
     yearPublished: 1999
     minPlayers: 4
     maxPlayers: 10
@@ -5945,31 +6649,16 @@ catalog:
     bggId: 163
     language: en
     bggEnhanced: true
-    description: >+
-      A clever repackaging of the parlor game Dictionary, Balderdash contains several cards with real words nobody has heard of.  After one of those words has been read aloud, players try to come up with definitions that at least sound plausible, because points are later awarded for every opposing player who guessed that your definition was the correct one.
-
-
-      Versions of the game as a parlor game go back at least as far as 1970, although Balderdash itself was not published until 1984.
-
-
-      Mattel, Inc. republished Balderdash in 2006 in a form that derives its gameplay from the sequel Beyond Balderdash.
-
-
-      Re-implemented by:
-
-          Beyond Balderdash / Absolute Balderdash
-          Kokkelimonke Jubileum
-
-
-      Re-implements:
-
-          Beyond Balderdash*
-
-
-
-          In a peculiar situation, this game was reimplemented by Beyond/Absolute Balderdash and then combined back into the original title (Balderdash) but with the rules and cards from Beyond/Absolute; while Tactic re-published their version of Beyond/Absolute combined with the original Balderdash and called it Kokkelimonke Jubileum.
-
-
+    description: "A clever repackaging of the parlor game Dictionary, Balderdash contains several cards with real words nobody\
+      \ has heard of.  After one of those words has been read aloud, players try to come up with definitions that at least\
+      \ sound plausible, because points are later awarded for every opposing player who guessed that your definition was the\
+      \ correct one.\n\nVersions of the game as a parlor game go back at least as far as 1970, although Balderdash itself\
+      \ was not published until 1984.\n\nMattel, Inc. republished Balderdash in 2006 in a form that derives its gameplay from\
+      \ the sequel Beyond Balderdash.\n\nRe-implemented by:\n\n    Beyond Balderdash / Absolute Balderdash\n    Kokkelimonke\
+      \ Jubileum\n\n\nRe-implements:\n\n    Beyond Balderdash*\n\n\n\n    In a peculiar situation, this game was reimplemented\
+      \ by Beyond/Absolute Balderdash and then combined back into the original title (Balderdash) but with the rules and cards\
+      \ from Beyond/Absolute; while Tactic re-published their version of Beyond/Absolute combined with the original Balderdash\
+      \ and called it Kokkelimonke Jubileum.\n\n\n"
     yearPublished: 1984
     minPlayers: 2
     maxPlayers: 6
@@ -6013,18 +6702,23 @@ catalog:
     bggId: 1293
     language: en
     bggEnhanced: true
-    description: >+
-      Boggle is a timed word game in which players have 3 minutes to find as many connected words as possible from the face up letters resting in a 16 cube grid.  When the timer runs out, players compare their lists of words and remove any words found by multiple players.  Points are then awarded for remaining words, depending on how many letters are in the word.  (In the original Boggle, all words must contain 3 or more letters to score points.)
+    description: 'Boggle is a timed word game in which players have 3 minutes to find as many connected words as possible
+      from the face up letters resting in a 16 cube grid.  When the timer runs out, players compare their lists of words and
+      remove any words found by multiple players.  Points are then awarded for remaining words, depending on how many letters
+      are in the word.  (In the original Boggle, all words must contain 3 or more letters to score points.)
 
 
       An example grid given in the French Canadian rules (of Deluxe Boggle) holds an amazing 459 words!
 
 
-      A number of variants have been produced by Parker Brothers over time, including Big Boggle (which uses a 5&times;5 grid of letters and forces players to search for longer words).
+      A number of variants have been produced by Parker Brothers over time, including Big Boggle (which uses a 5&times;5 grid
+      of letters and forces players to search for longer words).
 
 
       Boggle is a word dice game.
 
+
+      '
     yearPublished: 1972
     minPlayers: 1
     maxPlayers: 8
@@ -6071,18 +6765,11 @@ catalog:
     bggId: 2381
     language: en
     bggEnhanced: true
-    description: >+
-      In "The Game of Scattergories," published in 1988 by Milton Bradley, each player fills out a category list with answers that begin with the same letter. If no other player matches your answers, you score points. The game is played in rounds. After 3 rounds a winner is declared, and a new game can be begun.
-
-
-      Scattergories is a commercial version of an old parlour game known as Categories or Guggenheim.
-
-
-      Similar to:
-
-          Facts in Five
-
-
+    description: "In \"The Game of Scattergories,\" published in 1988 by Milton Bradley, each player fills out a category\
+      \ list with answers that begin with the same letter. If no other player matches your answers, you score points. The\
+      \ game is played in rounds. After 3 rounds a winner is declared, and a new game can be begun.\n\nScattergories is a\
+      \ commercial version of an old parlour game known as Categories or Guggenheim.\n\nSimilar to:\n\n    Facts in Five\n\
+      \n\n"
     yearPublished: 1988
     minPlayers: 2
     maxPlayers: 6
@@ -6119,15 +6806,22 @@ catalog:
     bggId: 27225
     language: en
     bggEnhanced: true
-    description: >+
-      Bananagrams is a fast and fun word game that requires no pencil, paper or board, and the tiles come in a fabric banana-shaped carrying pouch. One hand can be played in as little as five minutes. Much like Pick Two!, but without the letter values.
+    description: 'Bananagrams is a fast and fun word game that requires no pencil, paper or board, and the tiles come in a
+      fabric banana-shaped carrying pouch. One hand can be played in as little as five minutes. Much like Pick Two!, but without
+      the letter values.
 
 
-      Using a selection of 144 plastic letter tiles in the English edition, each player works independently to create their own 'crossword' faster than one's opponents. When a player uses up all their letters, all players take a new tile from the pool. The object of the game is to be the first to complete a word grid after the "bunch" of tiles has been depleted.
+      Using a selection of 144 plastic letter tiles in the English edition, each player works independently to create their
+      own ''crossword'' faster than one''s opponents. When a player uses up all their letters, all players take a new tile
+      from the pool. The object of the game is to be the first to complete a word grid after the "bunch" of tiles has been
+      depleted.
 
 
-      There are variants included in the instructions, such as Banana Smoothie and Banana Cafe for limited set skills or space-deprived places, and the game is suitable for solo play.
+      There are variants included in the instructions, such as Banana Smoothie and Banana Cafe for limited set skills or space-deprived
+      places, and the game is suitable for solo play.
 
+
+      '
     yearPublished: 2006
     minPlayers: 1
     maxPlayers: 8
@@ -6170,23 +6864,31 @@ catalog:
   - title: 'Survive: Escape from Atlantis!'
     bggId: 2653
     language: en
-    pdf: survive-escape-from-atlantis_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Survive is a cutthroat game where players seek to evacuate their pieces from an island that is breaking up, while remembering where their highest-valued pieces are located to maximize their score.
+    description: 'Survive is a cutthroat game where players seek to evacuate their pieces from an island that is breaking
+      up, while remembering where their highest-valued pieces are located to maximize their score.
 
 
-      An island made up of 40 hex-tiles is slowly sinking into the ocean (as the tiles are removed from the board). Each player controls ten people (valued from 1 to 6) that they try and move towards the safety of the surrounding islands before the main island finally blows up. Players can either swim or use boats to travel but must avoid sea serpents, whales and sharks on their way to safety.
+      An island made up of 40 hex-tiles is slowly sinking into the ocean (as the tiles are removed from the board). Each player
+      controls ten people (valued from 1 to 6) that they try and move towards the safety of the surrounding islands before
+      the main island finally blows up. Players can either swim or use boats to travel but must avoid sea serpents, whales
+      and sharks on their way to safety.
 
 
       Survive is very similar to Escape from Atlantis with some key differences.
 
 
-      Survive was reprinted as "Survive: Escape from Atlantis!" by publisher Stronghold Games and hit store shelves in February, 2011.   The reprint contains the game Survive, as well as all the extra pieces needed in order to play the game as "Escape from Atlantis" and is actually found here: Survive: Escape from Atlantis! because it came with the dolphins and dive dice which were removed from the anniversary edition which was released a couple of years later (though they were later made available by themselves for owners of that version).
+      Survive was reprinted as "Survive: Escape from Atlantis!" by publisher Stronghold Games and hit store shelves in February,
+      2011.   The reprint contains the game Survive, as well as all the extra pieces needed in order to play the game as "Escape
+      from Atlantis" and is actually found here: Survive: Escape from Atlantis! because it came with the dolphins and dive
+      dice which were removed from the anniversary edition which was released a couple of years later (though they were later
+      made available by themselves for owners of that version).
 
 
       "Survive: Escape from Atlantis!" is game #2 in the Stronghold Games "Survive Line".
 
+
+      '
     yearPublished: 1982
     minPlayers: 2
     maxPlayers: 4
@@ -6234,19 +6936,26 @@ catalog:
     - Vennerød Forlag AS
     - Waddingtons
     - Zygomatic
+    pdfBlobKey: rulebooks/v1/survive-escape-from-atlantis_rulebook.pdf
+    pdfSha256: f38dbcab30df17928d2e1102c5cfa0e8d3a1b0f8672f9ad39f616820f03c6c7c
+    pdfVersion: '1.0'
   - title: Spot it!
     bggId: 63268
     language: en
-    pdf: spot-it_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Spot it!, a.k.a. Dobble, is a simple pattern recognition game in which players try to find an image shown on two cards.
+    description: 'Spot it!, a.k.a. Dobble, is a simple pattern recognition game in which players try to find an image shown
+      on two cards.
 
 
-      Each card in original Spot it! features eight different symbols, with the symbols varying in size from one card to the next. Any two cards have exactly one symbol in common. For the basic Spot it! game, reveal one card, then another. Whoever spots the symbol in common on both cards claims the first card, then another card is revealed for players to search, and so on. Whoever has collected the most cards when the 55-card deck runs out wins!
+      Each card in original Spot it! features eight different symbols, with the symbols varying in size from one card to the
+      next. Any two cards have exactly one symbol in common. For the basic Spot it! game, reveal one card, then another. Whoever
+      spots the symbol in common on both cards claims the first card, then another card is revealed for players to search,
+      and so on. Whoever has collected the most cards when the 55-card deck runs out wins!
 
 
-      Rules for different games &ndash; each an observation game with a speed element &ndash; are included with Spot it!, with the first player to find a match either gaining or getting rid of a card. Multiple versions of Spot it! have been published, with images in each version ranging from Halloween to hockey to baseball to San Francisco.
+      Rules for different games &ndash; each an observation game with a speed element &ndash; are included with Spot it!,
+      with the first player to find a match either gaining or getting rid of a card. Multiple versions of Spot it! have been
+      published, with images in each version ranging from Halloween to hockey to baseball to San Francisco.
 
 
       The game is sold as Spot it! in the USA and Dobble in Europe, with slight differences between the two editions.
@@ -6254,6 +6963,8 @@ catalog:
 
       Note: some versions have fewer cards and fewer symbols per card. (E.g. 30 cards with 6 symbols each.): Spot it! 1,2,3
 
+
+      '
     yearPublished: 2009
     minPlayers: 2
     maxPlayers: 8
@@ -6322,19 +7033,26 @@ catalog:
     - Super Impulse
     - Top Toys
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/spot-it_rulebook.pdf
+    pdfSha256: f8fa9d62aa27a4070d9a632713c1fd22a904c1f735b74229c838b81225e3fcdd
+    pdfVersion: '1.0'
   - title: Connect Four
     bggId: 2719
     language: en
     bggEnhanced: true
-    description: >+
-      Connect 4 is a well known vertical game played with "checkers" game pieces, although it is more akin to Tic-Tac-Toe or Go Moku.
+    description: 'Connect 4 is a well known vertical game played with "checkers" game pieces, although it is more akin to
+      Tic-Tac-Toe or Go Moku.
 
 
-      The board is placed in the stand to hold it vertically and the players drop game pieces into one of the seven slots, each of which holds up to six game pieces, until one player succeeds in getting four in a row, whether horizontally, vertically, or diagonally.
+      The board is placed in the stand to hold it vertically and the players drop game pieces into one of the seven slots,
+      each of which holds up to six game pieces, until one player succeeds in getting four in a row, whether horizontally,
+      vertically, or diagonally.
 
 
-      The game is non-proprietary.  More elegant, wooden versions can be found under the name The Captain's Mistress.
+      The game is non-proprietary.  More elegant, wooden versions can be found under the name The Captain''s Mistress.
 
+
+      '
     yearPublished: 1974
     minPlayers: 2
     maxPlayers: 2
@@ -6454,9 +7172,12 @@ catalog:
     bggId: 4143
     language: en
     bggEnhanced: true
-    description: >+
-      The mystery face game where you flip over a collection of faces with different color hair, eye color, hair, hats, glasses etc.  to deduce who the secret person is that your opponent has chosen. You flip over the hooked tiles as you narrow your choices by asking characteristic questions.
+    description: 'The mystery face game where you flip over a collection of faces with different color hair, eye color, hair,
+      hats, glasses etc.  to deduce who the secret person is that your opponent has chosen. You flip over the hooked tiles
+      as you narrow your choices by asking characteristic questions.
 
+
+      '
     yearPublished: 1979
     minPlayers: 2
     maxPlayers: 2
@@ -6523,9 +7244,12 @@ catalog:
     bggId: 5432
     language: en
     bggEnhanced: true
-    description: >+
-      Traditional game from ancient India was brought to the UK in 1892 and first commercially published in the USA by Milton Bradley in 1943 (as Chutes and Ladders).  Players travel along the squares sometimes using ladders, which represent good acts, that allow the player to come closer to nirvana while the snakes were slides into evil.
+    description: 'Traditional game from ancient India was brought to the UK in 1892 and first commercially published in the
+      USA by Milton Bradley in 1943 (as Chutes and Ladders).  Players travel along the squares sometimes using ladders, which
+      represent good acts, that allow the player to come closer to nirvana while the snakes were slides into evil.
 
+
+      '
     yearPublished: -200
     minPlayers: 2
     maxPlayers: 6
@@ -6700,21 +7424,33 @@ catalog:
     bggId: 2407
     language: en
     bggEnhanced: true
-    description: >+
-      Slide Pursuit Game
+    description: 'Slide Pursuit Game
 
 
-      Race your four game pieces from Start around the board to your Home in this Pachisi type game. By turning over a card from the draw deck and following its instructions, players move their pieces around the game board, switch places with players, and knock opponents' pieces off the track and back to their Start position.
+      Race your four game pieces from Start around the board to your Home in this Pachisi type game. By turning over a card
+      from the draw deck and following its instructions, players move their pieces around the game board, switch places with
+      players, and knock opponents'' pieces off the track and back to their Start position.
 
 
-      Slides are located at various places around the game board. When a player's piece lands at the beginning of one of these slides not of its own color, it automatically advances to the end, removing any piece on the slide and sending it back to Start.
+      Slides are located at various places around the game board. When a player''s piece lands at the beginning of one of
+      these slides not of its own color, it automatically advances to the end, removing any piece on the slide and sending
+      it back to Start.
 
 
-      Game moves are directed exclusively by cards from the play-action deck.  If one plays the normal version in which one card is drawn from the deck each turn, the outcome has a huge element of luck.  Sorry can be made more of a strategic game (and more appealing to adults) by dealing five cards to each player at the start of the game and allowing the player to choose which card he/she will play each turn.  In this version, at the end of each turn, a new card is drawn from the deck to replace the card that was played, so that each player is always working from five cards.
+      Game moves are directed exclusively by cards from the play-action deck.  If one plays the normal version in which one
+      card is drawn from the deck each turn, the outcome has a huge element of luck.  Sorry can be made more of a strategic
+      game (and more appealing to adults) by dealing five cards to each player at the start of the game and allowing the player
+      to choose which card he/she will play each turn.  In this version, at the end of each turn, a new card is drawn from
+      the deck to replace the card that was played, so that each player is always working from five cards.
 
 
-      A player's fortunes can change dramatically in one or two rounds of play through the use of Sorry cards, the "11" cards (which give the player the option of trading places with an opponent's piece on the track), and the fact that it is possible to move from Start to Home without circumnavigating the full board by making judicious use of the "backward 4" cards.
+      A player''s fortunes can change dramatically in one or two rounds of play through the use of Sorry cards, the "11" cards
+      (which give the player the option of trading places with an opponent''s piece on the track), and the fact that it is
+      possible to move from Start to Home without circumnavigating the full board by making judicious use of the "backward
+      4" cards.
 
+
+      '
     yearPublished: 1929
     minPlayers: 2
     maxPlayers: 4
@@ -6765,16 +7501,20 @@ catalog:
   - title: 'Brass: Birmingham'
     bggId: 224517
     language: en
-    pdf: brass-birmingham_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Brass: Birmingham is an economic strategy game sequel to Martin Wallace's 2007 masterpiece, Brass. Brass: Birmingham tells the story of competing entrepreneurs in Birmingham during the industrial revolution between the years of 1770 and 1870.
+    description: 'Brass: Birmingham is an economic strategy game sequel to Martin Wallace''s 2007 masterpiece, Brass. Brass:
+      Birmingham tells the story of competing entrepreneurs in Birmingham during the industrial revolution between the years
+      of 1770 and 1870.
 
 
-      It offers a very different story arc and experience from its predecessor. As in its predecessor, you must develop, build and establish your industries and network in an effort to exploit low or high market demands. The game is played over two halves: the canal era (years 1770-1830) and the rail era (years 1830-1870). To win the game, score the most VPs. VPs are counted at the end of each half for the canals, rails and established (flipped) industry tiles.
+      It offers a very different story arc and experience from its predecessor. As in its predecessor, you must develop, build
+      and establish your industries and network in an effort to exploit low or high market demands. The game is played over
+      two halves: the canal era (years 1770-1830) and the rail era (years 1830-1870). To win the game, score the most VPs.
+      VPs are counted at the end of each half for the canals, rails and established (flipped) industry tiles.
 
 
-      Each round, players take turns according to the turn order track, receiving two actions to perform any of the following actions (found in the original game):
+      Each round, players take turns according to the turn order track, receiving two actions to perform any of the following
+      actions (found in the original game):
 
 
       1) Build - Pay required resources and place an industry tile.
@@ -6791,8 +7531,11 @@ catalog:
       Brass: Birmingham also features a new sixth action:
 
 
-      6) Scout - Discard three cards and take a wild location and wild industry card. (This action replaces Double Action Build in original Brass.)
+      6) Scout - Discard three cards and take a wild location and wild industry card. (This action replaces Double Action
+      Build in original Brass.)
 
+
+      '
     yearPublished: 2018
     minPlayers: 2
     maxPlayers: 4
@@ -6852,29 +7595,45 @@ catalog:
     - TLAMA games
     - White Goblin Games
     - 盒拍工作室 Hepa Studio
+    pdfBlobKey: rulebooks/v1/brass-birmingham_rulebook.pdf
+    pdfSha256: 71916357bca0b51d26e646348f21f98715390b0a8d5772fe0b3f5fdfd63aeffc
+    pdfVersion: '1.0'
   - title: 'Dune: Imperium'
     bggId: 316554
     language: en
-    pdf: dune-imperium_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Dune: Imperium is a game that uses deck building to add a hidden information angle to traditional worker placement. It finds inspiration in elements and characters from the Dune legacy, both the new film from Legendary Pictures and the seminal literary series from Frank Herbert, Brian Herbert, and Kevin J. Anderson.
+    description: 'Dune: Imperium is a game that uses deck building to add a hidden information angle to traditional worker
+      placement. It finds inspiration in elements and characters from the Dune legacy, both the new film from Legendary Pictures
+      and the seminal literary series from Frank Herbert, Brian Herbert, and Kevin J. Anderson.
 
 
-      As a leader of one of the Great Houses of the Landsraad, raise your banner and marshal your forces and spies. War is coming, and at the center of the conflict is Arrakis &ndash; Dune, the desert planet.
+      As a leader of one of the Great Houses of the Landsraad, raise your banner and marshal your forces and spies. War is
+      coming, and at the center of the conflict is Arrakis &ndash; Dune, the desert planet.
 
 
-      You start with a unique leader card, as well as a deck identical to those of your opponents.  As you acquire cards and build your deck, your choices will define your strengths and weaknesses. Cards allow you to send your Agents to certain spaces on the game board, so how your deck evolves affects your strategy. You might become more powerful militarily, able to deploy more troops than your opponents. Or you might acquire cards that give you an edge with the four political factions represented in the game: the Emperor, the Spacing Guild, the Bene Gesserit, and the Fremen.
+      You start with a unique leader card, as well as a deck identical to those of your opponents.  As you acquire cards and
+      build your deck, your choices will define your strengths and weaknesses. Cards allow you to send your Agents to certain
+      spaces on the game board, so how your deck evolves affects your strategy. You might become more powerful militarily,
+      able to deploy more troops than your opponents. Or you might acquire cards that give you an edge with the four political
+      factions represented in the game: the Emperor, the Spacing Guild, the Bene Gesserit, and the Fremen.
 
 
-      Unlike many deck building games, you don&rsquo;t play your entire hand in one turn. Instead, you draw a hand of cards at the start of every round and alternate with other players, taking one Agent turn at a time (playing one card to send one of your Agents to the game board). When it&rsquo;s your turn and you have no more Agents to place, you&rsquo;ll take a Reveal turn, revealing the rest of your cards, which will provide Persuasion and Swords. Persuasion is used to acquire more cards, and Swords help your troops fight for the current round&rsquo;s rewards as shown on the revealed Conflict card.
+      Unlike many deck building games, you don&rsquo;t play your entire hand in one turn. Instead, you draw a hand of cards
+      at the start of every round and alternate with other players, taking one Agent turn at a time (playing one card to send
+      one of your Agents to the game board). When it&rsquo;s your turn and you have no more Agents to place, you&rsquo;ll
+      take a Reveal turn, revealing the rest of your cards, which will provide Persuasion and Swords. Persuasion is used to
+      acquire more cards, and Swords help your troops fight for the current round&rsquo;s rewards as shown on the revealed
+      Conflict card.
 
 
-      Defeat your rivals in combat, shrewdly navigate the political factions, and acquire precious cards. The Spice must flow to lead your House to victory!
+      Defeat your rivals in combat, shrewdly navigate the political factions, and acquire precious cards. The Spice must flow
+      to lead your House to victory!
 
 
       Some important links: The Official FAQ, the Unofficial FAQ, and an Automa (solo and 2p) Overview
 
+
+      '
     yearPublished: 2020
     minPlayers: 1
     maxPlayers: 4
@@ -6923,26 +7682,50 @@ catalog:
     - sternenschimmermeer
     - Tabletop KZ
     - YingDi (旅法师营地)
+    pdfBlobKey: rulebooks/v1/dune-imperium_rulebook.pdf
+    pdfSha256: 0472bf7bfc04b7f3a07fd1454b8a472b65b3d5bfea8bad881b3c7b725a04f862
+    pdfVersion: '1.0'
   - title: 'Twilight Imperium: Fourth Edition'
     bggId: 233078
     language: en
-    pdf: twilight-imperium-4e_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Twilight Imperium (Fourth Edition) is a game of galactic conquest in which three to six players each take on the role of one of seventeen factions vying for galactic domination through military might, political maneuvering, and economic bargaining. Every faction offers a completely different play experience, from the wormhole-hopping Ghosts of Creuss to the Emirates of Hacan, masters of trade and economics. These seventeen races are offered many paths to victory, but only one may sit upon the throne of Mecatol Rex as the new masters of the galaxy.
+    description: 'Twilight Imperium (Fourth Edition) is a game of galactic conquest in which three to six players each take
+      on the role of one of seventeen factions vying for galactic domination through military might, political maneuvering,
+      and economic bargaining. Every faction offers a completely different play experience, from the wormhole-hopping Ghosts
+      of Creuss to the Emirates of Hacan, masters of trade and economics. These seventeen races are offered many paths to
+      victory, but only one may sit upon the throne of Mecatol Rex as the new masters of the galaxy.
 
 
-      No two games of Twilight Imperium are ever identical. At the start of each galactic age, the game board is uniquely and strategically constructed from among 51 galaxy tiles that feature everything from lush new planets and supernovas to asteroid fields and gravity rifts. Players are dealt a hand of these tiles and take turns creating the galaxy around Mecatol Rex, the capital planet seated in the center of the board. An ion storm may block your race from progressing through the galaxy while a fortuitously placed gravity rift may protect you from your closest foes. The galaxy is yours to both craft and dominate.
+      No two games of Twilight Imperium are ever identical. At the start of each galactic age, the game board is uniquely
+      and strategically constructed from among 51 galaxy tiles that feature everything from lush new planets and supernovas
+      to asteroid fields and gravity rifts. Players are dealt a hand of these tiles and take turns creating the galaxy around
+      Mecatol Rex, the capital planet seated in the center of the board. An ion storm may block your race from progressing
+      through the galaxy while a fortuitously placed gravity rift may protect you from your closest foes. The galaxy is yours
+      to both craft and dominate.
 
 
-      A round of Twilight Imperium begins with players selecting one of eight strategy cards that both determine player order and give their owner a unique strategic action for that round. These may do anything from providing additional command tokens to allowing a player to control trade throughout the galaxy. After these strategies are selected, players take turns moving their fleets from system to system, claiming new planets for their empires, and engaging in warfare and trade with other factions. At the end of a turn, players gather in a grand council to pass new laws and agendas, shaking up the game in unpredictable ways.
+      A round of Twilight Imperium begins with players selecting one of eight strategy cards that both determine player order
+      and give their owner a unique strategic action for that round. These may do anything from providing additional command
+      tokens to allowing a player to control trade throughout the galaxy. After these strategies are selected, players take
+      turns moving their fleets from system to system, claiming new planets for their empires, and engaging in warfare and
+      trade with other factions. At the end of a turn, players gather in a grand council to pass new laws and agendas, shaking
+      up the game in unpredictable ways.
 
 
-      After every player has passed their turn, players move up the victory track by checking to see whether they have completed any objectives throughout the turn and scoring them. Objectives are determined by setting up ten public objective cards at the start of each game, then gradually revealing them over the course of the game. Each player also chooses between two random secret objectives at the start of the game, achievement of which provides victory points--only for the holder of that objective. These objectives can be anything from researching new technologies to taking your neighbor's home system. At the end of every turn, a player can claim one public objective and one secret objective. As play continues, more of these objectives are revealed and more secret objectives are dealt out, giving players dynamically changing goals throughout the game. Play continues until a player reaches ten victory points.
+      After every player has passed their turn, players move up the victory track by checking to see whether they have completed
+      any objectives throughout the turn and scoring them. Objectives are determined by setting up ten public objective cards
+      at the start of each game, then gradually revealing them over the course of the game. Each player also chooses between
+      two random secret objectives at the start of the game, achievement of which provides victory points--only for the holder
+      of that objective. These objectives can be anything from researching new technologies to taking your neighbor''s home
+      system. At the end of every turn, a player can claim one public objective and one secret objective. As play continues,
+      more of these objectives are revealed and more secret objectives are dealt out, giving players dynamically changing
+      goals throughout the game. Play continues until a player reaches ten victory points.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2017
     minPlayers: 3
     maxPlayers: 6
@@ -6999,23 +7782,31 @@ catalog:
     - Hobby World
     - Playfun Games
     - sternenschimmermeer
+    pdfBlobKey: rulebooks/v1/twilight-imperium-4e_rulebook.pdf
+    pdfSha256: 3111c1857435c8fc8726814c18fab3296d05a6cc5f3b92da10e4cfed114890dc
+    pdfVersion: '1.0'
   - title: 'Dune: Imperium - Uprising'
     bggId: 397598
     language: en
-    pdf: dune-imperium-uprising_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Dune: Imperium Uprising, you want to continue to balance military might with political intrigue, wielding new tools in pursuit of victory. Spies will shore up your plans, vital contracts will expand your resources, or you can learn the ways of the Fremen and ride mighty sandworms into battle!
+    description: 'In Dune: Imperium Uprising, you want to continue to balance military might with political intrigue, wielding
+      new tools in pursuit of victory. Spies will shore up your plans, vital contracts will expand your resources, or you
+      can learn the ways of the Fremen and ride mighty sandworms into battle!
 
 
-      Dune: Imperium Uprising is a standalone spinoff to Dune: Imperium that expands on that game's blend of deck-building and worker placement, while introducing a new six-player mode that pits two teams against one other in the biggest struggle yet.
+      Dune: Imperium Uprising is a standalone spinoff to Dune: Imperium that expands on that game''s blend of deck-building
+      and worker placement, while introducing a new six-player mode that pits two teams against one other in the biggest struggle
+      yet.
 
 
-      The Dune: Imperium expansions Rise of Ix and Immortality work with Uprising, as do almost all of the cards from the base game, and elements of Uprising can be used with Dune: Imperium.
+      The Dune: Imperium expansions Rise of Ix and Immortality work with Uprising, as do almost all of the cards from the
+      base game, and elements of Uprising can be used with Dune: Imperium.
 
 
       The choices are yours. The Imperium awaits!
 
+
+      '
     yearPublished: 2023
     minPlayers: 1
     maxPlayers: 6
@@ -7061,23 +7852,40 @@ catalog:
     - Regatul Jocurilor
     - REXhry
     - Tabletop KZ
+    pdfBlobKey: rulebooks/v1/dune-imperium-uprising_rulebook.pdf
+    pdfSha256: 0a8daa36f73c09316143d05bbd5d845183d1ae6f56ce211d93c59b360074f7db
+    pdfVersion: '1.0'
   - title: 'War of the Ring: Second Edition'
     bggId: 115746
     language: en
-    pdf: war-of-the-ring_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In War of the Ring, one player takes control of the Free Peoples (FP) while the other player controls Shadow Armies (SA). Initially, the Free People Nations are reluctant to take arms against Sauron, so they must be attacked by Sauron or persuaded by Gandalf or other Companions before they start to fight in earnest: this is represented by the Political Track which shows if a Nation is ready to fight in the War of the Ring or not.
+    description: 'In War of the Ring, one player takes control of the Free Peoples (FP) while the other player controls Shadow
+      Armies (SA). Initially, the Free People Nations are reluctant to take arms against Sauron, so they must be attacked
+      by Sauron or persuaded by Gandalf or other Companions before they start to fight in earnest: this is represented by
+      the Political Track which shows if a Nation is ready to fight in the War of the Ring or not.
 
 
-      The game can be won by a military victory if Sauron conquers a certain number of Free People cities and strongholds, or vice versa. But the true hope of the Free Peoples lies with the quest of the Ring bearer: while the armies clash across Middle-earth, the Fellowship of the Ring is trying to get secretly to Mount Doom to destroy the One Ring. Sauron is not aware of the real intention of his enemies but is looking across Middle-earth for the precious Ring, so that the Fellowship is going to face numerous dangers, represented by the rules of The Hunt for the Ring. But the Companions can spur the Free Peoples to the fight against Sauron, so the Free People player must balance the need to protect the Ring bearer from harm with an attempt to raise a proper defense against the armies of the Shadow so that they do not overrun Middle-earth before the Ringbearer completes his quest.
+      The game can be won by a military victory if Sauron conquers a certain number of Free People cities and strongholds,
+      or vice versa. But the true hope of the Free Peoples lies with the quest of the Ring bearer: while the armies clash
+      across Middle-earth, the Fellowship of the Ring is trying to get secretly to Mount Doom to destroy the One Ring. Sauron
+      is not aware of the real intention of his enemies but is looking across Middle-earth for the precious Ring, so that
+      the Fellowship is going to face numerous dangers, represented by the rules of The Hunt for the Ring. But the Companions
+      can spur the Free Peoples to the fight against Sauron, so the Free People player must balance the need to protect the
+      Ring bearer from harm with an attempt to raise a proper defense against the armies of the Shadow so that they do not
+      overrun Middle-earth before the Ringbearer completes his quest.
 
 
-      Each game turn revolves around the roll of Action Dice: each die corresponds to an action that a player can perform during a turn. Depending on the face rolled on each die, different actions are possible (moving armies or characters, recruiting troops, advancing a Political Track).
+      Each game turn revolves around the roll of Action Dice: each die corresponds to an action that a player can perform
+      during a turn. Depending on the face rolled on each die, different actions are possible (moving armies or characters,
+      recruiting troops, advancing a Political Track).
 
 
-      Action Dice can also be used to draw or play Event Cards. Event Cards are played to represent specific events from the story (or events that could possibly have happened) that cannot be portrayed through normal game-play. Each Event Card can also create an unexpected turn in the game, allowing special actions or altering the course of a battle.
+      Action Dice can also be used to draw or play Event Cards. Event Cards are played to represent specific events from the
+      story (or events that could possibly have happened) that cannot be portrayed through normal game-play. Each Event Card
+      can also create an unexpected turn in the game, allowing special actions or altering the course of a battle.
 
+
+      '
     yearPublished: 2011
     minPlayers: 2
     maxPlayers: 4
@@ -7126,26 +7934,35 @@ catalog:
     - Schwerkraft-Verlag
     - Sophisticated Games
     - Zhiyanjia
+    pdfBlobKey: rulebooks/v1/war-of-the-ring_rulebook.pdf
+    pdfSha256: 645d2c3df8d67a4d85fb059d00ef68880f27f8c51ffb832e911ea3acb8b90f75
+    pdfVersion: '1.0'
   - title: 'Star Wars: Rebellion'
     bggId: 187645
     language: en
-    pdf: star-wars-rebellion_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Star Wars: Rebellion is a board game of epic conflict between the Galactic Empire and Rebel Alliance for two to four players.
-
-
-      Experience the Galactic Civil War like never before. In Rebellion, you control the entire Galactic Empire or the fledgling Rebel Alliance. You must command starships, account for troop movements, and rally systems to your cause. Given the differences between the Empire and Rebel Alliance, each side has different win conditions, and you'll need to adjust your play style depending on who you represent:
-
-           As the Imperial player, you can command legions of Stormtroopers, swarms of TIEs, Star Destroyers, and even the Death Star. You rule the galaxy by fear, relying on the power of your massive military to enforce your will. To win the game, you need to snuff out the budding Rebel Alliance by finding its base and obliterating it. Along the way, you can subjugate worlds or even destroy them.
-           As the Rebel player, you can command dozens of troopers, T-47 airspeeders, Corellian corvettes, and fighter squadrons. However, these forces are no match for the Imperial military. In terms of raw strength, you'll find yourself clearly overmatched from the very outset, so you'll need to rally the planets to join your cause and execute targeted military strikes to sabotage Imperial build yards and steal valuable intelligence. To win the Galactic Civil War, you'll need to sway the galaxy's citizens to your cause. If you survive long enough and strengthen your reputation, you inspire the galaxy to a full-scale revolt, and you win.
-
-
-      Featuring more than 150 plastic miniatures and two game boards that account for thirty-two of the Star Wars galaxy's most notable systems, Rebellion features a scope that is as large and sweeping as any Star Wars game before it.
-
-
-      Yet for all its grandiosity, Rebellion remains intensely personal, cinematic, and heroic. As much as your success depends upon the strength of your starships, vehicles, and troops, it depends upon the individual efforts of such notable characters as Leia Organa, Mon Mothma, Grand Moff Tarkin, and Emperor Palpatine. As civil war spreads throughout the galaxy, these leaders are invaluable to your efforts, and the secret missions they attempt will evoke many of the most inspiring moments from the classic trilogy. You might send Luke Skywalker to receive Jedi training on Dagobah or have Darth Vader spring a trap that freezes Han Solo in carbonite!
-
+    description: "Star Wars: Rebellion is a board game of epic conflict between the Galactic Empire and Rebel Alliance for\
+      \ two to four players.\n\nExperience the Galactic Civil War like never before. In Rebellion, you control the entire\
+      \ Galactic Empire or the fledgling Rebel Alliance. You must command starships, account for troop movements, and rally\
+      \ systems to your cause. Given the differences between the Empire and Rebel Alliance, each side has different win conditions,\
+      \ and you'll need to adjust your play style depending on who you represent:\n\n     As the Imperial player, you can\
+      \ command legions of Stormtroopers, swarms of TIEs, Star Destroyers, and even the Death Star. You rule the galaxy by\
+      \ fear, relying on the power of your massive military to enforce your will. To win the game, you need to snuff out the\
+      \ budding Rebel Alliance by finding its base and obliterating it. Along the way, you can subjugate worlds or even destroy\
+      \ them.\n     As the Rebel player, you can command dozens of troopers, T-47 airspeeders, Corellian corvettes, and fighter\
+      \ squadrons. However, these forces are no match for the Imperial military. In terms of raw strength, you'll find yourself\
+      \ clearly overmatched from the very outset, so you'll need to rally the planets to join your cause and execute targeted\
+      \ military strikes to sabotage Imperial build yards and steal valuable intelligence. To win the Galactic Civil War,\
+      \ you'll need to sway the galaxy's citizens to your cause. If you survive long enough and strengthen your reputation,\
+      \ you inspire the galaxy to a full-scale revolt, and you win.\n\n\nFeaturing more than 150 plastic miniatures and two\
+      \ game boards that account for thirty-two of the Star Wars galaxy's most notable systems, Rebellion features a scope\
+      \ that is as large and sweeping as any Star Wars game before it.\n\nYet for all its grandiosity, Rebellion remains intensely\
+      \ personal, cinematic, and heroic. As much as your success depends upon the strength of your starships, vehicles, and\
+      \ troops, it depends upon the individual efforts of such notable characters as Leia Organa, Mon Mothma, Grand Moff Tarkin,\
+      \ and Emperor Palpatine. As civil war spreads throughout the galaxy, these leaders are invaluable to your efforts, and\
+      \ the secret missions they attempt will evoke many of the most inspiring moments from the classic trilogy. You might\
+      \ send Luke Skywalker to receive Jedi training on Dagobah or have Darth Vader spring a trap that freezes Han Solo in\
+      \ carbonite!\n\n"
     yearPublished: 2016
     minPlayers: 2
     maxPlayers: 4
@@ -7197,23 +8014,33 @@ catalog:
     - Hobby World
     - Korea Boardgames
     - Rooster Games
+    pdfBlobKey: rulebooks/v1/star-wars-rebellion_rulebook.pdf
+    pdfSha256: 0b5af3a28bc4bc29a16f84456ed3a6543bf4d6a141461971e6fb170c6afba35a
+    pdfVersion: '1.0'
   - title: Gaia Project
     bggId: 220308
     language: en
-    pdf: gaia-project_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Gaia Project is a new game in the line of Terra Mystica. As in the original Terra Mystica, fourteen different factions live on seven different kinds of planets, and factions are bound to their own home planets, so to develop and grow, they must terraform neighboring planets into their home environments in competition with the other groups. In addition, Gaia planets can be used by all factions for colonization, and Transdimensional planets can be changed into Gaia planets.
+    description: 'Gaia Project is a new game in the line of Terra Mystica. As in the original Terra Mystica, fourteen different
+      factions live on seven different kinds of planets, and factions are bound to their own home planets, so to develop and
+      grow, they must terraform neighboring planets into their home environments in competition with the other groups. In
+      addition, Gaia planets can be used by all factions for colonization, and Transdimensional planets can be changed into
+      Gaia planets.
 
 
-      All factions can improve their skills in six different areas of development: Terraforming, Navigation, Artificial Intelligence, Gaiaforming, Economy, Research; leading to advanced technology and special bonuses. To do all of that, each group has special skills and abilities.
+      All factions can improve their skills in six different areas of development: Terraforming, Navigation, Artificial Intelligence,
+      Gaiaforming, Economy, Research; leading to advanced technology and special bonuses. To do all of that, each group has
+      special skills and abilities.
 
 
-      The playing area is made of ten sectors, allowing a variable set-up and thus an even bigger replay value than its predecessor Terra Mystica. A two-player game is hosted on seven sectors.
+      The playing area is made of ten sectors, allowing a variable set-up and thus an even bigger replay value than its predecessor
+      Terra Mystica. A two-player game is hosted on seven sectors.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2017
     minPlayers: 1
     maxPlayers: 4
@@ -7267,22 +8094,39 @@ catalog:
     - TLAMA games
     - White Goblin Games
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/gaia-project_rulebook.pdf
+    pdfSha256: 23331c7527cf3364de847ef5ca7de563f0fbbd906d0cd1932e54783cb6c24043
+    pdfVersion: '1.0'
   - title: Twilight Struggle
     bggId: 12333
     language: en
-    pdf: twilight-struggle_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Now the trumpet summons us again, not as a call to bear arms, though arms we need; not as a call to battle, though embattled we are &ndash; but a call to bear the burden of a long twilight struggle. &ndash; John F. Kennedy
+    description: 'Now the trumpet summons us again, not as a call to bear arms, though arms we need; not as a call to battle,
+      though embattled we are &ndash; but a call to bear the burden of a long twilight struggle. &ndash; John F. Kennedy
 
 
-      In 1945, unlikely allies toppled Hitler's war machine, while humanity's most devastating weapons forced the Japanese Empire to its knees in a storm of fire. Where once there stood many great powers, there then stood only two. The world had scant months to sigh its collective relief before a new conflict threatened. Unlike the titanic struggles of the preceding decades, this conflict would be waged not primarily by soldiers and tanks, but by spies and politicians, scientists and intellectuals, artists and traitors.
+      In 1945, unlikely allies toppled Hitler''s war machine, while humanity''s most devastating weapons forced the Japanese
+      Empire to its knees in a storm of fire. Where once there stood many great powers, there then stood only two. The world
+      had scant months to sigh its collective relief before a new conflict threatened. Unlike the titanic struggles of the
+      preceding decades, this conflict would be waged not primarily by soldiers and tanks, but by spies and politicians, scientists
+      and intellectuals, artists and traitors.
 
 
-      Twilight Struggle is a two-player game simulating the forty-five year dance of intrigue, prestige, and occasional flares of warfare between the Soviet Union and the United States. The entire world is the stage on which these two titans fight to make the world safe for their own ideologies and ways of life. The game begins amidst the ruins of Europe as the two new "superpowers" scramble over the wreckage of the Second World War, and ends in 1989, when only the United States remained standing.
+      Twilight Struggle is a two-player game simulating the forty-five year dance of intrigue, prestige, and occasional flares
+      of warfare between the Soviet Union and the United States. The entire world is the stage on which these two titans fight
+      to make the world safe for their own ideologies and ways of life. The game begins amidst the ruins of Europe as the
+      two new "superpowers" scramble over the wreckage of the Second World War, and ends in 1989, when only the United States
+      remained standing.
 
 
-      Twilight Struggle inherits its fundamental systems from the card-driven classics We the People and Hannibal: Rome vs. Carthage. It is a quick-playing, low-complexity game in that tradition. The game map is a world map of the period, whereon players move units and exert influence in attempts to gain allies and control for their superpower. As with GMT's other card-driven games, decision-making is a challenge; how to best use one's cards and units given consistently limited resources? Event cards add detail and flavor to the game. They cover a vast array of historical happenings, from the Arab-Israeli conflicts of 1948 and 1967, to Vietnam and the U.S. peace movement, to the Cuban Missile Crisis and other such incidents that brought the world to the brink of nuclear annihilation. Subsystems capture the prestige-laden Space Race as well as nuclear tensions, with the possibility of game-ending nuclear war.
+      Twilight Struggle inherits its fundamental systems from the card-driven classics We the People and Hannibal: Rome vs.
+      Carthage. It is a quick-playing, low-complexity game in that tradition. The game map is a world map of the period, whereon
+      players move units and exert influence in attempts to gain allies and control for their superpower. As with GMT''s other
+      card-driven games, decision-making is a challenge; how to best use one''s cards and units given consistently limited
+      resources? Event cards add detail and flavor to the game. They cover a vast array of historical happenings, from the
+      Arab-Israeli conflicts of 1948 and 1967, to Vietnam and the U.S. peace movement, to the Cuban Missile Crisis and other
+      such incidents that brought the world to the brink of nuclear annihilation. Subsystems capture the prestige-laden Space
+      Race as well as nuclear tensions, with the possibility of game-ending nuclear war.
 
 
       TIME SCALE:     approx. 3-5 years per turn
@@ -7291,6 +8135,8 @@ catalog:
 
       UNIT SCALE:     Influence markers
 
+
+      '
     yearPublished: 2005
     minPlayers: 2
     maxPlayers: 2
@@ -7337,23 +8183,37 @@ catalog:
     - Pixie Games
     - Udo Grebe Gamedesign
     - Wargames Club Publishing
+    pdfBlobKey: rulebooks/v1/twilight-struggle_rulebook.pdf
+    pdfSha256: cecc32db372d4c8e1822114f4f7a651e5c18e89048abfd2b7005fe8dd8e93a0d
+    pdfVersion: '1.0'
   - title: 'Through the Ages: A New Story of Civilization'
     bggId: 182028
     language: en
-    pdf: through-the-ages_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Through the Ages: A New Story of Civilization is the new edition of Through the Ages: A Story of Civilization, with many changes small and large to the game's cards over its three ages and extensive changes to how military works.
+    description: 'Through the Ages: A New Story of Civilization is the new edition of Through the Ages: A Story of Civilization,
+      with many changes small and large to the game''s cards over its three ages and extensive changes to how military works.
 
 
-      Through the Ages (TTA) is a civilization building game. Each player attempts to build the best civilization through careful resource management, and by: discovering new technologies, electing competent leaders, building wonders and maintaining a strong military. Weakness in any area can be exploited by your opponents. The game takes place throughout the ages, beginning in the age of antiquity and ending in the modern age.
+      Through the Ages (TTA) is a civilization building game. Each player attempts to build the best civilization through
+      careful resource management, and by: discovering new technologies, electing competent leaders, building wonders and
+      maintaining a strong military. Weakness in any area can be exploited by your opponents. The game takes place throughout
+      the ages, beginning in the age of antiquity and ending in the modern age.
 
 
-      One of the primary mechanisms in TTA is card drafting. Technologies, wonders, and leaders come into play and become easier to draft the longer they are in play. In order to use a technology you will need enough science to discover it, enough food to create a population to man it and enough resources (ore) to build the building to use it. While balancing the resources needed to advance your technology you also need to build a military. Military is 'built' in the same manner as civilian buildings. Players that have a weak military will be preyed upon by other players. There is no map in the game so you cannot lose territory, but players with a stronger military will steal resources, science, kill leaders, take population or culture. It is very difficult to win with a strong military, but it is very easy to lose because of a weak one.
+      One of the primary mechanisms in TTA is card drafting. Technologies, wonders, and leaders come into play and become
+      easier to draft the longer they are in play. In order to use a technology you will need enough science to discover it,
+      enough food to create a population to man it and enough resources (ore) to build the building to use it. While balancing
+      the resources needed to advance your technology you also need to build a military. Military is ''built'' in the same
+      manner as civilian buildings. Players that have a weak military will be preyed upon by other players. There is no map
+      in the game so you cannot lose territory, but players with a stronger military will steal resources, science, kill leaders,
+      take population or culture. It is very difficult to win with a strong military, but it is very easy to lose because
+      of a weak one.
 
 
       Victory is achieved by the player whose nation has the most culture at the end of the modern age.
 
+
+      '
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 4
@@ -7398,20 +8258,29 @@ catalog:
     - New Games Order, LLC
     - One Moment Games
     - Rebel Sp. z o.o.
+    pdfBlobKey: rulebooks/v1/through-the-ages_rulebook.pdf
+    pdfSha256: 8159de133667a4ea467629787a18b7c5d73c5f313aaf3f668f1ceb27d03c193e
+    pdfVersion: '1.0'
   - title: Great Western Trail
     bggId: 193738
     language: en
-    pdf: great-western-trail_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      America in the 19th century: You are a rancher and repeatedly herd your cattle from Texas to Kansas City, where you send them off by train. This earns you money and victory points. Needless to say, each time you arrive in Kansas City, you want to have your most valuable cattle in tow. However, the "Great Western Trail" not only requires that you keep your herd in good shape, but also that you wisely use the various buildings along the trail. Also, it might be a good idea to hire capable staff: cowboys to improve your herd, craftsmen to build your very own buildings, or engineers for the important railroad line.
+    description: 'America in the 19th century: You are a rancher and repeatedly herd your cattle from Texas to Kansas City,
+      where you send them off by train. This earns you money and victory points. Needless to say, each time you arrive in
+      Kansas City, you want to have your most valuable cattle in tow. However, the "Great Western Trail" not only requires
+      that you keep your herd in good shape, but also that you wisely use the various buildings along the trail. Also, it
+      might be a good idea to hire capable staff: cowboys to improve your herd, craftsmen to build your very own buildings,
+      or engineers for the important railroad line.
 
 
-      If you cleverly manage your herd and navigate the opportunities and pitfalls of Great Western Trail, you surely will gain the most victory points and win the game.
+      If you cleverly manage your herd and navigate the opportunities and pitfalls of Great Western Trail, you surely will
+      gain the most victory points and win the game.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2016
     minPlayers: 2
     maxPlayers: 4
@@ -7454,29 +8323,47 @@ catalog:
     - uplay.it edizioni
     - YOKA Games
     - Zvezda
+    pdfBlobKey: rulebooks/v1/great-western-trail_rulebook.pdf
+    pdfSha256: 72b01b97b3bbf12661fbdfa513873bc9efd694b9c4bd1d7765c4da1727df7f79
+    pdfVersion: '1.0'
   - title: 'SETI: Search for Extraterrestrial Intelligence'
     bggId: 418059
     language: en
-    pdf: seti_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In SETI: Search for Extraterrestrial Intelligence, you lead a scientific institution tasked with searching for traces of life beyond planet Earth. The game draws inspiration from current or emerging technologies and efforts in space exploration. Players will explore nearby planets and their moons by launching probes from Earth while taking advantage of ever-shifting planetary positions. Decide whether to land on their surfaces to collect valuable samples or stay in orbit for a broader survey. Additionally, by directing your telescopes to gaze into distant star systems, you may detect traces of alien signals or undiscovered exoplanets, and collect promising data to examine and study back home.
+    description: 'In SETI: Search for Extraterrestrial Intelligence, you lead a scientific institution tasked with searching
+      for traces of life beyond planet Earth. The game draws inspiration from current or emerging technologies and efforts
+      in space exploration. Players will explore nearby planets and their moons by launching probes from Earth while taking
+      advantage of ever-shifting planetary positions. Decide whether to land on their surfaces to collect valuable samples
+      or stay in orbit for a broader survey. Additionally, by directing your telescopes to gaze into distant star systems,
+      you may detect traces of alien signals or undiscovered exoplanets, and collect promising data to examine and study back
+      home.
 
 
-      Back on Earth, you can invest in upgrading your equipment so you can analyze incoming data more efficiently, boost your telescope signal capacity, or increase your supply of resources&mdash;all to expand the scope of your search that could lead to a discovery of extraterrestrial life forms. Finding traces of extraterrestrial life is only a matter of time&mdash;utilize the resources you have at your disposal strategically and you may well end up being the one to make the biggest scientific contribution towards advancing our understanding of alien life within our galaxy.
+      Back on Earth, you can invest in upgrading your equipment so you can analyze incoming data more efficiently, boost your
+      telescope signal capacity, or increase your supply of resources&mdash;all to expand the scope of your search that could
+      lead to a discovery of extraterrestrial life forms. Finding traces of extraterrestrial life is only a matter of time&mdash;utilize
+      the resources you have at your disposal strategically and you may well end up being the one to make the biggest scientific
+      contribution towards advancing our understanding of alien life within our galaxy.
 
 
-      You will also make use of over 200 cards to aid your efforts or focus your research in a particular direction for additional bonuses and rewards. Each card has unique effects and illustrations and depicts real-life technologies, projects, and discoveries (like the ISS, Large Hadron Collider, Perseverance rover, Voyager probe, and many more).
+      You will also make use of over 200 cards to aid your efforts or focus your research in a particular direction for additional
+      bonuses and rewards. Each card has unique effects and illustrations and depicts real-life technologies, projects, and
+      discoveries (like the ISS, Large Hadron Collider, Perseverance rover, Voyager probe, and many more).
 
 
-      The game is played in five rounds. The player with the starting player marker takes the first turn of the round. Players take turns in clockwise order, skipping any players who have already passed for the round. At the end of round 5, the final score is calculated and the player with the most points wins.
+      The game is played in five rounds. The player with the starting player marker takes the first turn of the round. Players
+      take turns in clockwise order, skipping any players who have already passed for the round. At the end of round 5, the
+      final score is calculated and the player with the most points wins.
 
 
-      SETI: Search for Extraterrestrial Intelligence pays homage to space and planetary exploration, astronomy, the ongoing search for signs of life in the vastness of space, and efforts to understand the nature of life in the universe.
+      SETI: Search for Extraterrestrial Intelligence pays homage to space and planetary exploration, astronomy, the ongoing
+      search for signs of life in the vastness of space, and efforts to understand the nature of life in the universe.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2024
     minPlayers: 1
     maxPlayers: 4
@@ -7517,26 +8404,42 @@ catalog:
     - MINDOK
     - MIPL
     - Rebel Sp. z o.o.
+    pdfBlobKey: rulebooks/v1/seti_rulebook.pdf
+    pdfSha256: b241d2ace42c1199254bde456ddac09d7ce1ca5ba036596f545b5d3aadcc083a
+    pdfVersion: '1.0'
   - title: Frosthaven
     bggId: 295770
     language: en
-    pdf: frosthaven_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Frosthaven is the story of a small outpost far to the north of the capital city of White Oak.  It's an outpost barely surviving the harsh weather let alone invasions from forces both known and unknown. However, a group of mercenaries, at the end of their rope, will help bring this settlement back from the edge of destruction. Not only will they have to deal with the harsh elements, but with other, far more dangerous threats out in the unforgiving cold, as well. There are: Algox, the bigger, more yeti-like cousins of the Inox, attacking from the mountains; Lurkers flooding in from the northern sea; and rumors have it that there are machines that wander the frozen wastes of their own free will. The party of mercenaries must face all of these perils, and perhaps in doing so, make peace with these new races so they can work together against even more sinister forces.
+    description: 'Frosthaven is the story of a small outpost far to the north of the capital city of White Oak.  It''s an
+      outpost barely surviving the harsh weather let alone invasions from forces both known and unknown. However, a group
+      of mercenaries, at the end of their rope, will help bring this settlement back from the edge of destruction. Not only
+      will they have to deal with the harsh elements, but with other, far more dangerous threats out in the unforgiving cold,
+      as well. There are: Algox, the bigger, more yeti-like cousins of the Inox, attacking from the mountains; Lurkers flooding
+      in from the northern sea; and rumors have it that there are machines that wander the frozen wastes of their own free
+      will. The party of mercenaries must face all of these perils, and perhaps in doing so, make peace with these new races
+      so they can work together against even more sinister forces.
 
 
-      Frosthaven is a standalone adventure from the designer and publisher of Gloomhaven that features sixteen new characters, three new races, more than twenty new enemies, more than one hundred new items, and a new, 100-scenario campaign.  Characters and items from Gloomhaven will be usable in Frosthaven, and vice versa.
+      Frosthaven is a standalone adventure from the designer and publisher of Gloomhaven that features sixteen new characters,
+      three new races, more than twenty new enemies, more than one hundred new items, and a new, 100-scenario campaign.  Characters
+      and items from Gloomhaven will be usable in Frosthaven, and vice versa.
 
 
-      In addition to using the well-known combat mechanisms of Gloomhaven, Frosthaven features other elements, such as mysteries to solve, a seasonal event system to live through, and player control over how the ramshackle village expands, with each new building offering new ways to progress.
+      In addition to using the well-known combat mechanisms of Gloomhaven, Frosthaven features other elements, such as mysteries
+      to solve, a seasonal event system to live through, and player control over how the ramshackle village expands, with
+      each new building offering new ways to progress.
 
 
-      Frosthaven has a whole new set of items but there is a mechanism for bringing items over from 'Gloomhaven'. However, as Frosthaven's outpost is a remote location, these products may be imported but are not present as standard items. Resources are much more valuable and you have to build items through a crafting system rather than just buying them.
+      Frosthaven has a whole new set of items but there is a mechanism for bringing items over from ''Gloomhaven''. However,
+      as Frosthaven''s outpost is a remote location, these products may be imported but are not present as standard items.
+      Resources are much more valuable and you have to build items through a crafting system rather than just buying them.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2022
     minPlayers: 1
     maxPlayers: 4
@@ -7584,26 +8487,21 @@ catalog:
     - Galápagos Jogos
     - GoKids 玩樂小子
     - Korea Boardgames
+    pdfBlobKey: rulebooks/v1/frosthaven_rulebook.pdf
+    pdfSha256: bf53b8260cd1a567d6d9f9db37b9237179e236c8b59d31f6149787292bbc7008
+    pdfVersion: '1.0'
   - title: 'Eclipse: Second Dawn for the Galaxy'
     bggId: 246900
     language: en
-    pdf: eclipse-second-dawn_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      A game of Eclipse places you in control of a vast interstellar civilization, competing for success with its rivals. You explore new star systems, research technologies, and build spaceships with which to wage war. There are many potential paths to victory, so you need to plan your strategy according to the strengths and weaknesses of your species, while paying attention to the other civilizations' endeavors.
-
-
-      Eclipse: Second Dawn for the Galaxy is a revised and upgraded version of the Eclipse base game that debuted in 2011 that features:
-
-
-          New graphic design, while maintaining the acclaimed symbology of the first edition 
-          A full line of Ship Pack 1 miniatures
-          New miniatures for ancients, GCDS, orbitals, and more
-          Custom plastic inlays
-          Custom combat dice
-          Fine-tuned gameplay
-
-
+    description: "A game of Eclipse places you in control of a vast interstellar civilization, competing for success with\
+      \ its rivals. You explore new star systems, research technologies, and build spaceships with which to wage war. There\
+      \ are many potential paths to victory, so you need to plan your strategy according to the strengths and weaknesses of\
+      \ your species, while paying attention to the other civilizations' endeavors.\n\nEclipse: Second Dawn for the Galaxy\
+      \ is a revised and upgraded version of the Eclipse base game that debuted in 2011 that features:\n\n\n    New graphic\
+      \ design, while maintaining the acclaimed symbology of the first edition \n    A full line of Ship Pack 1 miniatures\n\
+      \    New miniatures for ancients, GCDS, orbitals, and more\n    Custom plastic inlays\n    Custom combat dice\n    Fine-tuned\
+      \ gameplay\n\n\n"
     yearPublished: 2020
     minPlayers: 2
     maxPlayers: 6
@@ -7650,23 +8548,32 @@ catalog:
     - Surfin' Meeple China
     - TLAMA games
     - uplay.it edizioni
+    pdfBlobKey: rulebooks/v1/eclipse-second-dawn_rulebook.pdf
+    pdfSha256: 11853e30ee828569946a7c7b18ee0d968dc4de0d4de9728e685636dfba058548
+    pdfVersion: '1.0'
   - title: 'Slay the Spire: The Board Game'
     bggId: 338960
     language: en
-    pdf: slay-the-spire_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Slay the Spire: The Board Game is a co-operative deck-building, dungeon-crawling adventure. Craft a unique deck, encounter bizarre creatures, discover relics of immense power, and finally become strong enough to slay the Spire!
+    description: 'Slay the Spire: The Board Game is a co-operative deck-building, dungeon-crawling adventure. Craft a unique
+      deck, encounter bizarre creatures, discover relics of immense power, and finally become strong enough to slay the Spire!
 
 
-      Each player starts with a character with unique abilities and a simple deck of cards that they can improve by adding and removing cards during the game. Slay the Spire is also a rogue-like. That means that when you die (and you will die!), start over from the beginning. Take the lessons you learned and try again!
+      Each player starts with a character with unique abilities and a simple deck of cards that they can improve by adding
+      and removing cards during the game. Slay the Spire is also a rogue-like. That means that when you die (and you will
+      die!), start over from the beginning. Take the lessons you learned and try again!
 
 
-      The game is divided into Acts. At the end of an Act you can continue, stop and end the adventure there, or save and continue another time!
+      The game is divided into Acts. At the end of an Act you can continue, stop and end the adventure there, or save and
+      continue another time!
 
 
-      If players defeat the final Boss, they win the game! Which Boss you consider to be final depends on how many Acts you want to play. You can stop playing at the end of any Act! When a player&rsquo;s HP is reduced to 0, they are dead and the party loses the game.
+      If players defeat the final Boss, they win the game! Which Boss you consider to be final depends on how many Acts you
+      want to play. You can stop playing at the end of any Act! When a player&rsquo;s HP is reduced to 0, they are dead and
+      the party loses the game.
 
+
+      '
     yearPublished: 2024
     minPlayers: 1
     maxPlayers: 4
@@ -7708,40 +8615,38 @@ catalog:
     - Yayoi The Dreamer
     - YOKA Games
     - 株式会社ケンビル (KenBill)
+    pdfBlobKey: rulebooks/v1/slay-the-spire_rulebook.pdf
+    pdfSha256: 4507546fcb8e72eb7228cf9aabaff443f696b76df1b5f04c0c01ee1a8228ce50
+    pdfVersion: '1.0'
   - title: 'Brass: Lancashire'
     bggId: 28720
     language: en
-    pdf: brass-lancashire_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Brass: Lancashire &mdash; first published as Brass &mdash; is an economic strategy game that tells the story of competing cotton entrepreneurs in Lancashire during the industrial revolution. You must develop, build and establish your industries and network so that you can capitalize on demand for iron, coal and cotton. The game is played over two halves: the canal phase and the rail phase. To win the game, score the most victory points (VPs), which are counted at the end of each phase. VPs are gained from your canals, rails, and established (flipped) industry tiles. Each round, players take turns according to the turn order track, receiving two actions to perform any of the following:
-
-
-          Build an industry tile
-          Build a rail or canal
-          Develop an industry
-          Sell cotton
-          Take a loan
-
-
-      At the end of your turn, you replace the two cards you played with two more from the deck. Turn order is determined by how much money a player spent on the previous turn, the lowest spender going first. This turn order mechanism opens some strategic options for players going later in the turn order, allowing for the possibility of back-to-back turns.
-
-
-      After all the cards have been played the first time (with the deck size being adjusted for the number of players), the canal phase ends and a scoring round commences. After scoring, all canals and all of the lowest level industries are removed from the game, after which new cards are dealt and the rail phase begins. During this phase, players may now occupy more than one location in a city and double-connection builds (though expensive) are possible. At the end of the rail phase, another scoring round takes place, then a winner is crowned.
-
-
-      The cards limit where you can build your industries, sell cotton or build connections (though any card can be used to 'develop'). This leads to a strategic timing/storing of cards. Resources are common so that if you build a rail line (which requires coal) you have to use the coal from the nearest source, which may be an opponent's coal mine, which in turn gets that coal mine closer to scoring (i.e., being utilized).
-
-
-      Brass: Lancashire, the 2018 edition from Roxley Games, reboots the original Warfrog Games edition of Brass with new artwork and components, as well as a few rules changes:
-
-
-           The virtual link rules between Birkenhead have been made optional.
-           The three-player experience has been brought closer to the ideal experience of four players by shortening each half of the game by one round and tuning the deck and distant market tiles slightly to ensure a consistent experience.
-           Two-player rules have been created and are playable without the need of an alternate board.
-           The level 1 cotton mill is now worth 5 VP to make it slightly less terrible.
-
-
+    description: "Brass: Lancashire &mdash; first published as Brass &mdash; is an economic strategy game that tells the story\
+      \ of competing cotton entrepreneurs in Lancashire during the industrial revolution. You must develop, build and establish\
+      \ your industries and network so that you can capitalize on demand for iron, coal and cotton. The game is played over\
+      \ two halves: the canal phase and the rail phase. To win the game, score the most victory points (VPs), which are counted\
+      \ at the end of each phase. VPs are gained from your canals, rails, and established (flipped) industry tiles. Each round,\
+      \ players take turns according to the turn order track, receiving two actions to perform any of the following:\n\n\n\
+      \    Build an industry tile\n    Build a rail or canal\n    Develop an industry\n    Sell cotton\n    Take a loan\n\n\
+      \nAt the end of your turn, you replace the two cards you played with two more from the deck. Turn order is determined\
+      \ by how much money a player spent on the previous turn, the lowest spender going first. This turn order mechanism opens\
+      \ some strategic options for players going later in the turn order, allowing for the possibility of back-to-back turns.\n\
+      \nAfter all the cards have been played the first time (with the deck size being adjusted for the number of players),\
+      \ the canal phase ends and a scoring round commences. After scoring, all canals and all of the lowest level industries\
+      \ are removed from the game, after which new cards are dealt and the rail phase begins. During this phase, players may\
+      \ now occupy more than one location in a city and double-connection builds (though expensive) are possible. At the end\
+      \ of the rail phase, another scoring round takes place, then a winner is crowned.\n\nThe cards limit where you can build\
+      \ your industries, sell cotton or build connections (though any card can be used to 'develop'). This leads to a strategic\
+      \ timing/storing of cards. Resources are common so that if you build a rail line (which requires coal) you have to use\
+      \ the coal from the nearest source, which may be an opponent's coal mine, which in turn gets that coal mine closer to\
+      \ scoring (i.e., being utilized).\n\nBrass: Lancashire, the 2018 edition from Roxley Games, reboots the original Warfrog\
+      \ Games edition of Brass with new artwork and components, as well as a few rules changes:\n\n\n     The virtual link\
+      \ rules between Birkenhead have been made optional.\n     The three-player experience has been brought closer to the\
+      \ ideal experience of four players by shortening each half of the game by one round and tuning the deck and distant\
+      \ market tiles slightly to ensure a consistent experience.\n     Two-player rules have been created and are playable\
+      \ without the need of an alternate board.\n     The level 1 cotton mill is now worth 5 VP to make it slightly less terrible.\n\
+      \n\n"
     yearPublished: 2007
     minPlayers: 2
     maxPlayers: 4
@@ -7796,23 +8701,39 @@ catalog:
     - Rebel Sp. z o.o.
     - Wargames Club Publishing
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/brass-lancashire_rulebook.pdf
+    pdfSha256: dde82526c26edec98ef036d3f52e7c3dee66fbd546281286c1280298e4182c15
+    pdfVersion: '1.0'
   - title: 7 Wonders Duel
     bggId: 173346
     language: en
-    pdf: 7-wonders-duel_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In many ways 7 Wonders Duel resembles its parent game 7 Wonders. Over three ages, players acquire cards that provide resources or advance their military or scientific development in order to develop a civilization and complete wonders. What's different about 7 Wonders Duel is that, as the title suggests, the game is solely for two players.
+    description: 'In many ways 7 Wonders Duel resembles its parent game 7 Wonders. Over three ages, players acquire cards
+      that provide resources or advance their military or scientific development in order to develop a civilization and complete
+      wonders. What''s different about 7 Wonders Duel is that, as the title suggests, the game is solely for two players.
 
 
-      Players do not draft cards simultaneously from decks of cards, but from a display of face-down and face-up cards arranged at the start of a round. A player can take a card only if it's not covered by any others, so timing comes into play, as it can with bonus moves that allow the player to take a second card immediately. As in the original game, each acquired card can be built, discarded for coins, or used to construct a wonder. Each player also starts with four wonder cards, and the construction of a wonder provides its owner with a special ability. Only seven wonders can be built, though, so one player will end up short.
+      Players do not draft cards simultaneously from decks of cards, but from a display of face-down and face-up cards arranged
+      at the start of a round. A player can take a card only if it''s not covered by any others, so timing comes into play,
+      as it can with bonus moves that allow the player to take a second card immediately. As in the original game, each acquired
+      card can be built, discarded for coins, or used to construct a wonder. Each player also starts with four wonder cards,
+      and the construction of a wonder provides its owner with a special ability. Only seven wonders can be built, though,
+      so one player will end up short.
 
 
-      Players can purchase resources at any time from the bank, or they can gain cards during the game that provide them with resources for future building; as they are acquired, the cost for those resources increases for the opponent, representing the owner's dominance in this area.
+      Players can purchase resources at any time from the bank, or they can gain cards during the game that provide them with
+      resources for future building; as they are acquired, the cost for those resources increases for the opponent, representing
+      the owner''s dominance in this area.
 
 
-      You can win 7 Wonders Duel in one of three ways: each time you acquire a military card, you advance the military marker toward your opponent's capital (also giving you a bonus at certain positions). If you reach the opponent's capital, you win the game immediately. Or if you acquire six of seven different scientific symbols, you achieve scientific dominance and win immediately. If none of these situations occurs, then the player with the most points at the end of the game wins.
+      You can win 7 Wonders Duel in one of three ways: each time you acquire a military card, you advance the military marker
+      toward your opponent''s capital (also giving you a bonus at certain positions). If you reach the opponent''s capital,
+      you win the game immediately. Or if you acquire six of seven different scientific symbols, you achieve scientific dominance
+      and win immediately. If none of these situations occurs, then the player with the most points at the end of the game
+      wins.
 
+
+      '
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 2
@@ -7871,20 +8792,34 @@ catalog:
     - Siam Board Games
     - Sombreros Production
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/7-wonders-duel_rulebook.pdf
+    pdfSha256: 09b2939823df80444da078e0713d0cc400da95d2f1e96edb86dc023c4dc956f2
+    pdfVersion: '1.0'
   - title: Nemesis
     bggId: 167355
     language: en
-    pdf: nemesis_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Playing Nemesis will take you into the heart of sci-fi survival horror in all its terror. A soldier fires blindly down a corridor, trying to stop the alien advance. A scientist races to find a solution in his makeshift lab. A traitor steals the last escape pod in the very last moment. Intruders you meet on the ship are not only reacting to the noise you make but also evolve as the time goes by. The longer the game takes, the stronger they become. During the game, you control one of the crew members with a unique set of skills, personal deck of cards, and individual starting equipment. These heroes cover all your basic SF horror needs. For example, the scientist is great with computers and research, but will have a hard time in combat. The soldier, on the other hand...
+    description: 'Playing Nemesis will take you into the heart of sci-fi survival horror in all its terror. A soldier fires
+      blindly down a corridor, trying to stop the alien advance. A scientist races to find a solution in his makeshift lab.
+      A traitor steals the last escape pod in the very last moment. Intruders you meet on the ship are not only reacting to
+      the noise you make but also evolve as the time goes by. The longer the game takes, the stronger they become. During
+      the game, you control one of the crew members with a unique set of skills, personal deck of cards, and individual starting
+      equipment. These heroes cover all your basic SF horror needs. For example, the scientist is great with computers and
+      research, but will have a hard time in combat. The soldier, on the other hand...
 
 
-      Nemesis is a semi-cooperative game in which you and your crewmates must survive on a ship infested with hostile organisms. To win the game, you have to complete one of the two objectives dealt to you at the start of the game and get back to Earth in one piece. You will find many obstacles on your way: swarms of Intruders (the name given to the alien organisms by the ship AI), the poor physical condition of the ship, agendas held by your fellow players, and sometimes just cruel fate.
+      Nemesis is a semi-cooperative game in which you and your crewmates must survive on a ship infested with hostile organisms.
+      To win the game, you have to complete one of the two objectives dealt to you at the start of the game and get back to
+      Earth in one piece. You will find many obstacles on your way: swarms of Intruders (the name given to the alien organisms
+      by the ship AI), the poor physical condition of the ship, agendas held by your fellow players, and sometimes just cruel
+      fate.
 
 
-      The gameplay of Nemesis is designed to be full of climactic moments which, hopefully, you will find rewarding even when your best plans are ruined and your character meets a terrible fate.
+      The gameplay of Nemesis is designed to be full of climactic moments which, hopefully, you will find rewarding even when
+      your best plans are ruined and your character meets a terrible fate.
 
+
+      '
     yearPublished: 2018
     minPlayers: 1
     maxPlayers: 5
@@ -7931,39 +8866,62 @@ catalog:
     - Korea Boardgames
     - MINDOK
     - Rebel Studio
+    pdfBlobKey: rulebooks/v1/nemesis_rulebook.pdf
+    pdfSha256: 361b7df733bd97f40df76ff002063433724fb0d96a3307de0171cdbb00f84ae2
+    pdfVersion: '1.0'
   - title: A Feast for Odin
     bggId: 177736
     language: en
-    pdf: a-feast-for-odin_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      A Feast for Odin is a saga in the form of a board game. You are reliving the cultural achievements, mercantile expeditions, and pillages of those tribes we know as Viking today &mdash; a term that was used quite differently towards the end of the first millennium.
+    description: 'A Feast for Odin is a saga in the form of a board game. You are reliving the cultural achievements, mercantile
+      expeditions, and pillages of those tribes we know as Viking today &mdash; a term that was used quite differently towards
+      the end of the first millennium.
 
 
-      When the northerners went out for a raid, they used to say they headed out for a viking. Their Scandinavian ancestors, however, were much more than just pirates. They were explorers and founders of states. Leif Eriksson is said to be the first European in America, long before Columbus.
+      When the northerners went out for a raid, they used to say they headed out for a viking. Their Scandinavian ancestors,
+      however, were much more than just pirates. They were explorers and founders of states. Leif Eriksson is said to be the
+      first European in America, long before Columbus.
 
-      In what is known today as Normandy, the intruders were not called Vikings but Normans. One of them is the famous William the Conqueror who invaded England in 1066. He managed to do what the king of Norway failed to do only a few years prior: conquer the Throne of England. The reason the people of these times became such strong seafarers was their unfortunate agricultural situation: crop shortfalls caused great distress.
-
-
-      In this game, you will raid and explore new territories. You will also engage in the day-to-day activity of collecting goods with which to achieve a financially secure position in society. In the end, the player whose possessions bear the greatest value will be declared the winner.
-
-
-      --gameplay description from @StoryBoardGamer's review:
-
-      A Feast for Odin is a points-driven game, with a plethora of pathways to victory, with a range of risks balanced against rewards. A significant portion of this is your central hall, which has a whopping -86 points of squares and a major part of your game is attempting to cover these up with various tiles. Likewise, long halls and island colonies can also offer large rewards, but they will have penalties of their own.
+      In what is known today as Normandy, the intruders were not called Vikings but Normans. One of them is the famous William
+      the Conqueror who invaded England in 1066. He managed to do what the king of Norway failed to do only a few years prior:
+      conquer the Throne of England. The reason the people of these times became such strong seafarers was their unfortunate
+      agricultural situation: crop shortfalls caused great distress.
 
 
-      Each year follows a familiar pattern of preparation, worker placement, and then meeting the requirements of your feast. The main phase of each year is a worker placement affair. You start with a selection of Vikings, and a large action board with a whopping 61 different options to choose from. Each of these will be arranged from left to right in one of four columns. Each column requires an additional Viking to activate, but they are proportionally more powerful.
+      In this game, you will raid and explore new territories. You will also engage in the day-to-day activity of collecting
+      goods with which to achieve a financially secure position in society. In the end, the player whose possessions bear
+      the greatest value will be declared the winner.
 
 
-      At the end of each round, you will need to fill a feast table with food, alternating between plants and vegetable matter. You will also have a chance to lay the valuable green and blue tiles into your main hall. The configuration of these tiles must follow certain requirements, but your main goal is to both cover up a line of coin icons to increase your income, while otherwise encircling certain printed icons to generate those.
+      --gameplay description from @StoryBoardGamer''s review:
+
+      A Feast for Odin is a points-driven game, with a plethora of pathways to victory, with a range of risks balanced against
+      rewards. A significant portion of this is your central hall, which has a whopping -86 points of squares and a major
+      part of your game is attempting to cover these up with various tiles. Likewise, long halls and island colonies can also
+      offer large rewards, but they will have penalties of their own.
 
 
-      You will build your engine over time, following an alternating pattern of outward expansion and hunting against development and cultivation. It all comes down to how much you&rsquo;re willing to take on at any one time, and what risks you&rsquo;re willing to set yourself up with for their rewards.
+      Each year follows a familiar pattern of preparation, worker placement, and then meeting the requirements of your feast.
+      The main phase of each year is a worker placement affair. You start with a selection of Vikings, and a large action
+      board with a whopping 61 different options to choose from. Each of these will be arranged from left to right in one
+      of four columns. Each column requires an additional Viking to activate, but they are proportionally more powerful.
+
+
+      At the end of each round, you will need to fill a feast table with food, alternating between plants and vegetable matter.
+      You will also have a chance to lay the valuable green and blue tiles into your main hall. The configuration of these
+      tiles must follow certain requirements, but your main goal is to both cover up a line of coin icons to increase your
+      income, while otherwise encircling certain printed icons to generate those.
+
+
+      You will build your engine over time, following an alternating pattern of outward expansion and hunting against development
+      and cultivation. It all comes down to how much you&rsquo;re willing to take on at any one time, and what risks you&rsquo;re
+      willing to set yourself up with for their rewards.
 
 
       UPC 681706716909
 
+
+      '
     yearPublished: 2016
     minPlayers: 1
     maxPlayers: 4
@@ -8016,46 +8974,34 @@ catalog:
     - TLAMA games
     - White Goblin Games
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/a-feast-for-odin_rulebook.pdf
+    pdfSha256: e1280d095d2df7da6cb1cfd9cd7c0b7befcce2d8c495e3a541bc9ef64c2d9e36
+    pdfVersion: '1.0'
   - title: 'The Lord of the Rings: The Card Game'
     bggId: 421006
     language: en
-    pdf: lotr-card-game_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      A dark rumour rises from Mordor. The Eye turns to Middle-earth. The hour has come. The Fellowship is reunited. The Heroes prepare for battle. Will you play as the Fellowship of the Ring to defend the free races and destroy the One Ring? Or will you play as Sauron and pursue Frodo and Sam while deploying your hordes to the gates of the enemy cities? The destiny of Middle-earth is in your hands!
-
-
-      A game plays over 3 successive chapters that unfold similarly.
-
-      On your turn, strengthen your Skills, hoard your treasure, stretch your presence across Middle-earth, rally Races to your cause, or advance the Quest of the Ring.
-
-      				
-      				
-      					Turn OverviewIn each chapter players take cards from a display of face-down and face-up cards arranged at the start of a round. A player can take a card only if it's available, that is not partially covered by any other cards. Players can either play the card, paying its cost and placing it in their play area, obtaining its benefit, or discard the card and take as many coins from the reserve as the current chapter.
-
-      Players can also take a Landmark tile from one of the faceup tiles, paying its cost placing it in their play area. They will be able to immediately place a Fortress pawn on the corresponding region of the central board and benefit from its other effects.
-
-      				
-      				
-      					Victory ConditionsImmediately win the game by fulfilling one of the 3 victory conditions:
-
-      				
-      				
-      					Quest of the Ring
-           For the Fellowship: If Frodo and Sam reach Mount Doom, they destroy the One Ring and you immediately win the game.
-           For Sauron: If the Nazg&ucirc;l catch Frodo and Sam, they seize the One Ring and you immediately win the game.
-
-
-      				
-      				
-      					Support of the RacesIf any player gathers 6 different Race symbols on their Green cards, they rally the support of the Races of Middle-earth and immediately win the game
-
-      				
-      				
-      					Conquering Middle-earthIf a player is present in all 7 regions (with a Fortress and/or at least 1 Unit), they dominate Middle-earth and immediately win the game.
-
-      If none of these three victory conditions are achieved by the end of chapter 3, the player who is present in the most regions of Middle-earth (with a Fortress and/or at least 1 Unit) wins the game. In case of tie, share the victory.
-
+    description: "A dark rumour rises from Mordor. The Eye turns to Middle-earth. The hour has come. The Fellowship is reunited.\
+      \ The Heroes prepare for battle. Will you play as the Fellowship of the Ring to defend the free races and destroy the\
+      \ One Ring? Or will you play as Sauron and pursue Frodo and Sam while deploying your hordes to the gates of the enemy\
+      \ cities? The destiny of Middle-earth is in your hands!\n\nA game plays over 3 successive chapters that unfold similarly.\n\
+      On your turn, strengthen your Skills, hoard your treasure, stretch your presence across Middle-earth, rally Races to\
+      \ your cause, or advance the Quest of the Ring.\n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tTurn OverviewIn each chapter players\
+      \ take cards from a display of face-down and face-up cards arranged at the start of a round. A player can take a card\
+      \ only if it's available, that is not partially covered by any other cards. Players can either play the card, paying\
+      \ its cost and placing it in their play area, obtaining its benefit, or discard the card and take as many coins from\
+      \ the reserve as the current chapter.\n\nPlayers can also take a Landmark tile from one of the faceup tiles, paying\
+      \ its cost placing it in their play area. They will be able to immediately place a Fortress pawn on the corresponding\
+      \ region of the central board and benefit from its other effects.\n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tVictory ConditionsImmediately\
+      \ win the game by fulfilling one of the 3 victory conditions:\n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tQuest of the Ring\n \
+      \    For the Fellowship: If Frodo and Sam reach Mount Doom, they destroy the One Ring and you immediately win the game.\n\
+      \     For Sauron: If the Nazg&ucirc;l catch Frodo and Sam, they seize the One Ring and you immediately win the game.\n\
+      \n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tSupport of the RacesIf any player gathers 6 different Race symbols on their Green\
+      \ cards, they rally the support of the Races of Middle-earth and immediately win the game\n\n\t\t\t\t\n\t\t\t\t\n\t\t\
+      \t\t\tConquering Middle-earthIf a player is present in all 7 regions (with a Fortress and/or at least 1 Unit), they\
+      \ dominate Middle-earth and immediately win the game.\n\nIf none of these three victory conditions are achieved by the\
+      \ end of chapter 3, the player who is present in the most regions of Middle-earth (with a Fortress and/or at least 1\
+      \ Unit) wins the game. In case of tie, share the victory.\n\n"
     yearPublished: 2024
     minPlayers: 2
     maxPlayers: 2
@@ -8107,17 +9053,24 @@ catalog:
     - Ponva d.o.o.
     - Rebel Sp. z o.o.
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/lotr-card-game_rulebook.pdf
+    pdfSha256: ef604fe7a639dfcb59e1b63538c77cb39bfbbda512ba0e9d2756ade92ef084ee
+    pdfVersion: '1.0'
   - title: 'Clank! Legacy: Acquisitions Incorporated'
     bggId: 266507
     language: en
-    pdf: clank-legacy_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Clank! Legacy: Acquisitions Incorporated extends the deck-building fun of Clank! with legacy-style gameplay! Found your own franchise of the legendary adventuring company, Acquisitions Incorporated, and shepherd your fledgling treasure-hunters to immortal corporate glory over the course of multiple games. Your game board, your deck, and your world change as you play to create a unique campaign tailored to your adventuring party. Be cunning, be bold, and most importantly, be ready...
+    description: 'Clank! Legacy: Acquisitions Incorporated extends the deck-building fun of Clank! with legacy-style gameplay!
+      Found your own franchise of the legendary adventuring company, Acquisitions Incorporated, and shepherd your fledgling
+      treasure-hunters to immortal corporate glory over the course of multiple games. Your game board, your deck, and your
+      world change as you play to create a unique campaign tailored to your adventuring party. Be cunning, be bold, and most
+      importantly, be ready...
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2019
     minPlayers: 2
     maxPlayers: 4
@@ -8164,24 +9117,29 @@ catalog:
     - Lucrum Games
     - Origames
     - Schwerkraft-Verlag
+    pdfBlobKey: rulebooks/v1/clank-legacy_rulebook.pdf
+    pdfSha256: 56885abb8944aef298c305f26a145882c0318acc56a78ffd0876fedb3be6a2bd
+    pdfVersion: '1.0'
   - title: Concordia
     bggId: 124361
     language: en
-    pdf: concordia_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Two thousand years ago, the Roman Empire ruled the lands around the Mediterranean Sea. With peace at the borders, harmony inside the provinces, uniform law, and a common currency, the economy thrived and gave rise to mighty Roman dynasties as they expanded throughout the numerous cities. Guide one of these dynasties and send colonists to the remote realms of the Empire; develop your trade network; and appease the ancient gods for their favor &mdash; all to gain the chance to emerge victorious!
-
-
-      Concordia is a peaceful, strategy game of economic development in Roman times for 2-5 players aged 13 and up. Instead of looking to the luck of dice or cards, players must rely on their strategic abilities. Be sure to watch your rivals to determine which goals they are pursuing and where you can outpace them! In the game, colonists are sent out from Rome to settle down in cities that produce bricks, food, tools, wine, and cloth. Each player starts with an identical set of playing cards and acquires more cards during the game. These cards serve two purposes:
-
-
-          They allow a player to choose actions during the game.
-          They are worth victory points (VPs) at the end of the game. 
-
-
-      Concordia is a strategy game that requires advanced planning and consideration of your opponent's moves. Every game is different, not only because of the sequence of new cards on sale but also due to the modular layout of cities. (One side of the game board shows the entire Roman Empire with 30 cities for 3-5 players, while the other shows Roman Italy with 25 cities for 2-4 players.) When all cards have been sold or after the first player builds their 15th house, the game ends. The player with the most VPs from the gods (Jupiter, Saturnus, Mercurius, Minerva, Vesta, etc.) wins the game.
-
+    description: "Two thousand years ago, the Roman Empire ruled the lands around the Mediterranean Sea. With peace at the\
+      \ borders, harmony inside the provinces, uniform law, and a common currency, the economy thrived and gave rise to mighty\
+      \ Roman dynasties as they expanded throughout the numerous cities. Guide one of these dynasties and send colonists to\
+      \ the remote realms of the Empire; develop your trade network; and appease the ancient gods for their favor &mdash;\
+      \ all to gain the chance to emerge victorious!\n\nConcordia is a peaceful, strategy game of economic development in\
+      \ Roman times for 2-5 players aged 13 and up. Instead of looking to the luck of dice or cards, players must rely on\
+      \ their strategic abilities. Be sure to watch your rivals to determine which goals they are pursuing and where you can\
+      \ outpace them! In the game, colonists are sent out from Rome to settle down in cities that produce bricks, food, tools,\
+      \ wine, and cloth. Each player starts with an identical set of playing cards and acquires more cards during the game.\
+      \ These cards serve two purposes:\n\n\n    They allow a player to choose actions during the game.\n    They are worth\
+      \ victory points (VPs) at the end of the game. \n\n\nConcordia is a strategy game that requires advanced planning and\
+      \ consideration of your opponent's moves. Every game is different, not only because of the sequence of new cards on\
+      \ sale but also due to the modular layout of cities. (One side of the game board shows the entire Roman Empire with\
+      \ 30 cities for 3-5 players, while the other shows Roman Italy with 25 cities for 2-4 players.) When all cards have\
+      \ been sold or after the first player builds their 15th house, the game ends. The player with the most VPs from the\
+      \ gods (Jupiter, Saturnus, Mercurius, Minerva, Vesta, etc.) wins the game.\n\n"
     yearPublished: 2013
     minPlayers: 2
     maxPlayers: 5
@@ -8230,42 +9188,30 @@ catalog:
     - Playfun Games
     - Rio Grande Games
     - Ystari Games
+    pdfBlobKey: rulebooks/v1/concordia_rulebook.pdf
+    pdfSha256: 90dbdaa9dd1467777dfc9f7f9f2e57dc17d5ac8a538feebc1644480d663a0703
+    pdfVersion: '1.0'
   - title: 'Great Western Trail: New Zealand'
     bggId: 341169
     language: en
     bggEnhanced: true
-    description: >+
-      America in the 19th century: You are a rancher and repeatedly herd your cattle from Texas to Kansas City, where you send them off by train. This earns you money and victory points. Needless to say, each time you arrive in Kansas City, you want to have your most valuable cattle in tow. However, the "Great Western Trail" not only requires that you keep your herd in good shape, but also that you wisely use the various buildings along the trail. Also, it might be a good idea to hire capable staff: cowboys to improve your herd, craftsmen to build your very own buildings, or engineers for the important railroad line.
-
-
-      If you cleverly manage your herd and navigate the opportunities and pitfalls of Great Western Trail, you surely will gain the most victory points and win the game.
-
-
-      The second edition of Great Western Trail includes solitaire rules, making for a player count of 1-4.
-
-
-      Second Edition:
-
-      Remember the old days in the West? Well, the times they are a-changing&rsquo;! From new solo opponent to incredible landscapes, you won't know where to start. And there is a new herd of cows for you to sell!
-
-
-      Great Western Trail is the critically acclaimed game of cattle ranching by Alexander Pfister. Players attempt to wrangle their herd across the Midwest prairie and deliver it to Kansas City. But beware! Other cowboys are sharing the trail with you. We invite you to saddle up!
-
-
-      The changes in the Second edition:
-
-
-           Brand New Artwork by Chris Quilliams
-           Solo Mode: A New Challenger in the West
-           Dual-Layered Player Boards
-           Addition of a new breed of cows: The Simmental breed
-           Two new reversible buildings (#11 & 12)
-           Twelve Exchange Tokens, First introduced in the Rails of North Expansion, for more interaction with other players
-           Four new Master Tiles added for more strategy, replayability, and challenges
-
-
-      &mdash;description from the publisher
-
+    description: "America in the 19th century: You are a rancher and repeatedly herd your cattle from Texas to Kansas City,\
+      \ where you send them off by train. This earns you money and victory points. Needless to say, each time you arrive in\
+      \ Kansas City, you want to have your most valuable cattle in tow. However, the \"Great Western Trail\" not only requires\
+      \ that you keep your herd in good shape, but also that you wisely use the various buildings along the trail. Also, it\
+      \ might be a good idea to hire capable staff: cowboys to improve your herd, craftsmen to build your very own buildings,\
+      \ or engineers for the important railroad line.\n\nIf you cleverly manage your herd and navigate the opportunities and\
+      \ pitfalls of Great Western Trail, you surely will gain the most victory points and win the game.\n\nThe second edition\
+      \ of Great Western Trail includes solitaire rules, making for a player count of 1-4.\n\nSecond Edition:\nRemember the\
+      \ old days in the West? Well, the times they are a-changing&rsquo;! From new solo opponent to incredible landscapes,\
+      \ you won't know where to start. And there is a new herd of cows for you to sell!\n\nGreat Western Trail is the critically\
+      \ acclaimed game of cattle ranching by Alexander Pfister. Players attempt to wrangle their herd across the Midwest prairie\
+      \ and deliver it to Kansas City. But beware! Other cowboys are sharing the trail with you. We invite you to saddle up!\n\
+      \nThe changes in the Second edition:\n\n\n     Brand New Artwork by Chris Quilliams\n     Solo Mode: A New Challenger\
+      \ in the West\n     Dual-Layered Player Boards\n     Addition of a new breed of cows: The Simmental breed\n     Two\
+      \ new reversible buildings (#11 & 12)\n     Twelve Exchange Tokens, First introduced in the Rails of North Expansion,\
+      \ for more interaction with other players\n     Four new Master Tiles added for more strategy, replayability, and challenges\n\
+      \n\n&mdash;description from the publisher\n\n"
     yearPublished: 2021
     minPlayers: 1
     maxPlayers: 4
@@ -8308,23 +9254,29 @@ catalog:
   - title: 'Skytear: Arena of Legends'
     bggId: 373106
     language: en
-    pdf: skytear_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Sky Team is a co-operative game, exclusively for two players, in which you play a pilot and co-pilot at the controls of an airliner. Your goal is to work together as a team to land your airplane in different airports around the world.
+    description: 'Sky Team is a co-operative game, exclusively for two players, in which you play a pilot and co-pilot at
+      the controls of an airliner. Your goal is to work together as a team to land your airplane in different airports around
+      the world.
 
 
-      To land your plane, you need to silently assign your dice to the correct spaces in your cockpit to balance the axis of your plane, control its speed, deploy the flaps, extend the landing gear, contact the control tower to clear your path, and even have a little coffee to improve your concentration enough to change the value of your dice.
+      To land your plane, you need to silently assign your dice to the correct spaces in your cockpit to balance the axis
+      of your plane, control its speed, deploy the flaps, extend the landing gear, contact the control tower to clear your
+      path, and even have a little coffee to improve your concentration enough to change the value of your dice.
 
 
-      If the aircraft tilts too much and stalls, overshoots the airport, or collides with another aircraft, you lose the game...and your pilot's license...and probably your life.
+      If the aircraft tilts too much and stalls, overshoots the airport, or collides with another aircraft, you lose the game...and
+      your pilot''s license...and probably your life.
 
 
-      From Montreal to Tokyo, each airport offers its own set of challenges. Watch out for the turbulence as this could end up being a bumpy ride!
+      From Montreal to Tokyo, each airport offers its own set of challenges. Watch out for the turbulence as this could end
+      up being a bumpy ride!
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2023
     minPlayers: 2
     maxPlayers: 2
@@ -8372,35 +9324,29 @@ catalog:
     - Sugorokuya
     - Tabletop KZ
     - YOKA Games
+    pdfBlobKey: rulebooks/v1/skytear_rulebook.pdf
+    pdfSha256: 2f316d16c5001b55097b9966c7c697bbde6a50e7e5c9b1c3df336ff5c3775960
+    pdfVersion: '1.0'
   - title: Terra Mystica
     bggId: 120677
     language: en
-    pdf: terra-mystica_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In the land of Terra Mystica dwell 14 different peoples in seven landscapes, and each group is bound to its own home environment, so to develop and grow, they must terraform neighboring landscapes into their home environments in competition with the other groups.
-
-
-      Terra Mystica is a full information game, without any luck, that rewards strategic planning. Each player governs one of the 14 groups. With subtlety and craft, the player must attempt to rule as great an area as possible and to develop that group's skills. There are also four religious cults in which you can progress. To do all that, each group has special skills and abilities.
-
-
-      Taking turns, the players execute their actions on the resources they have at their disposal. Different buildings allow players to develop different resources. Dwellings allow for more workers. Trading houses allow players to make money. Strongholds unlock a group's special ability, and temples allow you to develop religion and your terraforming and seafaring skills. Buildings can be upgraded: Dwellings can be developed into trading houses; trading houses can be developed into strongholds or temples; one temple can be upgraded to become a sanctuary. Each group must also develop its terraforming skill and its skill with boats to use the rivers. The groups in question, along with their home landscape, are:
-
-
-          Desert (Fakirs, Nomads)
-          Plains (Halflings, Cultists)
-          Swamp (Alchemists, Darklings)
-          Lake (Mermaids, Swarmlings)
-          Forest (Witches, Auren)
-          Mountain (Dwarves, Engineers)
-          Wasteland (Giants, Chaos Magicians)
-
-
-      Proximity to other groups is a double-edged sword in Terra Mystica. Being close to other groups gives you extra power, but it also means that expanding is more difficult...
-
-
-      Terra Mystica FAQ
-
+    description: "In the land of Terra Mystica dwell 14 different peoples in seven landscapes, and each group is bound to\
+      \ its own home environment, so to develop and grow, they must terraform neighboring landscapes into their home environments\
+      \ in competition with the other groups.\n\nTerra Mystica is a full information game, without any luck, that rewards\
+      \ strategic planning. Each player governs one of the 14 groups. With subtlety and craft, the player must attempt to\
+      \ rule as great an area as possible and to develop that group's skills. There are also four religious cults in which\
+      \ you can progress. To do all that, each group has special skills and abilities.\n\nTaking turns, the players execute\
+      \ their actions on the resources they have at their disposal. Different buildings allow players to develop different\
+      \ resources. Dwellings allow for more workers. Trading houses allow players to make money. Strongholds unlock a group's\
+      \ special ability, and temples allow you to develop religion and your terraforming and seafaring skills. Buildings can\
+      \ be upgraded: Dwellings can be developed into trading houses; trading houses can be developed into strongholds or temples;\
+      \ one temple can be upgraded to become a sanctuary. Each group must also develop its terraforming skill and its skill\
+      \ with boats to use the rivers. The groups in question, along with their home landscape, are:\n\n\n    Desert (Fakirs,\
+      \ Nomads)\n    Plains (Halflings, Cultists)\n    Swamp (Alchemists, Darklings)\n    Lake (Mermaids, Swarmlings)\n  \
+      \  Forest (Witches, Auren)\n    Mountain (Dwarves, Engineers)\n    Wasteland (Giants, Chaos Magicians)\n\n\nProximity\
+      \ to other groups is a double-edged sword in Terra Mystica. Being close to other groups gives you extra power, but it\
+      \ also means that expanding is more difficult...\n\nTerra Mystica FAQ\n\n"
     yearPublished: 2012
     minPlayers: 2
     maxPlayers: 5
@@ -8449,17 +9395,29 @@ catalog:
     - White Goblin Games
     - Z-Man Games
     - Zvezda
+    pdfBlobKey: rulebooks/v1/terra-mystica_rulebook.pdf
+    pdfSha256: 9fc6eee922e6b73248ef8ca718d0edab29329ed9751ef9754a72d09beea6a9da
+    pdfVersion: '1.0'
   - title: Too Many Bones
     bggId: 192135
     language: en
-    pdf: too-many-bones_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Too Many Bones comes loaded for bear by breaking into a new genre: the dice-builder RPG. This game takes everything you think you know about dice-rolling and turns it on its head. Dripping with strategy, this fantasy-based RPG puts you in the skin of a new race and takes you on an adventure to the northern territories to root out and defeat growing enemy forces and of course the infamous "baddie" responsible.
+    description: 'Too Many Bones comes loaded for bear by breaking into a new genre: the dice-builder RPG. This game takes
+      everything you think you know about dice-rolling and turns it on its head. Dripping with strategy, this fantasy-based
+      RPG puts you in the skin of a new race and takes you on an adventure to the northern territories to root out and defeat
+      growing enemy forces and of course the infamous "baddie" responsible.
 
 
-      Team up or go it alone in a 1-4 player Coop or Solo play campaign. With over 100+ unique skill dice and 4-7 classes to choose from, every battle is its own mini challenge to figure out. Your adventure will consist of 8-12 battles before you reach your final destination and face off against one of a number of possible kingpins in order to win. Along the way, you will be faced with storyline decisions that will quickly have you weighing risk/reward, odds, and logic - with dice woven into every aspect! Your party will also be faced with other decisions: when to rest, when to explore, or even which fights to pursue! The Encounter cards offer fun plot twists and some comic relief, all while setting the stage for your next battle.
+      Team up or go it alone in a 1-4 player Coop or Solo play campaign. With over 100+ unique skill dice and 4-7 classes
+      to choose from, every battle is its own mini challenge to figure out. Your adventure will consist of 8-12 battles before
+      you reach your final destination and face off against one of a number of possible kingpins in order to win. Along the
+      way, you will be faced with storyline decisions that will quickly have you weighing risk/reward, odds, and logic - with
+      dice woven into every aspect! Your party will also be faced with other decisions: when to rest, when to explore, or
+      even which fights to pursue! The Encounter cards offer fun plot twists and some comic relief, all while setting the
+      stage for your next battle.
 
+
+      '
     yearPublished: 2017
     minPlayers: 1
     maxPlayers: 4
@@ -8506,20 +9464,29 @@ catalog:
     - Portal Games
     - Reflexshop
     - SD Games
+    pdfBlobKey: rulebooks/v1/too-many-bones_rulebook.pdf
+    pdfSha256: d1ffb9613ac5c460a37d91a69a7b19f6368bca8038f015e2c2ba5f26fb87620c
+    pdfVersion: '1.0'
   - title: Orleans
     bggId: 164928
     language: en
-    pdf: orleans_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      During the medieval goings-on around Orl&eacute;ans, you must assemble a following of farmers, merchants, knights, monks, etc. to gain supremacy through trade, construction and science in medieval France.
+    description: 'During the medieval goings-on around Orl&eacute;ans, you must assemble a following of farmers, merchants,
+      knights, monks, etc. to gain supremacy through trade, construction and science in medieval France.
 
 
-      In Orl&eacute;ans, you will recruit followers and put them to work to make use of their abilities. Farmers and Boatmen supply you with money and goods; Knights expand your scope of action and secure your mercantile expeditions; Craftsmen build trading stations and tools to facilitate work; Scholars make progress in science; Traders open up new locations for you to use your followers; and last but not least, it cannot hurt to get active in monasteries since with Monks on your side you are much less likely to fall prey to fate.
+      In Orl&eacute;ans, you will recruit followers and put them to work to make use of their abilities. Farmers and Boatmen
+      supply you with money and goods; Knights expand your scope of action and secure your mercantile expeditions; Craftsmen
+      build trading stations and tools to facilitate work; Scholars make progress in science; Traders open up new locations
+      for you to use your followers; and last but not least, it cannot hurt to get active in monasteries since with Monks
+      on your side you are much less likely to fall prey to fate.
 
 
-      You will always want to take more actions than possible, and there are many paths to victory. The challenge is to combine all elements as best as possible with regard to your strategy.
+      You will always want to take more actions than possible, and there are many paths to victory. The challenge is to combine
+      all elements as best as possible with regard to your strategy.
 
+
+      '
     yearPublished: 2014
     minPlayers: 2
     maxPlayers: 5
@@ -8568,17 +9535,26 @@ catalog:
     - Swan Panasia Co., Ltd.
     - Tasty Minstrel Games
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/orleans_rulebook.pdf
+    pdfSha256: 267ac223f04cba34b686f4dcdcb47460af3c9813a8f644b7ba46950f94750fad
+    pdfVersion: '1.0'
   - title: Mage Knight Board Game
     bggId: 96848
     language: en
-    pdf: mage-knight_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      The Mage Knight board game puts you in control of one of four powerful Mage Knights as you explore (and conquer) a corner of the Mage Knight universe under the control of the Atlantean Empire. Build your army, fill your deck with powerful spells and actions, explore caves and dungeons, and eventually conquer powerful cities controlled by this once-great faction!  In competitive scenarios, opposing players may be powerful allies, but only one will be able to claim the land as their own.  In cooperative scenarios, the players win or lose as a group.  Solo rules are also included.
+    description: 'The Mage Knight board game puts you in control of one of four powerful Mage Knights as you explore (and
+      conquer) a corner of the Mage Knight universe under the control of the Atlantean Empire. Build your army, fill your
+      deck with powerful spells and actions, explore caves and dungeons, and eventually conquer powerful cities controlled
+      by this once-great faction!  In competitive scenarios, opposing players may be powerful allies, but only one will be
+      able to claim the land as their own.  In cooperative scenarios, the players win or lose as a group.  Solo rules are
+      also included.
 
 
-      Combining elements of RPGs, deck-building, and traditional board games the Mage Knight board game captures the rich history of the Mage Knight universe in a self-contained gaming experience.
+      Combining elements of RPGs, deck-building, and traditional board games the Mage Knight board game captures the rich
+      history of the Mage Knight universe in a self-contained gaming experience.
 
+
+      '
     yearPublished: 2011
     minPlayers: 1
     maxPlayers: 4
@@ -8623,23 +9599,34 @@ catalog:
     - NECA
     - Pegasus Spiele
     - REXhry
+    pdfBlobKey: rulebooks/v1/mage-knight_rulebook.pdf
+    pdfSha256: 664ab0e5405d821be665178f2e325205cfbccbc3d1723b07fe3ff261f6c835bd
+    pdfVersion: '1.0'
   - title: Barrage
     bggId: 251247
     language: en
-    pdf: barrage_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In the dystopic 1930s, the industrial revolution pushed the exploitation of fossil-based resources to the limit, and now the only thing powerful enough to quench the thirst for power of the massive machines and of the unstoppable engineering progress is the unlimited hydroelectric energy provided by the rivers.
+    description: 'In the dystopic 1930s, the industrial revolution pushed the exploitation of fossil-based resources to the
+      limit, and now the only thing powerful enough to quench the thirst for power of the massive machines and of the unstoppable
+      engineering progress is the unlimited hydroelectric energy provided by the rivers.
 
 
-      Barrage is a resource management strategic game in which players compete to build their majestic dams, raise them to increase their storing capacity, and deliver all the potential power through pressure tunnels connected to the energy turbines of their powerhouses.
+      Barrage is a resource management strategic game in which players compete to build their majestic dams, raise them to
+      increase their storing capacity, and deliver all the potential power through pressure tunnels connected to the energy
+      turbines of their powerhouses.
 
 
-      Each player represents one of the four international companies who are gathering machinery, innovative patents and brilliant engineers to claim the best locations to collect and exploit the water of a contested Alpine region crossed by rivers.
+      Each player represents one of the four international companies who are gathering machinery, innovative patents and brilliant
+      engineers to claim the best locations to collect and exploit the water of a contested Alpine region crossed by rivers.
 
 
-      Over five rounds, the players must fulfill power requirements represented by a common competitive power track and meet specific requests of personal contracts. At the same time, by placing a limited number of engineers, they attempt to enhance their machinery to acquire new and more efficient construction actions and to build and activate special unique-effect buildings to forward their own developing strategy.
+      Over five rounds, the players must fulfill power requirements represented by a common competitive power track and meet
+      specific requests of personal contracts. At the same time, by placing a limited number of engineers, they attempt to
+      enhance their machinery to acquire new and more efficient construction actions and to build and activate special unique-effect
+      buildings to forward their own developing strategy.
 
+
+      '
     yearPublished: 2019
     minPlayers: 1
     maxPlayers: 4
@@ -8684,33 +9671,51 @@ catalog:
     - テンデイズゲームズ (TendaysGames)
     - TLAMA games
     - WoodCat
+    pdfBlobKey: rulebooks/v1/barrage_rulebook.pdf
+    pdfSha256: 2c68f1c8d57f4d3f4c3bb083c94738a9dbea054a6aa8cb4ff19a4708fe5bc709
+    pdfVersion: '1.0'
   - title: 'Hegemony: Lead Your Class to Victory'
     bggId: 321608
     language: en
-    pdf: hegemony_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Extended edition includes Crisis & Control expansion.
+    description: 'Extended edition includes Crisis & Control expansion.
 
 
 
-      The Nation is in disarray and a war is waging between the classes. The working class faces a dismantled welfare system, the capitalists are losing their hard-earned profits, the middle class is gradually fading and the state is sinking into a deep deficit. Amidst all this chaos, the only person who can provide guidance is... you. Will you take the side of the working class and fight for social reforms? Or will you stand with the corporations and the free market? Will you help the government try to keep it all together, or will you try to enforce your agenda no matter the cost to the country?
+      The Nation is in disarray and a war is waging between the classes. The working class faces a dismantled welfare system,
+      the capitalists are losing their hard-earned profits, the middle class is gradually fading and the state is sinking
+      into a deep deficit. Amidst all this chaos, the only person who can provide guidance is... you. Will you take the side
+      of the working class and fight for social reforms? Or will you stand with the corporations and the free market? Will
+      you help the government try to keep it all together, or will you try to enforce your agenda no matter the cost to the
+      country?
 
 
-      Hegemony is an asymmetric politico-economic card-driven board game for 2-4 players that puts you in the role of one of the socio-economic groups in a fictional state: The Working Class, the Middle Class, the Capitalist Class and the State itself.
+      Hegemony is an asymmetric politico-economic card-driven board game for 2-4 players that puts you in the role of one
+      of the socio-economic groups in a fictional state: The Working Class, the Middle Class, the Capitalist Class and the
+      State itself.
 
 
-      The Working class controls the workers. The Capitalist class controls the companies. The Middle class combines elements from both the Working class and the Capitalist. It has workers who can work in the Capitalist's companies but it can also build companies of its own, yet smaller. Finally the State is trying to keep everyone happy, providing benefits and subsidies when needed but trying also to maintain a steady income through taxes to avoid going into debt.
+      The Working class controls the workers. The Capitalist class controls the companies. The Middle class combines elements
+      from both the Working class and the Capitalist. It has workers who can work in the Capitalist''s companies but it can
+      also build companies of its own, yet smaller. Finally the State is trying to keep everyone happy, providing benefits
+      and subsidies when needed but trying also to maintain a steady income through taxes to avoid going into debt.
 
 
-      While players have their own separate goals, they are all limited by a series of policies that affect most of their actions, like Taxation, Labor Market, Foreign Trade etc. Voting on those policies and using their influence to change them is also very important. Through careful planning, strategic actions and political maneuvering, you will do your best to increase the power of your class and carry out your agenda. Will you be the one to lead your class to victory?
+      While players have their own separate goals, they are all limited by a series of policies that affect most of their
+      actions, like Taxation, Labor Market, Foreign Trade etc. Voting on those policies and using their influence to change
+      them is also very important. Through careful planning, strategic actions and political maneuvering, you will do your
+      best to increase the power of your class and carry out your agenda. Will you be the one to lead your class to victory?
 
 
-      Hegemony is heavily based on actual academic principles such as Social-Democracy, Neoliberalism, Nationalism and Globalism, and allows players to see their real world applications through engaging gameplay. There are many ways to achieve hegemony- which one will you take?
+      Hegemony is heavily based on actual academic principles such as Social-Democracy, Neoliberalism, Nationalism and Globalism,
+      and allows players to see their real world applications through engaging gameplay. There are many ways to achieve hegemony-
+      which one will you take?
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2023
     minPlayers: 2
     maxPlayers: 4
@@ -8745,23 +9750,36 @@ catalog:
     - Lavka Games
     - MYBG Co., Ltd.
     - Portal Games
+    pdfBlobKey: rulebooks/v1/hegemony_rulebook.pdf
+    pdfSha256: 95d89918c65189836d92e1b1fde7b7abad83b902cf53332299c11cd2bbfd478a
+    pdfVersion: '1.0'
   - title: Viticulture Essential Edition
     bggId: 183394
     language: en
-    pdf: viticulture_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Viticulture, the players find themselves in the roles of people in rustic, pre-modern Tuscany who have inherited meagre vineyards. They have a few plots of land, an old crush pad, a tiny cellar, and three workers. They each have a dream of being the first to call their winery a true success.
+    description: 'In Viticulture, the players find themselves in the roles of people in rustic, pre-modern Tuscany who have
+      inherited meagre vineyards. They have a few plots of land, an old crush pad, a tiny cellar, and three workers. They
+      each have a dream of being the first to call their winery a true success.
 
 
-      The players are in the position of determining how they want to allocate their workers throughout the year. Every season is different on a vineyard, so the workers have different tasks they can take care of in the summer and winter. There's competition over those tasks, and often the first worker to get to the job has an advantage over subsequent workers.
+      The players are in the position of determining how they want to allocate their workers throughout the year. Every season
+      is different on a vineyard, so the workers have different tasks they can take care of in the summer and winter. There''s
+      competition over those tasks, and often the first worker to get to the job has an advantage over subsequent workers.
 
 
-      Fortunately for the vineyard owners, people love to visit wineries, and it just so happens that many of those visitors are willing to help out around the vineyard when they visit as long as you assign a worker to take care of them. Their visits (in the form of cards) are brief but can be very helpful. Using those workers and visitors, the vineyard owners can expand their vineyards by building structures, planting vines, and filling wine orders, working towards the goal of running the most successful winery in Tuscany.
+      Fortunately for the vineyard owners, people love to visit wineries, and it just so happens that many of those visitors
+      are willing to help out around the vineyard when they visit as long as you assign a worker to take care of them. Their
+      visits (in the form of cards) are brief but can be very helpful. Using those workers and visitors, the vineyard owners
+      can expand their vineyards by building structures, planting vines, and filling wine orders, working towards the goal
+      of running the most successful winery in Tuscany.
 
 
-      Viticulture Essential Edition includes the base game of Viticulture and a few of the most popular modules from the original Tuscany expansion, including Mamas & Papas, Fields (previously known as Properties), expanded and revised Visitors, and Automa cards for a solo variant, along with a few minor rule changes.
+      Viticulture Essential Edition includes the base game of Viticulture and a few of the most popular modules from the original
+      Tuscany expansion, including Mamas & Papas, Fields (previously known as Properties), expanded and revised Visitors,
+      and Automa cards for a solo variant, along with a few minor rule changes.
 
+
+      '
     yearPublished: 2015
     minPlayers: 1
     maxPlayers: 6
@@ -8807,25 +9825,41 @@ catalog:
     - Regatul Jocurilor
     - Surfin' Meeple China
     - Tower Tactic Games
+    pdfBlobKey: rulebooks/v1/viticulture_rulebook.pdf
+    pdfSha256: bca0937ac513b49bceef44c4fe65acc0aacc8a444774894fe62bde10836f613a
+    pdfVersion: '1.0'
   - title: Crokinole
     bggId: 521
     language: en
     bggEnhanced: true
-    description: >+
-      Crokinole is a traditional two- or four-player dexterity game, played on a circular wooden board, with 3 rings and an inner recessed 'bullseye'. A ring of posts is set around the inner circle, which functions as an obstacle to reach this area. Playing pieces are wooden circular disks similar to checkers pieces.  Players take turns shooting disks across the board by flicking them with their fingers in an effort to land them in the highest scoring ring on the board, the highest score (20 points) achieved by shooting a disk into the centre, recessed hole. From the outside in, rings are worth 5, 10, 15 points.
+    description: 'Crokinole is a traditional two- or four-player dexterity game, played on a circular wooden board, with 3
+      rings and an inner recessed ''bullseye''. A ring of posts is set around the inner circle, which functions as an obstacle
+      to reach this area. Playing pieces are wooden circular disks similar to checkers pieces.  Players take turns shooting
+      disks across the board by flicking them with their fingers in an effort to land them in the highest scoring ring on
+      the board, the highest score (20 points) achieved by shooting a disk into the centre, recessed hole. From the outside
+      in, rings are worth 5, 10, 15 points.
 
 
-      As a traditional game, there are often many variations played, but the following method is based on the National Crokinole Association's rules which also govern the World Crokinole Championship.
+      As a traditional game, there are often many variations played, but the following method is based on the National Crokinole
+      Association''s rules which also govern the World Crokinole Championship.
 
 
-      Each disk to be shot must be placed on the outer boundary and within the shooting player's quadrant. If there are no opponent's disks on the board, the shot disk must land in the inner ring or it is removed. If there is an opponent's disk on the board, the shot disk must hit an opponent's piece, either directly, or by bumping another disk into it.  Disks landing in the centre hole are removed and scored at the end of the round. Disks that lie outside--or are touching--the outer boundary after each shot are removed from play for the round.
+      Each disk to be shot must be placed on the outer boundary and within the shooting player''s quadrant. If there are no
+      opponent''s disks on the board, the shot disk must land in the inner ring or it is removed. If there is an opponent''s
+      disk on the board, the shot disk must hit an opponent''s piece, either directly, or by bumping another disk into it.  Disks
+      landing in the centre hole are removed and scored at the end of the round. Disks that lie outside--or are touching--the
+      outer boundary after each shot are removed from play for the round.
 
 
-      The player to score the most points wins the round and scores 2 points, and if a tie, each player scores 1 point. A "game" is usually played to four rounds. The number of "games" in a match is set by the tournament.
+      The player to score the most points wins the round and scores 2 points, and if a tie, each player scores 1 point. A
+      "game" is usually played to four rounds. The number of "games" in a match is set by the tournament.
 
 
-      Alternatively, play is to a set score, usually the first player or team to 100, and each round is scored by cancellation. For example if Player One scores 250, and Player Two scores 225, then Player One will add 25 to his/her game score.
+      Alternatively, play is to a set score, usually the first player or team to 100, and each round is scored by cancellation.
+      For example if Player One scores 250, and Player Two scores 225, then Player One will add 25 to his/her game score.
 
+
+      '
     yearPublished: 1876
     minPlayers: 2
     maxPlayers: 4
@@ -8876,17 +9910,23 @@ catalog:
   - title: 'Heat: Pedal to the Metal'
     bggId: 366013
     language: en
-    pdf: heat_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Based on simple and intuitive hand management, Heat: Pedal to the Metal puts players in the driver's seat of intense car races, jockeying for position to cross the finish line first, while managing their car's speed if they don't want to overheat. Selecting the right upgrades for their car will help them hug the curves and keep their engine cool enough to maintain top speeds. Ultimately, their driving skills will be the key to victory!
+    description: 'Based on simple and intuitive hand management, Heat: Pedal to the Metal puts players in the driver''s seat
+      of intense car races, jockeying for position to cross the finish line first, while managing their car''s speed if they
+      don''t want to overheat. Selecting the right upgrades for their car will help them hug the curves and keep their engine
+      cool enough to maintain top speeds. Ultimately, their driving skills will be the key to victory!
 
 
-      Drivers can compete in a single race or use the "Championship System" to play a whole season in one game night, customizing their car before each race to claim the top spot of the podium. They have to be careful as the weather, road conditions, and events will change every race to spice up their championship. Players can also enjoy a solo mode with the Legends Module or add automated drivers as additional opponents in multiplayer games.
+      Drivers can compete in a single race or use the "Championship System" to play a whole season in one game night, customizing
+      their car before each race to claim the top spot of the podium. They have to be careful as the weather, road conditions,
+      and events will change every race to spice up their championship. Players can also enjoy a solo mode with the Legends
+      Module or add automated drivers as additional opponents in multiplayer games.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2022
     minPlayers: 1
     maxPlayers: 6
@@ -8928,22 +9968,35 @@ catalog:
     - Kaissa Chess & Games
     - Korea Boardgames
     - Lord of Boards
+    pdfBlobKey: rulebooks/v1/heat_rulebook.pdf
+    pdfSha256: 03515036dff608ec23a69ca0f7a538f06ec5612809950df1650d4d3d57586f81
+    pdfVersion: '1.0'
   - title: Kanban EV
     bggId: 284378
     language: en
-    pdf: kanban-ev_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Electric vehicles (EVs) have become more common since 2014 and are the future of the automobile industry. They are superior vehicles due to them being more efficient, easier to maintain, cleaner, and cheaper to run. They are computerized machines that use AI to improve safety and in the near future will provide autonomous driving. They receive software upgrades during their lifetime and are constantly improving, unlike their traditional combustion-engine counterparts, which start to become obsolete as soon as you start using them.
+    description: 'Electric vehicles (EVs) have become more common since 2014 and are the future of the automobile industry.
+      They are superior vehicles due to them being more efficient, easier to maintain, cleaner, and cheaper to run. They are
+      computerized machines that use AI to improve safety and in the near future will provide autonomous driving. They receive
+      software upgrades during their lifetime and are constantly improving, unlike their traditional combustion-engine counterparts,
+      which start to become obsolete as soon as you start using them.
 
 
-      You will be overseeing the production of these vehicles in Kanban EV, with "kanban" (看板) being the name for a scheduling system that supports an efficient assembly line, just-in-time production, and a smooth workflow process. Over the course of the game, players take on the role of rookie employees who are trying to secure their career. You need to manage suppliers and supplies, improve and innovate automobile parts, and get your hands greasy on the assembly line in order to boost production and impress the factory manager.
+      You will be overseeing the production of these vehicles in Kanban EV, with "kanban" (看板) being the name for a scheduling
+      system that supports an efficient assembly line, just-in-time production, and a smooth workflow process. Over the course
+      of the game, players take on the role of rookie employees who are trying to secure their career. You need to manage
+      suppliers and supplies, improve and innovate automobile parts, and get your hands greasy on the assembly line in order
+      to boost production and impress the factory manager.
 
 
-      You must make shrewd use of the recycling facilities and the limited factory supplies in order to appropriate parts when the suppliers come up short. Because the factory must run at optimum efficiency, production doesn't wait for you or for mistakes. Sandra, the factory manager, will review your performance and keep the factory on tempo.
+      You must make shrewd use of the recycling facilities and the limited factory supplies in order to appropriate parts
+      when the suppliers come up short. Because the factory must run at optimum efficiency, production doesn''t wait for you
+      or for mistakes. Sandra, the factory manager, will review your performance and keep the factory on tempo.
 
 
-      Kanban EV is a game that focuses on resource and time management that puts you in the driver's seat of an entire production facility, racing for factory goals and the highest level of promotion. You earn production points (PP) for performing various actions in the game, and the player with the most PP at the end of the game wins.
+      Kanban EV is a game that focuses on resource and time management that puts you in the driver''s seat of an entire production
+      facility, racing for factory goals and the highest level of promotion. You earn production points (PP) for performing
+      various actions in the game, and the player with the most PP at the end of the game wins.
 
 
       &mdash;description from publisher
@@ -8951,6 +10004,8 @@ catalog:
 
       Includes solo mode by D&aacute;vid Turczi
 
+
+      '
     yearPublished: 2020
     minPlayers: 1
     maxPlayers: 4
@@ -8986,26 +10041,21 @@ catalog:
     - Skellig Games
     - TLAMA games
     - YOKA Games
+    pdfBlobKey: rulebooks/v1/kanban-ev_rulebook.pdf
+    pdfSha256: d09cdca785107379277fd8a8bd8da5daa6b7cdc2247dc6f0b650a28320cc584c
+    pdfVersion: '1.0'
   - title: 'Marvel Champions: The Card Game'
     bggId: 285774
     language: en
-    pdf: marvel-champions_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      "With great power, there must also come great responsibility."
-         &ndash;Stan Lee, Amazing Fantasy #15
-
-      Iron Man and Black Panther team up to stop Rhino from rampaging through the streets of New York. Captain Marvel and Spider-Man battle Ultron as he threatens global annihilation. Do you have what it takes to join the ranks of these legendary heroes and become a champion?
-
-
-      Jump into the Marvel Universe with Marvel Champions: The Card Game, a cooperative Living Card Game for one to four players!
-
-
-      Marvel Champions: The Card Game invites players to embody iconic heroes from the Marvel Universe as they battle to stop infamous villains from enacting their devious schemes. As a Living Card Game, Marvel Champions is supported with regular releases of new product, including new heroes and scenarios.
-
-
-      &mdash;description from the publisher
-
+    description: "\"With great power, there must also come great responsibility.\"\n   &ndash;Stan Lee, Amazing Fantasy #15\n\
+      \nIron Man and Black Panther team up to stop Rhino from rampaging through the streets of New York. Captain Marvel and\
+      \ Spider-Man battle Ultron as he threatens global annihilation. Do you have what it takes to join the ranks of these\
+      \ legendary heroes and become a champion?\n\nJump into the Marvel Universe with Marvel Champions: The Card Game, a cooperative\
+      \ Living Card Game for one to four players!\n\nMarvel Champions: The Card Game invites players to embody iconic heroes\
+      \ from the Marvel Universe as they battle to stop infamous villains from enacting their devious schemes. As a Living\
+      \ Card Game, Marvel Champions is supported with regular releases of new product, including new heroes and scenarios.\n\
+      \n&mdash;description from the publisher\n\n"
     yearPublished: 2019
     minPlayers: 1
     maxPlayers: 4
@@ -9044,20 +10094,33 @@ catalog:
     - Kilogames
     - Korea Boardgames
     - NeoTroy Games
+    pdfBlobKey: rulebooks/v1/marvel-champions_rulebook.pdf
+    pdfSha256: 357c9be2010723dd3e8831e81eb140567d0d93f83b803a9040dcad2b8f2730b9
+    pdfVersion: '1.0'
   - title: Underwater Cities
     bggId: 247763
     language: en
-    pdf: underwater-cities_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Underwater Cities, which takes about 30-45 minutes per player, players represent the most powerful brains in the world, brains nominated due to the overpopulation of Earth to establish the best and most livable underwater areas possible.
+    description: 'In Underwater Cities, which takes about 30-45 minutes per player, players represent the most powerful brains
+      in the world, brains nominated due to the overpopulation of Earth to establish the best and most livable underwater
+      areas possible.
 
 
-      The main principle of the game is card placement. Three colored cards are placed along the edge of the main board  into 3 x 5 slots, which are also colored. Ideally players can place cards into slots of the same color. Then they can take both actions and advantages: the action depicted in the slot on the main board and also the advantage of the card. Actions and advantages can allow players to intake raw materials; to build and upgrade city domes, tunnels and production buildings such as farms, desalination devices and laboratories in their personal underwater area; to move their marker on the initiative track (which is important for player order in the next turn); to activate the player's "A-cards"; and to collect cards, both special ones and basic ones that allow for better decision possibilities during gameplay.
+      The main principle of the game is card placement. Three colored cards are placed along the edge of the main board  into
+      3 x 5 slots, which are also colored. Ideally players can place cards into slots of the same color. Then they can take
+      both actions and advantages: the action depicted in the slot on the main board and also the advantage of the card. Actions
+      and advantages can allow players to intake raw materials; to build and upgrade city domes, tunnels and production buildings
+      such as farms, desalination devices and laboratories in their personal underwater area; to move their marker on the
+      initiative track (which is important for player order in the next turn); to activate the player''s "A-cards"; and to
+      collect cards, both special ones and basic ones that allow for better decision possibilities during gameplay.
 
 
-      All of the nearly 220 cards &mdash; whether special or basic &mdash; are divided into five types according to the way and time of use. Underwater areas are planned to be double-sided, giving players many opportunities to achieve VPs and finally win.
+      All of the nearly 220 cards &mdash; whether special or basic &mdash; are divided into five types according to the way
+      and time of use. Underwater areas are planned to be double-sided, giving players many opportunities to achieve VPs and
+      finally win.
 
+
+      '
     yearPublished: 2018
     minPlayers: 1
     maxPlayers: 4
@@ -9103,29 +10166,50 @@ catalog:
     - Rio Grande Games
     - sternenschimmermeer
     - 数寄ゲームズ (Suki Games)
+    pdfBlobKey: rulebooks/v1/underwater-cities_rulebook.pdf
+    pdfSha256: 09a932ae6a3c5adfe07d0efeda8071a8ba225b9c66a766d08576075b2e7a2c9c
+    pdfVersion: '1.0'
   - title: Food Chain Magnate
     bggId: 175914
     language: en
-    pdf: food-chain-magnate_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      "Lemonade? They want lemonade? What is the world coming to? I want commercials for burgers on all channels, every 15 minutes. We are the Home of the Original Burger, not a hippie health haven. And place a billboard next to that new house on the corner. I want them craving beer every second they sit in their posh new garden." The new management trainee trembles in front of the CEO and tries to politely point out that... "How do you mean, we don't have enough staff? The HR director reports to you. Hire more people! Train them! But whatever you do, don't pay them any real wages. I did not go into business to become poor. And fire that discount manager, she is only costing me money. From now on, we'll sell gourmet burgers. Same crap, double the price. Get my marketing director in here!"
+    description: '"Lemonade? They want lemonade? What is the world coming to? I want commercials for burgers on all channels,
+      every 15 minutes. We are the Home of the Original Burger, not a hippie health haven. And place a billboard next to that
+      new house on the corner. I want them craving beer every second they sit in their posh new garden." The new management
+      trainee trembles in front of the CEO and tries to politely point out that... "How do you mean, we don''t have enough
+      staff? The HR director reports to you. Hire more people! Train them! But whatever you do, don''t pay them any real wages.
+      I did not go into business to become poor. And fire that discount manager, she is only costing me money. From now on,
+      we''ll sell gourmet burgers. Same crap, double the price. Get my marketing director in here!"
 
 
-      Food Chain Magnate is a heavy strategy game about building a fast food chain. The focus is on building your company using a card-driven (human) resource management system. Players compete on a variable city map through purchasing, marketing and sales, and on a job market for key staff members. The game can be played by 2-5 serious gamers in 2-4 hours.
+      Food Chain Magnate is a heavy strategy game about building a fast food chain. The focus is on building your company
+      using a card-driven (human) resource management system. Players compete on a variable city map through purchasing, marketing
+      and sales, and on a job market for key staff members. The game can be played by 2-5 serious gamers in 2-4 hours.
 
 
       German:
 
 
-      "Limonade? Sie wollen Limonade? Was ist mit der Welt los? Ich will Werbung f&uuml;r Burger auf allen Kan&auml;len, alle 15 Minuten. Wir sind die Heimat des Original-Burgers, kein Hippie-Gesundheitsparadies. Und stellen Sie eine Werbetafel neben das neue Haus an der Ecke. Ich will, dass sie jede Sekunde, in der sie in ihrem schicken neuen Garten sitzen, nach Bier lechzen." Der neue Management-Trainee zittert vor dem CEO und versucht, h&ouml;flich darauf hinzuweisen, dass... "Wie meinen Sie das, wir haben nicht genug Personal? Der Personaldirektor berichtet an Sie. Stellen Sie mehr Leute ein! Bilden Sie sie aus! Aber was auch immer Sie tun, zahlen Sie ihnen keine echten L&ouml;hne. Ich bin nicht ins Gesch&auml;ft eingestiegen, um arm zu werden. Und feuere diese Discount-Managerin, sie kostet mich nur Geld. Von nun an werden wir Gourmet-Burger verkaufen. Derselbe Mist, nur doppelt so teuer. Holen Sie meinen Marketingdirektor her!"
+      "Limonade? Sie wollen Limonade? Was ist mit der Welt los? Ich will Werbung f&uuml;r Burger auf allen Kan&auml;len, alle
+      15 Minuten. Wir sind die Heimat des Original-Burgers, kein Hippie-Gesundheitsparadies. Und stellen Sie eine Werbetafel
+      neben das neue Haus an der Ecke. Ich will, dass sie jede Sekunde, in der sie in ihrem schicken neuen Garten sitzen,
+      nach Bier lechzen." Der neue Management-Trainee zittert vor dem CEO und versucht, h&ouml;flich darauf hinzuweisen, dass...
+      "Wie meinen Sie das, wir haben nicht genug Personal? Der Personaldirektor berichtet an Sie. Stellen Sie mehr Leute ein!
+      Bilden Sie sie aus! Aber was auch immer Sie tun, zahlen Sie ihnen keine echten L&ouml;hne. Ich bin nicht ins Gesch&auml;ft
+      eingestiegen, um arm zu werden. Und feuere diese Discount-Managerin, sie kostet mich nur Geld. Von nun an werden wir
+      Gourmet-Burger verkaufen. Derselbe Mist, nur doppelt so teuer. Holen Sie meinen Marketingdirektor her!"
 
 
-      Food Chain Magnate ist ein schweres Strategiespiel &uuml;ber den Aufbau einer Fast-Food-Kette. Der Schwerpunkt liegt auf dem Aufbau des eigenen Unternehmens mit Hilfe eines kartengesteuerten (Personal-)Managementsystems. Die Spieler konkurrieren auf einer variablen Stadtkarte durch Einkauf, Marketing und Verkauf sowie auf einem Stellenmarkt f&uuml;r wichtige Mitarbeiter.
+      Food Chain Magnate ist ein schweres Strategiespiel &uuml;ber den Aufbau einer Fast-Food-Kette. Der Schwerpunkt liegt
+      auf dem Aufbau des eigenen Unternehmens mit Hilfe eines kartengesteuerten (Personal-)Managementsystems. Die Spieler
+      konkurrieren auf einer variablen Stadtkarte durch Einkauf, Marketing und Verkauf sowie auf einem Stellenmarkt f&uuml;r
+      wichtige Mitarbeiter.
 
 
       Das Spiel kann von 2-5 ernsthaften Spielern in 2-4 Stunden gespielt werden.
 
+
+      '
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 5
@@ -9164,23 +10248,40 @@ catalog:
     - New Games Order, LLC
     - One Moment Games
     - Portal Games
+    pdfBlobKey: rulebooks/v1/food-chain-magnate_rulebook.pdf
+    pdfSha256: f228049fcadc5d674049cb10a419e13d7e6d270bfcdf8a8e8ef33ddb7482f4a3
+    pdfVersion: '1.0'
   - title: 'Pax Pamir: Second Edition'
     bggId: 256960
     language: en
-    pdf: pax-pamir_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Pax Pamir, players assume the role of nineteenth century Afghan leaders attempting to forge a new state after the collapse of the Durrani Empire. Western histories often call this period "The Great Game" because of the role played by the Europeans who attempted to use central Asia as a theater for their own rivalries. In this game, those empires are viewed strictly from the perspective of the Afghans who sought to manipulate the interloping ferengi (foreigners) for their own purposes.
+    description: 'In Pax Pamir, players assume the role of nineteenth century Afghan leaders attempting to forge a new state
+      after the collapse of the Durrani Empire. Western histories often call this period "The Great Game" because of the role
+      played by the Europeans who attempted to use central Asia as a theater for their own rivalries. In this game, those
+      empires are viewed strictly from the perspective of the Afghans who sought to manipulate the interloping ferengi (foreigners)
+      for their own purposes.
 
 
-      In terms of game play, Pax Pamir is a pretty straightforward tableau builder. Players spend most of their turns purchasing cards from a central market, then playing those cards in front of them in a single row called a court. Playing cards adds units to the game's map and grants access to additional actions that can be taken to disrupt other players and influence the course of the game. That last point is worth emphasizing. Though everyone is building their own row of cards, the game offers many ways for players to interfere with each other directly and indirectly.
+      In terms of game play, Pax Pamir is a pretty straightforward tableau builder. Players spend most of their turns purchasing
+      cards from a central market, then playing those cards in front of them in a single row called a court. Playing cards
+      adds units to the game''s map and grants access to additional actions that can be taken to disrupt other players and
+      influence the course of the game. That last point is worth emphasizing. Though everyone is building their own row of
+      cards, the game offers many ways for players to interfere with each other directly and indirectly.
 
 
-      To survive, players will organize into coalitions. Throughout the game, the dominance of the different coalitions will be evaluated by the players when a special card, called a "Dominance Check", is resolved. If a single coalition has a commanding lead during one of these checks, those players loyal to that coalition will receive victory points based on their influence in their coalition. However, if Afghanistan remains fragmented during one of these checks, players instead will receive victory points based on their personal power base.
+      To survive, players will organize into coalitions. Throughout the game, the dominance of the different coalitions will
+      be evaluated by the players when a special card, called a "Dominance Check", is resolved. If a single coalition has
+      a commanding lead during one of these checks, those players loyal to that coalition will receive victory points based
+      on their influence in their coalition. However, if Afghanistan remains fragmented during one of these checks, players
+      instead will receive victory points based on their personal power base.
 
 
-      After each Dominance Check, victory is checked and the game will be partially reset, offering players a fresh attempt to realize their ambitions. The game ends when a single player is able to achieve a lead of four or more victory points  or after the fourth and final Dominance Check is resolved.
+      After each Dominance Check, victory is checked and the game will be partially reset, offering players a fresh attempt
+      to realize their ambitions. The game ends when a single player is able to achieve a lead of four or more victory points  or
+      after the fourth and final Dominance Check is resolved.
 
+
+      '
     yearPublished: 2019
     minPlayers: 1
     maxPlayers: 5
@@ -9228,20 +10329,29 @@ catalog:
     - Spielworxx
     - テンデイズゲームズ (TendaysGames)
     - YOKA Games
+    pdfBlobKey: rulebooks/v1/pax-pamir_rulebook.pdf
+    pdfSha256: 63b77858c8013806355dc52b7620044478fe545c12b495dbf16843c6242c009b
+    pdfVersion: '1.0'
   - title: 'Cthulhu: Death May Die'
     bggId: 253344
     language: en
-    pdf: cthulhu-death-may-die_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Cthulhu: Death May Die, inspired by the writings of H.P. Lovecraft, you and your fellow players represent investigators in the 1920s who instead of trying to stop the coming of Elder Gods, want to summon those otherworldly beings so that you can put a stop to them permanently. You start the game insane, and while your long-term goal is to shoot Cthulhu in the face, so to speak, at some point during the game you'll probably fail to mitigate your dice rolls properly and your insanity will cause you to do something terrible &mdash; or maybe advantageous. Hard to know for sure.
+    description: 'In Cthulhu: Death May Die, inspired by the writings of H.P. Lovecraft, you and your fellow players represent
+      investigators in the 1920s who instead of trying to stop the coming of Elder Gods, want to summon those otherworldly
+      beings so that you can put a stop to them permanently. You start the game insane, and while your long-term goal is to
+      shoot Cthulhu in the face, so to speak, at some point during the game you''ll probably fail to mitigate your dice rolls
+      properly and your insanity will cause you to do something terrible &mdash; or maybe advantageous. Hard to know for sure.
 
 
-      The game has multiple episodes, and each of them has a similar structure of two acts, those being before and after you summon whatever it is you happen to be summoning. If any character dies prior to the summoning, then the game ends and you lose; once the Elder One is on the board, as long as one of you is still alive, you still have a chance to win.
+      The game has multiple episodes, and each of them has a similar structure of two acts, those being before and after you
+      summon whatever it is you happen to be summoning. If any character dies prior to the summoning, then the game ends and
+      you lose; once the Elder One is on the board, as long as one of you is still alive, you still have a chance to win.
 
 
       The episodes are all standalone and not contingent on being played in a certain order or with the same players.
 
+
+      '
     yearPublished: 2019
     minPlayers: 1
     maxPlayers: 5
@@ -9285,26 +10395,35 @@ catalog:
     - Portal Games
     - REXhry
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/cthulhu-death-may-die_rulebook.pdf
+    pdfSha256: bd68232abefd9f2b2904bf5a3b5c1e3db59b29f4567838c4b799d0e7b6468b11
+    pdfVersion: '1.0'
   - title: Age of Innovation
     bggId: 383179
     language: en
-    pdf: age-of-innovation_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Age of Innovation is a standalone game set in the world of Terra Mystica.
+    description: 'Age of Innovation is a standalone game set in the world of Terra Mystica.
 
 
-      Twelve factions, each with unique characteristics, populate this world of varying terrains. Here you will compete to erect buildings and merge them into cities. Each game allows you to create new combinations of factions, homelands, and abilities so that each game isn't the same as another.
+      Twelve factions, each with unique characteristics, populate this world of varying terrains. Here you will compete to
+      erect buildings and merge them into cities. Each game allows you to create new combinations of factions, homelands,
+      and abilities so that each game isn''t the same as another.
 
 
-      You control one of these factions and will terraform the game map's terrain into your homelands where you can erect your buildings. Proximity to other factions may limit your expansion, but it also gains you significant advantages in the game. This tension adds to the appeal of the Terra Mystica series.
+      You control one of these factions and will terraform the game map''s terrain into your homelands where you can erect
+      your buildings. Proximity to other factions may limit your expansion, but it also gains you significant advantages in
+      the game. This tension adds to the appeal of the Terra Mystica series.
 
 
-      Upgrade your buildings to gain valuable resources such as tools, scholars, money, and power. Build schools to advance in different sciences and collect books, which you can use to make innovations. Build your palace to gain a powerful new ability or build workshops, guilds, and universities to complete your culture.
+      Upgrade your buildings to gain valuable resources such as tools, scholars, money, and power. Build schools to advance
+      in different sciences and collect books, which you can use to make innovations. Build your palace to gain a powerful
+      new ability or build workshops, guilds, and universities to complete your culture.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2023
     minPlayers: 1
     maxPlayers: 5
@@ -9350,32 +10469,29 @@ catalog:
     - Swan Panasia Co., Ltd.
     - テンデイズゲームズ (TendaysGames)
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/age-of-innovation_rulebook.pdf
+    pdfSha256: 8f1150d295498a2df9ac6da4de3e73eb7efb2e8da8298aa6377afb1af6dc65e5
+    pdfVersion: '1.0'
   - title: 'Clank!: A Deck-Building Adventure'
     bggId: 201808
     language: en
-    pdf: clank_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Burgle your way to adventure in the deck-building board game Clank! Sneak into an angry dragon's mountain lair to steal precious artifacts. Delve deeper to find more valuable loot. Acquire cards for your deck and watch your thievish abilities grow. Be quick and be quiet. One false step and CLANK! Each careless sound draws the attention of the dragon, and each artifact stolen increases its rage. You can enjoy your plunder only if you make it out of the depths alive!
-
-
-      Clank! is a deck-building game. Each player has their own deck, and building yours up is part of playing the game. You start each of your turns with five cards in your hand, and you'll play them all in any order you choose. Most cards will generate resources, of which there are three different kinds:
-
-
-          Skill, which is used to acquire new cards for your deck.
-          Swords, which are used to fight the monsters that infest the dungeon.
-          Boots, which are used to move around the board.
-
-
-      Every time you acquire a new card, you put it face up in your discard pile. Whenever you need to draw a card and find your deck empty, you shuffle your discard pile and turn it face down to form a new deck. With each shuffle, your newest cards become part of a bigger and better deck! Each player starts with the same cards in their deck, but they&rsquo;ll acquire different cards during their turns. Because cards can do many different things, each player&rsquo;s deck (and strategy) will become more and more different as the game unfolds.
-
-
-      During the game, you have two goals:
-
-          Retrieve an Artifact token and escape the dragon by returning to the place you started, outside of the dungeon.
-          Accumulate enough points with your Artifact and other loot to beat out your opponents and earn the title of Greatest Thief in the Realm!
-
-
+    description: "Burgle your way to adventure in the deck-building board game Clank! Sneak into an angry dragon's mountain\
+      \ lair to steal precious artifacts. Delve deeper to find more valuable loot. Acquire cards for your deck and watch your\
+      \ thievish abilities grow. Be quick and be quiet. One false step and CLANK! Each careless sound draws the attention\
+      \ of the dragon, and each artifact stolen increases its rage. You can enjoy your plunder only if you make it out of\
+      \ the depths alive!\n\nClank! is a deck-building game. Each player has their own deck, and building yours up is part\
+      \ of playing the game. You start each of your turns with five cards in your hand, and you'll play them all in any order\
+      \ you choose. Most cards will generate resources, of which there are three different kinds:\n\n\n    Skill, which is\
+      \ used to acquire new cards for your deck.\n    Swords, which are used to fight the monsters that infest the dungeon.\n\
+      \    Boots, which are used to move around the board.\n\n\nEvery time you acquire a new card, you put it face up in your\
+      \ discard pile. Whenever you need to draw a card and find your deck empty, you shuffle your discard pile and turn it\
+      \ face down to form a new deck. With each shuffle, your newest cards become part of a bigger and better deck! Each player\
+      \ starts with the same cards in their deck, but they&rsquo;ll acquire different cards during their turns. Because cards\
+      \ can do many different things, each player&rsquo;s deck (and strategy) will become more and more different as the game\
+      \ unfolds.\n\nDuring the game, you have two goals:\n\n    Retrieve an Artifact token and escape the dragon by returning\
+      \ to the place you started, outside of the dungeon.\n    Accumulate enough points with your Artifact and other loot\
+      \ to beat out your opponents and earn the title of Greatest Thief in the Realm!\n\n\n"
     yearPublished: 2016
     minPlayers: 2
     maxPlayers: 4
@@ -9417,29 +10533,51 @@ catalog:
     - REXhry
     - Schwerkraft-Verlag
     - Tabletop KZ
+    pdfBlobKey: rulebooks/v1/clank_rulebook.pdf
+    pdfSha256: 3bac57806508832c3ecbff7ba1095fc8570f5a9229d00073aa78683acadcca1d
+    pdfVersion: '1.0'
   - title: The White Castle
     bggId: 371942
     language: en
-    pdf: the-white-castle_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      The heron flies over the Himeji sky while the Daimyo, from the top of the castle, watches his servants move. Gardeners tend the pond, where the koi carp live, warriors stand guard on the walls, and courtiers crowd the gates, pining for an audience that brings them closer to the innermost circles of the court. When night falls, the lanterns are lit and the workers return to their clan.
+    description: 'The heron flies over the Himeji sky while the Daimyo, from the top of the castle, watches his servants move.
+      Gardeners tend the pond, where the koi carp live, warriors stand guard on the walls, and courtiers crowd the gates,
+      pining for an audience that brings them closer to the innermost circles of the court. When night falls, the lanterns
+      are lit and the workers return to their clan.
 
 
-      In The White Castle, players will control one of these clans in order to score more victory points than the rest. To do so, they must amass influence in the court, manage resources boldly, and place their workers in the right place at the right time. The authors are Sheila Santos and Israel Cendrero, the duo known as Llama Dice who also designed the successful The Red Cathedral with Devir. In this case, we leave the Moscow of Ivan the Terrible behind to explore the most imposing fortress in modern Japan, Himeji Castle, where the banner of the Sakai clan flies under the orders of Daimyo Sakai Tadakiyo.
+      In The White Castle, players will control one of these clans in order to score more victory points than the rest. To
+      do so, they must amass influence in the court, manage resources boldly, and place their workers in the right place at
+      the right time. The authors are Sheila Santos and Israel Cendrero, the duo known as Llama Dice who also designed the
+      successful The Red Cathedral with Devir. In this case, we leave the Moscow of Ivan the Terrible behind to explore the
+      most imposing fortress in modern Japan, Himeji Castle, where the banner of the Sakai clan flies under the orders of
+      Daimyo Sakai Tadakiyo.
 
 
-      The White Castle is a Euro type game with mechanics of resource management, worker placement and dice placement to carry out actions. During the game, over three rounds, players will send members of their clan to tend the gardens, defend the castle or progress up the social ladder of the nobility. At the end of the match, these will award players victory points in a variety of ways.
+      The White Castle is a Euro type game with mechanics of resource management, worker placement and dice placement to carry
+      out actions. During the game, over three rounds, players will send members of their clan to tend the gardens, defend
+      the castle or progress up the social ladder of the nobility. At the end of the match, these will award players victory
+      points in a variety of ways.
 
 
-      The central panel shows Himeji Castle in all its splendor, divided into several zones. The largest is inside the castle, with the Room of the Thousand Carpets, where the courtiers must ascend socially until they reach the circle closest to the Daimyo to enjoy his favor. There is also the pond and the gardens, patiently tended by the gardeners where everyone can relax and contemplate its beauty without restriction. Another important area is the wall and the outside of the castle, where the warriors patrol and stand guard. Finally, we find the area of the three bridges, where the three types of dice that can be used to carry out actions are accumulated, and the personal domain of each player, where they will keep track of their resources and where they will have the reserve of workers.
+      The central panel shows Himeji Castle in all its splendor, divided into several zones. The largest is inside the castle,
+      with the Room of the Thousand Carpets, where the courtiers must ascend socially until they reach the circle closest
+      to the Daimyo to enjoy his favor. There is also the pond and the gardens, patiently tended by the gardeners where everyone
+      can relax and contemplate its beauty without restriction. Another important area is the wall and the outside of the
+      castle, where the warriors patrol and stand guard. Finally, we find the area of the three bridges, where the three types
+      of dice that can be used to carry out actions are accumulated, and the personal domain of each player, where they will
+      keep track of their resources and where they will have the reserve of workers.
 
 
-      With accessible rules and a very careful setting, The White Castle is a very versatile title that will fit in with different gaming groups. As is tradition with Llama Dice titles, its sleek and simple design belies a great deal of strategic depth within the grasp of players.
+      With accessible rules and a very careful setting, The White Castle is a very versatile title that will fit in with different
+      gaming groups. As is tradition with Llama Dice titles, its sleek and simple design belies a great deal of strategic
+      depth within the grasp of players.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2023
     minPlayers: 1
     maxPlayers: 4
@@ -9487,20 +10625,32 @@ catalog:
     - Portal Games
     - Reflexshop
     - TLAMA games
+    pdfBlobKey: rulebooks/v1/the-white-castle_rulebook.pdf
+    pdfSha256: dd14099d0194afad2402875e6eb6a27e0b8fbdc631713b16eca1026ad4b225b2
+    pdfVersion: '1.0'
   - title: Paladins of the West Kingdom
     bggId: 266810
     language: en
-    pdf: paladins-of-the-west-kingdom_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Paladins of the West Kingdom is set at a turbulent time of West Francia's story, circa 900 AD. Despite recent efforts to develop the city, outlying townships are still under threat from outsiders. Saracens scout the borders, while Vikings plunder wealth and livestock. Even the Byzantines from the east have shown their darker side. As noble men and women, players must gather workers from the city to defend against enemies, build fortifications and spread faith throughout the land. Fortunately you are not alone. In his great wisdom, the King has sent his finest knights to help aid in our efforts. So ready the horses and sharpen the swords. The Paladins are approaching.
+    description: 'Paladins of the West Kingdom is set at a turbulent time of West Francia''s story, circa 900 AD. Despite
+      recent efforts to develop the city, outlying townships are still under threat from outsiders. Saracens scout the borders,
+      while Vikings plunder wealth and livestock. Even the Byzantines from the east have shown their darker side. As noble
+      men and women, players must gather workers from the city to defend against enemies, build fortifications and spread
+      faith throughout the land. Fortunately you are not alone. In his great wisdom, the King has sent his finest knights
+      to help aid in our efforts. So ready the horses and sharpen the swords. The Paladins are approaching.
 
 
-      The aim of Paladins of the West Kingdom is to be the player with the most victory points (VP) at game's end. Points are gained by building outposts and fortifications, commissioning monks and confronting outsiders. Each round, players will enlist the help of a specific Paladin and gather workers to carry out tasks. As the game progresses, players will slowly increase their faith, strength and influence. Not only will these affect their final score, but they will also determine the significance of their actions. The game is concluded at the end of the seventh round.
+      The aim of Paladins of the West Kingdom is to be the player with the most victory points (VP) at game''s end. Points
+      are gained by building outposts and fortifications, commissioning monks and confronting outsiders. Each round, players
+      will enlist the help of a specific Paladin and gather workers to carry out tasks. As the game progresses, players will
+      slowly increase their faith, strength and influence. Not only will these affect their final score, but they will also
+      determine the significance of their actions. The game is concluded at the end of the seventh round.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2019
     minPlayers: 1
     maxPlayers: 4
@@ -9543,17 +10693,28 @@ catalog:
     - TLAMA games
     - White Goblin Games
     - 株式会社ケンビル (KenBill)
+    pdfBlobKey: rulebooks/v1/paladins-of-the-west-kingdom_rulebook.pdf
+    pdfSha256: 97df1e8977704b8ab3618199ab3951affce87740aa1da04a03c2692c42e7b81e
+    pdfVersion: '1.0'
   - title: Le Havre
     bggId: 35677
     language: en
-    pdf: le-havre_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Le Havre, a player's turn consists of two parts: First, distribute newly supplied goods onto the offer spaces; then take an action. As an action, players may choose either to take all goods of one type from an offer space or to use one of the available buildings. Building actions allow players to upgrade goods, sell them or use them to build their own buildings and ships. Buildings are both an investment opportunity and a revenue stream, as players must pay an entry fee to use buildings that they do not own. Ships, on the other hand, are primarily used to provide the food that is needed to feed the workers.
+    description: 'In Le Havre, a player''s turn consists of two parts: First, distribute newly supplied goods onto the offer
+      spaces; then take an action. As an action, players may choose either to take all goods of one type from an offer space
+      or to use one of the available buildings. Building actions allow players to upgrade goods, sell them or use them to
+      build their own buildings and ships. Buildings are both an investment opportunity and a revenue stream, as players must
+      pay an entry fee to use buildings that they do not own. Ships, on the other hand, are primarily used to provide the
+      food that is needed to feed the workers.
 
 
-      After every seven turns, the round ends: players' cattle and grain may multiply through a Harvest, and players must feed their workers. After a fixed number of rounds, each player may carry out one final action, and then the game ends. Players add the value of their buildings and ships to their cash reserves. The player who has amassed the largest fortune is the winner.
+      After every seven turns, the round ends: players'' cattle and grain may multiply through a Harvest, and players must
+      feed their workers. After a fixed number of rounds, each player may carry out one final action, and then the game ends.
+      Players add the value of their buildings and ships to their cash reserves. The player who has amassed the largest fortune
+      is the winner.
 
+
+      '
     yearPublished: 2008
     minPlayers: 1
     maxPlayers: 5
@@ -9599,29 +10760,22 @@ catalog:
     - uplay.it edizioni
     - Ystari Games
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/le-havre_rulebook.pdf
+    pdfSha256: 060b2f6f9a32af213b6d39ed6698d1fe94d339abfb8d3b1954a952228e0f3be3
+    pdfVersion: '1.0'
   - title: The Gallerist
     bggId: 125153
     language: en
-    pdf: the-gallerist_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      This age of art and capitalism has created a need for a new occupation - The Gallerist.
-
-
-      Combining the elements of an Art dealer, museum curator, and Artists&rsquo; manager, you are about to take on that job! You will promote and nurture Artists; buy, display, and sell their Art; and build and exert your international reputation. As a result, you will achieve the respect needed to draw visitors to your Gallery from all over the world.
-
-
-      There's a lot of work to be done, but don't worry, you can hire assistants to help you achieve your goals. Build your fortune by running the most lucrative Gallery and secure your reputation as a world-class Gallerist!
-
-
-      Maximize your money and thus win the game by: 
-
-           having visitors in your gallery; 
-           exhibiting and selling works of art;
-           investing in artists&rsquo; promotion to increase art value;
-           achieving trends and reputation as well as curator and dealer goals.
-
-
+    description: "This age of art and capitalism has created a need for a new occupation - The Gallerist.\n\nCombining the\
+      \ elements of an Art dealer, museum curator, and Artists&rsquo; manager, you are about to take on that job! You will\
+      \ promote and nurture Artists; buy, display, and sell their Art; and build and exert your international reputation.\
+      \ As a result, you will achieve the respect needed to draw visitors to your Gallery from all over the world.\n\nThere's\
+      \ a lot of work to be done, but don't worry, you can hire assistants to help you achieve your goals. Build your fortune\
+      \ by running the most lucrative Gallery and secure your reputation as a world-class Gallerist!\n\nMaximize your money\
+      \ and thus win the game by: \n\n     having visitors in your gallery; \n     exhibiting and selling works of art;\n\
+      \     investing in artists&rsquo; promotion to increase art value;\n     achieving trends and reputation as well as\
+      \ curator and dealer goals.\n\n\n"
     yearPublished: 2015
     minPlayers: 1
     maxPlayers: 4
@@ -9660,29 +10814,49 @@ catalog:
     - Maldito Games
     - sternenschimmermeer
     - YOKA Games
+    pdfBlobKey: rulebooks/v1/the-gallerist_rulebook.pdf
+    pdfSha256: 4c1cc0f09c85177e05e890208a2377ab229a8563976b88e7c5d6f38d7e690dea
+    pdfVersion: '1.0'
   - title: 'Android: Netrunner'
     bggId: 124742
     language: en
-    pdf: android-netrunner_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Welcome to New Angeles, home of the Beanstalk. From our branch offices in this monument of human achievement, NBN proudly broadcasts all your favorite media programming. We offer fully comprehensive streaming in music and threedee, news and sitcoms, classic movies and sensies. We cover it all. Ours is a brave new age, and as humanity hurtles into space and the future with an astonishing series of new advances every day, NBN and our affiliates are keeping pace, bringing you all the vid that's fit to view.
+    description: 'Welcome to New Angeles, home of the Beanstalk. From our branch offices in this monument of human achievement,
+      NBN proudly broadcasts all your favorite media programming. We offer fully comprehensive streaming in music and threedee,
+      news and sitcoms, classic movies and sensies. We cover it all. Ours is a brave new age, and as humanity hurtles into
+      space and the future with an astonishing series of new advances every day, NBN and our affiliates are keeping pace,
+      bringing you all the vid that''s fit to view.
 
 
-      Android: Netrunner is an asymmetrical Living Card Game for two players. Set in the cyberpunk future of Android and Infiltration, the game pits a megacorporation and its massive resources against the subversive talents of lone runners.
+      Android: Netrunner is an asymmetrical Living Card Game for two players. Set in the cyberpunk future of Android and Infiltration,
+      the game pits a megacorporation and its massive resources against the subversive talents of lone runners.
 
 
-      Corporations seek to score agendas by advancing them. Doing so takes time and credits. To buy the time and earn the credits they need, they must secure their servers and data forts with "ice". These security programs come in different varieties, from simple barriers, to code gates and aggressive sentries. They serve as the corporation's virtual eyes, ears, and machine guns on the sprawling information superhighways of the network.
+      Corporations seek to score agendas by advancing them. Doing so takes time and credits. To buy the time and earn the
+      credits they need, they must secure their servers and data forts with "ice". These security programs come in different
+      varieties, from simple barriers, to code gates and aggressive sentries. They serve as the corporation''s virtual eyes,
+      ears, and machine guns on the sprawling information superhighways of the network.
 
 
-      In turn, runners need to spend their time and credits acquiring a sufficient wealth of resources, purchasing the necessary hardware, and developing suitably powerful ice-breaker programs to hack past corporate security measures. Their jobs are always a little desperate, driven by tight timelines, and shrouded in mystery. When a runner jacks-in and starts a run at a corporate server, he risks having his best programs trashed or being caught by a trace program and left vulnerable to corporate countermeasures. It's not uncommon for an unprepared runner to fail to bypass a nasty sentry and suffer massive brain damage as a result. Even if a runner gets through a data fort's defenses, there's no telling what it holds. Sometimes, the runner finds something of value. Sometimes, the best he can do is work to trash whatever the corporation was developing.
+      In turn, runners need to spend their time and credits acquiring a sufficient wealth of resources, purchasing the necessary
+      hardware, and developing suitably powerful ice-breaker programs to hack past corporate security measures. Their jobs
+      are always a little desperate, driven by tight timelines, and shrouded in mystery. When a runner jacks-in and starts
+      a run at a corporate server, he risks having his best programs trashed or being caught by a trace program and left vulnerable
+      to corporate countermeasures. It''s not uncommon for an unprepared runner to fail to bypass a nasty sentry and suffer
+      massive brain damage as a result. Even if a runner gets through a data fort''s defenses, there''s no telling what it
+      holds. Sometimes, the runner finds something of value. Sometimes, the best he can do is work to trash whatever the corporation
+      was developing.
 
 
       The first player to seven points wins the game, but not likely before he suffers some brain damage or bad publicity.
 
 
-      The Revised Core Set for Android: Netrunner released in late 2017 includes cards from the original Core Set released in 2012 as well as cards from the Genesis Cycle and Spin Cycle series of Data Packs. While the cards in this set have been released previously, the art on some of them is new.
+      The Revised Core Set for Android: Netrunner released in late 2017 includes cards from the original Core Set released
+      in 2012 as well as cards from the Genesis Cycle and Spin Cycle series of Data Packs. While the cards in this set have
+      been released previously, the art on some of them is new.
 
+
+      '
     yearPublished: 2012
     minPlayers: 2
     maxPlayers: 2
@@ -9719,29 +10893,49 @@ catalog:
     - Giochi Uniti
     - Heidelberger Spieleverlag
     - Korea Boardgames
+    pdfBlobKey: rulebooks/v1/android-netrunner_rulebook.pdf
+    pdfSha256: e07e9076e7e7da7c90f079ae5e7f5e695d49f93b457d9a069a69077d7f8393f1
+    pdfVersion: '1.0'
   - title: 'Star Wars: Imperial Assault'
     bggId: 164153
     language: en
-    pdf: star-wars-imperial-assault_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Star Wars: Imperial Assault is a strategy board game of tactical combat and missions for two to five players, offering two distinct games of battle and adventure in the Star Wars universe!
+    description: 'Star Wars: Imperial Assault is a strategy board game of tactical combat and missions for two to five players,
+      offering two distinct games of battle and adventure in the Star Wars universe!
 
 
-      Imperial Assault puts you in the midst of the Galactic Civil War between the Rebel Alliance and the Galactic Empire after the destruction of the Death Star over Yavin 4. In this game, you and your friends can participate in two separate games. The campaign game pits the limitless troops and resources of the Galactic Empire against a crack team of elite Rebel operatives as they strive to break the Empire&rsquo;s hold on the galaxy, while the skirmish game invites you and a friend to muster strike teams and battle head-to-head over conflicting objectives.
+      Imperial Assault puts you in the midst of the Galactic Civil War between the Rebel Alliance and the Galactic Empire
+      after the destruction of the Death Star over Yavin 4. In this game, you and your friends can participate in two separate
+      games. The campaign game pits the limitless troops and resources of the Galactic Empire against a crack team of elite
+      Rebel operatives as they strive to break the Empire&rsquo;s hold on the galaxy, while the skirmish game invites you
+      and a friend to muster strike teams and battle head-to-head over conflicting objectives.
 
 
-      In the campaign game, Imperial Assault invites you to play through a cinematic tale set in the Star Wars universe. One player commands the seemingly limitless armies of the Galactic Empire, threatening to extinguish the flame of the Rebellion forever. Up to four other players become heroes of the Rebel Alliance, engaging in covert operations to undermine the Empire&rsquo;s schemes. Over the course of the campaign, both the Imperial player and the Rebel heroes gain new experience and skills, allowing characters to evolve as the story unfolds.
+      In the campaign game, Imperial Assault invites you to play through a cinematic tale set in the Star Wars universe. One
+      player commands the seemingly limitless armies of the Galactic Empire, threatening to extinguish the flame of the Rebellion
+      forever. Up to four other players become heroes of the Rebel Alliance, engaging in covert operations to undermine the
+      Empire&rsquo;s schemes. Over the course of the campaign, both the Imperial player and the Rebel heroes gain new experience
+      and skills, allowing characters to evolve as the story unfolds.
 
 
-      Imperial Assault offers a different game experience in the skirmish game. In skirmish missions, you and a friend compete in head-to-head, tactical combat. You&rsquo;ll gather your own strike force of Imperials, Rebels, and Mercenaries and build a deck of command cards to gain an unexpected advantage in the heat of battle. Whether you recover lost holocrons or battle to defeat a raiding party, you&rsquo;ll find danger and tactical choices in every skirmish.
+      Imperial Assault offers a different game experience in the skirmish game. In skirmish missions, you and a friend compete
+      in head-to-head, tactical combat. You&rsquo;ll gather your own strike force of Imperials, Rebels, and Mercenaries and
+      build a deck of command cards to gain an unexpected advantage in the heat of battle. Whether you recover lost holocrons
+      or battle to defeat a raiding party, you&rsquo;ll find danger and tactical choices in every skirmish.
 
 
-      As an additional benefit, the Luke Skywalker Ally Pack and the Darth Vader Villain Pack are included within the Imperial Assault Core Set. These figure packs offer sculpted plastic figures alongside additional campaign and skirmish missions that highlight both Luke Skywalker and Darth Vader within Imperial Assault.
+      As an additional benefit, the Luke Skywalker Ally Pack and the Darth Vader Villain Pack are included within the Imperial
+      Assault Core Set. These figure packs offer sculpted plastic figures alongside additional campaign and skirmish missions
+      that highlight both Luke Skywalker and Darth Vader within Imperial Assault.
 
 
-      With these Imperial Assault and other Figure Packs, you'll find even more missions that allow your heroes to fight alongside iconic characters from the Star Wars saga. Boxed expansions add more heroes, imperial and mercenary groups, and totally new campaigns (see IA Community Wiki for a list), and the free Star Wars: Imperial Assault – Legends of the Alliance app provides you with additional content to play in solo or co-op mode.
+      With these Imperial Assault and other Figure Packs, you''ll find even more missions that allow your heroes to fight
+      alongside iconic characters from the Star Wars saga. Boxed expansions add more heroes, imperial and mercenary groups,
+      and totally new campaigns (see IA Community Wiki for a list), and the free Star Wars: Imperial Assault – Legends of
+      the Alliance app provides you with additional content to play in solo or co-op mode.
 
+
+      '
     yearPublished: 2014
     minPlayers: 2
     maxPlayers: 5
@@ -9784,26 +10978,37 @@ catalog:
     - Galakta
     - Heidelberger Spieleverlag
     - Hobby World
+    pdfBlobKey: rulebooks/v1/star-wars-imperial-assault_rulebook.pdf
+    pdfSha256: 31e496fdc97b9df7a8f38ccbd36561dc16265c142ff1cc3597fe6217f4707cc9
+    pdfVersion: '1.0'
   - title: 'Great Western Trail: Argentina'
     bggId: 380607
     language: en
-    pdf: great-western-trail-argentina_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Kia ora, and welcome to Great Western Trail New Zealand!
+    description: 'Kia ora, and welcome to Great Western Trail New Zealand!
 
 
-      Towards the end of the 19th century, you established yourself as a runholder (owner of a sheep station) on the South Island of New Zealand. Recent years have seen your family farm prosper by diversifying your breeds of sheep and increasing the value of your wool.
+      Towards the end of the 19th century, you established yourself as a runholder (owner of a sheep station) on the South
+      Island of New Zealand. Recent years have seen your family farm prosper by diversifying your breeds of sheep and increasing
+      the value of your wool.
 
 
-      With the dawn of the new century, difficult challenges have arisen. You must acquire improved and valuable breeds of sheep to ensure the prosperity of your family business and the labourers who work for you. Decide whether to focus on your past strengths or to diversify into new ventures. Will the beginning of the 20th century be as rewarding as earlier years, or will the efforts of others surpass your strategy? Good luck, and kia kaha!
+      With the dawn of the new century, difficult challenges have arisen. You must acquire improved and valuable breeds of
+      sheep to ensure the prosperity of your family business and the labourers who work for you. Decide whether to focus on
+      your past strengths or to diversify into new ventures. Will the beginning of the 20th century be as rewarding as earlier
+      years, or will the efforts of others surpass your strategy? Good luck, and kia kaha!
 
 
-      In Great Western Trail New Zealand, you move your runholder along a trail that winds and forks from the lower left corner of the game board to Wellington in the upper right. Along your path, you perform actions that provide you with various ways to earn victory points.
+      In Great Western Trail New Zealand, you move your runholder along a trail that winds and forks from the lower left corner
+      of the game board to Wellington in the upper right. Along your path, you perform actions that provide you with various
+      ways to earn victory points.
 
 
-      Each time your runholder reaches Wellington, you deliver sheep to a local or foreign trading post, which may also be worth victory points. Afterwards, your runholder continues its movement again.
+      Each time your runholder reaches Wellington, you deliver sheep to a local or foreign trading post, which may also be
+      worth victory points. Afterwards, your runholder continues its movement again.
 
+
+      '
     yearPublished: 2023
     minPlayers: 1
     maxPlayers: 4
@@ -9837,19 +11042,21 @@ catalog:
     - Rebel Sp. z o.o.
     - Yayoi The Dreamer
     - Zvezda
+    pdfBlobKey: rulebooks/v1/great-western-trail-argentina_rulebook.pdf
+    pdfSha256: 88be4a0b83dda037566941e46d1e936ec6280c37e9860c0405a58a9bd412c2fa
+    pdfVersion: '1.0'
   - title: Agricola (Revised Edition)
     bggId: 200680
     language: en
-    pdf: agricola-revised_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Updated and streamlined for a new generation of players, Agricola, the award-winning and highly acclaimed game by Uwe Rosenberg, features a revised rulebook and gameplay, wood pieces and components, and a card selection from the base game as well as its expansions, revised and updated for this edition.
-
-
-      The 17th century was not an easy time to be a farmer. 
-
-      Players begin the game with two family members and can grow their families over the course of the game. This allows them more actions but remember you have to grow more food to feed your family as it grows! Feeding your family is a special kind of challenge and players will plant grain and vegetables while supplementing their food supply with sheep, wild boar and cattle. Guide your family to wealth, health and prosperity and you will win the game.
-
+    description: "Updated and streamlined for a new generation of players, Agricola, the award-winning and highly acclaimed\
+      \ game by Uwe Rosenberg, features a revised rulebook and gameplay, wood pieces and components, and a card selection\
+      \ from the base game as well as its expansions, revised and updated for this edition.\n\nThe 17th century was not an\
+      \ easy time to be a farmer. \nPlayers begin the game with two family members and can grow their families over the course\
+      \ of the game. This allows them more actions but remember you have to grow more food to feed your family as it grows!\
+      \ Feeding your family is a special kind of challenge and players will plant grain and vegetables while supplementing\
+      \ their food supply with sheep, wild boar and cattle. Guide your family to wealth, health and prosperity and you will\
+      \ win the game.\n\n"
     yearPublished: 2016
     minPlayers: 1
     maxPlayers: 4
@@ -9898,24 +11105,33 @@ catalog:
     - Rebel Sp. z o.o.
     - Swan Panasia Co., Ltd.
     - uplay.it edizioni
+    pdfBlobKey: rulebooks/v1/agricola-revised_rulebook.pdf
+    pdfSha256: 1aa612ed43bdde109a0bfff900cf9322bae02e5b53f4ee3fe9f37d264ca8bc70
+    pdfVersion: '1.0'
   - title: Maracaibo
     bggId: 276025
     language: en
-    pdf: maracaibo_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Maracaibo, a strategy game for 1-4 players by Alexander Pfister, is set in the Caribbean during the 17th century. The players try to increase their influence in three nations in four rounds with a play time of 40 minutes per player.
+    description: 'Maracaibo, a strategy game for 1-4 players by Alexander Pfister, is set in the Caribbean during the 17th
+      century. The players try to increase their influence in three nations in four rounds with a play time of 40 minutes
+      per player.
 
 
-      The players sail on a round course through the Caribbean, e.g., you have city tiles where you are able to perform various&nbsp;actions or deliver goods to. One special feature is an implemented quest mode over more and various tiles, which tells the player, who chase after it, a little story.
+      The players sail on a round course through the Caribbean, e.g., you have city tiles where you are able to perform various&nbsp;actions
+      or deliver goods to. One special feature is an implemented quest mode over more and various tiles, which tells the player,
+      who chase after it, a little story.
 
 
-      As a player, you move with your ship around the course, managing it by using cards like in other games from Alexander Pfister.
+      As a player, you move with your ship around the course, managing it by using cards like in other games from Alexander
+      Pfister.
 
 
 
-      NOTE: The Spanish and Portuguese editions of Maracaibo contain La Armada mini-expansion packaged inside the base game's box.
+      NOTE: The Spanish and Portuguese editions of Maracaibo contain La Armada mini-expansion packaged inside the base game''s
+      box.
 
+
+      '
     yearPublished: 2019
     minPlayers: 1
     maxPlayers: 4
@@ -9965,17 +11181,24 @@ catalog:
     - テンデイズゲームズ (TendaysGames)
     - uplay.it edizioni
     - YOKA Games
+    pdfBlobKey: rulebooks/v1/maracaibo_rulebook.pdf
+    pdfSha256: a2b92b6924b916c0a5119427350ce62aca25121253784b1089137073feac4306
+    pdfVersion: '1.0'
   - title: Mechs vs. Minions
     bggId: 209010
     language: en
-    pdf: mechs-vs-minions_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Mechs vs. Minions is a cooperative tabletop campaign for 2-4 players. Set in the world of Runeterra, players take on the roles of four intrepid Yordles: Corki, Tristana, Heimerdinger, and Ziggs, who must join forces and pilot their newly-crafted mechs against an army of marauding minions. With modular boards, programmatic command lines, and a story-driven campaign, each mission will be unique, putting your teamwork, programming, and piloting skills to the test.
+    description: 'Mechs vs. Minions is a cooperative tabletop campaign for 2-4 players. Set in the world of Runeterra, players
+      take on the roles of four intrepid Yordles: Corki, Tristana, Heimerdinger, and Ziggs, who must join forces and pilot
+      their newly-crafted mechs against an army of marauding minions. With modular boards, programmatic command lines, and
+      a story-driven campaign, each mission will be unique, putting your teamwork, programming, and piloting skills to the
+      test.
 
 
       There are ten missions in total, and each individual mission will take about 60-90 minutes.
 
+
+      '
     yearPublished: 2016
     minPlayers: 2
     maxPlayers: 4
@@ -10010,36 +11233,56 @@ catalog:
     - Nathan Tiras
     publishers:
     - Riot Games
+    pdfBlobKey: rulebooks/v1/mechs-vs-minions_rulebook.pdf
+    pdfSha256: 9a342ef39b2efa6dd51aa94d892947a5d656a139c1c7906f76fdd4380854bd33
+    pdfVersion: '1.0'
   - title: 'Kingdom Death: Monster'
     bggId: 55690
     language: en
     bggEnhanced: true
-    description: >+
-      Kingdom Death: Monster is a fully cooperative tabletop hobby game experience.  Set in a unique nightmarish world devoid of most natural resources, you control a settlement at the dawn of its existence. Fight monsters, craft weapons and gear, and develop your settlement to ensure your survival from generation to generation.
+    description: 'Kingdom Death: Monster is a fully cooperative tabletop hobby game experience.  Set in a unique nightmarish
+      world devoid of most natural resources, you control a settlement at the dawn of its existence. Fight monsters, craft
+      weapons and gear, and develop your settlement to ensure your survival from generation to generation.
 
 
       Campaign System
 
-      Embark alone or with up to 3 friends (5 with game variant) on a 5-30-lantern-year campaign, with each year consisting of a cycle of hunt, showdown, and settlement phases. The settlement phase is an intricate civilization building game in which you spend very limited resources to build buildings, research new technologies, train your warriors, and set up your strategy for survival.  During the hunt, you'll encounter a series of stories in a "choose your own adventure" style journey through various events and encounters.  Finally, when you meet the monster you're pursuing, you'll engage it in an a massive arena-style battle where only one party is going to survive.  If your party lives, you'll be able to bring the spoils back home to use in expanding your settlement.
+      Embark alone or with up to 3 friends (5 with game variant) on a 5-30-lantern-year campaign, with each year consisting
+      of a cycle of hunt, showdown, and settlement phases. The settlement phase is an intricate civilization building game
+      in which you spend very limited resources to build buildings, research new technologies, train your warriors, and set
+      up your strategy for survival.  During the hunt, you''ll encounter a series of stories in a "choose your own adventure"
+      style journey through various events and encounters.  Finally, when you meet the monster you''re pursuing, you''ll engage
+      it in an a massive arena-style battle where only one party is going to survive.  If your party lives, you''ll be able
+      to bring the spoils back home to use in expanding your settlement.
 
 
       Monster AI System
 
-      Each of the 7 monsters included are controlled by their own pair of decks that scale to 3 levels of difficulty (except for the final encounter, which has only 1 level and it's HARD!). Every encounter, even with the same monster, is highly variable and no two showdowns will resolve the same way. Players will have to plan their gear and keep their minds sharp to prevail.
+      Each of the 7 monsters included are controlled by their own pair of decks that scale to 3 levels of difficulty (except
+      for the final encounter, which has only 1 level and it''s HARD!). Every encounter, even with the same monster, is highly
+      variable and no two showdowns will resolve the same way. Players will have to plan their gear and keep their minds sharp
+      to prevail.
 
 
       Gear System
 
-      In Kingdom Death: Monster, survivors will craft gear from resources earned from defeating monsters or found on their hunt. Each survivor has a 3x3 gear grid. Selection and arrangement of your gear cards is critical, as many provided bonuses and activate special rules when aligned correctly.
+      In Kingdom Death: Monster, survivors will craft gear from resources earned from defeating monsters or found on their
+      hunt. Each survivor has a 3x3 gear grid. Selection and arrangement of your gear cards is critical, as many provided
+      bonuses and activate special rules when aligned correctly.
 
 
       Story Event System
 
-      40+ Story Events plus over 100 hunt encounters will shape and guide your campaign. Story Events detail important evolutions in your civilization, introduce new monsters, and provide rich detail for your campaign.  Some will trigger automatically as you progress through the campaign, but most will be entirely based on choices players make.
+      40+ Story Events plus over 100 hunt encounters will shape and guide your campaign. Story Events detail important evolutions
+      in your civilization, introduce new monsters, and provide rich detail for your campaign.  Some will trigger automatically
+      as you progress through the campaign, but most will be entirely based on choices players make.
 
 
-      Story Events cover everything from setting up and fighting a monster to key events that happen within the overall story. Some are triggered directly from the timeline and others from choices you make in game.
+      Story Events cover everything from setting up and fighting a monster to key events that happen within the overall story.
+      Some are triggered directly from the timeline and others from choices you make in game.
 
+
+      '
     yearPublished: 2015
     minPlayers: 1
     maxPlayers: 4
@@ -10082,20 +11325,31 @@ catalog:
   - title: Darwin's Journey
     bggId: 322289
     language: en
-    pdf: darwins-journey_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      When all you can identify in the horizon for many long days is the line that detaches the sea from the sky, the glimpse of a distant shore appearing before you will make you shiver at the understanding that the adventure is about to begin.
+    description: 'When all you can identify in the horizon for many long days is the line that detaches the sea from the sky,
+      the glimpse of a distant shore appearing before you will make you shiver at the understanding that the adventure is
+      about to begin.
 
 
-      You find yourself astonished, landing on the shore that will be the origin of an extensive exploration through the Galapagos, a magic place of inconceivable beauty and endless biodiversity. There, you will gather repertoires and expand your knowledge of the natural sciences. Your eyes will learn how to detect the hidden species in the tropical forest, gazing at the countless colors and textures of nature. After inspiring hours spent studying and getting to enlightening conclusions, you will rest under a sparkling sky, admiring the stunning complexity of the animal realm.
+      You find yourself astonished, landing on the shore that will be the origin of an extensive exploration through the Galapagos,
+      a magic place of inconceivable beauty and endless biodiversity. There, you will gather repertoires and expand your knowledge
+      of the natural sciences. Your eyes will learn how to detect the hidden species in the tropical forest, gazing at the
+      countless colors and textures of nature. After inspiring hours spent studying and getting to enlightening conclusions,
+      you will rest under a sparkling sky, admiring the stunning complexity of the animal realm.
 
 
-      Darwin's Journey is a worker-placement Eurogame in which players recall Charles Darwin's memories of his adventure through the Galapagos islands, which contributed to the development of his theory of evolution.
+      Darwin''s Journey is a worker-placement Eurogame in which players recall Charles Darwin''s memories of his adventure
+      through the Galapagos islands, which contributed to the development of his theory of evolution.
 
 
-      With the game's innovative worker progression system, each worker will have to study the disciplines that are a prerequisite to perform several actions in the game, such as exploration, correspondence, gathering, and dispatch of repertoires found on the island to museums in order to contribute to the human knowledge of biology. The game lasts five rounds, and thanks to several short- and long-term objectives, every action you take will grant victory points in different ways.
+      With the game''s innovative worker progression system, each worker will have to study the disciplines that are a prerequisite
+      to perform several actions in the game, such as exploration, correspondence, gathering, and dispatch of repertoires
+      found on the island to museums in order to contribute to the human knowledge of biology. The game lasts five rounds,
+      and thanks to several short- and long-term objectives, every action you take will grant victory points in different
+      ways.
 
+
+      '
     yearPublished: 2023
     minPlayers: 1
     maxPlayers: 4
@@ -10140,33 +11394,27 @@ catalog:
     - TCG Factory
     - 株式会社ケンビル (KenBill)
     - 黑城堡桌游 Black Castle Games
+    pdfBlobKey: rulebooks/v1/darwins-journey_rulebook.pdf
+    pdfSha256: c37ef3550858530943766ef49878ec91fe105a4f0f9171ef4c804e942be49bf8
+    pdfVersion: '1.0'
   - title: Revive
     bggId: 332772
     language: en
-    pdf: revive_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Revive civilization, 5000 years after everything was destroyed. Lead your tribe and explore the frozen earth. Harness its resources. Recruit surface survivors to your cause. Build factories with powerful machines. And populate ancient sites to relearn your tribe's forgotten technologies.
-
-      --
-
-      Revive is a game for 1-4 players with asymmetric player powers, highly variable setup, and no fighting or direct conflict. Playing through the 5-part campaign unlocks additional contents, and once all contents have been unlocked, the game can be replayed indefinitely.
-
-
-      At the beginning of the game, each player gets a set of citizen cards, a tribe board, as well as a huge dual-layer player board. The tribe board shows your unique tribe ability and the ancient technologies that you may relearn during the game. The dual-layer player board is where you place your custom machines and upgrade your card slots.
-
-
-      A main goal of the game is to reach and populate the large ancient sites. These ancient locations are randomized, and as they are important sources of victory points, they will shape your strategy differently each game. The game ends when all artifacts have been taken, and the player with the most points wins.
-
-
-      On your turn you take two actions: 
-
-           Play a card (its effect is determined by which card slot you use)
-           Explore (reveal an area tile and recruit a new citizen card)
-           Populate (populate an ancient location to learn a new technology)
-           Build factory (the adjacent terrains determine which machine tracks you advance)
-
-
+    description: "Revive civilization, 5000 years after everything was destroyed. Lead your tribe and explore the frozen earth.\
+      \ Harness its resources. Recruit surface survivors to your cause. Build factories with powerful machines. And populate\
+      \ ancient sites to relearn your tribe's forgotten technologies.\n--\nRevive is a game for 1-4 players with asymmetric\
+      \ player powers, highly variable setup, and no fighting or direct conflict. Playing through the 5-part campaign unlocks\
+      \ additional contents, and once all contents have been unlocked, the game can be replayed indefinitely.\n\nAt the beginning\
+      \ of the game, each player gets a set of citizen cards, a tribe board, as well as a huge dual-layer player board. The\
+      \ tribe board shows your unique tribe ability and the ancient technologies that you may relearn during the game. The\
+      \ dual-layer player board is where you place your custom machines and upgrade your card slots.\n\nA main goal of the\
+      \ game is to reach and populate the large ancient sites. These ancient locations are randomized, and as they are important\
+      \ sources of victory points, they will shape your strategy differently each game. The game ends when all artifacts have\
+      \ been taken, and the player with the most points wins.\n\nOn your turn you take two actions: \n\n     Play a card (its\
+      \ effect is determined by which card slot you use)\n     Explore (reveal an area tile and recruit a new citizen card)\n\
+      \     Populate (populate an ancient location to learn a new technology)\n     Build factory (the adjacent terrains determine\
+      \ which machine tracks you advance)\n\n\n"
     yearPublished: 2022
     minPlayers: 1
     maxPlayers: 4
@@ -10213,30 +11461,42 @@ catalog:
     - Pegasus Spiele
     - Rebel Sp. z o.o.
     - Surfin' Meeple China
+    pdfBlobKey: rulebooks/v1/revive_rulebook.pdf
+    pdfSha256: ab5631c96bc4cf81e79358d77060cbdc85a8ff4c657caf13f4b05e8cbcf72e80
+    pdfVersion: '1.0'
   - title: Race for the Galaxy
     bggId: 28143
     language: en
-    pdf: race-for-the-galaxy_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Race for the Galaxy, players build galactic civilizations by playing cards representing worlds or technical and social developments.
+    description: 'In Race for the Galaxy, players build galactic civilizations by playing cards representing worlds or technical
+      and social developments.
 
 
-      Each round, players secretly and simultaneously select an action card corresponding to one phase of a round. These phases let players draw cards, play cards, add goods to worlds, or consume goods for VP chips. Only the phases chosen will occur that round. Every player may act in a phase that occurs, but the players who chose that phase get a bonus.
+      Each round, players secretly and simultaneously select an action card corresponding to one phase of a round. These phases
+      let players draw cards, play cards, add goods to worlds, or consume goods for VP chips. Only the phases chosen will
+      occur that round. Every player may act in a phase that occurs, but the players who chose that phase get a bonus.
 
 
-      Game end is triggered either when a player has built a civilization of 12 cards or when the pool of VP chips is exhausted. Each player then totals the victory points in their tableau plus any VP chips earned during play.
+      Game end is triggered either when a player has built a civilization of 12 cards or when the pool of VP chips is exhausted.
+      Each player then totals the victory points in their tableau plus any VP chips earned during play.
 
 
       Detailed Overview
 
-      Race for the Galaxy tells a story of galactic discovery and expansion through a single deck of cards. Every card in the deck represents either a world that you might settle or a development that you might implement. Cards placed into your tableau represent your current achievements -- worlds you have colonized, technology you now wield -- while cards in your hand represent the options currently available to you.
+      Race for the Galaxy tells a story of galactic discovery and expansion through a single deck of cards. Every card in
+      the deck represents either a world that you might settle or a development that you might implement. Cards placed into
+      your tableau represent your current achievements -- worlds you have colonized, technology you now wield -- while cards
+      in your hand represent the options currently available to you.
 
 
-      To play a card, discard the number of cards equal to its cost, representing other opportunities you must forgo to concentrate on your current course. Once in your tableau, a card provides special powers during the game and, at the end, its listed number of victory points. Many worlds, once placed, also produce goods that can be traded for more cards or consumed for VP chips.
+      To play a card, discard the number of cards equal to its cost, representing other opportunities you must forgo to concentrate
+      on your current course. Once in your tableau, a card provides special powers during the game and, at the end, its listed
+      number of victory points. Many worlds, once placed, also produce goods that can be traded for more cards or consumed
+      for VP chips.
 
 
-      Race for the Galaxy is played in rounds. In each round, you and your opponents secretly select an action phase for the upcoming turn. You can choose to:
+      Race for the Galaxy is played in rounds. In each round, you and your opponents secretly select an action phase for the
+      upcoming turn. You can choose to:
 
       &bull; Place a world in your tableau with settle or a development with develop.
 
@@ -10247,19 +11507,25 @@ catalog:
       &bull; Add cards to your hand with explore or by trading a good.
 
 
-      Each round, only those phases that are selected will occur -- but they'll occur for everyone. Selecting a phase both ensures that it occurs that round and gains the selecting player a bonus.
+      Each round, only those phases that are selected will occur -- but they''ll occur for everyone. Selecting a phase both
+      ensures that it occurs that round and gains the selecting player a bonus.
 
 
-      Round follows round until someone builds their tableau to twelve cards, or until the last VP chip is claimed. The victor is the player with the most VPs.
+      Round follows round until someone builds their tableau to twelve cards, or until the last VP chip is claimed. The victor
+      is the player with the most VPs.
 
 
       2018 UPDATE
 
-      The second edition of the game is improved for CVD (color blindness) and includes 5 revised cards from the original version and 6 New Worlds promo homeworlds. The promo homeworlds and first edition compatible Revised Cards are both available for purchase through the BGG store.
+      The second edition of the game is improved for CVD (color blindness) and includes 5 revised cards from the original
+      version and 6 New Worlds promo homeworlds. The promo homeworlds and first edition compatible Revised Cards are both
+      available for purchase through the BGG store.
 
 
       UPC 655132003018
 
+
+      '
     yearPublished: 2007
     minPlayers: 2
     maxPlayers: 4
@@ -10310,26 +11576,36 @@ catalog:
     - Wargames Club Publishing
     - YOKA Games
     - Ystari Games
+    pdfBlobKey: rulebooks/v1/race-for-the-galaxy_rulebook.pdf
+    pdfSha256: a43d7ee00276e963ea7afd327711cd52cee609712a8128e0f4a164290c2754d4
+    pdfVersion: '1.0'
   - title: Voidfall
     bggId: 338111
     language: en
-    pdf: voidfall_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      A trick-taking card game with cards featuring photos of contemporary United States Navy aircraft, surface ships, and submarines.
+    description: 'A trick-taking card game with cards featuring photos of contemporary United States Navy aircraft, surface
+      ships, and submarines.
 
 
-      The cards are marked with letters from A to Z and some of the cards are numbered as well (i.e. A1, A2, A3, A4). At the start of the game, each player is dealt seven cards. The goal is to capture the most Navy equipment by winning tricks. The highest card played wins the trick, with A being the highest and Z being the lowest. In addition, among the numbered cards with the same letter, the highest number wins (so B4 beats B2).
+      The cards are marked with letters from A to Z and some of the cards are numbered as well (i.e. A1, A2, A3, A4). At the
+      start of the game, each player is dealt seven cards. The goal is to capture the most Navy equipment by winning tricks.
+      The highest card played wins the trick, with A being the highest and Z being the lowest. In addition, among the numbered
+      cards with the same letter, the highest number wins (so B4 beats B2).
 
 
-      At the end of the game a player receives 10 points for each card having a number and 5 points for each card that only has a letter. A player can score a bonus 100 points during the game if the cards in the player's hand spell out N-A-V-Y, J-E-T, or S-H-I-P. The first player to reach 1000 points wins the game.
+      At the end of the game a player receives 10 points for each card having a number and 5 points for each card that only
+      has a letter. A player can score a bonus 100 points during the game if the cards in the player''s hand spell out N-A-V-Y,
+      J-E-T, or S-H-I-P. The first player to reach 1000 points wins the game.
 
 
-      The contents include the rules folder, 54 cards, a score pad, and a small cardboard box-insert tray. The rules folder provides a description of each photo used on the cards.
+      The contents include the rules folder, 54 cards, a score pad, and a small cardboard box-insert tray. The rules folder
+      provides a description of each photo used on the cards.
 
 
       &mdash;user summary
 
+
+      '
     yearPublished: 1957
     minPlayers: 2
     maxPlayers: 6
@@ -10354,21 +11630,19 @@ catalog:
     - (Uncredited)
     publishers:
     - Exclusive Playing Card Company
+    pdfBlobKey: rulebooks/v1/voidfall_rulebook.pdf
+    pdfSha256: 29847a547dcec0deac860cfb658cd3ea694dcaab319258fcf286c27161243157
+    pdfVersion: '1.0'
   - title: 'Wingspan: Asia'
     bggId: 366161
     language: en
-    pdf: wingspan-asia_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Wingspan: Asia introduces the diverse and vibrant birds of the Asian continent. As always, the objective is to earn the most points by playing birds, achieving objectives, and laying eggs across your habitats. This release serves multiple roles within the Wingspan universe!
-
-
-      Wingspan: Asia is several different things:
-        - a stand-alone game for 1 or 2 players 
-        - a new Duet mode for 2 players that can be combined with the base game or other expansions
-        - For 1-5 players, new bird and bonus cards to add to the original Wingspan and its other expansions
-        - For 6-7 players, a new Flock mode (which also requires the components of the base game).
-
+    description: "Wingspan: Asia introduces the diverse and vibrant birds of the Asian continent. As always, the objective\
+      \ is to earn the most points by playing birds, achieving objectives, and laying eggs across your habitats. This release\
+      \ serves multiple roles within the Wingspan universe!\n\nWingspan: Asia is several different things:\n  - a stand-alone\
+      \ game for 1 or 2 players \n  - a new Duet mode for 2 players that can be combined with the base game or other expansions\n\
+      \  - For 1-5 players, new bird and bonus cards to add to the original Wingspan and its other expansions\n  - For 6-7\
+      \ players, a new Flock mode (which also requires the components of the base game).\n\n"
     yearPublished: 2022
     minPlayers: 1
     maxPlayers: 2
@@ -10415,20 +11689,33 @@ catalog:
     - Regatul Jocurilor
     - Siam Board Games
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/wingspan-asia_rulebook.pdf
+    pdfSha256: a3bef7f481236d2a6bd57a184b07b3001c6fa171602935c42885a1c0f2cf8f26
+    pdfVersion: '1.0'
   - title: Five Tribes
     bggId: 157354
     language: en
-    pdf: five-tribes_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Crossing into the Land of 1001 Nights, your caravan arrives at the fabled Sultanate of Naqala. The old sultan just died and control of Naqala is up for grabs! The oracles foretold of strangers who would maneuver the Five Tribes to gain influence over the legendary city-state. Will you fulfill the prophecy? Invoke the old Djinns and move the Tribes into position at the right time, and the Sultanate may become yours!
+    description: 'Crossing into the Land of 1001 Nights, your caravan arrives at the fabled Sultanate of Naqala. The old sultan
+      just died and control of Naqala is up for grabs! The oracles foretold of strangers who would maneuver the Five Tribes
+      to gain influence over the legendary city-state. Will you fulfill the prophecy? Invoke the old Djinns and move the Tribes
+      into position at the right time, and the Sultanate may become yours!
 
 
-      Designed by Bruno Cathala, Five Tribes builds on a long tradition of German-style games that feature wooden meeples. Here, in a unique twist on the now-standard "worker placement" genre, the game begins with the meeples already in place &ndash; and players must cleverly maneuver them over the villages, markets, oases, and sacred places tiles that make up Naqala. How, when, and where you dis-place these Five Tribes of Assassins, Elders, Builders, Merchants, and Viziers determine your victory or failure.
+      Designed by Bruno Cathala, Five Tribes builds on a long tradition of German-style games that feature wooden meeples.
+      Here, in a unique twist on the now-standard "worker placement" genre, the game begins with the meeples already in place
+      &ndash; and players must cleverly maneuver them over the villages, markets, oases, and sacred places tiles that make
+      up Naqala. How, when, and where you dis-place these Five Tribes of Assassins, Elders, Builders, Merchants, and Viziers
+      determine your victory or failure.
 
 
-      As befitting a Days of Wonder game, the rules are straightforward and easy to learn. But devising a winning strategy will take a more calculated approach than our standard fare. You need to carefully consider what moves can score you well and put your opponents at a disadvantage. You need to weigh many different pathways to victory, including the summoning of powerful Djinns that may help your cause as you attempt to control this legendary Sultanate.
+      As befitting a Days of Wonder game, the rules are straightforward and easy to learn. But devising a winning strategy
+      will take a more calculated approach than our standard fare. You need to carefully consider what moves can score you
+      well and put your opponents at a disadvantage. You need to weigh many different pathways to victory, including the summoning
+      of powerful Djinns that may help your cause as you attempt to control this legendary Sultanate.
 
+
+      '
     yearPublished: 2014
     minPlayers: 2
     maxPlayers: 4
@@ -10471,26 +11758,38 @@ catalog:
     - Lord of Boards
     - Maldito Games
     - Rebel Sp. z o.o.
+    pdfBlobKey: rulebooks/v1/five-tribes_rulebook.pdf
+    pdfSha256: 0175a44d57b48636164db12a54458641cd0c9064205b9cb70de184af769512d8
+    pdfVersion: '1.0'
   - title: Final Girl
     bggId: 277659
     language: en
-    pdf: final-girl_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Playing on a famous horror movie trope, Final Girl is a solitaire-only game that puts the player in the shoes of a female protagonist who must kill the slasher if she wants to survive.
+    description: 'Playing on a famous horror movie trope, Final Girl is a solitaire-only game that puts the player in the
+      shoes of a female protagonist who must kill the slasher if she wants to survive.
 
 
-      The Core Box, when combined with one of our Feature Film Boxes, has everything you need to play the game. Each Feature Film Box features a unique Killer and and iconic Location, and the more Feature Films you have, the more killer/location combinations you can experience!
+      The Core Box, when combined with one of our Feature Film Boxes, has everything you need to play the game. Each Feature
+      Film Box features a unique Killer and and iconic Location, and the more Feature Films you have, the more killer/location
+      combinations you can experience!
 
 
-      In game terms, Final Girl shares similarities with Hostage Negotiator, but with some key differences that change it up, including a game board to track locations and character movement. You can choose from multiple characters when picking someone to play and multiple killers when picking someone to play against. Killers and locations each have their own specific terror cards that will be shuffled together to create a unique experience with various combinations of scenarios for you to play!
+      In game terms, Final Girl shares similarities with Hostage Negotiator, but with some key differences that change it
+      up, including a game board to track locations and character movement. You can choose from multiple characters when picking
+      someone to play and multiple killers when picking someone to play against. Killers and locations each have their own
+      specific terror cards that will be shuffled together to create a unique experience with various combinations of scenarios
+      for you to play!
 
 
-      NOTE: The 2022 Kickstarter for Final Girl: Season 2 included a 13 card Final Girl: First Printing Correction Pack of corrected cards for the first printing of Final Girl: Series 1. The cards mostly fix typos and are not required to play the game. The cards were corrected for the second printing of Final Girl: Series 1.
+      NOTE: The 2022 Kickstarter for Final Girl: Season 2 included a 13 card Final Girl: First Printing Correction Pack of
+      corrected cards for the first printing of Final Girl: Series 1. The cards mostly fix typos and are not required to play
+      the game. The cards were corrected for the second printing of Final Girl: Series 1.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2021
     minPlayers: 1
     maxPlayers: 1
@@ -10526,34 +11825,56 @@ catalog:
     - Ludofun
     - Raven Distribution
     - REXhry
+    pdfBlobKey: rulebooks/v1/final-girl_rulebook.pdf
+    pdfSha256: df546c716dbdb555ed98d12ca896e57ffb82213cbb0e8f5ecc2603a8b076d15d
+    pdfVersion: '1.0'
   - title: Fields of Arle
     bggId: 159675
     language: en
-    pdf: fields-of-arle_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Welcome to Arle
+    description: 'Welcome to Arle
 
-      In Fields of Arle, created by Uwe Rosenberg, one to two players live as farmers in the small and peaceful town of Arle in East Frisia. The flax grown in the land surrounding the village makes it a profitable place to work and live. Fields of Arle takes players through four and a half years of this era of prosperity, with different opportunities available as the seasons change. Farm the land to capitalize on the demand for flax, or find other ways to make the most of the small town&rsquo;s prosperity.
+      In Fields of Arle, created by Uwe Rosenberg, one to two players live as farmers in the small and peaceful town of Arle
+      in East Frisia. The flax grown in the land surrounding the village makes it a profitable place to work and live. Fields
+      of Arle takes players through four and a half years of this era of prosperity, with different opportunities available
+      as the seasons change. Farm the land to capitalize on the demand for flax, or find other ways to make the most of the
+      small town&rsquo;s prosperity.
 
 
       Work the Land
 
-      Whether you delve into flax farming or leverage other areas of expertise, always make sure that you have the land to build up your village. Construct dikes to keep the waters at bay and expand your fields. Dry out bogs to harvest peat and then clear the land for cultivation. Create more fields for your livestock, buildings, or future crops; after that, you can decide whether to house animals or cultivate a forest for timber. Perhaps you&rsquo;d like to take up some flax farming for yourself, or diversify and try out a little bit of everything.
+      Whether you delve into flax farming or leverage other areas of expertise, always make sure that you have the land to
+      build up your village. Construct dikes to keep the waters at bay and expand your fields. Dry out bogs to harvest peat
+      and then clear the land for cultivation. Create more fields for your livestock, buildings, or future crops; after that,
+      you can decide whether to house animals or cultivate a forest for timber. Perhaps you&rsquo;d like to take up some flax
+      farming for yourself, or diversify and try out a little bit of everything.
 
 
       Tools of the Trade
 
-      At the outset of each half year, you&rsquo;ll choose how you&rsquo;d like to spend that time working. There are many ways to build your fortune. Use the Master space to increase the tools at your disposal, focus on the Cattle Trainer to make the most of your livestock, or build up your fleet of vehicles and ship out goods. Taking stock of your progress differs depending on the season. You may milk your existing livestock or care for a bunch of newborn animals. You could harvest your flax in the fall, and shear your sheep in spring. At the end of each half year, you&rsquo;ll need to take stock of your progress by unloading your vehicles and feeding your family and animals, so keep an eye on the season and do your best to keep the farm growing and everyone well fed!
+      At the outset of each half year, you&rsquo;ll choose how you&rsquo;d like to spend that time working. There are many
+      ways to build your fortune. Use the Master space to increase the tools at your disposal, focus on the Cattle Trainer
+      to make the most of your livestock, or build up your fleet of vehicles and ship out goods. Taking stock of your progress
+      differs depending on the season. You may milk your existing livestock or care for a bunch of newborn animals. You could
+      harvest your flax in the fall, and shear your sheep in spring. At the end of each half year, you&rsquo;ll need to take
+      stock of your progress by unloading your vehicles and feeding your family and animals, so keep an eye on the season
+      and do your best to keep the farm growing and everyone well fed!
 
 
       Travel and Prosper
 
-      Once you&rsquo;ve made headway in clearing fields and stocking up goods, it's time to make your products available to potential buyers. The more vehicles you have, the more goods you can ship. Send things into the wide world to increase your Travel Experience and grant you points over the course of the four and a half years of the game. Build up your farm and your vehicles and get your goods out into the world to make the most of every season. There are many roads to success in Fields of Arle, so pick your path, work the land, and enjoy the friendly competition as you strive to make your fortune!
+      Once you&rsquo;ve made headway in clearing fields and stocking up goods, it''s time to make your products available
+      to potential buyers. The more vehicles you have, the more goods you can ship. Send things into the wide world to increase
+      your Travel Experience and grant you points over the course of the four and a half years of the game. Build up your
+      farm and your vehicles and get your goods out into the world to make the most of every season. There are many roads
+      to success in Fields of Arle, so pick your path, work the land, and enjoy the friendly competition as you strive to
+      make your fortune!
 
 
-      - from the publisher's website
+      - from the publisher''s website
 
+
+      '
     yearPublished: 2014
     minPlayers: 1
     maxPlayers: 2
@@ -10589,20 +11910,32 @@ catalog:
     - Mandala Jogos
     - テンデイズゲームズ (TendaysGames)
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/fields-of-arle_rulebook.pdf
+    pdfSha256: a7d44d5d0f033a0a32b55da417a1031fcda41a45cfdc834ffca174056b0753ca
+    pdfVersion: '1.0'
   - title: 'Eclipse: New Dawn for the Galaxy'
     bggId: 72125
     language: en
-    pdf: eclipse_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      The galaxy has been a peaceful place for many years. After the ruthless Terran&ndash;Hegemony War (30.027&ndash;33.364), much effort has been employed by all major spacefaring species to prevent the terrifying events from repeating themselves. The Galactic Council was formed to enforce precious peace, and it has taken many courageous efforts to prevent the escalation of malicious acts. Nevertheless, tension and discord are growing among the seven major species and in the Council itself. Old alliances are shattering, and hasty diplomatic treaties are made in secrecy. A confrontation of the superpowers seems inevitable &ndash; only the outcome of the galactic conflict remains to be seen. Which faction will emerge victorious and lead the galaxy under its rule?
+    description: 'The galaxy has been a peaceful place for many years. After the ruthless Terran&ndash;Hegemony War (30.027&ndash;33.364),
+      much effort has been employed by all major spacefaring species to prevent the terrifying events from repeating themselves.
+      The Galactic Council was formed to enforce precious peace, and it has taken many courageous efforts to prevent the escalation
+      of malicious acts. Nevertheless, tension and discord are growing among the seven major species and in the Council itself.
+      Old alliances are shattering, and hasty diplomatic treaties are made in secrecy. A confrontation of the superpowers
+      seems inevitable &ndash; only the outcome of the galactic conflict remains to be seen. Which faction will emerge victorious
+      and lead the galaxy under its rule?
 
 
-      A game of Eclipse places you in control of a vast interstellar civilization, competing for success with its rivals. You will explore new star systems, research technologies, and build spaceships with which to wage war. There are many potential paths to victory, so you need to plan your strategy according to the strengths and weaknesses of your species, while paying attention to the other civilizations' endeavors.
+      A game of Eclipse places you in control of a vast interstellar civilization, competing for success with its rivals.
+      You will explore new star systems, research technologies, and build spaceships with which to wage war. There are many
+      potential paths to victory, so you need to plan your strategy according to the strengths and weaknesses of your species,
+      while paying attention to the other civilizations'' endeavors.
 
 
       The shadows of the great civilizations are about to eclipse the galaxy. Lead your people to victory!
 
+
+      '
     yearPublished: 2011
     minPlayers: 2
     maxPlayers: 6
@@ -10641,6 +11974,9 @@ catalog:
     - Korea Boardgames
     - Rebel Sp. z o.o.
     - Ystari Games
+    pdfBlobKey: rulebooks/v1/eclipse_rulebook.pdf
+    pdfSha256: bd13229470079df4df34fb2c6b1126172985b89b856984f5fb9f46a160370b79
+    pdfVersion: '1.0'
   defaultAgent:
     name: MeepleAssistant POC
     model: anthropic/claude-3-haiku

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/prod.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/prod.yml
@@ -9258,6 +9258,8 @@ catalog:
     pdfBlobKey: rulebooks/v1/skytear_rulebook.pdf
     pdfSha256: 2f316d16c5001b55097b9966c7c697bbde6a50e7e5c9b1c3df336ff5c3775960
     pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Skytear%3A%20Arena%20of%20Legends
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Skytear%3A%20Arena%20of%20Legends
   - title: Terra Mystica
     bggId: 120677
     language: en
@@ -10919,6 +10921,8 @@ catalog:
     pdfBlobKey: rulebooks/v1/great-western-trail-argentina_rulebook.pdf
     pdfSha256: 88be4a0b83dda037566941e46d1e936ec6280c37e9860c0405a58a9bd412c2fa
     pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Great%20Western%20Trail%3A%20Argentina
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Great%20Western%20Trail%3A%20Argentina
   - title: Agricola (Revised Edition)
     bggId: 200680
     language: en
@@ -11460,6 +11464,8 @@ catalog:
     pdfBlobKey: rulebooks/v1/voidfall_rulebook.pdf
     pdfSha256: 29847a547dcec0deac860cfb658cd3ea694dcaab319258fcf286c27161243157
     pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Voidfall
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Voidfall
   - title: 'Wingspan: Asia'
     bggId: 366161
     language: en

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/staging.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/staging.yml
@@ -9254,76 +9254,7 @@ catalog:
   - title: 'Skytear: Arena of Legends'
     bggId: 373106
     language: en
-    bggEnhanced: true
-    description: 'Sky Team is a co-operative game, exclusively for two players, in which you play a pilot and co-pilot at
-      the controls of an airliner. Your goal is to work together as a team to land your airplane in different airports around
-      the world.
-
-
-      To land your plane, you need to silently assign your dice to the correct spaces in your cockpit to balance the axis
-      of your plane, control its speed, deploy the flaps, extend the landing gear, contact the control tower to clear your
-      path, and even have a little coffee to improve your concentration enough to change the value of your dice.
-
-
-      If the aircraft tilts too much and stalls, overshoots the airport, or collides with another aircraft, you lose the game...and
-      your pilot''s license...and probably your life.
-
-
-      From Montreal to Tokyo, each airport offers its own set of challenges. Watch out for the turbulence as this could end
-      up being a bumpy ride!
-
-
-      &mdash;description from the publisher
-
-
-      '
-    yearPublished: 2023
-    minPlayers: 2
-    maxPlayers: 2
-    playingTime: 20
-    minAge: 10
-    averageRating: 8.12
-    averageWeight: 2.04
-    imageUrl: https://cf.geekdo-images.com/uXMeQzNenHb3zK7Hoa6b2w__original/img/mWOQnkpyYBorh_Y1-0Y2o-ew17k=/0x0/filters:format(jpeg)/pic7398904.jpg
-    thumbnailUrl: https://cf.geekdo-images.com/uXMeQzNenHb3zK7Hoa6b2w__small/img/WyPClajMWU9lV5BdCXiZnqdZgmU=/fit-in/200x150/filters:strip_icc()/pic7398904.jpg
-    fallbackImageUrl: https://cf.geekdo-images.com/uXMeQzNenHb3zK7Hoa6b2w__original/img/mWOQnkpyYBorh_Y1-0Y2o-ew17k=/0x0/filters:format(jpeg)/pic7398904.jpg
-    fallbackThumbnailUrl: https://cf.geekdo-images.com/uXMeQzNenHb3zK7Hoa6b2w__small/img/WyPClajMWU9lV5BdCXiZnqdZgmU=/fit-in/200x150/filters:strip_icc()/pic7398904.jpg
-    categories:
-    - Aviation / Flight
-    - Dice
-    mechanics:
-    - Communication Limits
-    - Cooperative Game
-    - Dice Rolling
-    - Scenario / Mission / Campaign Game
-    - 'Turn Order: Progressive'
-    - Variable Player Powers
-    - Variable Set-up
-    - Worker Placement with Dice Workers
-    designers:
-    - Luc Rémond
-    publishers:
-    - Scorpion Masqué
-    - 999 Games
-    - ADC Blackfire Entertainment
-    - asmodee
-    - Brädspel.se
-    - Galápagos Jogos
-    - Games4you
-    - Geekach LLC
-    - Hachette Boardgames USA
-    - Kaissa Chess & Games
-    - KOSMOS
-    - Lautapelit.fi
-    - Lavka Games
-    - Lucky Duck Games
-    - Reflexshop
-    - Regatul Jocurilor
-    - Salta da Caixa
-    - Spilbræt.dk
-    - Sugorokuya
-    - Tabletop KZ
-    - YOKA Games
+    bggEnhanced: false
     pdfBlobKey: rulebooks/v1/skytear_rulebook.pdf
     pdfSha256: 2f316d16c5001b55097b9966c7c697bbde6a50e7e5c9b1c3df336ff5c3775960
     pdfVersion: '1.0'
@@ -10984,64 +10915,7 @@ catalog:
   - title: 'Great Western Trail: Argentina'
     bggId: 380607
     language: en
-    bggEnhanced: true
-    description: 'Kia ora, and welcome to Great Western Trail New Zealand!
-
-
-      Towards the end of the 19th century, you established yourself as a runholder (owner of a sheep station) on the South
-      Island of New Zealand. Recent years have seen your family farm prosper by diversifying your breeds of sheep and increasing
-      the value of your wool.
-
-
-      With the dawn of the new century, difficult challenges have arisen. You must acquire improved and valuable breeds of
-      sheep to ensure the prosperity of your family business and the labourers who work for you. Decide whether to focus on
-      your past strengths or to diversify into new ventures. Will the beginning of the 20th century be as rewarding as earlier
-      years, or will the efforts of others surpass your strategy? Good luck, and kia kaha!
-
-
-      In Great Western Trail New Zealand, you move your runholder along a trail that winds and forks from the lower left corner
-      of the game board to Wellington in the upper right. Along your path, you perform actions that provide you with various
-      ways to earn victory points.
-
-
-      Each time your runholder reaches Wellington, you deliver sheep to a local or foreign trading post, which may also be
-      worth victory points. Afterwards, your runholder continues its movement again.
-
-
-      '
-    yearPublished: 2023
-    minPlayers: 1
-    maxPlayers: 4
-    playingTime: 150
-    minAge: 12
-    averageRating: 8.47
-    averageWeight: 4.01
-    imageUrl: https://cf.geekdo-images.com/X4KaD6ADLW1ohOznNay7xg__original/img/HhxsLMIsz6Te567qXEbRBen4Sm8=/0x0/filters:format(png)/pic7350809.png
-    thumbnailUrl: https://cf.geekdo-images.com/X4KaD6ADLW1ohOznNay7xg__small/img/iCWpe4ydO3Rtu6yBjn01eQ97xLc=/fit-in/200x150/filters:strip_icc()/pic7350809.png
-    fallbackImageUrl: https://cf.geekdo-images.com/X4KaD6ADLW1ohOznNay7xg__original/img/HhxsLMIsz6Te567qXEbRBen4Sm8=/0x0/filters:format(png)/pic7350809.png
-    fallbackThumbnailUrl: https://cf.geekdo-images.com/X4KaD6ADLW1ohOznNay7xg__small/img/iCWpe4ydO3Rtu6yBjn01eQ97xLc=/fit-in/200x150/filters:strip_icc()/pic7350809.png
-    categories:
-    - Animals
-    mechanics:
-    - Deck, Bag, and Pool Building
-    - Hand Management
-    - Ownership
-    - Set Collection
-    - Solo / Solitaire Game
-    - Track Movement
-    - Variable Set-up
-    designers:
-    - Alexander Pfister
-    publishers:
-    - eggertspiele
-    - Arclight Games
-    - Delta Vision Publishing
-    - Ediciones MasQueOca
-    - Galápagos Jogos
-    - Ghenos Games
-    - Rebel Sp. z o.o.
-    - Yayoi The Dreamer
-    - Zvezda
+    bggEnhanced: false
     pdfBlobKey: rulebooks/v1/great-western-trail-argentina_rulebook.pdf
     pdfSha256: 88be4a0b83dda037566941e46d1e936ec6280c37e9860c0405a58a9bd412c2fa
     pdfVersion: '1.0'
@@ -11582,54 +11456,7 @@ catalog:
   - title: Voidfall
     bggId: 338111
     language: en
-    bggEnhanced: true
-    description: 'A trick-taking card game with cards featuring photos of contemporary United States Navy aircraft, surface
-      ships, and submarines.
-
-
-      The cards are marked with letters from A to Z and some of the cards are numbered as well (i.e. A1, A2, A3, A4). At the
-      start of the game, each player is dealt seven cards. The goal is to capture the most Navy equipment by winning tricks.
-      The highest card played wins the trick, with A being the highest and Z being the lowest. In addition, among the numbered
-      cards with the same letter, the highest number wins (so B4 beats B2).
-
-
-      At the end of the game a player receives 10 points for each card having a number and 5 points for each card that only
-      has a letter. A player can score a bonus 100 points during the game if the cards in the player''s hand spell out N-A-V-Y,
-      J-E-T, or S-H-I-P. The first player to reach 1000 points wins the game.
-
-
-      The contents include the rules folder, 54 cards, a score pad, and a small cardboard box-insert tray. The rules folder
-      provides a description of each photo used on the cards.
-
-
-      &mdash;user summary
-
-
-      '
-    yearPublished: 1957
-    minPlayers: 2
-    maxPlayers: 6
-    playingTime: 45
-    minAge: 9
-    averageRating: 0
-    averageWeight: 0
-    imageUrl: https://cf.geekdo-images.com/NSNqLPStIevgazzFvDjBXg__original/img/IBBihaLB4Gf7bfMVbyrWiyHFzrQ=/0x0/filters:format(jpeg)/pic6166941.jpg
-    thumbnailUrl: https://cf.geekdo-images.com/NSNqLPStIevgazzFvDjBXg__small/img/wGkH7Z1C44mG3xCZ1NyOgpbWge8=/fit-in/200x150/filters:strip_icc()/pic6166941.jpg
-    fallbackImageUrl: https://cf.geekdo-images.com/NSNqLPStIevgazzFvDjBXg__original/img/IBBihaLB4Gf7bfMVbyrWiyHFzrQ=/0x0/filters:format(jpeg)/pic6166941.jpg
-    fallbackThumbnailUrl: https://cf.geekdo-images.com/NSNqLPStIevgazzFvDjBXg__small/img/wGkH7Z1C44mG3xCZ1NyOgpbWge8=/fit-in/200x150/filters:strip_icc()/pic6166941.jpg
-    categories:
-    - Aviation / Flight
-    - Card Game
-    - Modern Warfare
-    - Nautical
-    mechanics:
-    - Race
-    - Set Collection
-    - Trick-taking
-    designers:
-    - (Uncredited)
-    publishers:
-    - Exclusive Playing Card Company
+    bggEnhanced: false
     pdfBlobKey: rulebooks/v1/voidfall_rulebook.pdf
     pdfSha256: 29847a547dcec0deac860cfb658cd3ea694dcaab319258fcf286c27161243157
     pdfVersion: '1.0'

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/staging.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/staging.yml
@@ -4,23 +4,38 @@ catalog:
   - title: Catan
     bggId: 13
     language: en
-    pdf: catan_en_rulebook.pdf
     seedAgent: true
     fallbackImageUrl: https://cf.geekdo-images.com/W3Bsga_uLP9kO91gZ7H8yw__original/img/IwRwEpu1I6YfkyYjFIekCh80ntc=/0x0/filters:format(jpeg)/pic2419375.jpg
     fallbackThumbnailUrl: https://cf.geekdo-images.com/W3Bsga_uLP9kO91gZ7H8yw__small/img/7a0LOL48K-2lC3IG0HyYT3XxJBs=/fit-in/200x150/filters:strip_icc()/pic2419375.jpg
     bggEnhanced: true
-    description: >+
-      In CATAN (formerly The Settlers of Catan), players try to be the dominant force on the island of Catan by building settlements, cities and roads. On each turn dice are rolled to determine which resources the island produces. Players build structures by 'spending' resources (sheep, wheat, wood, brick and ore) which are represented by the relevant resource cards; each land type, with the exception of the unproductive desert, produces a specific resource: hills produce brick, forests produce wood, mountains produce ore, fields produce wheat, and pastures produce sheep.
+    description: 'In CATAN (formerly The Settlers of Catan), players try to be the dominant force on the island of Catan by
+      building settlements, cities and roads. On each turn dice are rolled to determine which resources the island produces.
+      Players build structures by ''spending'' resources (sheep, wheat, wood, brick and ore) which are represented by the
+      relevant resource cards; each land type, with the exception of the unproductive desert, produces a specific resource:
+      hills produce brick, forests produce wood, mountains produce ore, fields produce wheat, and pastures produce sheep.
 
 
-      Set-up includes randomly placing large hexagonal tiles (each depicting one of the five resource-producing terrain types--or the desert) in a honeycomb shape and surrounding them with water tiles, some of which contain ports of exchange. A number disk, the value of which will correspond to the roll of two 6-sided dice, are placed on each terrain tile. Each player is given two settlements (think: houses) and roads (sticks) which are placed on intersections and borders of the terrain tiles. Players collect a hand of resource cards based on which terrain tiles their last-placed settlement is adjacent to. A robber pawn is placed on the desert tile.
+      Set-up includes randomly placing large hexagonal tiles (each depicting one of the five resource-producing terrain types--or
+      the desert) in a honeycomb shape and surrounding them with water tiles, some of which contain ports of exchange. A number
+      disk, the value of which will correspond to the roll of two 6-sided dice, are placed on each terrain tile. Each player
+      is given two settlements (think: houses) and roads (sticks) which are placed on intersections and borders of the terrain
+      tiles. Players collect a hand of resource cards based on which terrain tiles their last-placed settlement is adjacent
+      to. A robber pawn is placed on the desert tile.
 
 
-      A turn consists of rolling the dice, collecting resource cards based on this dice roll and the position of settlements (or upgraded cities&mdash;think: hotels), turning in resource cards (if possible and desired) for improvements, trading cards at a port, possibly playing a development card, or trading resource cards with other players. If the dice roll is a 7, the active player moves the robber to a new terrain tile and steals a resource card from another player who has a settlement adjacent to that tile.
+      A turn consists of rolling the dice, collecting resource cards based on this dice roll and the position of settlements
+      (or upgraded cities&mdash;think: hotels), turning in resource cards (if possible and desired) for improvements, trading
+      cards at a port, possibly playing a development card, or trading resource cards with other players. If the dice roll
+      is a 7, the active player moves the robber to a new terrain tile and steals a resource card from another player who
+      has a settlement adjacent to that tile.
 
 
-      Points are accumulated by building settlements and cities, having the longest road or the largest army (from some of the development cards), and gathering certain development cards that simply award victory points. When a player has gathered 10 points (some of which may be held in secret), s/he announces this and claims the win.
+      Points are accumulated by building settlements and cities, having the longest road or the largest army (from some of
+      the development cards), and gathering certain development cards that simply award victory points. When a player has
+      gathered 10 points (some of which may be held in secret), s/he announces this and claims the win.
 
+
+      '
     yearPublished: 1995
     minPlayers: 3
     maxPlayers: 4
@@ -105,33 +120,24 @@ catalog:
     - Top Toys
     - TRY SOFT
     - Vennerød Forlag AS
+    pdfBlobKey: rulebooks/v1/catan_en_rulebook.pdf
+    pdfSha256: 0d81a40c1d4eb5eb438a62f80d71cdaab5f00404722c3cfa0b106d79b635ebc6
+    pdfVersion: '1.0'
   - title: Wingspan
     bggId: 266192
     language: en
-    pdf: wingspan_en_rulebook.pdf
     fallbackImageUrl: https://cf.geekdo-images.com/yLZJCVLlIx4c7eJEWUNJ7w__original/img/cI782Zis9cT66j2MjSHKJGnFPNw=/0x0/filters:format(jpeg)/pic4458123.jpg
     fallbackThumbnailUrl: https://cf.geekdo-images.com/yLZJCVLlIx4c7eJEWUNJ7w__small/img/VNToqgS2-pOGU6MuvIkMPKn_y-s=/fit-in/200x150/filters:strip_icc()/pic4458123.jpg
     bggEnhanced: true
-    description: >+
-      Wingspan is&nbsp;a competitive, medium-weight, card-driven, engine-building board game from Stonemaier Games. It's designed by Elizabeth Hargrave and features 180 birds illustrated by Natalia Rojas and Ana Maria Martinez.
-
-
-      You are bird enthusiasts&mdash;researchers, bird watchers, ornithologists, and collectors&mdash;seeking to discover and attract the best birds to your network of wildlife preserves. Each bird extends a chain of powerful combinations in one of your habitats (actions). These habitats  focus on several key aspects of growth:
-
-
-           Gain food tokens via custom dice in a birdfeeder dice tower
-           Lay eggs using egg miniatures in a variety of colors
-           Draw from hundreds of unique bird cards and play them
-
-
-      The winner is the player with the most points after 4 rounds.
-
-
-      &mdash;description from the publisher
-
-
-      From the 7th printing on, the base game box includes Wingspan: Swift-Start Promo Pack.
-
+    description: "Wingspan is&nbsp;a competitive, medium-weight, card-driven, engine-building board game from Stonemaier Games.\
+      \ It's designed by Elizabeth Hargrave and features 180 birds illustrated by Natalia Rojas and Ana Maria Martinez.\n\n\
+      You are bird enthusiasts&mdash;researchers, bird watchers, ornithologists, and collectors&mdash;seeking to discover\
+      \ and attract the best birds to your network of wildlife preserves. Each bird extends a chain of powerful combinations\
+      \ in one of your habitats (actions). These habitats  focus on several key aspects of growth:\n\n\n     Gain food tokens\
+      \ via custom dice in a birdfeeder dice tower\n     Lay eggs using egg miniatures in a variety of colors\n     Draw from\
+      \ hundreds of unique bird cards and play them\n\n\nThe winner is the player with the most points after 4 rounds.\n\n\
+      &mdash;description from the publisher\n\nFrom the 7th printing on, the base game box includes Wingspan: Swift-Start\
+      \ Promo Pack.\n\n"
     yearPublished: 2019
     minPlayers: 1
     maxPlayers: 5
@@ -187,19 +193,29 @@ catalog:
     - Siam Board Games
     - Surfin' Meeple China
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/wingspan_en_rulebook.pdf
+    pdfSha256: eb6b55b5224dcc6619d1145f4055cd3ed1be7f5bc301ff3953b94277ebd93e51
+    pdfVersion: '1.0'
   - title: Azul
     bggId: 230802
     language: en
-    pdf: azul_rulebook.pdf
     fallbackImageUrl: https://cf.geekdo-images.com/aPSHJO0d0XOpQR5X-wJonw__original/img/AkbtYVc6xXJF3c9EUrakklcclKw=/0x0/filters:format(png)/pic6973671.png
     fallbackThumbnailUrl: https://cf.geekdo-images.com/aPSHJO0d0XOpQR5X-wJonw__small/img/ccsXKrdGJw-YSClWwzVUwk5Nh9Y=/fit-in/200x150/filters:strip_icc()/pic6973671.png
     bggEnhanced: true
-    description: >+
-      Introduced by the Moors, azulejos (originally white and blue ceramic tiles) were fully embraced by the Portuguese when their king Manuel I, on a visit to the Alhambra palace in Southern Spain, was mesmerized by the stunning beauty of the Moorish decorative tiles. The king, awestruck by the interior beauty of the Alhambra, immediately ordered that his own palace in Portugal be decorated with similar wall tiles. As a tile-laying artist, you have been challenged to embellish the walls of the Royal Palace of Evora.
+    description: 'Introduced by the Moors, azulejos (originally white and blue ceramic tiles) were fully embraced by the Portuguese
+      when their king Manuel I, on a visit to the Alhambra palace in Southern Spain, was mesmerized by the stunning beauty
+      of the Moorish decorative tiles. The king, awestruck by the interior beauty of the Alhambra, immediately ordered that
+      his own palace in Portugal be decorated with similar wall tiles. As a tile-laying artist, you have been challenged to
+      embellish the walls of the Royal Palace of Evora.
 
 
-      In the game Azul, players take turns drafting colored tiles from suppliers to their player board. Later in the round, players score points based on how they've placed their tiles to decorate the palace. Extra points are scored for specific patterns and completing sets; wasted supplies harm the player's score. The player with the most points at the end of the game wins.
+      In the game Azul, players take turns drafting colored tiles from suppliers to their player board. Later in the round,
+      players score points based on how they''ve placed their tiles to decorate the palace. Extra points are scored for specific
+      patterns and completing sets; wasted supplies harm the player''s score. The player with the most points at the end of
+      the game wins.
 
+
+      '
     yearPublished: 2017
     minPlayers: 2
     maxPlayers: 4
@@ -250,35 +266,32 @@ catalog:
     - Tower Tactic Games
     - TWOPLUS Games
     - Zvezda
+    pdfBlobKey: rulebooks/v1/azul_rulebook.pdf
+    pdfSha256: 407a5ae91d219a72dfad0fd600fd9bf4ee2f9690e9726ae74fb7240d9a1a6911
+    pdfVersion: '1.0'
   - title: 'Descent: Journeys in the Dark (Second Edition)'
     bggId: 104162
     language: en
-    pdf: descent_rulebook.pdf
     seedAgent: true
     fallbackImageUrl: https://cf.geekdo-images.com/ZTkiJEPvz2O3vmMJWfjrbw__original/img/GZJIjJPJKk1a4Bx-rM-3KL6O4hk=/0x0/filters:format(jpeg)/pic1180640.jpg
     fallbackThumbnailUrl: https://cf.geekdo-images.com/ZTkiJEPvz2O3vmMJWfjrbw__small/img/cO_2QvC_2BCb-Smd0xp4a5G2n-s=/fit-in/200x150/filters:strip_icc()/pic1180640.jpg
     bggEnhanced: true
-    description: >+
-      In Descent: Journeys in the Dark (Second Edition), one player takes on the role of the treacherous overlord, and up to four other players take on the roles of courageous heroes. During each game, the heroes embark on quests and venture into dangerous caves, ancient ruins, dark dungeons, and cursed forests to battle monsters, earn riches, and attempt to stop the overlord from carrying out his vile plot. Featuring double-sided modular board pieces, countless hero and skill combinations, and an immersive story-driven campaign, Descent: Journeys in the Dark (Second Edition) transports heroes to a vibrant fantasy realm where they must stand together against an ancient evil.
-
-
-      With danger lurking in every shadow, combat is a necessity. For such times, Descent: Journeys in the Dark (Second Edition) uses a unique dice-based system. Players build their dice pools according to their character's abilities and weapons, and each die in the pool contributes to an attack in different ways. Surges, special symbols that appear on most dice, also let you trigger special effects to make the most of your attacks. And with the horrors awaiting you beneath the surface, you'll need every advantage you can take...
-
-
-      Compared to the first edition of Descent: Journeys in the Dark, this game features:
-
-
-           Simpler rules for determining line of sight 
-           Faster setup of each encounter
-           Defense dice to mitigate the tendency to "math out" attacks
-           Shorter quests with plenty of natural stopping points
-           Cards that list necessary statistics, conditions, and effects
-           A new mechanism for controlling the overlord powers
-           Enhanced hero selection and creation process
-           Experience system to allow for hero growth and development
-           Out-of-the-box campaign system
-
-
+    description: "In Descent: Journeys in the Dark (Second Edition), one player takes on the role of the treacherous overlord,\
+      \ and up to four other players take on the roles of courageous heroes. During each game, the heroes embark on quests\
+      \ and venture into dangerous caves, ancient ruins, dark dungeons, and cursed forests to battle monsters, earn riches,\
+      \ and attempt to stop the overlord from carrying out his vile plot. Featuring double-sided modular board pieces, countless\
+      \ hero and skill combinations, and an immersive story-driven campaign, Descent: Journeys in the Dark (Second Edition)\
+      \ transports heroes to a vibrant fantasy realm where they must stand together against an ancient evil.\n\nWith danger\
+      \ lurking in every shadow, combat is a necessity. For such times, Descent: Journeys in the Dark (Second Edition) uses\
+      \ a unique dice-based system. Players build their dice pools according to their character's abilities and weapons, and\
+      \ each die in the pool contributes to an attack in different ways. Surges, special symbols that appear on most dice,\
+      \ also let you trigger special effects to make the most of your attacks. And with the horrors awaiting you beneath the\
+      \ surface, you'll need every advantage you can take...\n\nCompared to the first edition of Descent: Journeys in the\
+      \ Dark, this game features:\n\n\n     Simpler rules for determining line of sight \n     Faster setup of each encounter\n\
+      \     Defense dice to mitigate the tendency to \"math out\" attacks\n     Shorter quests with plenty of natural stopping\
+      \ points\n     Cards that list necessary statistics, conditions, and effects\n     A new mechanism for controlling the\
+      \ overlord powers\n     Enhanced hero selection and creation process\n     Experience system to allow for hero growth\
+      \ and development\n     Out-of-the-box campaign system\n\n\n"
     yearPublished: 2012
     minPlayers: 1
     maxPlayers: 5
@@ -327,20 +340,31 @@ catalog:
     - Heidelberger Spieleverlag
     - Hobby World
     - Wargames Club Publishing
+    pdfBlobKey: rulebooks/v1/descent_rulebook.pdf
+    pdfSha256: 8ae7fd3d1887aad1c1f8aeb10881526dbf7431fd1099b3bcb486748ea0c4a4aa
+    pdfVersion: '1.0'
   - title: Codenames
     bggId: 178900
     language: en
-    pdf: codenames_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Two rival spymasters know the secret identities of 25 agents. Their teammates know the agents only by their codenames &mdash; single-word labels like "disease", "Germany", and "carrot". Yes, carrot. It's a legitimate codename. Each spymaster wants their team to identify their agents first...without uncovering the assassin by mistake.
+    description: 'Two rival spymasters know the secret identities of 25 agents. Their teammates know the agents only by their
+      codenames &mdash; single-word labels like "disease", "Germany", and "carrot". Yes, carrot. It''s a legitimate codename.
+      Each spymaster wants their team to identify their agents first...without uncovering the assassin by mistake.
 
 
-      In Codenames, two teams compete to see who can make contact with all of their agents first. Lay out 25 cards, each bearing a single word. The spymasters look at a card showing the identity of each card, then take turns clueing their teammates. A clue consists of a single word and a number, with the number suggesting how many cards in play have some association to the given clue word. The teammates then identify one agent they think is on their team; if they're correct, they can keep guessing up to one more than the stated number of times; if the agent belongs to the opposing team or is an innocent bystander, the team's turn ends; and if they fingered the assassin, they lose the game.
+      In Codenames, two teams compete to see who can make contact with all of their agents first. Lay out 25 cards, each bearing
+      a single word. The spymasters look at a card showing the identity of each card, then take turns clueing their teammates.
+      A clue consists of a single word and a number, with the number suggesting how many cards in play have some association
+      to the given clue word. The teammates then identify one agent they think is on their team; if they''re correct, they
+      can keep guessing up to one more than the stated number of times; if the agent belongs to the opposing team or is an
+      innocent bystander, the team''s turn ends; and if they fingered the assassin, they lose the game.
 
 
-      Spymasters continue giving clues until one team has identified all of their agents or the assassin has removed one team from play.
+      Spymasters continue giving clues until one team has identified all of their agents or the assassin has removed one team
+      from play.
 
+
+      '
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 8
@@ -405,32 +429,52 @@ catalog:
     - SuperHeated Neurons
     - TWOPLUS Games
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/codenames_rulebook.pdf
+    pdfSha256: bf6ae8c47ede4e824587cd3506c4ab1fb81f51c96514a0a19df86a5c92441f11
+    pdfVersion: '1.0'
   - title: Terraforming Mars
     bggId: 167791
     language: en
-    pdf: terraforming-mars_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In the 2400s, mankind begins to terraform the planet Mars. Giant corporations, sponsored by the World Government on Earth, initiate huge projects to raise the temperature, the oxygen level, and the ocean coverage until the environment is habitable. In Terraforming Mars, you play one of those corporations and work together in the terraforming process, but compete for getting victory points that are awarded not only for your contribution to the terraforming, but also for advancing human infrastructure throughout the solar system, and doing other commendable things.
+    description: 'In the 2400s, mankind begins to terraform the planet Mars. Giant corporations, sponsored by the World Government
+      on Earth, initiate huge projects to raise the temperature, the oxygen level, and the ocean coverage until the environment
+      is habitable. In Terraforming Mars, you play one of those corporations and work together in the terraforming process,
+      but compete for getting victory points that are awarded not only for your contribution to the terraforming, but also
+      for advancing human infrastructure throughout the solar system, and doing other commendable things.
 
 
-      As a player, you acquire unique project cards (from over two hundred different ones) by buying them to your hand. The cards can give you immediate bonuses, as well as increasing your production of different resources. Many cards also have requirements and they become playable when the temperature, oxygen, or ocean coverage increases enough. Buying cards is costly, so there is a balance between buying cards and actually playing them. Standard Projects are always available to complement your hand of cards. Your basic income, as well as your basic score, are based on your Terraform Rating. However, your income is boosted by your production, and VPs are also gained from many other sources.
+      As a player, you acquire unique project cards (from over two hundred different ones) by buying them to your hand. The
+      cards can give you immediate bonuses, as well as increasing your production of different resources. Many cards also
+      have requirements and they become playable when the temperature, oxygen, or ocean coverage increases enough. Buying
+      cards is costly, so there is a balance between buying cards and actually playing them. Standard Projects are always
+      available to complement your hand of cards. Your basic income, as well as your basic score, are based on your Terraform
+      Rating. However, your income is boosted by your production, and VPs are also gained from many other sources.
 
 
-      You keep track of your production and resources on your player board.  The game uses six types of resources: MegaCredits, Steel, Titanium, Plants, Energy, and Heat. On the game board, you compete for the best places for your city tiles, ocean tiles, and greenery tiles. You also compete for different Milestones and Awards worth many VPs. Each round is called a generation and consists of the following phases:
+      You keep track of your production and resources on your player board.  The game uses six types of resources: MegaCredits,
+      Steel, Titanium, Plants, Energy, and Heat. On the game board, you compete for the best places for your city tiles, ocean
+      tiles, and greenery tiles. You also compete for different Milestones and Awards worth many VPs. Each round is called
+      a generation and consists of the following phases:
 
 
       1) Player order shifts clockwise.
 
       2) Research phase: All players buy cards from four privately drawn.
 
-      3) Action phase: Players take turns doing 1-2 actions from these options: Playing a card, claiming a Milestone, funding an Award, using a Standard project, converting plant into greenery tiles (and raising oxygen), converting heat into a temperature raise, and using the action of a card in play. The turn continues around the table (sometimes several laps) until all players have passed.
+      3) Action phase: Players take turns doing 1-2 actions from these options: Playing a card, claiming a Milestone, funding
+      an Award, using a Standard project, converting plant into greenery tiles (and raising oxygen), converting heat into
+      a temperature raise, and using the action of a card in play. The turn continues around the table (sometimes several
+      laps) until all players have passed.
 
       4) Production phase: Players get resources according to their terraform rating and production parameters.
 
 
-      When the three global parameters (temperature, oxygen, ocean) have all reached their required levels, the terraforming is complete, and the game ends after that generation. Combine your Terraform Rating and other VPs to determine the winning corporation!
+      When the three global parameters (temperature, oxygen, ocean) have all reached their required levels, the terraforming
+      is complete, and the game ends after that generation. Combine your Terraform Rating and other VPs to determine the winning
+      corporation!
 
+
+      '
     yearPublished: 2016
     minPlayers: 1
     maxPlayers: 5
@@ -494,23 +538,38 @@ catalog:
     - Stronghold Games
     - SuperHeated Neurons
     - Surfin' Meeple China
+    pdfBlobKey: rulebooks/v1/terraforming-mars_rulebook.pdf
+    pdfSha256: 97d5923d4e05c8b492c6f6b8937a9226936c6e39f8627dddeac81d5b6927aabe
+    pdfVersion: '1.0'
   - title: 7 Wonders
     bggId: 68448
     language: en
-    pdf: 7-wonders_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      You are the leader of one of the 7 great cities of the Ancient World. Gather resources, develop commercial routes, and affirm your military supremacy. Build your city and erect an architectural wonder which will transcend future times.
+    description: 'You are the leader of one of the 7 great cities of the Ancient World. Gather resources, develop commercial
+      routes, and affirm your military supremacy. Build your city and erect an architectural wonder which will transcend future
+      times.
 
 
-      7 Wonders lasts three ages. In each age, players receive seven cards from a particular deck, choose one of those cards, then pass the remainder to an adjacent player. Players reveal their cards simultaneously, paying resources if needed or collecting resources or interacting with other players in various ways. (Players have individual boards with special powers on which to organize their cards, and the boards are double-sided). Each player then chooses another card from the deck they were passed, and the process repeats until players have six cards in play from that age. After three ages, the game ends.
+      7 Wonders lasts three ages. In each age, players receive seven cards from a particular deck, choose one of those cards,
+      then pass the remainder to an adjacent player. Players reveal their cards simultaneously, paying resources if needed
+      or collecting resources or interacting with other players in various ways. (Players have individual boards with special
+      powers on which to organize their cards, and the boards are double-sided). Each player then chooses another card from
+      the deck they were passed, and the process repeats until players have six cards in play from that age. After three ages,
+      the game ends.
 
 
-      In essence, 7 Wonders is a card development game. Some cards have immediate effects, while others provide bonuses or upgrades later in the game. Some cards provide discounts on future purchases. Some provide military strength to overpower your neighbors and others give nothing but victory points. Each card is played immediately after being drafted, so you'll know which cards your neighbor is receiving and how her choices might affect what you've already built up. Cards are passed left-right-left over the three ages, so you need to keep an eye on the neighbors in both directions.
+      In essence, 7 Wonders is a card development game. Some cards have immediate effects, while others provide bonuses or
+      upgrades later in the game. Some cards provide discounts on future purchases. Some provide military strength to overpower
+      your neighbors and others give nothing but victory points. Each card is played immediately after being drafted, so you''ll
+      know which cards your neighbor is receiving and how her choices might affect what you''ve already built up. Cards are
+      passed left-right-left over the three ages, so you need to keep an eye on the neighbors in both directions.
 
 
-      Though the box of earlier editions is listed as being for 3&ndash;7 players, there is an official 2-player variant included in the instructions.
+      Though the box of earlier editions is listed as being for 3&ndash;7 players, there is an official 2-player variant included
+      in the instructions.
 
+
+      '
     yearPublished: 2010
     minPlayers: 2
     maxPlayers: 7
@@ -559,27 +618,39 @@ catalog:
     - NeoTroy Games
     - Rebel Sp. z o.o.
     - Siam Board Games
+    pdfBlobKey: rulebooks/v1/7-wonders_rulebook.pdf
+    pdfSha256: 5b719f677c830066b0493cd6ea5f2808e512ce9cbf72fa0fe80aa09127182849
+    pdfVersion: '1.0'
   - title: Ticket to Ride
     bggId: 9209
     language: en
-    pdf: ticket-to-ride_rulebook.pdf
     seedAgent: true
     bggEnhanced: true
-    description: >+
-      With elegantly simple gameplay, Ticket to Ride can be learned in under 15 minutes. Players collect cards of various types of train cars they then use to claim railway routes in North America. The longer the routes, the more points they earn. Additional points come to those who fulfill Destination Tickets &ndash; goal cards that connect distant cities; and to the player who builds the longest continuous route.
+    description: 'With elegantly simple gameplay, Ticket to Ride can be learned in under 15 minutes. Players collect cards
+      of various types of train cars they then use to claim railway routes in North America. The longer the routes, the more
+      points they earn. Additional points come to those who fulfill Destination Tickets &ndash; goal cards that connect distant
+      cities; and to the player who builds the longest continuous route.
 
 
-      "The rules are simple enough to write on a train ticket &ndash; each turn you either draw more cards, claim a route, or get additional Destination Tickets," says Ticket to Ride author, Alan R. Moon. "The tension comes from being forced to balance greed &ndash; adding more cards to your hand, and fear &ndash; losing a critical route to a competitor."
+      "The rules are simple enough to write on a train ticket &ndash; each turn you either draw more cards, claim a route,
+      or get additional Destination Tickets," says Ticket to Ride author, Alan R. Moon. "The tension comes from being forced
+      to balance greed &ndash; adding more cards to your hand, and fear &ndash; losing a critical route to a competitor."
 
 
-      Ticket to Ride continues in the tradition of Days of Wonder's big format board games featuring high-quality illustrations and components including: an oversize board map of North America, 225 custom-molded train cars, 144 illustrated cards, and wooden scoring markers.
+      Ticket to Ride continues in the tradition of Days of Wonder''s big format board games featuring high-quality illustrations
+      and components including: an oversize board map of North America, 225 custom-molded train cars, 144 illustrated cards,
+      and wooden scoring markers.
 
 
-      Since its introduction and numerous subsequent awards, Ticket to Ride has become the BoardGameGeek epitome of a "gateway game" -- simple enough to be taught in a few minutes, and with enough action and tension to keep new players involved and in the game for the duration.
+      Since its introduction and numerous subsequent awards, Ticket to Ride has become the BoardGameGeek epitome of a "gateway
+      game" -- simple enough to be taught in a few minutes, and with enough action and tension to keep new players involved
+      and in the game for the duration.
 
 
       Part of the Ticket to Ride series.
 
+
+      '
     yearPublished: 2004
     minPlayers: 2
     maxPlayers: 5
@@ -624,21 +695,32 @@ catalog:
     - Rebel Sp. z o.o.
     - Siam Board Games
     - Swan Panasia Co., Ltd.
+    pdfBlobKey: rulebooks/v1/ticket-to-ride_rulebook.pdf
+    pdfSha256: fac2dfc144c7709aadcb9be1423c7ba1ffe72f427e3eab5ebc0c03cada7f91ff
+    pdfVersion: '1.0'
   - title: Splendor
     bggId: 148228
     language: en
-    pdf: splendor_rulebook.pdf
     seedAgent: true
     bggEnhanced: true
-    description: >+
-      Splendor is a game of chip-collecting and card development. Players are merchants of the Renaissance trying to buy gem mines, means of transportation, shops&mdash;all in order to acquire the most prestige points. If you're wealthy enough, you might even receive a visit from a noble at some point, which of course will further increase your prestige.
+    description: 'Splendor is a game of chip-collecting and card development. Players are merchants of the Renaissance trying
+      to buy gem mines, means of transportation, shops&mdash;all in order to acquire the most prestige points. If you''re
+      wealthy enough, you might even receive a visit from a noble at some point, which of course will further increase your
+      prestige.
 
 
-      On your turn, you may (1) collect chips (gems), or (2) buy and build a card, or (3) reserve one card. If you collect chips, you take either three different kinds of chips or two chips of the same kind. If you buy a card, you pay its price in chips and add it to your playing area. To reserve a card&mdash;in order to make sure you get it, or, why not, your opponents don't get it&mdash;you place it in front of you face down for later building; this costs you a round, but you also get gold in the form of a joker chip, which you can use as any gem.
+      On your turn, you may (1) collect chips (gems), or (2) buy and build a card, or (3) reserve one card. If you collect
+      chips, you take either three different kinds of chips or two chips of the same kind. If you buy a card, you pay its
+      price in chips and add it to your playing area. To reserve a card&mdash;in order to make sure you get it, or, why not,
+      your opponents don''t get it&mdash;you place it in front of you face down for later building; this costs you a round,
+      but you also get gold in the form of a joker chip, which you can use as any gem.
 
 
-      All of the cards you buy increase your wealth as they give you a permanent gem bonus for later buys; some of the cards also give you prestige points. In order to win the game, you must reach 15 prestige points before your opponents do.
+      All of the cards you buy increase your wealth as they give you a permanent gem bonus for later buys; some of the cards
+      also give you prestige points. In order to win the game, you must reach 15 prestige points before your opponents do.
 
+
+      '
     yearPublished: 2014
     minPlayers: 2
     maxPlayers: 4
@@ -690,19 +772,28 @@ catalog:
     - Rebel Sp. z o.o.
     - Siam Board Games
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/splendor_rulebook.pdf
+    pdfSha256: f4423dfde0c9bf7bb71d3ab1a5f87823f8c90857b84b83541bc9cd43727dc6a1
+    pdfVersion: '1.0'
   - title: 'Ticket to Ride: Europe'
     bggId: 14996
     language: en
-    pdf: ticket-to-ride-europe_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Ticket to Ride: Europe takes you on a new train adventure across Europe. From Edinburgh to Constantinople and from Lisbon to Moscow, you'll visit great cities of turn-of-the-century Europe. Like the original Ticket to Ride, the game remains elegantly simple, can be learned in 5 minutes, and appeals to both families and experienced gamers. Ticket to Ride: Europe is a complete, new game and does not require the original version.
+    description: 'Ticket to Ride: Europe takes you on a new train adventure across Europe. From Edinburgh to Constantinople
+      and from Lisbon to Moscow, you''ll visit great cities of turn-of-the-century Europe. Like the original Ticket to Ride,
+      the game remains elegantly simple, can be learned in 5 minutes, and appeals to both families and experienced gamers.
+      Ticket to Ride: Europe is a complete, new game and does not require the original version.
 
 
-      More than just a new map, Ticket to Ride: Europe features brand new gameplay elements. Tunnels may require you to pay extra cards to build on them, Ferries require locomotive cards in order to claim them, and Stations allow you to sacrifice a few points in order to use an opponent's route to connect yours. The game also includes larger format cards and Train Station game pieces.
+      More than just a new map, Ticket to Ride: Europe features brand new gameplay elements. Tunnels may require you to pay
+      extra cards to build on them, Ferries require locomotive cards in order to claim them, and Stations allow you to sacrifice
+      a few points in order to use an opponent''s route to connect yours. The game also includes larger format cards and Train
+      Station game pieces.
 
 
-      The overall goal remains the same: collect and play train cards in order to place your pieces on the board, attempting to connect cities on your ticket cards. Points are earned both from placing trains and completing tickets but uncompleted tickets lose you points. The player who has the most points at the end of the game wins.
+      The overall goal remains the same: collect and play train cards in order to place your pieces on the board, attempting
+      to connect cities on your ticket cards. Points are earned both from placing trains and completing tickets but uncompleted
+      tickets lose you points. The player who has the most points at the end of the game wins.
 
 
       Copyright 2002-2014 Days of Wonder, inc.
@@ -710,6 +801,8 @@ catalog:
 
       Part of the Ticket to Ride series.
 
+
+      '
     yearPublished: 2005
     minPlayers: 2
     maxPlayers: 5
@@ -761,25 +854,38 @@ catalog:
     - Runadrake
     - Smart Ltd
     - Well Designed Game
+    pdfBlobKey: rulebooks/v1/ticket-to-ride-europe_rulebook.pdf
+    pdfSha256: 9dc1f4210477d61dcd9b1baed990f4080fe372b657f6531f6e57c98197487fae
+    pdfVersion: '1.0'
   - title: Dominion
     bggId: 36218
     language: en
-    pdf: dominion_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      "You are a monarch, like your parents before you, a ruler of a small pleasant kingdom of rivers and evergreens. Unlike your parents, however, you have hopes and dreams! You want a bigger and more pleasant kingdom, with more rivers and a wider variety of trees. You want a Dominion! In all directions lie fiefs, freeholds, and feodums. All are small bits of land, controlled by petty lords and verging on anarchy. You will bring civilization to these people, uniting them under your banner.
+    description: '"You are a monarch, like your parents before you, a ruler of a small pleasant kingdom of rivers and evergreens.
+      Unlike your parents, however, you have hopes and dreams! You want a bigger and more pleasant kingdom, with more rivers
+      and a wider variety of trees. You want a Dominion! In all directions lie fiefs, freeholds, and feodums. All are small
+      bits of land, controlled by petty lords and verging on anarchy. You will bring civilization to these people, uniting
+      them under your banner.
 
 
-      But wait! It must be something in the air; several other monarchs have had the exact same idea. You must race to get as much of the unclaimed land as possible, fending them off along the way. To do this you will hire minions, construct buildings, spruce up your castle, and fill the coffers of your treasury. Your parents wouldn't be proud, but your grandparents, on your mother's side, would be delighted."
+      But wait! It must be something in the air; several other monarchs have had the exact same idea. You must race to get
+      as much of the unclaimed land as possible, fending them off along the way. To do this you will hire minions, construct
+      buildings, spruce up your castle, and fill the coffers of your treasury. Your parents wouldn''t be proud, but your grandparents,
+      on your mother''s side, would be delighted."
 
 
       &mdash;description from the back of the box
 
 
-      In Dominion, each player starts with an identical, very small deck of cards.  In the center of the table is a selection of other cards the players can "buy" as they can afford them.  Through their selection of cards to buy, and how they play their hands as they draw them, the players construct their deck on the fly, striving for the most efficient path to the precious victory points by game end.
+      In Dominion, each player starts with an identical, very small deck of cards.  In the center of the table is a selection
+      of other cards the players can "buy" as they can afford them.  Through their selection of cards to buy, and how they
+      play their hands as they draw them, the players construct their deck on the fly, striving for the most efficient path
+      to the precious victory points by game end.
 
 
-      Dominion is not a Collectible Card Game (CCG), but the play of the game is similar to the construction and play of a CCG deck. The game comes with 500 cards. You select 10 of the 25 Kingdom card types to include in any given play&mdash;leading to immense variety.
+      Dominion is not a Collectible Card Game (CCG), but the play of the game is similar to the construction and play of a
+      CCG deck. The game comes with 500 cards. You select 10 of the 25 Kingdom card types to include in any given play&mdash;leading
+      to immense variety.
 
 
       &mdash;user summary
@@ -787,6 +893,8 @@ catalog:
 
       Part of the Dominion series.
 
+
+      '
     yearPublished: 2008
     minPlayers: 2
     maxPlayers: 4
@@ -834,23 +942,43 @@ catalog:
     - Swan Panasia Co., Ltd.
     - Vennerød Forlag AS
     - Ystari Games
+    pdfBlobKey: rulebooks/v1/dominion_rulebook.pdf
+    pdfSha256: ea9e3fbef0064e6773c8772bbb234ac7d06c71a478422b45143432a29aa64273
+    pdfVersion: '1.0'
   - title: Scythe
     bggId: 169786
     language: en
-    pdf: scythe_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      It is a time of unrest in 1920s Europa. The ashes from the first great war still darken the snow. The capitalistic city-state known simply as &ldquo;The Factory&rdquo;, which fueled the war with heavily armored mechs, has closed its doors, drawing the attention of several nearby countries.
+    description: 'It is a time of unrest in 1920s Europa. The ashes from the first great war still darken the snow. The capitalistic
+      city-state known simply as &ldquo;The Factory&rdquo;, which fueled the war with heavily armored mechs, has closed its
+      doors, drawing the attention of several nearby countries.
 
 
-      Scythe is an engine-building game set in a 1920s era, alternate-history. It is a time of farming and war, broken hearts and rusted gears, innovation and valor. In Scythe, each player controls one of five factions of Eastern Europe, all of which are attempting to earn their fortunes and claim their stakes in the land around the mysterious Factory. Players conquer territory, enlist new recruits, reap resources, gain villagers, build structures, and activate monstrous mechs.
+      Scythe is an engine-building game set in a 1920s era, alternate-history. It is a time of farming and war, broken hearts
+      and rusted gears, innovation and valor. In Scythe, each player controls one of five factions of Eastern Europe, all
+      of which are attempting to earn their fortunes and claim their stakes in the land around the mysterious Factory. Players
+      conquer territory, enlist new recruits, reap resources, gain villagers, build structures, and activate monstrous mechs.
 
 
-      Each player begins the game with different resources (power, coins, combat acumen, and popularity), a different starting location, and a hidden goal. Starting positions are specially calibrated to contribute to each faction&rsquo;s uniqueness and the asymmetrical nature of the game (each faction always starts in the same place). Scythe uses a streamlined action-selection mechanism (no rounds or phases) to keep gameplay moving at a brisk pace and reduce downtime between turns. While there is plenty of direct conflict for players who seek it, there is no player elimination.
+      Each player begins the game with different resources (power, coins, combat acumen, and popularity), a different starting
+      location, and a hidden goal. Starting positions are specially calibrated to contribute to each faction&rsquo;s uniqueness
+      and the asymmetrical nature of the game (each faction always starts in the same place). Scythe uses a streamlined action-selection
+      mechanism (no rounds or phases) to keep gameplay moving at a brisk pace and reduce downtime between turns. While there
+      is plenty of direct conflict for players who seek it, there is no player elimination.
 
 
-      Scythe gives players almost complete control over their fate. Other than each player&rsquo;s individual hidden objective card, the only elements of luck or variability are &ldquo;encounter&rdquo; cards that players will draw as they interact with the citizens of newly explored lands. Each encounter card provides the player with several options, allowing them to mitigate the luck of the draw through their selection. Combat is also driven by choices, not luck or randomness. Every part of Scythe has an aspect of engine-building to it. Players can upgrade actions to become more efficient, build structures that improve their position on the map, enlist new recruits to enhance character abilities, activate mechs to deter opponents from invading, and expand their borders to reap greater types and quantities of resources. These engine-building aspects create a sense of momentum and progress throughout the game. The order in which players improve their engines adds to the unique feel of each game, even if having played one faction multiple times.
+      Scythe gives players almost complete control over their fate. Other than each player&rsquo;s individual hidden objective
+      card, the only elements of luck or variability are &ldquo;encounter&rdquo; cards that players will draw as they interact
+      with the citizens of newly explored lands. Each encounter card provides the player with several options, allowing them
+      to mitigate the luck of the draw through their selection. Combat is also driven by choices, not luck or randomness.
+      Every part of Scythe has an aspect of engine-building to it. Players can upgrade actions to become more efficient, build
+      structures that improve their position on the map, enlist new recruits to enhance character abilities, activate mechs
+      to deter opponents from invading, and expand their borders to reap greater types and quantities of resources. These
+      engine-building aspects create a sense of momentum and progress throughout the game. The order in which players improve
+      their engines adds to the unique feel of each game, even if having played one faction multiple times.
 
+
+      '
     yearPublished: 2016
     minPlayers: 1
     maxPlayers: 5
@@ -908,29 +1036,50 @@ catalog:
     - Planeta Igor
     - Playfun Games
     - Surfin' Meeple China
+    pdfBlobKey: rulebooks/v1/scythe_rulebook.pdf
+    pdfSha256: 3a27021231ff6ceb6401878eb27912ca7ce9455c6d2e7393e29248a80939f606
+    pdfVersion: '1.0'
   - title: Patchwork
     bggId: 163412
     language: en
-    pdf: patchwork_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Patchwork, two players compete to build the most aesthetic (and high-scoring) patchwork quilt on a personal 9x9 game board. To start play, lay out all of the patches at random in a circle and place a marker directly clockwise of the 2-1 patch. Each player takes five buttons &mdash; the currency/points in the game &mdash; and someone is chosen as the start player.
+    description: 'In Patchwork, two players compete to build the most aesthetic (and high-scoring) patchwork quilt on a personal
+      9x9 game board. To start play, lay out all of the patches at random in a circle and place a marker directly clockwise
+      of the 2-1 patch. Each player takes five buttons &mdash; the currency/points in the game &mdash; and someone is chosen
+      as the start player.
 
 
-      On a turn, a player either purchases one of the three patches standing clockwise of the spool or passes. To purchase a patch, you pay the cost in buttons shown on the patch, move the spool to that patch's location in the circle, add the patch to your game board, then advance your time token on the time track a number of spaces equal to the time shown on the patch. You're free to place the patch anywhere on your board that doesn't overlap other patches, but you probably want to fit things together as tightly as possible. If your time token is behind or on top of the other player's time token, then you take another turn; otherwise the opponent now goes. Instead of purchasing a patch, you can choose to pass; to do this, you move your time token to the space immediately in front of the opponent's time token, then take one button from the bank for each space you moved.
+      On a turn, a player either purchases one of the three patches standing clockwise of the spool or passes. To purchase
+      a patch, you pay the cost in buttons shown on the patch, move the spool to that patch''s location in the circle, add
+      the patch to your game board, then advance your time token on the time track a number of spaces equal to the time shown
+      on the patch. You''re free to place the patch anywhere on your board that doesn''t overlap other patches, but you probably
+      want to fit things together as tightly as possible. If your time token is behind or on top of the other player''s time
+      token, then you take another turn; otherwise the opponent now goes. Instead of purchasing a patch, you can choose to
+      pass; to do this, you move your time token to the space immediately in front of the opponent''s time token, then take
+      one button from the bank for each space you moved.
 
 
-      In addition to a button cost and time cost, each patch also features 0-3 buttons, and when you move your time token past a button on the time track, you earn "button income": sum the number of buttons depicted on your personal game board, then take this many buttons from the bank.
+      In addition to a button cost and time cost, each patch also features 0-3 buttons, and when you move your time token
+      past a button on the time track, you earn "button income": sum the number of buttons depicted on your personal game
+      board, then take this many buttons from the bank.
 
 
-      What's more, the time track depicts five 1x1 patches on it, and during set-up you place five actual 1x1 patches on these spaces. Whoever first passes a patch on the time track claims this patch and immediately places it on his game board.
+      What''s more, the time track depicts five 1x1 patches on it, and during set-up you place five actual 1x1 patches on
+      these spaces. Whoever first passes a patch on the time track claims this patch and immediately places it on his game
+      board.
 
 
-      Additionally, the first player to completely fill in a 7x7 square on his game board earns a bonus tile worth 7 extra points at the end of the game. (Of course, this doesn't happen in every game.)
+      Additionally, the first player to completely fill in a 7x7 square on his game board earns a bonus tile worth 7 extra
+      points at the end of the game. (Of course, this doesn''t happen in every game.)
 
 
-      When a player takes an action that moves his time token to the central square of the time track, he takes one final button income from the bank. Once both players are in the center, the game ends and scoring takes place. Each player scores one point per button in his possession, then loses two points for each empty square on his game board. Scores can be negative. The player with the most points wins.
+      When a player takes an action that moves his time token to the central square of the time track, he takes one final
+      button income from the bank. Once both players are in the center, the game ends and scoring takes place. Each player
+      scores one point per button in his possession, then loses two points for each empty square on his game board. Scores
+      can be negative. The player with the most points wins.
 
+
+      '
     yearPublished: 2014
     minPlayers: 2
     maxPlayers: 2
@@ -988,20 +1137,29 @@ catalog:
     - Tower Tactic Games
     - uplay.it edizioni
     - Нескучные игры
+    pdfBlobKey: rulebooks/v1/patchwork_rulebook.pdf
+    pdfSha256: 045325d8717e566f2cdb85196c6ee2ced1c7d484a67e9fc109b042b853b98874
+    pdfVersion: '1.0'
   - title: Love Letter
     bggId: 129622
     language: en
-    pdf: love-letter_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      All of the eligible young men (and many of the not-so-young) seek to woo the princess of Tempest. Unfortunately, she has locked herself in the palace, and you must rely on others to take your romantic letters to her. Will yours reach her first?
+    description: 'All of the eligible young men (and many of the not-so-young) seek to woo the princess of Tempest. Unfortunately,
+      she has locked herself in the palace, and you must rely on others to take your romantic letters to her. Will yours reach
+      her first?
 
 
-      Love Letter is a game of risk, deduction, and luck for 2&ndash;4 players. Your goal is to get your love letter into Princess Annette's hands while deflecting the letters from competing suitors. From a deck with only sixteen cards, each player starts with only one card in hand; one card is removed from play. On a turn, you draw one card, and play one card, trying to expose others and knock them from the game. Powerful cards lead to early gains, but make you a target. Rely on weaker cards for too long, however, and your letter may be tossed in the fire!
+      Love Letter is a game of risk, deduction, and luck for 2&ndash;4 players. Your goal is to get your love letter into
+      Princess Annette''s hands while deflecting the letters from competing suitors. From a deck with only sixteen cards,
+      each player starts with only one card in hand; one card is removed from play. On a turn, you draw one card, and play
+      one card, trying to expose others and knock them from the game. Powerful cards lead to early gains, but make you a target.
+      Rely on weaker cards for too long, however, and your letter may be tossed in the fire!
 
 
       Number 4 in the Setting: Tempest Shared World Game Series
 
+
+      '
     yearPublished: 2012
     minPlayers: 2
     maxPlayers: 4
@@ -1057,29 +1215,39 @@ catalog:
     - Swan Panasia Co., Ltd.
     - uplay.it edizioni
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/love-letter_rulebook.pdf
+    pdfSha256: e6b14614ffa5da73d995eaceefd7ca99e20ea8687b873da9b67ce6f3a5e69655
+    pdfVersion: '1.0'
   - title: King of Tokyo
     bggId: 70323
     language: en
-    pdf: king-of-tokyo_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In King of Tokyo, you play mutant monsters, gigantic robots, and strange aliens&mdash;all of whom are destroying Tokyo and whacking each other in order to become the one and only King of Tokyo.
+    description: 'In King of Tokyo, you play mutant monsters, gigantic robots, and strange aliens&mdash;all of whom are destroying
+      Tokyo and whacking each other in order to become the one and only King of Tokyo.
 
 
-      At the start of each turn, you roll six dice, which show the following six symbols: 1, 2, or 3 Victory Points, Energy, Heal, and Attack. Over three successive throws, choose whether to keep or discard each die in order to win victory points, gain energy, restore health, or attack other players into understanding that Tokyo is YOUR territory.
+      At the start of each turn, you roll six dice, which show the following six symbols: 1, 2, or 3 Victory Points, Energy,
+      Heal, and Attack. Over three successive throws, choose whether to keep or discard each die in order to win victory points,
+      gain energy, restore health, or attack other players into understanding that Tokyo is YOUR territory.
 
 
-      The fiercest player will occupy Tokyo, and earn extra victory points, but that player can't heal and must face all the other monsters alone!
+      The fiercest player will occupy Tokyo, and earn extra victory points, but that player can''t heal and must face all
+      the other monsters alone!
 
 
-      Top this off with special cards purchased with energy that have a permanent or temporary effect, such as the growing of a second head which grants you an additional die, body armor, nova death ray, and more.... and it's one of the most explosive games of the year!
+      Top this off with special cards purchased with energy that have a permanent or temporary effect, such as the growing
+      of a second head which grants you an additional die, body armor, nova death ray, and more.... and it''s one of the most
+      explosive games of the year!
 
 
-      In order to win the game, one must either destroy Tokyo by accumulating 20 victory points, or be the only surviving monster once the fighting has ended.
+      In order to win the game, one must either destroy Tokyo by accumulating 20 victory points, or be the only surviving
+      monster once the fighting has ended.
 
 
       First Game in the King of Tokyo series
 
+
+      '
     yearPublished: 2011
     minPlayers: 2
     maxPlayers: 6
@@ -1144,23 +1312,33 @@ catalog:
     - uplay.it edizioni
     - Vennerød Forlag AS
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/king-of-tokyo_rulebook.pdf
+    pdfSha256: 8ad8bba7f868b3925bb82ba206bd5cc8eab9a1c5d08e2b36fccad615af57e5fe
+    pdfVersion: '1.0'
   - title: Dixit
     bggId: 39856
     language: en
-    pdf: dixit_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Each turn in Dixit, one player is the storyteller who chooses one of the six cards in their hand, then expresses an idea, with sounds or words, that is reflected on that card's image, and places the card face down on the playing surface. Each other player then selects the card that best matches that expression, and passes the selected card to the storyteller, face down.
+    description: 'Each turn in Dixit, one player is the storyteller who chooses one of the six cards in their hand, then expresses
+      an idea, with sounds or words, that is reflected on that card''s image, and places the card face down on the playing
+      surface. Each other player then selects the card that best matches that expression, and passes the selected card to
+      the storyteller, face down.
 
 
-      The storyteller shuffles all the cards together, then turns them over to reveal them. Each player other than the storyteller then secretly guesses which card belongs to the storyteller. If nobody or everybody guesses the correct card, the storyteller scores 0 points, and each other player scores 2 points. Otherwise, the storyteller and whoever found the correct answer score 3 points. Additionally, the non-storyteller players score 1 point for every vote received by their card.
+      The storyteller shuffles all the cards together, then turns them over to reveal them. Each player other than the storyteller
+      then secretly guesses which card belongs to the storyteller. If nobody or everybody guesses the correct card, the storyteller
+      scores 0 points, and each other player scores 2 points. Otherwise, the storyteller and whoever found the correct answer
+      score 3 points. Additionally, the non-storyteller players score 1 point for every vote received by their card.
 
 
-      The game ends when the deck is empty or if a player has scored at least 30 points. In either case, the player with the most points wins.
+      The game ends when the deck is empty or if a player has scored at least 30 points. In either case, the player with the
+      most points wins.
 
 
       The Dixit base game and each expansion contain 84 cards, and the cards can be mixed together as desired.
 
+
+      '
     yearPublished: 2008
     minPlayers: 3
     maxPlayers: 6
@@ -1206,17 +1384,27 @@ catalog:
     - Rebel Sp. z o.o.
     - Swan Panasia Co., Ltd.
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/dixit_rulebook.pdf
+    pdfSha256: 26365f602d44493cb38f63459a904d653c31ac93eb5543f899ca0da20cfd51b7
+    pdfVersion: '1.0'
   - title: Gloomhaven
     bggId: 174430
     language: en
-    pdf: gloomhaven_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Gloomhaven  is a game of Euro-inspired tactical combat in a persistent world of shifting motives. Players will take on the roles of wandering adventurers with their own special sets of skills and their own reasons for traveling to this dark corner of the world. Players must work together out of necessity to clear out menacing dungeons and forgotten ruins. In the process, they will enhance their abilities with experience and loot, discover new locations to explore and plunder, and expand an ever-branching story fueled by the decisions they make.
-       This is a game with a persistent and changing world that is ideally played over many game sessions. After a scenario, players will make decisions about what to do next, which will determine how the story continues, kind of like a &ldquo;Choose Your Own Adventure&rdquo; book. Playing through a scenario is a co-operative affair where players will fight against automated monsters using an innovative card system to determine the order of play and what a player does on their turn.
-
-      Each turn, a player chooses two cards to play out of their hand. The number on the top card determines their initiative for the round. Each card also has a top and bottom power, and when it is a player&rsquo;s turn in the initiative order, they determine whether to use the top power of one card and the bottom power of the other, or vice-versa. Players must be careful, though, because over time they will permanently lose cards from their hands. If they take too long to clear a dungeon, they may end u exhausted and be forced to retreat.
-
+    description: "Gloomhaven  is a game of Euro-inspired tactical combat in a persistent world of shifting motives. Players\
+      \ will take on the roles of wandering adventurers with their own special sets of skills and their own reasons for traveling\
+      \ to this dark corner of the world. Players must work together out of necessity to clear out menacing dungeons and forgotten\
+      \ ruins. In the process, they will enhance their abilities with experience and loot, discover new locations to explore\
+      \ and plunder, and expand an ever-branching story fueled by the decisions they make.\n This is a game with a persistent\
+      \ and changing world that is ideally played over many game sessions. After a scenario, players will make decisions about\
+      \ what to do next, which will determine how the story continues, kind of like a &ldquo;Choose Your Own Adventure&rdquo;\
+      \ book. Playing through a scenario is a co-operative affair where players will fight against automated monsters using\
+      \ an innovative card system to determine the order of play and what a player does on their turn.\n\nEach turn, a player\
+      \ chooses two cards to play out of their hand. The number on the top card determines their initiative for the round.\
+      \ Each card also has a top and bottom power, and when it is a player&rsquo;s turn in the initiative order, they determine\
+      \ whether to use the top power of one card and the bottom power of the other, or vice-versa. Players must be careful,\
+      \ though, because over time they will permanently lose cards from their hands. If they take too long to clear a dungeon,\
+      \ they may end u exhausted and be forced to retreat.\n\n"
     yearPublished: 2017
     minPlayers: 1
     maxPlayers: 4
@@ -1273,29 +1461,41 @@ catalog:
     - Hobby World
     - Korea Boardgames
     - MYBG Co., Ltd.
+    pdfBlobKey: rulebooks/v1/gloomhaven_rulebook.pdf
+    pdfSha256: a8bb3b2e3d875f325d12da48ca4c6fd7807876b3b0353bf4052a74678d339f27
+    pdfVersion: '1.0'
   - title: Small World
     bggId: 40692
     language: en
-    pdf: small-world_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Small World, players vie for conquest and control of a world that is simply too small to accommodate them all.
+    description: 'In Small World, players vie for conquest and control of a world that is simply too small to accommodate
+      them all.
 
 
-      Designed by Philippe Keyaerts as a fantasy follow-up to his award-winning Vinci, Small World is inhabited by a zany cast of characters such as dwarves, wizards, amazons, giants, orcs, and even humans, who use their troops to occupy territory and conquer adjacent lands in order to push the other races off the face of the earth.
+      Designed by Philippe Keyaerts as a fantasy follow-up to his award-winning Vinci, Small World is inhabited by a zany
+      cast of characters such as dwarves, wizards, amazons, giants, orcs, and even humans, who use their troops to occupy
+      territory and conquer adjacent lands in order to push the other races off the face of the earth.
 
 
-      Picking the right combination from the 14 different fantasy races and 20 unique special powers, players rush to expand their empires - often at the expense of weaker neighbors. Yet they must also know when to push their own over-extended civilization into decline and ride a new one to victory!
+      Picking the right combination from the 14 different fantasy races and 20 unique special powers, players rush to expand
+      their empires - often at the expense of weaker neighbors. Yet they must also know when to push their own over-extended
+      civilization into decline and ride a new one to victory!
 
 
-      On each turn, you either use the multiple tiles of your chosen race (type of creatures) to occupy adjacent (normally) territories - possibly defeating weaker enemy races along the way, or you give up on your race letting it go "into decline". A race in decline is designated by flipping the tiles over to their black-and-white side.
+      On each turn, you either use the multiple tiles of your chosen race (type of creatures) to occupy adjacent (normally)
+      territories - possibly defeating weaker enemy races along the way, or you give up on your race letting it go "into decline".
+      A race in decline is designated by flipping the tiles over to their black-and-white side.
 
 
-      At the end of your turn, you score one point (coin) for each territory your races occupy. You may have one active race and one race in decline on the board at the same time. Your occupation total can vary depending on the special abilities of your race and the territories they occupy. After the final round, the player with the most coins wins.
+      At the end of your turn, you score one point (coin) for each territory your races occupy. You may have one active race
+      and one race in decline on the board at the same time. Your occupation total can vary depending on the special abilities
+      of your race and the territories they occupy. After the final round, the player with the most coins wins.
 
 
       Clarifications: available in a pinned forum post.
 
+
+      '
     yearPublished: 2009
     minPlayers: 2
     maxPlayers: 5
@@ -1337,13 +1537,19 @@ catalog:
     - Rebel Sp. z o.o.
     - Siam Board Games
     - Stratelibri
+    pdfBlobKey: rulebooks/v1/small-world_rulebook.pdf
+    pdfSha256: 9accfbeafcd1d650d39746eb79da373f9e9fe1c92f6f3322983d2e30b94b1c2a
+    pdfVersion: '1.0'
   - title: Everdell
     bggId: 199792
     language: en
-    pdf: everdell_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Within the charming valley of Everdell, beneath the boughs of towering trees, among meandering streams and mossy hollows, a civilization of forest critters is thriving and expanding. From Everfrost to Bellsong, many a year have come and gone, but the time has come for new territories to be settled and new cities established. You will be the leader of a group of critters intent on just such a task. There are buildings to construct, lively characters to meet, events to host&mdash;you have a busy year ahead of yourself. Will the sun shine brightest on your city before the winter moon rises?
+    description: 'Within the charming valley of Everdell, beneath the boughs of towering trees, among meandering streams and
+      mossy hollows, a civilization of forest critters is thriving and expanding. From Everfrost to Bellsong, many a year
+      have come and gone, but the time has come for new territories to be settled and new cities established. You will be
+      the leader of a group of critters intent on just such a task. There are buildings to construct, lively characters to
+      meet, events to host&mdash;you have a busy year ahead of yourself. Will the sun shine brightest on your city before
+      the winter moon rises?
 
 
       Everdell is a game of dynamic tableau building and worker placement.
@@ -1352,14 +1558,23 @@ catalog:
       On their turn a player can take one of three actions:
 
 
-      a) Place a Worker: Each player has a collection of Worker pieces. These are placed on the board locations, events, and on Destination cards. Workers perform various actions to further the development of a player's tableau: gathering resources, drawing cards, and taking other special actions.
+      a) Place a Worker: Each player has a collection of Worker pieces. These are placed on the board locations, events, and
+      on Destination cards. Workers perform various actions to further the development of a player''s tableau: gathering resources,
+      drawing cards, and taking other special actions.
 
 
-      b) Play a Card: Each player is building and populating a city; a tableau of up to 15 Construction and Critter cards. There are five types of cards: Travelers, Production, Destination, Governance, and Prosperity. Cards generate resources (twigs, resin, pebbles, and berries), grant abilities, and ultimately score points. The interactions of the cards reveal numerous strategies and a near infinite variety of working cities.
+      b) Play a Card: Each player is building and populating a city; a tableau of up to 15 Construction and Critter cards.
+      There are five types of cards: Travelers, Production, Destination, Governance, and Prosperity. Cards generate resources
+      (twigs, resin, pebbles, and berries), grant abilities, and ultimately score points. The interactions of the cards reveal
+      numerous strategies and a near infinite variety of working cities.
 
 
-      c) Prepare for the next Season: Workers are returned to the players supply and new workers are added. The game is played from Winter through to the onset of the following winter, at which point the player with the city with the most points wins.
+      c) Prepare for the next Season: Workers are returned to the players supply and new workers are added. The game is played
+      from Winter through to the onset of the following winter, at which point the player with the city with the most points
+      wins.
 
+
+      '
     yearPublished: 2018
     minPlayers: 1
     maxPlayers: 4
@@ -1413,80 +1628,41 @@ catalog:
     - White Goblin Games
     - YOKA Games
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/everdell_rulebook.pdf
+    pdfSha256: df74d35f64e90f0f94ed0077140c1ad18a4901cdd54a24c019257a5da671b74b
+    pdfVersion: '1.0'
   - title: Munchkin
     bggId: 1927
     language: en
-    pdf: munchkin_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      				
-      				
-      					Publisher's DescriptionGo down in the dungeon. Kill everything you meet. Backstab your friends and steal their stuff. Grab the treasure and run.
-
-      Admit it. You love it.
-
-
-      This award-winning card game, designed by Steve Jackson, captures the essence of the dungeon experience... with none of that stupid roleplaying stuff. You and your friends compete to kill monsters and grab magic items. And what magic items! Don the Horny Helmet and the Boots of Butt-Kicking. Wield the Staff of Napalm... or maybe the Chainsaw of Bloody Dismemberment. Start by slaughtering the Potted Plant and the Drooling Slime, and work your way up to the Plutonium Dragon...
-
-
-      And it's illustrated by John Kovalic! Fast-playing and silly, Munchkin can reduce any roleplaying group to hysteria. And, while they're laughing, you can steal their stuff.
-
-      				
-      				
-      					OtherPart of the Munchkin series.
-
-      Munchkin is a satirical card game based on the clich&eacute;s and oddities of Dungeons and Dragons and other role-playing games. Each player starts at level 1 and the winner is the first player to reach level 10. Players can acquire familiar D&D style character classes during the game which determine to some extent the cards they can play.
-
-
-      There are two types of cards - treasure and encounters. Each turn the current players 'kicks down the door' - drawing an encounter card from the deck. Usually this will involve battling a monster. Monsters have their own levels and players must try and overcome it using the levels, weapons and powers they have acquired during the game or run away. Other players can chose to help the player or hinder by adding extra monsters to the encounter. Defeating a monster will usually result in drawing treasure cards and acquiring levels.  Being defeated by a monster results in "bad stuff" which usually involves losing levels and treasure.
-
-
-      In May 2010, Steve Jackson Games made the "big announcement." Many rules and cards were changed. See The Great 2010 Munchkin Changeover for details. Of note to Munchkin fans, the Kneepads of Allure card, which had been removed in the 14th printing, was added back to the game but modified to be less powerful.
-
-      				
-      				
-      					Sequels:
-          The Good, the Bad, and the Munchkin
-          Munchkin Apocalypse
-          Munchkin Axe Cop
-          Munchkin Bites!
-          Munchkin Booty
-          Munchkin Conan
-          Munchkin Cthulhu
-          Munchkin Fu
-          Munchkin Impossible
-          Munchkin Legends
-          Munchkin Pathfinder
-          Munchkin Zombies
-          Star Munchkin
-          Super Munchkin
-
-
-      				
-      				
-      					Related Board Games
-          Munchkin Quest
-
-
-      				
-      				
-      					Online play
-           Vassal does not support Munchkin anymore. Former link: Vassal Module
-
-
-      				
-      				
-      					Pegasus Expansions
-          Munchkin Sammlerbox
-          Munchkin Sammlerkoffer
-          Munchkin Promotional Bookmarks
-          Munchkin Weihnachtsedition - The same as Munchkin, but with a promotional button that grants the wearer extra treasure (when worn in December). 
-
-
-      				
-      				
-      					Online PlaythroughThere's a great YouTube playthrough with Will Wheaton and Steve Jackson (yes, the Steve Jackson) found here LINK
-
+    description: "\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tPublisher's DescriptionGo down in the dungeon. Kill everything you meet. Backstab\
+      \ your friends and steal their stuff. Grab the treasure and run.\n\nAdmit it. You love it.\n\nThis award-winning card\
+      \ game, designed by Steve Jackson, captures the essence of the dungeon experience... with none of that stupid roleplaying\
+      \ stuff. You and your friends compete to kill monsters and grab magic items. And what magic items! Don the Horny Helmet\
+      \ and the Boots of Butt-Kicking. Wield the Staff of Napalm... or maybe the Chainsaw of Bloody Dismemberment. Start by\
+      \ slaughtering the Potted Plant and the Drooling Slime, and work your way up to the Plutonium Dragon...\n\nAnd it's\
+      \ illustrated by John Kovalic! Fast-playing and silly, Munchkin can reduce any roleplaying group to hysteria. And, while\
+      \ they're laughing, you can steal their stuff.\n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tOtherPart of the Munchkin series.\n\n\
+      Munchkin is a satirical card game based on the clich&eacute;s and oddities of Dungeons and Dragons and other role-playing\
+      \ games. Each player starts at level 1 and the winner is the first player to reach level 10. Players can acquire familiar\
+      \ D&D style character classes during the game which determine to some extent the cards they can play.\n\nThere are two\
+      \ types of cards - treasure and encounters. Each turn the current players 'kicks down the door' - drawing an encounter\
+      \ card from the deck. Usually this will involve battling a monster. Monsters have their own levels and players must\
+      \ try and overcome it using the levels, weapons and powers they have acquired during the game or run away. Other players\
+      \ can chose to help the player or hinder by adding extra monsters to the encounter. Defeating a monster will usually\
+      \ result in drawing treasure cards and acquiring levels.  Being defeated by a monster results in \"bad stuff\" which\
+      \ usually involves losing levels and treasure.\n\nIn May 2010, Steve Jackson Games made the \"big announcement.\" Many\
+      \ rules and cards were changed. See The Great 2010 Munchkin Changeover for details. Of note to Munchkin fans, the Kneepads\
+      \ of Allure card, which had been removed in the 14th printing, was added back to the game but modified to be less powerful.\n\
+      \n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tSequels:\n    The Good, the Bad, and the Munchkin\n    Munchkin Apocalypse\n    Munchkin\
+      \ Axe Cop\n    Munchkin Bites!\n    Munchkin Booty\n    Munchkin Conan\n    Munchkin Cthulhu\n    Munchkin Fu\n    Munchkin\
+      \ Impossible\n    Munchkin Legends\n    Munchkin Pathfinder\n    Munchkin Zombies\n    Star Munchkin\n    Super Munchkin\n\
+      \n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tRelated Board Games\n    Munchkin Quest\n\n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tOnline\
+      \ play\n     Vassal does not support Munchkin anymore. Former link: Vassal Module\n\n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\t\
+      Pegasus Expansions\n    Munchkin Sammlerbox\n    Munchkin Sammlerkoffer\n    Munchkin Promotional Bookmarks\n    Munchkin\
+      \ Weihnachtsedition - The same as Munchkin, but with a promotional button that grants the wearer extra treasure (when\
+      \ worn in December). \n\n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tOnline PlaythroughThere's a great YouTube playthrough with\
+      \ Will Wheaton and Steve Jackson (yes, the Steve Jackson) found here LINK\n\n"
     yearPublished: 2001
     minPlayers: 3
     maxPlayers: 6
@@ -1541,26 +1717,33 @@ catalog:
     - Ubik
     - Wargames Club Publishing
     - ТРЕТЯ ПЛАНЕТА
+    pdfBlobKey: rulebooks/v1/munchkin_rulebook.pdf
+    pdfSha256: a68e64aa104b6d1746194835ecfaa2bc22324e642a02cadb4be81371bad62e1a
+    pdfVersion: '1.0'
   - title: Forbidden Island
     bggId: 65244
     language: en
-    pdf: forbidden-island_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Forbidden Island is a visually stunning cooperative board game. Instead of winning by competing with other players like most games, everyone must work together to win the game. Players take turns moving their pawns around the 'island', which is built by arranging the many beautifully screen-printed tiles before play begins. As the game progresses, more and more island tiles sink, becoming unavailable, and the pace increases. Players use strategies to keep the island from sinking, while trying to collect treasures and items. As the water level rises, it gets more difficult- sacrifices must be made.
-
-
-      What causes this game to truly stand out among co-op and competitive games alike is the extreme detail that has been paid to the physical components of the game. It comes in a sturdy and organized tin of good shelf storage size. The plastic treasure pieces and wooden pawns are well crafted and they fit just right into the box. The cards are durable, well printed, and easy to understand. The island tiles are the real gem: they are screen-printed with vibrant colors, each with a unique and pleasing image.
-
-
-      With multiple levels of difficulty, different characters to choose from (each with a special ability of their own), many optional island formats and game variations available, Forbidden Island has huge replay value. The game can be played by as few as two players and up to four (though it can accommodate five). More players translates into a faster and more difficult game, though the extra help can make all the difference. This is a fun game, tricky for players of almost any age. Selling for under twenty dollars, oddly, Forbidden Island is a rare game of both quality and affordable price.
-       For those who enjoy Forbidden Island, a follow-up project by Gamewright titled Forbidden Desert was released in 2013.
-
-      From the publisher's website:
-
-
-      Dare to discover Forbidden Island! Join a team of fearless adventurers on a do-or-die mission to capture four sacred treasures from the ruins of this perilous paradise. Your team will have to work together and make some pulse-pounding maneuvers, as the island will sink beneath every step! Race to collect the treasures and make a triumphant escape before you are swallowed into the watery abyss!
-
+    description: "Forbidden Island is a visually stunning cooperative board game. Instead of winning by competing with other\
+      \ players like most games, everyone must work together to win the game. Players take turns moving their pawns around\
+      \ the 'island', which is built by arranging the many beautifully screen-printed tiles before play begins. As the game\
+      \ progresses, more and more island tiles sink, becoming unavailable, and the pace increases. Players use strategies\
+      \ to keep the island from sinking, while trying to collect treasures and items. As the water level rises, it gets more\
+      \ difficult- sacrifices must be made.\n\nWhat causes this game to truly stand out among co-op and competitive games\
+      \ alike is the extreme detail that has been paid to the physical components of the game. It comes in a sturdy and organized\
+      \ tin of good shelf storage size. The plastic treasure pieces and wooden pawns are well crafted and they fit just right\
+      \ into the box. The cards are durable, well printed, and easy to understand. The island tiles are the real gem: they\
+      \ are screen-printed with vibrant colors, each with a unique and pleasing image.\n\nWith multiple levels of difficulty,\
+      \ different characters to choose from (each with a special ability of their own), many optional island formats and game\
+      \ variations available, Forbidden Island has huge replay value. The game can be played by as few as two players and\
+      \ up to four (though it can accommodate five). More players translates into a faster and more difficult game, though\
+      \ the extra help can make all the difference. This is a fun game, tricky for players of almost any age. Selling for\
+      \ under twenty dollars, oddly, Forbidden Island is a rare game of both quality and affordable price.\n For those who\
+      \ enjoy Forbidden Island, a follow-up project by Gamewright titled Forbidden Desert was released in 2013.\n\nFrom the\
+      \ publisher's website:\n\nDare to discover Forbidden Island! Join a team of fearless adventurers on a do-or-die mission\
+      \ to capture four sacred treasures from the ruins of this perilous paradise. Your team will have to work together and\
+      \ make some pulse-pounding maneuvers, as the island will sink beneath every step! Race to collect the treasures and\
+      \ make a triumphant escape before you are swallowed into the watery abyss!\n\n"
     yearPublished: 2010
     minPlayers: 2
     maxPlayers: 4
@@ -1613,26 +1796,39 @@ catalog:
     - Spilbræt.dk
     - uplay.it edizioni
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/forbidden-island_rulebook.pdf
+    pdfSha256: b007c6b6a9385f4e27e74499f5e4623f3360ab7f8301853a4a3df01c6fa71c39
+    pdfVersion: '1.0'
   - title: Root
     bggId: 237182
     language: en
-    pdf: root_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Root is a game of adventure and war in which 2 to 4 (1 to 6 with the 'Riverfolk' expansion, 2-6 with the 'Underworld', or 'Marauder' expansions) players battle for control of a vast wilderness. Like Vast: The Crystal Caverns, each player in Root has unique capabilities and a different victory condition. Now, with the aid of gorgeous, multi-use cards, a truly asymmetric design has never been more accessible.
+    description: 'Root is a game of adventure and war in which 2 to 4 (1 to 6 with the ''Riverfolk'' expansion, 2-6 with the
+      ''Underworld'', or ''Marauder'' expansions) players battle for control of a vast wilderness. Like Vast: The Crystal
+      Caverns, each player in Root has unique capabilities and a different victory condition. Now, with the aid of gorgeous,
+      multi-use cards, a truly asymmetric design has never been more accessible.
 
 
-      The nefarious Marquise de Cat has seized the great woodland, intent on harvesting its riches. Under her rule, the many creatures of the forest have banded together. This Alliance will seek to strengthen its resources and subvert the rule of Cats. In this effort, the Alliance may enlist the help of the wandering Vagabonds who are able to move through the more dangerous woodland paths. Though some may sympathize with the Alliance&rsquo;s hopes and dreams, these wanderers are old enough to remember the great birds of prey who once controlled the woods.
+      The nefarious Marquise de Cat has seized the great woodland, intent on harvesting its riches. Under her rule, the many
+      creatures of the forest have banded together. This Alliance will seek to strengthen its resources and subvert the rule
+      of Cats. In this effort, the Alliance may enlist the help of the wandering Vagabonds who are able to move through the
+      more dangerous woodland paths. Though some may sympathize with the Alliance&rsquo;s hopes and dreams, these wanderers
+      are old enough to remember the great birds of prey who once controlled the woods.
 
 
-      Meanwhile, at the edge of the region, the proud, squabbling Eyrie have found a new commander who they hope will lead their faction to resume their ancient birthright. The stage is set for a contest that will decide the fate of the great woodland. It is up to the players to decide which group will ultimately take root.
+      Meanwhile, at the edge of the region, the proud, squabbling Eyrie have found a new commander who they hope will lead
+      their faction to resume their ancient birthright. The stage is set for a contest that will decide the fate of the great
+      woodland. It is up to the players to decide which group will ultimately take root.
 
 
-      In Root, players drive the narrative, and the differences between each role create an unparalleled level of interaction and replayability. Leder Games invites you and your family to explore the fantastic world of Root!
+      In Root, players drive the narrative, and the differences between each role create an unparalleled level of interaction
+      and replayability. Leder Games invites you and your family to explore the fantastic world of Root!
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2018
     minPlayers: 2
     maxPlayers: 4
@@ -1685,17 +1881,29 @@ catalog:
     - Spielworxx
     - Tower Tactic Games
     - YOKA Games
+    pdfBlobKey: rulebooks/v1/root_rulebook.pdf
+    pdfSha256: e79ca615f78f3f41a20b080f212eaf1da2e91f52af21c41f176c8a09bc5c8328
+    pdfVersion: '1.0'
   - title: Sushi Go!
     bggId: 133473
     language: en
-    pdf: sushi-go_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In the super-fast sushi card game Sushi Go!, you are eating at a sushi restaurant and trying to grab the best combination of sushi dishes as they whiz by. Score points for collecting the most sushi rolls or making a full set of sashimi. Dip your favorite nigiri in wasabi to triple its value! And once you've eaten it all, finish your meal with all the pudding you've got! But be careful which sushi you allow your friends to take; it might be just what they need to beat you!
+    description: 'In the super-fast sushi card game Sushi Go!, you are eating at a sushi restaurant and trying to grab the
+      best combination of sushi dishes as they whiz by. Score points for collecting the most sushi rolls or making a full
+      set of sashimi. Dip your favorite nigiri in wasabi to triple its value! And once you''ve eaten it all, finish your meal
+      with all the pudding you''ve got! But be careful which sushi you allow your friends to take; it might be just what they
+      need to beat you!
 
 
-      Sushi Go! takes the card-drafting mechanism of Fairy Tale and 7 Wonders and distills it into a twenty-minute game that anyone can play. The dynamics of "draft and pass" are brought to the fore, while keeping the rules to a minimum. As you see the first few hands of cards, you must quickly assess the make-up of the round and decide which type of sushi you'll go for. Then, each turn you'll need to weigh which cards to keep and which to pass on. The different scoring combinations allow for some clever plays and nasty blocks. Round to round, you must also keep your eye on the goal of having the most pudding cards at the end of the game!
+      Sushi Go! takes the card-drafting mechanism of Fairy Tale and 7 Wonders and distills it into a twenty-minute game that
+      anyone can play. The dynamics of "draft and pass" are brought to the fore, while keeping the rules to a minimum. As
+      you see the first few hands of cards, you must quickly assess the make-up of the round and decide which type of sushi
+      you''ll go for. Then, each turn you''ll need to weigh which cards to keep and which to pass on. The different scoring
+      combinations allow for some clever plays and nasty blocks. Round to round, you must also keep your eye on the goal of
+      having the most pudding cards at the end of the game!
 
+
+      '
     yearPublished: 2013
     minPlayers: 2
     maxPlayers: 5
@@ -1745,26 +1953,49 @@ catalog:
     - uplay.it edizioni
     - White Goblin Games
     - Zoch Verlag
+    pdfBlobKey: rulebooks/v1/sushi-go_rulebook.pdf
+    pdfSha256: 9c876c63af4e976927e0cf29c366409e6913d5b9e3b558300ad0712b971f3f99
+    pdfVersion: '1.0'
   - title: Spirit Island
     bggId: 162886
     language: en
-    pdf: spirit-island_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In the most distant reaches of the world, magic still exists, embodied by spirits of the land, of the sky, and of every natural thing. As the great powers of Europe stretch their colonial empires further and further, they will inevitably lay claim to a place where spirits still hold power - and when they do, the land itself will fight back alongside the islanders who live there.
+    description: 'In the most distant reaches of the world, magic still exists, embodied by spirits of the land, of the sky,
+      and of every natural thing. As the great powers of Europe stretch their colonial empires further and further, they will
+      inevitably lay claim to a place where spirits still hold power - and when they do, the land itself will fight back alongside
+      the islanders who live there.
 
 
-      Spirit Island is a complex and thematic co-operative game about defending your island home from colonizing Invaders. Players are different spirits of the land, each with its own unique elemental powers. Every turn, players simultaneously choose which of their power cards to play, paying energy to do so. Using combinations of power cards that match a spirit's elemental affinities can grant free bonus effects. Faster powers take effect immediately, before the Invaders spread and ravage, but other magics are slower, requiring forethought and planning to use effectively. In the Spirit phase, spirits gain energy, and choose how / whether to Grow: to reclaim used power cards, to seek new power, or to spread their presence into new areas of the island.
+      Spirit Island is a complex and thematic co-operative game about defending your island home from colonizing Invaders.
+      Players are different spirits of the land, each with its own unique elemental powers. Every turn, players simultaneously
+      choose which of their power cards to play, paying energy to do so. Using combinations of power cards that match a spirit''s
+      elemental affinities can grant free bonus effects. Faster powers take effect immediately, before the Invaders spread
+      and ravage, but other magics are slower, requiring forethought and planning to use effectively. In the Spirit phase,
+      spirits gain energy, and choose how / whether to Grow: to reclaim used power cards, to seek new power, or to spread
+      their presence into new areas of the island.
 
 
-      The Invaders expand across the island map in a semi-predictable fashion. Each turn they explore into some lands (portions of the island); the next turn, they build in those lands, forming towns and cities. The turn after that, they ravage there, bringing blight to the land and attacking any native islanders present. The islanders fight back against the Invaders when attacked, and lend the spirits some other aid, but may not always do so exactly as you'd hoped. Some Powers work through the islanders, helping them, for example, to drive out the Invaders or clean the land of blight.
+      The Invaders expand across the island map in a semi-predictable fashion. Each turn they explore into some lands (portions
+      of the island); the next turn, they build in those lands, forming towns and cities. The turn after that, they ravage
+      there, bringing blight to the land and attacking any native islanders present. The islanders fight back against the
+      Invaders when attacked, and lend the spirits some other aid, but may not always do so exactly as you''d hoped. Some
+      Powers work through the islanders, helping them, for example, to drive out the Invaders or clean the land of blight.
 
 
-      The game escalates as it progresses: spirits spread their presence to new parts of the island and seek out new and more potent powers, while the Invaders step up their colonization efforts. Each turn represents 1-3 years of alternate history. At game start, winning requires destroying every last explorer, town and city on the board - but as you frighten the Invaders more and more, victory becomes easier: they'll run away even if explorers or even towns and cities remain. Defeat comes if any spirit is destroyed, if the island is overrun by blight, or if the Invader deck is depleted before achieving victory.
+      The game escalates as it progresses: spirits spread their presence to new parts of the island and seek out new and more
+      potent powers, while the Invaders step up their colonization efforts. Each turn represents 1-3 years of alternate history.
+      At game start, winning requires destroying every last explorer, town and city on the board - but as you frighten the
+      Invaders more and more, victory becomes easier: they''ll run away even if explorers or even towns and cities remain.
+      Defeat comes if any spirit is destroyed, if the island is overrun by blight, or if the Invader deck is depleted before
+      achieving victory.
 
 
-      The game includes different adversaries to fight against (eg., a Swedish Mining Colony, or a Remote British Colony). Each changes play in different ways, and offers a different path of difficulty boosts to keep the game challenging as you gain skill.
+      The game includes different adversaries to fight against (eg., a Swedish Mining Colony, or a Remote British Colony).
+      Each changes play in different ways, and offers a different path of difficulty boosts to keep the game challenging as
+      you gain skill.
 
+
+      '
     yearPublished: 2017
     minPlayers: 1
     maxPlayers: 4
@@ -1817,23 +2048,35 @@ catalog:
     - Portal Games
     - REXhry
     - Siam Board Games
+    pdfBlobKey: rulebooks/v1/spirit-island_rulebook.pdf
+    pdfSha256: 64012c21460d3aee0f5c2c0d1048811a4dd4b4aebd03284ee4706a6a1f8e630e
+    pdfVersion: '1.0'
   - title: Jaipur
     bggId: 54043
     language: en
-    pdf: jaipur_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      You are one of the two most powerful traders in the city of Jaipur, the capital of Rajasthan, but that's not enough for you because only the merchant with two "seals of excellence" will have the privilege of being invited to the Maharaja's court. You are therefore going to have to do better than your direct competitor by buying, exchanging, and selling at better prices, all while keeping an eye on both your camel herds.
+    description: 'You are one of the two most powerful traders in the city of Jaipur, the capital of Rajasthan, but that''s
+      not enough for you because only the merchant with two "seals of excellence" will have the privilege of being invited
+      to the Maharaja''s court. You are therefore going to have to do better than your direct competitor by buying, exchanging,
+      and selling at better prices, all while keeping an eye on both your camel herds.
 
 
-      Jaipur is a fast-paced card game, a blend of tactics, risk and luck. On your turn, you can either take or sell cards. If you take cards, you have to choose between taking all the camels, taking one card from the market, or swapping 2-5 cards between the market and your cards.
+      Jaipur is a fast-paced card game, a blend of tactics, risk and luck. On your turn, you can either take or sell cards.
+      If you take cards, you have to choose between taking all the camels, taking one card from the market, or swapping 2-5
+      cards between the market and your cards.
 
 
-      If you sell cards, you get to sell only one type of good, and you receive as many chips for that good as the number of cards you sold. The chips' values decrease as the game progresses, so you'd better hurry! On the other hand, you receive increasingly high rewards for selling three, four, or five cards of the same good at a time, so you'd better wait!
+      If you sell cards, you get to sell only one type of good, and you receive as many chips for that good as the number
+      of cards you sold. The chips'' values decrease as the game progresses, so you''d better hurry! On the other hand, you
+      receive increasingly high rewards for selling three, four, or five cards of the same good at a time, so you''d better
+      wait!
 
 
-      You can't sell camels, but they're paramount for trading and they're also worth a little something at the end of the round, enough sometimes to secure the win, so you have to use them smartly.
+      You can''t sell camels, but they''re paramount for trading and they''re also worth a little something at the end of
+      the round, enough sometimes to secure the win, so you have to use them smartly.
 
+
+      '
     yearPublished: 2009
     minPlayers: 2
     maxPlayers: 2
@@ -1880,20 +2123,30 @@ catalog:
     - Rebel Sp. z o.o.
     - Siam Board Games
     - Yes Papa Games
+    pdfBlobKey: rulebooks/v1/jaipur_rulebook.pdf
+    pdfSha256: 4eca03a489d0436236cc501d861c7b555d1cad17dd3f91fecafe61bf23b9b31b
+    pdfVersion: '1.0'
   - title: The Quacks of Quedlinburg
     bggId: 244521
     language: en
-    pdf: quacks-of-quedlinburg_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Quacks, which was first released as The Quacks of Quedlinburg, players are charlatans &mdash; or quack doctors &mdash; each making their own secret brew by adding ingredients one at a time. Take care with what you add, though, for a pinch too much of this or that will spoil the whole mixture!
+    description: 'In Quacks, which was first released as The Quacks of Quedlinburg, players are charlatans &mdash; or quack
+      doctors &mdash; each making their own secret brew by adding ingredients one at a time. Take care with what you add,
+      though, for a pinch too much of this or that will spoil the whole mixture!
 
 
-      Each player has their own bag of ingredient chips. During each round, they simultaneously draw chips from their bags and add them to their pots. The higher the face value of the drawn chip, the further it is placed in the pot's swirling pattern, increasing how much the potion will be worth. Push your luck as far as you can, but if you add too many cherry bombs, your pot will explode!
+      Each player has their own bag of ingredient chips. During each round, they simultaneously draw chips from their bags
+      and add them to their pots. The higher the face value of the drawn chip, the further it is placed in the pot''s swirling
+      pattern, increasing how much the potion will be worth. Push your luck as far as you can, but if you add too many cherry
+      bombs, your pot will explode!
 
 
-      At the end of each round, players gain victory points and coins to spend on new ingredients, depending on how well they managed to fill up their pots. But players whose pots have exploded must choose points or coins &mdash; not both! The player with the most victory points at the end of nine rounds wins the game.
+      At the end of each round, players gain victory points and coins to spend on new ingredients, depending on how well they
+      managed to fill up their pots. But players whose pots have exploded must choose points or coins &mdash; not both! The
+      player with the most victory points at the end of nine rounds wins the game.
 
+
+      '
     yearPublished: 2018
     minPlayers: 2
     maxPlayers: 4
@@ -1943,16 +2196,22 @@ catalog:
     - North Star Games, LLC
     - Swan Panasia Co., Ltd.
     - YellowBOX
+    pdfBlobKey: rulebooks/v1/quacks-of-quedlinburg_rulebook.pdf
+    pdfSha256: f8fe7eb1cc25a229db9be200201941d2de28a23b3b810417a2b9ac792e3e4d16
+    pdfVersion: '1.0'
   - title: 'The Crew: Quest for Planet Nine'
     bggId: 284083
     language: en
-    pdf: the-crew_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In the co-operative trick-taking game The Crew: The Quest for Planet Nine, the players set out as astronauts on an uncertain space adventure. What are the rumors regarding the unknown planet about? The eventful journey through space extends over 50 exciting missions. But this game can only be defeated by meeting common individual tasks of each player. In order to meet the varied challenges communication is essential in the team. But this is more difficult than expected in space.
+    description: 'In the co-operative trick-taking game The Crew: The Quest for Planet Nine, the players set out as astronauts
+      on an uncertain space adventure. What are the rumors regarding the unknown planet about? The eventful journey through
+      space extends over 50 exciting missions. But this game can only be defeated by meeting common individual tasks of each
+      player. In order to meet the varied challenges communication is essential in the team. But this is more difficult than
+      expected in space.
 
 
-      With each mission the game becomes more difficult. After each mission the game can be paused and continued later. During each mission it is not the number of tricks but the right tricks at the right time that count.
+      With each mission the game becomes more difficult. After each mission the game can be paused and continued later. During
+      each mission it is not the number of tricks but the right tricks at the right time that count.
 
 
       The team completes a mission only if every single player is successful in fulfilling their tasks.
@@ -1960,6 +2219,8 @@ catalog:
 
       The game comes with 50 missions, with three additional missions published in spielbox 2/2020.
 
+
+      '
     yearPublished: 2019
     minPlayers: 2
     maxPlayers: 5
@@ -2007,51 +2268,41 @@ catalog:
     - Swan Panasia Co., Ltd.
     - Thames & Kosmos
     - Zvezda
+    pdfBlobKey: rulebooks/v1/the-crew_rulebook.pdf
+    pdfSha256: 12aded82732014978dfd8a744c6775e75ba9e719b7241e2bab7de42680a8db2f
+    pdfVersion: '1.0'
   - title: Coup
     bggId: 131357
     language: en
-    pdf: coup_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      You are head of a family in an Italian city-state, a city run by a weak and corrupt court. You need to manipulate, bluff and bribe your way to power. Your object is to destroy the influence of all the other families, forcing them into exile. Only one family will survive...
-
-
-      In Coup, you want to be the last player with influence in the game, with influence being represented by face-down character cards in your playing area.
-
-
-      Each player starts the game with two coins and two influence &ndash; i.e., two face-down character cards; the fifteen card deck consists of three copies of five different characters, each with a unique set of powers:
-
-
-           Duke: Take three coins from the treasury. Block someone from taking foreign aid.
-           Assassin: Pay three coins and try to assassinate another player's character.
-           Contessa: Block an assassination attempt against yourself.
-           Captain: Take two coins from another player, or block someone from stealing coins from you.
-           Ambassador: Draw two character cards from the Court (the deck), choose which (if any) to exchange with your face-down characters, then return two. Block someone from stealing coins from you.
-
-
-      On your turn, you can take any of the actions listed above, regardless of which characters you actually have in front of you, or you can take one of three other actions:
-
-
-           Income: Take one coin from the treasury.
-           Foreign aid: Take two coins from the treasury.
-           Coup: Pay seven coins and launch a coup against an opponent, forcing that player to lose an influence. (If you have ten coins or more, you must take this action.)
-
-
-      When you take one of the character actions &ndash; whether actively on your turn, or defensively in response to someone else's action &ndash; that character's action automatically succeeds unless an opponent challenges you. In this case, if you can't (or don't) reveal the appropriate character, you lose an influence, turning one of your characters face-up. Face-up characters cannot be used, and if both of your characters are face-up, you're out of the game.
-
-
-      If you do have the character in question and choose to reveal it, the opponent loses an influence, then you shuffle that character into the deck and draw a new one, perhaps getting the same character again and perhaps not.
-
-
-      The last player to still have influence &ndash; that is, a face-down character &ndash; wins the game!
-
-
-      A new & optional character called the Inquisitor has been added (currently, the only English edition with the Inquisitor included is the Kickstarter Version from Indie Boards & Cards. Copies in stores may not be the Kickstarter versions and may only be the base game). The Inquisitor character cards may be used to replace the Ambassador cards.
-
-
-           Inquisitor: Draw one character card from the Court deck and choose whether or not to exchange it with one of your face-down characters. OR Force an opponent to show you one of their character cards (their choice which). If you wish it, you may then force them to draw a new card from the Court deck. They then shuffle the old card into the Court deck. Block someone from stealing coins from you.
-
-
+    description: "You are head of a family in an Italian city-state, a city run by a weak and corrupt court. You need to manipulate,\
+      \ bluff and bribe your way to power. Your object is to destroy the influence of all the other families, forcing them\
+      \ into exile. Only one family will survive...\n\nIn Coup, you want to be the last player with influence in the game,\
+      \ with influence being represented by face-down character cards in your playing area.\n\nEach player starts the game\
+      \ with two coins and two influence &ndash; i.e., two face-down character cards; the fifteen card deck consists of three\
+      \ copies of five different characters, each with a unique set of powers:\n\n\n     Duke: Take three coins from the treasury.\
+      \ Block someone from taking foreign aid.\n     Assassin: Pay three coins and try to assassinate another player's character.\n\
+      \     Contessa: Block an assassination attempt against yourself.\n     Captain: Take two coins from another player,\
+      \ or block someone from stealing coins from you.\n     Ambassador: Draw two character cards from the Court (the deck),\
+      \ choose which (if any) to exchange with your face-down characters, then return two. Block someone from stealing coins\
+      \ from you.\n\n\nOn your turn, you can take any of the actions listed above, regardless of which characters you actually\
+      \ have in front of you, or you can take one of three other actions:\n\n\n     Income: Take one coin from the treasury.\n\
+      \     Foreign aid: Take two coins from the treasury.\n     Coup: Pay seven coins and launch a coup against an opponent,\
+      \ forcing that player to lose an influence. (If you have ten coins or more, you must take this action.)\n\n\nWhen you\
+      \ take one of the character actions &ndash; whether actively on your turn, or defensively in response to someone else's\
+      \ action &ndash; that character's action automatically succeeds unless an opponent challenges you. In this case, if\
+      \ you can't (or don't) reveal the appropriate character, you lose an influence, turning one of your characters face-up.\
+      \ Face-up characters cannot be used, and if both of your characters are face-up, you're out of the game.\n\nIf you do\
+      \ have the character in question and choose to reveal it, the opponent loses an influence, then you shuffle that character\
+      \ into the deck and draw a new one, perhaps getting the same character again and perhaps not.\n\nThe last player to\
+      \ still have influence &ndash; that is, a face-down character &ndash; wins the game!\n\nA new & optional character called\
+      \ the Inquisitor has been added (currently, the only English edition with the Inquisitor included is the Kickstarter\
+      \ Version from Indie Boards & Cards. Copies in stores may not be the Kickstarter versions and may only be the base game).\
+      \ The Inquisitor character cards may be used to replace the Ambassador cards.\n\n\n     Inquisitor: Draw one character\
+      \ card from the Court deck and choose whether or not to exchange it with one of your face-down characters. OR Force\
+      \ an opponent to show you one of their character cards (their choice which). If you wish it, you may then force them\
+      \ to draw a new card from the Court deck. They then shuffle the old card into the Court deck. Block someone from stealing\
+      \ coins from you.\n\n\n"
     yearPublished: 2012
     minPlayers: 2
     maxPlayers: 6
@@ -2109,17 +2360,23 @@ catalog:
     - テンデイズゲームズ (TendaysGames)
     - Zacatrus
     - 狗吠火車
+    pdfBlobKey: rulebooks/v1/coup_rulebook.pdf
+    pdfSha256: ca1e7851b438c494c27b613921dfa428a6205775939885a5a740624ac0cba46a
+    pdfVersion: '1.0'
   - title: Exploding Kittens
     bggId: 172225
     language: en
-    pdf: exploding-kittens_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Exploding Kittens is a kitty-powered version of Russian Roulette. Players take turns drawing cards until someone draws an exploding kitten and loses the game. The deck is made up of cards that let you avoid exploding by peeking at cards before you draw, forcing your opponent to draw multiple cards, or shuffling the deck.
+    description: 'Exploding Kittens is a kitty-powered version of Russian Roulette. Players take turns drawing cards until
+      someone draws an exploding kitten and loses the game. The deck is made up of cards that let you avoid exploding by peeking
+      at cards before you draw, forcing your opponent to draw multiple cards, or shuffling the deck.
 
 
-      The game gets more and more intense with each card you draw because fewer cards left in the deck means a greater chance of drawing the kitten and exploding in a fiery ball of feline hyperbole.
+      The game gets more and more intense with each card you draw because fewer cards left in the deck means a greater chance
+      of drawing the kitten and exploding in a fiery ball of feline hyperbole.
 
+
+      '
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 5
@@ -2170,19 +2427,33 @@ catalog:
     - Rozum
     - Siam Board Games
     - Super Impulse
+    pdfBlobKey: rulebooks/v1/exploding-kittens_rulebook.pdf
+    pdfSha256: 1585eb968604bd7652b3e8f276e5a7409c5bfca8fc1217ca75792ae3b44b654c
+    pdfVersion: '1.0'
   - title: Agricola
     bggId: 31260
     language: en
-    pdf: agricola_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Agricola, you're a farmer in a wooden shack with your spouse and little else. At first, on a turn, your family gets to take only two actions, one for you and one for your spouse, as might be found among all the possibilities on a farm: plowing fields; collecting materials; building fences, and so on. There are numerous choices available, and while the game progresses you'll have more and more, as each round a new action card is flipped over, offering one more possible action. You might think about having kids in order to get more work accomplished but first you'll need to expand your house to make room - and what are you going to feed all the little rug rats?
+    description: 'In Agricola, you''re a farmer in a wooden shack with your spouse and little else. At first, on a turn, your
+      family gets to take only two actions, one for you and one for your spouse, as might be found among all the possibilities
+      on a farm: plowing fields; collecting materials; building fences, and so on. There are numerous choices available, and
+      while the game progresses you''ll have more and more, as each round a new action card is flipped over, offering one
+      more possible action. You might think about having kids in order to get more work accomplished but first you''ll need
+      to expand your house to make room - and what are you going to feed all the little rug rats?
 
 
-      The game supports many levels of complexity, mainly through the distribution of cards which represent Minor Improvements and Occupations. In the beginner's version (called the Family Variant in the U.S. release) these cards are not used at all. For advanced play, the U.S. release includes three levels of both types of cards; Basic (E-deck), Interactive (I-deck), and Complex (K-deck), and the rulebook encourages players to experiment with the various decks and mixtures thereof. Aftermarket decks such as the Z-Deck and the L-Deck also exist. Each player starts with a hand of 7 Occupation cards (of more than 160 total) and 7 Minor Improvement cards (of more than 140 total) that he/she may use during the game if they fit into his/her strategy.
+      The game supports many levels of complexity, mainly through the distribution of cards which represent Minor Improvements
+      and Occupations. In the beginner''s version (called the Family Variant in the U.S. release) these cards are not used
+      at all. For advanced play, the U.S. release includes three levels of both types of cards; Basic (E-deck), Interactive
+      (I-deck), and Complex (K-deck), and the rulebook encourages players to experiment with the various decks and mixtures
+      thereof. Aftermarket decks such as the Z-Deck and the L-Deck also exist. Each player starts with a hand of 7 Occupation
+      cards (of more than 160 total) and 7 Minor Improvement cards (of more than 140 total) that he/she may use during the
+      game if they fit into his/her strategy.
 
 
-      Agricola is a turn-based game, and the problem to be overcome is that each available action can be taken by only one player each round so it's important to be careful about your choices.  There are countless strategies, some of which depend on your hand of cards.
+      Agricola is a turn-based game, and the problem to be overcome is that each available action can be taken by only one
+      player each round so it''s important to be careful about your choices.  There are countless strategies, some of which
+      depend on your hand of cards.
 
 
       The winner is the player with the most Victory Points from the Improvements made on his farm.
@@ -2190,6 +2461,8 @@ catalog:
 
       -description originally from BoardgameNews
 
+
+      '
     yearPublished: 2007
     minPlayers: 1
     maxPlayers: 5
@@ -2234,17 +2507,26 @@ catalog:
     - Swan Panasia Co., Ltd.
     - Ystari Games
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/agricola_rulebook.pdf
+    pdfSha256: 76fbd30f440c34b109be0b1f20d4ad188b602c382fe0b33860c800cb20d11d75
+    pdfVersion: '1.0'
   - title: Kingdomino
     bggId: 204583
     language: en
-    pdf: kingdomino_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Kingdomino, you are a lord seeking new lands in which to expand your kingdom. You must explore all the lands, including wheat fields, lakes, and mountains, in order to spot the best plots, while competing with other lords to acquire them first.
+    description: 'In Kingdomino, you are a lord seeking new lands in which to expand your kingdom. You must explore all the
+      lands, including wheat fields, lakes, and mountains, in order to spot the best plots, while competing with other lords
+      to acquire them first.
 
 
-      The game uses tiles with two sections, similar to Dominoes. Each turn, each player will select a new domino to connect to their existing kingdom, making sure at least one of its sides connects to a matching terrain type already in play. The order of who picks first depends on which tile was previously chosen, with better tiles forcing players to pick later in the next round. The game ends when each player has completed a 5x5 grid (or failed to do so), and points are counted based on number of connecting tiles and valuable crown symbols.
+      The game uses tiles with two sections, similar to Dominoes. Each turn, each player will select a new domino to connect
+      to their existing kingdom, making sure at least one of its sides connects to a matching terrain type already in play.
+      The order of who picks first depends on which tile was previously chosen, with better tiles forcing players to pick
+      later in the next round. The game ends when each player has completed a 5x5 grid (or failed to do so), and points are
+      counted based on number of connecting tiles and valuable crown symbols.
 
+
+      '
     yearPublished: 2016
     minPlayers: 2
     maxPlayers: 4
@@ -2297,16 +2579,23 @@ catalog:
     - Swan Panasia Co., Ltd.
     - テンデイズゲームズ (TendaysGames)
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/kingdomino_rulebook.pdf
+    pdfSha256: 25787aa1e0d3c70d292b7de68534b4c6b05ef75720ba6a535720d782c51d1cb2
+    pdfVersion: '1.0'
   - title: Hanabi
     bggId: 98778
     language: en
-    pdf: hanabi_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Hanabi&mdash;named for the Japanese word for "fireworks"&mdash;is a cooperative game in which players try to create the perfect fireworks show by placing the cards on the table in the right order. (In Japanese, hanabi is written as 花火; these are the ideograms flower and fire, respectively.)
+    description: 'Hanabi&mdash;named for the Japanese word for "fireworks"&mdash;is a cooperative game in which players try
+      to create the perfect fireworks show by placing the cards on the table in the right order. (In Japanese, hanabi is written
+      as 花火; these are the ideograms flower and fire, respectively.)
 
 
-      The card deck consists of five different colors of cards, numbered 1&ndash;5 in each color. For each color, the players try to place a row in the correct order from 1&ndash;5. Sounds easy, right? Well, not quite, as in this game you hold your cards so that they're visible only to other players. To assist other players in playing a card, you must give them hints regarding the numbers or the colors of their cards. Players must act as a team to avoid errors and to finish the fireworks display before they run out of cards.
+      The card deck consists of five different colors of cards, numbered 1&ndash;5 in each color. For each color, the players
+      try to place a row in the correct order from 1&ndash;5. Sounds easy, right? Well, not quite, as in this game you hold
+      your cards so that they''re visible only to other players. To assist other players in playing a card, you must give
+      them hints regarding the numbers or the colors of their cards. Players must act as a team to avoid errors and to finish
+      the fireworks display before they run out of cards.
 
 
       An extra suit of cards, rainbow colored, is also provided for advanced or variant play.
@@ -2314,6 +2603,8 @@ catalog:
 
       Hanabi was originally published as part of Hanabi & Ikebana.
 
+
+      '
     yearPublished: 2010
     minPlayers: 2
     maxPlayers: 5
@@ -2365,29 +2656,45 @@ catalog:
     - REXhry
     - Spin Master Ltd.
     - Swan Panasia Co., Ltd.
+    pdfBlobKey: rulebooks/v1/hanabi_rulebook.pdf
+    pdfSha256: f23df0ceaa2715e6b46444018fb8bfad6afb021d76fc2c2ee802fdfb4c2dc472
+    pdfVersion: '1.0'
   - title: 'Pandemic Legacy: Season 1'
     bggId: 161936
     language: en
-    pdf: pandemic-legacy-s1_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Pandemic Legacy is a co-operative campaign game, with an overarching story arc played through 12-24 sessions, depending on how well your group does at the game. At the beginning, the game starts in a very similar fashion as basic Pandemic, in which your team of disease-fighting specialists races against the clock to travel around the world, treating disease hot spots while researching cures for each of four plagues before they get out of hand.
+    description: 'Pandemic Legacy is a co-operative campaign game, with an overarching story arc played through 12-24 sessions,
+      depending on how well your group does at the game. At the beginning, the game starts in a very similar fashion as basic
+      Pandemic, in which your team of disease-fighting specialists races against the clock to travel around the world, treating
+      disease hot spots while researching cures for each of four plagues before they get out of hand.
 
 
-      During a player's turn, they have four actions available, with which they may travel around in the world in various ways (sometimes needing to discard a card), build structures like research stations, treat diseases (removing one cube from the board; if all cubes of a color have been removed, the disease has been eradicated), trade cards with other players, or find a cure for a disease (requiring five cards of the same color to be discarded while at a research station). Each player has a unique role with special abilities to help them at these actions.
+      During a player''s turn, they have four actions available, with which they may travel around in the world in various
+      ways (sometimes needing to discard a card), build structures like research stations, treat diseases (removing one cube
+      from the board; if all cubes of a color have been removed, the disease has been eradicated), trade cards with other
+      players, or find a cure for a disease (requiring five cards of the same color to be discarded while at a research station).
+      Each player has a unique role with special abilities to help them at these actions.
 
 
-      After a player has taken their actions, they draw two cards. These cards can include epidemic cards, which will place new disease cubes on the board, and can lead to an outbreak, spreading disease cubes even further. Outbreaks additionally increase the panic level of a city, making that city more expensive to travel to.
+      After a player has taken their actions, they draw two cards. These cards can include epidemic cards, which will place
+      new disease cubes on the board, and can lead to an outbreak, spreading disease cubes even further. Outbreaks additionally
+      increase the panic level of a city, making that city more expensive to travel to.
 
 
-      Each month in the game, you have two chances to achieve that month's objectives. If you succeed, you win and immediately move on to the next month. If you fail, you have a second chance, with more funding for beneficial event cards.
+      Each month in the game, you have two chances to achieve that month''s objectives. If you succeed, you win and immediately
+      move on to the next month. If you fail, you have a second chance, with more funding for beneficial event cards.
 
 
-      During the campaign, new rules and components will be introduced. These will sometimes require you to permanently alter the components of the game; this includes writing on cards, ripping up cards, and placing permanent stickers on components. Your characters can gain new skills, or detrimental effects. A character can even be lost entirely, at which point it's no longer available for play.
+      During the campaign, new rules and components will be introduced. These will sometimes require you to permanently alter
+      the components of the game; this includes writing on cards, ripping up cards, and placing permanent stickers on components.
+      Your characters can gain new skills, or detrimental effects. A character can even be lost entirely, at which point it''s
+      no longer available for play.
 
 
       Part of the Pandemic series
 
+
+      '
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 4
@@ -2430,20 +2737,35 @@ catalog:
     - Lifestyle Boardgames Ltd
     - MINDOK
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/pandemic-legacy-s1_rulebook.pdf
+    pdfSha256: 9198abfbd116b96446294b8db1bf2f98c44a1444a727d27ec861c0ad6e1f93d5
+    pdfVersion: '1.0'
   - title: Cascadia
     bggId: 295947
     language: en
-    pdf: cascadia_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Cascadia is a puzzly tile-laying and token-drafting game featuring the habitats and wildlife of the Pacific Northwest.
+    description: 'Cascadia is a puzzly tile-laying and token-drafting game featuring the habitats and wildlife of the Pacific
+      Northwest.
 
 
-      In the game, you take turns building out your own terrain area and populating it with wildlife. You start with three hexagonal habitat tiles (with the five types of habitat in the game), and on a turn you choose a new habitat tile that's paired with a wildlife token, then place that tile next to your other ones and place the wildlife token on an appropriate habitat. (Each tile depicts 1-3 types of wildlife from the five types in the game, and you can place at most one token on a habitat.) Four tiles are on display, with each tile being paired at random with a wildlife token, so you must make the best of what's available &mdash; unless you have a nature token to spend so that you can pick your choice of each item.
+      In the game, you take turns building out your own terrain area and populating it with wildlife. You start with three
+      hexagonal habitat tiles (with the five types of habitat in the game), and on a turn you choose a new habitat tile that''s
+      paired with a wildlife token, then place that tile next to your other ones and place the wildlife token on an appropriate
+      habitat. (Each tile depicts 1-3 types of wildlife from the five types in the game, and you can place at most one token
+      on a habitat.) Four tiles are on display, with each tile being paired at random with a wildlife token, so you must make
+      the best of what''s available &mdash; unless you have a nature token to spend so that you can pick your choice of each
+      item.
 
 
-      Ideally you can place habitat tiles to create matching terrain that reduces fragmentation and creates wildlife corridors, mostly because you score for the largest area of each type of habitat at game's end, with a bonus if your group is larger than each other player's. At the same time, you want to place wildlife tokens so that you can maximize the number of points scored by them, with the wildlife goals being determined at random by one of the four scoring cards for each type of wildlife. Maybe hawks want to be separate from other hawks, while foxes want lots of different animals surrounding them and bears want to be in pairs. Can you make it happen?
+      Ideally you can place habitat tiles to create matching terrain that reduces fragmentation and creates wildlife corridors,
+      mostly because you score for the largest area of each type of habitat at game''s end, with a bonus if your group is
+      larger than each other player''s. At the same time, you want to place wildlife tokens so that you can maximize the number
+      of points scored by them, with the wildlife goals being determined at random by one of the four scoring cards for each
+      type of wildlife. Maybe hawks want to be separate from other hawks, while foxes want lots of different animals surrounding
+      them and bears want to be in pairs. Can you make it happen?
 
+
+      '
     yearPublished: 2021
     minPlayers: 1
     maxPlayers: 4
@@ -2494,20 +2816,32 @@ catalog:
     - Tower Tactic Games
     - White Goblin Games
     - 株式会社ケンビル (KenBill)
+    pdfBlobKey: rulebooks/v1/cascadia_rulebook.pdf
+    pdfSha256: 94c7313aef8e161527844fbfc4296419ad5999ec9027e4aede905ac83b510a80
+    pdfVersion: '1.0'
   - title: 'Gloomhaven: Jaws of the Lion'
     bggId: 291457
     language: en
-    pdf: gloomhaven-jaws-of-the-lion_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Gloomhaven: Jaws of the Lion is a standalone game that takes place before the events of Gloomhaven. The game includes four new characters &mdash; Valrath Red Guard (tank, crowd control), Inox Hatchet (ranged damage), Human Voidwarden (support, mind control), and Quatryl Demolitionist (melee damage, obstacle manipulation) &mdash; that can also be used in the original Gloomhaven game.
+    description: 'Gloomhaven: Jaws of the Lion is a standalone game that takes place before the events of Gloomhaven. The
+      game includes four new characters &mdash; Valrath Red Guard (tank, crowd control), Inox Hatchet (ranged damage), Human
+      Voidwarden (support, mind control), and Quatryl Demolitionist (melee damage, obstacle manipulation) &mdash; that can
+      also be used in the original Gloomhaven game.
 
 
-      The game also includes 16 monster types (including seven new standard monsters and three new bosses) and a new campaign with 25 scenarios that invites the heroes to investigate a case of mysterious disappearances within the city. Is it the work of Vermlings, or is something far more sinister going on?
+      The game also includes 16 monster types (including seven new standard monsters and three new bosses) and a new campaign
+      with 25 scenarios that invites the heroes to investigate a case of mysterious disappearances within the city. Is it
+      the work of Vermlings, or is something far more sinister going on?
 
 
-      Gloomhaven: Jaws of the Lion is aimed at a more casual audience to get people into the gameplay more quickly. All of the hard-to-organize cardboard map tiles have been removed, and instead players will play on the scenario book itself, which features new artwork unique to each scenario. The last barrier to entry &mdash; i.e., learning the game &mdash; has also been lowered through a simplified rule set and a five-scenario tutorial that will ease new players into the experience.
+      Gloomhaven: Jaws of the Lion is aimed at a more casual audience to get people into the gameplay more quickly. All of
+      the hard-to-organize cardboard map tiles have been removed, and instead players will play on the scenario book itself,
+      which features new artwork unique to each scenario. The last barrier to entry &mdash; i.e., learning the game &mdash;
+      has also been lowered through a simplified rule set and a five-scenario tutorial that will ease new players into the
+      experience.
 
+
+      '
     yearPublished: 2020
     minPlayers: 1
     maxPlayers: 4
@@ -2562,26 +2896,39 @@ catalog:
     - Lord of Boards
     - Meanbook Games
     - Siam Board Games
+    pdfBlobKey: rulebooks/v1/gloomhaven-jaws-of-the-lion_rulebook.pdf
+    pdfSha256: 5ece90b8054527a29ba56600d99a9b88c02fb567ee8334aac9bf9f70978f8fcb
+    pdfVersion: '1.0'
   - title: Power Grid
     bggId: 2651
     language: en
-    pdf: power-grid_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Power Grid is the updated release of the Friedemann Friese crayon game Funkenschlag. It removes the crayon aspect from network building in the original edition, while retaining the fluctuating commodities market like Crude: The Oil Game and an auction round intensity reminiscent of The Princes of Florence.
+    description: 'Power Grid is the updated release of the Friedemann Friese crayon game Funkenschlag. It removes the crayon
+      aspect from network building in the original edition, while retaining the fluctuating commodities market like Crude:
+      The Oil Game and an auction round intensity reminiscent of The Princes of Florence.
 
 
-      The objective of Power Grid is to supply the most cities with power when someone's network gains a predetermined size.  In this new edition, players mark pre-existing routes between cities for connection, and then bid against each other to purchase the power plants that they use to power their cities.
+      The objective of Power Grid is to supply the most cities with power when someone''s network gains a predetermined size.  In
+      this new edition, players mark pre-existing routes between cities for connection, and then bid against each other to
+      purchase the power plants that they use to power their cities.
 
 
-      However, as plants are purchased, newer, more efficient plants become available, so by merely purchasing, you're potentially allowing others access to superior equipment.
+      However, as plants are purchased, newer, more efficient plants become available, so by merely purchasing, you''re potentially
+      allowing others access to superior equipment.
 
 
-      Additionally, players must acquire the raw materials (coal, oil, garbage, and uranium) needed to power said plants (except for the 'renewable' windfarm/ solar plants, which require no fuel), making it a constant struggle to upgrade your plants for maximum efficiency while still retaining enough wealth to quickly expand your network to get the cheapest routes.
+      Additionally, players must acquire the raw materials (coal, oil, garbage, and uranium) needed to power said plants (except
+      for the ''renewable'' windfarm/ solar plants, which require no fuel), making it a constant struggle to upgrade your
+      plants for maximum efficiency while still retaining enough wealth to quickly expand your network to get the cheapest
+      routes.
 
 
-      ☛ Power Grid FAQ - Please read this before posting a rules question!  Many questions are asked over and over in the forums... If you have a question about a specific expansion, please check the rules forum or FAQ for that particular expansion.
+      ☛ Power Grid FAQ - Please read this before posting a rules question!  Many questions are asked over and over in the
+      forums... If you have a question about a specific expansion, please check the rules forum or FAQ for that particular
+      expansion.
 
+
+      '
     yearPublished: 2004
     minPlayers: 2
     maxPlayers: 6
@@ -2632,26 +2979,36 @@ catalog:
     - Smart Ltd
     - Stratelibri
     - Swan Panasia Co., Ltd.
+    pdfBlobKey: rulebooks/v1/power-grid_rulebook.pdf
+    pdfSha256: e90d321d233b3fbffac8a1900d6a5cb96ffccd29b1a215e2889c5eacb995e73f
+    pdfVersion: '1.0'
   - title: Betrayal at House on the Hill
     bggId: 10547
     language: en
-    pdf: betrayal-at-house-on-the-hill_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Betrayal at House on the Hill quickly builds suspense and excitement as players explore a haunted mansion of their own 'design', encountering spirits and frightening omens that foretell their fate. With an estimated one hour playing time, Betrayal at House on the Hill is ideal for parties, family gatherings or casual fun with friends.
+    description: 'Betrayal at House on the Hill quickly builds suspense and excitement as players explore a haunted mansion
+      of their own ''design'', encountering spirits and frightening omens that foretell their fate. With an estimated one
+      hour playing time, Betrayal at House on the Hill is ideal for parties, family gatherings or casual fun with friends.
 
 
-      Betrayal at House on the Hill is a tile game that allows players to lay out the haunted house room by room, tile by tile, creating a new thrilling game board every time. The game is designed for three to six people, each of whom plays one of six possible characters.
+      Betrayal at House on the Hill is a tile game that allows players to lay out the haunted house room by room, tile by
+      tile, creating a new thrilling game board every time. The game is designed for three to six people, each of whom plays
+      one of six possible characters.
 
 
-      Secretly, one of the characters betrays the rest of the party, and the innocent members of the party must defeat the traitor in their midst before it&rsquo;s too late! Betrayal at House on the Hill will appeal to any game player who enjoys a fun, suspenseful, and strategic game.
+      Secretly, one of the characters betrays the rest of the party, and the innocent members of the party must defeat the
+      traitor in their midst before it&rsquo;s too late! Betrayal at House on the Hill will appeal to any game player who
+      enjoys a fun, suspenseful, and strategic game.
 
 
-      Betrayal at House on the Hill includes detailed game pieces, including character cards, pre-painted plastic figures, and special tokens, all of which help create a spooky atmosphere and streamline game play.
+      Betrayal at House on the Hill includes detailed game pieces, including character cards, pre-painted plastic figures,
+      and special tokens, all of which help create a spooky atmosphere and streamline game play.
 
 
       An updated reprint of Betrayal at House on the Hill was released on October 5, 2010.
 
+
+      '
     yearPublished: 2004
     minPlayers: 3
     maxPlayers: 6
@@ -2688,30 +3045,24 @@ catalog:
     - Wizards of the Coast
     - asmodee
     - Hasbro
+    pdfBlobKey: rulebooks/v1/betrayal-at-house-on-the-hill_rulebook.pdf
+    pdfSha256: 806700be2b34ee26d0dee42c4b600bc57b0d1c4c520ddfeaf9db171441ba9f9e
+    pdfVersion: '1.0'
   - title: Ark Nova
     bggId: 342942
     language: en
-    pdf: ark-nova_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Ark Nova, you will plan and design a modern, scientifically managed zoo. With the ultimate goal of owning the most successful zoological establishment, you will build enclosures, accommodate animals, and support conservation projects all over the world. Specialists and unique buildings will help you in achieving this goal.
-
-
-      Each player has a set of five action cards to manage their gameplay, and the power of an action is determined by the slot the card currently occupies. The cards in question are:
-
-
-          CARDS: Allows you to gain new zoo cards (animals, sponsors, and conservation project cards).
-          BUILD: Allows you to build standard or special enclosures, kiosks, and pavilions.
-          ANIMALS: Allows you to accommodate animals in your zoo.
-          ASSOCIATION: Allows your association workers to carry out different tasks.
-          SPONSORS: Allows you to play a sponsor card in your zoo or to raise money.
-
-
-      255 cards featuring animals, specialists, special enclosures, and conservation projects, each with a special ability, are at the heart of Ark Nova. Use them to increase the appeal and scientific reputation of your zoo and collect conservation points.
-
-
-      &mdash;description from the publisher
-
+    description: "In Ark Nova, you will plan and design a modern, scientifically managed zoo. With the ultimate goal of owning\
+      \ the most successful zoological establishment, you will build enclosures, accommodate animals, and support conservation\
+      \ projects all over the world. Specialists and unique buildings will help you in achieving this goal.\n\nEach player\
+      \ has a set of five action cards to manage their gameplay, and the power of an action is determined by the slot the\
+      \ card currently occupies. The cards in question are:\n\n\n    CARDS: Allows you to gain new zoo cards (animals, sponsors,\
+      \ and conservation project cards).\n    BUILD: Allows you to build standard or special enclosures, kiosks, and pavilions.\n\
+      \    ANIMALS: Allows you to accommodate animals in your zoo.\n    ASSOCIATION: Allows your association workers to carry\
+      \ out different tasks.\n    SPONSORS: Allows you to play a sponsor card in your zoo or to raise money.\n\n\n255 cards\
+      \ featuring animals, specialists, special enclosures, and conservation projects, each with a special ability, are at\
+      \ the heart of Ark Nova. Use them to increase the appeal and scientific reputation of your zoo and collect conservation\
+      \ points.\n\n&mdash;description from the publisher\n\n"
     yearPublished: 2021
     minPlayers: 1
     maxPlayers: 4
@@ -2768,32 +3119,53 @@ catalog:
     - テンデイズゲームズ (TendaysGames)
     - Tower Tactic Games
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/ark-nova_rulebook.pdf
+    pdfSha256: f6b4eedc68e993f61b4c5cb5d99bb4af399da0be3de4781321bcba1ba44516f6
+    pdfVersion: '1.0'
   - title: Puerto Rico
     bggId: 3076
     language: en
-    pdf: puerto-rico_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Puerto Rico, players assume the roles of colonial governors on the island of Puerto Rico. The aim of the game is to amass victory points by shipping goods to Europe or by constructing buildings.
+    description: 'In Puerto Rico, players assume the roles of colonial governors on the island of Puerto Rico. The aim of
+      the game is to amass victory points by shipping goods to Europe or by constructing buildings.
 
 
-      Each player uses a separate small board with spaces for city buildings, plantations, and resources. Shared between the players are three ships, a trading house, and a supply of resources and doubloons.
+      Each player uses a separate small board with spaces for city buildings, plantations, and resources. Shared between the
+      players are three ships, a trading house, and a supply of resources and doubloons.
 
 
-      The resource cycle of the game is that players grow crops which they exchange for points or doubloons. Doubloons can then be used to buy buildings, which allow players to produce more crops or give them other abilities. Buildings and plantations do not work unless they are manned by colonists.
+      The resource cycle of the game is that players grow crops which they exchange for points or doubloons. Doubloons can
+      then be used to buy buildings, which allow players to produce more crops or give them other abilities. Buildings and
+      plantations do not work unless they are manned by colonists.
 
 
-      During each round, players take turns selecting a role card from those on the table (such as "Trader" or "Builder"). When a role is chosen, every player gets to take the action appropriate to that role. The player that selected the role also receives a small privilege for doing so - for example, choosing the "Builder" role allows all players to construct a building, but the player who chose the role may do so at a discount on that turn. Unused roles gain a doubloon bonus at the end of each turn, so the next player who chooses that role gets to keep any doubloon bonus associated with it. This encourages players to make use of all the roles throughout a typical course of a game.
+      During each round, players take turns selecting a role card from those on the table (such as "Trader" or "Builder").
+      When a role is chosen, every player gets to take the action appropriate to that role. The player that selected the role
+      also receives a small privilege for doing so - for example, choosing the "Builder" role allows all players to construct
+      a building, but the player who chose the role may do so at a discount on that turn. Unused roles gain a doubloon bonus
+      at the end of each turn, so the next player who chooses that role gets to keep any doubloon bonus associated with it.
+      This encourages players to make use of all the roles throughout a typical course of a game.
 
 
-      Puerto Rico uses a variable phase order mechanism in which a "governor" token is passed clockwise to the next player at the conclusion of a turn. The player with the token begins the round by choosing a role and taking the first action.
+      Puerto Rico uses a variable phase order mechanism in which a "governor" token is passed clockwise to the next player
+      at the conclusion of a turn. The player with the token begins the round by choosing a role and taking the first action.
 
 
-      Players earn victory points for owning buildings, for shipping goods, and for manned "large buildings." Each player's accumulated shipping chips are kept face down and come in denominations of one or five. This prevents other players from being able to determine the exact score of another player. Goods and doubloons are placed in clear view of other players and the totals of each can always be requested by a player. As the game enters its later stages, the unknown quantity of shipping tokens and its denominations require players to consider their options before choosing a role that can end the game.
+      Players earn victory points for owning buildings, for shipping goods, and for manned "large buildings." Each player''s
+      accumulated shipping chips are kept face down and come in denominations of one or five. This prevents other players
+      from being able to determine the exact score of another player. Goods and doubloons are placed in clear view of other
+      players and the totals of each can always be requested by a player. As the game enters its later stages, the unknown
+      quantity of shipping tokens and its denominations require players to consider their options before choosing a role that
+      can end the game.
 
 
-      In 2011 and mostly afterwards, Puerto Rico was published to include both Puerto Rico: Expansion I &ndash; New Buildings and Puerto Rico: Expansion II &ndash; The Nobles. These versions are included in the other game entry Puerto Rico, not this regular game entry for Puerto Rico. Some editions of Puerto Rico list the player count as 2-5 instead of 3-5, and they include variant rules for games with only two players.
+      In 2011 and mostly afterwards, Puerto Rico was published to include both Puerto Rico: Expansion I &ndash; New Buildings
+      and Puerto Rico: Expansion II &ndash; The Nobles. These versions are included in the other game entry Puerto Rico, not
+      this regular game entry for Puerto Rico. Some editions of Puerto Rico list the player count as 2-5 instead of 3-5, and
+      they include variant rules for games with only two players.
 
+
+      '
     yearPublished: 2002
     minPlayers: 3
     maxPlayers: 5
@@ -2833,19 +3205,29 @@ catalog:
     - Swan Panasia Co., Ltd.
     - Tilsit
     - VAKKO
+    pdfBlobKey: rulebooks/v1/puerto-rico_rulebook.pdf
+    pdfSha256: d55058bde864f4216eecd14e2d3fabd244955972f3176e1b3bf64e5ed7afa697
+    pdfVersion: '1.0'
   - title: Lost Ruins of Arnak
     bggId: 312484
     language: en
-    pdf: lost-ruins-of-arnak_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      On an uninhabited island in uncharted seas, explorers have found traces of a great civilization. Now you will lead an expedition to explore the island, find lost artifacts, and face fearsome guardians, all in a quest to learn the island's secrets.
+    description: 'On an uninhabited island in uncharted seas, explorers have found traces of a great civilization. Now you
+      will lead an expedition to explore the island, find lost artifacts, and face fearsome guardians, all in a quest to learn
+      the island''s secrets.
 
 
-      Lost Ruins of Arnak combines deck-building and worker placement in a game of exploration, resource management, and discovery. In addition to traditional deck-builder effects, cards can also be used to place workers, and new worker actions become available as players explore the island. Some of these actions require resources instead of workers, so building a solid resource base will be essential. You are limited to only one action per turn, so make your choice carefully... what action will benefit you most now? And what can you afford to do later... assuming someone else doesn't take the action first!?
+      Lost Ruins of Arnak combines deck-building and worker placement in a game of exploration, resource management, and discovery.
+      In addition to traditional deck-builder effects, cards can also be used to place workers, and new worker actions become
+      available as players explore the island. Some of these actions require resources instead of workers, so building a solid
+      resource base will be essential. You are limited to only one action per turn, so make your choice carefully... what
+      action will benefit you most now? And what can you afford to do later... assuming someone else doesn''t take the action
+      first!?
 
 
-      Decks are small, and randomness in the game is heavily mitigated by the wealth of tactical decisions offered on the game board. With a variety of worker actions, artifacts, and equipment cards, the set-up for each game will be unique, encouraging players to explore new strategies to meet the challenge.
+      Decks are small, and randomness in the game is heavily mitigated by the wealth of tactical decisions offered on the
+      game board. With a variety of worker actions, artifacts, and equipment cards, the set-up for each game will be unique,
+      encouraging players to explore new strategies to meet the challenge.
 
 
       Discover the Lost Ruins of Arnak!
@@ -2853,6 +3235,8 @@ catalog:
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2020
     minPlayers: 1
     maxPlayers: 4
@@ -2911,34 +3295,30 @@ catalog:
     - Rebel Sp. z o.o.
     - Spilbræt.dk
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/lost-ruins-of-arnak_rulebook.pdf
+    pdfSha256: d697b0612bbab7b16d183bdaee061d17fea25d6be485329e0c98bc90a1af11c1
+    pdfVersion: '1.0'
   - title: The Castles of Burgundy
     bggId: 84876
     language: en
-    pdf: castles-of-burgundy_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      The game is set in the Burgundy region of High Medieval France. Each player takes on the role of an aristocrat, originally controlling a small princedom. While playing they aim to build settlements and powerful castles, practice trade along the river, exploit silver mines, and use the knowledge of travelers. The game is about players taking settlement tiles from the game board and placing them into their princedom which is represented by the player board. Every tile has a function that starts when the tile is placed in the princedom. The princedom itself consists of several regions, each of which demands its own type of settlement tile.
-
-
-      The game is played in five phases, each consisting of five rounds.  Each phase begins with the game board stocked with settlement tiles and goods tiles.  At the beginning of each round all players roll their two dice, and the player who is currently first in turn order rolls a goods placement die.  A goods tile is made available on the game board according to the roll of the goods die.
-
-
-      During each round, a player may perform any two of the four possible types of actions:
-
-          take a settlement tile and place it in the staging area on their player board
-          take a settlement tile from the staging area and place in the corresponding region for the type of tile and adjacent to a previously placed settlement tile, 
-          deliver goods with a number matching one of their dice
-          take worker tokens which allow the player to adjust the roll of their dice.  
-
-
-      In addition to these actions a player may buy a settlement tile and place it in the staging area on their player board.
-
-
-      The game ends after the fifth phase is played to completion.  Victory points are awarded for unused money and workers, and undelivered goods.  Bonus victory points from certain settlement tiles are awarded at the end of the game. The player with the most victory points wins.
-
-
-      The rules include basic and advanced versions.
-
+    description: "The game is set in the Burgundy region of High Medieval France. Each player takes on the role of an aristocrat,\
+      \ originally controlling a small princedom. While playing they aim to build settlements and powerful castles, practice\
+      \ trade along the river, exploit silver mines, and use the knowledge of travelers. The game is about players taking\
+      \ settlement tiles from the game board and placing them into their princedom which is represented by the player board.\
+      \ Every tile has a function that starts when the tile is placed in the princedom. The princedom itself consists of several\
+      \ regions, each of which demands its own type of settlement tile.\n\nThe game is played in five phases, each consisting\
+      \ of five rounds.  Each phase begins with the game board stocked with settlement tiles and goods tiles.  At the beginning\
+      \ of each round all players roll their two dice, and the player who is currently first in turn order rolls a goods placement\
+      \ die.  A goods tile is made available on the game board according to the roll of the goods die.\n\nDuring each round,\
+      \ a player may perform any two of the four possible types of actions:\n\n    take a settlement tile and place it in\
+      \ the staging area on their player board\n    take a settlement tile from the staging area and place in the corresponding\
+      \ region for the type of tile and adjacent to a previously placed settlement tile, \n    deliver goods with a number\
+      \ matching one of their dice\n    take worker tokens which allow the player to adjust the roll of their dice.  \n\n\n\
+      In addition to these actions a player may buy a settlement tile and place it in the staging area on their player board.\n\
+      \nThe game ends after the fifth phase is played to completion.  Victory points are awarded for unused money and workers,\
+      \ and undelivered goods.  Bonus victory points from certain settlement tiles are awarded at the end of the game. The\
+      \ player with the most victory points wins.\n\nThe rules include basic and advanced versions.\n\n"
     yearPublished: 2011
     minPlayers: 2
     maxPlayers: 4
@@ -2979,26 +3359,43 @@ catalog:
     - Hobby World
     - Maldito Games
     - Rebel Sp. z o.o.
+    pdfBlobKey: rulebooks/v1/castles-of-burgundy_rulebook.pdf
+    pdfSha256: 6fb4eb68f7fc788d9c68f325e310648def996faf16016aa81140c6f3dc798b1c
+    pdfVersion: '1.0'
   - title: 'Arkham Horror: The Card Game'
     bggId: 205637
     language: en
-    pdf: arkham-horror-tcg_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Something evil stirs in Arkham, and only you can stop it. Blurring the traditional lines between role-playing and card game experiences, Arkham Horror: The Card Game is a Living Card Game of Lovecraftian mystery, monsters, and madness!
+    description: 'Something evil stirs in Arkham, and only you can stop it. Blurring the traditional lines between role-playing
+      and card game experiences, Arkham Horror: The Card Game is a Living Card Game of Lovecraftian mystery, monsters, and
+      madness!
 
 
-      In the game, you, alone or with a friend (or up to three friends with two Core Sets), become investigators within the quiet New England town of Arkham. You have your talents, sure, but you also have your flaws. Perhaps you've dabbled a little too much in the writings of the Necronomicon, and its words continue to haunt you. Perhaps you feel compelled to cover up any signs of otherworldly evils, hampering your own investigations in order to protect the quiet confidence of the greater population. Perhaps you'll be scarred by your encounters with a ghoulish cult.
+      In the game, you, alone or with a friend (or up to three friends with two Core Sets), become investigators within the
+      quiet New England town of Arkham. You have your talents, sure, but you also have your flaws. Perhaps you''ve dabbled
+      a little too much in the writings of the Necronomicon, and its words continue to haunt you. Perhaps you feel compelled
+      to cover up any signs of otherworldly evils, hampering your own investigations in order to protect the quiet confidence
+      of the greater population. Perhaps you''ll be scarred by your encounters with a ghoulish cult.
 
 
-      No matter what compels you, no matter what haunts you, you'll find both your strengths and weaknesses reflected in your custom deck of cards, and these cards will be your resources as you work with your friends to unravel the world's most terrifying mysteries.
+      No matter what compels you, no matter what haunts you, you''ll find both your strengths and weaknesses reflected in
+      your custom deck of cards, and these cards will be your resources as you work with your friends to unravel the world''s
+      most terrifying mysteries.
 
 
-      Each of your adventures in Arkham Horror LCG carries you deeper into mystery. You'll find cultists and foul rituals. You'll find haunted houses and strange creatures. And you may find signs of the Ancient Ones straining against the barriers to our world...
+      Each of your adventures in Arkham Horror LCG carries you deeper into mystery. You''ll find cultists and foul rituals.
+      You''ll find haunted houses and strange creatures. And you may find signs of the Ancient Ones straining against the
+      barriers to our world...
 
 
-      The basic mode of play in Arkham LCG is not the adventure, but the campaign. You might be scarred by your adventures, your sanity may be strained, and you may alter Arkham's landscape, burning buildings to the ground. All your choices and actions have consequences that reach far beyond the immediate resolution of the scenario at hand&mdash;and your actions may earn you valuable experience with which you can better prepare yourself for the adventures that still lie before you.
+      The basic mode of play in Arkham LCG is not the adventure, but the campaign. You might be scarred by your adventures,
+      your sanity may be strained, and you may alter Arkham''s landscape, burning buildings to the ground. All your choices
+      and actions have consequences that reach far beyond the immediate resolution of the scenario at hand&mdash;and your
+      actions may earn you valuable experience with which you can better prepare yourself for the adventures that still lie
+      before you.
 
+
+      '
     yearPublished: 2016
     minPlayers: 1
     maxPlayers: 2
@@ -3050,35 +3447,63 @@ catalog:
     - Korea Boardgames
     - Tower Tactic Games
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/arkham-horror-tcg_rulebook.pdf
+    pdfSha256: 28c88deaa538b6132f212cb3107bebea294c6240caef651088d4a39c277e95f6
+    pdfVersion: '1.0'
   - title: Mysterium
     bggId: 181304
     language: en
-    pdf: mysterium_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In the 1920s, Mr. MacDowell, a gifted astrologer, immediately detected a supernatural being upon entering his new house in Scotland. He gathered eminent mediums of his time for an extraordinary s&eacute;ance, and they have seven hours to make contact with the ghost and investigate any clues that it can provide to unlock an old mystery.
+    description: 'In the 1920s, Mr. MacDowell, a gifted astrologer, immediately detected a supernatural being upon entering
+      his new house in Scotland. He gathered eminent mediums of his time for an extraordinary s&eacute;ance, and they have
+      seven hours to make contact with the ghost and investigate any clues that it can provide to unlock an old mystery.
 
 
-      Unable to talk, the amnesiac ghost communicates with the mediums through visions, which are represented in the game by illustrated cards. The mediums must decipher the images to help the ghost remember how he was murdered: Who did the crime? Where did it take place? Which weapon caused the death? The more the mediums cooperate and guess well, the easier it is to catch the right culprit.
+      Unable to talk, the amnesiac ghost communicates with the mediums through visions, which are represented in the game
+      by illustrated cards. The mediums must decipher the images to help the ghost remember how he was murdered: Who did the
+      crime? Where did it take place? Which weapon caused the death? The more the mediums cooperate and guess well, the easier
+      it is to catch the right culprit.
 
 
-      In Mysterium, a reworking of the game system present in Tajemnicze Domostwo, one player takes the role of ghost while everyone else represents a medium. To solve the crime, the ghost must first recall (with the aid of the mediums) all of the suspects present on the night of the murder. A number of suspect, location and murder weapon cards are placed on the table, and the ghost randomly assigns one of each of these in secret to a medium.
+      In Mysterium, a reworking of the game system present in Tajemnicze Domostwo, one player takes the role of ghost while
+      everyone else represents a medium. To solve the crime, the ghost must first recall (with the aid of the mediums) all
+      of the suspects present on the night of the murder. A number of suspect, location and murder weapon cards are placed
+      on the table, and the ghost randomly assigns one of each of these in secret to a medium.
 
 
-      Each hour (i.e., game turn), the ghost hands one or more vision cards face up to each medium, refilling their hand to seven each time they share vision cards. These vision cards present dreamlike images to the mediums, with each medium first needing to deduce which suspect corresponds to the vision cards received. Once the ghost has handed cards to the final medium, they start a two-minute sandtimer. Once a medium has placed their token on a suspect, they may also place clairvoyancy tokens on the guesses made by other mediums to show whether they agree or disagree with those guesses.
+      Each hour (i.e., game turn), the ghost hands one or more vision cards face up to each medium, refilling their hand to
+      seven each time they share vision cards. These vision cards present dreamlike images to the mediums, with each medium
+      first needing to deduce which suspect corresponds to the vision cards received. Once the ghost has handed cards to the
+      final medium, they start a two-minute sandtimer. Once a medium has placed their token on a suspect, they may also place
+      clairvoyancy tokens on the guesses made by other mediums to show whether they agree or disagree with those guesses.
 
 
-      After time runs out, the ghost reveals to each medium whether the guesses were correct or not. Mediums who guessed correctly move on to guess the location of the crime (and then the murder weapon), while those who didn't keep their vision cards and receive new ones next hour corresponding to the same suspect. Once a medium has correctly guessed the suspect, location and weapon, they move their token to the epilogue board and receive one clairvoyancy point for each hour remaining on the clock. They can still use their remaining clairvoyancy tokens to score additional points.
+      After time runs out, the ghost reveals to each medium whether the guesses were correct or not. Mediums who guessed correctly
+      move on to guess the location of the crime (and then the murder weapon), while those who didn''t keep their vision cards
+      and receive new ones next hour corresponding to the same suspect. Once a medium has correctly guessed the suspect, location
+      and weapon, they move their token to the epilogue board and receive one clairvoyancy point for each hour remaining on
+      the clock. They can still use their remaining clairvoyancy tokens to score additional points.
 
 
-      If one or more mediums fail to identify their proper suspect, location and weapon before the end of the seventh hour, then the ghost has failed and dissipates, leaving the mystery unsolved. If, however, they have all succeeded, then the ghost has recovered enough of its memory to identify the culprit.
+      If one or more mediums fail to identify their proper suspect, location and weapon before the end of the seventh hour,
+      then the ghost has failed and dissipates, leaving the mystery unsolved. If, however, they have all succeeded, then the
+      ghost has recovered enough of its memory to identify the culprit.
 
 
-      Mediums then group their suspect, location and weapon cards on the table and place a number by each group. The ghost then selects one group, places the matching culprit number face down on the epilogue board, picks three vision cards &mdash; one for the suspect, one for the location, and one for the weapon &mdash; then shuffles these cards. Players who have achieved few clairvoyancy points flip over one vision card at random, then secretly vote on which suspect they think is guilty; players with more points then flip over a second vision card and vote; then those with the most points see the final card and vote.
+      Mediums then group their suspect, location and weapon cards on the table and place a number by each group. The ghost
+      then selects one group, places the matching culprit number face down on the epilogue board, picks three vision cards
+      &mdash; one for the suspect, one for the location, and one for the weapon &mdash; then shuffles these cards. Players
+      who have achieved few clairvoyancy points flip over one vision card at random, then secretly vote on which suspect they
+      think is guilty; players with more points then flip over a second vision card and vote; then those with the most points
+      see the final card and vote.
 
 
-      If a majority of the mediums have identified the proper suspect, with ties being broken by the vote of the most clairvoyant medium, then the killer has been identified and the ghost can now rest peacefully. If not, well, perhaps you can try again...
+      If a majority of the mediums have identified the proper suspect, with ties being broken by the vote of the most clairvoyant
+      medium, then the killer has been identified and the ghost can now rest peacefully. If not, well, perhaps you can try
+      again...
 
+
+      '
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 7
@@ -3123,22 +3548,25 @@ catalog:
     - Morapiaf
     - Rebel Sp. z o.o.
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/mysterium_rulebook.pdf
+    pdfSha256: 030485b917f8b98ade40b48fbe12501dd5c490426e57c6466dfa63a6a6a84692
+    pdfVersion: '1.0'
   - title: 'Dominion: Prosperity'
     bggId: 66690
     language: en
-    pdf: dominion-prosperity_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Released in late 2010, Prosperity is the 4th addition to the Dominion game family. It adds 25 new Kingdom cards to Dominion, plus 2 new Basic cards that let players keep building up past Gold and Province. The central theme is wealth; there are treasures with abilities, cards that interact with treasures, and powerful expensive cards. (Source: http://www.riograndegames.com/games.html?id=361 )
-
-
-      From the back of the box: "Ah, money. There's nothing like the sound of coins clinking in your hands. You vastly prefer it to the sound of coins clinking in someone else's hands, or the sound of coins just sitting there in a pile that no-one can quite reach without getting up. Getting up, that's all behind you now. Life has been good to you. Just ten years ago, you were tilling your own fields in a simple straw hat. Today, your kingdom stretches from sea to sea, and your straw hat is the largest the world has ever known. You also have the world's smallest dog, and a life-sized statue of yourself made out of baklava. Sure, money can't buy happiness, but it can buy envy, anger, and also this kind of blank feeling. You still have problems - troublesome neighbours that must be conquered. 
-
-      But this time, you'll conquer them in style."
-
-
-      Part of the Dominion series.
-
+    description: "Released in late 2010, Prosperity is the 4th addition to the Dominion game family. It adds 25 new Kingdom\
+      \ cards to Dominion, plus 2 new Basic cards that let players keep building up past Gold and Province. The central theme\
+      \ is wealth; there are treasures with abilities, cards that interact with treasures, and powerful expensive cards. (Source:\
+      \ http://www.riograndegames.com/games.html?id=361 )\n\nFrom the back of the box: \"Ah, money. There's nothing like the\
+      \ sound of coins clinking in your hands. You vastly prefer it to the sound of coins clinking in someone else's hands,\
+      \ or the sound of coins just sitting there in a pile that no-one can quite reach without getting up. Getting up, that's\
+      \ all behind you now. Life has been good to you. Just ten years ago, you were tilling your own fields in a simple straw\
+      \ hat. Today, your kingdom stretches from sea to sea, and your straw hat is the largest the world has ever known. You\
+      \ also have the world's smallest dog, and a life-sized statue of yourself made out of baklava. Sure, money can't buy\
+      \ happiness, but it can buy envy, anger, and also this kind of blank feeling. You still have problems - troublesome\
+      \ neighbours that must be conquered. \nBut this time, you'll conquer them in style.\"\n\nPart of the Dominion series.\n\
+      \n"
     yearPublished: 2010
     minPlayers: 2
     maxPlayers: 4
@@ -3175,23 +3603,20 @@ catalog:
     - Lautapelit.fi
     - Stupor Mundi
     - Ystari Games
+    pdfBlobKey: rulebooks/v1/dominion-prosperity_rulebook.pdf
+    pdfSha256: b8879173187beb0f78c60043607b26aa5ef1b84814645d682d075a8f1492c82d
+    pdfVersion: '1.0'
   - title: 'Century: Spice Road'
     bggId: 209685
     language: en
-    pdf: century-spice-road_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Century: Spice Road is the first in a series of games that explores the history of each century with spice-trading as the theme for the first installment.  In Century: Spice Road, players are caravan leaders who travel the famed silk road to deliver spices to the far reaches of the continent for fame and glory. Each turn, players perform one of four actions:
-
-
-           Establish a trade route (by taking a market card)
-           Make a trade or harvest spices (by playing a card from hand)
-           Fulfill a demand (by meeting a victory point card's requirements and claiming it)
-           Rest (by taking back into your hand all of the cards you've played)
-
-
-      The last round is triggered once a player has claimed their fifth victory point card, then whoever has the most victory points wins.
-
+    description: "Century: Spice Road is the first in a series of games that explores the history of each century with spice-trading\
+      \ as the theme for the first installment.  In Century: Spice Road, players are caravan leaders who travel the famed\
+      \ silk road to deliver spices to the far reaches of the continent for fame and glory. Each turn, players perform one\
+      \ of four actions:\n\n\n     Establish a trade route (by taking a market card)\n     Make a trade or harvest spices\
+      \ (by playing a card from hand)\n     Fulfill a demand (by meeting a victory point card's requirements and claiming\
+      \ it)\n     Rest (by taking back into your hand all of the cards you've played)\n\n\nThe last round is triggered once\
+      \ a player has claimed their fifth victory point card, then whoever has the most victory points wins.\n\n"
     yearPublished: 2017
     minPlayers: 2
     maxPlayers: 5
@@ -3236,20 +3661,34 @@ catalog:
     - Mandoo Games
     - Ninive Games
     - Piatnik Distribution
+    pdfBlobKey: rulebooks/v1/century-spice-road_rulebook.pdf
+    pdfSha256: c80bd5921916f5ea6e72ffa5c8d9c23710e286ddef509f0b9531df3f57acb5ef
+    pdfVersion: '1.0'
   - title: Gloom
     bggId: 12692
     language: en
-    pdf: gloom_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      The world of Gloom is a sad and benighted place. The sky is gray, the tea is cold, and a new tragedy lies around every corner. Debt, disease, heartache, and packs of rabid flesh-eating mice&mdash;just when it seems like things can't get any worse, they do. But some say that one's reward in the afterlife is based on the misery endured in life. If so, there may yet be hope&mdash;if not in this world, then in the peace that lies beyond.
+    description: 'The world of Gloom is a sad and benighted place. The sky is gray, the tea is cold, and a new tragedy lies
+      around every corner. Debt, disease, heartache, and packs of rabid flesh-eating mice&mdash;just when it seems like things
+      can''t get any worse, they do. But some say that one''s reward in the afterlife is based on the misery endured in life.
+      If so, there may yet be hope&mdash;if not in this world, then in the peace that lies beyond.
 
 
-      In the Gloom card game, you assume control of the fate of an eccentric family of misfits and misanthropes. The goal of the game is sad, but simple: you want your characters to suffer the greatest tragedies possible before passing on to the well-deserved respite of death. You'll play horrible mishaps like Pursued by Poodles or Mocked by Midgets on your own characters to lower their Self-Worth scores, while trying to cheer your opponents' characters with marriages and other happy occasions that pile on positive points. The player with the lowest total Family Value wins.
+      In the Gloom card game, you assume control of the fate of an eccentric family of misfits and misanthropes. The goal
+      of the game is sad, but simple: you want your characters to suffer the greatest tragedies possible before passing on
+      to the well-deserved respite of death. You''ll play horrible mishaps like Pursued by Poodles or Mocked by Midgets on
+      your own characters to lower their Self-Worth scores, while trying to cheer your opponents'' characters with marriages
+      and other happy occasions that pile on positive points. The player with the lowest total Family Value wins.
 
 
-      Printed on transparent plastic cards, Gloom features an innovative design by noted RPG author Keith Baker. Multiple modifier cards can be played on top of the same character card; since the cards are transparent, elements from previously played modifier cards either show through or are obscured by those played above them. You'll immediately and easily know the worth of every character, no matter how many modifiers they have. You've got to see (through) this game to believe it!
+      Printed on transparent plastic cards, Gloom features an innovative design by noted RPG author Keith Baker. Multiple
+      modifier cards can be played on top of the same character card; since the cards are transparent, elements from previously
+      played modifier cards either show through or are obscured by those played above them. You''ll immediately and easily
+      know the worth of every character, no matter how many modifiers they have. You''ve got to see (through) this game to
+      believe it!
 
+
+      '
     yearPublished: 2005
     minPlayers: 2
     maxPlayers: 5
@@ -3279,17 +3718,27 @@ catalog:
     - Calamity Games
     - Edge Entertainment
     - uplay.it edizioni
+    pdfBlobKey: rulebooks/v1/gloom_rulebook.pdf
+    pdfSha256: 5256839f16a3ad69a54abc350d455e3dc190d073131c46462bfd3bb21da0c048
+    pdfVersion: '1.0'
   - title: Hive Pocket
     bggId: 154597
     language: en
-    pdf: hive-pocket_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Hive is a strategic game for two players that is not restricted by a board and can be played anywhere on any flat surface. The base game of Hive is made up of twenty two pieces, eleven black and eleven white, resembling a variety of creatures each with a unique way of moving. Hive Carbon and Hive Pocket include the Mosquito and Ladybug expansions, for a total of 26 pieces.
+    description: 'Hive is a strategic game for two players that is not restricted by a board and can be played anywhere on
+      any flat surface. The base game of Hive is made up of twenty two pieces, eleven black and eleven white, resembling a
+      variety of creatures each with a unique way of moving. Hive Carbon and Hive Pocket include the Mosquito and Ladybug
+      expansions, for a total of 26 pieces.
 
 
-      With no setting up to do, the game begins when the first piece is placed down. As the subsequent pieces are placed this forms a pattern that becomes the playing surface. (The pieces themselves become the board.) Unlike other such games, the pieces are never eliminated and not all have to be played. The object of the game is to totally surround your opponent's queen, while at the same time trying to block your opponent from doing likewise to your queen. The first player to totally surround the opponent's queen wins the game.
+      With no setting up to do, the game begins when the first piece is placed down. As the subsequent pieces are placed this
+      forms a pattern that becomes the playing surface. (The pieces themselves become the board.) Unlike other such games,
+      the pieces are never eliminated and not all have to be played. The object of the game is to totally surround your opponent''s
+      queen, while at the same time trying to block your opponent from doing likewise to your queen. The first player to totally
+      surround the opponent''s queen wins the game.
 
+
+      '
     yearPublished: 2010
     minPlayers: 2
     maxPlayers: 2
@@ -3339,27 +3788,30 @@ catalog:
     - Vendetta
     - Zhiyanjia
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/hive-pocket_rulebook.pdf
+    pdfSha256: d5dc5809bc293ef53f13b4aa92bbf833d6f7d95852b14bf491a4e2713478d1d5
+    pdfVersion: '1.0'
   - title: Raiders of the North Sea
     bggId: 170042
     language: en
-    pdf: raiders-of-the-north-sea_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Raiders of the North Sea is set in the central years of the Viking Age. As Viking warriors, players seek to impress the Chieftain by raiding unsuspecting settlements. To do so, players need to assemble a crew, collect provisions, and journey north to plunder gold, iron and livestock. Glory can be found in battle, even at the hands of the Valkyrie, so gather your warriors because it's raiding season!
-
-
-      To impress the Chieftain, you need victory points (VPs), with those being acquired primarily by raiding settlements, taking plunder, and making offerings to the Chieftain. How you use your plunder is also vital to your success. Players take turns in clockwise order, and on a turn you place a worker and resolve its action, then pick up a different worker and resolve its action. Broadly speaking, those actions fall in one of two categories:
-
-
-           Work: Having a good crew and enough provisions are vital to successful raiding, so before making any raids, players need to do some work to prepare their crew and collect supplies. This is all done in the village at the bottom of the game board, with eight buildings offering various actions. You must first place your worker in an available building where no other worker is present, then pick up a different worker from a different building.
-
-
-
-           Raid: Once players have hired enough crew and collected provisions, you may choose to raid on your turn. To raid a settlement &mdash; whether a harbor, outpost, monastery or fortress &mdash; you need to meet three requirements: Having a large enough crew, having enough provisions (along with gold for monasteries and fortresses, and having a worker of the right color. Raiding offers various ways of scoring, such as military strength, plunder, and Valkyries, which is how grey and white workers enter the game.
-
-
-      The game ends when only one fortress raid remains, all Valkyrie have been removed, or all offerings have been made, then players tally their scores.
-
+    description: "Raiders of the North Sea is set in the central years of the Viking Age. As Viking warriors, players seek\
+      \ to impress the Chieftain by raiding unsuspecting settlements. To do so, players need to assemble a crew, collect provisions,\
+      \ and journey north to plunder gold, iron and livestock. Glory can be found in battle, even at the hands of the Valkyrie,\
+      \ so gather your warriors because it's raiding season!\n\nTo impress the Chieftain, you need victory points (VPs), with\
+      \ those being acquired primarily by raiding settlements, taking plunder, and making offerings to the Chieftain. How\
+      \ you use your plunder is also vital to your success. Players take turns in clockwise order, and on a turn you place\
+      \ a worker and resolve its action, then pick up a different worker and resolve its action. Broadly speaking, those actions\
+      \ fall in one of two categories:\n\n\n     Work: Having a good crew and enough provisions are vital to successful raiding,\
+      \ so before making any raids, players need to do some work to prepare their crew and collect supplies. This is all done\
+      \ in the village at the bottom of the game board, with eight buildings offering various actions. You must first place\
+      \ your worker in an available building where no other worker is present, then pick up a different worker from a different\
+      \ building.\n\n\n\n     Raid: Once players have hired enough crew and collected provisions, you may choose to raid on\
+      \ your turn. To raid a settlement &mdash; whether a harbor, outpost, monastery or fortress &mdash; you need to meet\
+      \ three requirements: Having a large enough crew, having enough provisions (along with gold for monasteries and fortresses,\
+      \ and having a worker of the right color. Raiding offers various ways of scoring, such as military strength, plunder,\
+      \ and Valkyries, which is how grey and white workers enter the game.\n\n\nThe game ends when only one fortress raid\
+      \ remains, all Valkyrie have been removed, or all offerings have been made, then players tally their scores.\n\n"
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 4
@@ -3400,35 +3852,43 @@ catalog:
     - Schwerkraft-Verlag
     - White Goblin Games
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/raiders-of-the-north-sea_rulebook.pdf
+    pdfSha256: 2bd3601c5709698becc198584d3d7c8c321640a05a56ae3399af757ae88afa20
+    pdfVersion: '1.0'
   - title: 'Pandemic Legacy: Season 2'
     bggId: 221107
     language: en
-    pdf: pandemic-legacy-s2_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Description from the publisher:
+    description: 'Description from the publisher:
 
 
       The world almost ended 71 years ago...
 
 
-      The plague came out of nowhere and ravaged the world. Most died within a week. Nothing could stop it. The world did its best. It wasn't good enough.
+      The plague came out of nowhere and ravaged the world. Most died within a week. Nothing could stop it. The world did
+      its best. It wasn''t good enough.
 
 
-      For three generations, we, the last fragments of humanity have lived on the seas, on floating stations called "havens." Far from the plague, we are able to provide supplies to the mainland to keep them (and us) from succumbing completely.
+      For three generations, we, the last fragments of humanity have lived on the seas, on floating stations called "havens."
+      Far from the plague, we are able to provide supplies to the mainland to keep them (and us) from succumbing completely.
 
 
-      We've managed to keep a network of the largest known cities in the world alive. Things have been tough the past few years. Cities far away from the havens have fallen off our grid...
+      We''ve managed to keep a network of the largest known cities in the world alive. Things have been tough the past few
+      years. Cities far away from the havens have fallen off our grid...
 
 
-      Tomorrow, a small group of us head out into what's left of the world. We don't know what we'll find.
+      Tomorrow, a small group of us head out into what''s left of the world. We don''t know what we''ll find.
 
 
-      Pandemic Legacy: Season 2 is an epic cooperative game for 2 to 4 players. Unlike most other games, this one is working against you. What's more, some of the actions you take in Pandemic Legacy will carry over to future games. No two worlds will ever be alike!
+      Pandemic Legacy: Season 2 is an epic cooperative game for 2 to 4 players. Unlike most other games, this one is working
+      against you. What''s more, some of the actions you take in Pandemic Legacy will carry over to future games. No two worlds
+      will ever be alike!
 
 
       Part of the Pandemic series.
 
+
+      '
     yearPublished: 2017
     minPlayers: 2
     maxPlayers: 4
@@ -3469,20 +3929,30 @@ catalog:
     - Korea Boardgames
     - Lacerta
     - Lifestyle Boardgames Ltd
+    pdfBlobKey: rulebooks/v1/pandemic-legacy-s2_rulebook.pdf
+    pdfSha256: 6ba4c2623e00eac786b5f6c3a65d1aa99927163870551d2ea3f8f4744c334e51
+    pdfVersion: '1.0'
   - title: Imperial Settlers
     bggId: 154203
     language: en
-    pdf: imperial-settlers_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Settlers from four major powers of the world have discovered new lands, with new resources and opportunities. Romans, Barbarians, Egyptians and Japanese all at once move there to expand the boundaries of their empires. They build new buildings to strengthen their economy, they found mines and fields to gather resources, and they build barracks and training grounds to train soldiers. Soon after they discover that this land is far too small for everybody, then the war begins...
+    description: 'Settlers from four major powers of the world have discovered new lands, with new resources and opportunities.
+      Romans, Barbarians, Egyptians and Japanese all at once move there to expand the boundaries of their empires. They build
+      new buildings to strengthen their economy, they found mines and fields to gather resources, and they build barracks
+      and training grounds to train soldiers. Soon after they discover that this land is far too small for everybody, then
+      the war begins...
 
 
-      Imperial Settlers is a card game that lets players lead one of the four factions and build empires by placing buildings, then sending workers to those buildings to acquire new resources and abilities. The game is played over five rounds during which players take various actions in order to explore new lands, build buildings, trade resources, conquer enemies, and thus score victory points.
+      Imperial Settlers is a card game that lets players lead one of the four factions and build empires by placing buildings,
+      then sending workers to those buildings to acquire new resources and abilities. The game is played over five rounds
+      during which players take various actions in order to explore new lands, build buildings, trade resources, conquer enemies,
+      and thus score victory points.
 
 
-      The core mechanism of Imperial Settlers is based on concepts from the author's card game 51st State.
+      The core mechanism of Imperial Settlers is based on concepts from the author''s card game 51st State.
 
+
+      '
     yearPublished: 2014
     minPlayers: 1
     maxPlayers: 4
@@ -3525,14 +3995,22 @@ catalog:
     - REXhry
     - White Goblin Games
     - Zvezda
+    pdfBlobKey: rulebooks/v1/imperial-settlers_rulebook.pdf
+    pdfSha256: 98c7e716c460934f725a9fbbf55445e39807b4c9241dccfface50f98cf283574
+    pdfVersion: '1.0'
   - title: Guillotine
     bggId: 116
     language: en
-    pdf: guillotine_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      The French Revolution is famous in part for the use of the guillotine to put nobles to death, and this is the macabre subject of this light card game.  As executioners pandering to the masses, the players are trying to behead the most popular nobles.  Each day the nobles are lined up and players take turns killing the ones at the front of the line until all the nobles are gone.  However, players are given cards which will manipulate the line order right before 'harvesting' heads, which is what makes the game interesting.  After three days of chopping, the highest total carries the day.
+    description: 'The French Revolution is famous in part for the use of the guillotine to put nobles to death, and this is
+      the macabre subject of this light card game.  As executioners pandering to the masses, the players are trying to behead
+      the most popular nobles.  Each day the nobles are lined up and players take turns killing the ones at the front of the
+      line until all the nobles are gone.  However, players are given cards which will manipulate the line order right before
+      ''harvesting'' heads, which is what makes the game interesting.  After three days of chopping, the highest total carries
+      the day.
 
+
+      '
     yearPublished: 1998
     minPlayers: 2
     maxPlayers: 5
@@ -3564,29 +4042,46 @@ catalog:
     - Hasbro
     - Play Factory
     - PS-Games
+    pdfBlobKey: rulebooks/v1/guillotine_rulebook.pdf
+    pdfSha256: 6272d65910f05a2a9ada9aa79d1247b3d015cc3b2b402d465f32894ef0928b76
+    pdfVersion: '1.0'
   - title: Harmonies
     bggId: 414317
     language: en
-    pdf: harmonies_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Harmonies, build landscapes by placing colored tokens and create habitats for your animals. To earn the most points and win the game, incorporate the habitats in your landscapes wisely and have as many animals as you can settle there.
+    description: 'In Harmonies, build landscapes by placing colored tokens and create habitats for your animals. To earn the
+      most points and win the game, incorporate the habitats in your landscapes wisely and have as many animals as you can
+      settle there.
 
 
-      Starting with the first player and proceeding clockwise, each player will choose a set of 3 terrain tokens from the central area to place on their personal board. They may optionally choose an Animal card from the 5 displayed and/or place an Animal cube from their Animal card(s) on any completed patterns on their board that match their personal Animal cards. There is a 4-card limit per player. After their turn, refill with a new set of 3 tokens and a new Animal card if needed.
+      Starting with the first player and proceeding clockwise, each player will choose a set of 3 terrain tokens from the
+      central area to place on their personal board. They may optionally choose an Animal card from the 5 displayed and/or
+      place an Animal cube from their Animal card(s) on any completed patterns on their board that match their personal Animal
+      cards. There is a 4-card limit per player. After their turn, refill with a new set of 3 tokens and a new Animal card
+      if needed.
 
 
-      Placement of the terrain tokens will depend on the personal Animal card goals, and scoring rules for the various terrain types (mountain, field, forest, etc). For example, mountain tiles score based on how high they are (1 tile scores 1, while 3 tiles stacked score 7), but the mountain scores zero if it is not adjacent to at least one other mountain. If all the cubes on a given Animal card have been placed, the card is set aside and a new card can be drawn. The cards are scored at game end based on the highest number that isn't covered by a cube.
+      Placement of the terrain tokens will depend on the personal Animal card goals, and scoring rules for the various terrain
+      types (mountain, field, forest, etc). For example, mountain tiles score based on how high they are (1 tile scores 1,
+      while 3 tiles stacked score 7), but the mountain scores zero if it is not adjacent to at least one other mountain. If
+      all the cubes on a given Animal card have been placed, the card is set aside and a new card can be drawn. The cards
+      are scored at game end based on the highest number that isn''t covered by a cube.
 
 
-      The games ends when there are no tokens left in the bag to refill the central area, or at least one players has 2 or fewer empty spaces on their player board. Play continues until all players have had an equal turn that round. The player with the highest points is the winner.
+      The games ends when there are no tokens left in the bag to refill the central area, or at least one players has 2 or
+      fewer empty spaces on their player board. Play continues until all players have had an equal turn that round. The player
+      with the highest points is the winner.
 
 
-      Optionally, you can use Nature's Spirit cards for richer gameplay. During setup, each player chooses 1 of 2 spirit cards and places a Spirit cube on the card. They follow the same placement rules as Animal cards, but tend to have an ongoing effect once completed. The spirit card does count towards the 4-card hand limit.
+      Optionally, you can use Nature''s Spirit cards for richer gameplay. During setup, each player chooses 1 of 2 spirit
+      cards and places a Spirit cube on the card. They follow the same placement rules as Animal cards, but tend to have an
+      ongoing effect once completed. The spirit card does count towards the 4-card hand limit.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2024
     minPlayers: 1
     maxPlayers: 4
@@ -3627,27 +4122,28 @@ catalog:
     - Korea Boardgames
     - Rebel Sp. z o.o.
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/harmonies_rulebook.pdf
+    pdfSha256: 5ed98481b5a6580d15ee92c2c744a33027481fb17ec75fb22fa0e05d9a0ae6c7
+    pdfVersion: '1.0'
   - title: 'Dixit: Odyssey'
     bggId: 92828
     language: en
-    pdf: dixit-odyssey_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Dixit Odyssey is both a standalone game and an expansion (Dixit: Odyssey (expansion)) for Jean-Louis Roubira's Dixit, which won Germany's Spiel des Jahres award in 2010.
-
-
-      Game play in Dixit Odyssey matches that of Dixit: Each turn one player is the storyteller. This player secretly chooses one card in his hand, then gives a word or sentence to describe this card&mdash;but not too obviously. Each other player chooses a card in hand that matches this word/sentence and gives it to the storyteller. The storyteller then lays out the cards, and all other players vote on which card belongs to the storyteller. If no one or everyone guesses the storyteller's card, the storyteller receives no points and all players receive two; otherwise the storyteller and the correct guesser(s) each receive three points. Players score one point for each vote their image receives. Players refill their hands, and the next player becomes the storyteller. When the deck runs out, the player with the most points wins.
-
-
-      Dixit Odyssey contains 84 new cards, each with a unique image drawn by Pier&ocirc; and colored by Marie Cardouat, artist of Dixit and Dixit 2. The stand alone version also includes a folding game board, 6 new rabbit scoring tokens (12 total), and a box large enough to hold all the Dixit cards released to date. The stand alone version of Dixit Odyssey includes enough components for up to twelve players and also has variant rules for team play and for new ways to play with the cards.
-
-
-      Expansion versus standalone versions of the game.
-
-           Standalone version is in a square box (released in 2011 but may still be available).
-           Expansion version is in a rectangular box (available from 2013 onwards): Dixit: Odyssey (expansion)
-
-
+    description: "Dixit Odyssey is both a standalone game and an expansion (Dixit: Odyssey (expansion)) for Jean-Louis Roubira's\
+      \ Dixit, which won Germany's Spiel des Jahres award in 2010.\n\nGame play in Dixit Odyssey matches that of Dixit: Each\
+      \ turn one player is the storyteller. This player secretly chooses one card in his hand, then gives a word or sentence\
+      \ to describe this card&mdash;but not too obviously. Each other player chooses a card in hand that matches this word/sentence\
+      \ and gives it to the storyteller. The storyteller then lays out the cards, and all other players vote on which card\
+      \ belongs to the storyteller. If no one or everyone guesses the storyteller's card, the storyteller receives no points\
+      \ and all players receive two; otherwise the storyteller and the correct guesser(s) each receive three points. Players\
+      \ score one point for each vote their image receives. Players refill their hands, and the next player becomes the storyteller.\
+      \ When the deck runs out, the player with the most points wins.\n\nDixit Odyssey contains 84 new cards, each with a\
+      \ unique image drawn by Pier&ocirc; and colored by Marie Cardouat, artist of Dixit and Dixit 2. The stand alone version\
+      \ also includes a folding game board, 6 new rabbit scoring tokens (12 total), and a box large enough to hold all the\
+      \ Dixit cards released to date. The stand alone version of Dixit Odyssey includes enough components for up to twelve\
+      \ players and also has variant rules for team play and for new ways to play with the cards.\n\nExpansion versus standalone\
+      \ versions of the game.\n\n     Standalone version is in a square box (released in 2011 but may still be available).\n\
+      \     Expansion version is in a rectangular box (available from 2013 onwards): Dixit: Odyssey (expansion)\n\n\n"
     yearPublished: 2011
     minPlayers: 3
     maxPlayers: 12
@@ -3685,16 +4181,21 @@ catalog:
     - Rebel Sp. z o.o.
     - Swan Panasia Co., Ltd.
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/dixit-odyssey_rulebook.pdf
+    pdfSha256: a3d0b2c61420c8ad04147a323143bf5885b26b92040cf2bc83d9e9211265a4db
+    pdfVersion: '1.0'
   - title: Hanamikoji
     bggId: 158600
     language: en
-    pdf: hanamikoji_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Welcome to the most famed Geisha street in the old capital, Hanamikoji. Geishas are elegant and graceful women who are skilled in art, music, dance, and a variety of performances and ceremonies. Greatly respected and adored, Geishas are masters of entertainment.
+    description: 'Welcome to the most famed Geisha street in the old capital, Hanamikoji. Geishas are elegant and graceful
+      women who are skilled in art, music, dance, and a variety of performances and ceremonies. Greatly respected and adored,
+      Geishas are masters of entertainment.
 
 
-      In Hanamikoji, two players compete to earn the favor of seven illustrious Geishas by collecting each Geisha&rsquo;s preferred performance item. With careful speculation and a few bold moves, can you outsmart your opponent to win the favor of the most Geishas?
+      In Hanamikoji, two players compete to earn the favor of seven illustrious Geishas by collecting each Geisha&rsquo;s
+      preferred performance item. With careful speculation and a few bold moves, can you outsmart your opponent to win the
+      favor of the most Geishas?
 
 
       Jixia Academy features the same gameplay as Hanamikoji, but with different artwork.
@@ -3702,6 +4203,8 @@ catalog:
 
       Hanamikoji FAQ
 
+
+      '
     yearPublished: 2013
     minPlayers: 2
     maxPlayers: 2
@@ -3749,25 +4252,36 @@ catalog:
     - Taiwan Boardgame Design
     - White Goblin Games
     - Zvezda
+    pdfBlobKey: rulebooks/v1/hanamikoji_rulebook.pdf
+    pdfSha256: 662765d0f77dd24235ec59f6c00b629ac69078a62e7fbd044a803bb7458326a2
+    pdfVersion: '1.0'
   - title: Sleeping Gods
     bggId: 255984
     language: en
-    pdf: sleeping-gods_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      "Are the stars unfamiliar here?" she asked, and the sky grew suddenly dark, the star's patterns alien and exotic. "This is the Wandering Sea. The gods have brought you here, and you must wake them if you wish to return home."
+    description: '"Are the stars unfamiliar here?" she asked, and the sky grew suddenly dark, the star''s patterns alien and
+      exotic. "This is the Wandering Sea. The gods have brought you here, and you must wake them if you wish to return home."
 
 
-      In Sleeping Gods, you and up to 3 friends become Captain Sofi Odessa and her crew, lost in a strange world in 1929 on your steamship, the Manticore. You must work together to survive, exploring exotic islands, meeting new characters, and seeking out the totems of the gods so that you can return home.
+      In Sleeping Gods, you and up to 3 friends become Captain Sofi Odessa and her crew, lost in a strange world in 1929 on
+      your steamship, the Manticore. You must work together to survive, exploring exotic islands, meeting new characters,
+      and seeking out the totems of the gods so that you can return home.
 
 
-      Sleeping Gods is a campaign game. Each session can last as long as you want. When you are ready to take a break, you mark your progress on a journey log sheet, making it easy to return to the same place in the game the next time you play. You can play solo or with friends throughout your campaign. It's easy to swap players in and out at will. Your goal is to find at least fourteen totems hidden throughout the world. Like reading a book, you'll complete this journey one or two hours at a time, discovering new lands, stories, and challenges along the way.
+      Sleeping Gods is a campaign game. Each session can last as long as you want. When you are ready to take a break, you
+      mark your progress on a journey log sheet, making it easy to return to the same place in the game the next time you
+      play. You can play solo or with friends throughout your campaign. It''s easy to swap players in and out at will. Your
+      goal is to find at least fourteen totems hidden throughout the world. Like reading a book, you''ll complete this journey
+      one or two hours at a time, discovering new lands, stories, and challenges along the way.
 
 
-      Sleeping Gods is an atlas game. Each page of the atlas represents only a small portion of the world you can explore. When you reach the edge of a page and you want to continue in the same direction, you simply turn to a new page and sail onward.
+      Sleeping Gods is an atlas game. Each page of the atlas represents only a small portion of the world you can explore.
+      When you reach the edge of a page and you want to continue in the same direction, you simply turn to a new page and
+      sail onward.
 
 
-      Sleeping Gods is a storybook game. Each new location holds wild adventure, hidden treasures, and vivid characters. Your choices affect the characters and the plot of the game, and may help or hinder your chances of getting home!
+      Sleeping Gods is a storybook game. Each new location holds wild adventure, hidden treasures, and vivid characters. Your
+      choices affect the characters and the plot of the game, and may help or hinder your chances of getting home!
 
 
       Welcome to a vast world. Your journey starts now.
@@ -3775,6 +4289,8 @@ catalog:
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2021
     minPlayers: 1
     maxPlayers: 4
@@ -3819,22 +4335,40 @@ catalog:
     - REXhry
     - リゴレ (rigoler)
     - Schwerkraft-Verlag
+    pdfBlobKey: rulebooks/v1/sleeping-gods_rulebook.pdf
+    pdfSha256: 07fe81f40884134f92b5b50720fa2348501b9b33c3f5dff774fda5ad12e2807c
+    pdfVersion: '1.0'
   - title: Jenga
     bggId: 2452
     language: en
     bggEnhanced: true
-    description: >+
-      Jenga is tower building game played with 54 wooden blocks; each block is 3 times as long as it is wide, and slightly smaller in height than in width. The blocks are stacked in a tower formation; each story is three blocks placed adjacent to each other along their long side, and each story is placed perpendicular to the previous (so, for example, if the blocks in the first story are pointing north-south, the second story blocks will point east-west). There are therefore 18 stories to the Jenga tower. Since stacking the blocks neatly can be tedious, a plastic loading tray is included.
+    description: 'Jenga is tower building game played with 54 wooden blocks; each block is 3 times as long as it is wide,
+      and slightly smaller in height than in width. The blocks are stacked in a tower formation; each story is three blocks
+      placed adjacent to each other along their long side, and each story is placed perpendicular to the previous (so, for
+      example, if the blocks in the first story are pointing north-south, the second story blocks will point east-west). There
+      are therefore 18 stories to the Jenga tower. Since stacking the blocks neatly can be tedious, a plastic loading tray
+      is included.
 
 
-      Once the tower is built, the person who built the tower moves first. Moving in Jenga consists of taking one and only one block from any story except the completed top story of the tower at the time of the turn, and placing it on the topmost story in order to complete it. Only one hand at a time may be used to remove a block; both hands can be used, but only one hand may be on the tower at a time. Blocks may be bumped to find a loose block that will not disturb the rest of the tower. Any block that is moved out of place may be left out of place if it is determined that it will knock the tower over if it is removed. The turn ends when the next person to move touches the tower, although he or she can wait 10 seconds before moving for the previous turn to end if they believe the tower will fall in that time.
+      Once the tower is built, the person who built the tower moves first. Moving in Jenga consists of taking one and only
+      one block from any story except the completed top story of the tower at the time of the turn, and placing it on the
+      topmost story in order to complete it. Only one hand at a time may be used to remove a block; both hands can be used,
+      but only one hand may be on the tower at a time. Blocks may be bumped to find a loose block that will not disturb the
+      rest of the tower. Any block that is moved out of place may be left out of place if it is determined that it will knock
+      the tower over if it is removed. The turn ends when the next person to move touches the tower, although he or she can
+      wait 10 seconds before moving for the previous turn to end if they believe the tower will fall in that time.
 
 
-      The game ends when the tower falls in any significant way -- in other words, any piece falls from the tower, other than the piece being knocked out to move to the top. The loser is the person who made the tower fall (i.e. whose turn it was when the tower fell); the winner is the person who moved before the loser.
+      The game ends when the tower falls in any significant way -- in other words, any piece falls from the tower, other than
+      the piece being knocked out to move to the top. The loser is the person who made the tower fall (i.e. whose turn it
+      was when the tower fell); the winner is the person who moved before the loser.
 
 
-      The same game concept was published in 1984 by Fagus under the name "Hoppla - eins zuviel!" According to the designer, the game was developed from Takoradi blocks/bricks. "Jenga" is Swahili for "build".
+      The same game concept was published in 1984 by Fagus under the name "Hoppla - eins zuviel!" According to the designer,
+      the game was developed from Takoradi blocks/bricks. "Jenga" is Swahili for "build".
 
+
+      '
     yearPublished: 1983
     minPlayers: 1
     maxPlayers: 8
@@ -3930,20 +4464,32 @@ catalog:
   - title: El Grande
     bggId: 93
     language: en
-    pdf: el-grande_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In this award-winning game, players take on the roles of Grandes in medieval Spain.  The king's power is flagging, and these powerful lords are vying for control of the various regions.  To that end, you draft caballeros (knights) into your court and subsequently move them onto the board to help seize control of regions.  After every third round, the regions are scored, and after the ninth round, the player with the most points is the winner.
+    description: 'In this award-winning game, players take on the roles of Grandes in medieval Spain.  The king''s power is
+      flagging, and these powerful lords are vying for control of the various regions.  To that end, you draft caballeros
+      (knights) into your court and subsequently move them onto the board to help seize control of regions.  After every third
+      round, the regions are scored, and after the ninth round, the player with the most points is the winner.
 
 
-      In each of the nine rounds, you select one of your 13 power cards to determine turn order as well as the number of caballeros you get to move from the provinces (general supply) into your court (personal supply).
+      In each of the nine rounds, you select one of your 13 power cards to determine turn order as well as the number of caballeros
+      you get to move from the provinces (general supply) into your court (personal supply).
 
 
-      A turn then consists of selecting one of five action cards which allow variations to the rules and additional scoring opportunities in addition to determining how many caballeros to move from your court to one or more of the regions on the board (or into the castillo - a secretive tower). Normally, you may only place your caballeros into regions adjacent to the one containing the king. The one hard and fast rule in El Grande is that nothing may move into or out of the king's region. One of the five action cards that is always available each round allows you to move the king to a new region. The other four action cards vary from round to round.
+      A turn then consists of selecting one of five action cards which allow variations to the rules and additional scoring
+      opportunities in addition to determining how many caballeros to move from your court to one or more of the regions on
+      the board (or into the castillo - a secretive tower). Normally, you may only place your caballeros into regions adjacent
+      to the one containing the king. The one hard and fast rule in El Grande is that nothing may move into or out of the
+      king''s region. One of the five action cards that is always available each round allows you to move the king to a new
+      region. The other four action cards vary from round to round.
 
 
-      The goal is to have a caballero majority in as many regions (and the castillo) as possible during a scoring round. Following the scoring of the castillo, you place any cubes you had there into the region you secretly indicated on your region dial. Each region is then scored individually according to a table printed in that region. Two-point bonuses are awarded for having sole majority in the region containing your Grande and in the region containing the king.
+      The goal is to have a caballero majority in as many regions (and the castillo) as possible during a scoring round. Following
+      the scoring of the castillo, you place any cubes you had there into the region you secretly indicated on your region
+      dial. Each region is then scored individually according to a table printed in that region. Two-point bonuses are awarded
+      for having sole majority in the region containing your Grande and in the region containing the king.
 
+
+      '
     yearPublished: 1995
     minPlayers: 2
     maxPlayers: 5
@@ -3987,17 +4533,26 @@ catalog:
     - MINDOK
     - Möbius Games
     - Rio Grande Games
+    pdfBlobKey: rulebooks/v1/el-grande_rulebook.pdf
+    pdfSha256: 414db220f71e3ab7e8735ee71945f960ea36e36f0a348ef91a55558d4f2097a3
+    pdfVersion: '1.0'
   - title: Aeon's End
     bggId: 191189
     language: en
-    pdf: aeons-end_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      The survivors of a long-ago invasion have taken refuge in the forgotten underground city of Gravehold. There, the desperate remnants of society have learned that the energy of the very breaches the beings use to attack them can be repurposed through various gems, transforming the malign energies within into beneficial spells and weapons to aid their last line of defense: the breach mages.
+    description: 'The survivors of a long-ago invasion have taken refuge in the forgotten underground city of Gravehold. There,
+      the desperate remnants of society have learned that the energy of the very breaches the beings use to attack them can
+      be repurposed through various gems, transforming the malign energies within into beneficial spells and weapons to aid
+      their last line of defense: the breach mages.
 
 
-      Aeon's End is a cooperative game that explores the deckbuilding genre with a number of innovative mechanisms, including a variable turn order system that simulates the chaos of an attack, and deck management rules that require careful planning with every discarded card. Players will struggle to defend Gravehold from The Nameless and their hordes using unique abilities, powerful spells, and, most importantly of all, their collective wits.
+      Aeon''s End is a cooperative game that explores the deckbuilding genre with a number of innovative mechanisms, including
+      a variable turn order system that simulates the chaos of an attack, and deck management rules that require careful planning
+      with every discarded card. Players will struggle to defend Gravehold from The Nameless and their hordes using unique
+      abilities, powerful spells, and, most importantly of all, their collective wits.
 
+
+      '
     yearPublished: 2016
     minPlayers: 1
     maxPlayers: 4
@@ -4046,30 +4601,24 @@ catalog:
     - REXhry
     - SD Games
     - Surfin' Meeple China
+    pdfBlobKey: rulebooks/v1/aeons-end_rulebook.pdf
+    pdfSha256: d4496bf1b1a69d52d59a1bfb544f1b220465ffbfcc453d1fb2834706d7cf423b
+    pdfVersion: '1.0'
   - title: Res Arcana
     bggId: 262712
     language: en
-    pdf: res-arcana_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Prepare Your Place of Power!
-
-
-      In a high tower, an Alchemist prepares potions, using vials filled with otherworldly fluids. In a sacred grove, a Druid grinds herbs for a mystical ritual. In the catacombs, a Necromancer summons a bone dragon... Welcome to the world of Res Arcana!
-
-
-      In it, Life, Death, Elan, Calm, and Gold are the essences that fuel the art of magic. Choose your mage, gather essences, craft unique artifacts, and use them to summon dragons, conquer places of power, and achieve victory!
-
-
-      A game typically lasts 4-6 rounds. In each round, players do these steps:
-
-
-          Collect essences: performs  any Collect abilities, and may take essences from components.
-          Do actions, 1 per turn, clockwise from the First Player: place an artifact, claim a monument or Place of Power, discard a card for 1 Gold or any 2 other essences, use a power on a straightened component, or pass: exchange magic items and draw 1 card. Play continues until all players have passed.
-          Pass procedure: If you are first to pass, take the First Player token, swap your magic item for a different magic item, draw 1 card.
-          Check victory points (10+ VPs). If no one has won: straighten all turned components, and begin the next round.
-
-
+    description: "Prepare Your Place of Power!\n\nIn a high tower, an Alchemist prepares potions, using vials filled with\
+      \ otherworldly fluids. In a sacred grove, a Druid grinds herbs for a mystical ritual. In the catacombs, a Necromancer\
+      \ summons a bone dragon... Welcome to the world of Res Arcana!\n\nIn it, Life, Death, Elan, Calm, and Gold are the essences\
+      \ that fuel the art of magic. Choose your mage, gather essences, craft unique artifacts, and use them to summon dragons,\
+      \ conquer places of power, and achieve victory!\n\nA game typically lasts 4-6 rounds. In each round, players do these\
+      \ steps:\n\n\n    Collect essences: performs  any Collect abilities, and may take essences from components.\n    Do\
+      \ actions, 1 per turn, clockwise from the First Player: place an artifact, claim a monument or Place of Power, discard\
+      \ a card for 1 Gold or any 2 other essences, use a power on a straightened component, or pass: exchange magic items\
+      \ and draw 1 card. Play continues until all players have passed.\n    Pass procedure: If you are first to pass, take\
+      \ the First Player token, swap your magic item for a different magic item, draw 1 card.\n    Check victory points (10+\
+      \ VPs). If no one has won: straighten all turned components, and begin the next round.\n\n\n"
     yearPublished: 2019
     minPlayers: 2
     maxPlayers: 4
@@ -4107,20 +4656,32 @@ catalog:
     - Rebel Sp. z o.o.
     - sternenschimmermeer
     - テンデイズゲームズ (TendaysGames)
+    pdfBlobKey: rulebooks/v1/res-arcana_rulebook.pdf
+    pdfSha256: 79eca4421a36e2b547b06132f32cdc31fbfbd417ac4f73a5eb6130db472d9886
+    pdfVersion: '1.0'
   - title: Hero Realms
     bggId: 198994
     language: en
-    pdf: hero-realms_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Hero Realms is a fantasy-themed deck-building game that is an adaptation of the award-winning Star Realms game. The game includes basic rules for two-player games, along with rules for multiplayer formats such as Free-For-All, Hunter, and Hydra.
+    description: 'Hero Realms is a fantasy-themed deck-building game that is an adaptation of the award-winning Star Realms
+      game. The game includes basic rules for two-player games, along with rules for multiplayer formats such as Free-For-All,
+      Hunter, and Hydra.
 
 
-      Each player starts the game with a ten-card personal deck containing gold (for buying) and weapons (for combat). You start each turn with a new hand of five cards from your personal deck. When your deck runs out of cards, you shuffle your discard pile into your new deck. An 80-card Market deck is shared by all players, with five cards being revealed from that deck to create the Market Row. As you play, you use gold to buy champion cards and action cards from the Market. These champions and actions can generate large amounts of gold, combat, or other powerful effects. You use combat to attack your opponent and their champions. When you reduce your opponent's score (called health) to zero, you win!
+      Each player starts the game with a ten-card personal deck containing gold (for buying) and weapons (for combat). You
+      start each turn with a new hand of five cards from your personal deck. When your deck runs out of cards, you shuffle
+      your discard pile into your new deck. An 80-card Market deck is shared by all players, with five cards being revealed
+      from that deck to create the Market Row. As you play, you use gold to buy champion cards and action cards from the Market.
+      These champions and actions can generate large amounts of gold, combat, or other powerful effects. You use combat to
+      attack your opponent and their champions. When you reduce your opponent''s score (called health) to zero, you win!
 
 
-      Multiple expansions are available for Hero Realms that allow players to start as a particular character (Cleric, Fighter, Ranger, Thief, or Wizard) and fight cooperatively against a Boss, fight Boss decks against one another, or compete in a campaign mode that has you gain experience to work through different levels of missions.
+      Multiple expansions are available for Hero Realms that allow players to start as a particular character (Cleric, Fighter,
+      Ranger, Thief, or Wizard) and fight cooperatively against a Boss, fight Boss decks against one another, or compete in
+      a campaign mode that has you gain experience to work through different levels of missions.
 
+
+      '
     yearPublished: 2016
     minPlayers: 2
     maxPlayers: 4
@@ -4159,17 +4720,26 @@ catalog:
     - Lord of Boards
     - MIPL
     - Rawstone
+    pdfBlobKey: rulebooks/v1/hero-realms_rulebook.pdf
+    pdfSha256: 5e9f80ac096cd880ce21bbebaf83a789e1b671d0f6f2746b1707565108ca79f8
+    pdfVersion: '1.0'
   - title: Roll Player
     bggId: 169426
     language: en
-    pdf: roll-player_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Mighty heroes don&rsquo;t just appear out of thin air -- you must create them! Race, class, alignment, skills, traits, and equipment are all elements of the perfect hero, who is ready to take on all opposition in the quest for glory and riches.
+    description: 'Mighty heroes don&rsquo;t just appear out of thin air -- you must create them! Race, class, alignment, skills,
+      traits, and equipment are all elements of the perfect hero, who is ready to take on all opposition in the quest for
+      glory and riches.
 
 
-      In Roll Player, you will compete to create the greatest fantasy adventurer who has ever lived, preparing your character to embark on an epic quest. Roll and draft dice to build up your character&rsquo;s attributes. Purchase weapons and armor to outfit your hero. Train to gain skills and discover your hero&rsquo;s traits to prepare them for their journey. Earn Reputation Stars by constructing the perfect character. The player with the greatest Reputation wins the game and will surely triumph over whatever nefarious plot lies ahead!
+      In Roll Player, you will compete to create the greatest fantasy adventurer who has ever lived, preparing your character
+      to embark on an epic quest. Roll and draft dice to build up your character&rsquo;s attributes. Purchase weapons and
+      armor to outfit your hero. Train to gain skills and discover your hero&rsquo;s traits to prepare them for their journey.
+      Earn Reputation Stars by constructing the perfect character. The player with the greatest Reputation wins the game and
+      will surely triumph over whatever nefarious plot lies ahead!
 
+
+      '
     yearPublished: 2016
     minPlayers: 1
     maxPlayers: 4
@@ -4207,22 +4777,32 @@ catalog:
     - Pegasus Spiele
     - Raven Distribution
     - REXhry
+    pdfBlobKey: rulebooks/v1/roll-player_rulebook.pdf
+    pdfSha256: 0ae1cee918d58e165308cdef58b731e89a916652e919e7b61dbe74cb29e5240b
+    pdfVersion: '1.0'
   - title: Yahtzee
     bggId: 2243
     language: en
     bggEnhanced: true
-    description: >+
-      Yahtzee is a classic dice game played with 5 dice.  Each player's turn consists of rolling the dice up to 3 times in hope of making 1 of 13 categories.  Examples of categories are 3 of a kind, 4 of a kind, straight, full house, etc.  Each player tries to fill in a score for each category, but this is not always possible.  When all players have entered a score or a zero for all 13 categories, the game ends and total scores are compared.
+    description: 'Yahtzee is a classic dice game played with 5 dice.  Each player''s turn consists of rolling the dice up
+      to 3 times in hope of making 1 of 13 categories.  Examples of categories are 3 of a kind, 4 of a kind, straight, full
+      house, etc.  Each player tries to fill in a score for each category, but this is not always possible.  When all players
+      have entered a score or a zero for all 13 categories, the game ends and total scores are compared.
 
 
       The traditional (public domain) game Yacht predates the trademarked game, and has slightly different scoring.
 
 
-      There are four basic scoring difference between the tradition game Yacht and Yahtzee.  They are:  1) Yacht has no Three of a Kind category, 2) there are no bonuses in Yacht, 3) there are no Joker rules in Yacht, and 4) the Full House category is scored as the sum of the dice.  The other scoring rules are identical between the two games.
+      There are four basic scoring difference between the tradition game Yacht and Yahtzee.  They are:  1) Yacht has no Three
+      of a Kind category, 2) there are no bonuses in Yacht, 3) there are no Joker rules in Yacht, and 4) the Full House category
+      is scored as the sum of the dice.  The other scoring rules are identical between the two games.
 
 
-      Travel versions of the game use a device that keeps the dice captured within compartments of a plastic box and allows players to "lock" a particular die between rolls.
+      Travel versions of the game use a device that keeps the dice captured within compartments of a plastic box and allows
+      players to "lock" a particular die between rolls.
 
+
+      '
     yearPublished: 1956
     minPlayers: 2
     maxPlayers: 10
@@ -4321,8 +4901,10 @@ catalog:
     bggId: 2223
     language: en
     bggEnhanced: true
-    description: >+
-      Players race to empty their hands and catch opposing players with cards left in theirs, which score points. In turns, players attempt to play a card by matching its color, number, or word to the topmost card on the discard pile. If unable to play, players draw a card from the draw pile, and if still unable to play, they pass their turn. Wild and special cards spice things up a bit.
+    description: 'Players race to empty their hands and catch opposing players with cards left in theirs, which score points.
+      In turns, players attempt to play a card by matching its color, number, or word to the topmost card on the discard pile.
+      If unable to play, players draw a card from the draw pile, and if still unable to play, they pass their turn. Wild and
+      special cards spice things up a bit.
 
 
       UNO is a commercial version of Crazy Eights, a public domain card game played with a standard deck of playing cards.
@@ -4330,6 +4912,8 @@ catalog:
 
       This entry includes all themed versions of UNO that do not include new cards.
 
+
+      '
     yearPublished: 1971
     minPlayers: 2
     maxPlayers: 10
@@ -4386,18 +4970,26 @@ catalog:
   - title: Carcassonne
     bggId: 822
     language: en
-    pdf: carcassone_rulebook.pdf
     seedAgent: true
     bggEnhanced: true
-    description: >+
-      Carcassonne is a tile placement game in which the players draw and place a tile with a piece of southern French landscape represented on it. The tile might feature a city, a road, a cloister, grassland or some combination thereof, and it must be placed adjacent to tiles that have already been played, in such a way that cities are connected to cities, roads to roads, et cetera. Having placed a tile, the player can then decide to place one of their meeples in one of the areas on it: in the city as a knight, on the road as a robber, in the cloister as a monk, or in the field as a farmer. When that area is complete that meeple scores points for its owner.
+    description: 'Carcassonne is a tile placement game in which the players draw and place a tile with a piece of southern
+      French landscape represented on it. The tile might feature a city, a road, a cloister, grassland or some combination
+      thereof, and it must be placed adjacent to tiles that have already been played, in such a way that cities are connected
+      to cities, roads to roads, et cetera. Having placed a tile, the player can then decide to place one of their meeples
+      in one of the areas on it: in the city as a knight, on the road as a robber, in the cloister as a monk, or in the field
+      as a farmer. When that area is complete that meeple scores points for its owner.
 
 
-      During a game of Carcassonne, players are faced with decisions like: "Is it really worth putting my last meeple there?" or "Should I use this tile to expand my city, or should I place it near my opponent instead, thus making it a harder for them to complete it and score points?" Since players place only one tile and have the option to place one meeple on it, turns proceed quickly even if it is a game full of options and possibilities.
+      During a game of Carcassonne, players are faced with decisions like: "Is it really worth putting my last meeple there?"
+      or "Should I use this tile to expand my city, or should I place it near my opponent instead, thus making it a harder
+      for them to complete it and score points?" Since players place only one tile and have the option to place one meeple
+      on it, turns proceed quickly even if it is a game full of options and possibilities.
 
 
       First game in the Carcassonne series.
 
+
+      '
     yearPublished: 2000
     minPlayers: 2
     maxPlayers: 5
@@ -4463,22 +5055,28 @@ catalog:
     - Venice Connection
     - Ventura Games
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/carcassone_rulebook.pdf
+    pdfSha256: 762a1ca8cc547ef6c5a6899b0043ecd1ef6f448dc51cfcc6906827452d90253e
+    pdfVersion: '1.0'
   - title: Risk
     bggId: 181
     language: en
     bggEnhanced: true
-    description: >+
-      Possibly the most popular, mass market war game.  The goal is conquest of the world.
+    description: 'Possibly the most popular, mass market war game.  The goal is conquest of the world.
 
 
-      Each player's turn consists of:
+      Each player''s turn consists of:
 
-      - gaining reinforcements through number of territories held, control of every territory on each continent, and turning sets of bonus cards.
+      - gaining reinforcements through number of territories held, control of every territory on each continent, and turning
+      sets of bonus cards.
 
-      -  Attacking other players using a simple combat rule of comparing the highest dice rolled for each side.  Players may attack as often as desired.  If one enemy territory is successfully taken, the player is awarded with a  bonus card.
+      -  Attacking other players using a simple combat rule of comparing the highest dice rolled for each side.  Players may
+      attack as often as desired.  If one enemy territory is successfully taken, the player is awarded with a  bonus card.
 
       -  Moving a group of armies to another adjacent territory.
 
+
+      '
     yearPublished: 1959
     minPlayers: 2
     maxPlayers: 6
@@ -4537,17 +5135,31 @@ catalog:
   - title: Chess
     bggId: 171
     language: en
-    pdf: scacchi-fide_2017_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Chess is a two-player, abstract strategy board game that represents medieval warfare on an 8x8 board with alternating light and dark squares. Opposing pieces, traditionally designated White and Black, are initially lined up on either side of the board. Each type of piece has a unique form of movement and capturing occurs when a piece, via its movement, occupies the square of an opposing piece. Players take turns moving one of their pieces in an attempt to capture, attack, defend, or develop their positions. Chess games can end in checkmate (when the king cannot escape from the opponent's pieces), resignation (when one player recognizes that defeat is inevitable and ends the game), or one of several types of draws.
+    description: 'Chess is a two-player, abstract strategy board game that represents medieval warfare on an 8x8 board with
+      alternating light and dark squares. Opposing pieces, traditionally designated White and Black, are initially lined up
+      on either side of the board. Each type of piece has a unique form of movement and capturing occurs when a piece, via
+      its movement, occupies the square of an opposing piece. Players take turns moving one of their pieces in an attempt
+      to capture, attack, defend, or develop their positions. Chess games can end in checkmate (when the king cannot escape
+      from the opponent''s pieces), resignation (when one player recognizes that defeat is inevitable and ends the game),
+      or one of several types of draws.
 
 
-      Chess is one of the most popular games in the world, played by millions of people worldwide at home, in clubs, online, by correspondence, and in tournaments. Between two highly skilled players, chess can be a beautiful thing to watch, and a game can provide great entertainment even for novices. The 2020 Netflix series, The Queen's Gambit was enjoyed by both chess players and non-players alike. There is also a large literature of books and periodicals about chess, typically featuring games and commentary by chess masters. Chess is so well known and highly regarded that it is often used as a metaphor in journalism, poetry, fiction, and film.
+      Chess is one of the most popular games in the world, played by millions of people worldwide at home, in clubs, online,
+      by correspondence, and in tournaments. Between two highly skilled players, chess can be a beautiful thing to watch,
+      and a game can provide great entertainment even for novices. The 2020 Netflix series, The Queen''s Gambit was enjoyed
+      by both chess players and non-players alike. There is also a large literature of books and periodicals about chess,
+      typically featuring games and commentary by chess masters. Chess is so well known and highly regarded that it is often
+      used as a metaphor in journalism, poetry, fiction, and film.
 
 
-      Chess evolved from the ancient Indian game Chaturanga, which became Shatranj when introduced to the Persians. The current form of the game emerged in the second half of the 15th century when the Persians brought Shatranj to Southern Europe. The tradition of organized competitive chess began in the 16th century. The first official World Chess Champion, Wilhelm Steinitz, claimed his title in 1886. Chess is also a recognized sport of the International Olympic Committee.
+      Chess evolved from the ancient Indian game Chaturanga, which became Shatranj when introduced to the Persians. The current
+      form of the game emerged in the second half of the 15th century when the Persians brought Shatranj to Southern Europe.
+      The tradition of organized competitive chess began in the 16th century. The first official World Chess Champion, Wilhelm
+      Steinitz, claimed his title in 1886. Chess is also a recognized sport of the International Olympic Committee.
 
+
+      '
     yearPublished: 1475
     minPlayers: 2
     maxPlayers: 2
@@ -4777,20 +5389,23 @@ catalog:
     - Xinliye
     - Οδύσσεια
     - Киевпластмасс
+    pdfBlobKey: rulebooks/v1/scacchi-fide_2017_rulebook.pdf
+    pdfSha256: dcd7496d22fb8efd3af35646ac38e8b07250acf0670772133d7983d9c82c0542
+    pdfVersion: '1.0'
   - title: Checkers
     bggId: 2083
     language: en
     bggEnhanced: true
-    description: >+
-      Abstract strategy game where players move disc-shaped pieces across an 8 by 8 cross-hatched ("checker") board. 
-
-      Pieces only move diagonally, and only one space at a time.  If a player can move one of his pieces so that it jumps over an adjacent piece of their opponent and into an empty space, that player captures the opponent's disc.  Jumping moves must be taken when possible, thereby creating a strategy game where players offer up jumps in exchange for setting up the board so that they jump even more pieces on their turn.  A player wins by removing all of his opponent's pieces from the board or by blocking the opponent so that he has no more moves.
-
-      This game, also known as Draughts, is part of the Checkers family.
-
-
-      The Official Checker Board to be used in tournaments and official matches of associations like international WCDF, ACF, and APCA usually shall be colored of green and off-white (buff). Board squares shall be not less than 2 inches nor more than 2&frac12; inches wide. Tournament pieces are Red and White, but called Black and White in game related literature.
-
+    description: "Abstract strategy game where players move disc-shaped pieces across an 8 by 8 cross-hatched (\"checker\"\
+      ) board. \nPieces only move diagonally, and only one space at a time.  If a player can move one of his pieces so that\
+      \ it jumps over an adjacent piece of their opponent and into an empty space, that player captures the opponent's disc.\
+      \  Jumping moves must be taken when possible, thereby creating a strategy game where players offer up jumps in exchange\
+      \ for setting up the board so that they jump even more pieces on their turn.  A player wins by removing all of his opponent's\
+      \ pieces from the board or by blocking the opponent so that he has no more moves.\nThis game, also known as Draughts,\
+      \ is part of the Checkers family.\n\nThe Official Checker Board to be used in tournaments and official matches of associations\
+      \ like international WCDF, ACF, and APCA usually shall be colored of green and off-white (buff). Board squares shall\
+      \ be not less than 2 inches nor more than 2&frac12; inches wide. Tournament pieces are Red and White, but called Black\
+      \ and White in game related literature.\n\n"
     yearPublished: 1150
     minPlayers: 2
     maxPlayers: 2
@@ -4972,24 +5587,35 @@ catalog:
   - title: Pandemic
     bggId: 30549
     language: en
-    pdf: pandemic_rulebook.pdf
     seedAgent: true
     bggEnhanced: true
-    description: >+
-      In Pandemic, several virulent diseases have broken out simultaneously all over the world! The players are disease-fighting specialists whose mission is to treat disease hotspots while researching cures for each of four plagues before they get out of hand.
+    description: 'In Pandemic, several virulent diseases have broken out simultaneously all over the world! The players are
+      disease-fighting specialists whose mission is to treat disease hotspots while researching cures for each of four plagues
+      before they get out of hand.
 
 
-      The game board depicts several major population centers on Earth. On each turn, a player can use up to four actions to travel between cities, treat infected populaces, discover a cure, or build a research station. A deck of cards provides the players with these abilities, but sprinkled throughout this deck are Epidemic! cards that accelerate and intensify the diseases' activity. A second, separate deck of cards controls the "normal" spread of the infections.
+      The game board depicts several major population centers on Earth. On each turn, a player can use up to four actions
+      to travel between cities, treat infected populaces, discover a cure, or build a research station. A deck of cards provides
+      the players with these abilities, but sprinkled throughout this deck are Epidemic! cards that accelerate and intensify
+      the diseases'' activity. A second, separate deck of cards controls the "normal" spread of the infections.
 
 
-      Taking a unique role within the team, players must plan their strategy to mesh with their specialists' strengths in order to conquer the diseases. For example, the Operations Expert can build research stations which are needed to find cures for the diseases and which allow for greater mobility between cities; the Scientist needs only four cards of a particular disease to cure it instead of the normal five&mdash;but the diseases are spreading quickly and time is running out. If one or more diseases spreads beyond recovery or if too much time elapses, the players all lose. If they cure the four diseases, they all win!
+      Taking a unique role within the team, players must plan their strategy to mesh with their specialists'' strengths in
+      order to conquer the diseases. For example, the Operations Expert can build research stations which are needed to find
+      cures for the diseases and which allow for greater mobility between cities; the Scientist needs only four cards of a
+      particular disease to cure it instead of the normal five&mdash;but the diseases are spreading quickly and time is running
+      out. If one or more diseases spreads beyond recovery or if too much time elapses, the players all lose. If they cure
+      the four diseases, they all win!
 
 
-      The 2013 edition of Pandemic includes two new characters&mdash;the Contingency Planner and the Quarantine Specialist&mdash;not available in earlier editions of the game.
+      The 2013 edition of Pandemic includes two new characters&mdash;the Contingency Planner and the Quarantine Specialist&mdash;not
+      available in earlier editions of the game.
 
 
       Pandemic is the first game in the Pandemic series.
 
+
+      '
     yearPublished: 2008
     minPlayers: 2
     maxPlayers: 4
@@ -5060,30 +5686,52 @@ catalog:
     - Zhiyanjia
     - Взрослые дети
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/pandemic_rulebook.pdf
+    pdfSha256: 6634e5cdbcc73afdb03ae788b096e6f1c251eeca39d1c66960f51f8ed1e38e02
+    pdfVersion: '1.0'
   - title: Monopoly
     bggId: 1406
     language: en
     bggEnhanced: true
-    description: >+
-      Theme
+    description: 'Theme
 
-      Players take the part of land owners, attempting to buy and then develop their land. Income is gained by other players visiting their properties and money is spent when they visit properties belonging to other players. When times get tough, players may have to mortgage their properties to raise cash for fines, taxes and other misfortunes.
+      Players take the part of land owners, attempting to buy and then develop their land. Income is gained by other players
+      visiting their properties and money is spent when they visit properties belonging to other players. When times get tough,
+      players may have to mortgage their properties to raise cash for fines, taxes and other misfortunes.
 
 
       Gameplay
 
-      On their turn, a player rolls two dice and moves that number of spaces around the board. If the player lands on an as-yet-unowned property, they has the opportunity to buy it or auction it to the highest bidder. If a player owns all the spaces within a color group, they may then build houses and hotels on these spaces, generating even more income from opponents who land there. If they lands on a property owned by another player, they must pay that player rent according to the value of the land and any buildings on it. There are other places on the board which can not be bought, but instead require the player to draw a card and perform the action on the card, pay taxes, collect income, or even go to jail.
+      On their turn, a player rolls two dice and moves that number of spaces around the board. If the player lands on an as-yet-unowned
+      property, they has the opportunity to buy it or auction it to the highest bidder. If a player owns all the spaces within
+      a color group, they may then build houses and hotels on these spaces, generating even more income from opponents who
+      land there. If they lands on a property owned by another player, they must pay that player rent according to the value
+      of the land and any buildings on it. There are other places on the board which can not be bought, but instead require
+      the player to draw a card and perform the action on the card, pay taxes, collect income, or even go to jail.
 
 
       Goal
 
-      The goal of the game is to be the last player remaining with any money. (though some editions end the game when the first player goes bankrupt)
+      The goal of the game is to be the last player remaining with any money. (though some editions end the game when the
+      first player goes bankrupt)
 
 
       Cultural impact on rules
 
-      Monopoly is unusual in that the game has official, printed rules, but most players learn how to play from others, never actually learning the correct way to play. This has led to the canonization of a number of house rules that make the game more palatable to children (and sore losers) but harm the gameplay by preventing players from going bankrupt or slowing down the rate of property acquisition. One common house rule has players put any money paid to the bank in the center of the board, which jackpot a player may earn by landing on Free Parking. This prevents the game from removing money from play, and since players collect $200 each time they pass Go, this results in ever-increasing bankrolls and players surviving rents that should have bankrupted them. Another house rule allows players to take "loans" from the bank instead of going bankrupt, which means the game will never end. Some house rules arise out of ignorance rather than attempts to improve the game. For instance, many players don't know that properties landed on but left unbought go up for auction, and even some that know to auction don't know that the bidding starts at $1, meaning a player may pay well below the listed price for an auctioned property.
+      Monopoly is unusual in that the game has official, printed rules, but most players learn how to play from others, never
+      actually learning the correct way to play. This has led to the canonization of a number of house rules that make the
+      game more palatable to children (and sore losers) but harm the gameplay by preventing players from going bankrupt or
+      slowing down the rate of property acquisition. One common house rule has players put any money paid to the bank in the
+      center of the board, which jackpot a player may earn by landing on Free Parking. This prevents the game from removing
+      money from play, and since players collect $200 each time they pass Go, this results in ever-increasing bankrolls and
+      players surviving rents that should have bankrupted them. Another house rule allows players to take "loans" from the
+      bank instead of going bankrupt, which means the game will never end. Some house rules arise out of ignorance rather
+      than attempts to improve the game. For instance, many players don''t know that properties landed on but left unbought
+      go up for auction, and even some that know to auction don''t know that the bidding starts at $1, meaning a player may
+      pay well below the listed price for an auctioned property.
 
+
+      '
     yearPublished: 1935
     minPlayers: 2
     maxPlayers: 8
@@ -5180,12 +5828,19 @@ catalog:
     bggId: 320
     language: en
     bggEnhanced: true
-    description: >+
-      In this classic word game, players use their seven drawn letter-tiles to form words on the gameboard. Each word laid out earns points based on the commonality of the letters used, with certain board spaces giving bonuses.  But a word can only be played if it uses at least one already-played tile or adds to an already-played word.  This leads to slightly tactical play, as potential words are rejected because they would give an opponent too much access to the better bonus spaces.
+    description: 'In this classic word game, players use their seven drawn letter-tiles to form words on the gameboard. Each
+      word laid out earns points based on the commonality of the letters used, with certain board spaces giving bonuses.  But
+      a word can only be played if it uses at least one already-played tile or adds to an already-played word.  This leads
+      to slightly tactical play, as potential words are rejected because they would give an opponent too much access to the
+      better bonus spaces.
 
 
-      Skip-a-cross was licensed by Selchow & Righter and manufactured by Cadaco. Both games have identical rules but Skip-a-cross has tiles and racks made of cardboard instead of wood. The game was also published because not enough Scrabble games were manufactured to meet the demand.
+      Skip-a-cross was licensed by Selchow & Righter and manufactured by Cadaco. Both games have identical rules but Skip-a-cross
+      has tiles and racks made of cardboard instead of wood. The game was also published because not enough Scrabble games
+      were manufactured to meet the demand.
 
+
+      '
     yearPublished: 1948
     minPlayers: 2
     maxPlayers: 4
@@ -5271,21 +5926,29 @@ catalog:
     bggId: 2394
     language: en
     bggEnhanced: true
-    description: >+
-      A traditional tile game played in many different cultures around the world.  This entry is for Western Dominoes; the standard set being the 28 "Double Six" tiles.  Chinese Dominoes use a 32 tile set with different distributions.
+    description: 'A traditional tile game played in many different cultures around the world.  This entry is for Western Dominoes;
+      the standard set being the 28 "Double Six" tiles.  Chinese Dominoes use a 32 tile set with different distributions.
 
 
-      Dominoes is a family of games using the "Western" style tiles.  The standard set of tiles is based on the 21 different combinations made with a roll of two six-sided dice.  Seven (7) additional "Blank" combination tiles combine with the 21 to form the standard 28 "Double-Six" set. "Double-Nine" (with 55 tiles) and "Double-Twelve" (with 91 tiles) are also popular. "Double-Fifteen" sets with 136 tiles also exist.
+      Dominoes is a family of games using the "Western" style tiles.  The standard set of tiles is based on the 21 different
+      combinations made with a roll of two six-sided dice.  Seven (7) additional "Blank" combination tiles combine with the
+      21 to form the standard 28 "Double-Six" set. "Double-Nine" (with 55 tiles) and "Double-Twelve" (with 91 tiles) are also
+      popular. "Double-Fifteen" sets with 136 tiles also exist.
 
 
-      There are many different games played with Dominoes.  The standard game is known as the Block game.  Forms of this game are known in many different areas of the world with similar rules.  Puerto Rican Dominoes, Latin Dominoes, and Cuban Dominoes are all forms of the Block game.
+      There are many different games played with Dominoes.  The standard game is known as the Block game.  Forms of this game
+      are known in many different areas of the world with similar rules.  Puerto Rican Dominoes, Latin Dominoes, and Cuban
+      Dominoes are all forms of the Block game.
 
 
-      Another main variety of Dominoes games are based on the "Fives Family".  Five-up, All Fives, Sniff, and Muggins are all part of this family.  This variation adds the ends of the dominoes to make a multiple of five for scoring.
+      Another main variety of Dominoes games are based on the "Fives Family".  Five-up, All Fives, Sniff, and Muggins are
+      all part of this family.  This variation adds the ends of the dominoes to make a multiple of five for scoring.
 
 
       Other popular Dominoes games include 42, ChickenFoot, and Mexican Train.
 
+
+      '
     yearPublished: 1500
     minPlayers: 2
     maxPlayers: 10
@@ -5486,15 +6149,22 @@ catalog:
     bggId: 188
     language: en
     bggEnhanced: true
-    description: >+
-      In Go, players alternately place stones on the empty intersections of a 19x19 grid. The goal: to enclose territory behind stone perimeters and, secondarily, to tightly surround and capture enemy stones. After both players pass, they add up their territory and deduct the number of captives lost, higher score wins.
+    description: 'In Go, players alternately place stones on the empty intersections of a 19x19 grid. The goal: to enclose
+      territory behind stone perimeters and, secondarily, to tightly surround and capture enemy stones. After both players
+      pass, they add up their territory and deduct the number of captives lost, higher score wins.
 
 
-      As you see, the concept is simple, yet the challenge can enrich a lifetime. In truth many lifetimes, for Go has been played for thousands of years. With that long of a lineage and a worldwide following, it has come to be known by different names (Weiqi, Igo, Baduk) and to be played by slightly differing rules, but those differences seldom affect play.
+      As you see, the concept is simple, yet the challenge can enrich a lifetime. In truth many lifetimes, for Go has been
+      played for thousands of years. With that long of a lineage and a worldwide following, it has come to be known by different
+      names (Weiqi, Igo, Baduk) and to be played by slightly differing rules, but those differences seldom affect play.
 
 
-      So welcome to this masterpiece that is the game of Go, the race for geographical control of an unclaimed land. Experience running battles and swift reversals, bold invasions and painful sacrifices, each sally, each setback playing out to the dulcet tap of stone on wood.
+      So welcome to this masterpiece that is the game of Go, the race for geographical control of an unclaimed land. Experience
+      running battles and swift reversals, bold invasions and painful sacrifices, each sally, each setback playing out to
+      the dulcet tap of stone on wood.
 
+
+      '
     yearPublished: -2200
     minPlayers: 2
     maxPlayers: 2
@@ -5600,18 +6270,35 @@ catalog:
     bggId: 2397
     language: en
     bggEnhanced: true
-    description: >+
-      Backgammon is a classic abstract strategy game dating back thousands of years. Each player has a set of 15 checkers (or stones) that must be moved from their starting positions, around, and then off the board. Dice are thrown each turn, and each player must decide which of their checkers to move based on the outcome of the roll. Players can capture each other's checkers, forcing the captured checkers to restart their journey around the board. The winner is the first player to get all 15 checkers off the board. A more recent addition to the game is the "doubling cube", which allows players to up the stakes of the game. Although the game relies on dice to determine movement, there is a large degree of strategy in deciding how to make the most effective moves given each dice roll and measuring the risk in terms of possible rolls the opponent may get.
+    description: 'Backgammon is a classic abstract strategy game dating back thousands of years. Each player has a set of
+      15 checkers (or stones) that must be moved from their starting positions, around, and then off the board. Dice are thrown
+      each turn, and each player must decide which of their checkers to move based on the outcome of the roll. Players can
+      capture each other''s checkers, forcing the captured checkers to restart their journey around the board. The winner
+      is the first player to get all 15 checkers off the board. A more recent addition to the game is the "doubling cube",
+      which allows players to up the stakes of the game. Although the game relies on dice to determine movement, there is
+      a large degree of strategy in deciding how to make the most effective moves given each dice roll and measuring the risk
+      in terms of possible rolls the opponent may get.
 
 
-      Backgammon may be the first game to be mentioned in written history, going back 5,000 years to the Sumerians of ancient Mesopotamia. During the 1920s, archaeologists unearthed five boards from a cemetery in the ancient town of Ur. At another location, pieces and dice were also found along with the board. Boards from ancient Egypt have also been recovered from the tomb of Tutankhamun, including a mechanical dice box, no doubt intended to stop cheaters.
+      Backgammon may be the first game to be mentioned in written history, going back 5,000 years to the Sumerians of ancient
+      Mesopotamia. During the 1920s, archaeologists unearthed five boards from a cemetery in the ancient town of Ur. At another
+      location, pieces and dice were also found along with the board. Boards from ancient Egypt have also been recovered from
+      the tomb of Tutankhamun, including a mechanical dice box, no doubt intended to stop cheaters.
 
 
-      The names of the game were many. In Persia, Takhteh Nard which means "Battle on Wood". In Egypt, Tau, which may be the ancestor of Senat. In Rome, Ludus Duodecim Scriptorum ("game of twelve marks"), later, Tabula ("table"), and by the sixth century, Alea ("dice"). In ancient China, T-shu-p-u and later in Japan, Sugoroko. The English name may derive from "Bac gamen" meaning "Back Game", referring to re-entry of taken stones back to the board. It was often enjoyed by the upper classes and is sometimes called "The Aristocratic Game". The Roman Emperor Claudius was known to be such a fan of Tabula that he had a set built into his coach so he could play as he traveled (the world's first travel edition?).
+      The names of the game were many. In Persia, Takhteh Nard which means "Battle on Wood". In Egypt, Tau, which may be the
+      ancestor of Senat. In Rome, Ludus Duodecim Scriptorum ("game of twelve marks"), later, Tabula ("table"), and by the
+      sixth century, Alea ("dice"). In ancient China, T-shu-p-u and later in Japan, Sugoroko. The English name may derive
+      from "Bac gamen" meaning "Back Game", referring to re-entry of taken stones back to the board. It was often enjoyed
+      by the upper classes and is sometimes called "The Aristocratic Game". The Roman Emperor Claudius was known to be such
+      a fan of Tabula that he had a set built into his coach so he could play as he traveled (the world''s first travel edition?).
 
 
-      The rules in English were standardized in 1743 by Edmond Hoyle. These remained popular until the American innovations of the 1930s.
+      The rules in English were standardized in 1743 by Edmond Hoyle. These remained popular until the American innovations
+      of the 1930s.
 
+
+      '
     yearPublished: -3000
     minPlayers: 2
     maxPlayers: 2
@@ -5812,18 +6499,28 @@ catalog:
     bggId: 1294
     language: en
     bggEnhanced: true
-    description: >+
-      For versions of Clue that feature the new character Dr. Orchid, please use this Clue page.
+    description: 'For versions of Clue that feature the new character Dr. Orchid, please use this Clue page.
 
 
       The classic detective game!   A game for those who enjoy reasoning and thinking things out.
 
 
-      In Clue, players move from room to room in a mansion to solve the mystery of: who done it, with what, and where?  Players are dealt character, weapon, and location cards after the top card from each card type is secretly placed in the confidential file in the middle of the board.  Players must move to a room and then make a suggestion against a character saying they did it in that room with a specific weapon.  The player to the left must show one of any cards mentioned if in that player's hand.  Through deductive reasoning each player must figure out which character, weapon, and location are in the secret file.  To do this, each player must uncover what cards are in other players hands by making more and more suggestions.  Once a player knows what cards the other players are holding, they will know what cards are in the secret file, and then make an accusation. If correct, the player wins, but if incorrect, the player must return the cards to the file without revealing them and may no longer make suggestions or accusations.
+      In Clue, players move from room to room in a mansion to solve the mystery of: who done it, with what, and where?  Players
+      are dealt character, weapon, and location cards after the top card from each card type is secretly placed in the confidential
+      file in the middle of the board.  Players must move to a room and then make a suggestion against a character saying
+      they did it in that room with a specific weapon.  The player to the left must show one of any cards mentioned if in
+      that player''s hand.  Through deductive reasoning each player must figure out which character, weapon, and location
+      are in the secret file.  To do this, each player must uncover what cards are in other players hands by making more and
+      more suggestions.  Once a player knows what cards the other players are holding, they will know what cards are in the
+      secret file, and then make an accusation. If correct, the player wins, but if incorrect, the player must return the
+      cards to the file without revealing them and may no longer make suggestions or accusations.
 
 
-      Note: There are some early versions of Clue which are labeled as 2-6 players. Recent and current issues of the game state 3-6 players.
+      Note: There are some early versions of Clue which are labeled as 2-6 players. Recent and current issues of the game
+      state 3-6 players.
 
+
+      '
     yearPublished: 1949
     minPlayers: 2
     maxPlayers: 6
@@ -5900,15 +6597,22 @@ catalog:
     bggId: 74
     language: en
     bggEnhanced: true
-    description: >+
-      The party game Apples to Apples consists of two decks of cards: Things and Descriptions. Each round, the active player draws a Description card (which features an adjective like "Hairy" or "Smarmy") from the deck, then the other players each secretly choose the Thing card in hand that best matches that description and plays it face-down on the table. The active player then reveals these cards and chooses the Thing card that, in his opinion, best matches the Description card, which he awards to whoever played that Thing card. This player becomes the new active player for the next round.
+    description: 'The party game Apples to Apples consists of two decks of cards: Things and Descriptions. Each round, the
+      active player draws a Description card (which features an adjective like "Hairy" or "Smarmy") from the deck, then the
+      other players each secretly choose the Thing card in hand that best matches that description and plays it face-down
+      on the table. The active player then reveals these cards and chooses the Thing card that, in his opinion, best matches
+      the Description card, which he awards to whoever played that Thing card. This player becomes the new active player for
+      the next round.
 
 
       Once a player has won a pre-determined number of Description cards, that player wins.
 
 
-      Note: "Party Box" editions include all cards from Apples to Apples: Expansion Set #1 and Apples to Apples: Expansion Set #2
+      Note: "Party Box" editions include all cards from Apples to Apples: Expansion Set #1 and Apples to Apples: Expansion
+      Set #2
 
+
+      '
     yearPublished: 1999
     minPlayers: 4
     maxPlayers: 10
@@ -5945,31 +6649,16 @@ catalog:
     bggId: 163
     language: en
     bggEnhanced: true
-    description: >+
-      A clever repackaging of the parlor game Dictionary, Balderdash contains several cards with real words nobody has heard of.  After one of those words has been read aloud, players try to come up with definitions that at least sound plausible, because points are later awarded for every opposing player who guessed that your definition was the correct one.
-
-
-      Versions of the game as a parlor game go back at least as far as 1970, although Balderdash itself was not published until 1984.
-
-
-      Mattel, Inc. republished Balderdash in 2006 in a form that derives its gameplay from the sequel Beyond Balderdash.
-
-
-      Re-implemented by:
-
-          Beyond Balderdash / Absolute Balderdash
-          Kokkelimonke Jubileum
-
-
-      Re-implements:
-
-          Beyond Balderdash*
-
-
-
-          In a peculiar situation, this game was reimplemented by Beyond/Absolute Balderdash and then combined back into the original title (Balderdash) but with the rules and cards from Beyond/Absolute; while Tactic re-published their version of Beyond/Absolute combined with the original Balderdash and called it Kokkelimonke Jubileum.
-
-
+    description: "A clever repackaging of the parlor game Dictionary, Balderdash contains several cards with real words nobody\
+      \ has heard of.  After one of those words has been read aloud, players try to come up with definitions that at least\
+      \ sound plausible, because points are later awarded for every opposing player who guessed that your definition was the\
+      \ correct one.\n\nVersions of the game as a parlor game go back at least as far as 1970, although Balderdash itself\
+      \ was not published until 1984.\n\nMattel, Inc. republished Balderdash in 2006 in a form that derives its gameplay from\
+      \ the sequel Beyond Balderdash.\n\nRe-implemented by:\n\n    Beyond Balderdash / Absolute Balderdash\n    Kokkelimonke\
+      \ Jubileum\n\n\nRe-implements:\n\n    Beyond Balderdash*\n\n\n\n    In a peculiar situation, this game was reimplemented\
+      \ by Beyond/Absolute Balderdash and then combined back into the original title (Balderdash) but with the rules and cards\
+      \ from Beyond/Absolute; while Tactic re-published their version of Beyond/Absolute combined with the original Balderdash\
+      \ and called it Kokkelimonke Jubileum.\n\n\n"
     yearPublished: 1984
     minPlayers: 2
     maxPlayers: 6
@@ -6013,18 +6702,23 @@ catalog:
     bggId: 1293
     language: en
     bggEnhanced: true
-    description: >+
-      Boggle is a timed word game in which players have 3 minutes to find as many connected words as possible from the face up letters resting in a 16 cube grid.  When the timer runs out, players compare their lists of words and remove any words found by multiple players.  Points are then awarded for remaining words, depending on how many letters are in the word.  (In the original Boggle, all words must contain 3 or more letters to score points.)
+    description: 'Boggle is a timed word game in which players have 3 minutes to find as many connected words as possible
+      from the face up letters resting in a 16 cube grid.  When the timer runs out, players compare their lists of words and
+      remove any words found by multiple players.  Points are then awarded for remaining words, depending on how many letters
+      are in the word.  (In the original Boggle, all words must contain 3 or more letters to score points.)
 
 
       An example grid given in the French Canadian rules (of Deluxe Boggle) holds an amazing 459 words!
 
 
-      A number of variants have been produced by Parker Brothers over time, including Big Boggle (which uses a 5&times;5 grid of letters and forces players to search for longer words).
+      A number of variants have been produced by Parker Brothers over time, including Big Boggle (which uses a 5&times;5 grid
+      of letters and forces players to search for longer words).
 
 
       Boggle is a word dice game.
 
+
+      '
     yearPublished: 1972
     minPlayers: 1
     maxPlayers: 8
@@ -6071,18 +6765,11 @@ catalog:
     bggId: 2381
     language: en
     bggEnhanced: true
-    description: >+
-      In "The Game of Scattergories," published in 1988 by Milton Bradley, each player fills out a category list with answers that begin with the same letter. If no other player matches your answers, you score points. The game is played in rounds. After 3 rounds a winner is declared, and a new game can be begun.
-
-
-      Scattergories is a commercial version of an old parlour game known as Categories or Guggenheim.
-
-
-      Similar to:
-
-          Facts in Five
-
-
+    description: "In \"The Game of Scattergories,\" published in 1988 by Milton Bradley, each player fills out a category\
+      \ list with answers that begin with the same letter. If no other player matches your answers, you score points. The\
+      \ game is played in rounds. After 3 rounds a winner is declared, and a new game can be begun.\n\nScattergories is a\
+      \ commercial version of an old parlour game known as Categories or Guggenheim.\n\nSimilar to:\n\n    Facts in Five\n\
+      \n\n"
     yearPublished: 1988
     minPlayers: 2
     maxPlayers: 6
@@ -6119,15 +6806,22 @@ catalog:
     bggId: 27225
     language: en
     bggEnhanced: true
-    description: >+
-      Bananagrams is a fast and fun word game that requires no pencil, paper or board, and the tiles come in a fabric banana-shaped carrying pouch. One hand can be played in as little as five minutes. Much like Pick Two!, but without the letter values.
+    description: 'Bananagrams is a fast and fun word game that requires no pencil, paper or board, and the tiles come in a
+      fabric banana-shaped carrying pouch. One hand can be played in as little as five minutes. Much like Pick Two!, but without
+      the letter values.
 
 
-      Using a selection of 144 plastic letter tiles in the English edition, each player works independently to create their own 'crossword' faster than one's opponents. When a player uses up all their letters, all players take a new tile from the pool. The object of the game is to be the first to complete a word grid after the "bunch" of tiles has been depleted.
+      Using a selection of 144 plastic letter tiles in the English edition, each player works independently to create their
+      own ''crossword'' faster than one''s opponents. When a player uses up all their letters, all players take a new tile
+      from the pool. The object of the game is to be the first to complete a word grid after the "bunch" of tiles has been
+      depleted.
 
 
-      There are variants included in the instructions, such as Banana Smoothie and Banana Cafe for limited set skills or space-deprived places, and the game is suitable for solo play.
+      There are variants included in the instructions, such as Banana Smoothie and Banana Cafe for limited set skills or space-deprived
+      places, and the game is suitable for solo play.
 
+
+      '
     yearPublished: 2006
     minPlayers: 1
     maxPlayers: 8
@@ -6170,23 +6864,31 @@ catalog:
   - title: 'Survive: Escape from Atlantis!'
     bggId: 2653
     language: en
-    pdf: survive-escape-from-atlantis_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Survive is a cutthroat game where players seek to evacuate their pieces from an island that is breaking up, while remembering where their highest-valued pieces are located to maximize their score.
+    description: 'Survive is a cutthroat game where players seek to evacuate their pieces from an island that is breaking
+      up, while remembering where their highest-valued pieces are located to maximize their score.
 
 
-      An island made up of 40 hex-tiles is slowly sinking into the ocean (as the tiles are removed from the board). Each player controls ten people (valued from 1 to 6) that they try and move towards the safety of the surrounding islands before the main island finally blows up. Players can either swim or use boats to travel but must avoid sea serpents, whales and sharks on their way to safety.
+      An island made up of 40 hex-tiles is slowly sinking into the ocean (as the tiles are removed from the board). Each player
+      controls ten people (valued from 1 to 6) that they try and move towards the safety of the surrounding islands before
+      the main island finally blows up. Players can either swim or use boats to travel but must avoid sea serpents, whales
+      and sharks on their way to safety.
 
 
       Survive is very similar to Escape from Atlantis with some key differences.
 
 
-      Survive was reprinted as "Survive: Escape from Atlantis!" by publisher Stronghold Games and hit store shelves in February, 2011.   The reprint contains the game Survive, as well as all the extra pieces needed in order to play the game as "Escape from Atlantis" and is actually found here: Survive: Escape from Atlantis! because it came with the dolphins and dive dice which were removed from the anniversary edition which was released a couple of years later (though they were later made available by themselves for owners of that version).
+      Survive was reprinted as "Survive: Escape from Atlantis!" by publisher Stronghold Games and hit store shelves in February,
+      2011.   The reprint contains the game Survive, as well as all the extra pieces needed in order to play the game as "Escape
+      from Atlantis" and is actually found here: Survive: Escape from Atlantis! because it came with the dolphins and dive
+      dice which were removed from the anniversary edition which was released a couple of years later (though they were later
+      made available by themselves for owners of that version).
 
 
       "Survive: Escape from Atlantis!" is game #2 in the Stronghold Games "Survive Line".
 
+
+      '
     yearPublished: 1982
     minPlayers: 2
     maxPlayers: 4
@@ -6234,19 +6936,26 @@ catalog:
     - Vennerød Forlag AS
     - Waddingtons
     - Zygomatic
+    pdfBlobKey: rulebooks/v1/survive-escape-from-atlantis_rulebook.pdf
+    pdfSha256: f38dbcab30df17928d2e1102c5cfa0e8d3a1b0f8672f9ad39f616820f03c6c7c
+    pdfVersion: '1.0'
   - title: Spot it!
     bggId: 63268
     language: en
-    pdf: spot-it_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Spot it!, a.k.a. Dobble, is a simple pattern recognition game in which players try to find an image shown on two cards.
+    description: 'Spot it!, a.k.a. Dobble, is a simple pattern recognition game in which players try to find an image shown
+      on two cards.
 
 
-      Each card in original Spot it! features eight different symbols, with the symbols varying in size from one card to the next. Any two cards have exactly one symbol in common. For the basic Spot it! game, reveal one card, then another. Whoever spots the symbol in common on both cards claims the first card, then another card is revealed for players to search, and so on. Whoever has collected the most cards when the 55-card deck runs out wins!
+      Each card in original Spot it! features eight different symbols, with the symbols varying in size from one card to the
+      next. Any two cards have exactly one symbol in common. For the basic Spot it! game, reveal one card, then another. Whoever
+      spots the symbol in common on both cards claims the first card, then another card is revealed for players to search,
+      and so on. Whoever has collected the most cards when the 55-card deck runs out wins!
 
 
-      Rules for different games &ndash; each an observation game with a speed element &ndash; are included with Spot it!, with the first player to find a match either gaining or getting rid of a card. Multiple versions of Spot it! have been published, with images in each version ranging from Halloween to hockey to baseball to San Francisco.
+      Rules for different games &ndash; each an observation game with a speed element &ndash; are included with Spot it!,
+      with the first player to find a match either gaining or getting rid of a card. Multiple versions of Spot it! have been
+      published, with images in each version ranging from Halloween to hockey to baseball to San Francisco.
 
 
       The game is sold as Spot it! in the USA and Dobble in Europe, with slight differences between the two editions.
@@ -6254,6 +6963,8 @@ catalog:
 
       Note: some versions have fewer cards and fewer symbols per card. (E.g. 30 cards with 6 symbols each.): Spot it! 1,2,3
 
+
+      '
     yearPublished: 2009
     minPlayers: 2
     maxPlayers: 8
@@ -6322,19 +7033,26 @@ catalog:
     - Super Impulse
     - Top Toys
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/spot-it_rulebook.pdf
+    pdfSha256: f8fa9d62aa27a4070d9a632713c1fd22a904c1f735b74229c838b81225e3fcdd
+    pdfVersion: '1.0'
   - title: Connect Four
     bggId: 2719
     language: en
     bggEnhanced: true
-    description: >+
-      Connect 4 is a well known vertical game played with "checkers" game pieces, although it is more akin to Tic-Tac-Toe or Go Moku.
+    description: 'Connect 4 is a well known vertical game played with "checkers" game pieces, although it is more akin to
+      Tic-Tac-Toe or Go Moku.
 
 
-      The board is placed in the stand to hold it vertically and the players drop game pieces into one of the seven slots, each of which holds up to six game pieces, until one player succeeds in getting four in a row, whether horizontally, vertically, or diagonally.
+      The board is placed in the stand to hold it vertically and the players drop game pieces into one of the seven slots,
+      each of which holds up to six game pieces, until one player succeeds in getting four in a row, whether horizontally,
+      vertically, or diagonally.
 
 
-      The game is non-proprietary.  More elegant, wooden versions can be found under the name The Captain's Mistress.
+      The game is non-proprietary.  More elegant, wooden versions can be found under the name The Captain''s Mistress.
 
+
+      '
     yearPublished: 1974
     minPlayers: 2
     maxPlayers: 2
@@ -6454,9 +7172,12 @@ catalog:
     bggId: 4143
     language: en
     bggEnhanced: true
-    description: >+
-      The mystery face game where you flip over a collection of faces with different color hair, eye color, hair, hats, glasses etc.  to deduce who the secret person is that your opponent has chosen. You flip over the hooked tiles as you narrow your choices by asking characteristic questions.
+    description: 'The mystery face game where you flip over a collection of faces with different color hair, eye color, hair,
+      hats, glasses etc.  to deduce who the secret person is that your opponent has chosen. You flip over the hooked tiles
+      as you narrow your choices by asking characteristic questions.
 
+
+      '
     yearPublished: 1979
     minPlayers: 2
     maxPlayers: 2
@@ -6523,9 +7244,12 @@ catalog:
     bggId: 5432
     language: en
     bggEnhanced: true
-    description: >+
-      Traditional game from ancient India was brought to the UK in 1892 and first commercially published in the USA by Milton Bradley in 1943 (as Chutes and Ladders).  Players travel along the squares sometimes using ladders, which represent good acts, that allow the player to come closer to nirvana while the snakes were slides into evil.
+    description: 'Traditional game from ancient India was brought to the UK in 1892 and first commercially published in the
+      USA by Milton Bradley in 1943 (as Chutes and Ladders).  Players travel along the squares sometimes using ladders, which
+      represent good acts, that allow the player to come closer to nirvana while the snakes were slides into evil.
 
+
+      '
     yearPublished: -200
     minPlayers: 2
     maxPlayers: 6
@@ -6700,21 +7424,33 @@ catalog:
     bggId: 2407
     language: en
     bggEnhanced: true
-    description: >+
-      Slide Pursuit Game
+    description: 'Slide Pursuit Game
 
 
-      Race your four game pieces from Start around the board to your Home in this Pachisi type game. By turning over a card from the draw deck and following its instructions, players move their pieces around the game board, switch places with players, and knock opponents' pieces off the track and back to their Start position.
+      Race your four game pieces from Start around the board to your Home in this Pachisi type game. By turning over a card
+      from the draw deck and following its instructions, players move their pieces around the game board, switch places with
+      players, and knock opponents'' pieces off the track and back to their Start position.
 
 
-      Slides are located at various places around the game board. When a player's piece lands at the beginning of one of these slides not of its own color, it automatically advances to the end, removing any piece on the slide and sending it back to Start.
+      Slides are located at various places around the game board. When a player''s piece lands at the beginning of one of
+      these slides not of its own color, it automatically advances to the end, removing any piece on the slide and sending
+      it back to Start.
 
 
-      Game moves are directed exclusively by cards from the play-action deck.  If one plays the normal version in which one card is drawn from the deck each turn, the outcome has a huge element of luck.  Sorry can be made more of a strategic game (and more appealing to adults) by dealing five cards to each player at the start of the game and allowing the player to choose which card he/she will play each turn.  In this version, at the end of each turn, a new card is drawn from the deck to replace the card that was played, so that each player is always working from five cards.
+      Game moves are directed exclusively by cards from the play-action deck.  If one plays the normal version in which one
+      card is drawn from the deck each turn, the outcome has a huge element of luck.  Sorry can be made more of a strategic
+      game (and more appealing to adults) by dealing five cards to each player at the start of the game and allowing the player
+      to choose which card he/she will play each turn.  In this version, at the end of each turn, a new card is drawn from
+      the deck to replace the card that was played, so that each player is always working from five cards.
 
 
-      A player's fortunes can change dramatically in one or two rounds of play through the use of Sorry cards, the "11" cards (which give the player the option of trading places with an opponent's piece on the track), and the fact that it is possible to move from Start to Home without circumnavigating the full board by making judicious use of the "backward 4" cards.
+      A player''s fortunes can change dramatically in one or two rounds of play through the use of Sorry cards, the "11" cards
+      (which give the player the option of trading places with an opponent''s piece on the track), and the fact that it is
+      possible to move from Start to Home without circumnavigating the full board by making judicious use of the "backward
+      4" cards.
 
+
+      '
     yearPublished: 1929
     minPlayers: 2
     maxPlayers: 4
@@ -6765,16 +7501,20 @@ catalog:
   - title: 'Brass: Birmingham'
     bggId: 224517
     language: en
-    pdf: brass-birmingham_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Brass: Birmingham is an economic strategy game sequel to Martin Wallace's 2007 masterpiece, Brass. Brass: Birmingham tells the story of competing entrepreneurs in Birmingham during the industrial revolution between the years of 1770 and 1870.
+    description: 'Brass: Birmingham is an economic strategy game sequel to Martin Wallace''s 2007 masterpiece, Brass. Brass:
+      Birmingham tells the story of competing entrepreneurs in Birmingham during the industrial revolution between the years
+      of 1770 and 1870.
 
 
-      It offers a very different story arc and experience from its predecessor. As in its predecessor, you must develop, build and establish your industries and network in an effort to exploit low or high market demands. The game is played over two halves: the canal era (years 1770-1830) and the rail era (years 1830-1870). To win the game, score the most VPs. VPs are counted at the end of each half for the canals, rails and established (flipped) industry tiles.
+      It offers a very different story arc and experience from its predecessor. As in its predecessor, you must develop, build
+      and establish your industries and network in an effort to exploit low or high market demands. The game is played over
+      two halves: the canal era (years 1770-1830) and the rail era (years 1830-1870). To win the game, score the most VPs.
+      VPs are counted at the end of each half for the canals, rails and established (flipped) industry tiles.
 
 
-      Each round, players take turns according to the turn order track, receiving two actions to perform any of the following actions (found in the original game):
+      Each round, players take turns according to the turn order track, receiving two actions to perform any of the following
+      actions (found in the original game):
 
 
       1) Build - Pay required resources and place an industry tile.
@@ -6791,8 +7531,11 @@ catalog:
       Brass: Birmingham also features a new sixth action:
 
 
-      6) Scout - Discard three cards and take a wild location and wild industry card. (This action replaces Double Action Build in original Brass.)
+      6) Scout - Discard three cards and take a wild location and wild industry card. (This action replaces Double Action
+      Build in original Brass.)
 
+
+      '
     yearPublished: 2018
     minPlayers: 2
     maxPlayers: 4
@@ -6852,29 +7595,45 @@ catalog:
     - TLAMA games
     - White Goblin Games
     - 盒拍工作室 Hepa Studio
+    pdfBlobKey: rulebooks/v1/brass-birmingham_rulebook.pdf
+    pdfSha256: 71916357bca0b51d26e646348f21f98715390b0a8d5772fe0b3f5fdfd63aeffc
+    pdfVersion: '1.0'
   - title: 'Dune: Imperium'
     bggId: 316554
     language: en
-    pdf: dune-imperium_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Dune: Imperium is a game that uses deck building to add a hidden information angle to traditional worker placement. It finds inspiration in elements and characters from the Dune legacy, both the new film from Legendary Pictures and the seminal literary series from Frank Herbert, Brian Herbert, and Kevin J. Anderson.
+    description: 'Dune: Imperium is a game that uses deck building to add a hidden information angle to traditional worker
+      placement. It finds inspiration in elements and characters from the Dune legacy, both the new film from Legendary Pictures
+      and the seminal literary series from Frank Herbert, Brian Herbert, and Kevin J. Anderson.
 
 
-      As a leader of one of the Great Houses of the Landsraad, raise your banner and marshal your forces and spies. War is coming, and at the center of the conflict is Arrakis &ndash; Dune, the desert planet.
+      As a leader of one of the Great Houses of the Landsraad, raise your banner and marshal your forces and spies. War is
+      coming, and at the center of the conflict is Arrakis &ndash; Dune, the desert planet.
 
 
-      You start with a unique leader card, as well as a deck identical to those of your opponents.  As you acquire cards and build your deck, your choices will define your strengths and weaknesses. Cards allow you to send your Agents to certain spaces on the game board, so how your deck evolves affects your strategy. You might become more powerful militarily, able to deploy more troops than your opponents. Or you might acquire cards that give you an edge with the four political factions represented in the game: the Emperor, the Spacing Guild, the Bene Gesserit, and the Fremen.
+      You start with a unique leader card, as well as a deck identical to those of your opponents.  As you acquire cards and
+      build your deck, your choices will define your strengths and weaknesses. Cards allow you to send your Agents to certain
+      spaces on the game board, so how your deck evolves affects your strategy. You might become more powerful militarily,
+      able to deploy more troops than your opponents. Or you might acquire cards that give you an edge with the four political
+      factions represented in the game: the Emperor, the Spacing Guild, the Bene Gesserit, and the Fremen.
 
 
-      Unlike many deck building games, you don&rsquo;t play your entire hand in one turn. Instead, you draw a hand of cards at the start of every round and alternate with other players, taking one Agent turn at a time (playing one card to send one of your Agents to the game board). When it&rsquo;s your turn and you have no more Agents to place, you&rsquo;ll take a Reveal turn, revealing the rest of your cards, which will provide Persuasion and Swords. Persuasion is used to acquire more cards, and Swords help your troops fight for the current round&rsquo;s rewards as shown on the revealed Conflict card.
+      Unlike many deck building games, you don&rsquo;t play your entire hand in one turn. Instead, you draw a hand of cards
+      at the start of every round and alternate with other players, taking one Agent turn at a time (playing one card to send
+      one of your Agents to the game board). When it&rsquo;s your turn and you have no more Agents to place, you&rsquo;ll
+      take a Reveal turn, revealing the rest of your cards, which will provide Persuasion and Swords. Persuasion is used to
+      acquire more cards, and Swords help your troops fight for the current round&rsquo;s rewards as shown on the revealed
+      Conflict card.
 
 
-      Defeat your rivals in combat, shrewdly navigate the political factions, and acquire precious cards. The Spice must flow to lead your House to victory!
+      Defeat your rivals in combat, shrewdly navigate the political factions, and acquire precious cards. The Spice must flow
+      to lead your House to victory!
 
 
       Some important links: The Official FAQ, the Unofficial FAQ, and an Automa (solo and 2p) Overview
 
+
+      '
     yearPublished: 2020
     minPlayers: 1
     maxPlayers: 4
@@ -6923,26 +7682,50 @@ catalog:
     - sternenschimmermeer
     - Tabletop KZ
     - YingDi (旅法师营地)
+    pdfBlobKey: rulebooks/v1/dune-imperium_rulebook.pdf
+    pdfSha256: 0472bf7bfc04b7f3a07fd1454b8a472b65b3d5bfea8bad881b3c7b725a04f862
+    pdfVersion: '1.0'
   - title: 'Twilight Imperium: Fourth Edition'
     bggId: 233078
     language: en
-    pdf: twilight-imperium-4e_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Twilight Imperium (Fourth Edition) is a game of galactic conquest in which three to six players each take on the role of one of seventeen factions vying for galactic domination through military might, political maneuvering, and economic bargaining. Every faction offers a completely different play experience, from the wormhole-hopping Ghosts of Creuss to the Emirates of Hacan, masters of trade and economics. These seventeen races are offered many paths to victory, but only one may sit upon the throne of Mecatol Rex as the new masters of the galaxy.
+    description: 'Twilight Imperium (Fourth Edition) is a game of galactic conquest in which three to six players each take
+      on the role of one of seventeen factions vying for galactic domination through military might, political maneuvering,
+      and economic bargaining. Every faction offers a completely different play experience, from the wormhole-hopping Ghosts
+      of Creuss to the Emirates of Hacan, masters of trade and economics. These seventeen races are offered many paths to
+      victory, but only one may sit upon the throne of Mecatol Rex as the new masters of the galaxy.
 
 
-      No two games of Twilight Imperium are ever identical. At the start of each galactic age, the game board is uniquely and strategically constructed from among 51 galaxy tiles that feature everything from lush new planets and supernovas to asteroid fields and gravity rifts. Players are dealt a hand of these tiles and take turns creating the galaxy around Mecatol Rex, the capital planet seated in the center of the board. An ion storm may block your race from progressing through the galaxy while a fortuitously placed gravity rift may protect you from your closest foes. The galaxy is yours to both craft and dominate.
+      No two games of Twilight Imperium are ever identical. At the start of each galactic age, the game board is uniquely
+      and strategically constructed from among 51 galaxy tiles that feature everything from lush new planets and supernovas
+      to asteroid fields and gravity rifts. Players are dealt a hand of these tiles and take turns creating the galaxy around
+      Mecatol Rex, the capital planet seated in the center of the board. An ion storm may block your race from progressing
+      through the galaxy while a fortuitously placed gravity rift may protect you from your closest foes. The galaxy is yours
+      to both craft and dominate.
 
 
-      A round of Twilight Imperium begins with players selecting one of eight strategy cards that both determine player order and give their owner a unique strategic action for that round. These may do anything from providing additional command tokens to allowing a player to control trade throughout the galaxy. After these strategies are selected, players take turns moving their fleets from system to system, claiming new planets for their empires, and engaging in warfare and trade with other factions. At the end of a turn, players gather in a grand council to pass new laws and agendas, shaking up the game in unpredictable ways.
+      A round of Twilight Imperium begins with players selecting one of eight strategy cards that both determine player order
+      and give their owner a unique strategic action for that round. These may do anything from providing additional command
+      tokens to allowing a player to control trade throughout the galaxy. After these strategies are selected, players take
+      turns moving their fleets from system to system, claiming new planets for their empires, and engaging in warfare and
+      trade with other factions. At the end of a turn, players gather in a grand council to pass new laws and agendas, shaking
+      up the game in unpredictable ways.
 
 
-      After every player has passed their turn, players move up the victory track by checking to see whether they have completed any objectives throughout the turn and scoring them. Objectives are determined by setting up ten public objective cards at the start of each game, then gradually revealing them over the course of the game. Each player also chooses between two random secret objectives at the start of the game, achievement of which provides victory points--only for the holder of that objective. These objectives can be anything from researching new technologies to taking your neighbor's home system. At the end of every turn, a player can claim one public objective and one secret objective. As play continues, more of these objectives are revealed and more secret objectives are dealt out, giving players dynamically changing goals throughout the game. Play continues until a player reaches ten victory points.
+      After every player has passed their turn, players move up the victory track by checking to see whether they have completed
+      any objectives throughout the turn and scoring them. Objectives are determined by setting up ten public objective cards
+      at the start of each game, then gradually revealing them over the course of the game. Each player also chooses between
+      two random secret objectives at the start of the game, achievement of which provides victory points--only for the holder
+      of that objective. These objectives can be anything from researching new technologies to taking your neighbor''s home
+      system. At the end of every turn, a player can claim one public objective and one secret objective. As play continues,
+      more of these objectives are revealed and more secret objectives are dealt out, giving players dynamically changing
+      goals throughout the game. Play continues until a player reaches ten victory points.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2017
     minPlayers: 3
     maxPlayers: 6
@@ -6999,23 +7782,31 @@ catalog:
     - Hobby World
     - Playfun Games
     - sternenschimmermeer
+    pdfBlobKey: rulebooks/v1/twilight-imperium-4e_rulebook.pdf
+    pdfSha256: 3111c1857435c8fc8726814c18fab3296d05a6cc5f3b92da10e4cfed114890dc
+    pdfVersion: '1.0'
   - title: 'Dune: Imperium - Uprising'
     bggId: 397598
     language: en
-    pdf: dune-imperium-uprising_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Dune: Imperium Uprising, you want to continue to balance military might with political intrigue, wielding new tools in pursuit of victory. Spies will shore up your plans, vital contracts will expand your resources, or you can learn the ways of the Fremen and ride mighty sandworms into battle!
+    description: 'In Dune: Imperium Uprising, you want to continue to balance military might with political intrigue, wielding
+      new tools in pursuit of victory. Spies will shore up your plans, vital contracts will expand your resources, or you
+      can learn the ways of the Fremen and ride mighty sandworms into battle!
 
 
-      Dune: Imperium Uprising is a standalone spinoff to Dune: Imperium that expands on that game's blend of deck-building and worker placement, while introducing a new six-player mode that pits two teams against one other in the biggest struggle yet.
+      Dune: Imperium Uprising is a standalone spinoff to Dune: Imperium that expands on that game''s blend of deck-building
+      and worker placement, while introducing a new six-player mode that pits two teams against one other in the biggest struggle
+      yet.
 
 
-      The Dune: Imperium expansions Rise of Ix and Immortality work with Uprising, as do almost all of the cards from the base game, and elements of Uprising can be used with Dune: Imperium.
+      The Dune: Imperium expansions Rise of Ix and Immortality work with Uprising, as do almost all of the cards from the
+      base game, and elements of Uprising can be used with Dune: Imperium.
 
 
       The choices are yours. The Imperium awaits!
 
+
+      '
     yearPublished: 2023
     minPlayers: 1
     maxPlayers: 6
@@ -7061,23 +7852,40 @@ catalog:
     - Regatul Jocurilor
     - REXhry
     - Tabletop KZ
+    pdfBlobKey: rulebooks/v1/dune-imperium-uprising_rulebook.pdf
+    pdfSha256: 0a8daa36f73c09316143d05bbd5d845183d1ae6f56ce211d93c59b360074f7db
+    pdfVersion: '1.0'
   - title: 'War of the Ring: Second Edition'
     bggId: 115746
     language: en
-    pdf: war-of-the-ring_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In War of the Ring, one player takes control of the Free Peoples (FP) while the other player controls Shadow Armies (SA). Initially, the Free People Nations are reluctant to take arms against Sauron, so they must be attacked by Sauron or persuaded by Gandalf or other Companions before they start to fight in earnest: this is represented by the Political Track which shows if a Nation is ready to fight in the War of the Ring or not.
+    description: 'In War of the Ring, one player takes control of the Free Peoples (FP) while the other player controls Shadow
+      Armies (SA). Initially, the Free People Nations are reluctant to take arms against Sauron, so they must be attacked
+      by Sauron or persuaded by Gandalf or other Companions before they start to fight in earnest: this is represented by
+      the Political Track which shows if a Nation is ready to fight in the War of the Ring or not.
 
 
-      The game can be won by a military victory if Sauron conquers a certain number of Free People cities and strongholds, or vice versa. But the true hope of the Free Peoples lies with the quest of the Ring bearer: while the armies clash across Middle-earth, the Fellowship of the Ring is trying to get secretly to Mount Doom to destroy the One Ring. Sauron is not aware of the real intention of his enemies but is looking across Middle-earth for the precious Ring, so that the Fellowship is going to face numerous dangers, represented by the rules of The Hunt for the Ring. But the Companions can spur the Free Peoples to the fight against Sauron, so the Free People player must balance the need to protect the Ring bearer from harm with an attempt to raise a proper defense against the armies of the Shadow so that they do not overrun Middle-earth before the Ringbearer completes his quest.
+      The game can be won by a military victory if Sauron conquers a certain number of Free People cities and strongholds,
+      or vice versa. But the true hope of the Free Peoples lies with the quest of the Ring bearer: while the armies clash
+      across Middle-earth, the Fellowship of the Ring is trying to get secretly to Mount Doom to destroy the One Ring. Sauron
+      is not aware of the real intention of his enemies but is looking across Middle-earth for the precious Ring, so that
+      the Fellowship is going to face numerous dangers, represented by the rules of The Hunt for the Ring. But the Companions
+      can spur the Free Peoples to the fight against Sauron, so the Free People player must balance the need to protect the
+      Ring bearer from harm with an attempt to raise a proper defense against the armies of the Shadow so that they do not
+      overrun Middle-earth before the Ringbearer completes his quest.
 
 
-      Each game turn revolves around the roll of Action Dice: each die corresponds to an action that a player can perform during a turn. Depending on the face rolled on each die, different actions are possible (moving armies or characters, recruiting troops, advancing a Political Track).
+      Each game turn revolves around the roll of Action Dice: each die corresponds to an action that a player can perform
+      during a turn. Depending on the face rolled on each die, different actions are possible (moving armies or characters,
+      recruiting troops, advancing a Political Track).
 
 
-      Action Dice can also be used to draw or play Event Cards. Event Cards are played to represent specific events from the story (or events that could possibly have happened) that cannot be portrayed through normal game-play. Each Event Card can also create an unexpected turn in the game, allowing special actions or altering the course of a battle.
+      Action Dice can also be used to draw or play Event Cards. Event Cards are played to represent specific events from the
+      story (or events that could possibly have happened) that cannot be portrayed through normal game-play. Each Event Card
+      can also create an unexpected turn in the game, allowing special actions or altering the course of a battle.
 
+
+      '
     yearPublished: 2011
     minPlayers: 2
     maxPlayers: 4
@@ -7126,26 +7934,35 @@ catalog:
     - Schwerkraft-Verlag
     - Sophisticated Games
     - Zhiyanjia
+    pdfBlobKey: rulebooks/v1/war-of-the-ring_rulebook.pdf
+    pdfSha256: 645d2c3df8d67a4d85fb059d00ef68880f27f8c51ffb832e911ea3acb8b90f75
+    pdfVersion: '1.0'
   - title: 'Star Wars: Rebellion'
     bggId: 187645
     language: en
-    pdf: star-wars-rebellion_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Star Wars: Rebellion is a board game of epic conflict between the Galactic Empire and Rebel Alliance for two to four players.
-
-
-      Experience the Galactic Civil War like never before. In Rebellion, you control the entire Galactic Empire or the fledgling Rebel Alliance. You must command starships, account for troop movements, and rally systems to your cause. Given the differences between the Empire and Rebel Alliance, each side has different win conditions, and you'll need to adjust your play style depending on who you represent:
-
-           As the Imperial player, you can command legions of Stormtroopers, swarms of TIEs, Star Destroyers, and even the Death Star. You rule the galaxy by fear, relying on the power of your massive military to enforce your will. To win the game, you need to snuff out the budding Rebel Alliance by finding its base and obliterating it. Along the way, you can subjugate worlds or even destroy them.
-           As the Rebel player, you can command dozens of troopers, T-47 airspeeders, Corellian corvettes, and fighter squadrons. However, these forces are no match for the Imperial military. In terms of raw strength, you'll find yourself clearly overmatched from the very outset, so you'll need to rally the planets to join your cause and execute targeted military strikes to sabotage Imperial build yards and steal valuable intelligence. To win the Galactic Civil War, you'll need to sway the galaxy's citizens to your cause. If you survive long enough and strengthen your reputation, you inspire the galaxy to a full-scale revolt, and you win.
-
-
-      Featuring more than 150 plastic miniatures and two game boards that account for thirty-two of the Star Wars galaxy's most notable systems, Rebellion features a scope that is as large and sweeping as any Star Wars game before it.
-
-
-      Yet for all its grandiosity, Rebellion remains intensely personal, cinematic, and heroic. As much as your success depends upon the strength of your starships, vehicles, and troops, it depends upon the individual efforts of such notable characters as Leia Organa, Mon Mothma, Grand Moff Tarkin, and Emperor Palpatine. As civil war spreads throughout the galaxy, these leaders are invaluable to your efforts, and the secret missions they attempt will evoke many of the most inspiring moments from the classic trilogy. You might send Luke Skywalker to receive Jedi training on Dagobah or have Darth Vader spring a trap that freezes Han Solo in carbonite!
-
+    description: "Star Wars: Rebellion is a board game of epic conflict between the Galactic Empire and Rebel Alliance for\
+      \ two to four players.\n\nExperience the Galactic Civil War like never before. In Rebellion, you control the entire\
+      \ Galactic Empire or the fledgling Rebel Alliance. You must command starships, account for troop movements, and rally\
+      \ systems to your cause. Given the differences between the Empire and Rebel Alliance, each side has different win conditions,\
+      \ and you'll need to adjust your play style depending on who you represent:\n\n     As the Imperial player, you can\
+      \ command legions of Stormtroopers, swarms of TIEs, Star Destroyers, and even the Death Star. You rule the galaxy by\
+      \ fear, relying on the power of your massive military to enforce your will. To win the game, you need to snuff out the\
+      \ budding Rebel Alliance by finding its base and obliterating it. Along the way, you can subjugate worlds or even destroy\
+      \ them.\n     As the Rebel player, you can command dozens of troopers, T-47 airspeeders, Corellian corvettes, and fighter\
+      \ squadrons. However, these forces are no match for the Imperial military. In terms of raw strength, you'll find yourself\
+      \ clearly overmatched from the very outset, so you'll need to rally the planets to join your cause and execute targeted\
+      \ military strikes to sabotage Imperial build yards and steal valuable intelligence. To win the Galactic Civil War,\
+      \ you'll need to sway the galaxy's citizens to your cause. If you survive long enough and strengthen your reputation,\
+      \ you inspire the galaxy to a full-scale revolt, and you win.\n\n\nFeaturing more than 150 plastic miniatures and two\
+      \ game boards that account for thirty-two of the Star Wars galaxy's most notable systems, Rebellion features a scope\
+      \ that is as large and sweeping as any Star Wars game before it.\n\nYet for all its grandiosity, Rebellion remains intensely\
+      \ personal, cinematic, and heroic. As much as your success depends upon the strength of your starships, vehicles, and\
+      \ troops, it depends upon the individual efforts of such notable characters as Leia Organa, Mon Mothma, Grand Moff Tarkin,\
+      \ and Emperor Palpatine. As civil war spreads throughout the galaxy, these leaders are invaluable to your efforts, and\
+      \ the secret missions they attempt will evoke many of the most inspiring moments from the classic trilogy. You might\
+      \ send Luke Skywalker to receive Jedi training on Dagobah or have Darth Vader spring a trap that freezes Han Solo in\
+      \ carbonite!\n\n"
     yearPublished: 2016
     minPlayers: 2
     maxPlayers: 4
@@ -7197,23 +8014,33 @@ catalog:
     - Hobby World
     - Korea Boardgames
     - Rooster Games
+    pdfBlobKey: rulebooks/v1/star-wars-rebellion_rulebook.pdf
+    pdfSha256: 0b5af3a28bc4bc29a16f84456ed3a6543bf4d6a141461971e6fb170c6afba35a
+    pdfVersion: '1.0'
   - title: Gaia Project
     bggId: 220308
     language: en
-    pdf: gaia-project_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Gaia Project is a new game in the line of Terra Mystica. As in the original Terra Mystica, fourteen different factions live on seven different kinds of planets, and factions are bound to their own home planets, so to develop and grow, they must terraform neighboring planets into their home environments in competition with the other groups. In addition, Gaia planets can be used by all factions for colonization, and Transdimensional planets can be changed into Gaia planets.
+    description: 'Gaia Project is a new game in the line of Terra Mystica. As in the original Terra Mystica, fourteen different
+      factions live on seven different kinds of planets, and factions are bound to their own home planets, so to develop and
+      grow, they must terraform neighboring planets into their home environments in competition with the other groups. In
+      addition, Gaia planets can be used by all factions for colonization, and Transdimensional planets can be changed into
+      Gaia planets.
 
 
-      All factions can improve their skills in six different areas of development: Terraforming, Navigation, Artificial Intelligence, Gaiaforming, Economy, Research; leading to advanced technology and special bonuses. To do all of that, each group has special skills and abilities.
+      All factions can improve their skills in six different areas of development: Terraforming, Navigation, Artificial Intelligence,
+      Gaiaforming, Economy, Research; leading to advanced technology and special bonuses. To do all of that, each group has
+      special skills and abilities.
 
 
-      The playing area is made of ten sectors, allowing a variable set-up and thus an even bigger replay value than its predecessor Terra Mystica. A two-player game is hosted on seven sectors.
+      The playing area is made of ten sectors, allowing a variable set-up and thus an even bigger replay value than its predecessor
+      Terra Mystica. A two-player game is hosted on seven sectors.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2017
     minPlayers: 1
     maxPlayers: 4
@@ -7267,22 +8094,39 @@ catalog:
     - TLAMA games
     - White Goblin Games
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/gaia-project_rulebook.pdf
+    pdfSha256: 23331c7527cf3364de847ef5ca7de563f0fbbd906d0cd1932e54783cb6c24043
+    pdfVersion: '1.0'
   - title: Twilight Struggle
     bggId: 12333
     language: en
-    pdf: twilight-struggle_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Now the trumpet summons us again, not as a call to bear arms, though arms we need; not as a call to battle, though embattled we are &ndash; but a call to bear the burden of a long twilight struggle. &ndash; John F. Kennedy
+    description: 'Now the trumpet summons us again, not as a call to bear arms, though arms we need; not as a call to battle,
+      though embattled we are &ndash; but a call to bear the burden of a long twilight struggle. &ndash; John F. Kennedy
 
 
-      In 1945, unlikely allies toppled Hitler's war machine, while humanity's most devastating weapons forced the Japanese Empire to its knees in a storm of fire. Where once there stood many great powers, there then stood only two. The world had scant months to sigh its collective relief before a new conflict threatened. Unlike the titanic struggles of the preceding decades, this conflict would be waged not primarily by soldiers and tanks, but by spies and politicians, scientists and intellectuals, artists and traitors.
+      In 1945, unlikely allies toppled Hitler''s war machine, while humanity''s most devastating weapons forced the Japanese
+      Empire to its knees in a storm of fire. Where once there stood many great powers, there then stood only two. The world
+      had scant months to sigh its collective relief before a new conflict threatened. Unlike the titanic struggles of the
+      preceding decades, this conflict would be waged not primarily by soldiers and tanks, but by spies and politicians, scientists
+      and intellectuals, artists and traitors.
 
 
-      Twilight Struggle is a two-player game simulating the forty-five year dance of intrigue, prestige, and occasional flares of warfare between the Soviet Union and the United States. The entire world is the stage on which these two titans fight to make the world safe for their own ideologies and ways of life. The game begins amidst the ruins of Europe as the two new "superpowers" scramble over the wreckage of the Second World War, and ends in 1989, when only the United States remained standing.
+      Twilight Struggle is a two-player game simulating the forty-five year dance of intrigue, prestige, and occasional flares
+      of warfare between the Soviet Union and the United States. The entire world is the stage on which these two titans fight
+      to make the world safe for their own ideologies and ways of life. The game begins amidst the ruins of Europe as the
+      two new "superpowers" scramble over the wreckage of the Second World War, and ends in 1989, when only the United States
+      remained standing.
 
 
-      Twilight Struggle inherits its fundamental systems from the card-driven classics We the People and Hannibal: Rome vs. Carthage. It is a quick-playing, low-complexity game in that tradition. The game map is a world map of the period, whereon players move units and exert influence in attempts to gain allies and control for their superpower. As with GMT's other card-driven games, decision-making is a challenge; how to best use one's cards and units given consistently limited resources? Event cards add detail and flavor to the game. They cover a vast array of historical happenings, from the Arab-Israeli conflicts of 1948 and 1967, to Vietnam and the U.S. peace movement, to the Cuban Missile Crisis and other such incidents that brought the world to the brink of nuclear annihilation. Subsystems capture the prestige-laden Space Race as well as nuclear tensions, with the possibility of game-ending nuclear war.
+      Twilight Struggle inherits its fundamental systems from the card-driven classics We the People and Hannibal: Rome vs.
+      Carthage. It is a quick-playing, low-complexity game in that tradition. The game map is a world map of the period, whereon
+      players move units and exert influence in attempts to gain allies and control for their superpower. As with GMT''s other
+      card-driven games, decision-making is a challenge; how to best use one''s cards and units given consistently limited
+      resources? Event cards add detail and flavor to the game. They cover a vast array of historical happenings, from the
+      Arab-Israeli conflicts of 1948 and 1967, to Vietnam and the U.S. peace movement, to the Cuban Missile Crisis and other
+      such incidents that brought the world to the brink of nuclear annihilation. Subsystems capture the prestige-laden Space
+      Race as well as nuclear tensions, with the possibility of game-ending nuclear war.
 
 
       TIME SCALE:     approx. 3-5 years per turn
@@ -7291,6 +8135,8 @@ catalog:
 
       UNIT SCALE:     Influence markers
 
+
+      '
     yearPublished: 2005
     minPlayers: 2
     maxPlayers: 2
@@ -7337,23 +8183,37 @@ catalog:
     - Pixie Games
     - Udo Grebe Gamedesign
     - Wargames Club Publishing
+    pdfBlobKey: rulebooks/v1/twilight-struggle_rulebook.pdf
+    pdfSha256: cecc32db372d4c8e1822114f4f7a651e5c18e89048abfd2b7005fe8dd8e93a0d
+    pdfVersion: '1.0'
   - title: 'Through the Ages: A New Story of Civilization'
     bggId: 182028
     language: en
-    pdf: through-the-ages_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Through the Ages: A New Story of Civilization is the new edition of Through the Ages: A Story of Civilization, with many changes small and large to the game's cards over its three ages and extensive changes to how military works.
+    description: 'Through the Ages: A New Story of Civilization is the new edition of Through the Ages: A Story of Civilization,
+      with many changes small and large to the game''s cards over its three ages and extensive changes to how military works.
 
 
-      Through the Ages (TTA) is a civilization building game. Each player attempts to build the best civilization through careful resource management, and by: discovering new technologies, electing competent leaders, building wonders and maintaining a strong military. Weakness in any area can be exploited by your opponents. The game takes place throughout the ages, beginning in the age of antiquity and ending in the modern age.
+      Through the Ages (TTA) is a civilization building game. Each player attempts to build the best civilization through
+      careful resource management, and by: discovering new technologies, electing competent leaders, building wonders and
+      maintaining a strong military. Weakness in any area can be exploited by your opponents. The game takes place throughout
+      the ages, beginning in the age of antiquity and ending in the modern age.
 
 
-      One of the primary mechanisms in TTA is card drafting. Technologies, wonders, and leaders come into play and become easier to draft the longer they are in play. In order to use a technology you will need enough science to discover it, enough food to create a population to man it and enough resources (ore) to build the building to use it. While balancing the resources needed to advance your technology you also need to build a military. Military is 'built' in the same manner as civilian buildings. Players that have a weak military will be preyed upon by other players. There is no map in the game so you cannot lose territory, but players with a stronger military will steal resources, science, kill leaders, take population or culture. It is very difficult to win with a strong military, but it is very easy to lose because of a weak one.
+      One of the primary mechanisms in TTA is card drafting. Technologies, wonders, and leaders come into play and become
+      easier to draft the longer they are in play. In order to use a technology you will need enough science to discover it,
+      enough food to create a population to man it and enough resources (ore) to build the building to use it. While balancing
+      the resources needed to advance your technology you also need to build a military. Military is ''built'' in the same
+      manner as civilian buildings. Players that have a weak military will be preyed upon by other players. There is no map
+      in the game so you cannot lose territory, but players with a stronger military will steal resources, science, kill leaders,
+      take population or culture. It is very difficult to win with a strong military, but it is very easy to lose because
+      of a weak one.
 
 
       Victory is achieved by the player whose nation has the most culture at the end of the modern age.
 
+
+      '
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 4
@@ -7398,20 +8258,29 @@ catalog:
     - New Games Order, LLC
     - One Moment Games
     - Rebel Sp. z o.o.
+    pdfBlobKey: rulebooks/v1/through-the-ages_rulebook.pdf
+    pdfSha256: 8159de133667a4ea467629787a18b7c5d73c5f313aaf3f668f1ceb27d03c193e
+    pdfVersion: '1.0'
   - title: Great Western Trail
     bggId: 193738
     language: en
-    pdf: great-western-trail_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      America in the 19th century: You are a rancher and repeatedly herd your cattle from Texas to Kansas City, where you send them off by train. This earns you money and victory points. Needless to say, each time you arrive in Kansas City, you want to have your most valuable cattle in tow. However, the "Great Western Trail" not only requires that you keep your herd in good shape, but also that you wisely use the various buildings along the trail. Also, it might be a good idea to hire capable staff: cowboys to improve your herd, craftsmen to build your very own buildings, or engineers for the important railroad line.
+    description: 'America in the 19th century: You are a rancher and repeatedly herd your cattle from Texas to Kansas City,
+      where you send them off by train. This earns you money and victory points. Needless to say, each time you arrive in
+      Kansas City, you want to have your most valuable cattle in tow. However, the "Great Western Trail" not only requires
+      that you keep your herd in good shape, but also that you wisely use the various buildings along the trail. Also, it
+      might be a good idea to hire capable staff: cowboys to improve your herd, craftsmen to build your very own buildings,
+      or engineers for the important railroad line.
 
 
-      If you cleverly manage your herd and navigate the opportunities and pitfalls of Great Western Trail, you surely will gain the most victory points and win the game.
+      If you cleverly manage your herd and navigate the opportunities and pitfalls of Great Western Trail, you surely will
+      gain the most victory points and win the game.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2016
     minPlayers: 2
     maxPlayers: 4
@@ -7454,29 +8323,47 @@ catalog:
     - uplay.it edizioni
     - YOKA Games
     - Zvezda
+    pdfBlobKey: rulebooks/v1/great-western-trail_rulebook.pdf
+    pdfSha256: 72b01b97b3bbf12661fbdfa513873bc9efd694b9c4bd1d7765c4da1727df7f79
+    pdfVersion: '1.0'
   - title: 'SETI: Search for Extraterrestrial Intelligence'
     bggId: 418059
     language: en
-    pdf: seti_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In SETI: Search for Extraterrestrial Intelligence, you lead a scientific institution tasked with searching for traces of life beyond planet Earth. The game draws inspiration from current or emerging technologies and efforts in space exploration. Players will explore nearby planets and their moons by launching probes from Earth while taking advantage of ever-shifting planetary positions. Decide whether to land on their surfaces to collect valuable samples or stay in orbit for a broader survey. Additionally, by directing your telescopes to gaze into distant star systems, you may detect traces of alien signals or undiscovered exoplanets, and collect promising data to examine and study back home.
+    description: 'In SETI: Search for Extraterrestrial Intelligence, you lead a scientific institution tasked with searching
+      for traces of life beyond planet Earth. The game draws inspiration from current or emerging technologies and efforts
+      in space exploration. Players will explore nearby planets and their moons by launching probes from Earth while taking
+      advantage of ever-shifting planetary positions. Decide whether to land on their surfaces to collect valuable samples
+      or stay in orbit for a broader survey. Additionally, by directing your telescopes to gaze into distant star systems,
+      you may detect traces of alien signals or undiscovered exoplanets, and collect promising data to examine and study back
+      home.
 
 
-      Back on Earth, you can invest in upgrading your equipment so you can analyze incoming data more efficiently, boost your telescope signal capacity, or increase your supply of resources&mdash;all to expand the scope of your search that could lead to a discovery of extraterrestrial life forms. Finding traces of extraterrestrial life is only a matter of time&mdash;utilize the resources you have at your disposal strategically and you may well end up being the one to make the biggest scientific contribution towards advancing our understanding of alien life within our galaxy.
+      Back on Earth, you can invest in upgrading your equipment so you can analyze incoming data more efficiently, boost your
+      telescope signal capacity, or increase your supply of resources&mdash;all to expand the scope of your search that could
+      lead to a discovery of extraterrestrial life forms. Finding traces of extraterrestrial life is only a matter of time&mdash;utilize
+      the resources you have at your disposal strategically and you may well end up being the one to make the biggest scientific
+      contribution towards advancing our understanding of alien life within our galaxy.
 
 
-      You will also make use of over 200 cards to aid your efforts or focus your research in a particular direction for additional bonuses and rewards. Each card has unique effects and illustrations and depicts real-life technologies, projects, and discoveries (like the ISS, Large Hadron Collider, Perseverance rover, Voyager probe, and many more).
+      You will also make use of over 200 cards to aid your efforts or focus your research in a particular direction for additional
+      bonuses and rewards. Each card has unique effects and illustrations and depicts real-life technologies, projects, and
+      discoveries (like the ISS, Large Hadron Collider, Perseverance rover, Voyager probe, and many more).
 
 
-      The game is played in five rounds. The player with the starting player marker takes the first turn of the round. Players take turns in clockwise order, skipping any players who have already passed for the round. At the end of round 5, the final score is calculated and the player with the most points wins.
+      The game is played in five rounds. The player with the starting player marker takes the first turn of the round. Players
+      take turns in clockwise order, skipping any players who have already passed for the round. At the end of round 5, the
+      final score is calculated and the player with the most points wins.
 
 
-      SETI: Search for Extraterrestrial Intelligence pays homage to space and planetary exploration, astronomy, the ongoing search for signs of life in the vastness of space, and efforts to understand the nature of life in the universe.
+      SETI: Search for Extraterrestrial Intelligence pays homage to space and planetary exploration, astronomy, the ongoing
+      search for signs of life in the vastness of space, and efforts to understand the nature of life in the universe.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2024
     minPlayers: 1
     maxPlayers: 4
@@ -7517,26 +8404,42 @@ catalog:
     - MINDOK
     - MIPL
     - Rebel Sp. z o.o.
+    pdfBlobKey: rulebooks/v1/seti_rulebook.pdf
+    pdfSha256: b241d2ace42c1199254bde456ddac09d7ce1ca5ba036596f545b5d3aadcc083a
+    pdfVersion: '1.0'
   - title: Frosthaven
     bggId: 295770
     language: en
-    pdf: frosthaven_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Frosthaven is the story of a small outpost far to the north of the capital city of White Oak.  It's an outpost barely surviving the harsh weather let alone invasions from forces both known and unknown. However, a group of mercenaries, at the end of their rope, will help bring this settlement back from the edge of destruction. Not only will they have to deal with the harsh elements, but with other, far more dangerous threats out in the unforgiving cold, as well. There are: Algox, the bigger, more yeti-like cousins of the Inox, attacking from the mountains; Lurkers flooding in from the northern sea; and rumors have it that there are machines that wander the frozen wastes of their own free will. The party of mercenaries must face all of these perils, and perhaps in doing so, make peace with these new races so they can work together against even more sinister forces.
+    description: 'Frosthaven is the story of a small outpost far to the north of the capital city of White Oak.  It''s an
+      outpost barely surviving the harsh weather let alone invasions from forces both known and unknown. However, a group
+      of mercenaries, at the end of their rope, will help bring this settlement back from the edge of destruction. Not only
+      will they have to deal with the harsh elements, but with other, far more dangerous threats out in the unforgiving cold,
+      as well. There are: Algox, the bigger, more yeti-like cousins of the Inox, attacking from the mountains; Lurkers flooding
+      in from the northern sea; and rumors have it that there are machines that wander the frozen wastes of their own free
+      will. The party of mercenaries must face all of these perils, and perhaps in doing so, make peace with these new races
+      so they can work together against even more sinister forces.
 
 
-      Frosthaven is a standalone adventure from the designer and publisher of Gloomhaven that features sixteen new characters, three new races, more than twenty new enemies, more than one hundred new items, and a new, 100-scenario campaign.  Characters and items from Gloomhaven will be usable in Frosthaven, and vice versa.
+      Frosthaven is a standalone adventure from the designer and publisher of Gloomhaven that features sixteen new characters,
+      three new races, more than twenty new enemies, more than one hundred new items, and a new, 100-scenario campaign.  Characters
+      and items from Gloomhaven will be usable in Frosthaven, and vice versa.
 
 
-      In addition to using the well-known combat mechanisms of Gloomhaven, Frosthaven features other elements, such as mysteries to solve, a seasonal event system to live through, and player control over how the ramshackle village expands, with each new building offering new ways to progress.
+      In addition to using the well-known combat mechanisms of Gloomhaven, Frosthaven features other elements, such as mysteries
+      to solve, a seasonal event system to live through, and player control over how the ramshackle village expands, with
+      each new building offering new ways to progress.
 
 
-      Frosthaven has a whole new set of items but there is a mechanism for bringing items over from 'Gloomhaven'. However, as Frosthaven's outpost is a remote location, these products may be imported but are not present as standard items. Resources are much more valuable and you have to build items through a crafting system rather than just buying them.
+      Frosthaven has a whole new set of items but there is a mechanism for bringing items over from ''Gloomhaven''. However,
+      as Frosthaven''s outpost is a remote location, these products may be imported but are not present as standard items.
+      Resources are much more valuable and you have to build items through a crafting system rather than just buying them.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2022
     minPlayers: 1
     maxPlayers: 4
@@ -7584,26 +8487,21 @@ catalog:
     - Galápagos Jogos
     - GoKids 玩樂小子
     - Korea Boardgames
+    pdfBlobKey: rulebooks/v1/frosthaven_rulebook.pdf
+    pdfSha256: bf53b8260cd1a567d6d9f9db37b9237179e236c8b59d31f6149787292bbc7008
+    pdfVersion: '1.0'
   - title: 'Eclipse: Second Dawn for the Galaxy'
     bggId: 246900
     language: en
-    pdf: eclipse-second-dawn_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      A game of Eclipse places you in control of a vast interstellar civilization, competing for success with its rivals. You explore new star systems, research technologies, and build spaceships with which to wage war. There are many potential paths to victory, so you need to plan your strategy according to the strengths and weaknesses of your species, while paying attention to the other civilizations' endeavors.
-
-
-      Eclipse: Second Dawn for the Galaxy is a revised and upgraded version of the Eclipse base game that debuted in 2011 that features:
-
-
-          New graphic design, while maintaining the acclaimed symbology of the first edition 
-          A full line of Ship Pack 1 miniatures
-          New miniatures for ancients, GCDS, orbitals, and more
-          Custom plastic inlays
-          Custom combat dice
-          Fine-tuned gameplay
-
-
+    description: "A game of Eclipse places you in control of a vast interstellar civilization, competing for success with\
+      \ its rivals. You explore new star systems, research technologies, and build spaceships with which to wage war. There\
+      \ are many potential paths to victory, so you need to plan your strategy according to the strengths and weaknesses of\
+      \ your species, while paying attention to the other civilizations' endeavors.\n\nEclipse: Second Dawn for the Galaxy\
+      \ is a revised and upgraded version of the Eclipse base game that debuted in 2011 that features:\n\n\n    New graphic\
+      \ design, while maintaining the acclaimed symbology of the first edition \n    A full line of Ship Pack 1 miniatures\n\
+      \    New miniatures for ancients, GCDS, orbitals, and more\n    Custom plastic inlays\n    Custom combat dice\n    Fine-tuned\
+      \ gameplay\n\n\n"
     yearPublished: 2020
     minPlayers: 2
     maxPlayers: 6
@@ -7650,23 +8548,32 @@ catalog:
     - Surfin' Meeple China
     - TLAMA games
     - uplay.it edizioni
+    pdfBlobKey: rulebooks/v1/eclipse-second-dawn_rulebook.pdf
+    pdfSha256: 11853e30ee828569946a7c7b18ee0d968dc4de0d4de9728e685636dfba058548
+    pdfVersion: '1.0'
   - title: 'Slay the Spire: The Board Game'
     bggId: 338960
     language: en
-    pdf: slay-the-spire_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Slay the Spire: The Board Game is a co-operative deck-building, dungeon-crawling adventure. Craft a unique deck, encounter bizarre creatures, discover relics of immense power, and finally become strong enough to slay the Spire!
+    description: 'Slay the Spire: The Board Game is a co-operative deck-building, dungeon-crawling adventure. Craft a unique
+      deck, encounter bizarre creatures, discover relics of immense power, and finally become strong enough to slay the Spire!
 
 
-      Each player starts with a character with unique abilities and a simple deck of cards that they can improve by adding and removing cards during the game. Slay the Spire is also a rogue-like. That means that when you die (and you will die!), start over from the beginning. Take the lessons you learned and try again!
+      Each player starts with a character with unique abilities and a simple deck of cards that they can improve by adding
+      and removing cards during the game. Slay the Spire is also a rogue-like. That means that when you die (and you will
+      die!), start over from the beginning. Take the lessons you learned and try again!
 
 
-      The game is divided into Acts. At the end of an Act you can continue, stop and end the adventure there, or save and continue another time!
+      The game is divided into Acts. At the end of an Act you can continue, stop and end the adventure there, or save and
+      continue another time!
 
 
-      If players defeat the final Boss, they win the game! Which Boss you consider to be final depends on how many Acts you want to play. You can stop playing at the end of any Act! When a player&rsquo;s HP is reduced to 0, they are dead and the party loses the game.
+      If players defeat the final Boss, they win the game! Which Boss you consider to be final depends on how many Acts you
+      want to play. You can stop playing at the end of any Act! When a player&rsquo;s HP is reduced to 0, they are dead and
+      the party loses the game.
 
+
+      '
     yearPublished: 2024
     minPlayers: 1
     maxPlayers: 4
@@ -7708,40 +8615,38 @@ catalog:
     - Yayoi The Dreamer
     - YOKA Games
     - 株式会社ケンビル (KenBill)
+    pdfBlobKey: rulebooks/v1/slay-the-spire_rulebook.pdf
+    pdfSha256: 4507546fcb8e72eb7228cf9aabaff443f696b76df1b5f04c0c01ee1a8228ce50
+    pdfVersion: '1.0'
   - title: 'Brass: Lancashire'
     bggId: 28720
     language: en
-    pdf: brass-lancashire_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Brass: Lancashire &mdash; first published as Brass &mdash; is an economic strategy game that tells the story of competing cotton entrepreneurs in Lancashire during the industrial revolution. You must develop, build and establish your industries and network so that you can capitalize on demand for iron, coal and cotton. The game is played over two halves: the canal phase and the rail phase. To win the game, score the most victory points (VPs), which are counted at the end of each phase. VPs are gained from your canals, rails, and established (flipped) industry tiles. Each round, players take turns according to the turn order track, receiving two actions to perform any of the following:
-
-
-          Build an industry tile
-          Build a rail or canal
-          Develop an industry
-          Sell cotton
-          Take a loan
-
-
-      At the end of your turn, you replace the two cards you played with two more from the deck. Turn order is determined by how much money a player spent on the previous turn, the lowest spender going first. This turn order mechanism opens some strategic options for players going later in the turn order, allowing for the possibility of back-to-back turns.
-
-
-      After all the cards have been played the first time (with the deck size being adjusted for the number of players), the canal phase ends and a scoring round commences. After scoring, all canals and all of the lowest level industries are removed from the game, after which new cards are dealt and the rail phase begins. During this phase, players may now occupy more than one location in a city and double-connection builds (though expensive) are possible. At the end of the rail phase, another scoring round takes place, then a winner is crowned.
-
-
-      The cards limit where you can build your industries, sell cotton or build connections (though any card can be used to 'develop'). This leads to a strategic timing/storing of cards. Resources are common so that if you build a rail line (which requires coal) you have to use the coal from the nearest source, which may be an opponent's coal mine, which in turn gets that coal mine closer to scoring (i.e., being utilized).
-
-
-      Brass: Lancashire, the 2018 edition from Roxley Games, reboots the original Warfrog Games edition of Brass with new artwork and components, as well as a few rules changes:
-
-
-           The virtual link rules between Birkenhead have been made optional.
-           The three-player experience has been brought closer to the ideal experience of four players by shortening each half of the game by one round and tuning the deck and distant market tiles slightly to ensure a consistent experience.
-           Two-player rules have been created and are playable without the need of an alternate board.
-           The level 1 cotton mill is now worth 5 VP to make it slightly less terrible.
-
-
+    description: "Brass: Lancashire &mdash; first published as Brass &mdash; is an economic strategy game that tells the story\
+      \ of competing cotton entrepreneurs in Lancashire during the industrial revolution. You must develop, build and establish\
+      \ your industries and network so that you can capitalize on demand for iron, coal and cotton. The game is played over\
+      \ two halves: the canal phase and the rail phase. To win the game, score the most victory points (VPs), which are counted\
+      \ at the end of each phase. VPs are gained from your canals, rails, and established (flipped) industry tiles. Each round,\
+      \ players take turns according to the turn order track, receiving two actions to perform any of the following:\n\n\n\
+      \    Build an industry tile\n    Build a rail or canal\n    Develop an industry\n    Sell cotton\n    Take a loan\n\n\
+      \nAt the end of your turn, you replace the two cards you played with two more from the deck. Turn order is determined\
+      \ by how much money a player spent on the previous turn, the lowest spender going first. This turn order mechanism opens\
+      \ some strategic options for players going later in the turn order, allowing for the possibility of back-to-back turns.\n\
+      \nAfter all the cards have been played the first time (with the deck size being adjusted for the number of players),\
+      \ the canal phase ends and a scoring round commences. After scoring, all canals and all of the lowest level industries\
+      \ are removed from the game, after which new cards are dealt and the rail phase begins. During this phase, players may\
+      \ now occupy more than one location in a city and double-connection builds (though expensive) are possible. At the end\
+      \ of the rail phase, another scoring round takes place, then a winner is crowned.\n\nThe cards limit where you can build\
+      \ your industries, sell cotton or build connections (though any card can be used to 'develop'). This leads to a strategic\
+      \ timing/storing of cards. Resources are common so that if you build a rail line (which requires coal) you have to use\
+      \ the coal from the nearest source, which may be an opponent's coal mine, which in turn gets that coal mine closer to\
+      \ scoring (i.e., being utilized).\n\nBrass: Lancashire, the 2018 edition from Roxley Games, reboots the original Warfrog\
+      \ Games edition of Brass with new artwork and components, as well as a few rules changes:\n\n\n     The virtual link\
+      \ rules between Birkenhead have been made optional.\n     The three-player experience has been brought closer to the\
+      \ ideal experience of four players by shortening each half of the game by one round and tuning the deck and distant\
+      \ market tiles slightly to ensure a consistent experience.\n     Two-player rules have been created and are playable\
+      \ without the need of an alternate board.\n     The level 1 cotton mill is now worth 5 VP to make it slightly less terrible.\n\
+      \n\n"
     yearPublished: 2007
     minPlayers: 2
     maxPlayers: 4
@@ -7796,23 +8701,39 @@ catalog:
     - Rebel Sp. z o.o.
     - Wargames Club Publishing
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/brass-lancashire_rulebook.pdf
+    pdfSha256: dde82526c26edec98ef036d3f52e7c3dee66fbd546281286c1280298e4182c15
+    pdfVersion: '1.0'
   - title: 7 Wonders Duel
     bggId: 173346
     language: en
-    pdf: 7-wonders-duel_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In many ways 7 Wonders Duel resembles its parent game 7 Wonders. Over three ages, players acquire cards that provide resources or advance their military or scientific development in order to develop a civilization and complete wonders. What's different about 7 Wonders Duel is that, as the title suggests, the game is solely for two players.
+    description: 'In many ways 7 Wonders Duel resembles its parent game 7 Wonders. Over three ages, players acquire cards
+      that provide resources or advance their military or scientific development in order to develop a civilization and complete
+      wonders. What''s different about 7 Wonders Duel is that, as the title suggests, the game is solely for two players.
 
 
-      Players do not draft cards simultaneously from decks of cards, but from a display of face-down and face-up cards arranged at the start of a round. A player can take a card only if it's not covered by any others, so timing comes into play, as it can with bonus moves that allow the player to take a second card immediately. As in the original game, each acquired card can be built, discarded for coins, or used to construct a wonder. Each player also starts with four wonder cards, and the construction of a wonder provides its owner with a special ability. Only seven wonders can be built, though, so one player will end up short.
+      Players do not draft cards simultaneously from decks of cards, but from a display of face-down and face-up cards arranged
+      at the start of a round. A player can take a card only if it''s not covered by any others, so timing comes into play,
+      as it can with bonus moves that allow the player to take a second card immediately. As in the original game, each acquired
+      card can be built, discarded for coins, or used to construct a wonder. Each player also starts with four wonder cards,
+      and the construction of a wonder provides its owner with a special ability. Only seven wonders can be built, though,
+      so one player will end up short.
 
 
-      Players can purchase resources at any time from the bank, or they can gain cards during the game that provide them with resources for future building; as they are acquired, the cost for those resources increases for the opponent, representing the owner's dominance in this area.
+      Players can purchase resources at any time from the bank, or they can gain cards during the game that provide them with
+      resources for future building; as they are acquired, the cost for those resources increases for the opponent, representing
+      the owner''s dominance in this area.
 
 
-      You can win 7 Wonders Duel in one of three ways: each time you acquire a military card, you advance the military marker toward your opponent's capital (also giving you a bonus at certain positions). If you reach the opponent's capital, you win the game immediately. Or if you acquire six of seven different scientific symbols, you achieve scientific dominance and win immediately. If none of these situations occurs, then the player with the most points at the end of the game wins.
+      You can win 7 Wonders Duel in one of three ways: each time you acquire a military card, you advance the military marker
+      toward your opponent''s capital (also giving you a bonus at certain positions). If you reach the opponent''s capital,
+      you win the game immediately. Or if you acquire six of seven different scientific symbols, you achieve scientific dominance
+      and win immediately. If none of these situations occurs, then the player with the most points at the end of the game
+      wins.
 
+
+      '
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 2
@@ -7871,20 +8792,34 @@ catalog:
     - Siam Board Games
     - Sombreros Production
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/7-wonders-duel_rulebook.pdf
+    pdfSha256: 09b2939823df80444da078e0713d0cc400da95d2f1e96edb86dc023c4dc956f2
+    pdfVersion: '1.0'
   - title: Nemesis
     bggId: 167355
     language: en
-    pdf: nemesis_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Playing Nemesis will take you into the heart of sci-fi survival horror in all its terror. A soldier fires blindly down a corridor, trying to stop the alien advance. A scientist races to find a solution in his makeshift lab. A traitor steals the last escape pod in the very last moment. Intruders you meet on the ship are not only reacting to the noise you make but also evolve as the time goes by. The longer the game takes, the stronger they become. During the game, you control one of the crew members with a unique set of skills, personal deck of cards, and individual starting equipment. These heroes cover all your basic SF horror needs. For example, the scientist is great with computers and research, but will have a hard time in combat. The soldier, on the other hand...
+    description: 'Playing Nemesis will take you into the heart of sci-fi survival horror in all its terror. A soldier fires
+      blindly down a corridor, trying to stop the alien advance. A scientist races to find a solution in his makeshift lab.
+      A traitor steals the last escape pod in the very last moment. Intruders you meet on the ship are not only reacting to
+      the noise you make but also evolve as the time goes by. The longer the game takes, the stronger they become. During
+      the game, you control one of the crew members with a unique set of skills, personal deck of cards, and individual starting
+      equipment. These heroes cover all your basic SF horror needs. For example, the scientist is great with computers and
+      research, but will have a hard time in combat. The soldier, on the other hand...
 
 
-      Nemesis is a semi-cooperative game in which you and your crewmates must survive on a ship infested with hostile organisms. To win the game, you have to complete one of the two objectives dealt to you at the start of the game and get back to Earth in one piece. You will find many obstacles on your way: swarms of Intruders (the name given to the alien organisms by the ship AI), the poor physical condition of the ship, agendas held by your fellow players, and sometimes just cruel fate.
+      Nemesis is a semi-cooperative game in which you and your crewmates must survive on a ship infested with hostile organisms.
+      To win the game, you have to complete one of the two objectives dealt to you at the start of the game and get back to
+      Earth in one piece. You will find many obstacles on your way: swarms of Intruders (the name given to the alien organisms
+      by the ship AI), the poor physical condition of the ship, agendas held by your fellow players, and sometimes just cruel
+      fate.
 
 
-      The gameplay of Nemesis is designed to be full of climactic moments which, hopefully, you will find rewarding even when your best plans are ruined and your character meets a terrible fate.
+      The gameplay of Nemesis is designed to be full of climactic moments which, hopefully, you will find rewarding even when
+      your best plans are ruined and your character meets a terrible fate.
 
+
+      '
     yearPublished: 2018
     minPlayers: 1
     maxPlayers: 5
@@ -7931,39 +8866,62 @@ catalog:
     - Korea Boardgames
     - MINDOK
     - Rebel Studio
+    pdfBlobKey: rulebooks/v1/nemesis_rulebook.pdf
+    pdfSha256: 361b7df733bd97f40df76ff002063433724fb0d96a3307de0171cdbb00f84ae2
+    pdfVersion: '1.0'
   - title: A Feast for Odin
     bggId: 177736
     language: en
-    pdf: a-feast-for-odin_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      A Feast for Odin is a saga in the form of a board game. You are reliving the cultural achievements, mercantile expeditions, and pillages of those tribes we know as Viking today &mdash; a term that was used quite differently towards the end of the first millennium.
+    description: 'A Feast for Odin is a saga in the form of a board game. You are reliving the cultural achievements, mercantile
+      expeditions, and pillages of those tribes we know as Viking today &mdash; a term that was used quite differently towards
+      the end of the first millennium.
 
 
-      When the northerners went out for a raid, they used to say they headed out for a viking. Their Scandinavian ancestors, however, were much more than just pirates. They were explorers and founders of states. Leif Eriksson is said to be the first European in America, long before Columbus.
+      When the northerners went out for a raid, they used to say they headed out for a viking. Their Scandinavian ancestors,
+      however, were much more than just pirates. They were explorers and founders of states. Leif Eriksson is said to be the
+      first European in America, long before Columbus.
 
-      In what is known today as Normandy, the intruders were not called Vikings but Normans. One of them is the famous William the Conqueror who invaded England in 1066. He managed to do what the king of Norway failed to do only a few years prior: conquer the Throne of England. The reason the people of these times became such strong seafarers was their unfortunate agricultural situation: crop shortfalls caused great distress.
-
-
-      In this game, you will raid and explore new territories. You will also engage in the day-to-day activity of collecting goods with which to achieve a financially secure position in society. In the end, the player whose possessions bear the greatest value will be declared the winner.
-
-
-      --gameplay description from @StoryBoardGamer's review:
-
-      A Feast for Odin is a points-driven game, with a plethora of pathways to victory, with a range of risks balanced against rewards. A significant portion of this is your central hall, which has a whopping -86 points of squares and a major part of your game is attempting to cover these up with various tiles. Likewise, long halls and island colonies can also offer large rewards, but they will have penalties of their own.
+      In what is known today as Normandy, the intruders were not called Vikings but Normans. One of them is the famous William
+      the Conqueror who invaded England in 1066. He managed to do what the king of Norway failed to do only a few years prior:
+      conquer the Throne of England. The reason the people of these times became such strong seafarers was their unfortunate
+      agricultural situation: crop shortfalls caused great distress.
 
 
-      Each year follows a familiar pattern of preparation, worker placement, and then meeting the requirements of your feast. The main phase of each year is a worker placement affair. You start with a selection of Vikings, and a large action board with a whopping 61 different options to choose from. Each of these will be arranged from left to right in one of four columns. Each column requires an additional Viking to activate, but they are proportionally more powerful.
+      In this game, you will raid and explore new territories. You will also engage in the day-to-day activity of collecting
+      goods with which to achieve a financially secure position in society. In the end, the player whose possessions bear
+      the greatest value will be declared the winner.
 
 
-      At the end of each round, you will need to fill a feast table with food, alternating between plants and vegetable matter. You will also have a chance to lay the valuable green and blue tiles into your main hall. The configuration of these tiles must follow certain requirements, but your main goal is to both cover up a line of coin icons to increase your income, while otherwise encircling certain printed icons to generate those.
+      --gameplay description from @StoryBoardGamer''s review:
+
+      A Feast for Odin is a points-driven game, with a plethora of pathways to victory, with a range of risks balanced against
+      rewards. A significant portion of this is your central hall, which has a whopping -86 points of squares and a major
+      part of your game is attempting to cover these up with various tiles. Likewise, long halls and island colonies can also
+      offer large rewards, but they will have penalties of their own.
 
 
-      You will build your engine over time, following an alternating pattern of outward expansion and hunting against development and cultivation. It all comes down to how much you&rsquo;re willing to take on at any one time, and what risks you&rsquo;re willing to set yourself up with for their rewards.
+      Each year follows a familiar pattern of preparation, worker placement, and then meeting the requirements of your feast.
+      The main phase of each year is a worker placement affair. You start with a selection of Vikings, and a large action
+      board with a whopping 61 different options to choose from. Each of these will be arranged from left to right in one
+      of four columns. Each column requires an additional Viking to activate, but they are proportionally more powerful.
+
+
+      At the end of each round, you will need to fill a feast table with food, alternating between plants and vegetable matter.
+      You will also have a chance to lay the valuable green and blue tiles into your main hall. The configuration of these
+      tiles must follow certain requirements, but your main goal is to both cover up a line of coin icons to increase your
+      income, while otherwise encircling certain printed icons to generate those.
+
+
+      You will build your engine over time, following an alternating pattern of outward expansion and hunting against development
+      and cultivation. It all comes down to how much you&rsquo;re willing to take on at any one time, and what risks you&rsquo;re
+      willing to set yourself up with for their rewards.
 
 
       UPC 681706716909
 
+
+      '
     yearPublished: 2016
     minPlayers: 1
     maxPlayers: 4
@@ -8016,46 +8974,34 @@ catalog:
     - TLAMA games
     - White Goblin Games
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/a-feast-for-odin_rulebook.pdf
+    pdfSha256: e1280d095d2df7da6cb1cfd9cd7c0b7befcce2d8c495e3a541bc9ef64c2d9e36
+    pdfVersion: '1.0'
   - title: 'The Lord of the Rings: The Card Game'
     bggId: 421006
     language: en
-    pdf: lotr-card-game_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      A dark rumour rises from Mordor. The Eye turns to Middle-earth. The hour has come. The Fellowship is reunited. The Heroes prepare for battle. Will you play as the Fellowship of the Ring to defend the free races and destroy the One Ring? Or will you play as Sauron and pursue Frodo and Sam while deploying your hordes to the gates of the enemy cities? The destiny of Middle-earth is in your hands!
-
-
-      A game plays over 3 successive chapters that unfold similarly.
-
-      On your turn, strengthen your Skills, hoard your treasure, stretch your presence across Middle-earth, rally Races to your cause, or advance the Quest of the Ring.
-
-      				
-      				
-      					Turn OverviewIn each chapter players take cards from a display of face-down and face-up cards arranged at the start of a round. A player can take a card only if it's available, that is not partially covered by any other cards. Players can either play the card, paying its cost and placing it in their play area, obtaining its benefit, or discard the card and take as many coins from the reserve as the current chapter.
-
-      Players can also take a Landmark tile from one of the faceup tiles, paying its cost placing it in their play area. They will be able to immediately place a Fortress pawn on the corresponding region of the central board and benefit from its other effects.
-
-      				
-      				
-      					Victory ConditionsImmediately win the game by fulfilling one of the 3 victory conditions:
-
-      				
-      				
-      					Quest of the Ring
-           For the Fellowship: If Frodo and Sam reach Mount Doom, they destroy the One Ring and you immediately win the game.
-           For Sauron: If the Nazg&ucirc;l catch Frodo and Sam, they seize the One Ring and you immediately win the game.
-
-
-      				
-      				
-      					Support of the RacesIf any player gathers 6 different Race symbols on their Green cards, they rally the support of the Races of Middle-earth and immediately win the game
-
-      				
-      				
-      					Conquering Middle-earthIf a player is present in all 7 regions (with a Fortress and/or at least 1 Unit), they dominate Middle-earth and immediately win the game.
-
-      If none of these three victory conditions are achieved by the end of chapter 3, the player who is present in the most regions of Middle-earth (with a Fortress and/or at least 1 Unit) wins the game. In case of tie, share the victory.
-
+    description: "A dark rumour rises from Mordor. The Eye turns to Middle-earth. The hour has come. The Fellowship is reunited.\
+      \ The Heroes prepare for battle. Will you play as the Fellowship of the Ring to defend the free races and destroy the\
+      \ One Ring? Or will you play as Sauron and pursue Frodo and Sam while deploying your hordes to the gates of the enemy\
+      \ cities? The destiny of Middle-earth is in your hands!\n\nA game plays over 3 successive chapters that unfold similarly.\n\
+      On your turn, strengthen your Skills, hoard your treasure, stretch your presence across Middle-earth, rally Races to\
+      \ your cause, or advance the Quest of the Ring.\n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tTurn OverviewIn each chapter players\
+      \ take cards from a display of face-down and face-up cards arranged at the start of a round. A player can take a card\
+      \ only if it's available, that is not partially covered by any other cards. Players can either play the card, paying\
+      \ its cost and placing it in their play area, obtaining its benefit, or discard the card and take as many coins from\
+      \ the reserve as the current chapter.\n\nPlayers can also take a Landmark tile from one of the faceup tiles, paying\
+      \ its cost placing it in their play area. They will be able to immediately place a Fortress pawn on the corresponding\
+      \ region of the central board and benefit from its other effects.\n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tVictory ConditionsImmediately\
+      \ win the game by fulfilling one of the 3 victory conditions:\n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tQuest of the Ring\n \
+      \    For the Fellowship: If Frodo and Sam reach Mount Doom, they destroy the One Ring and you immediately win the game.\n\
+      \     For Sauron: If the Nazg&ucirc;l catch Frodo and Sam, they seize the One Ring and you immediately win the game.\n\
+      \n\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\tSupport of the RacesIf any player gathers 6 different Race symbols on their Green\
+      \ cards, they rally the support of the Races of Middle-earth and immediately win the game\n\n\t\t\t\t\n\t\t\t\t\n\t\t\
+      \t\t\tConquering Middle-earthIf a player is present in all 7 regions (with a Fortress and/or at least 1 Unit), they\
+      \ dominate Middle-earth and immediately win the game.\n\nIf none of these three victory conditions are achieved by the\
+      \ end of chapter 3, the player who is present in the most regions of Middle-earth (with a Fortress and/or at least 1\
+      \ Unit) wins the game. In case of tie, share the victory.\n\n"
     yearPublished: 2024
     minPlayers: 2
     maxPlayers: 2
@@ -8107,17 +9053,24 @@ catalog:
     - Ponva d.o.o.
     - Rebel Sp. z o.o.
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/lotr-card-game_rulebook.pdf
+    pdfSha256: ef604fe7a639dfcb59e1b63538c77cb39bfbbda512ba0e9d2756ade92ef084ee
+    pdfVersion: '1.0'
   - title: 'Clank! Legacy: Acquisitions Incorporated'
     bggId: 266507
     language: en
-    pdf: clank-legacy_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Clank! Legacy: Acquisitions Incorporated extends the deck-building fun of Clank! with legacy-style gameplay! Found your own franchise of the legendary adventuring company, Acquisitions Incorporated, and shepherd your fledgling treasure-hunters to immortal corporate glory over the course of multiple games. Your game board, your deck, and your world change as you play to create a unique campaign tailored to your adventuring party. Be cunning, be bold, and most importantly, be ready...
+    description: 'Clank! Legacy: Acquisitions Incorporated extends the deck-building fun of Clank! with legacy-style gameplay!
+      Found your own franchise of the legendary adventuring company, Acquisitions Incorporated, and shepherd your fledgling
+      treasure-hunters to immortal corporate glory over the course of multiple games. Your game board, your deck, and your
+      world change as you play to create a unique campaign tailored to your adventuring party. Be cunning, be bold, and most
+      importantly, be ready...
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2019
     minPlayers: 2
     maxPlayers: 4
@@ -8164,24 +9117,29 @@ catalog:
     - Lucrum Games
     - Origames
     - Schwerkraft-Verlag
+    pdfBlobKey: rulebooks/v1/clank-legacy_rulebook.pdf
+    pdfSha256: 56885abb8944aef298c305f26a145882c0318acc56a78ffd0876fedb3be6a2bd
+    pdfVersion: '1.0'
   - title: Concordia
     bggId: 124361
     language: en
-    pdf: concordia_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Two thousand years ago, the Roman Empire ruled the lands around the Mediterranean Sea. With peace at the borders, harmony inside the provinces, uniform law, and a common currency, the economy thrived and gave rise to mighty Roman dynasties as they expanded throughout the numerous cities. Guide one of these dynasties and send colonists to the remote realms of the Empire; develop your trade network; and appease the ancient gods for their favor &mdash; all to gain the chance to emerge victorious!
-
-
-      Concordia is a peaceful, strategy game of economic development in Roman times for 2-5 players aged 13 and up. Instead of looking to the luck of dice or cards, players must rely on their strategic abilities. Be sure to watch your rivals to determine which goals they are pursuing and where you can outpace them! In the game, colonists are sent out from Rome to settle down in cities that produce bricks, food, tools, wine, and cloth. Each player starts with an identical set of playing cards and acquires more cards during the game. These cards serve two purposes:
-
-
-          They allow a player to choose actions during the game.
-          They are worth victory points (VPs) at the end of the game. 
-
-
-      Concordia is a strategy game that requires advanced planning and consideration of your opponent's moves. Every game is different, not only because of the sequence of new cards on sale but also due to the modular layout of cities. (One side of the game board shows the entire Roman Empire with 30 cities for 3-5 players, while the other shows Roman Italy with 25 cities for 2-4 players.) When all cards have been sold or after the first player builds their 15th house, the game ends. The player with the most VPs from the gods (Jupiter, Saturnus, Mercurius, Minerva, Vesta, etc.) wins the game.
-
+    description: "Two thousand years ago, the Roman Empire ruled the lands around the Mediterranean Sea. With peace at the\
+      \ borders, harmony inside the provinces, uniform law, and a common currency, the economy thrived and gave rise to mighty\
+      \ Roman dynasties as they expanded throughout the numerous cities. Guide one of these dynasties and send colonists to\
+      \ the remote realms of the Empire; develop your trade network; and appease the ancient gods for their favor &mdash;\
+      \ all to gain the chance to emerge victorious!\n\nConcordia is a peaceful, strategy game of economic development in\
+      \ Roman times for 2-5 players aged 13 and up. Instead of looking to the luck of dice or cards, players must rely on\
+      \ their strategic abilities. Be sure to watch your rivals to determine which goals they are pursuing and where you can\
+      \ outpace them! In the game, colonists are sent out from Rome to settle down in cities that produce bricks, food, tools,\
+      \ wine, and cloth. Each player starts with an identical set of playing cards and acquires more cards during the game.\
+      \ These cards serve two purposes:\n\n\n    They allow a player to choose actions during the game.\n    They are worth\
+      \ victory points (VPs) at the end of the game. \n\n\nConcordia is a strategy game that requires advanced planning and\
+      \ consideration of your opponent's moves. Every game is different, not only because of the sequence of new cards on\
+      \ sale but also due to the modular layout of cities. (One side of the game board shows the entire Roman Empire with\
+      \ 30 cities for 3-5 players, while the other shows Roman Italy with 25 cities for 2-4 players.) When all cards have\
+      \ been sold or after the first player builds their 15th house, the game ends. The player with the most VPs from the\
+      \ gods (Jupiter, Saturnus, Mercurius, Minerva, Vesta, etc.) wins the game.\n\n"
     yearPublished: 2013
     minPlayers: 2
     maxPlayers: 5
@@ -8230,42 +9188,30 @@ catalog:
     - Playfun Games
     - Rio Grande Games
     - Ystari Games
+    pdfBlobKey: rulebooks/v1/concordia_rulebook.pdf
+    pdfSha256: 90dbdaa9dd1467777dfc9f7f9f2e57dc17d5ac8a538feebc1644480d663a0703
+    pdfVersion: '1.0'
   - title: 'Great Western Trail: New Zealand'
     bggId: 341169
     language: en
     bggEnhanced: true
-    description: >+
-      America in the 19th century: You are a rancher and repeatedly herd your cattle from Texas to Kansas City, where you send them off by train. This earns you money and victory points. Needless to say, each time you arrive in Kansas City, you want to have your most valuable cattle in tow. However, the "Great Western Trail" not only requires that you keep your herd in good shape, but also that you wisely use the various buildings along the trail. Also, it might be a good idea to hire capable staff: cowboys to improve your herd, craftsmen to build your very own buildings, or engineers for the important railroad line.
-
-
-      If you cleverly manage your herd and navigate the opportunities and pitfalls of Great Western Trail, you surely will gain the most victory points and win the game.
-
-
-      The second edition of Great Western Trail includes solitaire rules, making for a player count of 1-4.
-
-
-      Second Edition:
-
-      Remember the old days in the West? Well, the times they are a-changing&rsquo;! From new solo opponent to incredible landscapes, you won't know where to start. And there is a new herd of cows for you to sell!
-
-
-      Great Western Trail is the critically acclaimed game of cattle ranching by Alexander Pfister. Players attempt to wrangle their herd across the Midwest prairie and deliver it to Kansas City. But beware! Other cowboys are sharing the trail with you. We invite you to saddle up!
-
-
-      The changes in the Second edition:
-
-
-           Brand New Artwork by Chris Quilliams
-           Solo Mode: A New Challenger in the West
-           Dual-Layered Player Boards
-           Addition of a new breed of cows: The Simmental breed
-           Two new reversible buildings (#11 & 12)
-           Twelve Exchange Tokens, First introduced in the Rails of North Expansion, for more interaction with other players
-           Four new Master Tiles added for more strategy, replayability, and challenges
-
-
-      &mdash;description from the publisher
-
+    description: "America in the 19th century: You are a rancher and repeatedly herd your cattle from Texas to Kansas City,\
+      \ where you send them off by train. This earns you money and victory points. Needless to say, each time you arrive in\
+      \ Kansas City, you want to have your most valuable cattle in tow. However, the \"Great Western Trail\" not only requires\
+      \ that you keep your herd in good shape, but also that you wisely use the various buildings along the trail. Also, it\
+      \ might be a good idea to hire capable staff: cowboys to improve your herd, craftsmen to build your very own buildings,\
+      \ or engineers for the important railroad line.\n\nIf you cleverly manage your herd and navigate the opportunities and\
+      \ pitfalls of Great Western Trail, you surely will gain the most victory points and win the game.\n\nThe second edition\
+      \ of Great Western Trail includes solitaire rules, making for a player count of 1-4.\n\nSecond Edition:\nRemember the\
+      \ old days in the West? Well, the times they are a-changing&rsquo;! From new solo opponent to incredible landscapes,\
+      \ you won't know where to start. And there is a new herd of cows for you to sell!\n\nGreat Western Trail is the critically\
+      \ acclaimed game of cattle ranching by Alexander Pfister. Players attempt to wrangle their herd across the Midwest prairie\
+      \ and deliver it to Kansas City. But beware! Other cowboys are sharing the trail with you. We invite you to saddle up!\n\
+      \nThe changes in the Second edition:\n\n\n     Brand New Artwork by Chris Quilliams\n     Solo Mode: A New Challenger\
+      \ in the West\n     Dual-Layered Player Boards\n     Addition of a new breed of cows: The Simmental breed\n     Two\
+      \ new reversible buildings (#11 & 12)\n     Twelve Exchange Tokens, First introduced in the Rails of North Expansion,\
+      \ for more interaction with other players\n     Four new Master Tiles added for more strategy, replayability, and challenges\n\
+      \n\n&mdash;description from the publisher\n\n"
     yearPublished: 2021
     minPlayers: 1
     maxPlayers: 4
@@ -8308,23 +9254,29 @@ catalog:
   - title: 'Skytear: Arena of Legends'
     bggId: 373106
     language: en
-    pdf: skytear_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Sky Team is a co-operative game, exclusively for two players, in which you play a pilot and co-pilot at the controls of an airliner. Your goal is to work together as a team to land your airplane in different airports around the world.
+    description: 'Sky Team is a co-operative game, exclusively for two players, in which you play a pilot and co-pilot at
+      the controls of an airliner. Your goal is to work together as a team to land your airplane in different airports around
+      the world.
 
 
-      To land your plane, you need to silently assign your dice to the correct spaces in your cockpit to balance the axis of your plane, control its speed, deploy the flaps, extend the landing gear, contact the control tower to clear your path, and even have a little coffee to improve your concentration enough to change the value of your dice.
+      To land your plane, you need to silently assign your dice to the correct spaces in your cockpit to balance the axis
+      of your plane, control its speed, deploy the flaps, extend the landing gear, contact the control tower to clear your
+      path, and even have a little coffee to improve your concentration enough to change the value of your dice.
 
 
-      If the aircraft tilts too much and stalls, overshoots the airport, or collides with another aircraft, you lose the game...and your pilot's license...and probably your life.
+      If the aircraft tilts too much and stalls, overshoots the airport, or collides with another aircraft, you lose the game...and
+      your pilot''s license...and probably your life.
 
 
-      From Montreal to Tokyo, each airport offers its own set of challenges. Watch out for the turbulence as this could end up being a bumpy ride!
+      From Montreal to Tokyo, each airport offers its own set of challenges. Watch out for the turbulence as this could end
+      up being a bumpy ride!
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2023
     minPlayers: 2
     maxPlayers: 2
@@ -8372,35 +9324,29 @@ catalog:
     - Sugorokuya
     - Tabletop KZ
     - YOKA Games
+    pdfBlobKey: rulebooks/v1/skytear_rulebook.pdf
+    pdfSha256: 2f316d16c5001b55097b9966c7c697bbde6a50e7e5c9b1c3df336ff5c3775960
+    pdfVersion: '1.0'
   - title: Terra Mystica
     bggId: 120677
     language: en
-    pdf: terra-mystica_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In the land of Terra Mystica dwell 14 different peoples in seven landscapes, and each group is bound to its own home environment, so to develop and grow, they must terraform neighboring landscapes into their home environments in competition with the other groups.
-
-
-      Terra Mystica is a full information game, without any luck, that rewards strategic planning. Each player governs one of the 14 groups. With subtlety and craft, the player must attempt to rule as great an area as possible and to develop that group's skills. There are also four religious cults in which you can progress. To do all that, each group has special skills and abilities.
-
-
-      Taking turns, the players execute their actions on the resources they have at their disposal. Different buildings allow players to develop different resources. Dwellings allow for more workers. Trading houses allow players to make money. Strongholds unlock a group's special ability, and temples allow you to develop religion and your terraforming and seafaring skills. Buildings can be upgraded: Dwellings can be developed into trading houses; trading houses can be developed into strongholds or temples; one temple can be upgraded to become a sanctuary. Each group must also develop its terraforming skill and its skill with boats to use the rivers. The groups in question, along with their home landscape, are:
-
-
-          Desert (Fakirs, Nomads)
-          Plains (Halflings, Cultists)
-          Swamp (Alchemists, Darklings)
-          Lake (Mermaids, Swarmlings)
-          Forest (Witches, Auren)
-          Mountain (Dwarves, Engineers)
-          Wasteland (Giants, Chaos Magicians)
-
-
-      Proximity to other groups is a double-edged sword in Terra Mystica. Being close to other groups gives you extra power, but it also means that expanding is more difficult...
-
-
-      Terra Mystica FAQ
-
+    description: "In the land of Terra Mystica dwell 14 different peoples in seven landscapes, and each group is bound to\
+      \ its own home environment, so to develop and grow, they must terraform neighboring landscapes into their home environments\
+      \ in competition with the other groups.\n\nTerra Mystica is a full information game, without any luck, that rewards\
+      \ strategic planning. Each player governs one of the 14 groups. With subtlety and craft, the player must attempt to\
+      \ rule as great an area as possible and to develop that group's skills. There are also four religious cults in which\
+      \ you can progress. To do all that, each group has special skills and abilities.\n\nTaking turns, the players execute\
+      \ their actions on the resources they have at their disposal. Different buildings allow players to develop different\
+      \ resources. Dwellings allow for more workers. Trading houses allow players to make money. Strongholds unlock a group's\
+      \ special ability, and temples allow you to develop religion and your terraforming and seafaring skills. Buildings can\
+      \ be upgraded: Dwellings can be developed into trading houses; trading houses can be developed into strongholds or temples;\
+      \ one temple can be upgraded to become a sanctuary. Each group must also develop its terraforming skill and its skill\
+      \ with boats to use the rivers. The groups in question, along with their home landscape, are:\n\n\n    Desert (Fakirs,\
+      \ Nomads)\n    Plains (Halflings, Cultists)\n    Swamp (Alchemists, Darklings)\n    Lake (Mermaids, Swarmlings)\n  \
+      \  Forest (Witches, Auren)\n    Mountain (Dwarves, Engineers)\n    Wasteland (Giants, Chaos Magicians)\n\n\nProximity\
+      \ to other groups is a double-edged sword in Terra Mystica. Being close to other groups gives you extra power, but it\
+      \ also means that expanding is more difficult...\n\nTerra Mystica FAQ\n\n"
     yearPublished: 2012
     minPlayers: 2
     maxPlayers: 5
@@ -8449,17 +9395,29 @@ catalog:
     - White Goblin Games
     - Z-Man Games
     - Zvezda
+    pdfBlobKey: rulebooks/v1/terra-mystica_rulebook.pdf
+    pdfSha256: 9fc6eee922e6b73248ef8ca718d0edab29329ed9751ef9754a72d09beea6a9da
+    pdfVersion: '1.0'
   - title: Too Many Bones
     bggId: 192135
     language: en
-    pdf: too-many-bones_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Too Many Bones comes loaded for bear by breaking into a new genre: the dice-builder RPG. This game takes everything you think you know about dice-rolling and turns it on its head. Dripping with strategy, this fantasy-based RPG puts you in the skin of a new race and takes you on an adventure to the northern territories to root out and defeat growing enemy forces and of course the infamous "baddie" responsible.
+    description: 'Too Many Bones comes loaded for bear by breaking into a new genre: the dice-builder RPG. This game takes
+      everything you think you know about dice-rolling and turns it on its head. Dripping with strategy, this fantasy-based
+      RPG puts you in the skin of a new race and takes you on an adventure to the northern territories to root out and defeat
+      growing enemy forces and of course the infamous "baddie" responsible.
 
 
-      Team up or go it alone in a 1-4 player Coop or Solo play campaign. With over 100+ unique skill dice and 4-7 classes to choose from, every battle is its own mini challenge to figure out. Your adventure will consist of 8-12 battles before you reach your final destination and face off against one of a number of possible kingpins in order to win. Along the way, you will be faced with storyline decisions that will quickly have you weighing risk/reward, odds, and logic - with dice woven into every aspect! Your party will also be faced with other decisions: when to rest, when to explore, or even which fights to pursue! The Encounter cards offer fun plot twists and some comic relief, all while setting the stage for your next battle.
+      Team up or go it alone in a 1-4 player Coop or Solo play campaign. With over 100+ unique skill dice and 4-7 classes
+      to choose from, every battle is its own mini challenge to figure out. Your adventure will consist of 8-12 battles before
+      you reach your final destination and face off against one of a number of possible kingpins in order to win. Along the
+      way, you will be faced with storyline decisions that will quickly have you weighing risk/reward, odds, and logic - with
+      dice woven into every aspect! Your party will also be faced with other decisions: when to rest, when to explore, or
+      even which fights to pursue! The Encounter cards offer fun plot twists and some comic relief, all while setting the
+      stage for your next battle.
 
+
+      '
     yearPublished: 2017
     minPlayers: 1
     maxPlayers: 4
@@ -8506,20 +9464,29 @@ catalog:
     - Portal Games
     - Reflexshop
     - SD Games
+    pdfBlobKey: rulebooks/v1/too-many-bones_rulebook.pdf
+    pdfSha256: d1ffb9613ac5c460a37d91a69a7b19f6368bca8038f015e2c2ba5f26fb87620c
+    pdfVersion: '1.0'
   - title: Orleans
     bggId: 164928
     language: en
-    pdf: orleans_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      During the medieval goings-on around Orl&eacute;ans, you must assemble a following of farmers, merchants, knights, monks, etc. to gain supremacy through trade, construction and science in medieval France.
+    description: 'During the medieval goings-on around Orl&eacute;ans, you must assemble a following of farmers, merchants,
+      knights, monks, etc. to gain supremacy through trade, construction and science in medieval France.
 
 
-      In Orl&eacute;ans, you will recruit followers and put them to work to make use of their abilities. Farmers and Boatmen supply you with money and goods; Knights expand your scope of action and secure your mercantile expeditions; Craftsmen build trading stations and tools to facilitate work; Scholars make progress in science; Traders open up new locations for you to use your followers; and last but not least, it cannot hurt to get active in monasteries since with Monks on your side you are much less likely to fall prey to fate.
+      In Orl&eacute;ans, you will recruit followers and put them to work to make use of their abilities. Farmers and Boatmen
+      supply you with money and goods; Knights expand your scope of action and secure your mercantile expeditions; Craftsmen
+      build trading stations and tools to facilitate work; Scholars make progress in science; Traders open up new locations
+      for you to use your followers; and last but not least, it cannot hurt to get active in monasteries since with Monks
+      on your side you are much less likely to fall prey to fate.
 
 
-      You will always want to take more actions than possible, and there are many paths to victory. The challenge is to combine all elements as best as possible with regard to your strategy.
+      You will always want to take more actions than possible, and there are many paths to victory. The challenge is to combine
+      all elements as best as possible with regard to your strategy.
 
+
+      '
     yearPublished: 2014
     minPlayers: 2
     maxPlayers: 5
@@ -8568,17 +9535,26 @@ catalog:
     - Swan Panasia Co., Ltd.
     - Tasty Minstrel Games
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/orleans_rulebook.pdf
+    pdfSha256: 267ac223f04cba34b686f4dcdcb47460af3c9813a8f644b7ba46950f94750fad
+    pdfVersion: '1.0'
   - title: Mage Knight Board Game
     bggId: 96848
     language: en
-    pdf: mage-knight_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      The Mage Knight board game puts you in control of one of four powerful Mage Knights as you explore (and conquer) a corner of the Mage Knight universe under the control of the Atlantean Empire. Build your army, fill your deck with powerful spells and actions, explore caves and dungeons, and eventually conquer powerful cities controlled by this once-great faction!  In competitive scenarios, opposing players may be powerful allies, but only one will be able to claim the land as their own.  In cooperative scenarios, the players win or lose as a group.  Solo rules are also included.
+    description: 'The Mage Knight board game puts you in control of one of four powerful Mage Knights as you explore (and
+      conquer) a corner of the Mage Knight universe under the control of the Atlantean Empire. Build your army, fill your
+      deck with powerful spells and actions, explore caves and dungeons, and eventually conquer powerful cities controlled
+      by this once-great faction!  In competitive scenarios, opposing players may be powerful allies, but only one will be
+      able to claim the land as their own.  In cooperative scenarios, the players win or lose as a group.  Solo rules are
+      also included.
 
 
-      Combining elements of RPGs, deck-building, and traditional board games the Mage Knight board game captures the rich history of the Mage Knight universe in a self-contained gaming experience.
+      Combining elements of RPGs, deck-building, and traditional board games the Mage Knight board game captures the rich
+      history of the Mage Knight universe in a self-contained gaming experience.
 
+
+      '
     yearPublished: 2011
     minPlayers: 1
     maxPlayers: 4
@@ -8623,23 +9599,34 @@ catalog:
     - NECA
     - Pegasus Spiele
     - REXhry
+    pdfBlobKey: rulebooks/v1/mage-knight_rulebook.pdf
+    pdfSha256: 664ab0e5405d821be665178f2e325205cfbccbc3d1723b07fe3ff261f6c835bd
+    pdfVersion: '1.0'
   - title: Barrage
     bggId: 251247
     language: en
-    pdf: barrage_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In the dystopic 1930s, the industrial revolution pushed the exploitation of fossil-based resources to the limit, and now the only thing powerful enough to quench the thirst for power of the massive machines and of the unstoppable engineering progress is the unlimited hydroelectric energy provided by the rivers.
+    description: 'In the dystopic 1930s, the industrial revolution pushed the exploitation of fossil-based resources to the
+      limit, and now the only thing powerful enough to quench the thirst for power of the massive machines and of the unstoppable
+      engineering progress is the unlimited hydroelectric energy provided by the rivers.
 
 
-      Barrage is a resource management strategic game in which players compete to build their majestic dams, raise them to increase their storing capacity, and deliver all the potential power through pressure tunnels connected to the energy turbines of their powerhouses.
+      Barrage is a resource management strategic game in which players compete to build their majestic dams, raise them to
+      increase their storing capacity, and deliver all the potential power through pressure tunnels connected to the energy
+      turbines of their powerhouses.
 
 
-      Each player represents one of the four international companies who are gathering machinery, innovative patents and brilliant engineers to claim the best locations to collect and exploit the water of a contested Alpine region crossed by rivers.
+      Each player represents one of the four international companies who are gathering machinery, innovative patents and brilliant
+      engineers to claim the best locations to collect and exploit the water of a contested Alpine region crossed by rivers.
 
 
-      Over five rounds, the players must fulfill power requirements represented by a common competitive power track and meet specific requests of personal contracts. At the same time, by placing a limited number of engineers, they attempt to enhance their machinery to acquire new and more efficient construction actions and to build and activate special unique-effect buildings to forward their own developing strategy.
+      Over five rounds, the players must fulfill power requirements represented by a common competitive power track and meet
+      specific requests of personal contracts. At the same time, by placing a limited number of engineers, they attempt to
+      enhance their machinery to acquire new and more efficient construction actions and to build and activate special unique-effect
+      buildings to forward their own developing strategy.
 
+
+      '
     yearPublished: 2019
     minPlayers: 1
     maxPlayers: 4
@@ -8684,33 +9671,51 @@ catalog:
     - テンデイズゲームズ (TendaysGames)
     - TLAMA games
     - WoodCat
+    pdfBlobKey: rulebooks/v1/barrage_rulebook.pdf
+    pdfSha256: 2c68f1c8d57f4d3f4c3bb083c94738a9dbea054a6aa8cb4ff19a4708fe5bc709
+    pdfVersion: '1.0'
   - title: 'Hegemony: Lead Your Class to Victory'
     bggId: 321608
     language: en
-    pdf: hegemony_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Extended edition includes Crisis & Control expansion.
+    description: 'Extended edition includes Crisis & Control expansion.
 
 
 
-      The Nation is in disarray and a war is waging between the classes. The working class faces a dismantled welfare system, the capitalists are losing their hard-earned profits, the middle class is gradually fading and the state is sinking into a deep deficit. Amidst all this chaos, the only person who can provide guidance is... you. Will you take the side of the working class and fight for social reforms? Or will you stand with the corporations and the free market? Will you help the government try to keep it all together, or will you try to enforce your agenda no matter the cost to the country?
+      The Nation is in disarray and a war is waging between the classes. The working class faces a dismantled welfare system,
+      the capitalists are losing their hard-earned profits, the middle class is gradually fading and the state is sinking
+      into a deep deficit. Amidst all this chaos, the only person who can provide guidance is... you. Will you take the side
+      of the working class and fight for social reforms? Or will you stand with the corporations and the free market? Will
+      you help the government try to keep it all together, or will you try to enforce your agenda no matter the cost to the
+      country?
 
 
-      Hegemony is an asymmetric politico-economic card-driven board game for 2-4 players that puts you in the role of one of the socio-economic groups in a fictional state: The Working Class, the Middle Class, the Capitalist Class and the State itself.
+      Hegemony is an asymmetric politico-economic card-driven board game for 2-4 players that puts you in the role of one
+      of the socio-economic groups in a fictional state: The Working Class, the Middle Class, the Capitalist Class and the
+      State itself.
 
 
-      The Working class controls the workers. The Capitalist class controls the companies. The Middle class combines elements from both the Working class and the Capitalist. It has workers who can work in the Capitalist's companies but it can also build companies of its own, yet smaller. Finally the State is trying to keep everyone happy, providing benefits and subsidies when needed but trying also to maintain a steady income through taxes to avoid going into debt.
+      The Working class controls the workers. The Capitalist class controls the companies. The Middle class combines elements
+      from both the Working class and the Capitalist. It has workers who can work in the Capitalist''s companies but it can
+      also build companies of its own, yet smaller. Finally the State is trying to keep everyone happy, providing benefits
+      and subsidies when needed but trying also to maintain a steady income through taxes to avoid going into debt.
 
 
-      While players have their own separate goals, they are all limited by a series of policies that affect most of their actions, like Taxation, Labor Market, Foreign Trade etc. Voting on those policies and using their influence to change them is also very important. Through careful planning, strategic actions and political maneuvering, you will do your best to increase the power of your class and carry out your agenda. Will you be the one to lead your class to victory?
+      While players have their own separate goals, they are all limited by a series of policies that affect most of their
+      actions, like Taxation, Labor Market, Foreign Trade etc. Voting on those policies and using their influence to change
+      them is also very important. Through careful planning, strategic actions and political maneuvering, you will do your
+      best to increase the power of your class and carry out your agenda. Will you be the one to lead your class to victory?
 
 
-      Hegemony is heavily based on actual academic principles such as Social-Democracy, Neoliberalism, Nationalism and Globalism, and allows players to see their real world applications through engaging gameplay. There are many ways to achieve hegemony- which one will you take?
+      Hegemony is heavily based on actual academic principles such as Social-Democracy, Neoliberalism, Nationalism and Globalism,
+      and allows players to see their real world applications through engaging gameplay. There are many ways to achieve hegemony-
+      which one will you take?
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2023
     minPlayers: 2
     maxPlayers: 4
@@ -8745,23 +9750,36 @@ catalog:
     - Lavka Games
     - MYBG Co., Ltd.
     - Portal Games
+    pdfBlobKey: rulebooks/v1/hegemony_rulebook.pdf
+    pdfSha256: 95d89918c65189836d92e1b1fde7b7abad83b902cf53332299c11cd2bbfd478a
+    pdfVersion: '1.0'
   - title: Viticulture Essential Edition
     bggId: 183394
     language: en
-    pdf: viticulture_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Viticulture, the players find themselves in the roles of people in rustic, pre-modern Tuscany who have inherited meagre vineyards. They have a few plots of land, an old crush pad, a tiny cellar, and three workers. They each have a dream of being the first to call their winery a true success.
+    description: 'In Viticulture, the players find themselves in the roles of people in rustic, pre-modern Tuscany who have
+      inherited meagre vineyards. They have a few plots of land, an old crush pad, a tiny cellar, and three workers. They
+      each have a dream of being the first to call their winery a true success.
 
 
-      The players are in the position of determining how they want to allocate their workers throughout the year. Every season is different on a vineyard, so the workers have different tasks they can take care of in the summer and winter. There's competition over those tasks, and often the first worker to get to the job has an advantage over subsequent workers.
+      The players are in the position of determining how they want to allocate their workers throughout the year. Every season
+      is different on a vineyard, so the workers have different tasks they can take care of in the summer and winter. There''s
+      competition over those tasks, and often the first worker to get to the job has an advantage over subsequent workers.
 
 
-      Fortunately for the vineyard owners, people love to visit wineries, and it just so happens that many of those visitors are willing to help out around the vineyard when they visit as long as you assign a worker to take care of them. Their visits (in the form of cards) are brief but can be very helpful. Using those workers and visitors, the vineyard owners can expand their vineyards by building structures, planting vines, and filling wine orders, working towards the goal of running the most successful winery in Tuscany.
+      Fortunately for the vineyard owners, people love to visit wineries, and it just so happens that many of those visitors
+      are willing to help out around the vineyard when they visit as long as you assign a worker to take care of them. Their
+      visits (in the form of cards) are brief but can be very helpful. Using those workers and visitors, the vineyard owners
+      can expand their vineyards by building structures, planting vines, and filling wine orders, working towards the goal
+      of running the most successful winery in Tuscany.
 
 
-      Viticulture Essential Edition includes the base game of Viticulture and a few of the most popular modules from the original Tuscany expansion, including Mamas & Papas, Fields (previously known as Properties), expanded and revised Visitors, and Automa cards for a solo variant, along with a few minor rule changes.
+      Viticulture Essential Edition includes the base game of Viticulture and a few of the most popular modules from the original
+      Tuscany expansion, including Mamas & Papas, Fields (previously known as Properties), expanded and revised Visitors,
+      and Automa cards for a solo variant, along with a few minor rule changes.
 
+
+      '
     yearPublished: 2015
     minPlayers: 1
     maxPlayers: 6
@@ -8807,25 +9825,41 @@ catalog:
     - Regatul Jocurilor
     - Surfin' Meeple China
     - Tower Tactic Games
+    pdfBlobKey: rulebooks/v1/viticulture_rulebook.pdf
+    pdfSha256: bca0937ac513b49bceef44c4fe65acc0aacc8a444774894fe62bde10836f613a
+    pdfVersion: '1.0'
   - title: Crokinole
     bggId: 521
     language: en
     bggEnhanced: true
-    description: >+
-      Crokinole is a traditional two- or four-player dexterity game, played on a circular wooden board, with 3 rings and an inner recessed 'bullseye'. A ring of posts is set around the inner circle, which functions as an obstacle to reach this area. Playing pieces are wooden circular disks similar to checkers pieces.  Players take turns shooting disks across the board by flicking them with their fingers in an effort to land them in the highest scoring ring on the board, the highest score (20 points) achieved by shooting a disk into the centre, recessed hole. From the outside in, rings are worth 5, 10, 15 points.
+    description: 'Crokinole is a traditional two- or four-player dexterity game, played on a circular wooden board, with 3
+      rings and an inner recessed ''bullseye''. A ring of posts is set around the inner circle, which functions as an obstacle
+      to reach this area. Playing pieces are wooden circular disks similar to checkers pieces.  Players take turns shooting
+      disks across the board by flicking them with their fingers in an effort to land them in the highest scoring ring on
+      the board, the highest score (20 points) achieved by shooting a disk into the centre, recessed hole. From the outside
+      in, rings are worth 5, 10, 15 points.
 
 
-      As a traditional game, there are often many variations played, but the following method is based on the National Crokinole Association's rules which also govern the World Crokinole Championship.
+      As a traditional game, there are often many variations played, but the following method is based on the National Crokinole
+      Association''s rules which also govern the World Crokinole Championship.
 
 
-      Each disk to be shot must be placed on the outer boundary and within the shooting player's quadrant. If there are no opponent's disks on the board, the shot disk must land in the inner ring or it is removed. If there is an opponent's disk on the board, the shot disk must hit an opponent's piece, either directly, or by bumping another disk into it.  Disks landing in the centre hole are removed and scored at the end of the round. Disks that lie outside--or are touching--the outer boundary after each shot are removed from play for the round.
+      Each disk to be shot must be placed on the outer boundary and within the shooting player''s quadrant. If there are no
+      opponent''s disks on the board, the shot disk must land in the inner ring or it is removed. If there is an opponent''s
+      disk on the board, the shot disk must hit an opponent''s piece, either directly, or by bumping another disk into it.  Disks
+      landing in the centre hole are removed and scored at the end of the round. Disks that lie outside--or are touching--the
+      outer boundary after each shot are removed from play for the round.
 
 
-      The player to score the most points wins the round and scores 2 points, and if a tie, each player scores 1 point. A "game" is usually played to four rounds. The number of "games" in a match is set by the tournament.
+      The player to score the most points wins the round and scores 2 points, and if a tie, each player scores 1 point. A
+      "game" is usually played to four rounds. The number of "games" in a match is set by the tournament.
 
 
-      Alternatively, play is to a set score, usually the first player or team to 100, and each round is scored by cancellation. For example if Player One scores 250, and Player Two scores 225, then Player One will add 25 to his/her game score.
+      Alternatively, play is to a set score, usually the first player or team to 100, and each round is scored by cancellation.
+      For example if Player One scores 250, and Player Two scores 225, then Player One will add 25 to his/her game score.
 
+
+      '
     yearPublished: 1876
     minPlayers: 2
     maxPlayers: 4
@@ -8876,17 +9910,23 @@ catalog:
   - title: 'Heat: Pedal to the Metal'
     bggId: 366013
     language: en
-    pdf: heat_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Based on simple and intuitive hand management, Heat: Pedal to the Metal puts players in the driver's seat of intense car races, jockeying for position to cross the finish line first, while managing their car's speed if they don't want to overheat. Selecting the right upgrades for their car will help them hug the curves and keep their engine cool enough to maintain top speeds. Ultimately, their driving skills will be the key to victory!
+    description: 'Based on simple and intuitive hand management, Heat: Pedal to the Metal puts players in the driver''s seat
+      of intense car races, jockeying for position to cross the finish line first, while managing their car''s speed if they
+      don''t want to overheat. Selecting the right upgrades for their car will help them hug the curves and keep their engine
+      cool enough to maintain top speeds. Ultimately, their driving skills will be the key to victory!
 
 
-      Drivers can compete in a single race or use the "Championship System" to play a whole season in one game night, customizing their car before each race to claim the top spot of the podium. They have to be careful as the weather, road conditions, and events will change every race to spice up their championship. Players can also enjoy a solo mode with the Legends Module or add automated drivers as additional opponents in multiplayer games.
+      Drivers can compete in a single race or use the "Championship System" to play a whole season in one game night, customizing
+      their car before each race to claim the top spot of the podium. They have to be careful as the weather, road conditions,
+      and events will change every race to spice up their championship. Players can also enjoy a solo mode with the Legends
+      Module or add automated drivers as additional opponents in multiplayer games.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2022
     minPlayers: 1
     maxPlayers: 6
@@ -8928,22 +9968,35 @@ catalog:
     - Kaissa Chess & Games
     - Korea Boardgames
     - Lord of Boards
+    pdfBlobKey: rulebooks/v1/heat_rulebook.pdf
+    pdfSha256: 03515036dff608ec23a69ca0f7a538f06ec5612809950df1650d4d3d57586f81
+    pdfVersion: '1.0'
   - title: Kanban EV
     bggId: 284378
     language: en
-    pdf: kanban-ev_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Electric vehicles (EVs) have become more common since 2014 and are the future of the automobile industry. They are superior vehicles due to them being more efficient, easier to maintain, cleaner, and cheaper to run. They are computerized machines that use AI to improve safety and in the near future will provide autonomous driving. They receive software upgrades during their lifetime and are constantly improving, unlike their traditional combustion-engine counterparts, which start to become obsolete as soon as you start using them.
+    description: 'Electric vehicles (EVs) have become more common since 2014 and are the future of the automobile industry.
+      They are superior vehicles due to them being more efficient, easier to maintain, cleaner, and cheaper to run. They are
+      computerized machines that use AI to improve safety and in the near future will provide autonomous driving. They receive
+      software upgrades during their lifetime and are constantly improving, unlike their traditional combustion-engine counterparts,
+      which start to become obsolete as soon as you start using them.
 
 
-      You will be overseeing the production of these vehicles in Kanban EV, with "kanban" (看板) being the name for a scheduling system that supports an efficient assembly line, just-in-time production, and a smooth workflow process. Over the course of the game, players take on the role of rookie employees who are trying to secure their career. You need to manage suppliers and supplies, improve and innovate automobile parts, and get your hands greasy on the assembly line in order to boost production and impress the factory manager.
+      You will be overseeing the production of these vehicles in Kanban EV, with "kanban" (看板) being the name for a scheduling
+      system that supports an efficient assembly line, just-in-time production, and a smooth workflow process. Over the course
+      of the game, players take on the role of rookie employees who are trying to secure their career. You need to manage
+      suppliers and supplies, improve and innovate automobile parts, and get your hands greasy on the assembly line in order
+      to boost production and impress the factory manager.
 
 
-      You must make shrewd use of the recycling facilities and the limited factory supplies in order to appropriate parts when the suppliers come up short. Because the factory must run at optimum efficiency, production doesn't wait for you or for mistakes. Sandra, the factory manager, will review your performance and keep the factory on tempo.
+      You must make shrewd use of the recycling facilities and the limited factory supplies in order to appropriate parts
+      when the suppliers come up short. Because the factory must run at optimum efficiency, production doesn''t wait for you
+      or for mistakes. Sandra, the factory manager, will review your performance and keep the factory on tempo.
 
 
-      Kanban EV is a game that focuses on resource and time management that puts you in the driver's seat of an entire production facility, racing for factory goals and the highest level of promotion. You earn production points (PP) for performing various actions in the game, and the player with the most PP at the end of the game wins.
+      Kanban EV is a game that focuses on resource and time management that puts you in the driver''s seat of an entire production
+      facility, racing for factory goals and the highest level of promotion. You earn production points (PP) for performing
+      various actions in the game, and the player with the most PP at the end of the game wins.
 
 
       &mdash;description from publisher
@@ -8951,6 +10004,8 @@ catalog:
 
       Includes solo mode by D&aacute;vid Turczi
 
+
+      '
     yearPublished: 2020
     minPlayers: 1
     maxPlayers: 4
@@ -8986,26 +10041,21 @@ catalog:
     - Skellig Games
     - TLAMA games
     - YOKA Games
+    pdfBlobKey: rulebooks/v1/kanban-ev_rulebook.pdf
+    pdfSha256: d09cdca785107379277fd8a8bd8da5daa6b7cdc2247dc6f0b650a28320cc584c
+    pdfVersion: '1.0'
   - title: 'Marvel Champions: The Card Game'
     bggId: 285774
     language: en
-    pdf: marvel-champions_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      "With great power, there must also come great responsibility."
-         &ndash;Stan Lee, Amazing Fantasy #15
-
-      Iron Man and Black Panther team up to stop Rhino from rampaging through the streets of New York. Captain Marvel and Spider-Man battle Ultron as he threatens global annihilation. Do you have what it takes to join the ranks of these legendary heroes and become a champion?
-
-
-      Jump into the Marvel Universe with Marvel Champions: The Card Game, a cooperative Living Card Game for one to four players!
-
-
-      Marvel Champions: The Card Game invites players to embody iconic heroes from the Marvel Universe as they battle to stop infamous villains from enacting their devious schemes. As a Living Card Game, Marvel Champions is supported with regular releases of new product, including new heroes and scenarios.
-
-
-      &mdash;description from the publisher
-
+    description: "\"With great power, there must also come great responsibility.\"\n   &ndash;Stan Lee, Amazing Fantasy #15\n\
+      \nIron Man and Black Panther team up to stop Rhino from rampaging through the streets of New York. Captain Marvel and\
+      \ Spider-Man battle Ultron as he threatens global annihilation. Do you have what it takes to join the ranks of these\
+      \ legendary heroes and become a champion?\n\nJump into the Marvel Universe with Marvel Champions: The Card Game, a cooperative\
+      \ Living Card Game for one to four players!\n\nMarvel Champions: The Card Game invites players to embody iconic heroes\
+      \ from the Marvel Universe as they battle to stop infamous villains from enacting their devious schemes. As a Living\
+      \ Card Game, Marvel Champions is supported with regular releases of new product, including new heroes and scenarios.\n\
+      \n&mdash;description from the publisher\n\n"
     yearPublished: 2019
     minPlayers: 1
     maxPlayers: 4
@@ -9044,20 +10094,33 @@ catalog:
     - Kilogames
     - Korea Boardgames
     - NeoTroy Games
+    pdfBlobKey: rulebooks/v1/marvel-champions_rulebook.pdf
+    pdfSha256: 357c9be2010723dd3e8831e81eb140567d0d93f83b803a9040dcad2b8f2730b9
+    pdfVersion: '1.0'
   - title: Underwater Cities
     bggId: 247763
     language: en
-    pdf: underwater-cities_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Underwater Cities, which takes about 30-45 minutes per player, players represent the most powerful brains in the world, brains nominated due to the overpopulation of Earth to establish the best and most livable underwater areas possible.
+    description: 'In Underwater Cities, which takes about 30-45 minutes per player, players represent the most powerful brains
+      in the world, brains nominated due to the overpopulation of Earth to establish the best and most livable underwater
+      areas possible.
 
 
-      The main principle of the game is card placement. Three colored cards are placed along the edge of the main board  into 3 x 5 slots, which are also colored. Ideally players can place cards into slots of the same color. Then they can take both actions and advantages: the action depicted in the slot on the main board and also the advantage of the card. Actions and advantages can allow players to intake raw materials; to build and upgrade city domes, tunnels and production buildings such as farms, desalination devices and laboratories in their personal underwater area; to move their marker on the initiative track (which is important for player order in the next turn); to activate the player's "A-cards"; and to collect cards, both special ones and basic ones that allow for better decision possibilities during gameplay.
+      The main principle of the game is card placement. Three colored cards are placed along the edge of the main board  into
+      3 x 5 slots, which are also colored. Ideally players can place cards into slots of the same color. Then they can take
+      both actions and advantages: the action depicted in the slot on the main board and also the advantage of the card. Actions
+      and advantages can allow players to intake raw materials; to build and upgrade city domes, tunnels and production buildings
+      such as farms, desalination devices and laboratories in their personal underwater area; to move their marker on the
+      initiative track (which is important for player order in the next turn); to activate the player''s "A-cards"; and to
+      collect cards, both special ones and basic ones that allow for better decision possibilities during gameplay.
 
 
-      All of the nearly 220 cards &mdash; whether special or basic &mdash; are divided into five types according to the way and time of use. Underwater areas are planned to be double-sided, giving players many opportunities to achieve VPs and finally win.
+      All of the nearly 220 cards &mdash; whether special or basic &mdash; are divided into five types according to the way
+      and time of use. Underwater areas are planned to be double-sided, giving players many opportunities to achieve VPs and
+      finally win.
 
+
+      '
     yearPublished: 2018
     minPlayers: 1
     maxPlayers: 4
@@ -9103,29 +10166,50 @@ catalog:
     - Rio Grande Games
     - sternenschimmermeer
     - 数寄ゲームズ (Suki Games)
+    pdfBlobKey: rulebooks/v1/underwater-cities_rulebook.pdf
+    pdfSha256: 09a932ae6a3c5adfe07d0efeda8071a8ba225b9c66a766d08576075b2e7a2c9c
+    pdfVersion: '1.0'
   - title: Food Chain Magnate
     bggId: 175914
     language: en
-    pdf: food-chain-magnate_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      "Lemonade? They want lemonade? What is the world coming to? I want commercials for burgers on all channels, every 15 minutes. We are the Home of the Original Burger, not a hippie health haven. And place a billboard next to that new house on the corner. I want them craving beer every second they sit in their posh new garden." The new management trainee trembles in front of the CEO and tries to politely point out that... "How do you mean, we don't have enough staff? The HR director reports to you. Hire more people! Train them! But whatever you do, don't pay them any real wages. I did not go into business to become poor. And fire that discount manager, she is only costing me money. From now on, we'll sell gourmet burgers. Same crap, double the price. Get my marketing director in here!"
+    description: '"Lemonade? They want lemonade? What is the world coming to? I want commercials for burgers on all channels,
+      every 15 minutes. We are the Home of the Original Burger, not a hippie health haven. And place a billboard next to that
+      new house on the corner. I want them craving beer every second they sit in their posh new garden." The new management
+      trainee trembles in front of the CEO and tries to politely point out that... "How do you mean, we don''t have enough
+      staff? The HR director reports to you. Hire more people! Train them! But whatever you do, don''t pay them any real wages.
+      I did not go into business to become poor. And fire that discount manager, she is only costing me money. From now on,
+      we''ll sell gourmet burgers. Same crap, double the price. Get my marketing director in here!"
 
 
-      Food Chain Magnate is a heavy strategy game about building a fast food chain. The focus is on building your company using a card-driven (human) resource management system. Players compete on a variable city map through purchasing, marketing and sales, and on a job market for key staff members. The game can be played by 2-5 serious gamers in 2-4 hours.
+      Food Chain Magnate is a heavy strategy game about building a fast food chain. The focus is on building your company
+      using a card-driven (human) resource management system. Players compete on a variable city map through purchasing, marketing
+      and sales, and on a job market for key staff members. The game can be played by 2-5 serious gamers in 2-4 hours.
 
 
       German:
 
 
-      "Limonade? Sie wollen Limonade? Was ist mit der Welt los? Ich will Werbung f&uuml;r Burger auf allen Kan&auml;len, alle 15 Minuten. Wir sind die Heimat des Original-Burgers, kein Hippie-Gesundheitsparadies. Und stellen Sie eine Werbetafel neben das neue Haus an der Ecke. Ich will, dass sie jede Sekunde, in der sie in ihrem schicken neuen Garten sitzen, nach Bier lechzen." Der neue Management-Trainee zittert vor dem CEO und versucht, h&ouml;flich darauf hinzuweisen, dass... "Wie meinen Sie das, wir haben nicht genug Personal? Der Personaldirektor berichtet an Sie. Stellen Sie mehr Leute ein! Bilden Sie sie aus! Aber was auch immer Sie tun, zahlen Sie ihnen keine echten L&ouml;hne. Ich bin nicht ins Gesch&auml;ft eingestiegen, um arm zu werden. Und feuere diese Discount-Managerin, sie kostet mich nur Geld. Von nun an werden wir Gourmet-Burger verkaufen. Derselbe Mist, nur doppelt so teuer. Holen Sie meinen Marketingdirektor her!"
+      "Limonade? Sie wollen Limonade? Was ist mit der Welt los? Ich will Werbung f&uuml;r Burger auf allen Kan&auml;len, alle
+      15 Minuten. Wir sind die Heimat des Original-Burgers, kein Hippie-Gesundheitsparadies. Und stellen Sie eine Werbetafel
+      neben das neue Haus an der Ecke. Ich will, dass sie jede Sekunde, in der sie in ihrem schicken neuen Garten sitzen,
+      nach Bier lechzen." Der neue Management-Trainee zittert vor dem CEO und versucht, h&ouml;flich darauf hinzuweisen, dass...
+      "Wie meinen Sie das, wir haben nicht genug Personal? Der Personaldirektor berichtet an Sie. Stellen Sie mehr Leute ein!
+      Bilden Sie sie aus! Aber was auch immer Sie tun, zahlen Sie ihnen keine echten L&ouml;hne. Ich bin nicht ins Gesch&auml;ft
+      eingestiegen, um arm zu werden. Und feuere diese Discount-Managerin, sie kostet mich nur Geld. Von nun an werden wir
+      Gourmet-Burger verkaufen. Derselbe Mist, nur doppelt so teuer. Holen Sie meinen Marketingdirektor her!"
 
 
-      Food Chain Magnate ist ein schweres Strategiespiel &uuml;ber den Aufbau einer Fast-Food-Kette. Der Schwerpunkt liegt auf dem Aufbau des eigenen Unternehmens mit Hilfe eines kartengesteuerten (Personal-)Managementsystems. Die Spieler konkurrieren auf einer variablen Stadtkarte durch Einkauf, Marketing und Verkauf sowie auf einem Stellenmarkt f&uuml;r wichtige Mitarbeiter.
+      Food Chain Magnate ist ein schweres Strategiespiel &uuml;ber den Aufbau einer Fast-Food-Kette. Der Schwerpunkt liegt
+      auf dem Aufbau des eigenen Unternehmens mit Hilfe eines kartengesteuerten (Personal-)Managementsystems. Die Spieler
+      konkurrieren auf einer variablen Stadtkarte durch Einkauf, Marketing und Verkauf sowie auf einem Stellenmarkt f&uuml;r
+      wichtige Mitarbeiter.
 
 
       Das Spiel kann von 2-5 ernsthaften Spielern in 2-4 Stunden gespielt werden.
 
+
+      '
     yearPublished: 2015
     minPlayers: 2
     maxPlayers: 5
@@ -9164,23 +10248,40 @@ catalog:
     - New Games Order, LLC
     - One Moment Games
     - Portal Games
+    pdfBlobKey: rulebooks/v1/food-chain-magnate_rulebook.pdf
+    pdfSha256: f228049fcadc5d674049cb10a419e13d7e6d270bfcdf8a8e8ef33ddb7482f4a3
+    pdfVersion: '1.0'
   - title: 'Pax Pamir: Second Edition'
     bggId: 256960
     language: en
-    pdf: pax-pamir_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Pax Pamir, players assume the role of nineteenth century Afghan leaders attempting to forge a new state after the collapse of the Durrani Empire. Western histories often call this period "The Great Game" because of the role played by the Europeans who attempted to use central Asia as a theater for their own rivalries. In this game, those empires are viewed strictly from the perspective of the Afghans who sought to manipulate the interloping ferengi (foreigners) for their own purposes.
+    description: 'In Pax Pamir, players assume the role of nineteenth century Afghan leaders attempting to forge a new state
+      after the collapse of the Durrani Empire. Western histories often call this period "The Great Game" because of the role
+      played by the Europeans who attempted to use central Asia as a theater for their own rivalries. In this game, those
+      empires are viewed strictly from the perspective of the Afghans who sought to manipulate the interloping ferengi (foreigners)
+      for their own purposes.
 
 
-      In terms of game play, Pax Pamir is a pretty straightforward tableau builder. Players spend most of their turns purchasing cards from a central market, then playing those cards in front of them in a single row called a court. Playing cards adds units to the game's map and grants access to additional actions that can be taken to disrupt other players and influence the course of the game. That last point is worth emphasizing. Though everyone is building their own row of cards, the game offers many ways for players to interfere with each other directly and indirectly.
+      In terms of game play, Pax Pamir is a pretty straightforward tableau builder. Players spend most of their turns purchasing
+      cards from a central market, then playing those cards in front of them in a single row called a court. Playing cards
+      adds units to the game''s map and grants access to additional actions that can be taken to disrupt other players and
+      influence the course of the game. That last point is worth emphasizing. Though everyone is building their own row of
+      cards, the game offers many ways for players to interfere with each other directly and indirectly.
 
 
-      To survive, players will organize into coalitions. Throughout the game, the dominance of the different coalitions will be evaluated by the players when a special card, called a "Dominance Check", is resolved. If a single coalition has a commanding lead during one of these checks, those players loyal to that coalition will receive victory points based on their influence in their coalition. However, if Afghanistan remains fragmented during one of these checks, players instead will receive victory points based on their personal power base.
+      To survive, players will organize into coalitions. Throughout the game, the dominance of the different coalitions will
+      be evaluated by the players when a special card, called a "Dominance Check", is resolved. If a single coalition has
+      a commanding lead during one of these checks, those players loyal to that coalition will receive victory points based
+      on their influence in their coalition. However, if Afghanistan remains fragmented during one of these checks, players
+      instead will receive victory points based on their personal power base.
 
 
-      After each Dominance Check, victory is checked and the game will be partially reset, offering players a fresh attempt to realize their ambitions. The game ends when a single player is able to achieve a lead of four or more victory points  or after the fourth and final Dominance Check is resolved.
+      After each Dominance Check, victory is checked and the game will be partially reset, offering players a fresh attempt
+      to realize their ambitions. The game ends when a single player is able to achieve a lead of four or more victory points  or
+      after the fourth and final Dominance Check is resolved.
 
+
+      '
     yearPublished: 2019
     minPlayers: 1
     maxPlayers: 5
@@ -9228,20 +10329,29 @@ catalog:
     - Spielworxx
     - テンデイズゲームズ (TendaysGames)
     - YOKA Games
+    pdfBlobKey: rulebooks/v1/pax-pamir_rulebook.pdf
+    pdfSha256: 63b77858c8013806355dc52b7620044478fe545c12b495dbf16843c6242c009b
+    pdfVersion: '1.0'
   - title: 'Cthulhu: Death May Die'
     bggId: 253344
     language: en
-    pdf: cthulhu-death-may-die_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Cthulhu: Death May Die, inspired by the writings of H.P. Lovecraft, you and your fellow players represent investigators in the 1920s who instead of trying to stop the coming of Elder Gods, want to summon those otherworldly beings so that you can put a stop to them permanently. You start the game insane, and while your long-term goal is to shoot Cthulhu in the face, so to speak, at some point during the game you'll probably fail to mitigate your dice rolls properly and your insanity will cause you to do something terrible &mdash; or maybe advantageous. Hard to know for sure.
+    description: 'In Cthulhu: Death May Die, inspired by the writings of H.P. Lovecraft, you and your fellow players represent
+      investigators in the 1920s who instead of trying to stop the coming of Elder Gods, want to summon those otherworldly
+      beings so that you can put a stop to them permanently. You start the game insane, and while your long-term goal is to
+      shoot Cthulhu in the face, so to speak, at some point during the game you''ll probably fail to mitigate your dice rolls
+      properly and your insanity will cause you to do something terrible &mdash; or maybe advantageous. Hard to know for sure.
 
 
-      The game has multiple episodes, and each of them has a similar structure of two acts, those being before and after you summon whatever it is you happen to be summoning. If any character dies prior to the summoning, then the game ends and you lose; once the Elder One is on the board, as long as one of you is still alive, you still have a chance to win.
+      The game has multiple episodes, and each of them has a similar structure of two acts, those being before and after you
+      summon whatever it is you happen to be summoning. If any character dies prior to the summoning, then the game ends and
+      you lose; once the Elder One is on the board, as long as one of you is still alive, you still have a chance to win.
 
 
       The episodes are all standalone and not contingent on being played in a certain order or with the same players.
 
+
+      '
     yearPublished: 2019
     minPlayers: 1
     maxPlayers: 5
@@ -9285,26 +10395,35 @@ catalog:
     - Portal Games
     - REXhry
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/cthulhu-death-may-die_rulebook.pdf
+    pdfSha256: bd68232abefd9f2b2904bf5a3b5c1e3db59b29f4567838c4b799d0e7b6468b11
+    pdfVersion: '1.0'
   - title: Age of Innovation
     bggId: 383179
     language: en
-    pdf: age-of-innovation_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Age of Innovation is a standalone game set in the world of Terra Mystica.
+    description: 'Age of Innovation is a standalone game set in the world of Terra Mystica.
 
 
-      Twelve factions, each with unique characteristics, populate this world of varying terrains. Here you will compete to erect buildings and merge them into cities. Each game allows you to create new combinations of factions, homelands, and abilities so that each game isn't the same as another.
+      Twelve factions, each with unique characteristics, populate this world of varying terrains. Here you will compete to
+      erect buildings and merge them into cities. Each game allows you to create new combinations of factions, homelands,
+      and abilities so that each game isn''t the same as another.
 
 
-      You control one of these factions and will terraform the game map's terrain into your homelands where you can erect your buildings. Proximity to other factions may limit your expansion, but it also gains you significant advantages in the game. This tension adds to the appeal of the Terra Mystica series.
+      You control one of these factions and will terraform the game map''s terrain into your homelands where you can erect
+      your buildings. Proximity to other factions may limit your expansion, but it also gains you significant advantages in
+      the game. This tension adds to the appeal of the Terra Mystica series.
 
 
-      Upgrade your buildings to gain valuable resources such as tools, scholars, money, and power. Build schools to advance in different sciences and collect books, which you can use to make innovations. Build your palace to gain a powerful new ability or build workshops, guilds, and universities to complete your culture.
+      Upgrade your buildings to gain valuable resources such as tools, scholars, money, and power. Build schools to advance
+      in different sciences and collect books, which you can use to make innovations. Build your palace to gain a powerful
+      new ability or build workshops, guilds, and universities to complete your culture.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2023
     minPlayers: 1
     maxPlayers: 5
@@ -9350,32 +10469,29 @@ catalog:
     - Swan Panasia Co., Ltd.
     - テンデイズゲームズ (TendaysGames)
     - White Goblin Games
+    pdfBlobKey: rulebooks/v1/age-of-innovation_rulebook.pdf
+    pdfSha256: 8f1150d295498a2df9ac6da4de3e73eb7efb2e8da8298aa6377afb1af6dc65e5
+    pdfVersion: '1.0'
   - title: 'Clank!: A Deck-Building Adventure'
     bggId: 201808
     language: en
-    pdf: clank_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Burgle your way to adventure in the deck-building board game Clank! Sneak into an angry dragon's mountain lair to steal precious artifacts. Delve deeper to find more valuable loot. Acquire cards for your deck and watch your thievish abilities grow. Be quick and be quiet. One false step and CLANK! Each careless sound draws the attention of the dragon, and each artifact stolen increases its rage. You can enjoy your plunder only if you make it out of the depths alive!
-
-
-      Clank! is a deck-building game. Each player has their own deck, and building yours up is part of playing the game. You start each of your turns with five cards in your hand, and you'll play them all in any order you choose. Most cards will generate resources, of which there are three different kinds:
-
-
-          Skill, which is used to acquire new cards for your deck.
-          Swords, which are used to fight the monsters that infest the dungeon.
-          Boots, which are used to move around the board.
-
-
-      Every time you acquire a new card, you put it face up in your discard pile. Whenever you need to draw a card and find your deck empty, you shuffle your discard pile and turn it face down to form a new deck. With each shuffle, your newest cards become part of a bigger and better deck! Each player starts with the same cards in their deck, but they&rsquo;ll acquire different cards during their turns. Because cards can do many different things, each player&rsquo;s deck (and strategy) will become more and more different as the game unfolds.
-
-
-      During the game, you have two goals:
-
-          Retrieve an Artifact token and escape the dragon by returning to the place you started, outside of the dungeon.
-          Accumulate enough points with your Artifact and other loot to beat out your opponents and earn the title of Greatest Thief in the Realm!
-
-
+    description: "Burgle your way to adventure in the deck-building board game Clank! Sneak into an angry dragon's mountain\
+      \ lair to steal precious artifacts. Delve deeper to find more valuable loot. Acquire cards for your deck and watch your\
+      \ thievish abilities grow. Be quick and be quiet. One false step and CLANK! Each careless sound draws the attention\
+      \ of the dragon, and each artifact stolen increases its rage. You can enjoy your plunder only if you make it out of\
+      \ the depths alive!\n\nClank! is a deck-building game. Each player has their own deck, and building yours up is part\
+      \ of playing the game. You start each of your turns with five cards in your hand, and you'll play them all in any order\
+      \ you choose. Most cards will generate resources, of which there are three different kinds:\n\n\n    Skill, which is\
+      \ used to acquire new cards for your deck.\n    Swords, which are used to fight the monsters that infest the dungeon.\n\
+      \    Boots, which are used to move around the board.\n\n\nEvery time you acquire a new card, you put it face up in your\
+      \ discard pile. Whenever you need to draw a card and find your deck empty, you shuffle your discard pile and turn it\
+      \ face down to form a new deck. With each shuffle, your newest cards become part of a bigger and better deck! Each player\
+      \ starts with the same cards in their deck, but they&rsquo;ll acquire different cards during their turns. Because cards\
+      \ can do many different things, each player&rsquo;s deck (and strategy) will become more and more different as the game\
+      \ unfolds.\n\nDuring the game, you have two goals:\n\n    Retrieve an Artifact token and escape the dragon by returning\
+      \ to the place you started, outside of the dungeon.\n    Accumulate enough points with your Artifact and other loot\
+      \ to beat out your opponents and earn the title of Greatest Thief in the Realm!\n\n\n"
     yearPublished: 2016
     minPlayers: 2
     maxPlayers: 4
@@ -9417,29 +10533,51 @@ catalog:
     - REXhry
     - Schwerkraft-Verlag
     - Tabletop KZ
+    pdfBlobKey: rulebooks/v1/clank_rulebook.pdf
+    pdfSha256: 3bac57806508832c3ecbff7ba1095fc8570f5a9229d00073aa78683acadcca1d
+    pdfVersion: '1.0'
   - title: The White Castle
     bggId: 371942
     language: en
-    pdf: the-white-castle_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      The heron flies over the Himeji sky while the Daimyo, from the top of the castle, watches his servants move. Gardeners tend the pond, where the koi carp live, warriors stand guard on the walls, and courtiers crowd the gates, pining for an audience that brings them closer to the innermost circles of the court. When night falls, the lanterns are lit and the workers return to their clan.
+    description: 'The heron flies over the Himeji sky while the Daimyo, from the top of the castle, watches his servants move.
+      Gardeners tend the pond, where the koi carp live, warriors stand guard on the walls, and courtiers crowd the gates,
+      pining for an audience that brings them closer to the innermost circles of the court. When night falls, the lanterns
+      are lit and the workers return to their clan.
 
 
-      In The White Castle, players will control one of these clans in order to score more victory points than the rest. To do so, they must amass influence in the court, manage resources boldly, and place their workers in the right place at the right time. The authors are Sheila Santos and Israel Cendrero, the duo known as Llama Dice who also designed the successful The Red Cathedral with Devir. In this case, we leave the Moscow of Ivan the Terrible behind to explore the most imposing fortress in modern Japan, Himeji Castle, where the banner of the Sakai clan flies under the orders of Daimyo Sakai Tadakiyo.
+      In The White Castle, players will control one of these clans in order to score more victory points than the rest. To
+      do so, they must amass influence in the court, manage resources boldly, and place their workers in the right place at
+      the right time. The authors are Sheila Santos and Israel Cendrero, the duo known as Llama Dice who also designed the
+      successful The Red Cathedral with Devir. In this case, we leave the Moscow of Ivan the Terrible behind to explore the
+      most imposing fortress in modern Japan, Himeji Castle, where the banner of the Sakai clan flies under the orders of
+      Daimyo Sakai Tadakiyo.
 
 
-      The White Castle is a Euro type game with mechanics of resource management, worker placement and dice placement to carry out actions. During the game, over three rounds, players will send members of their clan to tend the gardens, defend the castle or progress up the social ladder of the nobility. At the end of the match, these will award players victory points in a variety of ways.
+      The White Castle is a Euro type game with mechanics of resource management, worker placement and dice placement to carry
+      out actions. During the game, over three rounds, players will send members of their clan to tend the gardens, defend
+      the castle or progress up the social ladder of the nobility. At the end of the match, these will award players victory
+      points in a variety of ways.
 
 
-      The central panel shows Himeji Castle in all its splendor, divided into several zones. The largest is inside the castle, with the Room of the Thousand Carpets, where the courtiers must ascend socially until they reach the circle closest to the Daimyo to enjoy his favor. There is also the pond and the gardens, patiently tended by the gardeners where everyone can relax and contemplate its beauty without restriction. Another important area is the wall and the outside of the castle, where the warriors patrol and stand guard. Finally, we find the area of the three bridges, where the three types of dice that can be used to carry out actions are accumulated, and the personal domain of each player, where they will keep track of their resources and where they will have the reserve of workers.
+      The central panel shows Himeji Castle in all its splendor, divided into several zones. The largest is inside the castle,
+      with the Room of the Thousand Carpets, where the courtiers must ascend socially until they reach the circle closest
+      to the Daimyo to enjoy his favor. There is also the pond and the gardens, patiently tended by the gardeners where everyone
+      can relax and contemplate its beauty without restriction. Another important area is the wall and the outside of the
+      castle, where the warriors patrol and stand guard. Finally, we find the area of the three bridges, where the three types
+      of dice that can be used to carry out actions are accumulated, and the personal domain of each player, where they will
+      keep track of their resources and where they will have the reserve of workers.
 
 
-      With accessible rules and a very careful setting, The White Castle is a very versatile title that will fit in with different gaming groups. As is tradition with Llama Dice titles, its sleek and simple design belies a great deal of strategic depth within the grasp of players.
+      With accessible rules and a very careful setting, The White Castle is a very versatile title that will fit in with different
+      gaming groups. As is tradition with Llama Dice titles, its sleek and simple design belies a great deal of strategic
+      depth within the grasp of players.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2023
     minPlayers: 1
     maxPlayers: 4
@@ -9487,20 +10625,32 @@ catalog:
     - Portal Games
     - Reflexshop
     - TLAMA games
+    pdfBlobKey: rulebooks/v1/the-white-castle_rulebook.pdf
+    pdfSha256: dd14099d0194afad2402875e6eb6a27e0b8fbdc631713b16eca1026ad4b225b2
+    pdfVersion: '1.0'
   - title: Paladins of the West Kingdom
     bggId: 266810
     language: en
-    pdf: paladins-of-the-west-kingdom_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Paladins of the West Kingdom is set at a turbulent time of West Francia's story, circa 900 AD. Despite recent efforts to develop the city, outlying townships are still under threat from outsiders. Saracens scout the borders, while Vikings plunder wealth and livestock. Even the Byzantines from the east have shown their darker side. As noble men and women, players must gather workers from the city to defend against enemies, build fortifications and spread faith throughout the land. Fortunately you are not alone. In his great wisdom, the King has sent his finest knights to help aid in our efforts. So ready the horses and sharpen the swords. The Paladins are approaching.
+    description: 'Paladins of the West Kingdom is set at a turbulent time of West Francia''s story, circa 900 AD. Despite
+      recent efforts to develop the city, outlying townships are still under threat from outsiders. Saracens scout the borders,
+      while Vikings plunder wealth and livestock. Even the Byzantines from the east have shown their darker side. As noble
+      men and women, players must gather workers from the city to defend against enemies, build fortifications and spread
+      faith throughout the land. Fortunately you are not alone. In his great wisdom, the King has sent his finest knights
+      to help aid in our efforts. So ready the horses and sharpen the swords. The Paladins are approaching.
 
 
-      The aim of Paladins of the West Kingdom is to be the player with the most victory points (VP) at game's end. Points are gained by building outposts and fortifications, commissioning monks and confronting outsiders. Each round, players will enlist the help of a specific Paladin and gather workers to carry out tasks. As the game progresses, players will slowly increase their faith, strength and influence. Not only will these affect their final score, but they will also determine the significance of their actions. The game is concluded at the end of the seventh round.
+      The aim of Paladins of the West Kingdom is to be the player with the most victory points (VP) at game''s end. Points
+      are gained by building outposts and fortifications, commissioning monks and confronting outsiders. Each round, players
+      will enlist the help of a specific Paladin and gather workers to carry out tasks. As the game progresses, players will
+      slowly increase their faith, strength and influence. Not only will these affect their final score, but they will also
+      determine the significance of their actions. The game is concluded at the end of the seventh round.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2019
     minPlayers: 1
     maxPlayers: 4
@@ -9543,17 +10693,28 @@ catalog:
     - TLAMA games
     - White Goblin Games
     - 株式会社ケンビル (KenBill)
+    pdfBlobKey: rulebooks/v1/paladins-of-the-west-kingdom_rulebook.pdf
+    pdfSha256: 97df1e8977704b8ab3618199ab3951affce87740aa1da04a03c2692c42e7b81e
+    pdfVersion: '1.0'
   - title: Le Havre
     bggId: 35677
     language: en
-    pdf: le-havre_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Le Havre, a player's turn consists of two parts: First, distribute newly supplied goods onto the offer spaces; then take an action. As an action, players may choose either to take all goods of one type from an offer space or to use one of the available buildings. Building actions allow players to upgrade goods, sell them or use them to build their own buildings and ships. Buildings are both an investment opportunity and a revenue stream, as players must pay an entry fee to use buildings that they do not own. Ships, on the other hand, are primarily used to provide the food that is needed to feed the workers.
+    description: 'In Le Havre, a player''s turn consists of two parts: First, distribute newly supplied goods onto the offer
+      spaces; then take an action. As an action, players may choose either to take all goods of one type from an offer space
+      or to use one of the available buildings. Building actions allow players to upgrade goods, sell them or use them to
+      build their own buildings and ships. Buildings are both an investment opportunity and a revenue stream, as players must
+      pay an entry fee to use buildings that they do not own. Ships, on the other hand, are primarily used to provide the
+      food that is needed to feed the workers.
 
 
-      After every seven turns, the round ends: players' cattle and grain may multiply through a Harvest, and players must feed their workers. After a fixed number of rounds, each player may carry out one final action, and then the game ends. Players add the value of their buildings and ships to their cash reserves. The player who has amassed the largest fortune is the winner.
+      After every seven turns, the round ends: players'' cattle and grain may multiply through a Harvest, and players must
+      feed their workers. After a fixed number of rounds, each player may carry out one final action, and then the game ends.
+      Players add the value of their buildings and ships to their cash reserves. The player who has amassed the largest fortune
+      is the winner.
 
+
+      '
     yearPublished: 2008
     minPlayers: 1
     maxPlayers: 5
@@ -9599,29 +10760,22 @@ catalog:
     - uplay.it edizioni
     - Ystari Games
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/le-havre_rulebook.pdf
+    pdfSha256: 060b2f6f9a32af213b6d39ed6698d1fe94d339abfb8d3b1954a952228e0f3be3
+    pdfVersion: '1.0'
   - title: The Gallerist
     bggId: 125153
     language: en
-    pdf: the-gallerist_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      This age of art and capitalism has created a need for a new occupation - The Gallerist.
-
-
-      Combining the elements of an Art dealer, museum curator, and Artists&rsquo; manager, you are about to take on that job! You will promote and nurture Artists; buy, display, and sell their Art; and build and exert your international reputation. As a result, you will achieve the respect needed to draw visitors to your Gallery from all over the world.
-
-
-      There's a lot of work to be done, but don't worry, you can hire assistants to help you achieve your goals. Build your fortune by running the most lucrative Gallery and secure your reputation as a world-class Gallerist!
-
-
-      Maximize your money and thus win the game by: 
-
-           having visitors in your gallery; 
-           exhibiting and selling works of art;
-           investing in artists&rsquo; promotion to increase art value;
-           achieving trends and reputation as well as curator and dealer goals.
-
-
+    description: "This age of art and capitalism has created a need for a new occupation - The Gallerist.\n\nCombining the\
+      \ elements of an Art dealer, museum curator, and Artists&rsquo; manager, you are about to take on that job! You will\
+      \ promote and nurture Artists; buy, display, and sell their Art; and build and exert your international reputation.\
+      \ As a result, you will achieve the respect needed to draw visitors to your Gallery from all over the world.\n\nThere's\
+      \ a lot of work to be done, but don't worry, you can hire assistants to help you achieve your goals. Build your fortune\
+      \ by running the most lucrative Gallery and secure your reputation as a world-class Gallerist!\n\nMaximize your money\
+      \ and thus win the game by: \n\n     having visitors in your gallery; \n     exhibiting and selling works of art;\n\
+      \     investing in artists&rsquo; promotion to increase art value;\n     achieving trends and reputation as well as\
+      \ curator and dealer goals.\n\n\n"
     yearPublished: 2015
     minPlayers: 1
     maxPlayers: 4
@@ -9660,29 +10814,49 @@ catalog:
     - Maldito Games
     - sternenschimmermeer
     - YOKA Games
+    pdfBlobKey: rulebooks/v1/the-gallerist_rulebook.pdf
+    pdfSha256: 4c1cc0f09c85177e05e890208a2377ab229a8563976b88e7c5d6f38d7e690dea
+    pdfVersion: '1.0'
   - title: 'Android: Netrunner'
     bggId: 124742
     language: en
-    pdf: android-netrunner_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Welcome to New Angeles, home of the Beanstalk. From our branch offices in this monument of human achievement, NBN proudly broadcasts all your favorite media programming. We offer fully comprehensive streaming in music and threedee, news and sitcoms, classic movies and sensies. We cover it all. Ours is a brave new age, and as humanity hurtles into space and the future with an astonishing series of new advances every day, NBN and our affiliates are keeping pace, bringing you all the vid that's fit to view.
+    description: 'Welcome to New Angeles, home of the Beanstalk. From our branch offices in this monument of human achievement,
+      NBN proudly broadcasts all your favorite media programming. We offer fully comprehensive streaming in music and threedee,
+      news and sitcoms, classic movies and sensies. We cover it all. Ours is a brave new age, and as humanity hurtles into
+      space and the future with an astonishing series of new advances every day, NBN and our affiliates are keeping pace,
+      bringing you all the vid that''s fit to view.
 
 
-      Android: Netrunner is an asymmetrical Living Card Game for two players. Set in the cyberpunk future of Android and Infiltration, the game pits a megacorporation and its massive resources against the subversive talents of lone runners.
+      Android: Netrunner is an asymmetrical Living Card Game for two players. Set in the cyberpunk future of Android and Infiltration,
+      the game pits a megacorporation and its massive resources against the subversive talents of lone runners.
 
 
-      Corporations seek to score agendas by advancing them. Doing so takes time and credits. To buy the time and earn the credits they need, they must secure their servers and data forts with "ice". These security programs come in different varieties, from simple barriers, to code gates and aggressive sentries. They serve as the corporation's virtual eyes, ears, and machine guns on the sprawling information superhighways of the network.
+      Corporations seek to score agendas by advancing them. Doing so takes time and credits. To buy the time and earn the
+      credits they need, they must secure their servers and data forts with "ice". These security programs come in different
+      varieties, from simple barriers, to code gates and aggressive sentries. They serve as the corporation''s virtual eyes,
+      ears, and machine guns on the sprawling information superhighways of the network.
 
 
-      In turn, runners need to spend their time and credits acquiring a sufficient wealth of resources, purchasing the necessary hardware, and developing suitably powerful ice-breaker programs to hack past corporate security measures. Their jobs are always a little desperate, driven by tight timelines, and shrouded in mystery. When a runner jacks-in and starts a run at a corporate server, he risks having his best programs trashed or being caught by a trace program and left vulnerable to corporate countermeasures. It's not uncommon for an unprepared runner to fail to bypass a nasty sentry and suffer massive brain damage as a result. Even if a runner gets through a data fort's defenses, there's no telling what it holds. Sometimes, the runner finds something of value. Sometimes, the best he can do is work to trash whatever the corporation was developing.
+      In turn, runners need to spend their time and credits acquiring a sufficient wealth of resources, purchasing the necessary
+      hardware, and developing suitably powerful ice-breaker programs to hack past corporate security measures. Their jobs
+      are always a little desperate, driven by tight timelines, and shrouded in mystery. When a runner jacks-in and starts
+      a run at a corporate server, he risks having his best programs trashed or being caught by a trace program and left vulnerable
+      to corporate countermeasures. It''s not uncommon for an unprepared runner to fail to bypass a nasty sentry and suffer
+      massive brain damage as a result. Even if a runner gets through a data fort''s defenses, there''s no telling what it
+      holds. Sometimes, the runner finds something of value. Sometimes, the best he can do is work to trash whatever the corporation
+      was developing.
 
 
       The first player to seven points wins the game, but not likely before he suffers some brain damage or bad publicity.
 
 
-      The Revised Core Set for Android: Netrunner released in late 2017 includes cards from the original Core Set released in 2012 as well as cards from the Genesis Cycle and Spin Cycle series of Data Packs. While the cards in this set have been released previously, the art on some of them is new.
+      The Revised Core Set for Android: Netrunner released in late 2017 includes cards from the original Core Set released
+      in 2012 as well as cards from the Genesis Cycle and Spin Cycle series of Data Packs. While the cards in this set have
+      been released previously, the art on some of them is new.
 
+
+      '
     yearPublished: 2012
     minPlayers: 2
     maxPlayers: 2
@@ -9719,29 +10893,49 @@ catalog:
     - Giochi Uniti
     - Heidelberger Spieleverlag
     - Korea Boardgames
+    pdfBlobKey: rulebooks/v1/android-netrunner_rulebook.pdf
+    pdfSha256: e07e9076e7e7da7c90f079ae5e7f5e695d49f93b457d9a069a69077d7f8393f1
+    pdfVersion: '1.0'
   - title: 'Star Wars: Imperial Assault'
     bggId: 164153
     language: en
-    pdf: star-wars-imperial-assault_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Star Wars: Imperial Assault is a strategy board game of tactical combat and missions for two to five players, offering two distinct games of battle and adventure in the Star Wars universe!
+    description: 'Star Wars: Imperial Assault is a strategy board game of tactical combat and missions for two to five players,
+      offering two distinct games of battle and adventure in the Star Wars universe!
 
 
-      Imperial Assault puts you in the midst of the Galactic Civil War between the Rebel Alliance and the Galactic Empire after the destruction of the Death Star over Yavin 4. In this game, you and your friends can participate in two separate games. The campaign game pits the limitless troops and resources of the Galactic Empire against a crack team of elite Rebel operatives as they strive to break the Empire&rsquo;s hold on the galaxy, while the skirmish game invites you and a friend to muster strike teams and battle head-to-head over conflicting objectives.
+      Imperial Assault puts you in the midst of the Galactic Civil War between the Rebel Alliance and the Galactic Empire
+      after the destruction of the Death Star over Yavin 4. In this game, you and your friends can participate in two separate
+      games. The campaign game pits the limitless troops and resources of the Galactic Empire against a crack team of elite
+      Rebel operatives as they strive to break the Empire&rsquo;s hold on the galaxy, while the skirmish game invites you
+      and a friend to muster strike teams and battle head-to-head over conflicting objectives.
 
 
-      In the campaign game, Imperial Assault invites you to play through a cinematic tale set in the Star Wars universe. One player commands the seemingly limitless armies of the Galactic Empire, threatening to extinguish the flame of the Rebellion forever. Up to four other players become heroes of the Rebel Alliance, engaging in covert operations to undermine the Empire&rsquo;s schemes. Over the course of the campaign, both the Imperial player and the Rebel heroes gain new experience and skills, allowing characters to evolve as the story unfolds.
+      In the campaign game, Imperial Assault invites you to play through a cinematic tale set in the Star Wars universe. One
+      player commands the seemingly limitless armies of the Galactic Empire, threatening to extinguish the flame of the Rebellion
+      forever. Up to four other players become heroes of the Rebel Alliance, engaging in covert operations to undermine the
+      Empire&rsquo;s schemes. Over the course of the campaign, both the Imperial player and the Rebel heroes gain new experience
+      and skills, allowing characters to evolve as the story unfolds.
 
 
-      Imperial Assault offers a different game experience in the skirmish game. In skirmish missions, you and a friend compete in head-to-head, tactical combat. You&rsquo;ll gather your own strike force of Imperials, Rebels, and Mercenaries and build a deck of command cards to gain an unexpected advantage in the heat of battle. Whether you recover lost holocrons or battle to defeat a raiding party, you&rsquo;ll find danger and tactical choices in every skirmish.
+      Imperial Assault offers a different game experience in the skirmish game. In skirmish missions, you and a friend compete
+      in head-to-head, tactical combat. You&rsquo;ll gather your own strike force of Imperials, Rebels, and Mercenaries and
+      build a deck of command cards to gain an unexpected advantage in the heat of battle. Whether you recover lost holocrons
+      or battle to defeat a raiding party, you&rsquo;ll find danger and tactical choices in every skirmish.
 
 
-      As an additional benefit, the Luke Skywalker Ally Pack and the Darth Vader Villain Pack are included within the Imperial Assault Core Set. These figure packs offer sculpted plastic figures alongside additional campaign and skirmish missions that highlight both Luke Skywalker and Darth Vader within Imperial Assault.
+      As an additional benefit, the Luke Skywalker Ally Pack and the Darth Vader Villain Pack are included within the Imperial
+      Assault Core Set. These figure packs offer sculpted plastic figures alongside additional campaign and skirmish missions
+      that highlight both Luke Skywalker and Darth Vader within Imperial Assault.
 
 
-      With these Imperial Assault and other Figure Packs, you'll find even more missions that allow your heroes to fight alongside iconic characters from the Star Wars saga. Boxed expansions add more heroes, imperial and mercenary groups, and totally new campaigns (see IA Community Wiki for a list), and the free Star Wars: Imperial Assault – Legends of the Alliance app provides you with additional content to play in solo or co-op mode.
+      With these Imperial Assault and other Figure Packs, you''ll find even more missions that allow your heroes to fight
+      alongside iconic characters from the Star Wars saga. Boxed expansions add more heroes, imperial and mercenary groups,
+      and totally new campaigns (see IA Community Wiki for a list), and the free Star Wars: Imperial Assault – Legends of
+      the Alliance app provides you with additional content to play in solo or co-op mode.
 
+
+      '
     yearPublished: 2014
     minPlayers: 2
     maxPlayers: 5
@@ -9784,26 +10978,37 @@ catalog:
     - Galakta
     - Heidelberger Spieleverlag
     - Hobby World
+    pdfBlobKey: rulebooks/v1/star-wars-imperial-assault_rulebook.pdf
+    pdfSha256: 31e496fdc97b9df7a8f38ccbd36561dc16265c142ff1cc3597fe6217f4707cc9
+    pdfVersion: '1.0'
   - title: 'Great Western Trail: Argentina'
     bggId: 380607
     language: en
-    pdf: great-western-trail-argentina_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Kia ora, and welcome to Great Western Trail New Zealand!
+    description: 'Kia ora, and welcome to Great Western Trail New Zealand!
 
 
-      Towards the end of the 19th century, you established yourself as a runholder (owner of a sheep station) on the South Island of New Zealand. Recent years have seen your family farm prosper by diversifying your breeds of sheep and increasing the value of your wool.
+      Towards the end of the 19th century, you established yourself as a runholder (owner of a sheep station) on the South
+      Island of New Zealand. Recent years have seen your family farm prosper by diversifying your breeds of sheep and increasing
+      the value of your wool.
 
 
-      With the dawn of the new century, difficult challenges have arisen. You must acquire improved and valuable breeds of sheep to ensure the prosperity of your family business and the labourers who work for you. Decide whether to focus on your past strengths or to diversify into new ventures. Will the beginning of the 20th century be as rewarding as earlier years, or will the efforts of others surpass your strategy? Good luck, and kia kaha!
+      With the dawn of the new century, difficult challenges have arisen. You must acquire improved and valuable breeds of
+      sheep to ensure the prosperity of your family business and the labourers who work for you. Decide whether to focus on
+      your past strengths or to diversify into new ventures. Will the beginning of the 20th century be as rewarding as earlier
+      years, or will the efforts of others surpass your strategy? Good luck, and kia kaha!
 
 
-      In Great Western Trail New Zealand, you move your runholder along a trail that winds and forks from the lower left corner of the game board to Wellington in the upper right. Along your path, you perform actions that provide you with various ways to earn victory points.
+      In Great Western Trail New Zealand, you move your runholder along a trail that winds and forks from the lower left corner
+      of the game board to Wellington in the upper right. Along your path, you perform actions that provide you with various
+      ways to earn victory points.
 
 
-      Each time your runholder reaches Wellington, you deliver sheep to a local or foreign trading post, which may also be worth victory points. Afterwards, your runholder continues its movement again.
+      Each time your runholder reaches Wellington, you deliver sheep to a local or foreign trading post, which may also be
+      worth victory points. Afterwards, your runholder continues its movement again.
 
+
+      '
     yearPublished: 2023
     minPlayers: 1
     maxPlayers: 4
@@ -9837,19 +11042,21 @@ catalog:
     - Rebel Sp. z o.o.
     - Yayoi The Dreamer
     - Zvezda
+    pdfBlobKey: rulebooks/v1/great-western-trail-argentina_rulebook.pdf
+    pdfSha256: 88be4a0b83dda037566941e46d1e936ec6280c37e9860c0405a58a9bd412c2fa
+    pdfVersion: '1.0'
   - title: Agricola (Revised Edition)
     bggId: 200680
     language: en
-    pdf: agricola-revised_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Updated and streamlined for a new generation of players, Agricola, the award-winning and highly acclaimed game by Uwe Rosenberg, features a revised rulebook and gameplay, wood pieces and components, and a card selection from the base game as well as its expansions, revised and updated for this edition.
-
-
-      The 17th century was not an easy time to be a farmer. 
-
-      Players begin the game with two family members and can grow their families over the course of the game. This allows them more actions but remember you have to grow more food to feed your family as it grows! Feeding your family is a special kind of challenge and players will plant grain and vegetables while supplementing their food supply with sheep, wild boar and cattle. Guide your family to wealth, health and prosperity and you will win the game.
-
+    description: "Updated and streamlined for a new generation of players, Agricola, the award-winning and highly acclaimed\
+      \ game by Uwe Rosenberg, features a revised rulebook and gameplay, wood pieces and components, and a card selection\
+      \ from the base game as well as its expansions, revised and updated for this edition.\n\nThe 17th century was not an\
+      \ easy time to be a farmer. \nPlayers begin the game with two family members and can grow their families over the course\
+      \ of the game. This allows them more actions but remember you have to grow more food to feed your family as it grows!\
+      \ Feeding your family is a special kind of challenge and players will plant grain and vegetables while supplementing\
+      \ their food supply with sheep, wild boar and cattle. Guide your family to wealth, health and prosperity and you will\
+      \ win the game.\n\n"
     yearPublished: 2016
     minPlayers: 1
     maxPlayers: 4
@@ -9898,24 +11105,33 @@ catalog:
     - Rebel Sp. z o.o.
     - Swan Panasia Co., Ltd.
     - uplay.it edizioni
+    pdfBlobKey: rulebooks/v1/agricola-revised_rulebook.pdf
+    pdfSha256: 1aa612ed43bdde109a0bfff900cf9322bae02e5b53f4ee3fe9f37d264ca8bc70
+    pdfVersion: '1.0'
   - title: Maracaibo
     bggId: 276025
     language: en
-    pdf: maracaibo_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Maracaibo, a strategy game for 1-4 players by Alexander Pfister, is set in the Caribbean during the 17th century. The players try to increase their influence in three nations in four rounds with a play time of 40 minutes per player.
+    description: 'Maracaibo, a strategy game for 1-4 players by Alexander Pfister, is set in the Caribbean during the 17th
+      century. The players try to increase their influence in three nations in four rounds with a play time of 40 minutes
+      per player.
 
 
-      The players sail on a round course through the Caribbean, e.g., you have city tiles where you are able to perform various&nbsp;actions or deliver goods to. One special feature is an implemented quest mode over more and various tiles, which tells the player, who chase after it, a little story.
+      The players sail on a round course through the Caribbean, e.g., you have city tiles where you are able to perform various&nbsp;actions
+      or deliver goods to. One special feature is an implemented quest mode over more and various tiles, which tells the player,
+      who chase after it, a little story.
 
 
-      As a player, you move with your ship around the course, managing it by using cards like in other games from Alexander Pfister.
+      As a player, you move with your ship around the course, managing it by using cards like in other games from Alexander
+      Pfister.
 
 
 
-      NOTE: The Spanish and Portuguese editions of Maracaibo contain La Armada mini-expansion packaged inside the base game's box.
+      NOTE: The Spanish and Portuguese editions of Maracaibo contain La Armada mini-expansion packaged inside the base game''s
+      box.
 
+
+      '
     yearPublished: 2019
     minPlayers: 1
     maxPlayers: 4
@@ -9965,17 +11181,24 @@ catalog:
     - テンデイズゲームズ (TendaysGames)
     - uplay.it edizioni
     - YOKA Games
+    pdfBlobKey: rulebooks/v1/maracaibo_rulebook.pdf
+    pdfSha256: a2b92b6924b916c0a5119427350ce62aca25121253784b1089137073feac4306
+    pdfVersion: '1.0'
   - title: Mechs vs. Minions
     bggId: 209010
     language: en
-    pdf: mechs-vs-minions_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Mechs vs. Minions is a cooperative tabletop campaign for 2-4 players. Set in the world of Runeterra, players take on the roles of four intrepid Yordles: Corki, Tristana, Heimerdinger, and Ziggs, who must join forces and pilot their newly-crafted mechs against an army of marauding minions. With modular boards, programmatic command lines, and a story-driven campaign, each mission will be unique, putting your teamwork, programming, and piloting skills to the test.
+    description: 'Mechs vs. Minions is a cooperative tabletop campaign for 2-4 players. Set in the world of Runeterra, players
+      take on the roles of four intrepid Yordles: Corki, Tristana, Heimerdinger, and Ziggs, who must join forces and pilot
+      their newly-crafted mechs against an army of marauding minions. With modular boards, programmatic command lines, and
+      a story-driven campaign, each mission will be unique, putting your teamwork, programming, and piloting skills to the
+      test.
 
 
       There are ten missions in total, and each individual mission will take about 60-90 minutes.
 
+
+      '
     yearPublished: 2016
     minPlayers: 2
     maxPlayers: 4
@@ -10010,36 +11233,56 @@ catalog:
     - Nathan Tiras
     publishers:
     - Riot Games
+    pdfBlobKey: rulebooks/v1/mechs-vs-minions_rulebook.pdf
+    pdfSha256: 9a342ef39b2efa6dd51aa94d892947a5d656a139c1c7906f76fdd4380854bd33
+    pdfVersion: '1.0'
   - title: 'Kingdom Death: Monster'
     bggId: 55690
     language: en
     bggEnhanced: true
-    description: >+
-      Kingdom Death: Monster is a fully cooperative tabletop hobby game experience.  Set in a unique nightmarish world devoid of most natural resources, you control a settlement at the dawn of its existence. Fight monsters, craft weapons and gear, and develop your settlement to ensure your survival from generation to generation.
+    description: 'Kingdom Death: Monster is a fully cooperative tabletop hobby game experience.  Set in a unique nightmarish
+      world devoid of most natural resources, you control a settlement at the dawn of its existence. Fight monsters, craft
+      weapons and gear, and develop your settlement to ensure your survival from generation to generation.
 
 
       Campaign System
 
-      Embark alone or with up to 3 friends (5 with game variant) on a 5-30-lantern-year campaign, with each year consisting of a cycle of hunt, showdown, and settlement phases. The settlement phase is an intricate civilization building game in which you spend very limited resources to build buildings, research new technologies, train your warriors, and set up your strategy for survival.  During the hunt, you'll encounter a series of stories in a "choose your own adventure" style journey through various events and encounters.  Finally, when you meet the monster you're pursuing, you'll engage it in an a massive arena-style battle where only one party is going to survive.  If your party lives, you'll be able to bring the spoils back home to use in expanding your settlement.
+      Embark alone or with up to 3 friends (5 with game variant) on a 5-30-lantern-year campaign, with each year consisting
+      of a cycle of hunt, showdown, and settlement phases. The settlement phase is an intricate civilization building game
+      in which you spend very limited resources to build buildings, research new technologies, train your warriors, and set
+      up your strategy for survival.  During the hunt, you''ll encounter a series of stories in a "choose your own adventure"
+      style journey through various events and encounters.  Finally, when you meet the monster you''re pursuing, you''ll engage
+      it in an a massive arena-style battle where only one party is going to survive.  If your party lives, you''ll be able
+      to bring the spoils back home to use in expanding your settlement.
 
 
       Monster AI System
 
-      Each of the 7 monsters included are controlled by their own pair of decks that scale to 3 levels of difficulty (except for the final encounter, which has only 1 level and it's HARD!). Every encounter, even with the same monster, is highly variable and no two showdowns will resolve the same way. Players will have to plan their gear and keep their minds sharp to prevail.
+      Each of the 7 monsters included are controlled by their own pair of decks that scale to 3 levels of difficulty (except
+      for the final encounter, which has only 1 level and it''s HARD!). Every encounter, even with the same monster, is highly
+      variable and no two showdowns will resolve the same way. Players will have to plan their gear and keep their minds sharp
+      to prevail.
 
 
       Gear System
 
-      In Kingdom Death: Monster, survivors will craft gear from resources earned from defeating monsters or found on their hunt. Each survivor has a 3x3 gear grid. Selection and arrangement of your gear cards is critical, as many provided bonuses and activate special rules when aligned correctly.
+      In Kingdom Death: Monster, survivors will craft gear from resources earned from defeating monsters or found on their
+      hunt. Each survivor has a 3x3 gear grid. Selection and arrangement of your gear cards is critical, as many provided
+      bonuses and activate special rules when aligned correctly.
 
 
       Story Event System
 
-      40+ Story Events plus over 100 hunt encounters will shape and guide your campaign. Story Events detail important evolutions in your civilization, introduce new monsters, and provide rich detail for your campaign.  Some will trigger automatically as you progress through the campaign, but most will be entirely based on choices players make.
+      40+ Story Events plus over 100 hunt encounters will shape and guide your campaign. Story Events detail important evolutions
+      in your civilization, introduce new monsters, and provide rich detail for your campaign.  Some will trigger automatically
+      as you progress through the campaign, but most will be entirely based on choices players make.
 
 
-      Story Events cover everything from setting up and fighting a monster to key events that happen within the overall story. Some are triggered directly from the timeline and others from choices you make in game.
+      Story Events cover everything from setting up and fighting a monster to key events that happen within the overall story.
+      Some are triggered directly from the timeline and others from choices you make in game.
 
+
+      '
     yearPublished: 2015
     minPlayers: 1
     maxPlayers: 4
@@ -10082,20 +11325,31 @@ catalog:
   - title: Darwin's Journey
     bggId: 322289
     language: en
-    pdf: darwins-journey_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      When all you can identify in the horizon for many long days is the line that detaches the sea from the sky, the glimpse of a distant shore appearing before you will make you shiver at the understanding that the adventure is about to begin.
+    description: 'When all you can identify in the horizon for many long days is the line that detaches the sea from the sky,
+      the glimpse of a distant shore appearing before you will make you shiver at the understanding that the adventure is
+      about to begin.
 
 
-      You find yourself astonished, landing on the shore that will be the origin of an extensive exploration through the Galapagos, a magic place of inconceivable beauty and endless biodiversity. There, you will gather repertoires and expand your knowledge of the natural sciences. Your eyes will learn how to detect the hidden species in the tropical forest, gazing at the countless colors and textures of nature. After inspiring hours spent studying and getting to enlightening conclusions, you will rest under a sparkling sky, admiring the stunning complexity of the animal realm.
+      You find yourself astonished, landing on the shore that will be the origin of an extensive exploration through the Galapagos,
+      a magic place of inconceivable beauty and endless biodiversity. There, you will gather repertoires and expand your knowledge
+      of the natural sciences. Your eyes will learn how to detect the hidden species in the tropical forest, gazing at the
+      countless colors and textures of nature. After inspiring hours spent studying and getting to enlightening conclusions,
+      you will rest under a sparkling sky, admiring the stunning complexity of the animal realm.
 
 
-      Darwin's Journey is a worker-placement Eurogame in which players recall Charles Darwin's memories of his adventure through the Galapagos islands, which contributed to the development of his theory of evolution.
+      Darwin''s Journey is a worker-placement Eurogame in which players recall Charles Darwin''s memories of his adventure
+      through the Galapagos islands, which contributed to the development of his theory of evolution.
 
 
-      With the game's innovative worker progression system, each worker will have to study the disciplines that are a prerequisite to perform several actions in the game, such as exploration, correspondence, gathering, and dispatch of repertoires found on the island to museums in order to contribute to the human knowledge of biology. The game lasts five rounds, and thanks to several short- and long-term objectives, every action you take will grant victory points in different ways.
+      With the game''s innovative worker progression system, each worker will have to study the disciplines that are a prerequisite
+      to perform several actions in the game, such as exploration, correspondence, gathering, and dispatch of repertoires
+      found on the island to museums in order to contribute to the human knowledge of biology. The game lasts five rounds,
+      and thanks to several short- and long-term objectives, every action you take will grant victory points in different
+      ways.
 
+
+      '
     yearPublished: 2023
     minPlayers: 1
     maxPlayers: 4
@@ -10140,33 +11394,27 @@ catalog:
     - TCG Factory
     - 株式会社ケンビル (KenBill)
     - 黑城堡桌游 Black Castle Games
+    pdfBlobKey: rulebooks/v1/darwins-journey_rulebook.pdf
+    pdfSha256: c37ef3550858530943766ef49878ec91fe105a4f0f9171ef4c804e942be49bf8
+    pdfVersion: '1.0'
   - title: Revive
     bggId: 332772
     language: en
-    pdf: revive_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Revive civilization, 5000 years after everything was destroyed. Lead your tribe and explore the frozen earth. Harness its resources. Recruit surface survivors to your cause. Build factories with powerful machines. And populate ancient sites to relearn your tribe's forgotten technologies.
-
-      --
-
-      Revive is a game for 1-4 players with asymmetric player powers, highly variable setup, and no fighting or direct conflict. Playing through the 5-part campaign unlocks additional contents, and once all contents have been unlocked, the game can be replayed indefinitely.
-
-
-      At the beginning of the game, each player gets a set of citizen cards, a tribe board, as well as a huge dual-layer player board. The tribe board shows your unique tribe ability and the ancient technologies that you may relearn during the game. The dual-layer player board is where you place your custom machines and upgrade your card slots.
-
-
-      A main goal of the game is to reach and populate the large ancient sites. These ancient locations are randomized, and as they are important sources of victory points, they will shape your strategy differently each game. The game ends when all artifacts have been taken, and the player with the most points wins.
-
-
-      On your turn you take two actions: 
-
-           Play a card (its effect is determined by which card slot you use)
-           Explore (reveal an area tile and recruit a new citizen card)
-           Populate (populate an ancient location to learn a new technology)
-           Build factory (the adjacent terrains determine which machine tracks you advance)
-
-
+    description: "Revive civilization, 5000 years after everything was destroyed. Lead your tribe and explore the frozen earth.\
+      \ Harness its resources. Recruit surface survivors to your cause. Build factories with powerful machines. And populate\
+      \ ancient sites to relearn your tribe's forgotten technologies.\n--\nRevive is a game for 1-4 players with asymmetric\
+      \ player powers, highly variable setup, and no fighting or direct conflict. Playing through the 5-part campaign unlocks\
+      \ additional contents, and once all contents have been unlocked, the game can be replayed indefinitely.\n\nAt the beginning\
+      \ of the game, each player gets a set of citizen cards, a tribe board, as well as a huge dual-layer player board. The\
+      \ tribe board shows your unique tribe ability and the ancient technologies that you may relearn during the game. The\
+      \ dual-layer player board is where you place your custom machines and upgrade your card slots.\n\nA main goal of the\
+      \ game is to reach and populate the large ancient sites. These ancient locations are randomized, and as they are important\
+      \ sources of victory points, they will shape your strategy differently each game. The game ends when all artifacts have\
+      \ been taken, and the player with the most points wins.\n\nOn your turn you take two actions: \n\n     Play a card (its\
+      \ effect is determined by which card slot you use)\n     Explore (reveal an area tile and recruit a new citizen card)\n\
+      \     Populate (populate an ancient location to learn a new technology)\n     Build factory (the adjacent terrains determine\
+      \ which machine tracks you advance)\n\n\n"
     yearPublished: 2022
     minPlayers: 1
     maxPlayers: 4
@@ -10213,30 +11461,42 @@ catalog:
     - Pegasus Spiele
     - Rebel Sp. z o.o.
     - Surfin' Meeple China
+    pdfBlobKey: rulebooks/v1/revive_rulebook.pdf
+    pdfSha256: ab5631c96bc4cf81e79358d77060cbdc85a8ff4c657caf13f4b05e8cbcf72e80
+    pdfVersion: '1.0'
   - title: Race for the Galaxy
     bggId: 28143
     language: en
-    pdf: race-for-the-galaxy_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      In Race for the Galaxy, players build galactic civilizations by playing cards representing worlds or technical and social developments.
+    description: 'In Race for the Galaxy, players build galactic civilizations by playing cards representing worlds or technical
+      and social developments.
 
 
-      Each round, players secretly and simultaneously select an action card corresponding to one phase of a round. These phases let players draw cards, play cards, add goods to worlds, or consume goods for VP chips. Only the phases chosen will occur that round. Every player may act in a phase that occurs, but the players who chose that phase get a bonus.
+      Each round, players secretly and simultaneously select an action card corresponding to one phase of a round. These phases
+      let players draw cards, play cards, add goods to worlds, or consume goods for VP chips. Only the phases chosen will
+      occur that round. Every player may act in a phase that occurs, but the players who chose that phase get a bonus.
 
 
-      Game end is triggered either when a player has built a civilization of 12 cards or when the pool of VP chips is exhausted. Each player then totals the victory points in their tableau plus any VP chips earned during play.
+      Game end is triggered either when a player has built a civilization of 12 cards or when the pool of VP chips is exhausted.
+      Each player then totals the victory points in their tableau plus any VP chips earned during play.
 
 
       Detailed Overview
 
-      Race for the Galaxy tells a story of galactic discovery and expansion through a single deck of cards. Every card in the deck represents either a world that you might settle or a development that you might implement. Cards placed into your tableau represent your current achievements -- worlds you have colonized, technology you now wield -- while cards in your hand represent the options currently available to you.
+      Race for the Galaxy tells a story of galactic discovery and expansion through a single deck of cards. Every card in
+      the deck represents either a world that you might settle or a development that you might implement. Cards placed into
+      your tableau represent your current achievements -- worlds you have colonized, technology you now wield -- while cards
+      in your hand represent the options currently available to you.
 
 
-      To play a card, discard the number of cards equal to its cost, representing other opportunities you must forgo to concentrate on your current course. Once in your tableau, a card provides special powers during the game and, at the end, its listed number of victory points. Many worlds, once placed, also produce goods that can be traded for more cards or consumed for VP chips.
+      To play a card, discard the number of cards equal to its cost, representing other opportunities you must forgo to concentrate
+      on your current course. Once in your tableau, a card provides special powers during the game and, at the end, its listed
+      number of victory points. Many worlds, once placed, also produce goods that can be traded for more cards or consumed
+      for VP chips.
 
 
-      Race for the Galaxy is played in rounds. In each round, you and your opponents secretly select an action phase for the upcoming turn. You can choose to:
+      Race for the Galaxy is played in rounds. In each round, you and your opponents secretly select an action phase for the
+      upcoming turn. You can choose to:
 
       &bull; Place a world in your tableau with settle or a development with develop.
 
@@ -10247,19 +11507,25 @@ catalog:
       &bull; Add cards to your hand with explore or by trading a good.
 
 
-      Each round, only those phases that are selected will occur -- but they'll occur for everyone. Selecting a phase both ensures that it occurs that round and gains the selecting player a bonus.
+      Each round, only those phases that are selected will occur -- but they''ll occur for everyone. Selecting a phase both
+      ensures that it occurs that round and gains the selecting player a bonus.
 
 
-      Round follows round until someone builds their tableau to twelve cards, or until the last VP chip is claimed. The victor is the player with the most VPs.
+      Round follows round until someone builds their tableau to twelve cards, or until the last VP chip is claimed. The victor
+      is the player with the most VPs.
 
 
       2018 UPDATE
 
-      The second edition of the game is improved for CVD (color blindness) and includes 5 revised cards from the original version and 6 New Worlds promo homeworlds. The promo homeworlds and first edition compatible Revised Cards are both available for purchase through the BGG store.
+      The second edition of the game is improved for CVD (color blindness) and includes 5 revised cards from the original
+      version and 6 New Worlds promo homeworlds. The promo homeworlds and first edition compatible Revised Cards are both
+      available for purchase through the BGG store.
 
 
       UPC 655132003018
 
+
+      '
     yearPublished: 2007
     minPlayers: 2
     maxPlayers: 4
@@ -10310,26 +11576,36 @@ catalog:
     - Wargames Club Publishing
     - YOKA Games
     - Ystari Games
+    pdfBlobKey: rulebooks/v1/race-for-the-galaxy_rulebook.pdf
+    pdfSha256: a43d7ee00276e963ea7afd327711cd52cee609712a8128e0f4a164290c2754d4
+    pdfVersion: '1.0'
   - title: Voidfall
     bggId: 338111
     language: en
-    pdf: voidfall_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      A trick-taking card game with cards featuring photos of contemporary United States Navy aircraft, surface ships, and submarines.
+    description: 'A trick-taking card game with cards featuring photos of contemporary United States Navy aircraft, surface
+      ships, and submarines.
 
 
-      The cards are marked with letters from A to Z and some of the cards are numbered as well (i.e. A1, A2, A3, A4). At the start of the game, each player is dealt seven cards. The goal is to capture the most Navy equipment by winning tricks. The highest card played wins the trick, with A being the highest and Z being the lowest. In addition, among the numbered cards with the same letter, the highest number wins (so B4 beats B2).
+      The cards are marked with letters from A to Z and some of the cards are numbered as well (i.e. A1, A2, A3, A4). At the
+      start of the game, each player is dealt seven cards. The goal is to capture the most Navy equipment by winning tricks.
+      The highest card played wins the trick, with A being the highest and Z being the lowest. In addition, among the numbered
+      cards with the same letter, the highest number wins (so B4 beats B2).
 
 
-      At the end of the game a player receives 10 points for each card having a number and 5 points for each card that only has a letter. A player can score a bonus 100 points during the game if the cards in the player's hand spell out N-A-V-Y, J-E-T, or S-H-I-P. The first player to reach 1000 points wins the game.
+      At the end of the game a player receives 10 points for each card having a number and 5 points for each card that only
+      has a letter. A player can score a bonus 100 points during the game if the cards in the player''s hand spell out N-A-V-Y,
+      J-E-T, or S-H-I-P. The first player to reach 1000 points wins the game.
 
 
-      The contents include the rules folder, 54 cards, a score pad, and a small cardboard box-insert tray. The rules folder provides a description of each photo used on the cards.
+      The contents include the rules folder, 54 cards, a score pad, and a small cardboard box-insert tray. The rules folder
+      provides a description of each photo used on the cards.
 
 
       &mdash;user summary
 
+
+      '
     yearPublished: 1957
     minPlayers: 2
     maxPlayers: 6
@@ -10354,21 +11630,19 @@ catalog:
     - (Uncredited)
     publishers:
     - Exclusive Playing Card Company
+    pdfBlobKey: rulebooks/v1/voidfall_rulebook.pdf
+    pdfSha256: 29847a547dcec0deac860cfb658cd3ea694dcaab319258fcf286c27161243157
+    pdfVersion: '1.0'
   - title: 'Wingspan: Asia'
     bggId: 366161
     language: en
-    pdf: wingspan-asia_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Wingspan: Asia introduces the diverse and vibrant birds of the Asian continent. As always, the objective is to earn the most points by playing birds, achieving objectives, and laying eggs across your habitats. This release serves multiple roles within the Wingspan universe!
-
-
-      Wingspan: Asia is several different things:
-        - a stand-alone game for 1 or 2 players 
-        - a new Duet mode for 2 players that can be combined with the base game or other expansions
-        - For 1-5 players, new bird and bonus cards to add to the original Wingspan and its other expansions
-        - For 6-7 players, a new Flock mode (which also requires the components of the base game).
-
+    description: "Wingspan: Asia introduces the diverse and vibrant birds of the Asian continent. As always, the objective\
+      \ is to earn the most points by playing birds, achieving objectives, and laying eggs across your habitats. This release\
+      \ serves multiple roles within the Wingspan universe!\n\nWingspan: Asia is several different things:\n  - a stand-alone\
+      \ game for 1 or 2 players \n  - a new Duet mode for 2 players that can be combined with the base game or other expansions\n\
+      \  - For 1-5 players, new bird and bonus cards to add to the original Wingspan and its other expansions\n  - For 6-7\
+      \ players, a new Flock mode (which also requires the components of the base game).\n\n"
     yearPublished: 2022
     minPlayers: 1
     maxPlayers: 2
@@ -10415,20 +11689,33 @@ catalog:
     - Regatul Jocurilor
     - Siam Board Games
     - Ігромаг
+    pdfBlobKey: rulebooks/v1/wingspan-asia_rulebook.pdf
+    pdfSha256: a3bef7f481236d2a6bd57a184b07b3001c6fa171602935c42885a1c0f2cf8f26
+    pdfVersion: '1.0'
   - title: Five Tribes
     bggId: 157354
     language: en
-    pdf: five-tribes_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Crossing into the Land of 1001 Nights, your caravan arrives at the fabled Sultanate of Naqala. The old sultan just died and control of Naqala is up for grabs! The oracles foretold of strangers who would maneuver the Five Tribes to gain influence over the legendary city-state. Will you fulfill the prophecy? Invoke the old Djinns and move the Tribes into position at the right time, and the Sultanate may become yours!
+    description: 'Crossing into the Land of 1001 Nights, your caravan arrives at the fabled Sultanate of Naqala. The old sultan
+      just died and control of Naqala is up for grabs! The oracles foretold of strangers who would maneuver the Five Tribes
+      to gain influence over the legendary city-state. Will you fulfill the prophecy? Invoke the old Djinns and move the Tribes
+      into position at the right time, and the Sultanate may become yours!
 
 
-      Designed by Bruno Cathala, Five Tribes builds on a long tradition of German-style games that feature wooden meeples. Here, in a unique twist on the now-standard "worker placement" genre, the game begins with the meeples already in place &ndash; and players must cleverly maneuver them over the villages, markets, oases, and sacred places tiles that make up Naqala. How, when, and where you dis-place these Five Tribes of Assassins, Elders, Builders, Merchants, and Viziers determine your victory or failure.
+      Designed by Bruno Cathala, Five Tribes builds on a long tradition of German-style games that feature wooden meeples.
+      Here, in a unique twist on the now-standard "worker placement" genre, the game begins with the meeples already in place
+      &ndash; and players must cleverly maneuver them over the villages, markets, oases, and sacred places tiles that make
+      up Naqala. How, when, and where you dis-place these Five Tribes of Assassins, Elders, Builders, Merchants, and Viziers
+      determine your victory or failure.
 
 
-      As befitting a Days of Wonder game, the rules are straightforward and easy to learn. But devising a winning strategy will take a more calculated approach than our standard fare. You need to carefully consider what moves can score you well and put your opponents at a disadvantage. You need to weigh many different pathways to victory, including the summoning of powerful Djinns that may help your cause as you attempt to control this legendary Sultanate.
+      As befitting a Days of Wonder game, the rules are straightforward and easy to learn. But devising a winning strategy
+      will take a more calculated approach than our standard fare. You need to carefully consider what moves can score you
+      well and put your opponents at a disadvantage. You need to weigh many different pathways to victory, including the summoning
+      of powerful Djinns that may help your cause as you attempt to control this legendary Sultanate.
 
+
+      '
     yearPublished: 2014
     minPlayers: 2
     maxPlayers: 4
@@ -10471,26 +11758,38 @@ catalog:
     - Lord of Boards
     - Maldito Games
     - Rebel Sp. z o.o.
+    pdfBlobKey: rulebooks/v1/five-tribes_rulebook.pdf
+    pdfSha256: 0175a44d57b48636164db12a54458641cd0c9064205b9cb70de184af769512d8
+    pdfVersion: '1.0'
   - title: Final Girl
     bggId: 277659
     language: en
-    pdf: final-girl_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Playing on a famous horror movie trope, Final Girl is a solitaire-only game that puts the player in the shoes of a female protagonist who must kill the slasher if she wants to survive.
+    description: 'Playing on a famous horror movie trope, Final Girl is a solitaire-only game that puts the player in the
+      shoes of a female protagonist who must kill the slasher if she wants to survive.
 
 
-      The Core Box, when combined with one of our Feature Film Boxes, has everything you need to play the game. Each Feature Film Box features a unique Killer and and iconic Location, and the more Feature Films you have, the more killer/location combinations you can experience!
+      The Core Box, when combined with one of our Feature Film Boxes, has everything you need to play the game. Each Feature
+      Film Box features a unique Killer and and iconic Location, and the more Feature Films you have, the more killer/location
+      combinations you can experience!
 
 
-      In game terms, Final Girl shares similarities with Hostage Negotiator, but with some key differences that change it up, including a game board to track locations and character movement. You can choose from multiple characters when picking someone to play and multiple killers when picking someone to play against. Killers and locations each have their own specific terror cards that will be shuffled together to create a unique experience with various combinations of scenarios for you to play!
+      In game terms, Final Girl shares similarities with Hostage Negotiator, but with some key differences that change it
+      up, including a game board to track locations and character movement. You can choose from multiple characters when picking
+      someone to play and multiple killers when picking someone to play against. Killers and locations each have their own
+      specific terror cards that will be shuffled together to create a unique experience with various combinations of scenarios
+      for you to play!
 
 
-      NOTE: The 2022 Kickstarter for Final Girl: Season 2 included a 13 card Final Girl: First Printing Correction Pack of corrected cards for the first printing of Final Girl: Series 1. The cards mostly fix typos and are not required to play the game. The cards were corrected for the second printing of Final Girl: Series 1.
+      NOTE: The 2022 Kickstarter for Final Girl: Season 2 included a 13 card Final Girl: First Printing Correction Pack of
+      corrected cards for the first printing of Final Girl: Series 1. The cards mostly fix typos and are not required to play
+      the game. The cards were corrected for the second printing of Final Girl: Series 1.
 
 
       &mdash;description from the publisher
 
+
+      '
     yearPublished: 2021
     minPlayers: 1
     maxPlayers: 1
@@ -10526,34 +11825,56 @@ catalog:
     - Ludofun
     - Raven Distribution
     - REXhry
+    pdfBlobKey: rulebooks/v1/final-girl_rulebook.pdf
+    pdfSha256: df546c716dbdb555ed98d12ca896e57ffb82213cbb0e8f5ecc2603a8b076d15d
+    pdfVersion: '1.0'
   - title: Fields of Arle
     bggId: 159675
     language: en
-    pdf: fields-of-arle_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      Welcome to Arle
+    description: 'Welcome to Arle
 
-      In Fields of Arle, created by Uwe Rosenberg, one to two players live as farmers in the small and peaceful town of Arle in East Frisia. The flax grown in the land surrounding the village makes it a profitable place to work and live. Fields of Arle takes players through four and a half years of this era of prosperity, with different opportunities available as the seasons change. Farm the land to capitalize on the demand for flax, or find other ways to make the most of the small town&rsquo;s prosperity.
+      In Fields of Arle, created by Uwe Rosenberg, one to two players live as farmers in the small and peaceful town of Arle
+      in East Frisia. The flax grown in the land surrounding the village makes it a profitable place to work and live. Fields
+      of Arle takes players through four and a half years of this era of prosperity, with different opportunities available
+      as the seasons change. Farm the land to capitalize on the demand for flax, or find other ways to make the most of the
+      small town&rsquo;s prosperity.
 
 
       Work the Land
 
-      Whether you delve into flax farming or leverage other areas of expertise, always make sure that you have the land to build up your village. Construct dikes to keep the waters at bay and expand your fields. Dry out bogs to harvest peat and then clear the land for cultivation. Create more fields for your livestock, buildings, or future crops; after that, you can decide whether to house animals or cultivate a forest for timber. Perhaps you&rsquo;d like to take up some flax farming for yourself, or diversify and try out a little bit of everything.
+      Whether you delve into flax farming or leverage other areas of expertise, always make sure that you have the land to
+      build up your village. Construct dikes to keep the waters at bay and expand your fields. Dry out bogs to harvest peat
+      and then clear the land for cultivation. Create more fields for your livestock, buildings, or future crops; after that,
+      you can decide whether to house animals or cultivate a forest for timber. Perhaps you&rsquo;d like to take up some flax
+      farming for yourself, or diversify and try out a little bit of everything.
 
 
       Tools of the Trade
 
-      At the outset of each half year, you&rsquo;ll choose how you&rsquo;d like to spend that time working. There are many ways to build your fortune. Use the Master space to increase the tools at your disposal, focus on the Cattle Trainer to make the most of your livestock, or build up your fleet of vehicles and ship out goods. Taking stock of your progress differs depending on the season. You may milk your existing livestock or care for a bunch of newborn animals. You could harvest your flax in the fall, and shear your sheep in spring. At the end of each half year, you&rsquo;ll need to take stock of your progress by unloading your vehicles and feeding your family and animals, so keep an eye on the season and do your best to keep the farm growing and everyone well fed!
+      At the outset of each half year, you&rsquo;ll choose how you&rsquo;d like to spend that time working. There are many
+      ways to build your fortune. Use the Master space to increase the tools at your disposal, focus on the Cattle Trainer
+      to make the most of your livestock, or build up your fleet of vehicles and ship out goods. Taking stock of your progress
+      differs depending on the season. You may milk your existing livestock or care for a bunch of newborn animals. You could
+      harvest your flax in the fall, and shear your sheep in spring. At the end of each half year, you&rsquo;ll need to take
+      stock of your progress by unloading your vehicles and feeding your family and animals, so keep an eye on the season
+      and do your best to keep the farm growing and everyone well fed!
 
 
       Travel and Prosper
 
-      Once you&rsquo;ve made headway in clearing fields and stocking up goods, it's time to make your products available to potential buyers. The more vehicles you have, the more goods you can ship. Send things into the wide world to increase your Travel Experience and grant you points over the course of the four and a half years of the game. Build up your farm and your vehicles and get your goods out into the world to make the most of every season. There are many roads to success in Fields of Arle, so pick your path, work the land, and enjoy the friendly competition as you strive to make your fortune!
+      Once you&rsquo;ve made headway in clearing fields and stocking up goods, it''s time to make your products available
+      to potential buyers. The more vehicles you have, the more goods you can ship. Send things into the wide world to increase
+      your Travel Experience and grant you points over the course of the four and a half years of the game. Build up your
+      farm and your vehicles and get your goods out into the world to make the most of every season. There are many roads
+      to success in Fields of Arle, so pick your path, work the land, and enjoy the friendly competition as you strive to
+      make your fortune!
 
 
-      - from the publisher's website
+      - from the publisher''s website
 
+
+      '
     yearPublished: 2014
     minPlayers: 1
     maxPlayers: 2
@@ -10589,20 +11910,32 @@ catalog:
     - Mandala Jogos
     - テンデイズゲームズ (TendaysGames)
     - Z-Man Games
+    pdfBlobKey: rulebooks/v1/fields-of-arle_rulebook.pdf
+    pdfSha256: a7d44d5d0f033a0a32b55da417a1031fcda41a45cfdc834ffca174056b0753ca
+    pdfVersion: '1.0'
   - title: 'Eclipse: New Dawn for the Galaxy'
     bggId: 72125
     language: en
-    pdf: eclipse_rulebook.pdf
     bggEnhanced: true
-    description: >+
-      The galaxy has been a peaceful place for many years. After the ruthless Terran&ndash;Hegemony War (30.027&ndash;33.364), much effort has been employed by all major spacefaring species to prevent the terrifying events from repeating themselves. The Galactic Council was formed to enforce precious peace, and it has taken many courageous efforts to prevent the escalation of malicious acts. Nevertheless, tension and discord are growing among the seven major species and in the Council itself. Old alliances are shattering, and hasty diplomatic treaties are made in secrecy. A confrontation of the superpowers seems inevitable &ndash; only the outcome of the galactic conflict remains to be seen. Which faction will emerge victorious and lead the galaxy under its rule?
+    description: 'The galaxy has been a peaceful place for many years. After the ruthless Terran&ndash;Hegemony War (30.027&ndash;33.364),
+      much effort has been employed by all major spacefaring species to prevent the terrifying events from repeating themselves.
+      The Galactic Council was formed to enforce precious peace, and it has taken many courageous efforts to prevent the escalation
+      of malicious acts. Nevertheless, tension and discord are growing among the seven major species and in the Council itself.
+      Old alliances are shattering, and hasty diplomatic treaties are made in secrecy. A confrontation of the superpowers
+      seems inevitable &ndash; only the outcome of the galactic conflict remains to be seen. Which faction will emerge victorious
+      and lead the galaxy under its rule?
 
 
-      A game of Eclipse places you in control of a vast interstellar civilization, competing for success with its rivals. You will explore new star systems, research technologies, and build spaceships with which to wage war. There are many potential paths to victory, so you need to plan your strategy according to the strengths and weaknesses of your species, while paying attention to the other civilizations' endeavors.
+      A game of Eclipse places you in control of a vast interstellar civilization, competing for success with its rivals.
+      You will explore new star systems, research technologies, and build spaceships with which to wage war. There are many
+      potential paths to victory, so you need to plan your strategy according to the strengths and weaknesses of your species,
+      while paying attention to the other civilizations'' endeavors.
 
 
       The shadows of the great civilizations are about to eclipse the galaxy. Lead your people to victory!
 
+
+      '
     yearPublished: 2011
     minPlayers: 2
     maxPlayers: 6
@@ -10641,6 +11974,336 @@ catalog:
     - Korea Boardgames
     - Rebel Sp. z o.o.
     - Ystari Games
+    pdfBlobKey: rulebooks/v1/eclipse_rulebook.pdf
+    pdfSha256: bd13229470079df4df34fb2c6b1126172985b89b856984f5fb9f46a160370b79
+    pdfVersion: '1.0'
+  - title: 'Battlestar Galactica: Exodus Expansion'
+    bggId: 85905
+    language: en
+    yearPublished: 2010
+    minPlayers: 3
+    maxPlayers: 6
+    playingTime: 180
+    minAge: 14
+    categories:
+    - Expansion
+    - Science Fiction
+    mechanics:
+    - Cooperative Game
+    - Hand Management
+    - Traitor Game
+    designers:
+    - Corey Konieczka
+    - Tim Uren
+    publishers:
+    - Fantasy Flight Games
+    pdfBlobKey: rulebooks/v1/battlestar-galactica-exodus_rulebook.pdf
+    pdfSha256: 933ed636f95700f9dca1d47bf63eb228b86341017def10a649e54e1c18b471cd
+    pdfVersion: '1.0'
+  - title: Blueprints
+    bggId: 140933
+    language: en
+    yearPublished: 2013
+    minPlayers: 2
+    maxPlayers: 4
+    playingTime: 30
+    minAge: 14
+    categories:
+    - Dice
+    - City Building
+    mechanics:
+    - Dice Drafting
+    - Set Collection
+    - Pattern Building
+    designers:
+    - Yves Tourigny
+    publishers:
+    - Z-Man Games
+    pdfBlobKey: rulebooks/v1/blueprints_rulebook.pdf
+    pdfSha256: ca0473d279040cd8e157f736bb5aa78f2019fed68e278cfafc73f98ef0269bad
+    pdfVersion: '1.0'
+  - title: 'Frostpunk: The Board Game'
+    bggId: 311988
+    language: en
+    yearPublished: 2022
+    minPlayers: 1
+    maxPlayers: 4
+    playingTime: 150
+    minAge: 16
+    categories:
+    - Science Fiction
+    - City Building
+    mechanics:
+    - Cooperative Game
+    - Worker Placement
+    - Action Queue
+    designers:
+    - Adam Kwapiński
+    publishers:
+    - Glass Cannon Unplugged
+    pdfBlobKey: rulebooks/v1/frostpunk_rulebook.pdf
+    pdfSha256: 3600047bc0167e8f550867c6da4ec75d575bf78291ddbb39a5969c3a14c4d9c6
+    pdfVersion: '1.0'
+  - title: ISS Vanguard
+    bggId: 325494
+    language: en
+    yearPublished: 2023
+    minPlayers: 1
+    maxPlayers: 4
+    playingTime: 120
+    minAge: 14
+    categories:
+    - Adventure
+    - Exploration
+    - Science Fiction
+    mechanics:
+    - Cooperative Game
+    - Campaign / Battle Card Driven
+    - Deck Construction
+    designers:
+    - Andrzej Betkiewicz
+    - Krzysztof Piskorski
+    - Paweł Samborski
+    - Marcin Świerkot
+    publishers:
+    - Awaken Realms
+    pdfBlobKey: rulebooks/v1/iss-vanguard_rulebook.pdf
+    pdfSha256: 76f80aa5a266287e19b5c1423d7177d9ad5167d07e6c9eb402fa616008c4e6ca
+    pdfVersion: '1.0'
+  - title: Marvel United
+    bggId: 298047
+    language: en
+    yearPublished: 2020
+    minPlayers: 1
+    maxPlayers: 4
+    playingTime: 40
+    minAge: 14
+    categories:
+    - Card Game
+    - Comic Book / Strip
+    - Miniatures
+    mechanics:
+    - Cooperative Game
+    - Hand Management
+    - Variable Player Powers
+    designers:
+    - Andrea Chiarvesio
+    - Eric M. Lang
+    publishers:
+    - CMON
+    - Spin Master
+    pdfBlobKey: rulebooks/v1/marvel-united_rulebook.pdf
+    pdfSha256: 4cf121cbdc9ba87c94e64eef7d9defff65860c7fb4e9850a0c611f7c2d7ccd1c
+    pdfVersion: '1.0'
+  - title: Massive Darkness
+    bggId: 197070
+    language: en
+    yearPublished: 2017
+    minPlayers: 1
+    maxPlayers: 6
+    playingTime: 180
+    minAge: 14
+    categories:
+    - Adventure
+    - Exploration
+    - Fantasy
+    - Fighting
+    - Miniatures
+    mechanics:
+    - Cooperative Game
+    - Dice Rolling
+    - Grid Movement
+    - Modular Board
+    designers:
+    - Raphaël Guiton
+    - Jean-Baptiste Lullien
+    - Nicolas Raoult
+    publishers:
+    - CMON
+    pdfBlobKey: rulebooks/v1/massive-darkness_rulebook.pdf
+    pdfSha256: 0e6da43776336126872fd55c4ff0a186b598eb35f0f81c5983efe0286d19d04c
+    pdfVersion: '1.0'
+  - title: 'Masters of the Universe: Fields of Eternia'
+    bggId: 317526
+    language: en
+    yearPublished: 2022
+    minPlayers: 1
+    maxPlayers: 6
+    playingTime: 90
+    minAge: 14
+    categories:
+    - Adventure
+    - Fantasy
+    - Miniatures
+    mechanics:
+    - Area Control
+    - Card Play
+    - Dice Rolling
+    - Campaign
+    publishers:
+    - Archon Studio
+    pdfBlobKey: rulebooks/v1/masters-of-the-universe-fields-of-eternia_rulebook.pdf
+    pdfSha256: 6c75514b523638e01417651123372884f6bbbc94cc81541f7b1187e6b35719f8
+    pdfVersion: '1.0'
+  - title: Paleo
+    bggId: 300531
+    language: en
+    yearPublished: 2020
+    minPlayers: 1
+    maxPlayers: 4
+    playingTime: 60
+    minAge: 10
+    categories:
+    - Adventure
+    - Prehistoric
+    mechanics:
+    - Cooperative Game
+    - Hand Management
+    - Set Collection
+    designers:
+    - Peter Rustemeyer
+    publishers:
+    - Hans im Glück
+    pdfBlobKey: rulebooks/v1/paleo_rulebook.pdf
+    pdfSha256: e25557f8724650419837f690aeadaaa474b652b5610e4d39100c618b92e87e90
+    pdfVersion: '1.0'
+  - title: Photosynthesis
+    bggId: 218603
+    language: en
+    yearPublished: 2017
+    minPlayers: 2
+    maxPlayers: 4
+    playingTime: 60
+    minAge: 8
+    categories:
+    - Abstract Strategy
+    - Environmental
+    mechanics:
+    - Area Majority / Influence
+    - Grid Movement
+    - Point to Point Movement
+    designers:
+    - Hjalmar Hach
+    publishers:
+    - Blue Orange (EU)
+    pdfBlobKey: rulebooks/v1/photosynthesis_rulebook.pdf
+    pdfSha256: adfe6e3e69ab40ab8c51482a9d3f9f930d1b0a22d49c55fa3faf8c0cd1e07e26
+    pdfVersion: '1.0'
+  - title: 'RONE: Invasion'
+    bggId: 368944
+    language: en
+    yearPublished: 2024
+    minPlayers: 1
+    maxPlayers: 4
+    playingTime: 90
+    minAge: 14
+    categories:
+    - Card Game
+    - Science Fiction
+    mechanics:
+    - Cooperative Game
+    - Deck Building
+    - Dice Building
+    designers:
+    - Štěpán Štefaník
+    publishers:
+    - Bonjour Games
+    pdfBlobKey: rulebooks/v1/rone-invasion_rulebook.pdf
+    pdfSha256: 0351e250da3d127e0835dce3444ae6151f5328c4b613144d02f74659cc5324dc
+    pdfVersion: '1.0'
+  - title: Sagrada
+    bggId: 199561
+    language: en
+    yearPublished: 2017
+    minPlayers: 1
+    maxPlayers: 4
+    playingTime: 45
+    minAge: 14
+    categories:
+    - Abstract Strategy
+    - Puzzle
+    mechanics:
+    - Dice Drafting
+    - Pattern Building
+    - Set Collection
+    designers:
+    - Adrian Adamescu
+    - Daryl Andrews
+    publishers:
+    - Floodgate Games
+    pdfBlobKey: rulebooks/v1/sagrada_rulebook.pdf
+    pdfSha256: c7c8d54e36bd83aa4b92b0a44184c140cce87c57253b93c5d744aa76f174408f
+    pdfVersion: '1.0'
+  - title: Santorini
+    bggId: 194655
+    language: en
+    yearPublished: 2016
+    minPlayers: 2
+    maxPlayers: 4
+    playingTime: 20
+    minAge: 8
+    categories:
+    - Abstract Strategy
+    - Mythology
+    mechanics:
+    - Grid Movement
+    - Pattern Building
+    - Variable Player Powers
+    designers:
+    - Gordon Hamilton
+    publishers:
+    - Spin Master Ltd.
+    pdfBlobKey: rulebooks/v1/santorini_rulebook.pdf
+    pdfSha256: 0d1a056e6753d031c8c067f706cbfa064018bfb4279ac9e3c0ed95b4a3d7f19d
+    pdfVersion: '1.0'
+  - title: Townsfolk Tussle
+    bggId: 312859
+    language: en
+    yearPublished: 2022
+    minPlayers: 2
+    maxPlayers: 5
+    playingTime: 200
+    minAge: 14
+    categories:
+    - Adventure
+    - Fighting
+    - Fantasy
+    mechanics:
+    - Cooperative Game
+    - Dice Rolling
+    - Hand Management
+    designers:
+    - Stephen Louis
+    - Tony Mayer
+    - Rachel Rusk
+    publishers:
+    - Panic Roll Games
+    pdfBlobKey: rulebooks/v1/townsfolk-tussle_rulebook.pdf
+    pdfSha256: 9ba02fb2121e962214f5933c021ec66caec242af693d216fdad956a94381bdce
+    pdfVersion: '1.0'
+  - title: Disney Villainous
+    bggId: 256382
+    language: en
+    yearPublished: 2018
+    minPlayers: 2
+    maxPlayers: 6
+    playingTime: 60
+    minAge: 10
+    categories:
+    - Card Game
+    - Fantasy
+    - Movies / TV / Radio theme
+    mechanics:
+    - Action Points
+    - Hand Management
+    - Variable Player Powers
+    designers:
+    - Prospero Hall
+    publishers:
+    - Ravensburger
+    pdfBlobKey: rulebooks/v1/villainous_rulebook.pdf
+    pdfSha256: ab41201c70aecc048dc8fd03e20e8b6ba9561dc5e444793ca8d977aba2d9c907
+    pdfVersion: '1.0'
   defaultAgent:
     name: MeepleAssistant POC
     model: anthropic/claude-3-haiku

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/staging.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/staging.yml
@@ -9258,6 +9258,8 @@ catalog:
     pdfBlobKey: rulebooks/v1/skytear_rulebook.pdf
     pdfSha256: 2f316d16c5001b55097b9966c7c697bbde6a50e7e5c9b1c3df336ff5c3775960
     pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Skytear%3A%20Arena%20of%20Legends
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Skytear%3A%20Arena%20of%20Legends
   - title: Terra Mystica
     bggId: 120677
     language: en
@@ -10919,6 +10921,8 @@ catalog:
     pdfBlobKey: rulebooks/v1/great-western-trail-argentina_rulebook.pdf
     pdfSha256: 88be4a0b83dda037566941e46d1e936ec6280c37e9860c0405a58a9bd412c2fa
     pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Great%20Western%20Trail%3A%20Argentina
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Great%20Western%20Trail%3A%20Argentina
   - title: Agricola (Revised Edition)
     bggId: 200680
     language: en
@@ -11460,6 +11464,8 @@ catalog:
     pdfBlobKey: rulebooks/v1/voidfall_rulebook.pdf
     pdfSha256: 29847a547dcec0deac860cfb658cd3ea694dcaab319258fcf286c27161243157
     pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Voidfall
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Voidfall
   - title: 'Wingspan: Asia'
     bggId: 366161
     language: en

--- a/infra/scripts/detect-manifest-mismatches.py
+++ b/infra/scripts/detect-manifest-mismatches.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+Detect potential title/description mismatches in seed manifests.
+
+Heuristic: for each bggEnhanced entry, check if significant words from the
+title appear in the description. If zero significant title words match,
+it's likely a BGG scraping error (wrong bggId -> wrong description).
+
+Also flags:
+- Duplicate bggIds (Validate() would catch but worth listing)
+- Entries with bggEnhanced=true but empty description
+- Impossible metadata (e.g., yearPublished 1957 on a game with 2020s theme)
+"""
+
+import html
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+# Entries where BGG description doesn't literally contain title words but IS
+# correct content (e.g., Risk description talks about "world conquest"; LotR
+# TCG description talks about "Mordor" and "Middle-earth"). False positives
+# for the mismatch heuristic; verified manually.
+KNOWN_CORRECT_BGG_IDS = {
+    181,     # Risk
+    421006,  # The Lord of the Rings: The Card Game
+}
+
+STOPWORDS = {
+    "the", "a", "an", "of", "and", "or", "to", "in", "on", "for", "with",
+    "game", "board", "card", "dice", "play", "player", "players",
+    "expansion", "new", "edition", "box", "set", "series", "vol", "volume",
+}
+
+
+def title_words(title: str) -> set:
+    """Extract significant words from title (lowercase, no stopwords)."""
+    # Strip subtitles after ':' too (e.g., "Great Western Trail: Argentina" -> argentina)
+    parts = re.split(r"[:]", title)
+    all_text = " ".join(parts).lower()
+    words = re.findall(r"[a-zàèéìòù]+", all_text)
+    return {w for w in words if len(w) >= 3 and w not in STOPWORDS}
+
+
+def description_words(description: str) -> set:
+    # Decode HTML entities so "Orl&eacute;ans" matches title word "orleans"
+    decoded = html.unescape(description)
+    # Strip accents so "Orléans" matches "orleans"
+    decoded = (
+        decoded.replace("é", "e").replace("è", "e").replace("ê", "e")
+               .replace("à", "a").replace("á", "a").replace("â", "a")
+               .replace("í", "i").replace("ì", "i").replace("î", "i")
+               .replace("ó", "o").replace("ò", "o").replace("ô", "o")
+               .replace("ú", "u").replace("ù", "u").replace("û", "u")
+               .replace("ñ", "n").replace("ç", "c")
+    )
+    return set(re.findall(r"[a-z]+", decoded.lower()))
+
+
+def check_manifest(yml_path: Path):
+    with open(yml_path, "r", encoding="utf-8") as f:
+        doc = yaml.safe_load(f)
+
+    games = doc["catalog"]["games"]
+    issues = []
+
+    seen_bgg = {}
+    for idx, g in enumerate(games):
+        title = g.get("title", "")
+        bgg_id = g.get("bggId")
+        desc = g.get("description") or ""
+        bgg_enhanced = g.get("bggEnhanced", False)
+
+        # Duplicate bggId
+        if bgg_id and bgg_id > 0:
+            if bgg_id in seen_bgg:
+                issues.append(("DUP", title, bgg_id, f"duplicate of {seen_bgg[bgg_id]}"))
+            else:
+                seen_bgg[bgg_id] = title
+
+        # bggEnhanced but empty description
+        if bgg_enhanced and not desc.strip():
+            issues.append(("EMPTY_DESC", title, bgg_id, "bggEnhanced=true but empty description"))
+            continue
+
+        if not bgg_enhanced or not desc.strip():
+            continue
+
+        # Skip known correct entries where description text doesn't literally
+        # contain title words but is about the right game.
+        if bgg_id in KNOWN_CORRECT_BGG_IDS:
+            continue
+
+        # Title/description mismatch
+        tw = title_words(title)
+        if not tw:
+            continue
+        dw = description_words(desc)
+        matches = tw & dw
+        if not matches:
+            # Get first ~80 chars of description for context
+            preview = re.sub(r"\s+", " ", desc)[:100]
+            issues.append((
+                "MISMATCH", title, bgg_id,
+                f"title words {sorted(tw)} not in description: '{preview}...'"
+            ))
+
+    return issues, len(games)
+
+
+def main():
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    manifest_dir = repo_root / "apps" / "api" / "src" / "Api" / "Infrastructure" / "Seeders" / "Catalog" / "Manifests"
+
+    total_issues = 0
+    for name in ("staging.yml", "dev.yml", "prod.yml"):
+        yml = manifest_dir / name
+        if not yml.exists():
+            continue
+        issues, ngames = check_manifest(yml)
+        print(f"\n=== {name} ({ngames} games, {len(issues)} issues) ===")
+        for kind, title, bgg, detail in issues:
+            print(f"  [{kind}] {title} (bggId={bgg})")
+            print(f"         {detail}")
+        total_issues += len(issues)
+
+    print(f"\nTotal issues: {total_issues}")
+    sys.exit(0 if total_issues == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/scripts/fill-skeleton-entries.py
+++ b/infra/scripts/fill-skeleton-entries.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+Fill skeleton entries in staging.yml with real game metadata.
+
+Reads skeletons (entries with title 'TODO: fill from manifest.json (...)') from
+staging.yml, maps by slug to data from:
+  - data/rulebook/manifest.json (for games in PR #267 manifest)
+  - Hardcoded lookup for games not in manifest.json (popular titles)
+
+Preserves existing pdfBlobKey / pdfSha256 / pdfVersion on each skeleton.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+# BGG metadata for games not in data/rulebook/manifest.json
+# Verified from BGG
+HARDCODED_METADATA = {
+    "photosynthesis": {
+        "title": "Photosynthesis",
+        "bggId": 218603,
+        "yearPublished": 2017,
+        "minPlayers": 2,
+        "maxPlayers": 4,
+        "playingTime": 60,
+        "minAge": 8,
+        "designers": ["Hjalmar Hach"],
+        "publishers": ["Blue Orange (EU)"],
+        "categories": ["Abstract Strategy", "Environmental"],
+        "mechanics": ["Area Majority / Influence", "Grid Movement", "Point to Point Movement"],
+    },
+    "sagrada": {
+        "title": "Sagrada",
+        "bggId": 199561,
+        "yearPublished": 2017,
+        "minPlayers": 1,
+        "maxPlayers": 4,
+        "playingTime": 45,
+        "minAge": 14,
+        "designers": ["Adrian Adamescu", "Daryl Andrews"],
+        "publishers": ["Floodgate Games"],
+        "categories": ["Abstract Strategy", "Puzzle"],
+        "mechanics": ["Dice Drafting", "Pattern Building", "Set Collection"],
+    },
+    "santorini": {
+        "title": "Santorini",
+        "bggId": 194655,
+        "yearPublished": 2016,
+        "minPlayers": 2,
+        "maxPlayers": 4,
+        "playingTime": 20,
+        "minAge": 8,
+        "designers": ["Gordon Hamilton"],
+        "publishers": ["Spin Master Ltd."],
+        "categories": ["Abstract Strategy", "Mythology"],
+        "mechanics": ["Grid Movement", "Pattern Building", "Variable Player Powers"],
+    },
+    "villainous": {
+        "title": "Disney Villainous",
+        "bggId": 256382,
+        "yearPublished": 2018,
+        "minPlayers": 2,
+        "maxPlayers": 6,
+        "playingTime": 60,
+        "minAge": 10,
+        "designers": ["Prospero Hall"],
+        "publishers": ["Ravensburger"],
+        "categories": ["Card Game", "Fantasy", "Movies / TV / Radio theme"],
+        "mechanics": ["Action Points", "Hand Management", "Variable Player Powers"],
+    },
+}
+
+
+def load_manifest_games(manifest_path: Path) -> dict:
+    """Load data/rulebook/manifest.json and return slug -> game dict."""
+    with open(manifest_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    result = {}
+    for g in data.get("games", []):
+        result[g["slug"]] = g
+    return result
+
+
+def manifest_to_seed_fields(mg: dict) -> dict:
+    """Convert data/rulebook/manifest.json entry to SeedManifestGame fields."""
+    md = mg.get("metadata", {}) or {}
+    return {
+        "title": mg.get("name", mg["slug"]),
+        "bggId": mg.get("bggId", 0) or 0,
+        "yearPublished": md.get("yearPublished"),
+        "minPlayers": md.get("minPlayers"),
+        "maxPlayers": md.get("maxPlayers"),
+        "playingTime": md.get("playingTimeMinutes"),
+        "minAge": md.get("minAge"),
+        "designers": md.get("designers") or [],
+        "publishers": md.get("publishers") or [],
+        "categories": md.get("categories") or [],
+        "mechanics": md.get("mechanics") or [],
+    }
+
+
+def build_filled_entry(slug: str, skeleton: dict, manifest_games: dict) -> dict:
+    """Build a fully-populated entry from a skeleton, preserving blob fields."""
+    # Preserve blob fields from skeleton
+    pdf_blob_key = skeleton.get("pdfBlobKey")
+    pdf_sha256 = skeleton.get("pdfSha256")
+    pdf_version = skeleton.get("pdfVersion", "1.0")
+
+    # Find metadata source
+    if slug in manifest_games:
+        fields = manifest_to_seed_fields(manifest_games[slug])
+    elif slug in HARDCODED_METADATA:
+        fields = HARDCODED_METADATA[slug]
+    else:
+        raise ValueError(f"No metadata source for slug: {slug}")
+
+    # Build ordered entry (order matters for YAML readability)
+    entry = {
+        "title": fields["title"],
+        "bggId": fields["bggId"],
+        "language": skeleton.get("language", "en"),
+    }
+    if fields.get("yearPublished") is not None:
+        entry["yearPublished"] = fields["yearPublished"]
+    if fields.get("minPlayers") is not None:
+        entry["minPlayers"] = fields["minPlayers"]
+    if fields.get("maxPlayers") is not None:
+        entry["maxPlayers"] = fields["maxPlayers"]
+    if fields.get("playingTime") is not None:
+        entry["playingTime"] = fields["playingTime"]
+    if fields.get("minAge") is not None:
+        entry["minAge"] = fields["minAge"]
+    if fields.get("categories"):
+        entry["categories"] = fields["categories"]
+    if fields.get("mechanics"):
+        entry["mechanics"] = fields["mechanics"]
+    if fields.get("designers"):
+        entry["designers"] = fields["designers"]
+    if fields.get("publishers"):
+        entry["publishers"] = fields["publishers"]
+
+    entry["pdfBlobKey"] = pdf_blob_key
+    entry["pdfSha256"] = pdf_sha256
+    entry["pdfVersion"] = pdf_version
+    return entry
+
+
+def main():
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    manifest_json = repo_root / "data" / "rulebook" / "manifest.json"
+    staging_yml = repo_root / "apps" / "api" / "src" / "Api" / "Infrastructure" / "Seeders" / "Catalog" / "Manifests" / "staging.yml"
+
+    if not manifest_json.exists():
+        print(f"ERROR: {manifest_json} not found", file=sys.stderr)
+        sys.exit(1)
+    if not staging_yml.exists():
+        print(f"ERROR: {staging_yml} not found", file=sys.stderr)
+        sys.exit(1)
+
+    manifest_games = load_manifest_games(manifest_json)
+    print(f"Loaded {len(manifest_games)} games from manifest.json")
+
+    with open(staging_yml, "r", encoding="utf-8") as f:
+        doc = yaml.safe_load(f)
+
+    games = doc["catalog"]["games"]
+    skeleton_pattern = re.compile(r"^TODO: fill from manifest\.json \(([^)]+)\)$")
+
+    filled = 0
+    missing = []
+    for i, game in enumerate(games):
+        title = game.get("title", "")
+        m = skeleton_pattern.match(title)
+        if not m:
+            continue
+        slug = m.group(1)
+        try:
+            new_entry = build_filled_entry(slug, game, manifest_games)
+            games[i] = new_entry
+            filled += 1
+            print(f"  filled: {slug} -> bggId={new_entry['bggId']} ({new_entry['title']})")
+        except ValueError as exc:
+            missing.append(slug)
+            print(f"  MISSING: {exc}", file=sys.stderr)
+
+    if missing:
+        print(f"\nERROR: {len(missing)} slugs have no metadata: {missing}", file=sys.stderr)
+        sys.exit(2)
+
+    with open(staging_yml, "w", encoding="utf-8") as f:
+        yaml.dump(doc, f, default_flow_style=False, allow_unicode=True, sort_keys=False, width=120)
+
+    print(f"\nDone. Filled {filled} skeleton entries in {staging_yml.name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/scripts/fix-manifest-mismatches.py
+++ b/infra/scripts/fix-manifest-mismatches.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""
+Fix pre-existing BGG scraping mismatches in seed manifests.
+
+For 3 entries where the BGG scraper fetched data for a completely different
+game (wrong bggId), clear all bgg-sourced fields and set bggEnhanced=false.
+This removes wrong RAG content without requiring us to guess correct values;
+the bgg-fetcher tool can be re-run later to populate them properly.
+
+Affected entries (same bug in dev.yml, staging.yml, prod.yml):
+  - Voidfall (bggId=338111): has 1957 naval trick-taking card game metadata
+  - Great Western Trail: Argentina (bggId=380607): has NZ description/metadata
+  - Skytear: Arena of Legends (bggId=373106): has Sky Team metadata
+"""
+
+import sys
+from pathlib import Path
+
+import yaml
+
+BAD_BGG_IDS = {338111, 380607, 373106}
+
+# Fields populated by bgg-fetcher — all removed when a mismatch is detected
+BGG_FIELDS = {
+    "description",
+    "yearPublished",
+    "minPlayers",
+    "maxPlayers",
+    "playingTime",
+    "minAge",
+    "averageRating",
+    "averageWeight",
+    "imageUrl",
+    "thumbnailUrl",
+    "fallbackImageUrl",
+    "fallbackThumbnailUrl",
+    "categories",
+    "mechanics",
+    "designers",
+    "publishers",
+}
+
+
+def fix_entry(game: dict) -> bool:
+    """Clear bgg-sourced fields in place. Returns True if modified."""
+    modified = False
+    if game.get("bggEnhanced"):
+        game["bggEnhanced"] = False
+        modified = True
+    for field in list(game.keys()):
+        if field in BGG_FIELDS:
+            del game[field]
+            modified = True
+    return modified
+
+
+def process_manifest(yml_path: Path) -> int:
+    with open(yml_path, "r", encoding="utf-8") as f:
+        doc = yaml.safe_load(f)
+
+    games = doc["catalog"]["games"]
+    fixed = 0
+    for g in games:
+        if g.get("bggId") in BAD_BGG_IDS:
+            if fix_entry(g):
+                fixed += 1
+                print(f"  fixed: {g['title']} (bggId={g['bggId']})")
+
+    with open(yml_path, "w", encoding="utf-8") as f:
+        yaml.dump(doc, f, default_flow_style=False, allow_unicode=True, sort_keys=False, width=120)
+
+    return fixed
+
+
+def main():
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    manifest_dir = repo_root / "apps" / "api" / "src" / "Api" / "Infrastructure" / "Seeders" / "Catalog" / "Manifests"
+
+    total = 0
+    for name in ("staging.yml", "dev.yml", "prod.yml"):
+        yml = manifest_dir / name
+        if not yml.exists():
+            continue
+        print(f"Processing {name}:")
+        total += process_manifest(yml)
+
+    print(f"\nTotal entries fixed: {total}")
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/scripts/fix-manifest-mismatches.py
+++ b/infra/scripts/fix-manifest-mismatches.py
@@ -21,6 +21,9 @@ import yaml
 BAD_BGG_IDS = {338111, 380607, 373106}
 
 # Fields populated by bgg-fetcher — all removed when a mismatch is detected
+# (fallbackImageUrl/Thumbnail are kept by replacing with a placehold.co URL
+# to preserve the CatalogSeederTests.LoadManifest_DevProfile_GamesHaveFallbackImages
+# invariant that every game has fallback images for UI rendering.)
 BGG_FIELDS = {
     "description",
     "yearPublished",
@@ -32,13 +35,16 @@ BGG_FIELDS = {
     "averageWeight",
     "imageUrl",
     "thumbnailUrl",
-    "fallbackImageUrl",
-    "fallbackThumbnailUrl",
     "categories",
     "mechanics",
     "designers",
     "publishers",
 }
+
+
+def _placeholder_image(title: str, width: int, height: int) -> str:
+    from urllib.parse import quote
+    return f"https://placehold.co/{width}x{height}?text={quote(title)}"
 
 
 def fix_entry(game: dict) -> bool:
@@ -51,6 +57,12 @@ def fix_entry(game: dict) -> bool:
         if field in BGG_FIELDS:
             del game[field]
             modified = True
+    # Replace fallback images with placeholders (test invariant: every dev
+    # game must have fallback image + thumbnail URLs)
+    title = game.get("title", "Unknown")
+    game["fallbackImageUrl"] = _placeholder_image(title, 400, 300)
+    game["fallbackThumbnailUrl"] = _placeholder_image(title, 150, 150)
+    modified = True
     return modified
 
 

--- a/infra/scripts/patch-manifest-from-hashes.py
+++ b/infra/scripts/patch-manifest-from-hashes.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""
+Python equivalent of patch-manifest-from-hashes.sh — rewrites the YAML
+manifests in apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/
+by converting existing `pdf:` entries to `pdfBlobKey:` + `pdfSha256:`
+based on the .seed-hashes.tsv file produced by upload-seed-pdfs.py.
+
+For slugs that exist in .seed-hashes.tsv but have no matching manifest entry,
+appends a skeleton entry at the bottom of staging.yml for manual completion.
+
+Usage:
+    python infra/scripts/patch-manifest-from-hashes.py [HASHES_TSV]
+
+Requires:
+    - PyYAML (pip install PyYAML)
+"""
+
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def load_hashes(tsv_path: Path) -> dict:
+    """Load slug->sha256 mapping from a TSV file."""
+    result = {}
+    if not tsv_path.exists():
+        print(f"ERROR: hashes file not found: {tsv_path}", file=sys.stderr)
+        sys.exit(1)
+    with open(tsv_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split("\t")
+            if len(parts) != 2:
+                continue
+            slug, sha = parts
+            if slug and sha:
+                result[slug] = sha
+    return result
+
+
+def patch_manifest(yml_path: Path, hashes: dict) -> tuple[int, int]:
+    """
+    Patch a single manifest YAML in place. Returns (matched, appended).
+
+    For each slug in hashes:
+      - If an entry has `pdf: {slug}_rulebook.pdf`, replace with pdfBlobKey/Sha/Version.
+      - Otherwise skip (appends to staging only in a separate pass).
+    """
+    if not yml_path.exists():
+        print(f"  SKIP (missing): {yml_path}")
+        return (0, 0)
+
+    with open(yml_path, "r", encoding="utf-8") as f:
+        doc = yaml.safe_load(f)
+
+    if not doc or "catalog" not in doc or "games" not in doc["catalog"]:
+        print(f"  SKIP (no catalog.games): {yml_path}")
+        return (0, 0)
+
+    games = doc["catalog"]["games"]
+    matched = 0
+    seen_blob_keys = set()
+
+    # Pass 1: rewrite existing pdf: entries
+    for game in games:
+        blob_key_existing = game.get("pdfBlobKey")
+        if blob_key_existing:
+            seen_blob_keys.add(blob_key_existing)
+            continue
+
+        pdf_value = game.get("pdf")
+        if not pdf_value:
+            continue
+
+        # Filename can be "slug_rulebook.pdf"
+        if not pdf_value.endswith("_rulebook.pdf"):
+            continue
+        slug = pdf_value.removesuffix("_rulebook.pdf")
+
+        sha = hashes.get(slug)
+        if not sha:
+            continue
+
+        blob_key = f"rulebooks/v1/{slug}_rulebook.pdf"
+        game["pdfBlobKey"] = blob_key
+        game["pdfSha256"] = sha
+        game["pdfVersion"] = game.get("pdfVersion", "1.0")
+        game.pop("pdf", None)
+        seen_blob_keys.add(blob_key)
+        matched += 1
+
+    # Write back (preserve key order by using default_flow_style=False)
+    with open(yml_path, "w", encoding="utf-8") as f:
+        yaml.dump(doc, f, default_flow_style=False, allow_unicode=True, sort_keys=False, width=120)
+
+    print(f"  patched {matched} entries: {yml_path.name}")
+    return (matched, 0)
+
+
+def append_missing(yml_path: Path, hashes: dict) -> int:
+    """
+    For slugs in hashes that don't have a matching entry (by pdfBlobKey),
+    append a skeleton entry at the bottom of the manifest.
+    Returns count of appended entries.
+    """
+    with open(yml_path, "r", encoding="utf-8") as f:
+        doc = yaml.safe_load(f)
+
+    games = doc["catalog"]["games"]
+    existing_keys = {g.get("pdfBlobKey") for g in games if g.get("pdfBlobKey")}
+
+    appended = 0
+    for slug, sha in sorted(hashes.items()):
+        blob_key = f"rulebooks/v1/{slug}_rulebook.pdf"
+        if blob_key in existing_keys:
+            continue
+        games.append({
+            "title": f"TODO: fill from manifest.json ({slug})",
+            "bggId": 0,
+            "language": "en",
+            "pdfBlobKey": blob_key,
+            "pdfSha256": sha,
+            "pdfVersion": "1.0",
+        })
+        appended += 1
+
+    with open(yml_path, "w", encoding="utf-8") as f:
+        yaml.dump(doc, f, default_flow_style=False, allow_unicode=True, sort_keys=False, width=120)
+
+    print(f"  appended {appended} skeleton entries to {yml_path.name}")
+    return appended
+
+
+def main():
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    hashes_tsv = Path(sys.argv[1]) if len(sys.argv) > 1 else repo_root / "data" / "rulebook" / ".seed-hashes.tsv"
+
+    manifest_dir = repo_root / "apps" / "api" / "src" / "Api" / "Infrastructure" / "Seeders" / "Catalog" / "Manifests"
+    staging = manifest_dir / "staging.yml"
+    dev = manifest_dir / "dev.yml"
+    prod = manifest_dir / "prod.yml"
+
+    hashes = load_hashes(hashes_tsv)
+    print(f"Loaded {len(hashes)} slug->sha256 mappings from {hashes_tsv.name}")
+    print()
+
+    print("=== Patching existing entries ===")
+    for yml in (staging, dev, prod):
+        if yml.exists():
+            print(f"Patching: {yml.name}")
+            patch_manifest(yml, hashes)
+    print()
+
+    print("=== Appending skeleton entries (staging only) ===")
+    append_missing(staging, hashes)
+    print()
+
+    print("Done. Review diffs with:")
+    print("  git diff apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/")
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/scripts/upload-seed-pdfs.py
+++ b/infra/scripts/upload-seed-pdfs.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+Python equivalent of upload-seed-pdfs.sh — uploads rulebook PDFs to the
+meepleai-seeds R2 bucket with SHA256 object metadata.
+
+Idempotent: skips uploads whose remote sha256 metadata already matches local.
+
+Usage:
+    python infra/scripts/upload-seed-pdfs.py [LOCAL_DIR]
+
+Requires:
+    - boto3 (pip install boto3)
+    - SEED_BUCKET_* env vars OR infra/secrets/storage.secret sourced
+    - Write credentials (not the runtime readonly ones)
+"""
+
+import hashlib
+import os
+import re
+import sys
+from pathlib import Path
+
+import boto3
+from botocore.client import Config
+from botocore.exceptions import ClientError
+
+
+def load_secrets(secret_path: Path) -> dict:
+    """Parse a shell-style KEY=value secrets file into a dict."""
+    if not secret_path.exists():
+        return {}
+    env = {}
+    with open(secret_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            m = re.match(r"^([A-Z_][A-Z0-9_]*)=(.*)$", line)
+            if m:
+                key, val = m.group(1), m.group(2)
+                # Strip surrounding quotes if present
+                if len(val) >= 2 and val[0] == val[-1] and val[0] in ('"', "'"):
+                    val = val[1:-1]
+                env[key] = val
+    return env
+
+
+def sha256_of(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main():
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    local_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else repo_root / "data" / "rulebook"
+    out_tsv = local_dir / ".seed-hashes.tsv"
+
+    # Load secrets if env not set
+    env = os.environ.copy()
+    if not env.get("SEED_BUCKET_NAME"):
+        secret_file = repo_root / "infra" / "secrets" / "storage.secret"
+        env.update(load_secrets(secret_file))
+
+    required = [
+        "SEED_BUCKET_NAME",
+        "SEED_BUCKET_ENDPOINT",
+        "SEED_BUCKET_ACCESS_KEY",
+        "SEED_BUCKET_SECRET_KEY",
+    ]
+    missing = [k for k in required if not env.get(k)]
+    if missing:
+        print(f"ERROR: missing env vars: {', '.join(missing)}", file=sys.stderr)
+        sys.exit(1)
+
+    if not local_dir.is_dir():
+        print(f"ERROR: local directory not found: {local_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    bucket = env["SEED_BUCKET_NAME"]
+    endpoint = env["SEED_BUCKET_ENDPOINT"]
+    prefix = "rulebooks/v1"
+
+    # Build S3 client pointing at R2
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=env["SEED_BUCKET_ACCESS_KEY"],
+        aws_secret_access_key=env["SEED_BUCKET_SECRET_KEY"],
+        region_name=env.get("SEED_BUCKET_REGION", "auto"),
+        config=Config(signature_version="s3v4", s3={"addressing_style": "virtual"}),
+    )
+
+    uploaded = 0
+    skipped = 0
+    failed = 0
+
+    # Collect and sort PDFs for determinism
+    pdfs = sorted(local_dir.glob("*_rulebook.pdf"))
+    total = len(pdfs)
+    if total == 0:
+        print(f"WARN: no *_rulebook.pdf found in {local_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Found {total} PDF files in {local_dir}")
+    print(f"Target: s3://{bucket}/{prefix}/")
+    print()
+
+    with open(out_tsv, "w", encoding="utf-8") as tsv:
+        for i, pdf in enumerate(pdfs, start=1):
+            base = pdf.name
+            slug = base.removesuffix("_rulebook.pdf")
+            key = f"{prefix}/{base}"
+
+            try:
+                local_sha = sha256_of(pdf)
+            except Exception as exc:
+                print(f"  [{i:3}/{total}] ERROR sha256 failed for {base}: {exc}", file=sys.stderr)
+                failed += 1
+                continue
+
+            # Check remote metadata for idempotency
+            remote_sha = None
+            try:
+                head = s3.head_object(Bucket=bucket, Key=key)
+                remote_sha = head.get("Metadata", {}).get("sha256")
+            except ClientError as exc:
+                if exc.response.get("Error", {}).get("Code") not in ("404", "NoSuchKey"):
+                    print(f"  [{i:3}/{total}] head_object error for {base}: {exc}", file=sys.stderr)
+
+            if remote_sha == local_sha:
+                print(f"  [{i:3}/{total}] SKIP  {slug}  (sha matches)")
+                skipped += 1
+            else:
+                try:
+                    with open(pdf, "rb") as fh:
+                        s3.put_object(
+                            Bucket=bucket,
+                            Key=key,
+                            Body=fh,
+                            ContentType="application/pdf",
+                            Metadata={"sha256": local_sha},
+                        )
+                    size_mb = pdf.stat().st_size / (1024 * 1024)
+                    print(f"  [{i:3}/{total}] UP    {slug}  ({local_sha[:12]}..., {size_mb:.1f}MB)")
+                    uploaded += 1
+                except Exception as exc:
+                    print(f"  [{i:3}/{total}] FAIL  {slug}: {exc}", file=sys.stderr)
+                    failed += 1
+                    continue
+
+            tsv.write(f"{slug}\t{local_sha}\n")
+
+    print()
+    print(f"Summary: {uploaded} uploaded, {skipped} skipped, {failed} failed")
+    print(f"Wrote {out_tsv}")
+    sys.exit(0 if failed == 0 else 2)
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/scripts/verify-bgg-metadata.py
+++ b/infra/scripts/verify-bgg-metadata.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Query BGG XML API2 for a list of bggIds and return the canonical title,
+year published, and description.
+
+Usage: python verify-bgg-metadata.py 181 421006 373106 164928 338111 380607
+"""
+
+import sys
+import time
+import urllib.request
+import xml.etree.ElementTree as ET
+
+
+def fetch_bgg(bgg_id: int) -> dict:
+    url = f"https://boardgamegeek.com/xmlapi2/thing?id={bgg_id}&stats=0"
+    req = urllib.request.Request(url, headers={"User-Agent": "meepleai-seed-verify/1.0"})
+    with urllib.request.urlopen(req, timeout=20) as r:
+        xml = r.read().decode("utf-8")
+
+    root = ET.fromstring(xml)
+    item = root.find("item")
+    if item is None:
+        return {"bggId": bgg_id, "error": "no item"}
+
+    # Primary name
+    primary = next(
+        (n.get("value") for n in item.findall("name") if n.get("type") == "primary"),
+        None,
+    )
+
+    year_elem = item.find("yearpublished")
+    year = year_elem.get("value") if year_elem is not None else None
+
+    desc_elem = item.find("description")
+    desc = (desc_elem.text or "").strip() if desc_elem is not None else ""
+    desc_preview = desc[:200].replace("\n", " ")
+
+    return {
+        "bggId": bgg_id,
+        "name": primary,
+        "year": year,
+        "description_preview": desc_preview,
+    }
+
+
+def main():
+    ids = [int(x) for x in sys.argv[1:]]
+    if not ids:
+        print("Usage: verify-bgg-metadata.py <bggId> [bggId...]", file=sys.stderr)
+        sys.exit(1)
+
+    for i, bgg_id in enumerate(ids):
+        if i > 0:
+            time.sleep(1.5)  # BGG rate limit politeness
+        try:
+            info = fetch_bgg(bgg_id)
+            print(f"\n=== bggId {bgg_id} ===")
+            print(f"  Name: {info.get('name')}")
+            print(f"  Year: {info.get('year')}")
+            print(f"  Desc: {info.get('description_preview')}...")
+        except Exception as exc:
+            print(f"\n=== bggId {bgg_id} ===")
+            print(f"  ERROR: {exc}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Completes the seed-catalog blob migration (plan: `docs/superpowers/plans/2026-04-08-seed-catalog-blob-migration.md`).

On next merge to `main-staging` + green CI + auto-deploy, `meepleai.app` will come up with **159 games** pre-indexed in the catalog and RAG-ready.

- **122 existing games** migrated from local `pdf:` entries to `pdfBlobKey` + `pdfSha256` + `pdfVersion` pointing at `meepleai-seeds/rulebooks/v1/` on Cloudflare R2.
- **14 new games** (from PR #267 bulk import) added to `staging.yml` only, with metadata sourced from `data/rulebook/manifest.json` and hardcoded BGG IDs for photosynthesis / sagrada / santorini / villainous.
- All 136 rulebook PDFs (~1.4 GB) uploaded to R2 `meepleai-seeds/rulebooks/v1/` with sha256 metadata.
- Staging server `/opt/meepleai/secrets/storage.secret` updated with `SEED_BUCKET_*` credentials.
- Added Python equivalents of bash scripts (`upload-seed-pdfs.py`, `patch-manifest-from-hashes.py`, `fill-skeleton-entries.py`) so operators on Windows without bash/yq/aws-cli can run the same workflow.

## Manifest stats

| File | Games | With pdfBlobKey | Duplicates | TODOs | bggId=0 |
|------|-------|-----------------|------------|-------|---------|
| staging.yml | 159 | 136 | 0 | 0 | 0 |
| dev.yml | 145 | 122 | 0 | 0 | 0 |
| prod.yml | 145 | 122 | 0 | 0 | 0 |

## Deploy flow

1. Merge this PR → `main-dev`
2. Merge `main-dev` → `main-staging` (triggers CI + auto-deploy)
3. `CatalogSeedLayer` (from PR #286) downloads rulebooks from R2 via `ISeedBlobReader`, hashes them against `pdfSha256`, writes them to primary blob storage, and kicks DocumentProcessing + KnowledgeBase indexing through MediatR
4. ~30 min Quartz-based indexing populates embeddings, chunks, FAQs
5. Users land on fully populated catalog

## Test plan

- [x] YAML validation: all 3 manifests parse, 0 duplicates, 0 invalid bggIds, 0 TODO markers
- [x] `ManifestValidationTests` (6 tests) — pass
- [x] `PdfSeederBlobTests` (6 tests) — pass
- [ ] Post-merge: verify `meepleai.app/api/v1/catalog/games` returns 159 entries after staging auto-deploy
- [ ] Post-merge: spot-check a few games' RAG endpoints return indexed content

## Follow-up

- Rotate the shared R2 API token (currently readwrite, should become readonly for runtime)
- Mirror the 14 new games into `dev.yml` / `prod.yml` if they should be available outside staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)