### PR TITLE
feat(web): desktop UX redesign phase 2 — dashboard gaming hub

### DIFF
--- a/apps/web/src/app/(authenticated)/dashboard/__tests__/dashboard-client.flag.test.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/__tests__/dashboard-client.flag.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// Mock the v2 composition so we don't need to mock all its downstream deps
+vi.mock('../v2', () => ({
+  DashboardClientV2: () => <div data-testid="dashboard-v2">V2 Dashboard</div>,
+}));
+
+// Mock legacy dependencies that would otherwise break in jsdom
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => '/dashboard',
+}));
+
+vi.mock('@/components/auth/AuthProvider', () => ({
+  useAuth: () => ({ user: { id: 'u1', displayName: 'Marco' } }),
+}));
+
+vi.mock('@/lib/stores/dashboard-store', () => ({
+  useDashboardStore: () => ({
+    stats: null,
+    recentSessions: [],
+    games: [],
+    totalGamesCount: 0,
+    trendingGames: [],
+    isLoadingStats: false,
+    isLoadingGames: false,
+    isLoadingTrending: false,
+    isLoadingSessions: false,
+    fetchStats: vi.fn(),
+    fetchGames: vi.fn(),
+    fetchRecentSessions: vi.fn(),
+    fetchTrendingGames: vi.fn(),
+    updateFilters: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/dashboard/StatsRow', () => ({
+  StatsRow: () => <div data-testid="stats-row" />,
+}));
+
+vi.mock('@/components/dashboard/WelcomeHero', () => ({
+  WelcomeHero: () => <div data-testid="welcome-hero" />,
+}));
+
+vi.mock('@/components/layout/FloatingActionPill', () => ({
+  FloatingActionPill: () => <div data-testid="floating-action-pill" />,
+}));
+
+const originalEnv = process.env.NEXT_PUBLIC_UX_REDESIGN;
+
+describe('DashboardClient feature flag branch', () => {
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.NEXT_PUBLIC_UX_REDESIGN;
+    else process.env.NEXT_PUBLIC_UX_REDESIGN = originalEnv;
+    vi.resetModules();
+  });
+
+  it('renders DashboardClientV2 when flag is on', async () => {
+    process.env.NEXT_PUBLIC_UX_REDESIGN = 'true';
+    vi.resetModules();
+    const mod = await import('../dashboard-client');
+    const DashboardClient =
+      (mod as { DashboardClient?: React.ComponentType }).DashboardClient ??
+      (mod as { default?: React.ComponentType }).default;
+    if (!DashboardClient) throw new Error('DashboardClient export not found');
+    render(<DashboardClient />);
+    expect(screen.getByTestId('dashboard-v2')).toBeInTheDocument();
+  });
+
+  it('does not render DashboardClientV2 when flag is off', async () => {
+    process.env.NEXT_PUBLIC_UX_REDESIGN = 'false';
+    vi.resetModules();
+    const mod = await import('../dashboard-client');
+    const DashboardClient =
+      (mod as { DashboardClient?: React.ComponentType }).DashboardClient ??
+      (mod as { default?: React.ComponentType }).default;
+    if (!DashboardClient) throw new Error('DashboardClient export not found');
+    render(<DashboardClient />);
+    expect(screen.queryByTestId('dashboard-v2')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(authenticated)/dashboard/dashboard-client.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/dashboard-client.tsx
@@ -23,8 +23,11 @@ import { StatsRow } from '@/components/dashboard/StatsRow';
 import { WelcomeHero } from '@/components/dashboard/WelcomeHero';
 import { FloatingActionPill } from '@/components/layout/FloatingActionPill';
 import type { SessionSummaryDto, TrendingGameDto, UserGameDto } from '@/lib/api/dashboard-client';
+import { isUxRedesignEnabled } from '@/lib/feature-flags';
 import { useDashboardStore } from '@/lib/stores/dashboard-store';
 import { cn } from '@/lib/utils';
+
+import { DashboardClientV2 } from './v2';
 
 // ─── Entity color tokens (CSS custom properties) ──────────────────────────────
 
@@ -626,6 +629,10 @@ export function DashboardClient() {
     fetchGames();
     // eslint-disable-next-line react-hooks/exhaustive-deps -- store actions are stable Zustand references
   }, []);
+
+  if (isUxRedesignEnabled()) {
+    return <DashboardClientV2 />;
+  }
 
   const firstName = user?.displayName?.split(' ')[0] ?? user?.displayName ?? 'Giocatore';
 

--- a/apps/web/src/app/(authenticated)/dashboard/v2/DashboardClientV2.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/v2/DashboardClientV2.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useEffect, useMemo } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import { useAuth } from '@/components/auth/AuthProvider';
+import { useMiniNavConfig } from '@/hooks/useMiniNavConfig';
+import { useCardHand } from '@/stores/use-card-hand';
+
+import { ChatRecentCards, type ChatRecentPreview } from './sections/ChatRecentCards';
+import { ContinueCarousel, type ContinueCarouselGame } from './sections/ContinueCarousel';
+import { FriendsRow, type FriendPreview } from './sections/FriendsRow';
+import { GreetingRow } from './sections/GreetingRow';
+import { HeroLiveSession, type LiveSessionPreview } from './sections/HeroLiveSession';
+import { KpiStrip } from './sections/KpiStrip';
+
+/**
+ * Phase 2 dashboard client — new layout with greeting, hero, KPI strip, carousel,
+ * chat cards, and friends row. Reads data from the existing useDashboardStore
+ * (fields not yet present in the store default to empty arrays / zeros).
+ */
+export function DashboardClientV2() {
+  const { user } = useAuth();
+  const router = useRouter();
+  const drawCard = useCardHand(s => s.drawCard);
+
+  // TODO(Phase 3): read from useDashboardStore once it exposes Phase 2 fields.
+  // For now we render the layout with empty defaults so the shell + hero empty
+  // state are visible and the page compiles without depending on data shape.
+  const liveSession: LiveSessionPreview | null = null;
+  const continueGames: ContinueCarouselGame[] = [];
+  const recentChats: ChatRecentPreview[] = [];
+  const activeFriends: FriendPreview[] = [];
+  const kpis = { games: 0, sessions: 0, friends: 0, chats: 0 };
+
+  // Memoize the mini-nav config so the structural key doesn't change across renders.
+  const miniNavConfig = useMemo(
+    () => ({
+      breadcrumb: 'Home · Gaming Hub',
+      tabs: [{ id: 'overview', label: 'Panoramica', href: '/dashboard' }],
+      activeTabId: 'overview',
+      primaryAction: {
+        label: 'Nuova partita',
+        icon: '＋',
+        onClick: () => router.push('/sessions/new'),
+      },
+    }),
+    [router]
+  );
+  useMiniNavConfig(miniNavConfig);
+
+  // Draw this page as a hand card for cross-page context memory
+  useEffect(() => {
+    drawCard({
+      id: 'section-dashboard',
+      entity: 'game',
+      title: 'Home',
+      href: '/dashboard',
+    });
+  }, [drawCard]);
+
+  const handleContinueSession = () => {
+    const session = liveSession as LiveSessionPreview | null;
+    if (session) {
+      router.push(`/sessions/live/${session.id}`);
+    } else {
+      router.push('/sessions/new');
+    }
+  };
+
+  const displayName = user?.displayName ?? 'giocatore';
+
+  return (
+    <div className="mx-auto max-w-[1440px] p-7 pb-12">
+      <GreetingRow
+        displayName={displayName}
+        subtitle="Ecco cosa succede nella tua tavola oggi"
+        stats={[
+          { label: 'Partite mese', value: String(kpis.sessions) },
+          { label: 'Giochi', value: String(kpis.games) },
+        ]}
+      />
+
+      <HeroLiveSession session={liveSession} onContinue={handleContinueSession} />
+
+      <KpiStrip kpis={kpis} />
+
+      <ContinueCarousel games={continueGames} />
+      <ChatRecentCards chats={recentChats} />
+      <FriendsRow friends={activeFriends} />
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/dashboard/v2/__tests__/ChatRecentCards.test.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/v2/__tests__/ChatRecentCards.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { ChatRecentCards } from '../sections/ChatRecentCards';
+
+describe('ChatRecentCards', () => {
+  const chats = [
+    {
+      id: 'c1',
+      gameName: 'Azul',
+      topic: 'Regola turno finale',
+      snippet: 'Il turno finale inizia quando un giocatore completa una riga orizzontale.',
+      confidence: 0.94,
+      timestamp: 'Oggi, 14:32',
+    },
+    {
+      id: 'c2',
+      gameName: 'Wingspan',
+      topic: 'Carte bonus a fine partita',
+      snippet: 'Le carte bonus vengono rivelate solo alla fine della partita.',
+      confidence: 0.98,
+      timestamp: 'Ieri, 21:15',
+    },
+  ];
+
+  it('renders the section header', () => {
+    render(<ChatRecentCards chats={chats} />);
+    expect(screen.getByText(/Chat recenti/i)).toBeInTheDocument();
+  });
+
+  it('renders all chat cards with titles and snippets', () => {
+    render(<ChatRecentCards chats={chats} />);
+    expect(screen.getByText('Azul · Regola turno finale')).toBeInTheDocument();
+    expect(screen.getByText('Wingspan · Carte bonus a fine partita')).toBeInTheDocument();
+    expect(screen.getAllByText(/accurata/i)).toHaveLength(2);
+  });
+
+  it('renders nothing when no chats', () => {
+    const { container } = render(<ChatRecentCards chats={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/src/app/(authenticated)/dashboard/v2/__tests__/ContinueCarousel.test.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/v2/__tests__/ContinueCarousel.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { ContinueCarousel } from '../sections/ContinueCarousel';
+
+describe('ContinueCarousel', () => {
+  const games = [
+    {
+      id: 'g1',
+      title: 'Azul',
+      subtitle: 'Plan B Games',
+      imageUrl: 'https://example.com/azul.jpg',
+      rating: 7.8,
+      players: '2–4',
+      duration: '45m',
+    },
+    {
+      id: 'g2',
+      title: 'Wingspan',
+      subtitle: 'Stonemaier',
+      rating: 8.1,
+      players: '1–5',
+      duration: '70m',
+    },
+  ];
+
+  it('renders the section header and see-all link', () => {
+    render(<ContinueCarousel games={games} />);
+    expect(screen.getByText(/Continua a giocare/i)).toBeInTheDocument();
+    expect(screen.getByText(/Vedi tutto/i)).toBeInTheDocument();
+  });
+
+  it('renders all provided games as cards', () => {
+    render(<ContinueCarousel games={games} />);
+    expect(screen.getByText('Azul')).toBeInTheDocument();
+    expect(screen.getByText('Wingspan')).toBeInTheDocument();
+  });
+
+  it('renders nothing when no games', () => {
+    const { container } = render(<ContinueCarousel games={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/src/app/(authenticated)/dashboard/v2/__tests__/DashboardClientV2.test.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/v2/__tests__/DashboardClientV2.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/dashboard',
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('@/components/auth/AuthProvider', () => ({
+  useAuth: () => ({
+    user: { id: 'u1', displayName: 'Marco' },
+  }),
+}));
+
+vi.mock('@/stores/use-card-hand', () => {
+  const state = {
+    cards: [],
+    pinnedIds: new Set(),
+    drawCard: vi.fn(),
+    pinCard: vi.fn(),
+    unpinCard: vi.fn(),
+  };
+  return {
+    useCardHand: (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state),
+  };
+});
+
+vi.mock('@/lib/stores/mini-nav-config-store', () => {
+  const state = {
+    config: null,
+    setConfig: vi.fn(),
+    clear: vi.fn(),
+  };
+  return {
+    useMiniNavConfigStore: (selector?: (s: typeof state) => unknown) =>
+      selector ? selector(state) : state,
+  };
+});
+
+import { DashboardClientV2 } from '../DashboardClientV2';
+
+describe('DashboardClientV2', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the greeting with the user name', () => {
+    render(<DashboardClientV2 />);
+    expect(screen.getByText('Marco')).toBeInTheDocument();
+  });
+
+  it('renders the KPI strip', () => {
+    render(<DashboardClientV2 />);
+    expect(screen.getByText(/libreria/i)).toBeInTheDocument();
+    expect(screen.getByText(/sessioni/i)).toBeInTheDocument();
+  });
+
+  it('renders the empty-state hero when no live session', () => {
+    render(<DashboardClientV2 />);
+    expect(screen.getByText(/Nessuna partita in corso/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(authenticated)/dashboard/v2/__tests__/FriendsRow.test.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/v2/__tests__/FriendsRow.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { FriendsRow } from '../sections/FriendsRow';
+
+describe('FriendsRow', () => {
+  const friends = [
+    { id: 'f1', name: 'Luca Marconi', status: 'Sta giocando Azul', presence: 'online' as const },
+    { id: 'f2', name: 'Sara Vitali', status: 'Online · 12 giochi', presence: 'online' as const },
+    { id: 'f3', name: 'Giulia Bianchi', status: 'Inattiva da 2 ore', presence: 'idle' as const },
+    { id: 'f4', name: 'Alessandro Rossi', status: 'Offline · ieri', presence: 'offline' as const },
+  ];
+
+  it('renders the section header', () => {
+    render(<FriendsRow friends={friends} />);
+    expect(screen.getByText(/Amici attivi/i)).toBeInTheDocument();
+  });
+
+  it('renders all 4 friends', () => {
+    render(<FriendsRow friends={friends} />);
+    expect(screen.getByText('Luca Marconi')).toBeInTheDocument();
+    expect(screen.getByText('Sara Vitali')).toBeInTheDocument();
+    expect(screen.getByText('Giulia Bianchi')).toBeInTheDocument();
+    expect(screen.getByText('Alessandro Rossi')).toBeInTheDocument();
+  });
+
+  it('renders initials from the name', () => {
+    render(<FriendsRow friends={[friends[0]]} />);
+    expect(screen.getByText('LM')).toBeInTheDocument();
+  });
+
+  it('renders nothing when empty', () => {
+    const { container } = render(<FriendsRow friends={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/src/app/(authenticated)/dashboard/v2/__tests__/GreetingRow.test.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/v2/__tests__/GreetingRow.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { GreetingRow } from '../sections/GreetingRow';
+
+describe('GreetingRow', () => {
+  it('renders the greeting with user display name', () => {
+    render(
+      <GreetingRow
+        displayName="Marco"
+        subtitle="Hai una partita in corso"
+        stats={[
+          { label: 'Partite mese', value: '24' },
+          { label: 'Win rate', value: '68%' },
+          { label: 'Tempo gioco', value: '42h' },
+        ]}
+      />
+    );
+    expect(screen.getByText(/Ciao/)).toBeInTheDocument();
+    expect(screen.getByText('Marco')).toBeInTheDocument();
+    expect(screen.getByText('Hai una partita in corso')).toBeInTheDocument();
+  });
+
+  it('renders all provided quick stats', () => {
+    render(
+      <GreetingRow
+        displayName="Anna"
+        subtitle="subtitle"
+        stats={[
+          { label: 'Partite mese', value: '24' },
+          { label: 'Win rate', value: '68%' },
+        ]}
+      />
+    );
+    expect(screen.getByText('24')).toBeInTheDocument();
+    expect(screen.getByText('Partite mese')).toBeInTheDocument();
+    expect(screen.getByText('68%')).toBeInTheDocument();
+    expect(screen.getByText('Win rate')).toBeInTheDocument();
+  });
+
+  it('omits the stats cluster when no stats provided', () => {
+    const { container } = render(<GreetingRow displayName="X" subtitle="Y" stats={[]} />);
+    expect(container.querySelector('[data-testid="greet-stats"]')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(authenticated)/dashboard/v2/__tests__/HeroLiveSession.test.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/v2/__tests__/HeroLiveSession.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+
+import { HeroLiveSession } from '../sections/HeroLiveSession';
+
+describe('HeroLiveSession', () => {
+  const baseSession = {
+    id: 'ses-1',
+    gameName: 'Azul',
+    locationName: 'Casa di Marco',
+    playerCount: 3,
+    roundCurrent: 4,
+    roundTotal: 6,
+    startedMinutesAgo: 38,
+  };
+
+  it('renders the session title and meta when a session is active', () => {
+    render(<HeroLiveSession session={baseSession} onContinue={() => {}} />);
+    expect(screen.getByText(/Serata Azul/)).toBeInTheDocument();
+    expect(screen.getByText(/Casa di Marco/)).toBeInTheDocument();
+    expect(screen.getByText(/In corso/i)).toBeInTheDocument();
+  });
+
+  it('calls onContinue when the primary action is clicked', async () => {
+    const onContinue = vi.fn();
+    const user = userEvent.setup();
+    render(<HeroLiveSession session={baseSession} onContinue={onContinue} />);
+    await user.click(screen.getAllByRole('button', { name: /Continua/i })[0]);
+    expect(onContinue).toHaveBeenCalled();
+  });
+
+  it('renders the empty state when no active session', () => {
+    render(<HeroLiveSession session={null} onContinue={() => {}} />);
+    expect(screen.getByText(/Nessuna partita/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Inizia nuova partita/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(authenticated)/dashboard/v2/__tests__/KpiStrip.test.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/v2/__tests__/KpiStrip.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { KpiStrip } from '../sections/KpiStrip';
+
+describe('KpiStrip', () => {
+  const kpis = {
+    games: 47,
+    sessions: 128,
+    friends: 8,
+    chats: 36,
+  };
+
+  it('renders all 4 KPI values', () => {
+    render(<KpiStrip kpis={kpis} />);
+    expect(screen.getByText('47')).toBeInTheDocument();
+    expect(screen.getByText('128')).toBeInTheDocument();
+    expect(screen.getByText('8')).toBeInTheDocument();
+    expect(screen.getByText('36')).toBeInTheDocument();
+  });
+
+  it('renders all 4 KPI labels', () => {
+    render(<KpiStrip kpis={kpis} />);
+    expect(screen.getByText(/libreria/i)).toBeInTheDocument();
+    expect(screen.getByText(/sessioni/i)).toBeInTheDocument();
+    expect(screen.getByText(/amici/i)).toBeInTheDocument();
+    expect(screen.getByText(/chat/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(authenticated)/dashboard/v2/index.ts
+++ b/apps/web/src/app/(authenticated)/dashboard/v2/index.ts
@@ -1,0 +1,1 @@
+export { DashboardClientV2 } from './DashboardClientV2';

--- a/apps/web/src/app/(authenticated)/dashboard/v2/sections/ChatRecentCards.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/v2/sections/ChatRecentCards.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import Link from 'next/link';
+
+export interface ChatRecentPreview {
+  id: string;
+  gameName: string;
+  topic: string;
+  snippet: string;
+  confidence: number;
+  timestamp: string;
+}
+
+interface ChatRecentCardsProps {
+  chats: ChatRecentPreview[];
+}
+
+function formatConfidence(score: number): string {
+  return `✓ ${Math.round(score * 100)}% accurata`;
+}
+
+export function ChatRecentCards({ chats }: ChatRecentCardsProps) {
+  if (chats.length === 0) return null;
+
+  return (
+    <section className="mb-7">
+      <div className="mb-3.5 flex items-center justify-between">
+        <h3 className="flex items-center gap-3 font-quicksand text-[1.1rem] font-extrabold">
+          <span
+            aria-hidden
+            className="inline-block h-[18px] w-1 rounded-sm"
+            style={{ background: 'hsl(220 80% 55%)' }}
+          />
+          Chat recenti con l&apos;agente
+        </h3>
+        <Link
+          href="/chat"
+          className="rounded-lg px-3 py-1.5 text-[0.78rem] font-bold text-[hsl(25_95%_40%)] transition-colors hover:bg-[hsla(25,95%,45%,0.08)]"
+        >
+          Vedi tutto →
+        </Link>
+      </div>
+      <div className="grid grid-cols-3 gap-4">
+        {chats.slice(0, 3).map(chat => (
+          <div
+            key={chat.id}
+            className="relative flex min-h-[140px] cursor-pointer flex-col gap-3 overflow-hidden rounded-[20px] border border-[var(--nh-border-default)] bg-[var(--nh-bg-elevated)] p-5 shadow-[var(--shadow-warm-sm)] transition-all duration-300 hover:-translate-y-0.5 hover:shadow-[var(--shadow-warm-md)]"
+          >
+            <span
+              aria-hidden
+              className="absolute left-0 top-0 bottom-0 w-1"
+              style={{ background: 'hsl(220 80% 55%)' }}
+            />
+            <div className="flex items-center gap-2.5">
+              <div
+                className="flex h-[38px] w-[38px] items-center justify-center rounded-[10px] text-lg"
+                style={{
+                  background: 'linear-gradient(135deg, hsl(220 72% 72%), hsl(220 80% 55%))',
+                }}
+                aria-hidden
+              >
+                💬
+              </div>
+              <div className="font-quicksand text-[0.88rem] font-extrabold leading-tight">
+                {chat.gameName} · {chat.topic}
+              </div>
+            </div>
+            <p className="line-clamp-2 text-[0.78rem] text-[var(--nh-text-secondary)]">
+              {chat.snippet}
+            </p>
+            <div className="mt-auto flex items-center justify-between">
+              <span
+                className="inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 font-nunito text-[0.68rem] font-extrabold uppercase tracking-wider"
+                style={{
+                  background: 'hsla(140, 60%, 45%, 0.12)',
+                  color: 'hsl(140 60% 30%)',
+                }}
+              >
+                {formatConfidence(chat.confidence)}
+              </span>
+              <span className="text-[0.7rem] font-semibold text-[var(--nh-text-muted)]">
+                {chat.timestamp}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/(authenticated)/dashboard/v2/sections/ContinueCarousel.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/v2/sections/ContinueCarousel.tsx
@@ -49,6 +49,7 @@ export function ContinueCarousel({ games }: ContinueCarouselProps) {
             subtitle={game.subtitle}
             imageUrl={game.imageUrl}
             rating={game.rating}
+            ratingMax={10}
             metadata={[
               ...(game.players ? [{ icon: '👥', label: game.players }] : []),
               ...(game.duration ? [{ icon: '⏱', label: game.duration }] : []),

--- a/apps/web/src/app/(authenticated)/dashboard/v2/sections/ContinueCarousel.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/v2/sections/ContinueCarousel.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import Link from 'next/link';
+
+import { MeepleCard } from '@/components/ui/data-display/meeple-card';
+
+export interface ContinueCarouselGame {
+  id: string;
+  title: string;
+  subtitle?: string;
+  imageUrl?: string;
+  rating?: number;
+  players?: string;
+  duration?: string;
+}
+
+interface ContinueCarouselProps {
+  games: ContinueCarouselGame[];
+}
+
+export function ContinueCarousel({ games }: ContinueCarouselProps) {
+  if (games.length === 0) return null;
+
+  return (
+    <section className="mb-7">
+      <div className="mb-3.5 flex items-center justify-between">
+        <h3 className="flex items-center gap-3 font-quicksand text-[1.1rem] font-extrabold">
+          <span
+            aria-hidden
+            className="inline-block h-[18px] w-1 rounded-sm"
+            style={{ background: 'hsl(25 95% 45%)' }}
+          />
+          Continua a giocare
+        </h3>
+        <Link
+          href="/library"
+          className="rounded-lg px-3 py-1.5 text-[0.78rem] font-bold text-[hsl(25_95%_40%)] transition-colors hover:bg-[hsla(25,95%,45%,0.08)]"
+        >
+          Vedi tutto →
+        </Link>
+      </div>
+      <div className="grid grid-cols-5 gap-4">
+        {games.slice(0, 5).map(game => (
+          <MeepleCard
+            key={game.id}
+            variant="grid"
+            entity="game"
+            title={game.title}
+            subtitle={game.subtitle}
+            imageUrl={game.imageUrl}
+            rating={game.rating}
+            metadata={[
+              ...(game.players ? [{ icon: '👥', label: game.players }] : []),
+              ...(game.duration ? [{ icon: '⏱', label: game.duration }] : []),
+            ]}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/(authenticated)/dashboard/v2/sections/FriendsRow.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/v2/sections/FriendsRow.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import Link from 'next/link';
+
+export interface FriendPreview {
+  id: string;
+  name: string;
+  status: string;
+  presence: 'online' | 'idle' | 'offline';
+}
+
+interface FriendsRowProps {
+  friends: FriendPreview[];
+}
+
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .map(part => part[0] ?? '')
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+const PRESENCE_BG: Record<FriendPreview['presence'], string> = {
+  online: 'hsl(140 60% 45%)',
+  idle: 'hsl(38 92% 55%)',
+  offline: '#cbd5e1',
+};
+
+export function FriendsRow({ friends }: FriendsRowProps) {
+  if (friends.length === 0) return null;
+
+  return (
+    <section className="mb-7">
+      <div className="mb-3.5 flex items-center justify-between">
+        <h3 className="flex items-center gap-3 font-quicksand text-[1.1rem] font-extrabold">
+          <span
+            aria-hidden
+            className="inline-block h-[18px] w-1 rounded-sm"
+            style={{ background: 'hsl(262 83% 58%)' }}
+          />
+          Amici attivi
+        </h3>
+        <Link
+          href="/players"
+          className="rounded-lg px-3 py-1.5 text-[0.78rem] font-bold text-[hsl(25_95%_40%)] transition-colors hover:bg-[hsla(25,95%,45%,0.08)]"
+        >
+          Vedi tutto →
+        </Link>
+      </div>
+      <div className="grid grid-cols-4 gap-3">
+        {friends.slice(0, 4).map(friend => (
+          <div
+            key={friend.id}
+            className="relative flex cursor-pointer items-center gap-2.5 rounded-xl border border-[var(--nh-border-default)] bg-[rgba(255,252,248,0.8)] px-3.5 py-2.5 transition-all duration-200 hover:translate-x-0.5 hover:bg-white hover:shadow-[var(--shadow-warm-sm)]"
+          >
+            <span
+              aria-hidden
+              className="absolute left-0 top-1/2 h-[60%] w-[3px] -translate-y-1/2 rounded-full"
+              style={{ background: 'hsl(262 83% 58%)' }}
+            />
+            <div
+              aria-hidden
+              className="flex h-[42px] w-[42px] shrink-0 items-center justify-center rounded-[10px] font-quicksand text-sm font-extrabold text-white"
+              style={{ background: 'linear-gradient(135deg, hsl(262 78% 75%), hsl(262 83% 55%))' }}
+            >
+              {initials(friend.name)}
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="font-quicksand text-[0.82rem] font-extrabold text-[var(--nh-text-primary)]">
+                {friend.name}
+              </div>
+              <div className="truncate text-[0.7rem] text-[var(--nh-text-muted)]">
+                {friend.status}
+              </div>
+            </div>
+            <span
+              aria-label={`Presence: ${friend.presence}`}
+              className="h-2 w-2 shrink-0 rounded-full"
+              style={{
+                background: PRESENCE_BG[friend.presence],
+                boxShadow: '0 0 0 2px rgba(255,255,255,0.9)',
+              }}
+            />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/(authenticated)/dashboard/v2/sections/GreetingRow.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/v2/sections/GreetingRow.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+export interface GreetingStat {
+  label: string;
+  value: string;
+}
+
+interface GreetingRowProps {
+  displayName: string;
+  subtitle: string;
+  stats: GreetingStat[];
+}
+
+/**
+ * Phase 2 dashboard greeting row: "Ciao {name}" with gradient wordmark on the name,
+ * subtitle underneath, and a right-aligned cluster of quick stats.
+ */
+export function GreetingRow({ displayName, subtitle, stats }: GreetingRowProps) {
+  return (
+    <div className="mb-6 flex items-end justify-between gap-6">
+      <div>
+        <h1 className="font-quicksand text-[1.8rem] font-extrabold leading-tight text-[var(--nh-text-primary)]">
+          Ciao{' '}
+          <span
+            className="bg-clip-text text-transparent"
+            style={{
+              backgroundImage: 'linear-gradient(135deg, hsl(25 95% 48%), hsl(38 92% 55%))',
+            }}
+          >
+            {displayName}
+          </span>{' '}
+          <span aria-hidden>👋</span>
+        </h1>
+        <p className="mt-1 text-sm text-[var(--nh-text-muted)]">{subtitle}</p>
+      </div>
+      {stats.length > 0 && (
+        <div data-testid="greet-stats" className="flex gap-5">
+          {stats.map(stat => (
+            <div key={stat.label} className="text-right">
+              <div className="font-quicksand text-[1.35rem] font-extrabold leading-none text-[var(--nh-text-primary)]">
+                {stat.value}
+              </div>
+              <div className="mt-1 text-[0.68rem] font-bold uppercase tracking-wider text-[var(--nh-text-muted)]">
+                {stat.label}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/dashboard/v2/sections/HeroLiveSession.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/v2/sections/HeroLiveSession.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+export interface LiveSessionPreview {
+  id: string;
+  gameName: string;
+  locationName: string;
+  playerCount: number;
+  roundCurrent: number;
+  roundTotal: number;
+  startedMinutesAgo: number;
+}
+
+interface HeroLiveSessionProps {
+  session: LiveSessionPreview | null;
+  onContinue: () => void;
+}
+
+export function HeroLiveSession({ session, onContinue }: HeroLiveSessionProps) {
+  if (!session) {
+    return (
+      <div className="mb-6 flex min-h-[180px] items-center justify-between gap-6 overflow-hidden rounded-3xl border border-[var(--nh-border-default)] bg-[var(--nh-bg-elevated)] p-8 shadow-[var(--shadow-warm-sm)]">
+        <div>
+          <h2 className="font-quicksand text-xl font-extrabold text-[var(--nh-text-primary)]">
+            Nessuna partita in corso
+          </h2>
+          <p className="mt-1 text-sm text-[var(--nh-text-muted)]">
+            Pronto per una nuova serata di gioco?
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onContinue}
+          className="rounded-xl px-5 py-3 font-nunito text-sm font-bold text-white transition-all hover:-translate-y-0.5"
+          style={{
+            background: 'linear-gradient(135deg, hsl(25 95% 48%), hsl(25 95% 40%))',
+            boxShadow: '0 2px 8px hsla(25, 95%, 45%, 0.35)',
+          }}
+        >
+          ▶ Inizia nuova partita
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="group relative mb-6 flex min-h-[220px] cursor-pointer gap-0 overflow-hidden rounded-3xl border border-[var(--nh-border-default)] shadow-[var(--shadow-warm-md)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[var(--shadow-warm-xl)]"
+      style={{
+        background:
+          'linear-gradient(135deg, hsla(240,60%,55%,0.12), hsla(262,83%,58%,0.08)), var(--nh-bg-elevated)',
+      }}
+      onClick={onContinue}
+      role="button"
+      tabIndex={0}
+      onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onContinue();
+        }
+      }}
+    >
+      <div
+        aria-hidden
+        className="absolute left-0 top-0 bottom-0 w-[5px] z-10"
+        style={{ background: 'hsl(240 60% 55%)' }}
+      />
+      <div
+        className="relative hidden md:flex w-[300px] shrink-0 items-center justify-center text-[80px] overflow-hidden"
+        style={{
+          background: 'linear-gradient(135deg, hsl(240 55% 65%), hsl(262 80% 55%))',
+        }}
+        aria-hidden
+      >
+        🎯
+      </div>
+      <div className="relative z-[2] flex flex-1 flex-col justify-between p-7 md:p-8">
+        <div>
+          <span
+            className="mb-2.5 inline-flex w-fit items-center gap-1.5 rounded-md px-2.5 py-1 font-quicksand text-[10px] font-extrabold uppercase tracking-wider text-white"
+            style={{ background: 'hsl(240 60% 55%)' }}
+          >
+            🎯 Session
+          </span>
+          <h2 className="mb-1.5 font-quicksand text-[1.75rem] font-extrabold leading-tight text-[var(--nh-text-primary)]">
+            Serata {session.gameName} · {session.locationName}
+          </h2>
+          <p className="mb-3.5 text-[0.92rem] text-[var(--nh-text-secondary)]">
+            {session.playerCount} giocatori · round {session.roundCurrent} di {session.roundTotal} ·
+            iniziata {session.startedMinutesAgo} min fa
+          </p>
+        </div>
+        <div className="flex gap-2.5">
+          <button
+            type="button"
+            onClick={e => {
+              e.stopPropagation();
+              onContinue();
+            }}
+            className="rounded-xl px-5 py-2.5 font-nunito text-[0.82rem] font-bold text-white transition-all hover:-translate-y-0.5"
+            style={{
+              background: 'linear-gradient(135deg, hsl(240 60% 55%), hsl(240 60% 42%))',
+              boxShadow: '0 2px 8px hsla(240, 60%, 55%, 0.35)',
+            }}
+          >
+            ▶ Continua partita
+          </button>
+        </div>
+      </div>
+      <div
+        className="absolute right-7 top-6 flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-nunito text-[0.7rem] font-extrabold uppercase tracking-wider"
+        style={{
+          background: 'hsla(140, 60%, 45%, 0.12)',
+          borderColor: 'hsla(140, 60%, 45%, 0.25)',
+          color: 'hsl(140 60% 30%)',
+        }}
+      >
+        <span
+          className="inline-block h-1.5 w-1.5 animate-pulse rounded-full"
+          style={{ background: 'hsl(140 60% 45%)' }}
+        />
+        In corso
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/dashboard/v2/sections/KpiStrip.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/v2/sections/KpiStrip.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+export interface KpiValues {
+  games: number;
+  sessions: number;
+  friends: number;
+  chats: number;
+}
+
+interface KpiStripProps {
+  kpis: KpiValues;
+}
+
+interface KpiCardData {
+  key: keyof KpiValues;
+  label: string;
+  icon: string;
+  entity: 'game' | 'session' | 'player' | 'chat';
+}
+
+const CARDS: KpiCardData[] = [
+  { key: 'games', label: 'Giochi in libreria', icon: '🎲', entity: 'game' },
+  { key: 'sessions', label: 'Sessioni totali', icon: '🎯', entity: 'session' },
+  { key: 'friends', label: 'Amici preferiti', icon: '👥', entity: 'player' },
+  { key: 'chats', label: 'Chat con agente', icon: '💬', entity: 'chat' },
+];
+
+const ENTITY_BG: Record<KpiCardData['entity'], string> = {
+  game: 'hsla(25, 95%, 45%, 0.12)',
+  session: 'hsla(240, 60%, 55%, 0.12)',
+  player: 'hsla(262, 83%, 58%, 0.12)',
+  chat: 'hsla(220, 80%, 55%, 0.12)',
+};
+
+const ENTITY_FG: Record<KpiCardData['entity'], string> = {
+  game: 'hsl(25 95% 38%)',
+  session: 'hsl(240 60% 45%)',
+  player: 'hsl(262 83% 50%)',
+  chat: 'hsl(220 80% 45%)',
+};
+
+export function KpiStrip({ kpis }: KpiStripProps) {
+  return (
+    <div className="mb-7 grid grid-cols-4 gap-3.5">
+      {CARDS.map(card => (
+        <div
+          key={card.key}
+          className="relative overflow-hidden rounded-2xl border border-[var(--nh-border-default)] bg-[var(--nh-bg-elevated)] p-5 shadow-[var(--shadow-warm-sm)] transition-all duration-300 hover:-translate-y-0.5 hover:shadow-[var(--shadow-warm-md)]"
+        >
+          <div
+            className="mb-3 flex h-10 w-10 items-center justify-center rounded-xl text-lg"
+            style={{ background: ENTITY_BG[card.entity], color: ENTITY_FG[card.entity] }}
+            aria-hidden
+          >
+            {card.icon}
+          </div>
+          <div className="text-[0.7rem] font-bold uppercase tracking-wider text-[var(--nh-text-muted)]">
+            {card.label}
+          </div>
+          <div className="mt-1 font-quicksand text-2xl font-extrabold leading-none text-[var(--nh-text-primary)]">
+            {kpis[card.key]}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/UserShell/v2/DesktopHandRail.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/DesktopHandRail.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 
 import { usePathname } from 'next/navigation';
 
+import { cn } from '@/lib/utils';
 import { useCardHand } from '@/stores/use-card-hand';
 
 import { HandRailItem } from './HandRailItem';
@@ -42,7 +43,11 @@ export function DesktopHandRail() {
     <aside
       data-testid="desktop-hand-rail"
       aria-label="Cards in hand"
-      className="hidden md:flex flex-col w-[76px] shrink-0 border-r border-[var(--nh-border-default)] py-3.5 pb-3 gap-2"
+      data-expanded={isExpanded}
+      className={cn(
+        'hidden md:flex flex-col shrink-0 border-r border-[var(--nh-border-default)] py-3.5 pb-3 gap-2 transition-[width] duration-200 ease-out',
+        isExpanded ? 'w-[220px]' : 'w-[76px]'
+      )}
       style={{
         background: 'linear-gradient(180deg, rgba(255,252,248,0.6), rgba(255,252,248,0.2))',
       }}

--- a/apps/web/src/components/layout/UserShell/v2/DesktopHandRail.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/DesktopHandRail.tsx
@@ -48,7 +48,7 @@ export function DesktopHandRail() {
       }}
     >
       <span
-        className="text-[9px] font-extrabold font-[var(--font-quicksand)] uppercase tracking-[0.12em] text-[var(--nh-text-muted)] pb-2 self-center"
+        className="text-[9px] font-extrabold font-quicksand uppercase tracking-[0.12em] text-[var(--nh-text-muted)] pb-2 self-center"
         style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}
       >
         La tua mano

--- a/apps/web/src/components/layout/UserShell/v2/HandRailItem.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/HandRailItem.tsx
@@ -82,7 +82,7 @@ export function HandRailItem({ card, isActive }: HandRailItemProps) {
           icon
         )}
       </div>
-      <span className="absolute bottom-[3px] left-[4px] right-[4px] text-[7px] font-bold font-[var(--font-quicksand)] leading-[1.1] text-[var(--nh-text-primary)] whitespace-nowrap overflow-hidden text-ellipsis text-center">
+      <span className="absolute bottom-[3px] left-[4px] right-[4px] text-[7px] font-bold font-quicksand leading-[1.1] text-[var(--nh-text-primary)] whitespace-nowrap overflow-hidden text-ellipsis text-center">
         {card.title}
       </span>
     </Link>

--- a/apps/web/src/components/layout/UserShell/v2/MiniNavSlot.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/MiniNavSlot.tsx
@@ -62,6 +62,7 @@ export function MiniNavSlot() {
             boxShadow: '0 2px 6px hsla(25, 95%, 45%, 0.3)',
           }}
         >
+          {config.primaryAction.icon && <span aria-hidden>{config.primaryAction.icon}</span>}
           {config.primaryAction.label}
         </button>
       )}

--- a/apps/web/src/components/layout/UserShell/v2/TopBarLogo.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/TopBarLogo.tsx
@@ -7,7 +7,7 @@ export function TopBarLogo() {
     <Link
       href="/"
       aria-label="MeepleAi home"
-      className="flex items-center gap-2.5 font-[var(--font-quicksand)] font-extrabold text-[1.05rem] shrink-0"
+      className="flex items-center gap-2.5 font-quicksand font-extrabold text-[1.05rem] shrink-0"
     >
       <span
         aria-hidden

--- a/apps/web/src/components/layout/UserShell/v2/TopBarNavLinks.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/TopBarNavLinks.tsx
@@ -42,7 +42,7 @@ export function TopBarNavLinks() {
             href={link.href}
             aria-current={active ? 'page' : undefined}
             className={cn(
-              'px-3.5 py-2 rounded-[10px] font-[var(--font-nunito)] font-bold text-[0.82rem] transition-colors',
+              'px-3.5 py-2 rounded-[10px] font-nunito font-bold text-[0.82rem] transition-colors',
               active
                 ? 'text-[hsl(25_95%_38%)] shadow-[inset_0_0_0_1px_hsla(25,95%,45%,0.25)]'
                 : 'text-[var(--nh-text-secondary)] hover:bg-[var(--nh-bg-surface)] hover:text-[var(--nh-text-primary)]'

--- a/apps/web/src/components/layout/UserShell/v2/__tests__/DesktopHandRail.test.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/__tests__/DesktopHandRail.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('@/stores/use-card-hand', () => {
@@ -53,9 +54,19 @@ describe('DesktopHandRail', () => {
     expect(screen.getByRole('button', { name: /expand/i })).toBeInTheDocument();
   });
 
-  it('is 76px wide by default', () => {
+  it('is 76px wide when collapsed (default)', () => {
     const { container } = render(<DesktopHandRail />);
     const rail = container.querySelector('[data-testid="desktop-hand-rail"]');
     expect(rail).toHaveClass('w-[76px]');
+    expect(rail).toHaveAttribute('data-expanded', 'false');
+  });
+
+  it('expands to 220px when toggle is clicked', async () => {
+    const { container } = render(<DesktopHandRail />);
+    const expandBtn = screen.getByRole('button', { name: /expand/i });
+    await userEvent.click(expandBtn);
+    const rail = container.querySelector('[data-testid="desktop-hand-rail"]');
+    expect(rail).toHaveClass('w-[220px]');
+    expect(rail).toHaveAttribute('data-expanded', 'true');
   });
 });

--- a/apps/web/src/components/layout/UserShell/v2/__tests__/MiniNavSlot.test.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/__tests__/MiniNavSlot.test.tsx
@@ -54,4 +54,20 @@ describe('MiniNavSlot', () => {
     render(<MiniNavSlot />);
     expect(screen.getByRole('button', { name: /Nuova partita/i })).toBeInTheDocument();
   });
+
+  it('renders the primary action icon when provided', () => {
+    useMiniNavConfigStore.getState().setConfig({
+      breadcrumb: 'Home',
+      tabs: [{ id: 'a', label: 'A', href: '/' }],
+      activeTabId: 'a',
+      primaryAction: {
+        label: 'Nuova partita',
+        icon: '＋',
+        onClick: () => {},
+      },
+    });
+    render(<MiniNavSlot />);
+    expect(screen.getByText('＋')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Nuova partita/i })).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/hooks/__tests__/useMiniNavConfig.test.tsx
+++ b/apps/web/src/hooks/__tests__/useMiniNavConfig.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 import { useMiniNavConfigStore } from '@/lib/stores/mini-nav-config-store';
 
@@ -50,5 +50,26 @@ describe('useMiniNavConfig', () => {
     expect(useMiniNavConfigStore.getState().config?.activeTabId).toBe('a');
     rerender({ activeTabId: 'b' });
     expect(useMiniNavConfigStore.getState().config?.activeTabId).toBe('b');
+  });
+
+  it('does not re-trigger setConfig when rerendered with equivalent inline config', () => {
+    const setConfigSpy = vi.spyOn(useMiniNavConfigStore.getState(), 'setConfig');
+
+    const { rerender } = renderHook(() =>
+      useMiniNavConfig({
+        breadcrumb: 'Home',
+        tabs: [{ id: 'a', label: 'A', href: '/' }],
+        activeTabId: 'a',
+      })
+    );
+
+    const initialCallCount = setConfigSpy.mock.calls.length;
+    // Simulate a page re-render that produces a new but equivalent inline object
+    rerender();
+    const finalCallCount = setConfigSpy.mock.calls.length;
+
+    // setConfig should NOT be called again on an equivalent rerender
+    expect(finalCallCount).toBe(initialCallCount);
+    setConfigSpy.mockRestore();
   });
 });

--- a/apps/web/src/hooks/useMiniNavConfig.ts
+++ b/apps/web/src/hooks/useMiniNavConfig.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { useMiniNavConfigStore, type MiniNavConfig } from '@/lib/stores/mini-nav-config-store';
 
@@ -8,13 +8,39 @@ import { useMiniNavConfigStore, type MiniNavConfig } from '@/lib/stores/mini-nav
  * Pages call this hook to register their mini-nav config with the global shell.
  * The shell reads the store and renders MiniNavSlot automatically.
  * Config is cleared on unmount (so navigating away hides the mini-nav).
+ *
+ * Shallow structural equality on the config's observable fields prevents
+ * re-registration loops when consumers pass inline object literals.
+ * (Carry-forward fix M3 from Phase 1 code review.)
  */
 export function useMiniNavConfig(config: MiniNavConfig): void {
   const setConfig = useMiniNavConfigStore(s => s.setConfig);
   const clear = useMiniNavConfigStore(s => s.clear);
+  const previousKeyRef = useRef<string | null>(null);
+
+  // Build a stable structural key from the config's observable fields.
+  // `onClick` is excluded because function refs change between renders but
+  // don't carry meaning independent of the label/icon.
+  const key = JSON.stringify({
+    breadcrumb: config.breadcrumb,
+    activeTabId: config.activeTabId,
+    tabs: config.tabs,
+    primaryActionLabel: config.primaryAction?.label ?? null,
+    primaryActionIcon: config.primaryAction?.icon ?? null,
+  });
 
   useEffect(() => {
+    if (previousKeyRef.current === key) return;
+    previousKeyRef.current = key;
     setConfig(config);
-    return () => clear();
-  }, [config, setConfig, clear]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, setConfig]);
+
+  // Separate effect for unmount cleanup — runs once, clears on teardown.
+  useEffect(() => {
+    return () => {
+      clear();
+      previousKeyRef.current = null;
+    };
+  }, [clear]);
 }

--- a/apps/web/src/lib/stores/mini-nav-config-store.ts
+++ b/apps/web/src/lib/stores/mini-nav-config-store.ts
@@ -25,6 +25,11 @@ export interface MiniNavTab {
 export interface MiniNavPrimaryAction {
   label: string;
   onClick: () => void;
+  /**
+   * Optional emoji or icon character prepended to the label.
+   * Keep it short — single emoji or ASCII symbol (e.g. '＋', '🎲', '▶').
+   * For complex icons, render them in the label text itself.
+   */
   icon?: string;
 }
 


### PR DESCRIPTION
## Summary

Phase 2 of the Desktop UX Redesign: new Dashboard Gaming Hub layout (GreetingRow + HeroLiveSession + KpiStrip + ContinueCarousel + ChatRecentCards + FriendsRow) behind the `NEXT_PUBLIC_UX_REDESIGN` feature flag. Also addresses the 4 carry-forward items flagged during Phase 1 code review.

**Dependency:** This PR depends on #296 (Phase 1 shell foundation). The base branch is `feature/desktop-ux-redesign-phase-1-shell`, not `main-dev`. Once #296 merges, this PR will need to be retargeted/rebased to `main-dev`.

**References:**
- Design spec: `docs/superpowers/specs/2026-04-08-desktop-ux-redesign-design.md` §5.1
- Implementation plan: `docs/superpowers/plans/2026-04-08-desktop-ux-redesign-phase-2-dashboard.md`
- Phase 1 PR: #296

## Phase 1 carry-forward fixes

The 4 items flagged in the Phase 1 code review are addressed as prerequisite tasks 1-3:

- **M1** — Replaced `font-[var(--font-quicksand)]` with the registered `font-quicksand` utility across 4 v2 shell files (4 replacements). `refactor(web): use font-quicksand/nunito utilities`
- **M3** — Stabilized `useMiniNavConfig` with a shallow-structural equality check via `useRef` + JSON key. Consumers can now pass inline config objects without triggering infinite re-registration loops. New regression test. `fix(web): stabilize useMiniNavConfig shallow equality`
- **M4** — Tightened `MiniNavPrimaryAction.icon?: string` with JSDoc (emoji/ASCII char) and actually renders it in `MiniNavSlot`. New test.
- **M6** — Wired `isExpanded` state in `DesktopHandRail` to actually change the rail width (`w-[76px]` → `w-[220px]` transition). New test.

## Phase 2 new dashboard

**6 new sections** under `apps/web/src/app/(authenticated)/dashboard/v2/sections/`:

| Section | Description | Tests |
|---|---|---|
| `GreetingRow` | "Ciao {name}" with gradient wordmark + subtitle + quick stats | 3 |
| `KpiStrip` | 4-column entity-colored stat cards (games/sessions/friends/chats) | 2 |
| `HeroLiveSession` | Full-width hero card with active session state + empty fallback | 3 |
| `ContinueCarousel` | MeepleCard GridCard horizontal grid for continue-playing | 3 |
| `ChatRecentCards` | 3 chat preview cards with ConfidenceBadge | 3 |
| `FriendsRow` | 4 compact player cards with presence dots | 4 |

**Composition:** `DashboardClientV2` integrates all 6 sections + registers the mini-nav config (`Home · Gaming Hub` breadcrumb + "＋ Nuova partita" primary action) + draws the dashboard card into the hand rail. Uses `useMemo` on the mini-nav config to keep the structural key stable across renders.

**Data wiring (TODO Phase 3):** The existing `useDashboardStore` exposes `stats`, `recentSessions`, `games`, `totalGamesCount`, `trendingGames` — but not the Phase 2-specific fields (`activeLiveSession`, `continuePlayingGames`, `recentChats`, `activeFriends`, `friendsCount`, `chatCount`). For Phase 2, the sections receive empty defaults and self-hide. Phase 3 will extend the store to compute/fetch these. A `TODO(Phase 3)` comment marks the wiring site in `DashboardClientV2.tsx`.

**Integration:** `dashboard-client.tsx` modified with a flag check AFTER all hooks (preserves React hooks order). Legacy bento grid completely untouched when flag is off.

## Quality gate

- ✅ `pnpm typecheck`: clean
- ✅ `pnpm lint`: 0 errors (no new warnings in Phase 2 files)
- ✅ `pnpm test`: **13,729 tests passing** (1024 test files). 2 pre-existing failures in `photo-store.test.ts` / `sessions/live/[sessionId]/photos` due to a missing `fake-indexeddb` devDependency (unrelated to Phase 2 — introduced in PR #283)
- ✅ `pnpm build` flag OFF: succeeds, 132 pages
- ✅ `pnpm build` flag ON: succeeds, 132 pages

## Test plan

- [x] Unit tests: 21 new test cases across 7 new test files (TDD red → green per task)
- [x] Integration test: `dashboard-client.flag.test.tsx` verifies both branches (flag on/off)
- [x] Regression test: `useMiniNavConfig` shallow equality asserts no re-registration on equivalent rerenders
- [x] Backward compatibility: existing dashboard suite passes (38 tests in dashboard namespace)
- [x] Production build: succeeds on both flag states
- [ ] **Manual smoke test** (reviewer): `NEXT_PUBLIC_UX_REDESIGN=true pnpm dev` and verify `/dashboard` renders the new layout with hero empty state, KPI strip (all zeros until Phase 3 wires real data), greeting, and mini-nav "Home · Gaming Hub" with "＋ Nuova partita" button in the shell

## Out of scope

- Dashboard data wiring — Phase 3 extends `useDashboardStore` with new fields
- Library Hub (Phase 3), Chat slide-over panel (Phase 4), cleanup (Phase 5)

## Commits (12 + marker)

- \`6b619101c\` refactor(web): use font-quicksand/nunito utilities (M1)
- \`fc556c851\` fix(web): stabilize useMiniNavConfig shallow equality (M3)
- \`c13d5e446\` feat(web): wire hand rail expand + render primary action icon (M4, M6)
- \`2391c8afa\` feat(web): GreetingRow section
- \`5f708cbbc\` feat(web): KpiStrip section
- \`12cc1b688\` feat(web): HeroLiveSession section
- \`d04de8201\` feat(web): ContinueCarousel section
- \`0375c47d3\` feat(web): ChatRecentCards section
- \`09f64cba1\` feat(web): FriendsRow section
- \`2ac102870\` feat(web): DashboardClientV2 composition
- \`eb9a2c607\` feat(web): wire DashboardClientV2 behind feature flag
- \`2497fca9d\` chore(web): phase 2 dashboard gaming hub complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)