### PR TITLE
chore(ci): trigger ci.yml on push to main-staging (Sprint 2a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,13 @@ name: CI
 on:
   pull_request:
     branches: [main, main-dev, main-staging, frontend-dev, backend-dev]
+  push:
+    # Spec R2 — CI optimization (2026-04-09): ci.yml must run on push to
+    # main-staging so deploy-staging.yml can gate on its conclusion via
+    # workflow_run. Only main-staging is listed here to avoid duplicate
+    # CI runs on every push to other branches (the pull_request trigger
+    # already covers feature branches via the PR flow).
+    branches: [main-staging]
   workflow_dispatch:
   workflow_call:  # Allow reuse by deploy-staging.yml
 


### PR DESCRIPTION
## Summary

Sprint 2a — preparatory step for the deploy quality gate. Adds `push: branches: [main-staging]` trigger to `ci.yml`.

This is a **strictly additive** change to enable Sprint 2b (workflow_run gating on deploy-staging.yml) to land in a separate, focused PR with its own dedicated review.

## Why split Sprint 2 into 2a + 2b?

During implementation I discovered that switching `deploy-staging.yml` from `on: push` to `on: workflow_run` is more invasive than the spec assumed:

- `workflow_run` events execute in the **default branch context**, so `${{ github.sha }}` and `${{ github.ref }}` no longer point to the commit/branch that triggered CI — they point to the default branch (main).
- This breaks ~10 references in `deploy-staging.yml`: checkout `ref:`, the SHA used by health-check API queries, the SHA in performance baseline payloads, the SHA propagated to Slack notifications, etc.
- The fix is mechanical (introduce `env.DEPLOY_SHA = github.event.workflow_run.head_sha || github.sha` and route everything through it) but invasive enough to deserve a focused review.

Following the panel discipline (Humble + Nygard "small atomic changes"), I'm landing 2a now and queuing 2b as the next PR.

## What this PR does

Single-trigger addition to `ci.yml`:

```diff
 on:
   pull_request:
     branches: [main, main-dev, main-staging, frontend-dev, backend-dev]
+  push:
+    branches: [main-staging]
   workflow_dispatch:
   workflow_call:
```

## Why this is needed

Today `ci.yml` fires only on `pull_request`, `workflow_dispatch`, and `workflow_call`. No CI run is associated with a direct push to `main-staging`. Without an associated CI run, there is nothing for `workflow_run: workflows: [CI]` to listen to in Sprint 2b.

After this PR merges and propagates to main-staging:
- A PR `main-dev` → `main-staging` runs ci.yml once (via pull_request trigger) — unchanged
- After merge, the resulting push commit on main-staging triggers ci.yml a second time — **new behavior**
- Sprint 2b will wire deploy-staging.yml to consume the post-merge run via workflow_run

## Cost analysis

Pushes to `main-staging` happen ~1-2 times per day (only via release PR merge from main-dev). Each adds one full ci.yml run (~30 min wall-clock with full integration suite enabled because base_ref is main-staging per the A3 logic).

Net cost: **~30-60 extra runner minutes per day**. Acceptable trade-off for the deploy gating capability that 2b will unlock.

## Test plan

- [x] YAML valid (`python -c "yaml.safe_load(...)"`)
- [x] `node scripts/validate-workflows.js` → 0 errors, 0 warnings
- [ ] After merge to main-dev, no behavior change (no push to main-staging happens directly from main-dev merges)
- [ ] After main-dev → main-staging release PR is merged, observe ci.yml runs on the resulting push to main-staging
- [ ] Confirm deploy-staging.yml still fires unchanged (existing `on: push: main-staging` trigger preserved by Sprint 2a — only Sprint 2b will replace it)

## Out of scope

- **Sprint 2b**: workflow_run gate on deploy-staging.yml + context references update + new gate job (separate PR, queued)
- **A4**: branch protection main-dev required checks (Sprint 1 leftover, manual via UI)

## Spec
- R2 — Quality-gated staging deploy (prerequisite step)
- Spec doc: TBD `docs/superpowers/specs/2026-04-09-ci-cd-optimization.md`

## Rollback
Single line revert. Zero behavioral side effects on the current deploy flow until Sprint 2b lands.