### PR TITLE
feat(chat-panel): 4 polish follow-ups from PR #344

### DIFF
--- a/apps/web/src/components/chat/panel/ChatContextSwitcher.tsx
+++ b/apps/web/src/components/chat/panel/ChatContextSwitcher.tsx
@@ -1,22 +1,67 @@
 'use client';
 
+import { useEffect, useRef, useState } from 'react';
+
 import type { ChatGameContext } from '@/lib/stores/chat-panel-store';
+
+export interface AvailableGame {
+  id: string;
+  name: string;
+}
 
 interface ChatContextSwitcherProps {
   gameContext: ChatGameContext | null;
-  onPickGame: () => void;
+  onPickGame: (gameId: string) => void;
+  availableGames?: AvailableGame[];
 }
 
-export function ChatContextSwitcher({ gameContext, onPickGame }: ChatContextSwitcherProps) {
+export function ChatContextSwitcher({
+  gameContext,
+  onPickGame,
+  availableGames = [],
+}: ChatContextSwitcherProps) {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  function handlePillClick() {
+    if (availableGames.length > 0) {
+      setOpen(prev => !prev);
+    } else {
+      onPickGame('');
+    }
+  }
+
+  function handleSelectGame(gameId: string) {
+    setOpen(false);
+    onPickGame(gameId);
+  }
+
   return (
-    <div className="flex flex-shrink-0 flex-wrap items-center gap-2.5 border-b border-[var(--nh-border-default)] bg-[var(--nh-bg-base)] px-5 py-3">
+    <div
+      ref={wrapperRef}
+      className="relative flex flex-shrink-0 flex-wrap items-center gap-2.5 border-b border-[var(--nh-border-default)] bg-[var(--nh-bg-base)] px-5 py-3"
+    >
       <span className="mr-0.5 text-[0.7rem] font-extrabold uppercase tracking-wider text-[var(--nh-text-muted)]">
         Contesto
       </span>
       {gameContext ? (
         <button
           type="button"
-          onClick={onPickGame}
+          onClick={handlePillClick}
+          aria-haspopup={availableGames.length > 0 ? 'listbox' : undefined}
+          aria-expanded={availableGames.length > 0 ? open : undefined}
           className="flex items-center gap-2.5 rounded-full border border-[hsla(25,95%,45%,0.35)] bg-[hsla(25,95%,45%,0.08)] py-1.5 pl-1.5 pr-3.5 shadow-[var(--shadow-warm-sm)] transition-all hover:-translate-y-px hover:shadow-[var(--shadow-warm-md)]"
         >
           <span
@@ -45,11 +90,33 @@ export function ChatContextSwitcher({ gameContext, onPickGame }: ChatContextSwit
       ) : (
         <button
           type="button"
-          onClick={onPickGame}
+          onClick={handlePillClick}
           className="rounded-full border border-dashed border-[var(--nh-border-default)] bg-[var(--nh-bg-elevated)] px-4 py-2 font-nunito text-[0.78rem] font-semibold text-[var(--nh-text-muted)] hover:bg-white hover:shadow-[var(--shadow-warm-sm)]"
         >
           Seleziona gioco
         </button>
+      )}
+
+      {/* Game picker dropdown */}
+      {open && availableGames.length > 0 && (
+        <div
+          role="listbox"
+          aria-label="Seleziona gioco"
+          className="absolute left-5 top-full z-10 mt-1.5 max-h-52 w-56 overflow-y-auto rounded-2xl border border-[var(--nh-border-default)] bg-[var(--nh-bg-surface)] py-1.5 shadow-[var(--shadow-warm-lg)]"
+        >
+          {availableGames.map(game => (
+            <button
+              key={game.id}
+              type="button"
+              role="option"
+              aria-selected={game.id === gameContext?.id}
+              onClick={() => handleSelectGame(game.id)}
+              className="w-full px-4 py-2.5 text-left font-nunito text-[0.82rem] font-semibold text-[var(--nh-text-secondary)] transition-colors hover:bg-[var(--nh-bg-elevated)] hover:text-[var(--nh-text-primary)] aria-selected:text-[hsl(25,95%,38%)]"
+            >
+              {game.name}
+            </button>
+          ))}
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/components/chat/panel/ChatMainArea.tsx
+++ b/apps/web/src/components/chat/panel/ChatMainArea.tsx
@@ -16,6 +16,8 @@ interface ChatMainAreaProps {
   gameName?: string;
   suggestedQuestions: string[];
   onSend: (message: string) => void;
+  /** Stream error message to show above the input bar. */
+  error?: string | null;
 }
 
 export function ChatMainArea({
@@ -23,6 +25,7 @@ export function ChatMainArea({
   gameName,
   suggestedQuestions,
   onSend,
+  error,
 }: ChatMainAreaProps) {
   const isEmpty = messages.length === 0;
 
@@ -77,6 +80,11 @@ export function ChatMainArea({
           </div>
         )}
       </div>
+      {error && (
+        <div className="mx-6 mb-3 rounded-xl border border-red-200 bg-red-50 px-4 py-2.5 font-nunito text-sm text-red-700">
+          {error}
+        </div>
+      )}
       <ChatInputBar
         placeholder={gameName ? `Chiedi una regola su ${gameName}…` : 'Chiedi una regola…'}
         onSend={onSend}

--- a/apps/web/src/components/chat/panel/ChatSlideOverPanel.tsx
+++ b/apps/web/src/components/chat/panel/ChatSlideOverPanel.tsx
@@ -7,11 +7,13 @@ import { useGameAgents } from '@/hooks/queries/useGameAgents';
 import { useGames } from '@/hooks/queries/useGames';
 import { useAgentChatStream } from '@/hooks/useAgentChatStream';
 import { useChatPanel } from '@/hooks/useChatPanel';
+import { useEmbeddingStatus } from '@/hooks/useEmbeddingStatus';
+import { useToast } from '@/hooks/useToast';
 import { api } from '@/lib/api';
 import type { ChatSessionSummaryDto } from '@/lib/api/schemas/chat-sessions.schemas';
 import type { Game } from '@/lib/api/schemas/games.schemas';
 
-import { ChatContextSwitcher } from './ChatContextSwitcher';
+import { ChatContextSwitcher, type AvailableGame } from './ChatContextSwitcher';
 import { ChatMainArea, type ChatMessage } from './ChatMainArea';
 import { ChatPanelHeader } from './ChatPanelHeader';
 import { ChatSidebar, type ChatRecentItem, type ChatKbGame } from './ChatSidebar';
@@ -72,6 +74,7 @@ function gameToKbGame(game: Game): ChatKbGame {
 
 export function ChatSlideOverPanel() {
   const { isOpen, gameContext, close, setGameContext } = useChatPanel();
+  const { toast } = useToast();
 
   // Local chat state — lives on the component so the store stays pure UI
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -89,6 +92,14 @@ export function ChatSlideOverPanel() {
     enabled: !!gameContext?.id,
   });
   const agentId = gameAgents?.[0]?.id ?? null;
+
+  // Live KB status for the selected game
+  const { isReady: kbIsReady, data: kbStatusData } = useEmbeddingStatus(gameContext?.id ?? null, {
+    enabled: !!gameContext?.id,
+  });
+  const liveKbStatus: 'ready' | 'indexing' =
+    kbStatusData?.status === 'Completed' || kbIsReady ? 'ready' : 'indexing';
+  const enrichedGameContext = gameContext ? { ...gameContext, kbStatus: liveKbStatus } : null;
 
   // SSE streaming
   const stream = useAgentChatStream({
@@ -213,7 +224,11 @@ export function ChatSlideOverPanel() {
         setMessages(mapped);
         stream.reset();
       } catch {
-        // Failure is surfaced via the stream error UI on next send
+        toast({
+          title: 'Errore caricamento chat',
+          description: 'Non è stato possibile caricare la conversazione.',
+          variant: 'destructive',
+        });
       }
     },
     [stream]
@@ -238,17 +253,19 @@ export function ChatSlideOverPanel() {
     [gamesResponse, setGameContext, stream]
   );
 
-  // Game picker reuses the KB games list; ChatContextSwitcher calls this on click.
-  // For now it simply cycles to the next available game — a real dropdown is a
-  // polish item separate from the wiring work in this PR.
-  const handlePickGame = useCallback(() => {
-    if (!gamesResponse || gamesResponse.games.length === 0) return;
-    const currentIndex = gameContext
-      ? gamesResponse.games.findIndex(g => g.id === gameContext.id)
-      : -1;
-    const nextIndex = (currentIndex + 1) % gamesResponse.games.length;
-    handleSelectGame(gamesResponse.games[nextIndex].id);
-  }, [gamesResponse, gameContext, handleSelectGame]);
+  // Game picker: called by ChatContextSwitcher dropdown with the selected gameId.
+  const handlePickGame = useCallback(
+    (gameId: string) => {
+      if (gameId) handleSelectGame(gameId);
+    },
+    [handleSelectGame]
+  );
+
+  // Games list passed to ChatContextSwitcher dropdown.
+  const availableGames: AvailableGame[] = useMemo(
+    () => (gamesResponse?.games ?? []).map(g => ({ id: g.id, name: g.title })),
+    [gamesResponse]
+  );
 
   if (!isOpen) return null;
 
@@ -277,13 +294,17 @@ export function ChatSlideOverPanel() {
       >
         <ChatPanelHeader
           subtitle={
-            gameContext?.kbStatus === 'ready'
+            enrichedGameContext?.kbStatus === 'ready'
               ? 'KB pronta · Powered by MeepleAI'
               : 'Powered by MeepleAI'
           }
           onClose={close}
         />
-        <ChatContextSwitcher gameContext={gameContext} onPickGame={handlePickGame} />
+        <ChatContextSwitcher
+          gameContext={enrichedGameContext}
+          onPickGame={handlePickGame}
+          availableGames={availableGames}
+        />
         <div className="flex min-h-0 flex-1">
           <ChatSidebar
             chats={recentChats}
@@ -297,6 +318,7 @@ export function ChatSlideOverPanel() {
             gameName={gameContext?.name}
             suggestedQuestions={suggestedQuestions}
             onSend={handleSend}
+            error={stream.state.error}
           />
         </div>
       </aside>


### PR DESCRIPTION
## Summary

- **Stream error UI**: `ChatMainArea` now shows a red error banner above the input bar when `stream.state.error` is set
- **handleSelectChat error toast**: replaces empty catch block with a destructive toast via `useToast`
- **Real game picker dropdown**: `ChatContextSwitcher` now renders an accessible `listbox` dropdown when `availableGames` is provided, replacing the previous cycle-to-next workaround
- **Live KB status polling**: `ChatSlideOverPanel` uses `useEmbeddingStatus` for the selected game; `ChatContextSwitcher` and header subtitle reflect live status

## Test plan

- [ ] Start a chat session, trigger a stream error — red error banner appears above input
- [ ] Click a chat item that fails to load — destructive toast appears
- [ ] Click game context pill — dropdown lists available games; selecting one switches context
- [ ] Open panel with a game that has a KB — header subtitle shows live KB status

🤖 Generated with [Claude Code](https://claude.ai/code)