### PR TITLE
feat(s5): mobile game page with top drawer + 5 tabs

### DIFF
--- a/apps/web/src/app/(authenticated)/library/games/[gameId]/game-detail-mobile.tsx
+++ b/apps/web/src/app/(authenticated)/library/games/[gameId]/game-detail-mobile.tsx
@@ -1,302 +1,96 @@
 /**
- * GameDetailMobile — Mobile-first game detail page
+ * GameDetailMobile — S5 (library-to-game epic)
  *
- * Vertical scroll layout with hero, action bar, AI section,
- * recent sessions, and game info.
+ * New mobile layout: MeepleCard hero foreground + top-sheet drawer with the 5
+ * game detail tabs (shared contract from S4). Replaces the previous 303-line
+ * vertical-scroll layout.
  *
- * Phase 3 Task 5
+ * Reference: docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md §4.5
  */
 
 'use client';
 
 import { useState } from 'react';
 
-import { useQueryClient } from '@tanstack/react-query';
-import {
-  MessageCircle,
-  BookOpen,
-  Share2,
-  Users,
-  Clock,
-  BarChart3,
-  Loader2,
-  Calendar,
-} from 'lucide-react';
-import Image from 'next/image';
-import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
-import { AiReadySection } from '@/components/library/AiReadySection';
-import { FavoriteToggle } from '@/components/library/FavoriteToggle';
-import { PdfUploadSheet } from '@/components/library/PdfUploadSheet';
-import { Badge } from '@/components/ui/data-display/badge';
-import { MobileHeader } from '@/components/ui/navigation/MobileHeader';
-import { GlassCard } from '@/components/ui/surfaces/GlassCard';
-import { useLibraryGameDetail, libraryKeys } from '@/hooks/queries/useLibrary';
-import { useGameKbStatus } from '@/lib/domain-hooks/useGameKbStatus';
+import { FocusedGameCard } from '@/components/game-detail/mobile/FocusedGameCard';
+import { GameDetailsDrawer } from '@/components/game-detail/mobile/GameDetailsDrawer';
+import { type GameTabId } from '@/components/game-detail/tabs';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/feedback/alert';
+import { Button } from '@/components/ui/primitives/button';
+import { useLibraryGameDetail } from '@/hooks/queries/useLibrary';
 
 export interface GameDetailMobileProps {
   gameId: string;
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function playerLabel(min: number | null, max: number | null): string | null {
-  if (min == null && max == null) return null;
-  if (min != null && max != null) return min === max ? `${min}` : `${min}-${max}`;
-  return `${min ?? max}`;
-}
-
-function formatDate(iso: string): string {
-  try {
-    return new Date(iso).toLocaleDateString('it-IT', {
-      day: 'numeric',
-      month: 'short',
-      year: 'numeric',
-    });
-  } catch {
-    return iso;
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
-
 export default function GameDetailMobile({ gameId }: GameDetailMobileProps) {
   const router = useRouter();
-  const queryClient = useQueryClient();
   const { data: game, isLoading, error } = useLibraryGameDetail(gameId);
-  const kbStatus = useGameKbStatus(gameId);
-  const [uploadOpen, setUploadOpen] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [initialTab, setInitialTab] = useState<GameTabId>('info');
 
-  // -- Loading --
+  const handleOpenDrawer = () => {
+    setInitialTab('info');
+    setDrawerOpen(true);
+  };
+
   if (isLoading) {
     return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin text-purple-400" />
+      <div
+        className="flex min-h-[60vh] items-center justify-center p-6 text-sm text-muted-foreground"
+        data-testid="game-detail-mobile-loading"
+      >
+        Caricamento in corso…
       </div>
     );
   }
 
-  // -- Error --
   if (error) {
     return (
-      <div className="px-4 py-12 text-center">
-        <p className="text-sm text-red-400">
-          {error instanceof Error ? error.message : 'Errore nel caricamento del gioco.'}
-        </p>
-        <button onClick={() => router.back()} className="mt-4 text-sm text-purple-400 underline">
-          Torna indietro
-        </button>
+      <div className="p-4" data-testid="game-detail-mobile-error">
+        <Alert variant="destructive">
+          <AlertTitle>Errore</AlertTitle>
+          <AlertDescription>
+            {error instanceof Error
+              ? error.message
+              : 'Si è verificato un errore nel caricamento del gioco.'}
+          </AlertDescription>
+        </Alert>
+        <Button variant="outline" className="mt-4 w-full" onClick={() => router.push('/library')}>
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Torna alla Libreria
+        </Button>
       </div>
     );
   }
 
-  // -- Not found --
   if (!game) {
     return (
-      <div className="px-4 py-12 text-center">
-        <p className="text-base font-semibold text-[var(--gaming-text-primary)]">
-          Gioco non trovato
-        </p>
-        <p className="mt-1 text-sm text-[var(--gaming-text-secondary)]">
-          Questo gioco non è presente nella tua libreria.
-        </p>
-        <button
-          onClick={() => router.push('/library')}
-          className="mt-4 text-sm text-purple-400 underline"
-        >
+      <div className="p-4" data-testid="game-detail-mobile-not-found">
+        <Alert>
+          <AlertTitle>Gioco non trovato</AlertTitle>
+          <AlertDescription>Questo gioco non è presente nella tua libreria.</AlertDescription>
+        </Alert>
+        <Button variant="outline" className="mt-4 w-full" onClick={() => router.push('/library')}>
+          <ArrowLeft className="mr-2 h-4 w-4" />
           Torna alla Libreria
-        </button>
+        </Button>
       </div>
     );
   }
 
-  const players = playerLabel(game.minPlayers, game.maxPlayers);
-  const subtitle =
-    [game.gamePublisher, game.gameYearPublished ? `(${game.gameYearPublished})` : null]
-      .filter(Boolean)
-      .join(' ') || undefined;
-
   return (
-    <div className="flex flex-col" data-testid="game-detail-mobile">
-      {/* Header */}
-      <MobileHeader title={game.gameTitle} subtitle={subtitle} onBack={() => router.back()} />
-
-      <div className="flex flex-col gap-4 p-4 pb-24">
-        {/* ---- Hero Section ---- */}
-        <GlassCard entity="game" className="overflow-hidden">
-          {/* Cover image */}
-          {game.gameImageUrl && (
-            <div className="relative aspect-[16/9] w-full">
-              <Image
-                src={game.gameImageUrl}
-                alt={game.gameTitle}
-                fill
-                className="object-cover"
-                sizes="(max-width: 768px) 100vw, 600px"
-                priority
-              />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/70 to-transparent" />
-            </div>
-          )}
-
-          <div className="space-y-3 p-4">
-            <h2 className="text-xl font-bold text-[var(--gaming-text-primary)]">
-              {game.gameTitle}
-            </h2>
-            {subtitle && <p className="text-sm text-[var(--gaming-text-secondary)]">{subtitle}</p>}
-
-            {/* Mana pips / quick stats */}
-            <div className="flex flex-wrap gap-3 text-xs text-[var(--gaming-text-secondary)]">
-              {players && (
-                <span className="flex items-center gap-1">
-                  <Users className="h-3.5 w-3.5" /> {players} giocatori
-                </span>
-              )}
-              {game.playingTimeMinutes != null && (
-                <span className="flex items-center gap-1">
-                  <Clock className="h-3.5 w-3.5" /> {game.playingTimeMinutes} min
-                </span>
-              )}
-              {game.averageRating != null && (
-                <span className="flex items-center gap-1">
-                  <BarChart3 className="h-3.5 w-3.5" /> {game.averageRating.toFixed(1)}/10
-                </span>
-              )}
-            </div>
-
-            {/* KB Coverage Badge */}
-            {kbStatus.isIndexed && (
-              <div className="space-y-2" data-testid="kb-status-mobile">
-                <Badge
-                  variant="secondary"
-                  className="gap-1 text-teal-600 border-teal-200 bg-teal-50"
-                  data-testid="kb-coverage-badge-mobile"
-                >
-                  <BookOpen className="h-3 w-3" />
-                  KB {kbStatus.coverageLevel}
-                </Badge>
-
-                {kbStatus.suggestedQuestions.length > 0 && (
-                  <div data-testid="suggested-questions-mobile">
-                    <p className="text-xs text-[var(--gaming-text-secondary)] mb-1.5">
-                      Domande frequenti:
-                    </p>
-                    <div className="flex flex-wrap gap-2">
-                      {kbStatus.suggestedQuestions.map((q, i) => (
-                        <button
-                          key={i}
-                          className="text-xs px-3 py-1 rounded-full border border-white/10 bg-white/5 text-[var(--gaming-text-secondary)] hover:bg-white/10 transition-colors"
-                          data-testid="suggested-question-btn-mobile"
-                        >
-                          {q}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-        </GlassCard>
-
-        {/* ---- Action Bar ---- */}
-        <div className="flex items-center justify-around rounded-xl bg-white/5 py-2">
-          <FavoriteToggle gameId={gameId} isFavorite={game.isFavorite} gameTitle={game.gameTitle} />
-
-          <Link
-            href={`/chat?gameId=${gameId}`}
-            className="flex flex-col items-center gap-0.5 text-[var(--gaming-text-secondary)] transition-colors hover:text-purple-400"
-            aria-label="Chat AI"
-          >
-            <MessageCircle className="h-5 w-5" />
-            <span className="text-[10px]">Chat AI</span>
-          </Link>
-
-          <button
-            onClick={() => setUploadOpen(true)}
-            className="flex flex-col items-center gap-0.5 text-[var(--gaming-text-secondary)] transition-colors hover:text-purple-400"
-            aria-label="Regole"
-          >
-            <BookOpen className="h-5 w-5" />
-            <span className="text-[10px]">Regole</span>
-          </button>
-
-          <button
-            onClick={() => {
-              if (navigator.share) {
-                navigator.share({
-                  title: game.gameTitle,
-                  url: window.location.href,
-                });
-              }
-            }}
-            className="flex flex-col items-center gap-0.5 text-[var(--gaming-text-secondary)] transition-colors hover:text-purple-400"
-            aria-label="Condividi"
-          >
-            <Share2 className="h-5 w-5" />
-            <span className="text-[10px]">Condividi</span>
-          </button>
-        </div>
-
-        {/* ---- AI Ready Section ---- */}
-        <AiReadySection
-          gameId={gameId}
-          hasCustomPdf={game.hasCustomPdf}
-          hasRagAccess={game.hasRagAccess}
-          onUploadClick={() => setUploadOpen(true)}
-        />
-
-        {/* ---- Recent Sessions ---- */}
-        {game.recentSessions && game.recentSessions.length > 0 && (
-          <GlassCard entity="session" className="p-4">
-            <h3 className="mb-3 text-sm font-semibold text-[var(--gaming-text-primary)]">
-              Sessioni Recenti
-            </h3>
-            <ul className="space-y-2">
-              {game.recentSessions.slice(0, 3).map(session => (
-                <li
-                  key={session.id}
-                  className="flex items-center justify-between rounded-lg bg-white/5 px-3 py-2 text-sm"
-                >
-                  <div className="flex items-center gap-2 text-[var(--gaming-text-secondary)]">
-                    <Calendar className="h-3.5 w-3.5" />
-                    <span>{formatDate(session.playedAt)}</span>
-                  </div>
-                  <span className="text-xs text-[var(--gaming-text-tertiary)]">
-                    {session.durationFormatted}
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </GlassCard>
-        )}
-
-        {/* ---- Description ---- */}
-        {game.description && (
-          <GlassCard className="p-4">
-            <h3 className="mb-2 text-sm font-semibold text-[var(--gaming-text-primary)]">
-              Descrizione
-            </h3>
-            <p className="text-sm leading-relaxed text-[var(--gaming-text-secondary)]">
-              {game.description}
-            </p>
-          </GlassCard>
-        )}
-      </div>
-
-      {/* ---- PDF Upload Sheet ---- */}
-      <PdfUploadSheet
-        open={uploadOpen}
-        onOpenChange={setUploadOpen}
+    <div className="flex h-full flex-col" data-testid="game-detail-mobile">
+      <FocusedGameCard game={game} onOpenDrawer={handleOpenDrawer} />
+      <GameDetailsDrawer
+        open={drawerOpen}
+        onOpenChange={setDrawerOpen}
         gameId={gameId}
-        onUploaded={() => {
-          queryClient.invalidateQueries({ queryKey: libraryKeys.gameDetail(gameId) });
-        }}
+        initialTab={initialTab}
+        isNotInLibrary={false}
       />
     </div>
   );

--- a/apps/web/src/components/game-detail/mobile/FocusedGameCard.tsx
+++ b/apps/web/src/components/game-detail/mobile/FocusedGameCard.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { FileText } from 'lucide-react';
+
+import { MeepleCard } from '@/components/ui/data-display/meeple-card/MeepleCard';
+import type { MeepleCardMetadata } from '@/components/ui/data-display/meeple-card/types';
+import { Button } from '@/components/ui/primitives/button';
+import type { LibraryGameDetail } from '@/hooks/queries/useLibrary';
+
+interface FocusedGameCardProps {
+  game: LibraryGameDetail;
+  onOpenDrawer: () => void;
+}
+
+/**
+ * Mobile hero card + "Dettagli" CTA button.
+ *
+ * Renders the game as a MeepleCard hero variant and exposes a prominent
+ * button that opens the `GameDetailsDrawer`. Designed to fill the viewport
+ * except for the MobileActionBar at the bottom.
+ *
+ * Reference: docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md §4.5
+ */
+export function FocusedGameCard({ game, onOpenDrawer }: FocusedGameCardProps) {
+  const metadata: MeepleCardMetadata[] = [];
+  if (game.gameYearPublished) {
+    metadata.push({ label: String(game.gameYearPublished) });
+  }
+  if (game.minPlayers && game.maxPlayers) {
+    metadata.push({
+      label:
+        game.minPlayers === game.maxPlayers
+          ? `${game.minPlayers} giocatori`
+          : `${game.minPlayers}-${game.maxPlayers} giocatori`,
+    });
+  }
+  if (game.playingTimeMinutes) {
+    metadata.push({ label: `${game.playingTimeMinutes} min` });
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-4 p-4" data-testid="focused-game-card">
+      <div className="flex-1">
+        <MeepleCard
+          entity="game"
+          variant="hero"
+          title={game.gameTitle}
+          subtitle={game.gamePublisher ?? undefined}
+          imageUrl={game.gameImageUrl ?? undefined}
+          rating={game.averageRating ?? undefined}
+          metadata={metadata.length > 0 ? metadata : undefined}
+          data-testid="focused-meeple-card"
+        />
+      </div>
+
+      <Button
+        type="button"
+        onClick={onOpenDrawer}
+        size="lg"
+        className="w-full gap-2"
+        data-testid="focused-game-details-button"
+      >
+        <FileText className="h-4 w-4" />
+        Dettagli
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/game-detail/mobile/GameDetailsDrawer.tsx
+++ b/apps/web/src/components/game-detail/mobile/GameDetailsDrawer.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Sheet, SheetContent } from '@/components/ui/navigation/sheet';
+import { cn } from '@/lib/utils';
+
+import {
+  GAME_TABS,
+  GameAiChatTab,
+  GameHouseRulesTab,
+  GameInfoTab,
+  GamePartiteTab,
+  GameToolboxTab,
+  type GameTabId,
+} from '../tabs';
+
+interface GameDetailsDrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  gameId: string;
+  initialTab?: GameTabId;
+  isPrivateGame?: boolean;
+  isNotInLibrary?: boolean;
+}
+
+/**
+ * Mobile top-sheet drawer containing the 5 game detail tabs.
+ *
+ * Reuses the S4 shared tab component contract (`variant='mobile'`).
+ * Slides down from the top (mirroring admin-mockups/mobile-card-layout-mockup.html).
+ *
+ * Reference: docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md §4.5
+ */
+export function GameDetailsDrawer({
+  open,
+  onOpenChange,
+  gameId,
+  initialTab = 'info',
+  isPrivateGame,
+  isNotInLibrary,
+}: GameDetailsDrawerProps) {
+  const [activeTab, setActiveTab] = useState<GameTabId>(initialTab);
+
+  const tabProps = {
+    gameId,
+    variant: 'mobile' as const,
+    isPrivateGame,
+    isNotInLibrary,
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="top"
+        className="h-auto max-h-[85vh] rounded-b-2xl p-0"
+        data-testid="game-details-drawer"
+      >
+        {/* Drawer handle */}
+        <div className="mx-auto mt-2 h-1 w-10 rounded-full bg-border" aria-hidden="true" />
+
+        {/* Tab bar */}
+        <div
+          role="tablist"
+          aria-label="Dettagli gioco"
+          className="flex gap-1 overflow-x-auto border-b border-border px-3 py-2"
+          style={{ scrollbarWidth: 'none' }}
+        >
+          {GAME_TABS.map(tab => {
+            const isActive = tab.id === activeTab;
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                role="tab"
+                id={`game-mobile-tab-${tab.id}`}
+                aria-selected={isActive}
+                aria-controls={`game-mobile-tabpanel-${tab.id}`}
+                onClick={() => setActiveTab(tab.id)}
+                className={cn(
+                  'flex shrink-0 items-center gap-1 whitespace-nowrap rounded-full px-3 py-1.5 text-xs font-bold transition-colors',
+                  'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                  isActive
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-transparent text-muted-foreground hover:bg-muted/60'
+                )}
+                data-testid={`game-mobile-tab-${tab.id}`}
+              >
+                <span aria-hidden="true">{tab.icon}</span>
+                <span>{tab.label}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Tab content */}
+        <div
+          id={`game-mobile-tabpanel-${activeTab}`}
+          className="flex-1 overflow-y-auto"
+          style={{ maxHeight: 'calc(85vh - 100px)' }}
+        >
+          {activeTab === 'info' && <GameInfoTab {...tabProps} />}
+          {activeTab === 'aiChat' && <GameAiChatTab {...tabProps} />}
+          {activeTab === 'toolbox' && <GameToolboxTab {...tabProps} />}
+          {activeTab === 'houseRules' && <GameHouseRulesTab {...tabProps} />}
+          {activeTab === 'partite' && <GamePartiteTab {...tabProps} />}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/web/src/components/game-detail/mobile/__tests__/FocusedGameCard.test.tsx
+++ b/apps/web/src/components/game-detail/mobile/__tests__/FocusedGameCard.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { FocusedGameCard } from '../FocusedGameCard';
+import type { LibraryGameDetail } from '@/hooks/queries/useLibrary';
+
+// Stub MeepleCard — we only care about FocusedGameCard's own behavior
+vi.mock('@/components/ui/data-display/meeple-card/MeepleCard', () => ({
+  MeepleCard: ({ title }: { title?: string }) => (
+    <div data-testid="meeple-card-stub">{title ?? 'no title'}</div>
+  ),
+}));
+
+const mockGame: LibraryGameDetail = {
+  libraryEntryId: 'entry-1',
+  userId: 'user-1',
+  gameId: 'game-1',
+  addedAt: '2025-01-01T00:00:00Z',
+  notes: null,
+  isFavorite: false,
+  currentState: 'Owned',
+  stateChangedAt: null,
+  stateNotes: null,
+  isAvailableForPlay: true,
+  hasCustomPdf: false,
+  hasRagAccess: true,
+  gameTitle: 'Catan',
+  gamePublisher: 'Kosmos',
+  gameYearPublished: 1995,
+  gameIconUrl: null,
+  gameImageUrl: null,
+  description: null,
+  minPlayers: 3,
+  maxPlayers: 4,
+  playingTimeMinutes: 90,
+  minAge: 10,
+  complexityRating: 2.3,
+  averageRating: 7.2,
+  timesPlayed: 5,
+  lastPlayed: null,
+  winRate: null,
+  avgDuration: null,
+};
+
+describe('FocusedGameCard', () => {
+  it('renders MeepleCard with the game title', () => {
+    render(<FocusedGameCard game={mockGame} onOpenDrawer={() => {}} />);
+    expect(screen.getByTestId('meeple-card-stub')).toHaveTextContent('Catan');
+  });
+
+  it('renders a Dettagli button that calls onOpenDrawer', () => {
+    const onOpenDrawer = vi.fn();
+    render(<FocusedGameCard game={mockGame} onOpenDrawer={onOpenDrawer} />);
+    const button = screen.getByTestId('focused-game-details-button');
+    expect(button).toHaveTextContent(/dettagli/i);
+    fireEvent.click(button);
+    expect(onOpenDrawer).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/components/game-detail/mobile/__tests__/GameDetailsDrawer.test.tsx
+++ b/apps/web/src/components/game-detail/mobile/__tests__/GameDetailsDrawer.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { GameDetailsDrawer } from '../GameDetailsDrawer';
+
+vi.mock('@/hooks/queries/useLibrary', () => ({
+  useLibraryGameDetail: () => ({ data: null, isLoading: false, isError: false }),
+}));
+
+describe('GameDetailsDrawer', () => {
+  it('does not render tab content when closed', () => {
+    render(<GameDetailsDrawer open={false} onOpenChange={() => {}} gameId="game-1" />);
+    expect(screen.queryByTestId('game-details-drawer')).not.toBeInTheDocument();
+  });
+
+  it('renders with 5 tabs when open', () => {
+    render(<GameDetailsDrawer open={true} onOpenChange={() => {}} gameId="game-1" />);
+    expect(screen.getByTestId('game-details-drawer')).toBeInTheDocument();
+    expect(screen.getByRole('tablist', { name: /dettagli gioco/i })).toBeInTheDocument();
+    expect(screen.getAllByRole('tab')).toHaveLength(5);
+  });
+
+  it('defaults to Info tab', () => {
+    render(<GameDetailsDrawer open={true} onOpenChange={() => {}} gameId="game-1" />);
+    expect(screen.getByRole('tab', { name: /info/i })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('switches tabs when clicked', () => {
+    render(<GameDetailsDrawer open={true} onOpenChange={() => {}} gameId="game-1" />);
+    const aiChatTab = screen.getByRole('tab', { name: /ai chat/i });
+    fireEvent.click(aiChatTab);
+    expect(aiChatTab).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('respects initialTab prop', () => {
+    render(
+      <GameDetailsDrawer open={true} onOpenChange={() => {}} gameId="game-1" initialTab="partite" />
+    );
+    expect(screen.getByRole('tab', { name: /partite/i })).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/docs/superpowers/plans/2026-04-09-s5-game-mobile.md
+++ b/docs/superpowers/plans/2026-04-09-s5-game-mobile.md
@@ -1,0 +1,96 @@
+# S5 — Game Page Mobile Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: `superpowers:executing-plans`.
+
+**Goal:** Rewrite the mobile variant of the game detail page to use a MeepleCard hero + a slide-down drawer containing the 5 tab components (Info / AI Chat / Toolbox / House Rules / Partite) built in S4.
+
+**Architecture:** Mobile-only change. Reuses the S4 shared tab component contract (`GameTabProps` with `variant='mobile'`), the existing `Sheet` primitive (Radix Dialog based, already in the codebase), and the existing `useLibraryGameDetail` hook. The drawer-from-top mechanism is implemented via `Sheet` with `side="top"` to mirror the reference mockup `admin-mockups/mobile-card-layout-mockup.html`.
+
+**Scope corrections from the spec (§4.5):**
+- **Hand stack deferred**: the 44px vertical strip of mini-cards for cross-game navigation is out of S5 scope. Reason: it requires virtualization + library fetch + swipe gestures on the focused card, which balloons the sub-feature without delivering core value. Documented as a known limitation; can be re-added in a polish follow-up.
+- **Top drawer via `Sheet side="top"`**: no custom drawer component. The existing `Sheet` primitive already supports top-anchored variants.
+- **No Zustand store**: local `useState` is sufficient for drawer open/close + active tab.
+- **Cross-game navigation** happens via the standard back button + library list, not the hand stack.
+
+**Reference spec:** `docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md` §4.5
+**Branch:** `feature/s5-game-mobile` (from `epic/library-to-game`)
+
+---
+
+## File Structure
+
+**New files:**
+- `apps/web/src/components/game-detail/mobile/GameDetailsDrawer.tsx` — Sheet-based top drawer with 5 tabs (horizontal scrollable tab bar + scrollable content)
+- `apps/web/src/components/game-detail/mobile/FocusedGameCard.tsx` — hero MeepleCard wrapper + "Dettagli" CTA button that opens the drawer
+- `apps/web/src/components/game-detail/mobile/__tests__/GameDetailsDrawer.test.tsx`
+- `apps/web/src/components/game-detail/mobile/__tests__/FocusedGameCard.test.tsx`
+
+**Modified files:**
+- `apps/web/src/app/(authenticated)/library/games/[gameId]/game-detail-mobile.tsx` — full rewrite (delete current 303-line implementation, replace with ~60-line composition of new components)
+
+**Total estimate:** ~5 new files + 1 modified, ~400 LOC + ~200 LOC tests.
+
+---
+
+## Tasks
+
+### Task 1 — `GameDetailsDrawer` (5 tabs via shared contract)
+
+Writes a `Sheet` (side="top") with:
+- Drawer handle at top
+- Horizontal tab bar (5 tabs, scrollable on small screens)
+- Active tab content rendered inline using the S4 tab components with `variant='mobile'`
+- Close button in header
+- State: `activeTab: GameTabId` via `useState`
+
+Props: `{ open: boolean; onOpenChange: (open: boolean) => void; gameId: string; isPrivateGame?: boolean; isNotInLibrary?: boolean; initialTab?: GameTabId }`
+
+### Task 2 — `FocusedGameCard` (MeepleCard hero + Dettagli button)
+
+Renders `MeepleCard variant='hero'` with a prominent "📋 Dettagli" button below. Tap → opens the drawer. Delegates all data fetching to the parent.
+
+Props: `{ gameDetail: LibraryGameDetail; onOpenDrawer: () => void }`
+
+### Task 3 — Rewrite `game-detail-mobile.tsx`
+
+Replace the current 303-line implementation. New composition:
+```tsx
+function GameDetailMobile({ gameId }) {
+  const { data: game, isLoading, isError } = useLibraryGameDetail(gameId);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [initialTab, setInitialTab] = useState<GameTabId>('info');
+
+  // ... loading / error states ...
+
+  return (
+    <>
+      <FocusedGameCard gameDetail={game} onOpenDrawer={() => setDrawerOpen(true)} />
+      <GameDetailsDrawer
+        open={drawerOpen}
+        onOpenChange={setDrawerOpen}
+        gameId={gameId}
+        initialTab={initialTab}
+        isNotInLibrary={!game}
+      />
+    </>
+  );
+}
+```
+
+### Task 4 — Tests + push + PR
+
+- Unit test for `GameDetailsDrawer` (tabs switching, close on backdrop)
+- Unit test for `FocusedGameCard` (renders MeepleCard, click dispatches callback)
+- Typecheck + lint
+- Push + PR to `epic/library-to-game`
+
+---
+
+## Known limitations
+
+- No hand stack (deferred to polish follow-up).
+- No swipe-to-navigate between games (deferred with hand stack).
+- MobileActionBar auto-hide (§4.5 bullet 5) is NOT implemented — current `ActionBar` is global (managed by UserShell) and its visibility is not coupled to the game page drawer state.
+- The Partite tab still uses the summary data from `useLibraryGameDetail` (full pagination deferred to S6b follow-up).
+
+These are acceptable scope cuts that keep S5 mergeable in the epic timeline.


### PR DESCRIPTION
## Summary

Implements S5 of the `library-to-game` epic: rewrites the mobile game detail page to use a MeepleCard hero foreground + top-sheet drawer containing the 5 game detail tabs (Info / AI Chat / Toolbox / House Rules / Partite).

Reuses the shared tab component contract established by S4 (`GameTabProps` with `variant='mobile'`), avoiding code duplication with the desktop `GameTabsPanel`.

## Changes

### New components

- `components/game-detail/mobile/GameDetailsDrawer.tsx` — top-sheet drawer using `Sheet side="top"` (navigation/sheet.tsx variant supporting top anchor). Horizontal scrollable tab bar + scrollable content. 5 tabs from S4 reused via shared contract.
- `components/game-detail/mobile/FocusedGameCard.tsx` — MeepleCard hero variant + prominent "📋 Dettagli" CTA button that opens the drawer.

### Rewrite

- `app/(authenticated)/library/games/[gameId]/game-detail-mobile.tsx` — replaced the previous 303-line `AiReadySection` + `PdfUploadSheet` + custom layout with a ~90-line composition of `FocusedGameCard` + `GameDetailsDrawer`. Preserves loading / error / not-found states.

### Tests

- `GameDetailsDrawer.test.tsx` — 5 tests (closed state, 5 tabs visible, default Info tab, tab switching, initialTab prop)
- `FocusedGameCard.test.tsx` — 2 tests (MeepleCard rendering, onOpenDrawer callback)

## Scope corrections from the spec

- **Hand stack deferred** (§4.5 bullet 1): the 44px vertical strip of mini-cards for cross-game navigation is out of S5 scope. Cross-game navigation now happens via the standard back button + library list. Hand stack can be re-added as a polish follow-up (needs virtualization + swipe gestures).
- **Top drawer via existing `Sheet` primitive**: no custom drawer component. `ui/navigation/sheet.tsx` already supports `side="top"`.
- **No Zustand store**: local `useState` is sufficient for drawer open/close + active tab. Simpler than the original spec's dedicated store.
- **`MobileActionBar` auto-hide** (§4.5 bullet 5): NOT implemented. Current action bar is global and its visibility is not coupled to the game page drawer state. Deferred as future UX polish.

## Test results

- `pnpm typecheck` — 0 errors
- `pnpm lint` — 0 errors
- **123/127 tests pass** across game-detail (desktop + mobile) and game-table regression (4 skipped, unrelated)
- S5 specifically: **7/7 unit tests green**

## Dependencies

**S5 depends on S4** (shared tab components). S4 is merged in `epic/library-to-game` so this PR can merge directly.

## Known limitations (deferred to follow-ups)

- Hand stack (cross-game navigation sidebar) — polish follow-up
- `MobileActionBar` auto-hide on focus — polish follow-up
- Full PlayRecord history integration in Partite tab — summary data via `useLibraryGameDetail` for now
- Swipe gestures between games — deferred with hand stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)
