### PR TITLE
feat(web): desktop UX redesign phase 4 — chat slide-over panel

### DIFF
--- a/apps/web/src/components/chat/panel/ChatCitationCard.tsx
+++ b/apps/web/src/components/chat/panel/ChatCitationCard.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+export interface ChatCitation {
+  documentName: string;
+  pages: number[];
+  excerpt: string;
+  openUrl?: string;
+}
+
+interface ChatCitationCardProps {
+  citation: ChatCitation;
+}
+
+export function ChatCitationCard({ citation }: ChatCitationCardProps) {
+  return (
+    <div
+      className="flex max-w-full gap-3 rounded-2xl border p-3.5"
+      style={{
+        background: 'hsla(210, 40%, 55%, 0.06)',
+        borderColor: 'hsla(210, 40%, 55%, 0.2)',
+      }}
+    >
+      <div
+        className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg text-white"
+        style={{ background: 'linear-gradient(135deg, hsl(210 40% 65%), hsl(210 40% 45%))' }}
+        aria-hidden
+      >
+        📄
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="mb-1.5 flex flex-wrap items-center gap-2">
+          <span
+            className="font-quicksand text-[0.78rem] font-extrabold"
+            style={{ color: 'hsl(210 40% 32%)' }}
+          >
+            {citation.documentName}
+          </span>
+          {citation.pages.map(page => (
+            <span
+              key={page}
+              className="rounded px-2 py-0.5 text-[0.68rem] font-extrabold"
+              style={{ background: 'hsla(210, 40%, 55%, 0.12)', color: 'hsl(210 40% 30%)' }}
+            >
+              pag. {page}
+            </span>
+          ))}
+        </div>
+        <p
+          className="border-l-2 pl-2.5 text-[0.78rem] italic leading-relaxed text-[var(--nh-text-secondary)]"
+          style={{ borderLeftColor: 'hsla(210, 40%, 55%, 0.3)' }}
+        >
+          &ldquo;{citation.excerpt}&rdquo;
+        </p>
+        {citation.openUrl && (
+          <a
+            href={citation.openUrl}
+            className="mt-1.5 inline-flex items-center gap-1 font-nunito text-[0.72rem] font-extrabold"
+            style={{ color: 'hsl(210 40% 40%)' }}
+          >
+            Apri regolamento →
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/panel/ChatContextSwitcher.tsx
+++ b/apps/web/src/components/chat/panel/ChatContextSwitcher.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import type { ChatGameContext } from '@/lib/stores/chat-panel-store';
+
+interface ChatContextSwitcherProps {
+  gameContext: ChatGameContext | null;
+  onPickGame: () => void;
+}
+
+export function ChatContextSwitcher({ gameContext, onPickGame }: ChatContextSwitcherProps) {
+  return (
+    <div className="flex flex-shrink-0 flex-wrap items-center gap-2.5 border-b border-[var(--nh-border-default)] bg-[var(--nh-bg-base)] px-5 py-3">
+      <span className="mr-0.5 text-[0.7rem] font-extrabold uppercase tracking-wider text-[var(--nh-text-muted)]">
+        Contesto
+      </span>
+      {gameContext ? (
+        <button
+          type="button"
+          onClick={onPickGame}
+          className="flex items-center gap-2.5 rounded-full border border-[hsla(25,95%,45%,0.35)] bg-[hsla(25,95%,45%,0.08)] py-1.5 pl-1.5 pr-3.5 shadow-[var(--shadow-warm-sm)] transition-all hover:-translate-y-px hover:shadow-[var(--shadow-warm-md)]"
+        >
+          <span
+            aria-hidden
+            className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-[7px] text-base"
+            style={{
+              background: 'linear-gradient(135deg, hsl(25 75% 78%), hsl(25 80% 55%))',
+            }}
+          >
+            🎲
+          </span>
+          <div className="text-left">
+            <div className="font-quicksand text-[0.82rem] font-extrabold leading-none text-[var(--nh-text-primary)]">
+              {gameContext.name}
+            </div>
+            <div className="mt-1 text-[0.66rem] font-semibold text-[var(--nh-text-muted)]">
+              {gameContext.year ? `${gameContext.year} · ` : ''}
+              {gameContext.pdfCount} PDF · KB{' '}
+              {gameContext.kbStatus === 'ready' ? 'pronta' : gameContext.kbStatus}
+            </div>
+          </div>
+          <span aria-hidden className="text-xs text-[var(--nh-text-muted)]">
+            ▾
+          </span>
+        </button>
+      ) : (
+        <button
+          type="button"
+          onClick={onPickGame}
+          className="rounded-full border border-dashed border-[var(--nh-border-default)] bg-[var(--nh-bg-elevated)] px-4 py-2 font-nunito text-[0.78rem] font-semibold text-[var(--nh-text-muted)] hover:bg-white hover:shadow-[var(--shadow-warm-sm)]"
+        >
+          Seleziona gioco
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/panel/ChatInputBar.tsx
+++ b/apps/web/src/components/chat/panel/ChatInputBar.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState, type KeyboardEvent } from 'react';
+
+interface ChatInputBarProps {
+  placeholder?: string;
+  onSend: (value: string) => void;
+}
+
+export function ChatInputBar({ placeholder = 'Chiedi una regola…', onSend }: ChatInputBarProps) {
+  const [value, setValue] = useState('');
+
+  const send = () => {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return;
+    onSend(trimmed);
+    setValue('');
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      send();
+    }
+  };
+
+  return (
+    <div className="flex-shrink-0 border-t border-[var(--nh-border-default)] bg-[rgba(255,252,248,0.8)] px-5 py-4 backdrop-blur-md">
+      <div className="flex items-end gap-2.5 rounded-2xl border border-[var(--nh-border-default)] bg-[var(--nh-bg-elevated)] py-2 pl-4 pr-2 shadow-[var(--shadow-warm-sm)] transition-all focus-within:border-[hsla(220,80%,55%,0.3)] focus-within:bg-white focus-within:shadow-[0_0_0_3px_hsla(220,80%,55%,0.1),var(--shadow-warm-md)]">
+        <textarea
+          value={value}
+          onChange={e => setValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          rows={1}
+          className="min-h-6 flex-1 resize-none border-none bg-transparent py-2 font-nunito text-[0.9rem] leading-relaxed text-[var(--nh-text-primary)] outline-none placeholder:text-[var(--nh-text-muted)]"
+        />
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            aria-label="Allega PDF"
+            className="flex h-9 w-9 items-center justify-center rounded-[10px] text-[var(--nh-text-muted)] transition-all hover:bg-[var(--nh-bg-base)] hover:text-[var(--nh-text-primary)]"
+          >
+            📎
+          </button>
+          <button
+            type="button"
+            aria-label="Dettatura"
+            className="flex h-9 w-9 items-center justify-center rounded-[10px] text-[var(--nh-text-muted)] transition-all hover:bg-[var(--nh-bg-base)] hover:text-[var(--nh-text-primary)]"
+          >
+            🎤
+          </button>
+          <button
+            type="button"
+            aria-label="Invia messaggio"
+            onClick={send}
+            className="flex h-9 w-9 items-center justify-center rounded-[10px] text-white transition-all hover:-translate-y-px"
+            style={{
+              background: 'linear-gradient(135deg, hsl(220 80% 58%), hsl(220 80% 42%))',
+              boxShadow: '0 2px 8px hsla(220, 80%, 55%, 0.35)',
+            }}
+          >
+            ➤
+          </button>
+        </div>
+      </div>
+      <div className="mt-2 flex items-center justify-between px-1.5 text-[0.68rem] text-[var(--nh-text-muted)]">
+        <div className="flex gap-3">
+          <span>
+            <kbd className="rounded border border-[var(--nh-border-default)] bg-[var(--nh-bg-base)] px-1.5 py-0.5 font-mono text-[9px] font-bold">
+              Enter
+            </kbd>{' '}
+            invia
+          </span>
+          <span>
+            <kbd className="rounded border border-[var(--nh-border-default)] bg-[var(--nh-bg-base)] px-1.5 py-0.5 font-mono text-[9px] font-bold">
+              ⇧ Enter
+            </kbd>{' '}
+            nuova riga
+          </span>
+        </div>
+        <span>✦ Risposte basate sulla KB caricata</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/panel/ChatMainArea.tsx
+++ b/apps/web/src/components/chat/panel/ChatMainArea.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { ChatInputBar } from './ChatInputBar';
+import { ChatMessageBubble, type ChatMessageRole } from './ChatMessageBubble';
+
+export interface ChatMessage {
+  id: string;
+  role: ChatMessageRole;
+  content: string;
+  authorName: string;
+  timestamp: string;
+}
+
+interface ChatMainAreaProps {
+  messages: ChatMessage[];
+  gameName?: string;
+  suggestedQuestions: string[];
+  onSend: (message: string) => void;
+}
+
+export function ChatMainArea({
+  messages,
+  gameName,
+  suggestedQuestions,
+  onSend,
+}: ChatMainAreaProps) {
+  const isEmpty = messages.length === 0;
+
+  return (
+    <div className="flex min-w-0 flex-1 flex-col bg-[var(--nh-bg-base)]">
+      <div className="flex-1 overflow-y-auto px-6 py-6">
+        {isEmpty ? (
+          <div className="mx-auto flex h-full max-w-md flex-col items-center justify-center text-center">
+            <div
+              aria-hidden
+              className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl text-3xl text-white shadow-[var(--shadow-warm-md)]"
+              style={{
+                background: 'linear-gradient(135deg, hsl(262 83% 70%), hsl(262 83% 50%))',
+              }}
+            >
+              🤖
+            </div>
+            <h3 className="mb-2 font-quicksand text-xl font-extrabold text-[var(--nh-text-primary)]">
+              Ciao! Sono il tuo assistente AI
+            </h3>
+            <p className="mb-6 text-sm text-[var(--nh-text-muted)]">
+              {gameName
+                ? `Chiedimi qualsiasi cosa sulle regole di ${gameName}.`
+                : 'Chiedimi qualsiasi cosa sui regolamenti dei tuoi giochi da tavolo.'}
+            </p>
+            {suggestedQuestions.length > 0 && (
+              <div className="flex flex-wrap justify-center gap-2">
+                {suggestedQuestions.map(q => (
+                  <button
+                    key={q}
+                    type="button"
+                    onClick={() => onSend(q)}
+                    className="rounded-full border border-[var(--nh-border-default)] bg-[var(--nh-bg-elevated)] px-3.5 py-2 font-nunito text-[0.76rem] font-bold text-[var(--nh-text-secondary)] transition-all hover:-translate-y-px hover:bg-white hover:shadow-[var(--shadow-warm-sm)]"
+                  >
+                    {q}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="mx-auto flex max-w-3xl flex-col gap-[18px]">
+            {messages.map(msg => (
+              <ChatMessageBubble
+                key={msg.id}
+                role={msg.role}
+                content={msg.content}
+                authorName={msg.authorName}
+                timestamp={msg.timestamp}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+      <ChatInputBar
+        placeholder={gameName ? `Chiedi una regola su ${gameName}…` : 'Chiedi una regola…'}
+        onSend={onSend}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/panel/ChatMessageBubble.tsx
+++ b/apps/web/src/components/chat/panel/ChatMessageBubble.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+export type ChatMessageRole = 'user' | 'assistant';
+
+interface ChatMessageBubbleProps {
+  role: ChatMessageRole;
+  content: string;
+  authorName: string;
+  timestamp: string;
+}
+
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .map(part => part[0] ?? '')
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+export function ChatMessageBubble({
+  role,
+  content,
+  authorName,
+  timestamp,
+}: ChatMessageBubbleProps) {
+  const isUser = role === 'user';
+
+  return (
+    <div
+      data-testid="chat-message-bubble"
+      data-role={role}
+      className={cn(
+        'flex gap-3',
+        isUser ? 'max-w-[78%] flex-row-reverse self-end' : 'max-w-[92%] self-start'
+      )}
+    >
+      <div
+        aria-hidden
+        className="flex h-[34px] w-[34px] flex-shrink-0 items-center justify-center rounded-full text-base text-white shadow-[var(--shadow-warm-sm)]"
+        style={{
+          background: isUser
+            ? 'linear-gradient(135deg, hsl(262 83% 68%), hsl(262 83% 48%))'
+            : 'linear-gradient(135deg, hsl(38 92% 60%), hsl(25 95% 48%))',
+          fontFamily: isUser ? 'var(--font-quicksand)' : 'inherit',
+          fontWeight: isUser ? 800 : undefined,
+          fontSize: isUser ? '12px' : undefined,
+        }}
+      >
+        {isUser ? initials(authorName) : '🎲'}
+      </div>
+      <div className={cn('flex min-w-0 flex-1 flex-col gap-2', isUser && 'items-end')}>
+        <div className="flex items-center gap-2 text-[0.66rem] font-semibold text-[var(--nh-text-muted)]">
+          <span className="font-quicksand font-extrabold text-[var(--nh-text-secondary)]">
+            {authorName}
+          </span>
+          <span>· {timestamp}</span>
+        </div>
+        <div
+          className={cn(
+            'rounded-2xl px-4 py-3.5 font-nunito text-[0.88rem] leading-relaxed',
+            isUser
+              ? 'rounded-tr-md'
+              : 'rounded-tl-md border border-[var(--nh-border-default)] bg-[var(--nh-bg-elevated)] text-[var(--nh-text-primary)] shadow-[var(--shadow-warm-sm)]'
+          )}
+          style={
+            isUser
+              ? {
+                  background: 'linear-gradient(135deg, hsl(25 95% 94%), hsl(25 95% 88%))',
+                  border: '1px solid hsla(25, 95%, 45%, 0.2)',
+                  color: 'hsl(25 60% 18%)',
+                }
+              : undefined
+          }
+        >
+          <p className="whitespace-pre-wrap">{content}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/panel/ChatPanelHeader.tsx
+++ b/apps/web/src/components/chat/panel/ChatPanelHeader.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+interface ChatPanelHeaderProps {
+  subtitle: string;
+  onClose: () => void;
+}
+
+export function ChatPanelHeader({ subtitle, onClose }: ChatPanelHeaderProps) {
+  return (
+    <div className="flex flex-shrink-0 items-center gap-3.5 border-b border-[var(--nh-border-default)] bg-[rgba(255,252,248,0.7)] px-5 py-4 backdrop-blur-md">
+      <div
+        className="flex h-[42px] w-[42px] flex-shrink-0 items-center justify-center rounded-xl text-xl text-white"
+        style={{
+          background: 'linear-gradient(135deg, hsl(220 80% 60%), hsl(220 80% 42%))',
+          boxShadow: '0 2px 8px hsla(220, 80%, 55%, 0.4)',
+        }}
+        aria-hidden
+      >
+        💬
+      </div>
+      <div className="min-w-0 flex-1">
+        <h2 className="font-quicksand text-[1.08rem] font-extrabold leading-tight">
+          Chat con l&apos;agente
+        </h2>
+        <p className="mt-0.5 text-[0.74rem] text-[var(--nh-text-muted)]">{subtitle}</p>
+      </div>
+      <button
+        type="button"
+        aria-label="Chiudi chat panel"
+        onClick={onClose}
+        className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-[10px] border border-[var(--nh-border-default)] bg-[var(--nh-bg-surface)] text-lg text-[var(--nh-text-secondary)] transition-all hover:bg-white hover:text-[var(--nh-text-primary)] hover:shadow-[var(--shadow-warm-sm)]"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/panel/ChatSidebar.tsx
+++ b/apps/web/src/components/chat/panel/ChatSidebar.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+export interface ChatRecentItem {
+  id: string;
+  emoji: string;
+  title: string;
+  timestamp: string;
+  active?: boolean;
+}
+
+export interface ChatKbGame {
+  id: string;
+  name: string;
+  status: 'ready' | 'indexing' | 'failed';
+  imageUrl?: string;
+}
+
+interface ChatSidebarProps {
+  chats: ChatRecentItem[];
+  kbGames: ChatKbGame[];
+  onNewChat: () => void;
+  onSelectChat: (chatId: string) => void;
+  onSelectGame: (gameId: string) => void;
+}
+
+const STATUS_COLORS: Record<ChatKbGame['status'], string> = {
+  ready: 'hsl(140 60% 45%)',
+  indexing: 'hsl(38 92% 50%)',
+  failed: 'hsl(0 70% 55%)',
+};
+
+export function ChatSidebar({
+  chats,
+  kbGames,
+  onNewChat,
+  onSelectChat,
+  onSelectGame,
+}: ChatSidebarProps) {
+  return (
+    <aside className="flex w-[220px] flex-shrink-0 flex-col gap-1 overflow-y-auto border-r border-[var(--nh-border-default)] bg-[rgba(255,252,248,0.5)] px-2.5 py-3.5">
+      <button
+        type="button"
+        onClick={onNewChat}
+        className="mb-2.5 flex items-center justify-center gap-2 rounded-[10px] px-3.5 py-2.5 font-nunito text-[0.8rem] font-extrabold text-white transition-all hover:-translate-y-px"
+        style={{
+          background: 'linear-gradient(135deg, hsl(220 80% 58%), hsl(220 80% 42%))',
+          boxShadow: '0 2px 8px hsla(220, 80%, 55%, 0.3)',
+        }}
+      >
+        ＋ Nuova chat
+      </button>
+
+      <div className="mt-2 px-2.5 pb-1 text-[0.64rem] font-extrabold uppercase tracking-wider text-[var(--nh-text-muted)]">
+        ▾ Chat recenti
+      </div>
+      {chats.map(chat => (
+        <button
+          key={chat.id}
+          type="button"
+          onClick={() => onSelectChat(chat.id)}
+          className={cn(
+            'relative flex items-start gap-2.5 rounded-[10px] px-2.5 py-2.5 text-left transition-all',
+            chat.active
+              ? 'bg-[hsla(220,80%,55%,0.08)] shadow-[inset_0_0_0_1px_hsla(220,80%,55%,0.2)]'
+              : 'hover:bg-[var(--nh-bg-elevated)]'
+          )}
+        >
+          {chat.active && (
+            <span
+              aria-hidden
+              className="absolute left-0 top-2.5 bottom-2.5 w-[3px] rounded-r"
+              style={{ background: 'hsl(220 80% 55%)' }}
+            />
+          )}
+          <span aria-hidden className="flex-shrink-0 text-[15px] leading-tight">
+            {chat.emoji}
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="truncate font-quicksand text-[0.76rem] font-bold leading-tight text-[var(--nh-text-primary)]">
+              {chat.title}
+            </div>
+            <div className="mt-0.5 text-[0.66rem] text-[var(--nh-text-muted)]">
+              {chat.timestamp}
+            </div>
+          </div>
+        </button>
+      ))}
+
+      <div className="mt-4 px-2.5 pb-1 text-[0.64rem] font-extrabold uppercase tracking-wider text-[var(--nh-text-muted)]">
+        ▾ Giochi con KB
+      </div>
+      {kbGames.map(game => (
+        <button
+          key={game.id}
+          type="button"
+          onClick={() => onSelectGame(game.id)}
+          className="flex items-center gap-2.5 rounded-[9px] px-2.5 py-1.5 text-left transition-all hover:bg-[var(--nh-bg-elevated)]"
+        >
+          <div
+            aria-hidden
+            className="flex h-[26px] w-[26px] flex-shrink-0 items-center justify-center overflow-hidden rounded-md"
+            style={{
+              background: 'linear-gradient(135deg, hsl(25 75% 78%), hsl(25 80% 55%))',
+            }}
+          >
+            {game.imageUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={game.imageUrl} alt="" className="h-full w-full object-cover" />
+            ) : (
+              <span className="text-[11px]">🎲</span>
+            )}
+          </div>
+          <span className="min-w-0 flex-1 truncate font-nunito text-[0.74rem] font-bold text-[var(--nh-text-primary)]">
+            {game.name}
+          </span>
+          <span
+            aria-hidden="true"
+            title={`KB status: ${game.status}`}
+            className={cn(
+              'h-[7px] w-[7px] flex-shrink-0 rounded-full',
+              game.status === 'indexing' && 'animate-pulse'
+            )}
+            style={{ background: STATUS_COLORS[game.status] }}
+          />
+        </button>
+      ))}
+    </aside>
+  );
+}

--- a/apps/web/src/components/chat/panel/ChatSlideOverPanel.tsx
+++ b/apps/web/src/components/chat/panel/ChatSlideOverPanel.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { useChatPanel } from '@/hooks/useChatPanel';
+
+import { ChatContextSwitcher } from './ChatContextSwitcher';
+import { ChatMainArea, type ChatMessage } from './ChatMainArea';
+import { ChatPanelHeader } from './ChatPanelHeader';
+import { ChatSidebar, type ChatRecentItem, type ChatKbGame } from './ChatSidebar';
+
+// Mock data — Phase 5 will wire real chat/KB services
+const MOCK_RECENT_CHATS: ChatRecentItem[] = [
+  { id: 'c1', emoji: '🎨', title: 'Azul · Turno finale', timestamp: 'Oggi, 14:32', active: true },
+  { id: 'c2', emoji: '🦅', title: 'Wingspan · Bonus fine', timestamp: 'Ieri, 21:15' },
+  { id: 'c3', emoji: '🌲', title: 'Everdell · Eventi autunno', timestamp: '2 giorni fa' },
+];
+
+const MOCK_KB_GAMES: ChatKbGame[] = [
+  { id: 'wings', name: 'Wingspan', status: 'ready' },
+  { id: 'everd', name: 'Everdell', status: 'indexing' },
+  { id: 'catan', name: 'Catan', status: 'ready' },
+  { id: 'brass', name: 'Brass: Birmingham', status: 'ready' },
+];
+
+const MOCK_SUGGESTED_QUESTIONS = [
+  'Come si vince?',
+  'Qual è la regola del turno finale?',
+  'Spiega i bonus di fine partita',
+  'Quante risorse si pescano?',
+];
+
+export function ChatSlideOverPanel() {
+  const { isOpen, gameContext, close } = useChatPanel();
+
+  // Esc key closes the panel
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        close();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isOpen, close]);
+
+  if (!isOpen) return null;
+
+  // TODO(Phase 5): wire real messages, recent chats, KB games via chat service
+  const messages: ChatMessage[] = [];
+
+  const handleSend = (_message: string) => {
+    // TODO(Phase 5): dispatch to chat service
+  };
+
+  const handleNewChat = () => {
+    // TODO(Phase 5): create new chat thread
+  };
+
+  const handleSelectChat = (_chatId: string) => {
+    // TODO(Phase 5): load messages for selected chat
+  };
+
+  const handleSelectGame = (_gameId: string) => {
+    // TODO(Phase 5): switch game context
+  };
+
+  const handlePickGame = () => {
+    // TODO(Phase 5): open game picker dropdown
+  };
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        data-testid="chat-panel-backdrop"
+        className="fixed inset-0 z-[var(--z-modal-backdrop,1040)]"
+        style={{
+          background: 'rgba(40, 28, 14, 0.28)',
+          backdropFilter: 'blur(2px)',
+        }}
+        onClick={close}
+        aria-hidden
+      />
+
+      {/* Panel */}
+      <aside
+        data-testid="chat-slide-over-panel"
+        className="fixed right-0 top-0 bottom-0 z-[var(--z-modal,1050)] flex w-[760px] max-w-[60vw] flex-col overflow-hidden border-l border-[var(--nh-border-default)] shadow-[var(--shadow-warm-2xl)]"
+        style={{
+          background: 'linear-gradient(180deg, var(--nh-bg-surface), var(--nh-bg-base))',
+          animation: 'chatPanelSlideIn 350ms cubic-bezier(0.4, 0, 0.2, 1)',
+        }}
+      >
+        <style>{`
+          @keyframes chatPanelSlideIn {
+            from {
+              transform: translateX(30px);
+              opacity: 0;
+            }
+            to {
+              transform: translateX(0);
+              opacity: 1;
+            }
+          }
+        `}</style>
+        <ChatPanelHeader
+          subtitle={
+            gameContext?.kbStatus === 'ready'
+              ? 'KB pronta · Powered by MeepleAI'
+              : 'Powered by MeepleAI'
+          }
+          onClose={close}
+        />
+        <ChatContextSwitcher gameContext={gameContext} onPickGame={handlePickGame} />
+        <div className="flex min-h-0 flex-1">
+          <ChatSidebar
+            chats={MOCK_RECENT_CHATS}
+            kbGames={MOCK_KB_GAMES}
+            onNewChat={handleNewChat}
+            onSelectChat={handleSelectChat}
+            onSelectGame={handleSelectGame}
+          />
+          <ChatMainArea
+            messages={messages}
+            gameName={gameContext?.name}
+            suggestedQuestions={MOCK_SUGGESTED_QUESTIONS}
+            onSend={handleSend}
+          />
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/apps/web/src/components/chat/panel/__tests__/ChatCitationCard.test.tsx
+++ b/apps/web/src/components/chat/panel/__tests__/ChatCitationCard.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { ChatCitationCard } from '../ChatCitationCard';
+
+describe('ChatCitationCard', () => {
+  const citation = {
+    documentName: 'Regolamento Azul v1.2',
+    pages: [7, 8],
+    excerpt:
+      'La partita termina alla fine del round in cui un giocatore ha completato almeno una riga.',
+  };
+
+  it('renders document name and pages', () => {
+    render(<ChatCitationCard citation={citation} />);
+    expect(screen.getByText(/Regolamento Azul/i)).toBeInTheDocument();
+    expect(screen.getByText(/pag\. 7/i)).toBeInTheDocument();
+    expect(screen.getByText(/pag\. 8/i)).toBeInTheDocument();
+  });
+
+  it('renders the excerpt as italic quote', () => {
+    render(<ChatCitationCard citation={citation} />);
+    expect(screen.getByText(/La partita termina/i)).toBeInTheDocument();
+  });
+
+  it('renders a single page without repetition', () => {
+    render(<ChatCitationCard citation={{ ...citation, pages: [7] }} />);
+    expect(screen.getByText(/pag\. 7/i)).toBeInTheDocument();
+    expect(screen.queryByText(/pag\. 8/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/chat/panel/__tests__/ChatContextSwitcher.test.tsx
+++ b/apps/web/src/components/chat/panel/__tests__/ChatContextSwitcher.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+
+import { ChatContextSwitcher } from '../ChatContextSwitcher';
+
+describe('ChatContextSwitcher', () => {
+  const game = {
+    id: 'azul',
+    name: 'Azul',
+    year: 2017,
+    pdfCount: 3,
+    kbStatus: 'ready' as const,
+  };
+
+  it('renders the game name and meta when context is set', () => {
+    render(<ChatContextSwitcher gameContext={game} onPickGame={() => {}} />);
+    expect(screen.getByText('Azul')).toBeInTheDocument();
+    expect(screen.getByText(/2017/)).toBeInTheDocument();
+    expect(screen.getByText(/3 PDF/)).toBeInTheDocument();
+  });
+
+  it('renders a placeholder when no context', () => {
+    render(<ChatContextSwitcher gameContext={null} onPickGame={() => {}} />);
+    expect(screen.getByText(/Seleziona gioco/i)).toBeInTheDocument();
+  });
+
+  it('calls onPickGame when pill clicked', async () => {
+    const onPickGame = vi.fn();
+    const user = userEvent.setup();
+    render(<ChatContextSwitcher gameContext={game} onPickGame={onPickGame} />);
+    await user.click(screen.getByRole('button', { name: /azul/i }));
+    expect(onPickGame).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/chat/panel/__tests__/ChatInputBar.test.tsx
+++ b/apps/web/src/components/chat/panel/__tests__/ChatInputBar.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+
+import { ChatInputBar } from '../ChatInputBar';
+
+describe('ChatInputBar', () => {
+  it('renders textarea and send button', () => {
+    render(<ChatInputBar placeholder="Chiedi una regola…" onSend={() => {}} />);
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /invia/i })).toBeInTheDocument();
+  });
+
+  it('calls onSend with trimmed value when send is clicked', async () => {
+    const onSend = vi.fn();
+    const user = userEvent.setup();
+    render(<ChatInputBar onSend={onSend} />);
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, '  come si vince?  ');
+    await user.click(screen.getByRole('button', { name: /invia/i }));
+    expect(onSend).toHaveBeenCalledWith('come si vince?');
+  });
+
+  it('does not call onSend when value is empty or whitespace', async () => {
+    const onSend = vi.fn();
+    const user = userEvent.setup();
+    render(<ChatInputBar onSend={onSend} />);
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, '   ');
+    await user.click(screen.getByRole('button', { name: /invia/i }));
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('sends on Enter (no shift)', async () => {
+    const onSend = vi.fn();
+    const user = userEvent.setup();
+    render(<ChatInputBar onSend={onSend} />);
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'hello{Enter}');
+    expect(onSend).toHaveBeenCalledWith('hello');
+  });
+
+  it('does NOT send on Shift+Enter (newline)', async () => {
+    const onSend = vi.fn();
+    const user = userEvent.setup();
+    render(<ChatInputBar onSend={onSend} />);
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'hello{Shift>}{Enter}{/Shift}');
+    expect(onSend).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/chat/panel/__tests__/ChatMainArea.test.tsx
+++ b/apps/web/src/components/chat/panel/__tests__/ChatMainArea.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+
+import { ChatMainArea } from '../ChatMainArea';
+
+describe('ChatMainArea', () => {
+  it('renders empty state with welcome when no messages', () => {
+    render(
+      <ChatMainArea
+        messages={[]}
+        gameName="Azul"
+        suggestedQuestions={['Come si vince?', 'Regole base']}
+        onSend={() => {}}
+      />
+    );
+    expect(screen.getByText(/Ciao! Sono il tuo assistente AI/i)).toBeInTheDocument();
+    expect(screen.getByText('Come si vince?')).toBeInTheDocument();
+    expect(screen.getByText('Regole base')).toBeInTheDocument();
+  });
+
+  it('renders messages list when messages present', () => {
+    const messages = [
+      {
+        id: 'm1',
+        role: 'user' as const,
+        content: 'Come si vince?',
+        authorName: 'Marco',
+        timestamp: '14:32',
+      },
+      {
+        id: 'm2',
+        role: 'assistant' as const,
+        content: 'Per vincere devi fare X.',
+        authorName: 'MeepleAI',
+        timestamp: '14:33',
+      },
+    ];
+    render(
+      <ChatMainArea messages={messages} gameName="Azul" suggestedQuestions={[]} onSend={() => {}} />
+    );
+    expect(screen.getByText('Come si vince?')).toBeInTheDocument();
+    expect(screen.getByText(/Per vincere devi fare X/i)).toBeInTheDocument();
+  });
+
+  it('calls onSend when message is sent via input', async () => {
+    const onSend = vi.fn();
+    const user = userEvent.setup();
+    render(<ChatMainArea messages={[]} gameName="Azul" suggestedQuestions={[]} onSend={onSend} />);
+    await user.type(screen.getByRole('textbox'), 'hello{Enter}');
+    expect(onSend).toHaveBeenCalledWith('hello');
+  });
+
+  it('calls onSend when a suggested question is clicked', async () => {
+    const onSend = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ChatMainArea
+        messages={[]}
+        gameName="Azul"
+        suggestedQuestions={['Come si vince?']}
+        onSend={onSend}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Come si vince?' }));
+    expect(onSend).toHaveBeenCalledWith('Come si vince?');
+  });
+});

--- a/apps/web/src/components/chat/panel/__tests__/ChatMessageBubble.test.tsx
+++ b/apps/web/src/components/chat/panel/__tests__/ChatMessageBubble.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { ChatMessageBubble } from '../ChatMessageBubble';
+
+describe('ChatMessageBubble', () => {
+  it('renders user message with initials', () => {
+    render(
+      <ChatMessageBubble
+        role="user"
+        content="Come si vince?"
+        authorName="Marco Rossi"
+        timestamp="14:32"
+      />
+    );
+    expect(screen.getByText('Come si vince?')).toBeInTheDocument();
+    expect(screen.getByText('MR')).toBeInTheDocument();
+  });
+
+  it('renders assistant message with dice avatar', () => {
+    render(
+      <ChatMessageBubble
+        role="assistant"
+        content="Per vincere devi…"
+        authorName="MeepleAI"
+        timestamp="14:33"
+      />
+    );
+    expect(screen.getByText(/Per vincere devi/i)).toBeInTheDocument();
+    expect(screen.getByText('🎲')).toBeInTheDocument();
+  });
+
+  it('applies data-role attribute', () => {
+    render(<ChatMessageBubble role="assistant" content="hi" authorName="AI" timestamp="00:00" />);
+    const bubble = screen.getByTestId('chat-message-bubble');
+    expect(bubble).toHaveAttribute('data-role', 'assistant');
+  });
+});

--- a/apps/web/src/components/chat/panel/__tests__/ChatPanelHeader.test.tsx
+++ b/apps/web/src/components/chat/panel/__tests__/ChatPanelHeader.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+
+import { ChatPanelHeader } from '../ChatPanelHeader';
+
+describe('ChatPanelHeader', () => {
+  it('renders the title and subtitle', () => {
+    render(<ChatPanelHeader subtitle="KB aggiornata 2 giorni fa" onClose={() => {}} />);
+    expect(screen.getByText(/Chat con l'agente/i)).toBeInTheDocument();
+    expect(screen.getByText(/KB aggiornata/i)).toBeInTheDocument();
+  });
+
+  it('calls onClose when close button clicked', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(<ChatPanelHeader subtitle="x" onClose={onClose} />);
+    await user.click(screen.getByRole('button', { name: /chiudi/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/chat/panel/__tests__/ChatSidebar.test.tsx
+++ b/apps/web/src/components/chat/panel/__tests__/ChatSidebar.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+
+import { ChatSidebar } from '../ChatSidebar';
+
+describe('ChatSidebar', () => {
+  const chats = [
+    { id: 'c1', emoji: '🎨', title: 'Azul · Turno finale', timestamp: 'Oggi, 14:32', active: true },
+    {
+      id: 'c2',
+      emoji: '🦅',
+      title: 'Wingspan · Bonus fine',
+      timestamp: 'Ieri, 21:15',
+      active: false,
+    },
+  ];
+  const kbGames = [
+    { id: 'azul', name: 'Azul', status: 'ready' as const },
+    { id: 'wings', name: 'Wingspan', status: 'ready' as const },
+    { id: 'everd', name: 'Everdell', status: 'indexing' as const },
+  ];
+
+  it('renders the new chat button', () => {
+    render(
+      <ChatSidebar
+        chats={chats}
+        kbGames={kbGames}
+        onNewChat={() => {}}
+        onSelectChat={() => {}}
+        onSelectGame={() => {}}
+      />
+    );
+    expect(screen.getByRole('button', { name: /nuova chat/i })).toBeInTheDocument();
+  });
+
+  it('renders all recent chats', () => {
+    render(
+      <ChatSidebar
+        chats={chats}
+        kbGames={kbGames}
+        onNewChat={() => {}}
+        onSelectChat={() => {}}
+        onSelectGame={() => {}}
+      />
+    );
+    expect(screen.getByText(/Azul · Turno finale/i)).toBeInTheDocument();
+    expect(screen.getByText(/Wingspan · Bonus fine/i)).toBeInTheDocument();
+  });
+
+  it('renders all KB games with status', () => {
+    render(
+      <ChatSidebar
+        chats={chats}
+        kbGames={kbGames}
+        onNewChat={() => {}}
+        onSelectChat={() => {}}
+        onSelectGame={() => {}}
+      />
+    );
+    expect(screen.getByText('Azul')).toBeInTheDocument();
+    expect(screen.getByText('Wingspan')).toBeInTheDocument();
+    expect(screen.getByText('Everdell')).toBeInTheDocument();
+  });
+
+  it('calls onNewChat when new chat button is clicked', async () => {
+    const onNewChat = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ChatSidebar
+        chats={chats}
+        kbGames={kbGames}
+        onNewChat={onNewChat}
+        onSelectChat={() => {}}
+        onSelectGame={() => {}}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /nuova chat/i }));
+    expect(onNewChat).toHaveBeenCalled();
+  });
+
+  it('calls onSelectChat with chat id', async () => {
+    const onSelectChat = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ChatSidebar
+        chats={chats}
+        kbGames={kbGames}
+        onNewChat={() => {}}
+        onSelectChat={onSelectChat}
+        onSelectGame={() => {}}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /Wingspan · Bonus/i }));
+    expect(onSelectChat).toHaveBeenCalledWith('c2');
+  });
+
+  it('calls onSelectGame with game id', async () => {
+    const onSelectGame = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ChatSidebar
+        chats={chats}
+        kbGames={kbGames}
+        onNewChat={() => {}}
+        onSelectChat={() => {}}
+        onSelectGame={onSelectGame}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Everdell' }));
+    expect(onSelectGame).toHaveBeenCalledWith('everd');
+  });
+});

--- a/apps/web/src/components/chat/panel/__tests__/ChatSlideOverPanel.test.tsx
+++ b/apps/web/src/components/chat/panel/__tests__/ChatSlideOverPanel.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { useChatPanelStore } from '@/lib/stores/chat-panel-store';
+
+import { ChatSlideOverPanel } from '../ChatSlideOverPanel';
+
+describe('ChatSlideOverPanel', () => {
+  beforeEach(() => {
+    useChatPanelStore.getState().close();
+    useChatPanelStore.getState().clearGameContext();
+  });
+
+  it('renders nothing when panel is closed', () => {
+    const { container } = render(<ChatSlideOverPanel />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders panel when open', () => {
+    useChatPanelStore.getState().open();
+    render(<ChatSlideOverPanel />);
+    expect(screen.getByText(/Chat con l'agente/i)).toBeInTheDocument();
+  });
+
+  it('renders game context in switcher when set', () => {
+    useChatPanelStore.getState().open({
+      id: 'azul',
+      name: 'Azul',
+      year: 2017,
+      pdfCount: 3,
+      kbStatus: 'ready',
+    });
+    render(<ChatSlideOverPanel />);
+    expect(screen.getByText('Azul')).toBeInTheDocument();
+  });
+
+  it('closes when the ✕ header button is clicked', async () => {
+    useChatPanelStore.getState().open();
+    const user = userEvent.setup();
+    render(<ChatSlideOverPanel />);
+    await user.click(screen.getByRole('button', { name: /chiudi/i }));
+    expect(useChatPanelStore.getState().isOpen).toBe(false);
+  });
+
+  it('closes on Esc keypress', () => {
+    useChatPanelStore.getState().open();
+    render(<ChatSlideOverPanel />);
+    const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true });
+    window.dispatchEvent(event);
+    expect(useChatPanelStore.getState().isOpen).toBe(false);
+  });
+});

--- a/apps/web/src/components/layout/UserShell/v2/DesktopShell.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/DesktopShell.tsx
@@ -2,6 +2,8 @@
 
 import type { ReactNode } from 'react';
 
+import { ChatSlideOverPanel } from '@/components/chat/panel/ChatSlideOverPanel';
+
 import { DesktopHandRail } from './DesktopHandRail';
 import { MiniNavSlot } from './MiniNavSlot';
 import { TopBar64 } from './TopBar64';
@@ -32,6 +34,7 @@ export function DesktopShell({ children }: DesktopShellProps) {
         <DesktopHandRail />
         <main className="flex-1 min-w-0 overflow-y-auto">{children}</main>
       </div>
+      <ChatSlideOverPanel />
     </div>
   );
 }

--- a/apps/web/src/components/layout/UserShell/v2/TopBar64.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/TopBar64.tsx
@@ -2,6 +2,7 @@
 
 import { UserMenuDropdown } from '@/components/layout/UserMenuDropdown';
 import { NotificationBell } from '@/components/notifications';
+import { useChatPanel } from '@/hooks/useChatPanel';
 
 import { TopBarChatButton } from './TopBarChatButton';
 import { TopBarLogo } from './TopBarLogo';
@@ -19,6 +20,8 @@ interface TopBar64Props {
  * Sticky positioning, backdrop-blur, border-bottom.
  */
 export function TopBar64({ onOpenChat, onOpenSearch }: TopBar64Props) {
+  const { open: openChat } = useChatPanel();
+
   return (
     <header
       data-testid="top-bar-64"
@@ -31,7 +34,7 @@ export function TopBar64({ onOpenChat, onOpenSearch }: TopBar64Props) {
       <TopBarNavLinks />
       <TopBarSearchPill onOpen={onOpenSearch} />
       <div className="flex items-center gap-2.5 shrink-0">
-        <TopBarChatButton onOpen={onOpenChat} />
+        <TopBarChatButton onOpen={onOpenChat ?? openChat} />
         <NotificationBell />
         <UserMenuDropdown />
       </div>

--- a/apps/web/src/components/layout/UserShell/v2/__tests__/TopBar64.test.tsx
+++ b/apps/web/src/components/layout/UserShell/v2/__tests__/TopBar64.test.tsx
@@ -7,6 +7,16 @@ vi.mock('next/navigation', () => ({
   usePathname: () => '/',
 }));
 
+vi.mock('@/hooks/useChatPanel', () => ({
+  useChatPanel: () => ({
+    isOpen: false,
+    gameContext: null,
+    open: vi.fn(),
+    close: vi.fn(),
+    setGameContext: vi.fn(),
+  }),
+}));
+
 // Mock the notification bell (existing component with runtime deps)
 vi.mock('@/components/notifications', () => ({
   NotificationBell: () => <button aria-label="Notifications">🔔</button>,

--- a/apps/web/src/hooks/__tests__/useChatPanel.test.tsx
+++ b/apps/web/src/hooks/__tests__/useChatPanel.test.tsx
@@ -1,0 +1,65 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { useChatPanelStore } from '@/lib/stores/chat-panel-store';
+
+import { useChatPanel } from '../useChatPanel';
+
+describe('useChatPanel', () => {
+  beforeEach(() => {
+    useChatPanelStore.getState().close();
+    useChatPanelStore.getState().clearGameContext();
+  });
+
+  it('exposes isOpen=false by default', () => {
+    const { result } = renderHook(() => useChatPanel());
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.gameContext).toBeNull();
+  });
+
+  it('open() updates isOpen to true', () => {
+    const { result } = renderHook(() => useChatPanel());
+    act(() => {
+      result.current.open();
+    });
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('open(gameContext) sets context and opens', () => {
+    const { result } = renderHook(() => useChatPanel());
+    act(() => {
+      result.current.open({
+        id: 'azul',
+        name: 'Azul',
+        pdfCount: 3,
+        kbStatus: 'ready',
+      });
+    });
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.gameContext?.name).toBe('Azul');
+  });
+
+  it('close() sets isOpen to false', () => {
+    const { result } = renderHook(() => useChatPanel());
+    act(() => {
+      result.current.open();
+      result.current.close();
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('setGameContext() updates context without closing', () => {
+    const { result } = renderHook(() => useChatPanel());
+    act(() => {
+      result.current.open();
+      result.current.setGameContext({
+        id: 'wings',
+        name: 'Wingspan',
+        pdfCount: 2,
+        kbStatus: 'ready',
+      });
+    });
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.gameContext?.name).toBe('Wingspan');
+  });
+});

--- a/apps/web/src/hooks/useChatPanel.ts
+++ b/apps/web/src/hooks/useChatPanel.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useChatPanelStore, type ChatGameContext } from '@/lib/stores/chat-panel-store';
+
+/**
+ * React hook for consuming the chat panel store.
+ *
+ * Returns a stable API: { isOpen, gameContext, open, close, setGameContext }.
+ * Usage:
+ *   const { isOpen, open, close } = useChatPanel();
+ *   <button onClick={() => open({ id: 'azul', name: 'Azul', pdfCount: 3, kbStatus: 'ready' })}>
+ *     Chiedi all'agente
+ *   </button>
+ *
+ * Phase 5 will add URL state sync (?chat=open&gameId=X) in this hook.
+ */
+export function useChatPanel() {
+  const isOpen = useChatPanelStore(s => s.isOpen);
+  const gameContext = useChatPanelStore(s => s.gameContext);
+  const open = useChatPanelStore(s => s.open);
+  const close = useChatPanelStore(s => s.close);
+  const setGameContext = useChatPanelStore(s => s.setGameContext);
+
+  return {
+    isOpen,
+    gameContext,
+    open,
+    close,
+    setGameContext,
+  };
+}
+
+export type { ChatGameContext };

--- a/apps/web/src/lib/stores/__tests__/chat-panel-store.test.ts
+++ b/apps/web/src/lib/stores/__tests__/chat-panel-store.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { useChatPanelStore, type ChatGameContext } from '../chat-panel-store';
+
+describe('chat-panel-store', () => {
+  beforeEach(() => {
+    useChatPanelStore.getState().close();
+  });
+
+  it('starts closed with no game context', () => {
+    const state = useChatPanelStore.getState();
+    expect(state.isOpen).toBe(false);
+    expect(state.gameContext).toBeNull();
+  });
+
+  it('open() sets isOpen to true', () => {
+    useChatPanelStore.getState().open();
+    expect(useChatPanelStore.getState().isOpen).toBe(true);
+  });
+
+  it('open(gameContext) sets isOpen and gameContext', () => {
+    const ctx: ChatGameContext = {
+      id: 'azul',
+      name: 'Azul',
+      year: 2017,
+      pdfCount: 3,
+      kbStatus: 'ready',
+    };
+    useChatPanelStore.getState().open(ctx);
+    const state = useChatPanelStore.getState();
+    expect(state.isOpen).toBe(true);
+    expect(state.gameContext).toEqual(ctx);
+  });
+
+  it('close() resets isOpen but keeps gameContext', () => {
+    useChatPanelStore.getState().open({
+      id: 'azul',
+      name: 'Azul',
+      pdfCount: 3,
+      kbStatus: 'ready',
+    });
+    useChatPanelStore.getState().close();
+    const state = useChatPanelStore.getState();
+    expect(state.isOpen).toBe(false);
+    expect(state.gameContext).not.toBeNull();
+  });
+
+  it('setGameContext() updates the game context without closing', () => {
+    useChatPanelStore.getState().open();
+    useChatPanelStore.getState().setGameContext({
+      id: 'wings',
+      name: 'Wingspan',
+      pdfCount: 2,
+      kbStatus: 'ready',
+    });
+    const state = useChatPanelStore.getState();
+    expect(state.isOpen).toBe(true);
+    expect(state.gameContext?.name).toBe('Wingspan');
+  });
+
+  it('clearGameContext() removes the context without closing', () => {
+    useChatPanelStore.getState().open({
+      id: 'azul',
+      name: 'Azul',
+      pdfCount: 3,
+      kbStatus: 'ready',
+    });
+    useChatPanelStore.getState().clearGameContext();
+    expect(useChatPanelStore.getState().gameContext).toBeNull();
+    expect(useChatPanelStore.getState().isOpen).toBe(true);
+  });
+});

--- a/apps/web/src/lib/stores/chat-panel-store.ts
+++ b/apps/web/src/lib/stores/chat-panel-store.ts
@@ -1,0 +1,45 @@
+/**
+ * Chat panel store.
+ *
+ * Holds the state of the global chat slide-over panel (open/closed + active
+ * game context). Pages and components open the panel via the `useChatPanel`
+ * hook (Task 2), which also handles URL state sync (?chat=open&gameId=X).
+ *
+ * The store is framework-agnostic — do NOT add a `'use client'` directive here.
+ * Client boundaries live on the consumers (hook + panel components).
+ *
+ * See: docs/superpowers/specs/2026-04-08-desktop-ux-redesign-design.md §5.3
+ */
+
+import { create } from 'zustand';
+
+export interface ChatGameContext {
+  id: string;
+  name: string;
+  year?: number;
+  pdfCount: number;
+  kbStatus: 'ready' | 'indexing' | 'failed';
+  imageUrl?: string;
+}
+
+interface ChatPanelState {
+  isOpen: boolean;
+  gameContext: ChatGameContext | null;
+  open: (gameContext?: ChatGameContext) => void;
+  close: () => void;
+  setGameContext: (gameContext: ChatGameContext) => void;
+  clearGameContext: () => void;
+}
+
+export const useChatPanelStore = create<ChatPanelState>(set => ({
+  isOpen: false,
+  gameContext: null,
+  open: gameContext =>
+    set(state => ({
+      isOpen: true,
+      gameContext: gameContext ?? state.gameContext,
+    })),
+  close: () => set({ isOpen: false }),
+  setGameContext: gameContext => set({ gameContext }),
+  clearGameContext: () => set({ gameContext: null }),
+}));


### PR DESCRIPTION
## Summary

Phase 4 of the Desktop UX Redesign: global chat slide-over panel triggered by the TopBar 💬 icon. Replaces the Phase 1 `TopBarChatButton` console.warn stub with a real open handler via a new `useChatPanel` hook.

**References:**
- Design spec: `docs/superpowers/specs/2026-04-08-desktop-ux-redesign-design.md` §5.3
- Phase 1 (#296), Phase 2 (#309), Phase 3 (#316) — all merged to main-dev

## Architecture

**Store + hook:**
- `chat-panel-store` (Zustand) — holds `{ isOpen, gameContext }` with `open/close/setGameContext/clearGameContext` actions
- `useChatPanel()` hook — stable API for components to trigger the panel

**Components** (under `apps/web/src/components/chat/panel/`):

| Component | Purpose | Tests |
|---|---|---|
| `ChatPanelHeader` | Icon box + title + subtitle + close button | 2 |
| `ChatContextSwitcher` | Game pill with cover, name, meta, chevron dropdown | 3 |
| `ChatSidebar` | New chat button + recent chats list + KB games list with status dots | 6 |
| `ChatMessageBubble` | User/assistant message bubble with avatar + timestamp | 3 |
| `ChatCitationCard` | RuleSourceCard-style citation (doc name + pages + italic excerpt) | 3 |
| `ChatInputBar` | Textarea + attach/mic/send buttons + Enter/⇧Enter keyboard hints | 5 |
| `ChatMainArea` | Empty state with welcome + suggested questions OR messages list + input | 4 |
| `ChatSlideOverPanel` | Full composition (header + ctx-bar + 2-col body) with backdrop + Esc close + slide-in animation | 5 |

**Integration:**
- `DesktopShell` renders `<ChatSlideOverPanel />` as a fixed overlay child
- `TopBar64` wires `useChatPanel().open` to `TopBarChatButton` (removes console.warn stub from Phase 1)
- Panel always mounts; internal `isOpen` gate controls visibility
- `Esc` key + backdrop click + `✕` close button all close the panel
- Panel width: 760px, `max-width: 60vw`, slide-in from right over 350ms

## Mock data & TODO(Phase 5)

Phase 4 ships with **mock data only** for:
- `MOCK_RECENT_CHATS` (3 chats: Azul / Wingspan / Everdell)
- `MOCK_KB_GAMES` (4 games with ready/indexing status)
- `MOCK_SUGGESTED_QUESTIONS` (4 questions)

Real backend wiring is Phase 5 scope. Current `onSend`, `onNewChat`, `onSelectChat`, `onSelectGame`, `onPickGame` handlers are no-ops marked with `TODO(Phase 5)`.

## Quality gate

- typecheck clean (0 errors)
- lint: 0 errors, warnings within threshold
- **13,848 tests** passing (35 skipped, 5 pre-existing failures unrelated to Phase 4: `photo-store`, `photos/page`, `CommentForm`, `ChatThreadView`, `LiveSessionChatWiring`, `definitions-builder`)
- build flag OFF: 132 pages, 25.1s
- build flag ON: 132 pages, 22.3s

## Test plan

- [x] 31 new unit test cases across 9 new test files (TDD red→green per task)
- [x] Integration: ChatSlideOverPanel test covers open/close/header button/Esc key/game context rendering
- [x] TopBar64 test updated with `useChatPanel` mock, verifies button still works
- [x] DesktopShell test unaffected (panel renders at root, conditionally null when closed)
- [ ] **Manual smoke test** (reviewer): `NEXT_PUBLIC_UX_REDESIGN=true pnpm dev` → click 💬 in top bar → panel slides in from right, Esc closes it, backdrop click closes it, typing in input + Enter is a no-op (Phase 5 TODO)

## Commits (12 + marker)

- \`de7d2984c\` feat(web): chat-panel-store Zustand
- \`4d7330cb5\` feat(web): useChatPanel hook
- \`82719d603\` feat(web): ChatPanelHeader
- \`e2054bce0\` feat(web): ChatContextSwitcher
- \`759f59356\` feat(web): ChatCitationCard
- \`91863a9dc\` feat(web): ChatInputBar
- \`9e905dc26\` feat(web): ChatSidebar
- \`a29057287\` feat(web): ChatMessageBubble
- \`f22a8c920\` feat(web): ChatMainArea composition
- \`a90ab444d\` feat(web): ChatSlideOverPanel full composition
- \`7f8c06e2b\` feat(web): wire ChatSlideOverPanel into DesktopShell + TopBarChatButton
- \`d9e08c587\` chore(web): phase 4 complete (marker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)