### PR TITLE
test(chat): add ChatMessageList characterization tests (#292 prereq)

### DIFF
--- a/apps/web/src/components/chat-unified/__tests__/ChatMessageList.test.tsx
+++ b/apps/web/src/components/chat-unified/__tests__/ChatMessageList.test.tsx
@@ -1,12 +1,21 @@
 /**
- * ChatMessageList — Windowed Slice Tests
- * Verifica che solo gli ultimi WINDOW_SIZE=50 messaggi siano renderizzati
- * e che il bottone "messaggi precedenti" carichi quelli nascosti.
+ * ChatMessageList Tests
+ *
+ * Windowed slice tests (pre-existing) + characterization tests (#292 prereq).
+ *
+ * The characterization tests pin behavior of:
+ * - Feedback round-trip (helpful / not-helpful / error silent-fail)
+ * - Streaming token accumulation
+ * - Per-message feedback state isolation
+ * - Feedback button visibility based on gameId/threadId
+ *
+ * Added as safety net before ChatMessageList is refactored (Issue #292).
+ * See docs/development/chat-message-list-behavior-baseline.md for rationale.
  */
 
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 
 import {
   ChatMessageList,
@@ -27,6 +36,44 @@ vi.mock('../ResponseMetaBadge', () => ({
 }));
 vi.mock('../TechnicalDetailsPanel', () => ({
   TechnicalDetailsPanel: () => null,
+}));
+
+// FeedbackButtons stub — exposes minimal API for tests to drive feedback flow
+vi.mock('@/components/ui/meeple/feedback-buttons', () => ({
+  FeedbackButtons: ({
+    value,
+    onFeedbackChange,
+    isLoading,
+  }: {
+    value: 'helpful' | 'not-helpful' | null;
+    onFeedbackChange: (v: 'helpful' | 'not-helpful' | null, comment?: string) => void;
+    isLoading: boolean;
+    showCommentOnNegative?: boolean;
+    size?: string;
+  }) => (
+    <div
+      data-testid="feedback-buttons"
+      data-value={value ?? 'null'}
+      data-loading={String(isLoading)}
+    >
+      <button type="button" onClick={() => onFeedbackChange('helpful')}>
+        Helpful
+      </button>
+      <button type="button" onClick={() => onFeedbackChange('not-helpful', 'Bad response')}>
+        Not helpful
+      </button>
+    </div>
+  ),
+}));
+
+// api mock — shared across tests
+const submitKbFeedbackMock = vi.fn();
+vi.mock('@/lib/api', () => ({
+  api: {
+    knowledgeBase: {
+      submitKbFeedback: (...args: unknown[]) => submitKbFeedbackMock(...args),
+    },
+  },
 }));
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -61,7 +108,7 @@ const defaultProps = {
   messagesEndRef: { current: null } as React.RefObject<HTMLDivElement | null>,
 };
 
-// ── Tests ─────────────────────────────────────────────────────────────────────
+// ── Tests: Windowed slice (pre-existing) ──────────────────────────────────────
 
 describe('ChatMessageList — windowed slice', () => {
   it('renders all messages when count is ≤ 50', () => {
@@ -74,11 +121,8 @@ describe('ChatMessageList — windowed slice', () => {
   it('renders only last 50 messages when count is 80', () => {
     const messages = makeMessages(80);
     render(<ChatMessageList {...defaultProps} messages={messages} />);
-    // Deve renderizzare esattamente 50 nodi
     expect(screen.getAllByTestId(/^message-/).length).toBe(50);
-    // L'ultimo messaggio è visibile
     expect(screen.getByText('Messaggio numero 79')).toBeInTheDocument();
-    // Il primo messaggio NON è visibile
     expect(screen.queryByText('Messaggio numero 0')).toBeNull();
   });
 
@@ -92,9 +136,7 @@ describe('ChatMessageList — windowed slice', () => {
     const messages = makeMessages(80);
     render(<ChatMessageList {...defaultProps} messages={messages} />);
     fireEvent.click(screen.getByRole('button', { name: /30 messaggi precedenti/ }));
-    // Ora tutti 80 sono visibili
     expect(screen.getAllByTestId(/^message-/).length).toBe(80);
-    // Il bottone scompare
     expect(screen.queryByRole('button', { name: /messaggi precedenti/ })).toBeNull();
   });
 
@@ -112,5 +154,201 @@ describe('ChatMessageList — windowed slice', () => {
       />
     );
     expect(screen.getByTestId('message-streaming')).toBeInTheDocument();
+  });
+});
+
+// ── Tests: Characterization — Feedback flow (#292 safety net) ─────────────────
+
+describe('ChatMessageList — feedback flow characterization', () => {
+  beforeEach(() => {
+    submitKbFeedbackMock.mockReset();
+  });
+
+  const assistantMessage: ChatMessageItem = {
+    id: 'msg-assistant-1',
+    role: 'assistant',
+    content: 'Puoi giocare 3 carte.',
+  };
+
+  it('submits helpful feedback and calls api.knowledgeBase.submitKbFeedback with correct payload', async () => {
+    submitKbFeedbackMock.mockResolvedValue(undefined);
+
+    render(
+      <ChatMessageList
+        {...defaultProps}
+        messages={[assistantMessage]}
+        gameId="game-1"
+        threadId="thread-42"
+      />
+    );
+
+    const helpfulButton = screen.getByRole('button', { name: 'Helpful' });
+    fireEvent.click(helpfulButton);
+
+    await waitFor(() => {
+      expect(submitKbFeedbackMock).toHaveBeenCalledWith('game-1', {
+        chatSessionId: 'thread-42',
+        messageId: 'msg-assistant-1',
+        outcome: 'helpful',
+        comment: undefined,
+      });
+    });
+  });
+
+  it('submits not-helpful feedback with comment and transforms outcome to snake_case', async () => {
+    submitKbFeedbackMock.mockResolvedValue(undefined);
+
+    render(
+      <ChatMessageList
+        {...defaultProps}
+        messages={[assistantMessage]}
+        gameId="game-1"
+        threadId="thread-42"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Not helpful' }));
+
+    await waitFor(() => {
+      expect(submitKbFeedbackMock).toHaveBeenCalledWith('game-1', {
+        chatSessionId: 'thread-42',
+        messageId: 'msg-assistant-1',
+        outcome: 'not_helpful',
+        comment: 'Bad response',
+      });
+    });
+  });
+
+  it('silently swallows API errors on feedback submission (no error bubbles to user)', async () => {
+    submitKbFeedbackMock.mockRejectedValue(new Error('Network down'));
+
+    // If error bubbled, React would log or throw — capture console.error to ensure none
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    render(
+      <ChatMessageList
+        {...defaultProps}
+        messages={[assistantMessage]}
+        gameId="game-1"
+        threadId="thread-42"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Helpful' }));
+
+    await waitFor(() => {
+      expect(submitKbFeedbackMock).toHaveBeenCalled();
+    });
+
+    // Key assertion: error did NOT re-throw or show toast (silent catch block at line 124-125)
+    expect(consoleErrorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Network down'),
+      expect.anything()
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('isolates feedback state per message — setting feedback on msg-1 does not affect msg-2', async () => {
+    submitKbFeedbackMock.mockResolvedValue(undefined);
+
+    const messages: ChatMessageItem[] = [
+      { id: 'msg-a', role: 'assistant', content: 'Risposta A' },
+      { id: 'msg-b', role: 'assistant', content: 'Risposta B' },
+    ];
+
+    render(
+      <ChatMessageList {...defaultProps} messages={messages} gameId="game-1" threadId="thread-42" />
+    );
+
+    const feedbackStubs = screen.getAllByTestId('feedback-buttons');
+    expect(feedbackStubs).toHaveLength(2);
+    expect(feedbackStubs[0]).toHaveAttribute('data-value', 'null');
+    expect(feedbackStubs[1]).toHaveAttribute('data-value', 'null');
+
+    // Click helpful inside the first feedback stub
+    const firstHelpful = feedbackStubs[0].querySelector('button') as HTMLButtonElement;
+    fireEvent.click(firstHelpful);
+
+    await waitFor(() => {
+      // After the round-trip, msg-a should be 'helpful'; msg-b unchanged
+      const updatedStubs = screen.getAllByTestId('feedback-buttons');
+      expect(updatedStubs[0]).toHaveAttribute('data-value', 'helpful');
+      expect(updatedStubs[1]).toHaveAttribute('data-value', 'null');
+    });
+  });
+
+  it('hides feedback buttons when gameId is missing', () => {
+    render(
+      <ChatMessageList {...defaultProps} messages={[assistantMessage]} threadId="thread-42" />
+    );
+    expect(screen.queryByTestId('feedback-buttons')).toBeNull();
+  });
+
+  it('hides feedback buttons when threadId is missing', () => {
+    render(<ChatMessageList {...defaultProps} messages={[assistantMessage]} gameId="game-1" />);
+    expect(screen.queryByTestId('feedback-buttons')).toBeNull();
+  });
+
+  it('does NOT render feedback buttons on user messages', () => {
+    const userMessage: ChatMessageItem = {
+      id: 'msg-user-1',
+      role: 'user',
+      content: 'Quante carte posso giocare?',
+    };
+    render(
+      <ChatMessageList
+        {...defaultProps}
+        messages={[userMessage]}
+        gameId="game-1"
+        threadId="thread-42"
+      />
+    );
+    expect(screen.queryByTestId('feedback-buttons')).toBeNull();
+  });
+});
+
+// ── Tests: Characterization — Streaming (#292 safety net) ─────────────────────
+
+describe('ChatMessageList — streaming characterization', () => {
+  it('updates streaming bubble content when currentAnswer changes across rerenders', () => {
+    const { rerender } = render(
+      <ChatMessageList
+        {...defaultProps}
+        messages={[]}
+        streamState={{ ...baseStream, isStreaming: true, currentAnswer: 'Ciao' }}
+      />
+    );
+
+    expect(screen.getByTestId('message-streaming')).toHaveTextContent('Ciao');
+
+    rerender(
+      <ChatMessageList
+        {...defaultProps}
+        messages={[]}
+        streamState={{
+          ...baseStream,
+          isStreaming: true,
+          currentAnswer: 'Ciao, come posso aiutarti?',
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('message-streaming')).toHaveTextContent('Ciao, come posso aiutarti?');
+  });
+
+  it('shows status message with role="status" and aria-live="polite"', () => {
+    render(
+      <ChatMessageList
+        {...defaultProps}
+        messages={[]}
+        streamState={{ ...baseStream, statusMessage: 'Collegamento in corso...' }}
+      />
+    );
+
+    const status = screen.getByTestId('stream-status');
+    expect(status).toHaveAttribute('role', 'status');
+    expect(status).toHaveAttribute('aria-live', 'polite');
+    expect(status).toHaveTextContent('Collegamento in corso...');
   });
 });


### PR DESCRIPTION
## Summary

Phase 4 of the orphan components execution plan — **safety net** for the pending `ChatMessageList` refactor in Issue #292.

**Does NOT include the refactor itself.** This PR adds characterization tests that pin current behavior so the refactor PR can be validated without regressions.

## Background

G0.1 audit (docs/development/chat-message-list-behavior-baseline.md) revealed current test coverage was ~35% and **insufficient** to safely reduce the component by 50% (311 → ~150 lines). Critical features like feedback submission, streaming token accumulation, and citation rendering had **zero coverage** in the component's own test file.

## What's added (9 new tests)

### Feedback flow (7 tests)
- `submits helpful feedback` — full round-trip with API payload verification
- `submits not-helpful feedback with comment` — verifies outcome transform to snake_case (`not_helpful`)
- `silently swallows API errors` — characterizes line 124-125 catch block
- `isolates feedback state per message` — verifies feedbackMap independence
- `hides feedback buttons when gameId missing`
- `hides feedback buttons when threadId missing`
- `does NOT render feedback buttons on user messages`

### Streaming (2 tests)
- `updates streaming bubble content across rerenders` — token accumulation
- `shows status message with a11y attributes` — role=status, aria-live=polite

## Mocks added

- **FeedbackButtons stub** — exposes `helpful`/`not-helpful` trigger buttons + state visibility
- **`api.knowledgeBase.submitKbFeedback` mock** — shared with per-test reset

## Test results

```
 Test Files  1 passed (1)
      Tests  15 passed (15)  (6 pre-existing + 9 new)
```

## Deferred to refactor PR

The G0.1 audit identified **17 characterization tests** total:
- ✅ **5 CRITICAL added** (feedback round-trip + streaming + state isolation)
- ⏳ **7 HIGH priority deferred** (model downgrade banner, TTS integration, citations rendering, strategy tier badge, etc.)
- ⏳ **5 MEDIUM priority deferred** (edge cases, a11y, technical details panel)

Rationale: the 5 CRITICAL tests cover the **data integrity** paths (feedback API round-trip, streaming token accumulation). The remaining 12 cover **visual rendering** paths which are less risky in refactor context (visual regressions are caught by design review).

## Partial DoD for #292

This PR is marked as **partial progress** on #292. The actual refactor (ChatMessageList 311 → ~150 lines) is deferred to a follow-up PR once more characterization tests are added (estimated 8-12h work).

- [x] CRITICAL characterization tests added (5 of 5)
- [ ] HIGH priority tests (7 deferred)
- [ ] MEDIUM priority tests (5 deferred)
- [ ] Actual refactor (deferred)

## Test plan

- [x] `pnpm test ChatMessageList --run` → 15/15 pass
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (pre-commit hook)
- [x] Backend build clean (pre-push hook)
- [ ] Post-merge: ensure these tests run in CI on every PR that touches ChatMessageList.tsx

Refs meepleAi-app/meepleai-monorepo#292
Refs docs/development/chat-message-list-behavior-baseline.md
Refs docs/development/orphan-components-execution-plan.md Phase 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)