### PR TITLE
chore(ci): Sprint 1 — reduce noise on main-dev PRs (A1+A3)

### DIFF
--- a/.github/workflows/auto-dependabot.yml
+++ b/.github/workflows/auto-dependabot.yml
@@ -2,6 +2,7 @@ name: Dependabot Auto-merge
 
 on:
   pull_request:
+    branches: [main, main-dev, main-staging]
     types: [opened, synchronize, reopened]
 
 # Ensure only one auto-merge workflow runs per PR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,11 +161,23 @@ jobs:
 
   # Backend Integration Tests (requires service containers, runs in parallel with unit tests)
   # Phase 2+3: 4 parallel threads per shard, 3-shard matrix for ~4-12x total speedup
+  #
+  # Spec R1 — CI optimization (2026-04-09): backend-integration runs ONLY on
+  # release-candidate PRs (target main-staging or main) and on workflow_dispatch
+  # / workflow_call (from deploy-staging.yml). Feature PRs against main-dev
+  # skip this job to keep wall-clock under 10min on the commit stage. Coverage
+  # is regained at the acceptance stage when merging into main-staging.
   backend-integration:
     name: Backend - Integration (${{ matrix.shard.name }})
     runs-on: ${{ needs.changes.outputs.runner }}
     needs: changes
-    if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'
+    if: |
+      github.event_name == 'workflow_dispatch'
+      || github.event_name == 'workflow_call'
+      || (
+        (github.base_ref == 'main-staging' || github.base_ref == 'main')
+        && needs.changes.outputs.backend == 'true'
+      )
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Sprint 1 of the CI/CD optimization spec drafted via the spec-panel multi-expert review on 2026-04-09. Reduces wall-clock + visual noise + runner cost for PRs targeting `main-dev`, with zero impact on the staging release path.

Spec section: **R1 — Reduce CI noise on main-dev PRs**

## Changes

### A1 — Branch filter on `auto-dependabot.yml`

The auto-dependabot workflow had no `branches` filter, so it fired on EVERY PR opened in the repo (including feature branches). The job is a no-op for non-Dependabot PRs but the runner spin-up still consumed Actions minutes and surfaced one extra status check on every PR.

Restricted to the canonical release branches: `[main, main-dev, main-staging]`.

### A3 — Defer `backend-integration` to release-candidate PRs

Backend integration tests (3-shard matrix × Postgres+Redis service containers, ~30 min wall-clock) now run **only** when the PR targets `main-staging` or `main`, or when `ci.yml` is invoked via `workflow_dispatch` / `workflow_call` (the latter from `deploy-staging.yml`).

**Trade-off**: integration regressions on a feature branch are now caught at the release PR (main-dev → main-staging), not on every commit PR. The full suite still runs at the acceptance stage before code reaches main-staging, so production safety is unchanged.

This applies the Humble/Farley CD pipeline pattern: cheap+fast checks at the commit stage, expensive checks at the acceptance stage.

`ci-success` (gate job) and `notify-end` (Slack) already treat `backend-integration` as advisory non-blocking via runtime `result` inspection, so a `skipped` outcome on feature PRs is a no-op for the gate.

## Expected impact

| Metric | Before (PR feature → main-dev, BE change) | After |
|--------|-----------------------------------------|-------|
| Wall-clock to all-green | ~25-35 min | ~5-10 min |
| Status checks fired | 13 | 8-9 |
| Runner minutes per PR | ~90 (3 shards × ~30min) | ~5-10 |
| Status checks REQUIRED (post A4) | 13 | 5 |

Estimated reduction: **~80% wall-clock**, **~85% runner minutes**, **~62% visual noise** on feature PRs touching backend code.

Zero impact on:
- PR `main-dev` → `main-staging` (full integration suite still runs)
- `deploy-staging.yml` (uses `workflow_call`, integration runs)
- `workflow_dispatch` (escape hatch preserved)

## Test plan

- [x] YAML syntactically valid (`python -c "yaml.safe_load(...)"`)
- [x] `node scripts/validate-workflows.js` → 0 errors, 0 warnings
- [ ] Open this PR (target main-dev): verify `backend-integration` is SKIPPED, `auto-dependabot` does NOT fire
- [ ] Verify `ci-success` still passes (skipped integration is non-blocking by design)
- [ ] After merge, A4 (manual): update branch protection on main-dev with 5 required checks

## Out of scope (separate PRs)

- **A2**: workflow_run gate on deploy-staging.yml (Sprint 2 — deploy gating)
- **A4**: branch protection update (manual via UI or `gh api` after this merges)
- **A5-A8**: Sprint 3 (observability + docs)

## Spec panel context

Multi-expert review converged on these 2 changes as the highest-impact, lowest-risk Sprint 1 actions:
- Humble (CD): commit stage vs acceptance stage separation
- Farley (deployment pipeline): every commit deployable, cheap fast first
- Crispin (Agile Testing): Q1 unit ovunque, Q2 integration solo su release PR
- Forsgren (DORA): reduce Lead Time for Changes without compromising Change Failure Rate
- Meadows (systems): close the noise feedback loop driving developers to bypass checks

Sprint 2 (workflow_run gate on deploy-staging.yml) is queued in a separate PR for incremental risk management.