### PR TITLE
feat(monitoring): add SessionAutoSaveJobStale warning alert

### DIFF
--- a/apps/api/tests/Api.Tests/Observability/AutoSaveHealthGaugeTests.cs
+++ b/apps/api/tests/Api.Tests/Observability/AutoSaveHealthGaugeTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using Api.BoundedContexts.SessionTracking.Infrastructure.Health;
+using Api.Observability;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Api.Tests.Observability;
+
+/// <summary>
+/// Verifies the AutoSave health observable gauge is registered with the exact
+/// instrument name and unit that the Prometheus alert rule
+/// `SessionAutoSaveJobStale` (infra/prometheus-rules.yml) depends on.
+///
+/// The alert expression uses the Prometheus-flattened metric name:
+///   meepleai_session_autosave_last_run_age_seconds
+///
+/// which the OpenTelemetry Prometheus exporter derives from the OTel name
+/// `meepleai.session.autosave.last_run_age_seconds` by converting dots to
+/// underscores. Because the OTel name already ends in `_seconds`, the
+/// exporter MUST NOT append a second `_seconds` suffix from the unit metadata.
+///
+/// These tests guard against future OTel exporter version bumps that could
+/// silently change the naming convention and break the alert.
+///
+/// PR #327 — follow-up minor #3 from the code review.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("Area", "Observability")]
+[Trait("BoundedContext", "SessionTracking")]
+public class AutoSaveHealthGaugeTests
+{
+    private const string ExpectedOtelInstrumentName = "meepleai.session.autosave.last_run_age_seconds";
+    private const string ExpectedUnit = "s";
+
+    /// <summary>
+    /// The exact Prometheus scrape name the alert rule depends on.
+    /// Keep this in sync with the expression in infra/prometheus-rules.yml
+    /// (group meepleai_warning_alerts, alert SessionAutoSaveJobStale).
+    /// </summary>
+    private const string ExpectedPrometheusScrapeName = "meepleai_session_autosave_last_run_age_seconds";
+
+    [Fact]
+    public void RegisterAutoSaveHealthGauge_PublishesInstrumentWithExpectedNameAndUnit()
+    {
+        var tracker = new AutoSaveHealthTracker(new FakeTimeProvider(DateTimeOffset.UtcNow));
+        Instrument? captured = null;
+
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == MeepleAiMetrics.MeterName
+                    && instrument.Name == ExpectedOtelInstrumentName)
+                {
+                    captured = instrument;
+                }
+            }
+        };
+        listener.Start();
+
+        MeepleAiMetrics.RegisterAutoSaveHealthGauge(tracker);
+
+        captured.Should().NotBeNull(
+            "RegisterAutoSaveHealthGauge must publish an instrument named {0} " +
+            "so the Prometheus exporter exposes it as {1} " +
+            "(alert SessionAutoSaveJobStale depends on this exact name)",
+            ExpectedOtelInstrumentName,
+            ExpectedPrometheusScrapeName);
+        captured!.Unit.Should().Be(ExpectedUnit,
+            "unit must be 's' so the exporter does NOT append a second _seconds suffix");
+        captured.Meter.Name.Should().Be(MeepleAiMetrics.MeterName);
+    }
+
+    [Fact]
+    public void PrometheusScrapeName_DerivedFromOtelName_MatchesAlertExpression()
+    {
+        // Pure string assertion: the Prometheus exporter converts dots to
+        // underscores. This test documents the conversion contract in code so
+        // any future rename of the OTel instrument is forced to update both
+        // sides (instrument + alert rule) simultaneously.
+        var derived = ExpectedOtelInstrumentName.Replace('.', '_');
+
+        derived.Should().Be(ExpectedPrometheusScrapeName,
+            "if this assertion fails, update infra/prometheus-rules.yml " +
+            "alert SessionAutoSaveJobStale to reference the new scrape name");
+    }
+
+    [Fact]
+    public void RegisteredGauge_ObservesMinusOneSentinel_WhenTrackerHasNeverRun()
+    {
+        var tracker = new AutoSaveHealthTracker(new FakeTimeProvider(DateTimeOffset.UtcNow));
+        var observed = new List<long>();
+
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == MeepleAiMetrics.MeterName
+                    && instrument.Name == ExpectedOtelInstrumentName)
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, _, _) => observed.Add(value));
+        listener.Start();
+
+        MeepleAiMetrics.RegisterAutoSaveHealthGauge(tracker);
+        listener.RecordObservableInstruments();
+
+        observed.Should().Contain(-1L,
+            "the gauge must emit the -1 sentinel when the tracker has never " +
+            "recorded a run, so the alert expression `>= 0` guard suppresses " +
+            "spurious cold-start alerts");
+    }
+
+    [Fact]
+    public void RegisteredGauge_ObservesElapsedSeconds_AfterRecordRun()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var timeProvider = new FakeTimeProvider(now);
+        var tracker = new AutoSaveHealthTracker(timeProvider);
+        var observed = new List<long>();
+
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == MeepleAiMetrics.MeterName
+                    && instrument.Name == ExpectedOtelInstrumentName)
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, _, _) => observed.Add(value));
+        listener.Start();
+
+        MeepleAiMetrics.RegisterAutoSaveHealthGauge(tracker);
+
+        tracker.RecordRun();
+        timeProvider.Advance(TimeSpan.FromSeconds(130));
+        listener.RecordObservableInstruments();
+
+        observed.Should().Contain(130L,
+            "the gauge must emit the elapsed seconds since the last run, " +
+            "not the -1 sentinel, so the alert can fire above 120");
+    }
+}

--- a/docs/operations/operations-manual.md
+++ b/docs/operations/operations-manual.md
@@ -2689,6 +2689,7 @@ Existing runbooks in `docs/operations/runbooks/`:
 | `error-spike.md` | Sudden increase in error rate |
 | `high-error-rate.md` | Sustained high error rate (> 5%) |
 | `infrastructure-monitoring.md` | Monitoring infrastructure issues |
+| `session-autosave-stale.md` | `AutoSaveSessionJob` has not run in over 120s (2 missed ticks) |
 | `slow-performance.md` | API latency exceeding thresholds |
 
 ---

--- a/docs/operations/runbooks/session-autosave-stale.md
+++ b/docs/operations/runbooks/session-autosave-stale.md
@@ -1,0 +1,120 @@
+# Runbook: SessionAutoSaveJobStale
+
+> **Alert**: `SessionAutoSaveJobStale`
+> **Severity**: warning
+> **Category**: `background_jobs` / `session_tracking`
+> **Source file**: [`infra/prometheus-rules.yml`](../../../infra/prometheus-rules.yml) (group `meepleai_warning_alerts`)
+> **Metric**: `meepleai_session_autosave_last_run_age_seconds`
+> **First added**: 2026-04-09 (follow-up to Issue #301 / PR #283 F3)
+
+## What this alert means
+
+The `AutoSaveSessionJob` (a Quartz.NET background job) has not executed in more than **120 seconds**, while the expected cadence is every **60 seconds**. This means **at least two scheduled ticks have been missed**, and any game-night sessions currently in progress are at risk of losing unsaved state.
+
+### Source metric
+
+The gauge is published from `Api.Observability.MeepleAiMetrics.RegisterAutoSaveHealthGauge`, which reads from the singleton `IAutoSaveHealthTracker`:
+
+- `RecordRun()` is called at the end of each successful `AutoSaveSessionJob.Execute()`
+- `GetLastRunAgeSeconds()` returns `null` at startup (before the first run) → the gauge emits **`-1`** as a sentinel
+- When the tracker has at least one recorded run, the gauge returns seconds since that run
+
+The alert expression explicitly excludes the `-1` sentinel so it does **not** fire during cold starts or in environments where no game-night sessions are active:
+
+```promql
+meepleai_session_autosave_last_run_age_seconds > 120
+and
+meepleai_session_autosave_last_run_age_seconds >= 0
+```
+
+### Related in-process signal
+
+`AutoSaveHealthLoggerService` (a `BackgroundService`) polls the same tracker every 30 seconds and emits a log-level warning when `ageSeconds > 120`. The Prometheus alert and the log warning fire in lockstep — they are two routing surfaces for the same underlying signal.
+
+## Impact
+
+- **Direct**: In-progress game-night sessions will not be auto-saved. If the API process is restarted or crashes, players will lose state back to the previous successful save.
+- **Indirect**: The AI agent memory (house rules, session notes) may also be stale if its persistence depends on the same job.
+- **User-visible**: None until the user tries to resume a session after a crash and discovers missing turns / scores.
+
+## Triage checklist
+
+Work through these in order. Each step is ~30–60 seconds.
+
+### 1. Confirm the alert is not a false positive
+
+- [ ] Check the metric in Grafana or query directly:
+  ```bash
+  curl -s http://api:8080/metrics | grep meepleai_session_autosave_last_run_age_seconds
+  ```
+- [ ] If the value is `-1`, the tracker has never recorded a run since process start. This is expected on a fresh boot or in an environment with no active sessions — the alert's `>= 0` guard should have suppressed it. If you're seeing the alert fire on `-1`, there is a **bug in the alert expression** — escalate.
+- [ ] If the value is a large positive number (e.g. > 300), proceed to step 2.
+
+### 2. Check Quartz scheduler health
+
+The job is scheduled by `QuartzAutoSaveSchedulerService` and registered in `SessionTrackingServiceExtensions.cs`. Verify:
+
+- [ ] The Quartz scheduler is running and the `IAutoSaveSchedulerService` is registered in DI.
+- [ ] No recent Quartz errors in the API logs:
+  ```bash
+  pwsh -c "docker logs meepleai-api --tail=500 | Select-String -Pattern 'AutoSave|Quartz'"
+  ```
+- [ ] The `AutoSaveHealthLoggerService` warning line (`"AutoSave job stale: last run {AgeSeconds} seconds ago"`) should appear in logs near the alert firing time. If not, the logger service itself may have crashed.
+
+### 3. Check for blocking work on the job thread
+
+The auto-save command (`AutoSaveSessionCommand`) hits the database and the session store. A stuck DB query, pgvector hotspot, or Redis latency can delay the job:
+
+- [ ] Check Postgres for long-running queries:
+  ```sql
+  SELECT pid, query_start, state, query
+  FROM pg_stat_activity
+  WHERE state != 'idle' AND query_start < now() - interval '30 seconds'
+  ORDER BY query_start;
+  ```
+- [ ] Check Redis responsiveness: `docker exec meepleai-redis redis-cli --latency-history`
+
+### 4. Check for missing DI registrations
+
+Two known root causes for silent job stalls:
+
+- [ ] `IAutoSaveSchedulerService` not registered → the job never fires. Verify in `apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/DependencyInjection/SessionTrackingServiceExtensions.cs`.
+- [ ] `IAutoSaveHealthTracker` registered as transient instead of singleton → the tracker instance observed by the gauge is different from the one the job writes to. Must be `AddSingleton`.
+
+### 5. Last resort: restart the API
+
+If triage does not reveal the root cause within a few minutes and active sessions are at risk:
+
+```bash
+cd infra && pwsh -c "docker compose restart api"
+```
+
+The alert will clear once the first successful `AutoSaveSessionJob.Execute()` runs and updates the tracker.
+
+## What does NOT clear this alert
+
+- Restarting Prometheus (the metric is exported by the API, not Prometheus)
+- Restarting Alertmanager (this only resets alert routing state, not the underlying gauge)
+- Scaling the API horizontally (the gauge is per-process; a second replica would publish its own value)
+
+## Observability references
+
+- **Metric source**: `apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.SessionAutoSave.cs`
+- **Tracker**: `apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Health/AutoSaveHealthTracker.cs`
+- **Log-level signal**: `apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Health/AutoSaveHealthLoggerService.cs`
+- **Quartz scheduler**: `apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Scheduling/QuartzAutoSaveSchedulerService.cs`
+- **Job**: `apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Scheduling/AutoSaveSessionJob.cs`
+
+## Dashboard
+
+The alert currently references `http://localhost:3001/d/api-performance` as a placeholder. There is **no dedicated background-jobs dashboard yet** — this is tracked as a follow-up. Until then, use Prometheus directly:
+
+```
+http://prometheus:9090/graph?g0.expr=meepleai_session_autosave_last_run_age_seconds
+```
+
+## Related
+
+- PR #283 (F3 follow-up): introduced the gauge and the log-level signal
+- PR #327: promoted the gauge to a routable Prometheus alert (this runbook)
+- Issue #301: spec-panel review that flagged the observability gap

--- a/infra/prometheus-rules.yml
+++ b/infra/prometheus-rules.yml
@@ -438,7 +438,7 @@ groups:
         annotations:
           summary: "Session AutoSave job has not run in over 2 minutes"
           description: |
-            AutoSaveSessionJob last ran {{ $value | humanizeDuration }} ago
+            AutoSaveSessionJob last ran {{ $value | humanize }}s ago
             (threshold: 120s, expected cadence: 60s).
             Active game-night sessions risk losing unsaved progress.
             Check Quartz scheduler health, API logs for AutoSaveHealthLoggerService warnings,

--- a/infra/prometheus-rules.yml
+++ b/infra/prometheus-rules.yml
@@ -417,6 +417,35 @@ groups:
           runbook_url: "https://docs.meepleai.dev/runbooks/infrastructure-monitoring"
           dashboard_url: "http://localhost:3001/d/infrastructure"
 
+      # WARNING: Session AutoSave job is stale
+      # Source gauge: Api.Observability.MeepleAiMetrics.RegisterAutoSaveHealthGauge
+      # Metric (OTel → Prometheus): meepleai.session.autosave.last_run_age_seconds
+      #   - Reports seconds since the last AutoSaveSessionJob execution
+      #   - Returns -1 when no run has happened yet (startup / no active sessions),
+      #     so we explicitly exclude that sentinel from the alert expression.
+      #   - Expected cadence: every 60s (Quartz trigger). Threshold 120s = 2 missed ticks.
+      - alert: SessionAutoSaveJobStale
+        expr: |
+          meepleai_session_autosave_last_run_age_seconds > 120
+          and
+          meepleai_session_autosave_last_run_age_seconds >= 0
+        for: 2m
+        labels:
+          severity: warning
+          service: meepleai-api
+          category: background_jobs
+          component: session_tracking
+        annotations:
+          summary: "Session AutoSave job has not run in over 2 minutes"
+          description: |
+            AutoSaveSessionJob last ran {{ $value | humanizeDuration }} ago
+            (threshold: 120s, expected cadence: 60s).
+            Active game-night sessions risk losing unsaved progress.
+            Check Quartz scheduler health, API logs for AutoSaveHealthLoggerService warnings,
+            and verify the IAutoSaveSchedulerService registration is active.
+          runbook_url: "https://docs.meepleai.dev/runbooks/session-autosave-stale"
+          dashboard_url: "http://localhost:3001/d/api-performance"
+
   - name: meepleai_info_alerts
     interval: 5m
     rules:


### PR DESCRIPTION
## Summary

- Adds a Prometheus warning alert `SessionAutoSaveJobStale` to `infra/prometheus-rules.yml`
- Fires when the `AutoSaveSessionJob` gauge reports more than 120s since last execution (2 missed ticks vs. the 60s expected cadence), for 2 minutes
- Closes the observability gap flagged during the Issue #301 spec-panel review

## Context

The underlying gauge `meepleai.session.autosave.last_run_age_seconds` was wired up in PR #283 (F3 follow-up) via `Api.Observability.MeepleAiMetrics.RegisterAutoSaveHealthGauge`, but no corresponding Prometheus alert existed. The only runtime signal was a log-level warning from `AutoSaveHealthLoggerService`, which is not routable via Alertmanager.

This PR promotes the existing metric to a `severity: warning` alert so that a stale autosave job becomes a visible, routable operational signal. Active game-night sessions risk losing unsaved progress when the job stalls.

## Alert expression

```promql
meepleai_session_autosave_last_run_age_seconds > 120
and
meepleai_session_autosave_last_run_age_seconds >= 0
```

The `>= 0` guard excludes the sentinel value `-1` which the gauge reports when no run has happened yet (process startup, no active sessions). This prevents spurious alerts on cold starts.

## Validation

```bash
promtool check rules infra/prometheus-rules.yml
# → SUCCESS: 58 rules found  (was 57)
```

## Test plan

- [x] `promtool check rules` passes (58 rules)
- [x] YAML syntactically valid (`python -c "import yaml; yaml.safe_load(...)"`)
- [x] Alert inserted inside the existing `meepleai_warning_alerts` group (loaded by all 3 prometheus configs: `prometheus.yml`, `prometheus.staging.yml`, `prometheus.prod.yml`)
- [x] Sentinel `-1` value excluded from the firing expression
- [ ] Manual smoke test in staging: verify alert does not fire on a healthy system
- [ ] Verify Alertmanager routing picks up `severity: warning` + `category: background_jobs`

## Related

- Follow-up to PR #315 (Issue #301)
- Sibling follow-up issues: #323 (lifecycle E2E), #324 (SSE diary E2E), #325 (autosave indicator E2E)