### PR TITLE
feat(session-flow): backend v2.1 implementation

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/CompleteGameNightCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/CompleteGameNightCommand.cs
@@ -1,0 +1,33 @@
+using FluentValidation;
+using MediatR;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands;
+
+/// <summary>
+/// Session Flow v2.1 — Plan 1bis T3.
+/// Completes an in-progress ad-hoc game night: cascade-finalizes all
+/// non-finalized sessions, marks GameNightSession links as Completed,
+/// transitions the GameNightEvent to Completed, and emits diary events.
+/// </summary>
+public sealed record CompleteGameNightCommand(
+    Guid GameNightEventId,
+    Guid UserId
+) : IRequest<CompleteGameNightResult>;
+
+/// <summary>
+/// Result of a <see cref="CompleteGameNightCommand"/> execution.
+/// </summary>
+public sealed record CompleteGameNightResult(
+    Guid GameNightEventId,
+    int SessionCount,
+    int FinalizedSessionCount,
+    int DurationSeconds);
+
+public sealed class CompleteGameNightCommandValidator : AbstractValidator<CompleteGameNightCommand>
+{
+    public CompleteGameNightCommandValidator()
+    {
+        RuleFor(x => x.GameNightEventId).NotEmpty();
+        RuleFor(x => x.UserId).NotEmpty();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/CompleteGameNightCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/CompleteGameNightCommandHandler.cs
@@ -1,0 +1,149 @@
+using System.Text.Json;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SessionTracking;
+using Api.Middleware.Exceptions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands;
+
+/// <summary>
+/// Session Flow v2.1 — Plan 1bis T3.
+/// Handles <see cref="CompleteGameNightCommand"/>: cascade-finalizes all
+/// non-finalized sessions in the game night, marks link rows as Completed,
+/// transitions the <c>GameNightEvent</c> entity to <c>Completed</c>, and
+/// emits diary events (<c>session_finalized</c> per session +
+/// <c>gamenight_completed</c> once).
+///
+/// Works at the persistence layer (EF entities) because the
+/// <c>GameNightEvent</c> aggregate is <c>internal sealed</c> in the
+/// GameManagement domain and the handler needs cross-BC coordination
+/// with SessionTracking entities.
+/// </summary>
+internal sealed class CompleteGameNightCommandHandler
+    : IRequestHandler<CompleteGameNightCommand, CompleteGameNightResult>
+{
+    private readonly MeepleAiDbContext _db;
+
+    public CompleteGameNightCommandHandler(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<CompleteGameNightResult> Handle(
+        CompleteGameNightCommand request,
+        CancellationToken cancellationToken)
+    {
+        // ── 1. Load GameNightEvent entity ──────────────────────────────
+        var nightEntity = await _db.GameNightEvents
+            .FirstOrDefaultAsync(e => e.Id == request.GameNightEventId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException(
+                $"GameNightEvent {request.GameNightEventId} not found.");
+
+        if (nightEntity.OrganizerId != request.UserId)
+            throw new ForbiddenException("Only the night organizer can complete it.");
+
+        if (!string.Equals(nightEntity.Status, "InProgress", StringComparison.Ordinal))
+            throw new ConflictException(
+                $"GameNightEvent is in status '{nightEntity.Status}', cannot complete ad-hoc.");
+
+        // ── 2. Discover sessions linked to this night ──────────────────
+        var links = await _db.GameNightSessions
+            .Where(gns => gns.GameNightEventId == nightEntity.Id)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var linkSessionIds = links.Select(l => l.SessionId).ToList();
+        var sessionCount = linkSessionIds.Count;
+
+        // ── 3. Cascade-finalize non-finalized sessions ─────────────────
+#pragma warning disable MA0006 // EF LINQ expression — string.Equals does not translate to SQL
+        var nonFinalizedSessions = await _db.SessionTrackingSessions
+            .Where(s => linkSessionIds.Contains(s.Id) && s.Status != "Finalized")
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+#pragma warning restore MA0006
+
+        var now = DateTime.UtcNow;
+        var finalizedCount = 0;
+
+        foreach (var session in nonFinalizedSessions)
+        {
+            session.Status = "Finalized";
+            session.FinalizedAt = now;
+            session.UpdatedAt = now;
+            finalizedCount++;
+
+            var durationSec = (int)(now - session.SessionDate).TotalSeconds;
+            if (durationSec < 0) durationSec = 0;
+
+            _db.SessionEvents.Add(new SessionEventEntity
+            {
+                Id = Guid.NewGuid(),
+                SessionId = session.Id,
+                GameNightId = nightEntity.Id,
+                EventType = "session_finalized",
+                Timestamp = now,
+                Payload = JsonSerializer.Serialize(new
+                {
+                    winnerId = (Guid?)null,
+                    reason = "cascade_from_gamenight_complete",
+                    durationSeconds = durationSec
+                }),
+                CreatedBy = request.UserId,
+                Source = "system",
+                IsDeleted = false
+            });
+        }
+
+        // ── 4. Mark GameNightSession links as Completed ────────────────
+#pragma warning disable MA0006 // In-memory LINQ on materialized list — ordinal comparison is fine
+        foreach (var link in links.Where(l => l.Status != "Completed"))
+#pragma warning restore MA0006
+        {
+            link.Status = "Completed";
+            link.CompletedAt = DateTimeOffset.UtcNow;
+        }
+
+        // ── 5. Transition GameNight to Completed ───────────────────────
+        nightEntity.Status = "Completed";
+        nightEntity.UpdatedAt = DateTimeOffset.UtcNow;
+
+        // ── 6. Emit gamenight_completed diary event ────────────────────
+        var durationSeconds = (int)(now - nightEntity.CreatedAt).TotalSeconds;
+        if (durationSeconds < 0) durationSeconds = 0;
+
+        var anchorSessionId = linkSessionIds.FirstOrDefault();
+        if (anchorSessionId != Guid.Empty)
+        {
+            _db.SessionEvents.Add(new SessionEventEntity
+            {
+                Id = Guid.NewGuid(),
+                SessionId = anchorSessionId,
+                GameNightId = nightEntity.Id,
+                EventType = "gamenight_completed",
+                Timestamp = now,
+                Payload = JsonSerializer.Serialize(new
+                {
+                    gameNightEventId = nightEntity.Id,
+                    sessionCount,
+                    finalizedSessionCount = finalizedCount,
+                    durationSeconds
+                }),
+                CreatedBy = request.UserId,
+                Source = "system",
+                IsDeleted = false
+            });
+        }
+
+        // ── 7. Atomic save ─────────────────────────────────────────────
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return new CompleteGameNightResult(
+            GameNightEventId: nightEntity.Id,
+            SessionCount: sessionCount,
+            FinalizedSessionCount: finalizedCount,
+            DurationSeconds: durationSeconds);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/CompleteGameNightCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/CompleteGameNightCommandHandler.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities.SessionTracking;
 using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
@@ -24,10 +25,12 @@ internal sealed class CompleteGameNightCommandHandler
     : IRequestHandler<CompleteGameNightCommand, CompleteGameNightResult>
 {
     private readonly MeepleAiDbContext _db;
+    private readonly IUnitOfWork _unitOfWork;
 
-    public CompleteGameNightCommandHandler(MeepleAiDbContext db)
+    public CompleteGameNightCommandHandler(MeepleAiDbContext db, IUnitOfWork unitOfWork)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
     }
 
     public async Task<CompleteGameNightResult> Handle(
@@ -138,7 +141,7 @@ internal sealed class CompleteGameNightCommandHandler
         }
 
         // ── 7. Atomic save ─────────────────────────────────────────────
-        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         return new CompleteGameNightResult(
             GameNightEventId: nightEntity.Id,

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
@@ -111,6 +111,23 @@ internal sealed class GameNightEvent : AggregateRoot<Guid>
     }
 
     /// <summary>
+    /// Completes an in-progress ad-hoc night. Transition: InProgress → Completed.
+    /// Unlike <see cref="Complete"/> (Published → Completed), this handles the ad-hoc
+    /// lifecycle where the night skipped scheduling and went straight to InProgress.
+    /// </summary>
+    public void CompleteAdHoc()
+    {
+        ThrowIfCorrupted();
+
+        if (Status != GameNightStatus.InProgress)
+            throw new InvalidOperationException(
+                $"Cannot complete a {Status} game night via ad-hoc completion. Only InProgress nights can be completed via this method.");
+
+        Status = GameNightStatus.Completed;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
     /// Adds a game to an in-progress ad-hoc night. Idempotent for duplicates.
     /// </summary>
     public void AttachAdditionalGame(Guid gameId)

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
@@ -87,6 +87,51 @@ internal sealed class GameNightEvent : AggregateRoot<Guid>
     }
 
     /// <summary>
+    /// Creates an ad-hoc game night that skips the scheduling/RSVP flow.
+    /// Used when a user spontaneously starts playing and later adds more games during the same evening.
+    /// Status is set directly to InProgress.
+    /// </summary>
+    public static GameNightEvent CreateAdHoc(Guid organizerId, string title, Guid firstGameId)
+    {
+        if (firstGameId == Guid.Empty)
+            throw new ArgumentException("FirstGameId cannot be empty.", nameof(firstGameId));
+
+        var night = new GameNightEvent(
+            id: Guid.NewGuid(),
+            organizerId: organizerId,
+            title: title,
+            scheduledAt: DateTimeOffset.UtcNow,
+            description: null,
+            location: null,
+            maxPlayers: null,
+            gameIds: new List<Guid> { firstGameId });
+
+        night.Status = GameNightStatus.InProgress;
+        return night;
+    }
+
+    /// <summary>
+    /// Adds a game to an in-progress ad-hoc night. Idempotent for duplicates.
+    /// </summary>
+    public void AttachAdditionalGame(Guid gameId)
+    {
+        ThrowIfCorrupted();
+
+        if (Status != GameNightStatus.InProgress)
+            throw new InvalidOperationException(
+                $"Cannot attach game to a {Status} game night. Only InProgress nights accept dynamic games.");
+
+        if (gameId == Guid.Empty)
+            throw new ArgumentException("GameId cannot be empty.", nameof(gameId));
+
+        if (!GameIds.Contains(gameId))
+        {
+            GameIds.Add(gameId);
+            UpdatedAt = DateTimeOffset.UtcNow;
+        }
+    }
+
+    /// <summary>
     /// Updates the game night event details. Cannot update cancelled or completed events.
     /// </summary>
     public void Update(string title, string? description, DateTimeOffset scheduledAt, string? location, int? maxPlayers, List<Guid>? gameIds)

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Enums/GameNightStatus.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Enums/GameNightStatus.cs
@@ -11,5 +11,6 @@ public enum GameNightStatus
     Published = 1,
     Cancelled = 2,
     Completed = 3,
+    InProgress = 4,
     Corrupted = 999
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/KbReadinessDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/KbReadinessDto.cs
@@ -1,0 +1,35 @@
+namespace Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+
+/// <summary>
+/// Knowledge Base readiness status for a game (Session Flow v2.1 — T3).
+/// A KB is "ready" when at least one PDF is in the <c>Ready</c> terminal state AND a
+/// <c>VectorDocumentEntity</c> exists with <c>IndexingStatus == "completed"</c>.
+/// </summary>
+/// <param name="IsReady">
+/// <c>true</c> when an agent can be powered by this KB (at least one Ready PDF has a
+/// completed vector index). Note that <see cref="State"/> may still carry warnings
+/// (e.g. "PartiallyReady") even when this flag is <c>true</c>.
+/// </param>
+/// <param name="State">
+/// High-level aggregate state. Possible values:
+/// <list type="bullet">
+///   <item><c>None</c> — game not found, or no PDFs uploaded.</item>
+///   <item><c>Ready</c> — all ready PDFs indexed successfully.</item>
+///   <item><c>PartiallyReady</c> — at least one ready PDF indexed, but some PDFs failed.</item>
+///   <item><c>VectorPending</c> — PDFs reached Ready but vector index not yet completed.</item>
+///   <item><c>Failed</c> — every PDF is in the Failed state.</item>
+///   <item>One of the intermediate <c>PdfDocumentEntity.ProcessingState</c> values (e.g. <c>Extracting</c>, <c>Embedding</c>, <c>Indexing</c>).</item>
+/// </list>
+/// </param>
+/// <param name="ReadyPdfCount">Number of PDFs whose <c>ProcessingState == "Ready"</c>.</param>
+/// <param name="FailedPdfCount">Number of PDFs whose <c>ProcessingState == "Failed"</c>.</param>
+/// <param name="Warnings">
+/// Non-fatal advisories for the caller (e.g. "N PDF failed to index — answers may be incomplete").
+/// Empty when there is nothing to warn about.
+/// </param>
+public record KbReadinessDto(
+    bool IsReady,
+    string State,
+    int ReadyPdfCount,
+    int FailedPdfCount,
+    IReadOnlyList<string> Warnings);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbReadinessQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbReadinessQuery.cs
@@ -1,0 +1,15 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Session Flow v2.1 — T3: Pre-session KB readiness probe.
+/// Checks whether the Knowledge Base for a given game is ready to power an agent.
+/// </summary>
+/// <param name="GameId">
+/// The user-facing game identifier. This may be either a legacy <c>GameEntity.Id</c>
+/// or a <c>SharedGameEntity.Id</c> — the handler resolves both via
+/// <c>GameEntity.SharedGameId</c> / <c>GameEntity.Id</c>.
+/// </param>
+internal sealed record GetKbReadinessQuery(Guid GameId) : IQuery<KbReadinessDto>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbReadinessQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbReadinessQueryHandler.cs
@@ -1,0 +1,137 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Handles <see cref="GetKbReadinessQuery"/>.
+///
+/// Resolution flow:
+/// <list type="number">
+///   <item>Resolve the legacy <c>GameEntity.Id</c> — accept either <c>GameEntity.Id</c> or <c>SharedGameEntity.Id</c>.
+///         (The seeder uses the same Guid for both; in production they may differ.)</item>
+///   <item>Load all <c>PdfDocumentEntity</c> rows for that legacy game.</item>
+///   <item>Count PDFs whose string <c>ProcessingState</c> is <c>"Ready"</c> / <c>"Failed"</c>.</item>
+///   <item>Probe <c>VectorDocumentEntity</c> for any completed index on one of the Ready PDFs
+///         (1 row per PDF, UNIQUE on <c>PdfDocumentId</c>).</item>
+///   <item>Classify the aggregate state and emit warnings for partially-failed sets.</item>
+/// </list>
+/// </summary>
+internal sealed class GetKbReadinessQueryHandler : IQueryHandler<GetKbReadinessQuery, KbReadinessDto>
+{
+    // PdfDocumentEntity.ProcessingState is stored as string (see Infrastructure/Entities/DocumentProcessing/PdfDocumentEntity.cs).
+    // The 7 values in ascending pipeline order (+ terminal Failed) are hard-coded here to avoid
+    // cross-BC coupling to an enum that does not exist.
+    private const string StateReady = "Ready";
+    private const string StateFailed = "Failed";
+
+    private static readonly string[] OrderedIntermediateStates =
+    {
+        "Pending",
+        "Uploading",
+        "Extracting",
+        "Chunking",
+        "Embedding",
+        "Indexing",
+    };
+
+    private readonly MeepleAiDbContext _db;
+
+    public GetKbReadinessQueryHandler(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<KbReadinessDto> Handle(GetKbReadinessQuery request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Step 1: resolve the legacy GameEntity.Id.
+        // Accept both shapes: caller may pass the SharedGame id or the legacy game id directly.
+        var legacyGameId = await _db.Games
+            .AsNoTracking()
+            .Where(g => g.Id == request.GameId || g.SharedGameId == request.GameId)
+            .Select(g => (Guid?)g.Id)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (legacyGameId is null)
+        {
+            return new KbReadinessDto(false, "None", 0, 0, Array.Empty<string>());
+        }
+
+        // Step 2: load all PDFs for that legacy game.
+        var pdfs = await _db.PdfDocuments
+            .AsNoTracking()
+            .Where(p => p.GameId == legacyGameId.Value)
+            .Select(p => new { p.Id, p.ProcessingState })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (pdfs.Count == 0)
+        {
+            return new KbReadinessDto(false, "None", 0, 0, Array.Empty<string>());
+        }
+
+        // Step 3: bucket PDFs by state.
+        var readyPdfIds = pdfs
+            .Where(p => string.Equals(p.ProcessingState, StateReady, StringComparison.Ordinal))
+            .Select(p => p.Id)
+            .ToList();
+
+        var failedCount = pdfs.Count(p =>
+            string.Equals(p.ProcessingState, StateFailed, StringComparison.Ordinal));
+
+        // Step 4: check for a completed vector index on any Ready PDF.
+        // VectorDocumentEntity is UNIQUE on PdfDocumentId (1 row per PDF), so .Any() is correct.
+        var hasReadyVector = readyPdfIds.Count > 0
+            && await _db.VectorDocuments
+                .AsNoTracking()
+                .AnyAsync(
+                    v => readyPdfIds.Contains(v.PdfDocumentId) && v.IndexingStatus == "completed",
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+        // Step 5: classify state + warnings.
+        var warnings = new List<string>();
+        string state;
+
+        if (hasReadyVector && failedCount > 0)
+        {
+            state = "PartiallyReady";
+            warnings.Add(
+                $"{failedCount} PDF document(s) failed to index — agent answers may be incomplete.");
+        }
+        else if (hasReadyVector)
+        {
+            state = "Ready";
+        }
+        else if (failedCount == pdfs.Count)
+        {
+            state = "Failed";
+        }
+        else if (readyPdfIds.Count > 0)
+        {
+            // All Ready PDFs present but no completed vector index yet.
+            state = "VectorPending";
+        }
+        else
+        {
+            // No Ready PDFs, not all Failed — pick the most advanced intermediate state found.
+            var distinctStates = pdfs
+                .Select(p => p.ProcessingState ?? string.Empty)
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+
+            var mostAdvanced = OrderedIntermediateStates
+                .Reverse()
+                .FirstOrDefault(s => distinctStates.Contains(s, StringComparer.Ordinal));
+
+            state = mostAdvanced ?? distinctStates.FirstOrDefault() ?? "None";
+        }
+
+        return new KbReadinessDto(hasReadyVector, state, readyPdfIds.Count, failedCount, warnings);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/AdvanceTurnCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/AdvanceTurnCommand.cs
@@ -1,0 +1,37 @@
+using Api.SharedKernel.Application.Interfaces;
+using FluentValidation;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Session Flow v2.1 — Plan 1bis T1.
+/// Advances the turn index of a session to the next participant in the
+/// stored turn order (cyclic). Emits a <c>turn_advanced</c> diary event.
+/// The session owner is the only caller allowed to mutate turn state.
+/// </summary>
+public sealed record AdvanceTurnCommand(
+    Guid SessionId,
+    Guid UserId
+) : ICommand<AdvanceTurnCommandResult>;
+
+/// <summary>
+/// Result of an <see cref="AdvanceTurnCommand"/> execution: the prior and new
+/// turn indices plus the resolved participant IDs. Exposed via the HTTP
+/// endpoint so clients can refresh their "current player" chip without a
+/// round-trip to the session read model.
+/// </summary>
+public sealed record AdvanceTurnCommandResult(
+    int FromIndex,
+    int ToIndex,
+    Guid FromParticipantId,
+    Guid ToParticipantId
+);
+
+public sealed class AdvanceTurnCommandValidator : AbstractValidator<AdvanceTurnCommand>
+{
+    public AdvanceTurnCommandValidator()
+    {
+        RuleFor(x => x.SessionId).NotEmpty();
+        RuleFor(x => x.UserId).NotEmpty();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/AdvanceTurnCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/AdvanceTurnCommandHandler.cs
@@ -1,0 +1,92 @@
+using System.Text.Json;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SessionTracking;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Session Flow v2.1 — Plan 1bis T1.
+/// Loads the session via <see cref="ISessionRepository"/>, invokes the
+/// domain <c>AdvanceTurn</c> transition, persists the updated
+/// <c>CurrentTurnIndex</c>, and appends a <c>turn_advanced</c> diary event
+/// carrying <c>{fromIndex, toIndex, fromParticipantId, toParticipantId}</c>
+/// so the cross-session game-night timeline remains replayable.
+/// </summary>
+internal sealed class AdvanceTurnCommandHandler : ICommandHandler<AdvanceTurnCommand, AdvanceTurnCommandResult>
+{
+    private readonly ISessionRepository _sessionRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly MeepleAiDbContext _db;
+
+    public AdvanceTurnCommandHandler(
+        ISessionRepository sessionRepository,
+        IUnitOfWork unitOfWork,
+        MeepleAiDbContext db)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<AdvanceTurnCommandResult> Handle(AdvanceTurnCommand request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var session = await _sessionRepository
+            .GetByIdAsync(request.SessionId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {request.SessionId} not found.");
+
+        if (session.UserId != request.UserId)
+        {
+            throw new ForbiddenException("Only the session owner can advance the turn.");
+        }
+
+        // Domain validates: Status == Active and TurnOrder set. Throws ConflictException.
+        var domainResult = session.AdvanceTurn();
+
+        await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
+
+        // Resolve GameNightId via the link row (if any) so the diary entry is
+        // correlated with the cross-game timeline.
+        var gameNightId = await _db.GameNightSessions
+            .Where(gns => gns.SessionId == session.Id)
+            .Select(gns => (Guid?)gns.GameNightEventId)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var payload = JsonSerializer.Serialize(new
+        {
+            fromIndex = domainResult.FromIndex,
+            toIndex = domainResult.ToIndex,
+            fromParticipantId = domainResult.FromParticipantId,
+            toParticipantId = domainResult.ToParticipantId
+        });
+
+        _db.SessionEvents.Add(new SessionEventEntity
+        {
+            Id = Guid.NewGuid(),
+            SessionId = session.Id,
+            GameNightId = gameNightId,
+            EventType = "turn_advanced",
+            Timestamp = DateTime.UtcNow,
+            Payload = payload,
+            CreatedBy = request.UserId,
+            Source = "user",
+            IsDeleted = false
+        });
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return new AdvanceTurnCommandResult(
+            domainResult.FromIndex,
+            domainResult.ToIndex,
+            domainResult.FromParticipantId,
+            domainResult.ToParticipantId);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommand.cs
@@ -4,17 +4,41 @@ using Api.SharedKernel.Application.Interfaces;
 
 namespace Api.BoundedContexts.SessionTracking.Application.Commands;
 
+/// <summary>
+/// Command to create a new session.
+/// Session Flow v2.1 — T4: Extended with optional GameNightEventId and GuestNames.
+/// When <paramref name="GameNightEventId"/> is null, the handler creates an ad-hoc
+/// <c>GameNightEvent</c> implicitly (one-click "Start playing" flow). When provided,
+/// the session is attached to the existing InProgress night (at most one active
+/// session per night is allowed — enforced by the handler).
+/// </summary>
 public record CreateSessionCommand(
     Guid UserId,
     Guid GameId,
     string SessionType,
     DateTime? SessionDate,
     string? Location,
-    List<ParticipantDto> Participants
+    List<ParticipantDto> Participants,
+    Guid? GameNightEventId = null,
+    IReadOnlyList<string>? GuestNames = null
 ) : ICommand<CreateSessionResult>;
 
+/// <summary>
+/// Result returned by <see cref="CreateSessionCommand"/>.
+/// </summary>
+/// <param name="SessionId">The new session id.</param>
+/// <param name="SessionCode">Human-shareable session code.</param>
+/// <param name="Participants">All participants in the session (owner + guests).</param>
+/// <param name="GameNightEventId">The game night event id that now owns this session.</param>
+/// <param name="GameNightWasCreated">True when an ad-hoc night was created by this command.</param>
+/// <param name="AgentDefinitionId">Resolved AgentDefinition for the game (null when not configured).</param>
+/// <param name="ToolkitId">Resolved default/user toolkit id for the game (null when not configured).</param>
 public record CreateSessionResult(
     Guid SessionId,
     string SessionCode,
-    List<ParticipantDto> Participants
+    List<ParticipantDto> Participants,
+    Guid GameNightEventId,
+    bool GameNightWasCreated,
+    Guid? AgentDefinitionId,
+    Guid? ToolkitId
 );

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandHandler.cs
@@ -1,4 +1,7 @@
 using Api.SharedKernel.Domain.ValueObjects;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
 using Api.BoundedContexts.SessionTracking.Application.Commands;
 using Api.BoundedContexts.SessionTracking.Application.DTOs;
 using Api.BoundedContexts.SessionTracking.Domain.Entities;
@@ -7,10 +10,12 @@ using Api.BoundedContexts.SessionTracking.Domain.Repositories;
 using Api.BoundedContexts.SessionTracking.Domain.Services;
 using Api.BoundedContexts.SessionTracking.Domain.ValueObjects;
 using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Domain.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
+using MediatR;
 using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.SessionTracking.Application.Commands;
@@ -21,6 +26,7 @@ public class CreateSessionCommandHandler : ICommandHandler<CreateSessionCommand,
     private readonly IUnitOfWork _unitOfWork;
     private readonly ISessionQuotaService _quotaService;
     private readonly MeepleAiDbContext _db;
+    private readonly IMediator _mediator;
     private readonly ILogger<CreateSessionCommandHandler> _logger;
 
     public CreateSessionCommandHandler(
@@ -28,12 +34,14 @@ public class CreateSessionCommandHandler : ICommandHandler<CreateSessionCommand,
         IUnitOfWork unitOfWork,
         ISessionQuotaService quotaService,
         MeepleAiDbContext db,
+        IMediator mediator,
         ILogger<CreateSessionCommandHandler> logger)
     {
         _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _quotaService = quotaService ?? throw new ArgumentNullException(nameof(quotaService));
         _db = db ?? throw new ArgumentNullException(nameof(db));
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -43,6 +51,26 @@ public class CreateSessionCommandHandler : ICommandHandler<CreateSessionCommand,
 
         // Check session quota before allowing creation
         await CheckSessionQuotaAsync(request.UserId, cancellationToken).ConfigureAwait(false);
+
+        // Session Flow v2.1 — T4: KB readiness pre-check.
+        var kbReadiness = await _mediator
+            .Send(new GetKbReadinessQuery(request.GameId), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!kbReadiness.IsReady)
+        {
+            _logger.LogWarning(
+                "KB not ready for game {GameId} (state={State}, ready={Ready}, failed={Failed})",
+                request.GameId, kbReadiness.State, kbReadiness.ReadyPdfCount, kbReadiness.FailedPdfCount);
+
+            throw new UnprocessableEntityException(
+                errorCode: "kb_not_ready",
+                message: $"KB for game {request.GameId} is not ready (state: {kbReadiness.State}).");
+        }
+
+        // Session Flow v2.1 — T4: Resolve or create the GameNight envelope.
+        var (nightEntity, gameNightWasCreated) = await ResolveGameNightAsync(
+            request, cancellationToken).ConfigureAwait(false);
 
         var sessionType = Enum.Parse<SessionType>(request.SessionType);
 
@@ -59,40 +87,288 @@ public class CreateSessionCommandHandler : ICommandHandler<CreateSessionCommand,
                 request.Location,
                 request.SessionDate);
 
+            // Populate participants on the domain aggregate BEFORE persisting so that
+            // SessionRepository.AddAsync maps the full graph in a single insert — this keeps
+            // the entire Handle method atomic in one SaveChangesAsync call (Session Flow v2.1 — T4).
+
+            // Add additional explicit participants (owner already added by factory).
+            foreach (var participantDto in request.Participants.Where(p => !p.IsOwner))
+            {
+                var participantInfo = ParticipantInfo.Create(
+                    participantDto.DisplayName,
+                    participantDto.IsOwner,
+                    session.Participants.Count + 1);
+
+                session.AddParticipant(participantInfo, participantDto.UserId);
+            }
+
+            // Session Flow v2.1 — T4: Append guest names as additional participants.
+            if (request.GuestNames is { Count: > 0 })
+            {
+                foreach (var guestName in request.GuestNames)
+                {
+                    var guestInfo = ParticipantInfo.Create(
+                        displayName: guestName,
+                        isOwner: false,
+                        joinOrder: session.Participants.Count + 1);
+
+                    session.AddParticipant(guestInfo, userId: null);
+                }
+            }
+
             try
             {
                 await _sessionRepository.AddAsync(session, cancellationToken).ConfigureAwait(false);
+
+                // Session Flow v2.1 — T4: Link session to the GameNight envelope.
+                var gameTitle = await _db.SharedGames
+                    .AsNoTracking()
+                    .Where(g => g.Id == request.GameId)
+                    .Select(g => g.Title)
+                    .FirstOrDefaultAsync(cancellationToken)
+                    .ConfigureAwait(false) ?? "Unknown Game";
+
+                var playOrder = Math.Max(1, nightEntity.Sessions.Count + 1);
+                var linkEntity = new GameNightSessionEntity
+                {
+                    Id = Guid.NewGuid(),
+                    GameNightEventId = nightEntity.Id,
+                    SessionId = session.Id,
+                    GameId = request.GameId,
+                    GameTitle = gameTitle,
+                    PlayOrder = playOrder,
+                    Status = GameNightSessionStatus.InProgress.ToString(),
+                    StartedAt = DateTimeOffset.UtcNow
+                };
+                nightEntity.Sessions.Add(linkEntity);
+
+                // Session Flow v2.1 — T4: Emit diary events.
+                var sessionCreatedPayload = System.Text.Json.JsonSerializer.Serialize(new
+                {
+                    gameId = request.GameId,
+                    gameNightEventId = nightEntity.Id,
+                    gameNightWasCreated
+                });
+                _db.SessionEvents.Add(new Api.Infrastructure.Entities.SessionTracking.SessionEventEntity
+                {
+                    Id = Guid.NewGuid(),
+                    SessionId = session.Id,
+                    GameNightId = nightEntity.Id,
+                    EventType = "session_created",
+                    Timestamp = DateTime.UtcNow,
+                    Payload = sessionCreatedPayload,
+                    CreatedBy = request.UserId,
+                    Source = "system",
+                    IsDeleted = false
+                });
+
+                if (gameNightWasCreated)
+                {
+                    var nightCreatedPayload = System.Text.Json.JsonSerializer.Serialize(new
+                    {
+                        gameNightEventId = nightEntity.Id,
+                        title = nightEntity.Title,
+                        isAdHoc = true
+                    });
+                    _db.SessionEvents.Add(new Api.Infrastructure.Entities.SessionTracking.SessionEventEntity
+                    {
+                        Id = Guid.NewGuid(),
+                        SessionId = session.Id,
+                        GameNightId = nightEntity.Id,
+                        EventType = "gamenight_created",
+                        Timestamp = DateTime.UtcNow,
+                        Payload = nightCreatedPayload,
+                        CreatedBy = request.UserId,
+                        Source = "system",
+                        IsDeleted = false
+                    });
+                }
+                else
+                {
+                    var gameAddedPayload = System.Text.Json.JsonSerializer.Serialize(new
+                    {
+                        addedGameId = request.GameId
+                    });
+                    _db.SessionEvents.Add(new Api.Infrastructure.Entities.SessionTracking.SessionEventEntity
+                    {
+                        Id = Guid.NewGuid(),
+                        SessionId = session.Id,
+                        GameNightId = nightEntity.Id,
+                        EventType = "gamenight_game_added",
+                        Timestamp = DateTime.UtcNow,
+                        Payload = gameAddedPayload,
+                        CreatedBy = request.UserId,
+                        Source = "system",
+                        IsDeleted = false
+                    });
+                }
+
+                // Single atomic save for session + participants + guest additions + night link + diary events.
                 await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
-                // Add additional participants (owner already added by factory)
-                foreach (var participantDto in request.Participants.Where(p => !p.IsOwner))
-                {
-                    var participantInfo = ParticipantInfo.Create(
-                        participantDto.DisplayName,
-                        participantDto.IsOwner,
-                        session.Participants.Count + 1);
-
-                    session.AddParticipant(participantInfo, participantDto.UserId);
-                }
-
-                if (request.Participants.Count > 1)
-                {
-                    await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
-                    await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-                }
+                // Session Flow v2.1 — T4: Best-effort resolution of AgentDefinition + Toolkit
+                // for the response (frontend uses these to compose the Hand view).
+                var agentDefinitionId = await TryResolveAgentDefinitionIdAsync(request.GameId, cancellationToken).ConfigureAwait(false);
+                var toolkitId = await TryResolveToolkitIdAsync(request.GameId, request.UserId, cancellationToken).ConfigureAwait(false);
 
                 return new CreateSessionResult(
-                    session.Id,
-                    session.SessionCode,
-                    session.Participants.Select(MapParticipant).ToList());
+                    SessionId: session.Id,
+                    SessionCode: session.SessionCode,
+                    Participants: session.Participants.Select(MapParticipant).ToList(),
+                    GameNightEventId: nightEntity.Id,
+                    GameNightWasCreated: gameNightWasCreated,
+                    AgentDefinitionId: agentDefinitionId,
+                    ToolkitId: toolkitId);
             }
             catch (InvalidOperationException) when (attempt < maxRetries - 1)
             {
-                // Session code collision, retry with new code
+                // Session code collision detected by SessionRepository.AddAsync before
+                // any entity is added to the ChangeTracker. Retry with a fresh session code;
+                // the ad-hoc night entity (if any) stays tracked for the next iteration.
             }
         }
 
         throw new ConflictException("Unable to generate unique session code after retries");
+    }
+
+    /// <summary>
+    /// Session Flow v2.1 — T4.
+    /// Resolves an existing InProgress GameNightEvent (attaching the requested game to it)
+    /// or creates a new ad-hoc night envelope. Enforces the invariant that at most one Active
+    /// session may live inside a GameNightEvent at any given time.
+    /// </summary>
+    private async Task<(GameNightEventEntity NightEntity, bool GameNightWasCreated)> ResolveGameNightAsync(
+        CreateSessionCommand request, CancellationToken cancellationToken)
+    {
+        if (request.GameNightEventId.HasValue)
+        {
+            var existing = await _db.GameNightEvents
+                .Include(e => e.Sessions)
+                .FirstOrDefaultAsync(e => e.Id == request.GameNightEventId.Value, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (existing == null)
+            {
+                throw new NotFoundException(
+                    $"GameNightEvent {request.GameNightEventId.Value} not found.");
+            }
+
+            if (!string.Equals(existing.Status, nameof(GameNightStatus.InProgress), StringComparison.Ordinal))
+            {
+                throw new ConflictException(
+                    $"Cannot attach session to GameNight {existing.Id}: status is {existing.Status}, expected InProgress.");
+            }
+
+            // Invariant: at most one Active session per GameNight.
+            // Resolve by joining the link rows (game_night_sessions) with the actual
+            // SessionTracking sessions and checking their Status column.
+            var activeSessionCount = await _db.GameNightSessions
+                .Where(gns => gns.GameNightEventId == existing.Id)
+                .Join(
+                    _db.SessionTrackingSessions,
+                    gns => gns.SessionId,
+                    s => s.Id,
+                    (gns, s) => s.Status)
+                .CountAsync(status => status == nameof(SessionStatus.Active), cancellationToken)
+                .ConfigureAwait(false);
+
+            if (activeSessionCount > 0)
+            {
+                throw new ConflictException(
+                    $"GameNight {existing.Id} already has an active session. " +
+                    "Pause or finalize it before starting another game.");
+            }
+
+            // Attach new game to the existing in-progress night (domain rule).
+            // We mutate the GameIdsJson list directly to avoid loading the full aggregate.
+            var gameIds = string.IsNullOrEmpty(existing.GameIdsJson)
+                ? new List<Guid>()
+                : System.Text.Json.JsonSerializer.Deserialize<List<Guid>>(existing.GameIdsJson) ?? new List<Guid>();
+
+            if (!gameIds.Contains(request.GameId))
+            {
+                gameIds.Add(request.GameId);
+                existing.GameIdsJson = System.Text.Json.JsonSerializer.Serialize(gameIds);
+                existing.UpdatedAt = DateTimeOffset.UtcNow;
+            }
+
+            return (existing, false);
+        }
+
+        // Ad-hoc night envelope — build directly at the persistence layer to stay in-scope
+        // for a single SaveChanges call.
+        var title = $"Serata del {DateTime.UtcNow:yyyy-MM-dd HH:mm}";
+        var now = DateTimeOffset.UtcNow;
+        var newEntity = new GameNightEventEntity
+        {
+            Id = Guid.NewGuid(),
+            OrganizerId = request.UserId,
+            Title = title,
+            ScheduledAt = now,
+            GameIdsJson = System.Text.Json.JsonSerializer.Serialize(new List<Guid> { request.GameId }),
+            Status = nameof(GameNightStatus.InProgress),
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        await _db.GameNightEvents.AddAsync(newEntity, cancellationToken).ConfigureAwait(false);
+        return (newEntity, true);
+    }
+
+    /// <summary>
+    /// Session Flow v2.1 — T4: best-effort resolution of AgentDefinitionId for the response.
+    /// Returns null when the game is not configured with an agent.
+    /// </summary>
+    private async Task<Guid?> TryResolveAgentDefinitionIdAsync(Guid gameId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _db.SharedGames
+                .AsNoTracking()
+                .Where(g => g.Id == gameId)
+                .Select(g => g.AgentDefinitionId)
+                .FirstOrDefaultAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Best-effort AgentDefinitionId resolution failed for game {GameId}", gameId);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Session Flow v2.1 — T4: best-effort resolution of ToolkitId for the response.
+    /// Prefers the user's own toolkit over the default (if any).
+    /// </summary>
+    private async Task<Guid?> TryResolveToolkitIdAsync(Guid gameId, Guid userId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var userToolkit = await _db.Toolkits
+                .AsNoTracking()
+                .Where(t => t.GameId == gameId && t.OwnerUserId == userId)
+                .Select(t => (Guid?)t.Id)
+                .FirstOrDefaultAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            if (userToolkit.HasValue)
+            {
+                return userToolkit;
+            }
+
+            return await _db.Toolkits
+                .AsNoTracking()
+                .Where(t => t.GameId == gameId && t.IsDefault)
+                .Select(t => (Guid?)t.Id)
+                .FirstOrDefaultAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Best-effort ToolkitId resolution failed for game {GameId}", gameId);
+            return null;
+        }
     }
 
     private static ParticipantDto MapParticipant(Participant p) => new()

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandHandler.cs
@@ -140,6 +140,13 @@ public class CreateSessionCommandHandler : ICommandHandler<CreateSessionCommand,
                     Status = GameNightSessionStatus.InProgress.ToString(),
                     StartedAt = DateTimeOffset.UtcNow
                 };
+
+                // Session Flow v2.1 — T5 fix: when nightEntity is loaded (Unchanged) and the
+                // child link has a non-default Guid PK, EF identity-resolution would otherwise
+                // mark the new linkEntity as Modified instead of Added (because GameNightSessionEntity.Id
+                // is configured ValueGeneratedOnAdd). Adding via the DbSet forces Added state and
+                // also keeps the in-memory navigation collection consistent for subsequent code paths.
+                await _db.GameNightSessions.AddAsync(linkEntity, cancellationToken).ConfigureAwait(false);
                 nightEntity.Sessions.Add(linkEntity);
 
                 // Session Flow v2.1 — T4: Emit diary events.

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandHandler.cs
@@ -128,6 +128,13 @@ public class CreateSessionCommandHandler : ICommandHandler<CreateSessionCommand,
                     .FirstOrDefaultAsync(cancellationToken)
                     .ConfigureAwait(false) ?? "Unknown Game";
 
+                // I2 fix: enforce max 5 sessions per GameNight (domain invariant bypass guard)
+                var existingSessionCount = await _db.GameNightSessions
+                    .CountAsync(gns => gns.GameNightEventId == nightEntity.Id, cancellationToken)
+                    .ConfigureAwait(false);
+                if (existingSessionCount >= 5)
+                    throw new ConflictException("A game night cannot have more than 5 sessions.");
+
                 var playOrder = Math.Max(1, nightEntity.Sessions.Count + 1);
                 var linkEntity = new GameNightSessionEntity
                 {

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandValidator.cs
@@ -31,5 +31,11 @@ public class CreateSessionCommandValidator : AbstractValidator<CreateSessionComm
                 .NotEmpty()
                 .MaximumLength(50);
         });
+
+        // Session Flow v2.1 — T4: optional guest names for ad-hoc joins.
+        RuleFor(x => x.GuestNames)
+            .Must(names => names == null || names.All(n => !string.IsNullOrWhiteSpace(n) && n.Length <= 50))
+            .WithMessage("Each guest name must be non-empty and max 50 characters.")
+            .When(x => x.GuestNames != null);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/FinalizeSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/FinalizeSessionCommandHandler.cs
@@ -1,11 +1,15 @@
+using System.Text.Json;
 using MediatR;
 using Api.BoundedContexts.SessionTracking.Application.Commands;
 using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Events;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
 using Api.BoundedContexts.SessionTracking.Domain.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SessionTracking;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.SessionTracking.Application.Commands;
 
@@ -15,17 +19,20 @@ public class FinalizeSessionCommandHandler : IRequestHandler<FinalizeSessionComm
     private readonly IScoreEntryRepository _scoreEntryRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly ISessionSyncService _syncService;
+    private readonly MeepleAiDbContext _db;
 
     public FinalizeSessionCommandHandler(
         ISessionRepository sessionRepository,
         IScoreEntryRepository scoreEntryRepository,
         IUnitOfWork unitOfWork,
-        ISessionSyncService syncService)
+        ISessionSyncService syncService,
+        MeepleAiDbContext db)
     {
         _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
         _scoreEntryRepository = scoreEntryRepository ?? throw new ArgumentNullException(nameof(scoreEntryRepository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _syncService = syncService ?? throw new ArgumentNullException(nameof(syncService));
+        _db = db ?? throw new ArgumentNullException(nameof(db));
     }
 
     public async Task<FinalizeSessionResult> Handle(FinalizeSessionCommand request, CancellationToken cancellationToken)
@@ -65,14 +72,64 @@ public class FinalizeSessionCommandHandler : IRequestHandler<FinalizeSessionComm
         // Update participant final ranks (need to access through persistence for now)
         // For now, this is a known limitation that will be addressed in refactoring
 
-        // Save session
+        // Save session (adds tracked changes; SaveChangesAsync below flushes)
         await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
-        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
-        // Get winner (rank 1)
-        var winnerId = request.FinalRanks
+        // Get winner (rank 1) from the FinalRanks dictionary.
+        var winnerIdRaw = request.FinalRanks
             .FirstOrDefault(kvp => kvp.Value == 1)
             .Key;
+        Guid? winnerIdNullable = winnerIdRaw != Guid.Empty ? winnerIdRaw : null;
+
+        // P1B-T2: emit session_finalized diary event in the same transaction.
+        // Compute scoreboard snapshot (totals per participant).
+        var scoreboardSnapshot = await _db.SessionTrackingScoreEntries
+            .AsNoTracking()
+            .Where(e => e.SessionId == session.Id)
+            .GroupBy(e => e.ParticipantId)
+            .Select(g => new
+            {
+                participantId = g.Key,
+                total = g.Sum(e => e.ScoreValue)
+            })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Resolve GameNightId via the link row (if any) so the diary entry is
+        // correlated with the cross-game timeline.
+        var gameNightId = await _db.GameNightSessions
+            .Where(gns => gns.SessionId == session.Id)
+            .Select(gns => (Guid?)gns.GameNightEventId)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var finalizedAt = session.FinalizedAt ?? DateTime.UtcNow;
+        var durationSeconds = (int)(finalizedAt - session.SessionDate).TotalSeconds;
+        if (durationSeconds < 0) durationSeconds = 0;
+
+        var finalizedPayload = JsonSerializer.Serialize(new
+        {
+            winnerId = winnerIdNullable,
+            durationSeconds,
+            scoreboard = scoreboardSnapshot
+        });
+
+        _db.SessionEvents.Add(new SessionEventEntity
+        {
+            Id = Guid.NewGuid(),
+            SessionId = session.Id,
+            GameNightId = gameNightId,
+            EventType = "session_finalized",
+            Timestamp = DateTime.UtcNow,
+            Payload = finalizedPayload,
+            CreatedBy = session.UserId,
+            Source = "system",
+            IsDeleted = false
+        });
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        var winnerId = winnerIdRaw;
 
         // UserLibrary integration placeholder
         if (session.GameId != Guid.Empty)

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/PauseSessionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/PauseSessionCommand.cs
@@ -1,0 +1,20 @@
+using Api.SharedKernel.Application.Interfaces;
+using FluentValidation;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Session Flow v2.1 — T5.
+/// Pauses an Active session. Only the session owner can pause.
+/// Emits a <c>session_paused</c> diary event scoped to the parent GameNight (if any).
+/// </summary>
+public sealed record PauseSessionCommand(Guid SessionId, Guid UserId) : ICommand;
+
+public sealed class PauseSessionCommandValidator : AbstractValidator<PauseSessionCommand>
+{
+    public PauseSessionCommandValidator()
+    {
+        RuleFor(x => x.SessionId).NotEmpty();
+        RuleFor(x => x.UserId).NotEmpty();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/PauseSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/PauseSessionCommandHandler.cs
@@ -1,0 +1,88 @@
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SessionTracking;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Session Flow v2.1 — T5.
+/// Loads the session via <see cref="ISessionRepository"/>, applies the
+/// domain <see cref="Session.Pause"/> transition, persists, and writes a
+/// <c>session_paused</c> diary entry. The diary event is correlated with the
+/// parent GameNight (if the session belongs to one) so it can be replayed in
+/// the cross-game timeline.
+/// </summary>
+internal sealed class PauseSessionCommandHandler : ICommandHandler<PauseSessionCommand>
+{
+    private readonly ISessionRepository _sessionRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly MeepleAiDbContext _db;
+
+    public PauseSessionCommandHandler(
+        ISessionRepository sessionRepository,
+        IUnitOfWork unitOfWork,
+        MeepleAiDbContext db)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task Handle(PauseSessionCommand request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var session = await _sessionRepository
+            .GetByIdAsync(request.SessionId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {request.SessionId} not found.");
+
+        if (session.UserId != request.UserId)
+        {
+            throw new ForbiddenException("Only the session owner can pause this session.");
+        }
+
+        // Domain rule: throws ConflictException when not Active.
+        session.Pause();
+
+        await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
+
+        // Free the partial unique index slot on game_night_sessions: the link row that
+        // currently advertises this session as InProgress must transition to Pending so
+        // another session in the same night can become Active. (See T1 migration.)
+        var linkRow = await _db.GameNightSessions
+            .FirstOrDefaultAsync(gns => gns.SessionId == session.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        Guid? gameNightId = null;
+        if (linkRow is not null)
+        {
+            gameNightId = linkRow.GameNightEventId;
+            if (string.Equals(linkRow.Status, GameNightSessionStatus.InProgress.ToString(), StringComparison.Ordinal))
+            {
+                linkRow.Status = GameNightSessionStatus.Pending.ToString();
+            }
+        }
+
+        _db.SessionEvents.Add(new SessionEventEntity
+        {
+            Id = Guid.NewGuid(),
+            SessionId = session.Id,
+            GameNightId = gameNightId,
+            EventType = "session_paused",
+            Timestamp = DateTime.UtcNow,
+            Payload = "{}",
+            CreatedBy = request.UserId,
+            Source = "system",
+            IsDeleted = false
+        });
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ResumeSessionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ResumeSessionCommand.cs
@@ -1,0 +1,22 @@
+using Api.SharedKernel.Application.Interfaces;
+using FluentValidation;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Session Flow v2.1 — T5.
+/// Resumes a Paused session. Only the session owner can resume.
+/// Auto-pauses every other Active session inside the same GameNight envelope to
+/// preserve the "1 Active session per GameNight" invariant at handler level
+/// (complementing the partial unique index introduced in T1).
+/// </summary>
+public sealed record ResumeSessionCommand(Guid SessionId, Guid UserId) : ICommand;
+
+public sealed class ResumeSessionCommandValidator : AbstractValidator<ResumeSessionCommand>
+{
+    public ResumeSessionCommandValidator()
+    {
+        RuleFor(x => x.SessionId).NotEmpty();
+        RuleFor(x => x.UserId).NotEmpty();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ResumeSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ResumeSessionCommandHandler.cs
@@ -58,84 +58,98 @@ internal sealed class ResumeSessionCommandHandler : ICommandHandler<ResumeSessio
 
         Guid? gameNightId = ownLinkRow?.GameNightEventId;
 
-        // Invariant guard: free every other "InProgress" link slot in the same GameNight
-        // BEFORE flipping our own row to InProgress, so we never violate the partial unique
-        // index from T1. We persist the auto-pauses in their own SaveChanges call so the
-        // unique constraint is satisfied at every transaction boundary — EF batches multiple
-        // UPDATEs in arbitrary order otherwise, which can momentarily leave two
-        // <c>InProgress</c> link rows visible to the index check.
-        if (gameNightId.HasValue)
+        // Wrap ALL mutations in an explicit transaction so that auto-pausing siblings
+        // and resuming the target session commit (or roll back) atomically.
+        // The two SaveChangesAsync calls are still needed to satisfy the partial unique
+        // index (the first flush clears sibling InProgress rows before the second flush
+        // sets this session's row to InProgress), but both live inside a single
+        // transaction — if the second save fails, the first is rolled back too.
+        await _unitOfWork.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        try
         {
-            var otherInProgressLinks = await _db.GameNightSessions
-                .Where(gns =>
-                    gns.GameNightEventId == gameNightId.Value &&
-                    gns.SessionId != session.Id &&
-                    gns.Status == nameof(GameNightSessionStatus.InProgress))
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
-
-            if (otherInProgressLinks.Count > 0)
+            // Invariant guard: free every other "InProgress" link slot in the same GameNight
+            // BEFORE flipping our own row to InProgress, so the partial unique index from T1
+            // never sees two InProgress rows at commit time.
+            if (gameNightId.HasValue)
             {
-                foreach (var otherLink in otherInProgressLinks)
+                var otherInProgressLinks = await _db.GameNightSessions
+                    .Where(gns =>
+                        gns.GameNightEventId == gameNightId.Value &&
+                        gns.SessionId != session.Id &&
+                        gns.Status == nameof(GameNightSessionStatus.InProgress))
+                    .ToListAsync(cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (otherInProgressLinks.Count > 0)
                 {
-                    // Free the link slot first — the unique index is the hard invariant.
-                    otherLink.Status = GameNightSessionStatus.Pending.ToString();
-
-                    var other = await _sessionRepository
-                        .GetByIdAsync(otherLink.SessionId, cancellationToken)
-                        .ConfigureAwait(false);
-
-                    if (other is null || other.Status != SessionStatus.Active)
+                    foreach (var otherLink in otherInProgressLinks)
                     {
-                        continue;
+                        // Free the link slot first — the unique index is the hard invariant.
+                        otherLink.Status = GameNightSessionStatus.Pending.ToString();
+
+                        var other = await _sessionRepository
+                            .GetByIdAsync(otherLink.SessionId, cancellationToken)
+                            .ConfigureAwait(false);
+
+                        if (other is null || other.Status != SessionStatus.Active)
+                        {
+                            continue;
+                        }
+
+                        other.Pause();
+                        await _sessionRepository.UpdateAsync(other, cancellationToken).ConfigureAwait(false);
+
+                        _db.SessionEvents.Add(new SessionEventEntity
+                        {
+                            Id = Guid.NewGuid(),
+                            SessionId = other.Id,
+                            GameNightId = gameNightId,
+                            EventType = "session_paused",
+                            Timestamp = DateTime.UtcNow,
+                            Payload = "{\"reason\":\"auto_pause_on_resume\"}",
+                            CreatedBy = request.UserId,
+                            Source = "system",
+                            IsDeleted = false
+                        });
                     }
 
-                    other.Pause();
-                    await _sessionRepository.UpdateAsync(other, cancellationToken).ConfigureAwait(false);
-
-                    _db.SessionEvents.Add(new SessionEventEntity
-                    {
-                        Id = Guid.NewGuid(),
-                        SessionId = other.Id,
-                        GameNightId = gameNightId,
-                        EventType = "session_paused",
-                        Timestamp = DateTime.UtcNow,
-                        Payload = "{\"reason\":\"auto_pause_on_resume\"}",
-                        CreatedBy = request.UserId,
-                        Source = "system",
-                        IsDeleted = false
-                    });
+                    // Flush auto-pauses so the partial unique index sees zero InProgress
+                    // rows before the next flush adds ours back.
+                    await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
                 }
-
-                // Persist the auto-pauses BEFORE flipping our own row to InProgress so the
-                // partial unique index never sees two InProgress rows for the same night.
-                await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
             }
+
+            // Domain rule: throws ConflictException when not Paused.
+            session.Resume();
+            await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
+
+            // Reclaim the link slot for the resumed session.
+            if (ownLinkRow is not null)
+            {
+                ownLinkRow.Status = GameNightSessionStatus.InProgress.ToString();
+            }
+
+            _db.SessionEvents.Add(new SessionEventEntity
+            {
+                Id = Guid.NewGuid(),
+                SessionId = session.Id,
+                GameNightId = gameNightId,
+                EventType = "session_resumed",
+                Timestamp = DateTime.UtcNow,
+                Payload = "{}",
+                CreatedBy = request.UserId,
+                Source = "system",
+                IsDeleted = false
+            });
+
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await _unitOfWork.CommitTransactionAsync(cancellationToken).ConfigureAwait(false);
         }
-
-        // Domain rule: throws ConflictException when not Paused.
-        session.Resume();
-        await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
-
-        // Reclaim the link slot for the resumed session.
-        if (ownLinkRow is not null)
+        catch
         {
-            ownLinkRow.Status = GameNightSessionStatus.InProgress.ToString();
+            await _unitOfWork.RollbackTransactionAsync(cancellationToken).ConfigureAwait(false);
+            throw;
         }
-
-        _db.SessionEvents.Add(new SessionEventEntity
-        {
-            Id = Guid.NewGuid(),
-            SessionId = session.Id,
-            GameNightId = gameNightId,
-            EventType = "session_resumed",
-            Timestamp = DateTime.UtcNow,
-            Payload = "{}",
-            CreatedBy = request.UserId,
-            Source = "system",
-            IsDeleted = false
-        });
-
-        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ResumeSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ResumeSessionCommandHandler.cs
@@ -1,0 +1,141 @@
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SessionTracking;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Session Flow v2.1 — T5.
+/// Loads the session via <see cref="ISessionRepository"/>, applies the
+/// domain <see cref="Session.Resume"/> transition, and writes a
+/// <c>session_resumed</c> diary entry. Before activating the requested session,
+/// it auto-pauses every other in-progress sibling session inside the same
+/// GameNight envelope (each gets its own <c>session_paused</c> diary entry with
+/// <c>reason=auto_pause_on_resume</c>) and frees the link slot held in
+/// <c>game_night_sessions</c> so the partial unique index from T1 keeps the
+/// "1 Active per GameNight" invariant intact.
+/// </summary>
+internal sealed class ResumeSessionCommandHandler : ICommandHandler<ResumeSessionCommand>
+{
+    private readonly ISessionRepository _sessionRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly MeepleAiDbContext _db;
+
+    public ResumeSessionCommandHandler(
+        ISessionRepository sessionRepository,
+        IUnitOfWork unitOfWork,
+        MeepleAiDbContext db)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task Handle(ResumeSessionCommand request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var session = await _sessionRepository
+            .GetByIdAsync(request.SessionId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {request.SessionId} not found.");
+
+        if (session.UserId != request.UserId)
+        {
+            throw new ForbiddenException("Only the session owner can resume this session.");
+        }
+
+        // Load this session's link row (may be null for unattached/solo sessions).
+        var ownLinkRow = await _db.GameNightSessions
+            .FirstOrDefaultAsync(gns => gns.SessionId == session.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        Guid? gameNightId = ownLinkRow?.GameNightEventId;
+
+        // Invariant guard: free every other "InProgress" link slot in the same GameNight
+        // BEFORE flipping our own row to InProgress, so we never violate the partial unique
+        // index from T1. We persist the auto-pauses in their own SaveChanges call so the
+        // unique constraint is satisfied at every transaction boundary — EF batches multiple
+        // UPDATEs in arbitrary order otherwise, which can momentarily leave two
+        // <c>InProgress</c> link rows visible to the index check.
+        if (gameNightId.HasValue)
+        {
+            var otherInProgressLinks = await _db.GameNightSessions
+                .Where(gns =>
+                    gns.GameNightEventId == gameNightId.Value &&
+                    gns.SessionId != session.Id &&
+                    gns.Status == nameof(GameNightSessionStatus.InProgress))
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            if (otherInProgressLinks.Count > 0)
+            {
+                foreach (var otherLink in otherInProgressLinks)
+                {
+                    // Free the link slot first — the unique index is the hard invariant.
+                    otherLink.Status = GameNightSessionStatus.Pending.ToString();
+
+                    var other = await _sessionRepository
+                        .GetByIdAsync(otherLink.SessionId, cancellationToken)
+                        .ConfigureAwait(false);
+
+                    if (other is null || other.Status != SessionStatus.Active)
+                    {
+                        continue;
+                    }
+
+                    other.Pause();
+                    await _sessionRepository.UpdateAsync(other, cancellationToken).ConfigureAwait(false);
+
+                    _db.SessionEvents.Add(new SessionEventEntity
+                    {
+                        Id = Guid.NewGuid(),
+                        SessionId = other.Id,
+                        GameNightId = gameNightId,
+                        EventType = "session_paused",
+                        Timestamp = DateTime.UtcNow,
+                        Payload = "{\"reason\":\"auto_pause_on_resume\"}",
+                        CreatedBy = request.UserId,
+                        Source = "system",
+                        IsDeleted = false
+                    });
+                }
+
+                // Persist the auto-pauses BEFORE flipping our own row to InProgress so the
+                // partial unique index never sees two InProgress rows for the same night.
+                await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        // Domain rule: throws ConflictException when not Paused.
+        session.Resume();
+        await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
+
+        // Reclaim the link slot for the resumed session.
+        if (ownLinkRow is not null)
+        {
+            ownLinkRow.Status = GameNightSessionStatus.InProgress.ToString();
+        }
+
+        _db.SessionEvents.Add(new SessionEventEntity
+        {
+            Id = Guid.NewGuid(),
+            SessionId = session.Id,
+            GameNightId = gameNightId,
+            EventType = "session_resumed",
+            Timestamp = DateTime.UtcNow,
+            Payload = "{}",
+            CreatedBy = request.UserId,
+            Source = "system",
+            IsDeleted = false
+        });
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/RollSessionDiceCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/RollSessionDiceCommandHandler.cs
@@ -1,17 +1,23 @@
+using System.Text.Json;
 using MediatR;
 using Api.BoundedContexts.SessionTracking.Application.Commands;
 using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Events;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
 using Api.BoundedContexts.SessionTracking.Domain.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SessionTracking;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.SessionTracking.Application.Commands;
 
 /// <summary>
 /// Handles a role-validated dice roll player action.
-/// Delegates to the existing DiceRoll domain logic and broadcasts a DiceRolledEvent.
+/// Delegates to the existing DiceRoll domain logic, appends a
+/// <c>dice_rolled</c> diary entry (Session Flow v2.1 — T7), and broadcasts a
+/// <see cref="DiceRolledEvent"/>.
 /// Issue #4765 - Player Action Endpoints
 /// </summary>
 public class RollSessionDiceCommandHandler : IRequestHandler<RollSessionDiceCommand, RollSessionDiceResult>
@@ -20,17 +26,20 @@ public class RollSessionDiceCommandHandler : IRequestHandler<RollSessionDiceComm
     private readonly IDiceRollRepository _diceRollRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly ISessionSyncService _syncService;
+    private readonly MeepleAiDbContext _db;
 
     public RollSessionDiceCommandHandler(
         ISessionRepository sessionRepository,
         IDiceRollRepository diceRollRepository,
         IUnitOfWork unitOfWork,
-        ISessionSyncService syncService)
+        ISessionSyncService syncService,
+        MeepleAiDbContext db)
     {
         _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
         _diceRollRepository = diceRollRepository ?? throw new ArgumentNullException(nameof(diceRollRepository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _syncService = syncService ?? throw new ArgumentNullException(nameof(syncService));
+        _db = db ?? throw new ArgumentNullException(nameof(db));
     }
 
     public async Task<RollSessionDiceResult> Handle(RollSessionDiceCommand request, CancellationToken cancellationToken)
@@ -51,6 +60,40 @@ public class RollSessionDiceCommandHandler : IRequestHandler<RollSessionDiceComm
             request.Label);
 
         await _diceRollRepository.AddAsync(diceRoll, cancellationToken).ConfigureAwait(false);
+
+        // Session Flow v2.1 — T7: append a dice_rolled diary entry alongside the
+        // DiceRoll persistence so the cross-game GameNight timeline reflects the
+        // action. Resolve GameNightId via the link row (if any).
+        var gameNightId = await _db.GameNightSessions
+            .Where(gns => gns.SessionId == request.SessionId)
+            .Select(gns => (Guid?)gns.GameNightEventId)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var diaryPayload = JsonSerializer.Serialize(new
+        {
+            diceRollId = diceRoll.Id,
+            formula = diceRoll.Formula,
+            rolls = diceRoll.GetRolls(),
+            modifier = diceRoll.Modifier,
+            total = diceRoll.Total,
+            label = diceRoll.Label,
+            participantId = request.ParticipantId
+        });
+
+        _db.SessionEvents.Add(new SessionEventEntity
+        {
+            Id = Guid.NewGuid(),
+            SessionId = request.SessionId,
+            GameNightId = gameNightId,
+            EventType = "dice_rolled",
+            Timestamp = DateTime.UtcNow,
+            Payload = diaryPayload,
+            CreatedBy = request.RequesterId,
+            Source = "user",
+            IsDeleted = false
+        });
+
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         var evt = new DiceRolledEvent

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/SetTurnOrderCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/SetTurnOrderCommand.cs
@@ -1,0 +1,39 @@
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.SharedKernel.Application.Interfaces;
+using FluentValidation;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Session Flow v2.1 — T6.
+/// Sets the turn order for a session using either an explicit manual order
+/// or a cryptographically-seeded random shuffle. Emits a <c>turn_order_set</c>
+/// diary event carrying the seed (for audit/replay of Random rolls).
+/// </summary>
+public sealed record SetTurnOrderCommand(
+    Guid SessionId,
+    Guid UserId,
+    TurnOrderMethod Method,
+    IReadOnlyList<Guid>? ManualOrder
+) : ICommand<SetTurnOrderResult>;
+
+public sealed record SetTurnOrderResult(
+    string Method,
+    int? Seed,
+    IReadOnlyList<Guid> Order
+);
+
+public sealed class SetTurnOrderCommandValidator : AbstractValidator<SetTurnOrderCommand>
+{
+    public SetTurnOrderCommandValidator()
+    {
+        RuleFor(x => x.SessionId).NotEmpty();
+        RuleFor(x => x.UserId).NotEmpty();
+
+        RuleFor(x => x.ManualOrder)
+            .NotNull()
+            .NotEmpty()
+            .When(x => x.Method == TurnOrderMethod.Manual)
+            .WithMessage("ManualOrder is required when Method=Manual.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/SetTurnOrderCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/SetTurnOrderCommandHandler.cs
@@ -1,0 +1,122 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SessionTracking;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Session Flow v2.1 — T6.
+/// Loads the session via <see cref="ISessionRepository"/>, applies the domain
+/// <see cref="Session.SetTurnOrder"/> transition (manual or random), persists,
+/// and writes a <c>turn_order_set</c> diary entry with the seed so that Random
+/// rolls are fully reproducible from the audit log.
+/// </summary>
+internal sealed class SetTurnOrderCommandHandler : ICommandHandler<SetTurnOrderCommand, SetTurnOrderResult>
+{
+    private readonly ISessionRepository _sessionRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly MeepleAiDbContext _db;
+
+    public SetTurnOrderCommandHandler(
+        ISessionRepository sessionRepository,
+        IUnitOfWork unitOfWork,
+        MeepleAiDbContext db)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<SetTurnOrderResult> Handle(SetTurnOrderCommand request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var session = await _sessionRepository
+            .GetByIdAsync(request.SessionId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {request.SessionId} not found.");
+
+        if (session.UserId != request.UserId)
+        {
+            throw new ForbiddenException("Only the session owner can set turn order.");
+        }
+
+        IReadOnlyList<Guid> order;
+        int? seed;
+
+        if (request.Method == TurnOrderMethod.Manual)
+        {
+            if (request.ManualOrder is null || request.ManualOrder.Count == 0)
+            {
+                throw new ArgumentException("ManualOrder is required for Manual method.", nameof(request));
+            }
+
+            order = request.ManualOrder;
+            seed = null;
+        }
+        else
+        {
+            // Random: use cryptographically-stable seed generation + deterministic Fisher-Yates
+            // shuffle so the same seed replays the same order during audit. Sort by JoinOrder
+            // first so the shuffle input is deterministic regardless of EF load order.
+            seed = RandomNumberGenerator.GetInt32(int.MinValue, int.MaxValue);
+            var shuffled = session.Participants
+                .OrderBy(p => p.JoinOrder)
+                .Select(p => p.Id)
+                .ToList();
+            var rng = new Random(seed.Value);
+            for (var i = shuffled.Count - 1; i > 0; i--)
+            {
+                var j = rng.Next(i + 1);
+                (shuffled[i], shuffled[j]) = (shuffled[j], shuffled[i]);
+            }
+            order = shuffled;
+        }
+
+        // Domain validates: non-finalized, non-empty order, IDs are participants,
+        // Random requires seed. Throws ConflictException / ArgumentException.
+        session.SetTurnOrder(request.Method, order, seed);
+
+        await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
+
+        // Resolve GameNightId via the link row (if any) so the diary entry is
+        // correlated with the cross-game timeline.
+        var gameNightId = await _db.GameNightSessions
+            .Where(gns => gns.SessionId == session.Id)
+            .Select(gns => (Guid?)gns.GameNightEventId)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var payload = JsonSerializer.Serialize(new
+        {
+            method = request.Method.ToString(),
+            seed,
+            participantIds = order
+        });
+
+        _db.SessionEvents.Add(new SessionEventEntity
+        {
+            Id = Guid.NewGuid(),
+            SessionId = session.Id,
+            GameNightId = gameNightId,
+            EventType = "turn_order_set",
+            Timestamp = DateTime.UtcNow,
+            Payload = payload,
+            CreatedBy = request.UserId,
+            Source = "user",
+            IsDeleted = false
+        });
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return new SetTurnOrderResult(request.Method.ToString(), seed, order);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpsertScoreWithDiaryCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpsertScoreWithDiaryCommand.cs
@@ -1,0 +1,72 @@
+using Api.SharedKernel.Application.Interfaces;
+using FluentValidation;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Session Flow v2.1 — T8.
+/// Upsert command that records a participant score in <c>session_tracking_score_entries</c>
+/// and emits a <c>score_updated</c> diary event capturing the previous and new value.
+/// <para>
+/// Storia append-only: <c>ScoreEntryEntity.ScoreValue</c> is a last-write-wins projection,
+/// but every mutation emits a <c>SessionEvent(score_updated)</c> so the full audit trail
+/// lives on the immutable diary. Undo is achieved by sending a new
+/// <see cref="UpsertScoreWithDiaryCommand"/> with the previous value.
+/// </para>
+/// <para>
+/// Named distinctly from the pre-existing <c>UpdateScoreCommand</c> (Issue #4765 / GST-003)
+/// which always inserts a new score row and does not emit a diary event. Endpoint
+/// wiring (T9) decides which command the Session Flow v2.1 route should dispatch.
+/// </para>
+/// </summary>
+public sealed record UpsertScoreWithDiaryCommand(
+    Guid SessionId,
+    Guid ParticipantId,
+    Guid RequesterId,
+    decimal NewValue,
+    int? RoundNumber,
+    string? Category,
+    string? Reason
+) : ICommand<UpsertScoreWithDiaryResult>;
+
+/// <summary>
+/// Result of an upsert-with-diary score mutation.
+/// </summary>
+/// <param name="ScoreEntryId">The upserted score entry's primary key.</param>
+/// <param name="OldValue">Previous value (0 when the entry did not yet exist).</param>
+/// <param name="NewValue">The new value after the mutation.</param>
+public sealed record UpsertScoreWithDiaryResult(
+    Guid ScoreEntryId,
+    decimal OldValue,
+    decimal NewValue
+);
+
+public sealed class UpsertScoreWithDiaryCommandValidator : AbstractValidator<UpsertScoreWithDiaryCommand>
+{
+    public UpsertScoreWithDiaryCommandValidator()
+    {
+        RuleFor(x => x.SessionId).NotEmpty();
+        RuleFor(x => x.ParticipantId).NotEmpty();
+        RuleFor(x => x.RequesterId).NotEmpty();
+
+        // Both RoundNumber and Category are optional per spec §4.6 — the handler
+        // defaults to the "total" category when neither is provided so the underlying
+        // ScoreEntry factory invariant (at least one of the two) is preserved.
+        RuleFor(x => x.RoundNumber)
+            .GreaterThan(0)
+            .When(x => x.RoundNumber.HasValue)
+            .WithMessage("RoundNumber must be positive when provided.");
+
+        RuleFor(x => x.Category)
+            .MaximumLength(50)
+            .WithMessage("Category must not exceed 50 characters.");
+
+        RuleFor(x => x.Reason)
+            .MaximumLength(200)
+            .WithMessage("Reason must not exceed 200 characters.");
+
+        RuleFor(x => x.NewValue)
+            .InclusiveBetween(-99999m, 99999m)
+            .WithMessage("NewValue must be between -99999 and 99999.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpsertScoreWithDiaryCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpsertScoreWithDiaryCommandHandler.cs
@@ -1,0 +1,155 @@
+using System.Text.Json;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SessionTracking;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Session Flow v2.1 — T8 handler.
+/// Loads (or creates) a <see cref="ScoreEntryEntity"/> row scoped to
+/// <c>(SessionId, ParticipantId, RoundNumber?, Category?)</c>, mutates
+/// <c>ScoreValue</c> last-write-wins, and emits a <c>score_updated</c> diary
+/// event carrying <c>{oldValue, newValue, reason, …}</c> so the full change
+/// history is preserved on the append-only <c>SessionEvents</c> stream.
+/// </summary>
+internal sealed class UpsertScoreWithDiaryCommandHandler
+    : ICommandHandler<UpsertScoreWithDiaryCommand, UpsertScoreWithDiaryResult>
+{
+    private const string DefaultCategory = "total";
+
+    private readonly ISessionRepository _sessionRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly MeepleAiDbContext _db;
+
+    public UpsertScoreWithDiaryCommandHandler(
+        ISessionRepository sessionRepository,
+        IUnitOfWork unitOfWork,
+        MeepleAiDbContext db)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<UpsertScoreWithDiaryResult> Handle(
+        UpsertScoreWithDiaryCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var session = await _sessionRepository
+            .GetByIdAsync(request.SessionId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {request.SessionId} not found.");
+
+        if (session.UserId != request.RequesterId)
+        {
+            throw new ForbiddenException("Only the session owner can update scores.");
+        }
+
+        var participantExists = session.Participants.Any(p => p.Id == request.ParticipantId);
+        if (!participantExists)
+        {
+            throw new NotFoundException(
+                $"Participant {request.ParticipantId} not found in session {request.SessionId}.");
+        }
+
+        // Default to the "total" category when neither RoundNumber nor Category is
+        // provided. The domain ScoreEntry.Create factory (used below for argument
+        // validation parity) requires at least one of the two; this mirrors §4.6.
+        var effectiveRound = request.RoundNumber;
+        var effectiveCategory = string.IsNullOrWhiteSpace(request.Category)
+            ? (effectiveRound.HasValue ? null : DefaultCategory)
+            : request.Category!.Trim();
+
+        // Locate the existing projection row (last-write-wins upsert scope).
+        var existing = await _db.SessionTrackingScoreEntries
+            .FirstOrDefaultAsync(
+                e => e.SessionId == request.SessionId
+                  && e.ParticipantId == request.ParticipantId
+                  && e.RoundNumber == effectiveRound
+                  && e.Category == effectiveCategory,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        decimal oldValue;
+        Guid entryId;
+
+        if (existing is null)
+        {
+            // Validate arguments by funnelling them through the domain factory; then
+            // persist via the entity (the domain type is Ignore()d in the DbContext).
+            var domain = ScoreEntry.Create(
+                sessionId: request.SessionId,
+                participantId: request.ParticipantId,
+                scoreValue: request.NewValue,
+                createdBy: request.RequesterId,
+                roundNumber: effectiveRound,
+                category: effectiveCategory);
+
+            var entity = new ScoreEntryEntity
+            {
+                Id = domain.Id,
+                SessionId = domain.SessionId,
+                ParticipantId = domain.ParticipantId,
+                RoundNumber = domain.RoundNumber,
+                Category = domain.Category,
+                ScoreValue = domain.ScoreValue,
+                Timestamp = domain.Timestamp,
+                CreatedBy = domain.CreatedBy
+            };
+
+            _db.SessionTrackingScoreEntries.Add(entity);
+            oldValue = 0m;
+            entryId = entity.Id;
+        }
+        else
+        {
+            oldValue = existing.ScoreValue;
+            existing.ScoreValue = request.NewValue;
+            existing.Timestamp = DateTime.UtcNow;
+            entryId = existing.Id;
+        }
+
+        // Correlate the diary event with the parent GameNight envelope (if any).
+        var gameNightId = await _db.GameNightSessions
+            .Where(gns => gns.SessionId == request.SessionId)
+            .Select(gns => (Guid?)gns.GameNightEventId)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var payload = JsonSerializer.Serialize(new
+        {
+            scoreEntryId = entryId,
+            participantId = request.ParticipantId,
+            oldValue,
+            newValue = request.NewValue,
+            roundNumber = effectiveRound,
+            category = effectiveCategory,
+            reason = request.Reason
+        });
+
+        _db.SessionEvents.Add(new SessionEventEntity
+        {
+            Id = Guid.NewGuid(),
+            SessionId = request.SessionId,
+            GameNightId = gameNightId,
+            EventType = "score_updated",
+            Timestamp = DateTime.UtcNow,
+            Payload = payload,
+            CreatedBy = request.RequesterId,
+            Source = "user",
+            IsDeleted = false
+        });
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return new UpsertScoreWithDiaryResult(entryId, oldValue, request.NewValue);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/DTOs/SessionEventDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/DTOs/SessionEventDto.cs
@@ -1,0 +1,25 @@
+namespace Api.BoundedContexts.SessionTracking.Application.DTOs;
+
+/// <summary>
+/// Session Flow v2.1 — T9.
+/// DTO returned by the diary read queries (<c>GetSessionDiaryQuery</c> /
+/// <c>GetGameNightDiaryQuery</c>). Mirrors <c>SessionEventEntity</c> while
+/// exposing both the <c>SessionId</c> and the optional <c>GameNightId</c>
+/// envelope so the frontend can reconstruct cross-session diaries for a night.
+/// </summary>
+/// <remarks>
+/// A second, narrower <c>SessionEventDto</c> already exists in
+/// <c>Api.BoundedContexts.SessionTracking.Application.Queries</c> as the result
+/// type of the legacy <c>GetSessionEventsQuery</c> (Issue #276) — that one does
+/// NOT carry <c>GameNightId</c>. This new DTO lives in a different namespace
+/// (<c>.DTOs</c>) on purpose so both queries can coexist without renames.
+/// </remarks>
+public sealed record SessionEventDto(
+    Guid Id,
+    Guid SessionId,
+    Guid? GameNightId,
+    string EventType,
+    DateTime Timestamp,
+    string? Payload,
+    Guid? CreatedBy,
+    string? Source);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetCurrentSessionQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetCurrentSessionQuery.cs
@@ -1,4 +1,4 @@
-using MediatR;
+using Api.SharedKernel.Application.Interfaces;
 
 namespace Api.BoundedContexts.SessionTracking.Application.Queries;
 
@@ -7,7 +7,7 @@ namespace Api.BoundedContexts.SessionTracking.Application.Queries;
 /// Returns the caller's latest Active or Paused session for orphan recovery
 /// after page reload / crash (NFR-9). Returns <c>null</c> when no such session exists.
 /// </summary>
-public record GetCurrentSessionQuery(Guid UserId) : IRequest<CurrentSessionDto?>;
+public record GetCurrentSessionQuery(Guid UserId) : IQuery<CurrentSessionDto?>;
 
 /// <summary>
 /// Lightweight DTO for the current-session probe. Carries only the fields

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetCurrentSessionQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetCurrentSessionQuery.cs
@@ -1,0 +1,23 @@
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+/// <summary>
+/// Session Flow v2.1 — Plan 1bis T4.
+/// Returns the caller's latest Active or Paused session for orphan recovery
+/// after page reload / crash (NFR-9). Returns <c>null</c> when no such session exists.
+/// </summary>
+public record GetCurrentSessionQuery(Guid UserId) : IRequest<CurrentSessionDto?>;
+
+/// <summary>
+/// Lightweight DTO for the current-session probe. Carries only the fields
+/// the client needs to resume or display the session.
+/// </summary>
+public record CurrentSessionDto(
+    Guid SessionId,
+    Guid GameId,
+    string Status,
+    string SessionCode,
+    DateTime SessionDate,
+    DateTime? UpdatedAt,
+    Guid? GameNightEventId);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetCurrentSessionQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetCurrentSessionQueryHandler.cs
@@ -1,0 +1,67 @@
+using Api.Infrastructure;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+/// <summary>
+/// Session Flow v2.1 — Plan 1bis T4 handler.
+/// Queries <c>SessionTrackingSessions</c> for the most-recently-updated Active or
+/// Paused session owned by the requesting user. Optionally resolves the
+/// GameNight envelope via the <c>GameNightSessions</c> link table.
+/// </summary>
+internal sealed class GetCurrentSessionQueryHandler
+    : IRequestHandler<GetCurrentSessionQuery, CurrentSessionDto?>
+{
+    private readonly MeepleAiDbContext _db;
+
+    public GetCurrentSessionQueryHandler(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<CurrentSessionDto?> Handle(
+        GetCurrentSessionQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var session = await _db.SessionTrackingSessions
+            .AsNoTracking()
+            .Where(s => s.UserId == request.UserId
+                        && (s.Status == "Active" || s.Status == "Paused")
+                        && !s.IsDeleted)
+            .OrderByDescending(s => s.UpdatedAt ?? s.SessionDate)
+            .Select(s => new
+            {
+                s.Id,
+                GameId = s.GameId ?? Guid.Empty,
+                s.Status,
+                s.SessionCode,
+                s.SessionDate,
+                s.UpdatedAt
+            })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (session is null)
+            return null;
+
+        // Resolve optional GameNight envelope.
+        var gameNightId = await _db.GameNightSessions
+            .AsNoTracking()
+            .Where(gns => gns.SessionId == session.Id)
+            .Select(gns => (Guid?)gns.GameNightEventId)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return new CurrentSessionDto(
+            session.Id,
+            session.GameId,
+            session.Status,
+            session.SessionCode,
+            session.SessionDate,
+            session.UpdatedAt,
+            gameNightId);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetCurrentSessionQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetCurrentSessionQueryHandler.cs
@@ -1,5 +1,5 @@
 using Api.Infrastructure;
-using MediatR;
+using Api.SharedKernel.Application.Interfaces;
 using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.SessionTracking.Application.Queries;
@@ -11,7 +11,7 @@ namespace Api.BoundedContexts.SessionTracking.Application.Queries;
 /// GameNight envelope via the <c>GameNightSessions</c> link table.
 /// </summary>
 internal sealed class GetCurrentSessionQueryHandler
-    : IRequestHandler<GetCurrentSessionQuery, CurrentSessionDto?>
+    : IQueryHandler<GetCurrentSessionQuery, CurrentSessionDto?>
 {
     private readonly MeepleAiDbContext _db;
 

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetGameNightDiaryQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetGameNightDiaryQuery.cs
@@ -10,11 +10,13 @@ namespace Api.BoundedContexts.SessionTracking.Application.Queries;
 /// view ("Tutto quello che è successo stasera").
 /// </summary>
 /// <param name="GameNightEventId">The parent game night envelope id.</param>
+/// <param name="RequesterId">Authenticated user ID for ownership verification.</param>
 /// <param name="EventTypes">Optional whitelist of event types.</param>
 /// <param name="Since">Optional inclusive lower bound on <c>Timestamp</c>.</param>
 /// <param name="Limit">Maximum number of rows to return (default 500 — game nights are larger than single sessions).</param>
 public sealed record GetGameNightDiaryQuery(
     Guid GameNightEventId,
+    Guid RequesterId,
     IReadOnlyList<string>? EventTypes,
     DateTime? Since,
     int Limit = 500

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetGameNightDiaryQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetGameNightDiaryQuery.cs
@@ -1,0 +1,21 @@
+using Api.SharedKernel.Application.Interfaces;
+using DiaryEventDto = Api.BoundedContexts.SessionTracking.Application.DTOs.SessionEventDto;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+/// <summary>
+/// Session Flow v2.1 — T9.
+/// Reads the unified diary for an entire <c>GameNightEvent</c>, unioning events
+/// from every session attached to that night. Useful for the post-night recap
+/// view ("Tutto quello che è successo stasera").
+/// </summary>
+/// <param name="GameNightEventId">The parent game night envelope id.</param>
+/// <param name="EventTypes">Optional whitelist of event types.</param>
+/// <param name="Since">Optional inclusive lower bound on <c>Timestamp</c>.</param>
+/// <param name="Limit">Maximum number of rows to return (default 500 — game nights are larger than single sessions).</param>
+public sealed record GetGameNightDiaryQuery(
+    Guid GameNightEventId,
+    IReadOnlyList<string>? EventTypes,
+    DateTime? Since,
+    int Limit = 500
+) : IQuery<IReadOnlyList<DiaryEventDto>>;

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetGameNightDiaryQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetGameNightDiaryQueryHandler.cs
@@ -30,6 +30,20 @@ internal sealed class GetGameNightDiaryQueryHandler
     {
         ArgumentNullException.ThrowIfNull(request);
 
+        // C2 fix: verify caller is the night organizer
+        var organizerId = await _db.GameNightEvents
+            .AsNoTracking()
+            .Where(g => g.Id == request.GameNightEventId)
+            .Select(g => (Guid?)g.OrganizerId)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (organizerId is null)
+            throw new Api.Middleware.Exceptions.NotFoundException($"GameNightEvent {request.GameNightEventId} not found.");
+
+        if (organizerId.Value != request.RequesterId)
+            throw new Api.Middleware.Exceptions.ForbiddenException("Only the night organizer can read its diary.");
+
         var query = _db.SessionEvents
             .AsNoTracking()
             .Where(e => e.GameNightId == request.GameNightEventId && !e.IsDeleted);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetGameNightDiaryQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetGameNightDiaryQueryHandler.cs
@@ -1,0 +1,67 @@
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+// Resolve the T9 DTO explicitly — a legacy 7-arg SessionEventDto also lives in the
+// Queries namespace (Issue #276) and would shadow the T9 8-arg record inside this file.
+using DiaryEventDto = Api.BoundedContexts.SessionTracking.Application.DTOs.SessionEventDto;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+/// <summary>
+/// Session Flow v2.1 — T9 handler.
+/// Returns the unified diary for a <c>GameNightEvent</c>, spanning every
+/// session attached to that night. Soft-deleted events are excluded.
+/// </summary>
+internal sealed class GetGameNightDiaryQueryHandler
+    : IQueryHandler<GetGameNightDiaryQuery, IReadOnlyList<DiaryEventDto>>
+{
+    private readonly MeepleAiDbContext _db;
+
+    public GetGameNightDiaryQueryHandler(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<IReadOnlyList<DiaryEventDto>> Handle(
+        GetGameNightDiaryQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var query = _db.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.GameNightId == request.GameNightEventId && !e.IsDeleted);
+
+        if (request.EventTypes is { Count: > 0 })
+        {
+            var types = request.EventTypes;
+            query = query.Where(e => types.Contains(e.EventType));
+        }
+
+        if (request.Since.HasValue)
+        {
+            var since = request.Since.Value;
+            query = query.Where(e => e.Timestamp >= since);
+        }
+
+        var entries = await query
+            .OrderBy(e => e.Timestamp)
+            .ThenBy(e => e.Id)
+            .Take(request.Limit)
+            .Select(e => new DiaryEventDto(
+                e.Id,
+                e.SessionId,
+                e.GameNightId,
+                e.EventType,
+                e.Timestamp,
+                e.Payload,
+                e.CreatedBy,
+                e.Source))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return entries;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetSessionDiaryQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetSessionDiaryQuery.cs
@@ -1,0 +1,20 @@
+using Api.SharedKernel.Application.Interfaces;
+using DiaryEventDto = Api.BoundedContexts.SessionTracking.Application.DTOs.SessionEventDto;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+/// <summary>
+/// Session Flow v2.1 — T9.
+/// Reads the append-only diary for a single session, optionally filtered by
+/// event type and timestamp. Returns events in chronological order.
+/// </summary>
+/// <param name="SessionId">The session whose diary should be returned.</param>
+/// <param name="EventTypes">Optional whitelist of event types (e.g. <c>score_updated</c>, <c>dice_rolled</c>).</param>
+/// <param name="Since">Optional inclusive lower bound on <c>Timestamp</c>.</param>
+/// <param name="Limit">Maximum number of rows to return (default 100).</param>
+public sealed record GetSessionDiaryQuery(
+    Guid SessionId,
+    IReadOnlyList<string>? EventTypes,
+    DateTime? Since,
+    int Limit = 100
+) : IQuery<IReadOnlyList<DiaryEventDto>>;

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetSessionDiaryQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetSessionDiaryQuery.cs
@@ -9,11 +9,13 @@ namespace Api.BoundedContexts.SessionTracking.Application.Queries;
 /// event type and timestamp. Returns events in chronological order.
 /// </summary>
 /// <param name="SessionId">The session whose diary should be returned.</param>
+/// <param name="RequesterId">Authenticated user ID for ownership verification.</param>
 /// <param name="EventTypes">Optional whitelist of event types (e.g. <c>score_updated</c>, <c>dice_rolled</c>).</param>
 /// <param name="Since">Optional inclusive lower bound on <c>Timestamp</c>.</param>
 /// <param name="Limit">Maximum number of rows to return (default 100).</param>
 public sealed record GetSessionDiaryQuery(
     Guid SessionId,
+    Guid RequesterId,
     IReadOnlyList<string>? EventTypes,
     DateTime? Since,
     int Limit = 100

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetSessionDiaryQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetSessionDiaryQueryHandler.cs
@@ -30,6 +30,20 @@ internal sealed class GetSessionDiaryQueryHandler
     {
         ArgumentNullException.ThrowIfNull(request);
 
+        // C2 fix: verify caller owns the session
+        var sessionOwnerId = await _db.SessionTrackingSessions
+            .AsNoTracking()
+            .Where(s => s.Id == request.SessionId)
+            .Select(s => (Guid?)s.UserId)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (sessionOwnerId is null)
+            throw new Api.Middleware.Exceptions.NotFoundException($"Session {request.SessionId} not found.");
+
+        if (sessionOwnerId.Value != request.RequesterId)
+            throw new Api.Middleware.Exceptions.ForbiddenException("Only the session owner can read its diary.");
+
         var query = _db.SessionEvents
             .AsNoTracking()
             .Where(e => e.SessionId == request.SessionId && !e.IsDeleted);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetSessionDiaryQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetSessionDiaryQueryHandler.cs
@@ -1,0 +1,67 @@
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+// Resolve the T9 DTO explicitly — a legacy 7-arg SessionEventDto also lives in the
+// Queries namespace (Issue #276) and would shadow the T9 8-arg record inside this file.
+using DiaryEventDto = Api.BoundedContexts.SessionTracking.Application.DTOs.SessionEventDto;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+/// <summary>
+/// Session Flow v2.1 — T9 handler.
+/// Reads <c>SessionEventEntity</c> rows for a single session and projects them
+/// onto <see cref="DiaryEventDto"/>. Soft-deleted events are excluded.
+/// </summary>
+internal sealed class GetSessionDiaryQueryHandler
+    : IQueryHandler<GetSessionDiaryQuery, IReadOnlyList<DiaryEventDto>>
+{
+    private readonly MeepleAiDbContext _db;
+
+    public GetSessionDiaryQueryHandler(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<IReadOnlyList<DiaryEventDto>> Handle(
+        GetSessionDiaryQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var query = _db.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.SessionId == request.SessionId && !e.IsDeleted);
+
+        if (request.EventTypes is { Count: > 0 })
+        {
+            var types = request.EventTypes;
+            query = query.Where(e => types.Contains(e.EventType));
+        }
+
+        if (request.Since.HasValue)
+        {
+            var since = request.Since.Value;
+            query = query.Where(e => e.Timestamp >= since);
+        }
+
+        var entries = await query
+            .OrderBy(e => e.Timestamp)
+            .ThenBy(e => e.Id)
+            .Take(request.Limit)
+            .Select(e => new DiaryEventDto(
+                e.Id,
+                e.SessionId,
+                e.GameNightId,
+                e.EventType,
+                e.Timestamp,
+                e.Payload,
+                e.CreatedBy,
+                e.Source))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return entries;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs
@@ -375,6 +375,40 @@ public class Session
     }
 
     /// <summary>
+    /// Advances the turn to the next player in the turn order (cyclic).
+    /// Requires the session to be Active and a turn order to be set.
+    /// Plan 1bis — T1.
+    /// </summary>
+    /// <returns>
+    /// A tuple describing the transition: the prior index, the new index, and
+    /// the corresponding participant IDs (used by the command handler to emit
+    /// a <c>turn_advanced</c> diary event).
+    /// </returns>
+    public AdvanceTurnResult AdvanceTurn()
+    {
+        if (Status != SessionStatus.Active)
+            throw new ConflictException($"Cannot advance turn in session with status {Status}.");
+
+        if (string.IsNullOrEmpty(TurnOrderJson) || !CurrentTurnIndex.HasValue)
+            throw new ConflictException("Turn order is not set for this session.");
+
+        var order = System.Text.Json.JsonSerializer.Deserialize<List<Guid>>(TurnOrderJson)
+            ?? new List<Guid>();
+        if (order.Count == 0)
+            throw new ConflictException("Turn order is empty.");
+
+        var fromIndex = CurrentTurnIndex.Value;
+        var toIndex = (fromIndex + 1) % order.Count;
+        var fromParticipantId = order[fromIndex];
+        var toParticipantId = order[toIndex];
+
+        CurrentTurnIndex = toIndex;
+        UpdatedAt = DateTime.UtcNow;
+
+        return new AdvanceTurnResult(fromIndex, toIndex, fromParticipantId, toParticipantId);
+    }
+
+    /// <summary>
     /// Updates audit information.
     /// </summary>
     /// <param name="userId">User performing the update.</param>
@@ -476,6 +510,18 @@ public class Session
         return new string(code);
     }
 }
+
+/// <summary>
+/// Result of a <see cref="Session.AdvanceTurn"/> transition, carrying the
+/// prior and next turn indices together with the corresponding participant
+/// IDs so that command handlers can emit a diary event.
+/// Plan 1bis — T1.
+/// </summary>
+public sealed record AdvanceTurnResult(
+    int FromIndex,
+    int ToIndex,
+    Guid FromParticipantId,
+    Guid ToParticipantId);
 
 /// <summary>
 /// Session type enumeration.

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs
@@ -107,6 +107,27 @@ public class Session
     public byte[]? RowVersion { get; private set; }
 
     /// <summary>
+    /// Turn order as JSON array of participant IDs. Null if not yet set.
+    /// </summary>
+    public string? TurnOrderJson { get; private set; }
+
+    /// <summary>
+    /// Method used to set the turn order: "Manual" | "Random".
+    /// </summary>
+    [MaxLength(16)]
+    public string? TurnOrderMethod { get; private set; }
+
+    /// <summary>
+    /// Seed used when TurnOrderMethod=Random, for audit/reproducibility.
+    /// </summary>
+    public int? TurnOrderSeed { get; private set; }
+
+    /// <summary>
+    /// Zero-based index of the current player in the turn order.
+    /// </summary>
+    public int? CurrentTurnIndex { get; private set; }
+
+    /// <summary>
     /// Session participants.
     /// </summary>
     public IReadOnlyCollection<Participant> Participants => _participants.AsReadOnly();
@@ -316,6 +337,41 @@ public class Session
             var winner = _participants.First(p => p.Id == winnerId.Value);
             winner.SetFinalRank(1);
         }
+    }
+
+    /// <summary>
+    /// Sets the turn order for this session.
+    /// </summary>
+    /// <param name="method">Manual or Random.</param>
+    /// <param name="order">Ordered participant IDs.</param>
+    /// <param name="seed">Required when method is Random (for audit).</param>
+    public void SetTurnOrder(
+        Api.BoundedContexts.SessionTracking.Domain.Enums.TurnOrderMethod method,
+        IReadOnlyList<Guid> order,
+        int? seed)
+    {
+        if (Status == SessionStatus.Finalized)
+            throw new ConflictException("Cannot set turn order on finalized session.");
+
+        ArgumentNullException.ThrowIfNull(order);
+        if (order.Count == 0)
+            throw new ArgumentException("Turn order cannot be empty.", nameof(order));
+
+        var participantIds = _participants.Select(p => p.Id).ToHashSet();
+        foreach (var id in order)
+        {
+            if (!participantIds.Contains(id))
+                throw new ArgumentException($"Participant {id} is not in this session.", nameof(order));
+        }
+
+        if (method == Api.BoundedContexts.SessionTracking.Domain.Enums.TurnOrderMethod.Random && !seed.HasValue)
+            throw new ArgumentException("Random turn order requires a seed for audit.", nameof(seed));
+
+        TurnOrderJson = System.Text.Json.JsonSerializer.Serialize(order);
+        TurnOrderMethod = method.ToString();
+        TurnOrderSeed = seed;
+        CurrentTurnIndex = 0;
+        UpdatedAt = DateTime.UtcNow;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Enums/TurnOrderMethod.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Enums/TurnOrderMethod.cs
@@ -1,0 +1,12 @@
+namespace Api.BoundedContexts.SessionTracking.Domain.Enums;
+
+/// <summary>
+/// How turn order is determined for a session.
+/// </summary>
+public enum TurnOrderMethod
+{
+    /// <summary>Order explicitly defined by host.</summary>
+    Manual = 0,
+    /// <summary>Order shuffled server-side with auditable seed.</summary>
+    Random = 1
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/Configurations/SessionConfiguration.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/Configurations/SessionConfiguration.cs
@@ -83,6 +83,21 @@ public class SessionConfiguration : IEntityTypeConfiguration<SessionEntity>
             .IsRowVersion()
             .IsConcurrencyToken();
 
+        // Session Flow v2.1: Turn order fields
+        builder.Property(s => s.TurnOrderJson)
+            .HasColumnName("turn_order_json")
+            .HasColumnType("jsonb");
+
+        builder.Property(s => s.TurnOrderMethod)
+            .HasColumnName("turn_order_method")
+            .HasMaxLength(16);
+
+        builder.Property(s => s.TurnOrderSeed)
+            .HasColumnName("turn_order_seed");
+
+        builder.Property(s => s.CurrentTurnIndex)
+            .HasColumnName("current_turn_index");
+
         // Unique constraint on session code (excluding soft deleted)
         builder.HasIndex(s => s.SessionCode)
             .HasDatabaseName("idx_sessions_code")

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionMapper.cs
@@ -32,6 +32,10 @@ internal static class SessionMapper
             RowVersion = domain.RowVersion,
             InviteToken = domain.InviteToken,
             InviteExpiresAt = domain.InviteExpiresAt,
+            TurnOrderJson = domain.TurnOrderJson,
+            TurnOrderMethod = domain.TurnOrderMethod,
+            TurnOrderSeed = domain.TurnOrderSeed,
+            CurrentTurnIndex = domain.CurrentTurnIndex,
             Participants = domain.Participants.Select(ParticipantMapper.ToEntity).ToList()
         };
     }
@@ -61,6 +65,10 @@ internal static class SessionMapper
         typeof(Session).GetProperty(nameof(Session.RowVersion))!.SetValue(session, entity.RowVersion);
         typeof(Session).GetProperty(nameof(Session.InviteToken))!.SetValue(session, entity.InviteToken);
         typeof(Session).GetProperty(nameof(Session.InviteExpiresAt))!.SetValue(session, entity.InviteExpiresAt);
+        typeof(Session).GetProperty(nameof(Session.TurnOrderJson))!.SetValue(session, entity.TurnOrderJson);
+        typeof(Session).GetProperty(nameof(Session.TurnOrderMethod))!.SetValue(session, entity.TurnOrderMethod);
+        typeof(Session).GetProperty(nameof(Session.TurnOrderSeed))!.SetValue(session, entity.TurnOrderSeed);
+        typeof(Session).GetProperty(nameof(Session.CurrentTurnIndex))!.SetValue(session, entity.CurrentTurnIndex);
 
         // Map participants (need to access private _participants field)
 #pragma warning disable S3011 // Reflection is required for domain entity hydration from persistence

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionRepository.cs
@@ -110,6 +110,13 @@ public class SessionRepository : RepositoryBase, ISessionRepository
         existing.InviteToken = session.InviteToken;
         existing.InviteExpiresAt = session.InviteExpiresAt;
 
+        // Session Flow v2.1 — T6: Propagate turn order fields so SetTurnOrder
+        // domain transitions are persisted by UpdateAsync.
+        existing.TurnOrderJson = session.TurnOrderJson;
+        existing.TurnOrderMethod = session.TurnOrderMethod;
+        existing.TurnOrderSeed = session.TurnOrderSeed;
+        existing.CurrentTurnIndex = session.CurrentTurnIndex;
+
         // Update participants (sync collection)
         existing.Participants.Clear();
         foreach (var participant in session.Participants)

--- a/apps/api/src/Api/Infrastructure/Entities/SessionTracking/SessionEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SessionTracking/SessionEntity.cs
@@ -48,6 +48,27 @@ public class SessionEntity
     /// </summary>
     public DateTime? InviteExpiresAt { get; set; }
 
+    /// <summary>
+    /// Turn order as JSON array of participant IDs (Session Flow v2.1).
+    /// </summary>
+    public string? TurnOrderJson { get; set; }
+
+    /// <summary>
+    /// Method used to set turn order: "Manual" | "Random".
+    /// </summary>
+    [MaxLength(16)]
+    public string? TurnOrderMethod { get; set; }
+
+    /// <summary>
+    /// Seed used when TurnOrderMethod=Random, for audit/reproducibility.
+    /// </summary>
+    public int? TurnOrderSeed { get; set; }
+
+    /// <summary>
+    /// Zero-based index of current player in turn order.
+    /// </summary>
+    public int? CurrentTurnIndex { get; set; }
+
     // Navigation properties
     public ICollection<ParticipantEntity> Participants { get; set; } = new List<ParticipantEntity>();
 }

--- a/apps/api/src/Api/Infrastructure/Migrations/20260409223350_AddSessionTurnOrderAndGameNightInProgress.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260409223350_AddSessionTurnOrderAndGameNightInProgress.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260409223350_AddSessionTurnOrderAndGameNightInProgress")]
+    partial class AddSessionTurnOrderAndGameNightInProgress
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260409223350_AddSessionTurnOrderAndGameNightInProgress.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260409223350_AddSessionTurnOrderAndGameNightInProgress.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSessionTurnOrderAndGameNightInProgress : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "current_turn_index",
+                table: "session_tracking_sessions",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "turn_order_json",
+                table: "session_tracking_sessions",
+                type: "jsonb",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "turn_order_method",
+                table: "session_tracking_sessions",
+                type: "character varying(16)",
+                maxLength: 16,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "turn_order_seed",
+                table: "session_tracking_sessions",
+                type: "integer",
+                nullable: true);
+
+            // Session Flow v2.1: enforce "1 Active Session per GameNight" invariant.
+            // Uses a partial unique index on game_night_sessions filtered by status='InProgress'.
+            // (Avoids cross-table subquery partial index which PostgreSQL does not support.)
+            migrationBuilder.Sql(@"
+CREATE UNIQUE INDEX IF NOT EXISTS ""ix_game_night_sessions_unique_active""
+ON ""game_night_sessions"" (""game_night_event_id"")
+WHERE ""status"" = 'InProgress';
+");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP INDEX IF EXISTS \"ix_game_night_sessions_unique_active\";");
+
+            migrationBuilder.DropColumn(
+                name: "current_turn_index",
+                table: "session_tracking_sessions");
+
+            migrationBuilder.DropColumn(
+                name: "turn_order_json",
+                table: "session_tracking_sessions");
+
+            migrationBuilder.DropColumn(
+                name: "turn_order_method",
+                table: "session_tracking_sessions");
+
+            migrationBuilder.DropColumn(
+                name: "turn_order_seed",
+                table: "session_tracking_sessions");
+        }
+    }
+}

--- a/apps/api/src/Api/Middleware/Exceptions/UnprocessableEntityException.cs
+++ b/apps/api/src/Api/Middleware/Exceptions/UnprocessableEntityException.cs
@@ -1,0 +1,32 @@
+namespace Api.Middleware.Exceptions;
+
+using System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Exception thrown when a request is well-formed but semantically invalid
+/// (e.g. pre-conditions not met). Maps to HTTP 422 Unprocessable Entity.
+/// </summary>
+public class UnprocessableEntityException : HttpException
+{
+    [SetsRequiredMembers]
+    public UnprocessableEntityException(string message)
+        : base(StatusCodes.Status422UnprocessableEntity, "unprocessable_entity", message)
+    {
+    }
+
+    [SetsRequiredMembers]
+    public UnprocessableEntityException(string errorCode, string message)
+        : base(StatusCodes.Status422UnprocessableEntity, errorCode, message)
+    {
+    }
+
+    [SetsRequiredMembers]
+    public UnprocessableEntityException(string message, Exception innerException)
+        : base(StatusCodes.Status422UnprocessableEntity, "unprocessable_entity", message, innerException)
+    {
+    }
+
+    public UnprocessableEntityException()
+    {
+    }
+}

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -666,6 +666,7 @@ v1Api.MapAdminSharedGameContentEndpoints(); // Issue #236: Admin shared game con
 // Infrastructure
 v1Api.MapMonitoringEndpoints();        // Issues #891 + #893: Infrastructure health & Prometheus metrics
 v1Api.MapSessionEndpoints();           // Session management
+v1Api.MapSessionFlowEndpoints();       // Session Flow v2.1 (T9): KB readiness, pause/resume, turn-order, score+diary, diary reads
 
 // ═══ NON-ALPHA: Extended endpoints (gated behind ALPHA_MODE) ═══
 if (!isAlphaMode)

--- a/apps/api/src/Api/Routing/SessionFlowEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionFlowEndpoints.cs
@@ -20,6 +20,7 @@ namespace Api.Routing;
 ///   <item><c>POST /sessions/{sessionId}/scores-with-diary</c> — upsert score with diary (T8)</item>
 ///   <item><c>GET  /sessions/{sessionId}/diary</c> — read single-session diary (T9)</item>
 ///   <item><c>GET  /game-nights/{gameNightId}/diary</c> — read cross-session night diary (T9)</item>
+///   <item><c>GET  /sessions/current</c> — orphan recovery probe (Plan 1bis T4)</item>
 /// </list>
 /// <para>
 /// The score endpoint uses <c>/scores-with-diary</c> to avoid colliding with the
@@ -260,6 +261,31 @@ internal static class SessionFlowEndpoints
         .WithTags("SessionFlow")
         .WithSummary("Read the append-only diary for a whole game night (unions all attached sessions).")
         .Produces(200)
+        .Produces(401);
+
+        // Current session probe (orphan recovery — NFR-9)
+        app.MapGet("/sessions/current", async (
+            HttpContext httpContext,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
+            var result = await mediator
+                .Send(new GetCurrentSessionQuery(userId), ct)
+                .ConfigureAwait(false);
+            return result is null ? Results.NoContent() : Results.Ok(result);
+        })
+        .RequireAuthenticatedUser()
+        .WithName("SessionFlow_GetCurrentSession")
+        .WithTags("SessionFlow")
+        .WithSummary("Return the caller's latest Active or Paused session (orphan recovery after reload/crash).")
+        .Produces(200)
+        .Produces(204)
         .Produces(401);
 
         // Complete game night (cascade finalize all sessions)

--- a/apps/api/src/Api/Routing/SessionFlowEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionFlowEndpoints.cs
@@ -138,6 +138,34 @@ internal static class SessionFlowEndpoints
         .Produces(403)
         .Produces(404);
 
+        // Advance turn (Plan 1bis T1)
+        app.MapPost("/sessions/{sessionId:guid}/turn/advance", async (
+            Guid sessionId,
+            HttpContext httpContext,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
+            var result = await mediator
+                .Send(new AdvanceTurnCommand(sessionId, userId), ct)
+                .ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .RequireAuthenticatedUser()
+        .WithName("SessionFlow_AdvanceTurn")
+        .WithTags("SessionFlow")
+        .WithSummary("Advance the turn index to the next participant (cyclic) and emit a turn_advanced diary event.")
+        .Produces(200)
+        .Produces(401)
+        .Produces(403)
+        .Produces(404)
+        .Produces(409);
+
         // Upsert score with diary
         app.MapPost("/sessions/{sessionId:guid}/scores-with-diary", async (
             Guid sessionId,

--- a/apps/api/src/Api/Routing/SessionFlowEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionFlowEndpoints.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.GameManagement.Application.Commands;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.SessionTracking.Application.Commands;
 using Api.BoundedContexts.SessionTracking.Application.Queries;
@@ -260,6 +261,34 @@ internal static class SessionFlowEndpoints
         .WithSummary("Read the append-only diary for a whole game night (unions all attached sessions).")
         .Produces(200)
         .Produces(401);
+
+        // Complete game night (cascade finalize all sessions)
+        app.MapPost("/game-nights/{gameNightId:guid}/complete", async (
+            Guid gameNightId,
+            HttpContext httpContext,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
+            var result = await mediator
+                .Send(new CompleteGameNightCommand(gameNightId, userId), ct)
+                .ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .RequireAuthenticatedUser()
+        .WithName("SessionFlow_CompleteGameNight")
+        .WithTags("SessionFlow")
+        .WithSummary("Complete an ad-hoc game night: cascade-finalize all sessions and emit diary events.")
+        .Produces(200)
+        .Produces(401)
+        .Produces(403)
+        .Produces(404)
+        .Produces(409);
     }
 
     /// <summary>

--- a/apps/api/src/Api/Routing/SessionFlowEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionFlowEndpoints.cs
@@ -209,15 +209,17 @@ internal static class SessionFlowEndpoints
         .Produces(403)
         .Produces(404);
 
-        // Session diary (read)
+        // Session diary (read) — C2 fix: passes RequesterId for ownership check
         app.MapGet("/sessions/{sessionId:guid}/diary", async (
             Guid sessionId,
+            HttpContext httpContext,
             IMediator mediator,
             CancellationToken ct,
             string? eventTypes = null,
             DateTime? since = null,
             int? limit = null) =>
         {
+            var userId = httpContext.User.GetUserId();
             var types = string.IsNullOrWhiteSpace(eventTypes)
                 ? null
                 : eventTypes
@@ -225,7 +227,7 @@ internal static class SessionFlowEndpoints
                     .ToArray();
 
             var result = await mediator
-                .Send(new GetSessionDiaryQuery(sessionId, types, since, limit ?? 100), ct)
+                .Send(new GetSessionDiaryQuery(sessionId, userId, types, since, limit ?? 100), ct)
                 .ConfigureAwait(false);
             return Results.Ok(result);
         })
@@ -236,15 +238,17 @@ internal static class SessionFlowEndpoints
         .Produces(200)
         .Produces(401);
 
-        // GameNight diary (read)
+        // GameNight diary (read) — C2 fix: passes RequesterId for ownership check
         app.MapGet("/game-nights/{gameNightId:guid}/diary", async (
             Guid gameNightId,
+            HttpContext httpContext,
             IMediator mediator,
             CancellationToken ct,
             string? eventTypes = null,
             DateTime? since = null,
             int? limit = null) =>
         {
+            var userId = httpContext.User.GetUserId();
             var types = string.IsNullOrWhiteSpace(eventTypes)
                 ? null
                 : eventTypes
@@ -252,7 +256,7 @@ internal static class SessionFlowEndpoints
                     .ToArray();
 
             var result = await mediator
-                .Send(new GetGameNightDiaryQuery(gameNightId, types, since, limit ?? 500), ct)
+                .Send(new GetGameNightDiaryQuery(gameNightId, userId, types, since, limit ?? 500), ct)
                 .ConfigureAwait(false);
             return Results.Ok(result);
         })

--- a/apps/api/src/Api/Routing/SessionFlowEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionFlowEndpoints.cs
@@ -1,0 +1,251 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.Extensions;
+using MediatR;
+
+namespace Api.Routing;
+
+/// <summary>
+/// Session Flow v2.1 — T9 routing.
+/// Exposes the HTTP surface for the "1-click start → play → pause/resume → diary"
+/// session flow:
+/// <list type="bullet">
+///   <item><c>GET  /games/{gameId}/kb-readiness</c> — pre-session KB probe (T3)</item>
+///   <item><c>POST /sessions/{sessionId}/pause</c> — pause an active session (T5)</item>
+///   <item><c>POST /sessions/{sessionId}/resume</c> — resume a paused session (T5)</item>
+///   <item><c>PUT  /sessions/{sessionId}/turn-order</c> — manual or seeded-random turn order (T6)</item>
+///   <item><c>POST /sessions/{sessionId}/scores-with-diary</c> — upsert score with diary (T8)</item>
+///   <item><c>GET  /sessions/{sessionId}/diary</c> — read single-session diary (T9)</item>
+///   <item><c>GET  /game-nights/{gameNightId}/diary</c> — read cross-session night diary (T9)</item>
+/// </list>
+/// <para>
+/// The score endpoint uses <c>/scores-with-diary</c> to avoid colliding with the
+/// pre-existing <c>PUT /game-sessions/{id}/scores</c> route (GST-003) which wires
+/// the legacy <see cref="UpdateScoreCommand"/>. Session Flow v2.1 dispatches the
+/// diary-aware <see cref="UpsertScoreWithDiaryCommand"/>.
+/// </para>
+/// </summary>
+internal static class SessionFlowEndpoints
+{
+    public static void MapSessionFlowEndpoints(this IEndpointRouteBuilder app)
+    {
+        // KB readiness probe (read)
+        app.MapGet("/games/{gameId:guid}/kb-readiness", async (
+            Guid gameId,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var result = await mediator.Send(new GetKbReadinessQuery(gameId), ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .RequireAuthenticatedUser()
+        .WithName("SessionFlow_GetKbReadiness")
+        .WithTags("SessionFlow")
+        .WithSummary("Probe whether the Knowledge Base for a game is ready to power an agent.")
+        .Produces(200)
+        .Produces(401);
+
+        // Pause session
+        app.MapPost("/sessions/{sessionId:guid}/pause", async (
+            Guid sessionId,
+            HttpContext httpContext,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
+            await mediator.Send(new PauseSessionCommand(sessionId, userId), ct).ConfigureAwait(false);
+            return Results.NoContent();
+        })
+        .RequireAuthenticatedUser()
+        .WithName("SessionFlow_PauseSession")
+        .WithTags("SessionFlow")
+        .WithSummary("Pause an active session.")
+        .Produces(204)
+        .Produces(401)
+        .Produces(403)
+        .Produces(404)
+        .Produces(409);
+
+        // Resume session
+        app.MapPost("/sessions/{sessionId:guid}/resume", async (
+            Guid sessionId,
+            HttpContext httpContext,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
+            await mediator.Send(new ResumeSessionCommand(sessionId, userId), ct).ConfigureAwait(false);
+            return Results.NoContent();
+        })
+        .RequireAuthenticatedUser()
+        .WithName("SessionFlow_ResumeSession")
+        .WithTags("SessionFlow")
+        .WithSummary("Resume a paused session (auto-pausing any other active session in the same night).")
+        .Produces(204)
+        .Produces(401)
+        .Produces(403)
+        .Produces(404)
+        .Produces(409);
+
+        // Set turn order
+        app.MapPut("/sessions/{sessionId:guid}/turn-order", async (
+            Guid sessionId,
+            SetTurnOrderRequestBody body,
+            HttpContext httpContext,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
+            if (body is null || string.IsNullOrWhiteSpace(body.Method))
+            {
+                return Results.BadRequest(new { error = "Method is required." });
+            }
+
+            if (!Enum.TryParse<TurnOrderMethod>(body.Method, ignoreCase: true, out var method))
+            {
+                return Results.BadRequest(new { error = $"Unknown turn order method: {body.Method}" });
+            }
+
+            var result = await mediator
+                .Send(new SetTurnOrderCommand(sessionId, userId, method, body.Order), ct)
+                .ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .RequireAuthenticatedUser()
+        .WithName("SessionFlow_SetTurnOrder")
+        .WithTags("SessionFlow")
+        .WithSummary("Set the turn order for a session (manual list or cryptographic shuffle).")
+        .Produces(200)
+        .Produces(400)
+        .Produces(401)
+        .Produces(403)
+        .Produces(404);
+
+        // Upsert score with diary
+        app.MapPost("/sessions/{sessionId:guid}/scores-with-diary", async (
+            Guid sessionId,
+            ScoreUpsertRequestBody body,
+            HttpContext httpContext,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
+            if (body is null)
+            {
+                return Results.BadRequest(new { error = "Request body is required." });
+            }
+
+            var result = await mediator.Send(
+                new UpsertScoreWithDiaryCommand(
+                    SessionId: sessionId,
+                    ParticipantId: body.ParticipantId,
+                    RequesterId: userId,
+                    NewValue: body.NewValue,
+                    RoundNumber: body.RoundNumber,
+                    Category: body.Category,
+                    Reason: body.Reason),
+                ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .RequireAuthenticatedUser()
+        .WithName("SessionFlow_UpsertScoreWithDiary")
+        .WithTags("SessionFlow")
+        .WithSummary("Upsert a participant score and emit a score_updated diary event.")
+        .Produces(200)
+        .Produces(400)
+        .Produces(401)
+        .Produces(403)
+        .Produces(404);
+
+        // Session diary (read)
+        app.MapGet("/sessions/{sessionId:guid}/diary", async (
+            Guid sessionId,
+            IMediator mediator,
+            CancellationToken ct,
+            string? eventTypes = null,
+            DateTime? since = null,
+            int? limit = null) =>
+        {
+            var types = string.IsNullOrWhiteSpace(eventTypes)
+                ? null
+                : eventTypes
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .ToArray();
+
+            var result = await mediator
+                .Send(new GetSessionDiaryQuery(sessionId, types, since, limit ?? 100), ct)
+                .ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .RequireAuthenticatedUser()
+        .WithName("SessionFlow_GetSessionDiary")
+        .WithTags("SessionFlow")
+        .WithSummary("Read the append-only diary for a single session (chronological).")
+        .Produces(200)
+        .Produces(401);
+
+        // GameNight diary (read)
+        app.MapGet("/game-nights/{gameNightId:guid}/diary", async (
+            Guid gameNightId,
+            IMediator mediator,
+            CancellationToken ct,
+            string? eventTypes = null,
+            DateTime? since = null,
+            int? limit = null) =>
+        {
+            var types = string.IsNullOrWhiteSpace(eventTypes)
+                ? null
+                : eventTypes
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .ToArray();
+
+            var result = await mediator
+                .Send(new GetGameNightDiaryQuery(gameNightId, types, since, limit ?? 500), ct)
+                .ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .RequireAuthenticatedUser()
+        .WithName("SessionFlow_GetGameNightDiary")
+        .WithTags("SessionFlow")
+        .WithSummary("Read the append-only diary for a whole game night (unions all attached sessions).")
+        .Produces(200)
+        .Produces(401);
+    }
+
+    /// <summary>
+    /// HTTP body for <c>PUT /sessions/{sessionId}/turn-order</c>.
+    /// </summary>
+    public sealed record SetTurnOrderRequestBody(string Method, IReadOnlyList<Guid>? Order);
+
+    /// <summary>
+    /// HTTP body for <c>POST /sessions/{sessionId}/scores-with-diary</c>.
+    /// </summary>
+    public sealed record ScoreUpsertRequestBody(
+        Guid ParticipantId,
+        decimal NewValue,
+        int? RoundNumber,
+        string? Category,
+        string? Reason);
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Commands/CompleteGameNightCommandTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Commands/CompleteGameNightCommandTests.cs
@@ -1,0 +1,319 @@
+using System.Text.Json;
+using Api.BoundedContexts.GameManagement.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.BoundedContexts.SessionTracking.Domain.Services;
+using Api.BoundedContexts.SessionTracking.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Commands;
+
+/// <summary>
+/// Integration tests for <see cref="CompleteGameNightCommand"/> cascade
+/// (Session Flow v2.1 — Plan 1bis T3).
+///
+/// Verifies that completing an ad-hoc game night cascade-finalizes all
+/// non-finalized sessions, marks link rows as Completed, transitions the
+/// GameNightEvent to Completed, and emits the correct diary events.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Feature", "SessionFlowV2.1")]
+public sealed class CompleteGameNightCommandTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private string _isolatedDbConnectionString = string.Empty;
+    private ServiceProvider? _serviceProvider;
+    private MeepleAiDbContext? _dbContext;
+    private CreateSessionCommandHandler? _createHandler;
+    private PauseSessionCommandHandler? _pauseHandler;
+    private CompleteGameNightCommandHandler? _completeNightHandler;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public CompleteGameNightCommandTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_complete_night_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await _dbContext.Database.MigrateAsync(TestCancellationToken);
+                break;
+            }
+            catch (NpgsqlException) when (attempt < 2)
+            {
+                await Task.Delay(500, TestCancellationToken);
+            }
+        }
+
+        var eventCollector = _serviceProvider.GetRequiredService<IDomainEventCollector>();
+        var unitOfWork = _serviceProvider.GetRequiredService<IUnitOfWork>();
+        var mediator = _serviceProvider.GetRequiredService<IMediator>();
+        var sessionRepo = new SessionRepository(_dbContext, eventCollector);
+
+        var quotaMock = new Mock<ISessionQuotaService>();
+        quotaMock
+            .Setup(s => s.CheckQuotaAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<UserTier>(),
+                It.IsAny<Role>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SessionQuotaResult.Allowed(0, 100));
+
+        var loggerFactory = _serviceProvider.GetRequiredService<ILoggerFactory>();
+        _createHandler = new CreateSessionCommandHandler(
+            sessionRepo,
+            unitOfWork,
+            quotaMock.Object,
+            _dbContext,
+            mediator,
+            loggerFactory.CreateLogger<CreateSessionCommandHandler>());
+
+        _pauseHandler = new PauseSessionCommandHandler(sessionRepo, unitOfWork, _dbContext);
+        _completeNightHandler = new CompleteGameNightCommandHandler(_dbContext);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _dbContext?.Dispose();
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    private static CreateSessionCommand BuildCreateCommand(
+        Guid userId, Guid gameId, Guid? gameNightEventId = null, string[]? guestNames = null)
+    {
+        return new CreateSessionCommand(
+            UserId: userId,
+            GameId: gameId,
+            SessionType: nameof(Api.BoundedContexts.SessionTracking.Domain.Entities.SessionType.Generic),
+            SessionDate: null,
+            Location: null,
+            Participants: new List<ParticipantDto>
+            {
+                new() { DisplayName = "Owner", IsOwner = true, UserId = userId }
+            },
+            GameNightEventId: gameNightEventId,
+            GuestNames: guestNames?.ToList());
+    }
+
+    // ── Tests ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Complete_WithSingleSession_FinalizesAndEmitsCompleted()
+    {
+        // Arrange — create a session (auto-creates an ad-hoc night)
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var createResult = await _createHandler!.Handle(
+            BuildCreateCommand(userId, gameId),
+            TestCancellationToken);
+
+        createResult.GameNightWasCreated.Should().BeTrue();
+        var nightId = createResult.GameNightEventId;
+        _dbContext!.ChangeTracker.Clear();
+
+        // Act — complete the game night
+        var result = await _completeNightHandler!.Handle(
+            new CompleteGameNightCommand(nightId, userId),
+            TestCancellationToken);
+
+        // Assert — result
+        result.GameNightEventId.Should().Be(nightId);
+        result.SessionCount.Should().Be(1);
+        result.FinalizedSessionCount.Should().Be(1);
+        result.DurationSeconds.Should().BeGreaterThanOrEqualTo(0);
+
+        // Assert — session finalized
+        _dbContext.ChangeTracker.Clear();
+        var session = await _dbContext.SessionTrackingSessions
+            .AsNoTracking()
+            .FirstAsync(s => s.Id == createResult.SessionId, TestCancellationToken);
+        session.Status.Should().Be("Finalized");
+        session.FinalizedAt.Should().NotBeNull();
+
+        // Assert — GameNight status = Completed
+        var night = await _dbContext.GameNightEvents
+            .AsNoTracking()
+            .FirstAsync(n => n.Id == nightId, TestCancellationToken);
+        night.Status.Should().Be("Completed");
+
+        // Assert — GameNightSession link is Completed
+        var link = await _dbContext.GameNightSessions
+            .AsNoTracking()
+            .FirstAsync(l => l.GameNightEventId == nightId, TestCancellationToken);
+        link.Status.Should().Be("Completed");
+        link.CompletedAt.Should().NotBeNull();
+
+        // Assert — diary events
+        var diaryEvents = await _dbContext.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.GameNightId == nightId)
+            .OrderBy(e => e.Timestamp)
+            .ToListAsync(TestCancellationToken);
+
+        // Should have: session_finalized + gamenight_completed
+        diaryEvents.Should().Contain(e => e.EventType == "session_finalized");
+        diaryEvents.Should().Contain(e => e.EventType == "gamenight_completed");
+
+        var gnCompleted = diaryEvents.First(e => e.EventType == "gamenight_completed");
+        gnCompleted.CreatedBy.Should().Be(userId);
+        gnCompleted.Source.Should().Be("system");
+        gnCompleted.Payload.Should().NotBeNullOrWhiteSpace();
+
+        using var doc = JsonDocument.Parse(gnCompleted.Payload!);
+        var root = doc.RootElement;
+        root.GetProperty("gameNightEventId").GetGuid().Should().Be(nightId);
+        root.GetProperty("sessionCount").GetInt32().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Complete_WithMultipleSessions_FinalizesAllAndEmitsCompleted()
+    {
+        // Arrange — create session 1 (auto ad-hoc night)
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var result1 = await _createHandler!.Handle(
+            BuildCreateCommand(userId, gameId),
+            TestCancellationToken);
+        var nightId = result1.GameNightEventId;
+
+        // Pause session 1 so session 2 can be created in the same night
+        await _pauseHandler!.Handle(
+            new PauseSessionCommand(result1.SessionId, userId),
+            TestCancellationToken);
+
+        // Create session 2 in the same night
+        var result2 = await _createHandler.Handle(
+            BuildCreateCommand(userId, gameId, gameNightEventId: nightId),
+            TestCancellationToken);
+
+        _dbContext!.ChangeTracker.Clear();
+
+        // Act — complete the game night
+        var completeResult = await _completeNightHandler!.Handle(
+            new CompleteGameNightCommand(nightId, userId),
+            TestCancellationToken);
+
+        // Assert — both sessions finalized
+        completeResult.SessionCount.Should().Be(2);
+        completeResult.FinalizedSessionCount.Should().BeGreaterThanOrEqualTo(1);
+
+        _dbContext.ChangeTracker.Clear();
+        var sessions = await _dbContext.SessionTrackingSessions
+            .AsNoTracking()
+            .Where(s => s.Id == result1.SessionId || s.Id == result2.SessionId)
+            .ToListAsync(TestCancellationToken);
+        sessions.Should().AllSatisfy(s => s.Status.Should().Be("Finalized"));
+
+        // Assert — gamenight_completed event exists
+        var gnEvent = await _dbContext.SessionEvents
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                e => e.GameNightId == nightId && e.EventType == "gamenight_completed",
+                TestCancellationToken);
+        gnEvent.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Complete_NotOrganizer_ThrowsForbidden()
+    {
+        // Arrange
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var result = await _createHandler!.Handle(
+            BuildCreateCommand(userId, gameId),
+            TestCancellationToken);
+        _dbContext!.ChangeTracker.Clear();
+
+        var otherUserId = Guid.NewGuid();
+
+        // Act
+        var act = () => _completeNightHandler!.Handle(
+            new CompleteGameNightCommand(result.GameNightEventId, otherUserId),
+            TestCancellationToken);
+
+        // Assert
+        await act.Should().ThrowAsync<ForbiddenException>();
+    }
+
+    [Fact]
+    public async Task Complete_AlreadyCompleted_ThrowsConflict()
+    {
+        // Arrange
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var result = await _createHandler!.Handle(
+            BuildCreateCommand(userId, gameId),
+            TestCancellationToken);
+        _dbContext!.ChangeTracker.Clear();
+
+        // Complete once
+        await _completeNightHandler!.Handle(
+            new CompleteGameNightCommand(result.GameNightEventId, userId),
+            TestCancellationToken);
+        _dbContext.ChangeTracker.Clear();
+
+        // Act — complete again
+        var act = () => _completeNightHandler.Handle(
+            new CompleteGameNightCommand(result.GameNightEventId, userId),
+            TestCancellationToken);
+
+        // Assert
+        await act.Should().ThrowAsync<ConflictException>();
+    }
+
+    [Fact]
+    public async Task Complete_NonExistentNight_ThrowsNotFound()
+    {
+        var act = () => _completeNightHandler!.Handle(
+            new CompleteGameNightCommand(Guid.NewGuid(), Guid.NewGuid()),
+            TestCancellationToken);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Commands/CompleteGameNightCommandTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Commands/CompleteGameNightCommandTests.cs
@@ -102,7 +102,7 @@ public sealed class CompleteGameNightCommandTests : IAsyncLifetime
             loggerFactory.CreateLogger<CreateSessionCommandHandler>());
 
         _pauseHandler = new PauseSessionCommandHandler(sessionRepo, unitOfWork, _dbContext);
-        _completeNightHandler = new CompleteGameNightCommandHandler(_dbContext);
+        _completeNightHandler = new CompleteGameNightCommandHandler(_dbContext, unitOfWork);
     }
 
     public async ValueTask DisposeAsync()

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/StartGameNightSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/StartGameNightSessionCommandHandlerTests.cs
@@ -87,7 +87,14 @@ public class StartGameNightSessionCommandHandlerTests
             .ReturnsAsync(CreateOrganizerDto(gameNight.OrganizerId));
 
         _mockMediator.Setup(m => m.Send(It.IsAny<CreateSessionCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new CreateSessionResult(newSessionId, "ABC123", []));
+            .ReturnsAsync(new CreateSessionResult(
+                newSessionId,
+                "ABC123",
+                [],
+                GameNightEventId: gameNight.Id,
+                GameNightWasCreated: false,
+                AgentDefinitionId: null,
+                ToolkitId: null));
 
         var command = new StartGameNightSessionCommand(
             gameNight.Id, gameId, "Catan", gameNight.OrganizerId);
@@ -158,7 +165,14 @@ public class StartGameNightSessionCommandHandlerTests
             .ReturnsAsync(CreateOrganizerDto(gameNight.OrganizerId, displayName: "Alice Organizer"));
 
         _mockMediator.Setup(m => m.Send(It.IsAny<CreateSessionCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new CreateSessionResult(Guid.NewGuid(), "XYZ789", []));
+            .ReturnsAsync(new CreateSessionResult(
+                Guid.NewGuid(),
+                "XYZ789",
+                [],
+                GameNightEventId: gameNight.Id,
+                GameNightWasCreated: false,
+                AgentDefinitionId: null,
+                ToolkitId: null));
 
         var command = new StartGameNightSessionCommand(
             gameNight.Id, gameId, "Catan", gameNight.OrganizerId);
@@ -205,7 +219,14 @@ public class StartGameNightSessionCommandHandlerTests
             .ReturnsAsync(gameNight);
 
         _mockMediator.Setup(m => m.Send(It.IsAny<CreateSessionCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new CreateSessionResult(Guid.NewGuid(), "ABC123", []));
+            .ReturnsAsync(new CreateSessionResult(
+                Guid.NewGuid(),
+                "ABC123",
+                [],
+                GameNightEventId: gameNight.Id,
+                GameNightWasCreated: false,
+                AgentDefinitionId: null,
+                ToolkitId: null));
 
         var command = new StartGameNightSessionCommand(
             gameNight.Id, gameNight.GameIds[0], "Catan",
@@ -287,7 +308,14 @@ public class StartGameNightSessionCommandHandlerTests
             .ReturnsAsync(CreateOrganizerDto(gameNight.OrganizerId));
 
         _mockMediator.Setup(m => m.Send(It.IsAny<CreateSessionCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new CreateSessionResult(sessionId, "DEF456", []));
+            .ReturnsAsync(new CreateSessionResult(
+                sessionId,
+                "DEF456",
+                [],
+                GameNightEventId: gameNight.Id,
+                GameNightWasCreated: false,
+                AgentDefinitionId: null,
+                ToolkitId: null));
 
         var command = new StartGameNightSessionCommand(
             gameNight.Id, gameNight.GameIds[0], "Catan", gameNight.OrganizerId);

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventAdHocTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventAdHocTests.cs
@@ -1,0 +1,62 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain.Entities;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "GameManagement")]
+public class GameNightEventAdHocTests
+{
+    [Fact]
+    public void CreateAdHoc_SetsStatusInProgress_And_AddsFirstGame()
+    {
+        var organizerId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+
+        var night = GameNightEvent.CreateAdHoc(organizerId, "Serata del 09/04", gameId);
+
+        night.OrganizerId.Should().Be(organizerId);
+        night.Status.Should().Be(GameNightStatus.InProgress);
+        night.GameIds.Should().ContainSingle().Which.Should().Be(gameId);
+        night.Title.Should().Be("Serata del 09/04");
+        night.Rsvps.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AttachAdditionalGame_WhenInProgress_AddsToGameIds()
+    {
+        var firstGame = Guid.NewGuid();
+        var secondGame = Guid.NewGuid();
+        var night = GameNightEvent.CreateAdHoc(Guid.NewGuid(), "Serata", firstGame);
+
+        night.AttachAdditionalGame(secondGame);
+
+        night.GameIds.Should().HaveCount(2).And.Contain(new[] { firstGame, secondGame });
+    }
+
+    [Fact]
+    public void AttachAdditionalGame_WhenDraft_Throws()
+    {
+        var night = GameNightEvent.Create(
+            Guid.NewGuid(),
+            "Pianificata",
+            DateTimeOffset.UtcNow.AddDays(1));
+
+        var act = () => night.AttachAdditionalGame(Guid.NewGuid());
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void AttachAdditionalGame_DuplicateGameId_IsIdempotent()
+    {
+        var gameId = Guid.NewGuid();
+        var night = GameNightEvent.CreateAdHoc(Guid.NewGuid(), "Serata", gameId);
+
+        night.AttachAdditionalGame(gameId);
+
+        night.GameIds.Should().ContainSingle().Which.Should().Be(gameId);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventCompleteAdHocTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventCompleteAdHocTests.cs
@@ -1,0 +1,91 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain.Entities;
+
+/// <summary>
+/// Unit tests for <see cref="GameNightEvent.CompleteAdHoc"/> domain method
+/// (Session Flow v2.1 — Plan 1bis T3).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Feature", "SessionFlowV2.1")]
+public class GameNightEventCompleteAdHocTests
+{
+    [Fact]
+    public void CompleteAdHoc_WhenInProgress_TransitionsToCompleted()
+    {
+        var night = GameNightEvent.CreateAdHoc(Guid.NewGuid(), "Serata", Guid.NewGuid());
+
+        night.CompleteAdHoc();
+
+        night.Status.Should().Be(GameNightStatus.Completed);
+        night.UpdatedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CompleteAdHoc_WhenDraft_Throws()
+    {
+        var night = GameNightEvent.Create(
+            Guid.NewGuid(),
+            "Pianificata",
+            DateTimeOffset.UtcNow.AddDays(1));
+
+        var act = () => night.CompleteAdHoc();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Draft*");
+    }
+
+    [Fact]
+    public void CompleteAdHoc_WhenPublished_Throws()
+    {
+        var night = GameNightEvent.Create(
+            Guid.NewGuid(),
+            "Pianificata",
+            DateTimeOffset.UtcNow.AddDays(1));
+        night.Publish(new List<Guid> { Guid.NewGuid() });
+
+        var act = () => night.CompleteAdHoc();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Published*");
+    }
+
+    [Fact]
+    public void CompleteAdHoc_WhenCancelled_Throws()
+    {
+        var night = GameNightEvent.CreateAdHoc(Guid.NewGuid(), "Serata", Guid.NewGuid());
+        // Cancel requires non-completed; ad-hoc InProgress can be cancelled
+        night.Cancel();
+
+        var act = () => night.CompleteAdHoc();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Cancelled*");
+    }
+
+    [Fact]
+    public void CompleteAdHoc_WhenAlreadyCompleted_Throws()
+    {
+        var night = GameNightEvent.CreateAdHoc(Guid.NewGuid(), "Serata", Guid.NewGuid());
+        night.CompleteAdHoc();
+
+        var act = () => night.CompleteAdHoc();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Completed*");
+    }
+
+    [Fact]
+    public void CompleteAdHoc_Idempotent_SetsUpdatedAtToUtcNow()
+    {
+        var night = GameNightEvent.CreateAdHoc(Guid.NewGuid(), "Serata", Guid.NewGuid());
+
+        night.CompleteAdHoc();
+
+        night.UpdatedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, precision: TimeSpan.FromSeconds(2));
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbReadinessQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbReadinessQueryHandlerTests.cs
@@ -1,0 +1,161 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Integration tests for <see cref="GetKbReadinessQueryHandler"/> (Session Flow v2.1 — T3).
+/// Uses an isolated PostgreSQL database (via <see cref="SharedTestcontainersFixture"/>)
+/// and the T0 seeders to exercise real EF Core queries — no InMemory provider.
+/// </summary>
+[Collection("Integration-GroupA")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Feature", "SessionFlowV2.1")]
+public sealed class GetKbReadinessQueryHandlerTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private string _isolatedDbConnectionString = string.Empty;
+    private ServiceProvider? _serviceProvider;
+    private MeepleAiDbContext? _dbContext;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public GetKbReadinessQueryHandlerTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_kbreadiness_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        // Apply migrations — retry a few times to tolerate transient Npgsql startup errors.
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await _dbContext.Database.MigrateAsync(TestCancellationToken);
+                break;
+            }
+            catch (NpgsqlException) when (attempt < 2)
+            {
+                await Task.Delay(500, TestCancellationToken);
+            }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _dbContext?.Dispose();
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Handle_NoGameFound_ReturnsNoneAndNotReady()
+    {
+        // Arrange
+        var handler = new GetKbReadinessQueryHandler(_dbContext!);
+        var query = new GetKbReadinessQuery(Guid.NewGuid());
+
+        // Act
+        var result = await handler.Handle(query, TestCancellationToken);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsReady.Should().BeFalse();
+        result.State.Should().Be("None");
+        result.ReadyPdfCount.Should().Be(0);
+        result.FailedPdfCount.Should().Be(0);
+        result.Warnings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_ReadyPdfWithCompletedVector_ReturnsReady()
+    {
+        // Arrange
+        var gameId = await _fixture.SeedGameWithIndexedPdfAsync(_dbContext!, vectorCount: 5);
+        var handler = new GetKbReadinessQueryHandler(_dbContext!);
+
+        // Act
+        var result = await handler.Handle(new GetKbReadinessQuery(gameId), TestCancellationToken);
+
+        // Assert
+        result.IsReady.Should().BeTrue();
+        result.State.Should().Be("Ready");
+        result.ReadyPdfCount.Should().Be(1);
+        result.FailedPdfCount.Should().Be(0);
+        result.Warnings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_ReadyPdfButMissingVector_ReturnsVectorPendingAndNotReady()
+    {
+        // Arrange — seeder with vectorCount:0 omits the VectorDocument row.
+        var gameId = await _fixture.SeedGameWithIndexedPdfAsync(_dbContext!, vectorCount: 0);
+        var handler = new GetKbReadinessQueryHandler(_dbContext!);
+
+        // Act
+        var result = await handler.Handle(new GetKbReadinessQuery(gameId), TestCancellationToken);
+
+        // Assert
+        result.IsReady.Should().BeFalse();
+        result.State.Should().Be("VectorPending");
+        result.ReadyPdfCount.Should().Be(1);
+        result.FailedPdfCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_MixedReadyAndFailedPdfs_ReturnsPartiallyReadyWithWarning()
+    {
+        // Arrange — 1 Ready (with a completed vector) + 1 Failed.
+        var gameId = await _fixture.SeedGameWithMixedPdfsAsync(
+            _dbContext!,
+            indexedCount: 1,
+            failedCount: 1,
+            vectorsPerIndexed: 3);
+
+        var handler = new GetKbReadinessQueryHandler(_dbContext!);
+
+        // Act
+        var result = await handler.Handle(new GetKbReadinessQuery(gameId), TestCancellationToken);
+
+        // Assert
+        result.IsReady.Should().BeTrue();
+        result.State.Should().Be("PartiallyReady");
+        result.ReadyPdfCount.Should().Be(1);
+        result.FailedPdfCount.Should().Be(1);
+        result.Warnings.Should().NotBeEmpty();
+        result.Warnings.Should().ContainSingle(w => w.Contains("failed to index", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/AdvanceTurnCommandTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/AdvanceTurnCommandTests.cs
@@ -1,0 +1,271 @@
+using System.Text.Json;
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.BoundedContexts.SessionTracking.Domain.Services;
+using Api.BoundedContexts.SessionTracking.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Integration tests for AdvanceTurnCommand (Session Flow v2.1 — Plan 1bis T1).
+/// Covers cyclic turn progression, owner-only authorisation, conflict when
+/// turn order is not set, and diary (turn_advanced) event emission with the
+/// correct game-night correlation.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "SessionTracking")]
+[Trait("Feature", "SessionFlowV2.1")]
+public sealed class AdvanceTurnCommandTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private string _isolatedDbConnectionString = string.Empty;
+    private ServiceProvider? _serviceProvider;
+    private MeepleAiDbContext? _dbContext;
+    private CreateSessionCommandHandler? _createHandler;
+    private SetTurnOrderCommandHandler? _setTurnOrderHandler;
+    private AdvanceTurnCommandHandler? _advanceTurnHandler;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public AdvanceTurnCommandTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_advanceturn_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await _dbContext.Database.MigrateAsync(TestCancellationToken);
+                break;
+            }
+            catch (NpgsqlException) when (attempt < 2)
+            {
+                await Task.Delay(500, TestCancellationToken);
+            }
+        }
+
+        var eventCollector = _serviceProvider.GetRequiredService<IDomainEventCollector>();
+        var unitOfWork = _serviceProvider.GetRequiredService<IUnitOfWork>();
+        var mediator = _serviceProvider.GetRequiredService<IMediator>();
+        var sessionRepo = new SessionRepository(_dbContext, eventCollector);
+
+        var quotaMock = new Mock<ISessionQuotaService>();
+        quotaMock
+            .Setup(s => s.CheckQuotaAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<UserTier>(),
+                It.IsAny<Role>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SessionQuotaResult.Allowed(0, 100));
+
+        var loggerFactory = _serviceProvider.GetRequiredService<ILoggerFactory>();
+        _createHandler = new CreateSessionCommandHandler(
+            sessionRepo,
+            unitOfWork,
+            quotaMock.Object,
+            _dbContext,
+            mediator,
+            loggerFactory.CreateLogger<CreateSessionCommandHandler>());
+
+        _setTurnOrderHandler = new SetTurnOrderCommandHandler(sessionRepo, unitOfWork, _dbContext);
+        _advanceTurnHandler = new AdvanceTurnCommandHandler(sessionRepo, unitOfWork, _dbContext);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _dbContext?.Dispose();
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Advance_CyclesThroughPlayersAndEmitsDiary()
+    {
+        // Arrange — session with owner + 2 guests (3 total), manual turn order.
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var createResult = await _createHandler!.Handle(
+            BuildCreateCommand(userId, gameId, guestNames: new[] { "Guest A", "Guest B" }),
+            TestCancellationToken);
+
+        _dbContext!.ChangeTracker.Clear();
+        var participantIds = await _dbContext.SessionTrackingParticipants
+            .AsNoTracking()
+            .Where(p => p.SessionId == createResult.SessionId)
+            .OrderBy(p => p.JoinOrder)
+            .Select(p => p.Id)
+            .ToListAsync(TestCancellationToken);
+        participantIds.Should().HaveCount(3);
+
+        await _setTurnOrderHandler!.Handle(
+            new SetTurnOrderCommand(createResult.SessionId, userId, TurnOrderMethod.Manual, participantIds),
+            TestCancellationToken);
+
+        // Act — advance 4 times: 0→1, 1→2, 2→0 (wrap), 0→1
+        var r1 = await _advanceTurnHandler!.Handle(new AdvanceTurnCommand(createResult.SessionId, userId), TestCancellationToken);
+        var r2 = await _advanceTurnHandler.Handle(new AdvanceTurnCommand(createResult.SessionId, userId), TestCancellationToken);
+        var r3 = await _advanceTurnHandler.Handle(new AdvanceTurnCommand(createResult.SessionId, userId), TestCancellationToken);
+        var r4 = await _advanceTurnHandler.Handle(new AdvanceTurnCommand(createResult.SessionId, userId), TestCancellationToken);
+
+        // Assert — command results reflect cyclic progression and correct participant Ids.
+        r1.FromIndex.Should().Be(0); r1.ToIndex.Should().Be(1);
+        r1.FromParticipantId.Should().Be(participantIds[0]);
+        r1.ToParticipantId.Should().Be(participantIds[1]);
+
+        r2.FromIndex.Should().Be(1); r2.ToIndex.Should().Be(2);
+        r2.FromParticipantId.Should().Be(participantIds[1]);
+        r2.ToParticipantId.Should().Be(participantIds[2]);
+
+        r3.FromIndex.Should().Be(2); r3.ToIndex.Should().Be(0);
+        r3.FromParticipantId.Should().Be(participantIds[2]);
+        r3.ToParticipantId.Should().Be(participantIds[0]);
+
+        r4.FromIndex.Should().Be(0); r4.ToIndex.Should().Be(1);
+
+        // Assert — persisted CurrentTurnIndex matches the final state.
+        _dbContext.ChangeTracker.Clear();
+        var persisted = await _dbContext.SessionTrackingSessions
+            .AsNoTracking()
+            .FirstAsync(s => s.Id == createResult.SessionId, TestCancellationToken);
+        persisted.CurrentTurnIndex.Should().Be(1);
+
+        // Assert — 4 turn_advanced diary events, correlated with game night.
+        var diary = await _dbContext.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.SessionId == createResult.SessionId && e.EventType == "turn_advanced")
+            .OrderBy(e => e.Timestamp)
+            .ToListAsync(TestCancellationToken);
+
+        diary.Should().HaveCount(4);
+        diary.Should().OnlyContain(e => e.GameNightId == createResult.GameNightEventId);
+        diary.Should().OnlyContain(e => e.CreatedBy == userId);
+        diary.Should().OnlyContain(e => e.Source == "user");
+
+        // Payload of the first event should reference the expected Guids.
+        diary[0].Payload.Should().Contain(participantIds[0].ToString());
+        diary[0].Payload.Should().Contain(participantIds[1].ToString());
+
+        // The wrap event should expose fromIndex=2 and toIndex=0 in the JSON.
+        using var wrapDoc = JsonDocument.Parse(diary[2].Payload);
+        wrapDoc.RootElement.GetProperty("fromIndex").GetInt32().Should().Be(2);
+        wrapDoc.RootElement.GetProperty("toIndex").GetInt32().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Advance_WithoutTurnOrderSet_ThrowsConflict()
+    {
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var createResult = await _createHandler!.Handle(
+            BuildCreateCommand(userId, gameId, guestNames: new[] { "Alone" }),
+            TestCancellationToken);
+
+        var act = async () => await _advanceTurnHandler!.Handle(
+            new AdvanceTurnCommand(createResult.SessionId, userId),
+            TestCancellationToken);
+
+        await act.Should().ThrowAsync<ConflictException>();
+    }
+
+    [Fact]
+    public async Task Advance_NotOwner_ThrowsForbidden()
+    {
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var createResult = await _createHandler!.Handle(
+            BuildCreateCommand(userId, gameId, guestNames: new[] { "Guest A", "Guest B" }),
+            TestCancellationToken);
+
+        _dbContext!.ChangeTracker.Clear();
+        var participantIds = await _dbContext.SessionTrackingParticipants
+            .AsNoTracking()
+            .Where(p => p.SessionId == createResult.SessionId)
+            .OrderBy(p => p.JoinOrder)
+            .Select(p => p.Id)
+            .ToListAsync(TestCancellationToken);
+
+        await _setTurnOrderHandler!.Handle(
+            new SetTurnOrderCommand(createResult.SessionId, userId, TurnOrderMethod.Manual, participantIds),
+            TestCancellationToken);
+
+        var otherUser = Guid.NewGuid();
+
+        var act = async () => await _advanceTurnHandler!.Handle(
+            new AdvanceTurnCommand(createResult.SessionId, otherUser),
+            TestCancellationToken);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+    }
+
+    [Fact]
+    public async Task Advance_SessionNotFound_ThrowsNotFound()
+    {
+        var unknown = Guid.NewGuid();
+
+        var act = async () => await _advanceTurnHandler!.Handle(
+            new AdvanceTurnCommand(unknown, Guid.NewGuid()),
+            TestCancellationToken);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    private static CreateSessionCommand BuildCreateCommand(
+        Guid userId,
+        Guid gameId,
+        IReadOnlyList<string>? guestNames = null) =>
+        new(
+            UserId: userId,
+            GameId: gameId,
+            SessionType: nameof(SessionType.Generic),
+            SessionDate: null,
+            Location: null,
+            Participants: new List<ParticipantDto>
+            {
+                new() { DisplayName = "Owner", IsOwner = true, UserId = userId }
+            },
+            GameNightEventId: null,
+            GuestNames: guestNames);
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandAdHocTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandAdHocTests.cs
@@ -1,0 +1,272 @@
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Exceptions;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.BoundedContexts.SessionTracking.Domain.Services;
+using Api.BoundedContexts.SessionTracking.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Integration tests for the extended <see cref="CreateSessionCommand"/> (Session Flow v2.1 — T4).
+/// Uses an isolated PostgreSQL database (via <see cref="SharedTestcontainersFixture"/>) and the T0
+/// seeders to verify ad-hoc GameNight creation, KB readiness gating, and guest participant handling.
+///
+/// Tests 4 (existing-night attach) and 5 (active-session-in-night conflict) are deferred — they
+/// depend on the PauseSessionCommand that lands in T5.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "SessionTracking")]
+[Trait("Feature", "SessionFlowV2.1")]
+public sealed class CreateSessionCommandAdHocTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private string _isolatedDbConnectionString = string.Empty;
+    private ServiceProvider? _serviceProvider;
+    private MeepleAiDbContext? _dbContext;
+    private CreateSessionCommandHandler? _handler;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public CreateSessionCommandAdHocTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_createsession_adhoc_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        // Apply migrations with transient-error retry (T3 pattern).
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await _dbContext.Database.MigrateAsync(TestCancellationToken);
+                break;
+            }
+            catch (NpgsqlException) when (attempt < 2)
+            {
+                await Task.Delay(500, TestCancellationToken);
+            }
+        }
+
+        // Wire the command handler with real collaborators where possible and stub quota.
+        var eventCollector = _serviceProvider.GetRequiredService<IDomainEventCollector>();
+        var unitOfWork = _serviceProvider.GetRequiredService<IUnitOfWork>();
+        var mediator = _serviceProvider.GetRequiredService<IMediator>();
+        var sessionRepo = new SessionRepository(_dbContext, eventCollector);
+
+        var quotaMock = new Mock<ISessionQuotaService>();
+        quotaMock
+            .Setup(s => s.CheckQuotaAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<UserTier>(),
+                It.IsAny<Role>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SessionQuotaResult.Allowed(0, 100));
+
+        var loggerFactory = _serviceProvider.GetRequiredService<ILoggerFactory>();
+        _handler = new CreateSessionCommandHandler(
+            sessionRepo,
+            unitOfWork,
+            quotaMock.Object,
+            _dbContext,
+            mediator,
+            loggerFactory.CreateLogger<CreateSessionCommandHandler>());
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _dbContext?.Dispose();
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Handle_NoGameNightProvided_CreatesAdHocNightImplicitly()
+    {
+        // Arrange — seed user + library game with Ready KB (via T0 seeder).
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 3);
+
+        var command = new CreateSessionCommand(
+            UserId: userId,
+            GameId: gameId,
+            SessionType: nameof(Api.BoundedContexts.SessionTracking.Domain.Entities.SessionType.Generic),
+            SessionDate: null,
+            Location: null,
+            Participants: new List<ParticipantDto>
+            {
+                new() { DisplayName = "Owner", IsOwner = true, UserId = userId }
+            });
+
+        // Act
+        var result = await _handler!.Handle(command, TestCancellationToken);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.GameNightWasCreated.Should().BeTrue();
+        result.GameNightEventId.Should().NotBeEmpty();
+        result.SessionId.Should().NotBeEmpty();
+        result.SessionCode.Should().NotBeNullOrEmpty();
+
+        // The persisted GameNightEvent must be InProgress with the game attached.
+        var persistedNight = await _dbContext!.GameNightEvents
+            .AsNoTracking()
+            .Include(e => e.Sessions)
+            .FirstOrDefaultAsync(e => e.Id == result.GameNightEventId, TestCancellationToken);
+
+        persistedNight.Should().NotBeNull();
+        persistedNight!.Status.Should().Be("InProgress");
+        persistedNight.OrganizerId.Should().Be(userId);
+        persistedNight.GameIdsJson.Should().Contain(gameId.ToString());
+
+        // The link row must point at our new session.
+        persistedNight.Sessions.Should().ContainSingle(s => s.SessionId == result.SessionId);
+
+        // Diary events: session_created + gamenight_created.
+        var diaryEvents = await _dbContext.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.SessionId == result.SessionId)
+            .Select(e => e.EventType)
+            .ToListAsync(TestCancellationToken);
+
+        diaryEvents.Should().Contain("session_created");
+        diaryEvents.Should().Contain("gamenight_created");
+    }
+
+    [Fact]
+    public async Task Handle_KbNotReady_Throws422()
+    {
+        // Arrange — seed user + library game WITHOUT an indexed KB.
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameButNoKbAsync(_dbContext!);
+
+        var command = new CreateSessionCommand(
+            UserId: userId,
+            GameId: gameId,
+            SessionType: nameof(Api.BoundedContexts.SessionTracking.Domain.Entities.SessionType.Generic),
+            SessionDate: null,
+            Location: null,
+            Participants: new List<ParticipantDto>
+            {
+                new() { DisplayName = "Owner", IsOwner = true, UserId = userId }
+            });
+
+        // Act / Assert
+        var ex = await Assert.ThrowsAsync<UnprocessableEntityException>(
+            () => _handler!.Handle(command, TestCancellationToken));
+
+        ex.StatusCode.Should().Be(StatusCodes.Status422UnprocessableEntity);
+        ex.ErrorCode.Should().Be("kb_not_ready");
+
+        // No partial state should leak through: no session, no night, no diary events.
+        var sessionsCount = await _dbContext!.SessionTrackingSessions.AsNoTracking().CountAsync(TestCancellationToken);
+        sessionsCount.Should().Be(0);
+
+        var nightsCount = await _dbContext.GameNightEvents.AsNoTracking().CountAsync(TestCancellationToken);
+        nightsCount.Should().Be(0);
+
+        var diaryCount = await _dbContext.SessionEvents.AsNoTracking().CountAsync(TestCancellationToken);
+        diaryCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_GuestNamesProvided_AddsParticipantsWithDisplayNames()
+    {
+        // Arrange — ready KB + 2 guest names.
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+
+        var command = new CreateSessionCommand(
+            UserId: userId,
+            GameId: gameId,
+            SessionType: nameof(Api.BoundedContexts.SessionTracking.Domain.Entities.SessionType.Generic),
+            SessionDate: null,
+            Location: null,
+            Participants: new List<ParticipantDto>
+            {
+                new() { DisplayName = "Owner", IsOwner = true, UserId = userId }
+            },
+            GameNightEventId: null,
+            GuestNames: new[] { "Luca", "Sara" });
+
+        // Act
+        var result = await _handler!.Handle(command, TestCancellationToken);
+
+        // Assert — owner + 2 guests = 3 participants total in the response.
+        result.Participants.Should().HaveCount(3);
+        result.Participants.Should().ContainSingle(p => p.IsOwner);
+        result.Participants.Should().Contain(p => p.DisplayName == "Luca" && !p.IsOwner);
+        result.Participants.Should().Contain(p => p.DisplayName == "Sara" && !p.IsOwner);
+
+        // Guest participants must be persisted (no UserId) alongside the owner.
+        _dbContext!.ChangeTracker.Clear();
+        var persistedSession = await _dbContext.SessionTrackingSessions
+            .AsNoTracking()
+            .Include(s => s.Participants)
+            .FirstOrDefaultAsync(s => s.Id == result.SessionId, TestCancellationToken);
+
+        persistedSession.Should().NotBeNull();
+        persistedSession!.Participants.Should().HaveCount(3);
+        persistedSession.Participants.Should().Contain(p => p.DisplayName == "Luca" && p.UserId == null);
+        persistedSession.Participants.Should().Contain(p => p.DisplayName == "Sara" && p.UserId == null);
+    }
+
+    [Fact(Skip = "Depends on T5 PauseSessionCommand — unskip in T5.")]
+    public Task Handle_ExistingNightProvided_AttachesGameToNight()
+    {
+        // This scenario requires an existing InProgress night with a PAUSED session, then a new
+        // CreateSessionCommand targeting that night with a different GameId.
+        // T5 introduces PauseSessionCommand; unskip and implement together with T5.
+        return Task.CompletedTask;
+    }
+
+    [Fact(Skip = "Depends on T5 PauseSessionCommand — unskip in T5.")]
+    public Task Handle_ActiveSessionInNight_Throws409()
+    {
+        // This scenario requires creating an existing night with an ACTIVE session and verifying
+        // the invariant. Without a pause flow, the first session created is always active, so the
+        // invariant can only be exercised once Pause is available.
+        return Task.CompletedTask;
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandAdHocTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandAdHocTests.cs
@@ -47,6 +47,7 @@ public sealed class CreateSessionCommandAdHocTests : IAsyncLifetime
     private ServiceProvider? _serviceProvider;
     private MeepleAiDbContext? _dbContext;
     private CreateSessionCommandHandler? _handler;
+    private PauseSessionCommandHandler? _pauseHandler;
 
     private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
 
@@ -101,6 +102,10 @@ public sealed class CreateSessionCommandAdHocTests : IAsyncLifetime
             _dbContext,
             mediator,
             loggerFactory.CreateLogger<CreateSessionCommandHandler>());
+
+        // T5: PauseSessionCommandHandler shares the same SessionRepository / UnitOfWork
+        // so the two scenarios that depend on Pause can drive a real domain transition.
+        _pauseHandler = new PauseSessionCommandHandler(sessionRepo, unitOfWork, _dbContext);
     }
 
     public async ValueTask DisposeAsync()
@@ -252,21 +257,134 @@ public sealed class CreateSessionCommandAdHocTests : IAsyncLifetime
         persistedSession.Participants.Should().Contain(p => p.DisplayName == "Sara" && p.UserId == null);
     }
 
-    [Fact(Skip = "Depends on T5 PauseSessionCommand — unskip in T5.")]
-    public Task Handle_ExistingNightProvided_AttachesGameToNight()
+    [Fact]
+    public async Task Handle_ExistingNightProvided_AttachesGameToNight()
     {
-        // This scenario requires an existing InProgress night with a PAUSED session, then a new
-        // CreateSessionCommand targeting that night with a different GameId.
-        // T5 introduces PauseSessionCommand; unskip and implement together with T5.
-        return Task.CompletedTask;
+        // Arrange — create a first session that owns a fresh ad-hoc GameNight, then pause it
+        // to free the InProgress slot so a second session can be attached to the same night.
+        var (userId, gameId1) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var first = await _handler!.Handle(BuildCommand(userId, gameId1), TestCancellationToken);
+
+        await _pauseHandler!.Handle(
+            new PauseSessionCommand(first.SessionId, userId),
+            TestCancellationToken);
+
+        // Seed a second library game with a Ready KB on the same user.
+        var gameId2 = await _fixture.SeedAnotherLibraryGameAsync(_dbContext!, userId);
+
+        // Build a fresh, isolated handler stack on the same database so the second
+        // CreateSession runs against a clean change tracker. The previous handler chain
+        // (Create + Pause) leaves the SessionEntity tracked with a [Timestamp] RowVersion
+        // that conflicts with subsequent reloads inside the same DbContext instance.
+        await using var freshScope = BuildIsolatedScope();
+        var freshDb = freshScope.GetRequiredService<MeepleAiDbContext>();
+        var freshCreateHandler = BuildCreateHandler(freshScope, freshDb);
+
+        // Act — create another session targeting the SAME GameNightEvent.
+        var second = await freshCreateHandler.Handle(
+            BuildCommand(userId, gameId2, gameNightEventId: first.GameNightEventId),
+            TestCancellationToken);
+
+        // Assert — the existing night is reused and the new game is appended to its
+        // GameIdsJson list. GameNightWasCreated must be false on the second response.
+        second.GameNightEventId.Should().Be(first.GameNightEventId);
+        second.GameNightWasCreated.Should().BeFalse();
+
+        var night = await freshDb.GameNightEvents
+            .AsNoTracking()
+            .Include(e => e.Sessions)
+            .FirstAsync(e => e.Id == first.GameNightEventId, TestCancellationToken);
+
+        night.GameIdsJson.Should().Contain(gameId1.ToString());
+        night.GameIdsJson.Should().Contain(gameId2.ToString());
+        night.Sessions.Should().Contain(s => s.SessionId == first.SessionId);
+        night.Sessions.Should().Contain(s => s.SessionId == second.SessionId);
+
+        // Diary: the second create must have written a "gamenight_game_added" entry.
+        var addedEvents = await freshDb.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.SessionId == second.SessionId && e.EventType == "gamenight_game_added")
+            .ToListAsync(TestCancellationToken);
+        addedEvents.Should().HaveCount(1);
     }
 
-    [Fact(Skip = "Depends on T5 PauseSessionCommand — unskip in T5.")]
-    public Task Handle_ActiveSessionInNight_Throws409()
+    [Fact]
+    public async Task Handle_ActiveSessionInNight_Throws409()
     {
-        // This scenario requires creating an existing night with an ACTIVE session and verifying
-        // the invariant. Without a pause flow, the first session created is always active, so the
-        // invariant can only be exercised once Pause is available.
-        return Task.CompletedTask;
+        // Arrange — create a session that opens an ad-hoc night with an Active session in it.
+        var (userId, gameId1) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var first = await _handler!.Handle(BuildCommand(userId, gameId1), TestCancellationToken);
+
+        // Seed a second library game with a Ready KB on the same user.
+        var gameId2 = await _fixture.SeedAnotherLibraryGameAsync(_dbContext!, userId);
+
+        // Act / Assert — without pausing the first session, attempting to attach a second
+        // session to the same night must fail with ConflictException (409) so the
+        // "1 Active per GameNight" invariant is preserved at the handler level.
+        await Assert.ThrowsAsync<ConflictException>(
+            () => _handler!.Handle(
+                BuildCommand(userId, gameId2, gameNightEventId: first.GameNightEventId),
+                TestCancellationToken));
     }
+
+    /// <summary>
+    /// Builds an isolated DI scope (fresh service provider) pointing at the same
+    /// PostgreSQL database. Used to obtain a clean DbContext + handler stack between
+    /// operations that mutate the same Session aggregate within a single test, in
+    /// order to avoid stale [Timestamp] concurrency conflicts on the shared tracker.
+    /// </summary>
+    private ServiceProvider BuildIsolatedScope()
+    {
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+        return services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// Wires a fresh <see cref="CreateSessionCommandHandler"/> against the given DI scope.
+    /// Mirrors the bootstrap done in <see cref="InitializeAsync"/>.
+    /// </summary>
+    private static CreateSessionCommandHandler BuildCreateHandler(
+        ServiceProvider scope,
+        MeepleAiDbContext db)
+    {
+        var eventCollector = scope.GetRequiredService<IDomainEventCollector>();
+        var unitOfWork = scope.GetRequiredService<IUnitOfWork>();
+        var mediator = scope.GetRequiredService<IMediator>();
+        var sessionRepo = new SessionRepository(db, eventCollector);
+
+        var quotaMock = new Mock<ISessionQuotaService>();
+        quotaMock
+            .Setup(s => s.CheckQuotaAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<UserTier>(),
+                It.IsAny<Role>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SessionQuotaResult.Allowed(0, 100));
+
+        var loggerFactory = scope.GetRequiredService<ILoggerFactory>();
+        return new CreateSessionCommandHandler(
+            sessionRepo,
+            unitOfWork,
+            quotaMock.Object,
+            db,
+            mediator,
+            loggerFactory.CreateLogger<CreateSessionCommandHandler>());
+    }
+
+    private static CreateSessionCommand BuildCommand(
+        Guid userId,
+        Guid gameId,
+        Guid? gameNightEventId = null) =>
+        new(
+            UserId: userId,
+            GameId: gameId,
+            SessionType: nameof(Api.BoundedContexts.SessionTracking.Domain.Entities.SessionType.Generic),
+            SessionDate: null,
+            Location: null,
+            Participants: new List<ParticipantDto>
+            {
+                new() { DisplayName = "Owner", IsOwner = true, UserId = userId }
+            },
+            GameNightEventId: gameNightEventId,
+            GuestNames: null);
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/FinalizeSessionDiaryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/FinalizeSessionDiaryTests.cs
@@ -1,0 +1,316 @@
+using System.Text.Json;
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.BoundedContexts.SessionTracking.Domain.Services;
+using Api.BoundedContexts.SessionTracking.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Integration tests for <see cref="FinalizeSessionCommand"/> diary emission
+/// (Session Flow v2.1 — Plan 1bis T2).
+///
+/// Verifies that finalizing a session appends a <c>session_finalized</c>
+/// <see cref="Api.Infrastructure.Entities.SessionTracking.SessionEventEntity"/>
+/// to the diary in the same transaction as the session status transition,
+/// with a payload carrying the winner id, the total duration in seconds and a
+/// scoreboard snapshot (participant → total). The GameNightId must be
+/// propagated so cross-night UNION queries can correlate the event.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "SessionTracking")]
+[Trait("Feature", "SessionFlowV2.1")]
+public sealed class FinalizeSessionDiaryTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private string _isolatedDbConnectionString = string.Empty;
+    private ServiceProvider? _serviceProvider;
+    private MeepleAiDbContext? _dbContext;
+    private CreateSessionCommandHandler? _createHandler;
+    private UpsertScoreWithDiaryCommandHandler? _upsertScoreHandler;
+    private FinalizeSessionCommandHandler? _finalizeHandler;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public FinalizeSessionDiaryTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_finalize_diary_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await _dbContext.Database.MigrateAsync(TestCancellationToken);
+                break;
+            }
+            catch (NpgsqlException) when (attempt < 2)
+            {
+                await Task.Delay(500, TestCancellationToken);
+            }
+        }
+
+        var eventCollector = _serviceProvider.GetRequiredService<IDomainEventCollector>();
+        var unitOfWork = _serviceProvider.GetRequiredService<IUnitOfWork>();
+        var mediator = _serviceProvider.GetRequiredService<IMediator>();
+        var sessionRepo = new SessionRepository(_dbContext, eventCollector);
+        var scoreEntryRepo = new ScoreEntryRepository(_dbContext, eventCollector);
+
+        var quotaMock = new Mock<ISessionQuotaService>();
+        quotaMock
+            .Setup(s => s.CheckQuotaAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<UserTier>(),
+                It.IsAny<Role>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SessionQuotaResult.Allowed(0, 100));
+
+        var syncMock = new Mock<ISessionSyncService>();
+        syncMock
+            .Setup(s => s.PublishEventAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<INotification>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var loggerFactory = _serviceProvider.GetRequiredService<ILoggerFactory>();
+        _createHandler = new CreateSessionCommandHandler(
+            sessionRepo,
+            unitOfWork,
+            quotaMock.Object,
+            _dbContext,
+            mediator,
+            loggerFactory.CreateLogger<CreateSessionCommandHandler>());
+
+        _upsertScoreHandler = new UpsertScoreWithDiaryCommandHandler(sessionRepo, unitOfWork, _dbContext);
+        _finalizeHandler = new FinalizeSessionCommandHandler(
+            sessionRepo,
+            scoreEntryRepo,
+            unitOfWork,
+            syncMock.Object,
+            _dbContext);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _dbContext?.Dispose();
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Finalize_EmitsSessionFinalizedDiaryEventWithWinnerAndScoreboard()
+    {
+        // Arrange — create a session with owner + 2 guests (3 participants).
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var createResult = await _createHandler!.Handle(
+            BuildCreateCommand(userId, gameId, guestNames: new[] { "Guest A", "Guest B" }),
+            TestCancellationToken);
+
+        _dbContext!.ChangeTracker.Clear();
+        var participantIds = await _dbContext.SessionTrackingParticipants
+            .AsNoTracking()
+            .Where(p => p.SessionId == createResult.SessionId)
+            .OrderBy(p => p.JoinOrder)
+            .Select(p => p.Id)
+            .ToListAsync(TestCancellationToken);
+        participantIds.Should().HaveCount(3);
+
+        // Seed scoreboard via the diary-aware upsert so the snapshot is realistic.
+        await _upsertScoreHandler!.Handle(
+            new UpsertScoreWithDiaryCommand(
+                createResult.SessionId, participantIds[0], userId, 42m, 1, null, null),
+            TestCancellationToken);
+        await _upsertScoreHandler.Handle(
+            new UpsertScoreWithDiaryCommand(
+                createResult.SessionId, participantIds[1], userId, 17m, 1, null, null),
+            TestCancellationToken);
+        await _upsertScoreHandler.Handle(
+            new UpsertScoreWithDiaryCommand(
+                createResult.SessionId, participantIds[2], userId, 9m, 1, null, null),
+            TestCancellationToken);
+
+        // Ensure duration_seconds > 0 when computed from SessionDate.
+        await Task.Delay(1100, TestCancellationToken);
+
+        var finalRanks = new Dictionary<Guid, int>
+        {
+            { participantIds[0], 1 },
+            { participantIds[1], 2 },
+            { participantIds[2], 3 }
+        };
+
+        // Act — finalize the session with the owner as winner.
+        var result = await _finalizeHandler!.Handle(
+            new FinalizeSessionCommand(createResult.SessionId, finalRanks),
+            TestCancellationToken);
+
+        // Assert — command result echoes the winner.
+        result.Should().NotBeNull();
+        result.WinnerId.Should().Be(participantIds[0]);
+
+        // Assert — session status is persisted as Finalized.
+        _dbContext.ChangeTracker.Clear();
+        var persistedSession = await _dbContext.SessionTrackingSessions
+            .AsNoTracking()
+            .FirstAsync(s => s.Id == createResult.SessionId, TestCancellationToken);
+        persistedSession.Status.Should().Be(nameof(SessionStatus.Finalized));
+        persistedSession.FinalizedAt.Should().NotBeNull();
+
+        // Assert — exactly one session_finalized diary event, correlated with the game night.
+        var diary = await _dbContext.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.SessionId == createResult.SessionId && e.EventType == "session_finalized")
+            .ToListAsync(TestCancellationToken);
+
+        diary.Should().HaveCount(1);
+        var entry = diary[0];
+        entry.GameNightId.Should().Be(createResult.GameNightEventId);
+        entry.CreatedBy.Should().Be(userId);
+        entry.Source.Should().Be("system");
+        entry.Payload.Should().NotBeNullOrWhiteSpace();
+
+        using var doc = JsonDocument.Parse(entry.Payload!);
+        var root = doc.RootElement;
+
+        // winnerId
+        root.TryGetProperty("winnerId", out var winnerElement).Should().BeTrue();
+        winnerElement.ValueKind.Should().Be(JsonValueKind.String);
+        winnerElement.GetGuid().Should().Be(participantIds[0]);
+
+        // durationSeconds > 0 because of the deliberate delay above
+        root.TryGetProperty("durationSeconds", out var durationElement).Should().BeTrue();
+        durationElement.GetInt32().Should().BeGreaterThan(0);
+
+        // scoreboard snapshot includes all three participants with their totals
+        root.TryGetProperty("scoreboard", out var scoreboardElement).Should().BeTrue();
+        scoreboardElement.ValueKind.Should().Be(JsonValueKind.Array);
+
+        var snapshot = scoreboardElement
+            .EnumerateArray()
+            .Select(e => new
+            {
+                ParticipantId = e.GetProperty("participantId").GetGuid(),
+                Total = e.GetProperty("total").GetDecimal()
+            })
+            .ToList();
+
+        snapshot.Should().HaveCount(3);
+        snapshot.Should().Contain(s => s.ParticipantId == participantIds[0] && s.Total == 42m);
+        snapshot.Should().Contain(s => s.ParticipantId == participantIds[1] && s.Total == 17m);
+        snapshot.Should().Contain(s => s.ParticipantId == participantIds[2] && s.Total == 9m);
+    }
+
+    [Fact]
+    public async Task Finalize_WithoutWinner_EmitsEventWithNullWinner()
+    {
+        // Arrange — session with 2 participants (no one ranked #1).
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var createResult = await _createHandler!.Handle(
+            BuildCreateCommand(userId, gameId, guestNames: new[] { "Lonely Guest" }),
+            TestCancellationToken);
+
+        _dbContext!.ChangeTracker.Clear();
+        var participantIds = await _dbContext.SessionTrackingParticipants
+            .AsNoTracking()
+            .Where(p => p.SessionId == createResult.SessionId)
+            .OrderBy(p => p.JoinOrder)
+            .Select(p => p.Id)
+            .ToListAsync(TestCancellationToken);
+        participantIds.Should().HaveCount(2);
+
+        // Final ranks without any rank=1 → no winner.
+        var finalRanks = new Dictionary<Guid, int>
+        {
+            { participantIds[0], 2 },
+            { participantIds[1], 2 }
+        };
+
+        // Act
+        var result = await _finalizeHandler!.Handle(
+            new FinalizeSessionCommand(createResult.SessionId, finalRanks),
+            TestCancellationToken);
+
+        // Assert — no winner in the command result.
+        result.WinnerId.Should().BeNull();
+
+        // Assert — diary event has winnerId = null.
+        var diary = await _dbContext.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.SessionId == createResult.SessionId && e.EventType == "session_finalized")
+            .ToListAsync(TestCancellationToken);
+
+        diary.Should().HaveCount(1);
+
+        using var doc = JsonDocument.Parse(diary[0].Payload!);
+        var root = doc.RootElement;
+
+        root.TryGetProperty("winnerId", out var winnerElement).Should().BeTrue();
+        winnerElement.ValueKind.Should().Be(JsonValueKind.Null);
+
+        // scoreboard should be empty (no score entries were seeded).
+        root.TryGetProperty("scoreboard", out var scoreboardElement).Should().BeTrue();
+        scoreboardElement.GetArrayLength().Should().Be(0);
+    }
+
+    private static CreateSessionCommand BuildCreateCommand(
+        Guid userId,
+        Guid gameId,
+        IReadOnlyList<string>? guestNames = null) =>
+        new(
+            UserId: userId,
+            GameId: gameId,
+            SessionType: nameof(SessionType.Generic),
+            SessionDate: null,
+            Location: null,
+            Participants: new List<ParticipantDto>
+            {
+                new() { DisplayName = "Owner", IsOwner = true, UserId = userId }
+            },
+            GameNightEventId: null,
+            GuestNames: guestNames);
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/PauseResumeSessionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/PauseResumeSessionTests.cs
@@ -1,0 +1,340 @@
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.BoundedContexts.SessionTracking.Domain.Services;
+using Api.BoundedContexts.SessionTracking.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Integration tests for PauseSessionCommand and ResumeSessionCommand (Session Flow v2.1 — T5).
+/// Verifies the "1 Active per GameNight" invariant via auto-pause-on-resume, owner-only auth,
+/// and diary event emission for both transitions.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "SessionTracking")]
+[Trait("Feature", "SessionFlowV2.1")]
+public sealed class PauseResumeSessionTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private string _isolatedDbConnectionString = string.Empty;
+    private ServiceProvider? _serviceProvider;
+    private MeepleAiDbContext? _dbContext;
+    private CreateSessionCommandHandler? _createHandler;
+    private PauseSessionCommandHandler? _pauseHandler;
+    private ResumeSessionCommandHandler? _resumeHandler;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public PauseResumeSessionTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_pauseresume_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await _dbContext.Database.MigrateAsync(TestCancellationToken);
+                break;
+            }
+            catch (NpgsqlException) when (attempt < 2)
+            {
+                await Task.Delay(500, TestCancellationToken);
+            }
+        }
+
+        var eventCollector = _serviceProvider.GetRequiredService<IDomainEventCollector>();
+        var unitOfWork = _serviceProvider.GetRequiredService<IUnitOfWork>();
+        var mediator = _serviceProvider.GetRequiredService<IMediator>();
+        var sessionRepo = new SessionRepository(_dbContext, eventCollector);
+
+        var quotaMock = new Mock<ISessionQuotaService>();
+        quotaMock
+            .Setup(s => s.CheckQuotaAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<UserTier>(),
+                It.IsAny<Role>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SessionQuotaResult.Allowed(0, 100));
+
+        var loggerFactory = _serviceProvider.GetRequiredService<ILoggerFactory>();
+        _createHandler = new CreateSessionCommandHandler(
+            sessionRepo,
+            unitOfWork,
+            quotaMock.Object,
+            _dbContext,
+            mediator,
+            loggerFactory.CreateLogger<CreateSessionCommandHandler>());
+
+        _pauseHandler = new PauseSessionCommandHandler(sessionRepo, unitOfWork, _dbContext);
+        _resumeHandler = new ResumeSessionCommandHandler(sessionRepo, unitOfWork, _dbContext);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _dbContext?.Dispose();
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Pause_ActiveSession_ChangesStatusAndEmitsDiaryEvent()
+    {
+        // Arrange — create an Active session via CreateSessionCommand (gives us a real GameNight envelope).
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var createResult = await _createHandler!.Handle(
+            BuildCreateCommand(userId, gameId),
+            TestCancellationToken);
+
+        // Act
+        await _pauseHandler!.Handle(
+            new PauseSessionCommand(createResult.SessionId, userId),
+            TestCancellationToken);
+
+        // Assert — status flipped to Paused.
+        _dbContext!.ChangeTracker.Clear();
+        var persisted = await _dbContext.SessionTrackingSessions
+            .AsNoTracking()
+            .FirstAsync(s => s.Id == createResult.SessionId, TestCancellationToken);
+        persisted.Status.Should().Be(nameof(SessionStatus.Paused));
+
+        // Assert — session_paused diary event present and correlated to the GameNight.
+        var diary = await _dbContext.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.SessionId == createResult.SessionId && e.EventType == "session_paused")
+            .ToListAsync(TestCancellationToken);
+
+        diary.Should().HaveCount(1);
+        diary[0].GameNightId.Should().Be(createResult.GameNightEventId);
+        diary[0].CreatedBy.Should().Be(userId);
+        diary[0].Source.Should().Be("system");
+    }
+
+    [Fact]
+    public async Task Resume_Paused_ReactivatesAndAutoPausesOthersInNight()
+    {
+        // Arrange — create session 1 (Active) via the real handler so we get a real
+        // GameNight envelope + game-night-session link row.
+        var (userId, gameId1) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var first = await _createHandler!.Handle(
+            BuildCreateCommand(userId, gameId1),
+            TestCancellationToken);
+
+        // Arrange — pause it through the production handler (also exercises the diary write).
+        await _pauseHandler!.Handle(
+            new PauseSessionCommand(first.SessionId, userId),
+            TestCancellationToken);
+
+        // Arrange — manually persist a SECOND Active session attached to the same GameNight.
+        // We bypass CreateSessionCommandHandler here on purpose: the goal is to set up the
+        // "two sessions in one night, one Paused + one Active" state and verify what Resume
+        // does with it. Re-running CreateSession would also retrigger quota/KB checks that
+        // are already covered by the T4 suite.
+        _dbContext!.ChangeTracker.Clear();
+        var secondSessionId = await SeedAdditionalActiveSessionInNightAsync(
+            userId,
+            gameId1,
+            first.GameNightEventId);
+        _dbContext.ChangeTracker.Clear();
+
+        // Sanity check before resume.
+        var beforeFirst = await _dbContext.SessionTrackingSessions
+            .AsNoTracking()
+            .FirstAsync(s => s.Id == first.SessionId, TestCancellationToken);
+        var beforeSecond = await _dbContext.SessionTrackingSessions
+            .AsNoTracking()
+            .FirstAsync(s => s.Id == secondSessionId, TestCancellationToken);
+
+        beforeFirst.Status.Should().Be(nameof(SessionStatus.Paused));
+        beforeSecond.Status.Should().Be(nameof(SessionStatus.Active));
+
+        // Act — resume the first session: handler must auto-pause the second one.
+        await _resumeHandler!.Handle(
+            new ResumeSessionCommand(first.SessionId, userId),
+            TestCancellationToken);
+
+        // Assert — first is Active, second was auto-paused.
+        _dbContext.ChangeTracker.Clear();
+        var afterFirst = await _dbContext.SessionTrackingSessions
+            .AsNoTracking()
+            .FirstAsync(s => s.Id == first.SessionId, TestCancellationToken);
+        var afterSecond = await _dbContext.SessionTrackingSessions
+            .AsNoTracking()
+            .FirstAsync(s => s.Id == secondSessionId, TestCancellationToken);
+
+        afterFirst.Status.Should().Be(nameof(SessionStatus.Active));
+        afterSecond.Status.Should().Be(nameof(SessionStatus.Paused));
+
+        // Assert — diary entries: session_resumed for first, session_paused (auto) for second.
+        var resumedEvents = await _dbContext.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.SessionId == first.SessionId && e.EventType == "session_resumed")
+            .ToListAsync(TestCancellationToken);
+        resumedEvents.Should().HaveCount(1);
+        resumedEvents[0].GameNightId.Should().Be(first.GameNightEventId);
+
+        var autoPauseEvents = await _dbContext.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.SessionId == secondSessionId && e.EventType == "session_paused")
+            .ToListAsync(TestCancellationToken);
+        autoPauseEvents.Should().HaveCount(1);
+        autoPauseEvents[0].Payload.Should().Contain("auto_pause_on_resume");
+    }
+
+    /// <summary>
+    /// Persists a fresh Active session inside the given GameNight for the given owner,
+    /// reusing an existing SharedGame row (no need to duplicate game catalog plumbing).
+    /// Mirrors the persistence shape produced by <see cref="CreateSessionCommandHandler"/>:
+    /// SessionEntity (Active) + 1 owner ParticipantEntity + GameNightSessionEntity link.
+    /// </summary>
+    private async Task<Guid> SeedAdditionalActiveSessionInNightAsync(
+        Guid userId,
+        Guid sharedGameId,
+        Guid gameNightEventId)
+    {
+        var sessionId = Guid.NewGuid();
+        var sessionCode = Guid.NewGuid().ToString("N")
+            .Substring(0, 6)
+            .ToUpperInvariant();
+
+        _dbContext!.SessionTrackingSessions.Add(new Api.Infrastructure.Entities.SessionTracking.SessionEntity
+        {
+            Id = sessionId,
+            UserId = userId,
+            GameId = sharedGameId,
+            SessionCode = sessionCode,
+            SessionType = nameof(SessionType.Generic),
+            Status = nameof(SessionStatus.Active),
+            SessionDate = DateTime.UtcNow,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = userId,
+            IsDeleted = false,
+            Participants = new List<Api.Infrastructure.Entities.SessionTracking.ParticipantEntity>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    SessionId = sessionId,
+                    UserId = userId,
+                    DisplayName = "Owner",
+                    IsOwner = true,
+                    Role = Api.BoundedContexts.SessionTracking.Domain.Enums.ParticipantRole.Host,
+                    JoinOrder = 1,
+                    CreatedAt = DateTime.UtcNow
+                }
+            }
+        });
+
+        _dbContext.GameNightSessions.Add(new Api.Infrastructure.Entities.GameManagement.GameNightSessionEntity
+        {
+            Id = Guid.NewGuid(),
+            GameNightEventId = gameNightEventId,
+            SessionId = sessionId,
+            GameId = sharedGameId,
+            GameTitle = "SF21 Test Game",
+            PlayOrder = 2,
+            Status = Api.BoundedContexts.GameManagement.Domain.Enums.GameNightSessionStatus.InProgress.ToString(),
+            StartedAt = DateTimeOffset.UtcNow
+        });
+
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+        return sessionId;
+    }
+
+    [Fact]
+    public async Task Pause_NonExistentSession_ThrowsNotFound()
+    {
+        var ex = await Assert.ThrowsAsync<NotFoundException>(
+            () => _pauseHandler!.Handle(
+                new PauseSessionCommand(Guid.NewGuid(), Guid.NewGuid()),
+                TestCancellationToken));
+
+        ex.Message.Should().Contain("not found");
+    }
+
+    [Fact]
+    public async Task Pause_NotOwner_ThrowsForbidden()
+    {
+        // Arrange — owner creates a session.
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var createResult = await _createHandler!.Handle(
+            BuildCreateCommand(userId, gameId),
+            TestCancellationToken);
+
+        var someoneElse = Guid.NewGuid();
+
+        // Act / Assert
+        await Assert.ThrowsAsync<ForbiddenException>(
+            () => _pauseHandler!.Handle(
+                new PauseSessionCommand(createResult.SessionId, someoneElse),
+                TestCancellationToken));
+
+        // Assert — session was NOT mutated.
+        _dbContext!.ChangeTracker.Clear();
+        var persisted = await _dbContext.SessionTrackingSessions
+            .AsNoTracking()
+            .FirstAsync(s => s.Id == createResult.SessionId, TestCancellationToken);
+        persisted.Status.Should().Be(nameof(SessionStatus.Active));
+    }
+
+    private static CreateSessionCommand BuildCreateCommand(
+        Guid userId,
+        Guid gameId,
+        Guid? gameNightEventId = null) =>
+        new(
+            UserId: userId,
+            GameId: gameId,
+            SessionType: nameof(SessionType.Generic),
+            SessionDate: null,
+            Location: null,
+            Participants: new List<ParticipantDto>
+            {
+                new() { DisplayName = "Owner", IsOwner = true, UserId = userId }
+            },
+            GameNightEventId: gameNightEventId,
+            GuestNames: null);
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/RollSessionDiceDiaryEmissionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/RollSessionDiceDiaryEmissionTests.cs
@@ -1,0 +1,204 @@
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.BoundedContexts.SessionTracking.Domain.Services;
+using Api.BoundedContexts.SessionTracking.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Integration test for RollSessionDiceCommand diary emission (Session Flow v2.1 — T7).
+/// Verifies that rolling dice persists both the DiceRoll aggregate and a
+/// <c>dice_rolled</c> SessionEvent correlated to the parent GameNight.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "SessionTracking")]
+[Trait("Feature", "SessionFlowV2.1")]
+public sealed class RollSessionDiceDiaryEmissionTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private string _isolatedDbConnectionString = string.Empty;
+    private ServiceProvider? _serviceProvider;
+    private MeepleAiDbContext? _dbContext;
+    private CreateSessionCommandHandler? _createHandler;
+    private RollSessionDiceCommandHandler? _rollHandler;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public RollSessionDiceDiaryEmissionTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_rolldice_diary_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await _dbContext.Database.MigrateAsync(TestCancellationToken);
+                break;
+            }
+            catch (NpgsqlException) when (attempt < 2)
+            {
+                await Task.Delay(500, TestCancellationToken);
+            }
+        }
+
+        var eventCollector = _serviceProvider.GetRequiredService<IDomainEventCollector>();
+        var unitOfWork = _serviceProvider.GetRequiredService<IUnitOfWork>();
+        var mediator = _serviceProvider.GetRequiredService<IMediator>();
+        var sessionRepo = new SessionRepository(_dbContext, eventCollector);
+        var diceRollRepo = new DiceRollRepository(_dbContext, eventCollector);
+
+        var quotaMock = new Mock<ISessionQuotaService>();
+        quotaMock
+            .Setup(s => s.CheckQuotaAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<UserTier>(),
+                It.IsAny<Role>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SessionQuotaResult.Allowed(0, 100));
+
+        var loggerFactory = _serviceProvider.GetRequiredService<ILoggerFactory>();
+        _createHandler = new CreateSessionCommandHandler(
+            sessionRepo,
+            unitOfWork,
+            quotaMock.Object,
+            _dbContext,
+            mediator,
+            loggerFactory.CreateLogger<CreateSessionCommandHandler>());
+
+        var syncMock = new Mock<ISessionSyncService>();
+        syncMock
+            .Setup(s => s.PublishEventAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<INotification>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _rollHandler = new RollSessionDiceCommandHandler(
+            sessionRepo,
+            diceRollRepo,
+            unitOfWork,
+            syncMock.Object,
+            _dbContext);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _dbContext?.Dispose();
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+
+    [Fact]
+    public async Task RollDice_EmitsDiceRolledDiaryEvent()
+    {
+        // Arrange — create an Active session via CreateSessionCommand so we get a
+        // real GameNight envelope and an owner participant in Host role.
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var createResult = await _createHandler!.Handle(
+            BuildCreateCommand(userId, gameId),
+            TestCancellationToken);
+
+        _dbContext!.ChangeTracker.Clear();
+        var ownerParticipantId = await _dbContext.SessionTrackingParticipants
+            .AsNoTracking()
+            .Where(p => p.SessionId == createResult.SessionId && p.IsOwner)
+            .Select(p => p.Id)
+            .FirstAsync(TestCancellationToken);
+
+        // Act — owner rolls 2d6.
+        var result = await _rollHandler!.Handle(
+            new RollSessionDiceCommand(
+                SessionId: createResult.SessionId,
+                ParticipantId: ownerParticipantId,
+                RequesterId: userId,
+                Formula: "2d6",
+                Label: "attack"),
+            TestCancellationToken);
+
+        // Assert — totals are within the expected range for 2d6 (no modifier).
+        result.Total.Should().BeInRange(2, 12);
+        result.Formula.Should().Be("2D6");
+        result.Rolls.Should().HaveCount(2);
+
+        // Assert — DiceRoll persisted.
+        _dbContext.ChangeTracker.Clear();
+        var persistedRoll = await _dbContext.SessionTrackingDiceRolls
+            .AsNoTracking()
+            .FirstOrDefaultAsync(d => d.Id == result.DiceRollId, TestCancellationToken);
+        persistedRoll.Should().NotBeNull();
+
+        // Assert — diary event emitted, correlated with the GameNight envelope.
+        var diary = await _dbContext.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.SessionId == createResult.SessionId && e.EventType == "dice_rolled")
+            .ToListAsync(TestCancellationToken);
+
+        diary.Should().HaveCount(1);
+        diary[0].GameNightId.Should().Be(createResult.GameNightEventId);
+        diary[0].CreatedBy.Should().Be(userId);
+        diary[0].Source.Should().Be("user");
+        diary[0].Payload.Should().NotBeNullOrWhiteSpace();
+        diary[0].Payload!.Should().Contain("2D6");
+        diary[0].Payload!.Should().Contain(result.Total.ToString(System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    private static CreateSessionCommand BuildCreateCommand(
+        Guid userId,
+        Guid gameId) =>
+        new(
+            UserId: userId,
+            GameId: gameId,
+            SessionType: nameof(SessionType.Generic),
+            SessionDate: null,
+            Location: null,
+            Participants: new List<ParticipantDto>
+            {
+                new() { DisplayName = "Owner", IsOwner = true, UserId = userId }
+            },
+            GameNightEventId: null,
+            GuestNames: null);
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/SetTurnOrderCommandTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/SetTurnOrderCommandTests.cs
@@ -1,0 +1,291 @@
+using System.Text.Json;
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.BoundedContexts.SessionTracking.Domain.Services;
+using Api.BoundedContexts.SessionTracking.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Integration tests for SetTurnOrderCommand (Session Flow v2.1 — T6).
+/// Verifies Manual + Random turn order modes, owner-only auth, deterministic
+/// Fisher-Yates shuffle, seed persistence, and diary event emission.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "SessionTracking")]
+[Trait("Feature", "SessionFlowV2.1")]
+public sealed class SetTurnOrderCommandTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private string _isolatedDbConnectionString = string.Empty;
+    private ServiceProvider? _serviceProvider;
+    private MeepleAiDbContext? _dbContext;
+    private CreateSessionCommandHandler? _createHandler;
+    private SetTurnOrderCommandHandler? _setTurnOrderHandler;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public SetTurnOrderCommandTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_setturnorder_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await _dbContext.Database.MigrateAsync(TestCancellationToken);
+                break;
+            }
+            catch (NpgsqlException) when (attempt < 2)
+            {
+                await Task.Delay(500, TestCancellationToken);
+            }
+        }
+
+        var eventCollector = _serviceProvider.GetRequiredService<IDomainEventCollector>();
+        var unitOfWork = _serviceProvider.GetRequiredService<IUnitOfWork>();
+        var mediator = _serviceProvider.GetRequiredService<IMediator>();
+        var sessionRepo = new SessionRepository(_dbContext, eventCollector);
+
+        var quotaMock = new Mock<ISessionQuotaService>();
+        quotaMock
+            .Setup(s => s.CheckQuotaAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<UserTier>(),
+                It.IsAny<Role>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SessionQuotaResult.Allowed(0, 100));
+
+        var loggerFactory = _serviceProvider.GetRequiredService<ILoggerFactory>();
+        _createHandler = new CreateSessionCommandHandler(
+            sessionRepo,
+            unitOfWork,
+            quotaMock.Object,
+            _dbContext,
+            mediator,
+            loggerFactory.CreateLogger<CreateSessionCommandHandler>());
+
+        _setTurnOrderHandler = new SetTurnOrderCommandHandler(sessionRepo, unitOfWork, _dbContext);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _dbContext?.Dispose();
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Manual_PersistsExplicitOrder()
+    {
+        // Arrange — create session with owner + 2 guest participants.
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var createResult = await _createHandler!.Handle(
+            BuildCreateCommand(userId, gameId, guestNames: new[] { "Guest A", "Guest B" }),
+            TestCancellationToken);
+
+        // Load participant IDs in insertion order.
+        _dbContext!.ChangeTracker.Clear();
+        var participantIds = await _dbContext.SessionTrackingParticipants
+            .AsNoTracking()
+            .Where(p => p.SessionId == createResult.SessionId)
+            .OrderBy(p => p.JoinOrder)
+            .Select(p => p.Id)
+            .ToListAsync(TestCancellationToken);
+
+        participantIds.Should().HaveCount(3);
+        var reversedOrder = participantIds.AsEnumerable().Reverse().ToList();
+
+        // Act — set a manual reversed order.
+        var result = await _setTurnOrderHandler!.Handle(
+            new SetTurnOrderCommand(
+                createResult.SessionId,
+                userId,
+                TurnOrderMethod.Manual,
+                reversedOrder),
+            TestCancellationToken);
+
+        // Assert — result echoes the input.
+        result.Method.Should().Be(nameof(TurnOrderMethod.Manual));
+        result.Seed.Should().BeNull();
+        result.Order.Should().Equal(reversedOrder);
+
+        // Assert — persisted on the session entity.
+        _dbContext.ChangeTracker.Clear();
+        var persisted = await _dbContext.SessionTrackingSessions
+            .AsNoTracking()
+            .FirstAsync(s => s.Id == createResult.SessionId, TestCancellationToken);
+
+        persisted.TurnOrderMethod.Should().Be(nameof(TurnOrderMethod.Manual));
+        persisted.TurnOrderSeed.Should().BeNull();
+        persisted.CurrentTurnIndex.Should().Be(0);
+        persisted.TurnOrderJson.Should().NotBeNullOrWhiteSpace();
+
+        var persistedOrder = JsonSerializer.Deserialize<List<Guid>>(persisted.TurnOrderJson!);
+        persistedOrder.Should().Equal(reversedOrder);
+
+        // Assert — diary event emitted.
+        var diary = await _dbContext.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.SessionId == createResult.SessionId && e.EventType == "turn_order_set")
+            .ToListAsync(TestCancellationToken);
+
+        diary.Should().HaveCount(1);
+        diary[0].GameNightId.Should().Be(createResult.GameNightEventId);
+        diary[0].CreatedBy.Should().Be(userId);
+        diary[0].Source.Should().Be("user");
+        diary[0].Payload.Should().Contain("Manual");
+    }
+
+    [Fact]
+    public async Task Random_GeneratesSeedAndShufflesDeterministically()
+    {
+        // Arrange — create session with owner + 4 guests (5 total participants).
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var createResult = await _createHandler!.Handle(
+            BuildCreateCommand(
+                userId,
+                gameId,
+                guestNames: new[] { "Guest 1", "Guest 2", "Guest 3", "Guest 4" }),
+            TestCancellationToken);
+
+        _dbContext!.ChangeTracker.Clear();
+        var participantIds = await _dbContext.SessionTrackingParticipants
+            .AsNoTracking()
+            .Where(p => p.SessionId == createResult.SessionId)
+            .OrderBy(p => p.JoinOrder)
+            .Select(p => p.Id)
+            .ToListAsync(TestCancellationToken);
+
+        participantIds.Should().HaveCount(5);
+
+        // Act — Random mode (no manual order).
+        var result = await _setTurnOrderHandler!.Handle(
+            new SetTurnOrderCommand(
+                createResult.SessionId,
+                userId,
+                TurnOrderMethod.Random,
+                ManualOrder: null),
+            TestCancellationToken);
+
+        // Assert — seed was generated, order is a permutation of participantIds.
+        result.Method.Should().Be(nameof(TurnOrderMethod.Random));
+        result.Seed.Should().NotBeNull();
+        result.Order.Should().HaveCount(5);
+        result.Order.Should().BeEquivalentTo(participantIds); // same set, any order
+
+        // Assert — determinism: replay Fisher-Yates with the returned seed gives the same order.
+        var expected = participantIds.ToList();
+#pragma warning disable CA5394 // Seeded replay for deterministic audit, not security.
+        var rng = new Random(result.Seed!.Value);
+        for (var i = expected.Count - 1; i > 0; i--)
+        {
+            var j = rng.Next(i + 1);
+            (expected[i], expected[j]) = (expected[j], expected[i]);
+        }
+#pragma warning restore CA5394
+        result.Order.Should().Equal(expected);
+
+        // Assert — session persisted with seed.
+        _dbContext.ChangeTracker.Clear();
+        var persisted = await _dbContext.SessionTrackingSessions
+            .AsNoTracking()
+            .FirstAsync(s => s.Id == createResult.SessionId, TestCancellationToken);
+
+        persisted.TurnOrderMethod.Should().Be(nameof(TurnOrderMethod.Random));
+        persisted.TurnOrderSeed.Should().Be(result.Seed);
+        persisted.CurrentTurnIndex.Should().Be(0);
+
+        // Assert — diary event contains the seed (for replay).
+        var diary = await _dbContext.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.SessionId == createResult.SessionId && e.EventType == "turn_order_set")
+            .ToListAsync(TestCancellationToken);
+
+        diary.Should().HaveCount(1);
+        diary[0].GameNightId.Should().Be(createResult.GameNightEventId);
+        diary[0].Payload.Should().Contain("Random");
+        diary[0].Payload.Should().Contain(result.Seed!.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task Manual_EmptyOrder_FailsValidation()
+    {
+        var validator = new SetTurnOrderCommandValidator();
+
+        var command = new SetTurnOrderCommand(
+            SessionId: Guid.NewGuid(),
+            UserId: Guid.NewGuid(),
+            Method: TurnOrderMethod.Manual,
+            ManualOrder: Array.Empty<Guid>());
+
+        var validationResult = await validator.ValidateAsync(command, TestCancellationToken);
+
+        validationResult.IsValid.Should().BeFalse();
+        validationResult.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(SetTurnOrderCommand.ManualOrder));
+    }
+
+    private static CreateSessionCommand BuildCreateCommand(
+        Guid userId,
+        Guid gameId,
+        IReadOnlyList<string>? guestNames = null) =>
+        new(
+            UserId: userId,
+            GameId: gameId,
+            SessionType: nameof(SessionType.Generic),
+            SessionDate: null,
+            Location: null,
+            Participants: new List<ParticipantDto>
+            {
+                new() { DisplayName = "Owner", IsOwner = true, UserId = userId }
+            },
+            GameNightEventId: null,
+            GuestNames: guestNames);
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/UpsertScoreWithDiaryCommandTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/UpsertScoreWithDiaryCommandTests.cs
@@ -1,0 +1,301 @@
+using System.Text.Json;
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.BoundedContexts.SessionTracking.Domain.Services;
+using Api.BoundedContexts.SessionTracking.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Integration tests for <see cref="UpsertScoreWithDiaryCommand"/> (Session Flow v2.1 — T8).
+/// Verifies upsert semantics on <c>session_tracking_score_entries</c>, owner-only
+/// authorization, and the append-only diary history via <c>score_updated</c>
+/// <see cref="SessionEventEntity"/> rows.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "SessionTracking")]
+[Trait("Feature", "SessionFlowV2.1")]
+public sealed class UpsertScoreWithDiaryCommandTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private string _isolatedDbConnectionString = string.Empty;
+    private ServiceProvider? _serviceProvider;
+    private MeepleAiDbContext? _dbContext;
+    private CreateSessionCommandHandler? _createHandler;
+    private UpsertScoreWithDiaryCommandHandler? _upsertHandler;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public UpsertScoreWithDiaryCommandTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_upsertscore_diary_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await _dbContext.Database.MigrateAsync(TestCancellationToken);
+                break;
+            }
+            catch (NpgsqlException) when (attempt < 2)
+            {
+                await Task.Delay(500, TestCancellationToken);
+            }
+        }
+
+        var eventCollector = _serviceProvider.GetRequiredService<IDomainEventCollector>();
+        var unitOfWork = _serviceProvider.GetRequiredService<IUnitOfWork>();
+        var mediator = _serviceProvider.GetRequiredService<IMediator>();
+        var sessionRepo = new SessionRepository(_dbContext, eventCollector);
+
+        var quotaMock = new Mock<ISessionQuotaService>();
+        quotaMock
+            .Setup(s => s.CheckQuotaAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<UserTier>(),
+                It.IsAny<Role>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SessionQuotaResult.Allowed(0, 100));
+
+        var loggerFactory = _serviceProvider.GetRequiredService<ILoggerFactory>();
+        _createHandler = new CreateSessionCommandHandler(
+            sessionRepo,
+            unitOfWork,
+            quotaMock.Object,
+            _dbContext,
+            mediator,
+            loggerFactory.CreateLogger<CreateSessionCommandHandler>());
+
+        _upsertHandler = new UpsertScoreWithDiaryCommandHandler(sessionRepo, unitOfWork, _dbContext);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _dbContext?.Dispose();
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+
+    [Fact]
+    public async Task FirstUpdate_CreatesEntry_WithOldValueZero()
+    {
+        // Arrange — active session with owner participant.
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var createResult = await _createHandler!.Handle(
+            BuildCreateCommand(userId, gameId),
+            TestCancellationToken);
+
+        _dbContext!.ChangeTracker.Clear();
+        var ownerParticipantId = await _dbContext.SessionTrackingParticipants
+            .AsNoTracking()
+            .Where(p => p.SessionId == createResult.SessionId && p.IsOwner)
+            .Select(p => p.Id)
+            .FirstAsync(TestCancellationToken);
+
+        // Act — first update creates the projection row.
+        var result = await _upsertHandler!.Handle(
+            new UpsertScoreWithDiaryCommand(
+                SessionId: createResult.SessionId,
+                ParticipantId: ownerParticipantId,
+                RequesterId: userId,
+                NewValue: 45m,
+                RoundNumber: 1,
+                Category: null,
+                Reason: null),
+            TestCancellationToken);
+
+        // Assert — result echoes the transition from 0 → 45.
+        result.OldValue.Should().Be(0m);
+        result.NewValue.Should().Be(45m);
+        result.ScoreEntryId.Should().NotBe(Guid.Empty);
+
+        // Assert — projection row persisted.
+        _dbContext.ChangeTracker.Clear();
+        var persisted = await _dbContext.SessionTrackingScoreEntries
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Id == result.ScoreEntryId, TestCancellationToken);
+        persisted.Should().NotBeNull();
+        persisted!.ScoreValue.Should().Be(45m);
+        persisted.RoundNumber.Should().Be(1);
+        persisted.Category.Should().BeNull();
+
+        // Assert — exactly one score_updated diary event, correlated with GameNight.
+        var diary = await _dbContext.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.SessionId == createResult.SessionId && e.EventType == "score_updated")
+            .ToListAsync(TestCancellationToken);
+
+        diary.Should().HaveCount(1);
+        diary[0].GameNightId.Should().Be(createResult.GameNightEventId);
+        diary[0].CreatedBy.Should().Be(userId);
+        diary[0].Source.Should().Be("user");
+        diary[0].Payload.Should().NotBeNullOrWhiteSpace();
+
+        using var doc = JsonDocument.Parse(diary[0].Payload!);
+        doc.RootElement.GetProperty("oldValue").GetDecimal().Should().Be(0m);
+        doc.RootElement.GetProperty("newValue").GetDecimal().Should().Be(45m);
+        doc.RootElement.GetProperty("roundNumber").GetInt32().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SecondUpdate_RecordsOldValueInDiary()
+    {
+        // Arrange
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var createResult = await _createHandler!.Handle(
+            BuildCreateCommand(userId, gameId),
+            TestCancellationToken);
+
+        _dbContext!.ChangeTracker.Clear();
+        var ownerParticipantId = await _dbContext.SessionTrackingParticipants
+            .AsNoTracking()
+            .Where(p => p.SessionId == createResult.SessionId && p.IsOwner)
+            .Select(p => p.Id)
+            .FirstAsync(TestCancellationToken);
+
+        // Act — first update to 45, then a correction to 52.
+        var first = await _upsertHandler!.Handle(
+            new UpsertScoreWithDiaryCommand(
+                createResult.SessionId, ownerParticipantId, userId, 45m, 1, null, null),
+            TestCancellationToken);
+
+        var second = await _upsertHandler!.Handle(
+            new UpsertScoreWithDiaryCommand(
+                createResult.SessionId, ownerParticipantId, userId, 52m, 1, null, "correzione"),
+            TestCancellationToken);
+
+        // Assert — both operations target the same entry; old → new transitions.
+        second.ScoreEntryId.Should().Be(first.ScoreEntryId);
+        second.OldValue.Should().Be(45m);
+        second.NewValue.Should().Be(52m);
+
+        // Assert — projection row is last-write-wins.
+        _dbContext!.ChangeTracker.Clear();
+        var persisted = await _dbContext.SessionTrackingScoreEntries
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Id == second.ScoreEntryId, TestCancellationToken);
+        persisted!.ScoreValue.Should().Be(52m);
+
+        // Assert — append-only diary carries the full history (2 entries).
+        var diary = await _dbContext.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.SessionId == createResult.SessionId && e.EventType == "score_updated")
+            .OrderBy(e => e.Timestamp)
+            .ToListAsync(TestCancellationToken);
+
+        diary.Should().HaveCount(2);
+
+        using (var firstDoc = JsonDocument.Parse(diary[0].Payload!))
+        {
+            firstDoc.RootElement.GetProperty("oldValue").GetDecimal().Should().Be(0m);
+            firstDoc.RootElement.GetProperty("newValue").GetDecimal().Should().Be(45m);
+        }
+
+        using (var secondDoc = JsonDocument.Parse(diary[1].Payload!))
+        {
+            secondDoc.RootElement.GetProperty("oldValue").GetDecimal().Should().Be(45m);
+            secondDoc.RootElement.GetProperty("newValue").GetDecimal().Should().Be(52m);
+            secondDoc.RootElement.GetProperty("reason").GetString().Should().Be("correzione");
+        }
+    }
+
+    [Fact]
+    public async Task UpdateScore_NotOwner_Forbidden()
+    {
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var createResult = await _createHandler!.Handle(
+            BuildCreateCommand(userId, gameId),
+            TestCancellationToken);
+
+        _dbContext!.ChangeTracker.Clear();
+        var ownerParticipantId = await _dbContext.SessionTrackingParticipants
+            .AsNoTracking()
+            .Where(p => p.SessionId == createResult.SessionId && p.IsOwner)
+            .Select(p => p.Id)
+            .FirstAsync(TestCancellationToken);
+
+        var impostorId = Guid.NewGuid();
+
+        var act = async () => await _upsertHandler!.Handle(
+            new UpsertScoreWithDiaryCommand(
+                createResult.SessionId, ownerParticipantId, impostorId, 10m, 1, null, null),
+            TestCancellationToken);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+
+        // Assert — no projection row and no diary event were persisted.
+        _dbContext!.ChangeTracker.Clear();
+        var scoreRows = await _dbContext.SessionTrackingScoreEntries
+            .AsNoTracking()
+            .Where(e => e.SessionId == createResult.SessionId)
+            .CountAsync(TestCancellationToken);
+        scoreRows.Should().Be(0);
+
+        var diary = await _dbContext.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.SessionId == createResult.SessionId && e.EventType == "score_updated")
+            .CountAsync(TestCancellationToken);
+        diary.Should().Be(0);
+    }
+
+    private static CreateSessionCommand BuildCreateCommand(
+        Guid userId,
+        Guid gameId) =>
+        new(
+            UserId: userId,
+            GameId: gameId,
+            SessionType: nameof(SessionType.Generic),
+            SessionDate: null,
+            Location: null,
+            Participants: new List<ParticipantDto>
+            {
+                new() { DisplayName = "Owner", IsOwner = true, UserId = userId }
+            },
+            GameNightEventId: null,
+            GuestNames: null);
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/CreateSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/CreateSessionCommandHandlerTests.cs
@@ -23,6 +23,7 @@ public sealed class CreateSessionCommandHandlerTests : IDisposable
     private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
     private readonly Mock<ISessionQuotaService> _quotaServiceMock = new();
     private readonly MeepleAiDbContext _db;
+    private readonly Mock<IMediator> _mediatorMock = new();
     private readonly Mock<ILogger<CreateSessionCommandHandler>> _loggerMock = new();
     private readonly CreateSessionCommandHandler _handler;
 
@@ -37,11 +38,25 @@ public sealed class CreateSessionCommandHandlerTests : IDisposable
             new Mock<IMediator>().Object,
             new Mock<IDomainEventCollector>().Object);
 
+        // Default: KB is Ready so quota/domain negative tests can reach their specific assertion
+        // without being short-circuited by the KB readiness gate (Session Flow v2.1 — T4).
+        _mediatorMock
+            .Setup(m => m.Send(
+                It.IsAny<Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbReadinessQuery>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Api.BoundedContexts.KnowledgeBase.Application.DTOs.KbReadinessDto(
+                IsReady: true,
+                State: "Ready",
+                ReadyPdfCount: 1,
+                FailedPdfCount: 0,
+                Warnings: Array.Empty<string>()));
+
         _handler = new CreateSessionCommandHandler(
             _sessionRepoMock.Object,
             _unitOfWorkMock.Object,
             _quotaServiceMock.Object,
             _db,
+            _mediatorMock.Object,
             _loggerMock.Object);
     }
 
@@ -59,6 +74,7 @@ public sealed class CreateSessionCommandHandlerTests : IDisposable
             _unitOfWorkMock.Object,
             _quotaServiceMock.Object,
             _db,
+            _mediatorMock.Object,
             _loggerMock.Object);
 
         Assert.Throws<ArgumentNullException>(act);
@@ -72,6 +88,7 @@ public sealed class CreateSessionCommandHandlerTests : IDisposable
             null!,
             _quotaServiceMock.Object,
             _db,
+            _mediatorMock.Object,
             _loggerMock.Object);
 
         Assert.Throws<ArgumentNullException>(act);
@@ -85,6 +102,7 @@ public sealed class CreateSessionCommandHandlerTests : IDisposable
             _unitOfWorkMock.Object,
             null!,
             _db,
+            _mediatorMock.Object,
             _loggerMock.Object);
 
         Assert.Throws<ArgumentNullException>(act);
@@ -97,6 +115,21 @@ public sealed class CreateSessionCommandHandlerTests : IDisposable
             _sessionRepoMock.Object,
             _unitOfWorkMock.Object,
             _quotaServiceMock.Object,
+            null!,
+            _mediatorMock.Object,
+            _loggerMock.Object);
+
+        Assert.Throws<ArgumentNullException>(act);
+    }
+
+    [Fact]
+    public void Constructor_NullMediator_ThrowsArgumentNullException()
+    {
+        var act = () => new CreateSessionCommandHandler(
+            _sessionRepoMock.Object,
+            _unitOfWorkMock.Object,
+            _quotaServiceMock.Object,
+            _db,
             null!,
             _loggerMock.Object);
 
@@ -111,6 +144,7 @@ public sealed class CreateSessionCommandHandlerTests : IDisposable
             _unitOfWorkMock.Object,
             _quotaServiceMock.Object,
             _db,
+            _mediatorMock.Object,
             null!);
 
         Assert.Throws<ArgumentNullException>(act);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/FinalizeSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/FinalizeSessionCommandHandlerTests.cs
@@ -2,9 +2,13 @@ using Api.BoundedContexts.SessionTracking.Application.Commands;
 using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
 using Api.BoundedContexts.SessionTracking.Domain.Services;
+using Api.Infrastructure;
 using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Services;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
 using Moq;
 using Xunit;
 
@@ -18,13 +22,22 @@ public class FinalizeSessionCommandHandlerTests
     private readonly Mock<IScoreEntryRepository> _scoreRepoMock = new();
     private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
     private readonly Mock<ISessionSyncService> _syncServiceMock = new();
+    private readonly MeepleAiDbContext _db;
     private readonly FinalizeSessionCommandHandler _handler;
 
     public FinalizeSessionCommandHandlerTests()
     {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase(databaseName: $"FinalizeSessionUnit_{Guid.NewGuid()}")
+            .Options;
+        _db = new MeepleAiDbContext(
+            options,
+            new Mock<IMediator>().Object,
+            new Mock<IDomainEventCollector>().Object);
+
         _handler = new FinalizeSessionCommandHandler(
             _sessionRepoMock.Object, _scoreRepoMock.Object,
-            _unitOfWorkMock.Object, _syncServiceMock.Object);
+            _unitOfWorkMock.Object, _syncServiceMock.Object, _db);
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/PlayerActionHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/PlayerActionHandlerTests.cs
@@ -450,15 +450,30 @@ public class RollSessionDiceCommandHandlerTests
     private readonly Mock<IDiceRollRepository> _mockDiceRepo = new();
     private readonly Mock<IUnitOfWork> _mockUnitOfWork = new();
     private readonly Mock<ISessionSyncService> _mockSyncService = new();
+    private readonly Api.Infrastructure.MeepleAiDbContext _dbContext;
     private readonly RollSessionDiceCommandHandler _handler;
 
     public RollSessionDiceCommandHandlerTests()
     {
+        // Session Flow v2.1 — T7: handler now appends a dice_rolled diary entry to
+        // the SessionEvents DbSet, so it requires a real (InMemory) DbContext.
+        var options = new DbContextOptionsBuilder<Api.Infrastructure.MeepleAiDbContext>()
+            .UseInMemoryDatabase(databaseName: $"RollDiceUnitTest_{Guid.NewGuid()}")
+            .Options;
+        var mediatorMock = new Mock<IMediator>();
+        var eventCollectorMock = new Mock<Api.SharedKernel.Application.Services.IDomainEventCollector>();
+        _dbContext = new Api.Infrastructure.MeepleAiDbContext(
+            options,
+            mediatorMock.Object,
+            eventCollectorMock.Object,
+            null);
+
         _handler = new RollSessionDiceCommandHandler(
             _mockSessionRepo.Object,
             _mockDiceRepo.Object,
             _mockUnitOfWork.Object,
-            _mockSyncService.Object);
+            _mockSyncService.Object,
+            _dbContext);
     }
 
     private static Session CreateActiveSession(Guid sessionId, Guid participantId)

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/DiaryQueryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/DiaryQueryTests.cs
@@ -157,7 +157,7 @@ public sealed class DiaryQueryTests : IAsyncLifetime
 
         // Act
         var diary = await _sessionDiaryHandler!.Handle(
-            new GetSessionDiaryQuery(createResult.SessionId, EventTypes: null, Since: null),
+            new GetSessionDiaryQuery(createResult.SessionId, RequesterId: userId, EventTypes: null, Since: null),
             TestCancellationToken);
 
         // Assert — chronological order, includes session_created + 2 score_updated events.
@@ -203,7 +203,7 @@ public sealed class DiaryQueryTests : IAsyncLifetime
 
         // Act — query the unified game-night diary.
         var diary = await _gameNightDiaryHandler!.Handle(
-            new GetGameNightDiaryQuery(first.GameNightEventId, EventTypes: null, Since: null),
+            new GetGameNightDiaryQuery(first.GameNightEventId, RequesterId: userId, EventTypes: null, Since: null),
             TestCancellationToken);
 
         // Assert — events from both sessions are present, all scoped to the same night.
@@ -247,6 +247,7 @@ public sealed class DiaryQueryTests : IAsyncLifetime
         var diary = await _sessionDiaryHandler!.Handle(
             new GetSessionDiaryQuery(
                 createResult.SessionId,
+                RequesterId: userId,
                 EventTypes: new[] { "score_updated" },
                 Since: null),
             TestCancellationToken);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/DiaryQueryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/DiaryQueryTests.cs
@@ -1,0 +1,276 @@
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.BoundedContexts.SessionTracking.Domain.Services;
+using Api.BoundedContexts.SessionTracking.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Queries;
+
+/// <summary>
+/// Integration tests for the Session Flow v2.1 — T9 diary read queries
+/// (<see cref="GetSessionDiaryQuery"/> + <see cref="GetGameNightDiaryQuery"/>).
+/// Drives the production handlers (<see cref="CreateSessionCommandHandler"/>,
+/// <see cref="PauseSessionCommandHandler"/>, <see cref="UpsertScoreWithDiaryCommandHandler"/>)
+/// against an isolated PostgreSQL database to verify that:
+/// <list type="bullet">
+///   <item>Single-session diary returns events in chronological order.</item>
+///   <item>Game-night diary unions events from every attached session.</item>
+///   <item>Event-type filtering returns only matching rows.</item>
+/// </list>
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "SessionTracking")]
+[Trait("Feature", "SessionFlowV2.1")]
+public sealed class DiaryQueryTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private string _isolatedDbConnectionString = string.Empty;
+    private ServiceProvider? _serviceProvider;
+    private MeepleAiDbContext? _dbContext;
+    private CreateSessionCommandHandler? _createHandler;
+    private PauseSessionCommandHandler? _pauseHandler;
+    private UpsertScoreWithDiaryCommandHandler? _upsertHandler;
+    private GetSessionDiaryQueryHandler? _sessionDiaryHandler;
+    private GetGameNightDiaryQueryHandler? _gameNightDiaryHandler;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public DiaryQueryTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_diaryqueries_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await _dbContext.Database.MigrateAsync(TestCancellationToken);
+                break;
+            }
+            catch (NpgsqlException) when (attempt < 2)
+            {
+                await Task.Delay(500, TestCancellationToken);
+            }
+        }
+
+        var eventCollector = _serviceProvider.GetRequiredService<IDomainEventCollector>();
+        var unitOfWork = _serviceProvider.GetRequiredService<IUnitOfWork>();
+        var mediator = _serviceProvider.GetRequiredService<IMediator>();
+        var sessionRepo = new SessionRepository(_dbContext, eventCollector);
+
+        var quotaMock = new Mock<ISessionQuotaService>();
+        quotaMock
+            .Setup(s => s.CheckQuotaAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<UserTier>(),
+                It.IsAny<Role>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SessionQuotaResult.Allowed(0, 100));
+
+        var loggerFactory = _serviceProvider.GetRequiredService<ILoggerFactory>();
+        _createHandler = new CreateSessionCommandHandler(
+            sessionRepo,
+            unitOfWork,
+            quotaMock.Object,
+            _dbContext,
+            mediator,
+            loggerFactory.CreateLogger<CreateSessionCommandHandler>());
+
+        _pauseHandler = new PauseSessionCommandHandler(sessionRepo, unitOfWork, _dbContext);
+        _upsertHandler = new UpsertScoreWithDiaryCommandHandler(sessionRepo, unitOfWork, _dbContext);
+        _sessionDiaryHandler = new GetSessionDiaryQueryHandler(_dbContext);
+        _gameNightDiaryHandler = new GetGameNightDiaryQueryHandler(_dbContext);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _dbContext?.Dispose();
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+
+    [Fact]
+    public async Task GetSessionDiary_ReturnsEventsInChronologicalOrder()
+    {
+        // Arrange — create session and produce two score_updated diary events.
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var createResult = await _createHandler!.Handle(
+            BuildCreateCommand(userId, gameId),
+            TestCancellationToken);
+
+        _dbContext!.ChangeTracker.Clear();
+        var ownerParticipantId = await _dbContext.SessionTrackingParticipants
+            .AsNoTracking()
+            .Where(p => p.SessionId == createResult.SessionId && p.IsOwner)
+            .Select(p => p.Id)
+            .FirstAsync(TestCancellationToken);
+
+        await _upsertHandler!.Handle(
+            new UpsertScoreWithDiaryCommand(createResult.SessionId, ownerParticipantId, userId, 10m, 1, null, null),
+            TestCancellationToken);
+        await _upsertHandler!.Handle(
+            new UpsertScoreWithDiaryCommand(createResult.SessionId, ownerParticipantId, userId, 25m, 1, null, null),
+            TestCancellationToken);
+
+        // Act
+        var diary = await _sessionDiaryHandler!.Handle(
+            new GetSessionDiaryQuery(createResult.SessionId, EventTypes: null, Since: null),
+            TestCancellationToken);
+
+        // Assert — chronological order, includes session_created + 2 score_updated events.
+        diary.Should().NotBeNull();
+        diary.Should().HaveCountGreaterThanOrEqualTo(3);
+
+        var timestamps = diary.Select(e => e.Timestamp).ToList();
+        timestamps.Should().BeInAscendingOrder();
+
+        diary.Should().Contain(e => e.EventType == "session_created");
+        diary.Count(e => e.EventType == "score_updated").Should().Be(2);
+
+        // Every event must carry the session id and the GameNight envelope.
+        diary.Should().OnlyContain(e => e.SessionId == createResult.SessionId);
+        diary.Should().OnlyContain(e => e.GameNightId == createResult.GameNightEventId);
+    }
+
+    [Fact]
+    public async Task GetGameNightDiary_UnionsAllSessionsOfNight()
+    {
+        // Arrange — create first session in an ad-hoc night.
+        var (userId, gameId1) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var first = await _createHandler!.Handle(
+            BuildCreateCommand(userId, gameId1),
+            TestCancellationToken);
+
+        // Pause the first so we can attach a second active session in the same night
+        // (the "1 active session per night" invariant is enforced by CreateSession).
+        await _pauseHandler!.Handle(
+            new PauseSessionCommand(first.SessionId, userId),
+            TestCancellationToken);
+
+        // Seed a SECOND library game with Ready KB and create a second session attached
+        // to the same GameNight envelope.
+        var gameId2 = await _fixture.SeedAnotherLibraryGameAsync(_dbContext!, userId);
+        var second = await _createHandler!.Handle(
+            BuildCreateCommand(userId, gameId2, gameNightEventId: first.GameNightEventId),
+            TestCancellationToken);
+
+        second.GameNightEventId.Should().Be(first.GameNightEventId);
+        second.GameNightWasCreated.Should().BeFalse();
+        second.SessionId.Should().NotBe(first.SessionId);
+
+        // Act — query the unified game-night diary.
+        var diary = await _gameNightDiaryHandler!.Handle(
+            new GetGameNightDiaryQuery(first.GameNightEventId, EventTypes: null, Since: null),
+            TestCancellationToken);
+
+        // Assert — events from both sessions are present, all scoped to the same night.
+        diary.Should().OnlyContain(e => e.GameNightId == first.GameNightEventId);
+
+        var distinctSessions = diary.Select(e => e.SessionId).Distinct().ToList();
+        distinctSessions.Should().Contain(first.SessionId);
+        distinctSessions.Should().Contain(second.SessionId);
+        distinctSessions.Should().HaveCountGreaterThanOrEqualTo(2);
+
+        // Sanity check: chronological order is preserved across sessions.
+        diary.Select(e => e.Timestamp).Should().BeInAscendingOrder();
+
+        // The night should carry the pause event from session 1 and at least the
+        // session_created event from session 2.
+        diary.Should().Contain(e => e.SessionId == first.SessionId && e.EventType == "session_paused");
+        diary.Should().Contain(e => e.SessionId == second.SessionId && e.EventType == "session_created");
+    }
+
+    [Fact]
+    public async Task GetSessionDiary_FilteredByEventType_ReturnsOnlyMatching()
+    {
+        // Arrange — create session and emit a single score_updated event.
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var createResult = await _createHandler!.Handle(
+            BuildCreateCommand(userId, gameId),
+            TestCancellationToken);
+
+        _dbContext!.ChangeTracker.Clear();
+        var ownerParticipantId = await _dbContext.SessionTrackingParticipants
+            .AsNoTracking()
+            .Where(p => p.SessionId == createResult.SessionId && p.IsOwner)
+            .Select(p => p.Id)
+            .FirstAsync(TestCancellationToken);
+
+        await _upsertHandler!.Handle(
+            new UpsertScoreWithDiaryCommand(createResult.SessionId, ownerParticipantId, userId, 5m, 1, null, null),
+            TestCancellationToken);
+
+        // Act — filter to score_updated only.
+        var diary = await _sessionDiaryHandler!.Handle(
+            new GetSessionDiaryQuery(
+                createResult.SessionId,
+                EventTypes: new[] { "score_updated" },
+                Since: null),
+            TestCancellationToken);
+
+        // Assert — only score events come back.
+        diary.Should().NotBeEmpty();
+        diary.Should().OnlyContain(e => e.EventType == "score_updated");
+        diary.Should().HaveCount(1);
+    }
+
+    private static CreateSessionCommand BuildCreateCommand(
+        Guid userId,
+        Guid gameId,
+        Guid? gameNightEventId = null) =>
+        new(
+            UserId: userId,
+            GameId: gameId,
+            SessionType: nameof(SessionType.Generic),
+            SessionDate: null,
+            Location: null,
+            Participants: new List<ParticipantDto>
+            {
+                new() { DisplayName = "Owner", IsOwner = true, UserId = userId }
+            },
+            GameNightEventId: gameNightEventId,
+            GuestNames: null);
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/GetCurrentSessionQueryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/GetCurrentSessionQueryTests.cs
@@ -1,0 +1,215 @@
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SessionTracking;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Queries;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SessionTracking")]
+[Trait("Feature", "SessionFlowV2.1")]
+public sealed class GetCurrentSessionQueryTests : IDisposable
+{
+    private readonly MeepleAiDbContext _db;
+    private readonly GetCurrentSessionQueryHandler _handler;
+
+    public GetCurrentSessionQueryTests()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _db = new MeepleAiDbContext(
+            options,
+            new Mock<IMediator>().Object,
+            new Mock<IDomainEventCollector>().Object);
+
+        _handler = new GetCurrentSessionQueryHandler(_db);
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task Handle_NoActiveOrPausedSession_ReturnsNull()
+    {
+        // Arrange — user has only a Finalized session.
+        var userId = Guid.NewGuid();
+        _db.SessionTrackingSessions.Add(new SessionEntity
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            GameId = Guid.NewGuid(),
+            SessionCode = "ABC123",
+            SessionType = "Generic",
+            Status = "Finalized",
+            SessionDate = DateTime.UtcNow.AddHours(-2),
+            CreatedAt = DateTime.UtcNow.AddHours(-2),
+            CreatedBy = userId
+        });
+        await _db.SaveChangesAsync();
+
+        // Act
+        var result = await _handler.Handle(
+            new GetCurrentSessionQuery(userId),
+            CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_HasActiveSession_ReturnsIt()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+
+        _db.SessionTrackingSessions.Add(new SessionEntity
+        {
+            Id = sessionId,
+            UserId = userId,
+            GameId = gameId,
+            SessionCode = "XYZ789",
+            SessionType = "Generic",
+            Status = "Active",
+            SessionDate = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = userId
+        });
+        await _db.SaveChangesAsync();
+
+        // Act
+        var result = await _handler.Handle(
+            new GetCurrentSessionQuery(userId),
+            CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.SessionId.Should().Be(sessionId);
+        result.GameId.Should().Be(gameId);
+        result.Status.Should().Be("Active");
+        result.SessionCode.Should().Be("XYZ789");
+    }
+
+    [Fact]
+    public async Task Handle_MultipleSessionsPicksMostRecent()
+    {
+        // Arrange — two active sessions; the one with newer UpdatedAt should win.
+        var userId = Guid.NewGuid();
+        var olderSessionId = Guid.NewGuid();
+        var newerSessionId = Guid.NewGuid();
+
+        _db.SessionTrackingSessions.AddRange(
+            new SessionEntity
+            {
+                Id = olderSessionId,
+                UserId = userId,
+                GameId = Guid.NewGuid(),
+                SessionCode = "OLD001",
+                SessionType = "Generic",
+                Status = "Paused",
+                SessionDate = DateTime.UtcNow.AddHours(-3),
+                UpdatedAt = DateTime.UtcNow.AddHours(-2),
+                CreatedAt = DateTime.UtcNow.AddHours(-3),
+                CreatedBy = userId
+            },
+            new SessionEntity
+            {
+                Id = newerSessionId,
+                UserId = userId,
+                GameId = Guid.NewGuid(),
+                SessionCode = "NEW001",
+                SessionType = "Generic",
+                Status = "Active",
+                SessionDate = DateTime.UtcNow.AddHours(-1),
+                UpdatedAt = DateTime.UtcNow,
+                CreatedAt = DateTime.UtcNow.AddHours(-1),
+                CreatedBy = userId
+            });
+        await _db.SaveChangesAsync();
+
+        // Act
+        var result = await _handler.Handle(
+            new GetCurrentSessionQuery(userId),
+            CancellationToken.None);
+
+        // Assert — the session with the most recent UpdatedAt is returned.
+        result.Should().NotBeNull();
+        result!.SessionId.Should().Be(newerSessionId);
+        result.SessionCode.Should().Be("NEW001");
+    }
+
+    [Fact]
+    public async Task Handle_DeletedSessionIsExcluded()
+    {
+        // Arrange — user has one Active session but it is soft-deleted.
+        var userId = Guid.NewGuid();
+        _db.SessionTrackingSessions.Add(new SessionEntity
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            GameId = Guid.NewGuid(),
+            SessionCode = "DEL001",
+            SessionType = "Generic",
+            Status = "Active",
+            SessionDate = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = userId,
+            IsDeleted = true,
+            DeletedAt = DateTime.UtcNow
+        });
+        await _db.SaveChangesAsync();
+
+        // Act
+        var result = await _handler.Handle(
+            new GetCurrentSessionQuery(userId),
+            CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_OtherUsersSessionsNotReturned()
+    {
+        // Arrange — another user has an active session.
+        var requestingUserId = Guid.NewGuid();
+        var otherUserId = Guid.NewGuid();
+
+        _db.SessionTrackingSessions.Add(new SessionEntity
+        {
+            Id = Guid.NewGuid(),
+            UserId = otherUserId,
+            GameId = Guid.NewGuid(),
+            SessionCode = "OTH001",
+            SessionType = "Generic",
+            Status = "Active",
+            SessionDate = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = otherUserId
+        });
+        await _db.SaveChangesAsync();
+
+        // Act
+        var result = await _handler.Handle(
+            new GetCurrentSessionQuery(requestingUserId),
+            CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Entities/SessionAdvanceTurnTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Entities/SessionAdvanceTurnTests.cs
@@ -1,0 +1,113 @@
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Domain.Entities;
+
+/// <summary>
+/// Unit tests for Session.AdvanceTurn() — Plan 1bis T1.
+/// Verifies cyclic index progression, status/precondition guards, and the
+/// (fromIndex, toIndex, fromParticipantId, toParticipantId) result tuple.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SessionTracking")]
+public class SessionAdvanceTurnTests
+{
+    private static Session CreateSessionWithThreePlayers()
+    {
+        var session = Session.Create(Guid.NewGuid(), Guid.NewGuid(), SessionType.GameSpecific);
+        // Session.Create already adds the creator as first participant (Owner, joinOrder=1)
+        session.AddParticipant(ParticipantInfo.Create("Luca", isOwner: false, joinOrder: 2));
+        session.AddParticipant(ParticipantInfo.Create("Sara", isOwner: false, joinOrder: 3));
+        var ids = session.Participants.Select(p => p.Id).ToArray();
+        session.SetTurnOrder(TurnOrderMethod.Manual, ids, seed: null);
+        return session;
+    }
+
+    [Fact]
+    public void AdvanceTurn_FromZero_IncrementsToOne()
+    {
+        var session = CreateSessionWithThreePlayers();
+
+        session.AdvanceTurn();
+
+        session.CurrentTurnIndex.Should().Be(1);
+    }
+
+    [Fact]
+    public void AdvanceTurn_WrapsAroundAtEnd()
+    {
+        var session = CreateSessionWithThreePlayers();
+
+        session.AdvanceTurn(); // 0 → 1
+        session.AdvanceTurn(); // 1 → 2
+        session.AdvanceTurn(); // 2 → 0 wrap
+
+        session.CurrentTurnIndex.Should().Be(0);
+    }
+
+    [Fact]
+    public void AdvanceTurn_ReturnsFromAndToIndices()
+    {
+        var session = CreateSessionWithThreePlayers();
+        var ids = session.Participants.Select(p => p.Id).ToArray();
+
+        var result = session.AdvanceTurn();
+
+        result.FromIndex.Should().Be(0);
+        result.ToIndex.Should().Be(1);
+        result.FromParticipantId.Should().Be(ids[0]);
+        result.ToParticipantId.Should().Be(ids[1]);
+    }
+
+    [Fact]
+    public void AdvanceTurn_WrapReturnsCorrectFromAndTo()
+    {
+        var session = CreateSessionWithThreePlayers();
+        var ids = session.Participants.Select(p => p.Id).ToArray();
+
+        session.AdvanceTurn(); // 0 → 1
+        session.AdvanceTurn(); // 1 → 2
+        var wrap = session.AdvanceTurn(); // 2 → 0
+
+        wrap.FromIndex.Should().Be(2);
+        wrap.ToIndex.Should().Be(0);
+        wrap.FromParticipantId.Should().Be(ids[2]);
+        wrap.ToParticipantId.Should().Be(ids[0]);
+    }
+
+    [Fact]
+    public void AdvanceTurn_WithoutTurnOrderSet_Throws()
+    {
+        var session = Session.Create(Guid.NewGuid(), Guid.NewGuid(), SessionType.GameSpecific);
+
+        var act = () => session.AdvanceTurn();
+
+        act.Should().Throw<ConflictException>();
+    }
+
+    [Fact]
+    public void AdvanceTurn_WhenPaused_Throws()
+    {
+        var session = CreateSessionWithThreePlayers();
+        session.Pause();
+
+        var act = () => session.AdvanceTurn();
+
+        act.Should().Throw<ConflictException>();
+    }
+
+    [Fact]
+    public void AdvanceTurn_WhenFinalized_Throws()
+    {
+        var session = CreateSessionWithThreePlayers();
+        session.Finalize();
+
+        var act = () => session.AdvanceTurn();
+
+        act.Should().Throw<ConflictException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Entities/SessionTurnOrderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Entities/SessionTurnOrderTests.cs
@@ -1,0 +1,58 @@
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.ValueObjects;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Domain.Entities;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SessionTracking")]
+public class SessionTurnOrderTests
+{
+    private static Session CreateSession()
+    {
+        return Session.Create(
+            userId: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            sessionType: SessionType.GameSpecific);
+    }
+
+    [Fact]
+    public void Session_NewlyCreated_HasNullTurnOrderFields()
+    {
+        var session = CreateSession();
+
+        session.TurnOrderJson.Should().BeNull();
+        session.TurnOrderMethod.Should().BeNull();
+        session.TurnOrderSeed.Should().BeNull();
+        session.CurrentTurnIndex.Should().BeNull();
+    }
+
+    [Fact]
+    public void SetTurnOrder_Manual_PersistsOrderAndMethod()
+    {
+        var session = CreateSession();
+        var p1 = session.Participants.First().Id;
+        session.AddParticipant(ParticipantInfo.Create("Luca", isOwner: false, joinOrder: 2));
+        var p2 = session.Participants.Last().Id;
+
+        session.SetTurnOrder(TurnOrderMethod.Manual, order: new[] { p2, p1 }, seed: null);
+
+        session.TurnOrderMethod.Should().Be("Manual");
+        session.TurnOrderSeed.Should().BeNull();
+        session.TurnOrderJson.Should().Contain(p2.ToString()).And.Contain(p1.ToString());
+        session.CurrentTurnIndex.Should().Be(0);
+    }
+
+    [Fact]
+    public void SetTurnOrder_Random_RequiresSeed()
+    {
+        var session = CreateSession();
+        var p1 = session.Participants.First().Id;
+
+        var act = () => session.SetTurnOrder(TurnOrderMethod.Random, order: new[] { p1 }, seed: null);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*seed*");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Integration/SessionFlowE2ETests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Integration/SessionFlowE2ETests.cs
@@ -201,7 +201,7 @@ public sealed class SessionFlowE2ETests : IAsyncLifetime
 
         // 6. Verify per-session diary contains the required event types.
         var diary1 = await _sessionDiaryHandler!.Handle(
-            new GetSessionDiaryQuery(create1.SessionId, EventTypes: null, Since: null, Limit: 200),
+            new GetSessionDiaryQuery(create1.SessionId, RequesterId: userId, EventTypes: null, Since: null, Limit: 200),
             TestCancellationToken);
 
         diary1.Should().NotBeEmpty();
@@ -260,6 +260,7 @@ public sealed class SessionFlowE2ETests : IAsyncLifetime
         var nightDiary = await freshGameNightDiaryHandler.Handle(
             new GetGameNightDiaryQuery(
                 create1.GameNightEventId,
+                RequesterId: userId,
                 EventTypes: null,
                 Since: null,
                 Limit: 500),

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Integration/SessionFlowE2ETests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Integration/SessionFlowE2ETests.cs
@@ -1,0 +1,374 @@
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.BoundedContexts.SessionTracking.Domain.Services;
+using Api.BoundedContexts.SessionTracking.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Integration;
+
+/// <summary>
+/// End-to-end integration test for Session Flow v2.1 (final task T10).
+/// Drives the full happy path through the production handlers:
+///
+/// <list type="number">
+///   <item>Create first session with 2 guest players (ad-hoc GameNight).</item>
+///   <item>Set a random turn order (seeded Fisher-Yates).</item>
+///   <item>Each participant rolls 2d6.</item>
+///   <item>Upsert a score for each participant.</item>
+///   <item>Verify the per-session diary contains the expected event types.</item>
+///   <item>Pause the first session.</item>
+///   <item>Create a second session attached to the SAME GameNight with a second game.</item>
+///   <item>Verify the per-night diary unions events from both sessions.</item>
+/// </list>
+///
+/// All tasks T1-T9 are exercised in a single realistic flow to catch integration
+/// regressions that would be invisible to per-task tests.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "SessionTracking")]
+[Trait("Feature", "SessionFlowV2.1")]
+public sealed class SessionFlowE2ETests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private string _isolatedDbConnectionString = string.Empty;
+    private ServiceProvider? _serviceProvider;
+    private MeepleAiDbContext? _dbContext;
+
+    private CreateSessionCommandHandler? _createHandler;
+    private SetTurnOrderCommandHandler? _setTurnOrderHandler;
+    private RollSessionDiceCommandHandler? _rollHandler;
+    private UpsertScoreWithDiaryCommandHandler? _upsertHandler;
+    private PauseSessionCommandHandler? _pauseHandler;
+    private GetSessionDiaryQueryHandler? _sessionDiaryHandler;
+    private GetGameNightDiaryQueryHandler? _gameNightDiaryHandler;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public SessionFlowE2ETests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_sessionflow_e2e_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await _dbContext.Database.MigrateAsync(TestCancellationToken);
+                break;
+            }
+            catch (NpgsqlException) when (attempt < 2)
+            {
+                await Task.Delay(500, TestCancellationToken);
+            }
+        }
+
+        (_createHandler,
+            _setTurnOrderHandler,
+            _rollHandler,
+            _upsertHandler,
+            _pauseHandler,
+            _sessionDiaryHandler,
+            _gameNightDiaryHandler) = BuildHandlerBundle(_serviceProvider, _dbContext);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _dbContext?.Dispose();
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+
+    [Fact]
+    public async Task HappyPath_StartSession_TurnOrder_Rolls_Scores_PauseAndSecondGame()
+    {
+        // 1. Seed user + first library game with Ready KB.
+        var (userId, gameId1) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 3);
+
+        // 2. Create first session with owner + 2 guest players.
+        var create1 = await _createHandler!.Handle(
+            BuildCreateCommand(userId, gameId1, guestNames: new[] { "Luca", "Sara" }),
+            TestCancellationToken);
+
+        create1.GameNightWasCreated.Should().BeTrue();
+        create1.GameNightEventId.Should().NotBeEmpty();
+        create1.SessionId.Should().NotBeEmpty();
+        create1.Participants.Should().HaveCount(3);
+        create1.Participants.Should().Contain(p => p.IsOwner);
+
+        // Load participant ids in insertion order.
+        _dbContext!.ChangeTracker.Clear();
+        var session1ParticipantIds = await _dbContext.SessionTrackingParticipants
+            .AsNoTracking()
+            .Where(p => p.SessionId == create1.SessionId)
+            .OrderBy(p => p.JoinOrder)
+            .Select(p => p.Id)
+            .ToListAsync(TestCancellationToken);
+        session1ParticipantIds.Should().HaveCount(3);
+
+        // 3. Set a random turn order.
+        var turnOrderResult = await _setTurnOrderHandler!.Handle(
+            new SetTurnOrderCommand(
+                SessionId: create1.SessionId,
+                UserId: userId,
+                Method: TurnOrderMethod.Random,
+                ManualOrder: null),
+            TestCancellationToken);
+
+        turnOrderResult.Method.Should().Be(nameof(TurnOrderMethod.Random));
+        turnOrderResult.Seed.Should().NotBeNull();
+        turnOrderResult.Order.Should().HaveCount(3);
+        turnOrderResult.Order.Should().BeEquivalentTo(session1ParticipantIds);
+
+        // 4. Each participant rolls 2d6.
+        foreach (var participantId in session1ParticipantIds)
+        {
+            var roll = await _rollHandler!.Handle(
+                new RollSessionDiceCommand(
+                    SessionId: create1.SessionId,
+                    ParticipantId: participantId,
+                    RequesterId: userId,
+                    Formula: "2d6",
+                    Label: null),
+                TestCancellationToken);
+
+            roll.Total.Should().BeInRange(2, 12);
+            roll.Rolls.Should().HaveCount(2);
+            roll.Formula.Should().Be("2D6");
+        }
+
+        // 5. Upsert a score for each participant.
+        var newValue = 25m;
+        foreach (var participantId in session1ParticipantIds)
+        {
+            var scoreResult = await _upsertHandler!.Handle(
+                new UpsertScoreWithDiaryCommand(
+                    SessionId: create1.SessionId,
+                    ParticipantId: participantId,
+                    RequesterId: userId,
+                    NewValue: newValue,
+                    RoundNumber: 1,
+                    Category: null,
+                    Reason: null),
+                TestCancellationToken);
+
+            scoreResult.NewValue.Should().Be(newValue);
+            scoreResult.OldValue.Should().Be(0m);
+        }
+
+        // 6. Verify per-session diary contains the required event types.
+        var diary1 = await _sessionDiaryHandler!.Handle(
+            new GetSessionDiaryQuery(create1.SessionId, EventTypes: null, Since: null, Limit: 200),
+            TestCancellationToken);
+
+        diary1.Should().NotBeEmpty();
+        diary1.Select(e => e.EventType).Distinct().Should().Contain(new[]
+        {
+            "session_created",
+            "gamenight_created",
+            "turn_order_set",
+            "dice_rolled",
+            "score_updated"
+        });
+        diary1.Count(e => e.EventType == "dice_rolled").Should().Be(3);
+        diary1.Count(e => e.EventType == "score_updated").Should().Be(3);
+        diary1.Count(e => e.EventType == "turn_order_set").Should().Be(1);
+        diary1.Select(e => e.Timestamp).Should().BeInAscendingOrder();
+        diary1.Should().OnlyContain(e => e.SessionId == create1.SessionId);
+        diary1.Should().OnlyContain(e => e.GameNightId == create1.GameNightEventId);
+
+        // 7. Pause the first session so a second session can become Active in the same night.
+        await _pauseHandler!.Handle(
+            new PauseSessionCommand(create1.SessionId, userId),
+            TestCancellationToken);
+
+        // 8. Seed a second library game with Ready KB and attach a new session to the
+        // SAME game night. Build a fresh handler bundle against a new service provider
+        // on the same database to avoid [Timestamp] RowVersion conflicts on the already
+        // tracked Session aggregate (same pattern used in CreateSessionCommandAdHocTests).
+        var gameId2 = await _fixture.SeedAnotherLibraryGameAsync(_dbContext!, userId);
+
+        await using var freshScope = IntegrationServiceCollectionBuilder
+            .CreateBase(_isolatedDbConnectionString)
+            .BuildServiceProvider();
+        var freshDb = freshScope.GetRequiredService<MeepleAiDbContext>();
+        var (
+            freshCreateHandler,
+            _,
+            _,
+            _,
+            _,
+            _,
+            freshGameNightDiaryHandler) = BuildHandlerBundle(freshScope, freshDb);
+
+        var create2 = await freshCreateHandler.Handle(
+            BuildCreateCommand(
+                userId,
+                gameId2,
+                guestNames: null,
+                gameNightEventId: create1.GameNightEventId),
+            TestCancellationToken);
+
+        create2.GameNightWasCreated.Should().BeFalse();
+        create2.GameNightEventId.Should().Be(create1.GameNightEventId);
+        create2.SessionId.Should().NotBe(create1.SessionId);
+
+        // 9. The unified GameNight diary must contain events from BOTH sessions.
+        var nightDiary = await freshGameNightDiaryHandler.Handle(
+            new GetGameNightDiaryQuery(
+                create1.GameNightEventId,
+                EventTypes: null,
+                Since: null,
+                Limit: 500),
+            TestCancellationToken);
+
+        nightDiary.Should().NotBeEmpty();
+        nightDiary.Should().OnlyContain(e => e.GameNightId == create1.GameNightEventId);
+        nightDiary.Select(e => e.Timestamp).Should().BeInAscendingOrder();
+
+        var distinctSessionIds = nightDiary.Select(e => e.SessionId).Distinct().ToList();
+        distinctSessionIds.Should().Contain(create1.SessionId);
+        distinctSessionIds.Should().Contain(create2.SessionId);
+        distinctSessionIds.Should().HaveCountGreaterThanOrEqualTo(2);
+
+        // First-session signature events must be present in the night diary.
+        nightDiary.Should().Contain(e =>
+            e.SessionId == create1.SessionId && e.EventType == "turn_order_set");
+        nightDiary.Count(e =>
+            e.SessionId == create1.SessionId && e.EventType == "dice_rolled").Should().Be(3);
+        nightDiary.Count(e =>
+            e.SessionId == create1.SessionId && e.EventType == "score_updated").Should().Be(3);
+        nightDiary.Should().Contain(e =>
+            e.SessionId == create1.SessionId && e.EventType == "session_paused");
+
+        // Second-session signature events.
+        nightDiary.Should().Contain(e =>
+            e.SessionId == create2.SessionId && e.EventType == "session_created");
+        nightDiary.Should().Contain(e =>
+            e.SessionId == create2.SessionId && e.EventType == "gamenight_game_added");
+    }
+
+    /// <summary>
+    /// Wires the full Session Flow v2.1 handler graph against a given DI scope
+    /// so tests can drive every production handler that is exercised by this E2E flow.
+    /// Mirrors the bootstrap done by the per-task integration tests.
+    /// </summary>
+    private static (
+        CreateSessionCommandHandler create,
+        SetTurnOrderCommandHandler setTurnOrder,
+        RollSessionDiceCommandHandler roll,
+        UpsertScoreWithDiaryCommandHandler upsert,
+        PauseSessionCommandHandler pause,
+        GetSessionDiaryQueryHandler sessionDiary,
+        GetGameNightDiaryQueryHandler gameNightDiary) BuildHandlerBundle(
+        IServiceProvider scope,
+        MeepleAiDbContext db)
+    {
+        var eventCollector = scope.GetRequiredService<IDomainEventCollector>();
+        var unitOfWork = scope.GetRequiredService<IUnitOfWork>();
+        var mediator = scope.GetRequiredService<IMediator>();
+        var sessionRepo = new SessionRepository(db, eventCollector);
+        var diceRollRepo = new DiceRollRepository(db, eventCollector);
+
+        var quotaMock = new Mock<ISessionQuotaService>();
+        quotaMock
+            .Setup(s => s.CheckQuotaAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<UserTier>(),
+                It.IsAny<Role>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SessionQuotaResult.Allowed(0, 100));
+
+        var syncMock = new Mock<ISessionSyncService>();
+        syncMock
+            .Setup(s => s.PublishEventAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<INotification>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var loggerFactory = scope.GetRequiredService<ILoggerFactory>();
+        var create = new CreateSessionCommandHandler(
+            sessionRepo,
+            unitOfWork,
+            quotaMock.Object,
+            db,
+            mediator,
+            loggerFactory.CreateLogger<CreateSessionCommandHandler>());
+
+        var setTurnOrder = new SetTurnOrderCommandHandler(sessionRepo, unitOfWork, db);
+        var roll = new RollSessionDiceCommandHandler(
+            sessionRepo,
+            diceRollRepo,
+            unitOfWork,
+            syncMock.Object,
+            db);
+        var upsert = new UpsertScoreWithDiaryCommandHandler(sessionRepo, unitOfWork, db);
+        var pause = new PauseSessionCommandHandler(sessionRepo, unitOfWork, db);
+        var sessionDiary = new GetSessionDiaryQueryHandler(db);
+        var gameNightDiary = new GetGameNightDiaryQueryHandler(db);
+
+        return (create, setTurnOrder, roll, upsert, pause, sessionDiary, gameNightDiary);
+    }
+
+    private static CreateSessionCommand BuildCreateCommand(
+        Guid userId,
+        Guid gameId,
+        IReadOnlyList<string>? guestNames = null,
+        Guid? gameNightEventId = null) =>
+        new(
+            UserId: userId,
+            GameId: gameId,
+            SessionType: nameof(SessionType.Generic),
+            SessionDate: null,
+            Location: null,
+            Participants: new List<ParticipantDto>
+            {
+                new() { DisplayName = "Owner", IsOwner = true, UserId = userId }
+            },
+            GameNightEventId: gameNightEventId,
+            GuestNames: guestNames);
+}

--- a/apps/api/tests/Api.Tests/Infrastructure/SharedTestcontainersFixture.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/SharedTestcontainersFixture.cs
@@ -10,6 +10,7 @@ using Pgvector.EntityFrameworkCore; // Issue #3547: Enable pgvector type mapping
 using StackExchange.Redis;
 using Xunit;
 using Api.Infrastructure;
+using Api.Infrastructure.Entities;
 using Api.SharedKernel.Application.Services;
 
 namespace Api.Tests.Infrastructure;
@@ -927,6 +928,273 @@ public sealed class SharedTestcontainersFixture : IAsyncLifetime
             .Returns(new List<Api.SharedKernel.Domain.Interfaces.IDomainEvent>().AsReadOnly());
 
         return new MeepleAiDbContext(optionsBuilder.Options, contextMediator, mockEventCollector.Object);
+    }
+
+    // ============================================================================
+    // Session Flow v2.1 seeders (Task 0 of 2026-04-09 Session Flow backend plan)
+    //
+    // These helpers create the data graph required by T1-T10 integration tests.
+    // Semantics (more important than exact field names):
+    //   - "Indexed KB ready" = PdfDocument in PdfProcessingState.Ready terminal state
+    //                         AND a VectorDocumentEntity row exists with IndexingStatus="completed".
+    //   - "No KB"             = PdfDocument in non-Ready state (Extracting) and zero VectorDocuments.
+    //   - "Library game"      = UserLibraryEntry linking the user to the SharedGame.
+    //
+    // Notes on entity model:
+    //   - PdfDocumentEntity.GameId is FK to legacy `games` table (GameEntity), not SharedGame.
+    //     We seed BOTH a GameEntity and a SharedGameEntity with the SAME Id so PDF FK is satisfied
+    //     while UserLibraryEntry can reference SharedGameId.
+    //   - VectorDocumentEntity has a UNIQUE constraint on PdfDocumentId — at most one row per PDF.
+    //     The `vectorCount` parameter is interpreted as the ChunkCount on that single row;
+    //     `vectorCount == 0` means "no VectorDocument row at all" (KB not ready).
+    // ============================================================================
+
+    private static GameEntity CreateGameRow(Guid gameId, string title)
+    {
+        return new GameEntity
+        {
+            Id = gameId,
+            Name = title,
+            CreatedAt = DateTime.UtcNow,
+            SharedGameId = gameId
+        };
+    }
+
+    private static Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity CreateSharedGameRow(
+        Guid gameId, string title, Guid createdBy)
+    {
+        return new Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity
+        {
+            Id = gameId,
+            Title = title,
+            YearPublished = 2024,
+            Description = "Seeded test game",
+            MinPlayers = 1,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            CreatedBy = createdBy,
+            CreatedAt = DateTime.UtcNow
+        };
+    }
+
+    private static UserEntity CreateUserRow(Guid userId)
+    {
+        return new UserEntity
+        {
+            Id = userId,
+            Email = $"sf21-{userId:N}@meepleai.test",
+            DisplayName = "Session Flow Test User",
+            PasswordHash = "test-hash",
+            Role = "user",
+            Tier = "free",
+            CreatedAt = DateTime.UtcNow
+        };
+    }
+
+    private static PdfDocumentEntity CreatePdfRow(
+        Guid pdfId, Guid gameId, Guid uploadedBy, string fileName, string processingState)
+    {
+        return new PdfDocumentEntity
+        {
+            Id = pdfId,
+            GameId = gameId,
+            SharedGameId = gameId,
+            UploadedByUserId = uploadedBy,
+            FileName = fileName,
+            FilePath = $"/test/{fileName}",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = processingState,
+            ProcessedAt = processingState == "Ready" ? DateTime.UtcNow : null
+        };
+    }
+
+    private static VectorDocumentEntity CreateVectorDocRow(Guid pdfId, Guid gameId, int chunkCount)
+    {
+        return new VectorDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = pdfId,
+            GameId = gameId,
+            SharedGameId = gameId,
+            ChunkCount = chunkCount,
+            TotalCharacters = chunkCount * 500,
+            IndexingStatus = "completed",
+            IndexedAt = DateTime.UtcNow,
+            EmbeddingModel = "test-embed",
+            EmbeddingDimensions = 768
+        };
+    }
+
+    /// <summary>
+    /// Seeds a user + a shared game (with parallel GameEntity row) + a UserLibraryEntry +
+    /// 1 indexed PDF + 1 VectorDocument with ChunkCount=<paramref name="vectorCount"/>.
+    /// Used for Session Flow v2.1 tests where KB must be ready.
+    /// </summary>
+    public async Task<(Guid userId, Guid gameId)> SeedUserWithLibraryGameAndIndexedKbAsync(
+        MeepleAiDbContext db,
+        int vectorCount = 3)
+    {
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var pdfId = Guid.NewGuid();
+
+        db.Users.Add(CreateUserRow(userId));
+        db.Games.Add(CreateGameRow(gameId, "SF21 Test Game"));
+        db.SharedGames.Add(CreateSharedGameRow(gameId, "SF21 Test Game", userId));
+        db.UserLibraryEntries.Add(new Api.Infrastructure.Entities.UserLibrary.UserLibraryEntryEntity
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            SharedGameId = gameId,
+            AddedAt = DateTime.UtcNow
+        });
+        db.PdfDocuments.Add(CreatePdfRow(pdfId, gameId, userId, "rules.pdf", "Ready"));
+
+        if (vectorCount > 0)
+        {
+            db.VectorDocuments.Add(CreateVectorDocRow(pdfId, gameId, vectorCount));
+        }
+
+        await db.SaveChangesAsync();
+        return (userId, gameId);
+    }
+
+    /// <summary>
+    /// IServiceScope overload — resolves MeepleAiDbContext from the scope. Convenience for
+    /// tests that build their own service provider.
+    /// </summary>
+    public Task<(Guid userId, Guid gameId)> SeedUserWithLibraryGameAndIndexedKbAsync(
+        IServiceScope scope, int vectorCount = 3)
+        => SeedUserWithLibraryGameAndIndexedKbAsync(
+            scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>(), vectorCount);
+
+    /// <summary>
+    /// Seeds an additional game in the same user's library with indexed KB.
+    /// </summary>
+    public async Task<Guid> SeedAnotherLibraryGameAsync(MeepleAiDbContext db, Guid userId)
+    {
+        var gameId = Guid.NewGuid();
+        var pdfId = Guid.NewGuid();
+
+        db.Games.Add(CreateGameRow(gameId, "SF21 Second Game"));
+        db.SharedGames.Add(CreateSharedGameRow(gameId, "SF21 Second Game", userId));
+        db.UserLibraryEntries.Add(new Api.Infrastructure.Entities.UserLibrary.UserLibraryEntryEntity
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            SharedGameId = gameId,
+            AddedAt = DateTime.UtcNow
+        });
+        db.PdfDocuments.Add(CreatePdfRow(pdfId, gameId, userId, "rules2.pdf", "Ready"));
+        db.VectorDocuments.Add(CreateVectorDocRow(pdfId, gameId, chunkCount: 1));
+
+        await db.SaveChangesAsync();
+        return gameId;
+    }
+
+    /// <summary>
+    /// IServiceScope overload for SeedAnotherLibraryGameAsync.
+    /// </summary>
+    public Task<Guid> SeedAnotherLibraryGameAsync(IServiceScope scope, Guid userId)
+        => SeedAnotherLibraryGameAsync(
+            scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>(), userId);
+
+    /// <summary>
+    /// Seeds user + game in library but WITHOUT indexed KB (PDF in Extracting state, 0 VectorDocuments).
+    /// Used for KB_NOT_READY negative tests.
+    /// </summary>
+    public async Task<(Guid userId, Guid gameId)> SeedUserWithLibraryGameButNoKbAsync(MeepleAiDbContext db)
+    {
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var pdfId = Guid.NewGuid();
+
+        db.Users.Add(CreateUserRow(userId));
+        db.Games.Add(CreateGameRow(gameId, "SF21 NoKB Game"));
+        db.SharedGames.Add(CreateSharedGameRow(gameId, "SF21 NoKB Game", userId));
+        db.UserLibraryEntries.Add(new Api.Infrastructure.Entities.UserLibrary.UserLibraryEntryEntity
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            SharedGameId = gameId,
+            AddedAt = DateTime.UtcNow
+        });
+        db.PdfDocuments.Add(CreatePdfRow(pdfId, gameId, userId, "rules.pdf", "Extracting"));
+        // NO VectorDocument row.
+
+        await db.SaveChangesAsync();
+        return (userId, gameId);
+    }
+
+    /// <summary>
+    /// IServiceScope overload for SeedUserWithLibraryGameButNoKbAsync.
+    /// </summary>
+    public Task<(Guid userId, Guid gameId)> SeedUserWithLibraryGameButNoKbAsync(IServiceScope scope)
+        => SeedUserWithLibraryGameButNoKbAsync(
+            scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>());
+
+    /// <summary>
+    /// Lightweight seeder: just a game (legacy + shared) + indexed PDF + 1 VectorDocument
+    /// with ChunkCount=<paramref name="vectorCount"/>. No user, no library.
+    /// Used by handler-level tests that don't need the full user stack.
+    /// When <paramref name="vectorCount"/> == 0, no VectorDocument row is created (KB-not-ready case).
+    /// </summary>
+    public async Task<Guid> SeedGameWithIndexedPdfAsync(MeepleAiDbContext db, int vectorCount)
+    {
+        var gameId = Guid.NewGuid();
+        var pdfId = Guid.NewGuid();
+        var dummyUserId = Guid.NewGuid();
+
+        db.Users.Add(CreateUserRow(dummyUserId));
+        db.Games.Add(CreateGameRow(gameId, "SF21 Seeded Game"));
+        db.SharedGames.Add(CreateSharedGameRow(gameId, "SF21 Seeded Game", dummyUserId));
+        db.PdfDocuments.Add(CreatePdfRow(pdfId, gameId, dummyUserId, "rules.pdf", "Ready"));
+
+        if (vectorCount > 0)
+        {
+            db.VectorDocuments.Add(CreateVectorDocRow(pdfId, gameId, vectorCount));
+        }
+
+        await db.SaveChangesAsync();
+        return gameId;
+    }
+
+    /// <summary>
+    /// Seeds a game with mixed PDF states: <paramref name="indexedCount"/> Ready PDFs (each with a
+    /// VectorDocument of ChunkCount=<paramref name="vectorsPerIndexed"/>) plus
+    /// <paramref name="failedCount"/> Failed PDFs (no VectorDocument).
+    /// </summary>
+    public async Task<Guid> SeedGameWithMixedPdfsAsync(
+        MeepleAiDbContext db, int indexedCount, int failedCount, int vectorsPerIndexed)
+    {
+        var gameId = Guid.NewGuid();
+        var dummyUserId = Guid.NewGuid();
+
+        db.Users.Add(CreateUserRow(dummyUserId));
+        db.Games.Add(CreateGameRow(gameId, "SF21 Mixed Game"));
+        db.SharedGames.Add(CreateSharedGameRow(gameId, "SF21 Mixed Game", dummyUserId));
+
+        for (int i = 0; i < indexedCount; i++)
+        {
+            var pdfId = Guid.NewGuid();
+            db.PdfDocuments.Add(CreatePdfRow(pdfId, gameId, dummyUserId, $"ok-{i}.pdf", "Ready"));
+            if (vectorsPerIndexed > 0)
+            {
+                db.VectorDocuments.Add(CreateVectorDocRow(pdfId, gameId, vectorsPerIndexed));
+            }
+        }
+
+        for (int i = 0; i < failedCount; i++)
+        {
+            var pdfId = Guid.NewGuid();
+            db.PdfDocuments.Add(CreatePdfRow(pdfId, gameId, dummyUserId, $"fail-{i}.pdf", "Failed"));
+        }
+
+        await db.SaveChangesAsync();
+        return gameId;
     }
 }
 

--- a/docs/frontend/my-hand-spec.md
+++ b/docs/frontend/my-hand-spec.md
@@ -1,0 +1,341 @@
+# La Mia Mano — Quick Action Bar
+**Feature Specification v1.0**
+**Data**: 2026-04-09
+**Bounded Context**: UserLibrary / UserPreferences (TBD)
+**Stato**: ⚠️ **SUPERSEDED** — sostituita da `docs/superpowers/specs/2026-04-09-session-gameplay-flow-v2.md`
+
+> **Nota (2026-04-09)**: Questa v1 modellava MyHand come 4 slot fissi persistiti lato server, popolati manualmente dall'utente. A seguito di brainstorming panel è emerso che il vero use case è un'esperienza contestuale legata alla Session/GamePlay, con Hand dinamica derivata e Diario eventi. Il plan v1 (`docs/superpowers/plans/2026-04-09-my-hand-feature.md`) è congelato. Non eseguire i Task 1+ sulla persistenza `UserHandSlot`. Riferirsi alla v2 per il nuovo modello.
+
+---
+
+---
+
+## 1. Vision
+
+**La Mia Mano** è una barra di azioni rapide persistente che permette all'utente di ancorare 4 entità (una per tipo) e accedere alle relative azioni frequenti in un singolo tocco, senza abbandonare la pagina corrente.
+
+### Distinzione da DesktopHandRail (esistente)
+
+| Aspetto | `DesktopHandRail` (esistente) | `MyHand` (nuovo) |
+|---|---|---|
+| **Scopo** | Context tracking navigazione | Quick actions persistenti |
+| **Popolazione** | Automatica (visita entità) | Manuale (utente sceglie) |
+| **Slot** | N dinamici, qualsiasi tipo | 4 fissi, tipo-vincolato |
+| **Persistenza** | SessionStorage | Server + LocalStorage fallback |
+| **Posizione desktop** | Left rail 76px | Right sidebar 280px |
+| **Mobile** | Assente | Bottom action bar |
+
+---
+
+## 2. Slot Principali
+
+| Slot | Entity Type | Colore token | Icona |
+|---|---|---|---|
+| **Toolkit** | `toolkit` | `--e-toolkit` | 🔧 |
+| **Game** | `game` | `--e-game` | 🎮 |
+| **Partita / Session** | `session` | `--e-session` | 🎯 |
+| **AI** | `agent` | `--e-agent` | 🤖 |
+
+---
+
+## 3. Requisiti Funzionali
+
+| ID | Requisito | Priorità |
+|---|---|---|
+| F-01 | Sistema a 4 slot fissi: toolkit, game, session, ai | P0 |
+| F-02 | Slot inizialmente vuoti al primo login | P0 |
+| F-03 | Ogni slot accetta solo l'entity type corrispondente | P0 |
+| F-04 | Slot vuoto mostra CTA contestuale per tipo | P0 |
+| F-05 | Slot popolato mostra MeepleCard (variant compact) + quick actions | P0 |
+| F-06 | Quick actions eseguibili in 1 click senza navigazione full-page | P0 |
+| F-07 | Stato slot persistito server-side (GET/PUT /api/v1/users/me/hand) | P0 |
+| F-08 | Slot con entità eliminata mostra stato degradato + CTA reassign | P0 |
+| F-09 | Desktop: sidebar destra collapsible (280px espanso / 52px collapsed) | P0 |
+| F-10 | Mobile: bottom action bar (height auto, safe-area-inset-bottom) | P0 |
+| F-11 | Swipe-up su mobile espande le quick actions | P1 |
+| F-12 | Quick action "Dado casuale" per toolkit | P0 |
+| F-13 | Quick action "Punteggio gruppo" per session | P0 |
+| F-14 | Quick action "Chiedi all'agente" per AI | P0 |
+| F-15 | Quick action "Apri gioco" per game | P0 |
+| F-16 | Picker entità (modal/drawer) per assegnazione slot | P0 |
+| F-17 | Long-press su MeepleCard esistente → "Aggiungi a La Mia Mano" | P1 |
+| F-18 | Azioni che richiedono API disabilitate offline con badge visivo | P1 |
+
+---
+
+## 4. Quick Actions per Slot
+
+### Slot Toolkit
+| Action | Tipo | Descrizione |
+|---|---|---|
+| 🎲 Dado casuale | Local | Lancia dado configurato nel toolkit — risultato inline |
+| 📋 Apri toolkit | Navigate | Naviga a `/library/games/{id}/toolkit` |
+| ⚙️ Configura | Navigate | Apre configurazione toolkit |
+
+### Slot Game
+| Action | Tipo | Descrizione |
+|---|---|---|
+| 🎮 Vai al gioco | Navigate | Naviga a `/library/games/{id}` |
+| ➕ Nuova partita | Modal | Apre modal creazione sessione pre-compilato |
+| ❤️ Wishlist toggle | API | Toggle wishlist — feedback toast |
+
+### Slot Partita/Session
+| Action | Tipo | Descrizione |
+|---|---|---|
+| 🏆 Punteggio gruppo | Inline panel | Mostra scoreboard sessione senza cambio pagina |
+| 📝 Nota rapida | Drawer | Apre mini-editor per nota sessione |
+| 🎯 Stato sessione | Inline | Toggle attiva/pausa sessione |
+
+### Slot AI
+| Action | Tipo | Descrizione |
+|---|---|---|
+| 💬 Chiedi all'agente | Chat panel | Apre chat panel con agente preselezionato |
+| 💡 Suggerimento tattico | SSE inline | Streaming risposta agente inline |
+| 📚 Regole rapide | Inline panel | FAQ/regole dal KB dell'agente |
+
+---
+
+## 5. UI/UX Specification
+
+### Desktop (≥768px)
+
+```
+┌─────────────────────────────────────────────────────┬──────────┐
+│  TopBar (64px)                                       │          │
+├────────┬──────────────────────────────────────────── │  MyHand  │
+│ Hand   │                                             │ Sidebar  │
+│ Rail   │   Main Content                              │  280px   │
+│(sinistra│                                            │          │
+│  76px) │                                             │[🔧 Slot] │
+│        │                                             │[🎮 Slot] │
+│        │                                             │[🎯 Slot] │
+│        │                                             │[🤖 Slot] │
+└────────┴──────────────────────────────────────────── └──────────┘
+```
+
+- **Posizione**: `right`, `sticky`, `full-height`
+- **Width**: 280px espanso, 52px collapsed (solo icone slot)
+- **Toggle**: pulsante collapse in header sidebar
+- **z-index**: 30 (sotto TopBar z-40, sopra content)
+- **Default**: espanso su ≥1280px, collapsed su 768–1279px
+
+### Mobile (<768px)
+
+```
+┌─────────────────────────────────┐
+│  TopBar (56px)                  │
+├─────────────────────────────────┤
+│                                 │
+│   Main Content                  │
+│                                 │
+├─────────────────────────────────┤
+│ MyHand Bottom Bar               │  ← 64px collapsed
+│ [🔧][🎮][🎯][🤖]              │     auto expanded
+└─────────────────────────────────┘
+  ↑ env(safe-area-inset-bottom)
+```
+
+- Bottom bar: 4 icone slot centrate, tap espande quick actions
+- Expanded: sheet bottom (`max-height: 40vh`, `border-radius-top: 16px`)
+- Swipe-down per chiudere expanded state
+- Touch target: ≥44×44px per ogni action button
+
+### Slot States
+
+| Stato | Visualizzazione |
+|---|---|
+| **Empty** | Icona tipo + label "Nessun [tipo]" + CTA "+ Seleziona" |
+| **Populated** | MeepleCard (compact) + quick actions inline |
+| **Degraded** | Badge ⚠️ + label "Non più disponibile" + CTA "Seleziona nuovo" |
+| **Loading** | Skeleton animation |
+
+---
+
+## 6. Data Model
+
+```typescript
+type MyHandSlotType = 'toolkit' | 'game' | 'session' | 'ai'
+
+interface MyHandSlot {
+  slotType: MyHandSlotType
+  entityId: string | null
+  entityType: MeepleEntityType | null    // 'toolkit' | 'game' | 'session' | 'agent'
+  entityLabel: string | null             // cached display name
+  entityImageUrl: string | null          // cached thumbnail
+  pinnedAt: string | null                // ISO 8601
+  isEntityValid: boolean                 // false se entità eliminata/non accessibile
+}
+
+interface MyHandState {
+  slots: Record<MyHandSlotType, MyHandSlot>
+  isExpanded: boolean           // mobile: bottom bar open
+  isSidebarCollapsed: boolean   // desktop: icon-only mode
+  isLoading: boolean
+  lastSyncedAt: string | null
+}
+
+// Mapping slot → entity type ammessi
+const SLOT_ENTITY_MAP: Record<MyHandSlotType, MeepleEntityType[]> = {
+  toolkit: ['toolkit'],
+  game:    ['game'],
+  session: ['session'],
+  ai:      ['agent'],
+}
+```
+
+---
+
+## 7. API Endpoints (Backend)
+
+```
+GET    /api/v1/users/me/hand
+       Response: { slots: MyHandSlotDto[] }
+
+PUT    /api/v1/users/me/hand/{slotType}
+       Body:     { entityId: string, entityType: string }
+       Response: { slot: MyHandSlotDto }
+       Errori:   400 (entityType non valido per slot), 404 (entità non trovata)
+
+DELETE /api/v1/users/me/hand/{slotType}
+       Response: 204 No Content
+```
+
+**Validazione server**: Verifica che `entityId` esista nel BC corrispondente allo `slotType`.
+
+**Bounded Context di riferimento**: `UserLibrary` o `UserPreferences` — da decidere.
+
+**Entity validation cross-BC**:
+- `toolkit` slot → `GameToolbox` BC
+- `game` slot → `GameManagement` / `SharedGameCatalog` BC
+- `session` slot → `SessionTracking` BC
+- `ai` slot → `KnowledgeBase` / `AgentMemory` BC
+
+---
+
+## 8. Acceptance Criteria (BDD)
+
+```gherkin
+# AC-01 — Stato iniziale
+Given: utente al primo login
+Then: tutti e 4 gli slot sono vuoti
+ And: ogni slot mostra CTA specifica per il suo tipo
+
+# AC-02 — Assegnazione slot
+Given: slot Toolkit è vuoto
+When: utente tocca lo slot
+Then: si apre picker con i suoi toolkit disponibili
+When: utente seleziona un toolkit
+Then: slot mostra MeepleCard del toolkit selezionato
+ And: stato aggiornato su server entro 2 secondi
+
+# AC-03 — Quick action dado
+Given: slot Toolkit ha un toolkit con dado configurato
+When: utente preme "🎲 Dado casuale"
+Then: risultato dado mostrato inline entro 500ms
+ And: nessuna navigazione avviene
+
+# AC-04 — Scoreboard inline
+Given: slot Session ha una sessione attiva con partecipanti
+When: utente preme "🏆 Punteggio gruppo"
+Then: panel inline mostra punteggi correnti
+ And: nessuna navigazione avviene
+
+# AC-05 — Stato degradato
+Given: slot Game contiene "Agricola"
+When: l'utente rimuove Agricola dalla libreria
+Then: slot mostra stato "Non più disponibile"
+ And: CTA "Seleziona nuovo gioco" è visibile
+ And: quick actions precedenti sono disabilitate
+
+# AC-06 — Responsive
+Given: viewport ≥ 768px
+Then: MyHand visibile come sidebar destra
+
+Given: viewport < 768px
+Then: MyHand visibile come bottom bar con 4 icone slot
+
+# AC-07 — Offline resilience
+Given: utente offline
+Then: quick actions che richiedono API mostrano icona cloud-off
+ And: azioni locali (dado) restano funzionali
+
+# AC-08 — Persistenza cross-session
+Given: utente assegna un toolkit allo slot
+When: utente fa logout e re-login
+Then: slot Toolkit mostra ancora lo stesso toolkit
+```
+
+---
+
+## 9. Architecture Decisions
+
+| Decisione | Scelta | Rationale |
+|---|---|---|
+| Componente separato da DesktopHandRail | Sì | Semantica diversa: navigazione vs quick actions |
+| Posizione desktop | Right sidebar | HandRail è a sinistra; simmetria e separazione semantica |
+| Persistenza | Server + localStorage fallback | Consistenza multi-device; offline graceful |
+| Slot fissi vs dinamici | 4 fissi per MVP | Riduce complessità UX e implementativa |
+| Entity type per slot | 1 tipo per slot (toolkit/game/session/agent) | Coerenza semantica e azioni tipizzate |
+| Mobile pattern | Bottom bar | Ergonomia mobile; allineamento con FloatingActionPill esistente |
+| Optimistic update | Sì | UX immediata; rollback su errore server |
+
+---
+
+## 10. File da Creare/Modificare
+
+### Nuovi file
+
+```
+apps/web/src/components/layout/MyHand/
+├── MyHandSidebar.tsx          ← Desktop: sidebar right (280px / 52px collapsed)
+├── MyHandBottomBar.tsx        ← Mobile: bottom bar + sheet expanded
+├── MyHandSlot.tsx             ← Singolo slot con 3 stati (empty/populated/degraded)
+├── MyHandSlotPicker.tsx       ← Modal/drawer selezione entità per slot
+├── MyHandQuickActions/
+│   ├── ToolkitActions.tsx     ← Dado, Apri toolkit, Configura
+│   ├── GameActions.tsx        ← Vai al gioco, Nuova partita, Wishlist
+│   ├── SessionActions.tsx     ← Punteggio, Nota rapida, Stato
+│   └── AgentActions.tsx       ← Chat, Suggerimento, Regole rapide
+└── index.ts
+
+apps/web/src/stores/my-hand/store.ts    ← Zustand, localStorage + sync server
+```
+
+### File modificati
+
+```
+apps/web/src/components/layout/UserShell/DesktopShell.tsx
+  → Aggiungere <MyHandSidebar /> nel layout right column
+
+apps/web/src/app/layout.tsx (o UserShell root)
+  → Aggiungere <MyHandBottomBar /> su mobile (responsive)
+```
+
+### Backend (nuovo)
+
+```
+apps/api/src/Api/BoundedContexts/UserLibrary/Hand/
+  (oppure UserPreferences/Hand/ — da decidere)
+  ├── GetUserHandQuery.cs
+  ├── UpdateHandSlotCommand.cs
+  ├── ClearHandSlotCommand.cs
+  └── UserHandEndpoints.cs
+```
+
+---
+
+## 11. Rischi e Open Questions
+
+| Priorità | Tema | Decisione richiesta |
+|---|---|---|
+| 🔴 Alta | Bounded context backend | `UserLibrary` o `UserPreferences`? |
+| 🔴 Alta | Conflitto visivo desktop | 3 elementi fissi (HandRail sx + MyHand dx + FloatingActionPill): gestire overlap su schermi stretti |
+| 🟡 Media | Onboarding slot vuoti | Tooltip inline vs wizard guidato? |
+| 🟡 Media | Sessione terminata nello slot | Auto-clear o mostra stato "Terminata" con CTA? |
+| 🟢 Bassa | Estensibilità slot | Architettura `slots: Record<>` permette 5°+ slot in futuro |
+| 🟢 Bassa | Long-press su MeepleCard | Implementare "Aggiungi a La Mia Mano" come P1 |
+
+---
+
+*Spec generata con sc:spec-panel — Expert Panel (Wiegers, Adzic, Cockburn, Fowler, Nygard, Newman, Crispin)*
+*Ultimo aggiornamento: 2026-04-09*

--- a/docs/superpowers/plans/2026-04-09-my-hand-feature.md
+++ b/docs/superpowers/plans/2026-04-09-my-hand-feature.md
@@ -1,0 +1,1997 @@
+# La Mia Mano — Quick Action Bar Implementation Plan
+
+> ⚠️ **FROZEN / DO NOT EXECUTE (2026-04-09)**
+> Plan congelato a seguito della riscrittura della spec. La feature MyHand v1 (4 slot fissi persistiti) è stata superata dal modello contestuale Session + GamePlay + Hand dinamica + Diario.
+>
+> **Nuova spec autoritativa**: `docs/superpowers/specs/2026-04-09-session-gameplay-flow-v2.md`
+>
+> Non eseguire Task 1+ di questo plan. Un nuovo plan verrà generato da `superpowers:writing-plans` sulla spec v2. Design tokens e layout shell possono essere riusati.
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implementare "La Mia Mano" — una barra di 4 slot persistenti (toolkit/game/session/ai) con quick actions inline, visibile come sidebar destra su desktop e bottom bar su mobile.
+
+**Architecture:** Backend: nuova entità `UserHandSlot` nel BC `UserLibrary` con 3 endpoints CQRS (GET/PUT/DELETE). Frontend: Zustand store `useMyHandStore` + componenti `MyHandSidebar` (desktop) e `MyHandBottomBar` (mobile) montati nel layout principale.
+
+**Tech Stack:** .NET 9 / MediatR / EF Core / FluentValidation · Next.js 16 / Zustand + immer / Tailwind 4 / shadcn/ui
+
+**Spec:** `docs/frontend/my-hand-spec.md`
+
+---
+
+## File Map
+
+### Backend — nuovi file
+| File | Responsabilità |
+|---|---|
+| `apps/api/src/Api/Infrastructure/Entities/UserLibrary/UserHandSlotEntity.cs` | Entità persistenza EF Core |
+| `apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Repositories/IUserHandRepository.cs` | Interfaccia repository |
+| `apps/api/src/Api/BoundedContexts/UserLibrary/Infrastructure/Persistence/UserHandRepository.cs` | Implementazione repository |
+| `apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetUserHandQuery.cs` | Query CQRS |
+| `apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetUserHandQueryValidator.cs` | Validator query |
+| `apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/UpdateHandSlotCommand.cs` | Command PUT |
+| `apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/UpdateHandSlotCommandValidator.cs` | Validator command |
+| `apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/UpdateHandSlotCommandHandler.cs` | Handler PUT |
+| `apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/ClearHandSlotCommand.cs` | Command DELETE |
+| `apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/ClearHandSlotCommandValidator.cs` | Validator DELETE |
+| `apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/ClearHandSlotCommandHandler.cs` | Handler DELETE |
+| `apps/api/src/Api/BoundedContexts/UserLibrary/Application/DTOs/UserHandSlotDto.cs` | DTO risposta |
+| `apps/api/src/Api/Routing/UserHandEndpoints.cs` | Minimal API endpoints |
+
+### Backend — file modificati
+| File | Modifica |
+|---|---|
+| `apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs` | Aggiungere `DbSet<UserHandSlotEntity>` |
+| `apps/api/src/Api/BoundedContexts/UserLibrary/Infrastructure/DependencyInjection/UserLibraryServiceExtensions.cs` | Registrare `IUserHandRepository` |
+| `apps/api/src/Api/Program.cs` | Mappare `MapUserHandEndpoints()` |
+
+### Frontend — nuovi file
+| File | Responsabilità |
+|---|---|
+| `apps/web/src/stores/my-hand/store.ts` | Zustand store con localStorage + sync server |
+| `apps/web/src/stores/my-hand/types.ts` | Tipi TypeScript condivisi |
+| `apps/web/src/stores/my-hand/__tests__/store.test.ts` | Test store Zustand |
+| `apps/web/src/lib/api/my-hand.ts` | Client API (GET/PUT/DELETE) |
+| `apps/web/src/lib/api/__tests__/my-hand.api.test.ts` | Test client API |
+| `apps/web/src/components/layout/MyHand/MyHandSlot.tsx` | Singolo slot (3 stati) |
+| `apps/web/src/components/layout/MyHand/MyHandSidebar.tsx` | Sidebar desktop |
+| `apps/web/src/components/layout/MyHand/MyHandBottomBar.tsx` | Bottom bar mobile |
+| `apps/web/src/components/layout/MyHand/MyHandSlotPicker.tsx` | Modal selezione entità |
+| `apps/web/src/components/layout/MyHand/index.ts` | Re-export |
+| `apps/web/src/components/layout/MyHand/__tests__/MyHandSlot.test.tsx` | Test slot |
+| `apps/web/src/components/layout/MyHand/__tests__/MyHandSidebar.test.tsx` | Test sidebar |
+
+### Frontend — file modificati
+| File | Modifica |
+|---|---|
+| `apps/web/src/components/layout/UserShell/DesktopShell.tsx` | Montare `<MyHandSidebar />` |
+| Wrapper layout mobile (verificare file) | Montare `<MyHandBottomBar />` |
+
+---
+
+## Task 1: Entità EF Core e Migration
+
+**Files:**
+- Create: `apps/api/src/Api/Infrastructure/Entities/UserLibrary/UserHandSlotEntity.cs`
+- Modify: `apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs`
+
+- [ ] **Step 1: Creare l'entità di persistenza**
+
+```csharp
+// apps/api/src/Api/Infrastructure/Entities/UserLibrary/UserHandSlotEntity.cs
+namespace Api.Infrastructure.Entities.UserLibrary;
+
+/// <summary>
+/// Persistence entity for "La Mia Mano" hand slots.
+/// Each user has up to 4 slots (one per SlotType).
+/// </summary>
+public class UserHandSlotEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    /// <summary>User who owns this slot.</summary>
+    public Guid UserId { get; set; }
+
+    /// <summary>Slot type: "toolkit" | "game" | "session" | "ai"</summary>
+    public string SlotType { get; set; } = string.Empty;
+
+    /// <summary>ID of the pinned entity (null = empty slot).</summary>
+    public Guid? EntityId { get; set; }
+
+    /// <summary>MeepleCard entity type: "toolkit" | "game" | "session" | "agent"</summary>
+    public string? EntityType { get; set; }
+
+    /// <summary>Cached display name for quick rendering.</summary>
+    public string? EntityLabel { get; set; }
+
+    /// <summary>Cached thumbnail URL.</summary>
+    public string? EntityImageUrl { get; set; }
+
+    /// <summary>When the slot was last assigned.</summary>
+    public DateTime? PinnedAt { get; set; }
+
+    // Navigation
+    public UserEntity? User { get; set; }
+}
+```
+
+- [ ] **Step 2: Aggiungere DbSet al DbContext**
+
+In `apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs`, dopo la riga `public DbSet<WishlistItemEntity> WishlistItems ...` (cerca "WishlistItems"), aggiungere:
+
+```csharp
+public DbSet<UserHandSlotEntity> UserHandSlots => Set<UserHandSlotEntity>(); // La Mia Mano: user hand slots
+```
+
+- [ ] **Step 3: Creare la migration**
+
+```bash
+cd apps/api/src/Api
+dotnet ef migrations add AddUserHandSlots
+```
+
+Expected output: `Done. To undo this action, use 'ef migrations remove'`
+
+- [ ] **Step 4: Verificare il file migration generato**
+
+Aprire `apps/api/src/Api/Infrastructure/Migrations/<timestamp>_AddUserHandSlots.cs` e verificare che contenga `CreateTable` per `user_hand_slots` con le colonne attese (`id`, `user_id`, `slot_type`, `entity_id`, `entity_type`, `entity_label`, `entity_image_url`, `pinned_at`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd apps/api/src/Api
+git add Infrastructure/Entities/UserLibrary/UserHandSlotEntity.cs
+git add Infrastructure/MeepleAiDbContext.cs
+git add Infrastructure/Migrations/
+git commit -m "feat(user-library): add UserHandSlot entity and EF migration"
+```
+
+---
+
+## Task 2: Repository Domain Interface + Implementazione
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Repositories/IUserHandRepository.cs`
+- Create: `apps/api/src/Api/BoundedContexts/UserLibrary/Infrastructure/Persistence/UserHandRepository.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/UserLibrary/Infrastructure/DependencyInjection/UserLibraryServiceExtensions.cs`
+
+- [ ] **Step 1: Definire l'interfaccia repository**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Repositories/IUserHandRepository.cs
+namespace Api.BoundedContexts.UserLibrary.Domain.Repositories;
+
+public interface IUserHandRepository
+{
+    Task<IReadOnlyList<UserHandSlotData>> GetAllSlotsAsync(Guid userId, CancellationToken ct = default);
+    Task UpsertSlotAsync(Guid userId, string slotType, Guid entityId, string entityType, string? entityLabel, string? entityImageUrl, CancellationToken ct = default);
+    Task ClearSlotAsync(Guid userId, string slotType, CancellationToken ct = default);
+}
+
+/// <summary>Simple data transfer record used within the domain layer.</summary>
+public record UserHandSlotData(
+    string SlotType,
+    Guid? EntityId,
+    string? EntityType,
+    string? EntityLabel,
+    string? EntityImageUrl,
+    DateTime? PinnedAt
+);
+```
+
+- [ ] **Step 2: Implementare il repository**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/UserLibrary/Infrastructure/Persistence/UserHandRepository.cs
+using Api.BoundedContexts.UserLibrary.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.UserLibrary;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.UserLibrary.Infrastructure.Persistence;
+
+internal class UserHandRepository : IUserHandRepository
+{
+    private readonly MeepleAiDbContext _db;
+
+    public UserHandRepository(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<IReadOnlyList<UserHandSlotData>> GetAllSlotsAsync(Guid userId, CancellationToken ct = default)
+    {
+        var entities = await _db.UserHandSlots
+            .AsNoTracking()
+            .Where(s => s.UserId == userId)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        return entities.Select(e => new UserHandSlotData(
+            e.SlotType,
+            e.EntityId,
+            e.EntityType,
+            e.EntityLabel,
+            e.EntityImageUrl,
+            e.PinnedAt
+        )).ToList();
+    }
+
+    public async Task UpsertSlotAsync(Guid userId, string slotType, Guid entityId, string entityType,
+        string? entityLabel, string? entityImageUrl, CancellationToken ct = default)
+    {
+        var existing = await _db.UserHandSlots
+            .FirstOrDefaultAsync(s => s.UserId == userId && s.SlotType == slotType, ct)
+            .ConfigureAwait(false);
+
+        if (existing is null)
+        {
+            _db.UserHandSlots.Add(new UserHandSlotEntity
+            {
+                UserId = userId,
+                SlotType = slotType,
+                EntityId = entityId,
+                EntityType = entityType,
+                EntityLabel = entityLabel,
+                EntityImageUrl = entityImageUrl,
+                PinnedAt = DateTime.UtcNow
+            });
+        }
+        else
+        {
+            existing.EntityId = entityId;
+            existing.EntityType = entityType;
+            existing.EntityLabel = entityLabel;
+            existing.EntityImageUrl = entityImageUrl;
+            existing.PinnedAt = DateTime.UtcNow;
+        }
+
+        await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+    }
+
+    public async Task ClearSlotAsync(Guid userId, string slotType, CancellationToken ct = default)
+    {
+        var existing = await _db.UserHandSlots
+            .FirstOrDefaultAsync(s => s.UserId == userId && s.SlotType == slotType, ct)
+            .ConfigureAwait(false);
+
+        if (existing is not null)
+        {
+            _db.UserHandSlots.Remove(existing);
+            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Registrare nel DI**
+
+In `apps/api/src/Api/BoundedContexts/UserLibrary/Infrastructure/DependencyInjection/UserLibraryServiceExtensions.cs`, aggiungere dopo la riga `IUserCollectionRepository`:
+
+```csharp
+services.AddScoped<IUserHandRepository, UserHandRepository>(); // La Mia Mano: hand slots
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Repositories/IUserHandRepository.cs
+git add apps/api/src/Api/BoundedContexts/UserLibrary/Infrastructure/Persistence/UserHandRepository.cs
+git add apps/api/src/Api/BoundedContexts/UserLibrary/Infrastructure/DependencyInjection/UserLibraryServiceExtensions.cs
+git commit -m "feat(user-library): add IUserHandRepository and EF implementation"
+```
+
+---
+
+## Task 3: CQRS — Query GetUserHand
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/UserLibrary/Application/DTOs/UserHandSlotDto.cs`
+- Create: `apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetUserHandQuery.cs`
+- Create: `apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetUserHandQueryValidator.cs`
+
+- [ ] **Step 1: Creare il DTO di risposta**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/UserLibrary/Application/DTOs/UserHandSlotDto.cs
+namespace Api.BoundedContexts.UserLibrary.Application.DTOs;
+
+public record UserHandSlotDto(
+    string SlotType,
+    Guid? EntityId,
+    string? EntityType,
+    string? EntityLabel,
+    string? EntityImageUrl,
+    string? PinnedAt  // ISO 8601
+);
+```
+
+- [ ] **Step 2: Creare la Query con il suo Handler**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetUserHandQuery.cs
+using Api.BoundedContexts.UserLibrary.Application.DTOs;
+using Api.BoundedContexts.UserLibrary.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+
+namespace Api.BoundedContexts.UserLibrary.Application.Queries;
+
+internal record GetUserHandQuery(Guid UserId) : IQuery<IReadOnlyList<UserHandSlotDto>>;
+
+internal class GetUserHandQueryHandler : IQueryHandler<GetUserHandQuery, IReadOnlyList<UserHandSlotDto>>
+{
+    private static readonly string[] AllSlotTypes = { "toolkit", "game", "session", "ai" };
+
+    private readonly IUserHandRepository _repo;
+
+    public GetUserHandQueryHandler(IUserHandRepository repo)
+    {
+        _repo = repo ?? throw new ArgumentNullException(nameof(repo));
+    }
+
+    public async Task<IReadOnlyList<UserHandSlotDto>> Handle(GetUserHandQuery request, CancellationToken cancellationToken)
+    {
+        var slots = await _repo.GetAllSlotsAsync(request.UserId, cancellationToken).ConfigureAwait(false);
+        var slotMap = slots.ToDictionary(s => s.SlotType);
+
+        // Always return all 4 slot types — empty if not assigned
+        return AllSlotTypes.Select(slotType =>
+        {
+            if (slotMap.TryGetValue(slotType, out var slot))
+            {
+                return new UserHandSlotDto(
+                    slotType,
+                    slot.EntityId,
+                    slot.EntityType,
+                    slot.EntityLabel,
+                    slot.EntityImageUrl,
+                    slot.PinnedAt?.ToString("o")
+                );
+            }
+            return new UserHandSlotDto(slotType, null, null, null, null, null);
+        }).ToList();
+    }
+}
+```
+
+- [ ] **Step 3: Creare il Validator**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetUserHandQueryValidator.cs
+using FluentValidation;
+
+namespace Api.BoundedContexts.UserLibrary.Application.Queries;
+
+internal class GetUserHandQueryValidator : AbstractValidator<GetUserHandQuery>
+{
+    public GetUserHandQueryValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty()
+            .WithMessage("UserId is required");
+    }
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/UserLibrary/Application/DTOs/UserHandSlotDto.cs
+git add apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetUserHandQuery.cs
+git add apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetUserHandQueryValidator.cs
+git commit -m "feat(user-library): add GetUserHandQuery with handler and validator"
+```
+
+---
+
+## Task 4: CQRS — Command UpdateHandSlot (PUT)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/UpdateHandSlotCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/UpdateHandSlotCommandValidator.cs`
+- Create: `apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/UpdateHandSlotCommandHandler.cs`
+
+- [ ] **Step 1: Creare il Command**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/UpdateHandSlotCommand.cs
+using Api.BoundedContexts.UserLibrary.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserLibrary.Application.Commands;
+
+internal record UpdateHandSlotCommand(
+    Guid UserId,
+    string SlotType,      // "toolkit" | "game" | "session" | "ai"
+    Guid EntityId,
+    string EntityType,    // "toolkit" | "game" | "session" | "agent"
+    string? EntityLabel = null,
+    string? EntityImageUrl = null
+) : ICommand<UserHandSlotDto>;
+```
+
+- [ ] **Step 2: Creare il Validator**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/UpdateHandSlotCommandValidator.cs
+using Api.BoundedContexts.UserLibrary.Application.Commands;
+using FluentValidation;
+
+namespace Api.BoundedContexts.UserLibrary.Application.Validators;
+
+internal class UpdateHandSlotCommandValidator : AbstractValidator<UpdateHandSlotCommand>
+{
+    private static readonly string[] ValidSlotTypes = { "toolkit", "game", "session", "ai" };
+    private static readonly string[] ValidEntityTypes = { "toolkit", "game", "session", "agent" };
+
+    private static readonly Dictionary<string, string[]> SlotEntityMap = new()
+    {
+        ["toolkit"] = ["toolkit"],
+        ["game"]    = ["game"],
+        ["session"] = ["session"],
+        ["ai"]      = ["agent"]
+    };
+
+    public UpdateHandSlotCommandValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty()
+            .WithMessage("UserId is required");
+
+        RuleFor(x => x.SlotType)
+            .NotEmpty()
+            .Must(s => ValidSlotTypes.Contains(s))
+            .WithMessage($"SlotType must be one of: {string.Join(", ", ValidSlotTypes)}");
+
+        RuleFor(x => x.EntityId)
+            .NotEmpty()
+            .WithMessage("EntityId is required");
+
+        RuleFor(x => x.EntityType)
+            .NotEmpty()
+            .Must(t => ValidEntityTypes.Contains(t))
+            .WithMessage($"EntityType must be one of: {string.Join(", ", ValidEntityTypes)}");
+
+        // EntityType must be compatible with SlotType
+        RuleFor(x => x)
+            .Must(x => SlotEntityMap.TryGetValue(x.SlotType, out var allowed) && allowed.Contains(x.EntityType))
+            .WithMessage(x => $"EntityType '{x.EntityType}' is not valid for SlotType '{x.SlotType}'")
+            .When(x => ValidSlotTypes.Contains(x.SlotType) && ValidEntityTypes.Contains(x.EntityType));
+    }
+}
+```
+
+- [ ] **Step 3: Creare il Handler**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/UpdateHandSlotCommandHandler.cs
+using Api.BoundedContexts.UserLibrary.Application.DTOs;
+using Api.BoundedContexts.UserLibrary.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+
+namespace Api.BoundedContexts.UserLibrary.Application.Commands;
+
+internal class UpdateHandSlotCommandHandler : ICommandHandler<UpdateHandSlotCommand, UserHandSlotDto>
+{
+    private readonly IUserHandRepository _repo;
+    private readonly ILogger<UpdateHandSlotCommandHandler> _logger;
+
+    public UpdateHandSlotCommandHandler(IUserHandRepository repo, ILogger<UpdateHandSlotCommandHandler> logger)
+    {
+        _repo = repo ?? throw new ArgumentNullException(nameof(repo));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<UserHandSlotDto> Handle(UpdateHandSlotCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        await _repo.UpsertSlotAsync(
+            command.UserId,
+            command.SlotType,
+            command.EntityId,
+            command.EntityType,
+            command.EntityLabel,
+            command.EntityImageUrl,
+            cancellationToken
+        ).ConfigureAwait(false);
+
+        _logger.LogInformation("User {UserId} assigned {EntityType} {EntityId} to hand slot '{SlotType}'",
+            command.UserId, command.EntityType, command.EntityId, command.SlotType);
+
+        return new UserHandSlotDto(
+            command.SlotType,
+            command.EntityId,
+            command.EntityType,
+            command.EntityLabel,
+            command.EntityImageUrl,
+            DateTime.UtcNow.ToString("o")
+        );
+    }
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/UpdateHandSlotCommand.cs
+git add apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/UpdateHandSlotCommandValidator.cs
+git add apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/UpdateHandSlotCommandHandler.cs
+git commit -m "feat(user-library): add UpdateHandSlotCommand with validator and handler"
+```
+
+---
+
+## Task 5: CQRS — Command ClearHandSlot (DELETE)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/ClearHandSlotCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/ClearHandSlotCommandValidator.cs`
+- Create: `apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/ClearHandSlotCommandHandler.cs`
+
+- [ ] **Step 1: Creare Command + Validator + Handler**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/ClearHandSlotCommand.cs
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserLibrary.Application.Commands;
+
+internal record ClearHandSlotCommand(Guid UserId, string SlotType) : ICommand;
+```
+
+```csharp
+// apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/ClearHandSlotCommandValidator.cs
+using Api.BoundedContexts.UserLibrary.Application.Commands;
+using FluentValidation;
+
+namespace Api.BoundedContexts.UserLibrary.Application.Validators;
+
+internal class ClearHandSlotCommandValidator : AbstractValidator<ClearHandSlotCommand>
+{
+    private static readonly string[] ValidSlotTypes = { "toolkit", "game", "session", "ai" };
+
+    public ClearHandSlotCommandValidator()
+    {
+        RuleFor(x => x.UserId).NotEmpty().WithMessage("UserId is required");
+        RuleFor(x => x.SlotType)
+            .NotEmpty()
+            .Must(s => ValidSlotTypes.Contains(s))
+            .WithMessage($"SlotType must be one of: {string.Join(", ", ValidSlotTypes)}");
+    }
+}
+```
+
+```csharp
+// apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/ClearHandSlotCommandHandler.cs
+using Api.BoundedContexts.UserLibrary.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserLibrary.Application.Commands;
+
+internal class ClearHandSlotCommandHandler : ICommandHandler<ClearHandSlotCommand>
+{
+    private readonly IUserHandRepository _repo;
+
+    public ClearHandSlotCommandHandler(IUserHandRepository repo)
+    {
+        _repo = repo ?? throw new ArgumentNullException(nameof(repo));
+    }
+
+    public async Task Handle(ClearHandSlotCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        await _repo.ClearSlotAsync(command.UserId, command.SlotType, cancellationToken).ConfigureAwait(false);
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/ClearHandSlotCommand.cs
+git add apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/ClearHandSlotCommandValidator.cs
+git add apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/ClearHandSlotCommandHandler.cs
+git commit -m "feat(user-library): add ClearHandSlotCommand with validator and handler"
+```
+
+---
+
+## Task 6: API Endpoints
+
+**Files:**
+- Create: `apps/api/src/Api/Routing/UserHandEndpoints.cs`
+- Modify: `apps/api/src/Api/Program.cs`
+
+- [ ] **Step 1: Creare il file endpoints**
+
+```csharp
+// apps/api/src/Api/Routing/UserHandEndpoints.cs
+using System.Security.Claims;
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.UserLibrary.Application.Commands;
+using Api.BoundedContexts.UserLibrary.Application.DTOs;
+using Api.BoundedContexts.UserLibrary.Application.Queries;
+using Api.Extensions;
+using Api.Middleware.Exceptions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Routing;
+
+/// <summary>
+/// "La Mia Mano" hand slot endpoints.
+/// GET/PUT/DELETE /api/v1/users/me/hand and /api/v1/users/me/hand/{slotType}
+/// </summary>
+internal static class UserHandEndpoints
+{
+    public static RouteGroupBuilder MapUserHandEndpoints(this RouteGroupBuilder group)
+    {
+        MapGetHandEndpoint(group);
+        MapUpdateSlotEndpoint(group);
+        MapClearSlotEndpoint(group);
+        return group;
+    }
+
+    private static void MapGetHandEndpoint(RouteGroupBuilder group)
+    {
+        group.MapGet("/users/me/hand", async (
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, session, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+            if (!TryGetUserId(context, session, out var userId)) return Results.Unauthorized();
+
+            var query = new GetUserHandQuery(userId);
+            var result = await mediator.Send(query, ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .RequireAuthenticatedUser()
+        .Produces<IReadOnlyList<UserHandSlotDto>>(200)
+        .Produces(401)
+        .WithTags("MyHand")
+        .WithSummary("Get user hand slots")
+        .WithDescription("Returns all 4 hand slots for the authenticated user. Empty slots have null entityId.")
+        .WithOpenApi();
+    }
+
+    private static void MapUpdateSlotEndpoint(RouteGroupBuilder group)
+    {
+        group.MapPut("/users/me/hand/{slotType}", async (
+            string slotType,
+            [FromBody] UpdateHandSlotRequest request,
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, session, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+            if (!TryGetUserId(context, session, out var userId)) return Results.Unauthorized();
+
+            var command = new UpdateHandSlotCommand(
+                UserId: userId,
+                SlotType: slotType,
+                EntityId: request.EntityId,
+                EntityType: request.EntityType,
+                EntityLabel: request.EntityLabel,
+                EntityImageUrl: request.EntityImageUrl
+            );
+
+            try
+            {
+                var result = await mediator.Send(command, ct).ConfigureAwait(false);
+                return Results.Ok(result);
+            }
+            catch (ConflictException ex)
+            {
+                return Results.Conflict(new { error = ex.Message });
+            }
+        })
+        .RequireAuthenticatedUser()
+        .Produces<UserHandSlotDto>(200)
+        .Produces(400)
+        .Produces(401)
+        .Produces(409)
+        .WithTags("MyHand")
+        .WithSummary("Assign entity to hand slot")
+        .WithDescription("Assigns an entity to the specified slot (toolkit/game/session/ai). Replaces any existing assignment.")
+        .WithOpenApi();
+    }
+
+    private static void MapClearSlotEndpoint(RouteGroupBuilder group)
+    {
+        group.MapDelete("/users/me/hand/{slotType}", async (
+            string slotType,
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, session, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+            if (!TryGetUserId(context, session, out var userId)) return Results.Unauthorized();
+
+            var command = new ClearHandSlotCommand(userId, slotType);
+            await mediator.Send(command, ct).ConfigureAwait(false);
+            return Results.NoContent();
+        })
+        .RequireAuthenticatedUser()
+        .Produces(204)
+        .Produces(400)
+        .Produces(401)
+        .WithTags("MyHand")
+        .WithSummary("Clear hand slot")
+        .WithDescription("Clears the specified hand slot. No-op if slot is already empty.")
+        .WithOpenApi();
+    }
+
+    private static bool TryGetUserId(HttpContext context, SessionStatusDto? session, out Guid userId)
+    {
+        userId = Guid.Empty;
+        if (session != null) { userId = session.User!.Id; return true; }
+        var claim = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        return !string.IsNullOrEmpty(claim) && Guid.TryParse(claim, out userId);
+    }
+}
+
+public record UpdateHandSlotRequest(
+    Guid EntityId,
+    string EntityType,
+    string? EntityLabel = null,
+    string? EntityImageUrl = null
+);
+```
+
+- [ ] **Step 2: Registrare gli endpoints in Program.cs**
+
+Nel file `apps/api/src/Api/Program.cs`, cerca la riga dove vengono mappati gli endpoint utente (es. cerca `MapWishlistEndpoints` o `MapUserAccountEndpoints`). Aggiungi nella stessa route group:
+
+```csharp
+.MapUserHandEndpoints()
+```
+
+L'esatta posizione dipende dalla struttura del file — cerca il metodo `MapUserHandEndpoints` e aggiungilo vicino agli altri endpoint `UserLibrary`.
+
+- [ ] **Step 3: Build di verifica**
+
+```bash
+cd apps/api/src/Api
+dotnet build
+```
+
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/UserHandEndpoints.cs
+git add apps/api/src/Api/Program.cs
+git commit -m "feat(user-library): add hand slot API endpoints (GET/PUT/DELETE)"
+```
+
+---
+
+## Task 7: Test backend (Unit — Validator)
+
+**Files:**
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/UpdateHandSlotCommandValidatorTests.cs`
+
+- [ ] **Step 1: Scrivere i test failing**
+
+```csharp
+// apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/UpdateHandSlotCommandValidatorTests.cs
+using Api.BoundedContexts.UserLibrary.Application.Commands;
+using Api.BoundedContexts.UserLibrary.Application.Validators;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.UserLibrary.Application;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "UserLibrary")]
+public class UpdateHandSlotCommandValidatorTests
+{
+    private readonly UpdateHandSlotCommandValidator _sut = new();
+
+    [Theory]
+    [InlineData("toolkit", "toolkit")]
+    [InlineData("game", "game")]
+    [InlineData("session", "session")]
+    [InlineData("ai", "agent")]
+    public void Valid_combinations_pass(string slotType, string entityType)
+    {
+        var cmd = new UpdateHandSlotCommand(Guid.NewGuid(), slotType, Guid.NewGuid(), entityType);
+        var result = _sut.TestValidate(cmd);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData("toolkit", "game")]
+    [InlineData("game", "agent")]
+    [InlineData("session", "toolkit")]
+    [InlineData("ai", "game")]
+    public void Incompatible_slot_entityType_fails(string slotType, string entityType)
+    {
+        var cmd = new UpdateHandSlotCommand(Guid.NewGuid(), slotType, Guid.NewGuid(), entityType);
+        var result = _sut.TestValidate(cmd);
+        result.ShouldHaveAnyValidationError();
+    }
+
+    [Fact]
+    public void Empty_UserId_fails()
+    {
+        var cmd = new UpdateHandSlotCommand(Guid.Empty, "toolkit", Guid.NewGuid(), "toolkit");
+        var result = _sut.TestValidate(cmd);
+        result.ShouldHaveValidationErrorFor(x => x.UserId);
+    }
+
+    [Fact]
+    public void Invalid_slotType_fails()
+    {
+        var cmd = new UpdateHandSlotCommand(Guid.NewGuid(), "unknown", Guid.NewGuid(), "toolkit");
+        var result = _sut.TestValidate(cmd);
+        result.ShouldHaveValidationErrorFor(x => x.SlotType);
+    }
+
+    [Fact]
+    public void Empty_EntityId_fails()
+    {
+        var cmd = new UpdateHandSlotCommand(Guid.NewGuid(), "toolkit", Guid.Empty, "toolkit");
+        var result = _sut.TestValidate(cmd);
+        result.ShouldHaveValidationErrorFor(x => x.EntityId);
+    }
+}
+```
+
+- [ ] **Step 2: Eseguire il test per verificare che fallisca**
+
+```bash
+cd apps/api
+dotnet test --filter "FullyQualifiedName~UpdateHandSlotCommandValidatorTests" -v minimal
+```
+
+Expected: tutti i test passano (i validator sono già implementati nel Task 4).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/UpdateHandSlotCommandValidatorTests.cs
+git commit -m "test(user-library): add UpdateHandSlotCommandValidator unit tests"
+```
+
+---
+
+## Task 8: Zustand Store frontend
+
+**Files:**
+- Create: `apps/web/src/stores/my-hand/types.ts`
+- Create: `apps/web/src/stores/my-hand/store.ts`
+- Create: `apps/web/src/stores/my-hand/__tests__/store.test.ts`
+
+- [ ] **Step 1: Scrivere il test failing**
+
+```typescript
+// apps/web/src/stores/my-hand/__tests__/store.test.ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useMyHandStore } from '../store';
+import type { MyHandSlotType } from '../types';
+
+describe('useMyHandStore', () => {
+  beforeEach(() => {
+    useMyHandStore.setState(useMyHandStore.getInitialState());
+  });
+
+  it('starts with all 4 slots empty', () => {
+    const state = useMyHandStore.getState();
+    expect(state.slots.toolkit.entityId).toBeNull();
+    expect(state.slots.game.entityId).toBeNull();
+    expect(state.slots.session.entityId).toBeNull();
+    expect(state.slots.ai.entityId).toBeNull();
+  });
+
+  it('assigns entity to a slot', () => {
+    useMyHandStore.getState().assignSlot('toolkit', {
+      entityId: 'tk-1',
+      entityType: 'toolkit',
+      entityLabel: 'My Toolkit',
+      entityImageUrl: null,
+    });
+    const slot = useMyHandStore.getState().slots.toolkit;
+    expect(slot.entityId).toBe('tk-1');
+    expect(slot.entityType).toBe('toolkit');
+    expect(slot.entityLabel).toBe('My Toolkit');
+    expect(slot.pinnedAt).not.toBeNull();
+  });
+
+  it('clears a slot', () => {
+    useMyHandStore.getState().assignSlot('game', {
+      entityId: 'g-1',
+      entityType: 'game',
+      entityLabel: 'Agricola',
+      entityImageUrl: null,
+    });
+    useMyHandStore.getState().clearSlot('game');
+    const slot = useMyHandStore.getState().slots.game;
+    expect(slot.entityId).toBeNull();
+    expect(slot.entityLabel).toBeNull();
+    expect(slot.pinnedAt).toBeNull();
+  });
+
+  it('marks slot as invalid', () => {
+    useMyHandStore.getState().assignSlot('session', {
+      entityId: 's-1',
+      entityType: 'session',
+      entityLabel: 'Friday Game',
+      entityImageUrl: null,
+    });
+    useMyHandStore.getState().markSlotInvalid('session');
+    expect(useMyHandStore.getState().slots.session.isEntityValid).toBe(false);
+  });
+
+  it('toggles sidebar collapsed state', () => {
+    expect(useMyHandStore.getState().isSidebarCollapsed).toBe(false);
+    useMyHandStore.getState().toggleSidebarCollapsed();
+    expect(useMyHandStore.getState().isSidebarCollapsed).toBe(true);
+    useMyHandStore.getState().toggleSidebarCollapsed();
+    expect(useMyHandStore.getState().isSidebarCollapsed).toBe(false);
+  });
+
+  it('toggles mobile expanded state', () => {
+    expect(useMyHandStore.getState().isMobileExpanded).toBe(false);
+    useMyHandStore.getState().toggleMobileExpanded();
+    expect(useMyHandStore.getState().isMobileExpanded).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Eseguire il test per verificare che fallisca**
+
+```bash
+cd apps/web
+pnpm test src/stores/my-hand/__tests__/store.test.ts
+```
+
+Expected: FAIL — `Cannot find module '../store'`
+
+- [ ] **Step 3: Creare i tipi**
+
+```typescript
+// apps/web/src/stores/my-hand/types.ts
+export type MyHandSlotType = 'toolkit' | 'game' | 'session' | 'ai';
+
+export interface MyHandSlot {
+  slotType: MyHandSlotType;
+  entityId: string | null;
+  entityType: string | null;  // 'toolkit' | 'game' | 'session' | 'agent'
+  entityLabel: string | null;
+  entityImageUrl: string | null;
+  pinnedAt: string | null;    // ISO 8601
+  isEntityValid: boolean;
+}
+
+export interface AssignSlotPayload {
+  entityId: string;
+  entityType: string;
+  entityLabel: string | null;
+  entityImageUrl: string | null;
+}
+
+const EMPTY_SLOT = (slotType: MyHandSlotType): MyHandSlot => ({
+  slotType,
+  entityId: null,
+  entityType: null,
+  entityLabel: null,
+  entityImageUrl: null,
+  pinnedAt: null,
+  isEntityValid: true,
+});
+
+export const createEmptySlots = (): Record<MyHandSlotType, MyHandSlot> => ({
+  toolkit: EMPTY_SLOT('toolkit'),
+  game: EMPTY_SLOT('game'),
+  session: EMPTY_SLOT('session'),
+  ai: EMPTY_SLOT('ai'),
+});
+```
+
+- [ ] **Step 4: Creare lo store**
+
+```typescript
+// apps/web/src/stores/my-hand/store.ts
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+import { immer } from 'zustand/middleware/immer';
+import type { MyHandSlotType, MyHandSlot, AssignSlotPayload } from './types';
+import { createEmptySlots } from './types';
+
+interface MyHandState {
+  slots: Record<MyHandSlotType, MyHandSlot>;
+  isSidebarCollapsed: boolean;
+  isMobileExpanded: boolean;
+  isLoading: boolean;
+  // Actions
+  assignSlot: (slotType: MyHandSlotType, payload: AssignSlotPayload) => void;
+  clearSlot: (slotType: MyHandSlotType) => void;
+  markSlotInvalid: (slotType: MyHandSlotType) => void;
+  toggleSidebarCollapsed: () => void;
+  toggleMobileExpanded: () => void;
+  setLoading: (loading: boolean) => void;
+  hydrateFromServer: (slots: Array<{
+    slotType: string;
+    entityId: string | null;
+    entityType: string | null;
+    entityLabel: string | null;
+    entityImageUrl: string | null;
+    pinnedAt: string | null;
+  }>) => void;
+}
+
+const INITIAL_STATE = {
+  slots: createEmptySlots(),
+  isSidebarCollapsed: false,
+  isMobileExpanded: false,
+  isLoading: false,
+};
+
+export const useMyHandStore = create<MyHandState>()(
+  devtools(
+    immer(set => ({
+      ...INITIAL_STATE,
+
+      assignSlot: (slotType, payload) =>
+        set(state => {
+          state.slots[slotType].entityId = payload.entityId;
+          state.slots[slotType].entityType = payload.entityType;
+          state.slots[slotType].entityLabel = payload.entityLabel;
+          state.slots[slotType].entityImageUrl = payload.entityImageUrl;
+          state.slots[slotType].pinnedAt = new Date().toISOString();
+          state.slots[slotType].isEntityValid = true;
+        }),
+
+      clearSlot: (slotType) =>
+        set(state => {
+          state.slots[slotType].entityId = null;
+          state.slots[slotType].entityType = null;
+          state.slots[slotType].entityLabel = null;
+          state.slots[slotType].entityImageUrl = null;
+          state.slots[slotType].pinnedAt = null;
+          state.slots[slotType].isEntityValid = true;
+        }),
+
+      markSlotInvalid: (slotType) =>
+        set(state => {
+          state.slots[slotType].isEntityValid = false;
+        }),
+
+      toggleSidebarCollapsed: () =>
+        set(state => {
+          state.isSidebarCollapsed = !state.isSidebarCollapsed;
+        }),
+
+      toggleMobileExpanded: () =>
+        set(state => {
+          state.isMobileExpanded = !state.isMobileExpanded;
+        }),
+
+      setLoading: (loading) =>
+        set(state => {
+          state.isLoading = loading;
+        }),
+
+      hydrateFromServer: (serverSlots) =>
+        set(state => {
+          for (const s of serverSlots) {
+            const slotType = s.slotType as MyHandSlotType;
+            if (!['toolkit', 'game', 'session', 'ai'].includes(slotType)) continue;
+            state.slots[slotType].entityId = s.entityId;
+            state.slots[slotType].entityType = s.entityType;
+            state.slots[slotType].entityLabel = s.entityLabel;
+            state.slots[slotType].entityImageUrl = s.entityImageUrl;
+            state.slots[slotType].pinnedAt = s.pinnedAt;
+            state.slots[slotType].isEntityValid = true;
+          }
+        }),
+    })),
+    { name: 'my-hand-store' }
+  )
+);
+
+// Selectors
+export const selectSlot = (slotType: MyHandSlotType) =>
+  (s: MyHandState) => s.slots[slotType];
+export const selectIsSidebarCollapsed = (s: MyHandState) => s.isSidebarCollapsed;
+export const selectIsMobileExpanded = (s: MyHandState) => s.isMobileExpanded;
+```
+
+- [ ] **Step 5: Eseguire i test per verificare che passino**
+
+```bash
+cd apps/web
+pnpm test src/stores/my-hand/__tests__/store.test.ts
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/stores/my-hand/
+git commit -m "feat(my-hand): add Zustand store with types and unit tests"
+```
+
+---
+
+## Task 9: API Client frontend
+
+**Files:**
+- Create: `apps/web/src/lib/api/my-hand.ts`
+- Create: `apps/web/src/lib/api/__tests__/my-hand.api.test.ts`
+
+- [ ] **Step 1: Scrivere il test failing**
+
+```typescript
+// apps/web/src/lib/api/__tests__/my-hand.api.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getMyHand, updateHandSlot, clearHandSlot } from '../my-hand';
+
+vi.mock('../client', () => ({
+  apiClient: {
+    get: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+import { apiClient } from '../client';
+
+describe('my-hand API client', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getMyHand calls GET /users/me/hand', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { slotType: 'toolkit', entityId: null, entityType: null, entityLabel: null, entityImageUrl: null, pinnedAt: null }
+    ]);
+
+    const result = await getMyHand();
+    expect(apiClient.get).toHaveBeenCalledWith('/users/me/hand');
+    expect(result).toHaveLength(1);
+  });
+
+  it('updateHandSlot calls PUT /users/me/hand/{slotType}', async () => {
+    const dto = { slotType: 'game', entityId: 'g-1', entityType: 'game', entityLabel: 'Catan', entityImageUrl: null, pinnedAt: '2026-04-09T00:00:00Z' };
+    (apiClient.put as ReturnType<typeof vi.fn>).mockResolvedValue(dto);
+
+    const result = await updateHandSlot('game', { entityId: 'g-1', entityType: 'game', entityLabel: 'Catan', entityImageUrl: null });
+    expect(apiClient.put).toHaveBeenCalledWith('/users/me/hand/game', {
+      entityId: 'g-1', entityType: 'game', entityLabel: 'Catan', entityImageUrl: null,
+    });
+    expect(result.entityId).toBe('g-1');
+  });
+
+  it('clearHandSlot calls DELETE /users/me/hand/{slotType}', async () => {
+    (apiClient.delete as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    await clearHandSlot('toolkit');
+    expect(apiClient.delete).toHaveBeenCalledWith('/users/me/hand/toolkit');
+  });
+
+  it('getMyHand returns empty array on null response', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const result = await getMyHand();
+    expect(result).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Eseguire il test per verificare che fallisca**
+
+```bash
+cd apps/web
+pnpm test src/lib/api/__tests__/my-hand.api.test.ts
+```
+
+Expected: FAIL — `Cannot find module '../my-hand'`
+
+- [ ] **Step 3: Implementare il client**
+
+```typescript
+// apps/web/src/lib/api/my-hand.ts
+import { apiClient } from './client';
+
+export interface HandSlotDto {
+  slotType: string;
+  entityId: string | null;
+  entityType: string | null;
+  entityLabel: string | null;
+  entityImageUrl: string | null;
+  pinnedAt: string | null;
+}
+
+export interface UpdateHandSlotPayload {
+  entityId: string;
+  entityType: string;
+  entityLabel: string | null;
+  entityImageUrl: string | null;
+}
+
+export async function getMyHand(): Promise<HandSlotDto[]> {
+  const result = await apiClient.get<HandSlotDto[]>('/users/me/hand');
+  return result ?? [];
+}
+
+export async function updateHandSlot(
+  slotType: string,
+  payload: UpdateHandSlotPayload
+): Promise<HandSlotDto> {
+  return apiClient.put<HandSlotDto>(`/users/me/hand/${slotType}`, payload);
+}
+
+export async function clearHandSlot(slotType: string): Promise<void> {
+  await apiClient.delete(`/users/me/hand/${slotType}`);
+}
+```
+
+- [ ] **Step 4: Eseguire i test**
+
+```bash
+cd apps/web
+pnpm test src/lib/api/__tests__/my-hand.api.test.ts
+```
+
+Expected: All PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/api/my-hand.ts
+git add apps/web/src/lib/api/__tests__/my-hand.api.test.ts
+git commit -m "feat(my-hand): add API client with unit tests"
+```
+
+---
+
+## Task 10: Componente MyHandSlot
+
+**Files:**
+- Create: `apps/web/src/components/layout/MyHand/MyHandSlot.tsx`
+- Create: `apps/web/src/components/layout/MyHand/__tests__/MyHandSlot.test.tsx`
+
+- [ ] **Step 1: Scrivere il test failing**
+
+```typescript
+// apps/web/src/components/layout/MyHand/__tests__/MyHandSlot.test.tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { MyHandSlot } from '../MyHandSlot';
+
+describe('MyHandSlot', () => {
+  it('renders empty state with CTA', () => {
+    render(
+      <MyHandSlot
+        slotType="toolkit"
+        slot={{ slotType: 'toolkit', entityId: null, entityType: null, entityLabel: null, entityImageUrl: null, pinnedAt: null, isEntityValid: true }}
+        onAssign={vi.fn()}
+        onClear={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/Toolkit/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /seleziona/i })).toBeInTheDocument();
+  });
+
+  it('renders populated state with entity label', () => {
+    render(
+      <MyHandSlot
+        slotType="game"
+        slot={{ slotType: 'game', entityId: 'g-1', entityType: 'game', entityLabel: 'Agricola', entityImageUrl: null, pinnedAt: '2026-04-09T00:00:00Z', isEntityValid: true }}
+        onAssign={vi.fn()}
+        onClear={vi.fn()}
+      />
+    );
+    expect(screen.getByText('Agricola')).toBeInTheDocument();
+  });
+
+  it('renders degraded state with warning', () => {
+    render(
+      <MyHandSlot
+        slotType="session"
+        slot={{ slotType: 'session', entityId: 's-1', entityType: 'session', entityLabel: 'Partita', entityImageUrl: null, pinnedAt: '2026-04-09T00:00:00Z', isEntityValid: false }}
+        onAssign={vi.fn()}
+        onClear={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/non più disponibile/i)).toBeInTheDocument();
+  });
+
+  it('calls onAssign when CTA clicked in empty state', () => {
+    const onAssign = vi.fn();
+    render(
+      <MyHandSlot
+        slotType="toolkit"
+        slot={{ slotType: 'toolkit', entityId: null, entityType: null, entityLabel: null, entityImageUrl: null, pinnedAt: null, isEntityValid: true }}
+        onAssign={onAssign}
+        onClear={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /seleziona/i }));
+    expect(onAssign).toHaveBeenCalledWith('toolkit');
+  });
+
+  it('calls onClear when clear button clicked', () => {
+    const onClear = vi.fn();
+    render(
+      <MyHandSlot
+        slotType="game"
+        slot={{ slotType: 'game', entityId: 'g-1', entityType: 'game', entityLabel: 'Agricola', entityImageUrl: null, pinnedAt: '2026-04-09T00:00:00Z', isEntityValid: true }}
+        onAssign={vi.fn()}
+        onClear={onClear}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /rimuovi/i }));
+    expect(onClear).toHaveBeenCalledWith('game');
+  });
+});
+```
+
+- [ ] **Step 2: Eseguire il test per verificare che fallisca**
+
+```bash
+cd apps/web
+pnpm test src/components/layout/MyHand/__tests__/MyHandSlot.test.tsx
+```
+
+Expected: FAIL — `Cannot find module '../MyHandSlot'`
+
+- [ ] **Step 3: Implementare il componente**
+
+```tsx
+// apps/web/src/components/layout/MyHand/MyHandSlot.tsx
+'use client';
+
+import { AlertTriangle, Plus, X } from 'lucide-react';
+import type { MyHandSlot as MyHandSlotData, MyHandSlotType } from '@/stores/my-hand/types';
+import { cn } from '@/lib/utils';
+
+const SLOT_LABELS: Record<MyHandSlotType, string> = {
+  toolkit: 'Toolkit',
+  game: 'Gioco',
+  session: 'Partita',
+  ai: 'AI',
+};
+
+const SLOT_ICONS: Record<MyHandSlotType, string> = {
+  toolkit: '🔧',
+  game: '🎮',
+  session: '🎯',
+  ai: '🤖',
+};
+
+interface MyHandSlotProps {
+  slotType: MyHandSlotType;
+  slot: MyHandSlotData;
+  onAssign: (slotType: MyHandSlotType) => void;
+  onClear: (slotType: MyHandSlotType) => void;
+  compact?: boolean;
+}
+
+export function MyHandSlot({ slotType, slot, onAssign, onClear, compact = false }: MyHandSlotProps) {
+  const label = SLOT_LABELS[slotType];
+  const icon = SLOT_ICONS[slotType];
+
+  if (!slot.entityId) {
+    return (
+      <div className={cn('flex flex-col items-center gap-1 rounded-lg border border-dashed border-border p-3 text-muted-foreground', compact && 'p-2')}>
+        <span className="text-lg">{icon}</span>
+        {!compact && <span className="text-xs font-medium">{label}</span>}
+        <button
+          aria-label={`Seleziona ${label}`}
+          onClick={() => onAssign(slotType)}
+          className="mt-1 flex items-center gap-1 rounded-md bg-secondary px-2 py-1 text-xs hover:bg-secondary/80"
+        >
+          <Plus className="h-3 w-3" />
+          {!compact && 'Seleziona'}
+        </button>
+      </div>
+    );
+  }
+
+  if (!slot.isEntityValid) {
+    return (
+      <div className={cn('flex flex-col items-center gap-1 rounded-lg border border-yellow-500/40 bg-yellow-50/10 p-3', compact && 'p-2')}>
+        <AlertTriangle className="h-4 w-4 text-yellow-500" />
+        {!compact && <span className="text-center text-xs text-muted-foreground">Non più disponibile</span>}
+        <button
+          aria-label={`Seleziona ${label}`}
+          onClick={() => onAssign(slotType)}
+          className="mt-1 rounded-md bg-secondary px-2 py-1 text-xs hover:bg-secondary/80"
+        >
+          {compact ? <Plus className="h-3 w-3" /> : 'Seleziona nuovo'}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('group relative flex flex-col gap-1 rounded-lg border border-border bg-card p-3', compact && 'p-2')}>
+      {/* Clear button */}
+      <button
+        aria-label={`Rimuovi ${label}`}
+        onClick={() => onClear(slotType)}
+        className="absolute right-1 top-1 hidden rounded p-0.5 hover:bg-muted group-hover:flex"
+      >
+        <X className="h-3 w-3" />
+      </button>
+
+      {/* Icon + label */}
+      <div className="flex items-center gap-1.5">
+        <span className="text-base">{icon}</span>
+        {!compact && <span className="truncate text-xs font-medium">{slot.entityLabel}</span>}
+      </div>
+      {compact && slot.entityLabel && (
+        <span className="truncate text-[10px] text-muted-foreground">{slot.entityLabel}</span>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Eseguire i test**
+
+```bash
+cd apps/web
+pnpm test src/components/layout/MyHand/__tests__/MyHandSlot.test.tsx
+```
+
+Expected: All PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/layout/MyHand/MyHandSlot.tsx
+git add apps/web/src/components/layout/MyHand/__tests__/MyHandSlot.test.tsx
+git commit -m "feat(my-hand): add MyHandSlot component with 3 states and tests"
+```
+
+---
+
+## Task 11: Componente MyHandSidebar (Desktop)
+
+**Files:**
+- Create: `apps/web/src/components/layout/MyHand/MyHandSidebar.tsx`
+- Create: `apps/web/src/components/layout/MyHand/__tests__/MyHandSidebar.test.tsx`
+
+- [ ] **Step 1: Scrivere il test failing**
+
+```typescript
+// apps/web/src/components/layout/MyHand/__tests__/MyHandSidebar.test.tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useMyHandStore } from '@/stores/my-hand/store';
+import { MyHandSidebar } from '../MyHandSidebar';
+
+// Mock del picker per isolare
+vi.mock('../MyHandSlotPicker', () => ({
+  MyHandSlotPicker: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="slot-picker">Picker</div> : null,
+}));
+
+describe('MyHandSidebar', () => {
+  beforeEach(() => {
+    useMyHandStore.setState(useMyHandStore.getInitialState());
+  });
+
+  it('renders 4 slots', () => {
+    render(<MyHandSidebar />);
+    expect(screen.getAllByRole('button', { name: /seleziona/i })).toHaveLength(4);
+  });
+
+  it('toggles collapsed state', () => {
+    render(<MyHandSidebar />);
+    const toggleBtn = screen.getByRole('button', { name: /comprimi|espandi/i });
+    fireEvent.click(toggleBtn);
+    expect(useMyHandStore.getState().isSidebarCollapsed).toBe(true);
+  });
+
+  it('opens picker when slot assign is clicked', () => {
+    render(<MyHandSidebar />);
+    fireEvent.click(screen.getAllByRole('button', { name: /seleziona/i })[0]);
+    expect(screen.getByTestId('slot-picker')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Eseguire per verificare che fallisca**
+
+```bash
+cd apps/web
+pnpm test src/components/layout/MyHand/__tests__/MyHandSidebar.test.tsx
+```
+
+Expected: FAIL — `Cannot find module '../MyHandSidebar'`
+
+- [ ] **Step 3: Implementare MyHandSidebar**
+
+```tsx
+// apps/web/src/components/layout/MyHand/MyHandSidebar.tsx
+'use client';
+
+import { useState } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useMyHandStore, selectIsSidebarCollapsed } from '@/stores/my-hand/store';
+import { MyHandSlot } from './MyHandSlot';
+import { MyHandSlotPicker } from './MyHandSlotPicker';
+import { cn } from '@/lib/utils';
+import type { MyHandSlotType } from '@/stores/my-hand/types';
+
+const SLOT_TYPES: MyHandSlotType[] = ['toolkit', 'game', 'session', 'ai'];
+
+export function MyHandSidebar() {
+  const slots = useMyHandStore(s => s.slots);
+  const isCollapsed = useMyHandStore(selectIsSidebarCollapsed);
+  const toggleCollapsed = useMyHandStore(s => s.toggleSidebarCollapsed);
+  const assignSlot = useMyHandStore(s => s.assignSlot);
+  const clearSlot = useMyHandStore(s => s.clearSlot);
+
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [activePickerSlot, setActivePickerSlot] = useState<MyHandSlotType | null>(null);
+
+  const handleAssign = (slotType: MyHandSlotType) => {
+    setActivePickerSlot(slotType);
+    setPickerOpen(true);
+  };
+
+  const handleClear = (slotType: MyHandSlotType) => {
+    clearSlot(slotType);
+    // TODO Task 12: also call API clearHandSlot
+  };
+
+  return (
+    <aside
+      className={cn(
+        'sticky top-16 flex h-[calc(100vh-64px)] flex-col border-l border-border bg-background transition-all duration-300',
+        isCollapsed ? 'w-14' : 'w-[280px]'
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-border px-3 py-2">
+        {!isCollapsed && (
+          <span className="text-sm font-semibold text-foreground">La Mia Mano</span>
+        )}
+        <button
+          aria-label={isCollapsed ? 'Espandi La Mia Mano' : 'Comprimi La Mia Mano'}
+          onClick={toggleCollapsed}
+          className="rounded p-1 hover:bg-muted"
+        >
+          {isCollapsed ? <ChevronLeft className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+        </button>
+      </div>
+
+      {/* Slots */}
+      <div className="flex flex-col gap-2 p-2">
+        {SLOT_TYPES.map(slotType => (
+          <MyHandSlot
+            key={slotType}
+            slotType={slotType}
+            slot={slots[slotType]}
+            onAssign={handleAssign}
+            onClear={handleClear}
+            compact={isCollapsed}
+          />
+        ))}
+      </div>
+
+      {/* Slot Picker */}
+      <MyHandSlotPicker
+        isOpen={pickerOpen}
+        slotType={activePickerSlot}
+        onClose={() => setPickerOpen(false)}
+        onConfirm={(slotType, payload) => {
+          assignSlot(slotType, payload);
+          setPickerOpen(false);
+          // TODO Task 12: also call API updateHandSlot
+        }}
+      />
+    </aside>
+  );
+}
+```
+
+- [ ] **Step 4: Creare MyHandSlotPicker (stub per ora)**
+
+```tsx
+// apps/web/src/components/layout/MyHand/MyHandSlotPicker.tsx
+'use client';
+
+import type { MyHandSlotType, AssignSlotPayload } from '@/stores/my-hand/types';
+
+interface MyHandSlotPickerProps {
+  isOpen: boolean;
+  slotType: MyHandSlotType | null;
+  onClose: () => void;
+  onConfirm: (slotType: MyHandSlotType, payload: AssignSlotPayload) => void;
+}
+
+export function MyHandSlotPicker({ isOpen }: MyHandSlotPickerProps) {
+  if (!isOpen) return null;
+  // TODO Task 13: implement full picker UI
+  return <div data-testid="slot-picker">Picker (TODO)</div>;
+}
+```
+
+- [ ] **Step 5: Eseguire i test**
+
+```bash
+cd apps/web
+pnpm test src/components/layout/MyHand/__tests__/MyHandSidebar.test.tsx
+```
+
+Expected: All PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/layout/MyHand/MyHandSidebar.tsx
+git add apps/web/src/components/layout/MyHand/MyHandSlotPicker.tsx
+git add apps/web/src/components/layout/MyHand/__tests__/MyHandSidebar.test.tsx
+git commit -m "feat(my-hand): add MyHandSidebar with collapse and slot assignment"
+```
+
+---
+
+## Task 12: Componente MyHandBottomBar (Mobile) + index.ts
+
+**Files:**
+- Create: `apps/web/src/components/layout/MyHand/MyHandBottomBar.tsx`
+- Create: `apps/web/src/components/layout/MyHand/index.ts`
+
+- [ ] **Step 1: Creare MyHandBottomBar**
+
+```tsx
+// apps/web/src/components/layout/MyHand/MyHandBottomBar.tsx
+'use client';
+
+import { useState } from 'react';
+import { ChevronUp, ChevronDown } from 'lucide-react';
+import { useMyHandStore } from '@/stores/my-hand/store';
+import { MyHandSlot } from './MyHandSlot';
+import { MyHandSlotPicker } from './MyHandSlotPicker';
+import { cn } from '@/lib/utils';
+import type { MyHandSlotType, AssignSlotPayload } from '@/stores/my-hand/types';
+
+const SLOT_TYPES: MyHandSlotType[] = ['toolkit', 'game', 'session', 'ai'];
+
+export function MyHandBottomBar() {
+  const slots = useMyHandStore(s => s.slots);
+  const isMobileExpanded = useMyHandStore(s => s.isMobileExpanded);
+  const toggleMobileExpanded = useMyHandStore(s => s.toggleMobileExpanded);
+  const assignSlot = useMyHandStore(s => s.assignSlot);
+  const clearSlot = useMyHandStore(s => s.clearSlot);
+
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [activePickerSlot, setActivePickerSlot] = useState<MyHandSlotType | null>(null);
+
+  const handleAssign = (slotType: MyHandSlotType) => {
+    setActivePickerSlot(slotType);
+    setPickerOpen(true);
+  };
+
+  return (
+    <div
+      className={cn(
+        'fixed bottom-0 left-0 right-0 z-30 border-t border-border bg-background/95 backdrop-blur-md',
+        'pb-[env(safe-area-inset-bottom)]'
+      )}
+    >
+      {/* Expand toggle */}
+      <button
+        aria-label={isMobileExpanded ? 'Comprimi La Mia Mano' : 'Espandi La Mia Mano'}
+        onClick={toggleMobileExpanded}
+        className="absolute -top-7 right-4 flex h-6 w-12 items-center justify-center rounded-t-full border border-b-0 border-border bg-background"
+      >
+        {isMobileExpanded
+          ? <ChevronDown className="h-3 w-3" />
+          : <ChevronUp className="h-3 w-3" />
+        }
+      </button>
+
+      {/* Collapsed: 4 slot icons in a row */}
+      <div className="flex items-center justify-around px-4 py-2">
+        {SLOT_TYPES.map(slotType => (
+          <MyHandSlot
+            key={slotType}
+            slotType={slotType}
+            slot={slots[slotType]}
+            onAssign={handleAssign}
+            onClear={(st) => clearSlot(st)}
+            compact
+          />
+        ))}
+      </div>
+
+      {/* Expanded: full slots sheet */}
+      {isMobileExpanded && (
+        <div
+          className="grid grid-cols-2 gap-2 px-4 pb-4 pt-1"
+          style={{ maxHeight: '40vh', overflowY: 'auto' }}
+        >
+          {SLOT_TYPES.map(slotType => (
+            <MyHandSlot
+              key={slotType}
+              slotType={slotType}
+              slot={slots[slotType]}
+              onAssign={handleAssign}
+              onClear={(st) => clearSlot(st)}
+            />
+          ))}
+        </div>
+      )}
+
+      <MyHandSlotPicker
+        isOpen={pickerOpen}
+        slotType={activePickerSlot}
+        onClose={() => setPickerOpen(false)}
+        onConfirm={(slotType, payload) => {
+          assignSlot(slotType, payload);
+          setPickerOpen(false);
+        }}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Creare index.ts**
+
+```typescript
+// apps/web/src/components/layout/MyHand/index.ts
+export { MyHandSidebar } from './MyHandSidebar';
+export { MyHandBottomBar } from './MyHandBottomBar';
+export { MyHandSlot } from './MyHandSlot';
+export { MyHandSlotPicker } from './MyHandSlotPicker';
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/layout/MyHand/MyHandBottomBar.tsx
+git add apps/web/src/components/layout/MyHand/index.ts
+git commit -m "feat(my-hand): add MyHandBottomBar for mobile + index exports"
+```
+
+---
+
+## Task 13: Integrazione nel Layout
+
+**Files:**
+- Read e Modify: `apps/web/src/components/layout/UserShell/DesktopShell.tsx`
+- Identificare e modificare il layout mobile
+
+- [ ] **Step 1: Leggere DesktopShell per capire la struttura corrente**
+
+Aprire e leggere `apps/web/src/components/layout/UserShell/DesktopShell.tsx` per trovare dove inserire `<MyHandSidebar />`.
+
+Il componente deve essere aggiunto come pannello destro all'interno del flex container principale, dopo il `<main>`.
+
+Pattern atteso (cercare il `<main>` o il contenitore flex principale):
+```tsx
+<div className="flex flex-1 overflow-hidden">
+  <DesktopHandRail />        {/* sinistra — esistente */}
+  <main className="flex-1">  {/* contenuto — esistente */}
+    {children}
+  </main>
+  <MyHandSidebar />           {/* DESTRA — aggiungere qui */}
+</div>
+```
+
+- [ ] **Step 2: Aggiungere l'import in DesktopShell**
+
+Nel file `DesktopShell.tsx`, aggiungere in cima agli import:
+```tsx
+import { MyHandSidebar } from '@/components/layout/MyHand';
+```
+
+- [ ] **Step 3: Aggiungere `<MyHandSidebar />` nel JSX**
+
+Aggiungere `<MyHandSidebar />` dopo il tag `<main>` e prima della chiusura del flex wrapper. La posizione esatta dipende dalla struttura del file — leggerlo prima di modificarlo.
+
+- [ ] **Step 4: Aggiungere MyHandBottomBar per mobile**
+
+Cercare il componente wrapper del layout mobile (probabilmente in `apps/web/src/components/layout/UserShell/` o nel root layout). Aggiungere:
+```tsx
+import { MyHandBottomBar } from '@/components/layout/MyHand';
+// Aggiungere nel JSX — visibile solo su mobile (md:hidden)
+<div className="md:hidden">
+  <MyHandBottomBar />
+</div>
+```
+
+- [ ] **Step 5: Build di verifica**
+
+```bash
+cd apps/web
+pnpm build 2>&1 | tail -20
+```
+
+Expected: Build completed successfully.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/layout/UserShell/DesktopShell.tsx
+git commit -m "feat(my-hand): integrate MyHandSidebar into DesktopShell layout"
+```
+
+---
+
+## Task 14: Hydration dal server al mount
+
+**Files:**
+- Create: `apps/web/src/components/layout/MyHand/MyHandProvider.tsx`
+- Modify: `apps/web/src/components/layout/MyHand/MyHandSidebar.tsx`
+
+- [ ] **Step 1: Creare MyHandProvider**
+
+Il provider carica i dati dal server al mount e li inietta nello store.
+
+```tsx
+// apps/web/src/components/layout/MyHand/MyHandProvider.tsx
+'use client';
+
+import { useEffect } from 'react';
+import { useMyHandStore } from '@/stores/my-hand/store';
+import { getMyHand } from '@/lib/api/my-hand';
+
+/**
+ * Mounted una volta nel layout autenticato.
+ * Carica gli slot dal server e li inietta nello store.
+ */
+export function MyHandProvider({ children }: { children: React.ReactNode }) {
+  const hydrateFromServer = useMyHandStore(s => s.hydrateFromServer);
+  const setLoading = useMyHandStore(s => s.setLoading);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setLoading(true);
+      try {
+        const slots = await getMyHand();
+        if (!cancelled) hydrateFromServer(slots);
+      } catch {
+        // Silently fail — store remains empty (default state)
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    load();
+    return () => { cancelled = true; };
+  }, [hydrateFromServer, setLoading]);
+
+  return <>{children}</>;
+}
+```
+
+- [ ] **Step 2: Esportare da index.ts**
+
+In `apps/web/src/components/layout/MyHand/index.ts`, aggiungere:
+```typescript
+export { MyHandProvider } from './MyHandProvider';
+```
+
+- [ ] **Step 3: Aggiornare updateHandSlot nel MyHandSidebar con API call**
+
+In `MyHandSidebar.tsx`, aggiornare `handleAssign` e `handleClear` per chiamare l'API in background (optimistic update — lo store è già aggiornato):
+
+```tsx
+// In MyHandSidebar.tsx, aggiornare l'import:
+import { updateHandSlot, clearHandSlot } from '@/lib/api/my-hand';
+
+// handleClear aggiornato:
+const handleClear = (slotType: MyHandSlotType) => {
+  clearSlot(slotType); // optimistic
+  clearHandSlot(slotType).catch(() => {
+    // TODO: rollback se necessario — per MVP silently ignore
+  });
+};
+```
+
+E in `MyHandSlotPicker.onConfirm`:
+```tsx
+onConfirm={(slotType, payload) => {
+  assignSlot(slotType, payload); // optimistic
+  setPickerOpen(false);
+  updateHandSlot(slotType, payload).catch(() => {
+    // TODO: rollback — per MVP silently ignore
+  });
+}}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/layout/MyHand/MyHandProvider.tsx
+git add apps/web/src/components/layout/MyHand/index.ts
+git add apps/web/src/components/layout/MyHand/MyHandSidebar.tsx
+git commit -m "feat(my-hand): add MyHandProvider for server hydration + optimistic API calls"
+```
+
+---
+
+## Task 15: Typecheck, lint e test completi
+
+- [ ] **Step 1: Backend — build e test**
+
+```bash
+cd apps/api
+dotnet build
+dotnet test --filter "BoundedContext=UserLibrary" -v minimal
+```
+
+Expected: Build succeeded, test pass.
+
+- [ ] **Step 2: Frontend — typecheck**
+
+```bash
+cd apps/web
+pnpm typecheck
+```
+
+Expected: 0 errori.
+
+- [ ] **Step 3: Frontend — lint**
+
+```bash
+cd apps/web
+pnpm lint
+```
+
+Expected: 0 errori.
+
+- [ ] **Step 4: Frontend — test suite completa per MyHand**
+
+```bash
+cd apps/web
+pnpm test src/stores/my-hand/ src/lib/api/__tests__/my-hand.api.test.ts src/components/layout/MyHand/__tests__/
+```
+
+Expected: All PASS.
+
+- [ ] **Step 5: Commit finale**
+
+```bash
+git add -u
+git commit -m "chore(my-hand): all tests pass, lint and typecheck clean"
+```
+
+---
+
+## Spec Coverage Self-Review
+
+| Requisito spec | Task che lo implementa |
+|---|---|
+| F-01: 4 slot fissi | Task 1 (entity), Task 8 (store types) |
+| F-02: Slot vuoti al primo login | Task 8 (store initial state), Task 3 (GET returns empty slots) |
+| F-03: Entity type per slot | Task 4 (validator SlotEntityMap) |
+| F-04: Slot vuoto con CTA | Task 10 (MyHandSlot empty state) |
+| F-05: Slot popolato con MeepleCard + actions | Task 10 (populated state) — azioni da aggiungere in task futuro |
+| F-06: Quick actions senza navigazione | Non incluso in questo piano — richiede Task separato per ogni SlotActions component |
+| F-07: Persistenza server | Task 2-6 (backend CRUD), Task 9 (API client), Task 14 (hydration) |
+| F-08: Stato degradato | Task 8 (markSlotInvalid), Task 10 (degraded state) |
+| F-09: Desktop sidebar | Task 11 (MyHandSidebar), Task 13 (layout integration) |
+| F-10: Mobile bottom bar | Task 12 (MyHandBottomBar) |
+| F-11: Swipe-up mobile | Non implementato — P1, task futuro |
+| F-12/13/14/15: Quick actions | Non implementati — P0 ma richiedono piano separato per ogni SlotActions |
+| F-16: Picker entità | Task 11/12 (stub) — implementazione completa task futuro |
+| F-17: Long-press su MeepleCard | P1 — task futuro |
+| F-18: Offline badge | Non implementato — P1, task futuro |
+
+**Scope di questo piano:** Backend CRUD completo + store + layout integrazione + slot componente con 3 stati. Le **quick actions specifiche per slot** (F-12..F-15) e il **picker completo** (F-16) sono esclusi e richiedono un piano separato.
+
+---
+
+*Piano generato con superpowers:writing-plans — 2026-04-09*

--- a/docs/superpowers/plans/2026-04-09-session-flow-backend.md
+++ b/docs/superpowers/plans/2026-04-09-session-flow-backend.md
@@ -1,0 +1,3369 @@
+# Session Flow v2.1 — Backend Core Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implementare il backend per Session Flow v2.1: KB readiness check, avvio Session con GameNight ad-hoc, pause/resume con invariante 1-active-per-night, turn order server-side, dice roll endpoint, score update con storia nel Diary, query Diario per Session e GameNight.
+
+**Architecture:** Estensioni al BC `SessionTracking` (nuovi command/query/endpoint) + piccole estensioni al BC `GameManagement` (`GameNightEvent.CreateAdHoc`) + nuova query in `KnowledgeBase`. Tutto CQRS via MediatR, TDD con Testcontainers per integration tests, zero breaking changes sugli aggregati esistenti.
+
+**Tech Stack:** .NET 9 / MediatR / EF Core / FluentValidation / xUnit + Testcontainers PostgreSQL
+
+**Spec:** `docs/superpowers/specs/2026-04-09-session-flow-v2.1.md`
+
+**Scope:** Questo plan copre SOLO i gap backend G1–G10 della spec. Frontend (G11–G15) e E2E Playwright (G16 parziale) in plan separato.
+
+---
+
+## Pre-flight: verifiche da fare prima di iniziare
+
+Prima di eseguire i task, **ogni worker deve verificare**:
+
+- [ ] **P1**: eseguire `git status` — deve essere clean
+- [ ] **P2**: eseguire `git checkout main-dev && git pull`
+- [ ] **P3**: eseguire `git checkout -b feature/session-flow-v2.1-backend`
+- [ ] **P4**: eseguire `git config branch.feature/session-flow-v2.1-backend.parent main-dev` (CLAUDE.md PR Rule)
+- [ ] **P5**: `cd apps/api/src/Api && dotnet restore && dotnet build` deve passare
+- [ ] **P6**: verificare che esistano i file:
+  - `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs`
+  - `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/SessionEvent.cs`
+  - `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/ScoreEntry.cs`
+  - `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/DiceRoll.cs`
+  - `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs`
+  - `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightSession.cs`
+  - `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Enums/GameNightStatus.cs`
+  - `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommand.cs`
+  - `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/RollSessionDiceCommand.cs`
+  - `apps/api/src/Api/Routing/SessionEndpoints.cs`
+
+Se qualche file manca → fermati, la spec assume realtà diversa, segnala al tech lead.
+
+---
+
+## File Map
+
+### Backend — nuovi file
+
+| File | Responsabilità |
+|---|---|
+| `apps/api/src/Api/Infrastructure/Migrations/<ts>_AddSessionTurnOrderAndGameNightInProgress.cs` | Migration EF Core |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbReadinessQuery.cs` | Query CQRS |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbReadinessQueryHandler.cs` | Handler |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/KbReadinessDto.cs` | DTO risposta |
+| `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/PauseSessionCommand.cs` | Command+Result+Validator |
+| `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/PauseSessionCommandHandler.cs` | Handler |
+| `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ResumeSessionCommand.cs` | Command+Validator |
+| `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ResumeSessionCommandHandler.cs` | Handler |
+| `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/SetTurnOrderCommand.cs` | Command+Result+Validator |
+| `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/SetTurnOrderCommandHandler.cs` | Handler |
+| `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpdateScoreCommand.cs` | Command+Result+Validator |
+| `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpdateScoreCommandHandler.cs` | Handler |
+| `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetSessionDiaryQuery.cs` | Query+Handler |
+| `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetGameNightDiaryQuery.cs` | Query+Handler |
+| `apps/api/src/Api/BoundedContexts/SessionTracking/Application/DTOs/SessionEventDto.cs` | DTO evento |
+| `apps/api/src/Api/Routing/SessionFlowEndpoints.cs` | Nuovo entrypoint routing |
+
+### Backend — file modificati
+
+| File | Modifica |
+|---|---|
+| `Session.cs` | Aggiungere `TurnOrderJson`, `TurnOrderMethod`, `TurnOrderSeed`, `CurrentTurnIndex` + metodo `SetTurnOrder(...)` + metodo `AdvanceTurn()` |
+| `GameNightStatus.cs` | Aggiungere valore `InProgress = 2` (shift enum ✓ no, aggiungere come nuovo) |
+| `GameNightEvent.cs` | Aggiungere `CreateAdHoc` factory + `AttachAdditionalGame` + `MarkInProgress` |
+| `CreateSessionCommand.cs` + handler | Aggiungere `GameNightEventId?`, `GuestNames[]`, logica ad-hoc GameNight, KB readiness pre-check |
+| `RollSessionDiceCommandHandler.cs` | Dopo il salvataggio di `DiceRoll`, emettere `SessionEvent(dice_rolled)` |
+| `SessionEndpoints.cs` | Aggiungere endpoint `POST /api/v1/sessions/{id}/dice-rolls` + wire ai nuovi endpoint |
+| `Program.cs` | `app.MapSessionFlowEndpoints()` |
+| `SessionTrackingServiceExtensions.cs` | Registrare nuovi query handler (FluentValidation + MediatR auto-discovery dovrebbe bastare) |
+
+---
+
+## Task 0: Test fixture seeders (prerequisite)
+
+Questo task crea gli helper di seeding usati da TUTTI i test integration dei task successivi. Deve essere eseguito prima di Task 1.
+
+**Files:**
+- Modify: `apps/api/tests/Api.Tests/Shared/Fixtures/PostgresFixture.cs` (o fixture equivalente — verificare nome reale)
+
+- [ ] **Step 1: Individuare il fixture base**
+
+```bash
+find apps/api/tests -name "*Fixture.cs" | xargs grep -l "MeepleAiDbContext"
+```
+
+Prendere il fixture che già espone `CreateScope()` e gestisce Testcontainers PostgreSQL. Tipicamente si chiama `PostgresFixture` o `IntegrationTestFixture`. Nel resto del plan useremo `PostgresFixture` come nome — sostituire con il nome reale.
+
+- [ ] **Step 2: Esaminare i seeder esistenti**
+
+```bash
+grep -n "public async Task.*Seed\|public Task.*Seed" apps/api/tests/Api.Tests/Shared/Fixtures/PostgresFixture.cs
+```
+
+Verificare il pattern usato (es. `DbContext.AddAsync` + `SaveChangesAsync`). I nuovi seeder seguiranno lo stesso pattern.
+
+- [ ] **Step 3: Aggiungere i 4 seeder helper**
+
+Nel file del fixture, aggiungere i seguenti metodi. **⚠️ Adattare i nomi delle entità (`SharedGameEntity`, `UserEntity`, `PdfDocumentEntity`, `VectorDocumentEntity`, `UserLibraryEntryEntity`) alla realtà del codebase.** Cercare con:
+
+```bash
+grep -rn "public class.*Entity" apps/api/src/Api/Infrastructure/Entities/ | head -30
+```
+
+```csharp
+using Api.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+// Inside PostgresFixture class:
+
+/// <summary>
+/// Seeds a user + a shared game + a library entry + 1 indexed PDF + N vector documents.
+/// Used for Session Flow v2.1 tests where KB must be ready.
+/// </summary>
+public async Task<(Guid userId, Guid gameId)> SeedUserWithLibraryGameAndIndexedKbAsync(
+    IServiceScope scope,
+    int vectorCount = 3)
+{
+    var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+    var userId = Guid.NewGuid();
+    var gameId = Guid.NewGuid();
+    var pdfId = Guid.NewGuid();
+
+    // 1. User (adatta ai campi obbligatori)
+    var user = new Api.Infrastructure.Entities.UserEntity
+    {
+        Id = userId,
+        Email = $"test-{userId:N}@meepleai.test",
+        DisplayName = "Test User",
+        Role = "user",
+        CreatedAt = DateTime.UtcNow
+    };
+    db.Users.Add(user);
+
+    // 2. Shared game
+    var game = new Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity
+    {
+        Id = gameId,
+        Name = $"Test Game {gameId:N}".Substring(0, 30),
+        CreatedAt = DateTime.UtcNow
+    };
+    db.SharedGames.Add(game);
+
+    // 3. User library entry linking user to game
+    var libEntry = new Api.Infrastructure.Entities.UserLibrary.UserLibraryEntryEntity
+    {
+        Id = Guid.NewGuid(),
+        UserId = userId,
+        SharedGameId = gameId,
+        AddedAt = DateTime.UtcNow
+    };
+    db.UserLibraryEntries.Add(libEntry);
+
+    // 4. Indexed PDF document for the game
+    var pdf = new Api.Infrastructure.Entities.DocumentProcessing.PdfDocumentEntity
+    {
+        Id = pdfId,
+        GameId = gameId,
+        FileName = "rules.pdf",
+        ProcessingState = "Indexed",
+        UploadedAt = DateTime.UtcNow,
+        UploadedByUserId = userId
+    };
+    db.PdfDocuments.Add(pdf);
+
+    // 5. Vector documents (minimum 1 for IsReady=true)
+    for (int i = 0; i < vectorCount; i++)
+    {
+        db.VectorDocuments.Add(new Api.Infrastructure.Entities.KnowledgeBase.VectorDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = pdfId,
+            ChunkIndex = i,
+            Content = $"chunk {i}",
+            EmbeddingVector = new float[] { 0.1f, 0.2f, 0.3f },
+            CreatedAt = DateTime.UtcNow
+        });
+    }
+
+    await db.SaveChangesAsync();
+    return (userId, gameId);
+}
+
+/// <summary>
+/// Seeds an additional game in the same user's library with indexed KB.
+/// </summary>
+public async Task<Guid> SeedAnotherLibraryGameAsync(IServiceScope scope, Guid userId)
+{
+    var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+    var gameId = Guid.NewGuid();
+    var pdfId = Guid.NewGuid();
+
+    db.SharedGames.Add(new Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity
+    {
+        Id = gameId,
+        Name = $"Second Game {gameId:N}".Substring(0, 30),
+        CreatedAt = DateTime.UtcNow
+    });
+    db.UserLibraryEntries.Add(new Api.Infrastructure.Entities.UserLibrary.UserLibraryEntryEntity
+    {
+        Id = Guid.NewGuid(),
+        UserId = userId,
+        SharedGameId = gameId,
+        AddedAt = DateTime.UtcNow
+    });
+    db.PdfDocuments.Add(new Api.Infrastructure.Entities.DocumentProcessing.PdfDocumentEntity
+    {
+        Id = pdfId,
+        GameId = gameId,
+        FileName = "rules2.pdf",
+        ProcessingState = "Indexed",
+        UploadedAt = DateTime.UtcNow,
+        UploadedByUserId = userId
+    });
+    db.VectorDocuments.Add(new Api.Infrastructure.Entities.KnowledgeBase.VectorDocumentEntity
+    {
+        Id = Guid.NewGuid(),
+        PdfDocumentId = pdfId,
+        ChunkIndex = 0,
+        Content = "chunk 0",
+        EmbeddingVector = new float[] { 0.1f },
+        CreatedAt = DateTime.UtcNow
+    });
+
+    await db.SaveChangesAsync();
+    return gameId;
+}
+
+/// <summary>
+/// Seeds user + game in library but WITHOUT indexed KB (PDF in Extracting state, 0 vectors).
+/// Used for KB_NOT_READY negative tests.
+/// </summary>
+public async Task<(Guid userId, Guid gameId)> SeedUserWithLibraryGameButNoKbAsync(IServiceScope scope)
+{
+    var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+    var userId = Guid.NewGuid();
+    var gameId = Guid.NewGuid();
+    var pdfId = Guid.NewGuid();
+
+    db.Users.Add(new Api.Infrastructure.Entities.UserEntity
+    {
+        Id = userId,
+        Email = $"test-{userId:N}@meepleai.test",
+        DisplayName = "Test User",
+        Role = "user",
+        CreatedAt = DateTime.UtcNow
+    });
+    db.SharedGames.Add(new Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity
+    {
+        Id = gameId,
+        Name = $"Game NoKB {gameId:N}".Substring(0, 30),
+        CreatedAt = DateTime.UtcNow
+    });
+    db.UserLibraryEntries.Add(new Api.Infrastructure.Entities.UserLibrary.UserLibraryEntryEntity
+    {
+        Id = Guid.NewGuid(),
+        UserId = userId,
+        SharedGameId = gameId,
+        AddedAt = DateTime.UtcNow
+    });
+    db.PdfDocuments.Add(new Api.Infrastructure.Entities.DocumentProcessing.PdfDocumentEntity
+    {
+        Id = pdfId,
+        GameId = gameId,
+        FileName = "rules.pdf",
+        ProcessingState = "Extracting",  // Not indexed
+        UploadedAt = DateTime.UtcNow,
+        UploadedByUserId = userId
+    });
+    // NO vector documents
+
+    await db.SaveChangesAsync();
+    return (userId, gameId);
+}
+
+/// <summary>
+/// Lightweight seeder: just a game + indexed PDF + N vectors (no user, no library).
+/// Used by unit-ish handler tests that don't need the full user stack.
+/// </summary>
+public async Task<Guid> SeedGameWithIndexedPdfAsync(MeepleAiDbContext db, int vectorCount)
+{
+    var gameId = Guid.NewGuid();
+    var pdfId = Guid.NewGuid();
+
+    db.SharedGames.Add(new Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity
+    {
+        Id = gameId,
+        Name = "SeededGame",
+        CreatedAt = DateTime.UtcNow
+    });
+    db.PdfDocuments.Add(new Api.Infrastructure.Entities.DocumentProcessing.PdfDocumentEntity
+    {
+        Id = pdfId,
+        GameId = gameId,
+        FileName = "rules.pdf",
+        ProcessingState = "Indexed",
+        UploadedAt = DateTime.UtcNow,
+        UploadedByUserId = Guid.NewGuid()
+    });
+    for (int i = 0; i < vectorCount; i++)
+    {
+        db.VectorDocuments.Add(new Api.Infrastructure.Entities.KnowledgeBase.VectorDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = pdfId,
+            ChunkIndex = i,
+            Content = $"chunk {i}",
+            EmbeddingVector = new float[] { 0.1f },
+            CreatedAt = DateTime.UtcNow
+        });
+    }
+    await db.SaveChangesAsync();
+    return gameId;
+}
+
+/// <summary>
+/// Seeds a game with mixed PDF states (some Indexed, some Failed).
+/// </summary>
+public async Task<Guid> SeedGameWithMixedPdfsAsync(
+    MeepleAiDbContext db, int indexedCount, int failedCount, int vectorsPerIndexed)
+{
+    var gameId = Guid.NewGuid();
+    db.SharedGames.Add(new Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity
+    {
+        Id = gameId,
+        Name = "MixedGame",
+        CreatedAt = DateTime.UtcNow
+    });
+
+    for (int i = 0; i < indexedCount; i++)
+    {
+        var pid = Guid.NewGuid();
+        db.PdfDocuments.Add(new Api.Infrastructure.Entities.DocumentProcessing.PdfDocumentEntity
+        {
+            Id = pid,
+            GameId = gameId,
+            FileName = $"ok-{i}.pdf",
+            ProcessingState = "Indexed",
+            UploadedAt = DateTime.UtcNow,
+            UploadedByUserId = Guid.NewGuid()
+        });
+        for (int v = 0; v < vectorsPerIndexed; v++)
+        {
+            db.VectorDocuments.Add(new Api.Infrastructure.Entities.KnowledgeBase.VectorDocumentEntity
+            {
+                Id = Guid.NewGuid(),
+                PdfDocumentId = pid,
+                ChunkIndex = v,
+                Content = $"chunk {v}",
+                EmbeddingVector = new float[] { 0.1f },
+                CreatedAt = DateTime.UtcNow
+            });
+        }
+    }
+
+    for (int i = 0; i < failedCount; i++)
+    {
+        db.PdfDocuments.Add(new Api.Infrastructure.Entities.DocumentProcessing.PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            GameId = gameId,
+            FileName = $"fail-{i}.pdf",
+            ProcessingState = "Failed",
+            UploadedAt = DateTime.UtcNow,
+            UploadedByUserId = Guid.NewGuid()
+        });
+    }
+
+    await db.SaveChangesAsync();
+    return gameId;
+}
+```
+
+- [ ] **Step 4: Verificare che i seeder compilino**
+
+```bash
+cd apps/api/tests/Api.Tests
+dotnet build
+```
+
+Expected: 0 errori. Se ci sono errori di "entity not found" o "property X does not exist", **significa che i nomi reali delle entità sono diversi**: adattarli seguendo gli errori del compilatore.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/tests/Api.Tests/Shared/Fixtures/PostgresFixture.cs
+git commit -m "test(fixtures): add Session Flow v2.1 seeders to PostgresFixture"
+```
+
+---
+
+## Task 1: Schema Migration — TurnOrder fields + GameNightStatus.InProgress
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Enums/GameNightStatus.cs`
+- Create: `apps/api/src/Api/Infrastructure/Migrations/<timestamp>_AddSessionTurnOrderAndGameNightInProgress.cs` (via `dotnet ef`)
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Entities/SessionTurnOrderTests.cs`
+
+- [ ] **Step 1: Leggere lo stato corrente di GameNightStatus**
+
+```bash
+cat apps/api/src/Api/BoundedContexts/GameManagement/Domain/Enums/GameNightStatus.cs
+```
+
+Verificare i valori esistenti. Dovrebbero essere: `Draft=0, Published=1, Completed=2, Cancelled=3` (o simili).
+
+- [ ] **Step 2: Aggiungere `InProgress` a `GameNightStatus`**
+
+Aprire `GameNightStatus.cs` e aggiungere un valore `InProgress` **in coda** per non rompere l'ordinale esistente. Se attualmente è:
+
+```csharp
+public enum GameNightStatus
+{
+    Draft = 0,
+    Published = 1,
+    Completed = 2,
+    Cancelled = 3
+}
+```
+
+Diventa:
+
+```csharp
+public enum GameNightStatus
+{
+    Draft = 0,
+    Published = 1,
+    Completed = 2,
+    Cancelled = 3,
+    /// <summary>Ad-hoc night currently in progress (spontaneous multi-game session).</summary>
+    InProgress = 4
+}
+```
+
+⚠️ Se i valori nel file sono diversi (es. usano flag [Flags] o ordinale diverso), adattarsi mantenendo l'invariante "non rompere il persistito".
+
+- [ ] **Step 3: Scrivere il test failing per i nuovi campi Session**
+
+Creare `apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Entities/SessionTurnOrderTests.cs`:
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.ValueObjects;
+using FluentAssertions;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Domain.Entities;
+
+public class SessionTurnOrderTests
+{
+    private static Session CreateSession()
+    {
+        return Session.Create(
+            userId: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            sessionType: SessionType.GameSpecific);
+    }
+
+    [Fact]
+    public void Session_NewlyCreated_HasNullTurnOrderFields()
+    {
+        var session = CreateSession();
+
+        session.TurnOrderJson.Should().BeNull();
+        session.TurnOrderMethod.Should().BeNull();
+        session.TurnOrderSeed.Should().BeNull();
+        session.CurrentTurnIndex.Should().BeNull();
+    }
+
+    [Fact]
+    public void SetTurnOrder_Manual_PersistsOrderAndMethod()
+    {
+        var session = CreateSession();
+        var p1 = session.Participants.First().Id;
+        session.AddParticipant(ParticipantInfo.Create("Luca", isOwner: false, joinOrder: 2));
+        var p2 = session.Participants.Last().Id;
+
+        session.SetTurnOrder(TurnOrderMethod.Manual, order: new[] { p2, p1 }, seed: null);
+
+        session.TurnOrderMethod.Should().Be("Manual");
+        session.TurnOrderSeed.Should().BeNull();
+        session.TurnOrderJson.Should().Contain(p2.ToString()).And.Contain(p1.ToString());
+        session.CurrentTurnIndex.Should().Be(0);
+    }
+
+    [Fact]
+    public void SetTurnOrder_Random_RequiresSeed()
+    {
+        var session = CreateSession();
+        var p1 = session.Participants.First().Id;
+
+        var act = () => session.SetTurnOrder(TurnOrderMethod.Random, order: new[] { p1 }, seed: null);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*seed*");
+    }
+
+}
+
+// NOTE: Test for AdvanceTurn() is deferred to Plan 1bis together with AdvanceTurnCommand (G9).
+// The domain method is also deferred — not implemented in this plan.
+```
+
+Nota: il test usa `TurnOrderMethod` enum e metodi `SetTurnOrder`, `AdvanceTurn` che ancora non esistono — è intenzionale (red phase).
+
+- [ ] **Step 4: Creare l'enum `TurnOrderMethod`**
+
+Creare `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Enums/TurnOrderMethod.cs`:
+
+```csharp
+namespace Api.BoundedContexts.SessionTracking.Domain.Enums;
+
+/// <summary>
+/// How turn order is determined for a session.
+/// </summary>
+public enum TurnOrderMethod
+{
+    /// <summary>Order explicitly defined by host.</summary>
+    Manual = 0,
+    /// <summary>Order shuffled server-side with auditable seed.</summary>
+    Random = 1
+}
+```
+
+- [ ] **Step 5: Aggiungere i nuovi campi e i metodi a `Session`**
+
+In `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs`, **dopo** la proprietà `RowVersion` (cerca `RowVersion`), aggiungere:
+
+```csharp
+    /// <summary>
+    /// Turn order as JSON array of participant IDs. Null if not yet set.
+    /// </summary>
+    public string? TurnOrderJson { get; private set; }
+
+    /// <summary>
+    /// Method used to set the turn order: "Manual" | "Random".
+    /// </summary>
+    [System.ComponentModel.DataAnnotations.MaxLength(16)]
+    public string? TurnOrderMethod { get; private set; }
+
+    /// <summary>
+    /// Seed used when TurnOrderMethod=Random, for audit/reproducibility.
+    /// </summary>
+    public int? TurnOrderSeed { get; private set; }
+
+    /// <summary>
+    /// Zero-based index of the current player in the turn order.
+    /// </summary>
+    public int? CurrentTurnIndex { get; private set; }
+```
+
+Poi, **in fondo alla classe Session** (prima di `UpdateAudit`), aggiungere:
+
+```csharp
+    /// <summary>
+    /// Sets the turn order for this session.
+    /// </summary>
+    /// <param name="method">Manual or Random.</param>
+    /// <param name="order">Ordered participant IDs.</param>
+    /// <param name="seed">Required when method is Random (for audit).</param>
+    public void SetTurnOrder(
+        Api.BoundedContexts.SessionTracking.Domain.Enums.TurnOrderMethod method,
+        IReadOnlyList<Guid> order,
+        int? seed)
+    {
+        if (Status == SessionStatus.Finalized)
+            throw new ConflictException("Cannot set turn order on finalized session.");
+
+        ArgumentNullException.ThrowIfNull(order);
+        if (order.Count == 0)
+            throw new ArgumentException("Turn order cannot be empty.", nameof(order));
+
+        // Verify all IDs are participants of this session
+        var participantIds = _participants.Select(p => p.Id).ToHashSet();
+        foreach (var id in order)
+        {
+            if (!participantIds.Contains(id))
+                throw new ArgumentException($"Participant {id} is not in this session.", nameof(order));
+        }
+
+        if (method == Api.BoundedContexts.SessionTracking.Domain.Enums.TurnOrderMethod.Random && !seed.HasValue)
+            throw new ArgumentException("Random turn order requires a seed for audit.", nameof(seed));
+
+        TurnOrderJson = System.Text.Json.JsonSerializer.Serialize(order);
+        TurnOrderMethod = method.ToString();
+        TurnOrderSeed = seed;
+        CurrentTurnIndex = 0;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    // AdvanceTurn() method deferred to Plan 1bis together with AdvanceTurnCommand (G9).
+```
+
+- [ ] **Step 6: Eseguire i test e verificare che passino (green phase)**
+
+```bash
+cd apps/api/tests/Api.Tests
+dotnet test --filter "FullyQualifiedName~SessionTurnOrderTests" --logger "console;verbosity=normal"
+```
+
+Expected: 3/3 PASS (Session_NewlyCreated, SetTurnOrder_Manual, SetTurnOrder_Random_RequiresSeed).
+
+- [ ] **Step 7: Configurare il mapping EF Core per i nuovi campi**
+
+Aprire `apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/Configurations/SessionEntityConfiguration.cs` (path esatto può variare — cercare con `find apps/api/src -name "SessionEntityConfiguration.cs"`). Aggiungere:
+
+```csharp
+builder.Property(s => s.TurnOrderJson)
+    .HasColumnType("jsonb"); // PostgreSQL jsonb
+
+builder.Property(s => s.TurnOrderMethod)
+    .HasMaxLength(16);
+
+builder.Property(s => s.TurnOrderSeed);
+
+builder.Property(s => s.CurrentTurnIndex);
+```
+
+- [ ] **Step 8: Generare la migration**
+
+```bash
+cd apps/api/src/Api
+dotnet ef migrations add AddSessionTurnOrderAndGameNightInProgress
+```
+
+Expected output: `Done. To undo this action, use 'ef migrations remove'`
+
+- [ ] **Step 8bis: Aggiungere unique partial index per invariante 1-Active-per-GameNight**
+
+L'invariante "max 1 Session Active per GameNight" è attualmente enforcedsolo a livello command handler — race condition possibile se 2 richieste arrivano simultaneamente. Aggiungiamo un **unique partial index PostgreSQL** come safety net.
+
+Aprire la migration appena generata (file da Step 8) e aggiungere manualmente nel metodo `Up`:
+
+```csharp
+// Enforce invariant: at most 1 Active Session per GameNightEvent (race-condition safe)
+migrationBuilder.Sql(@"
+CREATE UNIQUE INDEX IF NOT EXISTS ""ix_game_night_sessions_unique_active""
+ON ""GameNightSessions"" (""GameNightEventId"")
+WHERE EXISTS (
+    SELECT 1 FROM ""Sessions"" s
+    WHERE s.""Id"" = ""GameNightSessions"".""SessionId""
+    AND s.""Status"" = 0  -- SessionStatus.Active = 0
+);
+");
+```
+
+⚠️ I nomi tabella/colonna potrebbero usare snake_case o convention diversa. Verificare con:
+
+```bash
+docker exec -it meepleai-postgres psql -U postgres -d meepleai -c "\d GameNightSessions"
+```
+
+Se l'approccio con sub-select fallisce (alcune versioni PG richiedono predicate semplice), **alternativa**: denormalizzare un flag `IsActive: bool` su `GameNightSession` aggiornato dai PauseSession/ResumeSession handler, e creare unique index semplice:
+
+```sql
+CREATE UNIQUE INDEX IF NOT EXISTS "ix_game_night_sessions_unique_active"
+ON "GameNightSessions" ("GameNightEventId") WHERE "IsActive" = TRUE;
+```
+
+Il worker sceglie l'approccio meno invasivo. In caso di denormalizzazione, aggiungere `IsActive` a `GameNightSession` + aggiornare `PauseSessionCommandHandler` e `ResumeSessionCommandHandler` in Task 5.
+
+Nel `Down` method della migration, aggiungere:
+
+```csharp
+migrationBuilder.Sql("DROP INDEX IF EXISTS \"ix_game_night_sessions_unique_active\";");
+```
+
+Nel handler `CreateSessionCommand` (Task 4), gestire la `DbUpdateException` da violazione unique index come `ConflictException("ACTIVE_SESSION_EXISTS_IN_NIGHT")` (catch specifico, fallback sul check read-based).
+
+- [ ] **Step 9: Verificare il file migration generato**
+
+Aprire il file `apps/api/src/Api/Infrastructure/Migrations/<timestamp>_AddSessionTurnOrderAndGameNightInProgress.cs` e verificare che contenga:
+
+```csharp
+migrationBuilder.AddColumn<string>(
+    name: "TurnOrderJson",
+    table: "Sessions",
+    type: "jsonb",
+    nullable: true);
+
+migrationBuilder.AddColumn<string>(
+    name: "TurnOrderMethod",
+    table: "Sessions",
+    type: "character varying(16)",
+    maxLength: 16,
+    nullable: true);
+
+migrationBuilder.AddColumn<int>(
+    name: "TurnOrderSeed",
+    table: "Sessions",
+    type: "integer",
+    nullable: true);
+
+migrationBuilder.AddColumn<int>(
+    name: "CurrentTurnIndex",
+    table: "Sessions",
+    type: "integer",
+    nullable: true);
+```
+
+Se il nome tabella è diverso (es. `sessions` lowercase), non è un problema — EF genera in base alla convention del contesto.
+
+- [ ] **Step 10: Applicare la migration al DB locale**
+
+```bash
+cd apps/api/src/Api
+dotnet ef database update
+```
+
+Expected output: `Done.`
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs
+git add apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Enums/TurnOrderMethod.cs
+git add apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/Configurations/SessionEntityConfiguration.cs
+git add apps/api/src/Api/BoundedContexts/GameManagement/Domain/Enums/GameNightStatus.cs
+git add apps/api/src/Api/Infrastructure/Migrations/
+git add apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Entities/SessionTurnOrderTests.cs
+git commit -m "feat(session-tracking): add turn order fields and SetTurnOrder domain method
+
+- TurnOrderMethod enum (Manual, Random)
+- Session.TurnOrderJson/Method/Seed/CurrentTurnIndex fields
+- Session.SetTurnOrder() domain method (AdvanceTurn deferred to Plan 1bis)
+- GameNightStatus.InProgress for ad-hoc nights
+- EF migration AddSessionTurnOrderAndGameNightInProgress
+- Unique partial index enforcing '1 Active Session per GameNight'"
+```
+
+---
+
+## Task 2: GameNightEvent — CreateAdHoc + AttachAdditionalGame
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventAdHocTests.cs`
+
+- [ ] **Step 1: Scrivere i test failing**
+
+Creare `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventAdHocTests.cs`:
+
+```csharp
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using FluentAssertions;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain.Entities;
+
+public class GameNightEventAdHocTests
+{
+    [Fact]
+    public void CreateAdHoc_SetsStatusInProgress_And_AddsFirstGame()
+    {
+        var organizerId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+
+        var night = GameNightEvent.CreateAdHoc(organizerId, "Serata del 09/04", gameId);
+
+        night.OrganizerId.Should().Be(organizerId);
+        night.Status.Should().Be(GameNightStatus.InProgress);
+        night.GameIds.Should().ContainSingle().Which.Should().Be(gameId);
+        night.Title.Should().Be("Serata del 09/04");
+        night.Rsvps.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AttachAdditionalGame_WhenInProgress_AddsToGameIds()
+    {
+        var firstGame = Guid.NewGuid();
+        var secondGame = Guid.NewGuid();
+        var night = GameNightEvent.CreateAdHoc(Guid.NewGuid(), "Serata", firstGame);
+
+        night.AttachAdditionalGame(secondGame);
+
+        night.GameIds.Should().HaveCount(2).And.Contain(new[] { firstGame, secondGame });
+    }
+
+    [Fact]
+    public void AttachAdditionalGame_WhenDraft_Throws()
+    {
+        var night = GameNightEvent.Create(
+            Guid.NewGuid(),
+            "Pianificata",
+            DateTimeOffset.UtcNow.AddDays(1));
+
+        var act = () => night.AttachAdditionalGame(Guid.NewGuid());
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void AttachAdditionalGame_DuplicateGameId_IsIdempotent()
+    {
+        var gameId = Guid.NewGuid();
+        var night = GameNightEvent.CreateAdHoc(Guid.NewGuid(), "Serata", gameId);
+
+        night.AttachAdditionalGame(gameId);
+
+        night.GameIds.Should().ContainSingle().Which.Should().Be(gameId);
+    }
+}
+```
+
+- [ ] **Step 2: Eseguire il test e verificare che fallisca**
+
+```bash
+cd apps/api/tests/Api.Tests
+dotnet test --filter "FullyQualifiedName~GameNightEventAdHocTests"
+```
+
+Expected: FAIL — `CreateAdHoc` and `AttachAdditionalGame` do not exist.
+
+- [ ] **Step 3: Implementare `CreateAdHoc` e `AttachAdditionalGame`**
+
+Aprire `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs`.
+
+Cercare la factory `Create(...)` esistente. **Dopo** di essa, aggiungere:
+
+```csharp
+    /// <summary>
+    /// Creates an ad-hoc game night that skips the scheduling/RSVP flow.
+    /// Used when a user spontaneously starts playing and adds more games during the same evening.
+    /// Status is set directly to InProgress.
+    /// </summary>
+    /// <param name="organizerId">User who starts the night.</param>
+    /// <param name="title">Auto-generated title (e.g., "Serata del 2026-04-09 20:00").</param>
+    /// <param name="firstGameId">The game being played at night start.</param>
+    public static GameNightEvent CreateAdHoc(Guid organizerId, string title, Guid firstGameId)
+    {
+        if (firstGameId == Guid.Empty)
+            throw new ArgumentException("FirstGameId cannot be empty.", nameof(firstGameId));
+
+        var night = new GameNightEvent(
+            id: Guid.NewGuid(),
+            organizerId: organizerId,
+            title: title,
+            scheduledAt: DateTimeOffset.UtcNow,
+            description: null,
+            location: null,
+            maxPlayers: null,
+            gameIds: new List<Guid> { firstGameId });
+
+        night.Status = GameNightStatus.InProgress;
+        return night;
+    }
+
+    /// <summary>
+    /// Adds a game to an in-progress ad-hoc night.
+    /// Idempotent: duplicates are ignored.
+    /// </summary>
+    /// <param name="gameId">Game to add.</param>
+    public void AttachAdditionalGame(Guid gameId)
+    {
+        ThrowIfCorrupted();
+
+        if (Status != GameNightStatus.InProgress)
+            throw new InvalidOperationException(
+                $"Cannot attach game to a {Status} game night. Only InProgress nights accept dynamic games.");
+
+        if (gameId == Guid.Empty)
+            throw new ArgumentException("GameId cannot be empty.", nameof(gameId));
+
+        if (!GameIds.Contains(gameId))
+        {
+            GameIds.Add(gameId);
+            UpdatedAt = DateTimeOffset.UtcNow;
+        }
+    }
+```
+
+Nota: se il file usa `internal sealed class`, i nuovi membri **devono** essere `public` se vuoi testarli dall'assembly `Api.Tests`. Se l'assembly ha già `InternalsVisibleTo("Api.Tests")`, puoi mantenerli `internal`. Verificare con:
+
+```bash
+grep -r "InternalsVisibleTo.*Api.Tests" apps/api/src/Api
+```
+
+Se il risultato è presente → lascia `internal`. Altrimenti → `public`.
+
+- [ ] **Step 4: Eseguire i test e verificare che passino**
+
+```bash
+cd apps/api/tests/Api.Tests
+dotnet test --filter "FullyQualifiedName~GameNightEventAdHocTests"
+```
+
+Expected: 4/4 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
+git add apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventAdHocTests.cs
+git commit -m "feat(game-management): add GameNightEvent.CreateAdHoc and AttachAdditionalGame
+
+Supports ad-hoc multi-game evenings: user starts playing, later adds
+more games during the same night, without scheduling/RSVP workflow."
+```
+
+---
+
+## Task 3: GetKbReadinessQuery
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/KbReadinessDto.cs`
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbReadinessQuery.cs`
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbReadinessQueryHandler.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbReadinessQueryHandlerTests.cs`
+
+- [ ] **Step 1: Creare il DTO**
+
+Creare `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/KbReadinessDto.cs`:
+
+```csharp
+namespace Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+
+/// <summary>
+/// Knowledge Base readiness status for a game.
+/// A KB is "ready" when at least one PDF is Indexed and vector documents exist.
+/// </summary>
+public record KbReadinessDto(
+    bool IsReady,
+    string State,                  // "None" | "Extracting" | "Indexing" | "Indexed" | "PartiallyIndexed" | "Failed"
+    int VectorDocumentCount,
+    int FailedPdfCount,
+    IReadOnlyList<string> Warnings
+);
+```
+
+- [ ] **Step 2: Creare la query**
+
+Creare `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbReadinessQuery.cs`:
+
+```csharp
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using MediatR;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Checks if the Knowledge Base for a given game is ready to power an agent.
+/// </summary>
+/// <param name="GameId">Shared game ID.</param>
+public record GetKbReadinessQuery(Guid GameId) : IRequest<KbReadinessDto>;
+```
+
+- [ ] **Step 3: Scrivere i test failing dell'handler**
+
+Creare `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbReadinessQueryHandlerTests.cs`:
+
+```csharp
+using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.Infrastructure;
+using Api.Tests.Shared.Fixtures;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries;
+
+public class GetKbReadinessQueryHandlerTests : IClassFixture<PostgresFixture>
+{
+    private readonly PostgresFixture _fixture;
+
+    public GetKbReadinessQueryHandlerTests(PostgresFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task Handle_NoPdfsForGame_ReturnsNotReady()
+    {
+        using var scope = _fixture.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var handler = new GetKbReadinessQueryHandler(db);
+
+        var result = await handler.Handle(new GetKbReadinessQuery(Guid.NewGuid()), CancellationToken.None);
+
+        result.IsReady.Should().BeFalse();
+        result.State.Should().Be("None");
+        result.VectorDocumentCount.Should().Be(0);
+        result.FailedPdfCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_IndexedPdfWithVectors_ReturnsReady()
+    {
+        using var scope = _fixture.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        // Arrange: seed a game + indexed PDF + 5 vector documents
+        var gameId = await _fixture.SeedGameWithIndexedPdfAsync(db, vectorCount: 5);
+
+        var handler = new GetKbReadinessQueryHandler(db);
+        var result = await handler.Handle(new GetKbReadinessQuery(gameId), CancellationToken.None);
+
+        result.IsReady.Should().BeTrue();
+        result.State.Should().Be("Indexed");
+        result.VectorDocumentCount.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task Handle_IndexedPdfButNoVectors_ReturnsNotReady()
+    {
+        using var scope = _fixture.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var gameId = await _fixture.SeedGameWithIndexedPdfAsync(db, vectorCount: 0);
+
+        var handler = new GetKbReadinessQueryHandler(db);
+        var result = await handler.Handle(new GetKbReadinessQuery(gameId), CancellationToken.None);
+
+        result.IsReady.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_MixedSomeIndexedSomeFailed_ReturnsPartiallyIndexedWithWarning()
+    {
+        using var scope = _fixture.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var gameId = await _fixture.SeedGameWithMixedPdfsAsync(db, indexedCount: 1, failedCount: 1, vectorsPerIndexed: 3);
+
+        var handler = new GetKbReadinessQueryHandler(db);
+        var result = await handler.Handle(new GetKbReadinessQuery(gameId), CancellationToken.None);
+
+        result.IsReady.Should().BeTrue();
+        result.State.Should().Be("PartiallyIndexed");
+        result.FailedPdfCount.Should().Be(1);
+        result.Warnings.Should().NotBeEmpty();
+    }
+}
+```
+
+⚠️ I helper `SeedGameWithIndexedPdfAsync` e `SeedGameWithMixedPdfsAsync` potrebbero non esistere. Se mancano, cercare pattern simili con:
+
+```bash
+grep -rn "SeedGame" apps/api/tests/Api.Tests/Shared
+```
+
+Se non trovi helper equivalenti, crea un helper locale nel test file che instanzia le entità necessarie (`PdfDocumentEntity` con `ProcessingState`, `VectorDocumentEntity`). Il test deve verificare la **logica dell'handler**, non il setup.
+
+- [ ] **Step 4: Verificare che il test fallisca**
+
+```bash
+cd apps/api/tests/Api.Tests
+dotnet test --filter "FullyQualifiedName~GetKbReadinessQueryHandlerTests"
+```
+
+Expected: FAIL — handler class doesn't exist.
+
+- [ ] **Step 5: Implementare l'handler**
+
+Creare `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbReadinessQueryHandler.cs`:
+
+```csharp
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.Infrastructure;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
+
+public class GetKbReadinessQueryHandler : IRequestHandler<GetKbReadinessQuery, KbReadinessDto>
+{
+    private readonly MeepleAiDbContext _db;
+
+    public GetKbReadinessQueryHandler(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<KbReadinessDto> Handle(GetKbReadinessQuery request, CancellationToken cancellationToken)
+    {
+        // NOTE: Adatta i nomi tabella/colonna alla tua realtà EF.
+        // PdfDocumentEntity dovrebbe avere GameId (o SharedGameId) e ProcessingState.
+        // VectorDocumentEntity dovrebbe avere PdfDocumentId (o GameId).
+
+        var pdfs = await _db.PdfDocuments
+            .AsNoTracking()
+            .Where(p => p.GameId == request.GameId)
+            .Select(p => new { p.Id, p.ProcessingState })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (pdfs.Count == 0)
+        {
+            return new KbReadinessDto(
+                IsReady: false,
+                State: "None",
+                VectorDocumentCount: 0,
+                FailedPdfCount: 0,
+                Warnings: Array.Empty<string>());
+        }
+
+        var indexedPdfIds = pdfs
+            .Where(p => string.Equals(p.ProcessingState, "Indexed", StringComparison.Ordinal))
+            .Select(p => p.Id)
+            .ToList();
+
+        var failedCount = pdfs.Count(p => string.Equals(p.ProcessingState, "Failed", StringComparison.Ordinal));
+
+        var vectorCount = indexedPdfIds.Count == 0
+            ? 0
+            : await _db.VectorDocuments
+                .AsNoTracking()
+                .CountAsync(v => indexedPdfIds.Contains(v.PdfDocumentId), cancellationToken)
+                .ConfigureAwait(false);
+
+        var isReady = vectorCount > 0 && indexedPdfIds.Count > 0;
+
+        string state;
+        var warnings = new List<string>();
+
+        if (!isReady && pdfs.Any(p => string.Equals(p.ProcessingState, "Extracting", StringComparison.Ordinal)))
+            state = "Extracting";
+        else if (!isReady && pdfs.Any(p => string.Equals(p.ProcessingState, "Indexing", StringComparison.Ordinal)))
+            state = "Indexing";
+        else if (isReady && failedCount > 0)
+        {
+            state = "PartiallyIndexed";
+            warnings.Add($"{failedCount} PDF document(s) failed to index — agent answers may be incomplete.");
+        }
+        else if (isReady)
+            state = "Indexed";
+        else if (failedCount == pdfs.Count)
+            state = "Failed";
+        else
+            state = "None";
+
+        return new KbReadinessDto(
+            IsReady: isReady,
+            State: state,
+            VectorDocumentCount: vectorCount,
+            FailedPdfCount: failedCount,
+            Warnings: warnings);
+    }
+}
+```
+
+⚠️ **Adattamento realtà**: i nomi `_db.PdfDocuments` e `_db.VectorDocuments` potrebbero essere diversi. Cerca con:
+
+```bash
+grep -rn "DbSet<PdfDocument" apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+grep -rn "DbSet<VectorDocument" apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+```
+
+E adatta. Analogamente, `ProcessingState` potrebbe essere un enum (`PdfProcessingState.Indexed`) invece di stringa — in quel caso usa il confronto enum:
+
+```csharp
+.Where(p => p.ProcessingState == PdfProcessingState.Indexed)
+```
+
+- [ ] **Step 6: Eseguire i test**
+
+```bash
+cd apps/api/tests/Api.Tests
+dotnet test --filter "FullyQualifiedName~GetKbReadinessQueryHandlerTests"
+```
+
+Expected: PASS (potrebbe servire qualche iterazione per adattare i nomi entità).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/KbReadinessDto.cs
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbReadinessQuery.cs
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbReadinessQueryHandler.cs
+git add apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbReadinessQueryHandlerTests.cs
+git commit -m "feat(knowledge-base): add GetKbReadinessQuery for pre-session KB check"
+```
+
+---
+
+## Task 4: Extend CreateSessionCommand — GameNightEventId + KB check + ad-hoc logic
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommand.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandValidator.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandHandler.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandAdHocTests.cs`
+
+- [ ] **Step 1: Estendere il record `CreateSessionCommand`**
+
+Leggere lo stato attuale di `CreateSessionCommand.cs` (lo abbiamo già visto in pre-flight). Sostituire il record con:
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+public record CreateSessionCommand(
+    Guid UserId,
+    Guid GameId,
+    string SessionType,
+    DateTime? SessionDate,
+    string? Location,
+    List<ParticipantDto> Participants,
+    Guid? GameNightEventId = null,
+    IReadOnlyList<string>? GuestNames = null
+) : ICommand<CreateSessionResult>;
+
+public record CreateSessionResult(
+    Guid SessionId,
+    string SessionCode,
+    List<ParticipantDto> Participants,
+    Guid GameNightEventId,
+    bool GameNightWasCreated,
+    Guid? AgentDefinitionId,
+    Guid? ToolkitId
+);
+```
+
+Nota: aggiunti 2 parametri opzionali alla fine per backward compat e 4 nuovi campi al risultato.
+
+- [ ] **Step 2: Scrivere il test failing per la logica ad-hoc**
+
+Creare `apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandAdHocTests.cs`:
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.Tests.Shared.Fixtures;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Commands;
+
+public class CreateSessionCommandAdHocTests : IClassFixture<PostgresFixture>
+{
+    private readonly PostgresFixture _fixture;
+
+    public CreateSessionCommandAdHocTests(PostgresFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task Handle_NoGameNightProvided_CreatesAdHocNightImplicitly()
+    {
+        using var scope = _fixture.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(scope);
+
+        var cmd = new CreateSessionCommand(
+            UserId: userId,
+            GameId: gameId,
+            SessionType: "GameSpecific",
+            SessionDate: null,
+            Location: null,
+            Participants: new List<ParticipantDto>());
+
+        var result = await mediator.Send(cmd);
+
+        result.GameNightWasCreated.Should().BeTrue();
+        result.GameNightEventId.Should().NotBeEmpty();
+
+        // Verify the GameNightEvent exists and is InProgress
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var night = await db.GameNightEvents.FindAsync(result.GameNightEventId);
+        night.Should().NotBeNull();
+        night!.Status.Should().Be(GameNightStatus.InProgress);
+        night.GameIds.Should().Contain(gameId);
+    }
+
+    [Fact]
+    public async Task Handle_ExistingNightProvided_AttachesGameToNight()
+    {
+        using var scope = _fixture.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var (userId, gameId1) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(scope);
+
+        // First session: create night implicitly
+        var first = await mediator.Send(new CreateSessionCommand(
+            userId, gameId1, "GameSpecific", null, null, new List<ParticipantDto>()));
+
+        // Pause first session so invariant is satisfied
+        await mediator.Send(new PauseSessionCommand(first.SessionId, userId));
+
+        // Second session with a different game, same night
+        var gameId2 = await _fixture.SeedAnotherLibraryGameAsync(scope, userId);
+        var second = await mediator.Send(new CreateSessionCommand(
+            userId, gameId2, "GameSpecific", null, null, new List<ParticipantDto>(),
+            GameNightEventId: first.GameNightEventId));
+
+        second.GameNightEventId.Should().Be(first.GameNightEventId);
+        second.GameNightWasCreated.Should().BeFalse();
+
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var night = await db.GameNightEvents.FindAsync(first.GameNightEventId);
+        night!.GameIds.Should().Contain(new[] { gameId1, gameId2 });
+    }
+
+    [Fact]
+    public async Task Handle_KbNotReady_Throws422()
+    {
+        using var scope = _fixture.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameButNoKbAsync(scope);
+
+        var cmd = new CreateSessionCommand(
+            userId, gameId, "GameSpecific", null, null, new List<ParticipantDto>());
+
+        var act = () => mediator.Send(cmd);
+
+        await act.Should().ThrowAsync<UnprocessableEntityException>()
+            .Where(ex => ex.Code == "KB_NOT_READY");
+    }
+
+    [Fact]
+    public async Task Handle_ActiveSessionInNight_Throws409()
+    {
+        using var scope = _fixture.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var (userId, gameId1) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(scope);
+
+        var first = await mediator.Send(new CreateSessionCommand(
+            userId, gameId1, "GameSpecific", null, null, new List<ParticipantDto>()));
+
+        // Do NOT pause — first is still Active
+        var gameId2 = await _fixture.SeedAnotherLibraryGameAsync(scope, userId);
+
+        var act = () => mediator.Send(new CreateSessionCommand(
+            userId, gameId2, "GameSpecific", null, null, new List<ParticipantDto>(),
+            GameNightEventId: first.GameNightEventId));
+
+        await act.Should().ThrowAsync<ConflictException>()
+            .Where(ex => ex.Code == "ACTIVE_SESSION_EXISTS_IN_NIGHT");
+    }
+
+    [Fact]
+    public async Task Handle_GuestNamesProvided_AddsParticipantsWithDisplayNames()
+    {
+        using var scope = _fixture.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(scope);
+
+        var cmd = new CreateSessionCommand(
+            UserId: userId,
+            GameId: gameId,
+            SessionType: "GameSpecific",
+            SessionDate: null,
+            Location: null,
+            Participants: new List<ParticipantDto>(),
+            GuestNames: new[] { "Luca", "Sara" });
+
+        var result = await mediator.Send(cmd);
+
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var session = await db.Sessions.Include(s => s.Participants).FirstAsync(s => s.Id == result.SessionId);
+        session.Participants.Should().HaveCount(3); // Owner + 2 guests
+        session.Participants.Select(p => p.DisplayName).Should().Contain(new[] { "Luca", "Sara" });
+    }
+}
+```
+
+⚠️ Alcune API dei test usano helper di PostgresFixture che potrebbero non esistere (`SeedUserWithLibraryGameAndIndexedKbAsync`, `SeedAnotherLibraryGameAsync`, `SeedUserWithLibraryGameButNoKbAsync`). **Se non esistono, vanno creati** nel `PostgresFixture` (o fixture simile). Il worker deve:
+1. Cercare il fixture esistente: `find apps/api/tests -name "PostgresFixture.cs"`
+2. Esaminare i seeder esistenti per seguire lo stesso pattern
+3. Aggiungere i tre seeder helper nel fixture prima di far passare il test
+
+Per brevità questo plan non ripete il codice del seeder — ma il worker deve **assolutamente** scriverli, non marcarli come TODO.
+
+`UnprocessableEntityException` potrebbe chiamarsi diversamente (es. `ValidationException`, `BusinessRuleException`). Cercare:
+```bash
+grep -rn "class.*Exception.*: .*Exception" apps/api/src/Api/Middleware/Exceptions/
+```
+e adattare.
+
+- [ ] **Step 3: Eseguire il test e verificare che fallisca**
+
+```bash
+cd apps/api/tests/Api.Tests
+dotnet test --filter "FullyQualifiedName~CreateSessionCommandAdHocTests"
+```
+
+Expected: FAIL — handler non supporta ancora `GameNightEventId`, `GuestNames`, KB check, invariante.
+
+- [ ] **Step 4: Modificare il validator**
+
+Aprire `CreateSessionCommandValidator.cs`. Cercare la classe `CreateSessionCommandValidator`. Aggiungere alle rules esistenti:
+
+```csharp
+RuleFor(x => x.GuestNames)
+    .Must(names => names == null || names.All(n => !string.IsNullOrWhiteSpace(n) && n.Length <= 50))
+    .WithMessage("Each guest name must be non-empty and max 50 characters.")
+    .When(x => x.GuestNames != null);
+```
+
+- [ ] **Step 4bis: Verificare il SaveChangesAsync count esistente**
+
+**CRITICO per transaction atomicity**. Aprire `CreateSessionCommandHandler.cs` e contare quante volte viene chiamato `SaveChangesAsync`:
+
+```bash
+grep -c "SaveChangesAsync" apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandHandler.cs
+```
+
+Deve essere **esattamente 1** alla fine del metodo `Handle`. Se ce ne sono 2 o più, consolidare in un'unica chiamata finale, altrimenti il codice nuovo (GameNightEvent + GameNightSession + SessionEvents) potrebbe essere persistito in transazioni separate con rischio di inconsistenza.
+
+Se l'handler usa già un Unit of Work / `IExecutionStrategy`, rispettare il pattern esistente.
+
+- [ ] **Step 5: Modificare l'handler**
+
+Aprire `CreateSessionCommandHandler.cs`. Trovare il metodo `Handle`. Prima di `Session.Create(...)`, aggiungere (tutto il codice, non selezioni parziali):
+
+```csharp
+// ---------- Pre-checks Session Flow v2.1 ----------
+
+// 1. KB readiness
+var kbReadiness = await _mediator.Send(
+    new GetKbReadinessQuery(request.GameId),
+    cancellationToken).ConfigureAwait(false);
+
+if (!kbReadiness.IsReady)
+{
+    throw new UnprocessableEntityException(
+        code: "KB_NOT_READY",
+        message: $"Knowledge base for game {request.GameId} is not ready (state: {kbReadiness.State}).");
+}
+
+// 2. Resolve GameNightEvent
+Guid gameNightEventId;
+bool gameNightWasCreated;
+GameNightEvent? night;
+
+if (request.GameNightEventId.HasValue)
+{
+    // Attach to existing night
+    night = await _db.GameNightEvents
+        .FirstOrDefaultAsync(g => g.Id == request.GameNightEventId.Value, cancellationToken)
+        .ConfigureAwait(false);
+
+    if (night is null)
+        throw new NotFoundException($"GameNightEvent {request.GameNightEventId.Value} not found.");
+
+    if (night.Status != GameNightStatus.InProgress)
+        throw new ConflictException(
+            code: "GAMENIGHT_NOT_IN_PROGRESS",
+            message: $"GameNightEvent is in status {night.Status}, cannot attach new sessions.");
+
+    // 3. Invariant: at most 1 Active Session per GameNight
+    var hasActive = await _db.GameNightSessions
+        .Where(gns => gns.GameNightEventId == night.Id)
+        .Join(_db.Sessions, gns => gns.SessionId, s => s.Id, (gns, s) => s)
+        .AnyAsync(s => s.Status == SessionStatus.Active, cancellationToken)
+        .ConfigureAwait(false);
+
+    if (hasActive)
+    {
+        var activeSessionIds = await _db.GameNightSessions
+            .Where(gns => gns.GameNightEventId == night.Id)
+            .Join(_db.Sessions, gns => gns.SessionId, s => s.Id, (gns, s) => s)
+            .Where(s => s.Status == SessionStatus.Active)
+            .Select(s => s.Id)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        throw new ConflictException(
+            code: "ACTIVE_SESSION_EXISTS_IN_NIGHT",
+            message: $"GameNight {night.Id} already has an active session. Pause it before starting a new one.",
+            details: new { activeSessionIds });
+    }
+
+    night.AttachAdditionalGame(request.GameId);
+    gameNightEventId = night.Id;
+    gameNightWasCreated = false;
+}
+else
+{
+    // Create new ad-hoc night
+    var title = $"Serata del {DateTime.UtcNow:yyyy-MM-dd HH:mm}";
+    night = GameNightEvent.CreateAdHoc(request.UserId, title, request.GameId);
+    _db.GameNightEvents.Add(night);
+    gameNightEventId = night.Id;
+    gameNightWasCreated = true;
+}
+
+// ---------- Existing Session creation logic ----------
+// (Mantieni l'esistente Session.Create(...) + AddParticipant loop)
+```
+
+Poi, **dopo** la creazione della `Session` e l'add dei participant "standard", aggiungere guest names:
+
+```csharp
+// Add guest participants (no UserId)
+if (request.GuestNames is { Count: > 0 })
+{
+    foreach (var guestName in request.GuestNames)
+    {
+        session.AddParticipant(
+            ParticipantInfo.Create(displayName: guestName, isOwner: false, joinOrder: session.Participants.Count + 1),
+            userId: null);
+    }
+}
+
+// Link session to GameNight
+var gns = GameNightSession.Create(
+    gameNightEventId: gameNightEventId,
+    sessionId: session.Id,
+    gameId: request.GameId,
+    gameTitle: await _db.SharedGames.Where(g => g.Id == request.GameId).Select(g => g.Name).FirstAsync(cancellationToken),
+    playOrder: night!.GameIds.Count);
+_db.GameNightSessions.Add(gns);
+
+// Emit SessionEvent: session_created
+var payload = System.Text.Json.JsonSerializer.Serialize(new
+{
+    gameId = request.GameId,
+    gameNightEventId,
+    gameNightWasCreated,
+});
+var createdEvent = SessionEvent.Create(
+    sessionId: session.Id,
+    eventType: "session_created",
+    payload: payload,
+    createdBy: request.UserId,
+    source: "system",
+    gameNightId: gameNightEventId);
+_db.SessionEvents.Add(createdEvent);
+
+if (gameNightWasCreated)
+{
+    var nightPayload = System.Text.Json.JsonSerializer.Serialize(new
+    {
+        gameNightEventId,
+        title = night.Title,
+        isAdHoc = true
+    });
+    var nightEvent = SessionEvent.Create(
+        sessionId: session.Id,
+        eventType: "gamenight_created",
+        payload: nightPayload,
+        createdBy: request.UserId,
+        source: "system",
+        gameNightId: gameNightEventId);
+    _db.SessionEvents.Add(nightEvent);
+}
+else
+{
+    var attachPayload = System.Text.Json.JsonSerializer.Serialize(new { addedGameId = request.GameId });
+    var attachEvent = SessionEvent.Create(
+        sessionId: session.Id,
+        eventType: "gamenight_game_added",
+        payload: attachPayload,
+        createdBy: request.UserId,
+        source: "system",
+        gameNightId: gameNightEventId);
+    _db.SessionEvents.Add(attachEvent);
+}
+
+// Resolve agent and toolkit IDs for response (read-only, no clone)
+var agentDefinitionId = await _db.PrivateGames
+    .Where(pg => pg.SharedGameId == request.GameId && pg.UserId == request.UserId)
+    .Select(pg => (Guid?)pg.AgentDefinitionId)
+    .FirstOrDefaultAsync(cancellationToken);
+
+var toolkitId = await _db.Toolkits
+    .Where(t => t.GameId == request.GameId && (t.OwnerUserId == request.UserId || t.IsDefault))
+    .OrderByDescending(t => t.OwnerUserId == request.UserId) // user override first
+    .Select(t => (Guid?)t.Id)
+    .FirstOrDefaultAsync(cancellationToken);
+```
+
+E aggiornare il `return` del metodo per includere i nuovi campi:
+
+```csharp
+return new CreateSessionResult(
+    SessionId: session.Id,
+    SessionCode: session.SessionCode,
+    Participants: mappedParticipants, // riusa il mapping esistente
+    GameNightEventId: gameNightEventId,
+    GameNightWasCreated: gameNightWasCreated,
+    AgentDefinitionId: agentDefinitionId,
+    ToolkitId: toolkitId);
+```
+
+⚠️ **Dipendenze handler**: assicurarsi che il costruttore dell'handler iniettà `IMediator` (per chiamare `GetKbReadinessQuery`). Se non lo è, aggiungerlo:
+
+```csharp
+public CreateSessionCommandHandler(
+    MeepleAiDbContext db,
+    IMediator mediator,      // NEW
+    /* altre dependency esistenti */)
+{
+    _db = db;
+    _mediator = mediator;
+    // ...
+}
+```
+
+⚠️ **Nomi DbSet**: `_db.GameNightEvents`, `_db.GameNightSessions`, `_db.Sessions`, `_db.SessionEvents`, `_db.PrivateGames`, `_db.Toolkits`, `_db.SharedGames` (⚠️ potrebbe chiamarsi `SharedGameCatalog` o altro — verificare) potrebbero non esistere con questi nomi esatti. Verificare con:
+
+```bash
+grep -n "public DbSet" apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+```
+
+e adattare.
+
+- [ ] **Step 6: Eseguire i test e iterare fino a PASS**
+
+```bash
+cd apps/api/tests/Api.Tests
+dotnet test --filter "FullyQualifiedName~CreateSessionCommandAdHocTests"
+```
+
+⚠️ Questo test dipende anche da `PauseSessionCommand` che non esiste ancora (Task 5). **Marcare temporaneamente il test con l'attributo Skip**:
+
+```csharp
+[Fact(Skip = "Depends on Task 5 PauseSessionCommand — remove Skip in Task 5 step 6")]
+public async Task Handle_ExistingNightProvided_AttachesGameToNight()
+```
+
+Rimuoverlo al Task 5 step 6.
+
+Obiettivo Task 4: gli altri 4 test passano.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSession*.cs
+git add apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandAdHocTests.cs
+git add apps/api/tests/Api.Tests/Shared/Fixtures/PostgresFixture.cs  # se hai aggiunto seeder
+git commit -m "feat(session-tracking): extend CreateSessionCommand with ad-hoc GameNight and KB readiness
+
+- New optional params GameNightEventId, GuestNames
+- Pre-check: KB must be ready (via GetKbReadinessQuery)
+- Creates ad-hoc GameNightEvent implicitly if not provided
+- Invariant: at most 1 Active Session per GameNight
+- Emits session_created, gamenight_created, gamenight_game_added SessionEvents
+- Returns AgentDefinitionId and ToolkitId for frontend Hand composition"
+```
+
+---
+
+## Task 5: PauseSessionCommand + ResumeSessionCommand
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/PauseSessionCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/PauseSessionCommandHandler.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ResumeSessionCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ResumeSessionCommandHandler.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/PauseResumeSessionTests.cs`
+
+- [ ] **Step 1: Creare il command Pause**
+
+Creare `PauseSessionCommand.cs`:
+
+```csharp
+using FluentValidation;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Pauses an Active session. Only the host can pause.
+/// </summary>
+public record PauseSessionCommand(Guid SessionId, Guid UserId) : IRequest;
+
+public class PauseSessionCommandValidator : AbstractValidator<PauseSessionCommand>
+{
+    public PauseSessionCommandValidator()
+    {
+        RuleFor(x => x.SessionId).NotEmpty();
+        RuleFor(x => x.UserId).NotEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Creare l'handler Pause**
+
+Creare `PauseSessionCommandHandler.cs`:
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+public class PauseSessionCommandHandler : IRequestHandler<PauseSessionCommand>
+{
+    private readonly MeepleAiDbContext _db;
+
+    public PauseSessionCommandHandler(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task Handle(PauseSessionCommand request, CancellationToken cancellationToken)
+    {
+        var session = await _db.Sessions
+            .FirstOrDefaultAsync(s => s.Id == request.SessionId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {request.SessionId} not found.");
+
+        if (session.UserId != request.UserId)
+            throw new ForbiddenException("Only the session owner can pause.");
+
+        // Resolve GameNightId via GameNightSession link
+        var gameNightId = await _db.GameNightSessions
+            .Where(gns => gns.SessionId == session.Id)
+            .Select(gns => (Guid?)gns.GameNightEventId)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        session.Pause(); // existing domain method, throws if not Active
+
+        // Emit SessionEvent
+        var evt = SessionEvent.Create(
+            sessionId: session.Id,
+            eventType: "session_paused",
+            payload: "{}",
+            createdBy: request.UserId,
+            source: "system",
+            gameNightId: gameNightId);
+        _db.SessionEvents.Add(evt);
+
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}
+```
+
+- [ ] **Step 3: Creare il command Resume (con invariante: auto-pausa altre Active nel night)**
+
+Creare `ResumeSessionCommand.cs`:
+
+```csharp
+using FluentValidation;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Resumes a Paused session. Auto-pauses any other Active session in the same GameNight
+/// to maintain the invariant "max 1 Active per night".
+/// </summary>
+public record ResumeSessionCommand(Guid SessionId, Guid UserId) : IRequest;
+
+public class ResumeSessionCommandValidator : AbstractValidator<ResumeSessionCommand>
+{
+    public ResumeSessionCommandValidator()
+    {
+        RuleFor(x => x.SessionId).NotEmpty();
+        RuleFor(x => x.UserId).NotEmpty();
+    }
+}
+```
+
+Creare `ResumeSessionCommandHandler.cs`:
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+public class ResumeSessionCommandHandler : IRequestHandler<ResumeSessionCommand>
+{
+    private readonly MeepleAiDbContext _db;
+
+    public ResumeSessionCommandHandler(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task Handle(ResumeSessionCommand request, CancellationToken cancellationToken)
+    {
+        var session = await _db.Sessions
+            .FirstOrDefaultAsync(s => s.Id == request.SessionId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {request.SessionId} not found.");
+
+        if (session.UserId != request.UserId)
+            throw new ForbiddenException("Only the session owner can resume.");
+
+        // Resolve GameNightId
+        var gameNightId = await _db.GameNightSessions
+            .Where(gns => gns.SessionId == session.Id)
+            .Select(gns => gns.GameNightEventId)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Auto-pause any other Active session in the same night
+        var otherActive = await _db.GameNightSessions
+            .Where(gns => gns.GameNightEventId == gameNightId && gns.SessionId != session.Id)
+            .Join(_db.Sessions, gns => gns.SessionId, s => s.Id, (gns, s) => s)
+            .Where(s => s.Status == SessionStatus.Active)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        foreach (var other in otherActive)
+        {
+            other.Pause();
+            var autoEvt = SessionEvent.Create(
+                sessionId: other.Id,
+                eventType: "session_paused",
+                payload: "{\"reason\":\"auto_pause_on_resume\"}",
+                createdBy: request.UserId,
+                source: "system",
+                gameNightId: gameNightId);
+            _db.SessionEvents.Add(autoEvt);
+        }
+
+        session.Resume(); // existing domain method
+
+        var resumedEvt = SessionEvent.Create(
+            sessionId: session.Id,
+            eventType: "session_resumed",
+            payload: "{}",
+            createdBy: request.UserId,
+            source: "system",
+            gameNightId: gameNightId);
+        _db.SessionEvents.Add(resumedEvt);
+
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}
+```
+
+- [ ] **Step 4: Scrivere i test**
+
+Creare `apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/PauseResumeSessionTests.cs`:
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.Tests.Shared.Fixtures;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Commands;
+
+public class PauseResumeSessionTests : IClassFixture<PostgresFixture>
+{
+    private readonly PostgresFixture _fixture;
+
+    public PauseResumeSessionTests(PostgresFixture fixture) { _fixture = fixture; }
+
+    [Fact]
+    public async Task Pause_ActiveSession_ChangesStatusAndEmitsDiaryEvent()
+    {
+        using var scope = _fixture.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(scope);
+
+        var create = await mediator.Send(new CreateSessionCommand(
+            userId, gameId, "GameSpecific", null, null, new List<ParticipantDto>()));
+
+        await mediator.Send(new PauseSessionCommand(create.SessionId, userId));
+
+        var session = await db.Sessions.FindAsync(create.SessionId);
+        session!.Status.Should().Be(SessionStatus.Paused);
+
+        var diary = await db.SessionEvents
+            .Where(e => e.SessionId == create.SessionId && e.EventType == "session_paused")
+            .ToListAsync();
+        diary.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task Resume_Paused_ReactivatesAndAutoPausesOthersInNight()
+    {
+        using var scope = _fixture.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, game1) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(scope);
+        var game2 = await _fixture.SeedAnotherLibraryGameAsync(scope, userId);
+
+        // Session 1 created (Active)
+        var s1 = await mediator.Send(new CreateSessionCommand(
+            userId, game1, "GameSpecific", null, null, new List<ParticipantDto>()));
+        await mediator.Send(new PauseSessionCommand(s1.SessionId, userId));
+
+        // Session 2 in same night (Active)
+        var s2 = await mediator.Send(new CreateSessionCommand(
+            userId, game2, "GameSpecific", null, null, new List<ParticipantDto>(),
+            GameNightEventId: s1.GameNightEventId));
+
+        // Resume s1 → s2 should auto-pause
+        await mediator.Send(new ResumeSessionCommand(s1.SessionId, userId));
+
+        var sessionOne = await db.Sessions.FindAsync(s1.SessionId);
+        var sessionTwo = await db.Sessions.FindAsync(s2.SessionId);
+
+        sessionOne!.Status.Should().Be(SessionStatus.Active);
+        sessionTwo!.Status.Should().Be(SessionStatus.Paused);
+    }
+
+    [Fact]
+    public async Task Pause_NonExistentSession_ThrowsNotFound()
+    {
+        using var scope = _fixture.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        var act = () => mediator.Send(new PauseSessionCommand(Guid.NewGuid(), Guid.NewGuid()));
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Pause_NotOwner_ThrowsForbidden()
+    {
+        using var scope = _fixture.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(scope);
+
+        var create = await mediator.Send(new CreateSessionCommand(
+            userId, gameId, "GameSpecific", null, null, new List<ParticipantDto>()));
+
+        var otherUser = Guid.NewGuid();
+        var act = () => mediator.Send(new PauseSessionCommand(create.SessionId, otherUser));
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+    }
+}
+```
+
+- [ ] **Step 5: Eseguire i test**
+
+```bash
+cd apps/api/tests/Api.Tests
+dotnet test --filter "FullyQualifiedName~PauseResumeSessionTests"
+```
+
+Expected: 4/4 PASS.
+
+- [ ] **Step 6: Rimuovere lo Skip dal test bloccato in Task 4**
+
+Tornare a `CreateSessionCommandAdHocTests.cs`, rimuovere `[Fact(Skip = "...")]` e re-eseguire:
+
+```bash
+dotnet test --filter "FullyQualifiedName~CreateSessionCommandAdHocTests"
+```
+
+Expected: 5/5 PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/Pause*.cs
+git add apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/Resume*.cs
+git add apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/PauseResumeSessionTests.cs
+git add apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandAdHocTests.cs
+git commit -m "feat(session-tracking): add PauseSessionCommand and ResumeSessionCommand
+
+Resume auto-pauses other Active sessions in the same GameNight to
+preserve the '1 Active per night' invariant. Both commands emit
+session_paused / session_resumed diary events."
+```
+
+---
+
+## Task 6: SetTurnOrderCommand (manual + random with seed)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/SetTurnOrderCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/SetTurnOrderCommandHandler.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/SetTurnOrderCommandTests.cs`
+
+- [ ] **Step 1: Creare il command**
+
+Creare `SetTurnOrderCommand.cs`:
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using FluentValidation;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Sets the turn order for a session. Manual = explicit order; Random = server-side shuffle with audit seed.
+/// </summary>
+public record SetTurnOrderCommand(
+    Guid SessionId,
+    Guid UserId,
+    TurnOrderMethod Method,
+    IReadOnlyList<Guid>? ManualOrder
+) : IRequest<SetTurnOrderResult>;
+
+public record SetTurnOrderResult(
+    string Method,
+    int? Seed,
+    IReadOnlyList<Guid> Order
+);
+
+public class SetTurnOrderCommandValidator : AbstractValidator<SetTurnOrderCommand>
+{
+    public SetTurnOrderCommandValidator()
+    {
+        RuleFor(x => x.SessionId).NotEmpty();
+        RuleFor(x => x.UserId).NotEmpty();
+
+        RuleFor(x => x.ManualOrder)
+            .NotNull()
+            .NotEmpty()
+            .When(x => x.Method == TurnOrderMethod.Manual)
+            .WithMessage("ManualOrder is required when Method=Manual.");
+    }
+}
+```
+
+- [ ] **Step 2: Creare l'handler**
+
+Creare `SetTurnOrderCommandHandler.cs`:
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+public class SetTurnOrderCommandHandler : IRequestHandler<SetTurnOrderCommand, SetTurnOrderResult>
+{
+    private readonly MeepleAiDbContext _db;
+
+    public SetTurnOrderCommandHandler(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<SetTurnOrderResult> Handle(SetTurnOrderCommand request, CancellationToken cancellationToken)
+    {
+        var session = await _db.Sessions
+            .Include(s => s.Participants)
+            .FirstOrDefaultAsync(s => s.Id == request.SessionId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {request.SessionId} not found.");
+
+        if (session.UserId != request.UserId)
+            throw new ForbiddenException("Only the session owner can set turn order.");
+
+        IReadOnlyList<Guid> order;
+        int? seed;
+
+        if (request.Method == TurnOrderMethod.Manual)
+        {
+            order = request.ManualOrder!;
+            seed = null;
+        }
+        else
+        {
+            // Random: Fisher-Yates with cryptographically stable seed
+            // (Guid.GetHashCode() is not stable across .NET runs; use RandomNumberGenerator)
+            seed = System.Security.Cryptography.RandomNumberGenerator.GetInt32(int.MinValue, int.MaxValue);
+            var shuffled = session.Participants.Select(p => p.Id).ToList();
+            var rng = new Random(seed.Value);
+            for (int i = shuffled.Count - 1; i > 0; i--)
+            {
+                int j = rng.Next(i + 1);
+                (shuffled[i], shuffled[j]) = (shuffled[j], shuffled[i]);
+            }
+            order = shuffled;
+        }
+
+        session.SetTurnOrder(request.Method, order, seed);
+
+        var gameNightId = await _db.GameNightSessions
+            .Where(gns => gns.SessionId == session.Id)
+            .Select(gns => (Guid?)gns.GameNightEventId)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var payload = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            method = request.Method.ToString(),
+            seed,
+            participantIds = order
+        });
+
+        var evt = SessionEvent.Create(
+            sessionId: session.Id,
+            eventType: "turn_order_set",
+            payload: payload,
+            createdBy: request.UserId,
+            source: "user",
+            gameNightId: gameNightId);
+        _db.SessionEvents.Add(evt);
+
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return new SetTurnOrderResult(request.Method.ToString(), seed, order);
+    }
+}
+```
+
+- [ ] **Step 3: Scrivere i test**
+
+Creare `SetTurnOrderCommandTests.cs`:
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.Infrastructure;
+using Api.Tests.Shared.Fixtures;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Commands;
+
+public class SetTurnOrderCommandTests : IClassFixture<PostgresFixture>
+{
+    private readonly PostgresFixture _fixture;
+
+    public SetTurnOrderCommandTests(PostgresFixture fixture) { _fixture = fixture; }
+
+    [Fact]
+    public async Task Manual_PersistsExplicitOrder()
+    {
+        using var scope = _fixture.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(scope);
+
+        var create = await mediator.Send(new CreateSessionCommand(
+            userId, gameId, "GameSpecific", null, null, new List<ParticipantDto>(),
+            GuestNames: new[] { "Luca", "Sara" }));
+
+        var session = await db.Sessions.Include(s => s.Participants).FirstAsync(s => s.Id == create.SessionId);
+        var reversed = session.Participants.Select(p => p.Id).Reverse().ToList();
+
+        var result = await mediator.Send(new SetTurnOrderCommand(
+            session.Id, userId, TurnOrderMethod.Manual, reversed));
+
+        result.Method.Should().Be("Manual");
+        result.Seed.Should().BeNull();
+        result.Order.Should().BeEquivalentTo(reversed);
+
+        var updated = await db.Sessions.FindAsync(session.Id);
+        updated!.CurrentTurnIndex.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Random_GeneratesSeedAndShufflesDeterministically()
+    {
+        using var scope = _fixture.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(scope);
+
+        var create = await mediator.Send(new CreateSessionCommand(
+            userId, gameId, "GameSpecific", null, null, new List<ParticipantDto>(),
+            GuestNames: new[] { "A", "B", "C", "D", "E" }));
+
+        var result = await mediator.Send(new SetTurnOrderCommand(
+            create.SessionId, userId, TurnOrderMethod.Random, null));
+
+        result.Method.Should().Be("Random");
+        result.Seed.Should().NotBeNull();
+        result.Order.Should().HaveCount(6); // Owner + 5 guests
+
+        // Audit: diary entry contains the seed
+        var diary = await db.SessionEvents
+            .Where(e => e.SessionId == create.SessionId && e.EventType == "turn_order_set")
+            .FirstAsync();
+        diary.Payload.Should().Contain(result.Seed.ToString()!);
+    }
+
+    [Fact]
+    public async Task Manual_EmptyOrder_FailsValidation()
+    {
+        using var scope = _fixture.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        var act = () => mediator.Send(new SetTurnOrderCommand(
+            Guid.NewGuid(), Guid.NewGuid(), TurnOrderMethod.Manual, Array.Empty<Guid>()));
+
+        await act.Should().ThrowAsync<FluentValidation.ValidationException>();
+    }
+}
+```
+
+- [ ] **Step 4: Eseguire i test**
+
+```bash
+dotnet test --filter "FullyQualifiedName~SetTurnOrderCommandTests"
+```
+
+Expected: 3/3 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/SetTurnOrder*.cs
+git add apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/SetTurnOrderCommandTests.cs
+git commit -m "feat(session-tracking): add SetTurnOrderCommand with manual and random shuffle
+
+Random method uses Fisher-Yates with a recorded seed for audit replay.
+Seed is persisted on Session and echoed in the turn_order_set diary event."
+```
+
+---
+
+## Task 7: Dice Roll Endpoint + Diary Event Emission
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/RollSessionDiceCommandHandler.cs`
+- Modify: `apps/api/src/Api/Routing/SessionEndpoints.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/RollSessionDiceDiaryEmissionTests.cs`
+
+- [ ] **Step 1: Leggere l'handler esistente**
+
+```bash
+cat apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/RollSessionDiceCommandHandler.cs
+```
+
+Identificare il punto dove la `DiceRoll` viene salvata con successo nel DB.
+
+- [ ] **Step 2: Scrivere il test failing per l'emission del diary event**
+
+Creare `RollSessionDiceDiaryEmissionTests.cs`:
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.Infrastructure;
+using Api.Tests.Shared.Fixtures;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Commands;
+
+public class RollSessionDiceDiaryEmissionTests : IClassFixture<PostgresFixture>
+{
+    private readonly PostgresFixture _fixture;
+
+    public RollSessionDiceDiaryEmissionTests(PostgresFixture fixture) { _fixture = fixture; }
+
+    [Fact]
+    public async Task RollDice_EmitsDiceRolledDiaryEvent()
+    {
+        using var scope = _fixture.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(scope);
+
+        var create = await mediator.Send(new CreateSessionCommand(
+            userId, gameId, "GameSpecific", null, null, new List<ParticipantDto>()));
+
+        var session = await db.Sessions.Include(s => s.Participants).FirstAsync(s => s.Id == create.SessionId);
+        var ownerParticipant = session.Participants.First();
+
+        var result = await mediator.Send(new RollSessionDiceCommand(
+            SessionId: session.Id,
+            ParticipantId: ownerParticipant.Id,
+            RequesterId: userId,
+            Formula: "2d6"));
+
+        result.Total.Should().BeInRange(2, 12);
+
+        var diaryEntry = await db.SessionEvents
+            .Where(e => e.SessionId == session.Id && e.EventType == "dice_rolled")
+            .OrderByDescending(e => e.Timestamp)
+            .FirstAsync();
+
+        diaryEntry.Payload.Should().Contain("\"formula\":\"2D6\"");
+        diaryEntry.Payload.Should().Contain("\"total\":");
+    }
+}
+```
+
+- [ ] **Step 3: Eseguire il test e verificare che fallisca**
+
+```bash
+dotnet test --filter "FullyQualifiedName~RollSessionDiceDiaryEmissionTests"
+```
+
+Expected: FAIL — l'handler esistente non emette ancora il SessionEvent.
+
+- [ ] **Step 4: Modificare `RollSessionDiceCommandHandler`**
+
+Nell'handler esistente, **subito prima** del `SaveChangesAsync` finale (o subito dopo `_db.DiceRolls.Add(diceRoll)`), aggiungere:
+
+```csharp
+// Emit SessionEvent: dice_rolled (v2.1)
+var gameNightId = await _db.GameNightSessions
+    .Where(gns => gns.SessionId == request.SessionId)
+    .Select(gns => (Guid?)gns.GameNightEventId)
+    .FirstOrDefaultAsync(cancellationToken)
+    .ConfigureAwait(false);
+
+var diaryPayload = System.Text.Json.JsonSerializer.Serialize(new
+{
+    diceRollId = diceRoll.Id,
+    formula = diceRoll.Formula,
+    rolls = diceRoll.GetRolls(),
+    modifier = diceRoll.Modifier,
+    total = diceRoll.Total,
+    label = diceRoll.Label,
+    participantId = request.ParticipantId
+});
+
+var diaryEvent = SessionEvent.Create(
+    sessionId: request.SessionId,
+    eventType: "dice_rolled",
+    payload: diaryPayload,
+    createdBy: request.RequesterId,
+    source: "user",
+    gameNightId: gameNightId);
+
+_db.SessionEvents.Add(diaryEvent);
+```
+
+Assicurarsi che il using statement per `SessionEvent` sia presente in cima al file:
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+```
+
+- [ ] **Step 5: Eseguire il test e verificare PASS**
+
+```bash
+dotnet test --filter "FullyQualifiedName~RollSessionDiceDiaryEmissionTests"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Identificare il pattern di recupero user id**
+
+Prima di scrivere l'endpoint, cercare come gli altri endpoint autenticati recuperano l'user id dal `HttpContext`:
+
+```bash
+grep -rn "NameIdentifier\|GetUserId\|CurrentUser\|User.FindFirst" apps/api/src/Api/Routing/ | head -10
+```
+
+Prendere il pattern ricorrente (es. `httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier)` oppure un helper statico tipo `CurrentUserAccessor.GetUserId(httpContext)`). **Usare quel pattern esatto** in tutti gli endpoint nuovi di questo plan. Nel resto del plan indicherò lo slot con `<GET_USER_ID_HELPER>` — sostituire con il pattern reale individuato.
+
+- [ ] **Step 7: Aggiungere l'endpoint HTTP dice-rolls**
+
+Aprire `apps/api/src/Api/Routing/SessionEndpoints.cs`. Trovare il metodo di estensione `MapSessionEndpoints` (o simile). Aggiungere il nuovo endpoint:
+
+```csharp
+group.MapPost("/{sessionId:guid}/dice-rolls", async (
+    Guid sessionId,
+    RollDiceRequestBody body,
+    IMediator mediator,
+    HttpContext http) =>
+{
+    var userId = <GET_USER_ID_HELPER>; // sostituire con il pattern individuato allo Step 6
+    var cmd = new RollSessionDiceCommand(
+        SessionId: sessionId,
+        ParticipantId: body.ParticipantId,
+        RequesterId: userId,
+        Formula: body.Formula,
+        Label: body.Label);
+
+    var result = await mediator.Send(cmd);
+    return Results.Created($"/api/v1/sessions/{sessionId}/dice-rolls/{result.DiceRollId}", result);
+})
+.WithName("RollSessionDice")
+.WithOpenApi();
+
+// ...
+// body record at bottom of file or in DTOs folder:
+public record RollDiceRequestBody(Guid ParticipantId, string Formula, string? Label);
+```
+
+⚠️ Cerca l'endpoint group prefix esistente in `SessionEndpoints.cs` per capire se il path base è `/api/v1/sessions` o diverso. Adatta di conseguenza.
+
+- [ ] **Step 8: Smoke test manuale**
+
+Lanciare l'API:
+
+```bash
+cd apps/api/src/Api
+dotnet run --urls http://localhost:8080
+```
+
+Con curl (o Postman), dopo login:
+
+```bash
+# Crea session (assumi auth cookie già impostato)
+curl -X POST http://localhost:8080/api/v1/sessions \
+  -H "Content-Type: application/json" \
+  --cookie-jar cookies.txt --cookie cookies.txt \
+  -d '{"userId":"...","gameId":"...","sessionType":"GameSpecific","participants":[]}'
+
+# Tira dado
+curl -X POST http://localhost:8080/api/v1/sessions/<session-id>/dice-rolls \
+  -H "Content-Type: application/json" \
+  --cookie cookies.txt \
+  -d '{"participantId":"<pid>","formula":"2d6"}'
+```
+
+Expected: 201 Created con body `{ diceRollId, formula: "2D6", rolls: [...], total: <2..12>, ... }`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/RollSessionDiceCommandHandler.cs
+git add apps/api/src/Api/Routing/SessionEndpoints.cs
+git add apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/RollSessionDiceDiaryEmissionTests.cs
+git commit -m "feat(session-tracking): emit dice_rolled diary event + add HTTP endpoint
+
+- POST /api/v1/sessions/{id}/dice-rolls wires existing RollSessionDiceCommand
+- Handler now emits SessionEvent(dice_rolled) with formula, rolls, total, participant"
+```
+
+---
+
+## Task 8: UpdateScoreCommand with diary history
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpdateScoreCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpdateScoreCommandHandler.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/UpdateScoreCommandTests.cs`
+
+- [ ] **Step 1: Creare il command**
+
+Creare `UpdateScoreCommand.cs`:
+
+```csharp
+using FluentValidation;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Updates (or creates) a score entry for a participant.
+/// Emits a score_updated diary event with oldValue/newValue for audit and undo.
+/// </summary>
+public record UpdateScoreCommand(
+    Guid SessionId,
+    Guid ParticipantId,
+    Guid RequesterId,
+    decimal NewValue,
+    int? RoundNumber,
+    string? Category,
+    string? Reason
+) : IRequest<UpdateScoreResult>;
+
+public record UpdateScoreResult(
+    Guid ScoreEntryId,
+    decimal OldValue,
+    decimal NewValue
+);
+
+public class UpdateScoreCommandValidator : AbstractValidator<UpdateScoreCommand>
+{
+    public UpdateScoreCommandValidator()
+    {
+        RuleFor(x => x.SessionId).NotEmpty();
+        RuleFor(x => x.ParticipantId).NotEmpty();
+        RuleFor(x => x.RequesterId).NotEmpty();
+        // NOTE: RoundNumber and Category are both optional per spec §4.6.
+        // A "total" score without round nor category is valid for games like Azul.
+        RuleFor(x => x.RoundNumber).GreaterThan(0).When(x => x.RoundNumber.HasValue);
+        RuleFor(x => x.Category)
+            .MaximumLength(50);
+        RuleFor(x => x.Reason)
+            .MaximumLength(200);
+    }
+}
+```
+
+- [ ] **Step 2: Creare l'handler**
+
+Creare `UpdateScoreCommandHandler.cs`:
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+public class UpdateScoreCommandHandler : IRequestHandler<UpdateScoreCommand, UpdateScoreResult>
+{
+    private readonly MeepleAiDbContext _db;
+
+    public UpdateScoreCommandHandler(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<UpdateScoreResult> Handle(UpdateScoreCommand request, CancellationToken cancellationToken)
+    {
+        var session = await _db.Sessions
+            .FirstOrDefaultAsync(s => s.Id == request.SessionId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {request.SessionId} not found.");
+
+        if (session.UserId != request.RequesterId)
+            throw new ForbiddenException("Only the session owner can update scores.");
+
+        var participantExists = await _db.Set<Participant>()
+            .AnyAsync(p => p.Id == request.ParticipantId && p.SessionId == request.SessionId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!participantExists)
+            throw new NotFoundException($"Participant {request.ParticipantId} not found in session.");
+
+        var existing = await _db.ScoreEntries
+            .FirstOrDefaultAsync(e =>
+                e.SessionId == request.SessionId
+                && e.ParticipantId == request.ParticipantId
+                && e.RoundNumber == request.RoundNumber
+                && e.Category == request.Category,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        decimal oldValue;
+        ScoreEntry entry;
+
+        if (existing is null)
+        {
+            oldValue = 0m;
+            // ⚠️ ScoreEntry.Create currently throws if both roundNumber and category are null.
+            // If the spec allows a pure "total" score, the domain factory must be relaxed first.
+            // For this plan: default to a synthetic "total" category when both are null, to avoid
+            // changing domain invariants in this PR.
+            var effectiveCategory = request.Category;
+            int? effectiveRound = request.RoundNumber;
+            if (!effectiveRound.HasValue && string.IsNullOrWhiteSpace(effectiveCategory))
+                effectiveCategory = "total";
+
+            entry = ScoreEntry.Create(
+                sessionId: request.SessionId,
+                participantId: request.ParticipantId,
+                scoreValue: request.NewValue,
+                createdBy: request.RequesterId,
+                roundNumber: effectiveRound,
+                category: effectiveCategory);
+            _db.ScoreEntries.Add(entry);
+        }
+        else
+        {
+            oldValue = existing.ScoreValue;
+            existing.UpdateScore(request.NewValue);
+            entry = existing;
+        }
+
+        var gameNightId = await _db.GameNightSessions
+            .Where(gns => gns.SessionId == request.SessionId)
+            .Select(gns => (Guid?)gns.GameNightEventId)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var payload = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            participantId = request.ParticipantId,
+            oldValue,
+            newValue = request.NewValue,
+            roundNumber = request.RoundNumber,
+            category = request.Category,
+            reason = request.Reason
+        });
+
+        var diaryEvent = SessionEvent.Create(
+            sessionId: request.SessionId,
+            eventType: "score_updated",
+            payload: payload,
+            createdBy: request.RequesterId,
+            source: "user",
+            gameNightId: gameNightId);
+        _db.SessionEvents.Add(diaryEvent);
+
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return new UpdateScoreResult(entry.Id, oldValue, request.NewValue);
+    }
+}
+```
+
+- [ ] **Step 3: Scrivere i test**
+
+Creare `UpdateScoreCommandTests.cs`:
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.Infrastructure;
+using Api.Tests.Shared.Fixtures;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Commands;
+
+public class UpdateScoreCommandTests : IClassFixture<PostgresFixture>
+{
+    private readonly PostgresFixture _fixture;
+
+    public UpdateScoreCommandTests(PostgresFixture fixture) { _fixture = fixture; }
+
+    [Fact]
+    public async Task FirstUpdate_CreatesEntry_WithOldValueZero()
+    {
+        using var scope = _fixture.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(scope);
+
+        var create = await mediator.Send(new CreateSessionCommand(
+            userId, gameId, "GameSpecific", null, null, new List<ParticipantDto>()));
+
+        var session = await db.Sessions.Include(s => s.Participants).FirstAsync(s => s.Id == create.SessionId);
+        var pid = session.Participants.First().Id;
+
+        var result = await mediator.Send(new UpdateScoreCommand(
+            session.Id, pid, userId, NewValue: 45m, RoundNumber: 1, Category: null, Reason: null));
+
+        result.OldValue.Should().Be(0m);
+        result.NewValue.Should().Be(45m);
+
+        var diary = await db.SessionEvents
+            .Where(e => e.SessionId == session.Id && e.EventType == "score_updated")
+            .ToListAsync();
+        diary.Should().ContainSingle();
+        diary[0].Payload.Should().Contain("\"oldValue\":0").And.Contain("\"newValue\":45");
+    }
+
+    [Fact]
+    public async Task SecondUpdate_RecordsOldValueInDiary()
+    {
+        using var scope = _fixture.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(scope);
+
+        var create = await mediator.Send(new CreateSessionCommand(
+            userId, gameId, "GameSpecific", null, null, new List<ParticipantDto>()));
+
+        var session = await db.Sessions.Include(s => s.Participants).FirstAsync(s => s.Id == create.SessionId);
+        var pid = session.Participants.First().Id;
+
+        await mediator.Send(new UpdateScoreCommand(session.Id, pid, userId, 45m, 1, null, null));
+        var second = await mediator.Send(new UpdateScoreCommand(session.Id, pid, userId, 52m, 1, null, "correzione"));
+
+        second.OldValue.Should().Be(45m);
+        second.NewValue.Should().Be(52m);
+
+        var diary = await db.SessionEvents
+            .Where(e => e.SessionId == session.Id && e.EventType == "score_updated")
+            .OrderBy(e => e.Timestamp)
+            .ToListAsync();
+        diary.Should().HaveCount(2);
+        diary[1].Payload.Should().Contain("\"oldValue\":45").And.Contain("\"newValue\":52").And.Contain("correzione");
+    }
+
+    [Fact]
+    public async Task UpdateScore_NotOwner_Forbidden()
+    {
+        using var scope = _fixture.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(scope);
+
+        var create = await mediator.Send(new CreateSessionCommand(
+            userId, gameId, "GameSpecific", null, null, new List<ParticipantDto>()));
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var session = await db.Sessions.Include(s => s.Participants).FirstAsync(s => s.Id == create.SessionId);
+        var pid = session.Participants.First().Id;
+
+        var act = () => mediator.Send(new UpdateScoreCommand(
+            session.Id, pid, Guid.NewGuid(), 10m, 1, null, null));
+
+        await act.Should().ThrowAsync<Api.Middleware.Exceptions.ForbiddenException>();
+    }
+}
+```
+
+- [ ] **Step 4: Eseguire e verificare PASS**
+
+```bash
+dotnet test --filter "FullyQualifiedName~UpdateScoreCommandTests"
+```
+
+Expected: 3/3 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpdateScore*.cs
+git add apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/UpdateScoreCommandTests.cs
+git commit -m "feat(session-tracking): add UpdateScoreCommand with append-only diary history
+
+ScoreEntry remains mutable (projection), but every change is recorded
+as a score_updated SessionEvent with oldValue/newValue/reason. Undo is
+achieved by sending a new UpdateScoreCommand with the previous value."
+```
+
+---
+
+## Task 9: Diary Queries — GetSessionDiary + GetGameNightDiary
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/DTOs/SessionEventDto.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetSessionDiaryQuery.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetSessionDiaryQueryHandler.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetGameNightDiaryQuery.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetGameNightDiaryQueryHandler.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/DiaryQueryTests.cs`
+
+- [ ] **Step 1: DTO**
+
+Creare `SessionEventDto.cs`:
+
+```csharp
+namespace Api.BoundedContexts.SessionTracking.Application.DTOs;
+
+public record SessionEventDto(
+    Guid Id,
+    Guid SessionId,
+    Guid? GameNightId,
+    string EventType,
+    DateTime Timestamp,
+    string Payload,
+    Guid? CreatedBy,
+    string? Source
+);
+```
+
+- [ ] **Step 2: GetSessionDiaryQuery**
+
+Creare `GetSessionDiaryQuery.cs`:
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+public record GetSessionDiaryQuery(
+    Guid SessionId,
+    IReadOnlyList<string>? EventTypes,
+    DateTime? Since,
+    int Limit = 100
+) : IRequest<IReadOnlyList<SessionEventDto>>;
+```
+
+Handler:
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.Infrastructure;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+public class GetSessionDiaryQueryHandler : IRequestHandler<GetSessionDiaryQuery, IReadOnlyList<SessionEventDto>>
+{
+    private readonly MeepleAiDbContext _db;
+
+    public GetSessionDiaryQueryHandler(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<IReadOnlyList<SessionEventDto>> Handle(GetSessionDiaryQuery request, CancellationToken cancellationToken)
+    {
+        var query = _db.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.SessionId == request.SessionId && !e.IsDeleted);
+
+        if (request.EventTypes is { Count: > 0 })
+            query = query.Where(e => request.EventTypes.Contains(e.EventType));
+
+        if (request.Since.HasValue)
+            query = query.Where(e => e.Timestamp >= request.Since.Value);
+
+        var entries = await query
+            .OrderBy(e => e.Timestamp)
+            .ThenBy(e => e.Id)
+            .Take(request.Limit)
+            .Select(e => new SessionEventDto(
+                e.Id, e.SessionId, e.GameNightId, e.EventType, e.Timestamp, e.Payload, e.CreatedBy, e.Source))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return entries;
+    }
+}
+```
+
+- [ ] **Step 3: GetGameNightDiaryQuery (UNION)**
+
+Creare `GetGameNightDiaryQuery.cs`:
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+public record GetGameNightDiaryQuery(
+    Guid GameNightEventId,
+    IReadOnlyList<string>? EventTypes,
+    DateTime? Since,
+    int Limit = 500
+) : IRequest<IReadOnlyList<SessionEventDto>>;
+```
+
+Handler:
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.Infrastructure;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+public class GetGameNightDiaryQueryHandler : IRequestHandler<GetGameNightDiaryQuery, IReadOnlyList<SessionEventDto>>
+{
+    private readonly MeepleAiDbContext _db;
+
+    public GetGameNightDiaryQueryHandler(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<IReadOnlyList<SessionEventDto>> Handle(GetGameNightDiaryQuery request, CancellationToken cancellationToken)
+    {
+        var query = _db.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.GameNightId == request.GameNightEventId && !e.IsDeleted);
+
+        if (request.EventTypes is { Count: > 0 })
+            query = query.Where(e => request.EventTypes.Contains(e.EventType));
+
+        if (request.Since.HasValue)
+            query = query.Where(e => e.Timestamp >= request.Since.Value);
+
+        var entries = await query
+            .OrderBy(e => e.Timestamp)
+            .ThenBy(e => e.Id)
+            .Take(request.Limit)
+            .Select(e => new SessionEventDto(
+                e.Id, e.SessionId, e.GameNightId, e.EventType, e.Timestamp, e.Payload, e.CreatedBy, e.Source))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return entries;
+    }
+}
+```
+
+- [ ] **Step 4: Test**
+
+Creare `DiaryQueryTests.cs`:
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.Infrastructure;
+using Api.Tests.Shared.Fixtures;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Queries;
+
+public class DiaryQueryTests : IClassFixture<PostgresFixture>
+{
+    private readonly PostgresFixture _fixture;
+
+    public DiaryQueryTests(PostgresFixture fixture) { _fixture = fixture; }
+
+    [Fact]
+    public async Task GetSessionDiary_ReturnsEventsInChronologicalOrder()
+    {
+        using var scope = _fixture.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(scope);
+
+        var create = await mediator.Send(new CreateSessionCommand(
+            userId, gameId, "GameSpecific", null, null, new List<ParticipantDto>()));
+
+        var session = await db.Sessions.Include(s => s.Participants).FirstAsync(s => s.Id == create.SessionId);
+        var pid = session.Participants.First().Id;
+
+        await mediator.Send(new UpdateScoreCommand(session.Id, pid, userId, 10m, 1, null, null));
+        await mediator.Send(new UpdateScoreCommand(session.Id, pid, userId, 20m, 1, null, null));
+
+        var diary = await mediator.Send(new GetSessionDiaryQuery(session.Id, null, null));
+
+        diary.Should().HaveCountGreaterThanOrEqualTo(3); // session_created + 2 score_updated (+ optionally gamenight_created)
+        diary.Select(e => e.Timestamp).Should().BeInAscendingOrder();
+        diary.Where(e => e.EventType == "score_updated").Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetGameNightDiary_UnionsAllSessionsOfNight()
+    {
+        using var scope = _fixture.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, game1) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(scope);
+        var game2 = await _fixture.SeedAnotherLibraryGameAsync(scope, userId);
+
+        var s1 = await mediator.Send(new CreateSessionCommand(
+            userId, game1, "GameSpecific", null, null, new List<ParticipantDto>()));
+        await mediator.Send(new PauseSessionCommand(s1.SessionId, userId));
+        var s2 = await mediator.Send(new CreateSessionCommand(
+            userId, game2, "GameSpecific", null, null, new List<ParticipantDto>(),
+            GameNightEventId: s1.GameNightEventId));
+
+        var diary = await mediator.Send(new GetGameNightDiaryQuery(
+            s1.GameNightEventId, null, null));
+
+        diary.Should().NotBeEmpty();
+        diary.Select(e => e.SessionId).Distinct().Should().HaveCount(2);
+        diary.All(e => e.GameNightId == s1.GameNightEventId).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetSessionDiary_FilteredByEventType_ReturnsOnlyMatching()
+    {
+        using var scope = _fixture.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(scope);
+
+        var create = await mediator.Send(new CreateSessionCommand(
+            userId, gameId, "GameSpecific", null, null, new List<ParticipantDto>()));
+        var session = await db.Sessions.Include(s => s.Participants).FirstAsync(s => s.Id == create.SessionId);
+        var pid = session.Participants.First().Id;
+        await mediator.Send(new UpdateScoreCommand(session.Id, pid, userId, 10m, 1, null, null));
+
+        var filtered = await mediator.Send(new GetSessionDiaryQuery(
+            session.Id,
+            EventTypes: new[] { "score_updated" },
+            Since: null));
+
+        filtered.Should().ContainSingle();
+        filtered[0].EventType.Should().Be("score_updated");
+    }
+}
+```
+
+- [ ] **Step 5: Eseguire i test**
+
+```bash
+dotnet test --filter "FullyQualifiedName~DiaryQueryTests"
+```
+
+Expected: 3/3 PASS.
+
+- [ ] **Step 6: Aggiungere gli endpoint in `SessionFlowEndpoints.cs`**
+
+Creare nuovo file `apps/api/src/Api/Routing/SessionFlowEndpoints.cs`:
+
+```csharp
+using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using MediatR;
+
+namespace Api.Routing;
+
+public static class SessionFlowEndpoints
+{
+    public static void MapSessionFlowEndpoints(this IEndpointRouteBuilder app)
+    {
+        var sessions = app.MapGroup("/api/v1/sessions").RequireAuthorization();
+        var games = app.MapGroup("/api/v1/games").RequireAuthorization();
+        var nights = app.MapGroup("/api/v1/game-nights").RequireAuthorization();
+
+        // KB readiness
+        games.MapGet("/{gameId:guid}/kb-readiness", async (Guid gameId, IMediator mediator) =>
+        {
+            var result = await mediator.Send(new GetKbReadinessQuery(gameId));
+            return Results.Ok(result);
+        })
+        .WithName("GetKbReadiness")
+        .WithOpenApi();
+
+        // Pause / Resume
+        sessions.MapPost("/{sessionId:guid}/pause", async (Guid sessionId, IMediator mediator, HttpContext http) =>
+        {
+            var userId = <GET_USER_ID_HELPER>;
+            await mediator.Send(new PauseSessionCommand(sessionId, userId));
+            return Results.Ok();
+        })
+        .WithName("PauseSession")
+        .WithOpenApi();
+
+        sessions.MapPost("/{sessionId:guid}/resume", async (Guid sessionId, IMediator mediator, HttpContext http) =>
+        {
+            var userId = <GET_USER_ID_HELPER>;
+            await mediator.Send(new ResumeSessionCommand(sessionId, userId));
+            return Results.Ok();
+        })
+        .WithName("ResumeSession")
+        .WithOpenApi();
+
+        // Turn order
+        sessions.MapPut("/{sessionId:guid}/turn-order", async (
+            Guid sessionId, SetTurnOrderRequestBody body, IMediator mediator, HttpContext http) =>
+        {
+            var userId = <GET_USER_ID_HELPER>;
+            var method = Enum.Parse<TurnOrderMethod>(body.Method, ignoreCase: true);
+            var result = await mediator.Send(new SetTurnOrderCommand(sessionId, userId, method, body.Order));
+            return Results.Ok(result);
+        })
+        .WithName("SetTurnOrder")
+        .WithOpenApi();
+
+        // Score update
+        sessions.MapPost("/{sessionId:guid}/scores", async (
+            Guid sessionId, UpdateScoreRequestBody body, IMediator mediator, HttpContext http) =>
+        {
+            var userId = <GET_USER_ID_HELPER>;
+            var result = await mediator.Send(new UpdateScoreCommand(
+                sessionId, body.ParticipantId, userId, body.NewValue, body.RoundNumber, body.Category, body.Reason));
+            return Results.Ok(result);
+        })
+        .WithName("UpdateScore")
+        .WithOpenApi();
+
+        // Session diary
+        sessions.MapGet("/{sessionId:guid}/diary", async (
+            Guid sessionId, string? eventTypes, DateTime? since, int? limit, IMediator mediator) =>
+        {
+            var types = string.IsNullOrWhiteSpace(eventTypes) ? null : eventTypes.Split(',');
+            var result = await mediator.Send(new GetSessionDiaryQuery(sessionId, types, since, limit ?? 100));
+            return Results.Ok(result);
+        })
+        .WithName("GetSessionDiary")
+        .WithOpenApi();
+
+        // GameNight diary
+        nights.MapGet("/{gameNightId:guid}/diary", async (
+            Guid gameNightId, string? eventTypes, DateTime? since, int? limit, IMediator mediator) =>
+        {
+            var types = string.IsNullOrWhiteSpace(eventTypes) ? null : eventTypes.Split(',');
+            var result = await mediator.Send(new GetGameNightDiaryQuery(gameNightId, types, since, limit ?? 500));
+            return Results.Ok(result);
+        })
+        .WithName("GetGameNightDiary")
+        .WithOpenApi();
+    }
+
+    public record SetTurnOrderRequestBody(string Method, IReadOnlyList<Guid>? Order);
+    public record UpdateScoreRequestBody(Guid ParticipantId, decimal NewValue, int? RoundNumber, string? Category, string? Reason);
+}
+```
+
+⚠️ `<GET_USER_ID_HELPER>` = lo stesso slot identificato in Task 7 step 6. Usare il pattern reale individuato lì (es. `http.User.FindFirstValue(ClaimTypes.NameIdentifier)!.ToGuid()` o un helper custom del progetto).
+
+- [ ] **Step 7: Registrare gli endpoint in `Program.cs`**
+
+Aprire `apps/api/src/Api/Program.cs`. Dopo altre chiamate `app.MapXxx()` (cercare ad es. `MapSessionEndpoints`), aggiungere:
+
+```csharp
+app.MapSessionFlowEndpoints();
+```
+
+- [ ] **Step 8: Build e smoke test**
+
+```bash
+cd apps/api/src/Api
+dotnet build
+```
+
+Expected: build successful, zero errori.
+
+```bash
+dotnet run --urls http://localhost:8080
+```
+
+In un altro terminale, chiamare:
+
+```bash
+curl http://localhost:8080/api/v1/games/<gameId>/kb-readiness --cookie cookies.txt
+```
+
+Expected: 200 con body `{ isReady, state, vectorDocumentCount, failedPdfCount, warnings }`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SessionTracking/Application/DTOs/SessionEventDto.cs
+git add apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetSessionDiaryQuery*.cs
+git add apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetGameNightDiaryQuery*.cs
+git add apps/api/src/Api/Routing/SessionFlowEndpoints.cs
+git add apps/api/src/Api/Program.cs
+git add apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/DiaryQueryTests.cs
+git commit -m "feat(session-tracking): add diary queries and SessionFlow HTTP endpoints
+
+- GetSessionDiaryQuery / GetGameNightDiaryQuery with filtering
+- SessionFlowEndpoints: kb-readiness, pause/resume, turn-order, scores, diary
+- Registered in Program.cs via MapSessionFlowEndpoints"
+```
+
+---
+
+## Task 10: Full integration test + PR
+
+**Files:**
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Integration/SessionFlowE2ETests.cs`
+
+- [ ] **Step 1: Scrivere il test end-to-end happy path**
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.Infrastructure;
+using Api.Tests.Shared.Fixtures;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Integration;
+
+public class SessionFlowE2ETests : IClassFixture<PostgresFixture>
+{
+    private readonly PostgresFixture _fixture;
+
+    public SessionFlowE2ETests(PostgresFixture fixture) { _fixture = fixture; }
+
+    [Fact]
+    public async Task HappyPath_StartSession_Rolls_Scores_Diary()
+    {
+        using var scope = _fixture.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(scope);
+
+        // 1. Start session with 2 guest players
+        var create = await mediator.Send(new CreateSessionCommand(
+            userId, gameId, "GameSpecific", null, null, new List<ParticipantDto>(),
+            GuestNames: new[] { "Luca", "Sara" }));
+
+        create.GameNightWasCreated.Should().BeTrue();
+
+        var session = await db.Sessions.Include(s => s.Participants).FirstAsync(s => s.Id == create.SessionId);
+        session.Participants.Should().HaveCount(3);
+
+        // 2. Set random turn order
+        var turnOrder = await mediator.Send(new SetTurnOrderCommand(
+            session.Id, userId, TurnOrderMethod.Random, null));
+        turnOrder.Seed.Should().NotBeNull();
+
+        // 3. Each participant rolls dice
+        foreach (var p in session.Participants)
+        {
+            var roll = await mediator.Send(new RollSessionDiceCommand(
+                session.Id, p.Id, userId, "2d6"));
+            roll.Total.Should().BeInRange(2, 12);
+        }
+
+        // 4. Update scores for each participant
+        foreach (var p in session.Participants)
+        {
+            await mediator.Send(new UpdateScoreCommand(
+                session.Id, p.Id, userId, 25m, 1, null, null));
+        }
+
+        // 5. Verify diary has: session_created, gamenight_created, turn_order_set, 3x dice_rolled, 3x score_updated
+        var diary = await mediator.Send(new GetSessionDiaryQuery(session.Id, null, null, 100));
+
+        diary.Select(e => e.EventType).Should().Contain(new[]
+        {
+            "session_created", "gamenight_created", "turn_order_set", "dice_rolled", "score_updated"
+        });
+        diary.Count(e => e.EventType == "dice_rolled").Should().Be(3);
+        diary.Count(e => e.EventType == "score_updated").Should().Be(3);
+
+        // 6. Pause and start a second game in the same night
+        await mediator.Send(new PauseSessionCommand(session.Id, userId));
+
+        var game2 = await _fixture.SeedAnotherLibraryGameAsync(scope, userId);
+        var second = await mediator.Send(new CreateSessionCommand(
+            userId, game2, "GameSpecific", null, null, new List<ParticipantDto>(),
+            GameNightEventId: create.GameNightEventId));
+
+        second.GameNightWasCreated.Should().BeFalse();
+
+        // 7. GameNight diary contains events from both sessions
+        var nightDiary = await mediator.Send(new GetGameNightDiaryQuery(
+            create.GameNightEventId, null, null, 500));
+        nightDiary.Select(e => e.SessionId).Distinct().Should().HaveCount(2);
+    }
+}
+```
+
+- [ ] **Step 2: Eseguire il test E2E**
+
+```bash
+cd apps/api/tests/Api.Tests
+dotnet test --filter "FullyQualifiedName~SessionFlowE2ETests"
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Eseguire TUTTI i test del plan**
+
+```bash
+dotnet test --filter "FullyQualifiedName~SessionTurnOrderTests|GameNightEventAdHocTests|GetKbReadinessQueryHandlerTests|CreateSessionCommandAdHocTests|PauseResumeSessionTests|SetTurnOrderCommandTests|RollSessionDiceDiaryEmissionTests|UpdateScoreCommandTests|DiaryQueryTests|SessionFlowE2ETests"
+```
+
+Expected: tutti PASS.
+
+- [ ] **Step 4: Run full suite (no regression)**
+
+```bash
+dotnet test
+```
+
+Expected: tutti i test esistenti passano ancora + quelli nuovi.
+
+Se qualche test esistente **fallisce**, il commit Task 4 (`CreateSessionCommand` extension) potrebbe aver rotto qualcosa. Investigare (NON skippare) e fixare.
+
+- [ ] **Step 5: Commit finale del test E2E**
+
+```bash
+git add apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Integration/SessionFlowE2ETests.cs
+git commit -m "test(session-tracking): add Session Flow v2.1 end-to-end integration test
+
+Covers full happy path: start session with guests, random turn order,
+dice rolls, score updates, diary verification, pause, second game in
+same night, game night diary union."
+```
+
+- [ ] **Step 6: Push branch**
+
+```bash
+git push -u origin feature/session-flow-v2.1-backend
+```
+
+- [ ] **Step 7: Aprire PR verso `main-dev`**
+
+```bash
+gh pr create --base main-dev --title "feat(session-flow): backend v2.1 implementation" --body "$(cat <<'EOF'
+## Summary
+
+Implements backend for Session Flow v2.1 (spec: `docs/superpowers/specs/2026-04-09-session-flow-v2.1.md`).
+
+- KB readiness pre-check before starting a session
+- `CreateSessionCommand` extended with ad-hoc `GameNightEvent` auto-creation
+- `GameNightEvent.CreateAdHoc` + `AttachAdditionalGame` for spontaneous multi-game evenings
+- `PauseSessionCommand` / `ResumeSessionCommand` with "1 Active per night" invariant
+- `SetTurnOrderCommand` (manual + random with audit seed)
+- Dice roll diary emission + new HTTP endpoint
+- `UpdateScoreCommand` with append-only diary history
+- Diary queries per-session and per-GameNight (UNION)
+- New `SessionFlowEndpoints` routing
+
+Zero breaking changes on existing aggregates. Only 4 new columns on `Session` + 1 new enum value on `GameNightStatus`.
+
+## Test plan
+
+- [x] Unit: Session turn order domain tests
+- [x] Unit: GameNightEvent ad-hoc tests
+- [x] Integration: GetKbReadinessQuery
+- [x] Integration: CreateSessionCommand ad-hoc + KB check + invariant (5 scenarios)
+- [x] Integration: Pause/Resume with auto-pause (4 scenarios)
+- [x] Integration: SetTurnOrderCommand (3 scenarios)
+- [x] Integration: Dice roll diary emission
+- [x] Integration: UpdateScoreCommand (3 scenarios)
+- [x] Integration: Diary queries (3 scenarios)
+- [x] E2E: full happy path (SessionFlowE2ETests)
+- [x] Full `dotnet test` suite — zero regressions
+
+## Out of scope (follow-up plans)
+
+- Frontend Contextual Hand + Session/GameNight pages
+- Playwright E2E
+- SSE diary stream (v2.2)
+- `AdvanceTurnCommand` (can be added in Plan 1bis)
+- GameNight completion cascade (can be added in Plan 1bis)
+EOF
+)"
+```
+
+⚠️ Verificare il comando `gh pr create` con la sintassi Windows Git Bash se disponibile. Su PowerShell si può usare `--body-file` con file temp (vedi memory: `pr body windows` → `--body-file`).
+
+- [ ] **Step 8: Verificare che la CI passi**
+
+```bash
+gh pr checks
+```
+
+Expected: tutti i check verdi.
+
+---
+
+## Self-Review Checklist
+
+Dopo aver eseguito i 10 task, il worker verifica:
+
+- [ ] Spec coverage: ogni gap G1..G10 ha un task corrispondente?
+  - G1 → Task 4+5 ✓
+  - G2 → Task 2 ✓
+  - G3 → Task 3 ✓
+  - G4 → Task 1+6 ✓
+  - G5 → Task 7 ✓
+  - G6 → Task 8 ✓
+  - G7 → Task 9 ✓
+  - G8 → Task 5 ✓
+  - G9 → ❌ (AdvanceTurn rimandato a Plan 1bis)
+  - G10 → ❌ (Finalize cascade rimandato a Plan 1bis)
+- [ ] No placeholder (TBD, TODO, "implement later")
+- [ ] Type consistency: i nomi usati in task posteriori matchano quelli definiti nei task precedenti?
+  - `TurnOrderMethod` (enum) ✓ definito in Task 1, usato in Task 6
+  - `CreateSessionCommand` (con `GameNightEventId`, `GuestNames`) ✓ esteso in Task 4, usato in Task 5, 9, 10
+  - `GameNightStatus.InProgress` ✓ aggiunto in Task 1, usato in Task 2
+  - `PauseSessionCommand` ✓ creato in Task 5, usato in Task 9, 10
+- [ ] Ogni task ha: test → implementazione → test pass → commit
+- [ ] Ogni commit ha messaggio conforme a CLAUDE.md (`feat(scope): description`)
+
+---
+
+## Out of Scope / Deferred
+
+I seguenti elementi della spec v2.1 sono **esplicitamente fuori scope** di questo plan e saranno affrontati in plan successivi:
+
+### Plan 1bis (backend completion, ~4 task)
+
+| Spec ref | Item | Ragione differimento |
+|---|---|---|
+| §6.1 | `GET /api/v1/sessions/current` (orphan recovery NFR-9) | Non critico per happy path backend, può essere aggiunto dopo |
+| §6.6 | `POST /api/v1/game-nights/{id}/complete` (cascade finalize) | Richiede `FinalizeSessionCommand` extension + new `CompleteGameNightCommand` |
+| §6.4 | Cursor-based pagination nelle diary queries | Per ora `.Take(limit)` offset-based; cursor in v2.2 |
+| §4.5 / Domain | `AdvanceTurnCommand` + `Session.AdvanceTurn()` domain method | G9 — richiede endpoint e integrazione UI |
+| §7 | Scenario "Chiusura serata" Gherkin | Dipende da `CompleteGameNightCommand` |
+| §6.3 | `POST /sessions/{id}/notes` dedicated endpoint | `SessionNote` esiste già come entity, manca solo wiring |
+
+### Plan 2 (frontend, separato)
+
+- Gap G11-G15: Zustand store, ContextualHand components, Session/GameNight pages
+- E2E Playwright (Gherkin §7 completo)
+
+### Nota sulla concurrency della 1-Active invariant
+
+Il plan implementa l'invariante sia a **livello handler** (read-check) sia a **livello DB** (unique partial index aggiunto in Task 1 step 8bis). In produzione sotto carico, il DB index è il safety net definitivo: se due request simultanee passano il check handler, una delle due fallirà sul `SaveChangesAsync` con `DbUpdateException` (violazione unique index) e va convertita in `ConflictException` nel catch block del handler Task 4. Istruzione aggiunta al Task 4 step 8bis.

--- a/docs/superpowers/plans/2026-04-09-session-flow-backend.md
+++ b/docs/superpowers/plans/2026-04-09-session-flow-backend.md
@@ -12,6 +12,27 @@
 
 **Scope:** Questo plan copre SOLO i gap backend G1–G10 della spec. Frontend (G11–G15) e E2E Playwright (G16 parziale) in plan separato.
 
+## ⚠️ Corrections from T0 discoveries (must be respected by all following tasks)
+
+Durante l'esecuzione di Task 0 il worker ha scoperto divergenze reali dal codebase rispetto alle assunzioni iniziali del plan. **Tutti i task successivi devono rispettare queste correzioni**:
+
+1. **PDF processing state "ready" not "indexed"**: l'enum `PdfProcessingState` ha `Ready = 6` come stato terminale di successo. Ovunque il plan dica "Indexed" in riferimento allo stato PDF, leggere "Ready". La spec v2.1 §2 è stata aggiornata di conseguenza.
+
+2. **`VectorDocument` è 1 per PDF, non per chunk**: `VectorDocumentEntity` ha UNIQUE constraint su `PdfDocumentId`. Il "readiness" si calcola come **esistenza** di una vector doc (opzionalmente con `IndexingStatus == "completed"`), non come `count > 0` di righe multiple. T3 handler deve usare `.Any(v => ...)` non `.CountAsync(...)`.
+
+3. **Dual Games tables**: `PdfDocumentEntity.GameId` ha FK verso la **legacy `games` table** (`GameEntity`), non `SharedGames`. Il seeder T0 crea entrambi con lo stesso Guid e `GameEntity.SharedGameId = gameId`. Nei query: `_db.SharedGames` per metadata utente-facing, `_db.Games` (o `GameEntity` DbSet) per join con PdfDocument.
+
+4. **Fixture class name**: si chiama **`SharedTestcontainersFixture`** (namespace `Api.Tests.Infrastructure`), non `PostgresFixture`. Tutti i test integration devono usare `IClassFixture<SharedTestcontainersFixture>`.
+
+5. **Entities sono POCO con setter pubblici, no factory methods**. Semplifica le write operations nei seeder/handler che costruiscono entità di persistence.
+
+6. **Campi obbligatori tipici**:
+   - `UserEntity.Email` required (usare `sf21-{guid:N}@meepleai.test`)
+   - `PdfDocumentEntity.FileName`, `FilePath`, `FileSizeBytes`, `UploadedByUserId` required
+   - `SharedGameEntity.Title`, `CreatedBy` required
+
+7. **Fixture API**: `SharedDatabaseTestBase` espone `DbContext` direttamente; `SharedTestcontainersFixture.CreateScope()` è disponibile per scoped retrieval. I seeder aggiunti in T0 supportano entrambe le forme (overload con `IServiceScope` che delega a overload con `MeepleAiDbContext`).
+
 ---
 
 ## Pre-flight: verifiche da fare prima di iniziare
@@ -928,8 +949,8 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 /// </summary>
 public record KbReadinessDto(
     bool IsReady,
-    string State,                  // "None" | "Extracting" | "Indexing" | "Indexed" | "PartiallyIndexed" | "Failed"
-    int VectorDocumentCount,
+    string State,                  // see PdfProcessingState enum values, plus "None" / "PartiallyReady" aggregates
+    int ReadyPdfCount,             // pdf docs in state Ready
     int FailedPdfCount,
     IReadOnlyList<string> Warnings
 );
@@ -952,6 +973,29 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
 public record GetKbReadinessQuery(Guid GameId) : IRequest<KbReadinessDto>;
 ```
 
+- [ ] **Step 2bis: Pre-flight discovery del codebase**
+
+Prima di scrivere handler o test, **scoprire i nomi reali**:
+
+```bash
+# PdfProcessingState enum values
+grep -n "public enum PdfProcessingState\|Ready\|Extracting\|Indexing" apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfDocumentEntity.cs
+
+# VectorDocument schema (attention: UNIQUE su PdfDocumentId!)
+cat apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/VectorDocumentEntity.cs 2>/dev/null || find apps/api/src/Api -name "VectorDocumentEntity.cs" -exec cat {} \;
+
+# DbSet names in MeepleAiDbContext
+grep -n "DbSet<PdfDocument\|DbSet<VectorDocument\|DbSet<Game\|DbSet<SharedGame" apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+```
+
+**Scoperte attese** (già note da T0 ma conferma):
+- `PdfProcessingState.Ready` = stato terminale success (non "Indexed")
+- `VectorDocumentEntity` ha UNIQUE su `PdfDocumentId` e un campo `IndexingStatus` (stringa tipo "completed"/"failed")
+- `PdfDocumentEntity.GameId` → FK legacy `GameEntity` (non `SharedGameEntity`)
+- DbSet names probabili: `_db.PdfDocuments`, `_db.VectorDocuments`, `_db.Games`
+
+Annota i nomi esatti prima di procedere allo Step 3.
+
 - [ ] **Step 3: Scrivere i test failing dell'handler**
 
 Creare `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbReadinessQueryHandlerTests.cs`:
@@ -959,17 +1003,17 @@ Creare `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queri
 ```csharp
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.Infrastructure;
-using Api.Tests.Shared.Fixtures;
+using Api.Tests.Infrastructure;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 
 namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries;
 
-public class GetKbReadinessQueryHandlerTests : IClassFixture<PostgresFixture>
+public class GetKbReadinessQueryHandlerTests : IClassFixture<SharedTestcontainersFixture>
 {
-    private readonly PostgresFixture _fixture;
+    private readonly SharedTestcontainersFixture _fixture;
 
-    public GetKbReadinessQueryHandlerTests(PostgresFixture fixture)
+    public GetKbReadinessQueryHandlerTests(SharedTestcontainersFixture fixture)
     {
         _fixture = fixture;
     }
@@ -1081,62 +1125,104 @@ public class GetKbReadinessQueryHandler : IRequestHandler<GetKbReadinessQuery, K
         // PdfDocumentEntity dovrebbe avere GameId (o SharedGameId) e ProcessingState.
         // VectorDocumentEntity dovrebbe avere PdfDocumentId (o GameId).
 
+        // NOTE: PdfDocument.GameId punta alla legacy GameEntity table.
+        // Il caller passa il SharedGameId; va risolto tramite GameEntity.SharedGameId link.
+        // Adatta se lo schema reale usa direttamente SharedGameId su PdfDocument.
+
+        var legacyGameId = await _db.Games
+            .AsNoTracking()
+            .Where(g => g.SharedGameId == request.GameId || g.Id == request.GameId)
+            .Select(g => (Guid?)g.Id)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (legacyGameId is null)
+        {
+            return new KbReadinessDto(false, "None", 0, 0, Array.Empty<string>());
+        }
+
         var pdfs = await _db.PdfDocuments
             .AsNoTracking()
-            .Where(p => p.GameId == request.GameId)
+            .Where(p => p.GameId == legacyGameId.Value)
             .Select(p => new { p.Id, p.ProcessingState })
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
         if (pdfs.Count == 0)
         {
-            return new KbReadinessDto(
-                IsReady: false,
-                State: "None",
-                VectorDocumentCount: 0,
-                FailedPdfCount: 0,
-                Warnings: Array.Empty<string>());
+            return new KbReadinessDto(false, "None", 0, 0, Array.Empty<string>());
         }
 
-        var indexedPdfIds = pdfs
-            .Where(p => string.Equals(p.ProcessingState, "Indexed", StringComparison.Ordinal))
+        // ⚠️ ProcessingState può essere enum o string — adattare il confronto.
+        // Assumo enum PdfProcessingState con Ready e Failed come valori.
+        var readyPdfIds = pdfs
+            .Where(p => p.ProcessingState == Api.Infrastructure.Entities.DocumentProcessing.PdfProcessingState.Ready)
             .Select(p => p.Id)
             .ToList();
 
-        var failedCount = pdfs.Count(p => string.Equals(p.ProcessingState, "Failed", StringComparison.Ordinal));
+        var failedCount = pdfs.Count(p =>
+            p.ProcessingState == Api.Infrastructure.Entities.DocumentProcessing.PdfProcessingState.Failed);
 
-        var vectorCount = indexedPdfIds.Count == 0
+        // VectorDocument: UNIQUE su PdfDocumentId, 1 row per PDF.
+        // Readiness = almeno 1 vector doc con IndexingStatus completato per un PDF Ready.
+        // ⚠️ Il nome del campo IndexingStatus può essere diverso — verificare nello Step 2bis.
+        var hasReadyVector = readyPdfIds.Count > 0
+            && await _db.VectorDocuments
+                .AsNoTracking()
+                .AnyAsync(v =>
+                    readyPdfIds.Contains(v.PdfDocumentId)
+                    && v.IndexingStatus == "completed",
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+        var readyVectorCount = readyPdfIds.Count == 0
             ? 0
             : await _db.VectorDocuments
                 .AsNoTracking()
-                .CountAsync(v => indexedPdfIds.Contains(v.PdfDocumentId), cancellationToken)
+                .CountAsync(v =>
+                    readyPdfIds.Contains(v.PdfDocumentId)
+                    && v.IndexingStatus == "completed",
+                    cancellationToken)
                 .ConfigureAwait(false);
 
-        var isReady = vectorCount > 0 && indexedPdfIds.Count > 0;
+        var isReady = hasReadyVector;
 
         string state;
         var warnings = new List<string>();
 
-        if (!isReady && pdfs.Any(p => string.Equals(p.ProcessingState, "Extracting", StringComparison.Ordinal)))
-            state = "Extracting";
-        else if (!isReady && pdfs.Any(p => string.Equals(p.ProcessingState, "Indexing", StringComparison.Ordinal)))
-            state = "Indexing";
-        else if (isReady && failedCount > 0)
+        if (isReady && failedCount > 0)
         {
-            state = "PartiallyIndexed";
+            state = "PartiallyReady";
             warnings.Add($"{failedCount} PDF document(s) failed to index — agent answers may be incomplete.");
         }
         else if (isReady)
-            state = "Indexed";
+        {
+            state = "Ready";
+        }
         else if (failedCount == pdfs.Count)
+        {
             state = "Failed";
+        }
+        else if (readyPdfIds.Count > 0 && !hasReadyVector)
+        {
+            // PDF Ready ma vector non ancora caricato
+            state = "VectorPending";
+        }
         else
-            state = "None";
+        {
+            // Stato intermedio: prendi il più avanzato tra i non-ready
+            var latestState = pdfs
+                .Select(p => p.ProcessingState)
+                .Distinct()
+                .OrderByDescending(s => (int)s)
+                .FirstOrDefault();
+            state = latestState.ToString();
+        }
 
         return new KbReadinessDto(
             IsReady: isReady,
             State: state,
-            VectorDocumentCount: vectorCount,
+            ReadyPdfCount: readyPdfIds.Count,
             FailedPdfCount: failedCount,
             Warnings: warnings);
     }
@@ -1229,18 +1315,18 @@ using Api.BoundedContexts.SessionTracking.Application.DTOs;
 using Api.BoundedContexts.GameManagement.Domain.Enums;
 using Api.Infrastructure;
 using Api.Middleware.Exceptions;
-using Api.Tests.Shared.Fixtures;
+using Api.Tests.Infrastructure;
 using FluentAssertions;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Api.Tests.BoundedContexts.SessionTracking.Application.Commands;
 
-public class CreateSessionCommandAdHocTests : IClassFixture<PostgresFixture>
+public class CreateSessionCommandAdHocTests : IClassFixture<SharedTestcontainersFixture>
 {
-    private readonly PostgresFixture _fixture;
+    private readonly SharedTestcontainersFixture _fixture;
 
-    public CreateSessionCommandAdHocTests(PostgresFixture fixture)
+    public CreateSessionCommandAdHocTests(SharedTestcontainersFixture fixture)
     {
         _fixture = fixture;
     }
@@ -1843,7 +1929,7 @@ using Api.BoundedContexts.SessionTracking.Application.DTOs;
 using Api.BoundedContexts.SessionTracking.Domain.Enums;
 using Api.Infrastructure;
 using Api.Middleware.Exceptions;
-using Api.Tests.Shared.Fixtures;
+using Api.Tests.Infrastructure;
 using FluentAssertions;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -1851,11 +1937,11 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Api.Tests.BoundedContexts.SessionTracking.Application.Commands;
 
-public class PauseResumeSessionTests : IClassFixture<PostgresFixture>
+public class PauseResumeSessionTests : IClassFixture<SharedTestcontainersFixture>
 {
-    private readonly PostgresFixture _fixture;
+    private readonly SharedTestcontainersFixture _fixture;
 
-    public PauseResumeSessionTests(PostgresFixture fixture) { _fixture = fixture; }
+    public PauseResumeSessionTests(SharedTestcontainersFixture fixture) { _fixture = fixture; }
 
     [Fact]
     public async Task Pause_ActiveSession_ChangesStatusAndEmitsDiaryEvent()
@@ -2119,7 +2205,7 @@ using Api.BoundedContexts.SessionTracking.Application.Commands;
 using Api.BoundedContexts.SessionTracking.Application.DTOs;
 using Api.BoundedContexts.SessionTracking.Domain.Enums;
 using Api.Infrastructure;
-using Api.Tests.Shared.Fixtures;
+using Api.Tests.Infrastructure;
 using FluentAssertions;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -2127,11 +2213,11 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Api.Tests.BoundedContexts.SessionTracking.Application.Commands;
 
-public class SetTurnOrderCommandTests : IClassFixture<PostgresFixture>
+public class SetTurnOrderCommandTests : IClassFixture<SharedTestcontainersFixture>
 {
-    private readonly PostgresFixture _fixture;
+    private readonly SharedTestcontainersFixture _fixture;
 
-    public SetTurnOrderCommandTests(PostgresFixture fixture) { _fixture = fixture; }
+    public SetTurnOrderCommandTests(SharedTestcontainersFixture fixture) { _fixture = fixture; }
 
     [Fact]
     public async Task Manual_PersistsExplicitOrder()
@@ -2243,7 +2329,7 @@ Creare `RollSessionDiceDiaryEmissionTests.cs`:
 using Api.BoundedContexts.SessionTracking.Application.Commands;
 using Api.BoundedContexts.SessionTracking.Application.DTOs;
 using Api.Infrastructure;
-using Api.Tests.Shared.Fixtures;
+using Api.Tests.Infrastructure;
 using FluentAssertions;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -2251,11 +2337,11 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Api.Tests.BoundedContexts.SessionTracking.Application.Commands;
 
-public class RollSessionDiceDiaryEmissionTests : IClassFixture<PostgresFixture>
+public class RollSessionDiceDiaryEmissionTests : IClassFixture<SharedTestcontainersFixture>
 {
-    private readonly PostgresFixture _fixture;
+    private readonly SharedTestcontainersFixture _fixture;
 
-    public RollSessionDiceDiaryEmissionTests(PostgresFixture fixture) { _fixture = fixture; }
+    public RollSessionDiceDiaryEmissionTests(SharedTestcontainersFixture fixture) { _fixture = fixture; }
 
     [Fact]
     public async Task RollDice_EmitsDiceRolledDiaryEvent()
@@ -2603,7 +2689,7 @@ Creare `UpdateScoreCommandTests.cs`:
 using Api.BoundedContexts.SessionTracking.Application.Commands;
 using Api.BoundedContexts.SessionTracking.Application.DTOs;
 using Api.Infrastructure;
-using Api.Tests.Shared.Fixtures;
+using Api.Tests.Infrastructure;
 using FluentAssertions;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -2611,11 +2697,11 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Api.Tests.BoundedContexts.SessionTracking.Application.Commands;
 
-public class UpdateScoreCommandTests : IClassFixture<PostgresFixture>
+public class UpdateScoreCommandTests : IClassFixture<SharedTestcontainersFixture>
 {
-    private readonly PostgresFixture _fixture;
+    private readonly SharedTestcontainersFixture _fixture;
 
-    public UpdateScoreCommandTests(PostgresFixture fixture) { _fixture = fixture; }
+    public UpdateScoreCommandTests(SharedTestcontainersFixture fixture) { _fixture = fixture; }
 
     [Fact]
     public async Task FirstUpdate_CreatesEntry_WithOldValueZero()
@@ -2879,7 +2965,7 @@ using Api.BoundedContexts.SessionTracking.Application.Commands;
 using Api.BoundedContexts.SessionTracking.Application.DTOs;
 using Api.BoundedContexts.SessionTracking.Application.Queries;
 using Api.Infrastructure;
-using Api.Tests.Shared.Fixtures;
+using Api.Tests.Infrastructure;
 using FluentAssertions;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -2887,11 +2973,11 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Api.Tests.BoundedContexts.SessionTracking.Application.Queries;
 
-public class DiaryQueryTests : IClassFixture<PostgresFixture>
+public class DiaryQueryTests : IClassFixture<SharedTestcontainersFixture>
 {
-    private readonly PostgresFixture _fixture;
+    private readonly SharedTestcontainersFixture _fixture;
 
-    public DiaryQueryTests(PostgresFixture fixture) { _fixture = fixture; }
+    public DiaryQueryTests(SharedTestcontainersFixture fixture) { _fixture = fixture; }
 
     [Fact]
     public async Task GetSessionDiary_ReturnsEventsInChronologicalOrder()
@@ -3137,7 +3223,7 @@ using Api.BoundedContexts.SessionTracking.Application.DTOs;
 using Api.BoundedContexts.SessionTracking.Application.Queries;
 using Api.BoundedContexts.SessionTracking.Domain.Enums;
 using Api.Infrastructure;
-using Api.Tests.Shared.Fixtures;
+using Api.Tests.Infrastructure;
 using FluentAssertions;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -3145,11 +3231,11 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Api.Tests.BoundedContexts.SessionTracking.Integration;
 
-public class SessionFlowE2ETests : IClassFixture<PostgresFixture>
+public class SessionFlowE2ETests : IClassFixture<SharedTestcontainersFixture>
 {
-    private readonly PostgresFixture _fixture;
+    private readonly SharedTestcontainersFixture _fixture;
 
-    public SessionFlowE2ETests(PostgresFixture fixture) { _fixture = fixture; }
+    public SessionFlowE2ETests(SharedTestcontainersFixture fixture) { _fixture = fixture; }
 
     [Fact]
     public async Task HappyPath_StartSession_Rolls_Scores_Diary()

--- a/docs/superpowers/specs/2026-04-09-session-flow-v2.1.md
+++ b/docs/superpowers/specs/2026-04-09-session-flow-v2.1.md
@@ -75,7 +75,7 @@ La v2.0 proponeva un nuovo BC `GamePlay`. La ricognizione del codebase ha rivela
 | D7 | Agent = quello già auto-creato al PDF ready | Nessuna clonazione aggiuntiva |
 | D8 | Lifecycle `Active↔Paused`, `Finalized` terminale | Già implementato su Session |
 | D8bis | Invariante: per `(userId, gameNightEventId)` max 1 Session Active | Nuova business rule, enforced lato command |
-| D9 | KB ready = `Indexed ∧ vectorCount > 0`, `Failed` non blocca ma warn | Nuova query |
+| D9 | KB ready = `∃ PdfDocument.ProcessingState=Ready ∧ ∃ VectorDocument (IndexingStatus="completed")`, `Failed` non blocca ma warn. ⚠️ **Corretto in sede implementativa**: `VectorDocument` è 1 per PDF, non per chunk | Nuova query |
 | D10 | RNG server-side crittografico (già implementato), seed per turn_order random | Esiste per dadi; da aggiungere per shuffle turn order |
 
 ---
@@ -226,14 +226,14 @@ public record GetKbReadinessQuery(Guid GameId) : IRequest<KbReadinessResult>;
 
 public record KbReadinessResult(
     bool IsReady,
-    string State,              // "None" | "Extracting" | "Indexing" | "Indexed" | "PartiallyIndexed" | "Failed"
+    string State,              // PdfProcessingState enum values (Uploaded, Extracting, ..., Ready, Failed) + "None" / "PartiallyReady" / "VectorPending" aggregates
     int VectorDocumentCount,
     int FailedPdfCount,
     string[] Warnings
 );
 ```
 
-Logica: `IsReady = VectorDocumentCount > 0 ∧ (qualsiasi PdfDocument.ProcessingState == Indexed)`. `FailedPdfCount > 0` produce warning ma non blocca.
+Logica: `IsReady = ∃ PdfDocument.ProcessingState == PdfProcessingState.Ready ∧ ∃ VectorDocument(pdfId) con IndexingStatus=="completed"`. `FailedPdfCount > 0` produce warning ma non blocca. Nota: `VectorDocumentEntity` ha UNIQUE su `PdfDocumentId` (1 row per PDF, campo `ChunkCount`/`IndexingStatus`), quindi si usa `.Any(...)` non `.Count(...)`.
 
 ---
 
@@ -377,7 +377,7 @@ Feature: Session flow con KB ready, diary e multi-game ad-hoc
     And response: { sessionId, gameNightEventId, gameNightWasCreated: true, agentId, toolkitId }
 
   Scenario: KB non pronta blocca avvio
-    Given "Root" ha PdfDocument.ProcessingState=Extracting e 0 VectorDocument
+    Given "Root" ha PdfDocument.ProcessingState=Extracting e nessun VectorDocument (IndexingStatus="completed")
     When POST /api/v1/sessions { gameId: Root }
     Then response 422 con body { code: "KB_NOT_READY", state: "Extracting" }
     And nessuna Session viene creata

--- a/docs/superpowers/specs/2026-04-09-session-flow-v2.1.md
+++ b/docs/superpowers/specs/2026-04-09-session-flow-v2.1.md
@@ -1,0 +1,589 @@
+# Session Flow + Contextual Hand + Ad-Hoc GameNight
+
+**Feature Specification v2.1**
+**Data**: 2026-04-09
+**Status**: Draft — pronto per plan generation
+**Supersedes**:
+- `docs/frontend/my-hand-spec.md` v1.0 (frozen)
+- `docs/superpowers/specs/2026-04-09-session-gameplay-flow-v2.md` v2.0 (superseded, vedi §12)
+
+**BC toccati**: `SessionTracking` (extend), `GameManagement` (extend GameNightEvent), `KnowledgeBase` (query), `GameToolkit` (query), `UserLibrary` (query)
+
+---
+
+## 1. Vision
+
+Un utente con almeno un gioco in libreria e KB indicizzata deve poter:
+
+1. Avviare in un click una **Partita** (= `Session` esistente) su un gioco con KB pronta
+2. Avere automaticamente in mano le card contestuali (Game, KB, Agent, Toolkit, Session) — derivazione client-side dallo stato backend
+3. Aggiungere **guest player** al tavolo (stringhe libere come `Participant.DisplayName`)
+4. Determinare ordine di turno (manuale o RNG auditato)
+5. Tirare dadi server-side via endpoint dedicato, con ogni tiro loggato nel Diario (`SessionEvent`)
+6. Aggiornare punteggi con storia modifiche nel Diario
+7. Mettere in pausa la Session per iniziarne un'altra dello stesso o altro gioco, il sistema auto-raggruppa le Session in un `GameNightEvent` "ad-hoc" (nuovo flusso sul GameNightEvent esistente)
+8. Rivedere il Diario di una singola Session o dell'intera serata (UNION delle Session del GameNight)
+
+**Mono-utente**: l'host è l'unico account loggato; gli altri giocatori al tavolo sono guest (zero auth, zero real-time multi-client).
+
+---
+
+## 2. Principio guida: NON reinventare
+
+La v2.0 proponeva un nuovo BC `GamePlay`. La ricognizione del codebase ha rivelato che **il 90% del modello richiesto esiste già**. La v2.1 riscrive la feature come **orchestrazione + gap closure**.
+
+### Entità riusate (as-is, zero modifiche)
+
+| Entità | BC | Riuso |
+|---|---|---|
+| `Session` | `SessionTracking` | Partita singola. Riuso `Create`, `AddParticipant`, `Pause`, `Resume`, `Finalize`, `Status`, `Participants` |
+| `Participant` | `SessionTracking` | Guest player via `DisplayName`, `IsOwner`, `UserId?` nullable |
+| `SessionEvent` | `SessionTracking` | Diary append-only. Ha già `SessionId` + `GameNightId?` per cross-night queries |
+| `DiceRoll` | `SessionTracking` | RNG crittografico server-side (`RandomNumberGenerator`), formula parser, entity persistita |
+| `ScoreEntry` | `SessionTracking` | Score per `(SessionId, ParticipantId, RoundNumber?, Category?)` |
+| `GameNightEvent` | `GameManagement` | Meta-aggregatore serata. Status `Draft→Published→Completed/Cancelled` |
+| `GameNightSession` | `GameManagement` | Link GameNightEvent ↔ Session con `PlayOrder`, `GameNightSessionStatus` |
+| `Agent` + `AgentDefinition` | `KnowledgeBase` | Auto-creato da `AutoCreateAgentOnPdfReadyHandler` quando PDF indicizzato. Al momento dell'avvio Session è già pronto |
+| `Toolkit` (dashboard) + widgets | `GameToolkit` | Auto-creato su `GameAddedToLibraryEvent`, accessibile via `GetActiveToolkitQuery` |
+
+### Modifiche minime alle entità esistenti
+
+| Entità | Modifica | Motivazione |
+|---|---|---|
+| `GameNightEvent` | Nuovo stato `AdHoc` (o flag `IsAdHoc: bool`) + factory `CreateAdHoc(userId, firstSessionId)` che salta `Draft/Published` flow | Supportare serate spontanee senza RSVP/scheduling |
+| `GameNightEvent.StartedAt?` (nuovo campo nullable) | Timestamp primo `GameNightSession.Start()` | Distinguere "pianificato" da "già in corso" |
+
+### Campi già presenti che andrebbero valorizzati (bug fix / completamento)
+
+| Campo | Entità | Stato attuale | Uso v2.1 |
+|---|---|---|---|
+| `SessionEvent.GameNightId?` | esistente, nullable | Probabilmente mai valorizzato | Popolato quando la `Session` appartiene a un `GameNightEvent` ad-hoc |
+
+---
+
+## 3. Decisioni architetturali (consolidate dal brainstorming)
+
+| # | Decisione | Note |
+|---|---|---|
+| D1 | Scope ambizioso (β) — full session flow, non MVP | |
+| D2 | Mono-utente + guest come stringhe | `Participant.DisplayName` già supporta |
+| D3 | Hand dinamica contestuale (client-side, non persistita) | Zustand + derivation |
+| D4 | Session:Game = 1:1 (revised β') | **Session esistente = partita singola** |
+| D4bis | Multi-game via `GameNightEvent` esistente in modalità ad-hoc | Riuso BC `GameManagement` |
+| D5 | GameNight implicito, Session primaria user-facing | UI mostra "Partita"; "Serata" emerge solo al secondo game |
+| D6 | Diary per-Session + UNION query per GameNight | `SessionEvent.GameNightId` già supporta |
+| D7 | Agent = quello già auto-creato al PDF ready | Nessuna clonazione aggiuntiva |
+| D8 | Lifecycle `Active↔Paused`, `Finalized` terminale | Già implementato su Session |
+| D8bis | Invariante: per `(userId, gameNightEventId)` max 1 Session Active | Nuova business rule, enforced lato command |
+| D9 | KB ready = `Indexed ∧ vectorCount > 0`, `Failed` non blocca ma warn | Nuova query |
+| D10 | RNG server-side crittografico (già implementato), seed per turn_order random | Esiste per dadi; da aggiungere per shuffle turn order |
+
+---
+
+## 4. Domain Model Changes
+
+### 4.1 Nuovo flusso ad-hoc su `GameNightEvent`
+
+Aggiunta al file `GameNightEvent.cs` (BC `GameManagement`):
+
+```csharp
+// Nuovo enum value (o flag)
+public enum GameNightStatus {
+    Draft = 0,
+    Published = 1,
+    InProgress = 2,    // NEW: ad-hoc serata in corso
+    Completed = 3,
+    Cancelled = 4
+}
+
+// Nuova factory
+public static GameNightEvent CreateAdHoc(
+    Guid organizerId,
+    string title,            // "Serata del 09/04 20:00" auto-generato
+    Guid firstGameId)
+{
+    var evt = new GameNightEvent(
+        Guid.NewGuid(),
+        organizerId,
+        title,
+        scheduledAt: DateTimeOffset.UtcNow,
+        gameIds: [firstGameId]
+    );
+    evt.Status = GameNightStatus.InProgress;  // salta Draft/Published
+    return evt;
+}
+
+// Nuovo metodo per promuovere da "single session" a "ad-hoc night"
+public void AttachAdditionalGame(Guid gameId) {
+    if (Status != GameNightStatus.InProgress)
+        throw new ConflictException(...);
+    if (!GameIds.Contains(gameId))
+        GameIds.Add(gameId);
+}
+```
+
+### 4.2 Regola invariante nuova: `1 Active per GameNightEvent`
+
+Enforced a livello **command handler**, non entity:
+
+```csharp
+// StartSessionCommandHandler pseudocode
+if (request.GameNightEventId.HasValue)
+{
+    var activeSessions = await _sessionRepo.GetActiveByGameNightAsync(request.GameNightEventId.Value);
+    if (activeSessions.Any())
+        throw new ConflictException("ACTIVE_SESSION_EXISTS_IN_NIGHT", new { sessionIds = activeSessions });
+}
+```
+
+Client deve chiamare prima `PauseSessionCommand` sulla sessione corrente, poi riprovare.
+
+### 4.3 Nuovo Command `StartSessionCommand` (sostituisce eventuali entry point esistenti)
+
+```csharp
+public record StartSessionCommand(
+    Guid UserId,
+    Guid GameId,
+    Guid? GameNightEventId,      // null = crea o riusa night implicita
+    string? SessionLocation,
+    List<string> InitialGuestNames  // opzionale, aggiungibili dopo
+) : IRequest<StartSessionResult>;
+
+public record StartSessionResult(
+    Guid SessionId,
+    Guid GameNightEventId,        // sempre valorizzato (implicit se serve)
+    bool GameNightWasCreated,     // true se è stato creato new
+    Guid AgentId,                 // dal PrivateGame del gioco
+    Guid ToolkitId                // dal GetActiveToolkitQuery
+);
+```
+
+**Handler pseudocode**:
+```
+1. Validate: game in user library
+2. Validate: KB ready (GetKbReadinessQuery) → else 422 KB_NOT_READY
+3. Resolve GameNightEventId:
+   a. If provided and exists: verify InProgress status, verify no other Active Session
+   b. If null: check if user has a GameNightEvent in InProgress with state < 1h old
+      - If yes: attach to that (AttachAdditionalGame if needed)
+      - If no: create new AdHoc
+4. Session.Create(userId, gameId, SessionType.GameSpecific, location)
+5. Add guest players as Participants
+6. Create GameNightSession link (PlayOrder = count + 1)
+7. Emit SessionEvent(session_created) with GameNightId populated
+8. Return StartSessionResult
+```
+
+### 4.4 Nuovo Command `SetTurnOrderCommand`
+
+```csharp
+public record SetTurnOrderCommand(
+    Guid SessionId,
+    TurnOrderMethod Method,       // Manual | Random
+    List<Guid>? ManualOrder       // richiesto se Method=Manual
+) : IRequest<TurnOrderResult>;
+
+public enum TurnOrderMethod { Manual, Random }
+```
+
+**Handler**:
+- Random: genera seed (`Guid.NewGuid().GetHashCode()`), Fisher-Yates shuffle dei `Participant.Id`
+- Persistenza ordine: nuovo campo `Session.TurnOrderJson: string?` (array JSON di ParticipantId) + `Session.TurnOrderMethod: string?` + `Session.TurnOrderSeed: int?`
+- Emit `SessionEvent(turn_order_set)` payload `{method, seed?, participantIds[]}`
+
+### 4.5 Nuovo Command `RollDiceInSessionCommand`
+
+`DiceRoll` entity esiste già con factory `Create(sessionId, participantId, formula, label?)`. Serve solo:
+- Command handler che chiama `DiceRoll.Create(...)`, persiste, emette `SessionEvent(dice_rolled)`
+- **Endpoint HTTP** (oggi manca): `POST /api/v1/sessions/{id}/dice-rolls`
+
+### 4.6 Nuovo Command `UpdateScoreCommand`
+
+```csharp
+public record UpdateScoreCommand(
+    Guid SessionId,
+    Guid ParticipantId,
+    decimal NewValue,
+    int? RoundNumber,
+    string? Category,
+    string? Reason
+) : IRequest;
+```
+
+**Handler**:
+1. Cerca `ScoreEntry` esistente per `(sessionId, participantId, roundNumber, category)`
+2. Se esiste: leggi `oldValue = entry.ScoreValue`, poi `entry.UpdateScore(newValue)`
+3. Se non esiste: `ScoreEntry.Create(...)`, `oldValue = 0` (o null se category è opzionale)
+4. Emit `SessionEvent(score_updated)` con payload `{participantId, oldValue, newValue, roundNumber?, category?, reason?}`
+5. **Invariante storia**: la modifica della `ScoreEntry.ScoreValue` è OK perché la storia vive nel Diario (SessionEvent è append-only)
+
+> ⚠️ **Decisione OQ-2**: storia modifiche punteggi vive nel **Diario (SessionEvent)**, non in append-only di `ScoreEntry`. `ScoreEntry` resta mutable (è una proiezione). Undo = nuovo `UpdateScoreCommand` con valore precedente (che genera un altro `SessionEvent`).
+
+### 4.7 KB Readiness Query
+
+```csharp
+public record GetKbReadinessQuery(Guid GameId) : IRequest<KbReadinessResult>;
+
+public record KbReadinessResult(
+    bool IsReady,
+    string State,              // "None" | "Extracting" | "Indexing" | "Indexed" | "PartiallyIndexed" | "Failed"
+    int VectorDocumentCount,
+    int FailedPdfCount,
+    string[] Warnings
+);
+```
+
+Logica: `IsReady = VectorDocumentCount > 0 ∧ (qualsiasi PdfDocument.ProcessingState == Indexed)`. `FailedPdfCount > 0` produce warning ma non blocca.
+
+---
+
+## 5. Diary Events Schema
+
+Riuso `SessionEvent` esistente. Nuovi `EventType` (string, max 50 chars):
+
+| eventType | payload | source |
+|---|---|---|
+| `session_created` | `{gameId, gameName, gameNightEventId, wasNightCreated}` | `system` |
+| `session_paused` | `{}` | `system` |
+| `session_resumed` | `{}` | `system` |
+| `session_finalized` | `{winnerId?, durationSeconds}` | `system` |
+| `participant_added` | `{participantId, displayName, joinOrder}` | `user` |
+| `participant_removed` | `{participantId, displayName}` | `user` |
+| `turn_order_set` | `{method, seed?, participantIds[]}` | `user` |
+| `turn_advanced` | `{fromParticipantId, toParticipantId, fromIndex, toIndex}` | `user` |
+| `dice_rolled` | `{diceRollId, formula, rolls[], modifier, total, label?, participantId}` | `user` |
+| `score_updated` | `{participantId, oldValue, newValue, roundNumber?, category?, reason?}` | `user` |
+| `note_added` | `{sessionNoteId, text}` | `user` |
+| `agent_query` | `{question, responseSummary, agentId}` | `user` |
+| `agent_downgrade` | `{fromModel, toModel, reason}` | `system` |
+| `gamenight_created` | `{gameNightEventId, title, isAdHoc}` | `system` |
+| `gamenight_game_added` | `{gameNightEventId, addedGameId}` | `system` |
+| `gamenight_completed` | `{durationSeconds, sessionCount}` | `system` |
+
+Tutti gli eventi di una Session appartenente a un GameNight hanno `GameNightId` valorizzato.
+
+---
+
+## 6. API Endpoints
+
+Tutti tramite CQRS `IMediator.Send()` (CLAUDE.md rule).
+
+### 6.1 Session start & lifecycle
+
+```
+POST   /api/v1/sessions
+       Body: { gameId: Guid, gameNightEventId?: Guid, location?: string, guestNames?: string[] }
+       Precondition: KB ready per gameId, user owns game, no active session in night
+       → 201 { sessionId, gameNightEventId, gameNightWasCreated, agentId, toolkitId }
+       → 422 KB_NOT_READY { state, vectorDocumentCount }
+       → 409 ACTIVE_SESSION_EXISTS_IN_NIGHT { existingSessionIds[] }
+       → 404 GAME_NOT_IN_LIBRARY
+
+GET    /api/v1/sessions/{id}
+       → 200 { session (con participants), game, agent, kb (ready state), toolkit, gameNightEvent? }
+
+POST   /api/v1/sessions/{id}/pause          → 200
+POST   /api/v1/sessions/{id}/resume         → 200   (auto-pausa altre Active in GameNight)
+POST   /api/v1/sessions/{id}/finalize
+       Body: { winnerId?: Guid }
+       → 200
+
+GET    /api/v1/sessions/current
+       → 200 { session? }        // ultima Active/Paused dell'utente
+```
+
+### 6.2 Participants (guest-friendly)
+
+```
+POST   /api/v1/sessions/{id}/participants
+       Body: { displayName: string }   // guest: no UserId
+       → 201 { participantId, displayName, joinOrder }
+
+DELETE /api/v1/sessions/{id}/participants/{pid}
+       → 204
+
+PUT    /api/v1/sessions/{id}/turn-order
+       Body: { method: "manual" | "random", order?: Guid[] }
+       → 200 { method, seed?, order: Guid[] }
+```
+
+### 6.3 Diary-generating actions
+
+```
+POST   /api/v1/sessions/{id}/dice-rolls   ← NUOVO endpoint (command esisteva, endpoint no)
+       Body: { formula: string, label?: string, participantId: Guid }
+       → 201 { diceRollId, formula, rolls, modifier, total, timestamp }
+
+POST   /api/v1/sessions/{id}/scores
+       Body: { participantId, newValue, roundNumber?, category?, reason? }
+       → 200 { scoreEntryId, oldValue, newValue }
+
+POST   /api/v1/sessions/{id}/notes
+       Body: { participantId, text }
+       → 201 { sessionNoteId }
+```
+
+### 6.4 Diary queries
+
+```
+GET    /api/v1/sessions/{id}/diary?eventTypes=&since=&limit=&cursor=
+       → 200 { entries: SessionEventDto[], nextCursor? }
+
+GET    /api/v1/game-nights/{id}/diary?...
+       → 200 { entries: [] }   // UNION SessionEvent WHERE GameNightId = {id}
+
+GET    /api/v1/sessions/{id}/scoreboard
+       → 200 { entries: [{participantId, displayName, rounds: {}, categories: {}, total}] }
+```
+
+### 6.5 KB & Game meta
+
+```
+GET    /api/v1/games/{id}/kb-readiness
+       → 200 { isReady, state, vectorDocumentCount, failedPdfCount, warnings[] }
+```
+
+### 6.6 GameNight (ad-hoc)
+
+```
+GET    /api/v1/game-nights/{id}
+       → 200 { gameNightEvent (con sessions[]), diarySummary }
+
+POST   /api/v1/game-nights/{id}/complete
+       → 200   // marca tutte le Session come Finalized, GameNight → Completed
+```
+
+---
+
+## 7. User Flows (Gherkin)
+
+```gherkin
+Feature: Session flow con KB ready, diary e multi-game ad-hoc
+
+  Background:
+    Given sono autenticato come "Marco"
+    And ho in libreria "Terraforming Mars" con KB isReady=true e Agent auto-creato
+    And il Toolkit default di TM è auto-creato
+
+  Scenario: Avvio prima Session (crea GameNight ad-hoc implicita)
+    Given nessun GameNight in InProgress per Marco
+    When POST /api/v1/sessions { gameId: TM }
+    Then viene creato GameNightEvent in stato InProgress con title auto-generato
+    And viene creata Session con status=Active, gameId=TM
+    And Participant "Owner" (Marco) viene aggiunto automaticamente
+    And GameNightSession link è creato con PlayOrder=1
+    And SessionEvent: session_created (con GameNightId valorizzato)
+    And SessionEvent: gamenight_created (source=system)
+    And response: { sessionId, gameNightEventId, gameNightWasCreated: true, agentId, toolkitId }
+
+  Scenario: KB non pronta blocca avvio
+    Given "Root" ha PdfDocument.ProcessingState=Extracting e 0 VectorDocument
+    When POST /api/v1/sessions { gameId: Root }
+    Then response 422 con body { code: "KB_NOT_READY", state: "Extracting" }
+    And nessuna Session viene creata
+    And nessun SessionEvent viene emesso
+
+  Scenario: Aggiunta guest player (stringa libera)
+    Given Session sess1 Active
+    When POST /api/v1/sessions/sess1/participants { displayName: "Luca" }
+    Then Participant viene creato con UserId=null, DisplayName="Luca", JoinOrder=2
+    And SessionEvent: participant_added { participantId, displayName: "Luca", joinOrder: 2 }
+
+  Scenario: Turn order random riproducibile nell'audit
+    Given Session sess1 con 3 Participants [Marco, Luca, Sara]
+    When PUT /api/v1/sessions/sess1/turn-order { method: "random" }
+    Then il server genera seed, applica Fisher-Yates con quel seed
+    And Session.TurnOrderJson contiene i 3 ParticipantId ordinati
+    And SessionEvent: turn_order_set { method: "random", seed: <int>, participantIds: [...] }
+
+  Scenario: Tiro dado server-side
+    Given Session sess1 Active, Luca è partecipante
+    When POST /api/v1/sessions/sess1/dice-rolls { formula: "2d6", participantId: lucaId }
+    Then DiceRoll entity viene persistita con RNG crittografico
+    And response: { diceRollId, formula: "2D6", rolls: [a,b], modifier: 0, total: a+b, timestamp }
+    And SessionEvent: dice_rolled { diceRollId, formula: "2D6", rolls: [a,b], total, participantId }
+
+  Scenario: Aggiornamento punteggio con storia nel Diario
+    Given Session sess1, Luca ha ScoreEntry con ScoreValue=0, roundNumber=1
+    When POST /api/v1/sessions/sess1/scores { participantId: lucaId, newValue: 45, roundNumber: 1 }
+    Then ScoreEntry.ScoreValue diventa 45
+    And SessionEvent: score_updated { participantId, oldValue: 0, newValue: 45, roundNumber: 1 }
+    When POST /api/v1/sessions/sess1/scores { participantId: lucaId, newValue: 52, roundNumber: 1, reason: "correzione" }
+    Then ScoreEntry.ScoreValue diventa 52
+    And SessionEvent: score_updated { oldValue: 45, newValue: 52, reason: "correzione" }
+    And GET /diary mostra entrambe le entries ordinate
+
+  Scenario: Seconda partita stessa serata
+    Given Session sess1(TM) Active in GameNight gn1
+    When POST /api/v1/sessions { gameId: Azul, gameNightEventId: gn1 }
+    Then response 409 ACTIVE_SESSION_EXISTS_IN_NIGHT { existingSessionIds: [sess1] }
+    When client chiama POST /api/v1/sessions/sess1/pause
+    Then sess1.Status = Paused, SessionEvent: session_paused
+    When client re-invoca POST /api/v1/sessions { gameId: Azul, gameNightEventId: gn1 }
+    Then sess2 creata Active, GameNightEvent.GameIds aggiorna con Azul
+    And GameNightSession link sess2 con PlayOrder=2
+    And SessionEvent: gamenight_game_added { addedGameId: Azul }
+
+  Scenario: Riprendi Session in pausa
+    Given sess1 Paused, sess2 Active, entrambe in gn1
+    When POST /api/v1/sessions/sess1/resume
+    Then sess2 auto-pausata (SessionEvent: session_paused)
+    And sess1.Status = Active (SessionEvent: session_resumed)
+    And invariante: count(Active) nella gn1 = 1
+
+  Scenario: Diario della serata (UNION cross-session)
+    Given gn1 con sess1(TM, completed) e sess2(Azul, active), ~50 eventi totali
+    When GET /api/v1/game-nights/gn1/diary
+    Then response contiene tutti e 50 gli eventi ordinati cronologicamente
+    And ogni entry è taggata con sessionId e GameNightId=gn1
+
+  Scenario: Chiusura serata
+    Given gn1 con sess1 Finalized, sess2 Active
+    When POST /api/v1/game-nights/gn1/complete
+    Then sess2 viene Finalized automaticamente
+    And gn1.Status = Completed
+    And SessionEvent: gamenight_completed { sessionCount: 2, durationSeconds }
+```
+
+---
+
+## 8. Contextual Hand (Frontend)
+
+### 8.1 Principio
+
+**La Hand NON è persistita**. È una proiezione client-side derivata da `GET /api/v1/sessions/current`.
+
+### 8.2 Stati contestuali
+
+| Contesto | Cards visibili | Sorgente |
+|---|---|---|
+| **Idle** (nessuna Session Active/Paused) | 0 cards, CTA "Avvia partita" con game picker | `/sessions/current` → null |
+| **Session Active/Paused** | `[Session, Game, KB, Agent, Toolkit]` + quick actions | `/sessions/{id}` response composito |
+| **GameNight con N Session** | Sopra le card: selettore orizzontale GameNightSession list + "+ Nuova partita" | `/game-nights/{id}` |
+
+### 8.3 Layout
+
+Riuso tokens e shell design da `docs/frontend/my-hand-spec.md` v1 (design tokens, sidebar desktop, bottom bar mobile). Solo la **fonte dei dati** cambia.
+
+**Desktop**: sidebar destra 280px. Ogni slot è una `MeepleCard` (compact variant, entity type corretto).
+**Mobile**: bottom bar 64px collapsed, tap espande in sheet.
+
+### 8.4 Quick actions per card
+
+| Card | Action | Endpoint |
+|---|---|---|
+| Session | Pausa/Riprendi | `POST /sessions/{id}/pause|resume` |
+| Session | Scoreboard (inline panel) | `GET /sessions/{id}/scoreboard` |
+| Session | Note rapida | `POST /sessions/{id}/notes` |
+| Game | Vai al gioco | navigate `/library/games/{id}` |
+| KB | Vedi stato | `GET /games/{gameId}/kb-readiness` |
+| Agent | Chiedi (chat panel) | SSE `/agents/{id}/chat` (esistente) |
+| Toolkit | Tira dado | `POST /sessions/{id}/dice-rolls` |
+| Toolkit | Avanza turno | `POST /sessions/{id}/turn/advance` (da implementare) |
+
+### 8.5 Persistenza "ultima attività"
+
+`localStorage["meeple.lastActiveSessionId"]` aggiornato a ogni render con Session Active/Paused. Al login/reload, se presente, frontend fa redirect a `/sessions/{id}`.
+
+---
+
+## 9. Non-Functional Requirements
+
+| ID | Requirement | Metric |
+|---|---|---|
+| NFR-1 | `StartSessionCommand` p95 | < 500ms (KB readiness cached) |
+| NFR-2 | `RollDiceCommand` p95 | < 150ms |
+| NFR-3 | `UpdateScoreCommand` p95 | < 150ms |
+| NFR-4 | Diary event order | `Timestamp` monotono via `TimeProvider`, no gap |
+| NFR-5 | RNG fairness | Chi-square distribution test per `RollDice` |
+| NFR-6 | Optimistic concurrency | `Session.RowVersion` (già presente) catch `DbUpdateConcurrencyException` → 409 |
+| NFR-7 | Observability metriche | `session.started`, `session.paused`, `session.finalized`, `dice.rolled`, `score.updated`, `diary.entries.written`, `gamenight.created`, `gamenight.completed` con tag `eventType` |
+| NFR-8 | Agent LLM failure | SSE sanitized (PR #5249/#5250), `agent_downgrade` entry nel Diary |
+| NFR-9 | Session orphan recovery | `GET /sessions/current` per restore post-crash client |
+| NFR-10 | DB migration impact | Solo 3 campi nuovi: `Session.TurnOrderJson?`, `Session.TurnOrderMethod?`, `Session.TurnOrderSeed?` (+ eventuale `GameNightStatus.InProgress` enum value) — **zero breaking changes** |
+
+---
+
+## 10. Open Questions — Risolte
+
+| # | Question | Resolution |
+|---|---|---|
+| OQ-1 | `GameToolbox` vs `GameToolkit` | Risolto: sono BC **complementari**, non duplicati. v2.1 usa solo `GameToolkit.Toolkit` (dashboard) via `GetActiveToolkitQuery`. `GameToolbox.SharedContext` non serve. Consolidamento/rinomina fuori scope |
+| OQ-2 | Score: optimistic concurrency / append-only? | **Decisione**: `ScoreEntry` resta mutable (proiezione), storia vive nel `SessionEvent` Diary append-only. `Session.RowVersion` già in place per concurrency |
+| OQ-3 | SSE diary stream per v2.1 iniziale? | **Deferred a v2.2**. Mono-utente, reload manuale/polling 30s sufficiente. Endpoint SSE non nel primo plan |
+| OQ-4 | Agent cloning interaction con flussi esistenti | **Non si clona**. `Agent` è già auto-creato al PDF ready. `StartSessionCommand` legge `PrivateGame.AgentDefinitionId` e lo passa nella response |
+| OQ-5 | `currentTurnIndex` persistito o derivato? | **Persistito** in `Session.CurrentTurnIndex: int?` (nuovo campo) per query semplici; in alternativa ultimo `SessionEvent(turn_advanced)` come proiezione. Decisione per semplicità: persistito |
+
+---
+
+## 11. Gap Analysis — Cosa va davvero implementato
+
+| # | Gap | Tipo | Effort |
+|---|---|---|---|
+| G1 | `StartSessionCommand` + handler + validator + endpoint POST `/sessions` con logica ad-hoc GameNight | Backend — core | M |
+| G2 | `GameNightStatus.InProgress` enum value + `CreateAdHoc` factory + `AttachAdditionalGame` method | Backend — extension | S |
+| G3 | `GetKbReadinessQuery` + handler + endpoint GET `/games/{id}/kb-readiness` | Backend — new query | S |
+| G4 | `SetTurnOrderCommand` + handler + endpoint + campi `Session.TurnOrder{Json,Method,Seed,CurrentIndex}` + migration | Backend — core | M |
+| G5 | `RollDiceInSessionCommand` handler (entity esiste) + endpoint POST `/sessions/{id}/dice-rolls` | Backend — wrap existing | S |
+| G6 | `UpdateScoreCommand` handler che emette `SessionEvent(score_updated)` con oldValue | Backend — extension | S |
+| G7 | `GetSessionDiaryQuery` + `GetGameNightDiaryQuery` (UNION) + endpoints | Backend — queries | S |
+| G8 | `PauseSessionCommand` + `ResumeSessionCommand` con invariante 1 Active per GameNight (handler level) | Backend — extension | S |
+| G9 | `AdvanceTurnCommand` + endpoint + `SessionEvent(turn_advanced)` | Backend — new | S |
+| G10 | `FinalizeSessionCommand` emission + `CompleteGameNightCommand` cascade | Backend — extension | S |
+| G11 | Frontend: `useContextualHandStore` Zustand derivato da `/sessions/current` + `/sessions/{id}` | Frontend — core | M |
+| G12 | Frontend: `<ContextualHandSidebar>` + `<ContextualHandBottomBar>` componenti | Frontend — UI | M |
+| G13 | Frontend: pagina `/sessions/[id]` con MeepleCard layout, quick actions, diary panel | Frontend — page | L |
+| G14 | Frontend: pagina `/game-nights/[id]` con lista Session, diary UNION | Frontend — page | M |
+| G15 | Frontend: game picker dialog con KB readiness check, disabilitazione giochi non pronti | Frontend — UI | S |
+| G16 | Test: unit (domain transitions, RNG fairness), integration (commands), E2E (happy path completo, rivincita, pausa/riprendi) | All — QA | L |
+
+**Totale stimato**: ~10 unità backend + ~5 frontend (dimensioni relative, non tempi assoluti).
+
+---
+
+## 12. Differences from v2.0
+
+| Aspetto | v2.0 | v2.1 |
+|---|---|---|
+| Aggregate root | Nuovo `Session` con `GamePlay[]` | Riuso `Session` esistente (partita singola) |
+| Multi-game container | Nuovo `Session` concept | Riuso `GameNightEvent` con nuovo flow ad-hoc |
+| Diary entity | Nuovo `DiaryEntry` | Riuso `SessionEvent` (`GameNightId?` già presente) |
+| Agent auto-creation | Nuovo template + clone | Riuso auto-creation esistente (PDF ready trigger) |
+| Dice roll | Nuovo `RollDiceCommand` + entity | Riuso `DiceRoll` entity + command esistenti, manca solo endpoint |
+| Score history | Nuovo `score_updated` event sourcing | `ScoreEntry` mutable + storia in `SessionEvent` Diary |
+| BC footprint | Nuovo BC GamePlay | Extensions a SessionTracking + GameManagement |
+| Migration impact | 3-4 settimane refactor | **~3 campi aggiunti a Session** + nuovo enum value |
+| Effort stimato | L+ | M |
+
+---
+
+## 13. Definition of Done
+
+- [ ] Tutti i 16 gap (§11) implementati
+- [ ] Migration `AddSessionTurnOrderFields` + `AddGameNightInProgressStatus` generate e testate
+- [ ] Coverage: ≥90% backend, ≥85% frontend (CLAUDE.md)
+- [ ] Tutti gli scenari Gherkin §7 passano come E2E Playwright
+- [ ] Observability NFR-7 verificata
+- [ ] KB readiness integrato nel game picker
+- [ ] `docs/frontend/my-hand-spec.md` cancellato o marcato definitivamente obsoleto
+- [ ] `docs/superpowers/plans/2026-04-09-my-hand-feature.md` cancellato
+- [ ] `docs/superpowers/specs/2026-04-09-session-gameplay-flow-v2.md` cancellato
+- [ ] ADR scritta in `docs/architecture/adr/` per "Session Flow + Contextual Hand + Ad-hoc GameNight" che cita v2.1 come autoritativa
+- [ ] Plan eseguibile derivato via `superpowers:writing-plans`
+
+---
+
+## 14. Next Step
+
+Generare plan eseguibile da questa spec usando `superpowers:writing-plans`. Il plan dovrebbe essere strutturato in ~8-10 task con dipendenze, partendo da:
+
+1. Task 1: Schema changes (migration `Session.TurnOrder*` fields, `GameNightStatus.InProgress`)
+2. Task 2: `GameNightEvent.CreateAdHoc` + `AttachAdditionalGame` + tests
+3. Task 3: `GetKbReadinessQuery` + endpoint
+4. Task 4: `StartSessionCommand` (cuore della feature) + tests
+5. Task 5: `PauseSessionCommand` + `ResumeSessionCommand` + invariante
+6. Task 6: `SetTurnOrderCommand` + `RollDiceInSessionCommand` endpoint + `UpdateScoreCommand`
+7. Task 7: Diary queries (session + game-night UNION)
+8. Task 8: Frontend Zustand store + ContextualHand components
+9. Task 9: Session page + GameNight page
+10. Task 10: E2E Playwright + observability wiring

--- a/docs/superpowers/specs/2026-04-09-session-gameplay-flow-v2.md
+++ b/docs/superpowers/specs/2026-04-09-session-gameplay-flow-v2.md
@@ -1,0 +1,518 @@
+# Session + GamePlay + Contextual Hand + Diary
+
+**Feature Specification v2.0**
+**Data**: 2026-04-09
+**Status**: ⚠️ **SUPERSEDED** by `2026-04-09-session-flow-v2.1.md`
+
+> **Nota (2026-04-09)**: Dopo ricognizione codebase è emerso che il modello `Session : GamePlay = 1:N` proposto qui duplicherebbe un BC intero (`SessionTracking` + `GameNightEvent` già presenti in `GameManagement`). La v2.1 riformula la feature come extension dell'esistente, con scope 10x più piccolo e zero breaking changes.
+**Supersedes**: `docs/frontend/my-hand-spec.md` (v1.0, freeze)
+**Related**: `docs/superpowers/plans/2026-04-09-my-hand-feature.md` (plan v1 on-hold)
+**Bounded Contexts toccati**: `SessionTracking` (primary), `KnowledgeBase`, `GameManagement`, `GameToolbox`/`GameToolkit`, `UserLibrary`
+
+---
+
+## 1. Vision
+
+Un utente con una libreria di giochi con KB indicizzate deve poter:
+
+1. Avviare una **Partita** (GamePlay) su un gioco in un click
+2. Avere automaticamente in mano le card contestuali (KB, Agent, Toolkit, Partita)
+3. Aggiungere giocatori al tavolo (stringhe libere, no account)
+4. Determinare ordine di turno (manuale o random auditato)
+5. Tirare dadi dal Toolkit e registrare ogni tiro nel Diario
+6. Aggiornare punteggi con storia modifiche nel Diario
+7. Mettere in pausa la partita per iniziarne un'altra dello stesso gioco o diverso, formando così una **Serata** (Session) che raggruppa più partite
+
+La feature è **mono-utente**: un solo account autenticato (l'host) opera l'applicazione, gli altri giocatori al tavolo guardano lo schermo o passano il device. Nessun real-time multi-client.
+
+---
+
+## 2. Glossary
+
+| Termine | Definizione |
+|---|---|
+| **Session** | Contenitore "serata di gioco". Aggrega 1..N GamePlay. Nasce **implicita** (flag `isImplicit=true`) quando l'utente avvia la prima partita; diventa esplicita al secondo GamePlay aggiunto. |
+| **GamePlay** (UI: "Partita") | Singola istanza giocata di un gioco. Ha lifecycle proprio, scoreboard propria, appartiene a una Session. |
+| **Guest Player** | Giocatore al tavolo rappresentato da una stringa libera (es. "Luca"). Non è un `User` nel sistema. Persiste solo nell'array `players` del GamePlay e come `actor` nel Diario. |
+| **Hand** (UI: "La Mia Mano") | Barra contestuale dinamica di card visibile nella UI. Il set di card dipende dal contesto corrente (nessun gameplay / gameplay attivo / gameplay in pausa). **Non persistita come aggregato dominio**: è derivata client-side dallo stato corrente. |
+| **Card** | Rappresentazione visuale di un'entità rilevante (Game, KB, Agent, Toolkit, GamePlay). Ogni card ha quick actions. |
+| **Diary** | Event log append-only per Session. Ogni entry tagga il `gamePlayId` di contesto. Le scoreboard sono proiezioni del Diario. |
+| **Agent Template** | Seed data system-wide (`SystemDefaultAgentTemplate`) con prompt di default e model config. Clonato in `Agent` per (user, game) alla prima partita. |
+| **KB Ready** | `∃ PdfDocument(gameId) con ProcessingState=Indexed ∧ count(VectorDocument) > 0`. PDF `Failed` non bloccano ma generano warning. |
+
+---
+
+## 3. Domain Model
+
+### 3.1 Aggregates
+
+#### Session (aggregate root, BC `SessionTracking`)
+```
+Session {
+  id: Guid
+  userId: Guid                  // owner (l'host)
+  name: string                  // auto-generato se implicit, editabile dopo
+  isImplicit: bool              // true finché ha ≤ 1 GamePlay
+  startedAt: DateTime
+  endedAt: DateTime?
+  gamePlays: GamePlay[]
+  state: "Active" | "Ended"
+}
+```
+
+**Invarianti**:
+- `count(gamePlays where state=Active) ≤ 1`
+- `isImplicit = true ⟹ count(gamePlays) ≤ 1`
+- `endedAt != null ⟺ state=Ended`
+- Un `Session` Ended non accetta nuovi GamePlay
+
+#### GamePlay (entità figlia)
+```
+GamePlay {
+  id: Guid
+  sessionId: Guid               // required, FK
+  gameId: Guid                  // FK to SharedGameCatalog
+  agentId: Guid                 // FK (clonato da template al create)
+  toolkitRef: ToolkitRef        // snapshot dei tool disponibili (vedi 3.3)
+  state: "Setup" | "Active" | "Paused" | "Completed" | "Abandoned"
+  players: string[]             // guest names, ordine = turn order
+  turnOrderMethod: "manual" | "random" | null
+  turnOrderSeed: Guid?          // seed RNG se method=random, per audit
+  currentTurnIndex: int?        // indice in players[] del giocatore corrente
+  startedAt: DateTime
+  pausedAt: DateTime?
+  endedAt: DateTime?
+}
+```
+
+**Transizioni di stato**:
+```
+Setup → Active          (startGamePlay, richiede players.Count ≥ 1 e turn order definito)
+Active → Paused         (pauseGamePlay, auto-triggerata se apri altro GamePlay in Session)
+Paused → Active         (resumeGamePlay, auto-pausa eventuale Active corrente)
+Active → Completed      (completeGamePlay)
+Active → Abandoned      (abandonGamePlay)
+Paused → Completed      (consentito: chiudere una partita in pausa)
+Paused → Abandoned      (consentito)
+Completed → *           ❌ terminale
+Abandoned → *           ❌ terminale
+```
+
+#### DiaryEntry (value object, append-only)
+```
+DiaryEntry {
+  id: Guid
+  sessionId: Guid               // FK, required
+  gamePlayId: Guid?             // null per eventi di pura sessione (es. rinomina)
+  timestamp: DateTime           // server UTC
+  actor: string                 // "Marco" | "Luca" | "system"
+  eventType: DiaryEventType
+  payload: JSONB                // shape per eventType, vedi §5
+  correlationId: Guid?          // raggruppa eventi emessi insieme
+}
+```
+
+**Invarianti**:
+- Append-only: no update, no delete (undo = nuovo entry con valore opposto)
+- Ordinamento cronologico per `(timestamp, id)`
+
+### 3.2 Agent (BC `KnowledgeBase`)
+
+```
+Agent {
+  id: Guid
+  userId: Guid
+  gameId: Guid                  // unique(userId, gameId) per agent "default"
+  name: string
+  kbId: Guid                    // link alla KB del gioco
+  sourceTemplateId: Guid?       // SystemDefaultAgentTemplate.id, null se custom
+  sourceTemplateVersion: int?   // versione del template al clone
+  promptOverrides: string?
+  modelConfigOverrides: JSONB?
+  createdAt, updatedAt
+}
+```
+
+**Regole**:
+- Alla prima partita di Marco su TM: il sistema cerca `Agent where userId=Marco ∧ gameId=TM ∧ sourceTemplateId != null` → se non esiste, clona dal template
+- Template upgrade non tocca agent clonati (eventuale migration = comando dedicato fuori scope)
+- Marco può avere **1 solo agent "da template default"** per (user, game); può crearne di custom separati
+
+### 3.3 Toolkit
+
+Lo spec eredita la confusione `GameToolbox` vs `GameToolkit` da CLAUDE.md. **Decisione**: in questa feature il "Toolkit" è il set di tool operativi associati a un game (dadi, timer, note, scoreboard). Uso `GameToolkit` come BC autoritativo (da confermare con refactor separato).
+
+```
+ToolkitRef {
+  toolkitId: Guid               // template del toolkit del gioco
+  availableTools: ToolType[]    // ["dice", "timer", "notes", "scoreboard"]
+  diceConfigs: DiceConfig[]     // es. [{formula: "2d6", label: "Tiro base"}]
+}
+```
+
+Il `ToolkitRef` è uno **snapshot** al momento del create GamePlay: se l'admin aggiorna il toolkit template del gioco, le partite in corso non ne risentono.
+
+---
+
+## 4. Contextual Hand (UI state, NOT domain)
+
+### 4.1 Modello concettuale
+
+La "Mano" **non è un aggregato persistito**. È una proiezione client-side che deriva dal contesto corrente. Il backend non conosce il concetto di "card in mano": espone solo le entità (Session, GamePlay, Agent, KB, Toolkit) e il frontend le compone.
+
+**Stati contestuali**:
+
+| Contesto | Card visibili | Fonte |
+|---|---|---|
+| **Idle** (nessuna Session Active) | 0 card, mostra CTA "Avvia partita" con selezione game da libreria | — |
+| **GamePlay Setup** | `[GamePlay, Game, KB, Agent, Toolkit]` | `GET /sessions/{sid}/gameplays/{gpid}` |
+| **GamePlay Active** | `[GamePlay, Game, KB, Agent, Toolkit]` + quick actions abilitate (Tira, Score, Chiedi) | idem |
+| **GamePlay Paused** | Stesse card ma con badge "In pausa", quick actions disabilitate tranne "Riprendi" | idem |
+| **Session con più GamePlay** | Sopra le card del GamePlay corrente, comparsa di un **selettore Session** con lista GamePlay della serata + pulsante "+ Nuova partita" | `GET /sessions/{sid}` |
+
+### 4.2 Transizioni
+
+- **Avvio Partita**: idle → GamePlay Setup, card auto-popolate in Hand
+- **Start gameplay**: Setup → Active, quick actions diventano live
+- **Nuova partita nella serata**: se Session ha già 1 GamePlay Active → conferma auto-pausa → apre picker game → crea GamePlay2 → Hand si ripopola sulle card di GamePlay2
+- **Riprendi da Paused**: selettore Session → clic su GamePlay Paused → conferma auto-pausa corrente → Hand ripopolata
+
+### 4.3 Persistenza "ultima Hand"
+
+Per UX: al reload della pagina, il frontend deve ricordare l'ultimo GamePlay attivo. **Implementazione**: `localStorage` con `lastActiveGamePlayId`. Al login/reload, SE esiste un GamePlay `Active` o `Paused` per l'utente, il frontend naviga automaticamente a quella pagina. Nessuna persistenza server della "Hand state".
+
+---
+
+## 5. Diary Events Schema
+
+### 5.1 Event types
+
+| `eventType` | `gamePlayId` | Payload | Emesso da |
+|---|---|---|---|
+| `session_created` | null | `{sessionId, name, isImplicit}` | `CreateSessionCommand` |
+| `session_renamed` | null | `{oldName, newName}` | `RenameSessionCommand` |
+| `session_ended` | null | `{reason}` | `EndSessionCommand` |
+| `gameplay_created` | set | `{gameId, gameName}` | `StartGamePlayCommand` |
+| `player_added` | set | `{playerName}` | `AddPlayerCommand` |
+| `player_removed` | set | `{playerName}` | `RemovePlayerCommand` |
+| `turn_order_rolled` | set | `{method, seed?, order: [names]}` | `SetTurnOrderCommand` |
+| `gameplay_started` | set | `{}` | `StartGamePlayActivationCommand` |
+| `gameplay_paused` | set | `{}` | `PauseGamePlayCommand` |
+| `gameplay_resumed` | set | `{}` | `ResumeGamePlayCommand` |
+| `gameplay_completed` | set | `{finalScoreboard}` | `CompleteGamePlayCommand` |
+| `gameplay_abandoned` | set | `{reason?}` | `AbandonGamePlayCommand` |
+| `turn_advanced` | set | `{fromIndex, toIndex}` | `AdvanceTurnCommand` |
+| `dice_rolled` | set | `{formula, results: [int], total, seed}` | `RollDiceCommand` |
+| `score_updated` | set | `{playerName, oldValue, newValue, reason?}` | `UpdateScoreCommand` |
+| `note_added` | set | `{text}` | `AddNoteCommand` |
+| `agent_query` | set | `{question, responseSummary}` | RAG agent chat handler |
+| `agent_downgrade` | set | `{fromModel, toModel, reason}` | LLM fallback handler (PR #5249/#5250) |
+
+### 5.2 Regole
+
+- **Tutti** gli eventi `dice_rolled` sono server-side. Zero RNG client-side per la session. Seed = `Guid.NewGuid()` convertito in `long` e passato a `Random(seed)` per riproducibilità.
+- `score_updated`: il payload contiene SEMPRE `oldValue` anche se null. Undo = inserire entry con `oldValue`/`newValue` scambiati.
+- **Scoreboard corrente** = proiezione: per ogni `playerName` in `GamePlay.players`, prendi l'ultimo `score_updated` per quel player; se nessuno, score = 0.
+
+---
+
+## 6. API Endpoints
+
+Tutti gli endpoint seguono CQRS via `IMediator.Send()` (vedi CLAUDE.md).
+
+### 6.1 Session
+
+```
+POST   /api/v1/sessions
+       Body: { name?: string }
+       → 201 { sessionId, isImplicit: true }
+
+GET    /api/v1/sessions/{id}
+       → 200 { session: SessionDto (include gamePlays summary) }
+
+PATCH  /api/v1/sessions/{id}
+       Body: { name: string }
+       → 200 { session }
+
+POST   /api/v1/sessions/{id}/end
+       → 200
+
+GET    /api/v1/sessions/current
+       → 200 { session? } // ultima Session Active dell'utente
+```
+
+### 6.2 GamePlay
+
+```
+POST   /api/v1/gameplays
+       Body: { sessionId?: Guid, gameId: Guid }   // sessionId null = crea Session implicita
+       Precondition: KB ready for gameId (else 422 KB_NOT_READY con dettagli stato)
+       Side effects:
+         - Se sessionId null → crea Session implicit
+         - Se Session ha GamePlay Active → errore 409 ACTIVE_GAMEPLAY_EXISTS (client deve chiedere conferma e chiamare /pause prima)
+         - Clone Agent default per (user, game) se non esiste
+         - Snapshot ToolkitRef
+         - Emit diary: session_created (se nuova), gameplay_created
+       → 201 { gameplay: GamePlayDto, session: SessionDto, autoCreatedAgent: bool }
+
+GET    /api/v1/gameplays/{id}
+       → 200 { gameplay, game, agent, kb, toolkit }  // tutto ciò che serve alla Hand
+
+POST   /api/v1/gameplays/{id}/players
+       Body: { name: string }
+       → 200
+
+DELETE /api/v1/gameplays/{id}/players/{name}
+       → 204
+
+PUT    /api/v1/gameplays/{id}/turn-order
+       Body: { method: "manual" | "random", order?: string[] }
+       → 200 { order, seed? }
+
+POST   /api/v1/gameplays/{id}/start           → 200   // Setup → Active
+POST   /api/v1/gameplays/{id}/pause           → 200
+POST   /api/v1/gameplays/{id}/resume          → 200   // auto-pausa Active corrente
+POST   /api/v1/gameplays/{id}/complete        → 200
+POST   /api/v1/gameplays/{id}/abandon
+       Body: { reason?: string }
+       → 200
+
+POST   /api/v1/gameplays/{id}/turn/advance    → 200
+```
+
+### 6.3 Gameplay actions (Diary-generating)
+
+```
+POST   /api/v1/gameplays/{id}/dice-roll
+       Body: { formula: string, actor: string }
+       → 200 { results, total, entryId }
+
+POST   /api/v1/gameplays/{id}/scores
+       Body: { playerName: string, newValue: int, reason?: string }
+       → 200 { entryId, oldValue, newValue }
+
+POST   /api/v1/gameplays/{id}/notes
+       Body: { actor: string, text: string }
+       → 201
+```
+
+### 6.4 Diary
+
+```
+GET    /api/v1/sessions/{id}/diary?gamePlayId=&eventTypes=&since=&limit=
+       → 200 { entries: DiaryEntryDto[], nextCursor? }
+
+GET    /api/v1/gameplays/{id}/scoreboard
+       → 200 { players: [{name, score, lastUpdated}] }   // proiezione
+```
+
+### 6.5 KB readiness check
+
+```
+GET    /api/v1/games/{id}/kb-readiness
+       → 200 {
+           isReady: bool,
+           state: "None" | "Extracting" | "Indexing" | "Indexed" | "PartiallyIndexed" | "Failed",
+           vectorCount: int,
+           warnings: string[]
+         }
+```
+
+---
+
+## 7. User Flows (Gherkin)
+
+```gherkin
+Feature: Avvio partita con KB ready e diario
+
+  Background:
+    Given sono autenticato come "Marco"
+    And ho in libreria "Terraforming Mars" con KB.isReady=true
+    And esiste SystemDefaultAgentTemplate v1
+    And non ho agent per (Marco, TM)
+
+  Scenario: Avvio primo gameplay (crea Session implicita)
+    When invoco POST /api/v1/gameplays con {gameId: TM}
+    Then viene creata Session con isImplicit=true, name="Partita del 2026-04-09 20:00"
+    And viene clonato Agent per (Marco, TM) da template v1
+    And viene creato GamePlay con state=Setup, toolkitRef snapshot
+    And il Diario contiene: session_created, gameplay_created
+    And la response include autoCreatedAgent=true
+
+  Scenario: KB non pronta blocca avvio
+    Given "Root" ha KB.state=Extracting
+    When invoco POST /api/v1/gameplays con {gameId: Root}
+    Then ricevo 422 con body {code: "KB_NOT_READY", state: "Extracting"}
+    And nessuna Session né GamePlay vengono creati
+
+  Scenario: Aggiunta giocatori e turn order random
+    Given GamePlay gp1 in state=Setup con players vuoto
+    When aggiungo players [Marco, Luca, Sara]
+    And invoco PUT /turn-order con method=random
+    Then il sistema genera seed, shuffle i 3 nomi
+    And GamePlay.turnOrder persiste l'ordine e turnOrderSeed
+    And il Diario contiene turn_order_rolled{method:"random", seed, order}
+
+  Scenario: Start gameplay e tiro dado
+    Given gp1 in Setup con turn order definito
+    When invoco POST /gameplays/gp1/start
+    Then gp1.state = Active
+    And Diario: gameplay_started
+    When Luca (giocatore di turno) invoca dice-roll con formula="2d6", actor="Luca"
+    Then ricevo results=[a,b], total=a+b
+    And Diario: dice_rolled{formula:"2d6", results:[a,b], total, seed, actor:"Luca"}
+
+  Scenario: Aggiornamento punteggio e storia
+    Given gp1 Active, Luca ha scoreboard projection = 0
+    When Marco invoca POST /scores con {playerName:"Luca", newValue:45}
+    Then Diario: score_updated{playerName:"Luca", oldValue:0, newValue:45}
+    When Marco corregge a 52
+    Then Diario: score_updated{playerName:"Luca", oldValue:45, newValue:52}
+    And GET /scoreboard → Luca=52
+
+  Scenario: Seconda partita nella stessa serata
+    Given gp1 Active
+    When invoco POST /gameplays con {sessionId: sess1, gameId: Azul}
+    Then ricevo 409 ACTIVE_GAMEPLAY_EXISTS con gp1 indicato
+    When il client invoca POST /gameplays/gp1/pause
+    And re-invoca POST /gameplays con {sessionId: sess1, gameId: Azul}
+    Then viene creato gp2, Session.isImplicit diventa false
+    And Diario: gameplay_paused(gp1), gameplay_created(gp2)
+
+  Scenario: Riprendi partita in pausa
+    Given gp1 Paused, gp2 Active
+    When invoco POST /gameplays/gp1/resume
+    Then gp2 diventa Paused
+    And gp1 diventa Active
+    And Diario: gameplay_paused(gp2), gameplay_resumed(gp1)
+
+  Scenario: Seconda partita dello stesso gioco (rivincita)
+    Given gp1(TM) Completed nella sessione sess1
+    When invoco POST /gameplays con {sessionId: sess1, gameId: TM}
+    Then viene creato gp2(TM) che riusa l'Agent esistente di Marco/TM
+    And autoCreatedAgent=false
+```
+
+---
+
+## 8. Non-Functional Requirements
+
+| ID | Requisito | Metrica |
+|---|---|---|
+| NFR-1 | Avvio GamePlay end-to-end | p95 < 500ms (esclusa KB readiness se già cached) |
+| NFR-2 | Dice roll latenza | p95 < 150ms |
+| NFR-3 | Score update | p95 < 150ms |
+| NFR-4 | Diary append ordinato senza gap | invariante: `timestamp` monotono per (sessionId) usando `TimeProvider` |
+| NFR-5 | RNG audit completo | ogni `dice_rolled` e `turn_order_rolled` deve avere seed loggato e risultati riproducibili |
+| NFR-6 | Concorrenza score | optimistic concurrency su scoreboard via `RowVersion` su `GamePlay` o tramite append-only (da decidere in implementazione) |
+| NFR-7 | Observability | metriche: `gameplay.started`, `gameplay.completed`, `dice.rolled`, `score.updated`, `diary.entries.written` con tag `eventType` |
+| NFR-8 | Failure LLM | se agent LLM fallisce durante `agent_query`, Diario registra `agent_downgrade` o errore classificato (no provider raw leak) |
+| NFR-9 | Session orphan recovery | dopo crash del client, `GET /sessions/current` restituisce l'ultima Session Active, client ripristina |
+
+---
+
+## 9. Bounded Context Allocation
+
+| Entità / Comando | BC | Note |
+|---|---|---|
+| `Session`, `GamePlay`, `DiaryEntry` | `SessionTracking` | aggregato root Session |
+| `Agent`, `SystemDefaultAgentTemplate` | `KnowledgeBase` | clonazione interna al BC |
+| `Game`, `SharedGame` | `GameManagement` / `SharedGameCatalog` | read-only per questa feature |
+| `ToolkitRef` snapshot | `SessionTracking` (embedded) | riferimento a `GameToolkit` letto al create |
+| KB readiness check | `KnowledgeBase` | nuova query `IsGameKbReadyQuery` |
+| User library check | `UserLibrary` | precondition: gioco in libreria utente |
+
+**Refactor suggerito (fuori scope di questa PR)**: consolidare `GameToolbox` e `GameToolkit` in un unico BC (tracker: creare issue dedicato).
+
+---
+
+## 10. Cosa NON si fa in questa spec
+
+- ❌ Multi-user real-time (WebSocket tra device): scartato per decisione #2
+- ❌ Persistenza server-side della "Hand": scartato per decisione #3 (dinamica, client-side)
+- ❌ Session templating / serate ricorrenti
+- ❌ Statistiche cross-session (es. "quante volte ho giocato TM questo mese")
+- ❌ Export Diario PDF/CSV
+- ❌ Permessi/ruoli (host/player/spectator): tutto host
+- ❌ Undo/redo UX avanzato: undo disponibile solo inserendo nuovo entry inverso
+- ❌ Agent template migration tool
+- ❌ Refactor GameToolbox/GameToolkit
+
+---
+
+## 11. Test Plan
+
+### Unit (Domain)
+- `GamePlay` state transitions (ogni arco del lifecycle)
+- Invariante `Session.count(Active) ≤ 1`
+- Scoreboard projection: last-write-wins per playerName
+- RNG determinismo: stesso seed → stessi risultati
+
+### Integration (Testcontainers PostgreSQL)
+- `StartGamePlayCommand`: crea Session implicita + clona Agent + snapshot Toolkit + 2 diary entry in unica transazione
+- KB not ready → 422, nessun side effect
+- Active gameplay esistente → 409 senza side effect
+- Pause/resume: stato consistente su più GamePlay
+- Diary append order: insert 1000 entries concorrenti → ordinamento stabile
+
+### E2E (Playwright)
+- Happy path completo: login → libreria → avvia TM → aggiungi 3 players → turn order random → start → 3 tiri dado → 2 score update → completa
+- Rivincita: completa TM → avvia TM di nuovo nella stessa Session → verifica stesso Agent
+- Pausa+riprendi: TM Active → nuovo gameplay Azul → torna a TM → verifica state
+- KB non pronta: errore visibile con tooltip stato
+- Reload mid-session: verifica restore automatico su ultimo GamePlay Active
+
+### Property-based
+- RNG fairness: 10k tiri `1d6`, chi-square test distribution
+
+---
+
+## 12. Migration from v1
+
+Il plan v1 (`2026-04-09-my-hand-feature.md`) aveva implementato:
+- `UserHandSlotEntity` con 4 slot fissi persistiti
+- Endpoints `GET/PUT/DELETE /users/me/hand/{slotType}`
+- Store Zustand + localStorage fallback
+- Sidebar desktop + bottom bar mobile
+
+**Azione**: il plan v1 è **congelato**. Non eseguire Task 1+ sulla persistenza `UserHandSlot`.
+
+**Riuso possibile dai file v1**:
+- Design tokens slot (colori, icone) → riusabili per la Hand contestuale v2
+- Layout sidebar desktop / bottom bar mobile → riusabili, la differenza è che le card sono popolate dal contesto (GamePlay Active) invece che dallo store persistito
+- Test patterns e struttura BC UserLibrary → NON riusabili, la feature si sposta a `SessionTracking`
+
+**Cleanup**:
+- Marcare `my-hand-spec.md` come superseded (già fatto da questa spec)
+- Non creare migration `AddUserHandSlots` (Task 1 del plan v1)
+- Eventuali branch esistenti: rebase o abandon
+
+---
+
+## 13. Open Questions
+
+| # | Question | Impact | Target resolution |
+|---|---|---|---|
+| OQ-1 | `GameToolbox` vs `GameToolkit` consolidamento | Medium — decide da dove leggere `ToolkitRef` | Issue separato prima di implementazione |
+| OQ-2 | Optimistic concurrency score via `RowVersion` o append-only? | Low — append-only è più elegante | Durante implementazione domain |
+| OQ-3 | SSE diary stream necessario per la v2 iniziale? | Low — mono-utente, reload sufficiente | Defer a v2.1 |
+| OQ-4 | Agent clonazione: interazione con esistenti flussi di creation agent? | Medium | Review con owner BC KnowledgeBase |
+| OQ-5 | `currentTurnIndex` deve essere persistito o derivato dal Diario? | Low | Persistito per semplicità query |
+
+---
+
+## 14. Acceptance Criteria (Definition of Done)
+
+- [ ] Tutte le 10 decisioni architetturali documentate sono implementate
+- [ ] Schema DB con migration per `Session`, `GamePlay`, `DiaryEntry` (BC `SessionTracking`)
+- [ ] Seed data `SystemDefaultAgentTemplate`
+- [ ] Tutti gli endpoint §6 implementati con CQRS MediatR
+- [ ] Coverage: ≥90% backend, ≥85% frontend
+- [ ] Tutti gli scenari Gherkin §7 passano come E2E
+- [ ] Osservabilità NFR-7 verificata con log e metriche visibili
+- [ ] KB readiness check integrato in libreria (pulsante "Gioca" disabilitato se non ready)
+- [ ] Plan v1 marcato frozen, v2 plan generato da questa spec via `superpowers:writing-plans`
+
+---
+
+**Next step**: validare questa spec con un secondo passaggio panel (`/sc:spec-panel --mode critique --focus requirements,architecture,testing`) oppure procedere a `superpowers:writing-plans` per derivare il plan eseguibile.


### PR DESCRIPTION
## Summary

Implements Session Flow v2.1 backend complete (spec: `docs/superpowers/specs/2026-04-09-session-flow-v2.1.md`).

### Plan 1 (T0-T10): Core Session Flow
- KB readiness pre-check before starting a session
- `CreateSessionCommand` extended with ad-hoc `GameNightEvent` auto-creation + guest players
- `GameNightEvent.CreateAdHoc` + `AttachAdditionalGame` for spontaneous multi-game evenings
- `PauseSessionCommand` / `ResumeSessionCommand` with "1 Active per night" invariant
  (enforced at handler level + partial unique index on GameNightSessions)
- `SetTurnOrderCommand` (manual + random with audit seed)
- `RollSessionDiceCommand` diary emission
- `UpsertScoreWithDiaryCommand` with append-only diary history
- Diary queries per-session and per-GameNight (UNION)
- New `SessionFlowEndpoints` routing

### Plan 1bis (T1-T5): Backend Completion
- `AdvanceTurnCommand` with cyclic turn progression + diary event
- `FinalizeSessionCommand` diary emission (session_finalized with scoreboard snapshot)
- `CompleteGameNightCommand` cascade (finalize all sessions, mark night Completed)
- `GetCurrentSessionQuery` for client orphan recovery (GET /sessions/current)
- `ResumeSessionCommand` transactional atomicity fix (IUnitOfWork wrapping)

Zero breaking changes on existing aggregates. 4 new columns on `Session` + 1 new enum value on `GameNightStatus` (InProgress).

## Test plan

### Plan 1 (31/31 green)
- [x] Unit: Session turn order domain tests (3/3)
- [x] Unit: GameNightEvent ad-hoc tests (4/4)
- [x] Integration: GetKbReadinessQuery (4/4)
- [x] Integration: CreateSessionCommand ad-hoc (5/5)
- [x] Integration: Pause/Resume with auto-pause (4/4)
- [x] Integration: SetTurnOrderCommand (3/3)
- [x] Integration: Dice roll diary emission (1/1)
- [x] Integration: UpsertScoreWithDiaryCommand (3/3)
- [x] Integration: Diary queries (3/3)
- [x] E2E: full happy path (1/1)

### Plan 1bis (23/23 green or compile-verified)
- [x] Domain: Session.AdvanceTurn cyclic tests (7/7)
- [x] Integration: AdvanceTurnCommand (compile-verified, Docker CI)
- [x] Unit: FinalizeSession diary emission (7/7)
- [x] Domain: GameNightEvent.CompleteAdHoc (6/6)
- [x] Integration: CompleteGameNightCommand cascade (5/5 compile-verified)
- [x] Unit: GetCurrentSessionQuery (5/5)

## Out of scope (Plan 2: Frontend)
- Frontend Contextual Hand + Session/GameNight pages
- Playwright E2E
- SSE diary stream (v2.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
