### PR TITLE
feat(chat): wire PageTransition pilot behind feature flag

### DIFF
--- a/apps/web/src/app/(chat)/layout.tsx
+++ b/apps/web/src/app/(chat)/layout.tsx
@@ -3,12 +3,27 @@
  *
  * Uses UserShell for the chat experience.
  * (chat) is a sibling of (authenticated), so it needs its own shell wrapper.
+ *
+ * Issue #293 — PageTransition pilot: when NEXT_PUBLIC_ENABLE_PAGE_TRANSITIONS=true,
+ * wraps children in a fade transition. Feature-flagged to allow runtime A/B.
+ * Scope limited to the chat route group (smallest blast radius).
  */
+
+'use client';
 
 import { type ReactNode } from 'react';
 
 import { UserShell } from '@/components/layout/UserShell';
+import { PageTransition } from '@/components/ui/animations/PageTransition';
+
+const PAGE_TRANSITIONS_ENABLED = process.env.NEXT_PUBLIC_ENABLE_PAGE_TRANSITIONS === 'true';
 
 export default function ChatLayout({ children }: { children: ReactNode }) {
-  return <UserShell>{children}</UserShell>;
+  const content = PAGE_TRANSITIONS_ENABLED ? (
+    <PageTransition variant="fade">{children}</PageTransition>
+  ) : (
+    children
+  );
+
+  return <UserShell>{content}</UserShell>;
 }

--- a/apps/web/src/components/showcase/stories/metadata.ts
+++ b/apps/web/src/components/showcase/stories/metadata.ts
@@ -175,7 +175,7 @@ export const STORY_METADATA: StoryMeta[] = [
     title: 'PageTransition',
     category: 'Animations',
     description:
-      '[ORPHAN] Smooth page transitions via Framer Motion. Not wired to any layout — integration deferred to UX motion pass.',
+      'Smooth page transitions via Framer Motion. Pilot active in (chat) layout behind NEXT_PUBLIC_ENABLE_PAGE_TRANSITIONS flag.',
     controlCount: 1,
     presetCount: 3,
   },

--- a/apps/web/src/components/ui/animations/PageTransition.tsx
+++ b/apps/web/src/components/ui/animations/PageTransition.tsx
@@ -6,14 +6,8 @@
  * Provides smooth page transition animations for route changes (fade / slide /
  * scale) via Framer Motion. Use in layout.tsx or page-specific layouts.
  *
- * @status ORPHAN — never wired into any layout. Candidate hosts:
- *   - `app/layout.tsx` (global, high blast radius)
- *   - `(authenticated)/layout.tsx` (scoped to authed pages)
- *   - `(chat)/layout.tsx` (scoped to chat routes)
- *
- * Integration is non-trivial: wrapping layout `children` changes animation
- * timing across the app and can interact badly with Next.js streaming and
- * Suspense boundaries. Defer until a UX motion pass owns the decision.
+ * **Active consumers:**
+ * - `(chat)/layout.tsx` — pilot behind `NEXT_PUBLIC_ENABLE_PAGE_TRANSITIONS` flag (#293)
  *
  * Usage:
  * <PageTransition>


### PR DESCRIPTION
## Summary

Phase 2b of the orphan components execution plan — wires `PageTransition` into `(chat)/layout.tsx` as a pilot, behind `NEXT_PUBLIC_ENABLE_PAGE_TRANSITIONS` feature flag.

**Gate:** G0.3 Option A signed (docs/development/page-transition-decision.md)

## Changes

- `apps/web/src/app/(chat)/layout.tsx` → converted to client component, conditionally wraps children in `<PageTransition variant='fade'>` based on env var
- `apps/web/src/components/ui/animations/PageTransition.tsx` → removed `@status ORPHAN` JSDoc
- `apps/web/src/components/showcase/stories/metadata.ts` → removed `[ORPHAN]` prefix

## Feature flag strategy

```bash
# Default (production): transitions OFF
pnpm build

# Pilot enabled: transitions ON for (chat) routes only
NEXT_PUBLIC_ENABLE_PAGE_TRANSITIONS=true pnpm build
```

Zero behavior change in production until explicitly enabled. Staging validation deferred to post-merge QA.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (pre-commit hook verified)
- [x] Backend build clean (pre-push hook verified)
- [ ] Post-merge: staging deploy with flag ON, manual navigation QA
- [ ] Post-merge: Lighthouse delta ≤ 5%

Closes meepleAi-app/meepleai-monorepo#293

🤖 Generated with [Claude Code](https://claude.com/claude-code)