### PR TITLE
chore(epic): post-review follow-ups (I2+M2+M4)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandler.cs
@@ -77,6 +77,16 @@ internal sealed class VectorDocumentIndexedForKbFlagHandler
         // appears immediately instead of waiting for the L1/L2 TTL to expire.
         // RemoveByTagAsync with the "search-games" tag evicts every entry in the
         // SearchSharedGamesQueryHandler cache namespace.
+        //
+        // Multi-instance deployment caveat (epic library-to-game CR-I2):
+        // HybridCache tag invalidation evicts the L2 distributed entry
+        // (shared across nodes) but only the L1 MemoryCache of THIS instance.
+        // Other API replicas still serve their own L1 cached values until
+        // `LocalCacheExpiration` (15 min) expires. Worst case: a sticky-session
+        // user on another replica sees a stale AI-ready flag for up to 15 min.
+        // Acceptable for staging (single node); for multi-replica prod consider
+        // either shortening LocalCacheExpiration or publishing an integration
+        // event that each instance subscribes to for L1 cleanup.
         await _cache.RemoveByTagAsync("search-games", cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation(

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Events/KnowledgeBaseDomainEventsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Events/KnowledgeBaseDomainEventsTests.cs
@@ -811,6 +811,38 @@ public sealed class KnowledgeBaseDomainEventsTests
         evt.ChunkCount.Should().Be(500);
     }
 
+    [Fact]
+    public void VectorDocumentIndexedEvent_WithSharedGameId_ExposesValueOnProperty()
+    {
+        // Arrange — library-to-game epic CR-M4 regression coverage
+        var documentId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var sharedGameId = Guid.NewGuid();
+
+        // Act
+        var evt = new VectorDocumentIndexedEvent(documentId, gameId, 42, sharedGameId);
+
+        // Assert
+        evt.DocumentId.Should().Be(documentId);
+        evt.GameId.Should().Be(gameId);
+        evt.ChunkCount.Should().Be(42);
+        evt.SharedGameId.Should().Be(sharedGameId);
+    }
+
+    [Fact]
+    public void VectorDocumentIndexedEvent_WithoutSharedGameId_DefaultsToNull()
+    {
+        // Arrange
+        var documentId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+
+        // Act — omit the optional sharedGameId parameter
+        var evt = new VectorDocumentIndexedEvent(documentId, gameId, 42);
+
+        // Assert
+        evt.SharedGameId.Should().BeNull();
+    }
+
     #endregion
 
     #region VectorDocumentMetadataUpdatedEvent Tests

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -148,17 +148,15 @@ export default defineConfig({
       use: {
         ...devices['Desktop Safari'],
         viewport: { width: 1920, height: 1080 },
+        // Override top-level chromium launchOptions — webkit does not accept
+        // `--no-sandbox` etc. Without this, ubuntu CI runners fail with
+        // "Unknown option --no-sandbox". Consistency with mobile-safari below.
+        // Epic library-to-game post-review M2.
+        launchOptions: {
+          args: [],
+        },
       },
     },
-
-    // Safari projects override launchOptions because webkit does not accept
-    // the chromium-only flags (`--no-sandbox`, `--disable-gpu`, etc.) set at
-    // the top level. Without this override, `browserType.launch` fails with
-    // "Unknown option --no-sandbox" on ubuntu runners. Epic library-to-game T2.
-    // NOTE: the desktop-safari project above also inherits the bad args; we
-    // keep it unchanged for backward compatibility with test-e2e.yml which
-    // was already passing locally (macOS). The targeted override below only
-    // affects mobile-safari, which is what the library-to-game epic runs.
 
     // Mobile - Chrome + Safari (iOS simulation critical for market coverage)
     // Issue #1497: Added Safari for iOS browser testing


### PR DESCRIPTION
## Summary

Addresses 3 follow-up items from the PR #348 tech debt review (non-blocking but worth shipping before the final epic→main-dev merge).

## Changes

- **I2** (important): inline comment in `VectorDocumentIndexedForKbFlagHandler` documenting the multi-instance cache invalidation caveat. `HybridCache.RemoveByTagAsync` only clears the L1 of the instance processing the event; other replicas keep their L1 until `LocalCacheExpiration` (15 min). Acceptable for staging; for multi-replica prod consider shortening the TTL or publishing an integration event.
- **M2** (minor): apply `launchOptions: { args: [] }` to `desktop-safari` as well. Previously only `mobile-safari` had the override, leaving `desktop-safari` as a ticking time bomb if someone runs it on ubuntu CI.
- **M4** (minor): two new explicit regression tests for `VectorDocumentIndexedEvent.SharedGameId`:
  - `WithSharedGameId_ExposesValueOnProperty` — verifies the new positional arg is stored
  - `WithoutSharedGameId_DefaultsToNull` — verifies the optional parameter defaults

## Tests

- `dotnet test --filter FullyQualifiedName~VectorDocumentIndexedEvent` → **12/12 passing**
- `pnpm typecheck` → 0 errors

## Reference

- Review: PR #348 tech debt sweep
- Epic: `library-to-game`

🤖 Generated with [Claude Code](https://claude.com/claude-code)