### PR TITLE
fix(dev): 2 real bugs in MeepleDev found during E2E smoke test

### DIFF
--- a/apps/web/src/dev-tools/scenarioValidator.ts
+++ b/apps/web/src/dev-tools/scenarioValidator.ts
@@ -1,7 +1,10 @@
 import Ajv2020, { type ErrorObject } from 'ajv/dist/2020';
 import addFormats from 'ajv-formats';
 
-import scenarioSchema from '../../../../docs/superpowers/fixtures/schema/scenario.schema.json';
+// Schema lives both in docs/superpowers/fixtures/schema/ (canonical) and here
+// (apps/web/src/dev-tools/schema/) because Turbopack does not reliably resolve
+// deep relative imports crossing package boundaries at runtime.
+import scenarioSchema from './schema/scenario.schema.json';
 
 import type { Scenario } from './types';
 

--- a/apps/web/src/dev-tools/schema/scenario.schema.json
+++ b/apps/web/src/dev-tools/schema/scenario.schema.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://meepleai.app/schemas/scenario.schema.json",
+  "title": "MeepleDev Scenario",
+  "type": "object",
+  "required": ["name", "description", "auth", "games", "sessions", "library", "chatHistory"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$",
+      "description": "Lowercase, kebab-case identifier"
+    },
+    "description": { "type": "string", "minLength": 1 },
+    "auth": {
+      "type": "object",
+      "required": ["currentUser", "availableUsers"],
+      "additionalProperties": false,
+      "properties": {
+        "currentUser": { "$ref": "#/$defs/user" },
+        "availableUsers": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/user" }
+        }
+      }
+    },
+    "games": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/game" }
+    },
+    "sessions": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/session" }
+    },
+    "library": {
+      "type": "object",
+      "required": ["ownedGameIds", "wishlistGameIds"],
+      "additionalProperties": false,
+      "properties": {
+        "ownedGameIds": { "type": "array", "items": { "type": "string" } },
+        "wishlistGameIds": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "chatHistory": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/chat" }
+    },
+    "bggGames": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/bggGame" },
+      "description": "Seed BGG lookups for MockBggApiService"
+    },
+    "documents": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/document" },
+      "description": "Seed PDF extractions for MockSmolDocling/Unstructured"
+    }
+  },
+  "$defs": {
+    "user": {
+      "type": "object",
+      "required": ["id", "email", "displayName", "role"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "pattern": "^MOCK-" },
+        "email": { "type": "string", "format": "email" },
+        "displayName": { "type": "string" },
+        "role": {
+          "type": "string",
+          "enum": ["Guest", "User", "Editor", "Admin", "SuperAdmin"]
+        }
+      }
+    },
+    "game": {
+      "type": "object",
+      "required": ["id", "title"],
+      "additionalProperties": true,
+      "properties": {
+        "id": { "type": "string", "pattern": "^MOCK-" },
+        "title": { "type": "string" },
+        "publisher": { "type": "string" },
+        "averageRating": { "type": "number", "minimum": 0, "maximum": 10 },
+        "bggId": { "type": "integer" }
+      }
+    },
+    "session": {
+      "type": "object",
+      "required": ["id", "gameId"],
+      "additionalProperties": true,
+      "properties": {
+        "id": { "type": "string", "pattern": "^MOCK-" },
+        "gameId": { "type": "string", "pattern": "^MOCK-" },
+        "startedAt": { "type": "string", "format": "date-time" }
+      }
+    },
+    "chat": {
+      "type": "object",
+      "required": ["chatId", "messages"],
+      "additionalProperties": false,
+      "properties": {
+        "chatId": { "type": "string", "pattern": "^MOCK-" },
+        "messages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["role", "content"],
+            "properties": {
+              "role": { "type": "string", "enum": ["user", "assistant", "system"] },
+              "content": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "bggGame": {
+      "type": "object",
+      "required": ["bggId", "name"],
+      "additionalProperties": true,
+      "properties": {
+        "bggId": { "type": "integer" },
+        "name": { "type": "string" }
+      }
+    },
+    "document": {
+      "type": "object",
+      "required": ["id", "pages"],
+      "additionalProperties": true,
+      "properties": {
+        "id": { "type": "string", "pattern": "^MOCK-" },
+        "pages": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/infra/.env.dev.local.example
+++ b/infra/.env.dev.local.example
@@ -11,8 +11,10 @@ DEV_REDIS=false                # true → docker compose redis
 
 # -- Leva 2: MSW frontend ---------------------------------------
 NEXT_PUBLIC_MOCK_MODE=true
-# Gruppi MSW attivi di default (virgole, vuoto = tutti)
-NEXT_PUBLIC_MSW_ENABLE=auth,games,chat,library,admin
+# Gruppi MSW attivi (virgole). Vuoto = tutti i 13 gruppi attivi (default safe).
+# Gruppi disponibili: auth, games, chat, documents, library, shared-games, catalog,
+# admin, sessions, game-nights, players, notifications, badges
+NEXT_PUBLIC_MSW_ENABLE=
 # Gruppi esplicitamente disabilitati (precedenza su ENABLE)
 NEXT_PUBLIC_MSW_DISABLE=
 # Scenario seed iniziale


### PR DESCRIPTION
## Summary

Hotfix for 2 bugs in PR #356 (MeepleDev fast dev loop) discovered during manual E2E smoke test:

### Bug 1 — scenarioValidator.ts import path broken at runtime (Turbopack)
\`scenarioValidator.ts\` imported \`scenario.schema.json\` via a deep relative path crossing package boundaries: \`'../../../../docs/superpowers/fixtures/schema/scenario.schema.json'\`. Vitest/ts-node resolved this correctly (33 unit tests green), but **Turbopack at runtime failed** with *\"Module not found: Can't resolve ...\"*. Result: homepage served 500 Internal Server Error when running \`make dev-fast\`.

**Fix**: copy \`scenario.schema.json\` into \`apps/web/src/dev-tools/schema/\` and import from there.

### Bug 2 — \`.env.dev.local.example\` template too restrictive
Template listed \`NEXT_PUBLIC_MSW_ENABLE=auth,games,chat,library,admin\` (5/13 groups). The app fetches \`/api/v1/notifications/*\` at boot, but \`notifications\` was not in the enable list → MSW bypass → Next.js proxy → 501 → **10 console errors on first page load**.

**Fix**: empty \`NEXT_PUBLIC_MSW_ENABLE=\` (all 13 groups active by default, safest).

## Evidence — E2E smoke test passed after fixes

- \`make dev-fast\` boots cold in ~2s (Next.js ready 1.6s, first 200 in 3.3s) — **SC-1 met**
- DevBadge visible bottom-right: \`MOCK · 13/13 · small-library · Admin\` (red border = all mocked)
- Console errors: **1** (pre-existing a11y landmark warning, unrelated)
- \`make dev-fast-api\` boots backend on Kestrel :5000 with all 8 mocks active
- \`GET /health/live\` → 200 OK with header:
  \`X-Meeple-Mock: backend-di:bgg,embedding,llm,n8n,reranker,s3,smoldocling,unstructured\`
- \`make dev-fast-down\` kills dotnet + next cleanly, zero orphans (confirms fix C2 from PR #356 code review)

## Testing lesson
Unit tests used a different module resolver (Vitest) than runtime (Turbopack). Gap caught only at manual smoke test. Phase 3 should add a post-build runtime smoke assertion in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)