### PR TITLE
feat(web): desktop UX redesign phase 3 — library hub

### DIFF
--- a/apps/web/src/app/(authenticated)/library/__tests__/library-content.flag.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/__tests__/library-content.flag.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// Mock the V2 hub so we don't pull in its downstream deps
+vi.mock('../v2', () => ({
+  LibraryHubV2: () => <div data-testid="library-hub-v2">V2 Library Hub</div>,
+}));
+
+// Mock legacy dynamic-imported components
+vi.mock('@/components/library/PersonalLibraryPage', () => ({
+  PersonalLibraryPage: () => <div data-testid="legacy-personal">Legacy Personal</div>,
+}));
+
+vi.mock('../public/PublicLibraryClient', () => ({
+  default: () => <div data-testid="legacy-catalog">Legacy Catalog</div>,
+}));
+
+vi.mock('../wishlist/page', () => ({
+  default: () => <div data-testid="legacy-wishlist">Legacy Wishlist</div>,
+}));
+
+vi.mock('../AddGameDrawer', () => ({
+  AddGameDrawerController: () => null,
+}));
+
+vi.mock('@/components/layout/FloatingActionPill', () => ({
+  FloatingActionPill: () => null,
+}));
+
+vi.mock('@/stores/use-card-hand', () => ({
+  useCardHand: () => ({ drawCard: vi.fn() }),
+}));
+
+const mockSearchParams = {
+  get: vi.fn<(key: string) => string | null>(),
+};
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams,
+}));
+
+const originalEnv = process.env.NEXT_PUBLIC_UX_REDESIGN;
+
+describe('LibraryContent feature flag branch', () => {
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.NEXT_PUBLIC_UX_REDESIGN;
+    else process.env.NEXT_PUBLIC_UX_REDESIGN = originalEnv;
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('renders V2 LibraryHub when flag is on and no tab', async () => {
+    process.env.NEXT_PUBLIC_UX_REDESIGN = 'true';
+    mockSearchParams.get.mockReturnValue(null);
+    vi.resetModules();
+    const mod = await import('../_content');
+    render(<mod.LibraryContent />);
+    expect(screen.getByTestId('library-hub-v2')).toBeInTheDocument();
+    expect(screen.queryByTestId('legacy-personal')).not.toBeInTheDocument();
+  });
+
+  it('renders legacy Personal when flag is off (no tab)', async () => {
+    process.env.NEXT_PUBLIC_UX_REDESIGN = 'false';
+    mockSearchParams.get.mockReturnValue(null);
+    vi.resetModules();
+    const mod = await import('../_content');
+    render(<mod.LibraryContent />);
+    expect(screen.queryByTestId('library-hub-v2')).not.toBeInTheDocument();
+  });
+
+  it('renders legacy Catalog when tab=catalogo (even with flag on)', async () => {
+    process.env.NEXT_PUBLIC_UX_REDESIGN = 'true';
+    mockSearchParams.get.mockReturnValue('catalogo');
+    vi.resetModules();
+    const mod = await import('../_content');
+    render(<mod.LibraryContent />);
+    expect(screen.queryByTestId('library-hub-v2')).not.toBeInTheDocument();
+  });
+
+  it('renders legacy Wishlist when tab=wishlist (even with flag on)', async () => {
+    process.env.NEXT_PUBLIC_UX_REDESIGN = 'true';
+    mockSearchParams.get.mockReturnValue('wishlist');
+    vi.resetModules();
+    const mod = await import('../_content');
+    render(<mod.LibraryContent />);
+    expect(screen.queryByTestId('library-hub-v2')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(authenticated)/library/_content.tsx
+++ b/apps/web/src/app/(authenticated)/library/_content.tsx
@@ -26,9 +26,11 @@ import { useSearchParams } from 'next/navigation';
 
 import { FloatingActionPill } from '@/components/layout/FloatingActionPill';
 import { Skeleton } from '@/components/ui/feedback/skeleton';
+import { isUxRedesignEnabled } from '@/lib/feature-flags';
 import { useCardHand } from '@/stores/use-card-hand';
 
 import { AddGameDrawerController } from './AddGameDrawer';
+import { LibraryHubV2 } from './v2';
 
 // ── Loading skeleton ──────────────────────────────────────────────────────────
 
@@ -91,10 +93,13 @@ export function LibraryContent() {
     });
   }, [drawCard]);
 
+  const useNewHub = isUxRedesignEnabled() && tab === null;
+
   return (
     <>
-      {/* Tab content — PersonalLibraryPage now includes its own sidebar */}
-      {tab === 'wishlist' ? (
+      {useNewHub ? (
+        <LibraryHubV2 />
+      ) : tab === 'wishlist' ? (
         <WishlistPageClient />
       ) : tab === 'catalogo' ? (
         <PublicLibraryPageClient />

--- a/apps/web/src/app/(authenticated)/library/v2/LibraryHubV2.tsx
+++ b/apps/web/src/app/(authenticated)/library/v2/LibraryHubV2.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import { useMiniNavConfig } from '@/hooks/useMiniNavConfig';
+import { useCardHand } from '@/stores/use-card-hand';
+
+import { CatalogCarouselSection, type CatalogGame } from './sections/CatalogCarouselSection';
+import {
+  ContinuePlayingSection,
+  type ContinuePlayingGame,
+} from './sections/ContinuePlayingSection';
+import {
+  LibraryFilterBar,
+  type LibraryFilterKey,
+  type LibraryViewMode,
+} from './sections/LibraryFilterBar';
+import { LibraryHeader } from './sections/LibraryHeader';
+import {
+  PersonalLibrarySection,
+  type PersonalLibraryGame,
+} from './sections/PersonalLibrarySection';
+import { WishlistCarouselSection, type WishlistGame } from './sections/WishlistCarouselSection';
+
+/**
+ * Phase 3 Library Hub client — new carousel-landing layout.
+ * Reads data from TODO(Phase 4) — useLibraryStore — for now, empty defaults.
+ */
+export function LibraryHubV2() {
+  const router = useRouter();
+  const drawCard = useCardHand(s => s.drawCard);
+
+  // TODO(Phase 4): wire to useLibraryStore once it exposes Phase 3 fields.
+  // For now, sections with no data self-hide and the Personal carousel
+  // renders only the "Aggiungi gioco" ghost card.
+  const continueGames: ContinuePlayingGame[] = [];
+  const personalGames: PersonalLibraryGame[] = [];
+  const catalogGames: CatalogGame[] = [];
+  const wishlistGames: WishlistGame[] = [];
+  const stats = { owned: 0, catalog: 0, wishlist: 0 };
+
+  const [activeFilter, setActiveFilter] = useState<LibraryFilterKey>('all');
+  const [activeView, setActiveView] = useState<LibraryViewMode>('carousels');
+
+  const miniNavConfig = useMemo(
+    () => ({
+      breadcrumb: 'Libreria · Hub',
+      tabs: [
+        { id: 'hub', label: 'Hub', href: '/library' },
+        { id: 'personal', label: 'Personal', href: '/library?tab=personal', count: stats.owned },
+        { id: 'catalogo', label: 'Catalogo', href: '/library?tab=catalogo', count: stats.catalog },
+        { id: 'wishlist', label: 'Wishlist', href: '/library?tab=wishlist', count: stats.wishlist },
+      ],
+      activeTabId: 'hub',
+      primaryAction: {
+        label: 'Aggiungi gioco',
+        icon: '＋',
+        onClick: () => router.push('/library?action=add'),
+      },
+    }),
+    [router, stats.owned, stats.catalog, stats.wishlist]
+  );
+  useMiniNavConfig(miniNavConfig);
+
+  useEffect(() => {
+    drawCard({
+      id: 'section-library-hub',
+      entity: 'game',
+      title: 'Library',
+      href: '/library',
+    });
+  }, [drawCard]);
+
+  const handleAddGame = () => {
+    router.push('/library?action=add');
+  };
+
+  const handleSortClick = () => {
+    // TODO(Phase 4): open sort menu
+  };
+
+  return (
+    <div className="mx-auto max-w-[1440px] p-7 pb-12">
+      <LibraryHeader stats={stats} />
+      <LibraryFilterBar
+        activeFilter={activeFilter}
+        onFilterChange={setActiveFilter}
+        activeView={activeView}
+        onViewChange={setActiveView}
+        sortLabel="Ultimo giocato"
+        onSortClick={handleSortClick}
+      />
+      <ContinuePlayingSection games={continueGames} />
+      <PersonalLibrarySection
+        games={personalGames}
+        totalCount={stats.owned}
+        onAddGame={handleAddGame}
+      />
+      <CatalogCarouselSection games={catalogGames} totalCount={stats.catalog} />
+      <WishlistCarouselSection games={wishlistGames} totalCount={stats.wishlist} />
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/library/v2/__tests__/CatalogCarouselSection.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/v2/__tests__/CatalogCarouselSection.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { CatalogCarouselSection } from '../sections/CatalogCarouselSection';
+
+describe('CatalogCarouselSection', () => {
+  const games = [
+    {
+      id: 'c1',
+      title: 'Gloomhaven',
+      subtitle: 'Cephalofair',
+      rating: 8.8,
+    },
+    {
+      id: 'c2',
+      title: 'Brass: Birmingham',
+      subtitle: 'Roxley',
+      rating: 8.6,
+    },
+  ];
+
+  it('renders title with total count', () => {
+    render(<CatalogCarouselSection games={games} totalCount={230} />);
+    expect(screen.getByText(/Dal catalogo community/i)).toBeInTheDocument();
+    expect(screen.getByText('230')).toBeInTheDocument();
+  });
+
+  it('renders all provided games', () => {
+    render(<CatalogCarouselSection games={games} totalCount={230} />);
+    expect(screen.getByText('Gloomhaven')).toBeInTheDocument();
+    expect(screen.getByText('Brass: Birmingham')).toBeInTheDocument();
+  });
+
+  it('returns null when no games', () => {
+    const { container } = render(<CatalogCarouselSection games={[]} totalCount={0} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/src/app/(authenticated)/library/v2/__tests__/ContinuePlayingSection.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/v2/__tests__/ContinuePlayingSection.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { ContinuePlayingSection } from '../sections/ContinuePlayingSection';
+
+describe('ContinuePlayingSection', () => {
+  const games = [
+    {
+      id: 'g1',
+      title: 'Azul',
+      subtitle: 'Plan B Games',
+      imageUrl: 'https://example.com/azul.jpg',
+      rating: 7.8,
+      lastPlayedLabel: 'In sessione · round 4/6',
+    },
+    {
+      id: 'g2',
+      title: 'Wingspan',
+      subtitle: 'Stonemaier',
+      rating: 8.1,
+      lastPlayedLabel: '2 giorni fa',
+    },
+  ];
+
+  it('renders section title and count', () => {
+    render(<ContinuePlayingSection games={games} />);
+    expect(screen.getByText(/Continua a giocare/i)).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('renders all games as cards', () => {
+    render(<ContinuePlayingSection games={games} />);
+    expect(screen.getByText('Azul')).toBeInTheDocument();
+    expect(screen.getByText('Wingspan')).toBeInTheDocument();
+  });
+
+  it('renders the last-played label for each game', () => {
+    render(<ContinuePlayingSection games={games} />);
+    expect(screen.getByText(/round 4\/6/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 giorni fa/i)).toBeInTheDocument();
+  });
+
+  it('returns null when no games', () => {
+    const { container } = render(<ContinuePlayingSection games={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/src/app/(authenticated)/library/v2/__tests__/LibraryFilterBar.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/v2/__tests__/LibraryFilterBar.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+
+import { LibraryFilterBar } from '../sections/LibraryFilterBar';
+
+describe('LibraryFilterBar', () => {
+  const defaultProps = {
+    activeFilter: 'all' as const,
+    onFilterChange: () => {},
+    activeView: 'carousels' as const,
+    onViewChange: () => {},
+    sortLabel: 'Ultimo giocato',
+    onSortClick: () => {},
+  };
+
+  it('renders filter chips', () => {
+    render(<LibraryFilterBar {...defaultProps} />);
+    expect(screen.getByText('Tutti')).toBeInTheDocument();
+    expect(screen.getByText('Strategici')).toBeInTheDocument();
+    expect(screen.getByText('Familiari')).toBeInTheDocument();
+    expect(screen.getByText('Cooperativi')).toBeInTheDocument();
+    expect(screen.getByText('Party')).toBeInTheDocument();
+  });
+
+  it('marks the active filter', () => {
+    render(<LibraryFilterBar {...defaultProps} activeFilter="strategici" />);
+    const strategici = screen.getByRole('button', { name: 'Strategici' });
+    expect(strategici).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('calls onFilterChange when a chip is clicked', async () => {
+    const onFilterChange = vi.fn();
+    const user = userEvent.setup();
+    render(<LibraryFilterBar {...defaultProps} onFilterChange={onFilterChange} />);
+    await user.click(screen.getByRole('button', { name: 'Familiari' }));
+    expect(onFilterChange).toHaveBeenCalledWith('familiari');
+  });
+
+  it('renders sort button with label', () => {
+    render(<LibraryFilterBar {...defaultProps} sortLabel="Rating" />);
+    expect(screen.getByRole('button', { name: /Rating/i })).toBeInTheDocument();
+  });
+
+  it('renders view toggle buttons (carousels/grid/list)', () => {
+    render(<LibraryFilterBar {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /carousels/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /grid/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /list/i })).toBeInTheDocument();
+  });
+
+  it('calls onViewChange when a view button is clicked', async () => {
+    const onViewChange = vi.fn();
+    const user = userEvent.setup();
+    render(<LibraryFilterBar {...defaultProps} onViewChange={onViewChange} />);
+    await user.click(screen.getByRole('button', { name: /list/i }));
+    expect(onViewChange).toHaveBeenCalledWith('list');
+  });
+});

--- a/apps/web/src/app/(authenticated)/library/v2/__tests__/LibraryHeader.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/v2/__tests__/LibraryHeader.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { LibraryHeader } from '../sections/LibraryHeader';
+
+describe('LibraryHeader', () => {
+  const stats = {
+    owned: 47,
+    catalog: 230,
+    wishlist: 8,
+  };
+
+  it('renders the title and subtitle', () => {
+    render(<LibraryHeader stats={stats} />);
+    expect(screen.getByText(/La tua libreria/i)).toBeInTheDocument();
+    expect(screen.getByText(/Personal collection/i)).toBeInTheDocument();
+  });
+
+  it('renders all 3 stat values', () => {
+    render(<LibraryHeader stats={stats} />);
+    expect(screen.getByText('47')).toBeInTheDocument();
+    expect(screen.getByText('230')).toBeInTheDocument();
+    expect(screen.getByText('8')).toBeInTheDocument();
+  });
+
+  it('renders all 3 stat labels', () => {
+    render(<LibraryHeader stats={stats} />);
+    expect(screen.getByText(/Tuoi giochi/i)).toBeInTheDocument();
+    expect(screen.getByText(/Catalogo/i)).toBeInTheDocument();
+    expect(screen.getByText(/Wishlist/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(authenticated)/library/v2/__tests__/LibraryHubCarousel.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/v2/__tests__/LibraryHubCarousel.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { LibraryHubCarousel } from '../sections/LibraryHubCarousel';
+
+describe('LibraryHubCarousel', () => {
+  it('renders title and count', () => {
+    render(
+      <LibraryHubCarousel
+        title="Continua a giocare"
+        count={4}
+        seeAllHref="/library?tab=continue"
+        entity="session"
+      >
+        <div>card 1</div>
+        <div>card 2</div>
+      </LibraryHubCarousel>
+    );
+    expect(screen.getByText('Continua a giocare')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+  });
+
+  it('renders children inside carousel track', () => {
+    render(
+      <LibraryHubCarousel title="X" seeAllHref="/x" entity="game">
+        <div data-testid="child-1">1</div>
+        <div data-testid="child-2">2</div>
+      </LibraryHubCarousel>
+    );
+    expect(screen.getByTestId('child-1')).toBeInTheDocument();
+    expect(screen.getByTestId('child-2')).toBeInTheDocument();
+  });
+
+  it('renders see-all link to seeAllHref', () => {
+    render(
+      <LibraryHubCarousel title="X" seeAllHref="/library?tab=personal" entity="game">
+        <div>x</div>
+      </LibraryHubCarousel>
+    );
+    const link = screen.getByRole('link', { name: /Vedi tutto/i });
+    expect(link).toHaveAttribute('href', '/library?tab=personal');
+  });
+
+  it('omits count badge when count is undefined', () => {
+    const { container } = render(
+      <LibraryHubCarousel title="X" seeAllHref="/x" entity="game">
+        <div>x</div>
+      </LibraryHubCarousel>
+    );
+    expect(container.querySelector('[data-testid="carousel-count"]')).not.toBeInTheDocument();
+  });
+
+  it('uses entity accent color for the bar', () => {
+    const { container } = render(
+      <LibraryHubCarousel title="X" seeAllHref="/x" entity="player">
+        <div>x</div>
+      </LibraryHubCarousel>
+    );
+    const bar = container.querySelector('[data-testid="carousel-accent-bar"]');
+    expect(bar).toHaveAttribute('data-entity', 'player');
+  });
+});

--- a/apps/web/src/app/(authenticated)/library/v2/__tests__/LibraryHubV2.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/v2/__tests__/LibraryHubV2.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/library',
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock('@/stores/use-card-hand', () => {
+  const state = {
+    cards: [],
+    pinnedIds: new Set(),
+    drawCard: vi.fn(),
+    pinCard: vi.fn(),
+    unpinCard: vi.fn(),
+    expandedStack: false,
+    toggleExpandStack: vi.fn(),
+  };
+  return {
+    useCardHand: (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state),
+  };
+});
+
+vi.mock('@/lib/stores/mini-nav-config-store', () => {
+  const state = {
+    config: null,
+    setConfig: vi.fn(),
+    clear: vi.fn(),
+  };
+  return {
+    useMiniNavConfigStore: (selector?: (s: typeof state) => unknown) =>
+      selector ? selector(state) : state,
+  };
+});
+
+import { LibraryHubV2 } from '../LibraryHubV2';
+
+describe('LibraryHubV2', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the library header', () => {
+    render(<LibraryHubV2 />);
+    expect(screen.getByText(/La tua libreria/i)).toBeInTheDocument();
+  });
+
+  it('renders the filter bar', () => {
+    render(<LibraryHubV2 />);
+    expect(screen.getByText('Tutti')).toBeInTheDocument();
+    expect(screen.getByText('Strategici')).toBeInTheDocument();
+  });
+
+  it('renders the personal library section with add card (always present)', () => {
+    render(<LibraryHubV2 />);
+    expect(screen.getByRole('button', { name: /aggiungi gioco/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(authenticated)/library/v2/__tests__/PersonalLibrarySection.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/v2/__tests__/PersonalLibrarySection.test.tsx
@@ -23,7 +23,7 @@ describe('PersonalLibrarySection', () => {
 
   it('renders title with total count', () => {
     render(<PersonalLibrarySection games={games} totalCount={47} onAddGame={() => {}} />);
-    expect(screen.getByText(/La tua libreria personale/i)).toBeInTheDocument();
+    expect(screen.getByText(/Libreria personale/i)).toBeInTheDocument();
     expect(screen.getByText('47')).toBeInTheDocument();
   });
 

--- a/apps/web/src/app/(authenticated)/library/v2/__tests__/PersonalLibrarySection.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/v2/__tests__/PersonalLibrarySection.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+
+import { PersonalLibrarySection } from '../sections/PersonalLibrarySection';
+
+describe('PersonalLibrarySection', () => {
+  const games = [
+    {
+      id: 'g1',
+      title: 'Ark Nova',
+      subtitle: 'Feuerland',
+      rating: 8.6,
+      imageUrl: 'https://example.com/arknova.jpg',
+    },
+    {
+      id: 'g2',
+      title: 'Wingspan',
+      subtitle: 'Stonemaier',
+      rating: 8.1,
+    },
+  ];
+
+  it('renders title with total count', () => {
+    render(<PersonalLibrarySection games={games} totalCount={47} onAddGame={() => {}} />);
+    expect(screen.getByText(/La tua libreria personale/i)).toBeInTheDocument();
+    expect(screen.getByText('47')).toBeInTheDocument();
+  });
+
+  it('renders all provided games', () => {
+    render(<PersonalLibrarySection games={games} totalCount={47} onAddGame={() => {}} />);
+    expect(screen.getByText('Ark Nova')).toBeInTheDocument();
+    expect(screen.getByText('Wingspan')).toBeInTheDocument();
+  });
+
+  it('renders the add-new-game ghost card', () => {
+    render(<PersonalLibrarySection games={games} totalCount={47} onAddGame={() => {}} />);
+    expect(screen.getByRole('button', { name: /aggiungi gioco/i })).toBeInTheDocument();
+  });
+
+  it('calls onAddGame when ghost card is clicked', async () => {
+    const onAddGame = vi.fn();
+    const user = userEvent.setup();
+    render(<PersonalLibrarySection games={games} totalCount={47} onAddGame={onAddGame} />);
+    await user.click(screen.getByRole('button', { name: /aggiungi gioco/i }));
+    expect(onAddGame).toHaveBeenCalled();
+  });
+
+  it('renders the add card even when no games', () => {
+    render(<PersonalLibrarySection games={[]} totalCount={0} onAddGame={() => {}} />);
+    expect(screen.getByRole('button', { name: /aggiungi gioco/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(authenticated)/library/v2/__tests__/WishlistCarouselSection.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/v2/__tests__/WishlistCarouselSection.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { WishlistCarouselSection } from '../sections/WishlistCarouselSection';
+
+describe('WishlistCarouselSection', () => {
+  const games = [
+    {
+      id: 'w1',
+      title: 'Terraforming Mars',
+      subtitle: 'FryxGames',
+      rating: 8.4,
+    },
+    {
+      id: 'w2',
+      title: 'Heat: Pedal to the Metal',
+      subtitle: 'Days of Wonder',
+      rating: 8.0,
+    },
+  ];
+
+  it('renders title with total count', () => {
+    render(<WishlistCarouselSection games={games} totalCount={8} />);
+    expect(screen.getByText(/La tua wishlist/i)).toBeInTheDocument();
+    expect(screen.getByText('8')).toBeInTheDocument();
+  });
+
+  it('renders all wishlist games', () => {
+    render(<WishlistCarouselSection games={games} totalCount={8} />);
+    expect(screen.getByText('Terraforming Mars')).toBeInTheDocument();
+    expect(screen.getByText('Heat: Pedal to the Metal')).toBeInTheDocument();
+  });
+
+  it('returns null when no games', () => {
+    const { container } = render(<WishlistCarouselSection games={[]} totalCount={0} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/src/app/(authenticated)/library/v2/index.ts
+++ b/apps/web/src/app/(authenticated)/library/v2/index.ts
@@ -1,0 +1,1 @@
+export { LibraryHubV2 } from './LibraryHubV2';

--- a/apps/web/src/app/(authenticated)/library/v2/sections/CatalogCarouselSection.tsx
+++ b/apps/web/src/app/(authenticated)/library/v2/sections/CatalogCarouselSection.tsx
@@ -26,7 +26,7 @@ export function CatalogCarouselSection({ games, totalCount }: CatalogCarouselSec
       count={totalCount}
       seeAllHref="/library?tab=catalogo"
       seeAllLabel="Esplora catalogo"
-      entity="session"
+      entity="game"
     >
       {games.map(game => (
         <div key={game.id} className="min-w-[200px] max-w-[200px] shrink-0 snap-start">

--- a/apps/web/src/app/(authenticated)/library/v2/sections/CatalogCarouselSection.tsx
+++ b/apps/web/src/app/(authenticated)/library/v2/sections/CatalogCarouselSection.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { MeepleCard } from '@/components/ui/data-display/meeple-card';
+
+import { LibraryHubCarousel } from './LibraryHubCarousel';
+
+export interface CatalogGame {
+  id: string;
+  title: string;
+  subtitle?: string;
+  imageUrl?: string;
+  rating?: number;
+}
+
+interface CatalogCarouselSectionProps {
+  games: CatalogGame[];
+  totalCount: number;
+}
+
+export function CatalogCarouselSection({ games, totalCount }: CatalogCarouselSectionProps) {
+  if (games.length === 0) return null;
+
+  return (
+    <LibraryHubCarousel
+      title="Dal catalogo community"
+      count={totalCount}
+      seeAllHref="/library?tab=catalogo"
+      seeAllLabel="Esplora catalogo"
+      entity="session"
+    >
+      {games.map(game => (
+        <div key={game.id} className="min-w-[200px] max-w-[200px] shrink-0 snap-start">
+          <MeepleCard
+            variant="grid"
+            entity="game"
+            title={game.title}
+            subtitle={game.subtitle}
+            imageUrl={game.imageUrl}
+            rating={game.rating}
+            ratingMax={10}
+            badge="Catalog"
+          />
+        </div>
+      ))}
+    </LibraryHubCarousel>
+  );
+}

--- a/apps/web/src/app/(authenticated)/library/v2/sections/ContinuePlayingSection.tsx
+++ b/apps/web/src/app/(authenticated)/library/v2/sections/ContinuePlayingSection.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { MeepleCard } from '@/components/ui/data-display/meeple-card';
+
+import { LibraryHubCarousel } from './LibraryHubCarousel';
+
+export interface ContinuePlayingGame {
+  id: string;
+  title: string;
+  subtitle?: string;
+  imageUrl?: string;
+  rating?: number;
+  lastPlayedLabel: string;
+}
+
+interface ContinuePlayingSectionProps {
+  games: ContinuePlayingGame[];
+}
+
+export function ContinuePlayingSection({ games }: ContinuePlayingSectionProps) {
+  if (games.length === 0) return null;
+
+  return (
+    <LibraryHubCarousel
+      title="Continua a giocare"
+      count={games.length}
+      seeAllHref="/library?tab=personal"
+      entity="session"
+    >
+      {games.map(game => (
+        <div
+          key={game.id}
+          className="flex min-w-[200px] max-w-[200px] shrink-0 snap-start flex-col gap-2"
+        >
+          <MeepleCard
+            variant="grid"
+            entity="game"
+            title={game.title}
+            subtitle={game.subtitle}
+            imageUrl={game.imageUrl}
+            rating={game.rating}
+            ratingMax={10}
+          />
+          <div className="rounded-[12px] border border-[var(--nh-border-default)] bg-[var(--nh-bg-elevated)] px-3 py-2 text-[0.72rem] font-semibold text-[var(--nh-text-secondary)] shadow-[var(--shadow-warm-sm)]">
+            <span aria-hidden className="mr-1.5">
+              ▶
+            </span>
+            {game.lastPlayedLabel}
+          </div>
+        </div>
+      ))}
+    </LibraryHubCarousel>
+  );
+}

--- a/apps/web/src/app/(authenticated)/library/v2/sections/LibraryFilterBar.tsx
+++ b/apps/web/src/app/(authenticated)/library/v2/sections/LibraryFilterBar.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+export type LibraryFilterKey = 'all' | 'strategici' | 'familiari' | 'cooperativi' | 'party';
+export type LibraryViewMode = 'carousels' | 'grid' | 'list';
+
+interface LibraryFilterBarProps {
+  activeFilter: LibraryFilterKey;
+  onFilterChange: (filter: LibraryFilterKey) => void;
+  activeView: LibraryViewMode;
+  onViewChange: (view: LibraryViewMode) => void;
+  sortLabel: string;
+  onSortClick: () => void;
+}
+
+interface FilterChip {
+  key: LibraryFilterKey;
+  label: string;
+}
+
+const FILTERS: FilterChip[] = [
+  { key: 'all', label: 'Tutti' },
+  { key: 'strategici', label: 'Strategici' },
+  { key: 'familiari', label: 'Familiari' },
+  { key: 'cooperativi', label: 'Cooperativi' },
+  { key: 'party', label: 'Party' },
+];
+
+const VIEWS: { key: LibraryViewMode; icon: string; label: string }[] = [
+  { key: 'carousels', icon: '▦', label: 'carousels' },
+  { key: 'grid', icon: '⊞', label: 'grid' },
+  { key: 'list', icon: '≡', label: 'list' },
+];
+
+export function LibraryFilterBar({
+  activeFilter,
+  onFilterChange,
+  activeView,
+  onViewChange,
+  sortLabel,
+  onSortClick,
+}: LibraryFilterBarProps) {
+  return (
+    <div className="mb-6 flex flex-wrap items-center gap-2.5 rounded-2xl border border-[var(--nh-border-default)] bg-[var(--nh-bg-elevated)] p-3 px-4 shadow-[var(--shadow-warm-sm)]">
+      <span className="mr-1 text-[0.7rem] font-extrabold uppercase tracking-wider text-[var(--nh-text-muted)]">
+        Filtra
+      </span>
+      {FILTERS.map(filter => {
+        const active = filter.key === activeFilter;
+        return (
+          <button
+            key={filter.key}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onFilterChange(filter.key)}
+            className={cn(
+              'rounded-full border px-3 py-1.5 font-nunito text-[0.76rem] font-bold transition-all',
+              active
+                ? 'border-[hsla(25,95%,45%,0.35)] text-[hsl(25_95%_38%)]'
+                : 'border-transparent bg-[rgba(160,120,60,0.08)] text-[var(--nh-text-secondary)] hover:bg-[rgba(160,120,60,0.15)]'
+            )}
+            style={active ? { background: 'hsla(25, 95%, 45%, 0.12)' } : undefined}
+          >
+            {filter.label}
+          </button>
+        );
+      })}
+      <div className="flex-1" />
+      <button
+        type="button"
+        onClick={onSortClick}
+        className="flex items-center gap-1.5 rounded-[10px] border border-[var(--nh-border-default)] bg-[var(--nh-bg-surface)] px-3 py-1.5 font-nunito text-[0.76rem] font-bold text-[var(--nh-text-secondary)]"
+      >
+        <span aria-hidden>⇅</span>
+        {sortLabel}
+      </button>
+      <div className="flex gap-0.5 rounded-[10px] border border-[var(--nh-border-default)] bg-[var(--nh-bg-surface)] p-0.5">
+        {VIEWS.map(view => {
+          const active = view.key === activeView;
+          return (
+            <button
+              key={view.key}
+              type="button"
+              aria-label={view.label}
+              aria-pressed={active}
+              onClick={() => onViewChange(view.key)}
+              className={cn(
+                'rounded-lg px-2.5 py-1 text-sm transition-all',
+                active
+                  ? 'bg-white text-[hsl(25_95%_40%)] shadow-[var(--shadow-warm-sm)]'
+                  : 'text-[var(--nh-text-muted)] hover:text-[var(--nh-text-primary)]'
+              )}
+            >
+              {view.icon}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/library/v2/sections/LibraryHeader.tsx
+++ b/apps/web/src/app/(authenticated)/library/v2/sections/LibraryHeader.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+export interface LibraryHeaderStats {
+  owned: number;
+  catalog: number;
+  wishlist: number;
+}
+
+interface LibraryHeaderProps {
+  stats: LibraryHeaderStats;
+}
+
+interface StatCardData {
+  key: keyof LibraryHeaderStats;
+  label: string;
+  color: string;
+}
+
+const STAT_CARDS: StatCardData[] = [
+  { key: 'owned', label: 'Tuoi giochi', color: 'hsl(25 95% 38%)' },
+  { key: 'catalog', label: 'Catalogo', color: 'hsl(240 60% 45%)' },
+  { key: 'wishlist', label: 'Wishlist', color: 'hsl(38 92% 42%)' },
+];
+
+export function LibraryHeader({ stats }: LibraryHeaderProps) {
+  return (
+    <div className="mb-6 flex items-end justify-between gap-6 border-b border-[var(--nh-border-default)] pb-5">
+      <div>
+        <h1 className="flex items-center gap-3.5 font-quicksand text-[2rem] font-extrabold leading-tight tracking-tight text-[var(--nh-text-primary)]">
+          <span
+            aria-hidden
+            className="inline-block h-8 w-1.5 rounded-sm"
+            style={{
+              background: 'linear-gradient(180deg, hsl(25 95% 52%), hsl(25 95% 38%))',
+            }}
+          />
+          La tua libreria
+        </h1>
+        <p className="ml-5 mt-1.5 text-sm text-[var(--nh-text-muted)]">
+          Personal collection · Community catalog · Lista desideri · Continua a giocare
+        </p>
+      </div>
+      <div className="flex gap-4">
+        {STAT_CARDS.map(card => (
+          <div
+            key={card.key}
+            className="min-w-[110px] cursor-pointer rounded-2xl border border-[var(--nh-border-default)] bg-[var(--nh-bg-elevated)] px-5 py-3 text-center shadow-[var(--shadow-warm-sm)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[var(--shadow-warm-md)]"
+          >
+            <div
+              className="font-quicksand text-[1.55rem] font-extrabold leading-none"
+              style={{ color: card.color }}
+            >
+              {stats[card.key]}
+            </div>
+            <div className="mt-1 text-[0.68rem] font-bold uppercase tracking-wider text-[var(--nh-text-muted)]">
+              {card.label}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/library/v2/sections/LibraryHubCarousel.tsx
+++ b/apps/web/src/app/(authenticated)/library/v2/sections/LibraryHubCarousel.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import Link from 'next/link';
+
+type CarouselEntity = 'game' | 'session' | 'player' | 'chat' | 'wishlist';
+
+interface LibraryHubCarouselProps {
+  title: string;
+  count?: number;
+  seeAllHref: string;
+  seeAllLabel?: string;
+  entity: CarouselEntity;
+  children: ReactNode;
+}
+
+const ENTITY_ACCENTS: Record<CarouselEntity, string> = {
+  game: 'hsl(25 95% 45%)',
+  session: 'hsl(240 60% 55%)',
+  player: 'hsl(262 83% 58%)',
+  chat: 'hsl(220 80% 55%)',
+  wishlist: 'hsl(38 92% 50%)',
+};
+
+export function LibraryHubCarousel({
+  title,
+  count,
+  seeAllHref,
+  seeAllLabel = 'Vedi tutto',
+  entity,
+  children,
+}: LibraryHubCarouselProps) {
+  const accent = ENTITY_ACCENTS[entity];
+
+  return (
+    <section className="relative mb-9">
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <span
+            data-testid="carousel-accent-bar"
+            data-entity={entity}
+            aria-hidden
+            className="inline-block h-[22px] w-1 rounded-sm"
+            style={{ background: accent }}
+          />
+          <h3 className="font-quicksand text-[1.2rem] font-extrabold tracking-tight">{title}</h3>
+          {count !== undefined && (
+            <span
+              data-testid="carousel-count"
+              className="rounded-full bg-[rgba(160,120,60,0.1)] px-2.5 py-1 font-quicksand text-[0.72rem] font-extrabold text-[var(--nh-text-secondary)]"
+            >
+              {count}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            aria-label="Scroll left"
+            className="flex h-9 w-9 items-center justify-center rounded-[10px] border border-[var(--nh-border-default)] bg-[var(--nh-bg-elevated)] text-sm text-[var(--nh-text-secondary)] transition-all hover:bg-white hover:shadow-[var(--shadow-warm-sm)] hover:text-[var(--nh-text-primary)]"
+          >
+            ‹
+          </button>
+          <button
+            type="button"
+            aria-label="Scroll right"
+            className="flex h-9 w-9 items-center justify-center rounded-[10px] border border-[var(--nh-border-default)] bg-[var(--nh-bg-elevated)] text-sm text-[var(--nh-text-secondary)] transition-all hover:bg-white hover:shadow-[var(--shadow-warm-sm)] hover:text-[var(--nh-text-primary)]"
+          >
+            ›
+          </button>
+          <Link
+            href={seeAllHref}
+            className="rounded-lg px-3 py-1.5 font-nunito text-[0.82rem] font-extrabold text-[hsl(25_95%_40%)] transition-colors hover:bg-[hsla(25,95%,45%,0.08)]"
+          >
+            {seeAllLabel} →
+          </Link>
+        </div>
+      </div>
+      <div className="-mx-1 flex snap-x snap-mandatory gap-4 overflow-x-auto pb-4 pt-1 [scrollbar-color:rgba(160,120,60,0.25)_transparent] [scrollbar-width:thin]">
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/(authenticated)/library/v2/sections/PersonalLibrarySection.tsx
+++ b/apps/web/src/app/(authenticated)/library/v2/sections/PersonalLibrarySection.tsx
@@ -25,7 +25,7 @@ export function PersonalLibrarySection({
 }: PersonalLibrarySectionProps) {
   return (
     <LibraryHubCarousel
-      title="La tua libreria personale"
+      title="Libreria personale"
       count={totalCount}
       seeAllHref="/library?tab=personal"
       seeAllLabel={`Vedi tutti ${totalCount}`}

--- a/apps/web/src/app/(authenticated)/library/v2/sections/PersonalLibrarySection.tsx
+++ b/apps/web/src/app/(authenticated)/library/v2/sections/PersonalLibrarySection.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { MeepleCard } from '@/components/ui/data-display/meeple-card';
+
+import { LibraryHubCarousel } from './LibraryHubCarousel';
+
+export interface PersonalLibraryGame {
+  id: string;
+  title: string;
+  subtitle?: string;
+  imageUrl?: string;
+  rating?: number;
+}
+
+interface PersonalLibrarySectionProps {
+  games: PersonalLibraryGame[];
+  totalCount: number;
+  onAddGame: () => void;
+}
+
+export function PersonalLibrarySection({
+  games,
+  totalCount,
+  onAddGame,
+}: PersonalLibrarySectionProps) {
+  return (
+    <LibraryHubCarousel
+      title="La tua libreria personale"
+      count={totalCount}
+      seeAllHref="/library?tab=personal"
+      seeAllLabel={`Vedi tutti ${totalCount}`}
+      entity="game"
+    >
+      {games.map(game => (
+        <div key={game.id} className="min-w-[200px] max-w-[200px] shrink-0 snap-start">
+          <MeepleCard
+            variant="grid"
+            entity="game"
+            title={game.title}
+            subtitle={game.subtitle}
+            imageUrl={game.imageUrl}
+            rating={game.rating}
+            ratingMax={10}
+          />
+        </div>
+      ))}
+      <button
+        type="button"
+        aria-label="Aggiungi gioco"
+        onClick={onAddGame}
+        className="flex min-h-[260px] min-w-[200px] max-w-[200px] shrink-0 snap-start flex-col items-center justify-center gap-2.5 rounded-[20px] border-2 border-dashed border-[rgba(160,120,60,0.3)] bg-[rgba(255,252,248,0.4)] p-6 font-nunito transition-all hover:-translate-y-1 hover:border-[hsl(25_95%_45%)] hover:bg-[rgba(255,252,248,0.8)] hover:shadow-[var(--shadow-warm-md)]"
+      >
+        <span
+          aria-hidden
+          className="flex h-12 w-12 items-center justify-center rounded-full text-2xl font-bold"
+          style={{
+            background: 'hsla(25, 95%, 45%, 0.1)',
+            color: 'hsl(25 95% 40%)',
+          }}
+        >
+          ＋
+        </span>
+        <span className="text-center font-quicksand text-[0.9rem] font-extrabold text-[var(--nh-text-primary)]">
+          Aggiungi gioco
+        </span>
+        <span className="text-center text-[0.7rem] leading-snug text-[var(--nh-text-muted)]">
+          Dal catalogo o dal tuo PDF
+        </span>
+      </button>
+    </LibraryHubCarousel>
+  );
+}

--- a/apps/web/src/app/(authenticated)/library/v2/sections/WishlistCarouselSection.tsx
+++ b/apps/web/src/app/(authenticated)/library/v2/sections/WishlistCarouselSection.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { MeepleCard } from '@/components/ui/data-display/meeple-card';
+
+import { LibraryHubCarousel } from './LibraryHubCarousel';
+
+export interface WishlistGame {
+  id: string;
+  title: string;
+  subtitle?: string;
+  imageUrl?: string;
+  rating?: number;
+}
+
+interface WishlistCarouselSectionProps {
+  games: WishlistGame[];
+  totalCount: number;
+}
+
+export function WishlistCarouselSection({ games, totalCount }: WishlistCarouselSectionProps) {
+  if (games.length === 0) return null;
+
+  return (
+    <LibraryHubCarousel
+      title="La tua wishlist"
+      count={totalCount}
+      seeAllHref="/library?tab=wishlist"
+      seeAllLabel="Gestisci wishlist"
+      entity="wishlist"
+    >
+      {games.map(game => (
+        <div key={game.id} className="min-w-[200px] max-w-[200px] shrink-0 snap-start">
+          <MeepleCard
+            variant="grid"
+            entity="game"
+            title={game.title}
+            subtitle={game.subtitle}
+            imageUrl={game.imageUrl}
+            rating={game.rating}
+            ratingMax={10}
+            status="wishlist"
+          />
+        </div>
+      ))}
+    </LibraryHubCarousel>
+  );
+}

--- a/apps/web/src/components/layout/UserShell/v2/DesktopHandRail.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/DesktopHandRail.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useState } from 'react';
-
 import { usePathname } from 'next/navigation';
 
 import { cn } from '@/lib/utils';
@@ -22,8 +20,9 @@ export function DesktopHandRail() {
   const pinnedIds = useCardHand(s => s.pinnedIds);
   const pinCard = useCardHand(s => s.pinCard);
   const unpinCard = useCardHand(s => s.unpinCard);
+  const isExpanded = useCardHand(s => s.expandedStack);
+  const toggleExpand = useCardHand(s => s.toggleExpandStack);
   const pathname = usePathname() ?? '';
-  const [isExpanded, setIsExpanded] = useState(false);
 
   const isCardActive = (href: string) => {
     if (href === '/') return pathname === '/';
@@ -46,7 +45,7 @@ export function DesktopHandRail() {
       data-expanded={isExpanded}
       className={cn(
         'hidden md:flex flex-col shrink-0 border-r border-[var(--nh-border-default)] py-3.5 pb-3 gap-2 transition-[width] duration-200 ease-out',
-        isExpanded ? 'w-[220px]' : 'w-[76px]'
+        isExpanded ? 'w-[var(--card-rack-hover-width,240px)]' : 'w-[var(--card-rack-width,76px)]'
       )}
       style={{
         background: 'linear-gradient(180deg, rgba(255,252,248,0.6), rgba(255,252,248,0.2))',
@@ -65,7 +64,7 @@ export function DesktopHandRail() {
       </div>
       <HandRailToolbar
         onTogglePin={handleTogglePin}
-        onToggleExpand={() => setIsExpanded(!isExpanded)}
+        onToggleExpand={toggleExpand}
         isPinned={isActivePinned}
         isExpanded={isExpanded}
       />

--- a/apps/web/src/components/layout/UserShell/v2/__tests__/DesktopHandRail.test.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/__tests__/DesktopHandRail.test.tsx
@@ -13,9 +13,12 @@ vi.mock('@/stores/use-card-hand', () => {
     pinnedIds: new Set<string>(),
     pinCard: vi.fn(),
     unpinCard: vi.fn(),
+    expandedStack: false,
+    toggleExpandStack: vi.fn(),
   };
   return {
     useCardHand: (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state),
+    __mockCardHandState: state,
   };
 });
 
@@ -25,9 +28,13 @@ vi.mock('next/navigation', () => ({
 
 import { DesktopHandRail } from '../DesktopHandRail';
 
+// @ts-expect-error mock accessor not in real module types
+import { __mockCardHandState } from '@/stores/use-card-hand';
+
 describe('DesktopHandRail', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    __mockCardHandState.expandedStack = false;
   });
 
   it('renders hand label', () => {
@@ -54,19 +61,25 @@ describe('DesktopHandRail', () => {
     expect(screen.getByRole('button', { name: /expand/i })).toBeInTheDocument();
   });
 
-  it('is 76px wide when collapsed (default)', () => {
+  it('is collapsed when expandedStack is false', () => {
     const { container } = render(<DesktopHandRail />);
     const rail = container.querySelector('[data-testid="desktop-hand-rail"]');
-    expect(rail).toHaveClass('w-[76px]');
+    expect(rail).toHaveClass('w-[var(--card-rack-width,76px)]');
     expect(rail).toHaveAttribute('data-expanded', 'false');
   });
 
-  it('expands to 220px when toggle is clicked', async () => {
+  it('is expanded to 240px when expandedStack is true', () => {
+    __mockCardHandState.expandedStack = true;
     const { container } = render(<DesktopHandRail />);
-    const expandBtn = screen.getByRole('button', { name: /expand/i });
-    await userEvent.click(expandBtn);
     const rail = container.querySelector('[data-testid="desktop-hand-rail"]');
-    expect(rail).toHaveClass('w-[220px]');
+    expect(rail).toHaveClass('w-[var(--card-rack-hover-width,240px)]');
     expect(rail).toHaveAttribute('data-expanded', 'true');
+  });
+
+  it('calls toggleExpandStack when toggle is clicked', async () => {
+    const user = userEvent.setup();
+    render(<DesktopHandRail />);
+    await user.click(screen.getByRole('button', { name: /expand/i }));
+    expect(__mockCardHandState.toggleExpandStack).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Phase 3 of the Desktop UX Redesign: new Library Hub landing layout (LibraryHeader + LibraryFilterBar + 4 carousels: ContinuePlaying / PersonalLibrary / Catalog / Wishlist) behind the `NEXT_PUBLIC_UX_REDESIGN` feature flag. Also resolves 2 carry-forward items from Phase 2 code review.

**Dependency:** This PR depends on #309 (Phase 2 dashboard) which depends on #296 (Phase 1 shell). Base branch is `feature/desktop-ux-redesign-phase-2-dashboard`. Will be retargeted/rebased after parent PRs merge.

**References:**
- Design spec: `docs/superpowers/specs/2026-04-08-desktop-ux-redesign-design.md` §5.2
- Phase 1 PR: #296 (shell foundation)
- Phase 2 PR: #309 (dashboard)

## Phase 2 carry-forward fixes

- **HandRail store wiring** (Phase 2 review #3, score 68): `DesktopHandRail` now uses `useCardHand(s => s.expandedStack)` and `toggleExpandStack()` instead of local `useState(false)`. Expand state survives navigation/refresh via localStorage persistence.
- **CSS var widths** (Phase 2 review #4, score 65): Replaced hardcoded `w-[220px]` / `w-[76px]` with `w-[var(--card-rack-hover-width,240px)]` / `w-[var(--card-rack-width,76px)]`. Matches spec §4.3 (240px expanded) and the legacy `CardRack` component.

## Phase 3 new library

**New sections** under `apps/web/src/app/(authenticated)/library/v2/sections/`:

| Section | Description | Tests |
|---|---|---|
| `LibraryHeader` | h1 with gradient accent bar + 3 stat cards (owned/catalog/wishlist) | 3 |
| `LibraryFilterBar` | 5 filter pills + sort button + 3 view toggles (carousels/grid/list) | 6 |
| `LibraryHubCarousel` | Reusable wrapper with section header + nav buttons + see-all + scroll-snap | 5 |
| `ContinuePlayingSection` | Hub carousel of in-progress games with last-played label | 4 |
| `PersonalLibrarySection` | Hub carousel of owned games + ghost "Aggiungi gioco" card | 5 |
| `CatalogCarouselSection` | Hub carousel of shared catalog games with `badge="Catalog"` | 3 |
| `WishlistCarouselSection` | Hub carousel of wishlist games with `status="wishlist"` (amber) | 3 |

**Composition:** `LibraryHubV2` integrates all sections + registers mini-nav config (`Libreria · Hub` breadcrumb + 4 tabs Hub/Personal/Catalogo/Wishlist with counts + `＋ Aggiungi gioco` primary action) + draws the library card into the hand stack.

**Data wiring (TODO Phase 4):** The existing library data layer is not yet adapted for Phase 3 fields. For now, sections receive empty defaults and self-hide (except PersonalLibrarySection which always renders the "Aggiungi gioco" ghost card). A `TODO(Phase 4)` comment marks the wiring site.

**Integration:** `library/_content.tsx` modified with a flag check AFTER all hooks. Only the default route (`/library` with no tab query) is routed to `LibraryHubV2`. Tab detail views (`?tab=personal`, `?tab=catalogo`, `?tab=wishlist`) remain fully legacy. Flag off preserves the existing Personal grid as default.

## Quality gate

- typecheck clean (0 errors)
- lint 0 errors (warnings within threshold, 0 new in v2 files)
- **13,801 tests** — 13,766 passing, 35 pre-existing skips, 2 pre-existing failures (`photo-store.test.ts` + `sessions/live/[sessionId]/photos` missing `fake-indexeddb` devDep — carried from PR #283, unrelated)
- build flag OFF: 132 pages, 47s
- build flag ON: 132 pages, 24s

## Test plan

- [x] 29 new unit test cases across 8 new test files (TDD red→green per task)
- [x] Integration test: `library-content.flag.test.tsx` covers 4 flag branches (on/off × hub/tab)
- [x] Regression: existing library suite passes (legacy tab routing untouched)
- [x] Production build: succeeds on both flag states
- [ ] Manual smoke test (reviewer): `NEXT_PUBLIC_UX_REDESIGN=true pnpm dev` → `/library` should render the new Hub (empty state, only "Aggiungi gioco" ghost card visible), `/library?tab=personal` unchanged legacy

## Commits (12)

- \`9a652fa49\` fix(web): DesktopHandRail store expandedStack + CSS var widths
- \`a76158a33\` feat(web): LibraryHeader section
- \`ab67a403f\` feat(web): LibraryFilterBar section
- \`b4b98b33a\` feat(web): LibraryHubCarousel wrapper
- \`f2b311ad0\` feat(web): ContinuePlayingSection
- \`c1bb6b8e1\` feat(web): PersonalLibrarySection
- \`3ec91bd86\` feat(web): CatalogCarouselSection
- \`09b60c31a\` feat(web): WishlistCarouselSection
- \`fa499e97f\` feat(web): LibraryHubV2 composition
- \`a5eb9f650\` feat(web): wire LibraryHubV2 into _content.tsx behind flag
- \`2c7e416f3\` fix(web): align PersonalLibrarySection test title
- \`006df671b\` chore(web): phase 3 library hub complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)