### PR TITLE
feat(agent-drawer): Agent Chat Drawer — layout 2-colonne chat-centrico

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts';
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/src/components/ui/data-display/extra-meeple-card/ExtraMeepleCardDrawer.tsx
+++ b/apps/web/src/components/ui/data-display/extra-meeple-card/ExtraMeepleCardDrawer.tsx
@@ -38,6 +38,7 @@ import { Sheet, SheetClose, SheetContent, SheetTitle } from '@/components/ui/nav
 import { cn } from '@/lib/utils';
 
 import { DrawerLoadingSkeleton, DrawerErrorState, DrawerComingSoon } from './drawer-states';
+import { AgentChatDrawerLayout } from './entities/AgentChatDrawerLayout';
 import { DRAWER_TEST_IDS } from './drawer-test-ids';
 import {
   GameExtraMeepleCard,
@@ -102,7 +103,7 @@ const ENTITY_CONFIG: Record<
 > = {
   // Implemented entity types
   game: { label: 'Dettaglio Gioco', color: '25 95% 45%', Icon: Gamepad2 },
-  agent: { label: 'Dettaglio Agente', color: '38 92% 50%', Icon: Bot },
+  agent: { label: "Chat con l'agente", color: '38 92% 50%', Icon: Bot },
   chat: { label: 'Dettaglio Chat', color: '220 80% 55%', Icon: MessageCircle },
   kb: { label: 'Documento KB', color: '174 60% 40%', Icon: FileText },
   links: { label: 'Connections', color: '210 40% 55%', Icon: LinkIcon },
@@ -148,7 +149,9 @@ export const ExtraMeepleCardDrawer = React.memo(function ExtraMeepleCardDrawer({
           // Layout overrides: remove default padding, set full-height flex column
           'flex flex-col p-0',
           // Width override for wide drawer
-          'w-full sm:w-[600px] sm:max-w-[600px]',
+          entityType === 'agent'
+            ? 'w-full sm:w-[800px] sm:max-w-[800px]'
+            : 'w-full sm:w-[600px] sm:max-w-[600px]',
           // Hide the built-in close button (we render our own in the colored header)
           '[&>button:first-child]:hidden',
           // Session context: subtle indigo ring glow
@@ -305,12 +308,7 @@ function AgentDrawerContent({ entityId }: { entityId: string }) {
   if (error) return <DrawerErrorState error={error} onRetry={retry} />;
   if (!data) return <DrawerLoadingSkeleton />;
 
-  return (
-    <AgentExtraMeepleCard
-      data={data}
-      className="w-full rounded-none border-0 shadow-none bg-transparent"
-    />
-  );
+  return <AgentChatDrawerLayout data={data} className="h-full" />;
 }
 
 function ChatDrawerContent({ entityId }: { entityId: string }) {

--- a/apps/web/src/components/ui/data-display/extra-meeple-card/ExtraMeepleCardDrawer.tsx
+++ b/apps/web/src/components/ui/data-display/extra-meeple-card/ExtraMeepleCardDrawer.tsx
@@ -42,7 +42,6 @@ import { AgentChatDrawerLayout } from './entities/AgentChatDrawerLayout';
 import { DRAWER_TEST_IDS } from './drawer-test-ids';
 import {
   GameExtraMeepleCard,
-  AgentExtraMeepleCard,
   ChatExtraMeepleCard,
   KbExtraMeepleCard,
 } from './EntityExtraMeepleCard';

--- a/apps/web/src/components/ui/data-display/extra-meeple-card/entities/AgentChatDrawerLayout.tsx
+++ b/apps/web/src/components/ui/data-display/extra-meeple-card/entities/AgentChatDrawerLayout.tsx
@@ -113,16 +113,23 @@ function AgentChatArea({
   agentName,
   selectedThreadId,
   onThreadCreated,
+  readiness,
+  readinessLoading,
 }: {
   agentId: string;
   agentName: string;
   selectedThreadId: string | null;
   onThreadCreated: (id: string) => void;
+  readiness: ReturnType<typeof useAgentStatus>['status'];
+  readinessLoading: boolean;
 }) {
-  const { status: readiness, isLoading: readinessLoading } = useAgentStatus(agentId);
-
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
+
+  const onThreadCreatedRef = React.useRef(onThreadCreated);
+  useEffect(() => {
+    onThreadCreatedRef.current = onThreadCreated;
+  });
 
   useEffect(() => {
     if (selectedThreadId !== 'new') return;
@@ -134,11 +141,12 @@ function AgentChatArea({
     api.chat
       .createThread({ agentId, title: `Chat con ${agentName}` })
       .then((thread) => {
-        if (!cancelled) onThreadCreated(thread.id);
+        if (!cancelled && thread?.id) onThreadCreatedRef.current(thread.id);
       })
       .catch((err: unknown) => {
         if (!cancelled)
           setCreateError(err instanceof Error ? err.message : 'Errore nella creazione della chat');
+        if (!cancelled) setCreating(false);
       })
       .finally(() => {
         if (!cancelled) setCreating(false);
@@ -147,8 +155,7 @@ function AgentChatArea({
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedThreadId]);
+  }, [selectedThreadId, agentId, agentName]); // onThreadCreated via ref, stabile
 
   // 1. Loading readiness
   if (readinessLoading) {
@@ -251,7 +258,13 @@ export const AgentChatDrawerLayout = React.memo(function AgentChatDrawerLayout({
         <button
           data-testid="new-chat-button"
           disabled={buttonDisabled}
-          title={buttonDisabled ? (readiness?.blockingReason ?? 'Configura la KB per abilitare la chat') : undefined}
+          title={
+            buttonDisabled
+              ? readinessLoading
+                ? 'Verifica disponibilità agente…'
+                : (readiness?.blockingReason ?? 'Configura la KB per abilitare la chat')
+              : undefined
+          }
           onClick={() => setSelectedThreadId('new')}
           className={cn(
             'flex w-full items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-semibold font-nunito',
@@ -303,6 +316,8 @@ export const AgentChatDrawerLayout = React.memo(function AgentChatDrawerLayout({
           agentName={data.name}
           selectedThreadId={selectedThreadId}
           onThreadCreated={(id) => setSelectedThreadId(id)}
+          readiness={readiness}
+          readinessLoading={readinessLoading}
         />
       </div>
     </div>

--- a/apps/web/src/components/ui/data-display/extra-meeple-card/entities/AgentChatDrawerLayout.tsx
+++ b/apps/web/src/components/ui/data-display/extra-meeple-card/entities/AgentChatDrawerLayout.tsx
@@ -1,10 +1,15 @@
 'use client';
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { AlertCircle, Bot, Gamepad2, Loader2, MessageSquare, Plus } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
+import { useAgentThreads, useAgentKbDocs } from '@/hooks/queries/useAgentData';
+import { useAgentStatus } from '@/hooks/useAgentStatus';
+import { api } from '@/lib/api';
+import { ChatThreadView } from '@/components/chat-unified/ChatThreadView';
 
-import type { AgentDetailData } from '../types';
+import type { AgentDetailData, ChatThreadPreview, KbDocumentPreview } from '../types';
 
 export interface AgentChatDrawerLayoutProps {
   data: AgentDetailData;
@@ -12,23 +17,294 @@ export interface AgentChatDrawerLayoutProps {
   'data-testid'?: string;
 }
 
+// ─── AgentContextCard ────────────────────────────────────────────────────────
+
+function AgentContextCard({ gameId, gameName }: { gameId?: string; gameName?: string }) {
+  if (!gameId || !gameName) {
+    return (
+      <div
+        data-testid="no-game-placeholder"
+        className="flex items-center gap-2 rounded-md bg-slate-100 px-2 py-2 text-xs text-slate-400"
+      >
+        <Bot className="h-3.5 w-3.5 shrink-0" />
+        <span>Nessun gioco collegato</span>
+      </div>
+    );
+  }
+  return (
+    <div className="flex items-center gap-2 rounded-md bg-amber-50 px-2 py-2 text-xs font-medium text-amber-800">
+      <Gamepad2 className="h-3.5 w-3.5 shrink-0 text-amber-600" />
+      <span className="truncate">{gameName}</span>
+    </div>
+  );
+}
+
+// ─── SidebarSection ──────────────────────────────────────────────────────────
+
+function SidebarSection({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <p className="px-1 text-[10px] font-semibold tracking-wider text-slate-400">{label}</p>
+      {children}
+    </div>
+  );
+}
+
+// ─── RecentThreadItem ─────────────────────────────────────────────────────────
+
+function RecentThreadItem({
+  thread,
+  isSelected,
+  onClick,
+}: {
+  thread: ChatThreadPreview;
+  isSelected: boolean;
+  onClick: () => void;
+}) {
+  const date = new Date(thread.createdAt).toLocaleDateString('it-IT', {
+    day: '2-digit',
+    month: '2-digit',
+  });
+  const preview =
+    thread.firstMessagePreview.length > 50
+      ? thread.firstMessagePreview.slice(0, 50) + '…'
+      : thread.firstMessagePreview;
+
+  return (
+    <button
+      data-testid={`thread-item-${thread.id}`}
+      onClick={onClick}
+      className={cn(
+        'flex w-full flex-col gap-0.5 rounded-md px-2 py-1.5 text-left text-xs transition-colors hover:bg-slate-100',
+        isSelected && 'border border-blue-300/60 bg-blue-100',
+      )}
+    >
+      <div className="flex items-center justify-between gap-1 text-[10px] text-slate-400">
+        <span>{date}</span>
+        <span>{thread.messageCount}m</span>
+      </div>
+      <p className="line-clamp-2 text-slate-600">{preview}</p>
+    </button>
+  );
+}
+
+// ─── KbDocItem ───────────────────────────────────────────────────────────────
+
+const statusDotClass: Record<KbDocumentPreview['status'], string> = {
+  indexed: 'bg-emerald-500',
+  processing: 'bg-amber-500',
+  failed: 'bg-red-500',
+  none: 'bg-slate-400',
+};
+
+function KbDocItem({ doc }: { doc: KbDocumentPreview }) {
+  return (
+    <div className="flex items-center gap-1.5 px-2 py-1">
+      <span className={cn('h-1.5 w-1.5 shrink-0 rounded-full', statusDotClass[doc.status])} />
+      <span className="truncate text-xs text-slate-600">{doc.fileName}</span>
+    </div>
+  );
+}
+
+// ─── AgentChatArea ───────────────────────────────────────────────────────────
+
+function AgentChatArea({
+  agentId,
+  agentName,
+  selectedThreadId,
+  onThreadCreated,
+}: {
+  agentId: string;
+  agentName: string;
+  selectedThreadId: string | null;
+  onThreadCreated: (id: string) => void;
+}) {
+  const { status: readiness, isLoading: readinessLoading } = useAgentStatus(agentId);
+
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (selectedThreadId !== 'new') return;
+    let cancelled = false;
+
+    setCreating(true);
+    setCreateError(null);
+
+    api.chat
+      .createThread({ agentId, title: `Chat con ${agentName}` })
+      .then((thread) => {
+        if (!cancelled) onThreadCreated(thread.id);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled)
+          setCreateError(err instanceof Error ? err.message : 'Errore nella creazione della chat');
+      })
+      .finally(() => {
+        if (!cancelled) setCreating(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedThreadId]);
+
+  // 1. Loading readiness
+  if (readinessLoading) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-2 text-slate-400">
+        <Loader2 className="h-5 w-5 animate-spin" />
+        <span className="text-xs">Verifica disponibilità agente…</span>
+      </div>
+    );
+  }
+
+  // 2. Not ready
+  if (readiness?.isReady === false) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center">
+        <AlertCircle className="h-8 w-8 text-amber-400" />
+        <p className="text-sm font-semibold text-slate-700">Agente non configurato</p>
+        {readiness.blockingReason && (
+          <p className="text-xs text-slate-500">{readiness.blockingReason}</p>
+        )}
+        <button
+          className="mt-1 rounded-md bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-blue-700"
+          onClick={() => {
+            window.location.href = `/admin/ai-lab/agents/${agentId}/edit`;
+          }}
+        >
+          Configura Agente
+        </button>
+      </div>
+    );
+  }
+
+  // 3. Thread selected (real UUID)
+  if (selectedThreadId && selectedThreadId !== 'new') {
+    return <ChatThreadView threadId={selectedThreadId} />;
+  }
+
+  // 4. Creating new thread
+  if (selectedThreadId === 'new') {
+    if (creating) {
+      return (
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 text-slate-400">
+          <Loader2 className="h-5 w-5 animate-spin" />
+          <span className="text-xs">Creazione chat in corso…</span>
+        </div>
+      );
+    }
+    if (createError) {
+      return (
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 text-red-500">
+          <AlertCircle className="h-5 w-5" />
+          <span className="text-xs">{createError}</span>
+        </div>
+      );
+    }
+    return null;
+  }
+
+  // 5. Default empty state
+  return (
+    <div
+      data-testid="chat-empty-state"
+      className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center text-slate-400"
+    >
+      <MessageSquare className="h-8 w-8" />
+      <p className="text-sm font-semibold text-slate-600">Chat con {agentName}</p>
+      <p className="text-xs">Seleziona una chat recente oppure avvia una nuova conversazione</p>
+    </div>
+  );
+}
+
+// ─── AgentChatDrawerLayout ────────────────────────────────────────────────────
+
 export const AgentChatDrawerLayout = React.memo(function AgentChatDrawerLayout({
   data,
   className,
   'data-testid': testId,
 }: AgentChatDrawerLayoutProps) {
+  const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
+
+  const { data: threads = [], isLoading: threadsLoading } = useAgentThreads(data.id);
+  const { data: docs = [], isLoading: docsLoading } = useAgentKbDocs(data.gameId);
+  const { status: readiness, isLoading: readinessLoading } = useAgentStatus(data.id);
+
+  const isReady = readiness?.isReady ?? false;
+  const buttonDisabled = !isReady || readinessLoading;
+
   return (
     <div
       className={cn('flex h-full w-full overflow-hidden', className)}
       data-testid={testId ?? 'agent-chat-drawer-layout'}
     >
-      <div data-testid="agent-chat-sidebar" className="w-[220px] shrink-0">
-        {data.gameName ? <span>{data.gameName}</span> : <span data-testid="no-game-placeholder" />}
-        <button data-testid="new-chat-button">+ Nuova chat</button>
-        <p>CHAT RECENTI</p>
-        <p>KNOWLEDGE BASE</p>
+      {/* Sidebar */}
+      <aside
+        data-testid="agent-chat-sidebar"
+        className="w-[220px] shrink-0 flex flex-col gap-4 overflow-y-auto border-r border-slate-200/60 bg-slate-50/80 px-3 py-4"
+      >
+        <AgentContextCard gameId={data.gameId} gameName={data.gameName} />
+
+        <button
+          data-testid="new-chat-button"
+          disabled={buttonDisabled}
+          title={buttonDisabled ? (readiness?.blockingReason ?? 'Configura la KB per abilitare la chat') : undefined}
+          onClick={() => setSelectedThreadId('new')}
+          className={cn(
+            'flex w-full items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-semibold font-nunito',
+            buttonDisabled
+              ? 'cursor-not-allowed bg-slate-200 text-slate-400'
+              : 'bg-blue-600 text-white hover:bg-blue-700',
+          )}
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Nuova chat
+        </button>
+
+        <SidebarSection label="CHAT RECENTI">
+          {threadsLoading ? (
+            <Loader2 className="mx-auto h-4 w-4 animate-spin text-slate-400" />
+          ) : threads.length === 0 ? (
+            <p className="px-2 text-xs text-slate-400">Nessuna chat</p>
+          ) : (
+            threads.slice(0, 8).map((thread) => (
+              <RecentThreadItem
+                key={thread.id}
+                thread={thread}
+                isSelected={selectedThreadId === thread.id}
+                onClick={() => setSelectedThreadId(thread.id)}
+              />
+            ))
+          )}
+        </SidebarSection>
+
+        <SidebarSection label="KNOWLEDGE BASE">
+          {docsLoading ? (
+            <Loader2 className="mx-auto h-4 w-4 animate-spin text-slate-400" />
+          ) : docs.length === 0 ? (
+            <p className="px-2 text-xs text-slate-400">Nessun documento</p>
+          ) : (
+            docs.slice(0, 5).map((doc) => <KbDocItem key={doc.id} doc={doc} />)
+          )}
+        </SidebarSection>
+      </aside>
+
+      {/* Chat area */}
+      <div
+        data-testid="agent-chat-area"
+        data-thread-id={selectedThreadId ?? ''}
+        className="flex flex-1 flex-col overflow-hidden"
+      >
+        <AgentChatArea
+          agentId={data.id}
+          agentName={data.name}
+          selectedThreadId={selectedThreadId}
+          onThreadCreated={(id) => setSelectedThreadId(id)}
+        />
       </div>
-      <div data-testid="agent-chat-area" className="flex-1" />
     </div>
   );
 });

--- a/apps/web/src/components/ui/data-display/extra-meeple-card/entities/AgentChatDrawerLayout.tsx
+++ b/apps/web/src/components/ui/data-display/extra-meeple-card/entities/AgentChatDrawerLayout.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import React from 'react';
+
+import { cn } from '@/lib/utils';
+
+import type { AgentDetailData } from '../types';
+
+export interface AgentChatDrawerLayoutProps {
+  data: AgentDetailData;
+  className?: string;
+  'data-testid'?: string;
+}
+
+export const AgentChatDrawerLayout = React.memo(function AgentChatDrawerLayout({
+  data,
+  className,
+  'data-testid': testId,
+}: AgentChatDrawerLayoutProps) {
+  return (
+    <div
+      className={cn('flex h-full w-full overflow-hidden', className)}
+      data-testid={testId ?? 'agent-chat-drawer-layout'}
+    >
+      <div data-testid="agent-chat-sidebar" className="w-[220px] shrink-0">
+        {data.gameName ? <span>{data.gameName}</span> : <span data-testid="no-game-placeholder" />}
+        <button data-testid="new-chat-button">+ Nuova chat</button>
+        <p>CHAT RECENTI</p>
+        <p>KNOWLEDGE BASE</p>
+      </div>
+      <div data-testid="agent-chat-area" className="flex-1" />
+    </div>
+  );
+});

--- a/apps/web/src/components/ui/data-display/extra-meeple-card/entities/__tests__/AgentChatDrawerLayout.test.tsx
+++ b/apps/web/src/components/ui/data-display/extra-meeple-card/entities/__tests__/AgentChatDrawerLayout.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { AgentChatDrawerLayout } from '../AgentChatDrawerLayout';
+import type { AgentDetailData } from '../../types';
+
+vi.mock('@/hooks/queries/useAgentData', () => ({
+  useAgentThreads: () => ({ data: [], isLoading: false }),
+  useAgentKbDocs: () => ({ data: [], isLoading: false }),
+}));
+vi.mock('@/hooks/useAgentStatus', () => ({
+  useAgentStatus: () => ({ status: null, isLoading: false, error: null }),
+}));
+
+const mockAgent: AgentDetailData = {
+  id: 'agent-1',
+  name: 'Azul Assistant',
+  type: 'qa',
+  strategyName: 'hybrid-rag',
+  strategyParameters: {},
+  isActive: true,
+  isIdle: false,
+  invocationCount: 3,
+  lastInvokedAt: null,
+  createdAt: '2024-01-01T00:00:00Z',
+  gameId: 'game-1',
+  gameName: 'Azul',
+};
+
+describe('AgentChatDrawerLayout', () => {
+  it('renders sidebar and chat area in 2-column layout', () => {
+    render(<AgentChatDrawerLayout data={mockAgent} />);
+    expect(screen.getByTestId('agent-chat-sidebar')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-chat-area')).toBeInTheDocument();
+  });
+
+  it('shows game name in sidebar context', () => {
+    render(<AgentChatDrawerLayout data={mockAgent} />);
+    expect(screen.getByText('Azul')).toBeInTheDocument();
+  });
+
+  it('shows "+ Nuova chat" button', () => {
+    render(<AgentChatDrawerLayout data={mockAgent} />);
+    expect(screen.getByTestId('new-chat-button')).toBeInTheDocument();
+  });
+
+  it('shows CHAT RECENTI section label', () => {
+    render(<AgentChatDrawerLayout data={mockAgent} />);
+    expect(screen.getByText('CHAT RECENTI')).toBeInTheDocument();
+  });
+
+  it('shows KNOWLEDGE BASE section label', () => {
+    render(<AgentChatDrawerLayout data={mockAgent} />);
+    expect(screen.getByText('KNOWLEDGE BASE')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no game linked', () => {
+    const noGameAgent = { ...mockAgent, gameId: undefined, gameName: undefined };
+    render(<AgentChatDrawerLayout data={noGameAgent} />);
+    expect(screen.getByTestId('no-game-placeholder')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ui/data-display/extra-meeple-card/entities/__tests__/AgentChatDrawerLayout.test.tsx
+++ b/apps/web/src/components/ui/data-display/extra-meeple-card/entities/__tests__/AgentChatDrawerLayout.test.tsx
@@ -1,14 +1,21 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
 import { AgentChatDrawerLayout } from '../AgentChatDrawerLayout';
 import type { AgentDetailData } from '../../types';
+import * as useAgentDataModule from '@/hooks/queries/useAgentData';
 
 vi.mock('@/hooks/queries/useAgentData', () => ({
-  useAgentThreads: () => ({ data: [], isLoading: false }),
-  useAgentKbDocs: () => ({ data: [], isLoading: false }),
+  useAgentThreads: vi.fn(() => ({ data: [], isLoading: false })),
+  useAgentKbDocs: vi.fn(() => ({ data: [], isLoading: false })),
 }));
 vi.mock('@/hooks/useAgentStatus', () => ({
   useAgentStatus: () => ({ status: null, isLoading: false, error: null }),
+}));
+vi.mock('@/components/chat-unified/ChatThreadView', () => ({
+  ChatThreadView: ({ threadId }: { threadId: string }) => (
+    <div data-testid="chat-thread-view" data-thread-id={threadId} />
+  ),
 }));
 
 const mockAgent: AgentDetailData = {
@@ -57,5 +64,25 @@ describe('AgentChatDrawerLayout', () => {
     const noGameAgent = { ...mockAgent, gameId: undefined, gameName: undefined };
     render(<AgentChatDrawerLayout data={noGameAgent} />);
     expect(screen.getByTestId('no-game-placeholder')).toBeInTheDocument();
+  });
+
+  it('shows thread preview in recent chats when threads exist', () => {
+    vi.mocked(useAgentDataModule.useAgentThreads).mockReturnValue({
+      data: [{ id: 't1', createdAt: '2024-03-01T00:00:00Z', messageCount: 5, firstMessagePreview: 'Qual è la regola finale?' }],
+      isLoading: false,
+    } as ReturnType<typeof useAgentDataModule.useAgentThreads>);
+    render(<AgentChatDrawerLayout data={mockAgent} />);
+    expect(screen.getByText('Qual è la regola finale?')).toBeInTheDocument();
+  });
+
+  it('clicking a recent thread updates chat area data-thread-id', async () => {
+    const user = userEvent.setup();
+    vi.mocked(useAgentDataModule.useAgentThreads).mockReturnValue({
+      data: [{ id: 't1', createdAt: '2024-03-01T00:00:00Z', messageCount: 5, firstMessagePreview: 'Domanda test' }],
+      isLoading: false,
+    } as ReturnType<typeof useAgentDataModule.useAgentThreads>);
+    render(<AgentChatDrawerLayout data={mockAgent} />);
+    await user.click(screen.getByTestId('thread-item-t1'));
+    expect(screen.getByTestId('agent-chat-area')).toHaveAttribute('data-thread-id', 't1');
   });
 });

--- a/docs/superpowers/plans/2026-04-09-agent-chat-drawer-layout.md
+++ b/docs/superpowers/plans/2026-04-09-agent-chat-drawer-layout.md
@@ -1,0 +1,342 @@
+# Agent Chat Drawer — Layout 2-colonne Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rimpiazzare il drawer agente tab-based con un layout a 2 colonne chat-centrico che corrisponde al mockup `admin-mockups/chatDesktop.png`.
+
+**Architecture:** Nuovo componente `AgentChatDrawerLayout` con sidebar sinistra (contesto + nuova chat + recenti + KB) e area destra (chat). Tutta la logica di fetch esistente viene riutilizzata. `AgentDrawerContent` in `ExtraMeepleCardDrawer` viene aggiornato per usare il nuovo layout.
+
+**Tech Stack:** Next.js 16, React 19, TypeScript, Tailwind 4, shadcn/ui, Vitest + React Testing Library
+
+**Branch:** `feature/issue-agent-chat-drawer-layout` (parent: `main-dev`)
+
+---
+
+## Struttura File
+
+**Creare:**
+- `apps/web/src/components/ui/data-display/extra-meeple-card/entities/AgentChatDrawerLayout.tsx`
+- `apps/web/src/components/ui/data-display/extra-meeple-card/entities/__tests__/AgentChatDrawerLayout.test.tsx`
+
+**Modificare:**
+- `apps/web/src/components/ui/data-display/extra-meeple-card/ExtraMeepleCardDrawer.tsx`
+  - `AgentDrawerContent`: sostituisce `AgentExtraMeepleCard` con `AgentChatDrawerLayout`
+  - Label agent: `'Dettaglio Agente'` → `"Chat con l'agente"`
+  - SheetContent: aggiungere classe width override per agent (`sm:w-[800px] sm:max-w-[800px]`)
+
+---
+
+### Task 1: Scaffolding + test failing
+
+**Files:**
+- Create: `apps/web/src/components/ui/data-display/extra-meeple-card/entities/__tests__/AgentChatDrawerLayout.test.tsx`
+- Create: `apps/web/src/components/ui/data-display/extra-meeple-card/entities/AgentChatDrawerLayout.tsx`
+
+- [ ] **Step 1.1: Scrivi il test failing per la struttura layout**
+
+```tsx
+// apps/web/src/components/ui/data-display/extra-meeple-card/entities/__tests__/AgentChatDrawerLayout.test.tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { AgentChatDrawerLayout } from '../AgentChatDrawerLayout';
+import type { AgentDetailData } from '../../types';
+
+vi.mock('@/hooks/queries/useAgentData', () => ({
+  useAgentThreads: () => ({ data: [], isLoading: false }),
+  useAgentKbDocs: () => ({ data: [], isLoading: false }),
+}));
+vi.mock('@/hooks/useAgentStatus', () => ({
+  useAgentStatus: () => ({ status: null, isLoading: false, error: null }),
+}));
+
+const mockAgent: AgentDetailData = {
+  id: 'agent-1',
+  name: 'Azul Assistant',
+  type: 'qa',
+  strategyName: 'hybrid-rag',
+  strategyParameters: {},
+  isActive: true,
+  isIdle: false,
+  invocationCount: 3,
+  lastInvokedAt: null,
+  createdAt: '2024-01-01T00:00:00Z',
+  gameId: 'game-1',
+  gameName: 'Azul',
+};
+
+describe('AgentChatDrawerLayout', () => {
+  it('renders sidebar and chat area in 2-column layout', () => {
+    render(<AgentChatDrawerLayout data={mockAgent} />);
+    expect(screen.getByTestId('agent-chat-sidebar')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-chat-area')).toBeInTheDocument();
+  });
+
+  it('shows game name in sidebar context', () => {
+    render(<AgentChatDrawerLayout data={mockAgent} />);
+    expect(screen.getByText('Azul')).toBeInTheDocument();
+  });
+
+  it('shows "+ Nuova chat" button', () => {
+    render(<AgentChatDrawerLayout data={mockAgent} />);
+    expect(screen.getByTestId('new-chat-button')).toBeInTheDocument();
+  });
+
+  it('shows CHAT RECENTI section label', () => {
+    render(<AgentChatDrawerLayout data={mockAgent} />);
+    expect(screen.getByText('CHAT RECENTI')).toBeInTheDocument();
+  });
+
+  it('shows KNOWLEDGE BASE section label', () => {
+    render(<AgentChatDrawerLayout data={mockAgent} />);
+    expect(screen.getByText('KNOWLEDGE BASE')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no game linked', () => {
+    const noGameAgent = { ...mockAgent, gameId: undefined, gameName: undefined };
+    render(<AgentChatDrawerLayout data={noGameAgent} />);
+    expect(screen.getByTestId('no-game-placeholder')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 1.2: Esegui il test per verificare che fallisce**
+
+```bash
+cd apps/web && pnpm test src/components/ui/data-display/extra-meeple-card/entities/__tests__/AgentChatDrawerLayout.test.tsx
+```
+
+Atteso: `FAIL — Cannot find module '../AgentChatDrawerLayout'`
+
+- [ ] **Step 1.3: Crea lo scaffolding minimo `AgentChatDrawerLayout.tsx`**
+
+```tsx
+// apps/web/src/components/ui/data-display/extra-meeple-card/entities/AgentChatDrawerLayout.tsx
+'use client';
+
+import React, { useState } from 'react';
+import { cn } from '@/lib/utils';
+import type { AgentDetailData } from '../types';
+
+export interface AgentChatDrawerLayoutProps {
+  data: AgentDetailData;
+  className?: string;
+  'data-testid'?: string;
+}
+
+export const AgentChatDrawerLayout = React.memo(function AgentChatDrawerLayout({
+  data,
+  className,
+  'data-testid': testId,
+}: AgentChatDrawerLayoutProps) {
+  return (
+    <div
+      className={cn('flex h-full w-full overflow-hidden', className)}
+      data-testid={testId ?? 'agent-chat-drawer-layout'}
+    >
+      <div data-testid="agent-chat-sidebar" className="w-[220px] shrink-0">
+        {data.gameName ? (
+          <span>{data.gameName}</span>
+        ) : (
+          <span data-testid="no-game-placeholder" />
+        )}
+        <button data-testid="new-chat-button">+ Nuova chat</button>
+        <p>CHAT RECENTI</p>
+        <p>KNOWLEDGE BASE</p>
+      </div>
+      <div data-testid="agent-chat-area" className="flex-1" />
+    </div>
+  );
+});
+```
+
+- [ ] **Step 1.4: Esegui test — devono passare**
+
+```bash
+cd apps/web && pnpm test src/components/ui/data-display/extra-meeple-card/entities/__tests__/AgentChatDrawerLayout.test.tsx
+```
+
+Atteso: `PASS — 6 tests passed`
+
+- [ ] **Step 1.5: Commit scaffolding**
+
+```bash
+git add apps/web/src/components/ui/data-display/extra-meeple-card/entities/AgentChatDrawerLayout.tsx apps/web/src/components/ui/data-display/extra-meeple-card/entities/__tests__/AgentChatDrawerLayout.test.tsx
+git commit -m "feat(agent-drawer): scaffold AgentChatDrawerLayout with failing-then-passing tests"
+```
+
+---
+
+### Task 2: Sidebar completa + AgentChatArea
+
+**Files:**
+- Modify: `apps/web/src/components/ui/data-display/extra-meeple-card/entities/AgentChatDrawerLayout.tsx`
+- Modify: `apps/web/src/components/ui/data-display/extra-meeple-card/entities/__tests__/AgentChatDrawerLayout.test.tsx`
+
+**Dipendenze riutilizzate (esistenti, NON ricreare):**
+- `useAgentThreads(agentId)` da `@/hooks/queries/useAgentData`
+- `useAgentKbDocs(gameId)` da `@/hooks/queries/useAgentData`
+- `useAgentStatus(agentId)` da `@/hooks/useAgentStatus` — ritorna `{ status: { isReady, documentCount, ragStatus, blockingReason }, isLoading, error }`
+- `ChatThreadView` da `@/components/chat-unified/ChatThreadView`
+- `api.chat.createThread({ agentId, title })` da `@/lib/api`
+- Tipi: `AgentDetailData`, `ChatThreadPreview`, `KbDocumentPreview` da `../types`
+
+**Comportamento:**
+- Sidebar 220px fissa, border-r, bg-slate-50/80
+- `AgentContextCard`: mostra icona Gamepad2 + gameName in card ambra; se no gameId → `data-testid="no-game-placeholder"`
+- `+ Nuova chat`: blu quando isReady, grigio disabled quando non ready o readinessLoading
+- `CHAT RECENTI`: lista `RecentThreadItem` clickable; click → imposta `selectedThreadId`; `data-testid="thread-item-{thread.id}"`; item selezionato ha classe blu
+- `KNOWLEDGE BASE`: lista `KbDocItem` con fileName + dot colorato (emerald=indexed, amber=processing, red=failed, slate=none)
+- Area chat (flex-1): state machine
+  - `readinessLoading` → spinner
+  - `readiness.isReady === false` → BlockingUI con link a `/admin/ai-lab/agents/{agentId}/edit`
+  - `selectedThreadId` nullo → empty state con testo "Seleziona una chat recente oppure avvia una nuova conversazione", `data-testid="chat-empty-state"`
+  - `selectedThreadId === 'new'` → chiama `api.chat.createThread` → poi passa a stato sotto
+  - `selectedThreadId` = UUID → `<ChatThreadView threadId={selectedThreadId} />`
+- Area chat: `data-thread-id={selectedThreadId ?? ''}`
+
+- [ ] **Step 2.1: Aggiungi test thread click e KB**
+
+Aggiungi nel file test esistente (importa `userEvent` da `@testing-library/user-event`):
+
+```tsx
+import userEvent from '@testing-library/user-event';
+
+const mockThreads = [
+  { id: 't1', createdAt: '2024-03-01T00:00:00Z', messageCount: 5, firstMessagePreview: 'Qual è la regola finale?' },
+];
+
+// Override mock per thread
+vi.mock('@/hooks/queries/useAgentData', () => ({
+  useAgentThreads: vi.fn(() => ({ data: mockThreads, isLoading: false })),
+  useAgentKbDocs: vi.fn(() => ({ data: [], isLoading: false })),
+}));
+
+it('shows thread preview in recent chats', () => {
+  render(<AgentChatDrawerLayout data={mockAgent} />);
+  expect(screen.getByText('Qual è la regola finale?')).toBeInTheDocument();
+});
+
+it('clicking a recent thread updates chat area data-thread-id', async () => {
+  render(<AgentChatDrawerLayout data={mockAgent} />);
+  const threadItem = screen.getByTestId('thread-item-t1');
+  await userEvent.click(threadItem);
+  expect(screen.getByTestId('agent-chat-area')).toHaveAttribute('data-thread-id', 't1');
+});
+```
+
+- [ ] **Step 2.2: Implementa `AgentChatDrawerLayout.tsx` completo**
+
+Rimpiazza il file con l'implementazione completa seguendo le specifiche sopra. Struttura suggerita:
+
+```
+AgentChatDrawerLayout (componente root, gestisce selectedThreadId state)
+├── aside[data-testid="agent-chat-sidebar"]
+│   ├── AgentContextCard (locale)
+│   ├── button[data-testid="new-chat-button"]
+│   ├── SidebarSection label="CHAT RECENTI"
+│   │   └── RecentThreadItem[] (o empty state)
+│   └── SidebarSection label="KNOWLEDGE BASE"
+│       └── KbDocItem[] (o empty state)
+└── div[data-testid="agent-chat-area"][data-thread-id=...]
+    └── AgentChatArea (locale, state machine)
+```
+
+- [ ] **Step 2.3: Esegui tutti i test**
+
+```bash
+cd apps/web && pnpm test src/components/ui/data-display/extra-meeple-card/entities/__tests__/AgentChatDrawerLayout.test.tsx
+```
+
+Atteso: tutti pass.
+
+- [ ] **Step 2.4: Typecheck**
+
+```bash
+cd apps/web && pnpm typecheck 2>&1 | head -30
+```
+
+Atteso: 0 errori nei nuovi file.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/extra-meeple-card/entities/AgentChatDrawerLayout.tsx apps/web/src/components/ui/data-display/extra-meeple-card/entities/__tests__/AgentChatDrawerLayout.test.tsx
+git commit -m "feat(agent-drawer): implement full AgentChatDrawerLayout — sidebar + chat area"
+```
+
+---
+
+### Task 3: Wire ExtraMeepleCardDrawer
+
+**Files:**
+- Modify: `apps/web/src/components/ui/data-display/extra-meeple-card/ExtraMeepleCardDrawer.tsx`
+
+**Contesto del file (righe chiave):**
+- Riga ~105: `ENTITY_CONFIG` — cambia label agent
+- Riga ~145-157: `SheetContent` className — aggiungi width override per agent
+- Riga ~301-314: `AgentDrawerContent` — sostituisce `AgentExtraMeepleCard` con `AgentChatDrawerLayout`
+- Import da aggiungere: `import { AgentChatDrawerLayout } from './entities/AgentChatDrawerLayout';`
+- Import da RIMUOVERE dall'uso interno (ma non dalla re-export): non rimuovere l'import di `AgentExtraMeepleCard` se è usato in altri posti del file; cambia solo `AgentDrawerContent`
+
+**Modifiche esatte:**
+
+1. In `ENTITY_CONFIG`, riga agent:
+```tsx
+// PRIMA
+agent: { label: 'Dettaglio Agente', color: '38 92% 50%', Icon: Bot },
+// DOPO
+agent: { label: "Chat con l'agente", color: '38 92% 50%', Icon: Bot },
+```
+
+2. In `SheetContent` className, sostituisci la riga width con:
+```tsx
+entityType === 'agent'
+  ? 'w-full sm:w-[800px] sm:max-w-[800px]'
+  : 'w-full sm:w-[600px] sm:max-w-[600px]',
+```
+
+3. `AgentDrawerContent`:
+```tsx
+function AgentDrawerContent({ entityId }: { entityId: string }) {
+  const { data, loading, error, retry } = useAgentDetail(entityId);
+  if (loading) return <DrawerLoadingSkeleton />;
+  if (error) return <DrawerErrorState error={error} onRetry={retry} />;
+  if (!data) return <DrawerLoadingSkeleton />;
+  return <AgentChatDrawerLayout data={data} className="h-full" />;
+}
+```
+
+- [ ] **Step 3.1: Leggi il file attuale**
+
+```bash
+# Solo per capire le righe esatte prima di modificare
+head -160 apps/web/src/components/ui/data-display/extra-meeple-card/ExtraMeepleCardDrawer.tsx
+```
+
+- [ ] **Step 3.2: Applica le 3 modifiche**
+
+Applica le modifiche descritte sopra.
+
+- [ ] **Step 3.3: Typecheck + test**
+
+```bash
+cd apps/web && pnpm typecheck 2>&1 | head -20
+cd apps/web && pnpm test src/components/ui/data-display/extra-meeple-card/ --run
+```
+
+Atteso: 0 errori, tutti i test passano.
+
+- [ ] **Step 3.4: Lint**
+
+```bash
+cd apps/web && pnpm lint 2>&1 | grep -E "error" | head -10
+```
+
+Atteso: 0 errori nei file modificati.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/extra-meeple-card/ExtraMeepleCardDrawer.tsx
+git commit -m "feat(agent-drawer): wire AgentDrawerContent to AgentChatDrawerLayout, update label+width"
+```


### PR DESCRIPTION
## Summary

- Nuovo componente `AgentChatDrawerLayout` che sostituisce il drawer agente tab-based con un layout a 2 colonne: sidebar sinistra (contesto gioco + nuova chat + recenti + KB) e area chat destra con state machine a 5 stati
- `ExtraMeepleCardDrawer`: label agent aggiornata a \"Chat con l'agente\", width aumentata a 800px per il tipo agent
- `AgentExtraMeepleCard` conservato intatto per altri contesti standalone

## Changes

- **NUOVO** `entities/AgentChatDrawerLayout.tsx` — layout 2-col con sidebar (220px) + chat area (flex-1); usa hook esistenti `useAgentThreads`, `useAgentKbDocs`, `useAgentStatus`; state machine: loading → not-ready blocking UI → thread attivo → new thread creation → empty state
- **NUOVO** `entities/__tests__/AgentChatDrawerLayout.test.tsx` — 8 test (struttura, gioco, button, sezioni, placeholder, threads, click)
- **MOD** `ExtraMeepleCardDrawer.tsx` — `AgentDrawerContent` ora usa `AgentChatDrawerLayout`; label e width agent aggiornati

## Quality Fixes (from code review)

- Rimossa doppia chiamata `useAgentStatus` (era in padre e figlio)
- `useEffect` deps complete: `[selectedThreadId, agentId, agentName]`; `onThreadCreated` stabilizzato via ref
- Rimosso import non utilizzato `AgentExtraMeepleCard`

## Known Follow-ups (non bloccanti)

- Verificare se `gameId` serve nel `api.chat.createThread()` (dipende da contratto BE)
- Sostituire `window.location.href` con Next.js router nel button \"Configura Agente\"
- Aggiungere test per stato not-ready e flusso creazione nuovo thread

## Test Plan

- [x] 12/12 test passano (`pnpm test src/components/ui/data-display/extra-meeple-card/`)
- [x] TypeCheck pulito (0 errori nei file modificati)
- [x] Build frontend OK
- [ ] Verifica visiva: aprire drawer agente → vedere sidebar + area chat 2-colonne
- [ ] Verifica: click \"Nuova chat\" → crea thread → mostra ChatThreadView
- [ ] Verifica: click su chat recente → carica thread nell'area destra

🤖 Generated with [Claude Code](https://claude.ai/claude-code)