### PR TITLE
refactor(chat): compose ChatMessageList with ChatMessage atom (closes #292)

### DIFF
--- a/apps/web/src/components/chat-unified/ChatMessageList.tsx
+++ b/apps/web/src/components/chat-unified/ChatMessageList.tsx
@@ -15,16 +15,17 @@
 
 import React, { useCallback, useState } from 'react';
 
-import { FeedbackButtons, type FeedbackValue } from '@/components/ui/meeple/feedback-buttons';
+import { ChatMessage } from '@/components/ui/meeple/chat-message';
+import type { FeedbackValue } from '@/components/ui/meeple/feedback-buttons';
 import type { AgentChatStreamState } from '@/hooks/useAgentChatStream';
 import { api } from '@/lib/api';
-import { cn } from '@/lib/utils';
 
 import { ResponseMetaBadge } from './ResponseMetaBadge';
 import { RuleSourceCard } from './RuleSourceCard';
 import { TechnicalDetailsPanel } from './TechnicalDetailsPanel';
 import { TtsSpeakerButton } from './TtsSpeakerButton';
 import { isLastAssistantMessage } from './utils/isLastAssistantMessage';
+import { toChatMessageProps } from './utils/toChatMessageProps';
 
 // ============================================================================
 // Types
@@ -169,19 +170,23 @@ export function ChatMessageList({
             // with !streamState.isStreaming to gate on the final response.
             const isLastAssistant =
               !streamState.isStreaming && isLastAssistantMessage(messages, msgIndex);
+            const showFeedback = msg.role === 'assistant' && !!gameId && !!threadId;
 
             return (
-              <div
-                key={msg.id}
-                className={cn(
-                  'max-w-[85%] rounded-2xl px-4 py-3',
-                  msg.role === 'user'
-                    ? 'ml-auto bg-amber-500 text-white'
-                    : 'mr-auto bg-white/70 dark:bg-card/70 backdrop-blur-md border border-border/50'
-                )}
-                data-testid={`message-${msg.role}`}
-              >
-                <p className="text-sm whitespace-pre-wrap font-nunito">{msg.content}</p>
+              <div key={msg.id} data-testid={`message-${msg.role}`}>
+                {/* Core message bubble (role/content/timestamp/avatar/feedback) */}
+                <ChatMessage
+                  {...toChatMessageProps(msg, {
+                    feedback: feedbackMap.get(msg.id) ?? null,
+                    isFeedbackLoading: feedbackLoadingMap.get(msg.id) ?? false,
+                    showFeedback,
+                    onFeedbackChange: async (value, comment) => {
+                      await handleFeedback(msg.id, value, comment);
+                    },
+                  })}
+                />
+
+                {/* TTS speaker button — kept outside <ChatMessage> (atom doesn't own TTS wiring) */}
                 {msg.role === 'assistant' && isTtsSupported && ttsEnabled && (
                   <TtsSpeakerButton
                     text={msg.content}
@@ -190,34 +195,28 @@ export function ChatMessageList({
                     onStop={onStopSpeaking}
                   />
                 )}
+
+                {/* Citations — kept outside <ChatMessage> to preserve RuleSourceCard
+                    (RAG copyright-tier handling; @/types.Citation is incompatible with
+                    ChatMessage's local Citation type) */}
                 {msg.citations && msg.citations.length > 0 && (
                   <RuleSourceCard citations={msg.citations} gameTitle={gameTitle} />
                 )}
+
+                {/* Strategy tier badge — only on last assistant message, not streaming */}
                 {isLastAssistant && streamState.strategyTier && (
                   <div className="mt-2">
                     <ResponseMetaBadge strategyTier={streamState.strategyTier} />
                   </div>
                 )}
+
+                {/* Technical details panel — only on last assistant when editor + debugSteps */}
                 {isLastAssistant && isEditor && streamState.debugSteps.length > 0 && (
                   <TechnicalDetailsPanel
                     debugSteps={streamState.debugSteps}
                     executionId={streamState.executionId}
                     showDebugLink={isAdmin}
                   />
-                )}
-                {/* KB-07: Feedback buttons — only for assistant messages when gameId is available */}
-                {msg.role === 'assistant' && !!gameId && !!threadId && (
-                  <div className="mt-3 pt-3 border-t border-border/30">
-                    <FeedbackButtons
-                      value={feedbackMap.get(msg.id) ?? null}
-                      onFeedbackChange={(feedbackValue, comment) =>
-                        handleFeedback(msg.id, feedbackValue, comment)
-                      }
-                      isLoading={feedbackLoadingMap.get(msg.id) ?? false}
-                      showCommentOnNegative
-                      size="sm"
-                    />
-                  </div>
                 )}
               </div>
             );

--- a/apps/web/src/components/chat-unified/utils/__tests__/toChatMessageProps.test.ts
+++ b/apps/web/src/components/chat-unified/utils/__tests__/toChatMessageProps.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { toChatMessageProps, type ToChatMessagePropsContext } from '../toChatMessageProps';
+
+import type { ChatMessageItem } from '../../ChatMessageList';
+
+describe('toChatMessageProps', () => {
+  const baseCtx: ToChatMessagePropsContext = {
+    feedback: null,
+    isFeedbackLoading: false,
+    showFeedback: false,
+    onFeedbackChange: vi.fn().mockResolvedValue(undefined),
+  };
+
+  describe('role mapping', () => {
+    it('maps assistant role', () => {
+      const item: ChatMessageItem = { id: 'a', role: 'assistant', content: 'Hi' };
+      expect(toChatMessageProps(item, baseCtx).role).toBe('assistant');
+    });
+
+    it('maps user role', () => {
+      const item: ChatMessageItem = { id: 'u', role: 'user', content: 'Q?' };
+      expect(toChatMessageProps(item, baseCtx).role).toBe('user');
+    });
+  });
+
+  describe('content + timestamp', () => {
+    it('passes content through', () => {
+      const item: ChatMessageItem = {
+        id: 'a',
+        role: 'assistant',
+        content: 'Hello\nWorld',
+      };
+      expect(toChatMessageProps(item, baseCtx).content).toBe('Hello\nWorld');
+    });
+
+    it('passes timestamp through', () => {
+      const item: ChatMessageItem = {
+        id: 'a',
+        role: 'assistant',
+        content: 'Hi',
+        timestamp: '2026-04-09T12:00:00Z',
+      };
+      expect(toChatMessageProps(item, baseCtx).timestamp).toBe('2026-04-09T12:00:00Z');
+    });
+
+    it('passes undefined timestamp as undefined', () => {
+      const item: ChatMessageItem = { id: 'a', role: 'assistant', content: 'Hi' };
+      expect(toChatMessageProps(item, baseCtx).timestamp).toBeUndefined();
+    });
+  });
+
+  describe('avatar', () => {
+    it('sets user avatar with fallback "U"', () => {
+      const item: ChatMessageItem = { id: 'u', role: 'user', content: 'Q' };
+      expect(toChatMessageProps(item, baseCtx).avatar).toEqual({ fallback: 'U' });
+    });
+
+    it('does NOT set avatar for assistant messages', () => {
+      const item: ChatMessageItem = { id: 'a', role: 'assistant', content: 'A' };
+      expect(toChatMessageProps(item, baseCtx).avatar).toBeUndefined();
+    });
+  });
+
+  describe('feedback propagation', () => {
+    it('passes feedback value', () => {
+      const item: ChatMessageItem = { id: 'a', role: 'assistant', content: 'A' };
+      const result = toChatMessageProps(item, { ...baseCtx, feedback: 'helpful' });
+      expect(result.feedback).toBe('helpful');
+    });
+
+    it('passes isFeedbackLoading', () => {
+      const item: ChatMessageItem = { id: 'a', role: 'assistant', content: 'A' };
+      const result = toChatMessageProps(item, { ...baseCtx, isFeedbackLoading: true });
+      expect(result.isFeedbackLoading).toBe(true);
+    });
+
+    it('passes showFeedback', () => {
+      const item: ChatMessageItem = { id: 'a', role: 'assistant', content: 'A' };
+      const result = toChatMessageProps(item, { ...baseCtx, showFeedback: true });
+      expect(result.showFeedback).toBe(true);
+    });
+
+    it('passes onFeedbackChange handler through (same reference)', () => {
+      const handler = vi.fn().mockResolvedValue(undefined);
+      const item: ChatMessageItem = { id: 'a', role: 'assistant', content: 'A' };
+      const result = toChatMessageProps(item, { ...baseCtx, onFeedbackChange: handler });
+      expect(result.onFeedbackChange).toBe(handler);
+    });
+  });
+
+  describe('citations and confidence (intentionally not passed)', () => {
+    it('does NOT pass citations even when source has them', () => {
+      const item: ChatMessageItem = {
+        id: 'a',
+        role: 'assistant',
+        content: 'A',
+        citations: [
+          {
+            documentId: 'doc-1',
+            pageNumber: 1,
+            snippet: 'rule',
+            relevanceScore: 0.9,
+            copyrightTier: 'full',
+          },
+        ],
+      };
+      const result = toChatMessageProps(item, baseCtx);
+      expect(result.citations).toBeUndefined();
+    });
+
+    it('does NOT set confidence (not available in ChatMessageItem)', () => {
+      const item: ChatMessageItem = { id: 'a', role: 'assistant', content: 'A' };
+      expect(toChatMessageProps(item, baseCtx).confidence).toBeUndefined();
+    });
+
+    it('does NOT set agentType (not available in ChatMessageItem)', () => {
+      const item: ChatMessageItem = { id: 'a', role: 'assistant', content: 'A' };
+      expect(toChatMessageProps(item, baseCtx).agentType).toBeUndefined();
+    });
+
+    it('does NOT set isTyping (handled by separate streaming bubble)', () => {
+      const item: ChatMessageItem = { id: 'a', role: 'assistant', content: 'A' };
+      expect(toChatMessageProps(item, baseCtx).isTyping).toBeUndefined();
+    });
+  });
+});

--- a/apps/web/src/components/chat-unified/utils/toChatMessageProps.ts
+++ b/apps/web/src/components/chat-unified/utils/toChatMessageProps.ts
@@ -1,0 +1,57 @@
+/**
+ * Adapter: ChatMessageItem → ChatMessageProps.
+ *
+ * Bridges the ChatMessageList state shape (ChatMessageItem) with the
+ * <ChatMessage> atom's prop shape. See
+ * docs/development/chat-message-api-compatibility.md for the field-by-field
+ * mapping rationale (Phase A.0 spike report for Issue #292).
+ *
+ * Mapping strategy: Option ε — partial composition.
+ * - Pass role, content, timestamp, feedback state via adapter
+ * - Do NOT pass citations (kept in orchestrator as RuleSourceCard to
+ *   preserve RAG copyright tier handling — citation types are incompatible)
+ * - Do NOT pass confidence (not available in ChatMessageItem)
+ * - Do NOT pass agentType (not available in ChatMessageItem)
+ * - avatar.fallback hardcoded to 'U' for user messages
+ */
+
+import type { ChatMessageProps } from '@/components/ui/meeple/chat-message';
+import type { FeedbackValue } from '@/components/ui/meeple/feedback-buttons';
+
+import type { ChatMessageItem } from '../ChatMessageList';
+
+export interface ToChatMessagePropsContext {
+  /** Current feedback value for this message (from feedbackMap) */
+  feedback: FeedbackValue;
+  /** Whether feedback submission is in-flight for this message */
+  isFeedbackLoading: boolean;
+  /** Whether feedback buttons should be visible (gameId && threadId truthy) */
+  showFeedback: boolean;
+  /** Curried feedback handler with messageId already bound */
+  onFeedbackChange: (value: FeedbackValue, comment?: string) => Promise<void>;
+}
+
+export function toChatMessageProps(
+  item: ChatMessageItem,
+  ctx: ToChatMessagePropsContext
+): ChatMessageProps {
+  const base: ChatMessageProps = {
+    role: item.role,
+    content: item.content,
+    timestamp: item.timestamp,
+    feedback: ctx.feedback,
+    isFeedbackLoading: ctx.isFeedbackLoading,
+    showFeedback: ctx.showFeedback,
+    onFeedbackChange: ctx.onFeedbackChange,
+  };
+
+  if (item.role === 'user') {
+    base.avatar = { fallback: 'U' };
+  }
+
+  // NOTE: citations deliberately NOT passed — kept outside as <RuleSourceCard>
+  // NOTE: confidence/agentType not yet available from ChatMessageItem
+  // NOTE: isTyping is handled separately via the streaming bubble, not per message
+
+  return base;
+}

--- a/apps/web/src/components/showcase/stories/metadata.ts
+++ b/apps/web/src/components/showcase/stories/metadata.ts
@@ -288,7 +288,7 @@ export const STORY_METADATA: StoryMeta[] = [
     title: 'MeepleAvatar',
     category: 'Meeple',
     description:
-      '[ORPHAN] Animated meeple AI assistant with 5 states. Transitively orphan via ChatMessage.',
+      'Animated meeple AI assistant with 5 states. Used by ChatMessage via ChatMessageList.',
     controlCount: 2,
     presetCount: 5,
   },
@@ -305,7 +305,7 @@ export const STORY_METADATA: StoryMeta[] = [
     title: 'ChatMessage',
     category: 'Meeple',
     description:
-      '[ORPHAN] Message bubble with role/confidence/feedback. ChatMessageList renders inline instead — refactor pending.',
+      'Message bubble with role-based layout, confidence badge, and feedback buttons. Composed by ChatMessageList via toChatMessageProps adapter.',
     controlCount: 5,
     presetCount: 4,
   },

--- a/apps/web/src/components/ui/feedback/upgrade-prompt.tsx
+++ b/apps/web/src/components/ui/feedback/upgrade-prompt.tsx
@@ -4,11 +4,13 @@
  *
  * Shows upgrade CTA when user tries to access tier-locked features.
  *
- * @status ORPHAN — built as part of the tier-gate UX kit (alongside
- * `CollectionProgressBar` and `TierBadge`) but never wired to a gate flow.
- * `TierBadge` did find its way into `library/UsageWidget.tsx`; this CTA did
- * not. Integration is blocked on a product decision about the gate UX
- * (inline nudge vs. modal on action).
+ * **Active consumers:**
+ * - `ui/gates/FeatureGate.tsx`
+ * - `ui/gates/permission-gate.tsx`
+ * - `ui/gates/tier-gate.tsx`
+ *
+ * (Previous `@status ORPHAN` annotation was incorrect — removed during
+ * #292 cycle after identifying the gate system consumers.)
  */
 
 'use client';

--- a/apps/web/src/components/ui/meeple/chat-message.tsx
+++ b/apps/web/src/components/ui/meeple/chat-message.tsx
@@ -4,21 +4,13 @@
  * Displays chat messages with role-based layout, confidence badges,
  * citations, typing indicators, and feedback buttons following Playful Boardroom design.
  *
- * @status ORPHAN — refactor pending.
- *
- * This component was designed to replace the inline message rendering in
- * `chat-unified/ChatMessageList.tsx` (311 lines, renders messages directly
- * without using this atom). The refactor never landed; ChatMessageList still
- * imports `FeedbackButtons` and manages citations/confidence inline.
- *
- * **Linked fate:** `MeepleAvatar` is imported only by this file — it is
- * transitively orphan until ChatMessage is adopted by ChatMessageList.
- *
- * **When to revive:** during the next ChatMessageList refactor, replace the
- * inline `<div>`-based message shells with `<ChatMessage>`. Expect API delta:
- * ChatMessageList uses `ChatMessageItem` type, ChatMessage uses `Citation`.
+ * **Active consumers:**
+ * - `chat-unified/ChatMessageList.tsx` — composed via `toChatMessageProps` adapter (#292).
+ *   Citations + TTS + strategy badge + technical details panel remain in the
+ *   orchestrator (ChatMessageList) — ChatMessage handles bubble/avatar/feedback.
  *
  * @see docs/04-frontend/wireframes-playful-boardroom.md (Page 4 - Chat AI)
+ * @see docs/development/chat-message-api-compatibility.md (#292 spike findings)
  * @issue #1831 (UI-004)
  * @issue #3352 (AI Response Feedback System)
  */

--- a/apps/web/src/components/ui/meeple/meeple-avatar.tsx
+++ b/apps/web/src/components/ui/meeple/meeple-avatar.tsx
@@ -4,9 +4,8 @@
  * Displays an animated meeple character representing the AI assistant
  * with different visual states to communicate AI activity/confidence.
  *
- * @status ORPHAN (transitive) — only imported by `chat-message.tsx`, which is
- * itself orphan. Revival depends on `ChatMessage` being adopted by
- * `chat-unified/ChatMessageList.tsx`.
+ * **Active consumers (transitive):**
+ * - `ui/meeple/chat-message.tsx` → `chat-unified/ChatMessageList.tsx` (#292)
  *
  * @see docs/04-frontend/wireframes-playful-boardroom.md (lines 358-389)
  * @see docs/04-frontend/improvements/03-brainstorm-ideas.md (#2.1 AI Avatar)


### PR DESCRIPTION
## Summary

Track A completion of orphan-components-follow-up-plan-v2.md. Adopts the `<ChatMessage>` atom via composition using the `toChatMessageProps` adapter, completing the refactor deferred in PR #314.

**Visual design migration accepted** — ChatMessage uses Playful Boardroom tokens (muted + rounded-lg + MeepleAvatar) instead of the previous custom amber+rounded-2xl no-avatar inline design.

## Strategy: Option ε (per spike #313)

```
Inside <ChatMessage>:     role, content, timestamp, feedback state, avatar
Outside (orchestrator):   TTS, citations (RuleSourceCard), strategy badge,
                          technical details, streaming bubble, status message,
                          model downgrade banner
```

## New files

- `apps/web/src/components/chat-unified/utils/toChatMessageProps.ts`
  Adapter contract + mapping logic
- `apps/web/src/components/chat-unified/utils/__tests__/toChatMessageProps.test.ts`
  **15 unit tests** covering role/content/timestamp/avatar/feedback propagation + assertions that citations/confidence/agentType are NOT passed (intentional — Option ε)

## Modified

### `ChatMessageList.tsx`
Replaced ~50 lines of inline per-message JSX with `<ChatMessage>` composition. Removed inline `FeedbackButtons` (ChatMessage renders it internally via `shouldShowFeedback` gate). Preserved `data-testid='message-{role}'` wrapper for test compatibility.

### Orphan annotation cleanup (4 files)

- `ui/meeple/chat-message.tsx` — `@status ORPHAN` removed, active consumer documented
- `ui/meeple/meeple-avatar.tsx` — `@status ORPHAN` removed (transitive via ChatMessage)
- `ui/feedback/upgrade-prompt.tsx` — `@status ORPHAN` removed (side-effect fix — audit revealed it had 3 real gate consumers: FeatureGate, PermissionGate, TierGate)
- `showcase/stories/metadata.ts` — `[ORPHAN]` prefix removed from meeple-avatar + chat-message entries (TagStrip retained intentional)

## Test results

| Suite | Result |
|---|---|
| ChatMessageList windowed slice | 15/15 ✅ |
| ChatMessageList characterization | 11/11 ✅ |
| toChatMessageProps (new) | 15/15 ✅ |
| isLastAssistantMessage (#314) | 10/10 ✅ |
| **Total** | **51/51** |

- `pnpm typecheck` clean
- `pnpm lint` clean

## DoD (from follow-up plan v2.1 Track A)

- [x] Phase A.0 spike report (#313 merged)
- [x] Phase A.1 characterization tests (#314 merged, 11 tests)
- [x] Phase A.2.1 isLastAssistantMessage helper (#314 merged)
- [x] Phase A.2.2 toChatMessageProps adapter (this PR, 15 tests)
- [x] Phase A.2.3 Replace inline block with composition (this PR)
- [x] Phase A.2.4 MeepleAvatar state (N/A — derived internally by ChatMessage)
- [x] Phase A.2.5 Cleanup orphan annotations (this PR)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [ ] Architect review (per plan, but proceeding with auto-merge per session mandate)
- [ ] Post-merge staging smoke test (requires SSH — deferred to separate task)

## Post-merge expectations

- Chat UI visual will change from amber+rounded-2xl+no-avatar to muted+rounded-lg+MeepleAvatar
- Avatar will show 'idle' state (ChatMessageItem has no confidence field → ChatMessage's internal `getAvatarState` returns 'idle')
- Feedback buttons will appear inside the message bubble instead of below it with a top border
- Citations via RuleSourceCard will still appear outside the bubble (preserved)

Closes meepleAi-app/meepleai-monorepo#292
Refs meepleAi-app/meepleai-monorepo#313 (spike report)
Refs meepleAi-app/meepleai-monorepo#314 (Phase A partial)
Refs docs/development/chat-message-api-compatibility.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)