### PR TITLE
fix(seed): PdfSeeder must enqueue ProcessingJob so Quartz picks up PDFs

### DIFF
--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/PdfSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/PdfSeeder.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.DocumentProcessing;
 using Api.Infrastructure.Seeders.Catalog.SeedBlob;
 using Api.Services.Pdf;
 using Microsoft.EntityFrameworkCore;
@@ -9,9 +10,16 @@ namespace Api.Infrastructure.Seeders.Catalog;
 
 /// <summary>
 /// Seeds PDF rulebook documents from the seed blob bucket (meepleai-seeds) using the YAML manifest.
-/// Creates PdfDocumentEntity records in <see cref="PdfProcessingState.Pending"/> state.
-/// The existing PdfProcessingQuartzJob (runs every 10s) will automatically pick up
-/// and process them through the full RAG pipeline (extract → chunk → embed → index).
+/// Creates PdfDocumentEntity records in <see cref="PdfProcessingState.Pending"/> state AND
+/// enqueues a corresponding ProcessingJob so PdfProcessingQuartzJob (runs every 10s) picks them
+/// up through the full RAG pipeline (extract → chunk → embed → index).
+///
+/// IMPORTANT: PdfProcessingQuartzJob reads from <c>processing_jobs WHERE Status='Queued'</c>,
+/// not from <c>pdf_documents WHERE ProcessingState='Pending'</c>. Without an explicit
+/// ProcessingJob row the seeded PDFs would stay in Pending forever (StalePdfRecoveryService
+/// only picks them up after 2 minutes of staleness and runs only once at boot, so they slip
+/// through the crack).
+///
 /// Idempotent: skips PDFs where GameId + FileName already exists with matching hash.
 /// Hash drift: deletes old document cascade and reinserts when hash changes.
 /// </summary>
@@ -171,13 +179,42 @@ internal static class PdfSeeder
                 db.PdfDocuments.Add(pdfEntity);
                 await db.SaveChangesAsync(ct).ConfigureAwait(false);
 
+                // Enqueue a ProcessingJob so PdfProcessingQuartzJob picks this PDF up.
+                // We write the EF entity directly (not the ProcessingJob.Create aggregate
+                // factory) to bypass the MaxQueueSize=100 guard — a seed run can push
+                // more than 100 PDFs and those limits are meant for user-driven enqueue,
+                // not batch seeding. We also initialise the five standard pipeline steps
+                // so the job row matches what EnqueuePdfCommandHandler would have produced.
+                var now = DateTimeOffset.UtcNow;
+                var jobEntity = new ProcessingJobEntity
+                {
+                    Id = Guid.NewGuid(),
+                    PdfDocumentId = pdfEntity.Id,
+                    UserId = systemUserId,
+                    Status = nameof(JobStatus.Queued),
+                    Priority = 0,
+                    CreatedAt = now,
+                    MaxRetries = 3,
+                    RetryCount = 0,
+                };
+                jobEntity.Steps = new List<ProcessingStepEntity>
+                {
+                    new() { Id = Guid.NewGuid(), ProcessingJobId = jobEntity.Id, StepName = nameof(ProcessingStepType.Upload),  Status = "Pending" },
+                    new() { Id = Guid.NewGuid(), ProcessingJobId = jobEntity.Id, StepName = nameof(ProcessingStepType.Extract), Status = "Pending" },
+                    new() { Id = Guid.NewGuid(), ProcessingJobId = jobEntity.Id, StepName = nameof(ProcessingStepType.Chunk),   Status = "Pending" },
+                    new() { Id = Guid.NewGuid(), ProcessingJobId = jobEntity.Id, StepName = nameof(ProcessingStepType.Embed),   Status = "Pending" },
+                    new() { Id = Guid.NewGuid(), ProcessingJobId = jobEntity.Id, StepName = nameof(ProcessingStepType.Index),   Status = "Pending" },
+                };
+                db.Set<ProcessingJobEntity>().Add(jobEntity);
+                await db.SaveChangesAsync(ct).ConfigureAwait(false);
+
                 // Track for subsequent iterations
                 existingMap[idempotencyKey] = new { pdfEntity.Id, pdfEntity.ContentHash, pdfEntity.FilePath };
 
                 seeded++;
                 logger.LogInformation(
-                    "PdfSeeder: stored blob '{FileName}' for game '{Title}' (GameId={GameId}, PdfId={PdfId}, {Size} bytes) in Pending state",
-                    fileName, entry.Title, gameId, pdfEntity.Id, result.FileSizeBytes);
+                    "PdfSeeder: stored blob '{FileName}' for game '{Title}' (GameId={GameId}, PdfId={PdfId}, JobId={JobId}, {Size} bytes) queued for processing",
+                    fileName, entry.Title, gameId, pdfEntity.Id, jobEntity.Id, result.FileSizeBytes);
             }
             catch (Exception ex)
             {

--- a/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/PdfSeederBlobTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/PdfSeederBlobTests.cs
@@ -8,6 +8,7 @@ using Api.Services.Pdf;
 using Api.Tests.Constants;
 using Api.Tests.TestHelpers;
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -145,6 +146,29 @@ public sealed class PdfSeederBlobTests
         doc.ProcessingState.Should().Be(nameof(PdfProcessingState.Pending));
         doc.UploadedByUserId.Should().Be(userId);
         doc.FileSizeBytes.Should().Be(4);
+
+        // Regression guard for PR #XXX: PdfSeeder must also create a ProcessingJob
+        // in Queued state so PdfProcessingQuartzJob picks the PDF up automatically.
+        // Without this, seeded PDFs stay in Pending forever.
+        var jobs = db.ProcessingJobs.Include(j => j.Steps).ToList();
+        jobs.Should().HaveCount(1);
+        var job = jobs[0];
+        job.PdfDocumentId.Should().Be(doc.Id);
+        job.UserId.Should().Be(userId);
+        job.Status.Should().Be(nameof(JobStatus.Queued));
+        job.Priority.Should().Be(0);
+        job.MaxRetries.Should().Be(3);
+        job.RetryCount.Should().Be(0);
+        job.Steps.Should().HaveCount(5);
+        job.Steps.Select(s => s.StepName).Should().BeEquivalentTo(new[]
+        {
+            nameof(ProcessingStepType.Upload),
+            nameof(ProcessingStepType.Extract),
+            nameof(ProcessingStepType.Chunk),
+            nameof(ProcessingStepType.Embed),
+            nameof(ProcessingStepType.Index),
+        });
+        job.Steps.Should().OnlyContain(s => s.Status == "Pending");
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix a silent bug in \`PdfSeeder\` where seeded PDFs were never actually processed through the RAG pipeline.

## Evidence

After the main-staging release merged yesterday, this is the actual state on \`meepleai.app\`:

\`\`\`
pdf_documents:          121 Pending, 2 Failed, 0 Ready
processing_jobs:        2 Completed, 0 Queued, 0 Processing
vector_documents:       2 (pre-existing, not from seed)
text_chunks:            130 (pre-existing, not from seed)
pgvector_embeddings:    0
\`\`\`

**Expected after a seed run**: 136 PDFs Ready, thousands of text_chunks, thousands of embeddings, RAG queries answering from rulebook content.

**Actual**: RAG pipeline empty. Users get no rulebook answers from any of the 136 seeded PDFs.

## Root cause

\`PdfSeeder\` creates \`PdfDocumentEntity\` in \`Pending\` state and relies on a commented assumption that \"PdfProcessingQuartzJob (runs every 10s) will automatically pick up and process them\". That assumption is **wrong**: \`PdfProcessingQuartzJob\` reads from \`processing_jobs WHERE Status='Queued'\`, not from \`pdf_documents WHERE ProcessingState='Pending'\`. Every other code path that creates a \`PdfDocumentEntity\` (\`UploadPdfCommandHandler\`, \`AddRulebookCommandHandler\`, \`ReindexDocumentCommandHandler\`, \`AddRagToSharedGameCommandHandler\`, \`LaunchAdminPdfProcessingCommandHandler\`) explicitly calls \`EnqueuePdfCommand\` to create a matching \`ProcessingJob\`. \`PdfSeeder\` was the only one that didn't.

\`StalePdfRecoveryService\` was supposed to be the safety net for orphaned Pending PDFs, but it only picks up PDFs older than 2 minutes AND runs exactly once, 30 seconds after boot. PDFs just seeded during startup are too fresh to be considered stale, so they slip through the safety net forever.

## Fix

After each \`PdfDocumentEntity\` insert, create a matching \`ProcessingJobEntity\` with \`Status=Queued\` and the five standard pipeline steps (\`Upload\`/\`Extract\`/\`Chunk\`/\`Embed\`/\`Index\`). The EF entity is written directly (not via \`ProcessingJob.Create\` aggregate factory) to intentionally bypass the \`MaxQueueSize=100\` guard — a seed run can push more than 100 PDFs and those limits exist for user-driven enqueue throttling, not batch seeding.

## Test plan

- [x] Extended \`PdfSeederBlobTests.SeedAsync_NewBlobEntry_CreatesPdfDocumentWithGameIdAndHash\` with regression assertions: every seeded PDF must produce exactly 1 queued ProcessingJob with 5 pending steps
- [x] Local \`dotnet test --filter 'PdfSeederBlobTests|CatalogSeederTests|ManifestValidation|PdfSeederTests|AgentSeeder'\` → **30/30 passing**
- [x] Release build: 0 warnings, 0 errors
- [ ] After merge + staging reset: verify staging processes all 136 seeded PDFs over ~30–60 min (embedding-service ARM64 throughput) and RAG queries return rulebook content

## Before/after

**Before**: staging reset → 0 RAG-ready PDFs, RAG pipeline silently empty.

**After**: staging reset → 136 PDFs queued → \`PdfProcessingQuartzJob\` drains the queue, populates \`text_chunks\` + \`pgvector_embeddings\` automatically. First RAG query works the moment the processing pipeline catches up.

## Related

- This is the \"option A\" fix for the broader gap identified after PR #308 — once staging is populated with vectors via this fix, we can do a one-time export to \`meepleai-seeds/rag-index/v1/\` and add a \`RagIndexSeeder\` that bypasses the processing pipeline entirely for future resets (instant seeding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)