### PR TITLE
fix(seed): rebuild dev.yml from staging (add seedAgent markers)

### DIFF
--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml
@@ -4,6 +4,7 @@ catalog:
   - title: Catan
     bggId: 13
     language: en
+    seedAgent: true
     fallbackImageUrl: https://cf.geekdo-images.com/W3Bsga_uLP9kO91gZ7H8yw__original/img/IwRwEpu1I6YfkyYjFIekCh80ntc=/0x0/filters:format(jpeg)/pic2419375.jpg
     fallbackThumbnailUrl: https://cf.geekdo-images.com/W3Bsga_uLP9kO91gZ7H8yw__small/img/7a0LOL48K-2lC3IG0HyYT3XxJBs=/fit-in/200x150/filters:strip_icc()/pic2419375.jpg
     bggEnhanced: true
@@ -271,6 +272,7 @@ catalog:
   - title: 'Descent: Journeys in the Dark (Second Edition)'
     bggId: 104162
     language: en
+    seedAgent: true
     fallbackImageUrl: https://cf.geekdo-images.com/ZTkiJEPvz2O3vmMJWfjrbw__original/img/GZJIjJPJKk1a4Bx-rM-3KL6O4hk=/0x0/filters:format(jpeg)/pic1180640.jpg
     fallbackThumbnailUrl: https://cf.geekdo-images.com/ZTkiJEPvz2O3vmMJWfjrbw__small/img/cO_2QvC_2BCb-Smd0xp4a5G2n-s=/fit-in/200x150/filters:strip_icc()/pic1180640.jpg
     bggEnhanced: true
@@ -622,6 +624,7 @@ catalog:
   - title: Ticket to Ride
     bggId: 9209
     language: en
+    seedAgent: true
     bggEnhanced: true
     description: 'With elegantly simple gameplay, Ticket to Ride can be learned in under 15 minutes. Players collect cards
       of various types of train cars they then use to claim railway routes in North America. The longer the routes, the more
@@ -698,6 +701,7 @@ catalog:
   - title: Splendor
     bggId: 148228
     language: en
+    seedAgent: true
     bggEnhanced: true
     description: 'Splendor is a game of chip-collecting and card development. Players are merchants of the Renaissance trying
       to buy gem mines, means of transportation, shops&mdash;all in order to acquire the most prestige points. If you''re
@@ -4966,6 +4970,7 @@ catalog:
   - title: Carcassonne
     bggId: 822
     language: en
+    seedAgent: true
     bggEnhanced: true
     description: 'Carcassonne is a tile placement game in which the players draw and place a tile with a piece of southern
       French landscape represented on it. The tile might feature a city, a road, a cloister, grassland or some combination
@@ -5582,6 +5587,7 @@ catalog:
   - title: Pandemic
     bggId: 30549
     language: en
+    seedAgent: true
     bggEnhanced: true
     description: 'In Pandemic, several virulent diseases have broken out simultaneously all over the world! The players are
       disease-fighting specialists whose mission is to treat disease hotspots while researching cures for each of four plagues

--- a/infra/scripts/diff-manifests.py
+++ b/infra/scripts/diff-manifests.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Diff dev.yml vs staging.yml: games, agents, default agent section."""
+
+from pathlib import Path
+import yaml
+
+repo_root = Path(__file__).resolve().parent.parent.parent
+manifest_dir = repo_root / "apps" / "api" / "src" / "Api" / "Infrastructure" / "Seeders" / "Catalog" / "Manifests"
+
+
+def load(name):
+    with open(manifest_dir / name, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+dev = load("dev.yml")
+stg = load("staging.yml")
+
+dev_games = dev["catalog"]["games"]
+stg_games = stg["catalog"]["games"]
+
+dev_bgg = {g["bggId"]: g for g in dev_games if g.get("bggId")}
+stg_bgg = {g["bggId"]: g for g in stg_games if g.get("bggId")}
+
+print(f"dev.yml:     {len(dev_games)} games  | defaultAgent={'defaultAgent' in dev['catalog']}")
+print(f"staging.yml: {len(stg_games)} games  | defaultAgent={'defaultAgent' in stg['catalog']}")
+print()
+
+only_in_stg = set(stg_bgg) - set(dev_bgg)
+only_in_dev = set(dev_bgg) - set(stg_bgg)
+print(f"Games only in staging: {len(only_in_stg)}")
+for bid in sorted(only_in_stg):
+    print(f"  + {stg_bgg[bid]['title']} ({bid})")
+print(f"Games only in dev: {len(only_in_dev)}")
+for bid in sorted(only_in_dev):
+    print(f"  - {dev_bgg[bid]['title']} ({bid})")
+
+print()
+print(f"seedAgent=true in dev:     {sum(1 for g in dev_games if g.get('seedAgent'))}")
+print(f"seedAgent=true in staging: {sum(1 for g in stg_games if g.get('seedAgent'))}")
+
+print()
+print("Field completeness (same bggId, different keys):")
+common = set(dev_bgg) & set(stg_bgg)
+fields_diff = {}
+for bid in common:
+    d, s = dev_bgg[bid], stg_bgg[bid]
+    for k in set(d.keys()) | set(s.keys()):
+        if k not in d:
+            fields_diff.setdefault(f"only in staging: {k}", []).append(d.get("title") or s.get("title"))
+        elif k not in s:
+            fields_diff.setdefault(f"only in dev: {k}", []).append(d.get("title"))
+for k, titles in sorted(fields_diff.items()):
+    print(f"  {k}: {len(titles)} games ({titles[:3]}...)")
+
+if "defaultAgent" in stg["catalog"]:
+    print()
+    print("staging.yml defaultAgent:")
+    print(f"  {stg['catalog']['defaultAgent']}")
+if "defaultAgent" in dev["catalog"]:
+    print("dev.yml defaultAgent:")
+    print(f"  {dev['catalog']['defaultAgent']}")

--- a/infra/scripts/rebuild-dev-from-staging.py
+++ b/infra/scripts/rebuild-dev-from-staging.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""
+Rebuild dev.yml as a clone of staging.yml with the profile marker changed.
+
+Rationale: dev.yml has drifted from staging.yml over time. Notably it is
+missing `seedAgent: true` on the 6 core games (Catan, Carcassonne, Pandemic,
+Splendor, Ticket to Ride, Descent), which means running the API locally in
+Dev profile creates zero AI agents — defeating the purpose of the Dev layer.
+
+This script overwrites dev.yml with staging.yml content, then edits only the
+top-level `profile:` field from "staging" to "dev". All games, fallback
+images, PDF blob keys, agent flags, and defaultAgent settings are kept
+in sync.
+
+Idempotent: safe to re-run.
+"""
+
+from pathlib import Path
+import yaml
+
+repo_root = Path(__file__).resolve().parent.parent.parent
+manifest_dir = repo_root / "apps" / "api" / "src" / "Api" / "Infrastructure" / "Seeders" / "Catalog" / "Manifests"
+
+
+def main():
+    staging_path = manifest_dir / "staging.yml"
+    dev_path = manifest_dir / "dev.yml"
+
+    with open(staging_path, "r", encoding="utf-8") as f:
+        doc = yaml.safe_load(f)
+
+    if doc.get("profile") != "staging":
+        raise SystemExit(f"Expected staging.yml profile='staging', got: {doc.get('profile')}")
+
+    # Flip the profile marker — SeedManifest.Validate() requires profile to
+    # match the resource filename/profile enum used by CatalogSeeder.LoadManifest.
+    doc["profile"] = "dev"
+
+    with open(dev_path, "w", encoding="utf-8") as f:
+        yaml.dump(doc, f, default_flow_style=False, allow_unicode=True, sort_keys=False, width=120)
+
+    games = doc["catalog"]["games"]
+    agents = sum(1 for g in games if g.get("seedAgent"))
+    blobs = sum(1 for g in games if g.get("pdfBlobKey"))
+    print(f"dev.yml rebuilt from staging.yml:")
+    print(f"  profile: dev")
+    print(f"  games: {len(games)}")
+    print(f"  seedAgent=true: {agents}")
+    print(f"  pdfBlobKey set: {blobs}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

dev.yml had drifted from staging.yml. After the mirror in PR #311 the two files had identical game lists (159 each), but dev.yml was **missing \`seedAgent: true\`** on the 6 core games:

- Catan
- Carcassonne
- Pandemic
- Splendor
- Ticket to Ride
- Descent: Journeys in the Dark (Second Edition)

## Why this matters

\`AgentSeeder\` only runs when \`profile >= Dev\` and iterates games with \`seedAgent == true\`:

\`\`\`csharp
// CatalogSeeder.cs:80
if (profile >= SeedProfile.Dev)
{
    await AgentSeeder.SeedAsync(db, manifest, gameMap, logger, ct);
}
\`\`\`

With dev.yml showing 0 \`seedAgent: true\` entries, running the API locally in Dev profile created **zero AI agents** — defeating the purpose of the Dev seed layer for local development.

## Fix

Rebuild dev.yml as a clone of staging.yml with only the \`profile:\` marker flipped from \`staging\` → \`dev\`. From now on the two files are managed as a single source of truth, and updates to staging should mirror into dev.

## Delta vs previous dev.yml

| Metric | Before | After |
|--------|--------|-------|
| Games | 159 | 159 |
| seedAgent=true | **0** | **6** |
| pdfBlobKey set | 136 | 136 |
| defaultAgent section | present | present (unchanged) |

No game content changed — only the \`seedAgent: true\` flag was added to 6 existing entries.

## New infra scripts

- \`rebuild-dev-from-staging.py\` — idempotent dev.yml regeneration from staging.yml
- \`diff-manifests.py\` — quick dev vs staging comparison tool

## Test plan

- [x] \`CatalogSeederTests\` + \`ManifestValidationTests\` + \`PdfSeederBlobTests\` + \`AgentSeeder\` = **28/28** passing locally in Release
- [x] \`detect-manifest-mismatches.py\`: 0 issues across all 3 manifests
- [x] \`diff-manifests.py\`: dev and staging now only differ by \`profile:\` marker
- [ ] CI on this PR
- [ ] Local dev run: verify 6 agents seeded in Dev profile after next reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)