### PR TITLE
feat(library): use RatingStars in GameHeader

### DIFF
--- a/apps/web/src/components/library/GameHeader.tsx
+++ b/apps/web/src/components/library/GameHeader.tsx
@@ -1,7 +1,8 @@
-import { Star, Users, Clock } from 'lucide-react';
+import { Users, Clock } from 'lucide-react';
 import Image from 'next/image';
 
 import { Badge } from '@/components/ui/data-display/badge';
+import { RatingStars } from '@/components/ui/data-display/rating-stars';
 
 interface GameHeaderProps {
   title: string;
@@ -60,16 +61,9 @@ export function GameHeader({
           </p>
         )}
 
+        {rating != null && <RatingStars rating={rating} maxRating={10} size="sm" showValue />}
+
         <div className="flex items-center flex-wrap gap-2">
-          {rating != null && (
-            <Badge
-              variant="secondary"
-              className="gap-1 bg-[hsl(var(--e-game))]/15 text-[hsl(var(--e-game))] border-[hsl(var(--e-game))]/30"
-            >
-              <Star className="w-3 h-3 fill-current" />
-              {rating.toFixed(1)}
-            </Badge>
-          )}
           {playerLabel && (
             <Badge variant="secondary" className="gap-1">
               <Users className="w-3 h-3" />

--- a/apps/web/src/components/library/__tests__/GameHeader.test.tsx
+++ b/apps/web/src/components/library/__tests__/GameHeader.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+
+import { GameHeader } from '../GameHeader';
+
+describe('GameHeader', () => {
+  describe('rating display', () => {
+    it('renders RatingStars when rating is provided', () => {
+      render(<GameHeader title="Catan" rating={7.8} />);
+      // RatingStars renders 5 stars with the numeric value next to them
+      expect(screen.getByText('7.8')).toBeInTheDocument();
+    });
+
+    it('hides rating row when rating is null', () => {
+      render(<GameHeader title="Catan" rating={null} />);
+      // No rating number should be displayed
+      expect(screen.queryByText(/\d+\.\d+/)).not.toBeInTheDocument();
+    });
+
+    it('hides rating row when rating is undefined', () => {
+      render(<GameHeader title="Catan" />);
+      expect(screen.queryByText(/\d+\.\d+/)).not.toBeInTheDocument();
+    });
+
+    it('renders a full 5-star display via RatingStars (not single inline star)', () => {
+      // This test drives the TDD red→green cycle for issue #290:
+      // Before: inline Badge with 1 <Star /> icon
+      // After:  <RatingStars /> component with 5 star icons (10-point BGG → 5-star scale)
+      const { container } = render(<GameHeader title="Catan" rating={7.8} />);
+      const svgs = container.querySelectorAll('svg');
+      expect(svgs.length).toBeGreaterThanOrEqual(5);
+    });
+  });
+
+  describe('metadata badges', () => {
+    it('renders player range badge when both players provided', () => {
+      render(<GameHeader title="Catan" minPlayers={3} maxPlayers={6} />);
+      expect(screen.getByText(/3–6 giocatori/)).toBeInTheDocument();
+    });
+
+    it('renders single-player label when min equals max', () => {
+      render(<GameHeader title="Solo" minPlayers={1} maxPlayers={1} />);
+      expect(screen.getByText(/1 giocatori/)).toBeInTheDocument();
+    });
+
+    it('renders duration badge when playing time provided', () => {
+      render(<GameHeader title="Catan" playingTimeMinutes={60} />);
+      expect(screen.getByText(/60 min/)).toBeInTheDocument();
+    });
+
+    it('omits player badge when players missing', () => {
+      render(<GameHeader title="Catan" minPlayers={null} maxPlayers={null} />);
+      expect(screen.queryByText(/giocatori/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('header content', () => {
+    it('renders game title', () => {
+      render(<GameHeader title="Brass: Birmingham" />);
+      expect(screen.getByRole('heading', { name: 'Brass: Birmingham' })).toBeInTheDocument();
+    });
+
+    it('renders publisher with year when both provided', () => {
+      render(<GameHeader title="Catan" publisher="Mayfair" year={1995} />);
+      expect(screen.getByText(/Mayfair.*1995/)).toBeInTheDocument();
+    });
+
+    it('renders only publisher when year missing', () => {
+      render(<GameHeader title="Catan" publisher="Mayfair" />);
+      expect(screen.getByText('Mayfair')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/showcase/stories/metadata.ts
+++ b/apps/web/src/components/showcase/stories/metadata.ts
@@ -67,7 +67,7 @@ export const STORY_METADATA: StoryMeta[] = [
     title: 'RatingStars',
     category: 'Data Display',
     description:
-      '[ORPHAN] Star rating display with BGG scale conversion. Public API variant — MeepleCard uses the internal parts/Rating instead.',
+      'Star rating display with BGG 10-point scale conversion. Supports half-stars. Used by GameHeader.',
     controlCount: 5,
     presetCount: 4,
   },

--- a/apps/web/src/components/ui/data-display/rating-stars.tsx
+++ b/apps/web/src/components/ui/data-display/rating-stars.tsx
@@ -1,17 +1,12 @@
 /**
- * @status ORPHAN — public API variant, not yet consumed in pages.
+ * RatingStars — star rating display with configurable scale and size.
  *
- * A richer alternative to the internal `meeple-card/parts/Rating.tsx` used by
- * Grid/List/Featured card variants. Supports sizes, half-stars, showValue, and
- * muted variant — features the internal one lacks.
+ * Use this on pages OUTSIDE the `MeepleCard` system (e.g., `GameHeader`, review
+ * lists, game detail hero). `MeepleCard` itself uses the internal token-based
+ * `parts/Rating.tsx` for its grid/list/featured variants.
  *
- * **When to use this instead of parts/Rating:**
- * - On pages that are NOT a MeepleCard (e.g., game detail header, reviews list).
- * - When you need the "muted" variant or configurable size.
- *
- * **Why not consumed today:** MeepleCard uses its internal token-based Rating;
- * non-card rating UIs haven't been built yet. Integrate when a dedicated rating
- * surface (reviews, game detail hero) ships.
+ * Features: half-stars, BGG 10-point → 5-star conversion, muted variant,
+ * optional numeric value display.
  */
 
 import React from 'react';


### PR DESCRIPTION
## Summary

Phase 1 of the orphan components execution plan — integrates `RatingStars` into `GameHeader.tsx`, replacing the inline single-star Badge.

**Target parent:** `chore/showcase-orphan-audit` (PR #298) — this PR depends on the `@status ORPHAN` annotations introduced there. After #298 merges to `main-dev`, this PR can be re-targeted or rebased to `main-dev` directly.

## Design decision

Original plan: drop-in replace the inline `<Star>` inside the rating Badge. **Problem discovered during TDD:** the Badge was a single-star icon pattern (design-consistent with Users/Clock badges below it). `RatingStars` renders 5 stars + value — too wide for a Badge chip.

**Resolution:** Extract rating into a **dedicated row above the metadata badges**. Rationale:
1. 5-star display gives more visual prominence to the most important game metric
2. Preserves design consistency of the remaining Users/Clock Badges
3. Better information density for users scanning game details

## Changes

**`apps/web/src/components/library/GameHeader.tsx`:**
- Remove `Star` import from `lucide-react`
- Add `RatingStars` import from `@/components/ui/data-display/rating-stars`
- Extract rating into a dedicated row between the publisher/year line and the metadata badges
- Remove inline `<Badge>` wrapping the single-star rating

**`apps/web/src/components/library/__tests__/GameHeader.test.tsx` (new):**
- 11 unit tests covering: rating display (including TDD red→green test counting SVG stars), metadata badges, header content
- Follows project testing patterns (Vitest + Testing Library)

**`apps/web/src/components/ui/data-display/rating-stars.tsx`:**
- Remove `@status ORPHAN` JSDoc (component now has a production consumer)
- Replace with clarifying JSDoc on when to use this vs the internal MeepleCard `parts/Rating.tsx`

**`apps/web/src/components/showcase/stories/metadata.ts`:**
- Remove `[ORPHAN]` prefix from `rating-stars` story description
- Update description to mention GameHeader as consumer

## Test plan

- [x] 11/11 unit tests pass (`pnpm test GameHeader --run`)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (0 errors, warnings unchanged from baseline)
- [x] TDD red→green verified (1 svg before → 5 svgs after `RatingStars` integration)
- [ ] Visual smoke test `/library/games/[id]` — verify 5-star row renders above metadata badges
- [ ] PR review against parent branch

## DoD (from orphan-components-execution-plan.md Phase 1)

- [x] GameHeader consumes RatingStars
- [x] Unit test for GameHeader rating display
- [x] `@status ORPHAN` removed from source
- [x] `[ORPHAN]` removed from showcase metadata
- [x] Typecheck + lint clean
- [x] PR opened against parent branch
- [ ] Issue #290 closed by merge

## Issue references

Closes meepleAi-app/meepleai-monorepo#290

🤖 Generated with [Claude Code](https://claude.com/claude-code)
