### PR TITLE
feat(my-hand): La Mia Mano — 4-slot quick action bar (backend CRUD + frontend)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/ClearHandSlotCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/ClearHandSlotCommand.cs
@@ -1,0 +1,8 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserLibrary.Application.Commands;
+
+/// <summary>
+/// Command to clear (remove) a user's hand slot assignment.
+/// </summary>
+internal record ClearHandSlotCommand(Guid UserId, string SlotType) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/ClearHandSlotCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/ClearHandSlotCommandHandler.cs
@@ -1,0 +1,29 @@
+using Api.BoundedContexts.UserLibrary.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.UserLibrary.Application.Commands;
+
+/// <summary>
+/// Handler for <see cref="ClearHandSlotCommand"/>.
+/// Removes the entity assignment from a hand slot and persists via the unit of work.
+/// </summary>
+internal class ClearHandSlotCommandHandler : ICommandHandler<ClearHandSlotCommand>
+{
+    private readonly IUserHandRepository _repo;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public ClearHandSlotCommandHandler(IUserHandRepository repo, IUnitOfWork unitOfWork)
+    {
+        _repo = repo ?? throw new ArgumentNullException(nameof(repo));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task Handle(ClearHandSlotCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        await _repo.ClearSlotAsync(command.UserId, command.SlotType, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/UpdateHandSlotCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/UpdateHandSlotCommand.cs
@@ -1,0 +1,16 @@
+using Api.BoundedContexts.UserLibrary.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserLibrary.Application.Commands;
+
+/// <summary>
+/// Command to assign or update an entity in a user's hand slot.
+/// </summary>
+internal record UpdateHandSlotCommand(
+    Guid UserId,
+    string SlotType,       // "toolkit" | "game" | "session" | "ai"
+    Guid EntityId,
+    string EntityType,     // "toolkit" | "game" | "session" | "agent"
+    string? EntityLabel = null,
+    string? EntityImageUrl = null
+) : ICommand<UserHandSlotDto>;

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/UpdateHandSlotCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/UpdateHandSlotCommandHandler.cs
@@ -24,7 +24,7 @@ internal class UpdateHandSlotCommandHandler : ICommandHandler<UpdateHandSlotComm
     {
         ArgumentNullException.ThrowIfNull(command);
 
-        await _repo.UpsertSlotAsync(
+        var pinnedAt = await _repo.UpsertSlotAsync(
             command.UserId,
             command.SlotType,
             command.EntityId,
@@ -42,7 +42,7 @@ internal class UpdateHandSlotCommandHandler : ICommandHandler<UpdateHandSlotComm
             command.EntityType,
             command.EntityLabel,
             command.EntityImageUrl,
-            DateTimeOffset.UtcNow.ToString("o")
+            pinnedAt.ToString("o")
         );
     }
 }

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/UpdateHandSlotCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/UpdateHandSlotCommandHandler.cs
@@ -1,0 +1,48 @@
+using Api.BoundedContexts.UserLibrary.Application.DTOs;
+using Api.BoundedContexts.UserLibrary.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.UserLibrary.Application.Commands;
+
+/// <summary>
+/// Handler for <see cref="UpdateHandSlotCommand"/>.
+/// Upserts the slot and persists changes via the unit of work.
+/// </summary>
+internal class UpdateHandSlotCommandHandler : ICommandHandler<UpdateHandSlotCommand, UserHandSlotDto>
+{
+    private readonly IUserHandRepository _repo;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public UpdateHandSlotCommandHandler(IUserHandRepository repo, IUnitOfWork unitOfWork)
+    {
+        _repo = repo ?? throw new ArgumentNullException(nameof(repo));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task<UserHandSlotDto> Handle(UpdateHandSlotCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        await _repo.UpsertSlotAsync(
+            command.UserId,
+            command.SlotType,
+            command.EntityId,
+            command.EntityType,
+            command.EntityLabel,
+            command.EntityImageUrl,
+            cancellationToken
+        ).ConfigureAwait(false);
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return new UserHandSlotDto(
+            command.SlotType,
+            command.EntityId,
+            command.EntityType,
+            command.EntityLabel,
+            command.EntityImageUrl,
+            DateTimeOffset.UtcNow.ToString("o")
+        );
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/DTOs/UserHandSlotDto.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/DTOs/UserHandSlotDto.cs
@@ -1,0 +1,13 @@
+namespace Api.BoundedContexts.UserLibrary.Application.DTOs;
+
+/// <summary>
+/// DTO representing a single slot in the user's hand (quick-access bar).
+/// </summary>
+public record UserHandSlotDto(
+    string SlotType,
+    Guid? EntityId,
+    string? EntityType,
+    string? EntityLabel,
+    string? EntityImageUrl,
+    string? PinnedAt  // ISO 8601
+);

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/HandSlotConstants.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/HandSlotConstants.cs
@@ -1,0 +1,22 @@
+namespace Api.BoundedContexts.UserLibrary.Application;
+
+internal static class HandSlotConstants
+{
+    public static readonly HashSet<string> ValidSlotTypes =
+        new(StringComparer.OrdinalIgnoreCase) { "toolkit", "game", "session", "ai" };
+
+    public static readonly HashSet<string> ValidEntityTypes =
+        new(StringComparer.OrdinalIgnoreCase) { "toolkit", "game", "session", "agent" };
+
+    public static readonly IReadOnlyDictionary<string, string[]> SlotEntityMap =
+        new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["toolkit"] = ["toolkit"],
+            ["game"]    = ["game"],
+            ["session"] = ["session"],
+            ["ai"]      = ["agent"]
+        };
+
+    /// <summary>All valid slot types in display order.</summary>
+    public static readonly string[] AllSlotTypes = ["toolkit", "game", "session", "ai"];
+}

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetUserHandQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetUserHandQuery.cs
@@ -1,0 +1,10 @@
+using Api.BoundedContexts.UserLibrary.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserLibrary.Application.Queries;
+
+/// <summary>
+/// Query to retrieve all hand slots for a user.
+/// Always returns all 4 slot types; empty slots have null entity fields.
+/// </summary>
+internal record GetUserHandQuery(Guid UserId) : IQuery<IReadOnlyList<UserHandSlotDto>>;

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetUserHandQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetUserHandQueryHandler.cs
@@ -10,8 +10,6 @@ namespace Api.BoundedContexts.UserLibrary.Application.Queries;
 /// </summary>
 internal class GetUserHandQueryHandler : IQueryHandler<GetUserHandQuery, IReadOnlyList<UserHandSlotDto>>
 {
-    private static readonly string[] AllSlotTypes = ["toolkit", "game", "session", "ai"];
-
     private readonly IUserHandRepository _repo;
 
     public GetUserHandQueryHandler(IUserHandRepository repo)
@@ -27,7 +25,7 @@ internal class GetUserHandQueryHandler : IQueryHandler<GetUserHandQuery, IReadOn
         var slotMap = slots.ToDictionary(s => s.SlotType, StringComparer.OrdinalIgnoreCase);
 
         // Always return all 4 slot types — empty if not assigned
-        return AllSlotTypes.Select(slotType =>
+        return HandSlotConstants.AllSlotTypes.Select(slotType =>
         {
             if (slotMap.TryGetValue(slotType, out var slot))
             {

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetUserHandQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetUserHandQueryHandler.cs
@@ -1,0 +1,46 @@
+using Api.BoundedContexts.UserLibrary.Application.DTOs;
+using Api.BoundedContexts.UserLibrary.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserLibrary.Application.Queries;
+
+/// <summary>
+/// Handler for <see cref="GetUserHandQuery"/>.
+/// Returns all 4 slot types, with null entity fields for unassigned slots.
+/// </summary>
+internal class GetUserHandQueryHandler : IQueryHandler<GetUserHandQuery, IReadOnlyList<UserHandSlotDto>>
+{
+    private static readonly string[] AllSlotTypes = ["toolkit", "game", "session", "ai"];
+
+    private readonly IUserHandRepository _repo;
+
+    public GetUserHandQueryHandler(IUserHandRepository repo)
+    {
+        _repo = repo ?? throw new ArgumentNullException(nameof(repo));
+    }
+
+    public async Task<IReadOnlyList<UserHandSlotDto>> Handle(GetUserHandQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var slots = await _repo.GetAllSlotsAsync(query.UserId, cancellationToken).ConfigureAwait(false);
+        var slotMap = slots.ToDictionary(s => s.SlotType);
+
+        // Always return all 4 slot types — empty if not assigned
+        return AllSlotTypes.Select(slotType =>
+        {
+            if (slotMap.TryGetValue(slotType, out var slot))
+            {
+                return new UserHandSlotDto(
+                    slotType,
+                    slot.EntityId,
+                    slot.EntityType,
+                    slot.EntityLabel,
+                    slot.EntityImageUrl,
+                    slot.PinnedAt?.ToString("o")
+                );
+            }
+            return new UserHandSlotDto(slotType, null, null, null, null, null);
+        }).ToList();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetUserHandQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetUserHandQueryHandler.cs
@@ -24,7 +24,7 @@ internal class GetUserHandQueryHandler : IQueryHandler<GetUserHandQuery, IReadOn
         ArgumentNullException.ThrowIfNull(query);
 
         var slots = await _repo.GetAllSlotsAsync(query.UserId, cancellationToken).ConfigureAwait(false);
-        var slotMap = slots.ToDictionary(s => s.SlotType);
+        var slotMap = slots.ToDictionary(s => s.SlotType, StringComparer.OrdinalIgnoreCase);
 
         // Always return all 4 slot types — empty if not assigned
         return AllSlotTypes.Select(slotType =>

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/ClearHandSlotCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/ClearHandSlotCommandValidator.cs
@@ -5,7 +5,8 @@ namespace Api.BoundedContexts.UserLibrary.Application.Validators;
 
 internal class ClearHandSlotCommandValidator : AbstractValidator<ClearHandSlotCommand>
 {
-    private static readonly string[] ValidSlotTypes = ["toolkit", "game", "session", "ai"];
+    private static readonly HashSet<string> ValidSlotTypes = new(StringComparer.OrdinalIgnoreCase)
+        { "toolkit", "game", "session", "ai" };
 
     public ClearHandSlotCommandValidator()
     {

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/ClearHandSlotCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/ClearHandSlotCommandValidator.cs
@@ -5,9 +5,6 @@ namespace Api.BoundedContexts.UserLibrary.Application.Validators;
 
 internal class ClearHandSlotCommandValidator : AbstractValidator<ClearHandSlotCommand>
 {
-    private static readonly HashSet<string> ValidSlotTypes = new(StringComparer.OrdinalIgnoreCase)
-        { "toolkit", "game", "session", "ai" };
-
     public ClearHandSlotCommandValidator()
     {
         RuleFor(x => x.UserId)
@@ -16,7 +13,7 @@ internal class ClearHandSlotCommandValidator : AbstractValidator<ClearHandSlotCo
 
         RuleFor(x => x.SlotType)
             .NotEmpty()
-            .Must(s => ValidSlotTypes.Contains(s))
-            .WithMessage($"SlotType must be one of: {string.Join(", ", ValidSlotTypes)}");
+            .Must(s => HandSlotConstants.ValidSlotTypes.Contains(s))
+            .WithMessage($"SlotType must be one of: {string.Join(", ", HandSlotConstants.ValidSlotTypes)}");
     }
 }

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/ClearHandSlotCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/ClearHandSlotCommandValidator.cs
@@ -1,0 +1,21 @@
+using Api.BoundedContexts.UserLibrary.Application.Commands;
+using FluentValidation;
+
+namespace Api.BoundedContexts.UserLibrary.Application.Validators;
+
+internal class ClearHandSlotCommandValidator : AbstractValidator<ClearHandSlotCommand>
+{
+    private static readonly string[] ValidSlotTypes = ["toolkit", "game", "session", "ai"];
+
+    public ClearHandSlotCommandValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty()
+            .WithMessage("UserId is required");
+
+        RuleFor(x => x.SlotType)
+            .NotEmpty()
+            .Must(s => ValidSlotTypes.Contains(s))
+            .WithMessage($"SlotType must be one of: {string.Join(", ", ValidSlotTypes)}");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/GetUserHandQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/GetUserHandQueryValidator.cs
@@ -1,0 +1,14 @@
+using Api.BoundedContexts.UserLibrary.Application.Queries;
+using FluentValidation;
+
+namespace Api.BoundedContexts.UserLibrary.Application.Validators;
+
+internal class GetUserHandQueryValidator : AbstractValidator<GetUserHandQuery>
+{
+    public GetUserHandQueryValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty()
+            .WithMessage("UserId is required");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/UpdateHandSlotCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/UpdateHandSlotCommandValidator.cs
@@ -1,0 +1,44 @@
+using Api.BoundedContexts.UserLibrary.Application.Commands;
+using FluentValidation;
+
+namespace Api.BoundedContexts.UserLibrary.Application.Validators;
+
+internal class UpdateHandSlotCommandValidator : AbstractValidator<UpdateHandSlotCommand>
+{
+    private static readonly string[] ValidSlotTypes = ["toolkit", "game", "session", "ai"];
+    private static readonly string[] ValidEntityTypes = ["toolkit", "game", "session", "agent"];
+
+    private static readonly Dictionary<string, string[]> SlotEntityMap = new()
+    {
+        ["toolkit"] = ["toolkit"],
+        ["game"]    = ["game"],
+        ["session"] = ["session"],
+        ["ai"]      = ["agent"]
+    };
+
+    public UpdateHandSlotCommandValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty()
+            .WithMessage("UserId is required");
+
+        RuleFor(x => x.SlotType)
+            .NotEmpty()
+            .Must(s => ValidSlotTypes.Contains(s))
+            .WithMessage($"SlotType must be one of: {string.Join(", ", ValidSlotTypes)}");
+
+        RuleFor(x => x.EntityId)
+            .NotEmpty()
+            .WithMessage("EntityId is required");
+
+        RuleFor(x => x.EntityType)
+            .NotEmpty()
+            .Must(t => ValidEntityTypes.Contains(t))
+            .WithMessage($"EntityType must be one of: {string.Join(", ", ValidEntityTypes)}");
+
+        RuleFor(x => x)
+            .Must(x => SlotEntityMap.TryGetValue(x.SlotType, out var allowed) && allowed.Contains(x.EntityType))
+            .WithMessage(x => $"EntityType '{x.EntityType}' is not valid for SlotType '{x.SlotType}'")
+            .When(x => ValidSlotTypes.Contains(x.SlotType) && ValidEntityTypes.Contains(x.EntityType));
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/UpdateHandSlotCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/UpdateHandSlotCommandValidator.cs
@@ -5,15 +5,18 @@ namespace Api.BoundedContexts.UserLibrary.Application.Validators;
 
 internal class UpdateHandSlotCommandValidator : AbstractValidator<UpdateHandSlotCommand>
 {
-    private static readonly string[] ValidSlotTypes = ["toolkit", "game", "session", "ai"];
-    private static readonly string[] ValidEntityTypes = ["toolkit", "game", "session", "agent"];
+    private static readonly HashSet<string> ValidSlotTypes = new(StringComparer.OrdinalIgnoreCase)
+        { "toolkit", "game", "session", "ai" };
 
-    private static readonly Dictionary<string, string[]> SlotEntityMap = new()
+    private static readonly HashSet<string> ValidEntityTypes = new(StringComparer.OrdinalIgnoreCase)
+        { "toolkit", "game", "session", "agent" };
+
+    private static readonly Dictionary<string, HashSet<string>> SlotEntityMap = new(StringComparer.OrdinalIgnoreCase)
     {
-        ["toolkit"] = ["toolkit"],
-        ["game"]    = ["game"],
-        ["session"] = ["session"],
-        ["ai"]      = ["agent"]
+        ["toolkit"] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "toolkit" },
+        ["game"]    = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "game" },
+        ["session"] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "session" },
+        ["ai"]      = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "agent" }
     };
 
     public UpdateHandSlotCommandValidator()

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/UpdateHandSlotCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/UpdateHandSlotCommandValidator.cs
@@ -5,20 +5,6 @@ namespace Api.BoundedContexts.UserLibrary.Application.Validators;
 
 internal class UpdateHandSlotCommandValidator : AbstractValidator<UpdateHandSlotCommand>
 {
-    private static readonly HashSet<string> ValidSlotTypes = new(StringComparer.OrdinalIgnoreCase)
-        { "toolkit", "game", "session", "ai" };
-
-    private static readonly HashSet<string> ValidEntityTypes = new(StringComparer.OrdinalIgnoreCase)
-        { "toolkit", "game", "session", "agent" };
-
-    private static readonly Dictionary<string, HashSet<string>> SlotEntityMap = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["toolkit"] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "toolkit" },
-        ["game"]    = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "game" },
-        ["session"] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "session" },
-        ["ai"]      = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "agent" }
-    };
-
     public UpdateHandSlotCommandValidator()
     {
         RuleFor(x => x.UserId)
@@ -27,8 +13,8 @@ internal class UpdateHandSlotCommandValidator : AbstractValidator<UpdateHandSlot
 
         RuleFor(x => x.SlotType)
             .NotEmpty()
-            .Must(s => ValidSlotTypes.Contains(s))
-            .WithMessage($"SlotType must be one of: {string.Join(", ", ValidSlotTypes)}");
+            .Must(s => HandSlotConstants.ValidSlotTypes.Contains(s))
+            .WithMessage($"SlotType must be one of: {string.Join(", ", HandSlotConstants.ValidSlotTypes)}");
 
         RuleFor(x => x.EntityId)
             .NotEmpty()
@@ -36,12 +22,14 @@ internal class UpdateHandSlotCommandValidator : AbstractValidator<UpdateHandSlot
 
         RuleFor(x => x.EntityType)
             .NotEmpty()
-            .Must(t => ValidEntityTypes.Contains(t))
-            .WithMessage($"EntityType must be one of: {string.Join(", ", ValidEntityTypes)}");
+            .Must(t => HandSlotConstants.ValidEntityTypes.Contains(t))
+            .WithMessage($"EntityType must be one of: {string.Join(", ", HandSlotConstants.ValidEntityTypes)}");
 
         RuleFor(x => x)
-            .Must(x => SlotEntityMap.TryGetValue(x.SlotType, out var allowed) && allowed.Contains(x.EntityType))
+            .Must(x => HandSlotConstants.SlotEntityMap.TryGetValue(x.SlotType, out var allowed)
+                       && allowed.Contains(x.EntityType, StringComparer.OrdinalIgnoreCase))
             .WithMessage(x => $"EntityType '{x.EntityType}' is not valid for SlotType '{x.SlotType}'")
-            .When(x => ValidSlotTypes.Contains(x.SlotType) && ValidEntityTypes.Contains(x.EntityType));
+            .When(x => HandSlotConstants.ValidSlotTypes.Contains(x.SlotType)
+                       && HandSlotConstants.ValidEntityTypes.Contains(x.EntityType));
     }
 }

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Repositories/IUserHandRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Repositories/IUserHandRepository.cs
@@ -1,0 +1,18 @@
+namespace Api.BoundedContexts.UserLibrary.Domain.Repositories;
+
+public interface IUserHandRepository
+{
+    Task<IReadOnlyList<UserHandSlotData>> GetAllSlotsAsync(Guid userId, CancellationToken ct = default);
+    Task UpsertSlotAsync(Guid userId, string slotType, Guid entityId, string entityType, string? entityLabel, string? entityImageUrl, CancellationToken ct = default);
+    Task ClearSlotAsync(Guid userId, string slotType, CancellationToken ct = default);
+}
+
+/// <summary>Simple data transfer record used within the domain layer.</summary>
+public record UserHandSlotData(
+    string SlotType,
+    Guid? EntityId,
+    string? EntityType,
+    string? EntityLabel,
+    string? EntityImageUrl,
+    DateTime? PinnedAt
+);

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Repositories/IUserHandRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Repositories/IUserHandRepository.cs
@@ -3,6 +3,6 @@ namespace Api.BoundedContexts.UserLibrary.Domain.Repositories;
 public interface IUserHandRepository
 {
     Task<IReadOnlyList<UserHandSlotData>> GetAllSlotsAsync(Guid userId, CancellationToken ct = default);
-    Task UpsertSlotAsync(Guid userId, string slotType, Guid entityId, string entityType, string? entityLabel, string? entityImageUrl, CancellationToken ct = default);
+    Task<DateTime> UpsertSlotAsync(Guid userId, string slotType, Guid entityId, string entityType, string? entityLabel, string? entityImageUrl, CancellationToken ct = default);
     Task ClearSlotAsync(Guid userId, string slotType, CancellationToken ct = default);
 }

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Repositories/IUserHandRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Repositories/IUserHandRepository.cs
@@ -6,13 +6,3 @@ public interface IUserHandRepository
     Task UpsertSlotAsync(Guid userId, string slotType, Guid entityId, string entityType, string? entityLabel, string? entityImageUrl, CancellationToken ct = default);
     Task ClearSlotAsync(Guid userId, string slotType, CancellationToken ct = default);
 }
-
-/// <summary>Simple data transfer record used within the domain layer.</summary>
-public record UserHandSlotData(
-    string SlotType,
-    Guid? EntityId,
-    string? EntityType,
-    string? EntityLabel,
-    string? EntityImageUrl,
-    DateTime? PinnedAt
-);

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Repositories/UserHandSlotData.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Repositories/UserHandSlotData.cs
@@ -1,0 +1,11 @@
+namespace Api.BoundedContexts.UserLibrary.Domain.Repositories;
+
+/// <summary>Simple data transfer record used within the domain layer.</summary>
+public record UserHandSlotData(
+    string SlotType,
+    Guid? EntityId,
+    string? EntityType,
+    string? EntityLabel,
+    string? EntityImageUrl,
+    DateTime? PinnedAt
+);

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Infrastructure/DependencyInjection/UserLibraryServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Infrastructure/DependencyInjection/UserLibraryServiceExtensions.cs
@@ -26,6 +26,7 @@ internal static class UserLibraryServiceExtensions
         services.AddScoped<IWishlistRepository, WishlistRepository>(); // Issue #3917: Wishlist management
         services.AddScoped<IUserCollectionRepository, UserCollectionRepository>(); // Issue #4263: Generic user collections
         services.AddScoped<IGameSuggestionRepository, GameSuggestionRepository>(); // Admin Invitation Flow: game suggestions
+        services.AddScoped<IUserHandRepository, UserHandRepository>(); // La Mia Mano: hand slots
 
         // Register domain services
         services.AddScoped<IGameLibraryQuotaService, GameLibraryQuotaService>();

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Infrastructure/Persistence/UserHandRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Infrastructure/Persistence/UserHandRepository.cs
@@ -1,0 +1,79 @@
+using Api.BoundedContexts.UserLibrary.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.UserLibrary;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.UserLibrary.Infrastructure.Persistence;
+
+internal class UserHandRepository : IUserHandRepository
+{
+    private readonly MeepleAiDbContext _db;
+
+    public UserHandRepository(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<IReadOnlyList<UserHandSlotData>> GetAllSlotsAsync(Guid userId, CancellationToken ct = default)
+    {
+        var entities = await _db.UserHandSlots
+            .AsNoTracking()
+            .Where(s => s.UserId == userId)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        return entities.Select(e => new UserHandSlotData(
+            e.SlotType,
+            e.EntityId,
+            e.EntityType,
+            e.EntityLabel,
+            e.EntityImageUrl,
+            e.PinnedAt
+        )).ToList();
+    }
+
+    public async Task UpsertSlotAsync(Guid userId, string slotType, Guid entityId, string entityType,
+        string? entityLabel, string? entityImageUrl, CancellationToken ct = default)
+    {
+        var existing = await _db.UserHandSlots
+            .FirstOrDefaultAsync(s => s.UserId == userId && s.SlotType == slotType, ct)
+            .ConfigureAwait(false);
+
+        if (existing is null)
+        {
+            _db.UserHandSlots.Add(new UserHandSlotEntity
+            {
+                UserId = userId,
+                SlotType = slotType,
+                EntityId = entityId,
+                EntityType = entityType,
+                EntityLabel = entityLabel,
+                EntityImageUrl = entityImageUrl,
+                PinnedAt = DateTime.UtcNow
+            });
+        }
+        else
+        {
+            existing.EntityId = entityId;
+            existing.EntityType = entityType;
+            existing.EntityLabel = entityLabel;
+            existing.EntityImageUrl = entityImageUrl;
+            existing.PinnedAt = DateTime.UtcNow;
+        }
+
+        await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+    }
+
+    public async Task ClearSlotAsync(Guid userId, string slotType, CancellationToken ct = default)
+    {
+        var existing = await _db.UserHandSlots
+            .FirstOrDefaultAsync(s => s.UserId == userId && s.SlotType == slotType, ct)
+            .ConfigureAwait(false);
+
+        if (existing is not null)
+        {
+            _db.UserHandSlots.Remove(existing);
+            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Infrastructure/Persistence/UserHandRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Infrastructure/Persistence/UserHandRepository.cs
@@ -8,10 +8,12 @@ namespace Api.BoundedContexts.UserLibrary.Infrastructure.Persistence;
 internal class UserHandRepository : IUserHandRepository
 {
     private readonly MeepleAiDbContext _db;
+    private readonly TimeProvider _timeProvider;
 
-    public UserHandRepository(MeepleAiDbContext db)
+    public UserHandRepository(MeepleAiDbContext db, TimeProvider timeProvider)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
     }
 
     public async Task<IReadOnlyList<UserHandSlotData>> GetAllSlotsAsync(Guid userId, CancellationToken ct = default)
@@ -35,6 +37,8 @@ internal class UserHandRepository : IUserHandRepository
     public async Task UpsertSlotAsync(Guid userId, string slotType, Guid entityId, string entityType,
         string? entityLabel, string? entityImageUrl, CancellationToken ct = default)
     {
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+
         var existing = await _db.UserHandSlots
             .FirstOrDefaultAsync(s => s.UserId == userId && s.SlotType == slotType, ct)
             .ConfigureAwait(false);
@@ -49,7 +53,7 @@ internal class UserHandRepository : IUserHandRepository
                 EntityType = entityType,
                 EntityLabel = entityLabel,
                 EntityImageUrl = entityImageUrl,
-                PinnedAt = DateTime.UtcNow
+                PinnedAt = now
             });
         }
         else
@@ -58,10 +62,8 @@ internal class UserHandRepository : IUserHandRepository
             existing.EntityType = entityType;
             existing.EntityLabel = entityLabel;
             existing.EntityImageUrl = entityImageUrl;
-            existing.PinnedAt = DateTime.UtcNow;
+            existing.PinnedAt = now;
         }
-
-        await _db.SaveChangesAsync(ct).ConfigureAwait(false);
     }
 
     public async Task ClearSlotAsync(Guid userId, string slotType, CancellationToken ct = default)
@@ -73,7 +75,6 @@ internal class UserHandRepository : IUserHandRepository
         if (existing is not null)
         {
             _db.UserHandSlots.Remove(existing);
-            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
         }
     }
 }

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Infrastructure/Persistence/UserHandRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Infrastructure/Persistence/UserHandRepository.cs
@@ -34,7 +34,7 @@ internal class UserHandRepository : IUserHandRepository
         )).ToList();
     }
 
-    public async Task UpsertSlotAsync(Guid userId, string slotType, Guid entityId, string entityType,
+    public async Task<DateTime> UpsertSlotAsync(Guid userId, string slotType, Guid entityId, string entityType,
         string? entityLabel, string? entityImageUrl, CancellationToken ct = default)
     {
         var now = _timeProvider.GetUtcNow().UtcDateTime;
@@ -64,6 +64,8 @@ internal class UserHandRepository : IUserHandRepository
             existing.EntityImageUrl = entityImageUrl;
             existing.PinnedAt = now;
         }
+
+        return now;
     }
 
     public async Task ClearSlotAsync(Guid userId, string slotType, CancellationToken ct = default)

--- a/apps/api/src/Api/Infrastructure/Entities/UserLibrary/UserHandSlotEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/UserLibrary/UserHandSlotEntity.cs
@@ -1,0 +1,34 @@
+namespace Api.Infrastructure.Entities.UserLibrary;
+
+/// <summary>
+/// Persistence entity for "La Mia Mano" hand slots.
+/// Each user has up to 4 slots (one per SlotType).
+/// </summary>
+public class UserHandSlotEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    /// <summary>User who owns this slot.</summary>
+    public Guid UserId { get; set; }
+
+    /// <summary>Slot type: "toolkit" | "game" | "session" | "ai"</summary>
+    public string SlotType { get; set; } = string.Empty;
+
+    /// <summary>ID of the pinned entity (null = empty slot).</summary>
+    public Guid? EntityId { get; set; }
+
+    /// <summary>MeepleCard entity type: "toolkit" | "game" | "session" | "agent"</summary>
+    public string? EntityType { get; set; }
+
+    /// <summary>Cached display name for quick rendering.</summary>
+    public string? EntityLabel { get; set; }
+
+    /// <summary>Cached thumbnail URL.</summary>
+    public string? EntityImageUrl { get; set; }
+
+    /// <summary>When the slot was last assigned.</summary>
+    public DateTime? PinnedAt { get; set; }
+
+    // Navigation
+    public UserEntity? User { get; set; }
+}

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/UserLibrary/UserHandSlotEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/UserLibrary/UserHandSlotEntityConfiguration.cs
@@ -1,0 +1,57 @@
+using Api.Infrastructure.Entities.UserLibrary;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations.UserLibrary;
+
+/// <summary>
+/// EF Core configuration for UserHandSlotEntity.
+/// La Mia Mano: user hand slots (up to 4 per user, one per SlotType).
+/// </summary>
+internal class UserHandSlotEntityConfiguration : IEntityTypeConfiguration<UserHandSlotEntity>
+{
+    public void Configure(EntityTypeBuilder<UserHandSlotEntity> builder)
+    {
+        builder.ToTable("user_hand_slots");
+
+        builder.HasKey(e => e.Id);
+
+        // Properties
+        builder.Property(e => e.UserId)
+            .IsRequired();
+
+        builder.Property(e => e.SlotType)
+            .IsRequired()
+            .HasMaxLength(20);
+
+        builder.Property(e => e.EntityId)
+            .IsRequired(false);
+
+        builder.Property(e => e.EntityType)
+            .HasMaxLength(50)
+            .IsRequired(false);
+
+        builder.Property(e => e.EntityLabel)
+            .HasMaxLength(200)
+            .IsRequired(false);
+
+        builder.Property(e => e.EntityImageUrl)
+            .HasMaxLength(500)
+            .IsRequired(false);
+
+        builder.Property(e => e.PinnedAt)
+            .IsRequired(false);
+
+        // Indexes
+        // Unique: one slot per type per user
+        builder.HasIndex(e => new { e.UserId, e.SlotType })
+            .IsUnique()
+            .HasDatabaseName("IX_user_hand_slots_user_id_slot_type");
+
+        // Relationships
+        builder.HasOne(e => e.User)
+            .WithMany()
+            .HasForeignKey(e => e.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -138,6 +138,7 @@ public class MeepleAiDbContext : DbContext
     public DbSet<QuickQuestionEntity> QuickQuestions => Set<QuickQuestionEntity>(); // ISSUE-2401: Sprint 3 - Quick questions AI generation
     public DbSet<UserLibraryEntryEntity> UserLibraryEntries => Set<UserLibraryEntryEntity>(); // User Library feature
     public DbSet<WishlistItemEntity> WishlistItems => Set<WishlistItemEntity>(); // ISSUE-3917: Wishlist management
+    public DbSet<UserHandSlotEntity> UserHandSlots => Set<UserHandSlotEntity>(); // La Mia Mano: user hand slots
     public DbSet<UserCollectionEntryEntity> UserCollectionEntries => Set<UserCollectionEntryEntity>(); // ISSUE-4263: Generic user collections
     public DbSet<LibraryShareLinkEntity> LibraryShareLinks => Set<LibraryShareLinkEntity>(); // ISSUE-2614: Library sharing
     public DbSet<GameLabelEntity> GameLabels => Set<GameLabelEntity>(); // ISSUE-3512: Game labels for library

--- a/apps/api/src/Api/Infrastructure/Migrations/20260409174122_AddUserHandSlots.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260409174122_AddUserHandSlots.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260409174122_AddUserHandSlots")]
+    partial class AddUserHandSlots
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260409174122_AddUserHandSlots.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260409174122_AddUserHandSlots.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserHandSlots : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserHandSlots",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SlotType = table.Column<string>(type: "text", nullable: false),
+                    EntityId = table.Column<Guid>(type: "uuid", nullable: true),
+                    EntityType = table.Column<string>(type: "text", nullable: true),
+                    EntityLabel = table.Column<string>(type: "text", nullable: true),
+                    EntityImageUrl = table.Column<string>(type: "text", nullable: true),
+                    PinnedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserHandSlots", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserHandSlots_users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserHandSlots_UserId",
+                table: "UserHandSlots",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserHandSlots");
+        }
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Migrations/20260409175159_AddUserHandSlots.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260409175159_AddUserHandSlots.Designer.cs
@@ -14,7 +14,7 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    [Migration("20260409174122_AddUserHandSlots")]
+    [Migration("20260409175159_AddUserHandSlots")]
     partial class AddUserHandSlots
     {
         /// <inheritdoc />
@@ -11381,29 +11381,35 @@ namespace Api.Infrastructure.Migrations
                         .HasColumnType("uuid");
 
                     b.Property<string>("EntityImageUrl")
-                        .HasColumnType("text");
+                        .HasMaxLength(500)
+                        .HasColumnType("character varying(500)");
 
                     b.Property<string>("EntityLabel")
-                        .HasColumnType("text");
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
 
                     b.Property<string>("EntityType")
-                        .HasColumnType("text");
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
 
                     b.Property<DateTime?>("PinnedAt")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("SlotType")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
 
                     b.Property<Guid>("UserId")
                         .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
-                    b.HasIndex("UserId");
+                    b.HasIndex("UserId", "SlotType")
+                        .IsUnique()
+                        .HasDatabaseName("IX_user_hand_slots_user_id_slot_type");
 
-                    b.ToTable("UserHandSlots");
+                    b.ToTable("user_hand_slots", (string)null);
                 });
 
             modelBuilder.Entity("Api.Infrastructure.Entities.UserLibrary.UserLibraryEntryEntity", b =>

--- a/apps/api/src/Api/Infrastructure/Migrations/20260409175159_AddUserHandSlots.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260409175159_AddUserHandSlots.cs
@@ -12,23 +12,23 @@ namespace Api.Infrastructure.Migrations
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.CreateTable(
-                name: "UserHandSlots",
+                name: "user_hand_slots",
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     UserId = table.Column<Guid>(type: "uuid", nullable: false),
-                    SlotType = table.Column<string>(type: "text", nullable: false),
+                    SlotType = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
                     EntityId = table.Column<Guid>(type: "uuid", nullable: true),
-                    EntityType = table.Column<string>(type: "text", nullable: true),
-                    EntityLabel = table.Column<string>(type: "text", nullable: true),
-                    EntityImageUrl = table.Column<string>(type: "text", nullable: true),
+                    EntityType = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    EntityLabel = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    EntityImageUrl = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
                     PinnedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_UserHandSlots", x => x.Id);
+                    table.PrimaryKey("PK_user_hand_slots", x => x.Id);
                     table.ForeignKey(
-                        name: "FK_UserHandSlots_users_UserId",
+                        name: "FK_user_hand_slots_users_UserId",
                         column: x => x.UserId,
                         principalTable: "users",
                         principalColumn: "Id",
@@ -36,16 +36,17 @@ namespace Api.Infrastructure.Migrations
                 });
 
             migrationBuilder.CreateIndex(
-                name: "IX_UserHandSlots_UserId",
-                table: "UserHandSlots",
-                column: "UserId");
+                name: "IX_user_hand_slots_user_id_slot_type",
+                table: "user_hand_slots",
+                columns: new[] { "UserId", "SlotType" },
+                unique: true);
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropTable(
-                name: "UserHandSlots");
+                name: "user_hand_slots");
         }
     }
 }

--- a/apps/api/src/Api/Infrastructure/Migrations/MeepleAiDbContextModelSnapshot.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/MeepleAiDbContextModelSnapshot.cs
@@ -11378,29 +11378,35 @@ namespace Api.Infrastructure.Migrations
                         .HasColumnType("uuid");
 
                     b.Property<string>("EntityImageUrl")
-                        .HasColumnType("text");
+                        .HasMaxLength(500)
+                        .HasColumnType("character varying(500)");
 
                     b.Property<string>("EntityLabel")
-                        .HasColumnType("text");
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
 
                     b.Property<string>("EntityType")
-                        .HasColumnType("text");
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
 
                     b.Property<DateTime?>("PinnedAt")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("SlotType")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
 
                     b.Property<Guid>("UserId")
                         .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
-                    b.HasIndex("UserId");
+                    b.HasIndex("UserId", "SlotType")
+                        .IsUnique()
+                        .HasDatabaseName("IX_user_hand_slots_user_id_slot_type");
 
-                    b.ToTable("UserHandSlots");
+                    b.ToTable("user_hand_slots", (string)null);
                 });
 
             modelBuilder.Entity("Api.Infrastructure.Entities.UserLibrary.UserLibraryEntryEntity", b =>

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -767,6 +767,7 @@ if (!isAlphaMode)
     v1Api.MapEntityLinkUserEndpoints();    // Entity link user endpoints (Issue #5137)
     v1Api.MapEntityLinkAdminEndpoints();   // Entity link admin endpoints (Issue #5138)
     v1Api.MapWishlistEndpoints();          // Wishlist management (Issue #3917)
+    v1Api.MapUserHandEndpoints();          // My Hand quick-access slots (La Mia Mano)
     v1Api.MapAchievementEndpoints();       // Achievement system (Issue #3922)
 
     // Audit & Analytics

--- a/apps/api/src/Api/Routing/UserHandEndpoints.cs
+++ b/apps/api/src/Api/Routing/UserHandEndpoints.cs
@@ -1,0 +1,141 @@
+using System.Security.Claims;
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.UserLibrary.Application.Commands;
+using Api.BoundedContexts.UserLibrary.Application.DTOs;
+using Api.BoundedContexts.UserLibrary.Application.Queries;
+using Api.Extensions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Routing;
+
+/// <summary>
+/// Hand slot management endpoints — the quick-access "La Mia Mano" sidebar.
+/// Each user has 4 fixed slots (toolkit, game, session, ai).
+/// </summary>
+internal static class UserHandEndpoints
+{
+    public static RouteGroupBuilder MapUserHandEndpoints(this RouteGroupBuilder group)
+    {
+        MapGetUserHandEndpoint(group);
+        MapUpdateHandSlotEndpoint(group);
+        MapClearHandSlotEndpoint(group);
+
+        return group;
+    }
+
+    private static void MapGetUserHandEndpoint(RouteGroupBuilder group)
+    {
+        group.MapGet("/users/me/hand", async (
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, session, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+
+            if (!TryGetUserId(context, session, out var userId))
+                return Results.Unauthorized();
+
+            var query = new GetUserHandQuery(userId);
+            var result = await mediator.Send(query, ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .RequireAuthenticatedUser()
+        .Produces<IReadOnlyList<UserHandSlotDto>>(200)
+        .Produces(401)
+        .WithTags("MyHand")
+        .WithSummary("Get user hand slots")
+        .WithDescription("Returns all 4 hand slots for the authenticated user. Empty slots have null entity fields.")
+        .WithOpenApi();
+    }
+
+    private static void MapUpdateHandSlotEndpoint(RouteGroupBuilder group)
+    {
+        group.MapPut("/users/me/hand/{slotType}", async (
+            string slotType,
+            [FromBody] UpdateHandSlotRequest request,
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, session, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+
+            if (!TryGetUserId(context, session, out var userId))
+                return Results.Unauthorized();
+
+            var command = new UpdateHandSlotCommand(
+                UserId: userId,
+                SlotType: slotType,
+                EntityId: request.EntityId,
+                EntityType: request.EntityType,
+                EntityLabel: request.EntityLabel,
+                EntityImageUrl: request.EntityImageUrl
+            );
+            var result = await mediator.Send(command, ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .RequireAuthenticatedUser()
+        .Produces<UserHandSlotDto>(200)
+        .Produces(400)
+        .Produces(401)
+        .WithTags("MyHand")
+        .WithSummary("Assign entity to hand slot")
+        .WithDescription("Assigns an entity (game, toolkit, session, or agent) to the specified hand slot. Valid slot types: toolkit, game, session, ai.")
+        .WithOpenApi();
+    }
+
+    private static void MapClearHandSlotEndpoint(RouteGroupBuilder group)
+    {
+        group.MapDelete("/users/me/hand/{slotType}", async (
+            string slotType,
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, session, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+
+            if (!TryGetUserId(context, session, out var userId))
+                return Results.Unauthorized();
+
+            var command = new ClearHandSlotCommand(UserId: userId, SlotType: slotType);
+            await mediator.Send(command, ct).ConfigureAwait(false);
+            return Results.NoContent();
+        })
+        .RequireAuthenticatedUser()
+        .Produces(204)
+        .Produces(401)
+        .WithTags("MyHand")
+        .WithSummary("Clear hand slot")
+        .WithDescription("Removes the entity assignment from the specified hand slot. Valid slot types: toolkit, game, session, ai.")
+        .WithOpenApi();
+    }
+
+    private static bool TryGetUserId(HttpContext context, SessionStatusDto? session, out Guid userId)
+    {
+        userId = Guid.Empty;
+        if (session != null)
+        {
+            userId = session.User!.Id;
+            return true;
+        }
+
+        var userIdClaim = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (!string.IsNullOrEmpty(userIdClaim) && Guid.TryParse(userIdClaim, out userId))
+            return true;
+
+        return false;
+    }
+}
+
+/// <summary>
+/// Request body for assigning an entity to a hand slot.
+/// </summary>
+public record UpdateHandSlotRequest(
+    Guid EntityId,
+    string EntityType,
+    string? EntityLabel = null,
+    string? EntityImageUrl = null
+);

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/UpdateHandSlotCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/UpdateHandSlotCommandValidatorTests.cs
@@ -1,0 +1,62 @@
+using Api.BoundedContexts.UserLibrary.Application.Commands;
+using Api.BoundedContexts.UserLibrary.Application.Validators;
+using Api.Tests.Constants;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.UserLibrary.Application;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "UserLibrary")]
+public class UpdateHandSlotCommandValidatorTests
+{
+    private readonly UpdateHandSlotCommandValidator _sut = new();
+
+    [Theory]
+    [InlineData("toolkit", "toolkit")]
+    [InlineData("game", "game")]
+    [InlineData("session", "session")]
+    [InlineData("ai", "agent")]
+    public void Valid_combinations_pass(string slotType, string entityType)
+    {
+        var cmd = new UpdateHandSlotCommand(Guid.NewGuid(), slotType, Guid.NewGuid(), entityType);
+        var result = _sut.TestValidate(cmd);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData("toolkit", "game")]
+    [InlineData("game", "agent")]
+    [InlineData("session", "toolkit")]
+    [InlineData("ai", "game")]
+    public void Incompatible_slot_entityType_fails(string slotType, string entityType)
+    {
+        var cmd = new UpdateHandSlotCommand(Guid.NewGuid(), slotType, Guid.NewGuid(), entityType);
+        var result = _sut.TestValidate(cmd);
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Empty_UserId_fails()
+    {
+        var cmd = new UpdateHandSlotCommand(Guid.Empty, "toolkit", Guid.NewGuid(), "toolkit");
+        var result = _sut.TestValidate(cmd);
+        result.ShouldHaveValidationErrorFor(x => x.UserId);
+    }
+
+    [Fact]
+    public void Invalid_slotType_fails()
+    {
+        var cmd = new UpdateHandSlotCommand(Guid.NewGuid(), "unknown", Guid.NewGuid(), "toolkit");
+        var result = _sut.TestValidate(cmd);
+        result.ShouldHaveValidationErrorFor(x => x.SlotType);
+    }
+
+    [Fact]
+    public void Empty_EntityId_fails()
+    {
+        var cmd = new UpdateHandSlotCommand(Guid.NewGuid(), "toolkit", Guid.Empty, "toolkit");
+        var result = _sut.TestValidate(cmd);
+        result.ShouldHaveValidationErrorFor(x => x.EntityId);
+    }
+}

--- a/apps/web/src/app/(authenticated)/library/LibraryHub.tsx
+++ b/apps/web/src/app/(authenticated)/library/LibraryHub.tsx
@@ -85,7 +85,10 @@ export function LibraryHub() {
   });
 
   // Section data derived from library entries
-  const allEntries: UserLibraryEntry[] = libraryData?.items ?? [];
+  const allEntries = useMemo<UserLibraryEntry[]>(
+    () => libraryData?.items ?? [],
+    [libraryData?.items]
+  );
 
   const personalGames = useMemo<PersonalLibraryGame[]>(
     () => allEntries.filter(e => e.currentState !== 'Wishlist').map(entryToPersonalGame),

--- a/apps/web/src/components/chat/panel/ChatSlideOverPanel.tsx
+++ b/apps/web/src/components/chat/panel/ChatSlideOverPanel.tsx
@@ -231,7 +231,7 @@ export function ChatSlideOverPanel() {
         });
       }
     },
-    [stream]
+    [stream, toast]
   );
 
   const handleSelectGame = useCallback(

--- a/apps/web/src/components/layout/MyHand/MyHandBottomBar.tsx
+++ b/apps/web/src/components/layout/MyHand/MyHandBottomBar.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import React, { useState } from 'react';
+
+import { ChevronDown, ChevronUp } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { useMyHandStore } from '@/stores/my-hand/store';
+import type { MyHandSlotType } from '@/stores/my-hand/types';
+
+import { MyHandSlot } from './MyHandSlot';
+import { MyHandSlotPicker } from './MyHandSlotPicker';
+
+const SLOT_TYPES: MyHandSlotType[] = ['toolkit', 'game', 'session', 'ai'];
+
+export function MyHandBottomBar(): React.JSX.Element {
+  const slots = useMyHandStore(s => s.slots);
+  const isMobileExpanded = useMyHandStore(s => s.isMobileExpanded);
+  const toggleMobileExpanded = useMyHandStore(s => s.toggleMobileExpanded);
+  const assignSlot = useMyHandStore(s => s.assignSlot);
+  const clearSlot = useMyHandStore(s => s.clearSlot);
+
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [activePickerSlot, setActivePickerSlot] = useState<MyHandSlotType | null>(null);
+
+  const handleAssign = (slotType: MyHandSlotType) => {
+    setActivePickerSlot(slotType);
+    setPickerOpen(true);
+  };
+
+  return (
+    <div
+      className={cn(
+        'fixed bottom-0 left-0 right-0 z-30 border-t border-border bg-background/95 backdrop-blur-md',
+        'pb-[env(safe-area-inset-bottom)]'
+      )}
+    >
+      <button
+        aria-label={isMobileExpanded ? 'Comprimi La Mia Mano' : 'Espandi La Mia Mano'}
+        onClick={toggleMobileExpanded}
+        className="absolute -top-7 right-4 flex h-6 w-12 items-center justify-center rounded-t-full border border-b-0 border-border bg-background"
+      >
+        {isMobileExpanded ? <ChevronDown className="h-3 w-3" /> : <ChevronUp className="h-3 w-3" />}
+      </button>
+
+      <div className="flex items-center justify-around px-4 py-2">
+        {SLOT_TYPES.map(slotType => (
+          <MyHandSlot
+            key={slotType}
+            slotType={slotType}
+            slot={slots[slotType]}
+            onAssign={handleAssign}
+            onClear={st => clearSlot(st)}
+            compact
+          />
+        ))}
+      </div>
+
+      {isMobileExpanded && (
+        <div
+          className="grid grid-cols-2 gap-2 px-4 pb-4 pt-1"
+          style={{ maxHeight: '40vh', overflowY: 'auto' }}
+        >
+          {SLOT_TYPES.map(slotType => (
+            <MyHandSlot
+              key={slotType}
+              slotType={slotType}
+              slot={slots[slotType]}
+              onAssign={handleAssign}
+              onClear={st => clearSlot(st)}
+            />
+          ))}
+        </div>
+      )}
+
+      <MyHandSlotPicker
+        isOpen={pickerOpen}
+        slotType={activePickerSlot}
+        onClose={() => setPickerOpen(false)}
+        onConfirm={(slotType, payload) => {
+          assignSlot(slotType, payload);
+          setPickerOpen(false);
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/MyHand/MyHandBottomBar.tsx
+++ b/apps/web/src/components/layout/MyHand/MyHandBottomBar.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 
 import { ChevronDown, ChevronUp } from 'lucide-react';
 
+import { clearHandSlot } from '@/lib/api/my-hand';
 import { cn } from '@/lib/utils';
 import { useMyHandStore } from '@/stores/my-hand/store';
 import type { MyHandSlotType } from '@/stores/my-hand/types';
@@ -28,6 +29,11 @@ export function MyHandBottomBar(): React.JSX.Element {
     setPickerOpen(true);
   };
 
+  const handleClear = (slotType: MyHandSlotType) => {
+    clearSlot(slotType);
+    clearHandSlot(slotType).catch(() => {});
+  };
+
   return (
     <div
       className={cn(
@@ -43,20 +49,20 @@ export function MyHandBottomBar(): React.JSX.Element {
         {isMobileExpanded ? <ChevronDown className="h-3 w-3" /> : <ChevronUp className="h-3 w-3" />}
       </button>
 
-      <div className="flex items-center justify-around px-4 py-2">
-        {SLOT_TYPES.map(slotType => (
-          <MyHandSlot
-            key={slotType}
-            slotType={slotType}
-            slot={slots[slotType]}
-            onAssign={handleAssign}
-            onClear={st => clearSlot(st)}
-            compact
-          />
-        ))}
-      </div>
-
-      {isMobileExpanded && (
+      {!isMobileExpanded ? (
+        <div className="flex items-center justify-around px-4 py-2">
+          {SLOT_TYPES.map(slotType => (
+            <MyHandSlot
+              key={slotType}
+              slotType={slotType}
+              slot={slots[slotType]}
+              onAssign={handleAssign}
+              onClear={handleClear}
+              compact
+            />
+          ))}
+        </div>
+      ) : (
         <div
           className="grid grid-cols-2 gap-2 px-4 pb-4 pt-1"
           style={{ maxHeight: '40vh', overflowY: 'auto' }}
@@ -67,7 +73,7 @@ export function MyHandBottomBar(): React.JSX.Element {
               slotType={slotType}
               slot={slots[slotType]}
               onAssign={handleAssign}
-              onClear={st => clearSlot(st)}
+              onClear={handleClear}
             />
           ))}
         </div>

--- a/apps/web/src/components/layout/MyHand/MyHandBottomBar.tsx
+++ b/apps/web/src/components/layout/MyHand/MyHandBottomBar.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 
 import { ChevronDown, ChevronUp } from 'lucide-react';
 
-import { clearHandSlot } from '@/lib/api/my-hand';
+import { clearHandSlot, updateHandSlot } from '@/lib/api/my-hand';
 import { cn } from '@/lib/utils';
 import { useMyHandStore } from '@/stores/my-hand/store';
 import type { MyHandSlotType } from '@/stores/my-hand/types';
@@ -86,6 +86,7 @@ export function MyHandBottomBar(): React.JSX.Element {
         onConfirm={(slotType, payload) => {
           assignSlot(slotType, payload);
           setPickerOpen(false);
+          updateHandSlot(slotType, payload).catch(() => {});
         }}
       />
     </div>

--- a/apps/web/src/components/layout/MyHand/MyHandProvider.tsx
+++ b/apps/web/src/components/layout/MyHand/MyHandProvider.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import React, { useEffect } from 'react';
+
+import { getMyHand } from '@/lib/api/my-hand';
+import { useMyHandStore } from '@/stores/my-hand/store';
+
+export function MyHandProvider({ children }: { children: React.ReactNode }): React.JSX.Element {
+  const hydrateFromServer = useMyHandStore(s => s.hydrateFromServer);
+  const setLoading = useMyHandStore(s => s.setLoading);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setLoading(true);
+      try {
+        const slots = await getMyHand();
+        if (!cancelled) hydrateFromServer(slots);
+      } catch {
+        // Silently fail — store remains empty (default state)
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [hydrateFromServer, setLoading]);
+
+  return <>{children}</>;
+}

--- a/apps/web/src/components/layout/MyHand/MyHandSidebar.tsx
+++ b/apps/web/src/components/layout/MyHand/MyHandSidebar.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import React, { useState } from 'react';
+
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { selectIsSidebarCollapsed, useMyHandStore } from '@/stores/my-hand/store';
+import type { MyHandSlotType } from '@/stores/my-hand/types';
+
+import { MyHandSlot } from './MyHandSlot';
+import { MyHandSlotPicker } from './MyHandSlotPicker';
+
+const SLOT_TYPES: MyHandSlotType[] = ['toolkit', 'game', 'session', 'ai'];
+
+export function MyHandSidebar(): React.JSX.Element {
+  const slots = useMyHandStore(s => s.slots);
+  const isCollapsed = useMyHandStore(selectIsSidebarCollapsed);
+  const toggleCollapsed = useMyHandStore(s => s.toggleSidebarCollapsed);
+  const assignSlot = useMyHandStore(s => s.assignSlot);
+  const clearSlot = useMyHandStore(s => s.clearSlot);
+
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [activePickerSlot, setActivePickerSlot] = useState<MyHandSlotType | null>(null);
+
+  const handleAssign = (slotType: MyHandSlotType) => {
+    setActivePickerSlot(slotType);
+    setPickerOpen(true);
+  };
+
+  const handleClear = (slotType: MyHandSlotType) => {
+    clearSlot(slotType);
+  };
+
+  return (
+    <aside
+      className={cn(
+        'sticky top-16 flex h-[calc(100vh-64px)] flex-col border-l border-border bg-background transition-all duration-300',
+        isCollapsed ? 'w-14' : 'w-[280px]'
+      )}
+    >
+      <div className="flex items-center justify-between border-b border-border px-3 py-2">
+        {!isCollapsed && <span className="text-sm font-semibold text-foreground">La Mia Mano</span>}
+        <button
+          aria-label={isCollapsed ? 'Espandi La Mia Mano' : 'Comprimi La Mia Mano'}
+          onClick={toggleCollapsed}
+          className="rounded p-1 hover:bg-muted"
+        >
+          {isCollapsed ? <ChevronLeft className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-2 p-2">
+        {SLOT_TYPES.map(slotType => (
+          <MyHandSlot
+            key={slotType}
+            slotType={slotType}
+            slot={slots[slotType]}
+            onAssign={handleAssign}
+            onClear={handleClear}
+            compact={isCollapsed}
+          />
+        ))}
+      </div>
+
+      <MyHandSlotPicker
+        isOpen={pickerOpen}
+        slotType={activePickerSlot}
+        onClose={() => setPickerOpen(false)}
+        onConfirm={(slotType, payload) => {
+          assignSlot(slotType, payload);
+          setPickerOpen(false);
+        }}
+      />
+    </aside>
+  );
+}

--- a/apps/web/src/components/layout/MyHand/MyHandSidebar.tsx
+++ b/apps/web/src/components/layout/MyHand/MyHandSidebar.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 
+import { clearHandSlot, updateHandSlot } from '@/lib/api/my-hand';
 import { cn } from '@/lib/utils';
 import { selectIsSidebarCollapsed, useMyHandStore } from '@/stores/my-hand/store';
 import type { MyHandSlotType } from '@/stores/my-hand/types';
@@ -30,6 +31,7 @@ export function MyHandSidebar(): React.JSX.Element {
 
   const handleClear = (slotType: MyHandSlotType) => {
     clearSlot(slotType);
+    clearHandSlot(slotType).catch(() => {});
   };
 
   return (
@@ -70,6 +72,7 @@ export function MyHandSidebar(): React.JSX.Element {
         onConfirm={(slotType, payload) => {
           assignSlot(slotType, payload);
           setPickerOpen(false);
+          updateHandSlot(slotType, payload).catch(() => {});
         }}
       />
     </aside>

--- a/apps/web/src/components/layout/MyHand/MyHandSidebar.tsx
+++ b/apps/web/src/components/layout/MyHand/MyHandSidebar.tsx
@@ -48,7 +48,7 @@ export function MyHandSidebar(): React.JSX.Element {
           onClick={toggleCollapsed}
           className="rounded p-1 hover:bg-muted"
         >
-          {isCollapsed ? <ChevronLeft className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+          {isCollapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
         </button>
       </div>
 

--- a/apps/web/src/components/layout/MyHand/MyHandSlot.tsx
+++ b/apps/web/src/components/layout/MyHand/MyHandSlot.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import React from 'react';
+
+import { AlertTriangle, Plus, X } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import type { MyHandSlot as MyHandSlotData, MyHandSlotType } from '@/stores/my-hand/types';
+
+const SLOT_LABELS: Record<MyHandSlotType, string> = {
+  toolkit: 'Toolkit',
+  game: 'Gioco',
+  session: 'Partita',
+  ai: 'AI',
+};
+
+const SLOT_ICONS: Record<MyHandSlotType, string> = {
+  toolkit: '🔧',
+  game: '🎮',
+  session: '🎯',
+  ai: '🤖',
+};
+
+interface MyHandSlotProps {
+  slotType: MyHandSlotType;
+  slot: MyHandSlotData;
+  onAssign: (slotType: MyHandSlotType) => void;
+  onClear: (slotType: MyHandSlotType) => void;
+  compact?: boolean;
+}
+
+export function MyHandSlot({
+  slotType,
+  slot,
+  onAssign,
+  onClear,
+  compact = false,
+}: MyHandSlotProps): React.JSX.Element {
+  const label = SLOT_LABELS[slotType];
+  const icon = SLOT_ICONS[slotType];
+
+  if (!slot.entityId) {
+    return (
+      <div
+        className={cn(
+          'flex flex-col items-center gap-1 rounded-lg border border-dashed border-border p-3 text-muted-foreground',
+          compact && 'p-2'
+        )}
+      >
+        <span className="text-lg">{icon}</span>
+        {!compact && <span className="text-xs font-medium">{label}</span>}
+        <button
+          aria-label={`Seleziona ${label}`}
+          onClick={() => onAssign(slotType)}
+          className="mt-1 flex items-center gap-1 rounded-md bg-secondary px-2 py-1 text-xs hover:bg-secondary/80"
+        >
+          <Plus className="h-3 w-3" />
+          {!compact && 'Seleziona'}
+        </button>
+      </div>
+    );
+  }
+
+  if (!slot.isEntityValid) {
+    return (
+      <div
+        className={cn(
+          'flex flex-col items-center gap-1 rounded-lg border border-yellow-500/40 bg-yellow-50/10 p-3',
+          compact && 'p-2'
+        )}
+      >
+        <AlertTriangle className="h-4 w-4 text-yellow-500" />
+        {!compact && (
+          <span className="text-center text-xs text-muted-foreground">Non più disponibile</span>
+        )}
+        <button
+          aria-label={`Seleziona ${label}`}
+          onClick={() => onAssign(slotType)}
+          className="mt-1 rounded-md bg-secondary px-2 py-1 text-xs hover:bg-secondary/80"
+        >
+          {compact ? <Plus className="h-3 w-3" /> : 'Seleziona nuovo'}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        'group relative flex flex-col gap-1 rounded-lg border border-border bg-card p-3',
+        compact && 'p-2'
+      )}
+    >
+      <button
+        aria-label={`Rimuovi ${label}`}
+        onClick={() => onClear(slotType)}
+        className="absolute right-1 top-1 rounded p-0.5 hover:bg-muted opacity-0 group-hover:opacity-100 focus:opacity-100"
+      >
+        <X className="h-3 w-3" />
+      </button>
+      <div className="flex items-center gap-1.5">
+        <span className="text-base">{icon}</span>
+        {!compact && <span className="truncate text-xs font-medium">{slot.entityLabel}</span>}
+      </div>
+      {compact && slot.entityLabel && (
+        <span className="truncate text-[10px] text-muted-foreground">{slot.entityLabel}</span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/MyHand/MyHandSlotPicker.tsx
+++ b/apps/web/src/components/layout/MyHand/MyHandSlotPicker.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import React from 'react';
+
+import type { AssignSlotPayload, MyHandSlotType } from '@/stores/my-hand/types';
+
+interface MyHandSlotPickerProps {
+  isOpen: boolean;
+  slotType: MyHandSlotType | null;
+  onClose: () => void;
+  onConfirm: (slotType: MyHandSlotType, payload: AssignSlotPayload) => void;
+}
+
+export function MyHandSlotPicker({ isOpen }: MyHandSlotPickerProps): React.JSX.Element | null {
+  if (!isOpen) return null;
+  return <div data-testid="slot-picker">Picker (TODO)</div>;
+}

--- a/apps/web/src/components/layout/MyHand/MyHandSlotPicker.tsx
+++ b/apps/web/src/components/layout/MyHand/MyHandSlotPicker.tsx
@@ -13,5 +13,5 @@ interface MyHandSlotPickerProps {
 
 export function MyHandSlotPicker({ isOpen }: MyHandSlotPickerProps): React.JSX.Element | null {
   if (!isOpen) return null;
-  return <div data-testid="slot-picker">Picker (TODO)</div>;
+  return <div data-testid="slot-picker" aria-hidden="true" />;
 }

--- a/apps/web/src/components/layout/MyHand/__tests__/MyHandSidebar.test.tsx
+++ b/apps/web/src/components/layout/MyHand/__tests__/MyHandSidebar.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useMyHandStore } from '@/stores/my-hand/store';
+import { MyHandSidebar } from '../MyHandSidebar';
+
+vi.mock('../MyHandSlotPicker', () => ({
+  MyHandSlotPicker: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="slot-picker">Picker</div> : null,
+}));
+
+describe('MyHandSidebar', () => {
+  beforeEach(() => {
+    useMyHandStore.setState(useMyHandStore.getInitialState());
+  });
+
+  it('renders 4 slots', () => {
+    render(<MyHandSidebar />);
+    expect(screen.getAllByRole('button', { name: /seleziona/i })).toHaveLength(4);
+  });
+
+  it('toggles collapsed state', () => {
+    render(<MyHandSidebar />);
+    const toggleBtn = screen.getByRole('button', { name: /comprimi|espandi/i });
+    fireEvent.click(toggleBtn);
+    expect(useMyHandStore.getState().isSidebarCollapsed).toBe(true);
+  });
+
+  it('opens picker when slot assign is clicked', () => {
+    render(<MyHandSidebar />);
+    fireEvent.click(screen.getAllByRole('button', { name: /seleziona/i })[0]);
+    expect(screen.getByTestId('slot-picker')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/layout/MyHand/__tests__/MyHandSlot.test.tsx
+++ b/apps/web/src/components/layout/MyHand/__tests__/MyHandSlot.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { MyHandSlot } from '../MyHandSlot';
+
+describe('MyHandSlot', () => {
+  it('renders empty state with CTA', () => {
+    render(
+      <MyHandSlot
+        slotType="toolkit"
+        slot={{
+          slotType: 'toolkit',
+          entityId: null,
+          entityType: null,
+          entityLabel: null,
+          entityImageUrl: null,
+          pinnedAt: null,
+          isEntityValid: true,
+        }}
+        onAssign={vi.fn()}
+        onClear={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/Toolkit/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /seleziona/i })).toBeInTheDocument();
+  });
+
+  it('renders populated state with entity label', () => {
+    render(
+      <MyHandSlot
+        slotType="game"
+        slot={{
+          slotType: 'game',
+          entityId: 'g-1',
+          entityType: 'game',
+          entityLabel: 'Agricola',
+          entityImageUrl: null,
+          pinnedAt: '2026-04-09T00:00:00Z',
+          isEntityValid: true,
+        }}
+        onAssign={vi.fn()}
+        onClear={vi.fn()}
+      />
+    );
+    expect(screen.getByText('Agricola')).toBeInTheDocument();
+  });
+
+  it('renders degraded state with warning', () => {
+    render(
+      <MyHandSlot
+        slotType="session"
+        slot={{
+          slotType: 'session',
+          entityId: 's-1',
+          entityType: 'session',
+          entityLabel: 'Partita',
+          entityImageUrl: null,
+          pinnedAt: '2026-04-09T00:00:00Z',
+          isEntityValid: false,
+        }}
+        onAssign={vi.fn()}
+        onClear={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/non più disponibile/i)).toBeInTheDocument();
+  });
+
+  it('calls onAssign when CTA clicked in empty state', () => {
+    const onAssign = vi.fn();
+    render(
+      <MyHandSlot
+        slotType="toolkit"
+        slot={{
+          slotType: 'toolkit',
+          entityId: null,
+          entityType: null,
+          entityLabel: null,
+          entityImageUrl: null,
+          pinnedAt: null,
+          isEntityValid: true,
+        }}
+        onAssign={onAssign}
+        onClear={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /seleziona/i }));
+    expect(onAssign).toHaveBeenCalledWith('toolkit');
+  });
+
+  it('calls onClear when clear button clicked', () => {
+    const onClear = vi.fn();
+    render(
+      <MyHandSlot
+        slotType="game"
+        slot={{
+          slotType: 'game',
+          entityId: 'g-1',
+          entityType: 'game',
+          entityLabel: 'Agricola',
+          entityImageUrl: null,
+          pinnedAt: '2026-04-09T00:00:00Z',
+          isEntityValid: true,
+        }}
+        onAssign={vi.fn()}
+        onClear={onClear}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /rimuovi/i }));
+    expect(onClear).toHaveBeenCalledWith('game');
+  });
+});

--- a/apps/web/src/components/layout/MyHand/index.ts
+++ b/apps/web/src/components/layout/MyHand/index.ts
@@ -2,3 +2,4 @@ export { MyHandSidebar } from './MyHandSidebar';
 export { MyHandBottomBar } from './MyHandBottomBar';
 export { MyHandSlot } from './MyHandSlot';
 export { MyHandSlotPicker } from './MyHandSlotPicker';
+export { MyHandProvider } from './MyHandProvider';

--- a/apps/web/src/components/layout/MyHand/index.ts
+++ b/apps/web/src/components/layout/MyHand/index.ts
@@ -1,0 +1,4 @@
+export { MyHandSidebar } from './MyHandSidebar';
+export { MyHandBottomBar } from './MyHandBottomBar';
+export { MyHandSlot } from './MyHandSlot';
+export { MyHandSlotPicker } from './MyHandSlotPicker';

--- a/apps/web/src/components/layout/UserShell/DesktopShell.tsx
+++ b/apps/web/src/components/layout/UserShell/DesktopShell.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from 'react';
 
 import { ChatSlideOverPanel } from '@/components/chat/panel/ChatSlideOverPanel';
+import { MyHandBottomBar, MyHandSidebar } from '@/components/layout/MyHand';
 
 import { DesktopHandRail } from './DesktopHandRail';
 import { MiniNavSlot } from './MiniNavSlot';
@@ -33,6 +34,12 @@ export function DesktopShell({ children }: DesktopShellProps) {
       <div className="flex-1 flex min-h-0">
         <DesktopHandRail />
         <main className="flex-1 min-w-0 overflow-y-auto">{children}</main>
+        <div className="hidden md:flex">
+          <MyHandSidebar />
+        </div>
+      </div>
+      <div className="md:hidden">
+        <MyHandBottomBar />
       </div>
       <ChatSlideOverPanel />
     </div>

--- a/apps/web/src/lib/api/__tests__/my-hand.api.test.ts
+++ b/apps/web/src/lib/api/__tests__/my-hand.api.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getMyHand, updateHandSlot, clearHandSlot } from '../my-hand';
+
+vi.mock('../client', () => ({
+  apiClient: {
+    get: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+import { apiClient } from '../client';
+
+describe('my-hand API client', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getMyHand calls GET /users/me/hand', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        slotType: 'toolkit',
+        entityId: null,
+        entityType: null,
+        entityLabel: null,
+        entityImageUrl: null,
+        pinnedAt: null,
+      },
+    ]);
+
+    const result = await getMyHand();
+    expect(apiClient.get).toHaveBeenCalledWith('/users/me/hand');
+    expect(result).toHaveLength(1);
+  });
+
+  it('updateHandSlot calls PUT /users/me/hand/{slotType}', async () => {
+    const dto = {
+      slotType: 'game',
+      entityId: 'g-1',
+      entityType: 'game',
+      entityLabel: 'Catan',
+      entityImageUrl: null,
+      pinnedAt: '2026-04-09T00:00:00Z',
+    };
+    (apiClient.put as ReturnType<typeof vi.fn>).mockResolvedValue(dto);
+
+    const result = await updateHandSlot('game', {
+      entityId: 'g-1',
+      entityType: 'game',
+      entityLabel: 'Catan',
+      entityImageUrl: null,
+    });
+    expect(apiClient.put).toHaveBeenCalledWith('/users/me/hand/game', {
+      entityId: 'g-1',
+      entityType: 'game',
+      entityLabel: 'Catan',
+      entityImageUrl: null,
+    });
+    expect(result.entityId).toBe('g-1');
+  });
+
+  it('clearHandSlot calls DELETE /users/me/hand/{slotType}', async () => {
+    (apiClient.delete as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    await clearHandSlot('toolkit');
+    expect(apiClient.delete).toHaveBeenCalledWith('/users/me/hand/toolkit');
+  });
+
+  it('getMyHand returns empty array on null response', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const result = await getMyHand();
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/api/my-hand.ts
+++ b/apps/web/src/lib/api/my-hand.ts
@@ -1,0 +1,33 @@
+import { apiClient } from './client';
+
+export interface HandSlotDto {
+  slotType: string;
+  entityId: string | null;
+  entityType: string | null;
+  entityLabel: string | null;
+  entityImageUrl: string | null;
+  pinnedAt: string | null;
+}
+
+export interface UpdateHandSlotPayload {
+  entityId: string;
+  entityType: string;
+  entityLabel: string | null;
+  entityImageUrl: string | null;
+}
+
+export async function getMyHand(): Promise<HandSlotDto[]> {
+  const result = await apiClient.get<HandSlotDto[]>('/users/me/hand');
+  return result ?? [];
+}
+
+export async function updateHandSlot(
+  slotType: string,
+  payload: UpdateHandSlotPayload
+): Promise<HandSlotDto> {
+  return apiClient.put<HandSlotDto>(`/users/me/hand/${slotType}`, payload);
+}
+
+export async function clearHandSlot(slotType: string): Promise<void> {
+  await apiClient.delete(`/users/me/hand/${slotType}`);
+}

--- a/apps/web/src/stores/my-hand/__tests__/store.test.ts
+++ b/apps/web/src/stores/my-hand/__tests__/store.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useMyHandStore } from '../store';
+import type { MyHandSlotType } from '../types';
+
+describe('useMyHandStore', () => {
+  beforeEach(() => {
+    useMyHandStore.setState(useMyHandStore.getInitialState());
+  });
+
+  it('starts with all 4 slots empty', () => {
+    const state = useMyHandStore.getState();
+    expect(state.slots.toolkit.entityId).toBeNull();
+    expect(state.slots.game.entityId).toBeNull();
+    expect(state.slots.session.entityId).toBeNull();
+    expect(state.slots.ai.entityId).toBeNull();
+  });
+
+  it('assigns entity to a slot', () => {
+    useMyHandStore.getState().assignSlot('toolkit', {
+      entityId: 'tk-1',
+      entityType: 'toolkit',
+      entityLabel: 'My Toolkit',
+      entityImageUrl: null,
+    });
+    const slot = useMyHandStore.getState().slots.toolkit;
+    expect(slot.entityId).toBe('tk-1');
+    expect(slot.entityType).toBe('toolkit');
+    expect(slot.entityLabel).toBe('My Toolkit');
+    expect(slot.pinnedAt).not.toBeNull();
+  });
+
+  it('clears a slot', () => {
+    useMyHandStore.getState().assignSlot('game', {
+      entityId: 'g-1',
+      entityType: 'game',
+      entityLabel: 'Agricola',
+      entityImageUrl: null,
+    });
+    useMyHandStore.getState().clearSlot('game');
+    const slot = useMyHandStore.getState().slots.game;
+    expect(slot.entityId).toBeNull();
+    expect(slot.entityLabel).toBeNull();
+    expect(slot.pinnedAt).toBeNull();
+  });
+
+  it('marks slot as invalid', () => {
+    useMyHandStore.getState().assignSlot('session', {
+      entityId: 's-1',
+      entityType: 'session',
+      entityLabel: 'Friday Game',
+      entityImageUrl: null,
+    });
+    useMyHandStore.getState().markSlotInvalid('session');
+    expect(useMyHandStore.getState().slots.session.isEntityValid).toBe(false);
+  });
+
+  it('toggles sidebar collapsed state', () => {
+    expect(useMyHandStore.getState().isSidebarCollapsed).toBe(false);
+    useMyHandStore.getState().toggleSidebarCollapsed();
+    expect(useMyHandStore.getState().isSidebarCollapsed).toBe(true);
+    useMyHandStore.getState().toggleSidebarCollapsed();
+    expect(useMyHandStore.getState().isSidebarCollapsed).toBe(false);
+  });
+
+  it('toggles mobile expanded state', () => {
+    expect(useMyHandStore.getState().isMobileExpanded).toBe(false);
+    useMyHandStore.getState().toggleMobileExpanded();
+    expect(useMyHandStore.getState().isMobileExpanded).toBe(true);
+  });
+});

--- a/apps/web/src/stores/my-hand/store.ts
+++ b/apps/web/src/stores/my-hand/store.ts
@@ -1,0 +1,109 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+import { immer } from 'zustand/middleware/immer';
+
+import { createEmptySlots } from './types';
+
+import type { MyHandSlotType, MyHandSlot, AssignSlotPayload } from './types';
+
+interface MyHandState {
+  slots: Record<MyHandSlotType, MyHandSlot>;
+  isSidebarCollapsed: boolean;
+  isMobileExpanded: boolean;
+  isLoading: boolean;
+  assignSlot: (slotType: MyHandSlotType, payload: AssignSlotPayload) => void;
+  clearSlot: (slotType: MyHandSlotType) => void;
+  markSlotInvalid: (slotType: MyHandSlotType) => void;
+  toggleSidebarCollapsed: () => void;
+  toggleMobileExpanded: () => void;
+  setLoading: (loading: boolean) => void;
+  hydrateFromServer: (
+    slots: Array<{
+      slotType: string;
+      entityId: string | null;
+      entityType: string | null;
+      entityLabel: string | null;
+      entityImageUrl: string | null;
+      pinnedAt: string | null;
+    }>
+  ) => void;
+}
+
+const INITIAL_STATE = {
+  slots: createEmptySlots(),
+  isSidebarCollapsed: false,
+  isMobileExpanded: false,
+  isLoading: false,
+};
+
+export const useMyHandStore = create<MyHandState>()(
+  devtools(
+    immer(set => ({
+      ...INITIAL_STATE,
+
+      assignSlot: (slotType, payload) =>
+        set(state => {
+          state.slots[slotType].entityId = payload.entityId;
+          state.slots[slotType].entityType = payload.entityType;
+          state.slots[slotType].entityLabel = payload.entityLabel;
+          state.slots[slotType].entityImageUrl = payload.entityImageUrl;
+          state.slots[slotType].pinnedAt = new Date().toISOString();
+          state.slots[slotType].isEntityValid = true;
+        }),
+
+      clearSlot: slotType =>
+        set(state => {
+          state.slots[slotType].entityId = null;
+          state.slots[slotType].entityType = null;
+          state.slots[slotType].entityLabel = null;
+          state.slots[slotType].entityImageUrl = null;
+          state.slots[slotType].pinnedAt = null;
+          state.slots[slotType].isEntityValid = true;
+        }),
+
+      markSlotInvalid: slotType =>
+        set(state => {
+          state.slots[slotType].isEntityValid = false;
+        }),
+
+      toggleSidebarCollapsed: () =>
+        set(state => {
+          state.isSidebarCollapsed = !state.isSidebarCollapsed;
+        }),
+
+      toggleMobileExpanded: () =>
+        set(state => {
+          state.isMobileExpanded = !state.isMobileExpanded;
+        }),
+
+      setLoading: loading =>
+        set(state => {
+          state.isLoading = loading;
+        }),
+
+      hydrateFromServer: serverSlots =>
+        set(state => {
+          for (const s of serverSlots) {
+            const slotType = s.slotType as MyHandSlotType;
+            if (!['toolkit', 'game', 'session', 'ai'].includes(slotType)) continue;
+            state.slots[slotType].entityId = s.entityId;
+            state.slots[slotType].entityType = s.entityType;
+            state.slots[slotType].entityLabel = s.entityLabel;
+            state.slots[slotType].entityImageUrl = s.entityImageUrl;
+            state.slots[slotType].pinnedAt = s.pinnedAt;
+            state.slots[slotType].isEntityValid = true;
+          }
+        }),
+    })),
+    { name: 'my-hand-store' }
+  )
+);
+
+// Expose getInitialState for test resets (Zustand devtools/immer does not auto-expose this)
+(useMyHandStore as unknown as { getInitialState: () => typeof INITIAL_STATE }).getInitialState =
+  () => INITIAL_STATE;
+
+// Selectors
+export const selectSlot = (slotType: MyHandSlotType) => (s: MyHandState) => s.slots[slotType];
+export const selectIsSidebarCollapsed = (s: MyHandState) => s.isSidebarCollapsed;
+export const selectIsMobileExpanded = (s: MyHandState) => s.isMobileExpanded;

--- a/apps/web/src/stores/my-hand/store.ts
+++ b/apps/web/src/stores/my-hand/store.ts
@@ -100,8 +100,9 @@ export const useMyHandStore = create<MyHandState>()(
 );
 
 // Expose getInitialState for test resets (Zustand devtools/immer does not auto-expose this)
+// Returns a fresh copy each call to avoid inter-test state leakage via shared references
 (useMyHandStore as unknown as { getInitialState: () => typeof INITIAL_STATE }).getInitialState =
-  () => INITIAL_STATE;
+  () => ({ ...INITIAL_STATE, slots: createEmptySlots() });
 
 // Selectors
 export const selectSlot = (slotType: MyHandSlotType) => (s: MyHandState) => s.slots[slotType];

--- a/apps/web/src/stores/my-hand/store.ts
+++ b/apps/web/src/stores/my-hand/store.ts
@@ -84,8 +84,9 @@ export const useMyHandStore = create<MyHandState>()(
       hydrateFromServer: serverSlots =>
         set(state => {
           for (const s of serverSlots) {
-            const slotType = s.slotType as MyHandSlotType;
-            if (!['toolkit', 'game', 'session', 'ai'].includes(slotType)) continue;
+            const rawType = s.slotType;
+            if (!['toolkit', 'game', 'session', 'ai'].includes(rawType)) continue;
+            const slotType = rawType as MyHandSlotType;
             state.slots[slotType].entityId = s.entityId;
             state.slots[slotType].entityType = s.entityType;
             state.slots[slotType].entityLabel = s.entityLabel;

--- a/apps/web/src/stores/my-hand/types.ts
+++ b/apps/web/src/stores/my-hand/types.ts
@@ -1,0 +1,35 @@
+export type MyHandSlotType = 'toolkit' | 'game' | 'session' | 'ai';
+
+export interface MyHandSlot {
+  slotType: MyHandSlotType;
+  entityId: string | null;
+  entityType: string | null;
+  entityLabel: string | null;
+  entityImageUrl: string | null;
+  pinnedAt: string | null;
+  isEntityValid: boolean;
+}
+
+export interface AssignSlotPayload {
+  entityId: string;
+  entityType: string;
+  entityLabel: string | null;
+  entityImageUrl: string | null;
+}
+
+const EMPTY_SLOT = (slotType: MyHandSlotType): MyHandSlot => ({
+  slotType,
+  entityId: null,
+  entityType: null,
+  entityLabel: null,
+  entityImageUrl: null,
+  pinnedAt: null,
+  isEntityValid: true,
+});
+
+export const createEmptySlots = (): Record<MyHandSlotType, MyHandSlot> => ({
+  toolkit: EMPTY_SLOT('toolkit'),
+  game: EMPTY_SLOT('game'),
+  session: EMPTY_SLOT('session'),
+  ai: EMPTY_SLOT('ai'),
+});


### PR DESCRIPTION
## Summary

- **Backend** (`UserLibrary` BC): nuovo endpoint CQRS completo per "La Mia Mano" — `GET/PUT/DELETE /api/v1/users/me/hand` con entity `UserHandSlot`, repository, 3 comandi/query, validatori, DI registration, EF migration
- **Frontend**: Zustand store (`useMyHandStore`) + API client + componenti `MyHandSlot`/`MyHandSidebar`/`MyHandBottomBar`/`MyHandProvider` + integrazione nel layout (`DesktopShell`)
- **Test**: 614 backend tests (UserLibrary BC) + 18 frontend unit tests — tutti verdi

## Cosa è incluso

| Layer | Dettaglio |
|---|---|
| EF Core | `user_hand_slots` table + composite unique index (UserId + SlotType) |
| CQRS | `GetUserHandQuery`, `UpdateHandSlotCommand`, `ClearHandSlotCommand` — tutti via `IMediator.Send()` |
| Validazione | `HandSlotConstants` condiviso; slot-entity type mapping validato server-side |
| UoW | Repository non chiama `SaveChangesAsync` — delegato agli handler |
| Frontend store | Zustand + immer + devtools; `hydrateFromServer`, `assignSlot`, `clearSlot`, `markSlotInvalid` |
| Layout desktop | `MyHandSidebar` (280px espanso / 52px collapsed) montata in `DesktopShell` |
| Layout mobile | `MyHandBottomBar` (fixed bottom, safe-area-inset-bottom) montata in `DesktopShell` |
| Hydration | `MyHandProvider` carica i dati al mount con cancellation e silent fail |
| Optimistic UI | `clearSlot`/`assignSlot` applicati allo store prima della risposta API |

## Scope escluso (piano separato)

- Quick actions per slot (dado casuale, scoreboard, ecc.) — F-12..F-15
- Picker entità completo (stub implementato) — F-16
- Swipe-up mobile, long-press su MeepleCard — P1

## Test plan

- [x] Backend build: 0 errori
- [x] `dotnet test --filter "BoundedContext=UserLibrary"`: 614 passed
- [x] `pnpm typecheck`: 0 errori
- [x] `pnpm lint`: 0 errori
- [x] `pnpm test` (MyHand suite): 18/18 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)