### PR TITLE
fix(deploy): paths-filter base + mirror 14 games to dev/prod

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -84,9 +84,22 @@ jobs:
             packages/
           sparse-checkout-cone-mode: true
 
+      # IMPORTANT: explicitly set `base` to github.event.before for push events.
+      # Without this, paths-filter falls back to comparing the current branch
+      # against the repository's default branch (main-dev), which on a
+      # main-dev → main-staging release shows only the files that diverged
+      # between branches — NOT the files brought in by the merge. This caused
+      # release PR #308 to build a web-only image and silently miss API manifest
+      # changes (apps/api/**/*.yml → SeedManifestGame entries for 159 games).
+      # See paths-filter README "push events" section.
+      #
+      # Only runs on push events. For workflow_dispatch the decision step
+      # below forces a full deploy regardless, so this step would be a no-op.
       - uses: dorny/paths-filter@v4
         id: changes
+        if: github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000'
         with:
+          base: ${{ github.event.before }}
           filters: |
             api:
               - 'apps/api/**'
@@ -100,15 +113,26 @@ jobs:
         id: decision
         run: |
           FORCE="${{ inputs.force_full_deploy }}"
+          EVENT="${{ github.event_name }}"
+          BEFORE="${{ github.event.before }}"
           API="${{ steps.changes.outputs.api }}"
           WEB="${{ steps.changes.outputs.web }}"
           INFRA="${{ steps.changes.outputs.infra }}"
 
-          # Force full deploy on: manual force, infra changes, or workflow_dispatch without force (deploy all by default)
-          if [ "$FORCE" = "true" ] || [ "$INFRA" = "true" ]; then
+          # Force full deploy on:
+          # - Manual workflow_dispatch (operator intent is always "deploy now")
+          # - Explicit force_full_deploy=true input
+          # - Infra config changes
+          # - Initial push to branch (before=zeros, paths-filter can't diff)
+          ZEROS="0000000000000000000000000000000000000000"
+          if [ "$EVENT" = "workflow_dispatch" ] \
+            || [ "$FORCE" = "true" ] \
+            || [ "$INFRA" = "true" ] \
+            || [ "$BEFORE" = "$ZEROS" ] \
+            || [ -z "$BEFORE" ]; then
             echo "deploy_api=true" >> $GITHUB_OUTPUT
             echo "deploy_web=true" >> $GITHUB_OUTPUT
-            echo "📦 Full deploy: force=$FORCE, infra=$INFRA"
+            echo "📦 Full deploy: event=$EVENT force=$FORCE infra=$INFRA before=$BEFORE"
           else
             echo "deploy_api=$API" >> $GITHUB_OUTPUT
             echo "deploy_web=$WEB" >> $GITHUB_OUTPUT

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml
@@ -11804,6 +11804,361 @@ catalog:
     pdfBlobKey: rulebooks/v1/eclipse_rulebook.pdf
     pdfSha256: bd13229470079df4df34fb2c6b1126172985b89b856984f5fb9f46a160370b79
     pdfVersion: '1.0'
+  - title: 'Battlestar Galactica: Exodus Expansion'
+    bggId: 85905
+    language: en
+    yearPublished: 2010
+    minPlayers: 3
+    maxPlayers: 6
+    playingTime: 180
+    minAge: 14
+    categories:
+    - Expansion
+    - Science Fiction
+    mechanics:
+    - Cooperative Game
+    - Hand Management
+    - Traitor Game
+    designers:
+    - Corey Konieczka
+    - Tim Uren
+    publishers:
+    - Fantasy Flight Games
+    pdfBlobKey: rulebooks/v1/battlestar-galactica-exodus_rulebook.pdf
+    pdfSha256: 933ed636f95700f9dca1d47bf63eb228b86341017def10a649e54e1c18b471cd
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Battlestar%20Galactica%3A%20Exodus%20Expansion
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Battlestar%20Galactica%3A%20Exodus%20Expansion
+  - title: Blueprints
+    bggId: 140933
+    language: en
+    yearPublished: 2013
+    minPlayers: 2
+    maxPlayers: 4
+    playingTime: 30
+    minAge: 14
+    categories:
+    - Dice
+    - City Building
+    mechanics:
+    - Dice Drafting
+    - Set Collection
+    - Pattern Building
+    designers:
+    - Yves Tourigny
+    publishers:
+    - Z-Man Games
+    pdfBlobKey: rulebooks/v1/blueprints_rulebook.pdf
+    pdfSha256: ca0473d279040cd8e157f736bb5aa78f2019fed68e278cfafc73f98ef0269bad
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Blueprints
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Blueprints
+  - title: 'Frostpunk: The Board Game'
+    bggId: 311988
+    language: en
+    yearPublished: 2022
+    minPlayers: 1
+    maxPlayers: 4
+    playingTime: 150
+    minAge: 16
+    categories:
+    - Science Fiction
+    - City Building
+    mechanics:
+    - Cooperative Game
+    - Worker Placement
+    - Action Queue
+    designers:
+    - Adam Kwapiński
+    publishers:
+    - Glass Cannon Unplugged
+    pdfBlobKey: rulebooks/v1/frostpunk_rulebook.pdf
+    pdfSha256: 3600047bc0167e8f550867c6da4ec75d575bf78291ddbb39a5969c3a14c4d9c6
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Frostpunk%3A%20The%20Board%20Game
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Frostpunk%3A%20The%20Board%20Game
+  - title: ISS Vanguard
+    bggId: 325494
+    language: en
+    yearPublished: 2023
+    minPlayers: 1
+    maxPlayers: 4
+    playingTime: 120
+    minAge: 14
+    categories:
+    - Adventure
+    - Exploration
+    - Science Fiction
+    mechanics:
+    - Cooperative Game
+    - Campaign / Battle Card Driven
+    - Deck Construction
+    designers:
+    - Andrzej Betkiewicz
+    - Krzysztof Piskorski
+    - Paweł Samborski
+    - Marcin Świerkot
+    publishers:
+    - Awaken Realms
+    pdfBlobKey: rulebooks/v1/iss-vanguard_rulebook.pdf
+    pdfSha256: 76f80aa5a266287e19b5c1423d7177d9ad5167d07e6c9eb402fa616008c4e6ca
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=ISS%20Vanguard
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=ISS%20Vanguard
+  - title: Marvel United
+    bggId: 298047
+    language: en
+    yearPublished: 2020
+    minPlayers: 1
+    maxPlayers: 4
+    playingTime: 40
+    minAge: 14
+    categories:
+    - Card Game
+    - Comic Book / Strip
+    - Miniatures
+    mechanics:
+    - Cooperative Game
+    - Hand Management
+    - Variable Player Powers
+    designers:
+    - Andrea Chiarvesio
+    - Eric M. Lang
+    publishers:
+    - CMON
+    - Spin Master
+    pdfBlobKey: rulebooks/v1/marvel-united_rulebook.pdf
+    pdfSha256: 4cf121cbdc9ba87c94e64eef7d9defff65860c7fb4e9850a0c611f7c2d7ccd1c
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Marvel%20United
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Marvel%20United
+  - title: Massive Darkness
+    bggId: 197070
+    language: en
+    yearPublished: 2017
+    minPlayers: 1
+    maxPlayers: 6
+    playingTime: 180
+    minAge: 14
+    categories:
+    - Adventure
+    - Exploration
+    - Fantasy
+    - Fighting
+    - Miniatures
+    mechanics:
+    - Cooperative Game
+    - Dice Rolling
+    - Grid Movement
+    - Modular Board
+    designers:
+    - Raphaël Guiton
+    - Jean-Baptiste Lullien
+    - Nicolas Raoult
+    publishers:
+    - CMON
+    pdfBlobKey: rulebooks/v1/massive-darkness_rulebook.pdf
+    pdfSha256: 0e6da43776336126872fd55c4ff0a186b598eb35f0f81c5983efe0286d19d04c
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Massive%20Darkness
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Massive%20Darkness
+  - title: 'Masters of the Universe: Fields of Eternia'
+    bggId: 317526
+    language: en
+    yearPublished: 2022
+    minPlayers: 1
+    maxPlayers: 6
+    playingTime: 90
+    minAge: 14
+    categories:
+    - Adventure
+    - Fantasy
+    - Miniatures
+    mechanics:
+    - Area Control
+    - Card Play
+    - Dice Rolling
+    - Campaign
+    publishers:
+    - Archon Studio
+    pdfBlobKey: rulebooks/v1/masters-of-the-universe-fields-of-eternia_rulebook.pdf
+    pdfSha256: 6c75514b523638e01417651123372884f6bbbc94cc81541f7b1187e6b35719f8
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Masters%20of%20the%20Universe%3A%20Fields%20of%20Eternia
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Masters%20of%20the%20Universe%3A%20Fields%20of%20Eternia
+  - title: Paleo
+    bggId: 300531
+    language: en
+    yearPublished: 2020
+    minPlayers: 1
+    maxPlayers: 4
+    playingTime: 60
+    minAge: 10
+    categories:
+    - Adventure
+    - Prehistoric
+    mechanics:
+    - Cooperative Game
+    - Hand Management
+    - Set Collection
+    designers:
+    - Peter Rustemeyer
+    publishers:
+    - Hans im Glück
+    pdfBlobKey: rulebooks/v1/paleo_rulebook.pdf
+    pdfSha256: e25557f8724650419837f690aeadaaa474b652b5610e4d39100c618b92e87e90
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Paleo
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Paleo
+  - title: Photosynthesis
+    bggId: 218603
+    language: en
+    yearPublished: 2017
+    minPlayers: 2
+    maxPlayers: 4
+    playingTime: 60
+    minAge: 8
+    categories:
+    - Abstract Strategy
+    - Environmental
+    mechanics:
+    - Area Majority / Influence
+    - Grid Movement
+    - Point to Point Movement
+    designers:
+    - Hjalmar Hach
+    publishers:
+    - Blue Orange (EU)
+    pdfBlobKey: rulebooks/v1/photosynthesis_rulebook.pdf
+    pdfSha256: adfe6e3e69ab40ab8c51482a9d3f9f930d1b0a22d49c55fa3faf8c0cd1e07e26
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Photosynthesis
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Photosynthesis
+  - title: 'RONE: Invasion'
+    bggId: 368944
+    language: en
+    yearPublished: 2024
+    minPlayers: 1
+    maxPlayers: 4
+    playingTime: 90
+    minAge: 14
+    categories:
+    - Card Game
+    - Science Fiction
+    mechanics:
+    - Cooperative Game
+    - Deck Building
+    - Dice Building
+    designers:
+    - Štěpán Štefaník
+    publishers:
+    - Bonjour Games
+    pdfBlobKey: rulebooks/v1/rone-invasion_rulebook.pdf
+    pdfSha256: 0351e250da3d127e0835dce3444ae6151f5328c4b613144d02f74659cc5324dc
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=RONE%3A%20Invasion
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=RONE%3A%20Invasion
+  - title: Sagrada
+    bggId: 199561
+    language: en
+    yearPublished: 2017
+    minPlayers: 1
+    maxPlayers: 4
+    playingTime: 45
+    minAge: 14
+    categories:
+    - Abstract Strategy
+    - Puzzle
+    mechanics:
+    - Dice Drafting
+    - Pattern Building
+    - Set Collection
+    designers:
+    - Adrian Adamescu
+    - Daryl Andrews
+    publishers:
+    - Floodgate Games
+    pdfBlobKey: rulebooks/v1/sagrada_rulebook.pdf
+    pdfSha256: c7c8d54e36bd83aa4b92b0a44184c140cce87c57253b93c5d744aa76f174408f
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Sagrada
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Sagrada
+  - title: Santorini
+    bggId: 194655
+    language: en
+    yearPublished: 2016
+    minPlayers: 2
+    maxPlayers: 4
+    playingTime: 20
+    minAge: 8
+    categories:
+    - Abstract Strategy
+    - Mythology
+    mechanics:
+    - Grid Movement
+    - Pattern Building
+    - Variable Player Powers
+    designers:
+    - Gordon Hamilton
+    publishers:
+    - Spin Master Ltd.
+    pdfBlobKey: rulebooks/v1/santorini_rulebook.pdf
+    pdfSha256: 0d1a056e6753d031c8c067f706cbfa064018bfb4279ac9e3c0ed95b4a3d7f19d
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Santorini
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Santorini
+  - title: Townsfolk Tussle
+    bggId: 312859
+    language: en
+    yearPublished: 2022
+    minPlayers: 2
+    maxPlayers: 5
+    playingTime: 200
+    minAge: 14
+    categories:
+    - Adventure
+    - Fighting
+    - Fantasy
+    mechanics:
+    - Cooperative Game
+    - Dice Rolling
+    - Hand Management
+    designers:
+    - Stephen Louis
+    - Tony Mayer
+    - Rachel Rusk
+    publishers:
+    - Panic Roll Games
+    pdfBlobKey: rulebooks/v1/townsfolk-tussle_rulebook.pdf
+    pdfSha256: 9ba02fb2121e962214f5933c021ec66caec242af693d216fdad956a94381bdce
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Townsfolk%20Tussle
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Townsfolk%20Tussle
+  - title: Disney Villainous
+    bggId: 256382
+    language: en
+    yearPublished: 2018
+    minPlayers: 2
+    maxPlayers: 6
+    playingTime: 60
+    minAge: 10
+    categories:
+    - Card Game
+    - Fantasy
+    - Movies / TV / Radio theme
+    mechanics:
+    - Action Points
+    - Hand Management
+    - Variable Player Powers
+    designers:
+    - Prospero Hall
+    publishers:
+    - Ravensburger
+    pdfBlobKey: rulebooks/v1/villainous_rulebook.pdf
+    pdfSha256: ab41201c70aecc048dc8fd03e20e8b6ba9561dc5e444793ca8d977aba2d9c907
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Disney%20Villainous
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Disney%20Villainous
   defaultAgent:
     name: MeepleAssistant POC
     model: anthropic/claude-3-haiku

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/prod.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/prod.yml
@@ -11810,6 +11810,361 @@ catalog:
     pdfBlobKey: rulebooks/v1/eclipse_rulebook.pdf
     pdfSha256: bd13229470079df4df34fb2c6b1126172985b89b856984f5fb9f46a160370b79
     pdfVersion: '1.0'
+  - title: 'Battlestar Galactica: Exodus Expansion'
+    bggId: 85905
+    language: en
+    yearPublished: 2010
+    minPlayers: 3
+    maxPlayers: 6
+    playingTime: 180
+    minAge: 14
+    categories:
+    - Expansion
+    - Science Fiction
+    mechanics:
+    - Cooperative Game
+    - Hand Management
+    - Traitor Game
+    designers:
+    - Corey Konieczka
+    - Tim Uren
+    publishers:
+    - Fantasy Flight Games
+    pdfBlobKey: rulebooks/v1/battlestar-galactica-exodus_rulebook.pdf
+    pdfSha256: 933ed636f95700f9dca1d47bf63eb228b86341017def10a649e54e1c18b471cd
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Battlestar%20Galactica%3A%20Exodus%20Expansion
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Battlestar%20Galactica%3A%20Exodus%20Expansion
+  - title: Blueprints
+    bggId: 140933
+    language: en
+    yearPublished: 2013
+    minPlayers: 2
+    maxPlayers: 4
+    playingTime: 30
+    minAge: 14
+    categories:
+    - Dice
+    - City Building
+    mechanics:
+    - Dice Drafting
+    - Set Collection
+    - Pattern Building
+    designers:
+    - Yves Tourigny
+    publishers:
+    - Z-Man Games
+    pdfBlobKey: rulebooks/v1/blueprints_rulebook.pdf
+    pdfSha256: ca0473d279040cd8e157f736bb5aa78f2019fed68e278cfafc73f98ef0269bad
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Blueprints
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Blueprints
+  - title: 'Frostpunk: The Board Game'
+    bggId: 311988
+    language: en
+    yearPublished: 2022
+    minPlayers: 1
+    maxPlayers: 4
+    playingTime: 150
+    minAge: 16
+    categories:
+    - Science Fiction
+    - City Building
+    mechanics:
+    - Cooperative Game
+    - Worker Placement
+    - Action Queue
+    designers:
+    - Adam Kwapiński
+    publishers:
+    - Glass Cannon Unplugged
+    pdfBlobKey: rulebooks/v1/frostpunk_rulebook.pdf
+    pdfSha256: 3600047bc0167e8f550867c6da4ec75d575bf78291ddbb39a5969c3a14c4d9c6
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Frostpunk%3A%20The%20Board%20Game
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Frostpunk%3A%20The%20Board%20Game
+  - title: ISS Vanguard
+    bggId: 325494
+    language: en
+    yearPublished: 2023
+    minPlayers: 1
+    maxPlayers: 4
+    playingTime: 120
+    minAge: 14
+    categories:
+    - Adventure
+    - Exploration
+    - Science Fiction
+    mechanics:
+    - Cooperative Game
+    - Campaign / Battle Card Driven
+    - Deck Construction
+    designers:
+    - Andrzej Betkiewicz
+    - Krzysztof Piskorski
+    - Paweł Samborski
+    - Marcin Świerkot
+    publishers:
+    - Awaken Realms
+    pdfBlobKey: rulebooks/v1/iss-vanguard_rulebook.pdf
+    pdfSha256: 76f80aa5a266287e19b5c1423d7177d9ad5167d07e6c9eb402fa616008c4e6ca
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=ISS%20Vanguard
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=ISS%20Vanguard
+  - title: Marvel United
+    bggId: 298047
+    language: en
+    yearPublished: 2020
+    minPlayers: 1
+    maxPlayers: 4
+    playingTime: 40
+    minAge: 14
+    categories:
+    - Card Game
+    - Comic Book / Strip
+    - Miniatures
+    mechanics:
+    - Cooperative Game
+    - Hand Management
+    - Variable Player Powers
+    designers:
+    - Andrea Chiarvesio
+    - Eric M. Lang
+    publishers:
+    - CMON
+    - Spin Master
+    pdfBlobKey: rulebooks/v1/marvel-united_rulebook.pdf
+    pdfSha256: 4cf121cbdc9ba87c94e64eef7d9defff65860c7fb4e9850a0c611f7c2d7ccd1c
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Marvel%20United
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Marvel%20United
+  - title: Massive Darkness
+    bggId: 197070
+    language: en
+    yearPublished: 2017
+    minPlayers: 1
+    maxPlayers: 6
+    playingTime: 180
+    minAge: 14
+    categories:
+    - Adventure
+    - Exploration
+    - Fantasy
+    - Fighting
+    - Miniatures
+    mechanics:
+    - Cooperative Game
+    - Dice Rolling
+    - Grid Movement
+    - Modular Board
+    designers:
+    - Raphaël Guiton
+    - Jean-Baptiste Lullien
+    - Nicolas Raoult
+    publishers:
+    - CMON
+    pdfBlobKey: rulebooks/v1/massive-darkness_rulebook.pdf
+    pdfSha256: 0e6da43776336126872fd55c4ff0a186b598eb35f0f81c5983efe0286d19d04c
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Massive%20Darkness
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Massive%20Darkness
+  - title: 'Masters of the Universe: Fields of Eternia'
+    bggId: 317526
+    language: en
+    yearPublished: 2022
+    minPlayers: 1
+    maxPlayers: 6
+    playingTime: 90
+    minAge: 14
+    categories:
+    - Adventure
+    - Fantasy
+    - Miniatures
+    mechanics:
+    - Area Control
+    - Card Play
+    - Dice Rolling
+    - Campaign
+    publishers:
+    - Archon Studio
+    pdfBlobKey: rulebooks/v1/masters-of-the-universe-fields-of-eternia_rulebook.pdf
+    pdfSha256: 6c75514b523638e01417651123372884f6bbbc94cc81541f7b1187e6b35719f8
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Masters%20of%20the%20Universe%3A%20Fields%20of%20Eternia
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Masters%20of%20the%20Universe%3A%20Fields%20of%20Eternia
+  - title: Paleo
+    bggId: 300531
+    language: en
+    yearPublished: 2020
+    minPlayers: 1
+    maxPlayers: 4
+    playingTime: 60
+    minAge: 10
+    categories:
+    - Adventure
+    - Prehistoric
+    mechanics:
+    - Cooperative Game
+    - Hand Management
+    - Set Collection
+    designers:
+    - Peter Rustemeyer
+    publishers:
+    - Hans im Glück
+    pdfBlobKey: rulebooks/v1/paleo_rulebook.pdf
+    pdfSha256: e25557f8724650419837f690aeadaaa474b652b5610e4d39100c618b92e87e90
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Paleo
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Paleo
+  - title: Photosynthesis
+    bggId: 218603
+    language: en
+    yearPublished: 2017
+    minPlayers: 2
+    maxPlayers: 4
+    playingTime: 60
+    minAge: 8
+    categories:
+    - Abstract Strategy
+    - Environmental
+    mechanics:
+    - Area Majority / Influence
+    - Grid Movement
+    - Point to Point Movement
+    designers:
+    - Hjalmar Hach
+    publishers:
+    - Blue Orange (EU)
+    pdfBlobKey: rulebooks/v1/photosynthesis_rulebook.pdf
+    pdfSha256: adfe6e3e69ab40ab8c51482a9d3f9f930d1b0a22d49c55fa3faf8c0cd1e07e26
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Photosynthesis
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Photosynthesis
+  - title: 'RONE: Invasion'
+    bggId: 368944
+    language: en
+    yearPublished: 2024
+    minPlayers: 1
+    maxPlayers: 4
+    playingTime: 90
+    minAge: 14
+    categories:
+    - Card Game
+    - Science Fiction
+    mechanics:
+    - Cooperative Game
+    - Deck Building
+    - Dice Building
+    designers:
+    - Štěpán Štefaník
+    publishers:
+    - Bonjour Games
+    pdfBlobKey: rulebooks/v1/rone-invasion_rulebook.pdf
+    pdfSha256: 0351e250da3d127e0835dce3444ae6151f5328c4b613144d02f74659cc5324dc
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=RONE%3A%20Invasion
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=RONE%3A%20Invasion
+  - title: Sagrada
+    bggId: 199561
+    language: en
+    yearPublished: 2017
+    minPlayers: 1
+    maxPlayers: 4
+    playingTime: 45
+    minAge: 14
+    categories:
+    - Abstract Strategy
+    - Puzzle
+    mechanics:
+    - Dice Drafting
+    - Pattern Building
+    - Set Collection
+    designers:
+    - Adrian Adamescu
+    - Daryl Andrews
+    publishers:
+    - Floodgate Games
+    pdfBlobKey: rulebooks/v1/sagrada_rulebook.pdf
+    pdfSha256: c7c8d54e36bd83aa4b92b0a44184c140cce87c57253b93c5d744aa76f174408f
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Sagrada
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Sagrada
+  - title: Santorini
+    bggId: 194655
+    language: en
+    yearPublished: 2016
+    minPlayers: 2
+    maxPlayers: 4
+    playingTime: 20
+    minAge: 8
+    categories:
+    - Abstract Strategy
+    - Mythology
+    mechanics:
+    - Grid Movement
+    - Pattern Building
+    - Variable Player Powers
+    designers:
+    - Gordon Hamilton
+    publishers:
+    - Spin Master Ltd.
+    pdfBlobKey: rulebooks/v1/santorini_rulebook.pdf
+    pdfSha256: 0d1a056e6753d031c8c067f706cbfa064018bfb4279ac9e3c0ed95b4a3d7f19d
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Santorini
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Santorini
+  - title: Townsfolk Tussle
+    bggId: 312859
+    language: en
+    yearPublished: 2022
+    minPlayers: 2
+    maxPlayers: 5
+    playingTime: 200
+    minAge: 14
+    categories:
+    - Adventure
+    - Fighting
+    - Fantasy
+    mechanics:
+    - Cooperative Game
+    - Dice Rolling
+    - Hand Management
+    designers:
+    - Stephen Louis
+    - Tony Mayer
+    - Rachel Rusk
+    publishers:
+    - Panic Roll Games
+    pdfBlobKey: rulebooks/v1/townsfolk-tussle_rulebook.pdf
+    pdfSha256: 9ba02fb2121e962214f5933c021ec66caec242af693d216fdad956a94381bdce
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Townsfolk%20Tussle
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Townsfolk%20Tussle
+  - title: Disney Villainous
+    bggId: 256382
+    language: en
+    yearPublished: 2018
+    minPlayers: 2
+    maxPlayers: 6
+    playingTime: 60
+    minAge: 10
+    categories:
+    - Card Game
+    - Fantasy
+    - Movies / TV / Radio theme
+    mechanics:
+    - Action Points
+    - Hand Management
+    - Variable Player Powers
+    designers:
+    - Prospero Hall
+    publishers:
+    - Ravensburger
+    pdfBlobKey: rulebooks/v1/villainous_rulebook.pdf
+    pdfSha256: ab41201c70aecc048dc8fd03e20e8b6ba9561dc5e444793ca8d977aba2d9c907
+    pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Disney%20Villainous
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Disney%20Villainous
   defaultAgent:
     name: MeepleAssistant POC
     model: anthropic/claude-3-haiku

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/staging.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/staging.yml
@@ -11833,6 +11833,8 @@ catalog:
     pdfBlobKey: rulebooks/v1/battlestar-galactica-exodus_rulebook.pdf
     pdfSha256: 933ed636f95700f9dca1d47bf63eb228b86341017def10a649e54e1c18b471cd
     pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Battlestar%20Galactica%3A%20Exodus%20Expansion
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Battlestar%20Galactica%3A%20Exodus%20Expansion
   - title: Blueprints
     bggId: 140933
     language: en
@@ -11855,6 +11857,8 @@ catalog:
     pdfBlobKey: rulebooks/v1/blueprints_rulebook.pdf
     pdfSha256: ca0473d279040cd8e157f736bb5aa78f2019fed68e278cfafc73f98ef0269bad
     pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Blueprints
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Blueprints
   - title: 'Frostpunk: The Board Game'
     bggId: 311988
     language: en
@@ -11877,6 +11881,8 @@ catalog:
     pdfBlobKey: rulebooks/v1/frostpunk_rulebook.pdf
     pdfSha256: 3600047bc0167e8f550867c6da4ec75d575bf78291ddbb39a5969c3a14c4d9c6
     pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Frostpunk%3A%20The%20Board%20Game
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Frostpunk%3A%20The%20Board%20Game
   - title: ISS Vanguard
     bggId: 325494
     language: en
@@ -11903,6 +11909,8 @@ catalog:
     pdfBlobKey: rulebooks/v1/iss-vanguard_rulebook.pdf
     pdfSha256: 76f80aa5a266287e19b5c1423d7177d9ad5167d07e6c9eb402fa616008c4e6ca
     pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=ISS%20Vanguard
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=ISS%20Vanguard
   - title: Marvel United
     bggId: 298047
     language: en
@@ -11928,6 +11936,8 @@ catalog:
     pdfBlobKey: rulebooks/v1/marvel-united_rulebook.pdf
     pdfSha256: 4cf121cbdc9ba87c94e64eef7d9defff65860c7fb4e9850a0c611f7c2d7ccd1c
     pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Marvel%20United
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Marvel%20United
   - title: Massive Darkness
     bggId: 197070
     language: en
@@ -11956,6 +11966,8 @@ catalog:
     pdfBlobKey: rulebooks/v1/massive-darkness_rulebook.pdf
     pdfSha256: 0e6da43776336126872fd55c4ff0a186b598eb35f0f81c5983efe0286d19d04c
     pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Massive%20Darkness
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Massive%20Darkness
   - title: 'Masters of the Universe: Fields of Eternia'
     bggId: 317526
     language: en
@@ -11978,6 +11990,8 @@ catalog:
     pdfBlobKey: rulebooks/v1/masters-of-the-universe-fields-of-eternia_rulebook.pdf
     pdfSha256: 6c75514b523638e01417651123372884f6bbbc94cc81541f7b1187e6b35719f8
     pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Masters%20of%20the%20Universe%3A%20Fields%20of%20Eternia
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Masters%20of%20the%20Universe%3A%20Fields%20of%20Eternia
   - title: Paleo
     bggId: 300531
     language: en
@@ -12000,6 +12014,8 @@ catalog:
     pdfBlobKey: rulebooks/v1/paleo_rulebook.pdf
     pdfSha256: e25557f8724650419837f690aeadaaa474b652b5610e4d39100c618b92e87e90
     pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Paleo
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Paleo
   - title: Photosynthesis
     bggId: 218603
     language: en
@@ -12022,6 +12038,8 @@ catalog:
     pdfBlobKey: rulebooks/v1/photosynthesis_rulebook.pdf
     pdfSha256: adfe6e3e69ab40ab8c51482a9d3f9f930d1b0a22d49c55fa3faf8c0cd1e07e26
     pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Photosynthesis
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Photosynthesis
   - title: 'RONE: Invasion'
     bggId: 368944
     language: en
@@ -12044,6 +12062,8 @@ catalog:
     pdfBlobKey: rulebooks/v1/rone-invasion_rulebook.pdf
     pdfSha256: 0351e250da3d127e0835dce3444ae6151f5328c4b613144d02f74659cc5324dc
     pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=RONE%3A%20Invasion
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=RONE%3A%20Invasion
   - title: Sagrada
     bggId: 199561
     language: en
@@ -12067,6 +12087,8 @@ catalog:
     pdfBlobKey: rulebooks/v1/sagrada_rulebook.pdf
     pdfSha256: c7c8d54e36bd83aa4b92b0a44184c140cce87c57253b93c5d744aa76f174408f
     pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Sagrada
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Sagrada
   - title: Santorini
     bggId: 194655
     language: en
@@ -12089,6 +12111,8 @@ catalog:
     pdfBlobKey: rulebooks/v1/santorini_rulebook.pdf
     pdfSha256: 0d1a056e6753d031c8c067f706cbfa064018bfb4279ac9e3c0ed95b4a3d7f19d
     pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Santorini
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Santorini
   - title: Townsfolk Tussle
     bggId: 312859
     language: en
@@ -12114,6 +12138,8 @@ catalog:
     pdfBlobKey: rulebooks/v1/townsfolk-tussle_rulebook.pdf
     pdfSha256: 9ba02fb2121e962214f5933c021ec66caec242af693d216fdad956a94381bdce
     pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Townsfolk%20Tussle
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Townsfolk%20Tussle
   - title: Disney Villainous
     bggId: 256382
     language: en
@@ -12137,6 +12163,8 @@ catalog:
     pdfBlobKey: rulebooks/v1/villainous_rulebook.pdf
     pdfSha256: ab41201c70aecc048dc8fd03e20e8b6ba9561dc5e444793ca8d977aba2d9c907
     pdfVersion: '1.0'
+    fallbackImageUrl: https://placehold.co/400x300?text=Disney%20Villainous
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Disney%20Villainous
   defaultAgent:
     name: MeepleAssistant POC
     model: anthropic/claude-3-haiku

--- a/infra/scripts/add-placeholder-fallback-images.py
+++ b/infra/scripts/add-placeholder-fallback-images.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""
+Add placehold.co fallback image URLs to entries missing them.
+
+The CatalogSeederTests.LoadManifest_DevProfile_GamesHaveFallbackImages test
+requires every dev game to have both fallbackImageUrl and fallbackThumbnailUrl.
+Entries created via fill-skeleton-entries.py don't set these fields, so this
+script patches all 3 manifests to add placehold.co URLs where missing.
+
+Idempotent: skips entries that already have both fields set.
+"""
+
+import sys
+from pathlib import Path
+from urllib.parse import quote
+
+import yaml
+
+
+def placeholder(title: str, width: int, height: int) -> str:
+    return f"https://placehold.co/{width}x{height}?text={quote(title)}"
+
+
+def process(yml_path: Path) -> int:
+    with open(yml_path, "r", encoding="utf-8") as f:
+        doc = yaml.safe_load(f)
+
+    games = doc["catalog"]["games"]
+    patched = 0
+    for g in games:
+        title = g.get("title", "Unknown")
+        if not g.get("fallbackImageUrl"):
+            g["fallbackImageUrl"] = placeholder(title, 400, 300)
+            patched += 1
+        if not g.get("fallbackThumbnailUrl"):
+            g["fallbackThumbnailUrl"] = placeholder(title, 150, 150)
+            patched += 1
+
+    with open(yml_path, "w", encoding="utf-8") as f:
+        yaml.dump(doc, f, default_flow_style=False, allow_unicode=True, sort_keys=False, width=120)
+
+    return patched
+
+
+def main():
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    manifest_dir = repo_root / "apps" / "api" / "src" / "Api" / "Infrastructure" / "Seeders" / "Catalog" / "Manifests"
+
+    total = 0
+    for name in ("staging.yml", "dev.yml", "prod.yml"):
+        yml = manifest_dir / name
+        if yml.exists():
+            patched = process(yml)
+            print(f"{name}: {patched} field(s) patched")
+            total += patched
+
+    print(f"\nTotal: {total} fields patched")
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/scripts/mirror-staging-to-dev-prod.py
+++ b/infra/scripts/mirror-staging-to-dev-prod.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Mirror games present in staging.yml but not in dev.yml/prod.yml.
+
+Computes the set difference by bggId and appends missing entries to
+dev.yml and prod.yml. Preserves entry order in the source (staging) and
+appends new entries at the end of catalog.games in the target files.
+
+This is useful when new games are added to staging for testing and later
+need to be promoted to dev (for local development) and prod (for
+production seeding).
+"""
+
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def load_manifest(yml_path: Path) -> dict:
+    with open(yml_path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def save_manifest(yml_path: Path, doc: dict) -> None:
+    with open(yml_path, "w", encoding="utf-8") as f:
+        yaml.dump(doc, f, default_flow_style=False, allow_unicode=True, sort_keys=False, width=120)
+
+
+def bgg_id_set(games: list) -> set:
+    return {g["bggId"] for g in games if g.get("bggId")}
+
+
+def main():
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    manifest_dir = repo_root / "apps" / "api" / "src" / "Api" / "Infrastructure" / "Seeders" / "Catalog" / "Manifests"
+
+    staging = load_manifest(manifest_dir / "staging.yml")
+    dev = load_manifest(manifest_dir / "dev.yml")
+    prod = load_manifest(manifest_dir / "prod.yml")
+
+    staging_games = staging["catalog"]["games"]
+    dev_games = dev["catalog"]["games"]
+    prod_games = prod["catalog"]["games"]
+
+    dev_bgg = bgg_id_set(dev_games)
+    prod_bgg = bgg_id_set(prod_games)
+
+    missing_from_dev = [g for g in staging_games if g.get("bggId") and g["bggId"] not in dev_bgg]
+    missing_from_prod = [g for g in staging_games if g.get("bggId") and g["bggId"] not in prod_bgg]
+
+    print(f"staging.yml: {len(staging_games)} games")
+    print(f"dev.yml:     {len(dev_games)} games  ({len(missing_from_dev)} missing)")
+    print(f"prod.yml:    {len(prod_games)} games  ({len(missing_from_prod)} missing)")
+
+    if missing_from_dev:
+        print("\nAppending to dev.yml:")
+        for g in missing_from_dev:
+            print(f"  + {g['title']} (bggId={g['bggId']})")
+            dev_games.append(g)
+        save_manifest(manifest_dir / "dev.yml", dev)
+
+    if missing_from_prod:
+        print("\nAppending to prod.yml:")
+        for g in missing_from_prod:
+            print(f"  + {g['title']} (bggId={g['bggId']})")
+            prod_games.append(g)
+        save_manifest(manifest_dir / "prod.yml", prod)
+
+    print(f"\nDone. dev.yml: {len(dev_games)} games, prod.yml: {len(prod_games)} games")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Two fixes bundled as follow-ups to PR #299 / #308.

### 1. Fix paths-filter detection bug in deploy-staging.yml

**Symptom**: Release PR #308 (main-dev → main-staging) built a web-only image and silently skipped the API rebuild, missing all 159 seed catalog manifest changes. The API container ran with stale staging.yml and failed to seed the 14 new games from PR #299.

**Root cause**: \`dorny/paths-filter@v4\` without an explicit \`base\` input falls back to comparing the current branch against the repo's **default branch** (main-dev). For a release merge this shows only the files that diverged between main-dev and main-staging — not the files brought in by the merge commit.

**CI log evidence**:
\`\`\`
Changes will be detected between main-dev and main-staging
Detected 4 changed files
  apps/web/src/lib/stores/cascadeNavigationStore.ts [added]
  apps/web/src/lib/stores/gameTableDrawerStore.ts [added]
  apps/web/src/lib/stores/navStore.ts [added]
Filter api = false
Changes output set to ["web"]
\`\`\`
...while \`git diff 3acce51bf..cbb7fa6fa --name-only\` reports **54 files** including \`apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/*.yml\`.

**Fix**:
- Set \`base: \${{ github.event.before }}\` so paths-filter compares against the exact push-before SHA
- Guard the step with \`if: event_name == 'push' && before != 0*\` so it's a no-op on workflow_dispatch / first-push
- Decision step now forces full deploy on \`workflow_dispatch\`, infra changes, explicit \`force_full_deploy\`, OR empty/zero before

### 2. Mirror 14 new games from staging.yml to dev/prod.yml

The 14 games added in PR #299 (Townsfolk Tussle, Voidfall, ISS Vanguard, Frostpunk, etc.) were staging-only. Promoted to dev.yml and prod.yml so local dev and future prod deploys get the same catalog.

| File | Before | After |
|------|--------|-------|
| staging.yml | 159 | 159 |
| dev.yml | 145 | **159** |
| prod.yml | 145 | **159** |

All 3 manifests validated: 0 mismatches, 0 duplicates, 0 invalid bggIds.

Added \`placehold.co\` fallback image URLs to the 14 entries (previously missing) to satisfy the \`CatalogSeederTests.LoadManifest_DevProfile_GamesHaveFallbackImages\` invariant.

## New infra scripts
- \`mirror-staging-to-dev-prod.py\` — idempotent set-difference by bggId
- \`add-placeholder-fallback-images.py\` — patches missing fallback URLs

## Test plan
- [x] \`CatalogSeederTests\` + \`ManifestValidationTests\` + \`PdfSeederBlobTests\` = **21/21** passing locally in Release config
- [x] Backend Release build: 0 warnings, 0 errors
- [x] Frontend typecheck: clean
- [x] \`detect-manifest-mismatches.py\` across all 3 manifests: 0 issues
- [ ] CI on this PR
- [ ] Next release PR (main-dev → main-staging) should correctly detect api+web changes and build both images

🤖 Generated with [Claude Code](https://claude.com/claude-code)