### PR TITLE
feat(s1): admin↔user view mode toggle in navbar

### DIFF
--- a/apps/web/e2e/sub-features/s1-admin-toggle.spec.ts
+++ b/apps/web/e2e/sub-features/s1-admin-toggle.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * S1 — Admin↔User view mode toggle E2E smoke tests.
+ *
+ * Validates the toggle is rendered for admin users, clicking it flips the
+ * view mode cookie, and the redirect happens as expected.
+ *
+ * Related spec: docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md §4.1
+ */
+import { test, expect } from '@playwright/test';
+
+import { loginAsAdmin } from '../fixtures/auth';
+
+test.describe('S1 · Admin↔User view mode toggle', () => {
+  test.beforeEach(async ({ context }) => {
+    // Ensure no stale view mode cookie from previous tests
+    const existing = await context.cookies();
+    const keep = existing.filter(c => c.name !== 'meepleai_view_mode');
+    await context.clearCookies();
+    if (keep.length > 0) {
+      await context.addCookies(keep);
+    }
+  });
+
+  test('toggle is visible for admin users on user home', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/');
+
+    const toggle = page.getByTestId('view-mode-toggle');
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute('role', 'switch');
+    // On '/' with no cookie, default mode is 'user'
+    await expect(toggle).toHaveAttribute('aria-checked', 'false');
+  });
+
+  test('toggle is visible on admin dashboard', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/admin/overview');
+
+    const toggle = page.getByTestId('view-mode-toggle');
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute('role', 'switch');
+    // On /admin with no cookie, default mode is 'admin'
+    await expect(toggle).toHaveAttribute('aria-checked', 'true');
+  });
+
+  test('clicking toggle from admin redirects to user shell', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/admin/overview');
+
+    const toggle = page.getByTestId('view-mode-toggle');
+    await toggle.click();
+
+    // Should navigate away from /admin/*
+    await page.waitForURL(url => !url.pathname.startsWith('/admin'), { timeout: 5000 });
+    expect(page.url()).not.toContain('/admin');
+  });
+
+  test('cookie is set after clicking toggle', async ({ page, context }) => {
+    await loginAsAdmin(page);
+    await page.goto('/admin/overview');
+
+    await page.getByTestId('view-mode-toggle').click();
+    await page.waitForLoadState('networkidle');
+
+    const cookies = await context.cookies();
+    const viewModeCookie = cookies.find(c => c.name === 'meepleai_view_mode');
+    expect(viewModeCookie?.value).toBe('user');
+  });
+
+  test('SSR redirects admin layout to / when cookie is user (no flash)', async ({
+    page,
+    context,
+    baseURL,
+  }) => {
+    await loginAsAdmin(page);
+    // Navigate to establish a real document origin before adding cookies.
+    const origin = baseURL || 'http://localhost:3000';
+    await page.goto('/');
+
+    // Pre-set the cookie with an absolute URL
+    await context.addCookies([
+      {
+        name: 'meepleai_view_mode',
+        value: 'user',
+        url: origin,
+        sameSite: 'Lax',
+      },
+    ]);
+
+    await page.goto('/admin/overview');
+    // Server-side redirect should send user to '/' before admin shell renders
+    expect(page.url()).not.toContain('/admin/overview');
+  });
+
+  test('toggle returns to admin when clicked from user shell', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/');
+
+    const toggle = page.getByTestId('view-mode-toggle');
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute('aria-checked', 'false');
+
+    await toggle.click();
+    await page.waitForURL(url => url.pathname.startsWith('/admin'), { timeout: 5000 });
+    expect(page.url()).toContain('/admin');
+  });
+});

--- a/apps/web/src/actions/auth.ts
+++ b/apps/web/src/actions/auth.ts
@@ -17,6 +17,7 @@ import { api, ApiError } from '@/lib/api';
 import { createErrorContext } from '@/lib/errors';
 import { getLocalizedError, type LocalizedError, successMessages } from '@/lib/i18n/errors';
 import { logger } from '@/lib/logger';
+import { clearViewModeCookie } from '@/lib/view-mode/cookie';
 import type { AuthUser } from '@/types';
 
 // ============================================================================
@@ -228,6 +229,10 @@ export async function logoutAction(): Promise<AuthActionState> {
   try {
     await api.auth.logout();
 
+    // Clear client-side view mode cookie. HttpOnly auth cookies are cleared
+    // by the server in api.auth.logout(); this handles the extra UX preference cookie.
+    clearViewModeCookie();
+
     // Force complete reload to clear middleware session cache and all client state
     // This bypasses the middleware's 2-minute session validation cache
     if (typeof window !== 'undefined') {
@@ -244,6 +249,9 @@ export async function logoutAction(): Promise<AuthActionState> {
       error instanceof Error ? error : new Error(String(error)),
       createErrorContext('AuthActions', 'logoutAction', { operation: 'logout' })
     );
+
+    // Even on error, clear the view mode cookie before reload.
+    clearViewModeCookie();
 
     // Even if API call fails, force reload to clear client state
     // User can't remain logged in if server rejected logout

--- a/apps/web/src/app/admin/(dashboard)/layout.tsx
+++ b/apps/web/src/app/admin/(dashboard)/layout.tsx
@@ -1,10 +1,12 @@
 import { type ReactNode } from 'react';
 
 import { type Metadata } from 'next';
+import { redirect } from 'next/navigation';
 
 import { PdfProcessingNotifier } from '@/components/admin/layout/PdfProcessingNotifier';
 import { RequireRole } from '@/components/auth/RequireRole';
 import { AdminShell } from '@/components/layout/AdminShell';
+import { readViewModeCookieServer } from '@/lib/view-mode/server';
 
 export const metadata: Metadata = {
   title: {
@@ -16,10 +18,20 @@ export const metadata: Metadata = {
 
 /**
  * Dashboard route group layout.
+ *
+ * Guard chain:
+ *  1. Server-side: if `meepleai_view_mode` cookie === 'user', redirect to '/'
+ *     before the admin shell renders (no flash).
+ *  2. Client-side: `RequireRole` enforces admin role (authoritative check).
+ *
  * Applies the AdminShell to all pages under /admin/(dashboard)/.
- * Wrapped with RequireRole to enforce admin access.
  */
-export default function DashboardLayout({ children }: { children: ReactNode }) {
+export default async function DashboardLayout({ children }: { children: ReactNode }) {
+  const viewMode = await readViewModeCookieServer();
+  if (viewMode === 'user') {
+    redirect('/');
+  }
+
   return (
     <RequireRole allowedRoles={['Admin']}>
       <PdfProcessingNotifier />

--- a/apps/web/src/components/layout/UserShell/UserTopNav.tsx
+++ b/apps/web/src/components/layout/UserShell/UserTopNav.tsx
@@ -9,13 +9,16 @@ import { SessionNavBar } from '@/components/dashboard/session-nav/SessionNavBar'
 import { useDashboardMode } from '@/components/dashboard/useDashboardMode';
 import { NotificationBell } from '@/components/notifications';
 import { getSectionEmoji } from '@/config/navigation-emoji';
+import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
 import { useNavigation } from '@/hooks/useNavigation';
 import { useNavbarHeightStore } from '@/lib/stores/navbar-height-store';
 import { useSessionStore } from '@/lib/stores/session-store';
 import { cn } from '@/lib/utils';
+import { isAdminRole } from '@/lib/utils/roles';
 
 import { ContextualCTA } from './ContextualCTA';
 import { UserMenuDropdown } from '../UserMenuDropdown';
+import { ViewModeToggle } from '../ViewModeToggle';
 
 interface UserTopNavProps {
   isAdmin?: boolean;
@@ -30,6 +33,8 @@ export function UserTopNav({ isAdmin, onMenuToggle, isMenuOpen }: UserTopNavProp
   const pathname = usePathname();
   const sectionEmoji = getSectionEmoji(pathname);
   const setNavbarHeight = useNavbarHeightStore(s => s.setHeight);
+  const { data: currentUser } = useCurrentUser();
+  const canToggleView = isAdminRole(currentUser?.role);
 
   // NavContextTabs removed — height is always 52px
   useEffect(() => {
@@ -132,6 +137,7 @@ export function UserTopNav({ isAdmin, onMenuToggle, isMenuOpen }: UserTopNavProp
 
       {/* Right: utility actions */}
       <div className="flex items-center gap-2 shrink-0">
+        {canToggleView && <ViewModeToggle />}
         <NotificationBell />
         <UserMenuDropdown />
       </div>

--- a/apps/web/src/components/layout/UserShell/__tests__/UserTopNav.test.tsx
+++ b/apps/web/src/components/layout/UserShell/__tests__/UserTopNav.test.tsx
@@ -36,6 +36,12 @@ vi.mock('../../UserMenuDropdown', () => ({
 vi.mock('@/config/navigation-emoji', () => ({
   getSectionEmoji: vi.fn(() => '🏠'),
 }));
+vi.mock('@/hooks/queries/useCurrentUser', () => ({
+  useCurrentUser: vi.fn(() => ({ data: null, isLoading: false, isError: false })),
+}));
+vi.mock('../../ViewModeToggle', () => ({
+  ViewModeToggle: () => <div data-testid="view-mode-toggle" />,
+}));
 
 import { usePathname } from 'next/navigation';
 import { UserTopNav } from '../UserTopNav';

--- a/apps/web/src/components/layout/ViewModeToggle.tsx
+++ b/apps/web/src/components/layout/ViewModeToggle.tsx
@@ -1,0 +1,82 @@
+/**
+ * ViewModeToggle — admin↔user view switcher for the top navbar.
+ *
+ * Icon pill switch (44×26) that flips between admin and user shells.
+ * Only rendered when the current user has an admin role — the parent
+ * component is responsible for gating visibility.
+ *
+ * Accessibility: role="switch" with aria-checked, keyboard-operable.
+ */
+'use client';
+
+import { useCallback, type KeyboardEvent } from 'react';
+
+import { useViewMode } from '@/hooks/useViewMode';
+import { cn } from '@/lib/utils';
+
+export function ViewModeToggle() {
+  const { viewMode, toggle } = useViewMode();
+  const isAdmin = viewMode === 'admin';
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLButtonElement>) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        toggle();
+      }
+    },
+    [toggle]
+  );
+
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={isAdmin}
+      aria-label="Cambia vista tra admin e utente"
+      onClick={toggle}
+      onKeyDown={handleKeyDown}
+      data-testid="view-mode-toggle"
+      className={cn(
+        'relative inline-flex h-[26px] w-[44px] shrink-0 items-center rounded-full',
+        'bg-gradient-to-br from-purple-500 to-orange-500',
+        'border-2 border-white shadow-sm',
+        'cursor-pointer transition-colors',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
+      )}
+    >
+      {/* Left indicator: user icon */}
+      <span
+        className={cn(
+          'absolute left-1 text-[9px] transition-opacity',
+          isAdmin ? 'opacity-70' : 'opacity-30'
+        )}
+        aria-hidden="true"
+      >
+        👤
+      </span>
+      {/* Right indicator: admin gear */}
+      <span
+        className={cn(
+          'absolute right-1 text-[9px] transition-opacity',
+          isAdmin ? 'opacity-30' : 'opacity-70'
+        )}
+        aria-hidden="true"
+      >
+        ⚙️
+      </span>
+      {/* Knob */}
+      <span
+        className={cn(
+          'pointer-events-none absolute top-[1px] h-5 w-5 rounded-full bg-white shadow-sm',
+          'flex items-center justify-center text-[11px]',
+          'transition-transform duration-200',
+          isAdmin ? 'translate-x-[18px]' : 'translate-x-[1px]'
+        )}
+        aria-hidden="true"
+      >
+        {isAdmin ? '⚙️' : '👤'}
+      </span>
+    </button>
+  );
+}

--- a/apps/web/src/components/layout/__tests__/ViewModeToggle.test.tsx
+++ b/apps/web/src/components/layout/__tests__/ViewModeToggle.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * Tests for ViewModeToggle component.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { ViewModeToggle } from '../ViewModeToggle';
+
+// Hoisted mocks
+const mockToggle = vi.fn();
+let mockViewMode: 'admin' | 'user' = 'admin';
+vi.mock('@/hooks/useViewMode', () => ({
+  useViewMode: () => ({ viewMode: mockViewMode, toggle: mockToggle }),
+}));
+
+describe('ViewModeToggle', () => {
+  beforeEach(() => {
+    mockToggle.mockReset();
+    mockViewMode = 'admin';
+  });
+
+  it('renders a switch with aria-checked reflecting admin mode', () => {
+    mockViewMode = 'admin';
+    render(<ViewModeToggle />);
+    const toggle = screen.getByRole('switch', { name: /cambia vista/i });
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('renders aria-checked=false when in user mode', () => {
+    mockViewMode = 'user';
+    render(<ViewModeToggle />);
+    const toggle = screen.getByRole('switch', { name: /cambia vista/i });
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('calls toggle() when clicked', () => {
+    render(<ViewModeToggle />);
+    const toggle = screen.getByRole('switch', { name: /cambia vista/i });
+    fireEvent.click(toggle);
+    expect(mockToggle).toHaveBeenCalledOnce();
+  });
+
+  it('is keyboard-operable via Enter key', () => {
+    render(<ViewModeToggle />);
+    const toggle = screen.getByRole('switch', { name: /cambia vista/i });
+    toggle.focus();
+    fireEvent.keyDown(toggle, { key: 'Enter' });
+    expect(mockToggle).toHaveBeenCalledOnce();
+  });
+
+  it('is keyboard-operable via Space key', () => {
+    render(<ViewModeToggle />);
+    const toggle = screen.getByRole('switch', { name: /cambia vista/i });
+    toggle.focus();
+    fireEvent.keyDown(toggle, { key: ' ' });
+    expect(mockToggle).toHaveBeenCalledOnce();
+  });
+
+  it('has data-testid for E2E selection', () => {
+    render(<ViewModeToggle />);
+    expect(screen.getByTestId('view-mode-toggle')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/hooks/__tests__/useViewMode.test.ts
+++ b/apps/web/src/hooks/__tests__/useViewMode.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for useViewMode client hook.
+ */
+import { act, renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { VIEW_MODE_COOKIE } from '@/lib/view-mode/constants';
+
+import { useViewMode } from '../useViewMode';
+
+// Mock next/navigation
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => '/admin/overview',
+}));
+
+describe('useViewMode', () => {
+  beforeEach(() => {
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      configurable: true,
+      value: '',
+    });
+    mockPush.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('defaults to "admin" when cookie absent and on /admin path', () => {
+    const { result } = renderHook(() => useViewMode());
+    expect(result.current.viewMode).toBe('admin');
+  });
+
+  it('reads initial value from cookie when present', () => {
+    document.cookie = `${VIEW_MODE_COOKIE}=user`;
+    const { result } = renderHook(() => useViewMode());
+    expect(result.current.viewMode).toBe('user');
+  });
+
+  it('toggle flips admin → user and writes cookie', () => {
+    document.cookie = `${VIEW_MODE_COOKIE}=admin`;
+    const { result } = renderHook(() => useViewMode());
+    act(() => {
+      result.current.toggle();
+    });
+    expect(result.current.viewMode).toBe('user');
+    expect(document.cookie).toContain(`${VIEW_MODE_COOKIE}=user`);
+  });
+
+  it('toggle flips user → admin', () => {
+    document.cookie = `${VIEW_MODE_COOKIE}=user`;
+    const { result } = renderHook(() => useViewMode());
+    act(() => {
+      result.current.toggle();
+    });
+    expect(result.current.viewMode).toBe('admin');
+  });
+
+  it('toggle navigates to / when switching to user mode', () => {
+    document.cookie = `${VIEW_MODE_COOKIE}=admin`;
+    const { result } = renderHook(() => useViewMode());
+    act(() => {
+      result.current.toggle();
+    });
+    expect(mockPush).toHaveBeenCalledWith('/');
+  });
+
+  it('toggle navigates to /admin/overview when switching to admin mode', () => {
+    document.cookie = `${VIEW_MODE_COOKIE}=user`;
+    const { result } = renderHook(() => useViewMode());
+    act(() => {
+      result.current.toggle();
+    });
+    expect(mockPush).toHaveBeenCalledWith('/admin/overview');
+  });
+});

--- a/apps/web/src/hooks/useViewMode.ts
+++ b/apps/web/src/hooks/useViewMode.ts
@@ -1,0 +1,53 @@
+/**
+ * useViewMode — client hook for view mode toggle state.
+ *
+ * Reads the `meepleai_view_mode` cookie on mount, exposes `viewMode` + `toggle`.
+ * On toggle: flips the value, writes the cookie, navigates to the opposite shell.
+ *
+ * Path-based default: if no cookie, defaults to 'admin' on /admin/* paths,
+ * 'user' elsewhere. This matches the shell the user is currently viewing.
+ *
+ * Cross-tab sync is intentionally NOT implemented: document.cookie has no
+ * change event, and BroadcastChannel is overkill for a UX preference.
+ * See spec §4.1 and the plan's "Known limitations" section.
+ */
+'use client';
+
+import { useCallback, useState } from 'react';
+
+import { usePathname, useRouter } from 'next/navigation';
+
+import type { ViewMode } from '@/lib/view-mode/constants';
+import { readViewModeCookie, writeViewModeCookie } from '@/lib/view-mode/cookie';
+
+interface UseViewModeResult {
+  viewMode: ViewMode;
+  toggle: () => void;
+}
+
+/**
+ * Default view mode inferred from URL path.
+ */
+function defaultViewMode(pathname: string): ViewMode {
+  return pathname.startsWith('/admin') ? 'admin' : 'user';
+}
+
+export function useViewMode(): UseViewModeResult {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // Initial state reads cookie synchronously (matches SSR when cookie exists)
+  const [viewMode, setViewMode] = useState<ViewMode>(() => {
+    if (typeof document === 'undefined') return defaultViewMode(pathname);
+    return readViewModeCookie() ?? defaultViewMode(pathname);
+  });
+
+  const toggle = useCallback(() => {
+    const next: ViewMode = viewMode === 'admin' ? 'user' : 'admin';
+    writeViewModeCookie(next);
+    setViewMode(next);
+    router.push(next === 'admin' ? '/admin/overview' : '/');
+  }, [viewMode, router]);
+
+  return { viewMode, toggle };
+}

--- a/apps/web/src/lib/view-mode/__tests__/cookie.test.ts
+++ b/apps/web/src/lib/view-mode/__tests__/cookie.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for client-side view mode cookie helpers.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { readViewModeCookie, writeViewModeCookie, clearViewModeCookie } from '../cookie';
+import { VIEW_MODE_COOKIE } from '../constants';
+
+describe('view-mode cookie helpers', () => {
+  beforeEach(() => {
+    // Reset document.cookie before each test.
+    // NOTE: `configurable: true` is REQUIRED — without it, the second
+    // beforeEach silently fails because the property becomes non-configurable
+    // after the first Object.defineProperty call, causing flaky tests.
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      configurable: true,
+      value: '',
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('readViewModeCookie', () => {
+    it('returns null when cookie is absent', () => {
+      document.cookie = '';
+      expect(readViewModeCookie()).toBeNull();
+    });
+
+    it('returns "admin" when cookie value is admin', () => {
+      document.cookie = `${VIEW_MODE_COOKIE}=admin`;
+      expect(readViewModeCookie()).toBe('admin');
+    });
+
+    it('returns "user" when cookie value is user', () => {
+      document.cookie = `${VIEW_MODE_COOKIE}=user`;
+      expect(readViewModeCookie()).toBe('user');
+    });
+
+    it('returns null when cookie value is invalid', () => {
+      document.cookie = `${VIEW_MODE_COOKIE}=malicious`;
+      expect(readViewModeCookie()).toBeNull();
+    });
+
+    it('correctly extracts cookie when multiple cookies present', () => {
+      document.cookie = `other_cookie=foo; ${VIEW_MODE_COOKIE}=admin; third=bar`;
+      expect(readViewModeCookie()).toBe('admin');
+    });
+  });
+
+  describe('writeViewModeCookie', () => {
+    it('writes admin value to document.cookie', () => {
+      writeViewModeCookie('admin');
+      expect(document.cookie).toContain(`${VIEW_MODE_COOKIE}=admin`);
+    });
+
+    it('writes user value to document.cookie', () => {
+      writeViewModeCookie('user');
+      expect(document.cookie).toContain(`${VIEW_MODE_COOKIE}=user`);
+    });
+
+    it('includes path=/ in the cookie string', () => {
+      const spy = vi.spyOn(document, 'cookie', 'set');
+      writeViewModeCookie('admin');
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('path=/'));
+    });
+
+    it('includes SameSite=Lax in the cookie string', () => {
+      const spy = vi.spyOn(document, 'cookie', 'set');
+      writeViewModeCookie('admin');
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('SameSite=Lax'));
+    });
+  });
+
+  describe('clearViewModeCookie', () => {
+    it('clears the cookie by setting expired date', () => {
+      const spy = vi.spyOn(document, 'cookie', 'set');
+      clearViewModeCookie();
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('Max-Age=0'));
+    });
+  });
+});

--- a/apps/web/src/lib/view-mode/__tests__/server.test.ts
+++ b/apps/web/src/lib/view-mode/__tests__/server.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests for server-side view mode cookie reader.
+ * Mocks `next/headers` cookies() API.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { readViewModeCookieServer } from '../server';
+import { VIEW_MODE_COOKIE } from '../constants';
+
+// Mock next/headers
+const mockGet = vi.fn();
+vi.mock('next/headers', () => ({
+  cookies: () => ({
+    get: mockGet,
+  }),
+}));
+
+describe('readViewModeCookieServer', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('returns null when cookie is absent', async () => {
+    mockGet.mockReturnValue(undefined);
+    const result = await readViewModeCookieServer();
+    expect(mockGet).toHaveBeenCalledWith(VIEW_MODE_COOKIE);
+    expect(result).toBeNull();
+  });
+
+  it('returns "admin" when cookie has admin value', async () => {
+    mockGet.mockReturnValue({ name: VIEW_MODE_COOKIE, value: 'admin' });
+    const result = await readViewModeCookieServer();
+    expect(result).toBe('admin');
+  });
+
+  it('returns "user" when cookie has user value', async () => {
+    mockGet.mockReturnValue({ name: VIEW_MODE_COOKIE, value: 'user' });
+    const result = await readViewModeCookieServer();
+    expect(result).toBe('user');
+  });
+
+  it('returns null when cookie has invalid value', async () => {
+    mockGet.mockReturnValue({ name: VIEW_MODE_COOKIE, value: 'malicious' });
+    const result = await readViewModeCookieServer();
+    expect(result).toBeNull();
+  });
+});

--- a/apps/web/src/lib/view-mode/constants.ts
+++ b/apps/web/src/lib/view-mode/constants.ts
@@ -1,0 +1,27 @@
+/**
+ * View Mode — Cookie constants
+ *
+ * The `meepleai_view_mode` cookie stores the admin user's preferred shell.
+ * Client-writable (not HttpOnly). Read server-side via `cookies()` from `next/headers`
+ * in layout.tsx guards for SSR-consistent rendering.
+ *
+ * Reference: docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md §4.1
+ */
+
+/** Cookie name used across client and server to persist view mode */
+export const VIEW_MODE_COOKIE = 'meepleai_view_mode';
+
+/** The two valid view mode values */
+export type ViewMode = 'admin' | 'user';
+
+/** All valid view modes (for runtime validation) */
+export const VIEW_MODES: readonly ViewMode[] = ['admin', 'user'] as const;
+
+/** Cookie max-age: undefined = session cookie (cleared when browser closes) */
+export const VIEW_MODE_COOKIE_MAX_AGE: number | undefined = undefined;
+
+/** SameSite attribute — lax allows top-level navigation redirects */
+export const VIEW_MODE_COOKIE_SAMESITE = 'lax' as const;
+
+/** Path scope — whole app */
+export const VIEW_MODE_COOKIE_PATH = '/' as const;

--- a/apps/web/src/lib/view-mode/cookie.ts
+++ b/apps/web/src/lib/view-mode/cookie.ts
@@ -1,0 +1,73 @@
+/**
+ * Client-side view mode cookie helpers.
+ *
+ * These functions are safe to call only in the browser. For server-side
+ * cookie reading, use `./server.ts` which uses `next/headers`.
+ */
+import {
+  VIEW_MODE_COOKIE,
+  VIEW_MODE_COOKIE_PATH,
+  VIEW_MODE_COOKIE_SAMESITE,
+  VIEW_MODES,
+  type ViewMode,
+} from './constants';
+
+/**
+ * Read the view mode cookie from `document.cookie`.
+ * Returns null if the cookie is absent or contains an invalid value.
+ *
+ * Safe to call only in browser environments (no-op in SSR).
+ */
+export function readViewModeCookie(): ViewMode | null {
+  if (typeof document === 'undefined') return null;
+
+  const match = document.cookie
+    .split(';')
+    .map(c => c.trim())
+    .find(c => c.startsWith(`${VIEW_MODE_COOKIE}=`));
+
+  if (!match) return null;
+
+  const value = match.slice(VIEW_MODE_COOKIE.length + 1);
+  return (VIEW_MODES as readonly string[]).includes(value) ? (value as ViewMode) : null;
+}
+
+/**
+ * Write the view mode cookie to `document.cookie`.
+ * Session-scoped (no Max-Age), SameSite=Lax, client-readable.
+ *
+ * Safe to call only in browser environments (no-op in SSR).
+ */
+export function writeViewModeCookie(mode: ViewMode): void {
+  if (typeof document === 'undefined') return;
+
+  const parts = [
+    `${VIEW_MODE_COOKIE}=${mode}`,
+    `path=${VIEW_MODE_COOKIE_PATH}`,
+    `SameSite=${VIEW_MODE_COOKIE_SAMESITE === 'lax' ? 'Lax' : VIEW_MODE_COOKIE_SAMESITE}`,
+  ];
+
+  // Secure flag in https contexts only
+  if (typeof window !== 'undefined' && window.location.protocol === 'https:') {
+    parts.push('Secure');
+  }
+
+  document.cookie = parts.join('; ');
+}
+
+/**
+ * Clear the view mode cookie by setting an expired date.
+ * Safe to call only in browser environments (no-op in SSR).
+ */
+export function clearViewModeCookie(): void {
+  if (typeof document === 'undefined') return;
+
+  const parts = [
+    `${VIEW_MODE_COOKIE}=`,
+    `path=${VIEW_MODE_COOKIE_PATH}`,
+    'Max-Age=0',
+    `SameSite=${VIEW_MODE_COOKIE_SAMESITE === 'lax' ? 'Lax' : VIEW_MODE_COOKIE_SAMESITE}`,
+  ];
+
+  document.cookie = parts.join('; ');
+}

--- a/apps/web/src/lib/view-mode/server.ts
+++ b/apps/web/src/lib/view-mode/server.ts
@@ -1,0 +1,29 @@
+/**
+ * Server-side view mode cookie reader.
+ *
+ * Uses Next.js 16 `cookies()` from `next/headers` to read the
+ * `meepleai_view_mode` cookie from Server Components, Route Handlers,
+ * and Server Actions. This enables SSR-consistent rendering of the
+ * correct shell (admin vs user) on first paint.
+ *
+ * @see https://nextjs.org/docs/app/api-reference/functions/cookies
+ */
+import { cookies } from 'next/headers';
+
+import { VIEW_MODE_COOKIE, VIEW_MODES, type ViewMode } from './constants';
+
+/**
+ * Read the view mode cookie from the current request's cookies.
+ * Returns null if absent or invalid.
+ *
+ * MUST be called from Server Components, Route Handlers, or Server Actions.
+ */
+export async function readViewModeCookieServer(): Promise<ViewMode | null> {
+  const cookieStore = await cookies();
+  const cookie = cookieStore.get(VIEW_MODE_COOKIE);
+
+  if (!cookie) return null;
+
+  const value = cookie.value;
+  return (VIEW_MODES as readonly string[]).includes(value) ? (value as ViewMode) : null;
+}


### PR DESCRIPTION
## Summary

Implements S1 of the `library-to-game` epic: a one-click cookie-based view mode toggle in the top navbar that flips admin users between admin shell and user shell while preserving their authenticated session.

## Changes

- New cookie `meepleai_view_mode` (client-writable, SameSite=Lax, session-scoped)
- New utilities: `lib/view-mode/{constants,cookie,server}.ts` for client + server cookie access
- New hook: `useViewMode` with toggle + router navigation
- New component: `ViewModeToggle` (icon pill switch, role="switch", keyboard-operable)
- `UserTopNav` conditionally renders the toggle when `isAdminRole(user.role)` — reused by `AdminShell`, so visible in both shells via a single mount
- `app/admin/(dashboard)/layout.tsx` gets a server-side guard that redirects to `/` if cookie = `user` (no first-paint flash)
- `logoutAction` clears the view mode cookie via client helper (not `next/headers` — `auth.ts` is `'use client'`)

## Reference

- Spec: `docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md` §4.1
- Plan: `docs/superpowers/plans/2026-04-09-s1-view-toggle.md` (rev 2, post code review)

## Test plan

- [x] Unit tests: `src/lib/view-mode/__tests__/cookie.test.ts` (10 tests)
- [x] Unit tests: `src/lib/view-mode/__tests__/server.test.ts` (4 tests)
- [x] Unit tests: `src/hooks/__tests__/useViewMode.test.ts` (6 tests)
- [x] Component tests: `src/components/layout/__tests__/ViewModeToggle.test.tsx` (6 tests)
- [x] Regression: `src/components/layout/UserShell/__tests__/UserTopNav.test.tsx` (7 tests, updated with mocks)
- [x] E2E smoke: `e2e/sub-features/s1-admin-toggle.spec.ts` (6 tests) — run in CI, not locally
- [x] `pnpm typecheck` and `pnpm lint` pass with 0 errors

Total: **33/33 unit+component tests green**. E2E tests will run in CI.

## Security

- Role check remains authoritative: `RequireRole` in admin layout still enforces admin-only access regardless of cookie
- Non-admin users with forged `view_mode=admin` cookie still get blocked by `RequireRole`
- Cookie is `SameSite=Lax` to prevent CSRF; no `HttpOnly` (client needs to read for toggle)
- Cookie value validated against whitelist `['admin', 'user']` on both client and server reads

## Code Review Fixes Applied

Plan was revised after initial code review. Critical fixes:
- C1: `auth.ts` is `'use client'`, cannot import `next/headers` → use `clearViewModeCookie()` client helper
- C3: E2E test used `page.url()` before navigation → now uses `baseURL` fixture + `page.goto('/')` first
- I1: Useless `useEffect` for cross-tab sync → removed; cross-tab is documented non-goal
- I3: `Object.defineProperty(document, 'cookie', ...)` needed `configurable: true` to avoid flaky tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
