### PR TITLE
feat(s2): HasKnowledgeBase filter on shared catalog (backend + frontend)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandler.cs
@@ -1,0 +1,80 @@
+using Api.BoundedContexts.KnowledgeBase.Domain.Events;
+using Api.Infrastructure;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.EventHandlers;
+
+/// <summary>
+/// Listens to VectorDocumentIndexedEvent and maintains the denormalized
+/// `has_knowledge_base` column on `shared_games`. Bridges the KnowledgeBase
+/// BC (write source) with SharedGameCatalog BC (read projection).
+///
+/// Flow:
+///   1. Read the VectorDocumentEntity by DocumentId to resolve SharedGameId
+///      (the event carries GameId which is the Game aggregate id; VectorDocuments
+///      carry their own separate SharedGameId per Issue #4921).
+///   2. If SharedGameId is not null, execute a targeted bulk update on
+///      shared_games to set has_knowledge_base = true. Uses ExecuteUpdateAsync
+///      to bypass change tracking — idempotent, low overhead.
+///
+/// DDD note: the cross-BC read in step 1 is acceptable as an async projection
+/// update (not at query time). The write path stays within SharedGameCatalog tables.
+///
+/// Reference: docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md §4.2
+/// Plan: docs/superpowers/plans/2026-04-09-s2-kb-filter.md Task 7
+/// </summary>
+internal sealed class VectorDocumentIndexedForKbFlagHandler
+    : INotificationHandler<VectorDocumentIndexedEvent>
+{
+    private readonly MeepleAiDbContext _context;
+    private readonly ILogger<VectorDocumentIndexedForKbFlagHandler> _logger;
+
+    public VectorDocumentIndexedForKbFlagHandler(
+        MeepleAiDbContext context,
+        ILogger<VectorDocumentIndexedForKbFlagHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(VectorDocumentIndexedEvent notification, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        // Look up the VectorDocument to resolve SharedGameId.
+        // This is the only cross-BC table read in the handler — the update
+        // below stays within SharedGameCatalog's own tables.
+        var sharedGameId = await _context.VectorDocuments
+            .AsNoTracking()
+            .Where(v => v.Id == notification.DocumentId)
+            .Select(v => v.SharedGameId)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (sharedGameId is null || sharedGameId == Guid.Empty)
+        {
+            _logger.LogDebug(
+                "VectorDocument {DocumentId} has no SharedGameId, skipping KB flag update",
+                notification.DocumentId);
+            return;
+        }
+
+        // Bulk update bypassing change tracking (perf + avoids loading aggregate).
+        // Idempotent: only updates if HasKnowledgeBase is currently false.
+        var rowsAffected = await _context.SharedGames
+            .Where(g => g.Id == sharedGameId.Value && !g.HasKnowledgeBase)
+            .ExecuteUpdateAsync(
+                setters => setters.SetProperty(g => g.HasKnowledgeBase, true),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        if (rowsAffected > 0)
+        {
+            _logger.LogInformation(
+                "Set HasKnowledgeBase=true for SharedGame {SharedGameId} triggered by VectorDocument {DocumentId}",
+                sharedGameId.Value,
+                notification.DocumentId);
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandler.cs
@@ -60,21 +60,24 @@ internal sealed class VectorDocumentIndexedForKbFlagHandler
             return;
         }
 
-        // Bulk update bypassing change tracking (perf + avoids loading aggregate).
-        // Idempotent: only updates if HasKnowledgeBase is currently false.
-        var rowsAffected = await _context.SharedGames
-            .Where(g => g.Id == sharedGameId.Value && !g.HasKnowledgeBase)
-            .ExecuteUpdateAsync(
-                setters => setters.SetProperty(g => g.HasKnowledgeBase, true),
-                cancellationToken)
+        // Load the SharedGame row, flip the flag if needed, save.
+        // Idempotent: returns early if HasKnowledgeBase is already true.
+        // Single-row update, no meaningful perf difference vs ExecuteUpdate.
+        var sharedGame = await _context.SharedGames
+            .FirstOrDefaultAsync(g => g.Id == sharedGameId.Value, cancellationToken)
             .ConfigureAwait(false);
 
-        if (rowsAffected > 0)
+        if (sharedGame is null || sharedGame.HasKnowledgeBase)
         {
-            _logger.LogInformation(
-                "Set HasKnowledgeBase=true for SharedGame {SharedGameId} triggered by VectorDocument {DocumentId}",
-                sharedGameId.Value,
-                notification.DocumentId);
+            return;
         }
+
+        sharedGame.HasKnowledgeBase = true;
+        await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Set HasKnowledgeBase=true for SharedGame {SharedGameId} triggered by VectorDocument {DocumentId}",
+            sharedGameId.Value,
+            notification.DocumentId);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetAllSharedGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetAllSharedGamesQueryHandler.cs
@@ -67,7 +67,8 @@ internal sealed class GetAllSharedGamesQueryHandler : IRequestHandler<GetAllShar
                 (GameStatus)g.Status,
                 g.CreatedAt,
                 g.ModifiedAt,
-                g.IsRagPublic))
+                g.IsRagPublic,
+                g.HasKnowledgeBase))
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandler.cs
@@ -97,7 +97,8 @@ internal sealed class GetFilteredSharedGamesQueryHandler : IRequestHandler<GetFi
                 (GameStatus)g.Status,
                 g.CreatedAt,
                 g.ModifiedAt,
-                g.IsRagPublic))
+                g.IsRagPublic,
+                g.HasKnowledgeBase))
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetPendingApprovalGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetPendingApprovalGamesQueryHandler.cs
@@ -62,7 +62,8 @@ internal sealed class GetPendingApprovalGamesQueryHandler : IRequestHandler<GetP
                 (GameStatus)g.Status,
                 g.CreatedAt,
                 g.ModifiedAt,
-                g.IsRagPublic))
+                g.IsRagPublic,
+                g.HasKnowledgeBase))
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQuery.cs
@@ -22,5 +22,6 @@ internal record SearchSharedGamesQuery(
     int PageNumber = 1,
     int PageSize = 20,
     string SortBy = "Title",
-    bool SortDescending = false
+    bool SortDescending = false,
+    bool? HasKnowledgeBase = null // S2 (library-to-game epic) — filter for AI-ready games
 ) : IQuery<PagedResult<SharedGameDto>>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQueryHandler.cs
@@ -137,6 +137,12 @@ internal sealed class SearchSharedGamesQueryHandler : IRequestHandler<SearchShar
             dbQuery = dbQuery.Where(g => g.ComplexityRating <= query.MaxComplexity.Value);
         }
 
+        // S2 — Knowledge Base filter: only games with indexed KB
+        if (query.HasKnowledgeBase.HasValue)
+        {
+            dbQuery = dbQuery.Where(g => g.HasKnowledgeBase == query.HasKnowledgeBase.Value);
+        }
+
         // Apply sorting
         dbQuery = query.SortBy switch
         {
@@ -183,7 +189,8 @@ internal sealed class SearchSharedGamesQueryHandler : IRequestHandler<SearchShar
                 (GameStatus)g.Status,
                 g.CreatedAt,
                 g.ModifiedAt,
-                g.IsRagPublic))
+                g.IsRagPublic,
+                g.HasKnowledgeBase))
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
@@ -215,7 +222,7 @@ internal sealed class SearchSharedGamesQueryHandler : IRequestHandler<SearchShar
         var statusStr = query.Status?.ToString() ?? "null";
 
         // Create compact hash for long parameter combinations
-        var keyComponents = $"{searchTerm}|{categoryIds}|{mechanicIds}|{query.MinPlayers}|{query.MaxPlayers}|{query.MaxPlayingTime}|{query.MinComplexity}|{query.MaxComplexity}|{statusStr}|{query.PageNumber}|{query.PageSize}|{query.SortBy}|{query.SortDescending}";
+        var keyComponents = $"{searchTerm}|{categoryIds}|{mechanicIds}|{query.MinPlayers}|{query.MaxPlayers}|{query.MaxPlayingTime}|{query.MinComplexity}|{query.MaxComplexity}|{statusStr}|{query.PageNumber}|{query.PageSize}|{query.SortBy}|{query.SortDescending}|{query.HasKnowledgeBase?.ToString() ?? "null"}";
 
         var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(keyComponents)));
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs
@@ -33,7 +33,8 @@ public sealed record SharedGameDto(
     GameStatus Status,
     DateTime CreatedAt,
     DateTime? ModifiedAt,
-    bool IsRagPublic = false);
+    bool IsRagPublic = false,
+    bool HasKnowledgeBase = false);
 
 /// <summary>
 /// Data transfer object for game rules.

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs
@@ -36,6 +36,14 @@ public class SharedGameEntity
     public bool IsRagPublic { get; set; }
 
     /// <summary>
+    /// Denormalized flag set to true when at least one VectorDocument with this
+    /// SharedGameId has been indexed. Maintained by
+    /// VectorDocumentIndexedForKbFlagHandler (async event projection).
+    /// Used by the public catalog filter "Solo giochi AI-ready" (S2 of library-to-game epic).
+    /// </summary>
+    public bool HasKnowledgeBase { get; set; }
+
+    /// <summary>
     /// Optimistic concurrency token. Managed by the database.
     /// Spec-panel recommendation C-3.
     /// </summary>

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameEntityConfiguration.cs
@@ -114,6 +114,12 @@ internal class SharedGameEntityConfiguration : IEntityTypeConfiguration<SharedGa
             .IsRequired()
             .HasDefaultValue(false);
 
+        // S2 (library-to-game epic) — denormalized KB flag for catalog filter
+        builder.Property(e => e.HasKnowledgeBase)
+            .HasColumnName("has_knowledge_base")
+            .IsRequired()
+            .HasDefaultValue(false);
+
         // Optimistic concurrency (spec-panel C-3)
         builder.Property(e => e.RowVersion)
             .HasColumnName("row_version")
@@ -141,6 +147,11 @@ internal class SharedGameEntityConfiguration : IEntityTypeConfiguration<SharedGa
         builder.HasIndex(e => e.Title)
             .HasDatabaseName("ix_shared_games_title")
             .HasFilter("is_deleted = false");
+
+        // S2 — partial index on the small "AI-ready" subset for the catalog filter
+        builder.HasIndex(e => e.HasKnowledgeBase)
+            .HasDatabaseName("ix_shared_games_has_knowledge_base")
+            .HasFilter("has_knowledge_base = true");
 
         // Note: SearchVector index will be added manually in migration with tsvector type
 

--- a/apps/api/src/Api/Infrastructure/Migrations/20260409124412_AddHasKnowledgeBaseToSharedGames.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260409124412_AddHasKnowledgeBaseToSharedGames.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260409124412_AddHasKnowledgeBaseToSharedGames")]
+    partial class AddHasKnowledgeBaseToSharedGames
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260409124412_AddHasKnowledgeBaseToSharedGames.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260409124412_AddHasKnowledgeBaseToSharedGames.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddHasKnowledgeBaseToSharedGames : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "has_knowledge_base",
+                table: "shared_games",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_shared_games_has_knowledge_base",
+                table: "shared_games",
+                column: "has_knowledge_base",
+                filter: "has_knowledge_base = true");
+
+            // S2 (library-to-game epic) — backfill: mark games with at least one
+            // indexed vector document as having KB. Uses vector_documents.shared_game_id
+            // cross-BC reference (Issue #4921). The "IndexingStatus" column is
+            // PascalCase (default EF naming) hence the quoted identifier.
+            migrationBuilder.Sql(@"
+                UPDATE shared_games
+                SET has_knowledge_base = true
+                WHERE id IN (
+                    SELECT DISTINCT shared_game_id
+                    FROM vector_documents
+                    WHERE shared_game_id IS NOT NULL
+                      AND ""IndexingStatus"" = 'completed'
+                );
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_shared_games_has_knowledge_base",
+                table: "shared_games");
+
+            migrationBuilder.DropColumn(
+                name: "has_knowledge_base",
+                table: "shared_games");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogPublicEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogPublicEndpoints.cs
@@ -89,6 +89,7 @@ internal static class SharedGameCatalogPublicEndpoints
         [FromQuery] int pageSize = 20,
         [FromQuery] string sortBy = "Title",
         [FromQuery] bool sortDescending = false,
+        [FromQuery] bool? hasKb = null, // S2 (library-to-game epic) — filter for AI-ready games
         CancellationToken ct = default)
     {
         var query = new SearchSharedGamesQuery(
@@ -104,7 +105,8 @@ internal static class SharedGameCatalogPublicEndpoints
             pageNumber,
             pageSize,
             sortBy,
-            sortDescending);
+            sortDescending,
+            HasKnowledgeBase: hasKb);
 
         var result = await mediator.Send(query, ct).ConfigureAwait(false);
         return Results.Ok(result);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandlerTests.cs
@@ -1,0 +1,158 @@
+using Api.BoundedContexts.KnowledgeBase.Domain.Events;
+using Api.BoundedContexts.SharedGameCatalog.Application.EventHandlers;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.EventHandlers;
+
+/// <summary>
+/// Unit tests for VectorDocumentIndexedForKbFlagHandler.
+/// S2 of library-to-game epic — maintains the denormalized
+/// <c>has_knowledge_base</c> column on <c>shared_games</c> in response to
+/// VectorDocumentIndexedEvent notifications from the KnowledgeBase BC.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class VectorDocumentIndexedForKbFlagHandlerTests
+{
+    private readonly Mock<ILogger<VectorDocumentIndexedForKbFlagHandler>> _logger = new();
+
+    private static SharedGameEntity CreateSharedGame(Guid id, bool hasKb = false) =>
+        new()
+        {
+            Id = id,
+            Title = "Test Game",
+            YearPublished = 2020,
+            Description = "Desc",
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 30,
+            MinAge = 8,
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            Status = 1,
+            CreatedBy = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            HasKnowledgeBase = hasKb,
+        };
+
+    private static VectorDocumentEntity CreateVectorDocument(Guid id, Guid? sharedGameId, Guid? gameId = null) =>
+        new()
+        {
+            Id = id,
+            GameId = gameId,
+            SharedGameId = sharedGameId,
+            PdfDocumentId = Guid.NewGuid(),
+            ChunkCount = 42,
+            TotalCharacters = 10000,
+            IndexingStatus = "completed",
+            EmbeddingModel = "nomic-embed-text",
+            EmbeddingDimensions = 768,
+        };
+
+    [Fact]
+    public async Task Handle_VectorDocumentWithSharedGameId_FlipsHasKnowledgeBaseToTrue()
+    {
+        // Arrange
+        var sharedGameId = Guid.NewGuid();
+        var documentId = Guid.NewGuid();
+
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.SharedGames.Add(CreateSharedGame(sharedGameId, hasKb: false));
+        db.VectorDocuments.Add(CreateVectorDocument(documentId, sharedGameId));
+        await db.SaveChangesAsync();
+
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, _logger.Object);
+        var evt = new VectorDocumentIndexedEvent(documentId, sharedGameId, 42);
+
+        // Act
+        await handler.Handle(evt, CancellationToken.None);
+
+        // Assert
+        var updated = await db.SharedGames.FindAsync(sharedGameId);
+        updated.Should().NotBeNull();
+        updated!.HasKnowledgeBase.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_VectorDocumentWithNullSharedGameId_DoesNotUpdateAnyGame()
+    {
+        // Arrange
+        var sharedGameId = Guid.NewGuid();
+        var documentId = Guid.NewGuid();
+        var unrelatedGameId = Guid.NewGuid();
+
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.SharedGames.Add(CreateSharedGame(sharedGameId, hasKb: false));
+        db.VectorDocuments.Add(CreateVectorDocument(documentId, sharedGameId: null, gameId: unrelatedGameId));
+        await db.SaveChangesAsync();
+
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, _logger.Object);
+        var evt = new VectorDocumentIndexedEvent(documentId, unrelatedGameId, 42);
+
+        // Act
+        await handler.Handle(evt, CancellationToken.None);
+
+        // Assert
+        var shouldNotChange = await db.SharedGames.FindAsync(sharedGameId);
+        shouldNotChange!.HasKnowledgeBase.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_VectorDocumentNotFound_DoesNotThrow()
+    {
+        // Arrange
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, _logger.Object);
+        var evt = new VectorDocumentIndexedEvent(Guid.NewGuid(), Guid.NewGuid(), 42);
+
+        // Act
+        var act = async () => await handler.Handle(evt, CancellationToken.None);
+
+        // Assert
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task Handle_SharedGameAlreadyHasKnowledgeBase_IsIdempotent()
+    {
+        // Arrange
+        var sharedGameId = Guid.NewGuid();
+        var documentId = Guid.NewGuid();
+
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.SharedGames.Add(CreateSharedGame(sharedGameId, hasKb: true));
+        db.VectorDocuments.Add(CreateVectorDocument(documentId, sharedGameId));
+        await db.SaveChangesAsync();
+
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, _logger.Object);
+        var evt = new VectorDocumentIndexedEvent(documentId, sharedGameId, 42);
+
+        // Act
+        await handler.Handle(evt, CancellationToken.None);
+
+        // Assert — still true, no exception
+        var stillTrue = await db.SharedGames.FindAsync(sharedGameId);
+        stillTrue!.HasKnowledgeBase.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_NullNotification_ThrowsArgumentNullException()
+    {
+        // Arrange
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, _logger.Object);
+
+        // Act
+        var act = async () => await handler.Handle(null!, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQuery_KbFilterTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQuery_KbFilterTests.cs
@@ -1,0 +1,151 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+/// <summary>
+/// Unit tests focused on the S2 (library-to-game epic) HasKnowledgeBase filter
+/// extension of SearchSharedGamesQueryHandler.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class SearchSharedGamesQuery_KbFilterTests
+{
+    private readonly Mock<ILogger<SearchSharedGamesQueryHandler>> _logger = new();
+
+    private static SharedGameEntity CreateGame(string title, bool hasKb) => new()
+    {
+        Id = Guid.NewGuid(),
+        Title = title,
+        YearPublished = 2020,
+        Description = "Desc",
+        MinPlayers = 2,
+        MaxPlayers = 4,
+        PlayingTimeMinutes = 30,
+        MinAge = 8,
+        ImageUrl = string.Empty,
+        ThumbnailUrl = string.Empty,
+        Status = (int)GameStatus.Published,
+        CreatedBy = Guid.NewGuid(),
+        CreatedAt = DateTime.UtcNow,
+        HasKnowledgeBase = hasKb,
+    };
+
+    private static HybridCache CreateHybridCache()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IMemoryCache, MemoryCache>();
+        services.AddSingleton<IDistributedCache>(new MemoryDistributedCache(
+            Microsoft.Extensions.Options.Options.Create(new MemoryDistributedCacheOptions())));
+        services.AddHybridCache();
+        return services.BuildServiceProvider().GetRequiredService<HybridCache>();
+    }
+
+    private static SearchSharedGamesQuery BuildQuery(bool? hasKnowledgeBase) =>
+        new(
+            SearchTerm: null,
+            CategoryIds: null,
+            MechanicIds: null,
+            MinPlayers: null,
+            MaxPlayers: null,
+            MaxPlayingTime: null,
+            MinComplexity: null,
+            MaxComplexity: null,
+            Status: GameStatus.Published,
+            PageNumber: 1,
+            PageSize: 20,
+            SortBy: "Title",
+            SortDescending: false,
+            HasKnowledgeBase: hasKnowledgeBase);
+
+    [Fact]
+    public async Task Handle_NoKbFilter_ReturnsAllGames()
+    {
+        // Arrange
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.SharedGames.AddRange(
+            CreateGame("With KB", hasKb: true),
+            CreateGame("Without KB", hasKb: false));
+        await db.SaveChangesAsync();
+
+        var handler = new SearchSharedGamesQueryHandler(db, CreateHybridCache(), _logger.Object);
+
+        // Act
+        var result = await handler.Handle(BuildQuery(hasKnowledgeBase: null), CancellationToken.None);
+
+        // Assert
+        result.Total.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Handle_HasKnowledgeBaseTrue_ReturnsOnlyKbGames()
+    {
+        // Arrange
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.SharedGames.AddRange(
+            CreateGame("Azul", hasKb: true),
+            CreateGame("Catan", hasKb: true),
+            CreateGame("Monopoly", hasKb: false));
+        await db.SaveChangesAsync();
+
+        var handler = new SearchSharedGamesQueryHandler(db, CreateHybridCache(), _logger.Object);
+
+        // Act
+        var result = await handler.Handle(BuildQuery(hasKnowledgeBase: true), CancellationToken.None);
+
+        // Assert
+        result.Total.Should().Be(2);
+        result.Items.Should().OnlyContain(g => g.HasKnowledgeBase);
+        result.Items.Select(g => g.Title).Should().BeEquivalentTo(new[] { "Azul", "Catan" });
+    }
+
+    [Fact]
+    public async Task Handle_HasKnowledgeBaseFalse_ReturnsOnlyNonKbGames()
+    {
+        // Arrange
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.SharedGames.AddRange(
+            CreateGame("Azul", hasKb: true),
+            CreateGame("Monopoly", hasKb: false),
+            CreateGame("Risk", hasKb: false));
+        await db.SaveChangesAsync();
+
+        var handler = new SearchSharedGamesQueryHandler(db, CreateHybridCache(), _logger.Object);
+
+        // Act
+        var result = await handler.Handle(BuildQuery(hasKnowledgeBase: false), CancellationToken.None);
+
+        // Assert
+        result.Total.Should().Be(2);
+        result.Items.Should().OnlyContain(g => !g.HasKnowledgeBase);
+    }
+
+    [Fact]
+    public async Task Handle_ProjectionIncludesHasKnowledgeBaseField()
+    {
+        // Arrange
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.SharedGames.Add(CreateGame("Azul", hasKb: true));
+        await db.SaveChangesAsync();
+
+        var handler = new SearchSharedGamesQueryHandler(db, CreateHybridCache(), _logger.Object);
+
+        // Act
+        var result = await handler.Handle(BuildQuery(hasKnowledgeBase: null), CancellationToken.None);
+
+        // Assert
+        result.Items.Should().ContainSingle()
+            .Which.HasKnowledgeBase.Should().BeTrue();
+    }
+}

--- a/apps/web/src/components/library/PublicLibraryPage.tsx
+++ b/apps/web/src/components/library/PublicLibraryPage.tsx
@@ -17,8 +17,8 @@
 
 import { useState, useMemo, useCallback, useEffect } from 'react';
 
-import { ChevronDown, Filter, Loader2, Search, X } from 'lucide-react';
-import { useRouter } from 'next/navigation';
+import { ChevronDown, Filter, Loader2, Search, Sparkles, X } from 'lucide-react';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import { MeepleGameCatalogCard } from '@/components/catalog/MeepleGameCatalogCard';
 import { EmptyState } from '@/components/empty-state/EmptyState';
@@ -76,6 +76,7 @@ export interface PublicLibraryPageProps {
  */
 export function PublicLibraryPage({ className }: PublicLibraryPageProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   // ------------------------------------------------------------------
   // Local state
@@ -83,8 +84,24 @@ export function PublicLibraryPage({ className }: PublicLibraryPageProps) {
   const [search, setSearch] = useState('');
   const [selectedMechanics, setSelectedMechanics] = useState<string[]>([]);
   const [page, setPage] = useState(1);
+  // S2 (library-to-game epic) — "AI-ready only" filter, persisted in URL `?hasKb=true`
+  const [aiReadyOnly, setAiReadyOnly] = useState(() => searchParams?.get('hasKb') === 'true');
 
   const debouncedSearch = useDebounce(search, 300);
+
+  // Sync filter state → URL
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    if (aiReadyOnly) {
+      params.set('hasKb', 'true');
+    } else {
+      params.delete('hasKb');
+    }
+    const qs = params.toString();
+    const newUrl = `${window.location.pathname}${qs ? `?${qs}` : ''}`;
+    window.history.replaceState(null, '', newUrl);
+  }, [aiReadyOnly]);
 
   // ------------------------------------------------------------------
   // Data fetching
@@ -119,6 +136,7 @@ export function PublicLibraryPage({ className }: PublicLibraryPageProps) {
     {
       searchTerm: debouncedSearch || undefined,
       mechanicIds,
+      hasKnowledgeBase: aiReadyOnly || undefined,
       page,
       pageSize: PAGE_SIZE,
       sortBy: 'title',
@@ -283,6 +301,33 @@ export function PublicLibraryPage({ className }: PublicLibraryPageProps) {
       {/* ---------------------------------------------------------------- */}
       {availableMechanicSlugs.length > 0 && (
         <div className="flex flex-wrap items-center gap-2" data-testid="mechanic-filter-row">
+          {/* S2 — AI-ready only toggle chip */}
+          <button
+            type="button"
+            onClick={() => {
+              setAiReadyOnly(v => !v);
+              setPage(1);
+            }}
+            data-testid="catalog-kb-filter"
+            aria-pressed={aiReadyOnly}
+            aria-label="Mostra solo giochi AI-ready"
+            className={cn(
+              'flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+              'bg-[#21262d] border text-[#e6edf3]',
+              aiReadyOnly
+                ? 'border-[#f0a030] text-[#f0a030]'
+                : 'border-[#30363d] hover:bg-[#30363d] hover:border-[#58a6ff]'
+            )}
+          >
+            <Sparkles className="h-4 w-4" aria-hidden="true" />
+            Solo giochi AI-ready
+            {aiReadyOnly && (
+              <span className="flex h-5 w-5 items-center justify-center rounded-full bg-[#f0a030] text-[10px] font-bold text-[#0d1117]">
+                ✓
+              </span>
+            )}
+          </button>
+
           <Popover>
             <PopoverTrigger asChild>
               <button

--- a/apps/web/src/lib/api/clients/sharedGamesClient.ts
+++ b/apps/web/src/lib/api/clients/sharedGamesClient.ts
@@ -245,6 +245,9 @@ export function createSharedGamesClient({ httpClient }: CreateSharedGamesClientP
       if (params.sortBy) queryParams.set('sortBy', params.sortBy);
       if (params.sortDescending !== undefined)
         queryParams.set('sortDescending', params.sortDescending.toString());
+      // S2 — filter for AI-ready games (matches backend hasKb query parameter)
+      if (params.hasKnowledgeBase !== undefined)
+        queryParams.set('hasKb', params.hasKnowledgeBase.toString());
 
       const queryString = queryParams.toString();
       const path = `/api/v1/shared-games${queryString ? `?${queryString}` : ''}`;

--- a/apps/web/src/lib/api/schemas/shared-games.schemas.ts
+++ b/apps/web/src/lib/api/schemas/shared-games.schemas.ts
@@ -179,6 +179,7 @@ export const SharedGameSchema = z.object({
   thumbnailUrl: z.string().catch(''), // coerce null/missing to empty string
   status: GameStatusSchema, // Now string enum with JsonStringEnumConverter
   isRagPublic: z.boolean().default(false), // whether RAG access is public for all owners
+  hasKnowledgeBase: z.boolean().default(false), // S2 — true when game has indexed KB (AI-ready)
   createdAt: z.string(), // Accept any datetime format from .NET serialization
   modifiedAt: z.string().nullable(),
 });
@@ -437,6 +438,8 @@ export const SearchSharedGamesParamsSchema = z.object({
   pageSize: z.number().int().positive().optional(),
   sortBy: z.string().optional(),
   sortDescending: z.boolean().optional(),
+  // S2 (library-to-game epic) — filter for AI-ready games
+  hasKnowledgeBase: z.boolean().optional(),
 });
 
 export type SearchSharedGamesParams = z.infer<typeof SearchSharedGamesParamsSchema>;

--- a/docs/superpowers/plans/2026-04-09-s2-kb-filter.md
+++ b/docs/superpowers/plans/2026-04-09-s2-kb-filter.md
@@ -1,0 +1,741 @@
+# S2 — `hasKnowledgeBase` Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: `superpowers:executing-plans`. TDD steps with checkbox syntax.
+
+**Goal:** Add a `HasKnowledgeBase` denormalized column to `SharedGameEntity`, maintain it via an event handler on `VectorDocumentIndexedEvent`, expose it as an optional filter on the public catalog endpoint, and render a toggle chip in the frontend `PublicLibraryPage`.
+
+**Architecture:** Denormalized column + event-driven projection update. Write path = event handler in `SharedGameCatalog.Application.EventHandlers/` reads `VectorDocumentEntity` by DocumentId to resolve `SharedGameId`, then executes `UPDATE shared_games SET has_knowledge_base = true WHERE id = :id`. Read path = `SearchSharedGamesQuery` handler adds WHERE clause + DTO mapping. One-time backfill in the EF migration.
+
+**Tech Stack:** .NET 9 / EF Core 9 / PostgreSQL / MediatR / xUnit + Testcontainers (backend), Next.js / TanStack Query / Zod (frontend).
+
+**Reference spec:** `docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md` §4.2
+**Branch:** `feature/s2-kb-filter` (from `epic/library-to-game`)
+
+**⚠️ Spec correction:** Spec decision CR-C1 named `GetFilteredSharedGamesQuery` as the target query. Verified via grep: the PUBLIC catalog endpoint (`GET /api/v1/shared-games`) uses **`SearchSharedGamesQuery`**. `GetFilteredSharedGamesQuery` is only used by the admin endpoint. S2 extends `SearchSharedGamesQuery` (user-facing). Admin endpoint is not in S2 scope.
+
+---
+
+## File Structure
+
+**New files (backend):**
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandler.cs` — event handler
+- `apps/api/src/Api/Infrastructure/Migrations/<timestamp>_AddHasKnowledgeBaseToSharedGames.cs` — auto-generated
+- `tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandlerTests.cs`
+- `tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQuery_KbFilterTests.cs`
+
+**Modified files (backend):**
+- `apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs` — add `HasKnowledgeBase` property
+- `apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameEntityConfiguration.cs` — add column config + index
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs` — add `HasKnowledgeBase: bool = false`
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQuery.cs` — add `HasKnowledgeBase: bool?`
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQueryHandler.cs` — filter + DTO mapping + cache key
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandler.cs` — add field to `.Select` (admin consistency, no filter param)
+- `apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogPublicEndpoints.cs` — accept `hasKb` query param, pass to query
+- `apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs` — pass-through update if needed
+
+**Modified files (frontend):**
+- `apps/web/src/lib/api/schemas/shared-games.schemas.ts` — add `hasKnowledgeBase?: boolean` to `SearchSharedGamesParamsSchema`; add `hasKnowledgeBase` to response `SharedGameSchema`
+- `apps/web/src/lib/api/clients/sharedGamesClient.ts` — map param to query string
+- `apps/web/src/components/library/PublicLibraryPage.tsx` — add filter chip state + UI + URL sync
+
+**New files (frontend):**
+- none — tests go alongside PublicLibraryPage existing tests if any, otherwise a new test file (TBD in task 11)
+
+**Total estimate:** ~14 files touched, ~400 LOC production + ~300 LOC tests.
+
+---
+
+## Task 1 — Backend entity column + EF configuration
+
+**Files:**
+- Modify: `apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs`
+- Modify: `apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameEntityConfiguration.cs`
+
+- [ ] **Step 1.1: Add `HasKnowledgeBase` property to entity**
+
+  In `SharedGameEntity.cs`, add after the existing `IsRagPublic` property:
+  ```csharp
+  /// <summary>
+  /// Denormalized flag set to true when at least one VectorDocument with this
+  /// SharedGameId has been indexed. Maintained by
+  /// VectorDocumentIndexedForKbFlagHandler (async event projection).
+  /// Used by the public catalog filter "Solo giochi AI-ready".
+  /// </summary>
+  public bool HasKnowledgeBase { get; set; }
+  ```
+
+- [ ] **Step 1.2: Add EF column configuration + index**
+
+  In `SharedGameEntityConfiguration.cs`, add after the `IsRagPublic` configuration:
+  ```csharp
+  builder.Property(e => e.HasKnowledgeBase)
+      .HasColumnName("has_knowledge_base")
+      .IsRequired()
+      .HasDefaultValue(false);
+
+  builder.HasIndex(e => e.HasKnowledgeBase)
+      .HasDatabaseName("ix_shared_games_has_knowledge_base")
+      .HasFilter("has_knowledge_base = true");  // Partial index — only the small "true" subset
+  ```
+
+- [ ] **Step 1.3: Verify backend builds**
+
+  ```bash
+  cd apps/api/src/Api
+  dotnet build 2>&1 | tail -10
+  ```
+  Expected: `Build succeeded` with 0 errors.
+
+- [ ] **Step 1.4: Commit**
+
+  ```bash
+  cd D:/Repositories/meepleai-monorepo-backend
+  git add apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs \
+          apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameEntityConfiguration.cs
+  git commit -m "feat(s2): add HasKnowledgeBase column to SharedGameEntity"
+  ```
+
+---
+
+## Task 2 — EF Core migration
+
+**Files:**
+- Create (auto-generated): `apps/api/src/Api/Infrastructure/Migrations/<timestamp>_AddHasKnowledgeBaseToSharedGames.cs`
+
+- [ ] **Step 2.1: Generate the migration**
+
+  ```bash
+  cd apps/api/src/Api
+  dotnet ef migrations add AddHasKnowledgeBaseToSharedGames
+  ```
+  Expected: two new files created under `Infrastructure/Migrations/` (the migration `.cs` file + its `.Designer.cs` counterpart). The migration should contain an `AddColumn<bool>("has_knowledge_base", "shared_games", nullable: false, defaultValue: false)` + `CreateIndex` with the partial filter.
+
+- [ ] **Step 2.2: Review the generated migration**
+
+  Open the newly-created `<timestamp>_AddHasKnowledgeBaseToSharedGames.cs` and verify:
+  - `Up()` contains `AddColumn<bool>` for `has_knowledge_base`
+  - `Up()` contains `CreateIndex` with `filter: "has_knowledge_base = true"`
+  - `Down()` contains `DropIndex` + `DropColumn`
+
+  If the generated migration looks wrong (e.g., extra unrelated changes from pending model diffs), STOP and ask — do not force-commit.
+
+- [ ] **Step 2.3: Add backfill SQL to the migration Up() method**
+
+  Edit the new migration file. At the end of `Up()`, before it exits, add:
+  ```csharp
+  // Backfill: mark games with at least one indexed vector document as having KB.
+  // Uses the existing vector_documents.shared_game_id cross-BC reference (Issue #4921).
+  migrationBuilder.Sql(@"
+      UPDATE shared_games
+      SET has_knowledge_base = true
+      WHERE id IN (
+          SELECT DISTINCT shared_game_id
+          FROM vector_documents
+          WHERE shared_game_id IS NOT NULL
+            AND indexing_status = 'completed'
+      );
+  ");
+  ```
+
+  Note: the vector_documents column name might be camelCase or snake_case in the generated SQL — verify against the existing VectorDocumentEntity EF config. If it's `SharedGameId` in quotes, use `"SharedGameId"` instead of `shared_game_id`. Check `VectorDocumentEntityConfiguration.cs` for the column name convention.
+
+- [ ] **Step 2.4: Verify backend builds after migration**
+
+  ```bash
+  cd apps/api/src/Api
+  dotnet build 2>&1 | tail -10
+  ```
+
+- [ ] **Step 2.5: Commit**
+
+  ```bash
+  cd D:/Repositories/meepleai-monorepo-backend
+  git add apps/api/src/Api/Infrastructure/Migrations/
+  git commit -m "feat(s2): add EF migration for HasKnowledgeBase column with backfill"
+  ```
+
+---
+
+## Task 3 — Update `SharedGameDto` and query record
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQuery.cs`
+
+- [ ] **Step 3.1: Add HasKnowledgeBase to `SharedGameDto`**
+
+  In `SharedGameDto.cs`, add the new field at the end of the record:
+  ```csharp
+  public sealed record SharedGameDto(
+      Guid Id,
+      int? BggId,
+      string Title,
+      int YearPublished,
+      string Description,
+      int MinPlayers,
+      int MaxPlayers,
+      int PlayingTimeMinutes,
+      int MinAge,
+      decimal? ComplexityRating,
+      decimal? AverageRating,
+      string ImageUrl,
+      string ThumbnailUrl,
+      GameStatus Status,
+      DateTime CreatedAt,
+      DateTime? ModifiedAt,
+      bool IsRagPublic = false,
+      bool HasKnowledgeBase = false);
+  ```
+
+- [ ] **Step 3.2: Add `HasKnowledgeBase` param to `SearchSharedGamesQuery`**
+
+  Add a new nullable bool parameter at the end of the record:
+  ```csharp
+  internal sealed record SearchSharedGamesQuery(
+      string? SearchTerm,
+      List<Guid>? CategoryIds,
+      List<Guid>? MechanicIds,
+      int? MinPlayers,
+      int? MaxPlayers,
+      int? MaxPlayingTime,
+      decimal? MinComplexity,
+      decimal? MaxComplexity,
+      GameStatus? Status,
+      int PageNumber,
+      int PageSize,
+      string? SortBy,
+      bool SortDescending,
+      bool? HasKnowledgeBase = null  // New: filter for AI-ready games
+  ) : IRequest<PagedResult<SharedGameDto>>;
+  ```
+  NOTE: I don't know the exact shape of `SearchSharedGamesQuery.cs` — read it first, then add the param at the end preserving existing parameters verbatim.
+
+- [ ] **Step 3.3: Verify backend builds**
+
+  ```bash
+  cd apps/api/src/Api
+  dotnet build 2>&1 | tail -10
+  ```
+
+- [ ] **Step 3.4: Commit**
+
+  ```bash
+  git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs \
+          apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQuery.cs
+  git commit -m "feat(s2): extend SharedGameDto and SearchSharedGamesQuery with HasKnowledgeBase"
+  ```
+
+---
+
+## Task 4 — Update `SearchSharedGamesQueryHandler`
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQueryHandler.cs`
+
+- [ ] **Step 4.1: Add the filter clause**
+
+  In `ExecuteSearchAsync`, add a new filter block between "Playing time filter" and "Complexity rating filter":
+  ```csharp
+  // Knowledge Base filter: only games with indexed KB (S2)
+  if (query.HasKnowledgeBase.HasValue)
+  {
+      dbQuery = dbQuery.Where(g => g.HasKnowledgeBase == query.HasKnowledgeBase.Value);
+  }
+  ```
+
+- [ ] **Step 4.2: Add `HasKnowledgeBase` to the DTO projection**
+
+  In the `.Select(g => new SharedGameDto(...))` call, add `g.HasKnowledgeBase` as the new final argument:
+  ```csharp
+  .Select(g => new SharedGameDto(
+      g.Id,
+      g.BggId,
+      g.Title,
+      g.YearPublished,
+      g.Description,
+      g.MinPlayers,
+      g.MaxPlayers,
+      g.PlayingTimeMinutes,
+      g.MinAge,
+      g.ComplexityRating,
+      g.AverageRating,
+      g.ImageUrl,
+      g.ThumbnailUrl,
+      (GameStatus)g.Status,
+      g.CreatedAt,
+      g.ModifiedAt,
+      g.IsRagPublic,
+      g.HasKnowledgeBase))  // S2
+  ```
+
+- [ ] **Step 4.3: Add `HasKnowledgeBase` to the cache key**
+
+  In `GenerateCacheKey`, append `query.HasKnowledgeBase?.ToString() ?? "null"` to the `keyComponents` string so different filter values produce different cache entries:
+  ```csharp
+  var keyComponents = $"{searchTerm}|{categoryIds}|{mechanicIds}|{query.MinPlayers}|{query.MaxPlayers}|{query.MaxPlayingTime}|{query.MinComplexity}|{query.MaxComplexity}|{statusStr}|{query.PageNumber}|{query.PageSize}|{query.SortBy}|{query.SortDescending}|{query.HasKnowledgeBase?.ToString() ?? "null"}";
+  ```
+
+- [ ] **Step 4.4: Build verification**
+
+  ```bash
+  cd apps/api/src/Api
+  dotnet build 2>&1 | tail -10
+  ```
+
+- [ ] **Step 4.5: Commit**
+
+  ```bash
+  git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQueryHandler.cs
+  git commit -m "feat(s2): add HasKnowledgeBase filter and DTO mapping to search handler"
+  ```
+
+---
+
+## Task 5 — Update `GetFilteredSharedGamesQueryHandler` projection (admin consistency)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandler.cs`
+
+- [ ] **Step 5.1: Add `g.HasKnowledgeBase` to the `.Select` projection**
+
+  In `GetFilteredSharedGamesQueryHandler.Handle()`, add `g.HasKnowledgeBase` as the new final constructor argument to the `new SharedGameDto(...)` call (same pattern as Task 4.2).
+
+  **Do NOT** add a filter parameter to the admin query — admin scope stays minimal.
+
+- [ ] **Step 5.2: Build verification**
+
+  ```bash
+  cd apps/api/src/Api
+  dotnet build 2>&1 | tail -10
+  ```
+
+- [ ] **Step 5.3: Commit**
+
+  ```bash
+  git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandler.cs
+  git commit -m "feat(s2): include HasKnowledgeBase in admin GetFilteredSharedGames projection"
+  ```
+
+---
+
+## Task 6 — Public endpoint `hasKb` query param wiring
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogPublicEndpoints.cs`
+
+- [ ] **Step 6.1: Read the endpoint handler signature**
+
+  Read the `HandleSearchGames` (or similar) method in the file — find where `SearchSharedGamesQuery` is constructed.
+
+- [ ] **Step 6.2: Add `hasKb` query parameter to handler**
+
+  Add a new parameter `[FromQuery] bool? hasKb = null` to the endpoint method signature, and pass it as `HasKnowledgeBase: hasKb` to the `SearchSharedGamesQuery` constructor. Preserve parameter order of existing params; add `hasKb` at the end of the method signature.
+
+  Example of the call site change (adapt to actual code):
+  ```csharp
+  var query = new SearchSharedGamesQuery(
+      search,
+      categoryIds?.ToList(),
+      // ... existing params ...
+      HasKnowledgeBase: hasKb);
+  ```
+
+- [ ] **Step 6.3: Update endpoint OpenAPI metadata if present**
+
+  If the endpoint uses `.WithDescription()` or Scalar metadata, append: `"Supports hasKb=true filter for AI-ready games (Issue #S2, epic/library-to-game)."`
+
+- [ ] **Step 6.4: Build verification**
+
+  ```bash
+  cd apps/api/src/Api
+  dotnet build 2>&1 | tail -10
+  ```
+
+- [ ] **Step 6.5: Commit**
+
+  ```bash
+  git add apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogPublicEndpoints.cs
+  git commit -m "feat(s2): expose hasKb filter on GET /api/v1/shared-games"
+  ```
+
+---
+
+## Task 7 — Event handler for async projection updates
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandler.cs`
+
+- [ ] **Step 7.1: Write the handler**
+
+  ```csharp
+  using Api.BoundedContexts.KnowledgeBase.Domain.Events;
+  using Api.Infrastructure;
+  using MediatR;
+  using Microsoft.EntityFrameworkCore;
+
+  namespace Api.BoundedContexts.SharedGameCatalog.Application.EventHandlers;
+
+  /// <summary>
+  /// Listens to VectorDocumentIndexedEvent and maintains the denormalized
+  /// `has_knowledge_base` column on `shared_games`. Bridges the KnowledgeBase
+  /// BC (write source) with SharedGameCatalog BC (read projection).
+  ///
+  /// The cross-BC dependency is limited to:
+  ///   1. Event subscription (standard DDD async projection pattern)
+  ///   2. A single targeted read of `vector_documents` to look up the
+  ///      SharedGameId of the indexed document (the event carries GameId
+  ///      which is the Game aggregate id, not SharedGameId).
+  ///
+  /// Reference: docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md §4.2
+  /// </summary>
+  internal sealed class VectorDocumentIndexedForKbFlagHandler
+      : INotificationHandler<VectorDocumentIndexedEvent>
+  {
+      private readonly MeepleAiDbContext _context;
+      private readonly ILogger<VectorDocumentIndexedForKbFlagHandler> _logger;
+
+      public VectorDocumentIndexedForKbFlagHandler(
+          MeepleAiDbContext context,
+          ILogger<VectorDocumentIndexedForKbFlagHandler> logger)
+      {
+          _context = context ?? throw new ArgumentNullException(nameof(context));
+          _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+      }
+
+      public async Task Handle(VectorDocumentIndexedEvent notification, CancellationToken cancellationToken)
+      {
+          ArgumentNullException.ThrowIfNull(notification);
+
+          // Look up the VectorDocument to resolve SharedGameId.
+          // This is the only cross-BC table read in the handler — the update
+          // below stays within SharedGameCatalog's own tables.
+          var sharedGameId = await _context.VectorDocuments
+              .AsNoTracking()
+              .Where(v => v.Id == notification.DocumentId)
+              .Select(v => v.SharedGameId)
+              .FirstOrDefaultAsync(cancellationToken)
+              .ConfigureAwait(false);
+
+          if (sharedGameId is null || sharedGameId == Guid.Empty)
+          {
+              _logger.LogDebug(
+                  "VectorDocument {DocumentId} has no SharedGameId, skipping KB flag update",
+                  notification.DocumentId);
+              return;
+          }
+
+          // Bulk update bypassing change tracking (perf + avoids loading aggregate).
+          var rowsAffected = await _context.SharedGames
+              .Where(g => g.Id == sharedGameId.Value && !g.HasKnowledgeBase)
+              .ExecuteUpdateAsync(
+                  setters => setters.SetProperty(g => g.HasKnowledgeBase, true),
+                  cancellationToken)
+              .ConfigureAwait(false);
+
+          if (rowsAffected > 0)
+          {
+              _logger.LogInformation(
+                  "Set HasKnowledgeBase=true for SharedGame {SharedGameId} triggered by VectorDocument {DocumentId}",
+                  sharedGameId.Value,
+                  notification.DocumentId);
+          }
+      }
+  }
+  ```
+
+- [ ] **Step 7.2: Verify the handler is picked up by MediatR auto-registration**
+
+  Check `Program.cs` (or `Startup.cs`) to ensure `services.AddMediatR(...)` scans the `SharedGameCatalog` assembly. If yes → no extra registration needed. If no → add the assembly to the scan list.
+
+  ```bash
+  cd D:/Repositories/meepleai-monorepo-backend
+  grep -rn "AddMediatR" apps/api/src/Api --include="*.cs" | head -5
+  ```
+
+- [ ] **Step 7.3: Build verification**
+
+  ```bash
+  cd apps/api/src/Api
+  dotnet build 2>&1 | tail -10
+  ```
+
+- [ ] **Step 7.4: Commit**
+
+  ```bash
+  git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandler.cs
+  git commit -m "feat(s2): add VectorDocumentIndexedForKbFlagHandler event projection"
+  ```
+
+---
+
+## Task 8 — Backend unit tests
+
+**Files:**
+- Create: `tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandlerTests.cs`
+- Create: `tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQuery_KbFilterTests.cs` (if the test file doesn't exist already)
+
+- [ ] **Step 8.1: Find existing test patterns**
+
+  ```bash
+  cd D:/Repositories/meepleai-monorepo-backend
+  ls tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/ 2>&1 | head -5
+  ls tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/ 2>&1 | head -10
+  ```
+
+- [ ] **Step 8.2: Write event handler test**
+
+  Use Testcontainers + an in-memory or real postgres fixture (follow the existing pattern in the neighbor test files). Cover:
+  - Test: VectorDocument with non-null SharedGameId → handler sets `HasKnowledgeBase=true` on the SharedGame
+  - Test: VectorDocument with null SharedGameId → handler skips (no update)
+  - Test: Non-existent DocumentId → handler returns gracefully, no throw
+  - Test: SharedGame already has `HasKnowledgeBase=true` → handler is a no-op (idempotent)
+
+  Follow the existing event handler test conventions — copy-paste the skeleton from `DocumentApprovedForRagEventHandlerTests.cs` if it exists, and adapt.
+
+- [ ] **Step 8.3: Write query handler filter test**
+
+  Cover:
+  - Test: query with `HasKnowledgeBase=null` returns all games
+  - Test: query with `HasKnowledgeBase=true` returns only games with flag set
+  - Test: query with `HasKnowledgeBase=false` returns only games without flag
+  - Test: DTO projection includes `HasKnowledgeBase` field
+
+- [ ] **Step 8.4: Run tests**
+
+  ```bash
+  cd apps/api
+  dotnet test tests/Api.Tests --filter "FullyQualifiedName~VectorDocumentIndexedForKbFlag|FullyQualifiedName~SearchSharedGamesQuery_KbFilter" 2>&1 | tail -20
+  ```
+  Expected: all new tests PASS.
+
+- [ ] **Step 8.5: Commit**
+
+  ```bash
+  git add tests/Api.Tests/BoundedContexts/SharedGameCatalog/
+  git commit -m "test(s2): add tests for KB filter and event handler"
+  ```
+
+---
+
+## Task 9 — Frontend schema + client
+
+**Files:**
+- Modify: `apps/web/src/lib/api/schemas/shared-games.schemas.ts`
+- Modify: `apps/web/src/lib/api/clients/sharedGamesClient.ts`
+
+- [ ] **Step 9.1: Add `hasKnowledgeBase` to `SearchSharedGamesParamsSchema`**
+
+  In `shared-games.schemas.ts`, extend the schema:
+  ```typescript
+  export const SearchSharedGamesParamsSchema = z.object({
+    searchTerm: z.string().optional(),
+    categoryIds: z.string().optional(),
+    mechanicIds: z.string().optional(),
+    minPlayers: z.number().int().positive().optional(),
+    maxPlayers: z.number().int().positive().optional(),
+    maxPlayingTime: z.number().int().positive().optional(),
+    status: GameStatusNumericSchema.optional(),
+    page: z.number().int().positive().optional(),
+    pageSize: z.number().int().positive().optional(),
+    sortBy: z.string().optional(),
+    sortDescending: z.boolean().optional(),
+    hasKnowledgeBase: z.boolean().optional(),  // S2: filter for AI-ready games
+  });
+  ```
+
+- [ ] **Step 9.2: Add `hasKnowledgeBase` to the `SharedGameSchema` response type**
+
+  Find the `SharedGameSchema` Zod definition in the same file and add:
+  ```typescript
+  hasKnowledgeBase: z.boolean().default(false),
+  ```
+
+- [ ] **Step 9.3: Map param to query string in the client**
+
+  In `sharedGamesClient.ts` `search` method, add:
+  ```typescript
+  if (params.hasKnowledgeBase !== undefined) {
+    queryParams.set('hasKb', params.hasKnowledgeBase.toString());
+  }
+  ```
+  Place it next to the other `if (params.xxx !== undefined)` lines. Verify the backend endpoint accepts `hasKb` (matches Task 6).
+
+- [ ] **Step 9.4: Typecheck**
+
+  ```bash
+  cd apps/web
+  pnpm typecheck 2>&1 | tail -5
+  ```
+
+- [ ] **Step 9.5: Commit**
+
+  ```bash
+  git add apps/web/src/lib/api/schemas/shared-games.schemas.ts apps/web/src/lib/api/clients/sharedGamesClient.ts
+  git commit -m "feat(s2): add hasKnowledgeBase to SearchSharedGamesParams schema and client"
+  ```
+
+---
+
+## Task 10 — Frontend filter chip in `PublicLibraryPage`
+
+**Files:**
+- Modify: `apps/web/src/components/library/PublicLibraryPage.tsx`
+
+- [ ] **Step 10.1: Add local state for the KB filter**
+
+  Near the other `useState` calls at the top of the component:
+  ```typescript
+  const [aiReadyOnly, setAiReadyOnly] = useState(false);
+  ```
+
+- [ ] **Step 10.2: Sync the filter with URL param `?hasKb=true`**
+
+  Add a `useEffect` that reads `searchParams.get('hasKb')` on mount and sets `aiReadyOnly` accordingly, and another effect that writes back to the URL when the state changes. Use the existing `useRouter` + `useSearchParams` pattern from the file.
+
+  If the file doesn't already import `useSearchParams`, add it from `next/navigation`.
+
+- [ ] **Step 10.3: Pass the param to `useSharedGames`**
+
+  Find the `useSharedGames(...)` call and add `hasKnowledgeBase: aiReadyOnly || undefined` to the params object. `undefined` avoids sending the param when disabled (matches backend default behavior).
+
+- [ ] **Step 10.4: Render the filter chip UI**
+
+  Near the existing mechanics filter button, add a toggle button:
+  ```tsx
+  <button
+    type="button"
+    onClick={() => setAiReadyOnly(v => !v)}
+    data-testid="catalog-kb-filter"
+    aria-pressed={aiReadyOnly}
+    className={cn(
+      'inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors',
+      aiReadyOnly
+        ? 'border-primary bg-primary text-primary-foreground'
+        : 'border-border bg-background text-muted-foreground hover:bg-muted'
+    )}
+  >
+    <span aria-hidden="true">✨</span>
+    <span>Solo giochi AI-ready</span>
+    {aiReadyOnly && <span aria-hidden="true">✓</span>}
+  </button>
+  ```
+
+- [ ] **Step 10.5: Render the `AI-READY` badge on MeepleCard when `hasKnowledgeBase === true`**
+
+  Find where `MeepleGameCatalogCard` or `MeepleCard` is rendered in `PublicLibraryPage.tsx`. If the card component already accepts a badge or feature flag prop, pass `hasKnowledgeBase` through. If not, defer the badge to a future polishing PR — S2 scope ends at the filter + backend.
+
+  Note: it's acceptable for S2 to ship without the visual badge on individual cards if the card component doesn't have a slot — the filter alone is the core feature.
+
+- [ ] **Step 10.6: Typecheck**
+
+  ```bash
+  cd apps/web
+  pnpm typecheck 2>&1 | tail -5
+  ```
+
+- [ ] **Step 10.7: Commit**
+
+  ```bash
+  git add apps/web/src/components/library/PublicLibraryPage.tsx
+  git commit -m "feat(s2): add AI-ready filter chip and URL sync to PublicLibraryPage"
+  ```
+
+---
+
+## Task 11 — Frontend test
+
+**Files:**
+- Create or modify: existing test file for `PublicLibraryPage` (if any) OR skip if component lacks test coverage and time doesn't permit a full test setup.
+
+- [ ] **Step 11.1: Check existing test coverage**
+
+  ```bash
+  cd apps/web
+  find src/components/library -name "*PublicLibrary*.test.*" 2>&1 | head -5
+  ```
+
+- [ ] **Step 11.2: Add tests if the file exists**
+
+  If a test file for `PublicLibraryPage` exists, add 2 test cases:
+  - Clicking the `[data-testid="catalog-kb-filter"]` button toggles `aria-pressed` and updates the URL with `?hasKb=true`
+  - The `useSharedGames` mock is called with `hasKnowledgeBase: true` after the filter is enabled
+
+  If no test file exists, write a minimal one inheriting the existing test utility setup. Skip if no test utils exist for catalog components (defer to a later PR).
+
+- [ ] **Step 11.3: Run tests**
+
+  ```bash
+  pnpm vitest run src/components/library 2>&1 | tail -15
+  ```
+
+- [ ] **Step 11.4: Commit (only if test file was modified)**
+
+  ```bash
+  git add apps/web/src/components/library/__tests__/
+  git commit -m "test(s2): add tests for AI-ready filter chip"
+  ```
+
+---
+
+## Task 12 — Final validation and PR
+
+- [ ] **Step 12.1: Full backend build + test**
+
+  ```bash
+  cd apps/api
+  dotnet build
+  dotnet test tests/Api.Tests --filter "FullyQualifiedName~SharedGameCatalog" 2>&1 | tail -15
+  ```
+  Expected: backend build OK, SharedGameCatalog tests PASS.
+
+- [ ] **Step 12.2: Full frontend typecheck + lint + test**
+
+  ```bash
+  cd apps/web
+  pnpm typecheck
+  pnpm lint
+  pnpm vitest run src/lib/api src/components/library src/hooks/queries 2>&1 | tail -20
+  ```
+
+- [ ] **Step 12.3: Push feature branch**
+
+  ```bash
+  cd D:/Repositories/meepleai-monorepo-backend
+  git push -u origin feature/s2-kb-filter
+  ```
+
+- [ ] **Step 12.4: Create PR into epic branch**
+
+  Use `gh pr create --base epic/library-to-game --head feature/s2-kb-filter` with a PR body that mentions:
+  - S2 scope (denormalized column + event handler + filter + chip)
+  - Spec correction: extended `SearchSharedGamesQuery`, not `GetFilteredSharedGamesQuery` (spec CR-C1 was wrong about target)
+  - Test results
+
+---
+
+## Rollback plan
+
+The migration is additive (new column + new index). To rollback:
+```bash
+dotnet ef migrations remove  # if not yet applied
+# OR create a reverse migration if already applied in staging
+```
+All frontend changes are additive: a new filter chip + a new optional param. Revert via `git revert <merge-commit>`.
+
+## Known scope decisions
+
+- **Single handler only**: `VectorDocumentIndexedForKbFlagHandler`. No `VectorDocumentDeletedForKbFlagHandler` — the `VectorDocument` delete flow doesn't currently emit a domain event, so we'd need to add one. Deferred to a potential S2b if it becomes a user-visible issue.
+- **Admin query extension**: only the `.Select` projection is updated, not the filter. Admin has other ways to see KB status.
+- **Backfill consistency**: the migration's SQL backfill uses `vector_documents.indexing_status = 'completed'` (not `processing_state`). Verify the column name in `VectorDocumentEntity` before running.
+- **HybridCache**: the new filter is added to the cache key so toggling it produces fresh results.
+
+## Plan self-review (inline — fix as you find)
+
+- [x] Every code step includes a concrete snippet.
+- [x] File paths are absolute-style (relative to repo root).
+- [x] Type consistency: `HasKnowledgeBase: bool` everywhere (C#) / `hasKnowledgeBase: boolean` everywhere (TS).
+- [x] Query target corrected to `SearchSharedGamesQuery` (spec CR-C1 pushback noted).
+- [x] Event handler is the only cross-BC code path, and it does 1 read + 1 write.
+- [x] Backfill SQL is in the migration's Up() so staging deploy is complete.
+- [x] Frontend chip has `data-testid` + `aria-pressed` (a11y) + URL sync.
+- [x] Frontend visual badge is explicitly deferred, not forgotten.


### PR DESCRIPTION
## Summary

Implements S2 of the `library-to-game` epic: a denormalized `HasKnowledgeBase` column on `SharedGameEntity`, maintained by an event handler on `VectorDocumentIndexedEvent`, exposed as an optional filter on the public catalog endpoint, and rendered as a toggle chip in `PublicLibraryPage`.

## Backend Changes

- **Entity + migration**: new `has_knowledge_base boolean NOT NULL DEFAULT false` column on `shared_games`, plus partial index `ix_shared_games_has_knowledge_base WHERE has_knowledge_base = true`. Migration `20260409124412_AddHasKnowledgeBaseToSharedGames` includes a backfill SQL for existing indexed vector documents.
- **DTO + query**: `SharedGameDto` gains `HasKnowledgeBase: bool = false`; `SearchSharedGamesQuery` gains `HasKnowledgeBase: bool? = null`. All 4 handlers that project to `SharedGameDto` updated (Search, GetAll, GetFiltered, GetPendingApproval) — optional args in expression trees required explicit argument at all call sites.
- **Handler filter**: `SearchSharedGamesQueryHandler` gains a WHERE clause on `g.HasKnowledgeBase == query.HasKnowledgeBase.Value` plus cache key inclusion.
- **Endpoint**: `GET /api/v1/shared-games` accepts new `?hasKb=<bool>` query parameter.
- **Event handler** (new): `VectorDocumentIndexedForKbFlagHandler` in `SharedGameCatalog.Application.EventHandlers/` subscribes to `VectorDocumentIndexedEvent`, reads the `VectorDocument` by `DocumentId` to resolve `SharedGameId`, and flips `HasKnowledgeBase = true` on the matching shared game. Idempotent, uses change tracking for in-memory test compatibility.

## Frontend Changes

- **Zod schema**: `SearchSharedGamesParamsSchema` gains `hasKnowledgeBase: z.boolean().optional()`. `SharedGameSchema` gains `hasKnowledgeBase: z.boolean().default(false)`.
- **Client**: `sharedGamesClient.search()` maps `hasKnowledgeBase` param to `?hasKb=<bool>` query string.
- **PublicLibraryPage**: new toggle chip "Solo giochi AI-ready" with `Sparkles` icon, `aria-pressed` for a11y, `data-testid="catalog-kb-filter"`. Persisted in URL `?hasKb=true` (bookmarkable). Passes `hasKnowledgeBase: aiReadyOnly || undefined` to `useSharedGames`.

## Spec correction

Spec decision CR-C1 originally named `GetFilteredSharedGamesQuery` as the filter target. Verified via grep that the **public** catalog endpoint uses **`SearchSharedGamesQuery`** instead; `GetFilteredSharedGamesQuery` is admin-only. S2 extends the correct query. Admin query still gets the DTO projection update for consistency but no filter param.

## Tests

- **Backend (new, 9 tests, all passing)**:
  - `VectorDocumentIndexedForKbFlagHandlerTests` — 5 tests (happy path, null SharedGameId, missing document, idempotency, null notification)
  - `SearchSharedGamesQuery_KbFilterTests` — 4 tests (no filter / true / false / projection includes field)
- **Backend regression**: `dotnet test --filter BoundedContext=SharedGameCatalog` → **845/845 passing**
- **Frontend regression**: `pnpm vitest run src/lib/api src/components/library` → **1335/1335 passing**
- **Typecheck + lint**: 0 errors

## DDD notes

The event handler has a single cross-BC read (`VectorDocuments` table via shared `MeepleAiDbContext`) to resolve `SharedGameId`. This is acceptable DDD practice for async projection updates: the read is outside the query hot path, the write stays within SharedGameCatalog tables, and the operation is idempotent. An alternative was to extend the `VectorDocumentIndexedEvent` payload to carry `SharedGameId`, but that required modifying the KnowledgeBase BC for marginal benefit.

## Reference

- Spec: `docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md` §4.2
- Plan: `docs/superpowers/plans/2026-04-09-s2-kb-filter.md`

## Dependency on other epic branches

None. S2 is independent of S1/S6a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
