### PR TITLE
chore(ci): add auto-rollback hook to deploy-staging.yml (Sprint 3 — A7)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandler.cs
@@ -1,0 +1,83 @@
+using Api.BoundedContexts.KnowledgeBase.Domain.Events;
+using Api.Infrastructure;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.EventHandlers;
+
+/// <summary>
+/// Listens to VectorDocumentIndexedEvent and maintains the denormalized
+/// `has_knowledge_base` column on `shared_games`. Bridges the KnowledgeBase
+/// BC (write source) with SharedGameCatalog BC (read projection).
+///
+/// Flow:
+///   1. Read the VectorDocumentEntity by DocumentId to resolve SharedGameId
+///      (the event carries GameId which is the Game aggregate id; VectorDocuments
+///      carry their own separate SharedGameId per Issue #4921).
+///   2. If SharedGameId is not null, execute a targeted bulk update on
+///      shared_games to set has_knowledge_base = true. Uses ExecuteUpdateAsync
+///      to bypass change tracking — idempotent, low overhead.
+///
+/// DDD note: the cross-BC read in step 1 is acceptable as an async projection
+/// update (not at query time). The write path stays within SharedGameCatalog tables.
+///
+/// Reference: docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md §4.2
+/// Plan: docs/superpowers/plans/2026-04-09-s2-kb-filter.md Task 7
+/// </summary>
+internal sealed class VectorDocumentIndexedForKbFlagHandler
+    : INotificationHandler<VectorDocumentIndexedEvent>
+{
+    private readonly MeepleAiDbContext _context;
+    private readonly ILogger<VectorDocumentIndexedForKbFlagHandler> _logger;
+
+    public VectorDocumentIndexedForKbFlagHandler(
+        MeepleAiDbContext context,
+        ILogger<VectorDocumentIndexedForKbFlagHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(VectorDocumentIndexedEvent notification, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        // Look up the VectorDocument to resolve SharedGameId.
+        // This is the only cross-BC table read in the handler — the update
+        // below stays within SharedGameCatalog's own tables.
+        var sharedGameId = await _context.VectorDocuments
+            .AsNoTracking()
+            .Where(v => v.Id == notification.DocumentId)
+            .Select(v => v.SharedGameId)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (sharedGameId is null || sharedGameId == Guid.Empty)
+        {
+            _logger.LogDebug(
+                "VectorDocument {DocumentId} has no SharedGameId, skipping KB flag update",
+                notification.DocumentId);
+            return;
+        }
+
+        // Load the SharedGame row, flip the flag if needed, save.
+        // Idempotent: returns early if HasKnowledgeBase is already true.
+        // Single-row update, no meaningful perf difference vs ExecuteUpdate.
+        var sharedGame = await _context.SharedGames
+            .FirstOrDefaultAsync(g => g.Id == sharedGameId.Value, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (sharedGame is null || sharedGame.HasKnowledgeBase)
+        {
+            return;
+        }
+
+        sharedGame.HasKnowledgeBase = true;
+        await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Set HasKnowledgeBase=true for SharedGame {SharedGameId} triggered by VectorDocument {DocumentId}",
+            sharedGameId.Value,
+            notification.DocumentId);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetAllSharedGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetAllSharedGamesQueryHandler.cs
@@ -67,7 +67,8 @@ internal sealed class GetAllSharedGamesQueryHandler : IRequestHandler<GetAllShar
                 (GameStatus)g.Status,
                 g.CreatedAt,
                 g.ModifiedAt,
-                g.IsRagPublic))
+                g.IsRagPublic,
+                g.HasKnowledgeBase))
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandler.cs
@@ -97,7 +97,8 @@ internal sealed class GetFilteredSharedGamesQueryHandler : IRequestHandler<GetFi
                 (GameStatus)g.Status,
                 g.CreatedAt,
                 g.ModifiedAt,
-                g.IsRagPublic))
+                g.IsRagPublic,
+                g.HasKnowledgeBase))
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetPendingApprovalGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetPendingApprovalGamesQueryHandler.cs
@@ -62,7 +62,8 @@ internal sealed class GetPendingApprovalGamesQueryHandler : IRequestHandler<GetP
                 (GameStatus)g.Status,
                 g.CreatedAt,
                 g.ModifiedAt,
-                g.IsRagPublic))
+                g.IsRagPublic,
+                g.HasKnowledgeBase))
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQuery.cs
@@ -22,5 +22,6 @@ internal record SearchSharedGamesQuery(
     int PageNumber = 1,
     int PageSize = 20,
     string SortBy = "Title",
-    bool SortDescending = false
+    bool SortDescending = false,
+    bool? HasKnowledgeBase = null // S2 (library-to-game epic) — filter for AI-ready games
 ) : IQuery<PagedResult<SharedGameDto>>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQueryHandler.cs
@@ -137,6 +137,12 @@ internal sealed class SearchSharedGamesQueryHandler : IRequestHandler<SearchShar
             dbQuery = dbQuery.Where(g => g.ComplexityRating <= query.MaxComplexity.Value);
         }
 
+        // S2 — Knowledge Base filter: only games with indexed KB
+        if (query.HasKnowledgeBase.HasValue)
+        {
+            dbQuery = dbQuery.Where(g => g.HasKnowledgeBase == query.HasKnowledgeBase.Value);
+        }
+
         // Apply sorting
         dbQuery = query.SortBy switch
         {
@@ -183,7 +189,8 @@ internal sealed class SearchSharedGamesQueryHandler : IRequestHandler<SearchShar
                 (GameStatus)g.Status,
                 g.CreatedAt,
                 g.ModifiedAt,
-                g.IsRagPublic))
+                g.IsRagPublic,
+                g.HasKnowledgeBase))
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
@@ -215,7 +222,7 @@ internal sealed class SearchSharedGamesQueryHandler : IRequestHandler<SearchShar
         var statusStr = query.Status?.ToString() ?? "null";
 
         // Create compact hash for long parameter combinations
-        var keyComponents = $"{searchTerm}|{categoryIds}|{mechanicIds}|{query.MinPlayers}|{query.MaxPlayers}|{query.MaxPlayingTime}|{query.MinComplexity}|{query.MaxComplexity}|{statusStr}|{query.PageNumber}|{query.PageSize}|{query.SortBy}|{query.SortDescending}";
+        var keyComponents = $"{searchTerm}|{categoryIds}|{mechanicIds}|{query.MinPlayers}|{query.MaxPlayers}|{query.MaxPlayingTime}|{query.MinComplexity}|{query.MaxComplexity}|{statusStr}|{query.PageNumber}|{query.PageSize}|{query.SortBy}|{query.SortDescending}|{query.HasKnowledgeBase?.ToString() ?? "null"}";
 
         var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(keyComponents)));
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs
@@ -33,7 +33,8 @@ public sealed record SharedGameDto(
     GameStatus Status,
     DateTime CreatedAt,
     DateTime? ModifiedAt,
-    bool IsRagPublic = false);
+    bool IsRagPublic = false,
+    bool HasKnowledgeBase = false);
 
 /// <summary>
 /// Data transfer object for game rules.

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs
@@ -36,6 +36,14 @@ public class SharedGameEntity
     public bool IsRagPublic { get; set; }
 
     /// <summary>
+    /// Denormalized flag set to true when at least one VectorDocument with this
+    /// SharedGameId has been indexed. Maintained by
+    /// VectorDocumentIndexedForKbFlagHandler (async event projection).
+    /// Used by the public catalog filter "Solo giochi AI-ready" (S2 of library-to-game epic).
+    /// </summary>
+    public bool HasKnowledgeBase { get; set; }
+
+    /// <summary>
     /// Optimistic concurrency token. Managed by the database.
     /// Spec-panel recommendation C-3.
     /// </summary>

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameEntityConfiguration.cs
@@ -114,6 +114,12 @@ internal class SharedGameEntityConfiguration : IEntityTypeConfiguration<SharedGa
             .IsRequired()
             .HasDefaultValue(false);
 
+        // S2 (library-to-game epic) — denormalized KB flag for catalog filter
+        builder.Property(e => e.HasKnowledgeBase)
+            .HasColumnName("has_knowledge_base")
+            .IsRequired()
+            .HasDefaultValue(false);
+
         // Optimistic concurrency (spec-panel C-3)
         builder.Property(e => e.RowVersion)
             .HasColumnName("row_version")
@@ -141,6 +147,11 @@ internal class SharedGameEntityConfiguration : IEntityTypeConfiguration<SharedGa
         builder.HasIndex(e => e.Title)
             .HasDatabaseName("ix_shared_games_title")
             .HasFilter("is_deleted = false");
+
+        // S2 — partial index on the small "AI-ready" subset for the catalog filter
+        builder.HasIndex(e => e.HasKnowledgeBase)
+            .HasDatabaseName("ix_shared_games_has_knowledge_base")
+            .HasFilter("has_knowledge_base = true");
 
         // Note: SearchVector index will be added manually in migration with tsvector type
 

--- a/apps/api/src/Api/Infrastructure/Migrations/20260409124412_AddHasKnowledgeBaseToSharedGames.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260409124412_AddHasKnowledgeBaseToSharedGames.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260409124412_AddHasKnowledgeBaseToSharedGames")]
+    partial class AddHasKnowledgeBaseToSharedGames
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260409124412_AddHasKnowledgeBaseToSharedGames.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260409124412_AddHasKnowledgeBaseToSharedGames.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddHasKnowledgeBaseToSharedGames : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "has_knowledge_base",
+                table: "shared_games",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_shared_games_has_knowledge_base",
+                table: "shared_games",
+                column: "has_knowledge_base",
+                filter: "has_knowledge_base = true");
+
+            // S2 (library-to-game epic) — backfill: mark games with at least one
+            // indexed vector document as having KB. Uses vector_documents.shared_game_id
+            // cross-BC reference (Issue #4921). The "IndexingStatus" column is
+            // PascalCase (default EF naming) hence the quoted identifier.
+            migrationBuilder.Sql(@"
+                UPDATE shared_games
+                SET has_knowledge_base = true
+                WHERE id IN (
+                    SELECT DISTINCT shared_game_id
+                    FROM vector_documents
+                    WHERE shared_game_id IS NOT NULL
+                      AND ""IndexingStatus"" = 'completed'
+                );
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_shared_games_has_knowledge_base",
+                table: "shared_games");
+
+            migrationBuilder.DropColumn(
+                name: "has_knowledge_base",
+                table: "shared_games");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogPublicEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogPublicEndpoints.cs
@@ -89,6 +89,7 @@ internal static class SharedGameCatalogPublicEndpoints
         [FromQuery] int pageSize = 20,
         [FromQuery] string sortBy = "Title",
         [FromQuery] bool sortDescending = false,
+        [FromQuery] bool? hasKb = null, // S2 (library-to-game epic) — filter for AI-ready games
         CancellationToken ct = default)
     {
         var query = new SearchSharedGamesQuery(
@@ -104,7 +105,8 @@ internal static class SharedGameCatalogPublicEndpoints
             pageNumber,
             pageSize,
             sortBy,
-            sortDescending);
+            sortDescending,
+            HasKnowledgeBase: hasKb);
 
         var result = await mediator.Send(query, ct).ConfigureAwait(false);
         return Results.Ok(result);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandlerTests.cs
@@ -1,0 +1,158 @@
+using Api.BoundedContexts.KnowledgeBase.Domain.Events;
+using Api.BoundedContexts.SharedGameCatalog.Application.EventHandlers;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.EventHandlers;
+
+/// <summary>
+/// Unit tests for VectorDocumentIndexedForKbFlagHandler.
+/// S2 of library-to-game epic — maintains the denormalized
+/// <c>has_knowledge_base</c> column on <c>shared_games</c> in response to
+/// VectorDocumentIndexedEvent notifications from the KnowledgeBase BC.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class VectorDocumentIndexedForKbFlagHandlerTests
+{
+    private readonly Mock<ILogger<VectorDocumentIndexedForKbFlagHandler>> _logger = new();
+
+    private static SharedGameEntity CreateSharedGame(Guid id, bool hasKb = false) =>
+        new()
+        {
+            Id = id,
+            Title = "Test Game",
+            YearPublished = 2020,
+            Description = "Desc",
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 30,
+            MinAge = 8,
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            Status = 1,
+            CreatedBy = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            HasKnowledgeBase = hasKb,
+        };
+
+    private static VectorDocumentEntity CreateVectorDocument(Guid id, Guid? sharedGameId, Guid? gameId = null) =>
+        new()
+        {
+            Id = id,
+            GameId = gameId,
+            SharedGameId = sharedGameId,
+            PdfDocumentId = Guid.NewGuid(),
+            ChunkCount = 42,
+            TotalCharacters = 10000,
+            IndexingStatus = "completed",
+            EmbeddingModel = "nomic-embed-text",
+            EmbeddingDimensions = 768,
+        };
+
+    [Fact]
+    public async Task Handle_VectorDocumentWithSharedGameId_FlipsHasKnowledgeBaseToTrue()
+    {
+        // Arrange
+        var sharedGameId = Guid.NewGuid();
+        var documentId = Guid.NewGuid();
+
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.SharedGames.Add(CreateSharedGame(sharedGameId, hasKb: false));
+        db.VectorDocuments.Add(CreateVectorDocument(documentId, sharedGameId));
+        await db.SaveChangesAsync();
+
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, _logger.Object);
+        var evt = new VectorDocumentIndexedEvent(documentId, sharedGameId, 42);
+
+        // Act
+        await handler.Handle(evt, CancellationToken.None);
+
+        // Assert
+        var updated = await db.SharedGames.FindAsync(sharedGameId);
+        updated.Should().NotBeNull();
+        updated!.HasKnowledgeBase.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_VectorDocumentWithNullSharedGameId_DoesNotUpdateAnyGame()
+    {
+        // Arrange
+        var sharedGameId = Guid.NewGuid();
+        var documentId = Guid.NewGuid();
+        var unrelatedGameId = Guid.NewGuid();
+
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.SharedGames.Add(CreateSharedGame(sharedGameId, hasKb: false));
+        db.VectorDocuments.Add(CreateVectorDocument(documentId, sharedGameId: null, gameId: unrelatedGameId));
+        await db.SaveChangesAsync();
+
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, _logger.Object);
+        var evt = new VectorDocumentIndexedEvent(documentId, unrelatedGameId, 42);
+
+        // Act
+        await handler.Handle(evt, CancellationToken.None);
+
+        // Assert
+        var shouldNotChange = await db.SharedGames.FindAsync(sharedGameId);
+        shouldNotChange!.HasKnowledgeBase.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_VectorDocumentNotFound_DoesNotThrow()
+    {
+        // Arrange
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, _logger.Object);
+        var evt = new VectorDocumentIndexedEvent(Guid.NewGuid(), Guid.NewGuid(), 42);
+
+        // Act
+        var act = async () => await handler.Handle(evt, CancellationToken.None);
+
+        // Assert
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task Handle_SharedGameAlreadyHasKnowledgeBase_IsIdempotent()
+    {
+        // Arrange
+        var sharedGameId = Guid.NewGuid();
+        var documentId = Guid.NewGuid();
+
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.SharedGames.Add(CreateSharedGame(sharedGameId, hasKb: true));
+        db.VectorDocuments.Add(CreateVectorDocument(documentId, sharedGameId));
+        await db.SaveChangesAsync();
+
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, _logger.Object);
+        var evt = new VectorDocumentIndexedEvent(documentId, sharedGameId, 42);
+
+        // Act
+        await handler.Handle(evt, CancellationToken.None);
+
+        // Assert — still true, no exception
+        var stillTrue = await db.SharedGames.FindAsync(sharedGameId);
+        stillTrue!.HasKnowledgeBase.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_NullNotification_ThrowsArgumentNullException()
+    {
+        // Arrange
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, _logger.Object);
+
+        // Act
+        var act = async () => await handler.Handle(null!, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQuery_KbFilterTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQuery_KbFilterTests.cs
@@ -1,0 +1,151 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+/// <summary>
+/// Unit tests focused on the S2 (library-to-game epic) HasKnowledgeBase filter
+/// extension of SearchSharedGamesQueryHandler.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class SearchSharedGamesQuery_KbFilterTests
+{
+    private readonly Mock<ILogger<SearchSharedGamesQueryHandler>> _logger = new();
+
+    private static SharedGameEntity CreateGame(string title, bool hasKb) => new()
+    {
+        Id = Guid.NewGuid(),
+        Title = title,
+        YearPublished = 2020,
+        Description = "Desc",
+        MinPlayers = 2,
+        MaxPlayers = 4,
+        PlayingTimeMinutes = 30,
+        MinAge = 8,
+        ImageUrl = string.Empty,
+        ThumbnailUrl = string.Empty,
+        Status = (int)GameStatus.Published,
+        CreatedBy = Guid.NewGuid(),
+        CreatedAt = DateTime.UtcNow,
+        HasKnowledgeBase = hasKb,
+    };
+
+    private static HybridCache CreateHybridCache()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IMemoryCache, MemoryCache>();
+        services.AddSingleton<IDistributedCache>(new MemoryDistributedCache(
+            Microsoft.Extensions.Options.Options.Create(new MemoryDistributedCacheOptions())));
+        services.AddHybridCache();
+        return services.BuildServiceProvider().GetRequiredService<HybridCache>();
+    }
+
+    private static SearchSharedGamesQuery BuildQuery(bool? hasKnowledgeBase) =>
+        new(
+            SearchTerm: null,
+            CategoryIds: null,
+            MechanicIds: null,
+            MinPlayers: null,
+            MaxPlayers: null,
+            MaxPlayingTime: null,
+            MinComplexity: null,
+            MaxComplexity: null,
+            Status: GameStatus.Published,
+            PageNumber: 1,
+            PageSize: 20,
+            SortBy: "Title",
+            SortDescending: false,
+            HasKnowledgeBase: hasKnowledgeBase);
+
+    [Fact]
+    public async Task Handle_NoKbFilter_ReturnsAllGames()
+    {
+        // Arrange
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.SharedGames.AddRange(
+            CreateGame("With KB", hasKb: true),
+            CreateGame("Without KB", hasKb: false));
+        await db.SaveChangesAsync();
+
+        var handler = new SearchSharedGamesQueryHandler(db, CreateHybridCache(), _logger.Object);
+
+        // Act
+        var result = await handler.Handle(BuildQuery(hasKnowledgeBase: null), CancellationToken.None);
+
+        // Assert
+        result.Total.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Handle_HasKnowledgeBaseTrue_ReturnsOnlyKbGames()
+    {
+        // Arrange
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.SharedGames.AddRange(
+            CreateGame("Azul", hasKb: true),
+            CreateGame("Catan", hasKb: true),
+            CreateGame("Monopoly", hasKb: false));
+        await db.SaveChangesAsync();
+
+        var handler = new SearchSharedGamesQueryHandler(db, CreateHybridCache(), _logger.Object);
+
+        // Act
+        var result = await handler.Handle(BuildQuery(hasKnowledgeBase: true), CancellationToken.None);
+
+        // Assert
+        result.Total.Should().Be(2);
+        result.Items.Should().OnlyContain(g => g.HasKnowledgeBase);
+        result.Items.Select(g => g.Title).Should().BeEquivalentTo(new[] { "Azul", "Catan" });
+    }
+
+    [Fact]
+    public async Task Handle_HasKnowledgeBaseFalse_ReturnsOnlyNonKbGames()
+    {
+        // Arrange
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.SharedGames.AddRange(
+            CreateGame("Azul", hasKb: true),
+            CreateGame("Monopoly", hasKb: false),
+            CreateGame("Risk", hasKb: false));
+        await db.SaveChangesAsync();
+
+        var handler = new SearchSharedGamesQueryHandler(db, CreateHybridCache(), _logger.Object);
+
+        // Act
+        var result = await handler.Handle(BuildQuery(hasKnowledgeBase: false), CancellationToken.None);
+
+        // Assert
+        result.Total.Should().Be(2);
+        result.Items.Should().OnlyContain(g => !g.HasKnowledgeBase);
+    }
+
+    [Fact]
+    public async Task Handle_ProjectionIncludesHasKnowledgeBaseField()
+    {
+        // Arrange
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        db.SharedGames.Add(CreateGame("Azul", hasKb: true));
+        await db.SaveChangesAsync();
+
+        var handler = new SearchSharedGamesQueryHandler(db, CreateHybridCache(), _logger.Object);
+
+        // Act
+        var result = await handler.Handle(BuildQuery(hasKnowledgeBase: null), CancellationToken.None);
+
+        // Assert
+        result.Items.Should().ContainSingle()
+            .Which.HasKnowledgeBase.Should().BeTrue();
+    }
+}

--- a/apps/web/e2e/sub-features/s1-admin-toggle.spec.ts
+++ b/apps/web/e2e/sub-features/s1-admin-toggle.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * S1 — Admin↔User view mode toggle E2E smoke tests.
+ *
+ * Validates the toggle is rendered for admin users, clicking it flips the
+ * view mode cookie, and the redirect happens as expected.
+ *
+ * Related spec: docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md §4.1
+ */
+import { test, expect } from '@playwright/test';
+
+import { loginAsAdmin } from '../fixtures/auth';
+
+test.describe('S1 · Admin↔User view mode toggle', () => {
+  test.beforeEach(async ({ context }) => {
+    // Ensure no stale view mode cookie from previous tests
+    const existing = await context.cookies();
+    const keep = existing.filter(c => c.name !== 'meepleai_view_mode');
+    await context.clearCookies();
+    if (keep.length > 0) {
+      await context.addCookies(keep);
+    }
+  });
+
+  test('toggle is visible for admin users on user home', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/');
+
+    const toggle = page.getByTestId('view-mode-toggle');
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute('role', 'switch');
+    // On '/' with no cookie, default mode is 'user'
+    await expect(toggle).toHaveAttribute('aria-checked', 'false');
+  });
+
+  test('toggle is visible on admin dashboard', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/admin/overview');
+
+    const toggle = page.getByTestId('view-mode-toggle');
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute('role', 'switch');
+    // On /admin with no cookie, default mode is 'admin'
+    await expect(toggle).toHaveAttribute('aria-checked', 'true');
+  });
+
+  test('clicking toggle from admin redirects to user shell', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/admin/overview');
+
+    const toggle = page.getByTestId('view-mode-toggle');
+    await toggle.click();
+
+    // Should navigate away from /admin/*
+    await page.waitForURL(url => !url.pathname.startsWith('/admin'), { timeout: 5000 });
+    expect(page.url()).not.toContain('/admin');
+  });
+
+  test('cookie is set after clicking toggle', async ({ page, context }) => {
+    await loginAsAdmin(page);
+    await page.goto('/admin/overview');
+
+    await page.getByTestId('view-mode-toggle').click();
+    await page.waitForLoadState('networkidle');
+
+    const cookies = await context.cookies();
+    const viewModeCookie = cookies.find(c => c.name === 'meepleai_view_mode');
+    expect(viewModeCookie?.value).toBe('user');
+  });
+
+  test('SSR redirects admin layout to / when cookie is user (no flash)', async ({
+    page,
+    context,
+    baseURL,
+  }) => {
+    await loginAsAdmin(page);
+    // Navigate to establish a real document origin before adding cookies.
+    const origin = baseURL || 'http://localhost:3000';
+    await page.goto('/');
+
+    // Pre-set the cookie with an absolute URL
+    await context.addCookies([
+      {
+        name: 'meepleai_view_mode',
+        value: 'user',
+        url: origin,
+        sameSite: 'Lax',
+      },
+    ]);
+
+    await page.goto('/admin/overview');
+    // Server-side redirect should send user to '/' before admin shell renders
+    expect(page.url()).not.toContain('/admin/overview');
+  });
+
+  test('toggle returns to admin when clicked from user shell', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/');
+
+    const toggle = page.getByTestId('view-mode-toggle');
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute('aria-checked', 'false');
+
+    await toggle.click();
+    await page.waitForURL(url => url.pathname.startsWith('/admin'), { timeout: 5000 });
+    expect(page.url()).toContain('/admin');
+  });
+});

--- a/apps/web/src/actions/auth.ts
+++ b/apps/web/src/actions/auth.ts
@@ -17,6 +17,7 @@ import { api, ApiError } from '@/lib/api';
 import { createErrorContext } from '@/lib/errors';
 import { getLocalizedError, type LocalizedError, successMessages } from '@/lib/i18n/errors';
 import { logger } from '@/lib/logger';
+import { clearViewModeCookie } from '@/lib/view-mode/cookie';
 import type { AuthUser } from '@/types';
 
 // ============================================================================
@@ -228,6 +229,10 @@ export async function logoutAction(): Promise<AuthActionState> {
   try {
     await api.auth.logout();
 
+    // Clear client-side view mode cookie. HttpOnly auth cookies are cleared
+    // by the server in api.auth.logout(); this handles the extra UX preference cookie.
+    clearViewModeCookie();
+
     // Force complete reload to clear middleware session cache and all client state
     // This bypasses the middleware's 2-minute session validation cache
     if (typeof window !== 'undefined') {
@@ -244,6 +249,9 @@ export async function logoutAction(): Promise<AuthActionState> {
       error instanceof Error ? error : new Error(String(error)),
       createErrorContext('AuthActions', 'logoutAction', { operation: 'logout' })
     );
+
+    // Even on error, clear the view mode cookie before reload.
+    clearViewModeCookie();
 
     // Even if API call fails, force reload to clear client state
     // User can't remain logged in if server rejected logout

--- a/apps/web/src/app/admin/(dashboard)/layout.tsx
+++ b/apps/web/src/app/admin/(dashboard)/layout.tsx
@@ -1,10 +1,12 @@
 import { type ReactNode } from 'react';
 
 import { type Metadata } from 'next';
+import { redirect } from 'next/navigation';
 
 import { PdfProcessingNotifier } from '@/components/admin/layout/PdfProcessingNotifier';
 import { RequireRole } from '@/components/auth/RequireRole';
 import { AdminShell } from '@/components/layout/AdminShell';
+import { readViewModeCookieServer } from '@/lib/view-mode/server';
 
 export const metadata: Metadata = {
   title: {
@@ -16,10 +18,20 @@ export const metadata: Metadata = {
 
 /**
  * Dashboard route group layout.
+ *
+ * Guard chain:
+ *  1. Server-side: if `meepleai_view_mode` cookie === 'user', redirect to '/'
+ *     before the admin shell renders (no flash).
+ *  2. Client-side: `RequireRole` enforces admin role (authoritative check).
+ *
  * Applies the AdminShell to all pages under /admin/(dashboard)/.
- * Wrapped with RequireRole to enforce admin access.
  */
-export default function DashboardLayout({ children }: { children: ReactNode }) {
+export default async function DashboardLayout({ children }: { children: ReactNode }) {
+  const viewMode = await readViewModeCookieServer();
+  if (viewMode === 'user') {
+    redirect('/');
+  }
+
   return (
     <RequireRole allowedRoles={['Admin']}>
       <PdfProcessingNotifier />

--- a/apps/web/src/components/layout/UserShell/UserTopNav.tsx
+++ b/apps/web/src/components/layout/UserShell/UserTopNav.tsx
@@ -9,13 +9,16 @@ import { SessionNavBar } from '@/components/dashboard/session-nav/SessionNavBar'
 import { useDashboardMode } from '@/components/dashboard/useDashboardMode';
 import { NotificationBell } from '@/components/notifications';
 import { getSectionEmoji } from '@/config/navigation-emoji';
+import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
 import { useNavigation } from '@/hooks/useNavigation';
 import { useNavbarHeightStore } from '@/lib/stores/navbar-height-store';
 import { useSessionStore } from '@/lib/stores/session-store';
 import { cn } from '@/lib/utils';
+import { isAdminRole } from '@/lib/utils/roles';
 
 import { ContextualCTA } from './ContextualCTA';
 import { UserMenuDropdown } from '../UserMenuDropdown';
+import { ViewModeToggle } from '../ViewModeToggle';
 
 interface UserTopNavProps {
   isAdmin?: boolean;
@@ -30,6 +33,8 @@ export function UserTopNav({ isAdmin, onMenuToggle, isMenuOpen }: UserTopNavProp
   const pathname = usePathname();
   const sectionEmoji = getSectionEmoji(pathname);
   const setNavbarHeight = useNavbarHeightStore(s => s.setHeight);
+  const { data: currentUser } = useCurrentUser();
+  const canToggleView = isAdminRole(currentUser?.role);
 
   // NavContextTabs removed — height is always 52px
   useEffect(() => {
@@ -132,6 +137,7 @@ export function UserTopNav({ isAdmin, onMenuToggle, isMenuOpen }: UserTopNavProp
 
       {/* Right: utility actions */}
       <div className="flex items-center gap-2 shrink-0">
+        {canToggleView && <ViewModeToggle />}
         <NotificationBell />
         <UserMenuDropdown />
       </div>

--- a/apps/web/src/components/layout/UserShell/__tests__/UserTopNav.test.tsx
+++ b/apps/web/src/components/layout/UserShell/__tests__/UserTopNav.test.tsx
@@ -36,6 +36,12 @@ vi.mock('../../UserMenuDropdown', () => ({
 vi.mock('@/config/navigation-emoji', () => ({
   getSectionEmoji: vi.fn(() => '🏠'),
 }));
+vi.mock('@/hooks/queries/useCurrentUser', () => ({
+  useCurrentUser: vi.fn(() => ({ data: null, isLoading: false, isError: false })),
+}));
+vi.mock('../../ViewModeToggle', () => ({
+  ViewModeToggle: () => <div data-testid="view-mode-toggle" />,
+}));
 
 import { usePathname } from 'next/navigation';
 import { UserTopNav } from '../UserTopNav';

--- a/apps/web/src/components/layout/ViewModeToggle.tsx
+++ b/apps/web/src/components/layout/ViewModeToggle.tsx
@@ -1,0 +1,82 @@
+/**
+ * ViewModeToggle — admin↔user view switcher for the top navbar.
+ *
+ * Icon pill switch (44×26) that flips between admin and user shells.
+ * Only rendered when the current user has an admin role — the parent
+ * component is responsible for gating visibility.
+ *
+ * Accessibility: role="switch" with aria-checked, keyboard-operable.
+ */
+'use client';
+
+import { useCallback, type KeyboardEvent } from 'react';
+
+import { useViewMode } from '@/hooks/useViewMode';
+import { cn } from '@/lib/utils';
+
+export function ViewModeToggle() {
+  const { viewMode, toggle } = useViewMode();
+  const isAdmin = viewMode === 'admin';
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLButtonElement>) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        toggle();
+      }
+    },
+    [toggle]
+  );
+
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={isAdmin}
+      aria-label="Cambia vista tra admin e utente"
+      onClick={toggle}
+      onKeyDown={handleKeyDown}
+      data-testid="view-mode-toggle"
+      className={cn(
+        'relative inline-flex h-[26px] w-[44px] shrink-0 items-center rounded-full',
+        'bg-gradient-to-br from-purple-500 to-orange-500',
+        'border-2 border-white shadow-sm',
+        'cursor-pointer transition-colors',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
+      )}
+    >
+      {/* Left indicator: user icon */}
+      <span
+        className={cn(
+          'absolute left-1 text-[9px] transition-opacity',
+          isAdmin ? 'opacity-70' : 'opacity-30'
+        )}
+        aria-hidden="true"
+      >
+        👤
+      </span>
+      {/* Right indicator: admin gear */}
+      <span
+        className={cn(
+          'absolute right-1 text-[9px] transition-opacity',
+          isAdmin ? 'opacity-30' : 'opacity-70'
+        )}
+        aria-hidden="true"
+      >
+        ⚙️
+      </span>
+      {/* Knob */}
+      <span
+        className={cn(
+          'pointer-events-none absolute top-[1px] h-5 w-5 rounded-full bg-white shadow-sm',
+          'flex items-center justify-center text-[11px]',
+          'transition-transform duration-200',
+          isAdmin ? 'translate-x-[18px]' : 'translate-x-[1px]'
+        )}
+        aria-hidden="true"
+      >
+        {isAdmin ? '⚙️' : '👤'}
+      </span>
+    </button>
+  );
+}

--- a/apps/web/src/components/layout/__tests__/ViewModeToggle.test.tsx
+++ b/apps/web/src/components/layout/__tests__/ViewModeToggle.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * Tests for ViewModeToggle component.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { ViewModeToggle } from '../ViewModeToggle';
+
+// Hoisted mocks
+const mockToggle = vi.fn();
+let mockViewMode: 'admin' | 'user' = 'admin';
+vi.mock('@/hooks/useViewMode', () => ({
+  useViewMode: () => ({ viewMode: mockViewMode, toggle: mockToggle }),
+}));
+
+describe('ViewModeToggle', () => {
+  beforeEach(() => {
+    mockToggle.mockReset();
+    mockViewMode = 'admin';
+  });
+
+  it('renders a switch with aria-checked reflecting admin mode', () => {
+    mockViewMode = 'admin';
+    render(<ViewModeToggle />);
+    const toggle = screen.getByRole('switch', { name: /cambia vista/i });
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('renders aria-checked=false when in user mode', () => {
+    mockViewMode = 'user';
+    render(<ViewModeToggle />);
+    const toggle = screen.getByRole('switch', { name: /cambia vista/i });
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('calls toggle() when clicked', () => {
+    render(<ViewModeToggle />);
+    const toggle = screen.getByRole('switch', { name: /cambia vista/i });
+    fireEvent.click(toggle);
+    expect(mockToggle).toHaveBeenCalledOnce();
+  });
+
+  it('is keyboard-operable via Enter key', () => {
+    render(<ViewModeToggle />);
+    const toggle = screen.getByRole('switch', { name: /cambia vista/i });
+    toggle.focus();
+    fireEvent.keyDown(toggle, { key: 'Enter' });
+    expect(mockToggle).toHaveBeenCalledOnce();
+  });
+
+  it('is keyboard-operable via Space key', () => {
+    render(<ViewModeToggle />);
+    const toggle = screen.getByRole('switch', { name: /cambia vista/i });
+    toggle.focus();
+    fireEvent.keyDown(toggle, { key: ' ' });
+    expect(mockToggle).toHaveBeenCalledOnce();
+  });
+
+  it('has data-testid for E2E selection', () => {
+    render(<ViewModeToggle />);
+    expect(screen.getByTestId('view-mode-toggle')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/library/PublicLibraryPage.tsx
+++ b/apps/web/src/components/library/PublicLibraryPage.tsx
@@ -17,8 +17,8 @@
 
 import { useState, useMemo, useCallback, useEffect } from 'react';
 
-import { ChevronDown, Filter, Loader2, Search, X } from 'lucide-react';
-import { useRouter } from 'next/navigation';
+import { ChevronDown, Filter, Loader2, Search, Sparkles, X } from 'lucide-react';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import { MeepleGameCatalogCard } from '@/components/catalog/MeepleGameCatalogCard';
 import { EmptyState } from '@/components/empty-state/EmptyState';
@@ -76,6 +76,7 @@ export interface PublicLibraryPageProps {
  */
 export function PublicLibraryPage({ className }: PublicLibraryPageProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   // ------------------------------------------------------------------
   // Local state
@@ -83,8 +84,24 @@ export function PublicLibraryPage({ className }: PublicLibraryPageProps) {
   const [search, setSearch] = useState('');
   const [selectedMechanics, setSelectedMechanics] = useState<string[]>([]);
   const [page, setPage] = useState(1);
+  // S2 (library-to-game epic) — "AI-ready only" filter, persisted in URL `?hasKb=true`
+  const [aiReadyOnly, setAiReadyOnly] = useState(() => searchParams?.get('hasKb') === 'true');
 
   const debouncedSearch = useDebounce(search, 300);
+
+  // Sync filter state → URL
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    if (aiReadyOnly) {
+      params.set('hasKb', 'true');
+    } else {
+      params.delete('hasKb');
+    }
+    const qs = params.toString();
+    const newUrl = `${window.location.pathname}${qs ? `?${qs}` : ''}`;
+    window.history.replaceState(null, '', newUrl);
+  }, [aiReadyOnly]);
 
   // ------------------------------------------------------------------
   // Data fetching
@@ -119,6 +136,7 @@ export function PublicLibraryPage({ className }: PublicLibraryPageProps) {
     {
       searchTerm: debouncedSearch || undefined,
       mechanicIds,
+      hasKnowledgeBase: aiReadyOnly || undefined,
       page,
       pageSize: PAGE_SIZE,
       sortBy: 'title',
@@ -283,6 +301,33 @@ export function PublicLibraryPage({ className }: PublicLibraryPageProps) {
       {/* ---------------------------------------------------------------- */}
       {availableMechanicSlugs.length > 0 && (
         <div className="flex flex-wrap items-center gap-2" data-testid="mechanic-filter-row">
+          {/* S2 — AI-ready only toggle chip */}
+          <button
+            type="button"
+            onClick={() => {
+              setAiReadyOnly(v => !v);
+              setPage(1);
+            }}
+            data-testid="catalog-kb-filter"
+            aria-pressed={aiReadyOnly}
+            aria-label="Mostra solo giochi AI-ready"
+            className={cn(
+              'flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+              'bg-[#21262d] border text-[#e6edf3]',
+              aiReadyOnly
+                ? 'border-[#f0a030] text-[#f0a030]'
+                : 'border-[#30363d] hover:bg-[#30363d] hover:border-[#58a6ff]'
+            )}
+          >
+            <Sparkles className="h-4 w-4" aria-hidden="true" />
+            Solo giochi AI-ready
+            {aiReadyOnly && (
+              <span className="flex h-5 w-5 items-center justify-center rounded-full bg-[#f0a030] text-[10px] font-bold text-[#0d1117]">
+                ✓
+              </span>
+            )}
+          </button>
+
           <Popover>
             <PopoverTrigger asChild>
               <button

--- a/apps/web/src/hooks/__tests__/useViewMode.test.ts
+++ b/apps/web/src/hooks/__tests__/useViewMode.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for useViewMode client hook.
+ */
+import { act, renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { VIEW_MODE_COOKIE } from '@/lib/view-mode/constants';
+
+import { useViewMode } from '../useViewMode';
+
+// Mock next/navigation
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => '/admin/overview',
+}));
+
+describe('useViewMode', () => {
+  beforeEach(() => {
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      configurable: true,
+      value: '',
+    });
+    mockPush.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('defaults to "admin" when cookie absent and on /admin path', () => {
+    const { result } = renderHook(() => useViewMode());
+    expect(result.current.viewMode).toBe('admin');
+  });
+
+  it('reads initial value from cookie when present', () => {
+    document.cookie = `${VIEW_MODE_COOKIE}=user`;
+    const { result } = renderHook(() => useViewMode());
+    expect(result.current.viewMode).toBe('user');
+  });
+
+  it('toggle flips admin → user and writes cookie', () => {
+    document.cookie = `${VIEW_MODE_COOKIE}=admin`;
+    const { result } = renderHook(() => useViewMode());
+    act(() => {
+      result.current.toggle();
+    });
+    expect(result.current.viewMode).toBe('user');
+    expect(document.cookie).toContain(`${VIEW_MODE_COOKIE}=user`);
+  });
+
+  it('toggle flips user → admin', () => {
+    document.cookie = `${VIEW_MODE_COOKIE}=user`;
+    const { result } = renderHook(() => useViewMode());
+    act(() => {
+      result.current.toggle();
+    });
+    expect(result.current.viewMode).toBe('admin');
+  });
+
+  it('toggle navigates to / when switching to user mode', () => {
+    document.cookie = `${VIEW_MODE_COOKIE}=admin`;
+    const { result } = renderHook(() => useViewMode());
+    act(() => {
+      result.current.toggle();
+    });
+    expect(mockPush).toHaveBeenCalledWith('/');
+  });
+
+  it('toggle navigates to /admin/overview when switching to admin mode', () => {
+    document.cookie = `${VIEW_MODE_COOKIE}=user`;
+    const { result } = renderHook(() => useViewMode());
+    act(() => {
+      result.current.toggle();
+    });
+    expect(mockPush).toHaveBeenCalledWith('/admin/overview');
+  });
+});

--- a/apps/web/src/hooks/useViewMode.ts
+++ b/apps/web/src/hooks/useViewMode.ts
@@ -1,0 +1,53 @@
+/**
+ * useViewMode — client hook for view mode toggle state.
+ *
+ * Reads the `meepleai_view_mode` cookie on mount, exposes `viewMode` + `toggle`.
+ * On toggle: flips the value, writes the cookie, navigates to the opposite shell.
+ *
+ * Path-based default: if no cookie, defaults to 'admin' on /admin/* paths,
+ * 'user' elsewhere. This matches the shell the user is currently viewing.
+ *
+ * Cross-tab sync is intentionally NOT implemented: document.cookie has no
+ * change event, and BroadcastChannel is overkill for a UX preference.
+ * See spec §4.1 and the plan's "Known limitations" section.
+ */
+'use client';
+
+import { useCallback, useState } from 'react';
+
+import { usePathname, useRouter } from 'next/navigation';
+
+import type { ViewMode } from '@/lib/view-mode/constants';
+import { readViewModeCookie, writeViewModeCookie } from '@/lib/view-mode/cookie';
+
+interface UseViewModeResult {
+  viewMode: ViewMode;
+  toggle: () => void;
+}
+
+/**
+ * Default view mode inferred from URL path.
+ */
+function defaultViewMode(pathname: string): ViewMode {
+  return pathname.startsWith('/admin') ? 'admin' : 'user';
+}
+
+export function useViewMode(): UseViewModeResult {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // Initial state reads cookie synchronously (matches SSR when cookie exists)
+  const [viewMode, setViewMode] = useState<ViewMode>(() => {
+    if (typeof document === 'undefined') return defaultViewMode(pathname);
+    return readViewModeCookie() ?? defaultViewMode(pathname);
+  });
+
+  const toggle = useCallback(() => {
+    const next: ViewMode = viewMode === 'admin' ? 'user' : 'admin';
+    writeViewModeCookie(next);
+    setViewMode(next);
+    router.push(next === 'admin' ? '/admin/overview' : '/');
+  }, [viewMode, router]);
+
+  return { viewMode, toggle };
+}

--- a/apps/web/src/lib/api/clients/sharedGamesClient.ts
+++ b/apps/web/src/lib/api/clients/sharedGamesClient.ts
@@ -245,6 +245,9 @@ export function createSharedGamesClient({ httpClient }: CreateSharedGamesClientP
       if (params.sortBy) queryParams.set('sortBy', params.sortBy);
       if (params.sortDescending !== undefined)
         queryParams.set('sortDescending', params.sortDescending.toString());
+      // S2 — filter for AI-ready games (matches backend hasKb query parameter)
+      if (params.hasKnowledgeBase !== undefined)
+        queryParams.set('hasKb', params.hasKnowledgeBase.toString());
 
       const queryString = queryParams.toString();
       const path = `/api/v1/shared-games${queryString ? `?${queryString}` : ''}`;

--- a/apps/web/src/lib/api/schemas/shared-games.schemas.ts
+++ b/apps/web/src/lib/api/schemas/shared-games.schemas.ts
@@ -179,6 +179,7 @@ export const SharedGameSchema = z.object({
   thumbnailUrl: z.string().catch(''), // coerce null/missing to empty string
   status: GameStatusSchema, // Now string enum with JsonStringEnumConverter
   isRagPublic: z.boolean().default(false), // whether RAG access is public for all owners
+  hasKnowledgeBase: z.boolean().default(false), // S2 — true when game has indexed KB (AI-ready)
   createdAt: z.string(), // Accept any datetime format from .NET serialization
   modifiedAt: z.string().nullable(),
 });
@@ -437,6 +438,8 @@ export const SearchSharedGamesParamsSchema = z.object({
   pageSize: z.number().int().positive().optional(),
   sortBy: z.string().optional(),
   sortDescending: z.boolean().optional(),
+  // S2 (library-to-game epic) — filter for AI-ready games
+  hasKnowledgeBase: z.boolean().optional(),
 });
 
 export type SearchSharedGamesParams = z.infer<typeof SearchSharedGamesParamsSchema>;

--- a/apps/web/src/lib/view-mode/__tests__/cookie.test.ts
+++ b/apps/web/src/lib/view-mode/__tests__/cookie.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for client-side view mode cookie helpers.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { readViewModeCookie, writeViewModeCookie, clearViewModeCookie } from '../cookie';
+import { VIEW_MODE_COOKIE } from '../constants';
+
+describe('view-mode cookie helpers', () => {
+  beforeEach(() => {
+    // Reset document.cookie before each test.
+    // NOTE: `configurable: true` is REQUIRED — without it, the second
+    // beforeEach silently fails because the property becomes non-configurable
+    // after the first Object.defineProperty call, causing flaky tests.
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      configurable: true,
+      value: '',
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('readViewModeCookie', () => {
+    it('returns null when cookie is absent', () => {
+      document.cookie = '';
+      expect(readViewModeCookie()).toBeNull();
+    });
+
+    it('returns "admin" when cookie value is admin', () => {
+      document.cookie = `${VIEW_MODE_COOKIE}=admin`;
+      expect(readViewModeCookie()).toBe('admin');
+    });
+
+    it('returns "user" when cookie value is user', () => {
+      document.cookie = `${VIEW_MODE_COOKIE}=user`;
+      expect(readViewModeCookie()).toBe('user');
+    });
+
+    it('returns null when cookie value is invalid', () => {
+      document.cookie = `${VIEW_MODE_COOKIE}=malicious`;
+      expect(readViewModeCookie()).toBeNull();
+    });
+
+    it('correctly extracts cookie when multiple cookies present', () => {
+      document.cookie = `other_cookie=foo; ${VIEW_MODE_COOKIE}=admin; third=bar`;
+      expect(readViewModeCookie()).toBe('admin');
+    });
+  });
+
+  describe('writeViewModeCookie', () => {
+    it('writes admin value to document.cookie', () => {
+      writeViewModeCookie('admin');
+      expect(document.cookie).toContain(`${VIEW_MODE_COOKIE}=admin`);
+    });
+
+    it('writes user value to document.cookie', () => {
+      writeViewModeCookie('user');
+      expect(document.cookie).toContain(`${VIEW_MODE_COOKIE}=user`);
+    });
+
+    it('includes path=/ in the cookie string', () => {
+      const spy = vi.spyOn(document, 'cookie', 'set');
+      writeViewModeCookie('admin');
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('path=/'));
+    });
+
+    it('includes SameSite=Lax in the cookie string', () => {
+      const spy = vi.spyOn(document, 'cookie', 'set');
+      writeViewModeCookie('admin');
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('SameSite=Lax'));
+    });
+  });
+
+  describe('clearViewModeCookie', () => {
+    it('clears the cookie by setting expired date', () => {
+      const spy = vi.spyOn(document, 'cookie', 'set');
+      clearViewModeCookie();
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('Max-Age=0'));
+    });
+  });
+});

--- a/apps/web/src/lib/view-mode/__tests__/server.test.ts
+++ b/apps/web/src/lib/view-mode/__tests__/server.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests for server-side view mode cookie reader.
+ * Mocks `next/headers` cookies() API.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { readViewModeCookieServer } from '../server';
+import { VIEW_MODE_COOKIE } from '../constants';
+
+// Mock next/headers
+const mockGet = vi.fn();
+vi.mock('next/headers', () => ({
+  cookies: () => ({
+    get: mockGet,
+  }),
+}));
+
+describe('readViewModeCookieServer', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('returns null when cookie is absent', async () => {
+    mockGet.mockReturnValue(undefined);
+    const result = await readViewModeCookieServer();
+    expect(mockGet).toHaveBeenCalledWith(VIEW_MODE_COOKIE);
+    expect(result).toBeNull();
+  });
+
+  it('returns "admin" when cookie has admin value', async () => {
+    mockGet.mockReturnValue({ name: VIEW_MODE_COOKIE, value: 'admin' });
+    const result = await readViewModeCookieServer();
+    expect(result).toBe('admin');
+  });
+
+  it('returns "user" when cookie has user value', async () => {
+    mockGet.mockReturnValue({ name: VIEW_MODE_COOKIE, value: 'user' });
+    const result = await readViewModeCookieServer();
+    expect(result).toBe('user');
+  });
+
+  it('returns null when cookie has invalid value', async () => {
+    mockGet.mockReturnValue({ name: VIEW_MODE_COOKIE, value: 'malicious' });
+    const result = await readViewModeCookieServer();
+    expect(result).toBeNull();
+  });
+});

--- a/apps/web/src/lib/view-mode/constants.ts
+++ b/apps/web/src/lib/view-mode/constants.ts
@@ -1,0 +1,27 @@
+/**
+ * View Mode — Cookie constants
+ *
+ * The `meepleai_view_mode` cookie stores the admin user's preferred shell.
+ * Client-writable (not HttpOnly). Read server-side via `cookies()` from `next/headers`
+ * in layout.tsx guards for SSR-consistent rendering.
+ *
+ * Reference: docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md §4.1
+ */
+
+/** Cookie name used across client and server to persist view mode */
+export const VIEW_MODE_COOKIE = 'meepleai_view_mode';
+
+/** The two valid view mode values */
+export type ViewMode = 'admin' | 'user';
+
+/** All valid view modes (for runtime validation) */
+export const VIEW_MODES: readonly ViewMode[] = ['admin', 'user'] as const;
+
+/** Cookie max-age: undefined = session cookie (cleared when browser closes) */
+export const VIEW_MODE_COOKIE_MAX_AGE: number | undefined = undefined;
+
+/** SameSite attribute — lax allows top-level navigation redirects */
+export const VIEW_MODE_COOKIE_SAMESITE = 'lax' as const;
+
+/** Path scope — whole app */
+export const VIEW_MODE_COOKIE_PATH = '/' as const;

--- a/apps/web/src/lib/view-mode/cookie.ts
+++ b/apps/web/src/lib/view-mode/cookie.ts
@@ -1,0 +1,73 @@
+/**
+ * Client-side view mode cookie helpers.
+ *
+ * These functions are safe to call only in the browser. For server-side
+ * cookie reading, use `./server.ts` which uses `next/headers`.
+ */
+import {
+  VIEW_MODE_COOKIE,
+  VIEW_MODE_COOKIE_PATH,
+  VIEW_MODE_COOKIE_SAMESITE,
+  VIEW_MODES,
+  type ViewMode,
+} from './constants';
+
+/**
+ * Read the view mode cookie from `document.cookie`.
+ * Returns null if the cookie is absent or contains an invalid value.
+ *
+ * Safe to call only in browser environments (no-op in SSR).
+ */
+export function readViewModeCookie(): ViewMode | null {
+  if (typeof document === 'undefined') return null;
+
+  const match = document.cookie
+    .split(';')
+    .map(c => c.trim())
+    .find(c => c.startsWith(`${VIEW_MODE_COOKIE}=`));
+
+  if (!match) return null;
+
+  const value = match.slice(VIEW_MODE_COOKIE.length + 1);
+  return (VIEW_MODES as readonly string[]).includes(value) ? (value as ViewMode) : null;
+}
+
+/**
+ * Write the view mode cookie to `document.cookie`.
+ * Session-scoped (no Max-Age), SameSite=Lax, client-readable.
+ *
+ * Safe to call only in browser environments (no-op in SSR).
+ */
+export function writeViewModeCookie(mode: ViewMode): void {
+  if (typeof document === 'undefined') return;
+
+  const parts = [
+    `${VIEW_MODE_COOKIE}=${mode}`,
+    `path=${VIEW_MODE_COOKIE_PATH}`,
+    `SameSite=${VIEW_MODE_COOKIE_SAMESITE === 'lax' ? 'Lax' : VIEW_MODE_COOKIE_SAMESITE}`,
+  ];
+
+  // Secure flag in https contexts only
+  if (typeof window !== 'undefined' && window.location.protocol === 'https:') {
+    parts.push('Secure');
+  }
+
+  document.cookie = parts.join('; ');
+}
+
+/**
+ * Clear the view mode cookie by setting an expired date.
+ * Safe to call only in browser environments (no-op in SSR).
+ */
+export function clearViewModeCookie(): void {
+  if (typeof document === 'undefined') return;
+
+  const parts = [
+    `${VIEW_MODE_COOKIE}=`,
+    `path=${VIEW_MODE_COOKIE_PATH}`,
+    'Max-Age=0',
+    `SameSite=${VIEW_MODE_COOKIE_SAMESITE === 'lax' ? 'Lax' : VIEW_MODE_COOKIE_SAMESITE}`,
+  ];
+
+  document.cookie = parts.join('; ');
+}

--- a/apps/web/src/lib/view-mode/server.ts
+++ b/apps/web/src/lib/view-mode/server.ts
@@ -1,0 +1,29 @@
+/**
+ * Server-side view mode cookie reader.
+ *
+ * Uses Next.js 16 `cookies()` from `next/headers` to read the
+ * `meepleai_view_mode` cookie from Server Components, Route Handlers,
+ * and Server Actions. This enables SSR-consistent rendering of the
+ * correct shell (admin vs user) on first paint.
+ *
+ * @see https://nextjs.org/docs/app/api-reference/functions/cookies
+ */
+import { cookies } from 'next/headers';
+
+import { VIEW_MODE_COOKIE, VIEW_MODES, type ViewMode } from './constants';
+
+/**
+ * Read the view mode cookie from the current request's cookies.
+ * Returns null if absent or invalid.
+ *
+ * MUST be called from Server Components, Route Handlers, or Server Actions.
+ */
+export async function readViewModeCookieServer(): Promise<ViewMode | null> {
+  const cookieStore = await cookies();
+  const cookie = cookieStore.get(VIEW_MODE_COOKIE);
+
+  if (!cookie) return null;
+
+  const value = cookie.value;
+  return (VIEW_MODES as readonly string[]).includes(value) ? (value as ViewMode) : null;
+}

--- a/docs/superpowers/plans/2026-04-09-s1-view-toggle.md
+++ b/docs/superpowers/plans/2026-04-09-s1-view-toggle.md
@@ -1,0 +1,1290 @@
+# S1 — Admin↔User View Toggle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a one-click cookie-based view mode toggle to the top navbar that lets admin users flip between the admin shell and the user shell while preserving their authenticated session.
+
+**Architecture:** A new `meepleai_view_mode` cookie (client-writable, SameSite=Lax) stores the current mode (`'admin' | 'user'`). A new `ViewModeToggle` client component renders an icon switch next to the avatar in `UserTopNav`. The guard in `app/admin/(dashboard)/layout.tsx` reads the cookie server-side via `cookies()` from `next/headers`. Role check (`isAdminRole`) is authoritative — a non-admin with `view_mode=admin` is always treated as user. Logout clears the cookie alongside auth cookies.
+
+**Tech Stack:** Next.js 16 App Router, React 19, Tailwind, shadcn/ui, Vitest for unit tests, Playwright for E2E, `cookies()` from `next/headers` for server-side reads, `document.cookie` for client writes.
+
+**Reference spec:** `docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md` §4.1
+**Epic branch:** `epic/library-to-game` (create from `main-dev` before task 1)
+**Feature branch:** `feature/s1-view-toggle` (from epic branch)
+
+---
+
+## File Structure (created or modified by this plan)
+
+**New files:**
+- `apps/web/src/lib/view-mode/cookie.ts` — cookie read/write helpers (client-safe)
+- `apps/web/src/lib/view-mode/server.ts` — server-side cookie reader (uses `next/headers`)
+- `apps/web/src/lib/view-mode/constants.ts` — cookie name + type exports
+- `apps/web/src/hooks/useViewMode.ts` — client hook: `{ viewMode, toggle }`
+- `apps/web/src/components/layout/ViewModeToggle.tsx` — the icon switch component
+- `apps/web/src/lib/view-mode/__tests__/cookie.test.ts` — unit tests for cookie helpers
+- `apps/web/src/hooks/__tests__/useViewMode.test.ts` — unit tests for the hook
+- `apps/web/src/components/layout/__tests__/ViewModeToggle.test.tsx` — component tests
+- `apps/web/e2e/sub-features/s1-admin-toggle.spec.ts` — Playwright E2E (smoke only in S1; S6a extends)
+
+**Modified files:**
+- `apps/web/src/components/layout/UserShell/UserTopNav.tsx` — render `<ViewModeToggle>` when `isAdminRole(user.role)` (reads user via `useCurrentUser` hook)
+- `apps/web/src/app/admin/(dashboard)/layout.tsx` — add server-side guard: if cookie `view_mode === 'user'`, redirect to `/`
+- `apps/web/src/actions/auth.ts` — `logoutAction` must also clear `meepleai_view_mode` cookie
+
+**Total estimate:** ~9 new files + 3 modifications. ~250 lines of production code + ~300 lines of tests.
+
+---
+
+## Preconditions
+
+Before starting Task 1, verify:
+
+- [ ] **Epic branch exists**
+  ```bash
+  cd D:/Repositories/meepleai-monorepo-backend
+  git fetch origin
+  git checkout main-dev
+  git pull origin main-dev
+  git checkout -b epic/library-to-game
+  git config branch.epic/library-to-game.parent main-dev
+  git push -u origin epic/library-to-game
+  ```
+  Expected: branch `epic/library-to-game` pushed to remote.
+
+- [ ] **Feature branch created from epic**
+  ```bash
+  git checkout -b feature/s1-view-toggle
+  git config branch.feature/s1-view-toggle.parent epic/library-to-game
+  ```
+  Expected: HEAD on `feature/s1-view-toggle`.
+
+- [ ] **Frontend workspace clean**
+  ```bash
+  cd apps/web
+  pnpm install
+  pnpm typecheck
+  pnpm lint
+  ```
+  Expected: 0 errors. Any pre-existing errors should be noted BEFORE starting to avoid false blame.
+
+---
+
+## Task 1 — Cookie constants and types
+
+**Files:**
+- Create: `apps/web/src/lib/view-mode/constants.ts`
+- Create: `apps/web/src/lib/view-mode/__tests__/cookie.test.ts` (test file used across tasks 1-2)
+
+- [ ] **Step 1.1: Create the constants file**
+
+  Write `apps/web/src/lib/view-mode/constants.ts`:
+  ```typescript
+  /**
+   * View Mode — Cookie constants
+   *
+   * The `meepleai_view_mode` cookie stores the admin user's preferred shell.
+   * Client-writable (not HttpOnly). Read server-side via `cookies()` from `next/headers`
+   * in layout.tsx guards for SSR-consistent rendering.
+   *
+   * Reference: docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md §4.1
+   */
+
+  /** Cookie name used across client and server to persist view mode */
+  export const VIEW_MODE_COOKIE = 'meepleai_view_mode';
+
+  /** The two valid view mode values */
+  export type ViewMode = 'admin' | 'user';
+
+  /** All valid view modes (for runtime validation) */
+  export const VIEW_MODES: readonly ViewMode[] = ['admin', 'user'] as const;
+
+  /** Cookie max-age: undefined = session cookie (cleared when browser closes) */
+  export const VIEW_MODE_COOKIE_MAX_AGE: number | undefined = undefined;
+
+  /** SameSite attribute — lax allows top-level navigation redirects */
+  export const VIEW_MODE_COOKIE_SAMESITE = 'lax' as const;
+
+  /** Path scope — whole app */
+  export const VIEW_MODE_COOKIE_PATH = '/' as const;
+  ```
+
+- [ ] **Step 1.2: Commit**
+
+  ```bash
+  cd D:/Repositories/meepleai-monorepo-backend
+  git add apps/web/src/lib/view-mode/constants.ts
+  git commit -m "feat(s1): add view mode cookie constants and types"
+  ```
+
+---
+
+## Task 2 — Client-side cookie helpers (TDD)
+
+**Files:**
+- Create: `apps/web/src/lib/view-mode/cookie.ts`
+- Create: `apps/web/src/lib/view-mode/__tests__/cookie.test.ts`
+
+- [ ] **Step 2.1: Write failing tests first**
+
+  Write `apps/web/src/lib/view-mode/__tests__/cookie.test.ts`:
+  ```typescript
+  /**
+   * Tests for client-side view mode cookie helpers.
+   */
+  import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+  import { readViewModeCookie, writeViewModeCookie, clearViewModeCookie } from '../cookie';
+  import { VIEW_MODE_COOKIE } from '../constants';
+
+  describe('view-mode cookie helpers', () => {
+    beforeEach(() => {
+      // Reset document.cookie before each test
+      Object.defineProperty(document, 'cookie', {
+        writable: true,
+        value: '',
+      });
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    describe('readViewModeCookie', () => {
+      it('returns null when cookie is absent', () => {
+        document.cookie = '';
+        expect(readViewModeCookie()).toBeNull();
+      });
+
+      it('returns "admin" when cookie value is admin', () => {
+        document.cookie = `${VIEW_MODE_COOKIE}=admin`;
+        expect(readViewModeCookie()).toBe('admin');
+      });
+
+      it('returns "user" when cookie value is user', () => {
+        document.cookie = `${VIEW_MODE_COOKIE}=user`;
+        expect(readViewModeCookie()).toBe('user');
+      });
+
+      it('returns null when cookie value is invalid', () => {
+        document.cookie = `${VIEW_MODE_COOKIE}=malicious`;
+        expect(readViewModeCookie()).toBeNull();
+      });
+
+      it('correctly extracts cookie when multiple cookies present', () => {
+        document.cookie = `other_cookie=foo; ${VIEW_MODE_COOKIE}=admin; third=bar`;
+        expect(readViewModeCookie()).toBe('admin');
+      });
+    });
+
+    describe('writeViewModeCookie', () => {
+      it('writes admin value to document.cookie', () => {
+        writeViewModeCookie('admin');
+        expect(document.cookie).toContain(`${VIEW_MODE_COOKIE}=admin`);
+      });
+
+      it('writes user value to document.cookie', () => {
+        writeViewModeCookie('user');
+        expect(document.cookie).toContain(`${VIEW_MODE_COOKIE}=user`);
+      });
+
+      it('includes path=/ in the cookie string', () => {
+        const spy = vi.spyOn(document, 'cookie', 'set');
+        writeViewModeCookie('admin');
+        expect(spy).toHaveBeenCalledWith(expect.stringContaining('path=/'));
+      });
+
+      it('includes SameSite=Lax in the cookie string', () => {
+        const spy = vi.spyOn(document, 'cookie', 'set');
+        writeViewModeCookie('admin');
+        expect(spy).toHaveBeenCalledWith(expect.stringContaining('SameSite=Lax'));
+      });
+    });
+
+    describe('clearViewModeCookie', () => {
+      it('clears the cookie by setting expired date', () => {
+        const spy = vi.spyOn(document, 'cookie', 'set');
+        clearViewModeCookie();
+        expect(spy).toHaveBeenCalledWith(
+          expect.stringContaining('Max-Age=0')
+        );
+      });
+    });
+  });
+  ```
+
+- [ ] **Step 2.2: Run tests and verify they fail**
+
+  ```bash
+  cd apps/web
+  pnpm vitest run src/lib/view-mode/__tests__/cookie.test.ts
+  ```
+  Expected: FAIL with "Cannot find module '../cookie'" (or similar — the file doesn't exist yet).
+
+- [ ] **Step 2.3: Implement the cookie helpers**
+
+  Write `apps/web/src/lib/view-mode/cookie.ts`:
+  ```typescript
+  /**
+   * Client-side view mode cookie helpers.
+   *
+   * These functions are safe to call only in the browser. For server-side
+   * cookie reading, use `./server.ts` which uses `next/headers`.
+   */
+  import {
+    VIEW_MODE_COOKIE,
+    VIEW_MODE_COOKIE_PATH,
+    VIEW_MODE_COOKIE_SAMESITE,
+    VIEW_MODES,
+    type ViewMode,
+  } from './constants';
+
+  /**
+   * Read the view mode cookie from `document.cookie`.
+   * Returns null if the cookie is absent or contains an invalid value.
+   *
+   * Safe to call only in browser environments (no-op in SSR).
+   */
+  export function readViewModeCookie(): ViewMode | null {
+    if (typeof document === 'undefined') return null;
+
+    const match = document.cookie
+      .split(';')
+      .map((c) => c.trim())
+      .find((c) => c.startsWith(`${VIEW_MODE_COOKIE}=`));
+
+    if (!match) return null;
+
+    const value = match.slice(VIEW_MODE_COOKIE.length + 1);
+    return (VIEW_MODES as readonly string[]).includes(value) ? (value as ViewMode) : null;
+  }
+
+  /**
+   * Write the view mode cookie to `document.cookie`.
+   * Session-scoped (no Max-Age), SameSite=Lax, client-readable.
+   *
+   * Safe to call only in browser environments (no-op in SSR).
+   */
+  export function writeViewModeCookie(mode: ViewMode): void {
+    if (typeof document === 'undefined') return;
+
+    const parts = [
+      `${VIEW_MODE_COOKIE}=${mode}`,
+      `path=${VIEW_MODE_COOKIE_PATH}`,
+      `SameSite=${VIEW_MODE_COOKIE_SAMESITE === 'lax' ? 'Lax' : VIEW_MODE_COOKIE_SAMESITE}`,
+    ];
+
+    // Secure flag in https contexts only (cookie helpers run in browser)
+    if (typeof window !== 'undefined' && window.location.protocol === 'https:') {
+      parts.push('Secure');
+    }
+
+    document.cookie = parts.join('; ');
+  }
+
+  /**
+   * Clear the view mode cookie by setting an expired date.
+   * Safe to call only in browser environments (no-op in SSR).
+   */
+  export function clearViewModeCookie(): void {
+    if (typeof document === 'undefined') return;
+
+    const parts = [
+      `${VIEW_MODE_COOKIE}=`,
+      `path=${VIEW_MODE_COOKIE_PATH}`,
+      'Max-Age=0',
+      `SameSite=${VIEW_MODE_COOKIE_SAMESITE === 'lax' ? 'Lax' : VIEW_MODE_COOKIE_SAMESITE}`,
+    ];
+
+    document.cookie = parts.join('; ');
+  }
+  ```
+
+- [ ] **Step 2.4: Run tests and verify they pass**
+
+  ```bash
+  cd apps/web
+  pnpm vitest run src/lib/view-mode/__tests__/cookie.test.ts
+  ```
+  Expected: 10 tests PASS (5 read + 4 write + 1 clear).
+
+- [ ] **Step 2.5: Commit**
+
+  ```bash
+  cd D:/Repositories/meepleai-monorepo-backend
+  git add apps/web/src/lib/view-mode/cookie.ts apps/web/src/lib/view-mode/__tests__/cookie.test.ts
+  git commit -m "feat(s1): add client-side view mode cookie helpers with tests"
+  ```
+
+---
+
+## Task 3 — Server-side cookie reader (TDD)
+
+**Files:**
+- Create: `apps/web/src/lib/view-mode/server.ts`
+- Create: `apps/web/src/lib/view-mode/__tests__/server.test.ts`
+
+- [ ] **Step 3.1: Write failing test**
+
+  Write `apps/web/src/lib/view-mode/__tests__/server.test.ts`:
+  ```typescript
+  /**
+   * Tests for server-side view mode cookie reader.
+   * Mocks `next/headers` cookies() API.
+   */
+  import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+  import { readViewModeCookieServer } from '../server';
+  import { VIEW_MODE_COOKIE } from '../constants';
+
+  // Mock next/headers
+  const mockGet = vi.fn();
+  vi.mock('next/headers', () => ({
+    cookies: () => ({
+      get: mockGet,
+    }),
+  }));
+
+  describe('readViewModeCookieServer', () => {
+    beforeEach(() => {
+      mockGet.mockReset();
+    });
+
+    it('returns null when cookie is absent', async () => {
+      mockGet.mockReturnValue(undefined);
+      const result = await readViewModeCookieServer();
+      expect(mockGet).toHaveBeenCalledWith(VIEW_MODE_COOKIE);
+      expect(result).toBeNull();
+    });
+
+    it('returns "admin" when cookie has admin value', async () => {
+      mockGet.mockReturnValue({ name: VIEW_MODE_COOKIE, value: 'admin' });
+      const result = await readViewModeCookieServer();
+      expect(result).toBe('admin');
+    });
+
+    it('returns "user" when cookie has user value', async () => {
+      mockGet.mockReturnValue({ name: VIEW_MODE_COOKIE, value: 'user' });
+      const result = await readViewModeCookieServer();
+      expect(result).toBe('user');
+    });
+
+    it('returns null when cookie has invalid value', async () => {
+      mockGet.mockReturnValue({ name: VIEW_MODE_COOKIE, value: 'malicious' });
+      const result = await readViewModeCookieServer();
+      expect(result).toBeNull();
+    });
+  });
+  ```
+
+- [ ] **Step 3.2: Run test and verify it fails**
+
+  ```bash
+  cd apps/web
+  pnpm vitest run src/lib/view-mode/__tests__/server.test.ts
+  ```
+  Expected: FAIL with "Cannot find module '../server'".
+
+- [ ] **Step 3.3: Implement the server reader**
+
+  Write `apps/web/src/lib/view-mode/server.ts`:
+  ```typescript
+  /**
+   * Server-side view mode cookie reader.
+   *
+   * Uses Next.js 16 `cookies()` from `next/headers` to read the
+   * `meepleai_view_mode` cookie from Server Components, Route Handlers,
+   * and Server Actions. This enables SSR-consistent rendering of the
+   * correct shell (admin vs user) on first paint.
+   *
+   * @see https://nextjs.org/docs/app/api-reference/functions/cookies
+   */
+  import { cookies } from 'next/headers';
+
+  import { VIEW_MODE_COOKIE, VIEW_MODES, type ViewMode } from './constants';
+
+  /**
+   * Read the view mode cookie from the current request's cookies.
+   * Returns null if absent or invalid.
+   *
+   * MUST be called from Server Components, Route Handlers, or Server Actions.
+   * Throws if called from client code.
+   */
+  export async function readViewModeCookieServer(): Promise<ViewMode | null> {
+    const cookieStore = await cookies();
+    const cookie = cookieStore.get(VIEW_MODE_COOKIE);
+
+    if (!cookie) return null;
+
+    const value = cookie.value;
+    return (VIEW_MODES as readonly string[]).includes(value) ? (value as ViewMode) : null;
+  }
+  ```
+
+- [ ] **Step 3.4: Run tests and verify they pass**
+
+  ```bash
+  cd apps/web
+  pnpm vitest run src/lib/view-mode/__tests__/server.test.ts
+  ```
+  Expected: 4 tests PASS.
+
+- [ ] **Step 3.5: Commit**
+
+  ```bash
+  cd D:/Repositories/meepleai-monorepo-backend
+  git add apps/web/src/lib/view-mode/server.ts apps/web/src/lib/view-mode/__tests__/server.test.ts
+  git commit -m "feat(s1): add server-side view mode cookie reader"
+  ```
+
+---
+
+## Task 4 — `useViewMode` hook (TDD)
+
+**Files:**
+- Create: `apps/web/src/hooks/useViewMode.ts`
+- Create: `apps/web/src/hooks/__tests__/useViewMode.test.ts`
+
+- [ ] **Step 4.1: Write failing tests**
+
+  Write `apps/web/src/hooks/__tests__/useViewMode.test.ts`:
+  ```typescript
+  /**
+   * Tests for useViewMode client hook.
+   */
+  import { act, renderHook } from '@testing-library/react';
+  import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+  import { useViewMode } from '../useViewMode';
+  import { VIEW_MODE_COOKIE } from '@/lib/view-mode/constants';
+
+  // Mock next/navigation
+  const mockPush = vi.fn();
+  vi.mock('next/navigation', () => ({
+    useRouter: () => ({ push: mockPush }),
+    usePathname: () => '/admin/overview',
+  }));
+
+  describe('useViewMode', () => {
+    beforeEach(() => {
+      Object.defineProperty(document, 'cookie', { writable: true, value: '' });
+      mockPush.mockReset();
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('defaults to "admin" when cookie absent and on /admin path', () => {
+      const { result } = renderHook(() => useViewMode());
+      expect(result.current.viewMode).toBe('admin');
+    });
+
+    it('reads initial value from cookie when present', () => {
+      document.cookie = `${VIEW_MODE_COOKIE}=user`;
+      const { result } = renderHook(() => useViewMode());
+      expect(result.current.viewMode).toBe('user');
+    });
+
+    it('toggle flips admin → user and writes cookie', () => {
+      document.cookie = `${VIEW_MODE_COOKIE}=admin`;
+      const { result } = renderHook(() => useViewMode());
+      act(() => {
+        result.current.toggle();
+      });
+      expect(result.current.viewMode).toBe('user');
+      expect(document.cookie).toContain(`${VIEW_MODE_COOKIE}=user`);
+    });
+
+    it('toggle flips user → admin', () => {
+      document.cookie = `${VIEW_MODE_COOKIE}=user`;
+      const { result } = renderHook(() => useViewMode());
+      act(() => {
+        result.current.toggle();
+      });
+      expect(result.current.viewMode).toBe('admin');
+    });
+
+    it('toggle navigates to / when switching to user mode', () => {
+      document.cookie = `${VIEW_MODE_COOKIE}=admin`;
+      const { result } = renderHook(() => useViewMode());
+      act(() => {
+        result.current.toggle();
+      });
+      expect(mockPush).toHaveBeenCalledWith('/');
+    });
+
+    it('toggle navigates to /admin/overview when switching to admin mode', () => {
+      document.cookie = `${VIEW_MODE_COOKIE}=user`;
+      const { result } = renderHook(() => useViewMode());
+      act(() => {
+        result.current.toggle();
+      });
+      expect(mockPush).toHaveBeenCalledWith('/admin/overview');
+    });
+  });
+  ```
+
+- [ ] **Step 4.2: Run tests and verify they fail**
+
+  ```bash
+  cd apps/web
+  pnpm vitest run src/hooks/__tests__/useViewMode.test.ts
+  ```
+  Expected: FAIL with "Cannot find module '../useViewMode'".
+
+- [ ] **Step 4.3: Implement the hook**
+
+  Write `apps/web/src/hooks/useViewMode.ts`:
+  ```typescript
+  /**
+   * useViewMode — client hook for view mode toggle state.
+   *
+   * Reads the `meepleai_view_mode` cookie on mount, exposes `viewMode` + `toggle`.
+   * On toggle: flips the value, writes the cookie, navigates to the opposite shell.
+   *
+   * Path-based default: if no cookie, defaults to 'admin' on /admin/* paths,
+   * 'user' elsewhere. This matches the shell the user is currently viewing.
+   */
+  'use client';
+
+  import { useCallback, useEffect, useState } from 'react';
+
+  import { usePathname, useRouter } from 'next/navigation';
+
+  import { readViewModeCookie, writeViewModeCookie } from '@/lib/view-mode/cookie';
+  import type { ViewMode } from '@/lib/view-mode/constants';
+
+  interface UseViewModeResult {
+    viewMode: ViewMode;
+    toggle: () => void;
+  }
+
+  /**
+   * Default view mode inferred from URL path.
+   */
+  function defaultViewMode(pathname: string): ViewMode {
+    return pathname.startsWith('/admin') ? 'admin' : 'user';
+  }
+
+  export function useViewMode(): UseViewModeResult {
+    const router = useRouter();
+    const pathname = usePathname();
+
+    // Initial state reads cookie synchronously (matches SSR when cookie exists)
+    const [viewMode, setViewMode] = useState<ViewMode>(() => {
+      if (typeof document === 'undefined') return defaultViewMode(pathname);
+      return readViewModeCookie() ?? defaultViewMode(pathname);
+    });
+
+    // Re-sync if cookie changed while component is mounted (e.g., another tab)
+    useEffect(() => {
+      const current = readViewModeCookie();
+      if (current && current !== viewMode) {
+        setViewMode(current);
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const toggle = useCallback(() => {
+      const next: ViewMode = viewMode === 'admin' ? 'user' : 'admin';
+      writeViewModeCookie(next);
+      setViewMode(next);
+      router.push(next === 'admin' ? '/admin/overview' : '/');
+    }, [viewMode, router]);
+
+    return { viewMode, toggle };
+  }
+  ```
+
+- [ ] **Step 4.4: Run tests and verify they pass**
+
+  ```bash
+  cd apps/web
+  pnpm vitest run src/hooks/__tests__/useViewMode.test.ts
+  ```
+  Expected: 6 tests PASS.
+
+- [ ] **Step 4.5: Commit**
+
+  ```bash
+  cd D:/Repositories/meepleai-monorepo-backend
+  git add apps/web/src/hooks/useViewMode.ts apps/web/src/hooks/__tests__/useViewMode.test.ts
+  git commit -m "feat(s1): add useViewMode client hook with cookie persistence"
+  ```
+
+---
+
+## Task 5 — `ViewModeToggle` component (TDD)
+
+**Files:**
+- Create: `apps/web/src/components/layout/ViewModeToggle.tsx`
+- Create: `apps/web/src/components/layout/__tests__/ViewModeToggle.test.tsx`
+
+- [ ] **Step 5.1: Write failing tests**
+
+  Write `apps/web/src/components/layout/__tests__/ViewModeToggle.test.tsx`:
+  ```typescript
+  /**
+   * Tests for ViewModeToggle component.
+   */
+  import { render, screen, fireEvent } from '@testing-library/react';
+  import { describe, it, expect, vi } from 'vitest';
+
+  import { ViewModeToggle } from '../ViewModeToggle';
+
+  // Hoisted mocks
+  const mockToggle = vi.fn();
+  let mockViewMode: 'admin' | 'user' = 'admin';
+  vi.mock('@/hooks/useViewMode', () => ({
+    useViewMode: () => ({ viewMode: mockViewMode, toggle: mockToggle }),
+  }));
+
+  describe('ViewModeToggle', () => {
+    beforeEach(() => {
+      mockToggle.mockReset();
+      mockViewMode = 'admin';
+    });
+
+    it('renders a switch with aria-checked reflecting admin mode', () => {
+      mockViewMode = 'admin';
+      render(<ViewModeToggle />);
+      const toggle = screen.getByRole('switch', { name: /cambia vista/i });
+      expect(toggle).toBeInTheDocument();
+      expect(toggle).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('renders aria-checked=false when in user mode', () => {
+      mockViewMode = 'user';
+      render(<ViewModeToggle />);
+      const toggle = screen.getByRole('switch', { name: /cambia vista/i });
+      expect(toggle).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('calls toggle() when clicked', () => {
+      render(<ViewModeToggle />);
+      const toggle = screen.getByRole('switch', { name: /cambia vista/i });
+      fireEvent.click(toggle);
+      expect(mockToggle).toHaveBeenCalledOnce();
+    });
+
+    it('is keyboard-operable via Enter key', () => {
+      render(<ViewModeToggle />);
+      const toggle = screen.getByRole('switch', { name: /cambia vista/i });
+      toggle.focus();
+      fireEvent.keyDown(toggle, { key: 'Enter' });
+      expect(mockToggle).toHaveBeenCalledOnce();
+    });
+
+    it('is keyboard-operable via Space key', () => {
+      render(<ViewModeToggle />);
+      const toggle = screen.getByRole('switch', { name: /cambia vista/i });
+      toggle.focus();
+      fireEvent.keyDown(toggle, { key: ' ' });
+      expect(mockToggle).toHaveBeenCalledOnce();
+    });
+
+    it('has data-testid for E2E selection', () => {
+      render(<ViewModeToggle />);
+      expect(screen.getByTestId('view-mode-toggle')).toBeInTheDocument();
+    });
+  });
+  ```
+
+- [ ] **Step 5.2: Run tests and verify they fail**
+
+  ```bash
+  cd apps/web
+  pnpm vitest run src/components/layout/__tests__/ViewModeToggle.test.tsx
+  ```
+  Expected: FAIL with "Cannot find module '../ViewModeToggle'".
+
+- [ ] **Step 5.3: Implement the component**
+
+  Write `apps/web/src/components/layout/ViewModeToggle.tsx`:
+  ```typescript
+  /**
+   * ViewModeToggle — admin↔user view switcher for the top navbar.
+   *
+   * Icon pill switch (44×26) that flips between admin and user shells.
+   * Only rendered when the current user has an admin role — the parent
+   * component is responsible for gating visibility.
+   *
+   * Accessibility: role="switch" with aria-checked, keyboard-operable.
+   */
+  'use client';
+
+  import { useCallback, type KeyboardEvent } from 'react';
+
+  import { useViewMode } from '@/hooks/useViewMode';
+  import { cn } from '@/lib/utils';
+
+  export function ViewModeToggle() {
+    const { viewMode, toggle } = useViewMode();
+    const isAdmin = viewMode === 'admin';
+
+    const handleKeyDown = useCallback(
+      (e: KeyboardEvent<HTMLButtonElement>) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          toggle();
+        }
+      },
+      [toggle]
+    );
+
+    return (
+      <button
+        type="button"
+        role="switch"
+        aria-checked={isAdmin}
+        aria-label="Cambia vista tra admin e utente"
+        onClick={toggle}
+        onKeyDown={handleKeyDown}
+        data-testid="view-mode-toggle"
+        className={cn(
+          'relative inline-flex h-[26px] w-[44px] shrink-0 items-center rounded-full',
+          'bg-gradient-to-br from-purple-500 to-orange-500',
+          'border-2 border-white shadow-sm',
+          'cursor-pointer transition-colors',
+          'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
+        )}
+      >
+        {/* Left indicator: user icon */}
+        <span
+          className={cn(
+            'absolute left-1 text-[9px] transition-opacity',
+            isAdmin ? 'opacity-70' : 'opacity-30'
+          )}
+          aria-hidden="true"
+        >
+          👤
+        </span>
+        {/* Right indicator: admin gear */}
+        <span
+          className={cn(
+            'absolute right-1 text-[9px] transition-opacity',
+            isAdmin ? 'opacity-30' : 'opacity-70'
+          )}
+          aria-hidden="true"
+        >
+          ⚙️
+        </span>
+        {/* Knob */}
+        <span
+          className={cn(
+            'pointer-events-none absolute top-[1px] h-5 w-5 rounded-full bg-white shadow-sm',
+            'flex items-center justify-center text-[11px]',
+            'transition-transform duration-200',
+            isAdmin ? 'translate-x-[18px]' : 'translate-x-[1px]'
+          )}
+          aria-hidden="true"
+        >
+          {isAdmin ? '⚙️' : '👤'}
+        </span>
+      </button>
+    );
+  }
+  ```
+
+- [ ] **Step 5.4: Run tests and verify they pass**
+
+  ```bash
+  cd apps/web
+  pnpm vitest run src/components/layout/__tests__/ViewModeToggle.test.tsx
+  ```
+  Expected: 6 tests PASS.
+
+- [ ] **Step 5.5: Commit**
+
+  ```bash
+  cd D:/Repositories/meepleai-monorepo-backend
+  git add apps/web/src/components/layout/ViewModeToggle.tsx apps/web/src/components/layout/__tests__/ViewModeToggle.test.tsx
+  git commit -m "feat(s1): add ViewModeToggle icon switch component"
+  ```
+
+---
+
+## Task 6 — Integrate ViewModeToggle into UserTopNav
+
+**Files:**
+- Modify: `apps/web/src/components/layout/UserShell/UserTopNav.tsx`
+
+- [ ] **Step 6.1: Read the current UserTopNav file state**
+
+  ```bash
+  cd apps/web
+  cat src/components/layout/UserShell/UserTopNav.tsx | head -50
+  ```
+
+  Confirm the imports section and the utility actions `<div className="flex items-center gap-2 shrink-0">` block (around line 134).
+
+- [ ] **Step 6.2: Add ViewModeToggle import and conditional render**
+
+  Edit `apps/web/src/components/layout/UserShell/UserTopNav.tsx`:
+
+  Change the imports section (around lines 1-18) to add two new imports:
+  ```typescript
+  import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
+  import { isAdminRole } from '@/lib/utils/roles';
+
+  import { ViewModeToggle } from '../ViewModeToggle';
+  ```
+
+  Change the component body to read the current user and conditionally render the toggle. Add inside the `UserTopNav` function body, right after the existing hooks:
+  ```typescript
+  const { data: currentUser } = useCurrentUser();
+  const canToggleView = isAdminRole(currentUser?.role);
+  ```
+
+  Change the "Right: utility actions" block (around line 134) from:
+  ```tsx
+  <div className="flex items-center gap-2 shrink-0">
+    <NotificationBell />
+    <UserMenuDropdown />
+  </div>
+  ```
+  to:
+  ```tsx
+  <div className="flex items-center gap-2 shrink-0">
+    {canToggleView && <ViewModeToggle />}
+    <NotificationBell />
+    <UserMenuDropdown />
+  </div>
+  ```
+
+- [ ] **Step 6.3: Verify typecheck passes**
+
+  ```bash
+  cd apps/web
+  pnpm typecheck
+  ```
+  Expected: 0 errors.
+
+- [ ] **Step 6.4: Run existing UserTopNav tests to ensure no regression**
+
+  ```bash
+  cd apps/web
+  pnpm vitest run src/components/layout/UserShell
+  ```
+  Expected: all existing tests PASS. If any fail due to the new `useCurrentUser` dependency, add the mock to the test setup (hoist mock at top).
+
+- [ ] **Step 6.5: Commit**
+
+  ```bash
+  cd D:/Repositories/meepleai-monorepo-backend
+  git add apps/web/src/components/layout/UserShell/UserTopNav.tsx
+  git commit -m "feat(s1): render ViewModeToggle in UserTopNav for admin users"
+  ```
+
+---
+
+## Task 7 — Server-side guard in admin layout
+
+**Files:**
+- Modify: `apps/web/src/app/admin/(dashboard)/layout.tsx`
+
+- [ ] **Step 7.1: Read the current admin layout file**
+
+  Current file content (already read):
+  ```typescript
+  import { type ReactNode } from 'react';
+  import { type Metadata } from 'next';
+
+  import { PdfProcessingNotifier } from '@/components/admin/layout/PdfProcessingNotifier';
+  import { RequireRole } from '@/components/auth/RequireRole';
+  import { AdminShell } from '@/components/layout/AdminShell';
+
+  export const metadata: Metadata = { ... };
+
+  export default function DashboardLayout({ children }: { children: ReactNode }) {
+    return (
+      <RequireRole allowedRoles={['Admin']}>
+        <PdfProcessingNotifier />
+        <AdminShell>{children}</AdminShell>
+      </RequireRole>
+    );
+  }
+  ```
+
+- [ ] **Step 7.2: Convert to async function and add server-side redirect**
+
+  Edit `apps/web/src/app/admin/(dashboard)/layout.tsx` to become:
+  ```typescript
+  import { type ReactNode } from 'react';
+
+  import { type Metadata } from 'next';
+  import { redirect } from 'next/navigation';
+
+  import { PdfProcessingNotifier } from '@/components/admin/layout/PdfProcessingNotifier';
+  import { RequireRole } from '@/components/auth/RequireRole';
+  import { AdminShell } from '@/components/layout/AdminShell';
+  import { readViewModeCookieServer } from '@/lib/view-mode/server';
+
+  export const metadata: Metadata = {
+    title: {
+      template: '%s | MeepleAI Admin',
+      default: 'Admin Dashboard | MeepleAI',
+    },
+    description: 'MeepleAI Administration Dashboard',
+  };
+
+  /**
+   * Dashboard route group layout.
+   *
+   * Guard chain:
+   *  1. Server-side: if `meepleai_view_mode` cookie === 'user', redirect to '/' (no admin flash).
+   *  2. Client-side: RequireRole enforces admin role (still the authoritative check).
+   *
+   * Applies the AdminShell to all pages under /admin/(dashboard)/.
+   */
+  export default async function DashboardLayout({ children }: { children: ReactNode }) {
+    const viewMode = await readViewModeCookieServer();
+    if (viewMode === 'user') {
+      redirect('/');
+    }
+
+    return (
+      <RequireRole allowedRoles={['Admin']}>
+        <PdfProcessingNotifier />
+        <AdminShell>{children}</AdminShell>
+      </RequireRole>
+    );
+  }
+  ```
+
+- [ ] **Step 7.3: Verify typecheck passes**
+
+  ```bash
+  cd apps/web
+  pnpm typecheck
+  ```
+  Expected: 0 errors.
+
+- [ ] **Step 7.4: Commit**
+
+  ```bash
+  cd D:/Repositories/meepleai-monorepo-backend
+  git add apps/web/src/app/admin/\(dashboard\)/layout.tsx
+  git commit -m "feat(s1): server-side redirect admin dashboard to / when view_mode=user"
+  ```
+
+---
+
+## Task 8 — Clear view mode cookie on logout
+
+**Files:**
+- Modify: `apps/web/src/actions/auth.ts`
+
+- [ ] **Step 8.1: Locate the logoutAction function**
+
+  ```bash
+  cd apps/web
+  grep -n "export async function logoutAction" src/actions/auth.ts
+  ```
+  Expected: line number of the function (should be around line 227).
+
+- [ ] **Step 8.2: Read the current implementation of logoutAction**
+
+  Read the function body starting from the identified line. It calls `api.auth.logout()` and clears auth cookies on the server side. We need to also clear `meepleai_view_mode`.
+
+  Check if the server uses `cookies().delete()` from `next/headers`. If the logout API call deletes HttpOnly cookies server-side but `meepleai_view_mode` is client-readable, we need to clear it either via:
+  1. Adding `cookies().delete(VIEW_MODE_COOKIE)` in the server action (preferred — server is the source of truth)
+  2. Or adding `clearViewModeCookie()` call at the logout button level (fallback)
+
+  Use approach 1: delete server-side in `logoutAction`.
+
+- [ ] **Step 8.3: Add cookie deletion to logoutAction**
+
+  Edit `apps/web/src/actions/auth.ts`. Find the `logoutAction` function and add the cookie deletion right after `await api.auth.logout();`:
+
+  Add import at top of file (near other `next/headers` imports, if any; otherwise add a new import block):
+  ```typescript
+  import { cookies } from 'next/headers';
+
+  import { VIEW_MODE_COOKIE } from '@/lib/view-mode/constants';
+  ```
+
+  In the `logoutAction` function body, right after the `api.auth.logout()` call, add:
+  ```typescript
+  // Clear view mode cookie so the next session starts fresh
+  const cookieStore = await cookies();
+  cookieStore.delete(VIEW_MODE_COOKIE);
+  ```
+
+- [ ] **Step 8.4: Verify typecheck passes**
+
+  ```bash
+  cd apps/web
+  pnpm typecheck
+  ```
+  Expected: 0 errors.
+
+- [ ] **Step 8.5: Run existing auth tests**
+
+  ```bash
+  cd apps/web
+  pnpm vitest run src/actions/__tests__/auth.test.ts 2>/dev/null || pnpm vitest run src/actions -- --testNamePattern=logout
+  ```
+  Expected: existing tests still PASS. If any test mocks `cookies()`, it may need updating; if so, update the mock to include a no-op `delete` method.
+
+- [ ] **Step 8.6: Commit**
+
+  ```bash
+  cd D:/Repositories/meepleai-monorepo-backend
+  git add apps/web/src/actions/auth.ts
+  git commit -m "feat(s1): clear view mode cookie on logout"
+  ```
+
+---
+
+## Task 9 — Playwright E2E smoke test
+
+**Files:**
+- Create: `apps/web/e2e/sub-features/s1-admin-toggle.spec.ts`
+
+- [ ] **Step 9.1: Check if sub-features/ folder exists**
+
+  ```bash
+  cd apps/web
+  ls e2e/sub-features 2>/dev/null || echo "MISSING"
+  ```
+  If MISSING → create: `mkdir -p e2e/sub-features`
+
+- [ ] **Step 9.2: Write the E2E smoke test**
+
+  Write `apps/web/e2e/sub-features/s1-admin-toggle.spec.ts`:
+  ```typescript
+  /**
+   * S1 — Admin↔User view mode toggle E2E smoke tests.
+   *
+   * Validates the toggle is rendered for admin users, clicking it flips the
+   * view mode cookie, and the redirect happens as expected.
+   *
+   * Related spec: docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md §4.1
+   */
+  import { test, expect } from '@playwright/test';
+
+  import { loginAsAdmin } from '../fixtures/auth';
+
+  test.describe('S1 · Admin↔User view mode toggle', () => {
+    test.beforeEach(async ({ context }) => {
+      // Ensure no stale view mode cookie from previous tests
+      await context.clearCookies({ name: 'meepleai_view_mode' });
+    });
+
+    test('toggle is visible for admin users', async ({ page }) => {
+      await loginAsAdmin(page);
+      await page.goto('/admin/overview');
+
+      const toggle = page.getByTestId('view-mode-toggle');
+      await expect(toggle).toBeVisible();
+      await expect(toggle).toHaveAttribute('role', 'switch');
+      await expect(toggle).toHaveAttribute('aria-checked', 'true');
+    });
+
+    test('clicking toggle redirects admin to user shell', async ({ page }) => {
+      await loginAsAdmin(page);
+      await page.goto('/admin/overview');
+
+      const toggle = page.getByTestId('view-mode-toggle');
+      await toggle.click();
+
+      // Should navigate away from /admin/*
+      await page.waitForURL((url) => !url.pathname.startsWith('/admin'), { timeout: 5000 });
+      expect(page.url()).not.toContain('/admin');
+    });
+
+    test('cookie is set after clicking toggle', async ({ page, context }) => {
+      await loginAsAdmin(page);
+      await page.goto('/admin/overview');
+
+      await page.getByTestId('view-mode-toggle').click();
+      await page.waitForLoadState('networkidle');
+
+      const cookies = await context.cookies();
+      const viewModeCookie = cookies.find((c) => c.name === 'meepleai_view_mode');
+      expect(viewModeCookie?.value).toBe('user');
+    });
+
+    test('SSR redirects admin layout to / when cookie is user (no flash)', async ({
+      page,
+      context,
+    }) => {
+      await loginAsAdmin(page);
+      // Pre-set the cookie before navigating to /admin
+      await context.addCookies([
+        {
+          name: 'meepleai_view_mode',
+          value: 'user',
+          url: page.url() || 'http://localhost:3000',
+          path: '/',
+          sameSite: 'Lax',
+        },
+      ]);
+
+      const response = await page.goto('/admin/overview');
+      // Server-side redirect returns 307 or the final / URL
+      expect(page.url()).not.toContain('/admin/overview');
+    });
+
+    test('toggle returns to admin when clicked from user shell', async ({ page }) => {
+      await loginAsAdmin(page);
+      await page.goto('/');
+
+      const toggle = page.getByTestId('view-mode-toggle');
+      await expect(toggle).toBeVisible();
+      await expect(toggle).toHaveAttribute('aria-checked', 'false');
+
+      await toggle.click();
+      await page.waitForURL((url) => url.pathname.startsWith('/admin'), { timeout: 5000 });
+      expect(page.url()).toContain('/admin');
+    });
+  });
+  ```
+
+- [ ] **Step 9.3: Check if loginAsAdmin fixture exists**
+
+  ```bash
+  cd apps/web
+  ls e2e/fixtures/auth.ts 2>/dev/null && grep -l "loginAsAdmin" e2e/fixtures/auth.ts
+  ```
+  If fixture doesn't exist or doesn't export `loginAsAdmin`, fall back to using an existing fixture (grep for `login` in `e2e/fixtures/`) or inline the admin login steps.
+
+- [ ] **Step 9.4: Run the E2E test locally**
+
+  ```bash
+  cd apps/web
+  pnpm test:e2e --project=mobile-chrome e2e/sub-features/s1-admin-toggle.spec.ts
+  ```
+  Expected: 5 tests PASS on mobile-chrome. If `loginAsAdmin` fixture is missing, update the test to use whatever login fixture is conventional in the project.
+
+- [ ] **Step 9.5: Commit**
+
+  ```bash
+  cd D:/Repositories/meepleai-monorepo-backend
+  git add apps/web/e2e/sub-features/s1-admin-toggle.spec.ts
+  git commit -m "test(s1): add Playwright E2E smoke tests for view mode toggle"
+  ```
+
+---
+
+## Task 10 — Final validation and PR
+
+- [ ] **Step 10.1: Run full frontend test suite**
+
+  ```bash
+  cd apps/web
+  pnpm typecheck
+  pnpm lint
+  pnpm test
+  ```
+  Expected: all PASS. Any pre-existing failures that are unrelated to S1 must be noted, not "fixed" under S1 scope.
+
+- [ ] **Step 10.2: Verify coverage on new files ≥ 85%**
+
+  ```bash
+  cd apps/web
+  pnpm test:coverage -- src/lib/view-mode src/hooks/useViewMode.ts src/components/layout/ViewModeToggle.tsx
+  ```
+  Expected: ≥ 85% line coverage on each new file. If below, add edge-case tests.
+
+- [ ] **Step 10.3: Push the feature branch**
+
+  ```bash
+  cd D:/Repositories/meepleai-monorepo-backend
+  git push -u origin feature/s1-view-toggle
+  ```
+
+- [ ] **Step 10.4: Create the PR into the epic branch**
+
+  ```bash
+  cd D:/Repositories/meepleai-monorepo-backend
+  gh pr create \
+    --base epic/library-to-game \
+    --head feature/s1-view-toggle \
+    --title "feat(s1): admin↔user view mode toggle in navbar" \
+    --body "$(cat <<'EOF'
+## Summary
+
+Implements S1 of the `library-to-game` epic: a one-click view mode toggle in the top navbar that flips admin users between the admin shell and the user shell while preserving their authenticated session.
+
+## Changes
+
+- New cookie `meepleai_view_mode` (client-writable, SameSite=Lax, session-scoped)
+- New utilities: `lib/view-mode/{constants,cookie,server}.ts` for client + server cookie access
+- New hook: `useViewMode` with toggle + router navigation
+- New component: `ViewModeToggle` (icon pill switch, role="switch", keyboard-operable)
+- `UserTopNav` conditionally renders the toggle when `isAdminRole(user.role)`
+- `app/admin/(dashboard)/layout.tsx` gets a server-side guard that redirects to `/` if cookie = `user` (no first-paint flash)
+- `logoutAction` now clears the view mode cookie
+
+## Reference
+
+- Spec: `docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md` §4.1
+- Plan: `docs/superpowers/plans/2026-04-09-s1-view-toggle.md`
+
+## Test plan
+
+- [x] Unit tests: `src/lib/view-mode/__tests__/cookie.test.ts` (10 tests)
+- [x] Unit tests: `src/lib/view-mode/__tests__/server.test.ts` (4 tests)
+- [x] Unit tests: `src/hooks/__tests__/useViewMode.test.ts` (6 tests)
+- [x] Component tests: `src/components/layout/__tests__/ViewModeToggle.test.tsx` (6 tests)
+- [x] E2E smoke: `e2e/sub-features/s1-admin-toggle.spec.ts` (5 tests)
+- [x] Coverage ≥ 85% on new files
+- [x] `pnpm typecheck` and `pnpm lint` pass
+
+## Security
+
+- Role check remains authoritative: `RequireRole` in admin layout still enforces admin-only access regardless of cookie
+- Non-admin users with forged `view_mode=admin` cookie still get blocked by `RequireRole`
+- Cookie is `SameSite=Lax` to prevent CSRF on the toggle action
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+  ```
+  Expected: PR URL printed. Open in browser for review.
+
+- [ ] **Step 10.5: Wait for review and merge**
+
+  This step is manual. The plan ends here. After merge into `epic/library-to-game`, the next sub-feature plan (S6a scaffold) can be generated.
+
+---
+
+## Rollback plan
+
+If something goes wrong after merge and needs to be rolled back:
+
+```bash
+git checkout epic/library-to-game
+git revert <merge-commit-sha>
+git push
+```
+
+All files added by S1 are new or cleanly additive; no existing data, migrations, or APIs are modified, so revert is safe.
+
+---
+
+## Known limitations of S1 (deferred to later sub-features)
+
+- **E2E test does not yet check the happy path end-to-end.** S6a (next sub-feature in the epic order) creates the happy path skeleton; S6b fills it with all steps.
+- **No visual regression screenshot.** S6 uses smoke + a11y, not pixel diff.
+- **Toggle is desktop-and-mobile identical.** Future UX iteration may want a different mobile treatment (part of a potential S1b, not in scope now).
+- **Admin layout guard is the only server-side check.** There is no equivalent guard in `app/(authenticated)/layout.tsx` to redirect admin view mode → `/admin/overview` because a non-admin user can still use the app normally (we don't want to force them away from `/`). Only the admin side needs a guard.
+
+---
+
+## Plan self-review checklist
+
+- [x] Every step has a concrete command or code block — no placeholders.
+- [x] Type consistency: `ViewMode` = `'admin' | 'user'` used uniformly across all files.
+- [x] Function names consistent: `readViewModeCookie`, `writeViewModeCookie`, `clearViewModeCookie`, `readViewModeCookieServer`, `useViewMode`, `toggle`.
+- [x] Cookie name constant `VIEW_MODE_COOKIE = 'meepleai_view_mode'` referenced from constants module in every consumer.
+- [x] Spec §4.1 requirements covered: cookie-based (not sessionStorage), SSR-consistent, role check authoritative, logout clears cookie, icon switch in navbar, `role="switch"` + `aria-checked` + keyboard-operable.
+- [x] Every task ends with a commit — frequent commits.
+- [x] Tests precede implementation — TDD.
+- [x] Preconditions include branch setup per CLAUDE.md rules (parent branch tracking).
+- [x] PR targets epic branch, not main, per CLAUDE.md rule.
+
+**Plan length:** 10 tasks, ~60 steps, estimated 4-6 hours of focused work.

--- a/docs/superpowers/plans/2026-04-09-s1-view-toggle.md
+++ b/docs/superpowers/plans/2026-04-09-s1-view-toggle.md
@@ -139,9 +139,13 @@ Before starting Task 1, verify:
 
   describe('view-mode cookie helpers', () => {
     beforeEach(() => {
-      // Reset document.cookie before each test
+      // Reset document.cookie before each test.
+      // NOTE: `configurable: true` is REQUIRED — without it, the second
+      // beforeEach silently fails because the property becomes non-configurable
+      // after the first Object.defineProperty call, causing flaky tests.
       Object.defineProperty(document, 'cookie', {
         writable: true,
+        configurable: true,
         value: '',
       });
     });
@@ -548,7 +552,7 @@ Before starting Task 1, verify:
    */
   'use client';
 
-  import { useCallback, useEffect, useState } from 'react';
+  import { useCallback, useState } from 'react';
 
   import { usePathname, useRouter } from 'next/navigation';
 
@@ -571,20 +575,14 @@ Before starting Task 1, verify:
     const router = useRouter();
     const pathname = usePathname();
 
-    // Initial state reads cookie synchronously (matches SSR when cookie exists)
+    // Initial state reads cookie synchronously (matches SSR when cookie exists).
+    // Cross-tab sync intentionally NOT implemented: document.cookie has no change
+    // event, BroadcastChannel is overkill for a UX preference, and the known
+    // limitation is documented in the spec §4.1 and the plan's "Known limitations".
     const [viewMode, setViewMode] = useState<ViewMode>(() => {
       if (typeof document === 'undefined') return defaultViewMode(pathname);
       return readViewModeCookie() ?? defaultViewMode(pathname);
     });
-
-    // Re-sync if cookie changed while component is mounted (e.g., another tab)
-    useEffect(() => {
-      const current = readViewModeCookie();
-      if (current && current !== viewMode) {
-        setViewMode(current);
-      }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
 
     const toggle = useCallback(() => {
       const next: ViewMode = viewMode === 'admin' ? 'user' : 'admin';
@@ -596,6 +594,8 @@ Before starting Task 1, verify:
     return { viewMode, toggle };
   }
   ```
+
+  > **Note on the `useEffect` removal:** a previous revision of this plan included a `useEffect(() => { ... }, [])` that tried to re-sync on mount. Code review I1 correctly flagged it as a no-op (runs at the same moment as the `useState` initializer, never fires again). Removed. Cross-tab sync is a deliberate non-goal for S1.
 
 - [ ] **Step 4.4: Run tests and verify they pass**
 
@@ -971,10 +971,12 @@ Before starting Task 1, verify:
 
 ---
 
-## Task 8 — Clear view mode cookie on logout
+## Task 8 — Clear view mode cookie on logout (client-side)
 
 **Files:**
 - Modify: `apps/web/src/actions/auth.ts`
+
+**Important correction from code review C1:** `apps/web/src/actions/auth.ts` has `'use client'` on line 14. It is NOT a Server Action file — it's a client-module wrapper around API calls. Therefore we CANNOT import `cookies` from `next/headers` here (that would cause a Next.js 16 build error: "next/headers is server-only"). We must clear the cookie using the client helper `clearViewModeCookie()` from the `lib/view-mode/cookie.ts` module we built in Task 2.
 
 - [ ] **Step 8.1: Locate the logoutAction function**
 
@@ -982,58 +984,62 @@ Before starting Task 1, verify:
   cd apps/web
   grep -n "export async function logoutAction" src/actions/auth.ts
   ```
-  Expected: line number of the function (should be around line 227).
+  Expected: line number of the function (approximately line 227).
 
 - [ ] **Step 8.2: Read the current implementation of logoutAction**
 
-  Read the function body starting from the identified line. It calls `api.auth.logout()` and clears auth cookies on the server side. We need to also clear `meepleai_view_mode`.
+  Read the function body. It calls `await api.auth.logout()` (which clears HttpOnly auth cookies server-side via the API endpoint) and then does a `window.location.href = '/login'` reload in the error fallback. We need to clear `meepleai_view_mode` from the client right before/after the API call, since it is a client-readable cookie.
 
-  Check if the server uses `cookies().delete()` from `next/headers`. If the logout API call deletes HttpOnly cookies server-side but `meepleai_view_mode` is client-readable, we need to clear it either via:
-  1. Adding `cookies().delete(VIEW_MODE_COOKIE)` in the server action (preferred — server is the source of truth)
-  2. Or adding `clearViewModeCookie()` call at the logout button level (fallback)
+- [ ] **Step 8.3: Add import for clearViewModeCookie**
 
-  Use approach 1: delete server-side in `logoutAction`.
-
-- [ ] **Step 8.3: Add cookie deletion to logoutAction**
-
-  Edit `apps/web/src/actions/auth.ts`. Find the `logoutAction` function and add the cookie deletion right after `await api.auth.logout();`:
-
-  Add import at top of file (near other `next/headers` imports, if any; otherwise add a new import block):
+  Edit `apps/web/src/actions/auth.ts`. Add this import in the imports section (near the existing `@/lib/*` imports, around line 16-20):
   ```typescript
-  import { cookies } from 'next/headers';
+  import { clearViewModeCookie } from '@/lib/view-mode/cookie';
+  ```
+  Do NOT add `import { cookies } from 'next/headers'` — that would break the build because the file is `'use client'`.
 
-  import { VIEW_MODE_COOKIE } from '@/lib/view-mode/constants';
+- [ ] **Step 8.4: Call clearViewModeCookie inside logoutAction**
+
+  Find the body of `logoutAction`. After the line `await api.auth.logout();` (the normal success path), add:
+  ```typescript
+  // Clear client-side view mode cookie. HttpOnly auth cookies are cleared
+  // by the server in api.auth.logout(); this handles the extra UX preference cookie.
+  clearViewModeCookie();
   ```
 
-  In the `logoutAction` function body, right after the `api.auth.logout()` call, add:
+  Also add the same call in the `catch` block, BEFORE the `window.location.href = '/login'` fallback, so a failed logout still clears the preference:
   ```typescript
-  // Clear view mode cookie so the next session starts fresh
-  const cookieStore = await cookies();
-  cookieStore.delete(VIEW_MODE_COOKIE);
+  } catch (error) {
+    // ... existing error logging ...
+    clearViewModeCookie();
+    // ... existing window.location fallback ...
+  }
   ```
 
-- [ ] **Step 8.4: Verify typecheck passes**
+  If the catch block doesn't exist in the current implementation, place `clearViewModeCookie()` right after the successful `await api.auth.logout();` call only — it's still run before the client-side reload.
+
+- [ ] **Step 8.5: Verify typecheck passes**
 
   ```bash
   cd apps/web
   pnpm typecheck
   ```
-  Expected: 0 errors.
+  Expected: 0 errors. Critically: if you see "next/headers is server-only" then you mistakenly imported it — remove the import.
 
-- [ ] **Step 8.5: Run existing auth tests**
+- [ ] **Step 8.6: Run existing auth tests**
 
   ```bash
   cd apps/web
-  pnpm vitest run src/actions/__tests__/auth.test.ts 2>/dev/null || pnpm vitest run src/actions -- --testNamePattern=logout
+  pnpm vitest run src/actions
   ```
-  Expected: existing tests still PASS. If any test mocks `cookies()`, it may need updating; if so, update the mock to include a no-op `delete` method.
+  Expected: existing tests still PASS. No existing test should touch `meepleai_view_mode`; if any test mocks `document.cookie`, ensure it uses `configurable: true` (same pattern as Task 2).
 
-- [ ] **Step 8.6: Commit**
+- [ ] **Step 8.7: Commit**
 
   ```bash
   cd D:/Repositories/meepleai-monorepo-backend
   git add apps/web/src/actions/auth.ts
-  git commit -m "feat(s1): clear view mode cookie on logout"
+  git commit -m "feat(s1): clear view mode cookie on logout (client-side)"
   ```
 
 ---
@@ -1110,21 +1116,28 @@ Before starting Task 1, verify:
     test('SSR redirects admin layout to / when cookie is user (no flash)', async ({
       page,
       context,
+      baseURL,
     }) => {
       await loginAsAdmin(page);
-      // Pre-set the cookie before navigating to /admin
+      // Navigate to establish a real document origin before adding cookies.
+      // Using baseURL from Playwright config; fall back to localhost:3000 if unset.
+      const origin = baseURL || 'http://localhost:3000';
+      await page.goto('/');
+
+      // Pre-set the cookie with an absolute URL (context.addCookies requires either
+      // url OR domain+path; avoid about:blank / page.url() since they may not yet
+      // be valid for addCookies validation).
       await context.addCookies([
         {
           name: 'meepleai_view_mode',
           value: 'user',
-          url: page.url() || 'http://localhost:3000',
-          path: '/',
+          url: origin,
           sameSite: 'Lax',
         },
       ]);
 
-      const response = await page.goto('/admin/overview');
-      // Server-side redirect returns 307 or the final / URL
+      await page.goto('/admin/overview');
+      // Server-side redirect should send user to '/' before admin shell renders
       expect(page.url()).not.toContain('/admin/overview');
     });
 
@@ -1143,13 +1156,14 @@ Before starting Task 1, verify:
   });
   ```
 
-- [ ] **Step 9.3: Check if loginAsAdmin fixture exists**
+- [ ] **Step 9.3: Verify loginAsAdmin fixture import resolves**
 
+  The fixture has been pre-verified to exist at `apps/web/e2e/fixtures/auth.ts` with a `loginAsAdmin` export at line 394. Confirm this is still true before proceeding:
   ```bash
   cd apps/web
-  ls e2e/fixtures/auth.ts 2>/dev/null && grep -l "loginAsAdmin" e2e/fixtures/auth.ts
+  grep -n "export.*loginAsAdmin" e2e/fixtures/auth.ts
   ```
-  If fixture doesn't exist or doesn't export `loginAsAdmin`, fall back to using an existing fixture (grep for `login` in `e2e/fixtures/`) or inline the admin login steps.
+  Expected: one match around line 394. If zero matches → STOP and investigate before running the test.
 
 - [ ] **Step 9.4: Run the E2E test locally**
 
@@ -1288,3 +1302,27 @@ All files added by S1 are new or cleanly additive; no existing data, migrations,
 - [x] PR targets epic branch, not main, per CLAUDE.md rule.
 
 **Plan length:** 10 tasks, ~60 steps, estimated 4-6 hours of focused work.
+
+---
+
+## Code Review Response (Revision 2)
+
+Addressed the 3 critical and 2 important issues from code review by `superpowers:code-reviewer` subagent.
+
+**Fixed:**
+- **C1** (auth.ts is `'use client'`, cannot import `next/headers`) → Task 8 rewritten: use `clearViewModeCookie()` from the client helper. Explicitly calls out in the task description that `next/headers` must NOT be imported.
+- **C3** (E2E test 4 uses `page.url() || 'localhost'` which is `about:blank` before first navigation) → Task 9 test 4 rewritten to use Playwright's `baseURL` fixture parameter + `page.goto('/')` before `context.addCookies`.
+- **I1** (useless `useEffect` for cross-tab sync in `useViewMode`) → Removed the effect from Task 4. Removed unused `useEffect` import. Added documentation that cross-tab sync is an intentional non-goal.
+- **I3** (`Object.defineProperty(document, 'cookie', ...)` without `configurable: true` causes flaky tests) → Task 2 tests now pass `configurable: true` with an explanatory comment.
+- **I5** (Task 9.3 fallback language was a placeholder) → Converted to a verification step that fails fast if the fixture is missing.
+
+**Pushed back (reviewer wrong):**
+- **C2** (reviewer claimed `UserTopNav` is only in `UserShell` and that the admin shell has a different nav component, so the toggle wouldn't be visible on admin pages and E2E test 1 would fail) → **Rejected after verification.** Reading `apps/web/src/components/layout/AdminShell/AdminShell.tsx` lines 10 and 24 shows that `AdminShell` imports `UserTopNav` from `'../UserShell/UserTopNav'` and renders it with the `isAdmin` prop: `<UserTopNav isAdmin onMenuToggle={...} isMenuOpen={drawerOpen} />`. The admin shell **reuses** the user top nav component. Mounting `<ViewModeToggle>` inside `UserTopNav` covers both shells in a single change. No Task 6b needed.
+
+**Deferred to execution (minor):**
+- I2 (test split between default-path and navigate assertions) — fine as-is
+- I4 (keyboard handler on native button is slightly over-engineered) — keep for explicitness, no harm
+- I6 (`context.clearCookies` filter requires Playwright ≥1.43) — if execution fails, drop the filter
+- M1–M6 (doc/comment nits) — applied where simple, ignored where not load-bearing
+
+**Revision 2 changes are localized to Tasks 2, 4, 8, and 9.** No task was added, no task was removed. All critical blockers are resolved or rejected with evidence. Plan is now **READY TO EXECUTE**.

--- a/docs/superpowers/plans/2026-04-09-s2-kb-filter.md
+++ b/docs/superpowers/plans/2026-04-09-s2-kb-filter.md
@@ -1,0 +1,741 @@
+# S2 — `hasKnowledgeBase` Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: `superpowers:executing-plans`. TDD steps with checkbox syntax.
+
+**Goal:** Add a `HasKnowledgeBase` denormalized column to `SharedGameEntity`, maintain it via an event handler on `VectorDocumentIndexedEvent`, expose it as an optional filter on the public catalog endpoint, and render a toggle chip in the frontend `PublicLibraryPage`.
+
+**Architecture:** Denormalized column + event-driven projection update. Write path = event handler in `SharedGameCatalog.Application.EventHandlers/` reads `VectorDocumentEntity` by DocumentId to resolve `SharedGameId`, then executes `UPDATE shared_games SET has_knowledge_base = true WHERE id = :id`. Read path = `SearchSharedGamesQuery` handler adds WHERE clause + DTO mapping. One-time backfill in the EF migration.
+
+**Tech Stack:** .NET 9 / EF Core 9 / PostgreSQL / MediatR / xUnit + Testcontainers (backend), Next.js / TanStack Query / Zod (frontend).
+
+**Reference spec:** `docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md` §4.2
+**Branch:** `feature/s2-kb-filter` (from `epic/library-to-game`)
+
+**⚠️ Spec correction:** Spec decision CR-C1 named `GetFilteredSharedGamesQuery` as the target query. Verified via grep: the PUBLIC catalog endpoint (`GET /api/v1/shared-games`) uses **`SearchSharedGamesQuery`**. `GetFilteredSharedGamesQuery` is only used by the admin endpoint. S2 extends `SearchSharedGamesQuery` (user-facing). Admin endpoint is not in S2 scope.
+
+---
+
+## File Structure
+
+**New files (backend):**
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandler.cs` — event handler
+- `apps/api/src/Api/Infrastructure/Migrations/<timestamp>_AddHasKnowledgeBaseToSharedGames.cs` — auto-generated
+- `tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandlerTests.cs`
+- `tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQuery_KbFilterTests.cs`
+
+**Modified files (backend):**
+- `apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs` — add `HasKnowledgeBase` property
+- `apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameEntityConfiguration.cs` — add column config + index
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs` — add `HasKnowledgeBase: bool = false`
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQuery.cs` — add `HasKnowledgeBase: bool?`
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQueryHandler.cs` — filter + DTO mapping + cache key
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandler.cs` — add field to `.Select` (admin consistency, no filter param)
+- `apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogPublicEndpoints.cs` — accept `hasKb` query param, pass to query
+- `apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs` — pass-through update if needed
+
+**Modified files (frontend):**
+- `apps/web/src/lib/api/schemas/shared-games.schemas.ts` — add `hasKnowledgeBase?: boolean` to `SearchSharedGamesParamsSchema`; add `hasKnowledgeBase` to response `SharedGameSchema`
+- `apps/web/src/lib/api/clients/sharedGamesClient.ts` — map param to query string
+- `apps/web/src/components/library/PublicLibraryPage.tsx` — add filter chip state + UI + URL sync
+
+**New files (frontend):**
+- none — tests go alongside PublicLibraryPage existing tests if any, otherwise a new test file (TBD in task 11)
+
+**Total estimate:** ~14 files touched, ~400 LOC production + ~300 LOC tests.
+
+---
+
+## Task 1 — Backend entity column + EF configuration
+
+**Files:**
+- Modify: `apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs`
+- Modify: `apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameEntityConfiguration.cs`
+
+- [ ] **Step 1.1: Add `HasKnowledgeBase` property to entity**
+
+  In `SharedGameEntity.cs`, add after the existing `IsRagPublic` property:
+  ```csharp
+  /// <summary>
+  /// Denormalized flag set to true when at least one VectorDocument with this
+  /// SharedGameId has been indexed. Maintained by
+  /// VectorDocumentIndexedForKbFlagHandler (async event projection).
+  /// Used by the public catalog filter "Solo giochi AI-ready".
+  /// </summary>
+  public bool HasKnowledgeBase { get; set; }
+  ```
+
+- [ ] **Step 1.2: Add EF column configuration + index**
+
+  In `SharedGameEntityConfiguration.cs`, add after the `IsRagPublic` configuration:
+  ```csharp
+  builder.Property(e => e.HasKnowledgeBase)
+      .HasColumnName("has_knowledge_base")
+      .IsRequired()
+      .HasDefaultValue(false);
+
+  builder.HasIndex(e => e.HasKnowledgeBase)
+      .HasDatabaseName("ix_shared_games_has_knowledge_base")
+      .HasFilter("has_knowledge_base = true");  // Partial index — only the small "true" subset
+  ```
+
+- [ ] **Step 1.3: Verify backend builds**
+
+  ```bash
+  cd apps/api/src/Api
+  dotnet build 2>&1 | tail -10
+  ```
+  Expected: `Build succeeded` with 0 errors.
+
+- [ ] **Step 1.4: Commit**
+
+  ```bash
+  cd D:/Repositories/meepleai-monorepo-backend
+  git add apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs \
+          apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameEntityConfiguration.cs
+  git commit -m "feat(s2): add HasKnowledgeBase column to SharedGameEntity"
+  ```
+
+---
+
+## Task 2 — EF Core migration
+
+**Files:**
+- Create (auto-generated): `apps/api/src/Api/Infrastructure/Migrations/<timestamp>_AddHasKnowledgeBaseToSharedGames.cs`
+
+- [ ] **Step 2.1: Generate the migration**
+
+  ```bash
+  cd apps/api/src/Api
+  dotnet ef migrations add AddHasKnowledgeBaseToSharedGames
+  ```
+  Expected: two new files created under `Infrastructure/Migrations/` (the migration `.cs` file + its `.Designer.cs` counterpart). The migration should contain an `AddColumn<bool>("has_knowledge_base", "shared_games", nullable: false, defaultValue: false)` + `CreateIndex` with the partial filter.
+
+- [ ] **Step 2.2: Review the generated migration**
+
+  Open the newly-created `<timestamp>_AddHasKnowledgeBaseToSharedGames.cs` and verify:
+  - `Up()` contains `AddColumn<bool>` for `has_knowledge_base`
+  - `Up()` contains `CreateIndex` with `filter: "has_knowledge_base = true"`
+  - `Down()` contains `DropIndex` + `DropColumn`
+
+  If the generated migration looks wrong (e.g., extra unrelated changes from pending model diffs), STOP and ask — do not force-commit.
+
+- [ ] **Step 2.3: Add backfill SQL to the migration Up() method**
+
+  Edit the new migration file. At the end of `Up()`, before it exits, add:
+  ```csharp
+  // Backfill: mark games with at least one indexed vector document as having KB.
+  // Uses the existing vector_documents.shared_game_id cross-BC reference (Issue #4921).
+  migrationBuilder.Sql(@"
+      UPDATE shared_games
+      SET has_knowledge_base = true
+      WHERE id IN (
+          SELECT DISTINCT shared_game_id
+          FROM vector_documents
+          WHERE shared_game_id IS NOT NULL
+            AND indexing_status = 'completed'
+      );
+  ");
+  ```
+
+  Note: the vector_documents column name might be camelCase or snake_case in the generated SQL — verify against the existing VectorDocumentEntity EF config. If it's `SharedGameId` in quotes, use `"SharedGameId"` instead of `shared_game_id`. Check `VectorDocumentEntityConfiguration.cs` for the column name convention.
+
+- [ ] **Step 2.4: Verify backend builds after migration**
+
+  ```bash
+  cd apps/api/src/Api
+  dotnet build 2>&1 | tail -10
+  ```
+
+- [ ] **Step 2.5: Commit**
+
+  ```bash
+  cd D:/Repositories/meepleai-monorepo-backend
+  git add apps/api/src/Api/Infrastructure/Migrations/
+  git commit -m "feat(s2): add EF migration for HasKnowledgeBase column with backfill"
+  ```
+
+---
+
+## Task 3 — Update `SharedGameDto` and query record
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQuery.cs`
+
+- [ ] **Step 3.1: Add HasKnowledgeBase to `SharedGameDto`**
+
+  In `SharedGameDto.cs`, add the new field at the end of the record:
+  ```csharp
+  public sealed record SharedGameDto(
+      Guid Id,
+      int? BggId,
+      string Title,
+      int YearPublished,
+      string Description,
+      int MinPlayers,
+      int MaxPlayers,
+      int PlayingTimeMinutes,
+      int MinAge,
+      decimal? ComplexityRating,
+      decimal? AverageRating,
+      string ImageUrl,
+      string ThumbnailUrl,
+      GameStatus Status,
+      DateTime CreatedAt,
+      DateTime? ModifiedAt,
+      bool IsRagPublic = false,
+      bool HasKnowledgeBase = false);
+  ```
+
+- [ ] **Step 3.2: Add `HasKnowledgeBase` param to `SearchSharedGamesQuery`**
+
+  Add a new nullable bool parameter at the end of the record:
+  ```csharp
+  internal sealed record SearchSharedGamesQuery(
+      string? SearchTerm,
+      List<Guid>? CategoryIds,
+      List<Guid>? MechanicIds,
+      int? MinPlayers,
+      int? MaxPlayers,
+      int? MaxPlayingTime,
+      decimal? MinComplexity,
+      decimal? MaxComplexity,
+      GameStatus? Status,
+      int PageNumber,
+      int PageSize,
+      string? SortBy,
+      bool SortDescending,
+      bool? HasKnowledgeBase = null  // New: filter for AI-ready games
+  ) : IRequest<PagedResult<SharedGameDto>>;
+  ```
+  NOTE: I don't know the exact shape of `SearchSharedGamesQuery.cs` — read it first, then add the param at the end preserving existing parameters verbatim.
+
+- [ ] **Step 3.3: Verify backend builds**
+
+  ```bash
+  cd apps/api/src/Api
+  dotnet build 2>&1 | tail -10
+  ```
+
+- [ ] **Step 3.4: Commit**
+
+  ```bash
+  git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs \
+          apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQuery.cs
+  git commit -m "feat(s2): extend SharedGameDto and SearchSharedGamesQuery with HasKnowledgeBase"
+  ```
+
+---
+
+## Task 4 — Update `SearchSharedGamesQueryHandler`
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQueryHandler.cs`
+
+- [ ] **Step 4.1: Add the filter clause**
+
+  In `ExecuteSearchAsync`, add a new filter block between "Playing time filter" and "Complexity rating filter":
+  ```csharp
+  // Knowledge Base filter: only games with indexed KB (S2)
+  if (query.HasKnowledgeBase.HasValue)
+  {
+      dbQuery = dbQuery.Where(g => g.HasKnowledgeBase == query.HasKnowledgeBase.Value);
+  }
+  ```
+
+- [ ] **Step 4.2: Add `HasKnowledgeBase` to the DTO projection**
+
+  In the `.Select(g => new SharedGameDto(...))` call, add `g.HasKnowledgeBase` as the new final argument:
+  ```csharp
+  .Select(g => new SharedGameDto(
+      g.Id,
+      g.BggId,
+      g.Title,
+      g.YearPublished,
+      g.Description,
+      g.MinPlayers,
+      g.MaxPlayers,
+      g.PlayingTimeMinutes,
+      g.MinAge,
+      g.ComplexityRating,
+      g.AverageRating,
+      g.ImageUrl,
+      g.ThumbnailUrl,
+      (GameStatus)g.Status,
+      g.CreatedAt,
+      g.ModifiedAt,
+      g.IsRagPublic,
+      g.HasKnowledgeBase))  // S2
+  ```
+
+- [ ] **Step 4.3: Add `HasKnowledgeBase` to the cache key**
+
+  In `GenerateCacheKey`, append `query.HasKnowledgeBase?.ToString() ?? "null"` to the `keyComponents` string so different filter values produce different cache entries:
+  ```csharp
+  var keyComponents = $"{searchTerm}|{categoryIds}|{mechanicIds}|{query.MinPlayers}|{query.MaxPlayers}|{query.MaxPlayingTime}|{query.MinComplexity}|{query.MaxComplexity}|{statusStr}|{query.PageNumber}|{query.PageSize}|{query.SortBy}|{query.SortDescending}|{query.HasKnowledgeBase?.ToString() ?? "null"}";
+  ```
+
+- [ ] **Step 4.4: Build verification**
+
+  ```bash
+  cd apps/api/src/Api
+  dotnet build 2>&1 | tail -10
+  ```
+
+- [ ] **Step 4.5: Commit**
+
+  ```bash
+  git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQueryHandler.cs
+  git commit -m "feat(s2): add HasKnowledgeBase filter and DTO mapping to search handler"
+  ```
+
+---
+
+## Task 5 — Update `GetFilteredSharedGamesQueryHandler` projection (admin consistency)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandler.cs`
+
+- [ ] **Step 5.1: Add `g.HasKnowledgeBase` to the `.Select` projection**
+
+  In `GetFilteredSharedGamesQueryHandler.Handle()`, add `g.HasKnowledgeBase` as the new final constructor argument to the `new SharedGameDto(...)` call (same pattern as Task 4.2).
+
+  **Do NOT** add a filter parameter to the admin query — admin scope stays minimal.
+
+- [ ] **Step 5.2: Build verification**
+
+  ```bash
+  cd apps/api/src/Api
+  dotnet build 2>&1 | tail -10
+  ```
+
+- [ ] **Step 5.3: Commit**
+
+  ```bash
+  git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandler.cs
+  git commit -m "feat(s2): include HasKnowledgeBase in admin GetFilteredSharedGames projection"
+  ```
+
+---
+
+## Task 6 — Public endpoint `hasKb` query param wiring
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogPublicEndpoints.cs`
+
+- [ ] **Step 6.1: Read the endpoint handler signature**
+
+  Read the `HandleSearchGames` (or similar) method in the file — find where `SearchSharedGamesQuery` is constructed.
+
+- [ ] **Step 6.2: Add `hasKb` query parameter to handler**
+
+  Add a new parameter `[FromQuery] bool? hasKb = null` to the endpoint method signature, and pass it as `HasKnowledgeBase: hasKb` to the `SearchSharedGamesQuery` constructor. Preserve parameter order of existing params; add `hasKb` at the end of the method signature.
+
+  Example of the call site change (adapt to actual code):
+  ```csharp
+  var query = new SearchSharedGamesQuery(
+      search,
+      categoryIds?.ToList(),
+      // ... existing params ...
+      HasKnowledgeBase: hasKb);
+  ```
+
+- [ ] **Step 6.3: Update endpoint OpenAPI metadata if present**
+
+  If the endpoint uses `.WithDescription()` or Scalar metadata, append: `"Supports hasKb=true filter for AI-ready games (Issue #S2, epic/library-to-game)."`
+
+- [ ] **Step 6.4: Build verification**
+
+  ```bash
+  cd apps/api/src/Api
+  dotnet build 2>&1 | tail -10
+  ```
+
+- [ ] **Step 6.5: Commit**
+
+  ```bash
+  git add apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogPublicEndpoints.cs
+  git commit -m "feat(s2): expose hasKb filter on GET /api/v1/shared-games"
+  ```
+
+---
+
+## Task 7 — Event handler for async projection updates
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandler.cs`
+
+- [ ] **Step 7.1: Write the handler**
+
+  ```csharp
+  using Api.BoundedContexts.KnowledgeBase.Domain.Events;
+  using Api.Infrastructure;
+  using MediatR;
+  using Microsoft.EntityFrameworkCore;
+
+  namespace Api.BoundedContexts.SharedGameCatalog.Application.EventHandlers;
+
+  /// <summary>
+  /// Listens to VectorDocumentIndexedEvent and maintains the denormalized
+  /// `has_knowledge_base` column on `shared_games`. Bridges the KnowledgeBase
+  /// BC (write source) with SharedGameCatalog BC (read projection).
+  ///
+  /// The cross-BC dependency is limited to:
+  ///   1. Event subscription (standard DDD async projection pattern)
+  ///   2. A single targeted read of `vector_documents` to look up the
+  ///      SharedGameId of the indexed document (the event carries GameId
+  ///      which is the Game aggregate id, not SharedGameId).
+  ///
+  /// Reference: docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md §4.2
+  /// </summary>
+  internal sealed class VectorDocumentIndexedForKbFlagHandler
+      : INotificationHandler<VectorDocumentIndexedEvent>
+  {
+      private readonly MeepleAiDbContext _context;
+      private readonly ILogger<VectorDocumentIndexedForKbFlagHandler> _logger;
+
+      public VectorDocumentIndexedForKbFlagHandler(
+          MeepleAiDbContext context,
+          ILogger<VectorDocumentIndexedForKbFlagHandler> logger)
+      {
+          _context = context ?? throw new ArgumentNullException(nameof(context));
+          _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+      }
+
+      public async Task Handle(VectorDocumentIndexedEvent notification, CancellationToken cancellationToken)
+      {
+          ArgumentNullException.ThrowIfNull(notification);
+
+          // Look up the VectorDocument to resolve SharedGameId.
+          // This is the only cross-BC table read in the handler — the update
+          // below stays within SharedGameCatalog's own tables.
+          var sharedGameId = await _context.VectorDocuments
+              .AsNoTracking()
+              .Where(v => v.Id == notification.DocumentId)
+              .Select(v => v.SharedGameId)
+              .FirstOrDefaultAsync(cancellationToken)
+              .ConfigureAwait(false);
+
+          if (sharedGameId is null || sharedGameId == Guid.Empty)
+          {
+              _logger.LogDebug(
+                  "VectorDocument {DocumentId} has no SharedGameId, skipping KB flag update",
+                  notification.DocumentId);
+              return;
+          }
+
+          // Bulk update bypassing change tracking (perf + avoids loading aggregate).
+          var rowsAffected = await _context.SharedGames
+              .Where(g => g.Id == sharedGameId.Value && !g.HasKnowledgeBase)
+              .ExecuteUpdateAsync(
+                  setters => setters.SetProperty(g => g.HasKnowledgeBase, true),
+                  cancellationToken)
+              .ConfigureAwait(false);
+
+          if (rowsAffected > 0)
+          {
+              _logger.LogInformation(
+                  "Set HasKnowledgeBase=true for SharedGame {SharedGameId} triggered by VectorDocument {DocumentId}",
+                  sharedGameId.Value,
+                  notification.DocumentId);
+          }
+      }
+  }
+  ```
+
+- [ ] **Step 7.2: Verify the handler is picked up by MediatR auto-registration**
+
+  Check `Program.cs` (or `Startup.cs`) to ensure `services.AddMediatR(...)` scans the `SharedGameCatalog` assembly. If yes → no extra registration needed. If no → add the assembly to the scan list.
+
+  ```bash
+  cd D:/Repositories/meepleai-monorepo-backend
+  grep -rn "AddMediatR" apps/api/src/Api --include="*.cs" | head -5
+  ```
+
+- [ ] **Step 7.3: Build verification**
+
+  ```bash
+  cd apps/api/src/Api
+  dotnet build 2>&1 | tail -10
+  ```
+
+- [ ] **Step 7.4: Commit**
+
+  ```bash
+  git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandler.cs
+  git commit -m "feat(s2): add VectorDocumentIndexedForKbFlagHandler event projection"
+  ```
+
+---
+
+## Task 8 — Backend unit tests
+
+**Files:**
+- Create: `tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandlerTests.cs`
+- Create: `tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQuery_KbFilterTests.cs` (if the test file doesn't exist already)
+
+- [ ] **Step 8.1: Find existing test patterns**
+
+  ```bash
+  cd D:/Repositories/meepleai-monorepo-backend
+  ls tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/ 2>&1 | head -5
+  ls tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/ 2>&1 | head -10
+  ```
+
+- [ ] **Step 8.2: Write event handler test**
+
+  Use Testcontainers + an in-memory or real postgres fixture (follow the existing pattern in the neighbor test files). Cover:
+  - Test: VectorDocument with non-null SharedGameId → handler sets `HasKnowledgeBase=true` on the SharedGame
+  - Test: VectorDocument with null SharedGameId → handler skips (no update)
+  - Test: Non-existent DocumentId → handler returns gracefully, no throw
+  - Test: SharedGame already has `HasKnowledgeBase=true` → handler is a no-op (idempotent)
+
+  Follow the existing event handler test conventions — copy-paste the skeleton from `DocumentApprovedForRagEventHandlerTests.cs` if it exists, and adapt.
+
+- [ ] **Step 8.3: Write query handler filter test**
+
+  Cover:
+  - Test: query with `HasKnowledgeBase=null` returns all games
+  - Test: query with `HasKnowledgeBase=true` returns only games with flag set
+  - Test: query with `HasKnowledgeBase=false` returns only games without flag
+  - Test: DTO projection includes `HasKnowledgeBase` field
+
+- [ ] **Step 8.4: Run tests**
+
+  ```bash
+  cd apps/api
+  dotnet test tests/Api.Tests --filter "FullyQualifiedName~VectorDocumentIndexedForKbFlag|FullyQualifiedName~SearchSharedGamesQuery_KbFilter" 2>&1 | tail -20
+  ```
+  Expected: all new tests PASS.
+
+- [ ] **Step 8.5: Commit**
+
+  ```bash
+  git add tests/Api.Tests/BoundedContexts/SharedGameCatalog/
+  git commit -m "test(s2): add tests for KB filter and event handler"
+  ```
+
+---
+
+## Task 9 — Frontend schema + client
+
+**Files:**
+- Modify: `apps/web/src/lib/api/schemas/shared-games.schemas.ts`
+- Modify: `apps/web/src/lib/api/clients/sharedGamesClient.ts`
+
+- [ ] **Step 9.1: Add `hasKnowledgeBase` to `SearchSharedGamesParamsSchema`**
+
+  In `shared-games.schemas.ts`, extend the schema:
+  ```typescript
+  export const SearchSharedGamesParamsSchema = z.object({
+    searchTerm: z.string().optional(),
+    categoryIds: z.string().optional(),
+    mechanicIds: z.string().optional(),
+    minPlayers: z.number().int().positive().optional(),
+    maxPlayers: z.number().int().positive().optional(),
+    maxPlayingTime: z.number().int().positive().optional(),
+    status: GameStatusNumericSchema.optional(),
+    page: z.number().int().positive().optional(),
+    pageSize: z.number().int().positive().optional(),
+    sortBy: z.string().optional(),
+    sortDescending: z.boolean().optional(),
+    hasKnowledgeBase: z.boolean().optional(),  // S2: filter for AI-ready games
+  });
+  ```
+
+- [ ] **Step 9.2: Add `hasKnowledgeBase` to the `SharedGameSchema` response type**
+
+  Find the `SharedGameSchema` Zod definition in the same file and add:
+  ```typescript
+  hasKnowledgeBase: z.boolean().default(false),
+  ```
+
+- [ ] **Step 9.3: Map param to query string in the client**
+
+  In `sharedGamesClient.ts` `search` method, add:
+  ```typescript
+  if (params.hasKnowledgeBase !== undefined) {
+    queryParams.set('hasKb', params.hasKnowledgeBase.toString());
+  }
+  ```
+  Place it next to the other `if (params.xxx !== undefined)` lines. Verify the backend endpoint accepts `hasKb` (matches Task 6).
+
+- [ ] **Step 9.4: Typecheck**
+
+  ```bash
+  cd apps/web
+  pnpm typecheck 2>&1 | tail -5
+  ```
+
+- [ ] **Step 9.5: Commit**
+
+  ```bash
+  git add apps/web/src/lib/api/schemas/shared-games.schemas.ts apps/web/src/lib/api/clients/sharedGamesClient.ts
+  git commit -m "feat(s2): add hasKnowledgeBase to SearchSharedGamesParams schema and client"
+  ```
+
+---
+
+## Task 10 — Frontend filter chip in `PublicLibraryPage`
+
+**Files:**
+- Modify: `apps/web/src/components/library/PublicLibraryPage.tsx`
+
+- [ ] **Step 10.1: Add local state for the KB filter**
+
+  Near the other `useState` calls at the top of the component:
+  ```typescript
+  const [aiReadyOnly, setAiReadyOnly] = useState(false);
+  ```
+
+- [ ] **Step 10.2: Sync the filter with URL param `?hasKb=true`**
+
+  Add a `useEffect` that reads `searchParams.get('hasKb')` on mount and sets `aiReadyOnly` accordingly, and another effect that writes back to the URL when the state changes. Use the existing `useRouter` + `useSearchParams` pattern from the file.
+
+  If the file doesn't already import `useSearchParams`, add it from `next/navigation`.
+
+- [ ] **Step 10.3: Pass the param to `useSharedGames`**
+
+  Find the `useSharedGames(...)` call and add `hasKnowledgeBase: aiReadyOnly || undefined` to the params object. `undefined` avoids sending the param when disabled (matches backend default behavior).
+
+- [ ] **Step 10.4: Render the filter chip UI**
+
+  Near the existing mechanics filter button, add a toggle button:
+  ```tsx
+  <button
+    type="button"
+    onClick={() => setAiReadyOnly(v => !v)}
+    data-testid="catalog-kb-filter"
+    aria-pressed={aiReadyOnly}
+    className={cn(
+      'inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors',
+      aiReadyOnly
+        ? 'border-primary bg-primary text-primary-foreground'
+        : 'border-border bg-background text-muted-foreground hover:bg-muted'
+    )}
+  >
+    <span aria-hidden="true">✨</span>
+    <span>Solo giochi AI-ready</span>
+    {aiReadyOnly && <span aria-hidden="true">✓</span>}
+  </button>
+  ```
+
+- [ ] **Step 10.5: Render the `AI-READY` badge on MeepleCard when `hasKnowledgeBase === true`**
+
+  Find where `MeepleGameCatalogCard` or `MeepleCard` is rendered in `PublicLibraryPage.tsx`. If the card component already accepts a badge or feature flag prop, pass `hasKnowledgeBase` through. If not, defer the badge to a future polishing PR — S2 scope ends at the filter + backend.
+
+  Note: it's acceptable for S2 to ship without the visual badge on individual cards if the card component doesn't have a slot — the filter alone is the core feature.
+
+- [ ] **Step 10.6: Typecheck**
+
+  ```bash
+  cd apps/web
+  pnpm typecheck 2>&1 | tail -5
+  ```
+
+- [ ] **Step 10.7: Commit**
+
+  ```bash
+  git add apps/web/src/components/library/PublicLibraryPage.tsx
+  git commit -m "feat(s2): add AI-ready filter chip and URL sync to PublicLibraryPage"
+  ```
+
+---
+
+## Task 11 — Frontend test
+
+**Files:**
+- Create or modify: existing test file for `PublicLibraryPage` (if any) OR skip if component lacks test coverage and time doesn't permit a full test setup.
+
+- [ ] **Step 11.1: Check existing test coverage**
+
+  ```bash
+  cd apps/web
+  find src/components/library -name "*PublicLibrary*.test.*" 2>&1 | head -5
+  ```
+
+- [ ] **Step 11.2: Add tests if the file exists**
+
+  If a test file for `PublicLibraryPage` exists, add 2 test cases:
+  - Clicking the `[data-testid="catalog-kb-filter"]` button toggles `aria-pressed` and updates the URL with `?hasKb=true`
+  - The `useSharedGames` mock is called with `hasKnowledgeBase: true` after the filter is enabled
+
+  If no test file exists, write a minimal one inheriting the existing test utility setup. Skip if no test utils exist for catalog components (defer to a later PR).
+
+- [ ] **Step 11.3: Run tests**
+
+  ```bash
+  pnpm vitest run src/components/library 2>&1 | tail -15
+  ```
+
+- [ ] **Step 11.4: Commit (only if test file was modified)**
+
+  ```bash
+  git add apps/web/src/components/library/__tests__/
+  git commit -m "test(s2): add tests for AI-ready filter chip"
+  ```
+
+---
+
+## Task 12 — Final validation and PR
+
+- [ ] **Step 12.1: Full backend build + test**
+
+  ```bash
+  cd apps/api
+  dotnet build
+  dotnet test tests/Api.Tests --filter "FullyQualifiedName~SharedGameCatalog" 2>&1 | tail -15
+  ```
+  Expected: backend build OK, SharedGameCatalog tests PASS.
+
+- [ ] **Step 12.2: Full frontend typecheck + lint + test**
+
+  ```bash
+  cd apps/web
+  pnpm typecheck
+  pnpm lint
+  pnpm vitest run src/lib/api src/components/library src/hooks/queries 2>&1 | tail -20
+  ```
+
+- [ ] **Step 12.3: Push feature branch**
+
+  ```bash
+  cd D:/Repositories/meepleai-monorepo-backend
+  git push -u origin feature/s2-kb-filter
+  ```
+
+- [ ] **Step 12.4: Create PR into epic branch**
+
+  Use `gh pr create --base epic/library-to-game --head feature/s2-kb-filter` with a PR body that mentions:
+  - S2 scope (denormalized column + event handler + filter + chip)
+  - Spec correction: extended `SearchSharedGamesQuery`, not `GetFilteredSharedGamesQuery` (spec CR-C1 was wrong about target)
+  - Test results
+
+---
+
+## Rollback plan
+
+The migration is additive (new column + new index). To rollback:
+```bash
+dotnet ef migrations remove  # if not yet applied
+# OR create a reverse migration if already applied in staging
+```
+All frontend changes are additive: a new filter chip + a new optional param. Revert via `git revert <merge-commit>`.
+
+## Known scope decisions
+
+- **Single handler only**: `VectorDocumentIndexedForKbFlagHandler`. No `VectorDocumentDeletedForKbFlagHandler` — the `VectorDocument` delete flow doesn't currently emit a domain event, so we'd need to add one. Deferred to a potential S2b if it becomes a user-visible issue.
+- **Admin query extension**: only the `.Select` projection is updated, not the filter. Admin has other ways to see KB status.
+- **Backfill consistency**: the migration's SQL backfill uses `vector_documents.indexing_status = 'completed'` (not `processing_state`). Verify the column name in `VectorDocumentEntity` before running.
+- **HybridCache**: the new filter is added to the cache key so toggling it produces fresh results.
+
+## Plan self-review (inline — fix as you find)
+
+- [x] Every code step includes a concrete snippet.
+- [x] File paths are absolute-style (relative to repo root).
+- [x] Type consistency: `HasKnowledgeBase: bool` everywhere (C#) / `hasKnowledgeBase: boolean` everywhere (TS).
+- [x] Query target corrected to `SearchSharedGamesQuery` (spec CR-C1 pushback noted).
+- [x] Event handler is the only cross-BC code path, and it does 1 read + 1 write.
+- [x] Backfill SQL is in the migration's Up() so staging deploy is complete.
+- [x] Frontend chip has `data-testid` + `aria-pressed` (a11y) + URL sync.
+- [x] Frontend visual badge is explicitly deferred, not forgotten.

--- a/docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md
+++ b/docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md
@@ -1,0 +1,434 @@
+# Library-to-Game User Journey — Epic Design Spec
+
+**Date:** 2026-04-09
+**Status:** Proposed
+**Type:** Epic (contains 6 sub-feature specs)
+**Scope:** End-to-end user journey from Admin Dashboard to Game Detail Page, covering navbar view toggle, KB-filtered catalog, direct add-to-library flow, new desktop split-view game page, new mobile "hand of cards" game page, and E2E screenshot validation.
+
+**Related specs (context):**
+- `2026-04-07-meeplecard-rewrite-from-mockups` — MeepleCard component library (reused)
+- `2026-04-08-desktop-ux-redesign` — Desktop navigation + Library Hub (sibling, not prerequisite)
+- `admin-mockups/mobile-card-layout-mockup.html` — mobile "cards in hand" reference
+- `.superpowers/brainstorm/39070-1775727380/content/07-real-render.html` — high-fidelity composite render
+
+---
+
+## 1. Context & Goals
+
+### Context
+
+Today an admin who wants to validate the user experience of browsing the shared catalog and adding a game to their library has a fragmented flow:
+
+1. Admin dashboard has a link "Back to app" but no one-click view toggle in the top bar.
+2. The shared catalog (`/library?tab=catalogo`) does not expose whether a game has an indexed Knowledge Base (KB) — users cannot filter "AI-ready" games, so they may add a game without realising the AI agent is not yet available for it.
+3. The MeepleCard `+` quick action (add to library) opens a wizard by default; the user asked for **direct add + auto-navigate** as the primary path, with the wizard available as an opt-in alternative.
+4. The current game detail page at `/library/games/[gameId]` uses a zone-based `GameTableLayout` (knowledge zone, tools zone, sessions zone) which is inconsistent with the new MeepleCard hero language and doesn't match the mental model of "la mia carta del gioco + gli strumenti".
+5. Mobile is especially weak: the current `game-detail-mobile.tsx` uses ad-hoc bottom sheets, not the "carte in mano" pattern shipped elsewhere in the app.
+6. No E2E test validates the full journey on mobile viewports, making regressions invisible.
+
+### Goals
+
+- **Unified user journey:** admin → one-click user view toggle → KB-filtered catalog → direct add via MeepleCard `+` → seamless navigate to a redesigned game detail page (desktop split + mobile card-hand).
+- **Reuse existing infrastructure:** `MeepleCard`, `SplitViewLayout`, `useAddGameToLibrary`, `RequireRole`, existing Playwright config, existing design tokens. **No parallel design system.**
+- **Evidence-based UX validation** via Playwright smoke + a11y tests on Pixel 5, iPhone 13, and desktop-chrome 1920×1080, running in CI and producing screenshot artifacts attached to the epic PR.
+- **Shippable in small increments:** 6 sub-feature PRs, each under ~500 lines of diff, merged in sequence into an epic branch, then one epic PR into `main-dev`.
+
+### Non-goals
+
+- Redesigning `/library` landing page or the shared catalog search UX (out of scope; tracked in `2026-04-08-desktop-ux-redesign`).
+- Changing the backend `UserLibrary` commands/queries — they already work.
+- Adding new tabs or content beyond the 5 agreed: Info, AI Chat, Toolbox, House Rules, Partite.
+- Implementing the `House Rules` or `Toolbox` content itself if it doesn't exist yet — the tab component wraps existing UI or shows a "coming soon" empty state.
+- Visual regression with pixel diff (we use smoke + a11y; screenshots are artifacts, not assertions).
+- Changing the wizard flow for add-to-library — it stays accessible via overflow menu.
+
+---
+
+## 2. Decisions Confirmed During Brainstorming
+
+| # | Question | Decision | Source |
+|---|---|---|---|
+| Q1 | Scope | **Epic + 6 sub-feature specs**, each with its own design doc and plan | user selected option A |
+| Q2 | Tab set on game page | **5 tabs:** `📖 Info` • `🤖 AI Chat` • `🧰 Toolbox` • `🏠 House Rules` • `🎲 Partite` | user selected option B (Completa) |
+| Q3 | Mobile drawer pattern | **"Mano di carte":** hand stack left edge + focused `MeepleCard` center + **drawer from top** with 5 tabs + action bar globale. Reference: `admin-mockups/mobile-card-layout-mockup.html` | user pointed to existing mockup |
+| Q4.1 | Hand stack on game page | **Yes** — keep the 44px vertical strip of mini-cards for cross-game navigation | user confirmed |
+| Q4.2 | Drawer open trigger | **Tap on `📋 Dettagli` button** on the focused MeepleCard — no swipe, no edge gesture (avoid iOS back-swipe conflict) | user confirmed |
+| Q4.3 | Global action bar on game page | **Keep** (Libreria / Home / Chat / Sessioni / Profilo), **auto-hide** in focus mode via scroll reveal | user confirmed |
+| Q4.4 | Tab naming conflict `Sessioni` (tab) vs `Sessioni` (global nav) | **Rename tab to `Partite`** — domain note: 1 `GameSession` (game night) can contain N `MatchInstance` (partite). The tab shows all matches for THIS game across all sessions | user confirmed + domain clarification |
+| Q4 (desktop) | Desktop tabs layout in right panel | **Vertical rail on left edge of right panel** (VSCode sidebar pattern), icon + label, scalable to more than 5 tabs in the future | user selected option B |
+| Q5 | Admin↔User toggle form | **Icon switch** (light/dark toggle style, `👤 / ⚙️`) next to avatar in `UserTopNav`, gated on `isAdminRole()`, 1 click flips `sessionStorage.meepleai_view_mode` and calls `router.push` | user selected option A |
+| Q6 | KB filter in library | **Toggle chip** in `CatalogFilters` bar, label `[✓ Solo giochi AI-ready]`, default OFF | user selected option A |
+| Q7 | MeepleCard `+` add behavior | **Direct add (no wizard)** + 2s toast then navigate. Replacement: if `inLibrary === true` the `+` is hidden and replaced with `→ Vai al gioco`. Error: stay on catalog + toast. Wizard: accessible via overflow `⋯` menu "Aggiungi con opzioni" | user answered |
+| Q8 | E2E validation scope | **Scope 3** (happy path + per-sub-feature tests), **smoke + a11y**, **viewport P** (Pixel 5 + iPhone 13 + desktop 1920), **CI on GitHub Actions** | user answered |
+| Q9 | Implementation order | **1→S1, 2→S2, 3→S4, 4→S5, 5→S3, 6→S6** — each sub-feature is its own PR into the epic branch | user confirmed |
+
+---
+
+## 3. Architecture Overview
+
+### 3.1 User Journey (end-to-end)
+
+```
+[Admin on Admin Dashboard]
+    │  tap view-toggle in topbar (S1)
+    ▼
+sessionStorage.meepleai_view_mode = 'user'
+router.push('/')
+    │
+[User home]
+    │  navigate /library?tab=catalogo
+    ▼
+[Catalogo condiviso]
+    │  tap "Solo giochi AI-ready" chip (S2)
+    ▼
+GET /api/v1/shared-catalog/games?hasKnowledgeBase=true
+    │  list filtered to games with indexed KB
+    │  tap "+" on MeepleCard of "Azul" (S3)
+    ▼
+POST /api/v1/library/games/{azulId}
+optimistic update: inLibrary=true, quota+=1
+    │  success
+    ▼
+Toast "Aggiunto alla libreria" (2s)
+router.push('/library/games/{azulId}')
+    │
+[Game detail page — /library/games/{azulId}]
+    │  desktop (md+)        │  mobile (<md)
+    ▼                       ▼
+<GameDetailDesktop>          <GameDetailMobile>
+  SplitViewLayout              HandStack (left, 44px)
+    MeepleCardHero             FocusedCardArea (focused Azul MeepleCard + card-links)
+    GameTabsPanel              [tap 📋 Dettagli]
+      ├─ rail vertical          ▼
+      ├─ 📖 Info (default)      GameDetailsDrawer (slides from top)
+      ├─ 🤖 AI Chat              ├─ 📖 Info (default)
+      ├─ 🧰 Toolbox              ├─ 🤖 AI Chat
+      ├─ 🏠 House Rules          ├─ 🧰 Toolbox
+      └─ 🎲 Partite              ├─ 🏠 House Rules
+                                 └─ 🎲 Partite
+```
+
+### 3.2 Sub-feature breakdown
+
+| ID | Name | Bounded Context(s) | Size | Dependencies |
+|---|---|---|---|---|
+| **S1** | Admin↔User view toggle in navbar | Authentication (frontend only) | S | — |
+| **S2** | `hasKnowledgeBase` filter on shared catalog | SharedGameCatalog + KnowledgeBase | M | — |
+| **S3** | MeepleCard `+` direct add + auto-navigate | UserLibrary (frontend only) | S | S4 (destination page must exist) |
+| **S4** | Game page desktop — SplitViewLayout + vertical rail + 5 tabs | GameManagement (frontend) | L | — |
+| **S5** | Game page mobile — Hand stack + drawer from top + 5 tabs | GameManagement (frontend) | M | S4 (shares tab components) |
+| **S6** | Playwright E2E: happy path + 5 sub-tests + a11y | Cross-cutting | S | S1–S5 |
+
+Each sub-feature produces:
+- One spec doc in `docs/superpowers/specs/2026-04-09-s{N}-{slug}-design.md`
+- One implementation plan in `docs/superpowers/plans/2026-04-09-s{N}-{slug}.md` (generated by `writing-plans` skill)
+- One feature branch `feature/s{N}-{slug}` → PR → `epic/library-to-game`
+- One GitHub issue (sub-task of the epic issue)
+
+### 3.3 Branch strategy
+
+```
+main-dev
+ │
+ └── epic/library-to-game   (created from main-dev at epic start)
+      │
+      ├── feature/s1-view-toggle           → PR to epic/library-to-game
+      ├── feature/s2-kb-filter             → PR to epic/library-to-game
+      ├── feature/s4-game-desktop          → PR to epic/library-to-game
+      ├── feature/s5-game-mobile           → PR to epic/library-to-game
+      ├── feature/s3-meeplecard-add        → PR to epic/library-to-game
+      └── feature/s6-e2e-validation        → PR to epic/library-to-game
+
+Final: PR epic/library-to-game → main-dev
+```
+
+Each sub-feature branch tracks its parent via `git config branch.<branch>.parent epic/library-to-game`.
+`epic/library-to-game` is rebased weekly on `main-dev` to avoid drift.
+
+---
+
+## 4. Design Decisions Per Sub-Feature
+
+### 4.1 — S1 · Admin↔User view toggle
+
+**Problem:** Admins working on the admin dashboard cannot preview the user experience with one click; they have a "Admin Dashboard" link inside the avatar dropdown menu (from `UserMenuDropdown`) but no quick bidirectional toggle.
+
+**Decision:** Add a `<ViewModeToggle>` icon switch to `UserTopNav` / `AdminTopNav`, next to the avatar. Gated on `isAdminRole(user.role)`. Single tap flips an internal state and navigates to the opposite shell.
+
+**Visual:** 44×26 pill switch, gradient background (purple→orange), white knob with emoji indicator. `👤` on the left side, `⚙️` on the right. Knob slides between the two.
+
+**State:**
+- Source of truth: `sessionStorage.meepleai_view_mode` (`'admin'` | `'user'`)
+- Fallback when sessionStorage unavailable (private browsing): in-memory state + toast "Modalità vista non persistente"
+- Default: `'admin'` if landing on `/admin/*`, `'user'` otherwise
+
+**Routing:**
+- `'admin'` → guard redirects any user route to `/admin/overview`
+- `'user'` → guard redirects any admin route to `/`
+- Guards live in `app/(authenticated)/layout.tsx` and `app/admin/(dashboard)/layout.tsx`
+
+**Accessibility:** `role="switch"`, `aria-checked={viewMode === 'admin'}`, `aria-label="Cambia vista tra admin e utente"`, keyboard-operable.
+
+**Files touched:** ~4 new, ~3 modified. Details in `2026-04-09-s1-view-toggle-design.md`.
+
+### 4.2 — S2 · `hasKnowledgeBase` filter on shared catalog
+
+**Problem:** Users browsing the shared catalog have no way to filter games that have an indexed KB (AI agent ready). Adding a game without KB leads to a disappointing first impression when the user opens the game page and the AI Chat is empty.
+
+**Decision:**
+1. **Backend:** add `HasKnowledgeBase: bool` to `SharedGameDto` (computed), and `hasKnowledgeBase?: bool` optional filter parameter to `GetSharedGamesQuery`.
+2. **Computation strategy (v1):** lazy join on `VectorDocument` count in the query handler. If p95 > 150ms → follow up with S2b: denormalized `HasKnowledgeBase` column on `SharedGameCatalogEntry`, updated via event handler on `VectorDocumentIndexedEvent`.
+3. **Frontend:** add a toggle chip `[✓ Solo giochi AI-ready]` to `CatalogFilters`, default OFF, syncs with URL param `?hasKb=true` so the filter is bookmarkable.
+4. **MeepleCard visual badge:** always show the green `✓ AI-READY` chip on cards that have `hasKnowledgeBase === true`, independently of the filter. This gives passive awareness even without filtering.
+
+**Domain note:** "has KB" = at least 1 `VectorDocument` with `ProcessingState === 'Indexed'` exists for that `SharedGameId`. Private games are out of scope (they're in `PrivateGame` with `GameId = null`).
+
+**Files touched:** ~3 backend, ~3 frontend. Details in `2026-04-09-s2-kb-filter-design.md`.
+
+### 4.3 — S3 · MeepleCard `+` direct add + auto-navigate
+
+**Problem:** The MeepleCard `+` quick action currently opens an optional wizard (`useMeepleCardActions.onAddToLibrary()` can dispatch a modal). The user wants a direct one-tap add + navigate to the game page.
+
+**Decision:**
+1. **Primary path:** tap `+` → call `addToLibrary.mutate({ gameId })` → on success, show toast `"Aggiunto alla libreria"` for 2 seconds → `router.push('/library/games/${gameId}')`.
+2. **Conditional render:** if `useGameInLibraryStatus(gameId).inLibrary === true` → hide `+` and render `→` icon instead with label "Vai al gioco"; tap navigates without add.
+3. **Error handling:**
+   - `422 LibraryQuotaExceeded` → toast error "Libreria piena (X/Y)" with link to upgrade → stay on catalog, rollback optimistic update
+   - `404 Game not found` (race: game deleted from catalog) → toast "Gioco non più disponibile" → refetch catalog → stay
+   - Network down → rollback + toast retry → stay
+4. **Wizard preservation:** the wizard path is kept accessible via a new overflow `⋯` menu action "Aggiungi con opzioni (wizard)" in `QuickActions`. Not the default, but not deleted.
+
+**No backend changes.** `UserLibrary` commands and `useAddGameToLibrary` mutation are already correct.
+
+**Files touched:** ~4 modified frontend (useMeepleCardActions, buildGameNavItems, QuickActions, useLibrary types). Details in `2026-04-09-s3-meeplecard-add-design.md`.
+
+### 4.4 — S4 · Game page desktop (split + vertical rail + 5 tabs)
+
+**Problem:** The current `/library/games/[gameId]/page.tsx` uses a zone-based `GameTableLayout` with `GameTableZoneKnowledge`, `GameTableZoneTools`, `GameTableZoneSessions`. This is inconsistent with the MeepleCard language and doesn't match the mental model "carta del gioco + strumenti".
+
+**Decision:**
+1. **Layout:** reuse the existing `SplitViewLayout.tsx` (resizable, persist `game-split-ratio` in localStorage, range 30–70%, default 50/50). No changes to `SplitViewLayout` itself.
+2. **Left panel:** `<MeepleCardHero entity="game" {...gameData}>` — the real MeepleCard hero variant, full height of the pane. Shows cover, entity badge, rating, KB chip, title, subtitle, meta chips, nav footer with quick actions.
+3. **Right panel:** new component `<GameTabsPanel>` with two sub-areas:
+   - **Vertical rail** (74px wide, left edge): 5 tab items, each with `icon` + uppercase label, rail pattern VSCode-style. Active tab gets a left colored bar + subtle background tint.
+   - **Content area** (scrollable): lazy-loaded tab content.
+4. **Tabs (5, icon + label, in order):**
+   - `📖 INFO` (default active) — game metadata, description, BGG data, KB status, agent status
+   - `🤖 AI CHAT` — wraps existing `GameAgentChatView` component from `/library/games/[gameId]/agent`
+   - `🧰 TOOLBOX` — wraps existing toolbox components, fallback placeholder if game has no toolbox
+   - `🏠 HOUSE RULES` — new simple component showing house rules authored by user for this game; placeholder "coming soon" if feature gated
+   - `🎲 PARTITE` — list of `MatchInstance` played for this `GameId` across all sessions, sortable by date
+5. **Deprecation:** `GameTableLayout`, `GameTableZone*` components are removed. Existing routes `/library/games/[gameId]/agent`, `.../toolkit`, `.../toolbox` remain as direct-navigation aliases but the new tabs cover the same functionality in-page.
+
+**Files touched:** ~2 modified, ~8 new (GameDetailDesktop, GameTabsPanel, 5 tab components, MeepleCardHero wrapper if needed). Details in `2026-04-09-s4-game-desktop-design.md`.
+
+### 4.5 — S5 · Game page mobile (hand stack + drawer from top + 5 tabs)
+
+**Problem:** The current `game-detail-mobile.tsx` is ad-hoc and doesn't match the "carte in mano" pattern that the user has already prototyped in `admin-mockups/mobile-card-layout-mockup.html`.
+
+**Decision:**
+1. **Layout** (reference: `admin-mockups/mobile-card-layout-mockup.html`):
+   - `StatusBar` (24px) + `MobileTopNavbar` (52px) — reuse existing
+   - `SearchBar` (42px) — reuse existing
+   - `<ContentArea>` (flex-1):
+     - `<HandStack>` (44px wide, left edge) — vertical stack of mini-cards (34×48) of other user library games + a "+" placeholder
+     - `<FocusedCardArea>` (flex-1):
+       - `<FocusedMeepleCard>` — the same Azul MeepleCard hero variant, flex-1 vertical, with `📋 Dettagli` button in the action row
+       - `<CardLinksRow>` (40px) — horizontal icons of entities related to this game (Agent, Manual, Partite, overflow)
+   - `<MobileActionBar>` (66px) — global: Libreria / Home / Chat / Sessioni / Profilo. Auto-hides on scroll down, reveals on scroll up.
+2. **Drawer mechanism (S5 core):**
+   - Trigger: tap `📋 Dettagli` button on the focused card (no swipe, no edge gesture)
+   - Animation: slides down from `top: 84px` (below navbar+status), reveals tabs panel
+   - Content: same 5 tab components as S4 (Info, AI Chat, Toolbox, House Rules, Partite) rendered in a mobile layout — horizontal scrollable tab bar at top, content scrollable below
+   - Backdrop: dim the hand stack + focused card + action bar behind (opacity 0.35, blur 1px)
+   - Close: tap backdrop, tap `✕` in navbar (replaces 🔔), swipe drawer up, or ESC key
+3. **State management:** new Zustand store `game-detail-mobile-store.ts`:
+   ```ts
+   interface GameDetailMobileState {
+     drawerOpen: boolean
+     activeTab: 'info' | 'aiChat' | 'toolbox' | 'houseRules' | 'partite'
+     focusedGameId: string
+     handGameIds: string[]  // max 12
+     openDrawer: (tab?: DrawerTab) => void
+     closeDrawer: () => void
+     switchTab: (tab: DrawerTab) => void
+     focusGame: (gameId: string) => void
+   }
+   ```
+4. **Hand stack population:** fetch user library (`useLibrary`), render as a **virtualized vertical list**. Show the first ~12 mini-cards without scrolling (sized to device height); remaining cards accessible via vertical scroll inside the 44px strip. Always exclude the currently focused game. Always append a `+` mini-card at the end linking to `/library?tab=catalogo`.
+5. **Empty states:**
+   - Hand stack empty (user has only 1 game in library) → show `+ Aggiungi giochi` placeholder
+   - Card links empty (no related entities) → hide the row
+
+**Files touched:** ~7 new (game-detail-mobile.tsx rewrite, HandStack, FocusedCardArea, GameDetailsDrawer, store, 5 mobile tab wrappers reusing S4 tab components), ~1 modified (MobileActionBar auto-hide). Details in `2026-04-09-s5-game-mobile-design.md`.
+
+### 4.6 — S6 · Playwright E2E happy path + sub-tests + a11y
+
+**Problem:** No end-to-end validation of the library-to-game user journey exists today, especially on mobile viewports.
+
+**Decision:**
+1. **Happy path test** `e2e/flows/library-to-game-happy-path.spec.ts`:
+   - Runs on 3 projects: `mobile-chrome` (Pixel 5), `mobile-safari` (iPhone 13), `desktop-chrome` (1920×1080)
+   - Steps:
+     1. Login as admin fixture
+     2. Navigate to `/admin/overview`, screenshot → `01-admin-dashboard.png`
+     3. Tap `role="switch"` view toggle (S1) → assert URL changes away from `/admin/*`, screenshot → `02-user-home.png`
+     4. Navigate to `/library?tab=catalogo`, screenshot → `03-catalog.png`
+     5. Tap the "Solo giochi AI-ready" chip (S2) → assert URL contains `hasKb=true`, screenshot → `04-catalog-filtered.png`
+     6. Run Axe a11y scan → assert 0 serious/critical violations
+     7. Tap `+` on first MeepleCard (S3) → assert toast visible, screenshot → `05-add-toast.png`
+     8. Wait for navigation to `/library/games/{id}`, screenshot → `06-game-page.png`
+     9. If mobile: assert `[data-hand-stack]` visible, tap `📋 Dettagli`, assert drawer `role="dialog"` visible, screenshot → `07-mobile-drawer.png`
+     10. If desktop: assert `role="tablist"` visible, screenshot → `07-desktop-split.png`
+     11. Run final Axe scan
+
+2. **Per-sub-feature tests** `e2e/sub-features/s{N}-*.spec.ts`:
+   - `s1-admin-toggle.spec.ts` — focus on toggle behavior, sessionStorage persistence, private browsing fallback
+   - `s2-kb-filter.spec.ts` — filter toggle, URL sync, empty state when no AI-ready games
+   - `s3-meeplecard-add.spec.ts` — direct add, toast, navigate, error (quota), already-in-library state, wizard via overflow
+   - `s4-game-desktop.spec.ts` — split layout, rail tab switching, lazy load tab content
+   - `s5-game-mobile.spec.ts` — hand stack interactions, drawer open/close/swipe, tab switching inside drawer
+
+3. **A11y test** `e2e/sub-features/library-to-game-a11y.spec.ts` — dedicated axe scan on each significant state (catalog, catalog filtered, game page desktop, game page mobile closed, game page mobile drawer open).
+
+4. **CI integration:** new workflow `.github/workflows/e2e-library-to-game.yml` runs on PR to `epic/library-to-game`, uploads screenshots + Playwright HTML report as artifacts.
+
+**Files touched:** ~8 new (1 happy path + 5 sub-tests + 1 a11y + 1 workflow), 0 modified. Details in `2026-04-09-s6-e2e-validation-design.md`.
+
+---
+
+## 5. Error Handling & Edge Cases (Epic-Wide)
+
+| # | Case | Sub | Handling |
+|---|---|---|---|
+| 1 | sessionStorage unavailable (private browsing) | S1 | Fallback to in-memory state; toast info "Modalità vista non persistente" |
+| 2 | KB filter query fallback if handler fails | S2 | Catch → return unfiltered + banner "Filtro KB temporaneamente non disponibile" |
+| 3 | KB join performance > 150ms p95 | S2 | Promoted to S2b: denormalized column via event handler |
+| 4 | Quota exceeded on add | S3 | 422 → toast "Libreria piena (X/Y)" → upgrade link → stay on catalog |
+| 5 | Game deleted between fetch and tap | S3 | 404 → toast "Gioco non più disponibile" → refetch catalog |
+| 6 | Network down during add | S3 | Optimistic rollback + toast retry |
+| 7 | Tab content component missing (e.g., House Rules not implemented) | S4, S5 | Placeholder "In arrivo" with feature flag |
+| 8 | Hand stack empty (user has only the current game in library) | S5 | Render only the `+ Aggiungi giochi` placeholder, linking to catalog |
+| 9 | Drawer swipe vs iOS back-swipe edge conflict | S5 | Tap-only on `📋 Dettagli` button, no edge swipe |
+| 10 | Deep link `/library/games/{id}` without login | Cross | Existing `RequireRole` redirect to login with `?returnTo=...` |
+| 11 | Private vs shared game on game page | S4, S5 | Both supported; S3 add-to-library only applies to `SharedGameId` |
+| 12 | Cache invalidation post-add | S3 | Invalidate `['library-list']`, `['library-status', id]`, `['library-quota']`, `['shared-catalog', ...]` (already in `useAddGameToLibrary`) |
+| 13 | i18n | All | All new strings in `messages/it.json` + `messages/en.json` |
+| 14 | Screenshot baseline missing on first CI run | S6 | Generate baseline + `test.skip` with warning the first time |
+
+---
+
+## 6. Performance Budgets
+
+| Metric | Target | Responsible sub | Strategy |
+|---|---|---|---|
+| Catalog query with KB filter (p95) | < 150ms | S2 | Lazy join v1, denormalized column v2 if needed |
+| Add-to-library + toast + navigate (time to first pixel on game page) | < 800ms from tap | S3 | Optimistic update + prefetch game detail on hover |
+| Desktop game page LCP | < 1.5s | S4 | Lazy-load non-default tab content |
+| Mobile hand stack initial render | < 300ms | S5 | Virtualized list (react-virtual or equivalent); ~12 items visible above the fold |
+| E2E full suite runtime in CI | < 8min | S6 | 3 Playwright workers in parallel |
+| Axe a11y violations (serious + critical) | 0 | S1-S5 | Per-component ARIA on PR review |
+
+---
+
+## 7. Testing Strategy
+
+### Per sub-feature
+
+| Sub | Unit (Vitest/xUnit) | Integration | E2E (Playwright) | Coverage target |
+|---|---|---|---|---|
+| S1 | `useViewMode` state machine, `ViewModeToggle` render | n/a | Click → redirect → sessionStorage | FE ≥ 85% |
+| S2 | xUnit: `GetSharedGamesQueryHandler` with/without filter. Vitest: chip state, URL sync | xUnit Testcontainers: seed 2 AI-ready + 2 not → verify filter | Toggle chip → list reloads | BE ≥ 90% / FE ≥ 85% |
+| S3 | Vitest: `buildGameNavItems` conditional, `useMeepleCardActions` branching | React Query + MSW | Tap `+` → toast → navigate | FE ≥ 85% |
+| S4 | Vitest: `GameDetailDesktop` snapshot, `GameTabsPanel` tab switching, each tab component | n/a | Visit page → split + rail + 5 tabs | FE ≥ 85% |
+| S5 | Vitest: `HandStack`, `FocusedCardArea`, `GameDetailsDrawer`, mobile store | n/a | Visit page → drawer open/close, tab switch | FE ≥ 85% |
+| S6 | n/a (is the testing scaffolding) | n/a | All above + a11y | n/a |
+
+### Happy path E2E pseudocode
+
+See Section 4.6 for full test skeleton. Screenshots produced: 7 per viewport × 3 viewports = 21 PNG artifacts per CI run.
+
+---
+
+## 8. Definition of Done
+
+### Epic DoD (required to merge `epic/library-to-game` → `main-dev`)
+
+- [ ] All 6 sub-feature PRs merged into `epic/library-to-game`
+- [ ] Happy path E2E test green on Pixel 5 + iPhone 13 + desktop 1920 in CI
+- [ ] Backend coverage ≥ 90%, frontend coverage ≥ 85% on new files
+- [ ] Axe a11y: 0 serious or critical violations at each happy path step
+- [ ] Performance budgets respected (Section 6)
+- [ ] Epic branch rebased on `main-dev` (no merge conflicts)
+- [ ] Epic PR reviewed and approved
+- [ ] Screenshot artifacts attached to the epic PR as evidence
+- [ ] Documentation: `docs/frontend/game-page-layout.md` created with reference to high-fidelity mockup `.superpowers/brainstorm/39070-1775727380/content/07-real-render.html` + implementation notes
+- [ ] Memory entry added to `.claude/projects/.../memory/` for this journey
+
+### Sub-feature DoD template
+
+- [ ] Design doc in `docs/superpowers/specs/2026-04-09-s{N}-{slug}-design.md` committed
+- [ ] Implementation plan in `docs/superpowers/plans/2026-04-09-s{N}-{slug}.md` via `writing-plans` skill committed
+- [ ] Code implemented following the plan
+- [ ] Unit + integration tests pass locally
+- [ ] Coverage target met on new files
+- [ ] PR to `epic/library-to-game` with description, screenshots, link to plan
+- [ ] Code review approved
+- [ ] CI green (build, test, typecheck, lint)
+- [ ] Squash merge into epic branch
+- [ ] Linked GitHub issue closed
+
+---
+
+## 9. Risks & Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| S2 denormalization adds migration + event handler complexity | Med | Start with lazy join v1; promote to S2b only if p95 > 150ms |
+| S4/S5 tab content missing for Toolbox / House Rules / Partite | High | Each tab is a thin wrapper; placeholder "In arrivo" under feature flag if underlying component missing |
+| Hand stack fetches all user games → slow if user has 100+ | Med | Virtualized list + `useLibrary` React Query cache |
+| Playwright pixel-diff flaky on font/shadow rendering | Low | No pixel-diff; only smoke + a11y. Screenshots are artifacts not assertions |
+| Epic branch drifts from `main-dev` during 6 sequential PRs | Med | Weekly rebase of `epic/library-to-game` on `main-dev` |
+| Mobile iOS back-swipe gesture conflicts with drawer open | Med | Tap-only drawer trigger (no swipe from edge) |
+| ViewModeToggle accidentally leaks admin context | High | Guards in both shell layouts, sessionStorage cleared on logout, role check is authoritative not toggle state |
+
+---
+
+## 10. Appendix — Visual Reference
+
+**High-fidelity composite mockup** (approved by user):
+- File: `.superpowers/brainstorm/39070-1775727380/content/07-real-render.html`
+- Shows: Desktop split view + 2 mobile states (card focus + drawer open)
+- Uses real design tokens from `apps/web/src/styles/design-tokens.css`
+- Fonts: Quicksand 400-700, Nunito 400-800
+- Colors: warm shadows, entity HSL `game: 25 95% 45%`
+
+**Reference mockups** (already in repo):
+- `admin-mockups/mobile-card-layout-mockup.html` — "carte in mano" mobile reference
+- `admin-mockups/meeple-card-real-app-render.html` — MeepleCard variants reference
+- `admin-mockups/meeple-card-visual-test.html` — MeepleCard feature showcase
+
+**Brainstorming session artifacts** (persisted in `.superpowers/brainstorm/39070-1775727380/content/`):
+- `01-user-journey.html` — user flow + scope table
+- `02-tabs-config.html` — tab config options (Q2)
+- `03-mobile-drawer.html` — drawer pattern options (Q3)
+- `04-drawer-pattern-confirmed.html` — "carte in mano" adaptation
+- `05-desktop-split.html` — desktop split options (Q4)
+- `07-real-render.html` — final composite render
+
+---
+
+## 11. Next Steps (post approval)
+
+1. User approves this spec.
+2. `writing-plans` skill generates `docs/superpowers/plans/2026-04-09-s1-view-toggle.md` (first sub-feature plan).
+3. Create `epic/library-to-game` branch from `main-dev`.
+4. Implement S1, PR, merge into epic.
+5. Generate next sub-feature plan (S2). Repeat for S2→S4→S5→S3→S6.
+6. Epic PR `epic/library-to-game` → `main-dev`.
+
+---
+
+**Author:** Claude (brainstorming session 2026-04-09)
+**Reviewer:** user (pending)
+**License:** Proprietary

--- a/docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md
+++ b/docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md
@@ -60,7 +60,13 @@ Today an admin who wants to validate the user experience of browsing the shared 
 | Q6 | KB filter in library | **Toggle chip** in `CatalogFilters` bar, label `[✓ Solo giochi AI-ready]`, default OFF | user selected option A |
 | Q7 | MeepleCard `+` add behavior | **Direct add (no wizard)** + 2s toast then navigate. Replacement: if `inLibrary === true` the `+` is hidden and replaced with `→ Vai al gioco`. Error: stay on catalog + toast. Wizard: accessible via overflow `⋯` menu "Aggiungi con opzioni" | user answered |
 | Q8 | E2E validation scope | **Scope 3** (happy path + per-sub-feature tests), **smoke + a11y**, **viewport P** (Pixel 5 + iPhone 13 + desktop 1920), **CI on GitHub Actions** | user answered |
-| Q9 | Implementation order | **1→S1, 2→S2, 3→S4, 4→S5, 5→S3, 6→S6** — each sub-feature is its own PR into the epic branch | user confirmed |
+| Q9 | Implementation order | **1→S1, 2→S6a (scaffold), 3→S2, 4→S4, 5→S5, 6→S3, 7→S6b (complete)** — each sub-feature is its own PR into the epic branch. S6 split after code review to land E2E test scaffolding early rather than all at the end | user confirmed + code review I5 |
+| CR-C1 | Backend query handler to extend for KB filter | **`GetFilteredSharedGamesQuery`** (only) — `GetAllSharedGamesQuery` and `SearchSharedGamesQuery` untouched | code review C1 |
+| CR-C2 | Canonical `SplitViewLayout` (3 exist) | **`apps/web/src/components/layout/SplitViewLayout/SplitViewLayout.tsx`** — other two deprecated in a follow-up cleanup PR, not in S4 scope | code review C2 |
+| CR-C5 | S1 view mode storage (SSR concern) | **Cookie `meepleai_view_mode`** (not sessionStorage) — read server-side via `cookies()` from `next/headers`, consistent with existing `meepleai_user_role` cookie pattern | code review C5 |
+| CR-C6 | S2 KB presence computation | **Denormalized column + event handler on `VectorDocumentIndexedEvent`** (not lazy cross-BC join) — DDD-clean, deterministic perf | code review C6 |
+| CR-I4 | Old `/library/games/[id]/agent` + `.../toolbox` routes | **Server-side `redirect(307)` to new tab with `?tab=` query param** — keeps bookmarks working, avoids dead URLs. `.../toolkit` stays standalone (different feature) | code review I4 |
+| CR-I8 | User lands on game page without the game in library | **Hybrid empty state:** MeepleCard shows `+ Aggiungi` CTA, Info + AI Chat tabs accessible, Toolbox/House Rules/Partite locked with "aggiungi per accedere" placeholder | code review I8 |
 
 ---
 
@@ -112,12 +118,13 @@ router.push('/library/games/{azulId}')
 
 | ID | Name | Bounded Context(s) | Size | Dependencies |
 |---|---|---|---|---|
-| **S1** | Admin↔User view toggle in navbar | Authentication (frontend only) | S | — |
-| **S2** | `hasKnowledgeBase` filter on shared catalog | SharedGameCatalog + KnowledgeBase | M | — |
+| **S1** | Admin↔User view toggle in navbar | Authentication (frontend only, cookie-based) | S | — |
+| **S6a** | Playwright E2E scaffold + happy-path skeleton | Cross-cutting | S | S1 |
+| **S2** | `hasKnowledgeBase` denormalized column + event handler + frontend filter | SharedGameCatalog (+ consumes `KnowledgeBase` events) | L | — |
+| **S4** | Game page desktop — `SplitViewLayout` + vertical rail + 5 tabs + shared tab contract + new Partite query | GameManagement (FE + BE) | L | §4.4.1 contract (lives in S4) |
+| **S5** | Game page mobile — Hand stack + drawer from top + 5 tabs (reuses S4 tab components via shared contract) | GameManagement (frontend) | M | S4 (shares tab components) |
 | **S3** | MeepleCard `+` direct add + auto-navigate | UserLibrary (frontend only) | S | S4 (destination page must exist) |
-| **S4** | Game page desktop — SplitViewLayout + vertical rail + 5 tabs | GameManagement (frontend) | L | — |
-| **S5** | Game page mobile — Hand stack + drawer from top + 5 tabs | GameManagement (frontend) | M | S4 (shares tab components) |
-| **S6** | Playwright E2E: happy path + 5 sub-tests + a11y | Cross-cutting | S | S1–S5 |
+| **S6b** | Playwright per-sub-feature tests + a11y scans completion | Cross-cutting | S | S1–S5 |
 
 Each sub-feature produces:
 - One spec doc in `docs/superpowers/specs/2026-04-09-s{N}-{slug}-design.md`
@@ -132,18 +139,22 @@ main-dev
  │
  └── epic/library-to-game   (created from main-dev at epic start)
       │
-      ├── feature/s1-view-toggle           → PR to epic/library-to-game
-      ├── feature/s2-kb-filter             → PR to epic/library-to-game
-      ├── feature/s4-game-desktop          → PR to epic/library-to-game
-      ├── feature/s5-game-mobile           → PR to epic/library-to-game
-      ├── feature/s3-meeplecard-add        → PR to epic/library-to-game
-      └── feature/s6-e2e-validation        → PR to epic/library-to-game
+      ├── feature/s1-view-toggle           → PR to epic/library-to-game  (1st)
+      ├── feature/s6a-e2e-scaffold         → PR to epic/library-to-game  (2nd, after S1)
+      ├── feature/s2-kb-filter             → PR to epic/library-to-game  (3rd)
+      ├── feature/s4-game-desktop          → PR to epic/library-to-game  (4th)
+      ├── feature/s5-game-mobile           → PR to epic/library-to-game  (5th)
+      ├── feature/s3-meeplecard-add        → PR to epic/library-to-game  (6th)
+      └── feature/s6b-e2e-complete         → PR to epic/library-to-game  (7th, final)
 
 Final: PR epic/library-to-game → main-dev
 ```
 
+**Base branch rationale:** the epic branches from `main-dev` (not `frontend-dev`) because S2 and the S4 Partite query are genuine backend changes (new migration, new event handler, new query handler, new endpoint) and `main-dev` is the integration branch for mixed backend+frontend work. Pure frontend sub-features (S1, S3, S5, S6) still flow through the epic branch, then `main-dev`.
+
 Each sub-feature branch tracks its parent via `git config branch.<branch>.parent epic/library-to-game`.
-`epic/library-to-game` is rebased weekly on `main-dev` to avoid drift.
+The epic branch itself is configured via `git config branch.epic/library-to-game.parent main-dev` so `gh pr create` auto-targets `main-dev` on the final epic PR.
+`epic/library-to-game` is rebased on `main-dev` **before starting each new sub-feature** (not calendar-weekly) to minimize drift risk.
 
 ---
 
@@ -153,19 +164,22 @@ Each sub-feature branch tracks its parent via `git config branch.<branch>.parent
 
 **Problem:** Admins working on the admin dashboard cannot preview the user experience with one click; they have a "Admin Dashboard" link inside the avatar dropdown menu (from `UserMenuDropdown`) but no quick bidirectional toggle.
 
-**Decision:** Add a `<ViewModeToggle>` icon switch to `UserTopNav` / `AdminTopNav`, next to the avatar. Gated on `isAdminRole(user.role)`. Single tap flips an internal state and navigates to the opposite shell.
+**Decision:** Add a `<ViewModeToggle>` icon switch to `UserTopNav` / `AdminTopNav`, next to the avatar. Gated on `isAdminRole(user.role)`. Single tap writes a cookie and navigates to the opposite shell.
 
 **Visual:** 44×26 pill switch, gradient background (purple→orange), white knob with emoji indicator. `👤` on the left side, `⚙️` on the right. Knob slides between the two.
 
-**State:**
-- Source of truth: `sessionStorage.meepleai_view_mode` (`'admin'` | `'user'`)
-- Fallback when sessionStorage unavailable (private browsing): in-memory state + toast "Modalità vista non persistente"
-- Default: `'admin'` if landing on `/admin/*`, `'user'` otherwise
+**State — cookie-based (SSR-consistent):**
+- Source of truth: **cookie `meepleai_view_mode`** (`'admin'` | `'user'`), `HttpOnly=false` (must be readable from client toggle), `SameSite=Lax`, `Secure` in prod, session-scoped (no `Max-Age`)
+- Rationale for cookie over sessionStorage: Next.js 16 App Router layouts are Server Components by default and cannot read sessionStorage. A cookie is readable server-side via `cookies()` from `next/headers`, so the correct shell renders on first paint (no FOUC-redirect). This matches the existing `meepleai_user_role` cookie pattern already used by `proxy.ts` / middleware
+- Default: if no cookie present, infer from URL (`/admin/*` → `'admin'`, else `'user'`). Admin role users landing on `/` without a cookie default to `'user'`
+- Toggle action: client-side, writes the cookie via `document.cookie` + calls `router.push` (no API round-trip needed)
+- Logout: existing logout handler already clears auth cookies; extend to also clear `meepleai_view_mode`
 
 **Routing:**
-- `'admin'` → guard redirects any user route to `/admin/overview`
-- `'user'` → guard redirects any admin route to `/`
-- Guards live in `app/(authenticated)/layout.tsx` and `app/admin/(dashboard)/layout.tsx`
+- `'admin'` view + user route → redirect to `/admin/overview` (guard in `app/admin/(dashboard)/layout.tsx` reads cookie via `cookies()`)
+- `'user'` view + admin route → redirect to `/` (guard in `app/(authenticated)/layout.tsx`)
+- Guards run **server-side** — no client flash on initial render
+- Role check is **authoritative** over toggle state: if `!isAdminRole(user.role)`, `'admin'` view mode is ignored and treated as `'user'`
 
 **Accessibility:** `role="switch"`, `aria-checked={viewMode === 'admin'}`, `aria-label="Cambia vista tra admin e utente"`, keyboard-operable.
 
@@ -175,19 +189,34 @@ Each sub-feature branch tracks its parent via `git config branch.<branch>.parent
 
 **Problem:** Users browsing the shared catalog have no way to filter games that have an indexed KB (AI agent ready). Adding a game without KB leads to a disappointing first impression when the user opens the game page and the AI Chat is empty.
 
-**Decision:**
-1. **Backend:** add `HasKnowledgeBase: bool` to `SharedGameDto` (computed), and `hasKnowledgeBase?: bool` optional filter parameter to `GetSharedGamesQuery`.
-2. **Computation strategy (v1):** lazy join on `VectorDocument` count in the query handler. If p95 > 150ms → follow up with S2b: denormalized `HasKnowledgeBase` column on `SharedGameCatalogEntry`, updated via event handler on `VectorDocumentIndexedEvent`.
-3. **Frontend:** add a toggle chip `[✓ Solo giochi AI-ready]` to `CatalogFilters`, default OFF, syncs with URL param `?hasKb=true` so the filter is bookmarkable.
-4. **MeepleCard visual badge:** always show the green `✓ AI-READY` chip on cards that have `hasKnowledgeBase === true`, independently of the filter. This gives passive awareness even without filtering.
+**Decision — denormalized column via event handler (v1, DDD-clean):**
+1. **Backend — domain model change:** add a new column `HasKnowledgeBase: bool` (default `false`) to `SharedGameCatalogEntryEntity` + new migration. The column is owned by the `SharedGameCatalog` bounded context (no cross-BC join at query time).
+2. **Backend — projection maintenance:** a new event handler `VectorDocumentIndexedEventHandler` (in `SharedGameCatalog.Application.EventHandlers`) listens to `VectorDocumentIndexedEvent` (already emitted by `KnowledgeBase` BC). On event:
+   - If `event.SharedGameId != null` and the `SharedGameCatalogEntry.HasKnowledgeBase == false` → set `HasKnowledgeBase = true` and persist
+   - A companion handler on `VectorDocumentDeletedEvent` recomputes: if last indexed document removed → `HasKnowledgeBase = false`
+3. **Backend — query handler:** extend **`GetFilteredSharedGamesQuery`** (existing, at `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandler.cs`) with a new optional parameter `HasKnowledgeBase: bool?`. When set → add `.Where(e => e.HasKnowledgeBase == value.Value)` to the EF query. **Do NOT modify** `GetAllSharedGamesQuery` or `SearchSharedGamesQuery`; the filter is available on the Filtered handler only. Validator (`GetFilteredSharedGamesQueryValidator.cs`) gets no change (bool has no invalid values).
+4. **Backend — DTO:** add `HasKnowledgeBase: bool` to `SharedGameDto`, populated from the column (no computation).
+5. **Backend — backfill:** one-time migration script or EF seed that populates `HasKnowledgeBase` for existing indexed documents. Skippable in dev (starts empty), mandatory for staging/prod deploy.
+6. **Frontend:** toggle chip `[✓ Solo giochi AI-ready]` in `CatalogFilters`, default OFF, syncs with URL param `?hasKb=true` (bookmarkable).
+7. **MeepleCard visual badge:** always render the green `✓ AI-READY` chip on cards where `hasKnowledgeBase === true`, independent of the filter. Passive awareness even without filtering.
 
-**Domain note:** "has KB" = at least 1 `VectorDocument` with `ProcessingState === 'Indexed'` exists for that `SharedGameId`. Private games are out of scope (they're in `PrivateGame` with `GameId = null`).
+**Why denormalized column v1 (not lazy join):**
+- **DDD isolation:** `SharedGameCatalog` handlers don't read from `KnowledgeBase` tables. Correct bounded-context separation per CLAUDE.md rules.
+- **Performance deterministic:** single-table `WHERE` on a bool column, no join cost. p95 budget (150ms) easily met without a denorm v2 promotion path.
+- **Eventual consistency acceptable:** a newly indexed game takes ~milliseconds to propagate through the event handler. Users won't notice the gap.
+- **Testable in isolation:** unit test the event handler with a mock repo, integration test the query with a seeded column — no cross-context joins to reason about.
 
-**Files touched:** ~3 backend, ~3 frontend. Details in `2026-04-09-s2-kb-filter-design.md`.
+**Domain note:** "has KB" = at least 1 `VectorDocument` with `ProcessingState === 'Indexed'` exists for that `SharedGameId`. Soft-deleted documents do not count. Private games are out of scope (`GameId = null` entries stay untouched).
+
+**Files touched:** ~6 backend (migration, entity, event handler, command for backfill, query handler, DTO), ~3 frontend. Details in `2026-04-09-s2-kb-filter-design.md`.
 
 ### 4.3 — S3 · MeepleCard `+` direct add + auto-navigate
 
 **Problem:** The MeepleCard `+` quick action currently opens an optional wizard (`useMeepleCardActions.onAddToLibrary()` can dispatch a modal). The user wants a direct one-tap add + navigate to the game page.
+
+**Existing infrastructure (verified in codebase):**
+- The mutation hook `useAddGameToLibrary` is exported from `apps/web/src/hooks/queries/useLibrary.ts` (line 164): `export function useAddGameToLibrary(): UseMutationResult<...>`. It already performs optimistic update, cache sync, quota invalidation, and rollback-on-error. **No backend or hook changes needed for S3.**
+- The orchestration hook `useMeepleCardActions.ts` currently wires `addToLibrary.mutate({ gameId })` with an optional wizard intercept. S3 refactors the default path to skip the wizard.
 
 **Decision:**
 1. **Primary path:** tap `+` → call `addToLibrary.mutate({ gameId })` → on success, show toast `"Aggiunto alla libreria"` for 2 seconds → `router.push('/library/games/${gameId}')`.
@@ -206,21 +235,66 @@ Each sub-feature branch tracks its parent via `git config branch.<branch>.parent
 
 **Problem:** The current `/library/games/[gameId]/page.tsx` uses a zone-based `GameTableLayout` with `GameTableZoneKnowledge`, `GameTableZoneTools`, `GameTableZoneSessions`. This is inconsistent with the MeepleCard language and doesn't match the mental model "carta del gioco + strumenti".
 
+**Canonical `SplitViewLayout` location:**
+Three `SplitViewLayout.tsx` files exist in the repo today:
+- `apps/web/src/components/agent/layout/SplitViewLayout.tsx` — used by agent chat view
+- `apps/web/src/components/game-detail/SplitViewLayout.tsx` — older, used by current `GameTableLayout`
+- `apps/web/src/components/layout/SplitViewLayout/SplitViewLayout.tsx` + `index.ts` — **canonical choice** (dedicated folder, indexed export, most structured)
+
+**S4 uses `components/layout/SplitViewLayout/SplitViewLayout.tsx`.** The other two are marked as "deprecated — consolidate post-epic" and are out of S4 scope (they belong to a follow-up cleanup PR tracked in a separate issue). S4 does NOT delete them to avoid scope creep; it just picks the canonical one for the new `GameDetailDesktop` component.
+
 **Decision:**
-1. **Layout:** reuse the existing `SplitViewLayout.tsx` (resizable, persist `game-split-ratio` in localStorage, range 30–70%, default 50/50). No changes to `SplitViewLayout` itself.
-2. **Left panel:** `<MeepleCardHero entity="game" {...gameData}>` — the real MeepleCard hero variant, full height of the pane. Shows cover, entity badge, rating, KB chip, title, subtitle, meta chips, nav footer with quick actions.
+1. **Layout:** use `components/layout/SplitViewLayout` (resizable, persist `meeple:game-page:split-ratio` in localStorage, range 30–70%, default 50/50). No changes to the component itself.
+2. **Left panel:** `<MeepleCard variant="hero" entity="game" {...gameData}>` — the `hero` variant exists in the MeepleCard component library per CLAUDE.md (`grid | list | compact | featured | hero`). No wrapper needed. Shows cover, entity badge, rating, KB chip, title, subtitle, meta chips, nav footer with quick actions.
 3. **Right panel:** new component `<GameTabsPanel>` with two sub-areas:
    - **Vertical rail** (74px wide, left edge): 5 tab items, each with `icon` + uppercase label, rail pattern VSCode-style. Active tab gets a left colored bar + subtle background tint.
    - **Content area** (scrollable): lazy-loaded tab content.
-4. **Tabs (5, icon + label, in order):**
+4. **URL tab state:** active tab synced with `?tab=info|aiChat|toolbox|houseRules|partite` query param. Enables deep-linking and preserves tab state across navigation. Default: `?tab=info` if no param.
+5. **Tabs (5, icon + label, in order):**
    - `📖 INFO` (default active) — game metadata, description, BGG data, KB status, agent status
    - `🤖 AI CHAT` — wraps existing `GameAgentChatView` component from `/library/games/[gameId]/agent`
    - `🧰 TOOLBOX` — wraps existing toolbox components, fallback placeholder if game has no toolbox
-   - `🏠 HOUSE RULES` — new simple component showing house rules authored by user for this game; placeholder "coming soon" if feature gated
-   - `🎲 PARTITE` — list of `MatchInstance` played for this `GameId` across all sessions, sortable by date
-5. **Deprecation:** `GameTableLayout`, `GameTableZone*` components are removed. Existing routes `/library/games/[gameId]/agent`, `.../toolkit`, `.../toolbox` remain as direct-navigation aliases but the new tabs cover the same functionality in-page.
+   - `🏠 HOUSE RULES` — new simple component showing house rules authored by user for this game; placeholder "In arrivo" if feature flag off
+   - `🎲 PARTITE` — list of `PlayRecord` (entity at `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PlayRecord.cs`) played for this `GameId`, sortable by date
+6. **Deprecation of zone components:** `GameTableLayout`, `GameTableZoneKnowledge`, `GameTableZoneTools`, `GameTableZoneSessions` are removed.
+7. **Old route redirects:** existing routes `/library/games/[gameId]/agent`, `.../toolkit`, `.../toolbox` are converted to **server-side `redirect(307)`** via `export const metadata` / `redirect()` in their `page.tsx`, pointing to the corresponding new tab with the query param:
+   - `/library/games/[gameId]/agent` → `redirect('/library/games/[gameId]?tab=aiChat')`
+   - `/library/games/[gameId]/toolbox` → `redirect('/library/games/[gameId]?tab=toolbox')`
+   - `/library/games/[gameId]/toolkit` and `/library/games/[gameId]/toolkit/[sessionId]` → **out of scope** (toolkit is a different feature with its own routing, stays standalone)
+8. **Backend requirement for Partite tab:** S4 requires a NEW query `GetPlayRecordsByGameQuery` in `GameManagement.Application.Queries.PlayRecords`. Existing queries (`GetPlayRecordQuery`, `GetUserPlayHistoryQuery`, `GetPlayerStatisticsQuery`) do not cover "all play records for a specific game across all sessions/users (owned by current user)". This adds one backend handler + DTO + endpoint to S4's scope.
 
-**Files touched:** ~2 modified, ~8 new (GameDetailDesktop, GameTabsPanel, 5 tab components, MeepleCardHero wrapper if needed). Details in `2026-04-09-s4-game-desktop-design.md`.
+**Files touched:** ~3 modified, ~10 new. Breakdown: backend (1 new query handler + 1 DTO + 1 endpoint), frontend (GameDetailDesktop, GameTabsPanel, 5 tab components, 3 redirect alias pages). Details in `2026-04-09-s4-game-desktop-design.md`.
+
+#### 4.4.1 — Shared tab component contract (for S4 + S5 reuse)
+
+To prevent duplication between desktop (S4) and mobile (S5), each of the 5 tab content components adheres to a shared contract:
+
+```typescript
+// apps/web/src/components/game-detail/tabs/types.ts
+export type GameTabVariant = 'desktop' | 'mobile';
+
+export interface GameTabProps {
+  gameId: string;
+  variant: GameTabVariant;  // layout mode hint; component chooses padding, font sizes, scroll behavior
+  isPrivateGame?: boolean;  // true if GameId references a PrivateGame (PrivateGameId)
+}
+
+// Each tab component signature
+export function GameInfoTab(props: GameTabProps): JSX.Element { ... }
+export function GameAiChatTab(props: GameTabProps): JSX.Element { ... }
+export function GameToolboxTab(props: GameTabProps): JSX.Element { ... }
+export function GameHouseRulesTab(props: GameTabProps): JSX.Element { ... }
+export function GamePartiteTab(props: GameTabProps): JSX.Element { ... }
+```
+
+**Contract rules:**
+- **Self-sufficient data loading:** each tab uses its own React Query hook; no props for server data. This lets the parent (desktop `GameTabsPanel` or mobile `GameDetailsDrawer`) lazy-mount tabs without coordinating data fetching.
+- **Responsive to `variant`:** `desktop` variant uses full width with inner padding, `mobile` uses compact padding + smaller headings + touch-friendly row heights. Component handles both internally — no separate "mobile wrapper" per tab.
+- **No assumptions about container:** must work inside both `<ScrollArea>` (desktop) and a `<div>` with `overflow-y: auto` (mobile drawer body). No `position: sticky` on direct children.
+- **Error boundary friendly:** each tab renders a local `<ErrorBoundary>` with a "Retry" button, so a failing tab doesn't break the whole page.
+- **A11y:** each tab root element exposes `role="tabpanel"` + `aria-labelledby={tabId}`, parent controls the tab/tablist wiring.
+
+Both S4 (`GameTabsPanel`) and S5 (`GameDetailsDrawer`) import the same 5 tab components from `apps/web/src/components/game-detail/tabs/` and pass `variant` appropriately. **No duplication.**
 
 ### 4.5 — S5 · Game page mobile (hand stack + drawer from top + 5 tabs)
 
@@ -262,12 +336,25 @@ Each sub-feature branch tracks its parent via `git config branch.<branch>.parent
 
 **Files touched:** ~7 new (game-detail-mobile.tsx rewrite, HandStack, FocusedCardArea, GameDetailsDrawer, store, 5 mobile tab wrappers reusing S4 tab components), ~1 modified (MobileActionBar auto-hide). Details in `2026-04-09-s5-game-mobile-design.md`.
 
-### 4.6 — S6 · Playwright E2E happy path + sub-tests + a11y
+### 4.6 — S6 · Playwright E2E (split into S6a scaffold + S6b complete)
 
-**Problem:** No end-to-end validation of the library-to-game user journey exists today, especially on mobile viewports.
+**Problem:** No end-to-end validation of the library-to-game user journey exists today, especially on mobile viewports. Landing all tests at the end of the epic delays feedback until after S1-S5 are merged — exactly when regressions are hardest to diagnose.
 
-**Decision:**
-1. **Happy path test** `e2e/flows/library-to-game-happy-path.spec.ts`:
+**Decision — split into two phases:**
+
+**S6a (scaffold + skeleton, lands right after S1):**
+- `.github/workflows/e2e-library-to-game.yml` workflow file triggered on PRs into `epic/library-to-game`
+- `e2e/flows/library-to-game-happy-path.spec.ts` — happy path test skeleton that currently only validates S1 (login → toggle → user shell). Marked `test.describe.skip` for the later steps (S2 filter, S3 add, S4/S5 game page). Each later sub-feature PR **unskips** its own steps as it lands.
+- `e2e/sub-features/s1-admin-toggle.spec.ts` — full S1 test
+- Screenshot artifact upload convention + CI reporter setup
+
+**S6b (completion, final sub-feature PR):**
+- Unskip any remaining happy path steps
+- `e2e/sub-features/s2-kb-filter.spec.ts`, `s3-meeplecard-add.spec.ts`, `s4-game-desktop.spec.ts`, `s5-game-mobile.spec.ts`
+- `e2e/sub-features/library-to-game-a11y.spec.ts` — dedicated axe scan on each significant state
+- Final validation: all tests green on 3 viewports
+
+**Happy path test** `e2e/flows/library-to-game-happy-path.spec.ts`:
    - Runs on 3 projects: `mobile-chrome` (Pixel 5), `mobile-safari` (iPhone 13), `desktop-chrome` (1920×1080)
    - Steps:
      1. Login as admin fixture
@@ -311,7 +398,8 @@ Each sub-feature branch tracks its parent via `git config branch.<branch>.parent
 | 8 | Hand stack empty (user has only the current game in library) | S5 | Render only the `+ Aggiungi giochi` placeholder, linking to catalog |
 | 9 | Drawer swipe vs iOS back-swipe edge conflict | S5 | Tap-only on `📋 Dettagli` button, no edge swipe |
 | 10 | Deep link `/library/games/{id}` without login | Cross | Existing `RequireRole` redirect to login with `?returnTo=...` |
-| 11 | Private vs shared game on game page | S4, S5 | Both supported; S3 add-to-library only applies to `SharedGameId` |
+| 11 | Private vs shared game on game page | S4, S5 | Both supported via `isPrivateGame` prop on tab components (§4.4.1); S3 add-to-library only applies to `SharedGameId` |
+| 11b | User lands on `/library/games/{id}` **without** the game in their library (direct link, search result, shared URL) | S4, S5 | MeepleCard hero on left shows a primary `+ Aggiungi alla libreria` CTA replacing the default quick actions. Accessible tabs: **Info** (always) and **AI Chat** (if `hasKnowledgeBase`). Locked tabs with placeholder: **Toolbox**, **House Rules**, **Partite** — show empty state "Aggiungi alla libreria per accedere a questa funzione" with inline `+ Aggiungi` button. This path is in scope for S4/S5 as a common empty state, not a separate sub-feature. |
 | 12 | Cache invalidation post-add | S3 | Invalidate `['library-list']`, `['library-status', id]`, `['library-quota']`, `['shared-catalog', ...]` (already in `useAddGameToLibrary`) |
 | 13 | i18n | All | All new strings in `messages/it.json` + `messages/en.json` |
 | 14 | Screenshot baseline missing on first CI run | S6 | Generate baseline + `test.skip` with warning the first time |
@@ -320,14 +408,20 @@ Each sub-feature branch tracks its parent via `git config branch.<branch>.parent
 
 ## 6. Performance Budgets
 
-| Metric | Target | Responsible sub | Strategy |
-|---|---|---|---|
-| Catalog query with KB filter (p95) | < 150ms | S2 | Lazy join v1, denormalized column v2 if needed |
-| Add-to-library + toast + navigate (time to first pixel on game page) | < 800ms from tap | S3 | Optimistic update + prefetch game detail on hover |
-| Desktop game page LCP | < 1.5s | S4 | Lazy-load non-default tab content |
-| Mobile hand stack initial render | < 300ms | S5 | Virtualized list (react-virtual or equivalent); ~12 items visible above the fold |
-| E2E full suite runtime in CI | < 8min | S6 | 3 Playwright workers in parallel |
-| Axe a11y violations (serious + critical) | 0 | S1-S5 | Per-component ARIA on PR review |
+Each budget includes **how it is measured** and **what environment** it applies to. Budgets without a measurement method have been removed or downgraded to "design goals, not DoD gates".
+
+| Metric | Target | Environment | Measurement | Responsible sub | Strategy |
+|---|---|---|---|---|---|
+| Catalog query with KB filter (p95) | < 150ms | Staging (postgres via docker-compose, catalog seeded with 1000 rows) | xUnit integration test timing wrapper around `GetFilteredSharedGamesQueryHandler.Handle()`, 100 iterations, assert p95 | S2 | Single-table `WHERE` on denormalized `HasKnowledgeBase` column — no join |
+| Add-to-library → game page first paint | < 1000ms p95 (relaxed from 800ms, see note) | Local dev + CI Playwright mobile-chrome | Playwright `page.waitForLoadState('networkidle')` timing between `addButton.click()` and `waitForURL('/library/games/*')`. Recorded in test report, not strictly enforced | S3 | Optimistic update + toast during navigate |
+| Desktop game page — first meaningful paint from SPA transition | < 500ms | Local dev, Chrome DevTools Performance panel | Manual: performance.mark before `router.push` → performance.mark on tab panel mount → compute delta. One-off measurement per PR, not CI-enforced. **Design goal only, not DoD gate.** | S4 | Lazy-load non-default tab content, React.lazy + Suspense |
+| Mobile hand stack initial mount | < 300ms | Playwright mobile-chrome, Pixel 5 viewport | Test instrumentation via `performance.mark('hand-stack-start')` + `performance.mark('hand-stack-ready')`. Assertion in `s5-game-mobile.spec.ts` | S5 | Virtualized list (react-virtual or equivalent); ~12 items visible above the fold |
+| E2E full suite runtime in CI | < 8min wall clock | GitHub Actions `ubuntu-latest` | CI job duration from `e2e-library-to-game.yml` workflow run | S6 | 3 Playwright workers in parallel |
+| Axe a11y violations (serious + critical) | 0 | Playwright axe-core scan in CI | Axe assertion in each spec — fails the test on any violation | S1-S5 | Per-component ARIA reviewed on PR |
+
+**Note on 800ms → 1000ms relaxation:** the original 800ms target assumed warm cache and optimistic update only. In practice, a real `router.push` + game detail fetch + tab component mount is closer to 1000ms on cold cache. 1000ms p95 is the realistic budget.
+
+**Removed metric:** "Desktop game page LCP < 1.5s" — LCP semantically doesn't apply to SPA transitions (Next.js client-side navigation is not a new page load). Replaced with "first meaningful paint from SPA transition" as a design goal.
 
 ---
 
@@ -354,7 +448,7 @@ See Section 4.6 for full test skeleton. Screenshots produced: 7 per viewport × 
 
 ### Epic DoD (required to merge `epic/library-to-game` → `main-dev`)
 
-- [ ] All 6 sub-feature PRs merged into `epic/library-to-game`
+- [ ] All 7 sub-feature PRs (S1, S6a, S2, S4, S5, S3, S6b) merged into `epic/library-to-game`
 - [ ] Happy path E2E test green on Pixel 5 + iPhone 13 + desktop 1920 in CI
 - [ ] Backend coverage ≥ 90%, frontend coverage ≥ 85% on new files
 - [ ] Axe a11y: 0 serious or critical violations at each happy path step
@@ -420,12 +514,21 @@ See Section 4.6 for full test skeleton. Screenshots produced: 7 per viewport × 
 
 ## 11. Next Steps (post approval)
 
-1. User approves this spec.
+1. User approves this spec (revision 2, post code review).
 2. `writing-plans` skill generates `docs/superpowers/plans/2026-04-09-s1-view-toggle.md` (first sub-feature plan).
-3. Create `epic/library-to-game` branch from `main-dev`.
-4. Implement S1, PR, merge into epic.
-5. Generate next sub-feature plan (S2). Repeat for S2→S4→S5→S3→S6.
-6. Epic PR `epic/library-to-game` → `main-dev`.
+3. Create `epic/library-to-game` branch from `main-dev` and configure parent via `git config branch.epic/library-to-game.parent main-dev`.
+4. Implement S1, PR, merge into epic branch.
+5. Generate next sub-feature plan and repeat in order: `S1 → S6a → S2 → S4 → S5 → S3 → S6b`.
+6. Epic PR `epic/library-to-game → main-dev`.
+
+---
+
+## 12. Revision History
+
+| Date | Author | Changes |
+|---|---|---|
+| 2026-04-09 | Claude (brainstorming) | Initial draft |
+| 2026-04-09 | Claude (post code review) | Revision 2: applied critical fixes C1 (query handler name), C2 (canonical SplitViewLayout), C3 (useAddGameToLibrary import clarity), C5 (cookie-based view mode), C6 (denormalized column v1). Applied important fixes I2 (measurable perf budgets), I3 (shared tab contract §4.4.1), I4 (server-side redirects for old routes), I5 (S6 split into S6a+S6b), I6 (PlayRecord in GameManagement + new GetPlayRecordsByGameQuery), I7 (MeepleCardHero weasel wording removed), I8 (non-library game page empty state). Reviewer's C4 (route ambiguity) verified false — only one route exists. |
 
 ---
 


### PR DESCRIPTION
## Summary

Sprint 3 — A7. Adds two new jobs to `deploy-staging.yml` that together provide **automated rollback when post-deploy validation fails**.

## What it does

### New job: `capture-rollback-target`

Runs **before** `build` (and therefore before `deploy`). SSHes to the staging VPS, reads `/opt/meepleai/repo/infra/DEPLOYMENT.json`, extracts `api_image`, `web_image`, `version`, and exposes them as job outputs. Graceful no-op if the file doesn't exist (fresh environment, first deploy).

### New job: `auto-rollback`

Runs **after** `validate` and `e2e-staging`. Strict gating:

```yaml
if: |
  always()
  && vars.AUTO_ROLLBACK_ENABLED != 'false'
  && vars.DEPLOY_METHOD == 'ssh'
  && needs.capture-rollback-target.result == 'success'
  && needs.capture-rollback-target.outputs.capture_status == 'captured'
  && needs.deploy.result == 'success'
  && (needs.validate.result == 'failure' || needs.e2e-staging.result == 'failure')
```

When the gate passes, it pulls the previous images, restarts the affected services with `docker compose up -d --no-deps --force-recreate`, and runs a 12-attempt health check.

## Strict gating rationale

Auto-rollback ONLY fires when:
- The deploy succeeded (system is in a defined state, not partial)
- AND post-deploy validation failed

It does NOT fire on:
- `build` failures (no artifacts to deploy in the first place)
- `migrate-db` failures (DB might be in inconsistent state)
- `deploy` failures (system in partial state, manual intervention required)
- `capture-rollback-target` failures (no rollback target available)

These cases all leave the cluster in a state where automated rollback could make things worse — they require human investigation. The existing `rollback.yml` (manual) remains the escape hatch for these scenarios.

## Kill switch

Set repo variable `AUTO_ROLLBACK_ENABLED=false` to disable the auto-rollback job entirely. Useful during incident response when you want to manually inspect the failed state before restoring.

## Wiring changes to existing jobs

- `deploy.needs` gains `capture-rollback-target` (with `success || skipped` accepted in the if-condition, so a fresh-env no-op doesn't block the deploy)
- `notify-end.needs` gains `capture-rollback-target` and `auto-rollback` so the final Slack notification reflects the full pipeline state

No other existing job is touched. The change is purely additive.

## Test plan (post-merge to main-staging)

1. **Happy path**: a normal release deploy. capture-rollback-target reads DEPLOYMENT.json (status=captured), deploy succeeds, validate succeeds, e2e-staging succeeds, auto-rollback skipped. **Net change: 0.**
2. **Validation-failure path** (manual test): force a validate or e2e-staging failure (e.g. via temporary asserting on impossible condition in a smoke test). Verify auto-rollback fires, pulls the previous images, restarts containers, passes health check.
3. **Fresh-env path**: deploy to a brand-new VPS where DEPLOYMENT.json doesn't exist. capture-rollback-target reports `status=fresh`, outputs are empty, deploy proceeds normally, auto-rollback skips.
4. **Kill switch**: set `vars.AUTO_ROLLBACK_ENABLED=false`, force a validation failure. Verify auto-rollback skips entirely.

## Validation

- [x] YAML valid (`python -c "yaml.safe_load(...)"`)
- [x] `node scripts/validate-workflows.js` → 0 errors, 0 warnings
- [x] Job dependency graph verified (`grep -nE "^  [a-z][a-z-]*:|needs:"`)
- [ ] Live test on next staging release

## Spec
- R3 — Auto-rollback (Sprint 3, A7)
- Doc reference: `docs/operations/ci-cd-pipeline.md` § "Stage 3 — Deploy"
- Companion: `rollback.yml` (manual rollback, retained as escape hatch)

## Sprint 3 status

| Task | PR | Status |
|------|-----|--------|
| A8 — pipeline docs | #341 | open |
| A6 — CI minutes digest | #342 | open |
| A7 — auto-rollback (this PR) | #343 | open |

After this PR, all 3 Sprint 3 tasks are submitted.