### PR TITLE
feat(seed): pre-indexed PDF snapshot workflow (bake + consume)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,3 +238,10 @@ infra/.env.dev.local
 infra/.dev-fast.pids
 infra/dev-fast.log
 infra/dotnet-watch.log
+
+# Seed snapshot artifacts — see docs/development/snapshot-seed-workflow.md
+# Dump files are large (~150MB) and stored on seed blob bucket, not git.
+# .meta.json sidecars are intentionally NOT ignored (committable log history).
+data/snapshots/*.dump
+data/snapshots/*.dump.sha256
+data/snapshots/.latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@
 |------|---------|----------|
 | Start Dev (full) | `make dev` | `infra/` |
 | Start Dev (core) | `make dev-core` | `infra/` |
+| Dev from Snapshot | `make dev-from-snapshot` | `infra/` — dev veloce con RAG pre-indicizzato ([guide](./docs/development/snapshot-seed-workflow.md)) |
+| Bake Snapshot | `make seed-index` | `infra/` — indicizza tutti i PDF e produce dump (raro) |
 | Start Integration | `make tunnel && make integration` | `infra/` — **Windows: usa Git Bash, non PowerShell** |
 | Deploy Staging | `make staging` | `infra/` (on server) |
 | Setup Secrets | `make secrets-setup` | `infra/` |
@@ -319,6 +321,7 @@ tests/Api.Tests/          # Backend test suite
 | Testhost blocking | `tasklist \| grep testhost` → `taskkill //PID <PID> //F` |
 | Port conflict | `netstat -ano \| findstr :8080` → `taskkill /PID <PID> /F` |
 | Operations Manual | `docs/operations/operations-manual.md` — full service management reference |
+| Snapshot drift | `cd infra && make seed-index` (rigenera) oppure `make dev` (fallback) — vedi [workflow](./docs/development/snapshot-seed-workflow.md#compat-gate--exit-codes) |
 
 ## AI Assistant Context
 

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeedLayer.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeedLayer.cs
@@ -32,6 +32,13 @@ internal sealed class CatalogSeedLayer : ISeedLayer
         var primaryBlob = context.Services.GetRequiredService<IBlobStorageService>();
         var seedBlob = context.Services.GetRequiredService<ISeedBlobReader>();
 
+        var manifestOverride = config?.GetValue<string>("SEED_CATALOG_MANIFEST_OVERRIDE");
+        if (!string.IsNullOrWhiteSpace(manifestOverride))
+        {
+            context.Logger.LogInformation(
+                "CatalogSeedLayer: using manifest override '{Manifest}'", manifestOverride);
+        }
+
         await CatalogSeeder.SeedAsync(
             context.Profile,
             context.DbContext,
@@ -41,6 +48,7 @@ internal sealed class CatalogSeedLayer : ISeedLayer
             seedBlob,
             context.Logger, cancellationToken,
             embeddingService,
-            config).ConfigureAwait(false);
+            config,
+            manifestNameOverride: manifestOverride).ConfigureAwait(false);
     }
 }

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeedLayer.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeedLayer.cs
@@ -20,6 +20,13 @@ internal sealed class CatalogSeedLayer : ISeedLayer
     public async Task SeedAsync(SeedContext context, CancellationToken cancellationToken = default)
     {
         var config = context.Services.GetService<IConfiguration>();
+
+        if (config?.GetValue<bool>("SKIP_CATALOG_SEED") == true)
+        {
+            context.Logger.LogInformation("CatalogSeedLayer: SKIP_CATALOG_SEED=true, skipping");
+            return;
+        }
+
         var bggService = context.Services.GetRequiredService<IBggApiService>();
         var embeddingService = context.Services.GetService<IEmbeddingService>();
         var primaryBlob = context.Services.GetRequiredService<IBlobStorageService>();

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeedLayer.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeedLayer.cs
@@ -32,8 +32,15 @@ internal sealed class CatalogSeedLayer : ISeedLayer
         var primaryBlob = context.Services.GetRequiredService<IBlobStorageService>();
         var seedBlob = context.Services.GetRequiredService<ISeedBlobReader>();
 
+        // Normalize blank/whitespace to null so an env var set to "" in docker-compose
+        // or .env doesn't propagate as an empty manifest name into LoadManifest
+        // (which would build "Manifests..yml" and throw FileNotFoundException).
         var manifestOverride = config?.GetValue<string>("SEED_CATALOG_MANIFEST_OVERRIDE");
-        if (!string.IsNullOrWhiteSpace(manifestOverride))
+        if (string.IsNullOrWhiteSpace(manifestOverride))
+        {
+            manifestOverride = null;
+        }
+        else
         {
             context.Logger.LogInformation(
                 "CatalogSeedLayer: using manifest override '{Manifest}'", manifestOverride);

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeeder.cs
@@ -36,6 +36,12 @@ internal static class CatalogSeeder
     /// <exception cref="InvalidOperationException">When manifest validation fails.</exception>
     public static SeedManifest LoadManifest(SeedProfile profile, string? manifestName = null)
     {
+        // Defense in depth: treat blank/whitespace override as "no override".
+        // Callers in CatalogSeedLayer already normalize, but this keeps the
+        // public static API robust against direct misuse.
+        if (string.IsNullOrWhiteSpace(manifestName))
+            manifestName = null;
+
         if (profile == SeedProfile.None && manifestName is null)
             throw new FileNotFoundException($"No manifest for profile '{profile}'");
 

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeeder.cs
@@ -21,18 +21,26 @@ internal static class CatalogSeeder
         .Build();
 
     /// <summary>
-    /// Loads and validates the embedded YAML manifest for the given profile.
+    /// Loads and validates the embedded YAML manifest for the given profile,
+    /// or a specific named manifest (e.g. <c>ci</c>) when <paramref name="manifestName"/>
+    /// is provided.
     /// </summary>
     /// <param name="profile">The seed profile to load (Dev, Staging, Prod).</param>
+    /// <param name="manifestName">
+    /// Optional explicit manifest file name (without extension). When set, takes
+    /// precedence over the profile-derived name and skips the profile-field
+    /// validation of the manifest body.
+    /// </param>
     /// <returns>A validated <see cref="SeedManifest"/>.</returns>
-    /// <exception cref="FileNotFoundException">When profile is None or manifest resource is missing.</exception>
+    /// <exception cref="FileNotFoundException">When profile is None without a name override or the manifest resource is missing.</exception>
     /// <exception cref="InvalidOperationException">When manifest validation fails.</exception>
-    public static SeedManifest LoadManifest(SeedProfile profile)
+    public static SeedManifest LoadManifest(SeedProfile profile, string? manifestName = null)
     {
-        if (profile == SeedProfile.None)
+        if (profile == SeedProfile.None && manifestName is null)
             throw new FileNotFoundException($"No manifest for profile '{profile}'");
 
-        var resourceName = $"Api.Infrastructure.Seeders.Catalog.Manifests.{profile.ToString().ToLowerInvariant()}.yml";
+        var effectiveName = manifestName ?? profile.ToString().ToLowerInvariant();
+        var resourceName = $"Api.Infrastructure.Seeders.Catalog.Manifests.{effectiveName}.yml";
         var assembly = Assembly.GetExecutingAssembly();
 
         using var stream = assembly.GetManifestResourceStream(resourceName)
@@ -40,7 +48,12 @@ internal static class CatalogSeeder
         using var reader = new StreamReader(stream);
 
         var manifest = YamlDeserializer.Deserialize<SeedManifest>(reader);
-        var errors = manifest.Validate(expectedProfile: profile);
+
+        // When loading via an explicit name override, skip profile-field validation
+        // (the ci.yml manifest may legitimately declare profile: dev while being
+        // a different logical resource).
+        var expectedForValidation = manifestName is null ? (SeedProfile?)profile : null;
+        var errors = manifest.Validate(expectedProfile: expectedForValidation);
         if (errors.Count > 0)
             throw new InvalidOperationException(
                 $"Manifest validation failed:\n{string.Join("\n", errors)}");
@@ -62,9 +75,10 @@ internal static class CatalogSeeder
         ILogger logger,
         CancellationToken ct,
         IEmbeddingService? embeddingService = null,
-        IConfiguration? configuration = null)
+        IConfiguration? configuration = null,
+        string? manifestNameOverride = null)
     {
-        var manifest = LoadManifest(profile);
+        var manifest = LoadManifest(profile, manifestNameOverride);
         logger.LogInformation("Catalog: {Count} games from {Profile}.yml",
             manifest.Catalog.Games.Count, profile);
 

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/ci.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/ci.yml
@@ -1,0 +1,50 @@
+version: 1
+profile: dev
+catalog:
+  games:
+  - title: Love Letter
+    bggId: 129622
+    language: en
+    bggEnhanced: false
+    yearPublished: 2012
+    minPlayers: 2
+    maxPlayers: 4
+    playingTime: 20
+    minAge: 10
+    averageRating: 7.23
+    averageWeight: 1.18
+    publishers:
+    - Z-Man Games
+    pdfBlobKey: rulebooks/v1/love-letter_rulebook.pdf
+    pdfSha256: e6b14614ffa5da73d995eaceefd7ca99e20ea8687b873da9b67ce6f3a5e69655
+    pdfVersion: '1.0'
+  - title: Patchwork
+    bggId: 163412
+    language: en
+    bggEnhanced: false
+    yearPublished: 2014
+    minPlayers: 2
+    maxPlayers: 2
+    playingTime: 30
+    minAge: 8
+    averageRating: 7.58
+    averageWeight: 1.63
+    publishers:
+    - Lookout Games
+    pdfBlobKey: rulebooks/v1/patchwork_rulebook.pdf
+    pdfVersion: '1.0'
+  - title: Jaipur
+    bggId: 54043
+    language: en
+    bggEnhanced: false
+    yearPublished: 2009
+    minPlayers: 2
+    maxPlayers: 2
+    playingTime: 30
+    minAge: 12
+    averageRating: 7.54
+    averageWeight: 1.48
+    publishers:
+    - GameWorks SàRL
+    pdfBlobKey: rulebooks/v1/jaipur_rulebook.pdf
+    pdfVersion: '1.0'

--- a/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/CatalogSeedLayerSkipFlagTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/CatalogSeedLayerSkipFlagTests.cs
@@ -1,0 +1,69 @@
+using Api.Infrastructure.Seeders;
+using Api.Infrastructure.Seeders.Catalog;
+using Api.Tests.Constants;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Api.Tests.Infrastructure.Seeders.Catalog;
+
+[Trait("Category", TestCategories.Unit)]
+public sealed class CatalogSeedLayerSkipFlagTests
+{
+    [Fact]
+    public async Task SeedAsync_WhenSkipFlagTrue_ReturnsImmediately()
+    {
+        // Arrange: configuration with SKIP_CATALOG_SEED=true
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["SKIP_CATALOG_SEED"] = "true"
+            })
+            .Build();
+
+        var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(config)
+            .BuildServiceProvider();
+
+        // DbContext is intentionally null — the skip path must NOT dereference it.
+        // If the skip logic is broken we expect a NullReferenceException or a
+        // ServiceNotFound exception when downstream services are resolved.
+        var context = new SeedContext(
+            Profile: SeedProfile.Dev,
+            DbContext: null!,
+            Services: services,
+            Logger: NullLogger.Instance,
+            SystemUserId: Guid.NewGuid());
+
+        var layer = new CatalogSeedLayer();
+
+        // Act + Assert: must complete without throwing
+        await layer.SeedAsync(context, default);
+    }
+
+    [Fact]
+    public async Task SeedAsync_WhenSkipFlagFalse_AttemptsToResolveDependencies()
+    {
+        // Arrange: SKIP_CATALOG_SEED not set — layer should try to resolve
+        // IBggApiService and fail because it's not registered.
+        var config = new ConfigurationBuilder().Build();
+        var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(config)
+            .BuildServiceProvider();
+
+        var context = new SeedContext(
+            Profile: SeedProfile.Dev,
+            DbContext: null!,
+            Services: services,
+            Logger: NullLogger.Instance,
+            SystemUserId: Guid.NewGuid());
+
+        var layer = new CatalogSeedLayer();
+
+        // Act + Assert: must throw because IBggApiService is not registered.
+        // This proves the skip-path is not being taken when the flag is absent.
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await layer.SeedAsync(context, default));
+    }
+}

--- a/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/CatalogSeederManifestOverrideTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/CatalogSeederManifestOverrideTests.cs
@@ -48,4 +48,18 @@ public sealed class CatalogSeederManifestOverrideTests
         manifest.Should().NotBeNull();
         manifest.Profile.Should().Be("dev");
     }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void LoadManifest_WithBlankOverride_FallsBackToProfile(string blank)
+    {
+        // Regression for PR #363 review: SEED_CATALOG_MANIFEST_OVERRIDE="" must
+        // not build "Manifests..yml" — treat blank/whitespace as no override.
+        var manifest = CatalogSeeder.LoadManifest(SeedProfile.Dev, manifestName: blank);
+
+        manifest.Should().NotBeNull();
+        manifest.Profile.Should().Be("dev");
+    }
 }

--- a/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/CatalogSeederManifestOverrideTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/CatalogSeederManifestOverrideTests.cs
@@ -1,0 +1,51 @@
+using Api.Infrastructure.Seeders;
+using Api.Infrastructure.Seeders.Catalog;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Infrastructure.Seeders.Catalog;
+
+[Trait("Category", TestCategories.Unit)]
+public sealed class CatalogSeederManifestOverrideTests
+{
+    [Fact]
+    public void LoadManifest_WithCiOverride_LoadsCiManifest()
+    {
+        var manifest = CatalogSeeder.LoadManifest(SeedProfile.Dev, manifestName: "ci");
+
+        manifest.Should().NotBeNull();
+        manifest.Catalog.Games.Should().HaveCount(3);
+        manifest.Catalog.Games.Select(g => g.Title).Should().BeEquivalentTo(
+            new[] { "Love Letter", "Patchwork", "Jaipur" });
+    }
+
+    [Fact]
+    public void LoadManifest_WithCiOverride_AllGamesHavePdfBlobKey()
+    {
+        var manifest = CatalogSeeder.LoadManifest(SeedProfile.Dev, manifestName: "ci");
+
+        manifest.Catalog.Games.Should().AllSatisfy(g =>
+            g.PdfBlobKey.Should().NotBeNullOrWhiteSpace(
+                $"ci.yml game '{g.Title}' must have a pdfBlobKey for e2e tests"));
+    }
+
+    [Fact]
+    public void LoadManifest_WithMissingOverride_Throws()
+    {
+        var act = () => CatalogSeeder.LoadManifest(SeedProfile.Dev, manifestName: "nonexistent");
+
+        act.Should().Throw<FileNotFoundException>()
+            .WithMessage("*nonexistent*");
+    }
+
+    [Fact]
+    public void LoadManifest_WithoutOverride_StillLoadsByProfile()
+    {
+        // Regression: ensure the existing call signature still works
+        var manifest = CatalogSeeder.LoadManifest(SeedProfile.Dev);
+
+        manifest.Should().NotBeNull();
+        manifest.Profile.Should().Be("dev");
+    }
+}

--- a/data/snapshots/meepleai_seed_baseline_14games.meta.json
+++ b/data/snapshots/meepleai_seed_baseline_14games.meta.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "20260409175159_AddUserHandSlots",
+  "ef_migration_head": "20260409175159_AddUserHandSlots",
+  "embedding_model": "BAAI/bge-large-en-v1.5",
+  "embedding_dim": 1024,
+  "app_commit": "1745adf5b",
+  "created_at": "2026-04-10T01:02:00Z",
+  "dev_yml_sha256": "see infra/scripts/seed-index-dump.sh for verification",
+  "pdf_count_ready": 14,
+  "pdf_count_failed": 122,
+  "chunk_count": 2076,
+  "embedding_count": 2076,
+  "ready_games": [
+    "Barrage",
+    "Battlestar Galactica: The Board Game – Exodus Expansion",
+    "Blueprints",
+    "Dominion",
+    "Frostpunk: The Board Game",
+    "ISS Vanguard",
+    "Mage Knight Board Game",
+    "Marvel Champions: The Card Game",
+    "Marvel United",
+    "Massive Darkness",
+    "Masters of The Universe: Fields of Eternia The Board Game",
+    "Paleo",
+    "RONE: Invasion",
+    "Townsfolk Tussle"
+  ],
+  "notes": "Baseline snapshot containing 14 fully indexed games (Ready state). 122 PDFs are in Failed state — to be retried separately. Use this snapshot via 'make dev-from-snapshot' to bootstrap a dev environment with pre-indexed RAG data instead of waiting for the embedding pipeline to process all PDFs."
+}

--- a/docs/development/snapshot-seed-workflow.md
+++ b/docs/development/snapshot-seed-workflow.md
@@ -1,0 +1,183 @@
+# Seed Snapshot Workflow
+
+Flusso a due fasi per avere un ambiente dev con RAG funzionante senza aspettare l'indicizzazione runtime dei 136 PDF del manifest `dev.yml`.
+
+**Spec di design**: `docs/superpowers/specs/2026-04-10-seed-pdf-pre-indexed-design.md`
+**Plan implementativo**: `docs/superpowers/plans/2026-04-10-seed-pdf-pre-indexed.md`
+
+## Quando usare questo flusso
+
+- **Primo setup su una macchina nuova**: `make dev-from-snapshot` invece di `make dev`
+- **Dopo `docker compose down -v`**: stesso
+- **In CI per e2e test**: usa il manifest `ci.yml` (3 PDF, bake in pochi minuti)
+
+## Architettura a due fasi
+
+### Fase bake — produrre lo snapshot
+
+Rara. Una volta per rilascio, o quando cambia: manifest `dev.yml`, modello di embedding, schema EF.
+
+```bash
+cd infra
+make seed-index          # ore su CPU, molto meno con GPU
+make seed-index-publish  # upload a seed blob bucket (opzionale)
+```
+
+Cosa fa `seed-index`:
+
+1. `seed-index-preflight.sh` — sanity check (docker, jq, manifest, seed blob, stato processing_jobs)
+2. `docker compose up -d postgres redis api embedding-service smoldocling-service`
+3. `wait-for-healthy api` — attesa del boot
+4. L'API al boot chiama automaticamente `SeedOrchestrator.RunAsync` (`Program.cs:535`) che enqueuea tutti i PDF del manifest
+5. `seed-index-wait.sh` — poll su `processing_jobs` finché tutti terminal (timeout 3h, fail-fast a 15%)
+6. `seed-index-dump.sh` — `pg_dump -Fc` (escluso `__EFMigrationsHistory`), sidecar `.meta.json`, sha256sum
+7. Il file si trova in `data/snapshots/` con naming `meepleai_seed_<ts>_<model>_<commit>`
+
+Parametri opzionali:
+
+| Var | Default | Scopo |
+|---|---|---|
+| `SEED_INDEX_TIMEOUT` | `10800` (3h) | timeout hard del polling |
+| `SEED_INDEX_POLL` | `15` (s) | intervallo di poll |
+| `SEED_INDEX_FAILURE_PCT` | `15` | soglia fail% oltre la quale abort |
+| `SEED_INDEX_ALLOW_PARTIAL` | `false` | permette dump con failures oltre soglia |
+
+### Fase consume — usare lo snapshot
+
+Default per qualunque developer.
+
+```bash
+cd infra
+make dev-from-snapshot
+```
+
+Cosa fa:
+
+1. `snapshot-fetch.sh` — cache-first (`SNAPSHOT_FILE` env > cache locale > download da bucket via `latest.txt`)
+2. `snapshot-verify.sh` — compat gate (vedi sotto)
+3. `docker compose up -d postgres` + wait healthy
+4. `snapshot-restore.sh` — `dotnet ef database update` (schema) poi `pg_restore --data-only --disable-triggers` (dati), smoke test finale
+5. `SKIP_CATALOG_SEED=true docker compose ... up -d` — avvia resto dello stack saltando il seed runtime
+
+Se qualcosa fallisce, il messaggio di errore ti dice esattamente cosa fare. **Fallback sempre disponibile**: `make dev`.
+
+### Force reset
+
+Se hai già un DB non vuoto e vuoi ripartire dallo snapshot, serve il force:
+
+```bash
+make dev-from-snapshot-force
+```
+
+⚠️ Distruttivo: cancella il volume postgres prima del restore.
+
+## Compat gate — exit codes
+
+Lo script `snapshot-verify.sh` blocca il restore con un exit code distinto per ogni tipo di drift:
+
+| Exit | Significato | Azione |
+|---|---|---|
+| `0` | Tutto compatibile | procedi con restore |
+| `1` | `.latest` o `.meta.json` mancante | `make seed-index` per rigenerare |
+| `2` | EF migration head del working tree ≠ snapshot | `git checkout` del commit compatibile, oppure `make seed-index` per rigenerare |
+| `3` | Embedding model del working tree ≠ snapshot | allinea `infra/secrets/embedding.secret` oppure rigenera |
+| `4` | Embedding dimension mismatch | idem come exit 3 |
+| `10` | DB non vuoto (guard di `snapshot-restore.sh`) | usa `make dev-from-snapshot-force` |
+| `124` | Timeout del bake (`seed-index-wait.sh`) | aumenta `SEED_INDEX_TIMEOUT` o investiga perché i job non progrediscono |
+
+Warning non bloccanti:
+- `dev.yml` sha256 diverso dallo snapshot → eventuali giochi aggiunti dopo il bake NON sono indicizzati
+- `failed_pdf_ids` non vuoto → lo snapshot contiene N PDF che sono falliti durante il bake (contabilizzati nel sidecar)
+
+## Contract dello snapshot
+
+### Naming
+
+```
+meepleai_seed_<timestamp>_<embedding_model_slug>_<commit>.dump
+meepleai_seed_<timestamp>_<embedding_model_slug>_<commit>.dump.sha256
+meepleai_seed_<timestamp>_<embedding_model_slug>_<commit>.meta.json
+```
+
+Esempio: `meepleai_seed_20260410T143022Z_sentence-transformers_all-MiniLM-L6-v2_3a75a9a10.dump`
+
+### Sidecar `.meta.json`
+
+```json
+{
+  "schema_version": "20260401_AddSearchVector",
+  "ef_migration_head": "20260401_AddSearchVector",
+  "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
+  "embedding_dim": 384,
+  "app_commit": "3a75a9a10",
+  "created_at": "2026-04-10T14:22:00Z",
+  "dev_yml_sha256": "…",
+  "pdf_count": 136,
+  "chunk_count": 18432,
+  "embedding_count": 18432,
+  "failed_pdf_ids": []
+}
+```
+
+### DB-only — vincolo esplicito
+
+Lo snapshot contiene **solo stato DB**. I PDF blob files vivono già idempotentemente nel seed blob bucket (`rulebooks/v1/*.pdf`). `make dev-from-snapshot` richiede che `STORAGE_PROVIDER` punti a un blob storage dove quei file sono raggiungibili, altrimenti i `FilePath` in `PdfDocumentEntity` puntano nel vuoto.
+
+### Esclusione `__EFMigrationsHistory`
+
+`pg_dump --exclude-table-data='__EFMigrationsHistory'` è intenzionale. Al restore si applica prima `dotnet ef database update` sul DB vuoto (scrive schema + history del working tree), poi `pg_restore --data-only` carica i dati. Questo garantisce che snapshot e working tree condividano sempre lo stesso schema.
+
+## Layout `data/snapshots/`
+
+```
+data/snapshots/
+├── meepleai_seed_20260410T143022Z_<model>_<commit>.dump         # gitignored
+├── meepleai_seed_20260410T143022Z_<model>_<commit>.dump.sha256  # gitignored
+├── meepleai_seed_20260410T143022Z_<model>_<commit>.meta.json    # committable (log storico)
+└── .latest                                                       # gitignored, pointer al basename
+```
+
+## Retention sul seed blob bucket
+
+Il target `make seed-index-publish` mantiene gli ultimi **3 snapshot** sul bucket (per `snapshots/` prefix). Quelli più vecchi vengono rimossi automaticamente (dump, sha, meta tutti insieme).
+
+`snapshots/latest.txt` è un piccolo file testuale con il basename dello snapshot corrente, aggiornato ad ogni publish. `snapshot-fetch.sh` lo legge per scoprire cosa scaricare senza dover listare il bucket.
+
+## Testing
+
+### Manual e2e con `ci.yml`
+
+Il manifest `ci.yml` contiene solo 3 PDF (Love Letter, Patchwork, Jaipur) e permette un bake+consume completo in pochi minuti. Per testare il flusso:
+
+```bash
+cd infra
+SEED_CATALOG_MANIFEST_OVERRIDE=ci SEED_INDEX_TIMEOUT=1800 make seed-index
+
+# verifica
+ls -lh data/snapshots/
+cat data/snapshots/*.meta.json | jq .
+
+# consume su clean env
+docker compose down postgres -v
+make dev-from-snapshot
+
+# smoke
+curl -s http://localhost:8080/health | jq .
+docker exec meepleai-postgres psql -U postgres -d meepleai -c \
+  "SELECT COUNT(*) FROM text_chunks;"
+```
+
+### Bats unit test (compat gate)
+
+`infra/scripts/tests/snapshot-verify.bats` copre tutti gli exit code con fixture JSON isolate. Richiede `bats-core`:
+
+```bash
+# Installa bats-core (Windows: choco install bats, macOS: brew install bats-core)
+bats infra/scripts/tests/snapshot-verify.bats
+```
+
+## Quando NON usare lo snapshot
+
+- Stai cambiando lo schema EF e vuoi testare la tua migration su dati runtime → usa `make dev`
+- Stai sviluppando il pipeline di indicizzazione → usa `make dev`
+- Vuoi un DB completamente pulito da debug → `docker compose down -v && make dev`

--- a/docs/superpowers/plans/2026-04-10-seed-pdf-pre-indexed.md
+++ b/docs/superpowers/plans/2026-04-10-seed-pdf-pre-indexed.md
@@ -1,0 +1,1346 @@
+# Seed con PDF Pre-Indicizzati — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fornire un workflow a due fasi (bake/consume) che produce un DB snapshot con tutti i rulebook già indicizzati e permette a qualunque dev di avviare l'ambiente locale saltando la pipeline RAG.
+
+**Architecture:** Bash scripts in `infra/scripts/` orchestrati da target Makefile. Il bake sfrutta l'auto-seed di `SeedOrchestrator.RunAsync` e attende che `PdfProcessingQuartzJob` smaltisca la coda. Il consume ripristina via `pg_restore --data-only` dopo `dotnet ef database update`, con compat gate su `.meta.json` sidecar.
+
+**Tech Stack:** Bash, jq, aws cli (S3-compatible), docker compose, PostgreSQL pg_dump/pg_restore, .NET 9 EF Core, bats-core per test.
+
+**Design reference:** `docs/superpowers/specs/2026-04-10-seed-pdf-pre-indexed-design.md`
+
+---
+
+## File Structure
+
+### Nuovi file
+
+| Path | Responsabilità |
+|---|---|
+| `infra/scripts/seed-index-preflight.sh` | Sanity check prima del bake |
+| `infra/scripts/seed-index-wait.sh` | Polling `processing_jobs` fino a terminale |
+| `infra/scripts/seed-index-dump.sh` | `pg_dump` + generazione sidecar `.meta.json` |
+| `infra/scripts/seed-index-publish.sh` | Upload dump+sidecar a seed blob bucket |
+| `infra/scripts/snapshot-fetch.sh` | Acquisizione snapshot (locale cache / bucket) |
+| `infra/scripts/snapshot-verify.sh` | Compat gate contro working tree |
+| `infra/scripts/snapshot-restore.sh` | `ef database update` + `pg_restore` + smoke |
+| `infra/scripts/tests/snapshot-verify.bats` | Unit test del compat gate |
+| `infra/scripts/tests/fixtures/meta-good.json` | Fixture valida |
+| `infra/scripts/tests/fixtures/meta-migration-drift.json` | Fixture exit 2 |
+| `infra/scripts/tests/fixtures/meta-model-drift.json` | Fixture exit 3 |
+| `infra/scripts/tests/fixtures/meta-dim-drift.json` | Fixture exit 4 |
+| `apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/ci.yml` | Manifest ridotto (3 PDF) per e2e |
+| `docs/development/snapshot-seed-workflow.md` | Guida developer |
+
+### File modificati
+
+| Path | Modifica |
+|---|---|
+| `apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeedLayer.cs` | Supporto `SKIP_CATALOG_SEED` + `SEED_CATALOG_MANIFEST_OVERRIDE` |
+| `apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeeder.cs` | `LoadManifest` accetta override esplicito del resource name |
+| `apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/CatalogSeedLayerTests.cs` (nuovo o modificato) | Test sui due nuovi flag |
+| `infra/Makefile` | Target `seed-index`, `seed-index-publish`, `dev-from-snapshot`, `dev-from-snapshot-force` |
+| `.gitignore` | Ignora `data/snapshots/*.dump`, `.sha256`, `.latest` |
+| `CLAUDE.md` | Quick reference + troubleshooting |
+
+---
+
+## Task 1: Aggiungere `SKIP_CATALOG_SEED` a `CatalogSeedLayer`
+
+**Files:**
+- Modify: `apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeedLayer.cs`
+- Test: `apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/CatalogSeedLayerTests.cs`
+
+- [ ] **Step 1: Scrivi il test fallente**
+
+Crea il file test (se non esiste cercalo con `find apps/api/tests -name "CatalogSeedLayerTests*"`). Aggiungi:
+
+```csharp
+using Api.Infrastructure.Seeders;
+using Api.Infrastructure.Seeders.Catalog;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+public class CatalogSeedLayerSkipFlagTests
+{
+    [Fact]
+    public async Task SeedAsync_SkipsWhenFlagTrue()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["SKIP_CATALOG_SEED"] = "true"
+            })
+            .Build();
+
+        var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(config)
+            .BuildServiceProvider();
+
+        var context = new SeedContext(
+            Profile: SeedProfile.Dev,
+            DbContext: null!,       // non dovrebbe essere usato quando skipped
+            Services: services,
+            SystemUserId: Guid.NewGuid(),
+            Logger: NullLogger.Instance);
+
+        var layer = new CatalogSeedLayer();
+
+        // Act + Assert: nessuna eccezione, ritorna immediatamente
+        await layer.SeedAsync(context, default);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/api/tests/Api.Tests
+dotnet test --filter "FullyQualifiedName~CatalogSeedLayerSkipFlagTests" -v n
+```
+
+Expected: FAIL — o con NullReferenceException (DbContext null dereferenced) o con eccezione da GetRequiredService.
+
+- [ ] **Step 3: Implementa il bypass**
+
+Modifica `apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeedLayer.cs`:
+
+```csharp
+public async Task SeedAsync(SeedContext context, CancellationToken cancellationToken = default)
+{
+    var config = context.Services.GetService<IConfiguration>();
+
+    if (config?.GetValue<bool>("SKIP_CATALOG_SEED") == true)
+    {
+        context.Logger.LogInformation("CatalogSeedLayer: SKIP_CATALOG_SEED=true, skipping");
+        return;
+    }
+
+    var bggService = context.Services.GetRequiredService<IBggApiService>();
+    var embeddingService = context.Services.GetService<IEmbeddingService>();
+    var primaryBlob = context.Services.GetRequiredService<IBlobStorageService>();
+    var seedBlob = context.Services.GetRequiredService<ISeedBlobReader>();
+
+    await CatalogSeeder.SeedAsync(
+        context.Profile,
+        context.DbContext,
+        bggService,
+        context.SystemUserId,
+        primaryBlob,
+        seedBlob,
+        context.Logger, cancellationToken,
+        embeddingService,
+        config).ConfigureAwait(false);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd apps/api/tests/Api.Tests
+dotnet test --filter "FullyQualifiedName~CatalogSeedLayerSkipFlagTests" -v n
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeedLayer.cs \
+        apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/CatalogSeedLayerTests.cs
+git commit -m "feat(seeding): add SKIP_CATALOG_SEED flag to CatalogSeedLayer"
+```
+
+---
+
+## Task 2: `SEED_CATALOG_MANIFEST_OVERRIDE` in `LoadManifest`
+
+Scopo: permettere di caricare `ci.yml` senza aggiungere un valore all'enum `SeedProfile`.
+
+**Files:**
+- Modify: `apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeeder.cs`
+- Modify: `apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeedLayer.cs`
+- Test: `apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/CatalogSeederLoadManifestTests.cs`
+
+- [ ] **Step 1: Scrivi il test fallente**
+
+```csharp
+using Api.Infrastructure.Seeders;
+using Api.Infrastructure.Seeders.Catalog;
+using Xunit;
+
+public class CatalogSeederLoadManifestTests
+{
+    [Fact]
+    public void LoadManifest_WithOverride_LoadsNamedResource()
+    {
+        // Act
+        var manifest = CatalogSeeder.LoadManifest(SeedProfile.Dev, manifestName: "ci");
+
+        // Assert
+        Assert.NotNull(manifest);
+        Assert.NotNull(manifest.Catalog);
+        Assert.Equal(3, manifest.Catalog.Games.Count);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/api/tests/Api.Tests
+dotnet test --filter "FullyQualifiedName~CatalogSeederLoadManifestTests" -v n
+```
+
+Expected: FAIL — signature mismatch o `ci.yml` non trovato.
+
+- [ ] **Step 3: Estendi `LoadManifest` con parametro override**
+
+Modifica `apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeeder.cs`:
+
+```csharp
+public static SeedManifest LoadManifest(SeedProfile profile, string? manifestName = null)
+{
+    if (profile == SeedProfile.None && manifestName == null)
+        throw new FileNotFoundException($"No manifest for profile '{profile}'");
+
+    var effectiveName = manifestName ?? profile.ToString().ToLowerInvariant();
+    var resourceName = $"Api.Infrastructure.Seeders.Catalog.Manifests.{effectiveName}.yml";
+    var assembly = Assembly.GetExecutingAssembly();
+
+    using var stream = assembly.GetManifestResourceStream(resourceName)
+        ?? throw new FileNotFoundException($"Embedded manifest not found: {resourceName}");
+    using var reader = new StreamReader(stream);
+
+    var manifest = YamlDeserializer.Deserialize<SeedManifest>(reader);
+
+    // Validation expected profile solo se NON è override (il ci.yml può dichiarare profile: Dev)
+    var expectedForValidation = manifestName == null ? (SeedProfile?)profile : null;
+    var errors = manifest.Validate(expectedProfile: expectedForValidation);
+    if (errors.Count > 0)
+        throw new InvalidOperationException(
+            $"Manifest validation failed:\n{string.Join("\n", errors)}");
+
+    return manifest;
+}
+```
+
+Estendi anche l'overload `SeedAsync` di `CatalogSeeder` per accettare `manifestName` opzionale e passarlo a `LoadManifest`:
+
+```csharp
+public static async Task SeedAsync(
+    SeedProfile profile,
+    MeepleAiDbContext db,
+    IBggApiService bggService,
+    Guid systemUserId,
+    IBlobStorageService primaryBlob,
+    ISeedBlobReader seedBlob,
+    ILogger logger,
+    CancellationToken ct,
+    IEmbeddingService? embeddingService = null,
+    IConfiguration? configuration = null,
+    string? manifestNameOverride = null)
+{
+    var manifest = LoadManifest(profile, manifestNameOverride);
+    // ... resto invariato
+```
+
+- [ ] **Step 4: Aggiorna `CatalogSeedLayer` per leggere l'override da config**
+
+Modifica `CatalogSeedLayer.SeedAsync` aggiungendo la lettura e il passaggio:
+
+```csharp
+var manifestOverride = config?.GetValue<string>("SEED_CATALOG_MANIFEST_OVERRIDE");
+
+await CatalogSeeder.SeedAsync(
+    context.Profile,
+    context.DbContext,
+    bggService,
+    context.SystemUserId,
+    primaryBlob,
+    seedBlob,
+    context.Logger, cancellationToken,
+    embeddingService,
+    config,
+    manifestNameOverride: manifestOverride).ConfigureAwait(false);
+```
+
+- [ ] **Step 5: Crea `ci.yml` embedded manifest**
+
+Crea `apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/ci.yml` come copia ridotta di `dev.yml`. Contenuto minimo:
+
+```yaml
+version: 1
+profile: Dev
+catalog:
+  games:
+  - title: Love Letter
+    bggId: 129622
+    minPlayers: 2
+    maxPlayers: 4
+    minPlaytimeMinutes: 15
+    maxPlaytimeMinutes: 30
+    complexity: 1.2
+    language: en
+    bggEnhanced: false
+    publishers:
+    - Z-Man Games
+    pdfBlobKey: rulebooks/v1/love-letter_rulebook.pdf
+    pdfSha256: "" # popolato durante bake reale; test e2e lo salta
+  - title: Patchwork
+    bggId: 163412
+    minPlayers: 2
+    maxPlayers: 2
+    minPlaytimeMinutes: 15
+    maxPlaytimeMinutes: 30
+    complexity: 1.6
+    language: en
+    bggEnhanced: false
+    publishers:
+    - Lookout Games
+    pdfBlobKey: rulebooks/v1/patchwork_rulebook.pdf
+    pdfSha256: ""
+  - title: Jaipur
+    bggId: 54043
+    minPlayers: 2
+    maxPlayers: 2
+    minPlaytimeMinutes: 20
+    maxPlaytimeMinutes: 30
+    complexity: 1.5
+    language: en
+    bggEnhanced: false
+    publishers:
+    - GameWorks SàRL
+    pdfBlobKey: rulebooks/v1/jaipur_rulebook.pdf
+    pdfSha256: ""
+```
+
+**Nota**: I 3 giochi sono scelti perché esistono già in `dev.yml` (riutilizza i dati), i PDF sono piccoli rulebook e il contenuto copia le stesse righe del manifest reale. Verifica estraendo le righe dal `dev.yml` per avere i dati corretti:
+
+```bash
+grep -A20 "title: Love Letter" apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml | head -25
+# usa l'output come base, rimuovi campi extra
+```
+
+- [ ] **Step 6: Registra `ci.yml` come embedded resource**
+
+Verifica in `apps/api/src/Api/Api.csproj` se i manifest sono inclusi automaticamente:
+
+```bash
+grep -n "Manifests" apps/api/src/Api/Api.csproj
+```
+
+Se c'è già un pattern `**/Manifests/*.yml` come `EmbeddedResource`, `ci.yml` è incluso automaticamente. Se invece sono listati uno a uno, aggiungi:
+
+```xml
+<EmbeddedResource Include="Infrastructure\Seeders\Catalog\Manifests\ci.yml" />
+```
+
+- [ ] **Step 7: Run test to verify it passes**
+
+```bash
+cd apps/api/tests/Api.Tests
+dotnet test --filter "FullyQualifiedName~CatalogSeederLoadManifestTests" -v n
+```
+
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeeder.cs \
+        apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeedLayer.cs \
+        apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/ci.yml \
+        apps/api/src/Api/Api.csproj \
+        apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/CatalogSeederLoadManifestTests.cs
+git commit -m "feat(seeding): add manifest override and ci.yml for e2e testing"
+```
+
+---
+
+## Task 3: `seed-index-preflight.sh`
+
+**Files:**
+- Create: `infra/scripts/seed-index-preflight.sh`
+
+- [ ] **Step 1: Scrivi lo script**
+
+```bash
+#!/usr/bin/env bash
+# infra/scripts/seed-index-preflight.sh
+# Fail-fast checks prima di lanciare seed-index
+set -euo pipefail
+
+log() { echo "[preflight] $*" >&2; }
+fail() { echo "::error:: $*" >&2; exit 1; }
+
+# 1. docker + compose
+command -v docker >/dev/null || fail "docker non installato"
+docker compose version >/dev/null || fail "docker compose non disponibile"
+
+# 2. jq + sha256sum + pg utilities nel container postgres (li usa dump script)
+command -v jq >/dev/null || fail "jq non installato"
+
+# 3. Manifest dev.yml presente
+MANIFEST="apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml"
+[ -f "$MANIFEST" ] || fail "manifest non trovato: $MANIFEST"
+
+# 4. Seed blob bucket configurato (opzionale ma senza di esso PdfSeeder è silenzioso)
+if ! grep -q "^SEED_BLOB_" infra/secrets/storage.secret 2>/dev/null; then
+    log "WARNING: seed blob non configurato in infra/secrets/storage.secret — PdfSeeder non seederà PDF"
+    log "Procedo comunque (il bake può essere legittimo per testare il flusso su 0 PDF)"
+fi
+
+# 5. Se postgres gira già, controlla che processing_jobs sia vuota o solo terminali
+if docker ps --format '{{.Names}}' | grep -q '^meepleai-postgres$'; then
+    pending=$(docker exec meepleai-postgres psql -U postgres -d meepleai -At -c \
+        "SELECT COUNT(*) FROM processing_jobs WHERE status IN ('Queued','Running','Retrying');" 2>/dev/null || echo "0")
+    if [ "$pending" -gt 0 ]; then
+        fail "processing_jobs contiene $pending job non terminali — ferma il run precedente o svuota la tabella"
+    fi
+fi
+
+log "OK"
+```
+
+- [ ] **Step 2: Rendi eseguibile**
+
+```bash
+chmod +x infra/scripts/seed-index-preflight.sh
+```
+
+- [ ] **Step 3: Smoke test rapido**
+
+```bash
+cd infra
+bash scripts/seed-index-preflight.sh
+```
+
+Expected: output `[preflight] OK` (o warning seed blob non configurato + OK).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add infra/scripts/seed-index-preflight.sh
+git commit -m "feat(seed-index): add preflight sanity check script"
+```
+
+---
+
+## Task 4: `seed-index-wait.sh`
+
+**Files:**
+- Create: `infra/scripts/seed-index-wait.sh`
+
+- [ ] **Step 1: Scrivi lo script**
+
+```bash
+#!/usr/bin/env bash
+# infra/scripts/seed-index-wait.sh
+# Polla processing_jobs finché tutti terminal, con timeout e fail-fast.
+set -euo pipefail
+
+TIMEOUT_SECONDS=${SEED_INDEX_TIMEOUT:-10800}        # 3h
+POLL_INTERVAL=${SEED_INDEX_POLL:-15}                 # 15s
+FAILURE_THRESHOLD_PCT=${SEED_INDEX_FAILURE_PCT:-15}  # 15%
+ALLOW_PARTIAL=${SEED_INDEX_ALLOW_PARTIAL:-false}
+
+log() { echo "[seed-index-wait] $*" >&2; }
+fail() { echo "::error:: $*" >&2; exit 1; }
+
+psql_count() {
+    docker exec meepleai-postgres psql -U postgres -d meepleai -At -c "$1"
+}
+
+start=$(date +%s)
+while :; do
+    read -r total completed failed dlq queued running < <(
+        docker exec meepleai-postgres psql -U postgres -d meepleai -At -F' ' -c \
+        "SELECT
+           COUNT(*),
+           COUNT(*) FILTER (WHERE status='Completed'),
+           COUNT(*) FILTER (WHERE status='Failed'),
+           COUNT(*) FILTER (WHERE status='DeadLettered'),
+           COUNT(*) FILTER (WHERE status='Queued'),
+           COUNT(*) FILTER (WHERE status='Running')
+         FROM processing_jobs;"
+    )
+    terminal=$((completed + failed + dlq))
+    log "total=$total completed=$completed failed=$failed dlq=$dlq queued=$queued running=$running"
+
+    if [ "$total" -gt 0 ] && [ "$terminal" -eq "$total" ]; then
+        break
+    fi
+
+    if [ $(( $(date +%s) - start )) -gt "$TIMEOUT_SECONDS" ]; then
+        fail "timeout dopo ${TIMEOUT_SECONDS}s — processing_jobs non drenata"
+        exit 124
+    fi
+
+    sleep "$POLL_INTERVAL"
+done
+
+if [ "$total" -eq 0 ]; then
+    log "WARNING: processing_jobs vuota — nessun PDF processato"
+    exit 0
+fi
+
+fail_count=$((failed + dlq))
+fail_pct=$(( fail_count * 100 / total ))
+log "termine: $completed/$total OK, $fail_count falliti (${fail_pct}%)"
+
+if [ "$fail_pct" -gt "$FAILURE_THRESHOLD_PCT" ] && [ "$ALLOW_PARTIAL" != "true" ]; then
+    log "fail rate ${fail_pct}% > soglia ${FAILURE_THRESHOLD_PCT}%"
+    docker exec meepleai-postgres psql -U postgres -d meepleai -c \
+      "SELECT j.id, p.file_name, s.error_message
+       FROM processing_jobs j
+       JOIN pdf_documents p ON p.id = j.pdf_document_id
+       LEFT JOIN processing_steps s ON s.processing_job_id = j.id AND s.status='Failed'
+       WHERE j.status IN ('Failed','DeadLettered')
+       LIMIT 50;" >&2 || true
+    fail "aborting — usa SEED_INDEX_ALLOW_PARTIAL=true per procedere comunque"
+fi
+
+log "OK"
+```
+
+- [ ] **Step 2: Rendi eseguibile + commit**
+
+```bash
+chmod +x infra/scripts/seed-index-wait.sh
+git add infra/scripts/seed-index-wait.sh
+git commit -m "feat(seed-index): add polling script with fail-fast threshold"
+```
+
+---
+
+## Task 5: `seed-index-dump.sh`
+
+**Files:**
+- Create: `infra/scripts/seed-index-dump.sh`
+
+- [ ] **Step 1: Scrivi lo script**
+
+```bash
+#!/usr/bin/env bash
+# infra/scripts/seed-index-dump.sh
+# pg_dump + sidecar .meta.json + sha256.
+set -euo pipefail
+
+OUT_DIR="${SEED_INDEX_OUT_DIR:-data/snapshots}"
+mkdir -p "$OUT_DIR"
+
+log() { echo "[dump] $*" >&2; }
+fail() { echo "::error:: $*" >&2; exit 1; }
+
+command -v jq >/dev/null || fail "jq non installato"
+
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+COMMIT=$(git rev-parse --short=9 HEAD)
+
+EMBEDDING_MODEL=$(docker exec meepleai-api printenv EMBEDDING_MODEL 2>/dev/null || echo "unknown")
+EMBEDDING_DIM=$(docker exec meepleai-api printenv EMBEDDING_DIM 2>/dev/null || echo "0")
+MODEL_SLUG=$(echo "$EMBEDDING_MODEL" | tr '/' '_' | tr -cd 'A-Za-z0-9_.-')
+
+BASENAME="meepleai_seed_${TS}_${MODEL_SLUG}_${COMMIT}"
+DUMP_FILE="$OUT_DIR/$BASENAME.dump"
+META_FILE="$OUT_DIR/$BASENAME.meta.json"
+SHA_FILE="$OUT_DIR/$BASENAME.dump.sha256"
+
+log "dumping DB → $DUMP_FILE"
+docker exec meepleai-postgres pg_dump -U postgres -d meepleai \
+    -Fc --no-owner --no-privileges \
+    --exclude-table-data='__EFMigrationsHistory' \
+    > "$DUMP_FILE"
+
+log "raccolgo stats per sidecar"
+STATS_JSON=$(docker exec meepleai-postgres psql -U postgres -d meepleai -At -c "
+SELECT json_build_object(
+  'ef_migration_head', (SELECT \"MigrationId\" FROM \"__EFMigrationsHistory\" ORDER BY \"MigrationId\" DESC LIMIT 1),
+  'pdf_count',         (SELECT COUNT(*) FROM pdf_documents WHERE processing_state='Completed'),
+  'chunk_count',       (SELECT COUNT(*) FROM text_chunks),
+  'embedding_count',   (SELECT COUNT(*) FROM pgvector_embeddings),
+  'failed_pdf_ids',    COALESCE((SELECT json_agg(pdf_document_id) FROM processing_jobs WHERE status IN ('Failed','DeadLettered')), '[]'::json)
+);")
+
+MANIFEST_SHA=$(sha256sum apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml | awk '{print $1}')
+
+jq -n \
+    --argjson stats "$STATS_JSON" \
+    --arg model "$EMBEDDING_MODEL" \
+    --argjson dim "$EMBEDDING_DIM" \
+    --arg commit "$COMMIT" \
+    --arg created "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg manifest_sha "$MANIFEST_SHA" \
+    '{
+       schema_version: $stats.ef_migration_head,
+       ef_migration_head: $stats.ef_migration_head,
+       embedding_model: $model,
+       embedding_dim: $dim,
+       app_commit: $commit,
+       created_at: $created,
+       dev_yml_sha256: $manifest_sha,
+       pdf_count: $stats.pdf_count,
+       chunk_count: $stats.chunk_count,
+       embedding_count: $stats.embedding_count,
+       failed_pdf_ids: $stats.failed_pdf_ids
+     }' > "$META_FILE"
+
+log "calcolo sha256"
+( cd "$OUT_DIR" && sha256sum "$BASENAME.dump" > "$BASENAME.dump.sha256" )
+
+# Aggiorna .latest (usato dal consume flow come cache locale)
+echo "$BASENAME" > "$OUT_DIR/.latest"
+
+log "snapshot pronto: $BASENAME"
+log "  dump:  $DUMP_FILE ($(du -h "$DUMP_FILE" | awk '{print $1}'))"
+log "  meta:  $META_FILE"
+log "  sha:   $SHA_FILE"
+
+echo "$BASENAME"
+```
+
+- [ ] **Step 2: Rendi eseguibile + commit**
+
+```bash
+chmod +x infra/scripts/seed-index-dump.sh
+git add infra/scripts/seed-index-dump.sh
+git commit -m "feat(seed-index): add pg_dump + sidecar generator script"
+```
+
+---
+
+## Task 6: `seed-index-publish.sh`
+
+**Files:**
+- Create: `infra/scripts/seed-index-publish.sh`
+
+- [ ] **Step 1: Scrivi lo script**
+
+```bash
+#!/usr/bin/env bash
+# infra/scripts/seed-index-publish.sh
+# Upload ultimo snapshot a seed blob bucket + rotation (tieni 3).
+set -euo pipefail
+
+OUT_DIR="${SEED_INDEX_OUT_DIR:-data/snapshots}"
+LATEST="$OUT_DIR/.latest"
+
+log() { echo "[publish] $*" >&2; }
+fail() { echo "::error:: $*" >&2; exit 1; }
+
+[ -f "$LATEST" ] || fail ".latest non trovato in $OUT_DIR — lancia prima make seed-index"
+BASENAME=$(cat "$LATEST")
+[ -f "$OUT_DIR/$BASENAME.dump" ] || fail "dump mancante: $OUT_DIR/$BASENAME.dump"
+[ -f "$OUT_DIR/$BASENAME.meta.json" ] || fail "meta mancante: $OUT_DIR/$BASENAME.meta.json"
+
+# Carica credenziali da storage.secret
+# shellcheck disable=SC1091
+set -a; source infra/secrets/storage.secret; set +a
+: "${SEED_BLOB_BUCKET:?SEED_BLOB_BUCKET mancante in storage.secret}"
+: "${S3_ENDPOINT:?S3_ENDPOINT mancante}"
+: "${S3_ACCESS_KEY:?S3_ACCESS_KEY mancante}"
+: "${S3_SECRET_KEY:?S3_SECRET_KEY mancante}"
+
+export AWS_ACCESS_KEY_ID="$S3_ACCESS_KEY"
+export AWS_SECRET_ACCESS_KEY="$S3_SECRET_KEY"
+AWS_S3="aws s3 --endpoint-url $S3_ENDPOINT"
+
+PREFIX="snapshots"
+
+log "uploading $BASENAME.dump"
+$AWS_S3 cp "$OUT_DIR/$BASENAME.dump" "s3://$SEED_BLOB_BUCKET/$PREFIX/$BASENAME.dump"
+log "uploading $BASENAME.dump.sha256"
+$AWS_S3 cp "$OUT_DIR/$BASENAME.dump.sha256" "s3://$SEED_BLOB_BUCKET/$PREFIX/$BASENAME.dump.sha256"
+# META PER ULTIMO — atomic marker
+log "uploading $BASENAME.meta.json (atomic marker last)"
+$AWS_S3 cp "$OUT_DIR/$BASENAME.meta.json" "s3://$SEED_BLOB_BUCKET/$PREFIX/$BASENAME.meta.json"
+
+# latest.txt pointer
+log "updating latest.txt pointer"
+echo "$BASENAME" | $AWS_S3 cp - "s3://$SEED_BLOB_BUCKET/$PREFIX/latest.txt"
+
+# Retention: tieni ultimi 3
+log "rotation: retain last 3 snapshots"
+$AWS_S3 ls "s3://$SEED_BLOB_BUCKET/$PREFIX/" \
+    | awk '{print $4}' \
+    | grep -E '^meepleai_seed_[0-9]{8}T[0-9]{6}Z.*\.meta\.json$' \
+    | sort -r \
+    | tail -n +4 \
+    | while read -r old_meta; do
+        old_base=${old_meta%.meta.json}
+        log "rimuovo obsoleto: $old_base"
+        $AWS_S3 rm "s3://$SEED_BLOB_BUCKET/$PREFIX/$old_base.dump"        || true
+        $AWS_S3 rm "s3://$SEED_BLOB_BUCKET/$PREFIX/$old_base.dump.sha256" || true
+        $AWS_S3 rm "s3://$SEED_BLOB_BUCKET/$PREFIX/$old_base.meta.json"   || true
+      done
+
+log "OK"
+```
+
+- [ ] **Step 2: Rendi eseguibile + commit**
+
+```bash
+chmod +x infra/scripts/seed-index-publish.sh
+git add infra/scripts/seed-index-publish.sh
+git commit -m "feat(seed-index): add publish script with bucket rotation"
+```
+
+---
+
+## Task 7: `snapshot-fetch.sh`
+
+**Files:**
+- Create: `infra/scripts/snapshot-fetch.sh`
+
+- [ ] **Step 1: Scrivi lo script**
+
+```bash
+#!/usr/bin/env bash
+# infra/scripts/snapshot-fetch.sh
+# Priorità: SNAPSHOT_FILE env > cache locale più recente > download da bucket.
+set -euo pipefail
+
+OUT_DIR="${SEED_INDEX_OUT_DIR:-data/snapshots}"
+mkdir -p "$OUT_DIR"
+
+log() { echo "[fetch] $*" >&2; }
+fail() { echo "::error:: $*" >&2; exit 1; }
+
+if [ -n "${SNAPSHOT_FILE:-}" ]; then
+    [ -f "$SNAPSHOT_FILE" ] || fail "SNAPSHOT_FILE non esiste: $SNAPSHOT_FILE"
+    BASENAME=$(basename "$SNAPSHOT_FILE" .dump)
+    log "override esplicito: $BASENAME"
+elif ls "$OUT_DIR"/meepleai_seed_*.meta.json >/dev/null 2>&1; then
+    BASENAME=$(ls -t "$OUT_DIR"/meepleai_seed_*.meta.json | head -1 | xargs basename | sed 's/\.meta\.json$//')
+    log "cache locale: $BASENAME"
+else
+    log "nessuna cache locale — download dal bucket"
+    # shellcheck disable=SC1091
+    set -a; source infra/secrets/storage.secret; set +a
+    : "${SEED_BLOB_BUCKET:?SEED_BLOB_BUCKET mancante}"
+    : "${S3_ENDPOINT:?S3_ENDPOINT mancante}"
+    : "${S3_ACCESS_KEY:?S3_ACCESS_KEY mancante}"
+    : "${S3_SECRET_KEY:?S3_SECRET_KEY mancante}"
+    export AWS_ACCESS_KEY_ID="$S3_ACCESS_KEY"
+    export AWS_SECRET_ACCESS_KEY="$S3_SECRET_KEY"
+    AWS_S3="aws s3 --endpoint-url $S3_ENDPOINT"
+    PREFIX="snapshots"
+
+    BASENAME=$($AWS_S3 cp "s3://$SEED_BLOB_BUCKET/$PREFIX/latest.txt" - | tr -d '[:space:]')
+    [ -n "$BASENAME" ] || fail "latest.txt vuoto sul bucket"
+
+    log "scarico $BASENAME (.dump + .sha256 + .meta.json)"
+    $AWS_S3 cp "s3://$SEED_BLOB_BUCKET/$PREFIX/$BASENAME.dump"        "$OUT_DIR/$BASENAME.dump.partial"
+    $AWS_S3 cp "s3://$SEED_BLOB_BUCKET/$PREFIX/$BASENAME.dump.sha256" "$OUT_DIR/$BASENAME.dump.sha256"
+    $AWS_S3 cp "s3://$SEED_BLOB_BUCKET/$PREFIX/$BASENAME.meta.json"   "$OUT_DIR/$BASENAME.meta.json.partial"
+
+    # Verifica checksum contro il .partial
+    ( cd "$OUT_DIR" && \
+      sed "s|$BASENAME.dump|$BASENAME.dump.partial|" "$BASENAME.dump.sha256" | sha256sum -c - ) \
+      || fail "sha256 mismatch"
+
+    # Atomic rename
+    mv "$OUT_DIR/$BASENAME.dump.partial"      "$OUT_DIR/$BASENAME.dump"
+    mv "$OUT_DIR/$BASENAME.meta.json.partial" "$OUT_DIR/$BASENAME.meta.json"
+fi
+
+echo "$BASENAME" > "$OUT_DIR/.latest"
+log "OK — basename: $BASENAME"
+```
+
+- [ ] **Step 2: Rendi eseguibile + commit**
+
+```bash
+chmod +x infra/scripts/snapshot-fetch.sh
+git add infra/scripts/snapshot-fetch.sh
+git commit -m "feat(snapshot): add fetch script with cache-first resolution"
+```
+
+---
+
+## Task 8: `snapshot-verify.sh` + bats test
+
+**Files:**
+- Create: `infra/scripts/snapshot-verify.sh`
+- Create: `infra/scripts/tests/snapshot-verify.bats`
+- Create: `infra/scripts/tests/fixtures/meta-good.json`
+- Create: `infra/scripts/tests/fixtures/meta-migration-drift.json`
+- Create: `infra/scripts/tests/fixtures/meta-model-drift.json`
+- Create: `infra/scripts/tests/fixtures/meta-dim-drift.json`
+
+- [ ] **Step 1: Crea fixture `meta-good.json`**
+
+```json
+{
+  "schema_version": "20260401_AddSearchVector",
+  "ef_migration_head": "20260401_AddSearchVector",
+  "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
+  "embedding_dim": 384,
+  "app_commit": "test0000",
+  "created_at": "2026-04-10T12:00:00Z",
+  "dev_yml_sha256": "MANIFEST_PLACEHOLDER",
+  "pdf_count": 130,
+  "chunk_count": 18000,
+  "embedding_count": 18000,
+  "failed_pdf_ids": []
+}
+```
+
+- [ ] **Step 2: Crea fixture `meta-migration-drift.json`**
+
+Copia di meta-good con `ef_migration_head: "99999999_Old"`.
+
+- [ ] **Step 3: Crea fixture `meta-model-drift.json`**
+
+Copia di meta-good con `embedding_model: "some/other-model"`.
+
+- [ ] **Step 4: Crea fixture `meta-dim-drift.json`**
+
+Copia di meta-good con `embedding_dim: 768`.
+
+- [ ] **Step 5: Scrivi `snapshot-verify.sh`**
+
+```bash
+#!/usr/bin/env bash
+# infra/scripts/snapshot-verify.sh
+# Compat gate: blocca il restore se snapshot incompatibile col working tree.
+# Exit codes: 0=ok, 2=migration drift, 3=model drift, 4=dim drift, 1=altro
+set -euo pipefail
+
+OUT_DIR="${SEED_INDEX_OUT_DIR:-data/snapshots}"
+
+log() { echo "[verify] $*" >&2; }
+
+BASENAME=$(cat "$OUT_DIR/.latest" 2>/dev/null || echo "")
+[ -n "$BASENAME" ] || { echo "::error:: .latest vuoto o mancante" >&2; exit 1; }
+META="$OUT_DIR/$BASENAME.meta.json"
+[ -f "$META" ] || { echo "::error:: meta.json mancante: $META" >&2; exit 1; }
+
+# 1. EF migration head
+expected_head=$(jq -r '.ef_migration_head' "$META")
+working_head=${EXPECTED_EF_HEAD:-}
+if [ -z "$working_head" ]; then
+    # Resolvi dal working tree — cerca file migration più recente
+    working_head=$(ls apps/api/src/Api/Infrastructure/Migrations/*.cs 2>/dev/null \
+        | grep -oE '[0-9]{14}_[A-Za-z0-9_]+' \
+        | sort -r | head -1 || echo "")
+fi
+
+if [ "$expected_head" != "$working_head" ]; then
+    cat >&2 <<EOF
+::error:: snapshot disallineato con le migrations del working tree
+  snapshot head : $expected_head
+  working head  : $working_head
+Opzioni:
+  1. git checkout del commit compatibile con lo snapshot
+  2. make seed-index  (rigenera lo snapshot sul commit corrente)
+EOF
+    exit 2
+fi
+
+# 2. Embedding model
+expected_model=$(jq -r '.embedding_model' "$META")
+current_model=${EXPECTED_EMBEDDING_MODEL:-}
+if [ -z "$current_model" ] && [ -f infra/secrets/embedding.secret ]; then
+    current_model=$(grep -E '^EMBEDDING_MODEL=' infra/secrets/embedding.secret | cut -d= -f2- || echo "")
+fi
+
+if [ "$expected_model" != "$current_model" ]; then
+    cat >&2 <<EOF
+::error:: embedding model mismatch
+  snapshot : $expected_model
+  current  : $current_model
+I vettori non sono confrontabili col model corrente.
+EOF
+    exit 3
+fi
+
+# 3. Embedding dim
+expected_dim=$(jq -r '.embedding_dim' "$META")
+current_dim=${EXPECTED_EMBEDDING_DIM:-}
+if [ -z "$current_dim" ] && [ -f infra/secrets/embedding.secret ]; then
+    current_dim=$(grep -E '^EMBEDDING_DIM=' infra/secrets/embedding.secret | cut -d= -f2- || echo "")
+fi
+
+if [ "$expected_dim" != "$current_dim" ]; then
+    echo "::error:: embedding_dim mismatch ($expected_dim vs $current_dim)" >&2
+    exit 4
+fi
+
+# 4. dev.yml drift — warning non bloccante
+expected_sha=$(jq -r '.dev_yml_sha256' "$META")
+current_sha=$(sha256sum apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml 2>/dev/null | awk '{print $1}' || echo "")
+if [ "$expected_sha" != "$current_sha" ]; then
+    echo "::warning:: dev.yml è cambiato dopo lo snapshot — eventuali giochi nuovi NON sono indicizzati" >&2
+fi
+
+failed_count=$(jq '.failed_pdf_ids | length' "$META")
+if [ "$failed_count" -gt 0 ]; then
+    echo "::warning:: snapshot contiene $failed_count PDF falliti" >&2
+fi
+
+log "OK — $BASENAME compatibile"
+```
+
+- [ ] **Step 6: Scrivi bats test**
+
+```bash
+#!/usr/bin/env bats
+# infra/scripts/tests/snapshot-verify.bats
+
+setup() {
+    SCRIPT_DIR="$BATS_TEST_DIRNAME/.."
+    FIXTURES="$BATS_TEST_DIRNAME/fixtures"
+    TMPDIR=$(mktemp -d)
+    export SEED_INDEX_OUT_DIR="$TMPDIR"
+}
+
+teardown() {
+    rm -rf "$TMPDIR"
+}
+
+install_fixture() {
+    local name=$1
+    cp "$FIXTURES/$name.json" "$TMPDIR/meepleai_seed_test.meta.json"
+    echo "meepleai_seed_test" > "$TMPDIR/.latest"
+}
+
+@test "exit 0 when all fields match" {
+    install_fixture meta-good
+    export EXPECTED_EF_HEAD="20260401_AddSearchVector"
+    export EXPECTED_EMBEDDING_MODEL="sentence-transformers/all-MiniLM-L6-v2"
+    export EXPECTED_EMBEDDING_DIM=384
+    run bash "$SCRIPT_DIR/snapshot-verify.sh"
+    [ "$status" -eq 0 ]
+}
+
+@test "exit 2 on migration drift" {
+    install_fixture meta-migration-drift
+    export EXPECTED_EF_HEAD="20260401_AddSearchVector"
+    export EXPECTED_EMBEDDING_MODEL="sentence-transformers/all-MiniLM-L6-v2"
+    export EXPECTED_EMBEDDING_DIM=384
+    run bash "$SCRIPT_DIR/snapshot-verify.sh"
+    [ "$status" -eq 2 ]
+}
+
+@test "exit 3 on model drift" {
+    install_fixture meta-model-drift
+    export EXPECTED_EF_HEAD="20260401_AddSearchVector"
+    export EXPECTED_EMBEDDING_MODEL="sentence-transformers/all-MiniLM-L6-v2"
+    export EXPECTED_EMBEDDING_DIM=384
+    run bash "$SCRIPT_DIR/snapshot-verify.sh"
+    [ "$status" -eq 3 ]
+}
+
+@test "exit 4 on dim drift" {
+    install_fixture meta-dim-drift
+    export EXPECTED_EF_HEAD="20260401_AddSearchVector"
+    export EXPECTED_EMBEDDING_MODEL="sentence-transformers/all-MiniLM-L6-v2"
+    export EXPECTED_EMBEDDING_DIM=384
+    run bash "$SCRIPT_DIR/snapshot-verify.sh"
+    [ "$status" -eq 4 ]
+}
+
+@test "exit 1 on missing .latest" {
+    run bash "$SCRIPT_DIR/snapshot-verify.sh"
+    [ "$status" -eq 1 ]
+}
+```
+
+- [ ] **Step 7: Esegui i bats test**
+
+```bash
+chmod +x infra/scripts/snapshot-verify.sh
+command -v bats >/dev/null || { echo "installa bats-core: https://github.com/bats-core/bats-core"; exit 1; }
+bats infra/scripts/tests/snapshot-verify.bats
+```
+
+Expected: 5 test pass. Se bats non è installato, salta questo step (è richiesto solo per il test suite completo).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add infra/scripts/snapshot-verify.sh \
+        infra/scripts/tests/snapshot-verify.bats \
+        infra/scripts/tests/fixtures/
+git commit -m "feat(snapshot): add verify script with compat gate + bats tests"
+```
+
+---
+
+## Task 9: `snapshot-restore.sh`
+
+**Files:**
+- Create: `infra/scripts/snapshot-restore.sh`
+
+- [ ] **Step 1: Scrivi lo script**
+
+```bash
+#!/usr/bin/env bash
+# infra/scripts/snapshot-restore.sh
+# Restore dello snapshot su un DB vuoto dopo ef update.
+set -euo pipefail
+
+OUT_DIR="${SEED_INDEX_OUT_DIR:-data/snapshots}"
+BASENAME=$(cat "$OUT_DIR/.latest" 2>/dev/null || echo "")
+
+log() { echo "[restore] $*" >&2; }
+fail() { echo "::error:: $*" >&2; exit 1; }
+
+[ -n "$BASENAME" ] || fail ".latest mancante"
+DUMP="$OUT_DIR/$BASENAME.dump"
+META="$OUT_DIR/$BASENAME.meta.json"
+[ -f "$DUMP" ] || fail "dump mancante: $DUMP"
+[ -f "$META" ] || fail "meta mancante: $META"
+
+# Guard: DB non deve contenere tabelle application (evita di sovrascrivere lavoro)
+table_count=$(docker exec meepleai-postgres psql -U postgres -d meepleai -At -c \
+    "SELECT COUNT(*) FROM information_schema.tables
+     WHERE table_schema='public' AND table_type='BASE TABLE' AND table_name NOT LIKE 'pg_%';")
+
+if [ "$table_count" -gt 0 ]; then
+    cat >&2 <<EOF
+::error:: DB non vuoto ($table_count tabelle application presenti)
+snapshot-restore rifiuta di sovrascrivere dati esistenti.
+Usa: make dev-from-snapshot-force   (DISTRUTTIVO, azzera il volume postgres)
+EOF
+    exit 10
+fi
+
+log "applico migrations dal working tree"
+( cd apps/api/src/Api && dotnet ef database update )
+
+log "pg_restore --data-only"
+docker exec -i meepleai-postgres pg_restore \
+    -U postgres -d meepleai \
+    --data-only --disable-triggers --no-owner --no-privileges \
+    < "$DUMP"
+
+# Smoke test
+log "smoke test: chunk count + orphans"
+actual_chunks=$(docker exec meepleai-postgres psql -U postgres -d meepleai -At -c "SELECT COUNT(*) FROM text_chunks;")
+expected_chunks=$(jq '.chunk_count' "$META")
+
+if [ "$actual_chunks" != "$expected_chunks" ]; then
+    fail "chunk count post-restore ($actual_chunks) ≠ sidecar ($expected_chunks)"
+fi
+
+orphan_chunks=$(docker exec meepleai-postgres psql -U postgres -d meepleai -At -c "
+    SELECT COUNT(*) FROM text_chunks tc
+    LEFT JOIN pdf_documents p ON p.id = tc.pdf_document_id
+    WHERE p.id IS NULL;")
+[ "$orphan_chunks" = "0" ] || fail "$orphan_chunks text_chunks orfani"
+
+orphan_embeds=$(docker exec meepleai-postgres psql -U postgres -d meepleai -At -c "
+    SELECT COUNT(*) FROM pgvector_embeddings e
+    LEFT JOIN text_chunks tc ON tc.id = e.text_chunk_id
+    WHERE tc.id IS NULL;")
+[ "$orphan_embeds" = "0" ] || fail "$orphan_embeds pgvector_embeddings orfani"
+
+log "OK — $actual_chunks chunks ripristinati, nessun orfano"
+```
+
+- [ ] **Step 2: Rendi eseguibile + commit**
+
+```bash
+chmod +x infra/scripts/snapshot-restore.sh
+git add infra/scripts/snapshot-restore.sh
+git commit -m "feat(snapshot): add restore script with smoke tests"
+```
+
+---
+
+## Task 10: Target Makefile
+
+**Files:**
+- Modify: `infra/Makefile`
+
+- [ ] **Step 1: Aggiungi i target prima della sezione `help:`**
+
+Trova una sezione appropriata (dopo `dev-down` o `dev-fast-full`) e inserisci:
+
+```makefile
+# ================================================================
+# Seed snapshot lifecycle (bake + consume)
+# ================================================================
+
+seed-index: ## Bake: indicizza tutti i PDF e produce snapshot locale
+	@bash scripts/seed-index-preflight.sh
+	$(COMPOSE) -f compose.dev.yml --profile ai up -d postgres redis api smoldocling-service embedding-service
+	@bash scripts/wait-for-healthy.sh api || { echo "api non healthy — controlla docker logs meepleai-api"; exit 1; }
+	@bash scripts/seed-index-wait.sh
+	@bash scripts/seed-index-dump.sh
+	@echo "::notice:: snapshot pronto in data/snapshots/ — lancia 'make seed-index-publish' per caricarlo"
+
+seed-index-publish: ## Upload snapshot più recente a seed blob bucket
+	@bash scripts/seed-index-publish.sh
+
+dev-from-snapshot: ## Dev env con seed pre-indicizzato (veloce, consume flow)
+	@bash scripts/snapshot-fetch.sh
+	@bash scripts/snapshot-verify.sh
+	$(COMPOSE) -f compose.dev.yml up -d postgres
+	@bash scripts/wait-for-healthy.sh postgres
+	@bash scripts/snapshot-restore.sh
+	@SKIP_CATALOG_SEED=true $(COMPOSE) -f compose.dev.yml --profile ai --profile proxy up -d
+	@echo "::notice:: dev env pronto (snapshot $$(cat data/snapshots/.latest))"
+
+dev-from-snapshot-force: ## Come dev-from-snapshot ma azzera il volume postgres
+	$(COMPOSE) -f compose.dev.yml down postgres -v
+	@$(MAKE) dev-from-snapshot
+```
+
+**Nota importante**: `wait-for-healthy.sh` deve esistere. Verifica:
+
+```bash
+ls infra/scripts/wait-for-healthy.sh 2>/dev/null && echo "esiste" || echo "da creare"
+```
+
+Se non esiste, crealo come utility helper minimale:
+
+```bash
+#!/usr/bin/env bash
+# infra/scripts/wait-for-healthy.sh
+set -euo pipefail
+SERVICE=${1:?service name richiesto}
+CONTAINER="meepleai-${SERVICE}"
+TIMEOUT=${2:-120}
+start=$(date +%s)
+while :; do
+    status=$(docker inspect -f '{{.State.Health.Status}}' "$CONTAINER" 2>/dev/null || echo "missing")
+    [ "$status" = "healthy" ] && exit 0
+    if [ $(( $(date +%s) - start )) -gt "$TIMEOUT" ]; then
+        echo "::error:: $CONTAINER non healthy dopo ${TIMEOUT}s (status=$status)" >&2
+        exit 1
+    fi
+    sleep 2
+done
+```
+
+- [ ] **Step 2: Verifica `make help` mostra i nuovi target**
+
+```bash
+cd infra && make help | grep -E "seed-index|dev-from-snapshot"
+```
+
+Expected: 4 righe nuove.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add infra/Makefile
+# + infra/scripts/wait-for-healthy.sh se creato
+git commit -m "feat(makefile): add seed-index and dev-from-snapshot targets"
+```
+
+---
+
+## Task 11: `.gitignore` + docs + CLAUDE.md quick ref
+
+**Files:**
+- Modify: `.gitignore`
+- Create: `docs/development/snapshot-seed-workflow.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Aggiorna `.gitignore`**
+
+Aggiungi in fondo al file:
+
+```gitignore
+
+# Seed snapshot artifacts (see docs/development/snapshot-seed-workflow.md)
+data/snapshots/*.dump
+data/snapshots/*.dump.sha256
+data/snapshots/.latest
+# NON ignorare i .meta.json — utile come log storico
+```
+
+- [ ] **Step 2: Crea `docs/development/snapshot-seed-workflow.md`**
+
+```markdown
+# Seed Snapshot Workflow
+
+Flusso a due fasi per avere un ambiente dev con RAG funzionante senza aspettare l'indicizzazione runtime dei 136 PDF del manifest.
+
+## Quando usare questo flusso
+
+- **Primo setup su una macchina nuova**: `make dev-from-snapshot` invece di `make dev`
+- **Dopo `docker compose down -v`**: stesso
+- **In CI per e2e test**: usa il manifest `ci.yml` (3 PDF, bake in <10 min)
+
+## Bake — produrre lo snapshot
+
+Raro. Una volta per rilascio, o quando cambia: manifest `dev.yml`, modello di embedding, schema EF.
+
+```bash
+cd infra
+make seed-index          # ~ore su CPU, molto meno con GPU
+make seed-index-publish  # upload a seed blob bucket (opzionale)
+```
+
+Parametri opzionali:
+- `SEED_INDEX_TIMEOUT=10800` — timeout totale (default 3h)
+- `SEED_INDEX_POLL=15` — intervallo poll (default 15s)
+- `SEED_INDEX_FAILURE_PCT=15` — soglia fail% oltre la quale abort
+- `SEED_INDEX_ALLOW_PARTIAL=true` — dump procede anche con failure oltre soglia
+
+## Consume — usare lo snapshot
+
+Default per qualunque sviluppatore.
+
+```bash
+cd infra
+make dev-from-snapshot
+```
+
+Cosa fa:
+1. Scarica lo snapshot (o usa cache locale in `data/snapshots/`)
+2. Verifica compatibilità con il tuo working tree
+3. Applica `dotnet ef database update` al DB vuoto
+4. `pg_restore --data-only` dei dati indicizzati
+5. Avvia lo stack con `SKIP_CATALOG_SEED=true`
+
+Se qualcosa fallisce (compat drift, DB non vuoto), il messaggio di errore ti dice esattamente cosa fare. In ultima istanza: `make dev` è sempre il fallback sicuro.
+
+## Troubleshooting compat drift
+
+| Exit code | Significato | Azione |
+|---|---|---|
+| 2 | EF migration head del working tree è più recente dello snapshot | `make seed-index` per rigenerare |
+| 3 | Embedding model del working tree è diverso da quello dello snapshot | allinea `infra/secrets/embedding.secret` o rigenera |
+| 4 | Embedding dimension mismatch | come sopra |
+| 10 | DB non è vuoto — il restore rifiuta di sovrascrivere | `make dev-from-snapshot-force` (DISTRUTTIVO) |
+| 124 | Timeout del bake | aumenta `SEED_INDEX_TIMEOUT` o investiga perché i job non progrediscono |
+
+## Layout `data/snapshots/`
+
+```
+data/snapshots/
+├── meepleai_seed_20260410T143022Z_<model>_<commit>.dump         # gitignored
+├── meepleai_seed_20260410T143022Z_<model>_<commit>.dump.sha256  # gitignored
+├── meepleai_seed_20260410T143022Z_<model>_<commit>.meta.json    # committable (log storico)
+└── .latest                                                       # gitignored, pointer
+```
+
+## Quando NON usare lo snapshot
+
+- Stai cambiando lo schema EF e vuoi testare la tua migration su dati runtime → `make dev`
+- Stai sviluppando il pipeline di indicizzazione → `make dev`
+- Vuoi un DB completamente pulito da debug → `docker compose down -v && make dev`
+```
+
+- [ ] **Step 3: Aggiorna `CLAUDE.md` Quick Reference**
+
+Cerca la tabella "Quick Reference" e aggiungi le nuove righe:
+
+```bash
+grep -n "Start Dev (full)" CLAUDE.md
+```
+
+Inserisci dopo la riga `Start Dev (core)`:
+
+```markdown
+| Bake Snapshot | `make seed-index` | `infra/` — indicizza tutti i PDF e produce dump |
+| Dev from Snapshot | `make dev-from-snapshot` | `infra/` — dev env veloce con RAG pre-indicizzato |
+```
+
+Aggiungi una voce in Troubleshooting:
+
+```markdown
+| Snapshot drift | `cd infra && make seed-index` (rigenera) oppure `make dev` (fallback) |
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .gitignore docs/development/snapshot-seed-workflow.md CLAUDE.md
+git commit -m "docs(seed): document snapshot workflow and update gitignore"
+```
+
+---
+
+## Task 12: Smoke test manuale end-to-end (verification)
+
+**Files:** nessuno (solo esecuzione)
+
+- [ ] **Step 1: Full bake+consume su `ci.yml`**
+
+Questo è il test di integrazione manuale. Non sempre fattibile in una sola session — documenta il comando e lascialo al user:
+
+```bash
+cd infra
+
+# Bake
+SEED_CATALOG_MANIFEST_OVERRIDE=ci SEED_INDEX_TIMEOUT=1800 make seed-index
+
+# Verifica output
+ls -lh data/snapshots/ | head
+
+# Consume (simula clean env)
+docker compose down postgres -v
+make dev-from-snapshot
+
+# Smoke test end-to-end
+curl -s http://localhost:8080/health | jq .
+docker exec meepleai-postgres psql -U postgres -d meepleai -c \
+  "SELECT COUNT(*) FROM text_chunks;"
+```
+
+Expected: chunk count > 0, health OK, stack in running.
+
+- [ ] **Step 2: Se tutto ok, documenta successo nel commit finale**
+
+```bash
+git commit --allow-empty -m "chore(seed): verified bake+consume e2e on ci.yml"
+```
+
+---
+
+## Self-Review
+
+### Spec coverage
+
+| Spec section | Task |
+|---|---|
+| `SKIP_CATALOG_SEED` flag | T1 ✓ |
+| Sidecar `.meta.json` schema | T5 ✓ |
+| Compat gate (migration/model/dim/sha) | T8 ✓ |
+| `ci.yml` manifest | T2 ✓ |
+| Preflight | T3 ✓ |
+| Polling + fail-fast 15% | T4 ✓ |
+| Dump + sha256 | T5 ✓ |
+| Publish + rotation | T6 ✓ |
+| Fetch con cache-first | T7 ✓ |
+| Restore con ef update + smoke | T9 ✓ |
+| Makefile targets | T10 ✓ |
+| `.gitignore` | T11 ✓ |
+| Docs | T11 ✓ |
+| Bats tests | T8 ✓ |
+| E2E manual verification | T12 ✓ |
+
+### Placeholder scan
+
+- Nessun "TBD", "implement later", "similar to Task N"
+- Tutti i code block sono completi
+- Exit codes espliciti (0, 1, 2, 3, 4, 10, 124)
+- File paths assoluti
+
+### Type consistency
+
+- `SEED_CATALOG_MANIFEST_OVERRIDE` nome costante in T2, usato coerente
+- `SEED_INDEX_OUT_DIR` default `data/snapshots` coerente in T5, T6, T7, T8, T9
+- `.latest` marker scritto da T5/T7, letto da T8/T9 — coerente
+- `BASENAME` pattern `meepleai_seed_<ts>_<model>_<commit>` coerente
+- `jq` field names (`ef_migration_head`, `embedding_model`, `embedding_dim`, `failed_pdf_ids`, `dev_yml_sha256`, `chunk_count`) coerenti fra T5 e T8/T9
+
+### Assumptions to verify during execution
+
+1. `wait-for-healthy.sh` può non esistere → T10 include creazione inline se mancante
+2. Embedded resource pattern in `Api.csproj` → T2 include verifica
+3. bats-core non garantito installato → T8 rende i bats test opzionali in locale
+4. `SEED_BLOB_*` env vars in `storage.secret` → T6/T7 falliscono con messaggio chiaro se mancanti
+5. `compose.dev.yml` profile names (`ai`, `proxy`, ecc.) — potrebbero differire, verificare in T10

--- a/docs/superpowers/specs/2026-04-10-seed-pdf-pre-indexed-design.md
+++ b/docs/superpowers/specs/2026-04-10-seed-pdf-pre-indexed-design.md
@@ -1,0 +1,371 @@
+# Seed con PDF pre-indicizzati — Design
+
+**Data**: 2026-04-10
+**Stato**: Draft (awaiting user review)
+**Autore**: brainstorming session
+
+## Problema
+
+Allo stato attuale, `PdfSeeder` crea `PdfDocumentEntity` in stato `Pending` ed enqueuea un `ProcessingJob` Queued. L'indicizzazione vettoriale vera (extract → chunk → embed → index) viene eseguita in background da `PdfProcessingQuartzJob` (ciclo 10s). Per il manifest `dev.yml` (136 PDF) questo significa ore di attesa e dipendenze pesanti (SmolDocling + embedding service) al primo avvio di un ambiente dev.
+
+Conseguenze:
+- Un developer che parte da DB vuoto non ha RAG funzionante prima di ore
+- Ogni reset del volume postgres re-innesca la pipeline
+- L'esperienza di onboarding è scoraggiante
+- CI integration test non può ragionevolmente aspettare il completamento
+
+## Obiettivo
+
+Produrre una volta un DB snapshot con **tutti i rulebook del manifest già indicizzati** (chunks + embeddings), e consentire a qualunque ambiente dev di partire da quello snapshot invece di rieseguire la pipeline.
+
+## Non-obiettivi
+
+- Sostituire il flusso `make dev` esistente (rimane alternativa disponibile)
+- Snapshot per `staging.yml` / `prod.yml` (questo spec copre solo `dev.yml` e `ci.yml`)
+- GitHub Actions automation (rimane trigger manuale on-demand)
+- Delta/incremental snapshots
+- Multi-embedding-model nello stesso snapshot
+- Encryption client-side del dump (il bucket S3 è già SSE-AES256 side-server)
+- Promozione di `make dev-from-snapshot` a default (verrà valutato dopo ≥1 settimana di uso)
+
+## Architettura — due fasi separate
+
+### Fase "bake" — produce lo snapshot
+
+On-demand, rara, idealmente una volta per rilascio o quando cambiano manifest / modello di embedding / migration schema. Gira su macchina con GPU (consigliata) o CPU con tempo a disposizione.
+
+```
+make seed-index
+  │
+  ├─ 1. preflight sanity check (api, smoldocling, embedding healthy; seed blob configurato; processing_jobs vuota)
+  ├─ 2. docker compose up -d postgres redis api smoldocling-service embedding-service
+  ├─ 3. wait-for-healthy api
+  │       (SeedOrchestrator.RunAsync parte automaticamente durante lo startup dell'API,
+  │        vedi apps/api/src/Api/Program.cs:535 — crea games, PDF Pending, jobs Queued)
+  ├─ 4. poll processing_jobs finché tutti terminal (Completed | Failed | DeadLettered) oppure timeout 3h
+  ├─ 5. fail-fast se fail_rate > 15% (soglia configurabile)
+  ├─ 6. pg_dump -Fc --exclude-table-data='__EFMigrationsHistory'
+  ├─ 7. scrivi sidecar .meta.json
+  ├─ 8. sha256sum del dump
+  └─ 9. (opzionale, target separato) upload a seed blob bucket
+```
+
+### Fase "consume" — usa lo snapshot
+
+```
+make dev-from-snapshot
+  │
+  ├─ 1. snapshot-fetch.sh    (cache locale first, fallback a latest.txt sul bucket)
+  ├─ 2. snapshot-verify.sh   (compat gate contro working tree)
+  ├─ 3. docker compose up -d postgres + wait healthy
+  ├─ 4. snapshot-restore.sh  (ef database update → pg_restore --data-only → smoke test)
+  └─ 5. SKIP_CATALOG_SEED=true docker compose up -d   (avvia resto dello stack saltando il seed)
+```
+
+`make dev` rimane invariato. `make dev-from-snapshot` è un target **parallelo e opt-in**. Il fallback esplicito è sempre `make dev`.
+
+## Contract dello snapshot
+
+### Naming convention
+
+```
+meepleai_seed_<timestamp>_<embedding_model_slug>_<commit>.dump
+meepleai_seed_<timestamp>_<embedding_model_slug>_<commit>.meta.json
+meepleai_seed_<timestamp>_<embedding_model_slug>_<commit>.dump.sha256
+```
+
+Esempio: `meepleai_seed_20260410T143022Z_sentence-transformers_all-MiniLM-L6-v2_3a75a9a10.dump`
+
+Il nome include tutto ciò che serve per capire a colpo d'occhio se uno snapshot è compatibile, ma il sidecar `.meta.json` rimane l'unica fonte autoritativa letta dagli script.
+
+### Sidecar `.meta.json`
+
+```json
+{
+  "schema_version": "20260401_AddSearchVector",
+  "ef_migration_head": "20260401_AddSearchVector",
+  "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
+  "embedding_dim": 384,
+  "smoldocling_version": "1.3.0",
+  "app_commit": "3a75a9a10",
+  "created_at": "2026-04-10T14:22:00Z",
+  "pdf_count": 136,
+  "chunk_count": 18432,
+  "embedding_count": 18432,
+  "failed_pdf_ids": [],
+  "dev_yml_sha256": "…"
+}
+```
+
+Note sui campi:
+- `smoldocling_version` è popolato interrogando `smoldocling-service/version` all'istante del dump; se il service non espone un endpoint version, il campo viene omesso (informational, non partecipa al compat gate).
+- `_comment_*` non è previsto, il sidecar è JSON stretto.
+- `failed_pdf_ids` è l'array dei `pdf_document_id` con job in stato `Failed` o `DeadLettered` al momento del dump. Vuoto nel caso strict, potenzialmente non vuoto nel caso `SEED_INDEX_ALLOW_PARTIAL=true`.
+
+### Compat-check al consume (gate)
+
+Tutti bloccanti tranne `dev_yml_sha256` (warning):
+
+| Check | Fonte "expected" | Exit code al mismatch |
+|---|---|---|
+| `ef_migration_head` vs `dotnet ef migrations list` del working tree | tree EF | 2 |
+| `embedding_model` vs `EMBEDDING_MODEL` env | `infra/secrets/embedding.secret` | 3 |
+| `embedding_dim` vs `EMBEDDING_DIM` env | `infra/secrets/embedding.secret` | 4 |
+| `dev_yml_sha256` vs `sha256sum dev.yml` | working tree | warning, non bloccante |
+
+Codici di uscita distinti per facilitare scripting/CI: exit 2 = "rigenera", exit 3/4 = "config drift".
+
+### DB-only — contratto esplicito
+
+Lo snapshot contiene **solo stato DB**. I PDF blob files vivono già idempotentemente nel seed blob bucket (`rulebooks/v1/*.pdf`). `make dev-from-snapshot` richiede che `STORAGE_PROVIDER` punti a un blob storage dove quei file sono raggiungibili, altrimenti i `FilePath` in `PdfDocumentEntity` puntano nel vuoto.
+
+### Esclusione `__EFMigrationsHistory`
+
+`pg_dump --exclude-table-data='__EFMigrationsHistory'` è intenzionale. Al restore si applica prima `dotnet ef database update` sul DB vuoto (scrive schema + history del working tree), poi `pg_restore --data-only` carica i dati. Questo garantisce che snapshot e working tree condividano sempre lo stesso schema, ed elimina il classico scenario "snapshot crede di avere migrations X, Y, Z applicate ma nel tree corrente ce ne sono solo X, Y".
+
+## Fase bake — dettaglio
+
+### Preflight (`infra/scripts/seed-index-preflight.sh`)
+
+Fail-fast prima di investire ore:
+
+- `api/health` OK
+- `smoldocling-service/health` OK
+- `embedding-service/health` OK
+- seed blob bucket raggiungibile e contiene almeno un `rulebooks/v1/*.pdf`
+- `processing_jobs` vuota o contiene solo job terminali (evita di mescolare run precedenti non chiusi)
+
+### Polling (`infra/scripts/seed-index-wait.sh`)
+
+Parametri (env var con default):
+
+| Var | Default | Scopo |
+|---|---|---|
+| `SEED_INDEX_TIMEOUT` | `10800` (3h) | timeout hard dell'intero loop |
+| `SEED_INDEX_POLL` | `15` (s) | intervallo fra poll |
+| `SEED_INDEX_FAILURE_PCT` | `15` | soglia fail% oltre la quale abort |
+| `SEED_INDEX_ALLOW_PARTIAL` | `false` | permette dump anche con failed > threshold |
+
+Logica:
+1. Ogni `SEED_INDEX_POLL` secondi query aggregata su `processing_jobs`:
+   - totale, completed, failed, dead-lettered, queued, running
+2. Terminal quando `completed + failed + dead-lettered == totale && totale > 0`
+3. Se supera `SEED_INDEX_TIMEOUT` → exit 124
+4. Al termine calcola `fail_pct`; se `> SEED_INDEX_FAILURE_PCT` (default 15%) e `SEED_INDEX_ALLOW_PARTIAL=false` → dump SQL dei falliti + exit 1
+5. Altrimenti prosegue
+
+### Politica sui fallimenti parziali
+
+- **Strict (default)**: abort se `fail% > 15%`. Soglia scelta in accordo con la realtà del set: ~20 rulebook su 136 possono fallire legittimamente (OCR scadente, layout esotico, lingua non supportata) senza invalidare lo snapshot complessivo. Se vuoi stringere, abbassa a 5% e investiga caso per caso.
+- **Permissive opt-in**: `SEED_INDEX_ALLOW_PARTIAL=true` → dump procede, `failed_pdf_ids` nel sidecar elenca i PDF assenti, il consumer può decidere.
+- **No auto-retry**: deliberatamente escluso. Retrymashing maschera bug veri (OOM, PDF corrotto, service giù).
+
+### Dump (`infra/scripts/seed-index-dump.sh`)
+
+```bash
+docker exec -e PGPASSWORD="$POSTGRES_PASSWORD" meepleai-postgres \
+  pg_dump -U postgres -d meepleai \
+    -Fc --no-owner --no-privileges \
+    --exclude-table-data='__EFMigrationsHistory' \
+  > "$DUMP"
+```
+
+Sidecar costruito interrogando il DB post-seed per `pdf_count`, `chunk_count`, `embedding_count`, `failed_pdf_ids`, e leggendo le env var per `embedding_model`/`embedding_dim`.
+
+Al termine: `sha256sum "$DUMP" > "$DUMP.sha256"`.
+
+### Upload (`infra/scripts/seed-index-publish.sh`, target separato `make seed-index-publish`)
+
+Ordine atomico:
+1. `.dump` → bucket
+2. `.dump.sha256` → bucket
+3. `.meta.json` → bucket (per ultimo; se il processo muore qui, il consumer vede dump senza sidecar e skippa)
+4. `latest.txt` aggiornato col basename
+
+Retention: ultimi 3 snapshot, più vecchi rimossi.
+
+### Target Makefile (bake)
+
+```makefile
+seed-index:                      ## Bake: indicizza tutti i PDF e produce snapshot locale
+	@bash scripts/seed-index-preflight.sh
+	@docker compose up -d postgres redis api smoldocling-service embedding-service
+	@bash scripts/wait-for-healthy.sh api
+	@bash scripts/seed-index-wait.sh         # polling processing_jobs
+	@bash scripts/seed-index-dump.sh         # pg_dump + sidecar
+	@echo "::notice:: snapshot in data/snapshots/"
+
+seed-index-publish: seed-index   ## Bake + upload a seed blob bucket
+	@bash scripts/seed-index-publish.sh
+```
+
+`seed-index` non chiama nessun endpoint HTTP — sfrutta l'auto-seed di `SeedOrchestrator.RunAsync` eseguito allo startup dell'API (`Program.cs:535`). `seed-index-publish` dipende da `seed-index` e aggiunge l'upload, così si possono tenere separati i due passi se vuoi validare localmente prima di pubblicare.
+
+## Fase consume — dettaglio
+
+### Target Makefile
+
+```makefile
+SNAPSHOT_DIR := data/snapshots
+LATEST_MARKER := $(SNAPSHOT_DIR)/.latest
+
+dev-from-snapshot:                        ## Dev env con seed pre-indicizzato (veloce)
+	@bash scripts/snapshot-fetch.sh
+	@bash scripts/snapshot-verify.sh
+	@docker compose up -d postgres
+	@bash scripts/wait-for-healthy.sh postgres
+	@bash scripts/snapshot-restore.sh
+	@SKIP_CATALOG_SEED=true docker compose up -d
+	@echo "::notice:: dev env pronto (snapshot $$(cat $(LATEST_MARKER)))"
+
+dev-from-snapshot-force:                  ## Come sopra ma azzera il volume postgres prima
+	@docker compose down postgres -v
+	@$(MAKE) dev-from-snapshot
+```
+
+Due entry point distinti: uno strict (rifiuta di sovrascrivere un DB non vuoto), uno esplicitamente distruttivo.
+
+### `snapshot-fetch.sh`
+
+Precedenze:
+1. `SNAPSHOT_FILE` env var (override esplicito per testing)
+2. Snapshot locale più recente in `data/snapshots/`
+3. Download da seed blob bucket usando `snapshots/latest.txt`
+
+Il download è atomic via `.partial` + `mv`, con verifica `sha256sum -c` prima del rename.
+
+### `snapshot-verify.sh`
+
+Legge `.meta.json` dello snapshot corrente e applica i 4 check del contract.
+
+### `snapshot-restore.sh`
+
+1. Guard: rifiuta se `information_schema.tables` public conta > 0 tabelle application (exit 10)
+2. `dotnet ef database update` (schema + history dal working tree)
+3. `pg_restore --data-only --disable-triggers` (carica i dati)
+4. Smoke test:
+   - `chunk_count` post-restore == sidecar `chunk_count` (exit 11 al mismatch)
+   - nessun `text_chunks` orfano (no parent `pdf_documents`)
+   - nessun `pgvector_embeddings` orfano (no parent `text_chunks`)
+   - `array_length(embedding::real[], 1)` == sidecar `embedding_dim`
+
+`--disable-triggers` è necessario per il multi-tabella con FK denso.
+
+### Interazione con `SKIP_CATALOG_SEED`
+
+Aggiungere short-circuit in `CatalogSeedLayer`:
+
+```csharp
+public async Task SeedAsync(SeedContext context, CancellationToken ct)
+{
+    if (context.Configuration.GetValue<bool>("SKIP_CATALOG_SEED"))
+    {
+        context.Logger.LogInformation("CatalogSeedLayer: SKIP_CATALOG_SEED=true, skipping");
+        return;
+    }
+    // resto invariato
+}
+```
+
+Default `false`, zero impatto sui flussi esistenti.
+
+### Fallback esplicito
+
+Qualunque errore in `make dev-from-snapshot` deve terminare con un messaggio che indica `make dev` come fallback. Una condizione "no snapshot disponibile" è normale nei primi commit di un branch nuovo.
+
+## Testing strategy
+
+### Livello 1 — Script contract tests (bats)
+
+```
+infra/scripts/tests/
+├── snapshot-verify.bats
+├── snapshot-fetch.bats
+└── fixtures/
+    ├── meta-good.json
+    ├── meta-migration-drift.json
+    ├── meta-model-drift.json
+    └── meta-malformed.json
+```
+
+Mock di `aws`, `docker`, `jq`, `dotnet ef` via PATH override. Target: ogni exit code di `snapshot-verify.sh` ha almeno un test case.
+
+### Livello 2 — e2e locale (`infra/scripts/tests/e2e-bake-and-consume.sh`)
+
+Usa un manifest ridotto `Manifests/ci.yml` con 3 PDF piccoli per completare bake+consume in pochi minuti. Il profile switch usa il meccanismo esistente (`dev.yml` / `staging.yml` / `prod.yml`) estendendolo con `ci.yml`.
+
+Flusso:
+1. Reset `data/snapshots/` + volume postgres
+2. `make seed-index CATALOG_PROFILE=ci SEED_INDEX_TIMEOUT=3600`
+3. Verify `.dump` + `.meta.json` + `.sha256` presenti e coerenti
+4. `docker compose down -v`
+5. `make dev-from-snapshot SNAPSHOT_FILE=<output>`
+6. `curl /api/v1/chat` con query nota → assert che il chunk atteso compare nel retrieval
+7. `docker compose down -v`
+
+### Livello 3 — smoke test post-restore
+
+Già descritto in `snapshot-restore.sh`. Gira sempre, anche in uso normale del consume flow.
+
+## Rollout
+
+### Step 1 — bake path (opt-in)
+- `make seed-index`, script bake, manifest `ci.yml`
+- Nessuna modifica a `make dev`
+- `SKIP_CATALOG_SEED` default false
+- Zero impatto per chi non lancia esplicitamente `make seed-index`
+
+### Step 2 — consume path (opt-in)
+- `make dev-from-snapshot`
+- Documentato come alternativa, non default
+- Almeno 2 dev lo provano in locale prima di procedere
+
+### Step 3 — default switch (FUORI SCOPE)
+Esplicitamente non parte di questo spec. Valutazione separata dopo ≥1 settimana di uso reale.
+
+## Documentazione da aggiornare
+
+| File | Modifiche |
+|---|---|
+| `CLAUDE.md` Quick Reference | +righe `make seed-index` + `make dev-from-snapshot` |
+| `CLAUDE.md` Troubleshooting | voce "snapshot drift" con exit codes |
+| `docs/development/snapshot-seed-workflow.md` | nuovo: quando bake, quando consume, compat errors, rigenerazione |
+| `docs/operations/operations-manual.md` | sezione "seed snapshot lifecycle" — chi rigenera, quando, dove pubblica |
+| `infra/Makefile` | `make help` include nuovi target |
+| `.gitignore` | `data/snapshots/*.dump`, `data/snapshots/*.sha256`, `data/snapshots/.latest`. I `.meta.json` NON vengono ignorati (log storico utile) |
+| `infra/secrets/storage.secret.example` | `SEED_BLOB_BUCKET`, `SEED_BLOB_SNAPSHOTS_PREFIX` (se mancanti) |
+
+## Rischi e mitigazioni
+
+| Rischio | Prob. | Mitigazione |
+|---|---|---|
+| Snapshot diventa "ombra di verità" vs manifest aggiornato | alta | `dev_yml_sha256` warning + retention 3 snapshot |
+| Dev dimentica di rigenerare dopo cambio embedding | media | `snapshot-verify.sh` blocca con exit 3 |
+| Bake appeso in CI | media | `SEED_INDEX_TIMEOUT` 3h + exit 124 |
+| Dump 150MB bloat nel repo | bassa | `.gitignore` + pre-commit hook rifiuta `*.dump > 10MB` |
+| Snapshot pubblicato con chunk corrotti | bassa | smoke test post-restore (orfani + dim check) |
+| Seed blob non accessibile → consume bloccato | media | fallback esplicito a `make dev` |
+
+## Decisioni di design principali
+
+| Aspetto | Decisione | Alternativa scartata | Perché |
+|---|---|---|---|
+| Tipo di artefatto | DB `.dump` | chunks+embeddings committati come JSONL per-rulebook | complessità loader custom, duplicazione stato |
+| `pg_dump` mode | `-Fc` (custom) | `-Fp` (plain SQL) | compressione, restore selettivo, `--data-only` |
+| `__EFMigrationsHistory` | escluso dal dump, ricreato via `ef update` | incluso | evita divergenze schema snapshot ↔ tree |
+| Trigger bake | manuale (`make seed-index`) | GitHub Action automatica | richiede GPU runner, rimandato |
+| Scope manifest | `dev.yml` + nuovo `ci.yml` | include `staging.yml`/`prod.yml` | prod non usa snapshot-seed, scope creep |
+| Failure policy bake | strict + permissive opt-in | auto-retry | retry maschera bug reali |
+| Policy consume DB non-vuoto | rifiuta con messaggio | sovrascrive sempre | evita di distruggere lavoro del dev |
+| Fallback a `make dev` | esplicito in tutti i messaggi errore | fallback automatico | trasparenza, dev capisce cosa sta succedendo |
+
+## Open questions (da chiudere prima del plan)
+
+Nessuna bloccante. Punti da validare in implementazione:
+
+1. ~~**Esistenza endpoint `/api/v1/admin/seeds/catalog`**~~: **RISOLTO** — verificato in `apps/api/src/Api/Routing/AdminSeedingEndpoints.cs`. L'endpoint reale è `POST /admin/seeding/orchestrate` protetto da `RequireAdminSessionFilter`. **Più importante**: il `SeedOrchestrator.RunAsync` viene invocato automaticamente allo startup in `Program.cs:535`, quindi il bake flow NON richiede una chiamata HTTP esplicita. Basta avviare lo stack e il seed parte da solo. L'endpoint rimane utile come re-trigger manuale (senza restart) ma non è nel path critico di `make seed-index`.
+2. **`EMBEDDING_DIM` env var**: assunta presente in `embedding.secret`. Da verificare; se manca, va aggiunta.
+3. **`SEED_BLOB_BUCKET` + credenziali**: il design assume che seed blob sia già configurato in storage.secret. Da verificare lo schema attuale di `storage.secret`.
+4. **Profile switch `ci.yml`**: il meccanismo `CatalogProfile` deve supportare "ci" come valore. Da verificare enum/parsing esistente.
+
+Queste non invalidano il design, ma vanno verificate nel plan implementativo per decidere se richiedono task aggiuntivi.

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -195,6 +195,36 @@ logs-ui: ## Open Grafana log explorer in browser (staging)
 	@echo "Grafana Logs: https://meepleai.app/grafana"
 	@echo "  Explore → Loki → {container_name=~\"meepleai-.*\"}"
 
+# ================================================================
+# Seed snapshot lifecycle (bake + consume)
+# See docs/development/snapshot-seed-workflow.md
+# ================================================================
+
+seed-index: ## Bake: indicizza tutti i PDF e produce snapshot locale
+	@bash scripts/seed-index-preflight.sh
+	$(COMPOSE) -f compose.dev.yml --profile ai up -d postgres redis api embedding-service smoldocling-service
+	@bash scripts/wait-for-healthy.sh api 180
+	@bash scripts/seed-index-wait.sh
+	@bash scripts/seed-index-dump.sh
+	@echo "::notice:: snapshot pronto in data/snapshots/ — lancia 'make seed-index-publish' per caricarlo"
+
+seed-index-publish: ## Upload snapshot più recente a seed blob bucket
+	@bash scripts/seed-index-publish.sh
+
+dev-from-snapshot: ## Dev env con seed pre-indicizzato (veloce, consume flow)
+	@bash scripts/snapshot-fetch.sh
+	@bash scripts/snapshot-verify.sh
+	$(COMPOSE) -f compose.dev.yml up -d postgres
+	@bash scripts/wait-for-healthy.sh postgres 60
+	@bash scripts/snapshot-restore.sh
+	@SKIP_CATALOG_SEED=true $(COMPOSE) -f compose.dev.yml --profile ai up -d
+	@echo "::notice:: dev env pronto (snapshot $$(cat data/snapshots/.latest))"
+
+dev-from-snapshot-force: ## Come dev-from-snapshot ma azzera il volume postgres
+	$(COMPOSE) -f compose.dev.yml rm -svf postgres || true
+	$(COMPOSE) -f compose.dev.yml down postgres -v || true
+	@$(MAKE) dev-from-snapshot
+
 ps: ## Show running containers
 	$(COMPOSE) ps
 

--- a/infra/scripts/seed-index-dump.sh
+++ b/infra/scripts/seed-index-dump.sh
@@ -23,20 +23,30 @@ DUMP_FILE="$OUT_DIR/$BASENAME.dump"
 META_FILE="$OUT_DIR/$BASENAME.meta.json"
 SHA_FILE="$OUT_DIR/$BASENAME.dump.sha256"
 
+# Resolve target DB credentials from infra/secrets/database.secret
+# (so the script works across all envs: dev=meepleai_staging, prod=meepleai, etc.)
+if [ -f infra/secrets/database.secret ]; then
+    # shellcheck disable=SC1091
+    set -a; source infra/secrets/database.secret; set +a
+fi
+PG_USER="${POSTGRES_USER:-meepleai}"
+PG_DB="${POSTGRES_DB:-meepleai_staging}"
+log "source: user=$PG_USER db=$PG_DB"
+
 log "dumping DB → $DUMP_FILE"
-docker exec meepleai-postgres pg_dump -U postgres -d meepleai \
+docker exec meepleai-postgres pg_dump -U "$PG_USER" -d "$PG_DB" \
     -Fc --no-owner --no-privileges \
     --exclude-table-data='__EFMigrationsHistory' \
     > "$DUMP_FILE"
 
 log "raccolgo stats per sidecar"
-STATS_JSON=$(docker exec meepleai-postgres psql -U postgres -d meepleai -At -c "
+STATS_JSON=$(docker exec meepleai-postgres psql -U "$PG_USER" -d "$PG_DB" -At -c "
 SELECT json_build_object(
   'ef_migration_head', (SELECT \"MigrationId\" FROM \"__EFMigrationsHistory\" ORDER BY \"MigrationId\" DESC LIMIT 1),
-  'pdf_count',         (SELECT COUNT(*) FROM pdf_documents WHERE processing_state='Completed'),
+  'pdf_count',         (SELECT COUNT(*) FROM pdf_documents WHERE processing_state IN ('Ready','Completed')),
   'chunk_count',       (SELECT COUNT(*) FROM text_chunks),
   'embedding_count',   (SELECT COUNT(*) FROM pgvector_embeddings),
-  'failed_pdf_ids',    COALESCE((SELECT json_agg(pdf_document_id) FROM processing_jobs WHERE status IN ('Failed','DeadLettered')), '[]'::json)
+  'failed_pdf_ids',    COALESCE((SELECT json_agg(\"Id\") FROM pdf_documents WHERE processing_state='Failed'), '[]'::json)
 );")
 
 MANIFEST_SHA=$(sha256sum apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml | awk '{print $1}')

--- a/infra/scripts/seed-index-dump.sh
+++ b/infra/scripts/seed-index-dump.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# infra/scripts/seed-index-dump.sh
+# pg_dump + sidecar .meta.json + sha256.
+set -euo pipefail
+
+OUT_DIR="${SEED_INDEX_OUT_DIR:-data/snapshots}"
+mkdir -p "$OUT_DIR"
+
+log() { echo "[dump] $*" >&2; }
+fail() { echo "::error:: $*" >&2; exit 1; }
+
+command -v jq >/dev/null || fail "jq non installato"
+
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+COMMIT=$(git rev-parse --short=9 HEAD)
+
+EMBEDDING_MODEL=$(docker exec meepleai-api printenv EMBEDDING_MODEL 2>/dev/null || echo "unknown")
+EMBEDDING_DIM=$(docker exec meepleai-api printenv EMBEDDING_DIM 2>/dev/null || echo "0")
+MODEL_SLUG=$(echo "$EMBEDDING_MODEL" | tr '/' '_' | tr -cd 'A-Za-z0-9_.-')
+
+BASENAME="meepleai_seed_${TS}_${MODEL_SLUG}_${COMMIT}"
+DUMP_FILE="$OUT_DIR/$BASENAME.dump"
+META_FILE="$OUT_DIR/$BASENAME.meta.json"
+SHA_FILE="$OUT_DIR/$BASENAME.dump.sha256"
+
+log "dumping DB → $DUMP_FILE"
+docker exec meepleai-postgres pg_dump -U postgres -d meepleai \
+    -Fc --no-owner --no-privileges \
+    --exclude-table-data='__EFMigrationsHistory' \
+    > "$DUMP_FILE"
+
+log "raccolgo stats per sidecar"
+STATS_JSON=$(docker exec meepleai-postgres psql -U postgres -d meepleai -At -c "
+SELECT json_build_object(
+  'ef_migration_head', (SELECT \"MigrationId\" FROM \"__EFMigrationsHistory\" ORDER BY \"MigrationId\" DESC LIMIT 1),
+  'pdf_count',         (SELECT COUNT(*) FROM pdf_documents WHERE processing_state='Completed'),
+  'chunk_count',       (SELECT COUNT(*) FROM text_chunks),
+  'embedding_count',   (SELECT COUNT(*) FROM pgvector_embeddings),
+  'failed_pdf_ids',    COALESCE((SELECT json_agg(pdf_document_id) FROM processing_jobs WHERE status IN ('Failed','DeadLettered')), '[]'::json)
+);")
+
+MANIFEST_SHA=$(sha256sum apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml | awk '{print $1}')
+
+jq -n \
+    --argjson stats "$STATS_JSON" \
+    --arg model "$EMBEDDING_MODEL" \
+    --argjson dim "$EMBEDDING_DIM" \
+    --arg commit "$COMMIT" \
+    --arg created "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg manifest_sha "$MANIFEST_SHA" \
+    '{
+       schema_version: $stats.ef_migration_head,
+       ef_migration_head: $stats.ef_migration_head,
+       embedding_model: $model,
+       embedding_dim: $dim,
+       app_commit: $commit,
+       created_at: $created,
+       dev_yml_sha256: $manifest_sha,
+       pdf_count: $stats.pdf_count,
+       chunk_count: $stats.chunk_count,
+       embedding_count: $stats.embedding_count,
+       failed_pdf_ids: $stats.failed_pdf_ids
+     }' > "$META_FILE"
+
+log "calcolo sha256"
+( cd "$OUT_DIR" && sha256sum "$BASENAME.dump" > "$BASENAME.dump.sha256" )
+
+# Aggiorna .latest (usato dal consume flow come cache locale)
+echo "$BASENAME" > "$OUT_DIR/.latest"
+
+log "snapshot pronto: $BASENAME"
+log "  dump:  $DUMP_FILE ($(du -h "$DUMP_FILE" | awk '{print $1}'))"
+log "  meta:  $META_FILE"
+log "  sha:   $SHA_FILE"
+
+echo "$BASENAME"

--- a/infra/scripts/seed-index-preflight.sh
+++ b/infra/scripts/seed-index-preflight.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# infra/scripts/seed-index-preflight.sh
+# Fail-fast checks prima di lanciare seed-index.
+set -euo pipefail
+
+log() { echo "[preflight] $*" >&2; }
+fail() { echo "::error:: $*" >&2; exit 1; }
+
+# 1. docker + compose
+command -v docker >/dev/null || fail "docker non installato"
+docker compose version >/dev/null || fail "docker compose non disponibile"
+
+# 2. jq (usato da dump/verify/fetch)
+command -v jq >/dev/null || fail "jq non installato"
+
+# 3. Manifest dev.yml presente
+MANIFEST="apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml"
+[ -f "$MANIFEST" ] || fail "manifest non trovato: $MANIFEST"
+
+# 4. Seed blob bucket configurato (opzionale ma senza di esso PdfSeeder è silenzioso)
+if [ ! -f infra/secrets/storage.secret ] || ! grep -q "^SEED_BLOB_" infra/secrets/storage.secret 2>/dev/null; then
+    log "WARNING: seed blob non configurato in infra/secrets/storage.secret — PdfSeeder non seederà PDF"
+    log "Procedo comunque (il bake può essere legittimo per testare il flusso su 0 PDF)"
+fi
+
+# 5. Se postgres gira già, controlla che processing_jobs sia vuota o solo terminali
+if docker ps --format '{{.Names}}' | grep -q '^meepleai-postgres$'; then
+    pending=$(docker exec meepleai-postgres psql -U postgres -d meepleai -At -c \
+        "SELECT COUNT(*) FROM processing_jobs WHERE status IN ('Queued','Running','Retrying');" 2>/dev/null || echo "0")
+    if [ "$pending" -gt 0 ]; then
+        fail "processing_jobs contiene $pending job non terminali — ferma il run precedente o svuota la tabella"
+    fi
+fi
+
+log "OK"

--- a/infra/scripts/seed-index-publish.sh
+++ b/infra/scripts/seed-index-publish.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# infra/scripts/seed-index-publish.sh
+# Upload ultimo snapshot a seed blob bucket + rotation (tieni 3).
+set -euo pipefail
+
+OUT_DIR="${SEED_INDEX_OUT_DIR:-data/snapshots}"
+LATEST="$OUT_DIR/.latest"
+
+log() { echo "[publish] $*" >&2; }
+fail() { echo "::error:: $*" >&2; exit 1; }
+
+[ -f "$LATEST" ] || fail ".latest non trovato in $OUT_DIR — lancia prima make seed-index"
+BASENAME=$(cat "$LATEST")
+[ -f "$OUT_DIR/$BASENAME.dump" ] || fail "dump mancante: $OUT_DIR/$BASENAME.dump"
+[ -f "$OUT_DIR/$BASENAME.meta.json" ] || fail "meta mancante: $OUT_DIR/$BASENAME.meta.json"
+
+# Carica credenziali da storage.secret
+# shellcheck disable=SC1091
+set -a; source infra/secrets/storage.secret; set +a
+: "${SEED_BLOB_BUCKET:?SEED_BLOB_BUCKET mancante in storage.secret}"
+: "${S3_ENDPOINT:?S3_ENDPOINT mancante}"
+: "${S3_ACCESS_KEY:?S3_ACCESS_KEY mancante}"
+: "${S3_SECRET_KEY:?S3_SECRET_KEY mancante}"
+
+export AWS_ACCESS_KEY_ID="$S3_ACCESS_KEY"
+export AWS_SECRET_ACCESS_KEY="$S3_SECRET_KEY"
+AWS_S3="aws s3 --endpoint-url $S3_ENDPOINT"
+
+PREFIX="snapshots"
+
+log "uploading $BASENAME.dump"
+$AWS_S3 cp "$OUT_DIR/$BASENAME.dump" "s3://$SEED_BLOB_BUCKET/$PREFIX/$BASENAME.dump"
+log "uploading $BASENAME.dump.sha256"
+$AWS_S3 cp "$OUT_DIR/$BASENAME.dump.sha256" "s3://$SEED_BLOB_BUCKET/$PREFIX/$BASENAME.dump.sha256"
+# META PER ULTIMO — atomic marker
+log "uploading $BASENAME.meta.json (atomic marker last)"
+$AWS_S3 cp "$OUT_DIR/$BASENAME.meta.json" "s3://$SEED_BLOB_BUCKET/$PREFIX/$BASENAME.meta.json"
+
+# latest.txt pointer
+log "updating latest.txt pointer"
+echo "$BASENAME" | $AWS_S3 cp - "s3://$SEED_BLOB_BUCKET/$PREFIX/latest.txt"
+
+# Retention: tieni ultimi 3
+log "rotation: retain last 3 snapshots"
+$AWS_S3 ls "s3://$SEED_BLOB_BUCKET/$PREFIX/" \
+    | awk '{print $4}' \
+    | grep -E '^meepleai_seed_[0-9]{8}T[0-9]{6}Z.*\.meta\.json$' \
+    | sort -r \
+    | tail -n +4 \
+    | while read -r old_meta; do
+        old_base=${old_meta%.meta.json}
+        log "rimuovo obsoleto: $old_base"
+        $AWS_S3 rm "s3://$SEED_BLOB_BUCKET/$PREFIX/$old_base.dump"        || true
+        $AWS_S3 rm "s3://$SEED_BLOB_BUCKET/$PREFIX/$old_base.dump.sha256" || true
+        $AWS_S3 rm "s3://$SEED_BLOB_BUCKET/$PREFIX/$old_base.meta.json"   || true
+      done
+
+log "OK"

--- a/infra/scripts/seed-index-wait.sh
+++ b/infra/scripts/seed-index-wait.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# infra/scripts/seed-index-wait.sh
+# Polla processing_jobs finché tutti terminal, con timeout e fail-fast.
+set -euo pipefail
+
+TIMEOUT_SECONDS=${SEED_INDEX_TIMEOUT:-10800}        # 3h
+POLL_INTERVAL=${SEED_INDEX_POLL:-15}                 # 15s
+FAILURE_THRESHOLD_PCT=${SEED_INDEX_FAILURE_PCT:-15}  # 15%
+ALLOW_PARTIAL=${SEED_INDEX_ALLOW_PARTIAL:-false}
+
+log() { echo "[seed-index-wait] $*" >&2; }
+fail() { echo "::error:: $*" >&2; exit 1; }
+
+start=$(date +%s)
+while :; do
+    read -r total completed failed dlq queued running < <(
+        docker exec meepleai-postgres psql -U postgres -d meepleai -At -F' ' -c \
+        "SELECT
+           COUNT(*),
+           COUNT(*) FILTER (WHERE status='Completed'),
+           COUNT(*) FILTER (WHERE status='Failed'),
+           COUNT(*) FILTER (WHERE status='DeadLettered'),
+           COUNT(*) FILTER (WHERE status='Queued'),
+           COUNT(*) FILTER (WHERE status='Running')
+         FROM processing_jobs;"
+    )
+    terminal=$((completed + failed + dlq))
+    log "total=$total completed=$completed failed=$failed dlq=$dlq queued=$queued running=$running"
+
+    if [ "$total" -gt 0 ] && [ "$terminal" -eq "$total" ]; then
+        break
+    fi
+
+    if [ $(( $(date +%s) - start )) -gt "$TIMEOUT_SECONDS" ]; then
+        echo "::error:: timeout dopo ${TIMEOUT_SECONDS}s — processing_jobs non drenata" >&2
+        exit 124
+    fi
+
+    sleep "$POLL_INTERVAL"
+done
+
+if [ "$total" -eq 0 ]; then
+    log "WARNING: processing_jobs vuota — nessun PDF processato"
+    exit 0
+fi
+
+fail_count=$((failed + dlq))
+fail_pct=$(( fail_count * 100 / total ))
+log "termine: $completed/$total OK, $fail_count falliti (${fail_pct}%)"
+
+if [ "$fail_pct" -gt "$FAILURE_THRESHOLD_PCT" ] && [ "$ALLOW_PARTIAL" != "true" ]; then
+    log "fail rate ${fail_pct}% > soglia ${FAILURE_THRESHOLD_PCT}%"
+    docker exec meepleai-postgres psql -U postgres -d meepleai -c \
+      "SELECT j.id, p.file_name, s.error_message
+       FROM processing_jobs j
+       JOIN pdf_documents p ON p.id = j.pdf_document_id
+       LEFT JOIN processing_steps s ON s.processing_job_id = j.id AND s.status='Failed'
+       WHERE j.status IN ('Failed','DeadLettered')
+       LIMIT 50;" >&2 || true
+    fail "aborting — usa SEED_INDEX_ALLOW_PARTIAL=true per procedere comunque"
+fi
+
+log "OK"

--- a/infra/scripts/snapshot-fetch.sh
+++ b/infra/scripts/snapshot-fetch.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# infra/scripts/snapshot-fetch.sh
+# Priorità: SNAPSHOT_FILE env > cache locale più recente > download da bucket.
+set -euo pipefail
+
+OUT_DIR="${SEED_INDEX_OUT_DIR:-data/snapshots}"
+mkdir -p "$OUT_DIR"
+
+log() { echo "[fetch] $*" >&2; }
+fail() { echo "::error:: $*" >&2; exit 1; }
+
+if [ -n "${SNAPSHOT_FILE:-}" ]; then
+    [ -f "$SNAPSHOT_FILE" ] || fail "SNAPSHOT_FILE non esiste: $SNAPSHOT_FILE"
+    BASENAME=$(basename "$SNAPSHOT_FILE" .dump)
+    log "override esplicito: $BASENAME"
+elif ls "$OUT_DIR"/meepleai_seed_*.meta.json >/dev/null 2>&1; then
+    BASENAME=$(ls -t "$OUT_DIR"/meepleai_seed_*.meta.json | head -1 | xargs basename | sed 's/\.meta\.json$//')
+    log "cache locale: $BASENAME"
+else
+    log "nessuna cache locale — download dal bucket"
+    # shellcheck disable=SC1091
+    set -a; source infra/secrets/storage.secret; set +a
+    : "${SEED_BLOB_BUCKET:?SEED_BLOB_BUCKET mancante}"
+    : "${S3_ENDPOINT:?S3_ENDPOINT mancante}"
+    : "${S3_ACCESS_KEY:?S3_ACCESS_KEY mancante}"
+    : "${S3_SECRET_KEY:?S3_SECRET_KEY mancante}"
+    export AWS_ACCESS_KEY_ID="$S3_ACCESS_KEY"
+    export AWS_SECRET_ACCESS_KEY="$S3_SECRET_KEY"
+    AWS_S3="aws s3 --endpoint-url $S3_ENDPOINT"
+    PREFIX="snapshots"
+
+    BASENAME=$($AWS_S3 cp "s3://$SEED_BLOB_BUCKET/$PREFIX/latest.txt" - | tr -d '[:space:]')
+    [ -n "$BASENAME" ] || fail "latest.txt vuoto sul bucket"
+
+    log "scarico $BASENAME (.dump + .sha256 + .meta.json)"
+    $AWS_S3 cp "s3://$SEED_BLOB_BUCKET/$PREFIX/$BASENAME.dump"        "$OUT_DIR/$BASENAME.dump.partial"
+    $AWS_S3 cp "s3://$SEED_BLOB_BUCKET/$PREFIX/$BASENAME.dump.sha256" "$OUT_DIR/$BASENAME.dump.sha256"
+    $AWS_S3 cp "s3://$SEED_BLOB_BUCKET/$PREFIX/$BASENAME.meta.json"   "$OUT_DIR/$BASENAME.meta.json.partial"
+
+    # Verifica checksum contro il .partial
+    ( cd "$OUT_DIR" && \
+      sed "s|$BASENAME.dump|$BASENAME.dump.partial|" "$BASENAME.dump.sha256" | sha256sum -c - ) \
+      || fail "sha256 mismatch"
+
+    # Atomic rename
+    mv "$OUT_DIR/$BASENAME.dump.partial"      "$OUT_DIR/$BASENAME.dump"
+    mv "$OUT_DIR/$BASENAME.meta.json.partial" "$OUT_DIR/$BASENAME.meta.json"
+fi
+
+echo "$BASENAME" > "$OUT_DIR/.latest"
+log "OK — basename: $BASENAME"

--- a/infra/scripts/snapshot-publish.py
+++ b/infra/scripts/snapshot-publish.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+Publish baseline snapshot to S3-compatible bucket (R2).
+
+Reads credentials from infra/secrets/storage.secret and uploads:
+  - {basename}.dump
+  - {basename}.dump.sha256
+  - {basename}.meta.json
+  - latest.txt (pointer to basename)
+
+Usage:
+  python infra/scripts/snapshot-publish.py [--basename NAME]
+
+If --basename is omitted, uses content of data/snapshots/.latest.
+"""
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import boto3
+from botocore.client import Config
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SNAPSHOTS_DIR = REPO_ROOT / "data" / "snapshots"
+SECRET_FILE = REPO_ROOT / "infra" / "secrets" / "storage.secret"
+PREFIX = "snapshots"
+
+
+def load_secrets() -> dict[str, str]:
+    secrets: dict[str, str] = {}
+    for line in SECRET_FILE.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, _, value = line.partition("=")
+        secrets[key.strip()] = value.strip()
+    return secrets
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Publish baseline snapshot to R2")
+    parser.add_argument("--basename", help="Snapshot basename (without extension)")
+    args = parser.parse_args()
+
+    if args.basename:
+        basename = args.basename
+    else:
+        latest_file = SNAPSHOTS_DIR / ".latest"
+        if not latest_file.exists():
+            print("ERROR: data/snapshots/.latest not found", file=sys.stderr)
+            return 1
+        basename = latest_file.read_text().strip()
+
+    dump = SNAPSHOTS_DIR / f"{basename}.dump"
+    sha = SNAPSHOTS_DIR / f"{basename}.dump.sha256"
+    meta = SNAPSHOTS_DIR / f"{basename}.meta.json"
+
+    for f in (dump, sha, meta):
+        if not f.exists():
+            print(f"ERROR: missing {f}", file=sys.stderr)
+            return 1
+
+    secrets = load_secrets()
+    bucket = secrets.get("SEED_BLOB_BUCKET") or secrets.get("S3_BUCKET_NAME")
+    endpoint = secrets["S3_ENDPOINT"]
+    access_key = secrets["S3_ACCESS_KEY"]
+    secret_key = secrets["S3_SECRET_KEY"]
+    region = secrets.get("S3_REGION", "auto")
+
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name=region,
+        config=Config(signature_version="s3v4"),
+    )
+
+    print(f"[publish] uploading {dump.name} ({dump.stat().st_size // (1024*1024)} MB)")
+    s3.upload_file(str(dump), bucket, f"{PREFIX}/{dump.name}")
+    print(f"[publish] uploading {sha.name}")
+    s3.upload_file(str(sha), bucket, f"{PREFIX}/{sha.name}")
+    print(f"[publish] uploading {meta.name} (atomic marker last)")
+    s3.upload_file(str(meta), bucket, f"{PREFIX}/{meta.name}")
+    print(f"[publish] updating latest.txt -> {basename}")
+    s3.put_object(
+        Bucket=bucket,
+        Key=f"{PREFIX}/latest.txt",
+        Body=basename.encode("utf-8"),
+        ContentType="text/plain",
+    )
+    print(f"[publish] OK — bucket={bucket}, prefix={PREFIX}/")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infra/scripts/snapshot-restore.sh
+++ b/infra/scripts/snapshot-restore.sh
@@ -15,8 +15,18 @@ META="$OUT_DIR/$BASENAME.meta.json"
 [ -f "$DUMP" ] || fail "dump mancante: $DUMP"
 [ -f "$META" ] || fail "meta mancante: $META"
 
+# Resolve target DB credentials from infra/secrets/database.secret
+# (so the script works across all envs: dev=meepleai_staging, prod=meepleai, etc.)
+if [ -f infra/secrets/database.secret ]; then
+    # shellcheck disable=SC1091
+    set -a; source infra/secrets/database.secret; set +a
+fi
+PG_USER="${POSTGRES_USER:-meepleai}"
+PG_DB="${POSTGRES_DB:-meepleai_staging}"
+log "target: user=$PG_USER db=$PG_DB"
+
 # Guard: DB non deve contenere tabelle application (evita di sovrascrivere lavoro)
-table_count=$(docker exec meepleai-postgres psql -U postgres -d meepleai -At -c \
+table_count=$(docker exec meepleai-postgres psql -U "$PG_USER" -d "$PG_DB" -At -c \
     "SELECT COUNT(*) FROM information_schema.tables
      WHERE table_schema='public' AND table_type='BASE TABLE' AND table_name NOT LIKE 'pg_%';")
 
@@ -34,26 +44,26 @@ log "applico migrations dal working tree"
 
 log "pg_restore --data-only"
 docker exec -i meepleai-postgres pg_restore \
-    -U postgres -d meepleai \
+    -U "$PG_USER" -d "$PG_DB" \
     --data-only --disable-triggers --no-owner --no-privileges \
     < "$DUMP"
 
 # Smoke test
 log "smoke test: chunk count + orphans"
-actual_chunks=$(docker exec meepleai-postgres psql -U postgres -d meepleai -At -c "SELECT COUNT(*) FROM text_chunks;")
+actual_chunks=$(docker exec meepleai-postgres psql -U "$PG_USER" -d "$PG_DB" -At -c "SELECT COUNT(*) FROM text_chunks;")
 expected_chunks=$(jq '.chunk_count' "$META")
 
 if [ "$actual_chunks" != "$expected_chunks" ]; then
     fail "chunk count post-restore ($actual_chunks) ≠ sidecar ($expected_chunks)"
 fi
 
-orphan_chunks=$(docker exec meepleai-postgres psql -U postgres -d meepleai -At -c "
+orphan_chunks=$(docker exec meepleai-postgres psql -U "$PG_USER" -d "$PG_DB" -At -c "
     SELECT COUNT(*) FROM text_chunks tc
     LEFT JOIN pdf_documents p ON p.id = tc.pdf_document_id
     WHERE p.id IS NULL;")
 [ "$orphan_chunks" = "0" ] || fail "$orphan_chunks text_chunks orfani"
 
-orphan_embeds=$(docker exec meepleai-postgres psql -U postgres -d meepleai -At -c "
+orphan_embeds=$(docker exec meepleai-postgres psql -U "$PG_USER" -d "$PG_DB" -At -c "
     SELECT COUNT(*) FROM pgvector_embeddings e
     LEFT JOIN text_chunks tc ON tc.id = e.text_chunk_id
     WHERE tc.id IS NULL;")

--- a/infra/scripts/snapshot-restore.sh
+++ b/infra/scripts/snapshot-restore.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# infra/scripts/snapshot-restore.sh
+# Restore dello snapshot su un DB vuoto dopo ef update.
+set -euo pipefail
+
+OUT_DIR="${SEED_INDEX_OUT_DIR:-data/snapshots}"
+BASENAME=$(cat "$OUT_DIR/.latest" 2>/dev/null || echo "")
+
+log() { echo "[restore] $*" >&2; }
+fail() { echo "::error:: $*" >&2; exit 1; }
+
+[ -n "$BASENAME" ] || fail ".latest mancante"
+DUMP="$OUT_DIR/$BASENAME.dump"
+META="$OUT_DIR/$BASENAME.meta.json"
+[ -f "$DUMP" ] || fail "dump mancante: $DUMP"
+[ -f "$META" ] || fail "meta mancante: $META"
+
+# Guard: DB non deve contenere tabelle application (evita di sovrascrivere lavoro)
+table_count=$(docker exec meepleai-postgres psql -U postgres -d meepleai -At -c \
+    "SELECT COUNT(*) FROM information_schema.tables
+     WHERE table_schema='public' AND table_type='BASE TABLE' AND table_name NOT LIKE 'pg_%';")
+
+if [ "$table_count" -gt 0 ]; then
+    cat >&2 <<EOF
+::error:: DB non vuoto ($table_count tabelle application presenti)
+snapshot-restore rifiuta di sovrascrivere dati esistenti.
+Usa: make dev-from-snapshot-force   (DISTRUTTIVO, azzera il volume postgres)
+EOF
+    exit 10
+fi
+
+log "applico migrations dal working tree"
+( cd apps/api/src/Api && dotnet ef database update )
+
+log "pg_restore --data-only"
+docker exec -i meepleai-postgres pg_restore \
+    -U postgres -d meepleai \
+    --data-only --disable-triggers --no-owner --no-privileges \
+    < "$DUMP"
+
+# Smoke test
+log "smoke test: chunk count + orphans"
+actual_chunks=$(docker exec meepleai-postgres psql -U postgres -d meepleai -At -c "SELECT COUNT(*) FROM text_chunks;")
+expected_chunks=$(jq '.chunk_count' "$META")
+
+if [ "$actual_chunks" != "$expected_chunks" ]; then
+    fail "chunk count post-restore ($actual_chunks) ≠ sidecar ($expected_chunks)"
+fi
+
+orphan_chunks=$(docker exec meepleai-postgres psql -U postgres -d meepleai -At -c "
+    SELECT COUNT(*) FROM text_chunks tc
+    LEFT JOIN pdf_documents p ON p.id = tc.pdf_document_id
+    WHERE p.id IS NULL;")
+[ "$orphan_chunks" = "0" ] || fail "$orphan_chunks text_chunks orfani"
+
+orphan_embeds=$(docker exec meepleai-postgres psql -U postgres -d meepleai -At -c "
+    SELECT COUNT(*) FROM pgvector_embeddings e
+    LEFT JOIN text_chunks tc ON tc.id = e.text_chunk_id
+    WHERE tc.id IS NULL;")
+[ "$orphan_embeds" = "0" ] || fail "$orphan_embeds pgvector_embeddings orfani"
+
+log "OK — $actual_chunks chunks ripristinati, nessun orfano"

--- a/infra/scripts/snapshot-verify.sh
+++ b/infra/scripts/snapshot-verify.sh
@@ -17,11 +17,13 @@ META="$OUT_DIR/$BASENAME.meta.json"
 expected_head=$(jq -r '.ef_migration_head' "$META")
 working_head=${EXPECTED_EF_HEAD:-}
 if [ -z "$working_head" ]; then
-    # Resolvi dal working tree — cerca file migration più recente
-    # Le migration EF sono nominate YYYYMMDDHHMMSS_Name.cs
-    working_head=$(find apps/api/src/Api -name '[0-9]*_*.cs' -path '*/Migrations/*' 2>/dev/null \
+    # Resolvi dal working tree — cerca file migration più recente.
+    # Le migration EF sono nominate YYYYMMDDHHMMSS_Name.cs ed EF genera una
+    # coppia <Name>.cs + <Name>.Designer.cs per ogni migration — escludi
+    # i Designer, altrimenti sort -r li ordina prima del file canonico.
+    working_head=$(find apps/api/src/Api -name '[0-9]*_*.cs' -not -name '*.Designer.cs' -path '*/Migrations/*' 2>/dev/null \
         | xargs -I{} basename {} .cs \
-        | grep -E '^[0-9]{14}_[A-Za-z0-9_]+' \
+        | grep -E '^[0-9]{14}_[A-Za-z0-9_]+$' \
         | sort -r | head -1 || echo "")
 fi
 

--- a/infra/scripts/snapshot-verify.sh
+++ b/infra/scripts/snapshot-verify.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# infra/scripts/snapshot-verify.sh
+# Compat gate: blocca il restore se snapshot incompatibile col working tree.
+# Exit codes: 0=ok, 2=migration drift, 3=model drift, 4=dim drift, 1=altro
+set -euo pipefail
+
+OUT_DIR="${SEED_INDEX_OUT_DIR:-data/snapshots}"
+
+log() { echo "[verify] $*" >&2; }
+
+BASENAME=$(cat "$OUT_DIR/.latest" 2>/dev/null || echo "")
+[ -n "$BASENAME" ] || { echo "::error:: .latest vuoto o mancante" >&2; exit 1; }
+META="$OUT_DIR/$BASENAME.meta.json"
+[ -f "$META" ] || { echo "::error:: meta.json mancante: $META" >&2; exit 1; }
+
+# 1. EF migration head
+expected_head=$(jq -r '.ef_migration_head' "$META")
+working_head=${EXPECTED_EF_HEAD:-}
+if [ -z "$working_head" ]; then
+    # Resolvi dal working tree — cerca file migration più recente
+    # Le migration EF sono nominate YYYYMMDDHHMMSS_Name.cs
+    working_head=$(find apps/api/src/Api -name '[0-9]*_*.cs' -path '*/Migrations/*' 2>/dev/null \
+        | xargs -I{} basename {} .cs \
+        | grep -E '^[0-9]{14}_[A-Za-z0-9_]+' \
+        | sort -r | head -1 || echo "")
+fi
+
+if [ "$expected_head" != "$working_head" ]; then
+    cat >&2 <<EOF
+::error:: snapshot disallineato con le migrations del working tree
+  snapshot head : $expected_head
+  working head  : $working_head
+Opzioni:
+  1. git checkout del commit compatibile con lo snapshot
+  2. make seed-index  (rigenera lo snapshot sul commit corrente)
+EOF
+    exit 2
+fi
+
+# 2. Embedding model
+expected_model=$(jq -r '.embedding_model' "$META")
+current_model=${EXPECTED_EMBEDDING_MODEL:-}
+if [ -z "$current_model" ] && [ -f infra/secrets/embedding.secret ]; then
+    current_model=$(grep -E '^EMBEDDING_MODEL=' infra/secrets/embedding.secret | cut -d= -f2- || echo "")
+fi
+
+if [ "$expected_model" != "$current_model" ]; then
+    cat >&2 <<EOF
+::error:: embedding model mismatch
+  snapshot : $expected_model
+  current  : $current_model
+I vettori non sono confrontabili col model corrente.
+EOF
+    exit 3
+fi
+
+# 3. Embedding dim
+expected_dim=$(jq -r '.embedding_dim' "$META")
+current_dim=${EXPECTED_EMBEDDING_DIM:-}
+if [ -z "$current_dim" ] && [ -f infra/secrets/embedding.secret ]; then
+    current_dim=$(grep -E '^EMBEDDING_DIM=' infra/secrets/embedding.secret | cut -d= -f2- || echo "")
+fi
+
+if [ "$expected_dim" != "$current_dim" ]; then
+    echo "::error:: embedding_dim mismatch ($expected_dim vs $current_dim)" >&2
+    exit 4
+fi
+
+# 4. dev.yml drift — warning non bloccante
+expected_sha=$(jq -r '.dev_yml_sha256' "$META")
+current_sha=$(sha256sum apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml 2>/dev/null | awk '{print $1}' || echo "")
+if [ "$expected_sha" != "$current_sha" ]; then
+    echo "::warning:: dev.yml è cambiato dopo lo snapshot — eventuali giochi nuovi NON sono indicizzati" >&2
+fi
+
+failed_count=$(jq '.failed_pdf_ids | length' "$META")
+if [ "$failed_count" -gt 0 ]; then
+    echo "::warning:: snapshot contiene $failed_count PDF falliti" >&2
+fi
+
+log "OK — $BASENAME compatibile"

--- a/infra/scripts/tests/fixtures/meta-dim-drift.json
+++ b/infra/scripts/tests/fixtures/meta-dim-drift.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "20260401_AddSearchVector",
+  "ef_migration_head": "20260401_AddSearchVector",
+  "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
+  "embedding_dim": 768,
+  "app_commit": "test0000",
+  "created_at": "2026-04-10T12:00:00Z",
+  "dev_yml_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+  "pdf_count": 130,
+  "chunk_count": 18000,
+  "embedding_count": 18000,
+  "failed_pdf_ids": []
+}

--- a/infra/scripts/tests/fixtures/meta-good.json
+++ b/infra/scripts/tests/fixtures/meta-good.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "20260401_AddSearchVector",
+  "ef_migration_head": "20260401_AddSearchVector",
+  "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
+  "embedding_dim": 384,
+  "app_commit": "test0000",
+  "created_at": "2026-04-10T12:00:00Z",
+  "dev_yml_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+  "pdf_count": 130,
+  "chunk_count": 18000,
+  "embedding_count": 18000,
+  "failed_pdf_ids": []
+}

--- a/infra/scripts/tests/fixtures/meta-migration-drift.json
+++ b/infra/scripts/tests/fixtures/meta-migration-drift.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "19991231_AncientMigration",
+  "ef_migration_head": "19991231_AncientMigration",
+  "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
+  "embedding_dim": 384,
+  "app_commit": "test0000",
+  "created_at": "2026-04-10T12:00:00Z",
+  "dev_yml_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+  "pdf_count": 130,
+  "chunk_count": 18000,
+  "embedding_count": 18000,
+  "failed_pdf_ids": []
+}

--- a/infra/scripts/tests/fixtures/meta-model-drift.json
+++ b/infra/scripts/tests/fixtures/meta-model-drift.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "20260401_AddSearchVector",
+  "ef_migration_head": "20260401_AddSearchVector",
+  "embedding_model": "some/other-model",
+  "embedding_dim": 384,
+  "app_commit": "test0000",
+  "created_at": "2026-04-10T12:00:00Z",
+  "dev_yml_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+  "pdf_count": 130,
+  "chunk_count": 18000,
+  "embedding_count": 18000,
+  "failed_pdf_ids": []
+}

--- a/infra/scripts/tests/snapshot-verify.bats
+++ b/infra/scripts/tests/snapshot-verify.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+# Unit tests for snapshot-verify.sh compat gate logic.
+#
+# Run with: bats infra/scripts/tests/snapshot-verify.bats
+# (requires bats-core: https://github.com/bats-core/bats-core)
+
+setup() {
+    SCRIPT_DIR="$BATS_TEST_DIRNAME/.."
+    FIXTURES="$BATS_TEST_DIRNAME/fixtures"
+    TMPDIR=$(mktemp -d)
+    export SEED_INDEX_OUT_DIR="$TMPDIR"
+}
+
+teardown() {
+    rm -rf "$TMPDIR"
+}
+
+install_fixture() {
+    local name=$1
+    cp "$FIXTURES/$name.json" "$TMPDIR/meepleai_seed_test.meta.json"
+    echo "meepleai_seed_test" > "$TMPDIR/.latest"
+}
+
+set_expected_env() {
+    export EXPECTED_EF_HEAD="20260401_AddSearchVector"
+    export EXPECTED_EMBEDDING_MODEL="sentence-transformers/all-MiniLM-L6-v2"
+    export EXPECTED_EMBEDDING_DIM=384
+}
+
+@test "exit 0 when all fields match" {
+    install_fixture meta-good
+    set_expected_env
+    run bash "$SCRIPT_DIR/snapshot-verify.sh"
+    [ "$status" -eq 0 ]
+}
+
+@test "exit 2 on migration drift" {
+    install_fixture meta-migration-drift
+    set_expected_env
+    run bash "$SCRIPT_DIR/snapshot-verify.sh"
+    [ "$status" -eq 2 ]
+}
+
+@test "exit 3 on model drift" {
+    install_fixture meta-model-drift
+    set_expected_env
+    run bash "$SCRIPT_DIR/snapshot-verify.sh"
+    [ "$status" -eq 3 ]
+}
+
+@test "exit 4 on dim drift" {
+    install_fixture meta-dim-drift
+    set_expected_env
+    run bash "$SCRIPT_DIR/snapshot-verify.sh"
+    [ "$status" -eq 4 ]
+}
+
+@test "exit 1 on missing .latest" {
+    set_expected_env
+    run bash "$SCRIPT_DIR/snapshot-verify.sh"
+    [ "$status" -eq 1 ]
+}
+
+@test "exit 1 on missing meta.json" {
+    set_expected_env
+    echo "nonexistent_snapshot" > "$TMPDIR/.latest"
+    run bash "$SCRIPT_DIR/snapshot-verify.sh"
+    [ "$status" -eq 1 ]
+}

--- a/infra/scripts/wait-for-healthy.sh
+++ b/infra/scripts/wait-for-healthy.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# infra/scripts/wait-for-healthy.sh
+# Attende che un container Docker raggiunga stato healthy.
+# Usage: bash wait-for-healthy.sh <service-name> [timeout-seconds=120]
+set -euo pipefail
+
+SERVICE=${1:?service name required (es. api, postgres)}
+TIMEOUT=${2:-120}
+CONTAINER="meepleai-${SERVICE}"
+
+start=$(date +%s)
+while :; do
+    status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$CONTAINER" 2>/dev/null || echo "missing")
+
+    case "$status" in
+        healthy)
+            echo "[wait-for-healthy] $CONTAINER: healthy" >&2
+            exit 0
+            ;;
+        running)
+            # Container senza healthcheck definito — considera OK dopo 5s di stabilità
+            if [ $(( $(date +%s) - start )) -gt 5 ]; then
+                echo "[wait-for-healthy] $CONTAINER: running (no healthcheck defined)" >&2
+                exit 0
+            fi
+            ;;
+        missing)
+            echo "[wait-for-healthy] $CONTAINER non esiste" >&2
+            ;;
+    esac
+
+    if [ $(( $(date +%s) - start )) -gt "$TIMEOUT" ]; then
+        echo "::error:: $CONTAINER non healthy dopo ${TIMEOUT}s (status=$status)" >&2
+        docker logs "$CONTAINER" --tail 30 >&2 2>/dev/null || true
+        exit 1
+    fi
+
+    sleep 2
+done

--- a/infra/secrets/storage.secret.example
+++ b/infra/secrets/storage.secret.example
@@ -86,3 +86,10 @@ SEED_BUCKET_REGION=auto
 SEED_BUCKET_FORCE_PATH_STYLE=false
 SEED_BUCKET_ACCESS_KEY=<readonly_access_key>
 SEED_BUCKET_SECRET_KEY=<readonly_secret_key>
+
+# ==============================================================================
+# SEED BLOB BUCKET (snapshot publish/fetch)
+# ==============================================================================
+# Used by `make seed-index-publish` and `make dev-from-snapshot` to upload/download
+# pg_dump snapshots of pre-indexed RAG data. Can be the same bucket as S3_BUCKET_NAME.
+SEED_BLOB_BUCKET=meepleai-uploads


### PR DESCRIPTION
## Summary

Two-phase workflow to skip runtime PDF re-indexing on a fresh dev env:
- **bake** (`make seed-index`): run the full RAG pipeline on all manifest PDFs, then `pg_dump` + sidecar `.meta.json`
- **consume** (`make dev-from-snapshot`): restore the dump with compat-gate verification (EF migration head, embedding model/dim) and skip runtime seeding via `SKIP_CATALOG_SEED=true`

Design: `docs/superpowers/specs/2026-04-10-seed-pdf-pre-indexed-design.md`
Plan: `docs/superpowers/plans/2026-04-10-seed-pdf-pre-indexed.md`

## What changed

- **C# (T1-T2)**
  - `CatalogSeedLayer.SeedAsync` reads `SKIP_CATALOG_SEED` from config and returns early
  - `CatalogSeeder.LoadManifest` accepts optional `manifestName` override (profile-field validation skipped when set)
  - `CatalogSeedLayer` reads `SEED_CATALOG_MANIFEST_OVERRIDE` env var
  - New embedded manifest `ci.yml` (3 PDFs: Love Letter, Patchwork, Jaipur) for e2e tests
  - 6 new unit tests (all passing)

- **Bash scripts (T3-T9)** in `infra/scripts/`
  - `seed-index-preflight.sh` — sanity checks
  - `seed-index-wait.sh` — poll `processing_jobs` with 3h timeout + 15% fail threshold
  - `seed-index-dump.sh` — `pg_dump -Fc` + sidecar `.meta.json` + sha256
  - `seed-index-publish.sh` — S3-compatible upload with atomic META-last marker + retention of last 3
  - `snapshot-fetch.sh` — cache-first resolution (`SNAPSHOT_FILE` > local > bucket)
  - `snapshot-verify.sh` — compat gate with distinct exit codes (0/1/2/3/4)
  - `snapshot-restore.sh` — `ef update` then `pg_restore --data-only` + smoke tests (orphans)
  - `wait-for-healthy.sh` — helper
  - Bats fixtures + test for the compat gate (4 exit codes)

- **Makefile (T10)**: `seed-index`, `seed-index-publish`, `dev-from-snapshot`, `dev-from-snapshot-force`

- **Docs (T11)**: `docs/development/snapshot-seed-workflow.md`, CLAUDE.md quick ref + troubleshooting, `.gitignore` for `data/snapshots/*.dump`

## Key design decisions

- **No HTTP call** to trigger the seed — sfrutta `SeedOrchestrator.RunAsync` auto-invoked allo startup dell'API (`Program.cs:535`)
- **`pg_dump --exclude-table-data='__EFMigrationsHistory'`** intenzionale: lo schema lo ricrea `dotnet ef database update` al restore, i dati vengono poi caricati con `--data-only`. Previene drift snapshot↔tree.
- **Snapshot è DB-only**: i PDF blob files vivono già nel seed blob bucket, non duplicati nello snapshot
- **Fallback esplicito a `make dev`** in tutti i path di errore

## Out of scope

- GitHub Actions automation del bake (rimane manuale)
- Snapshot per `staging.yml` / `prod.yml`
- Promozione di `make dev-from-snapshot` a default (valutazione separata)

## Test Plan

- [x] Unit tests C# (CatalogSeedLayerSkipFlagTests, CatalogSeederManifestOverrideTests + regression CatalogSeederTests) — 15/15 PASS
- [x] Smoke test manuale di `snapshot-verify.sh` contro le 4 fixture (0/2/3/4) — tutti PASS
- [x] Smoke test `seed-index-preflight.sh` — PASS
- [ ] E2E bake+consume con `SEED_CATALOG_MANIFEST_OVERRIDE=ci` (richiede stack dev attivo — rinviato a verifica post-merge)
- [ ] Bats test suite richiede `bats-core` (non installato localmente, gira in CI se attivato)

🤖 Generated with [Claude Code](https://claude.com/claude-code)