### PR TITLE
feat(dev): MeepleDev Phase 2 M0 — scaffold panel + backend endpoints

### DIFF
--- a/apps/api/src/Api/DevTools/Http/DevToggleDtos.cs
+++ b/apps/api/src/Api/DevTools/Http/DevToggleDtos.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+namespace Api.DevTools.Http;
+
+/// <summary>Response shape for GET /dev/toggles and POST /dev/toggles/reset.</summary>
+internal sealed record GetTogglesResponse
+{
+    public required IReadOnlyDictionary<string, bool> Toggles { get; init; }
+    public required IReadOnlyList<string> KnownServices { get; init; }
+}
+
+/// <summary>Request body for PATCH /dev/toggles. Partial update.</summary>
+internal sealed record PatchTogglesRequest
+{
+    public required Dictionary<string, bool> Toggles { get; init; }
+}
+
+/// <summary>Response shape for PATCH /dev/toggles.</summary>
+internal sealed record PatchTogglesResponse
+{
+    public required IReadOnlyList<string> Updated { get; init; }
+    public required IReadOnlyDictionary<string, bool> Toggles { get; init; }
+}
+
+/// <summary>Error response shape for 4xx/5xx.</summary>
+internal sealed record DevToolsErrorResponse
+{
+    public required string Error { get; init; }
+    public required string Message { get; init; }
+    public IReadOnlyList<string>? UnknownKeys { get; init; }
+    public string? TraceId { get; init; }
+}

--- a/apps/api/src/Api/DevTools/Http/DevToolsEndpoints.cs
+++ b/apps/api/src/Api/DevTools/Http/DevToolsEndpoints.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Logging;
+
+namespace Api.DevTools.Http;
+
+internal static class DevToolsEndpoints
+{
+    public static Ok<GetTogglesResponse> GetToggles(IMockToggleReader reader)
+    {
+        var toggles = reader.GetAll();
+        var known = KnownMockServices.All;
+        return TypedResults.Ok(new GetTogglesResponse
+        {
+            Toggles = toggles,
+            KnownServices = known,
+        });
+    }
+
+    public static Results<Ok<PatchTogglesResponse>, BadRequest<DevToolsErrorResponse>> PatchToggles(
+        PatchTogglesRequest request,
+        IMockToggleReader reader,
+        IMockToggleWriter writer,
+        ILogger<DevToolsRoot> logger)
+    {
+        if (request.Toggles.Count == 0)
+        {
+            return TypedResults.BadRequest(new DevToolsErrorResponse
+            {
+                Error = "empty-request",
+                Message = "PATCH /dev/toggles requires at least one toggle in the body",
+            });
+        }
+
+        var unknownKeys = request.Toggles.Keys
+            .Where(k => !KnownMockServices.All.Contains(k, System.StringComparer.OrdinalIgnoreCase))
+            .ToList();
+        if (unknownKeys.Count > 0)
+        {
+            return TypedResults.BadRequest(new DevToolsErrorResponse
+            {
+                Error = "unknown-service",
+                Message = $"Unknown mock service(s): {string.Join(", ", unknownKeys)}. Known: {string.Join(", ", KnownMockServices.All)}",
+                UnknownKeys = unknownKeys,
+            });
+        }
+
+        var updated = new List<string>();
+        foreach (var kv in request.Toggles)
+        {
+            writer.Set(kv.Key, kv.Value);
+            updated.Add(kv.Key);
+            logger.LogInformation("DevTools: toggle '{Service}' set to {Value} (via PATCH /dev/toggles)", kv.Key, kv.Value);
+        }
+
+        return TypedResults.Ok(new PatchTogglesResponse
+        {
+            Updated = updated,
+            Toggles = reader.GetAll(),
+        });
+    }
+
+    public static Ok<GetTogglesResponse> ResetToggles(
+        IMockToggleReader reader,
+        MockToggleStateProvider provider,
+        ILogger<DevToolsRoot> logger)
+    {
+        provider.ResetToDefaults();
+        logger.LogInformation("DevTools: all toggles reset to env defaults");
+        return TypedResults.Ok(new GetTogglesResponse
+        {
+            Toggles = reader.GetAll(),
+            KnownServices = KnownMockServices.All,
+        });
+    }
+
+    // Marker type used as generic parameter for ILogger<T> — intentionally empty.
+#pragma warning disable S2094 // Classes should not be empty
+    internal sealed class DevToolsRoot { }
+#pragma warning restore S2094
+}

--- a/apps/api/src/Api/DevTools/Http/DevToolsEndpointsExtensions.cs
+++ b/apps/api/src/Api/DevTools/Http/DevToolsEndpointsExtensions.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Api.DevTools.Http;
+
+internal static class DevToolsEndpointsExtensions
+{
+    public static IEndpointRouteBuilder MapMeepleDevTools(this IEndpointRouteBuilder app)
+    {
+        var env = app.ServiceProvider.GetRequiredService<IWebHostEnvironment>();
+        if (!env.IsDevelopment())
+        {
+            return app;
+        }
+
+        var group = app.MapGroup("/dev/toggles");
+        group.MapGet("/", DevToolsEndpoints.GetToggles).WithName("DevToolsGetToggles");
+        group.MapPatch("/", DevToolsEndpoints.PatchToggles).WithName("DevToolsPatchToggles");
+        group.MapPost("/reset", DevToolsEndpoints.ResetToggles).WithName("DevToolsResetToggles");
+
+        return app;
+    }
+}

--- a/apps/api/src/Api/DevTools/MockToggleStateProvider.cs
+++ b/apps/api/src/Api/DevTools/MockToggleStateProvider.cs
@@ -15,6 +15,7 @@ internal sealed class MockToggleStateProvider
 {
     private readonly ConcurrentDictionary<string, bool> _state;
     private readonly HashSet<string> _knownServices;
+    private readonly IReadOnlyDictionary<string, bool> _bootstrapDefaults;
 
     public event EventHandler<MockToggleChangedEventArgs>? ToggleChanged;
 
@@ -24,13 +25,16 @@ internal sealed class MockToggleStateProvider
     {
         _knownServices = new HashSet<string>(knownServiceNames, StringComparer.OrdinalIgnoreCase);
         _state = new ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+        var defaults = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
         foreach (var svc in _knownServices)
         {
             var envKey = $"MOCK_{svc.ToUpperInvariant()}";
             environment.TryGetValue(envKey, out var value);
             var mocked = string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
             _state[svc] = mocked;
+            defaults[svc] = mocked;
         }
+        _bootstrapDefaults = new ReadOnlyDictionary<string, bool>(defaults);
     }
 
     public bool IsMocked(string serviceName)
@@ -58,5 +62,18 @@ internal sealed class MockToggleStateProvider
         }
         _state[serviceName] = mocked;
         ToggleChanged?.Invoke(this, new MockToggleChangedEventArgs(serviceName, mocked));
+    }
+
+    public void ResetToDefaults()
+    {
+        foreach (var kvp in _bootstrapDefaults)
+        {
+            var previous = _state[kvp.Key];
+            _state[kvp.Key] = kvp.Value;
+            if (previous != kvp.Value)
+            {
+                ToggleChanged?.Invoke(this, new MockToggleChangedEventArgs(kvp.Key, kvp.Value));
+            }
+        }
     }
 }

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -474,6 +474,7 @@ var app = builder.Build();
 if (app.Environment.IsDevelopment())
 {
     Api.DevTools.DevToolsServiceCollectionExtensions.UseMeepleDevTools(app);
+    Api.DevTools.Http.DevToolsEndpointsExtensions.MapMeepleDevTools(app);
 }
 #endif
 

--- a/apps/api/tests/Api.Tests/DevTools/MockToggleStateProviderTests.cs
+++ b/apps/api/tests/Api.Tests/DevTools/MockToggleStateProviderTests.cs
@@ -102,4 +102,73 @@ public class MockToggleStateProviderTests
         Assert.True(snapshot["llm"]);
         Assert.IsAssignableFrom<IReadOnlyDictionary<string, bool>>(snapshot);
     }
+
+    [Fact]
+    public void ResetToDefaults_RestoresEnvBootstrapValues()
+    {
+        var env = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["MOCK_LLM"] = "true",
+            ["MOCK_EMBEDDING"] = "false",
+            ["MOCK_S3"] = "true"
+        };
+        var provider = new MockToggleStateProvider(env, new[] { "llm", "embedding", "s3" });
+
+        provider.Set("llm", false);
+        provider.Set("embedding", true);
+        provider.Set("s3", false);
+        Assert.False(provider.IsMocked("llm"));
+        Assert.True(provider.IsMocked("embedding"));
+        Assert.False(provider.IsMocked("s3"));
+
+        provider.ResetToDefaults();
+
+        Assert.True(provider.IsMocked("llm"));
+        Assert.False(provider.IsMocked("embedding"));
+        Assert.True(provider.IsMocked("s3"));
+    }
+
+    [Fact]
+    public async Task ResetToDefaults_ThreadSafe_WithConcurrentSets()
+    {
+        var env = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["MOCK_LLM"] = "false"
+        };
+        var provider = new MockToggleStateProvider(env, new[] { "llm" });
+
+        var tasks = new List<Task>();
+        for (int i = 0; i < 50; i++)
+        {
+            tasks.Add(Task.Run(() => provider.Set("llm", true)));
+            tasks.Add(Task.Run(() => provider.ResetToDefaults()));
+        }
+        await Task.WhenAll(tasks).ConfigureAwait(true);
+
+        var final = provider.IsMocked("llm");
+        Assert.True(final == true || final == false);
+    }
+
+    [Fact]
+    public void ResetToDefaults_FiresToggleChangedForChangedKeys()
+    {
+        var env = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["MOCK_LLM"] = "true",
+            ["MOCK_EMBEDDING"] = "true"
+        };
+        var provider = new MockToggleStateProvider(env, new[] { "llm", "embedding" });
+
+        provider.Set("llm", false);
+        provider.Set("embedding", false);
+
+        var fired = new List<MockToggleChangedEventArgs>();
+        provider.ToggleChanged += (_, args) => fired.Add(args);
+
+        provider.ResetToDefaults();
+
+        Assert.Equal(2, fired.Count);
+        Assert.Contains(fired, e => e.ServiceName == "llm" && e.Mocked);
+        Assert.Contains(fired, e => e.ServiceName == "embedding" && e.Mocked);
+    }
 }

--- a/apps/api/tests/Api.Tests/Integration/DevTools/DevToolsEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DevTools/DevToolsEndpointsIntegrationTests.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Api.DevTools;
+using Api.Infrastructure;
+using Api.Services;
+using Api.SharedKernel.Application.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Api.Tests.Integration.DevTools;
+
+/// <summary>
+/// Integration tests for the DevTools toggle HTTP endpoints:
+///   GET  /dev/toggles
+///   PATCH /dev/toggles
+///   POST /dev/toggles/reset
+///
+/// Uses "Testing" environment (skips secret validation) and manually wires
+/// AddMeepleDevTools + the endpoint routes via IStartupFilter/UseEndpoints.
+///
+/// Tests share a single WebApplicationFactory (IClassFixture) for startup performance.
+/// They are grouped in a collection to enforce sequential execution, since the
+/// MockToggleStateProvider singleton is shared across tests.
+/// </summary>
+[Collection("DevToolsEndpoints")]
+public class DevToolsEndpointsIntegrationTests
+    : IClassFixture<DevToolsEndpointsTestFactory>
+{
+    private readonly DevToolsEndpointsTestFactory _factory;
+
+    public DevToolsEndpointsIntegrationTests(DevToolsEndpointsTestFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GetToggles_ReturnsCurrentState()
+    {
+        using var client = _factory.CreateClient();
+
+        // Reset to env defaults first to ensure deterministic state regardless of test order
+        var resetResponse = await client.PostAsync("/dev/toggles/reset", null).ConfigureAwait(true);
+        Assert.Equal(HttpStatusCode.OK, resetResponse.StatusCode);
+
+        var response = await client.GetAsync("/dev/toggles").ConfigureAwait(true);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content
+            .ReadFromJsonAsync<TestGetTogglesResponse>()
+            .ConfigureAwait(true);
+
+        Assert.NotNull(body);
+        Assert.True(body!.Toggles.ContainsKey("llm"));
+        Assert.True(body.Toggles["llm"]);      // MOCK_LLM=true set in static ctor
+        Assert.False(body.Toggles["embedding"]); // MOCK_EMBEDDING=false set in static ctor
+        Assert.Contains("llm", body.KnownServices);
+    }
+
+    [Fact]
+    public async Task PatchToggles_UpdatesAndReturnsNewState()
+    {
+        using var client = _factory.CreateClient();
+        var response = await client.PatchAsJsonAsync("/dev/toggles", new
+        {
+            toggles = new Dictionary<string, bool> { ["llm"] = false }
+        }).ConfigureAwait(true);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content
+            .ReadFromJsonAsync<TestPatchTogglesResponse>()
+            .ConfigureAwait(true);
+
+        Assert.NotNull(body);
+        Assert.Contains("llm", body!.Updated);
+        Assert.False(body.Toggles["llm"]);
+    }
+
+    [Fact]
+    public async Task PatchToggles_UnknownService_Returns400()
+    {
+        using var client = _factory.CreateClient();
+        var response = await client.PatchAsJsonAsync("/dev/toggles", new
+        {
+            toggles = new Dictionary<string, bool> { ["nonexistent"] = true }
+        }).ConfigureAwait(true);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ResetToggles_RestoresEnvDefaults()
+    {
+        using var client = _factory.CreateClient();
+
+        // First flip llm to false
+        await client.PatchAsJsonAsync("/dev/toggles", new
+        {
+            toggles = new Dictionary<string, bool> { ["llm"] = false }
+        }).ConfigureAwait(true);
+
+        // Then reset
+        var response = await client.PostAsync("/dev/toggles/reset", null).ConfigureAwait(true);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content
+            .ReadFromJsonAsync<TestGetTogglesResponse>()
+            .ConfigureAwait(true);
+
+        Assert.NotNull(body);
+        // env default is MOCK_LLM=true (set in factory static ctor)
+        Assert.True(body!.Toggles["llm"]);
+    }
+
+    private sealed class TestGetTogglesResponse
+    {
+        public Dictionary<string, bool> Toggles { get; set; } = new();
+        public List<string> KnownServices { get; set; } = new();
+    }
+
+    private sealed class TestPatchTogglesResponse
+    {
+        public List<string> Updated { get; set; } = new();
+        public Dictionary<string, bool> Toggles { get; set; } = new();
+    }
+}
+
+/// <summary>
+/// WebApplicationFactory that boots the app in "Testing" environment
+/// (skipping secret validation) while manually wiring DevTools service
+/// registrations and endpoints. A fake IWebHostEnvironment reporting
+/// EnvironmentName="Development" is injected so that MapMeepleDevTools
+/// registers the /dev/toggles routes.
+/// </summary>
+public sealed class DevToolsEndpointsTestFactory : WebApplicationFactory<Program>
+{
+    /// <summary>
+    /// Set MOCK_LLM=true and MOCK_EMBEDDING=false before the host builds
+    /// so MockToggleStateProvider captures these as bootstrap defaults.
+    /// </summary>
+    static DevToolsEndpointsTestFactory()
+    {
+        Environment.SetEnvironmentVariable("MOCK_LLM", "true");
+        Environment.SetEnvironmentVariable("MOCK_EMBEDDING", "false");
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing"); // skips secret validation
+
+        builder.ConfigureAppConfiguration((_, cfg) =>
+        {
+            cfg.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["OPENROUTER_API_KEY"] = "test-key",
+                ["OPENROUTER_API_KEY_FILE"] = null,
+                ["ConnectionStrings:Postgres"] =
+                    "Host=localhost;Port=5432;Database=dummy;Username=dummy;Password=dummy",
+            });
+        });
+
+        builder.ConfigureServices(services =>
+        {
+            // InMemory DB — no real Postgres required
+            services.RemoveAll(typeof(DbContextOptions<MeepleAiDbContext>));
+            services.RemoveAll(typeof(MeepleAiDbContext));
+            services.AddDbContext<MeepleAiDbContext>(opts =>
+                opts.UseInMemoryDatabase("DevToolsEndpointsTestDb"));
+
+            // Mock Redis
+            services.RemoveAll(typeof(IConnectionMultiplexer));
+            var mockRedis = new Mock<IConnectionMultiplexer>();
+            var mockDb = new Mock<IDatabase>();
+            mockRedis.Setup(r => r.GetDatabase(It.IsAny<int>(), It.IsAny<object>()))
+                .Returns(mockDb.Object);
+            services.AddSingleton(mockRedis.Object);
+
+            // Mock EmbeddingService (external HTTP)
+            services.RemoveAll(typeof(IEmbeddingService));
+            services.AddScoped<IEmbeddingService>(_ => Mock.Of<IEmbeddingService>());
+
+            // Mock HybridCache
+            services.RemoveAll(typeof(IHybridCacheService));
+            services.AddScoped<IHybridCacheService>(_ => Mock.Of<IHybridCacheService>());
+
+            // DomainEventCollector is only registered in non-Testing path of
+            // InfrastructureServiceExtensions.AddDatabaseServices(); add it manually.
+            services.AddScoped<IDomainEventCollector, DomainEventCollector>();
+
+            // Wire DevTools services manually (guarded by #if DEBUG + IsDevelopment in Program.cs)
+            DevToolsServiceCollectionExtensions.AddMeepleDevTools(services);
+
+            // Wire DevTools middleware + endpoints via IStartupFilter.
+            // Routes are registered via UseEndpoints so they work in Testing environment
+            // without triggering the IsDevelopment() guard in MapMeepleDevTools.
+            services.AddSingleton<IStartupFilter, DevToolsEndpointsStartupFilter>();
+        });
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            Environment.SetEnvironmentVariable("MOCK_LLM", null);
+            Environment.SetEnvironmentVariable("MOCK_EMBEDDING", null);
+        }
+        base.Dispose(disposing);
+    }
+}
+
+/// <summary>
+/// IStartupFilter that wires both the MockHeaderMiddleware and the /dev/toggles
+/// routes directly using UseEndpoints, bypassing the IsDevelopment() guard in
+/// MapMeepleDevTools (which would block route registration in "Testing" env).
+/// </summary>
+internal sealed class DevToolsEndpointsStartupFilter : IStartupFilter
+{
+    public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+    {
+        return app =>
+        {
+            DevToolsServiceCollectionExtensions.UseMeepleDevTools(app);
+            next(app);
+
+            // Register /dev/toggles routes on top of the existing endpoint pipeline.
+            // UseEndpoints appends to the existing routing, not replacing it.
+            app.UseEndpoints(endpoints =>
+            {
+                var group = endpoints.MapGroup("/dev/toggles");
+                group.MapGet("/", Api.DevTools.Http.DevToolsEndpoints.GetToggles);
+                group.MapPatch("/", Api.DevTools.Http.DevToolsEndpoints.PatchToggles);
+                group.MapPost("/reset", Api.DevTools.Http.DevToolsEndpoints.ResetToggles);
+            });
+        };
+    }
+}

--- a/apps/web/__tests__/dev-tools/panel/devPanelClient.test.ts
+++ b/apps/web/__tests__/dev-tools/panel/devPanelClient.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { devPanelClient, DevPanelClientError } from '@/dev-tools/panel/api/devPanelClient';
+
+describe('devPanelClient', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('getToggles parses successful response', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        toggles: { llm: true, embedding: false },
+        knownServices: ['llm', 'embedding'],
+      }),
+      headers: new Headers(),
+    });
+    const result = await devPanelClient.getToggles();
+    expect(result.toggles.llm).toBe(true);
+    expect(result.knownServices).toEqual(['llm', 'embedding']);
+  });
+
+  it('getToggles sends X-Meepledev-Internal header', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ toggles: {}, knownServices: [] }),
+      headers: new Headers(),
+    });
+    global.fetch = fetchMock;
+    await devPanelClient.getToggles();
+    const headers = fetchMock.mock.calls[0][1]?.headers as Record<string, string>;
+    expect(headers['X-Meepledev-Internal']).toBe('1');
+  });
+
+  it('patchToggles posts batch body', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ updated: ['llm'], toggles: { llm: false, embedding: true } }),
+      headers: new Headers(),
+    });
+    global.fetch = fetchMock;
+    const result = await devPanelClient.patchToggles({ llm: false });
+    expect(result.updated).toEqual(['llm']);
+    expect(fetchMock.mock.calls[0][1]?.method).toBe('PATCH');
+  });
+
+  it('throws DevPanelClientError on 4xx response', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: 'unknown-service', message: 'Unknown' }),
+      headers: new Headers({ 'X-Trace-Id': 'abc123' }),
+    });
+    await expect(devPanelClient.patchToggles({ xyz: true })).rejects.toThrow(DevPanelClientError);
+  });
+
+  it('throws DevPanelClientError on network error', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new TypeError('network failure'));
+    await expect(devPanelClient.getToggles()).rejects.toThrow(DevPanelClientError);
+  });
+
+  it('resetToggles calls POST /reset', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ toggles: { llm: true }, knownServices: ['llm'] }),
+      headers: new Headers(),
+    });
+    global.fetch = fetchMock;
+    const result = await devPanelClient.resetToggles();
+    expect(result.toggles.llm).toBe(true);
+    expect(fetchMock.mock.calls[0][1]?.method).toBe('POST');
+    expect(fetchMock.mock.calls[0][0]).toContain('/reset');
+  });
+
+  it('aborts fetch after timeout (5s)', async () => {
+    vi.useFakeTimers();
+    let abortCalled = false;
+    global.fetch = vi.fn((_url, init) => {
+      const signal = (init as RequestInit)?.signal;
+      return new Promise((_resolve, reject) => {
+        if (signal) {
+          signal.addEventListener('abort', () => {
+            abortCalled = true;
+            reject(new DOMException('The operation was aborted.', 'AbortError'));
+          });
+        }
+      });
+    });
+    const promise = devPanelClient.getToggles();
+    vi.advanceTimersByTime(5500);
+    await expect(promise).rejects.toThrow();
+    expect(abortCalled).toBe(true);
+    vi.useRealTimers();
+  });
+});

--- a/apps/web/__tests__/dev-tools/panel/panelUiStore.test.ts
+++ b/apps/web/__tests__/dev-tools/panel/panelUiStore.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createPanelUiStore } from '@/dev-tools/panel/stores/panelUiStore';
+
+describe('panelUiStore', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('initializes with defaults when sessionStorage is empty', () => {
+    const store = createPanelUiStore();
+    const state = store.getState();
+    expect(state.isOpen).toBe(false);
+    expect(state.collapsed).toBe(false);
+    expect(state.activeTab).toBe('toggles');
+    expect(state.drawerWidth).toBe(420);
+  });
+
+  it('reads initial state from sessionStorage if present', () => {
+    sessionStorage.setItem('meepledev-panel-is-open', 'true');
+    sessionStorage.setItem('meepledev-panel-active-tab', 'inspector');
+    sessionStorage.setItem('meepledev-panel-collapsed', 'true');
+    sessionStorage.setItem('meepledev-panel-drawer-width', '600');
+    const store = createPanelUiStore();
+    const state = store.getState();
+    expect(state.isOpen).toBe(true);
+    expect(state.activeTab).toBe('inspector');
+    expect(state.collapsed).toBe(true);
+    expect(state.drawerWidth).toBe(600);
+  });
+
+  it('setOpen persists to sessionStorage', () => {
+    const store = createPanelUiStore();
+    store.getState().setOpen(true);
+    expect(sessionStorage.getItem('meepledev-panel-is-open')).toBe('true');
+    expect(store.getState().isOpen).toBe(true);
+  });
+
+  it('toggle flips isOpen', () => {
+    const store = createPanelUiStore();
+    expect(store.getState().isOpen).toBe(false);
+    store.getState().toggle();
+    expect(store.getState().isOpen).toBe(true);
+    store.getState().toggle();
+    expect(store.getState().isOpen).toBe(false);
+  });
+
+  it('setActiveTab persists', () => {
+    const store = createPanelUiStore();
+    store.getState().setActiveTab('scenarios');
+    expect(store.getState().activeTab).toBe('scenarios');
+    expect(sessionStorage.getItem('meepledev-panel-active-tab')).toBe('scenarios');
+  });
+
+  it('setCollapsed persists', () => {
+    const store = createPanelUiStore();
+    store.getState().setCollapsed(true);
+    expect(store.getState().collapsed).toBe(true);
+    expect(sessionStorage.getItem('meepledev-panel-collapsed')).toBe('true');
+  });
+
+  it('setDrawerWidth persists', () => {
+    const store = createPanelUiStore();
+    store.getState().setDrawerWidth(500);
+    expect(store.getState().drawerWidth).toBe(500);
+    expect(sessionStorage.getItem('meepledev-panel-drawer-width')).toBe('500');
+  });
+
+  it('falls back to in-memory state when sessionStorage throws', () => {
+    const originalSetItem = Storage.prototype.setItem;
+    Storage.prototype.setItem = () => {
+      throw new Error('QuotaExceededError');
+    };
+    const store = createPanelUiStore();
+    expect(() => store.getState().setOpen(true)).not.toThrow();
+    expect(store.getState().isOpen).toBe(true);
+    Storage.prototype.setItem = originalSetItem;
+  });
+
+  it('rejects invalid activeTab values from sessionStorage', () => {
+    sessionStorage.setItem('meepledev-panel-active-tab', 'malicious');
+    const store = createPanelUiStore();
+    expect(store.getState().activeTab).toBe('toggles');
+  });
+});

--- a/apps/web/__tests__/dev-tools/panel/useKeyboardShortcut.test.ts
+++ b/apps/web/__tests__/dev-tools/panel/useKeyboardShortcut.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useKeyboardShortcut } from '@/dev-tools/panel/hooks/useKeyboardShortcut';
+
+describe('useKeyboardShortcut', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fires handler on Ctrl+Shift+M', () => {
+    const handler = vi.fn();
+    renderHook(() => useKeyboardShortcut({ ctrl: true, shift: true, key: 'm' }, handler));
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'm', ctrlKey: true, shiftKey: true }));
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('fires handler on Cmd+Shift+M (macOS, metaKey)', () => {
+    const handler = vi.fn();
+    renderHook(() => useKeyboardShortcut({ ctrl: true, shift: true, key: 'm' }, handler));
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'm', metaKey: true, shiftKey: true }));
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT fire on Shift+M alone', () => {
+    const handler = vi.fn();
+    renderHook(() => useKeyboardShortcut({ ctrl: true, shift: true, key: 'm' }, handler));
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'm', shiftKey: true }));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire on Ctrl+M alone (no shift)', () => {
+    const handler = vi.fn();
+    renderHook(() => useKeyboardShortcut({ ctrl: true, shift: true, key: 'm' }, handler));
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'm', ctrlKey: true }));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('removes listener on unmount', () => {
+    const handler = vi.fn();
+    const { unmount } = renderHook(() =>
+      useKeyboardShortcut({ ctrl: true, shift: true, key: 'm' }, handler)
+    );
+    unmount();
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'm', ctrlKey: true, shiftKey: true }));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('matches key case-insensitively', () => {
+    const handler = vi.fn();
+    renderHook(() => useKeyboardShortcut({ ctrl: true, shift: true, key: 'm' }, handler));
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'M', ctrlKey: true, shiftKey: true }));
+    expect(handler).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/__tests__/dev-tools/panel/useQueryStringPanelOpen.test.ts
+++ b/apps/web/__tests__/dev-tools/panel/useQueryStringPanelOpen.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { createPanelUiStore } from '@/dev-tools/panel/stores/panelUiStore';
+import { useQueryStringPanelOpen } from '@/dev-tools/panel/hooks/useQueryStringPanelOpen';
+
+describe('useQueryStringPanelOpen', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('opens panel when ?devpanel=1 is in URL', () => {
+    window.history.replaceState({}, '', '/?devpanel=1');
+    const store = createPanelUiStore();
+    expect(store.getState().isOpen).toBe(false);
+    renderHook(() => useQueryStringPanelOpen(store));
+    expect(store.getState().isOpen).toBe(true);
+  });
+
+  it('strips devpanel param from URL after parsing', () => {
+    window.history.replaceState({}, '', '/?devpanel=1&other=keep');
+    const store = createPanelUiStore();
+    renderHook(() => useQueryStringPanelOpen(store));
+    expect(window.location.search).not.toContain('devpanel');
+    expect(window.location.search).toContain('other=keep');
+  });
+
+  it('does nothing when devpanel param is absent', () => {
+    window.history.replaceState({}, '', '/?other=value');
+    const store = createPanelUiStore();
+    renderHook(() => useQueryStringPanelOpen(store));
+    expect(store.getState().isOpen).toBe(false);
+    expect(window.location.search).toContain('other=value');
+  });
+
+  it('does nothing when devpanel=0', () => {
+    window.history.replaceState({}, '', '/?devpanel=0');
+    const store = createPanelUiStore();
+    renderHook(() => useQueryStringPanelOpen(store));
+    expect(store.getState().isOpen).toBe(false);
+  });
+});

--- a/apps/web/src/app/mock-provider.tsx
+++ b/apps/web/src/app/mock-provider.tsx
@@ -11,7 +11,7 @@
  * Generarlo con: cd apps/web && npx msw init public/ --save
  */
 
-import { useEffect, useState, type ComponentType } from 'react';
+import { useEffect, useRef, useState, type ComponentType } from 'react';
 
 const IS_DEV_MOCK =
   process.env.NODE_ENV === 'development' && process.env.NEXT_PUBLIC_MOCK_MODE === 'true';
@@ -34,6 +34,8 @@ type DevBadgeComponent = ComponentType<{
   scenarioStore: unknown;
   authStore: unknown;
 }>;
+
+type DevPanelMountComponent = ComponentType<{ uiStore: unknown }>;
 
 interface MockProviderProps {
   children: React.ReactNode;
@@ -85,6 +87,9 @@ export function MockProvider({ children }: MockProviderProps) {
   const [ready, setReady] = useState(false);
   const [tools, setTools] = useState<DevToolsBundle | null>(null);
   const [DevBadge, setDevBadge] = useState<DevBadgeComponent | null>(null);
+  const [DevPanelMountComp, setDevPanelMountComp] = useState<DevPanelMountComponent | null>(null);
+  // Track if panel mount has been loaded to avoid duplicate imports
+  const panelMountLoaded = useRef(false);
 
   useEffect(() => {
     if (!IS_DEV_MOCK) return;
@@ -99,8 +104,22 @@ export function MockProvider({ children }: MockProviderProps) {
       import(`${'@'}/dev-tools/devBadge` as string),
     ])
       .then(([devTools, badgeModule]) => {
-        setTools((devTools as { installDevTools: () => DevToolsBundle }).installDevTools());
+        const installed = (
+          devTools as { installDevTools: () => DevToolsBundle & { panel?: { uiStore: unknown } } }
+        ).installDevTools();
+        setTools(installed);
         setDevBadge(() => (badgeModule as { DevBadge: DevBadgeComponent }).DevBadge);
+        // Load DevPanelMount lazily (same bundle, just isolated via dynamic import)
+        if (installed.panel && !panelMountLoaded.current) {
+          panelMountLoaded.current = true;
+          import(`${'@'}/dev-tools/panel/DevPanelMount` as string)
+            .then(mod => {
+              setDevPanelMountComp(
+                () => (mod as { DevPanelMount: DevPanelMountComponent }).DevPanelMount
+              );
+            })
+            .catch(() => {});
+        }
       })
       .catch(() => {
         // dev-tools module not present (e.g. tree-shaken in prod) — silently skip
@@ -141,6 +160,14 @@ export function MockProvider({ children }: MockProviderProps) {
           authStore={tools.authStore}
         />
       )}
+      {IS_DEV_MOCK &&
+        tools &&
+        DevPanelMountComp &&
+        (tools as DevToolsBundle & { panel?: { uiStore: unknown } }).panel && (
+          <DevPanelMountComp
+            uiStore={(tools as DevToolsBundle & { panel?: { uiStore: unknown } }).panel!.uiStore}
+          />
+        )}
     </>
   );
 }

--- a/apps/web/src/dev-tools/install.ts
+++ b/apps/web/src/dev-tools/install.ts
@@ -2,6 +2,7 @@ import { setScenarioBridge } from '@/mocks/scenarioBridge';
 
 import { createMockAuthStore, readRoleFromEnv, readRoleFromQueryString } from './mockAuthStore';
 import { createMockControlStore, parseGroupList } from './mockControlCore';
+import { installPanel } from './panel';
 import { SCENARIO_MANIFEST } from './scenarioManifest';
 import { createScenarioStore } from './scenarioStore';
 import { validateScenario, SCENARIO_FALLBACK } from './scenarioValidator';
@@ -42,6 +43,7 @@ export interface InstalledDevTools {
   controlStore: ReturnType<typeof createMockControlStore>;
   scenarioStore: ReturnType<typeof createScenarioStore>;
   authStore: ReturnType<typeof createMockAuthStore>;
+  panel?: { uiStore: unknown };
 }
 
 export function installDevTools(): InstalledDevTools {
@@ -89,5 +91,7 @@ export function installDevTools(): InstalledDevTools {
     );
   }
 
-  return { controlStore, scenarioStore, authStore };
+  const panel = installPanel();
+
+  return { controlStore, scenarioStore, authStore, panel };
 }

--- a/apps/web/src/dev-tools/panel/DevPanel.tsx
+++ b/apps/web/src/dev-tools/panel/DevPanel.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import type { DevPanelTab } from '@/dev-tools/types';
+
+import { useStoreSlice } from './hooks/useStoreSlice';
+
+import type { PanelUiState } from './stores/panelUiStore';
+import type { StoreApi } from 'zustand/vanilla';
+
+export interface DevPanelProps {
+  uiStore: StoreApi<PanelUiState>;
+}
+
+const TABS: { id: DevPanelTab; label: string }[] = [
+  { id: 'toggles', label: 'Toggles' },
+  { id: 'scenarios', label: 'Scenarios' },
+  { id: 'auth', label: 'Auth' },
+  { id: 'inspector', label: 'Inspector' },
+];
+
+export function DevPanel({ uiStore }: DevPanelProps): React.JSX.Element | null {
+  const isOpen = useStoreSlice(uiStore, s => s.isOpen);
+  const activeTab = useStoreSlice(uiStore, s => s.activeTab);
+  const drawerWidth = useStoreSlice(uiStore, s => s.drawerWidth);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      data-testid="dev-panel"
+      role="dialog"
+      aria-modal="false"
+      aria-label="MeepleDev Panel"
+      style={{
+        position: 'fixed',
+        top: 0,
+        right: 0,
+        bottom: 0,
+        width: drawerWidth,
+        background: '#111827',
+        color: '#f9fafb',
+        boxShadow: '-4px 0 24px rgba(0,0,0,0.5)',
+        zIndex: 99998,
+        display: 'flex',
+        flexDirection: 'column',
+        fontFamily: 'monospace',
+      }}
+    >
+      <header
+        style={{
+          padding: '12px 16px',
+          borderBottom: '1px solid #374151',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <strong style={{ fontSize: 13, color: '#f59e0b' }}>MeepleDev Panel</strong>
+        <button
+          type="button"
+          onClick={() => uiStore.getState().setOpen(false)}
+          aria-label="Close Dev Panel"
+          style={{
+            background: 'transparent',
+            color: '#f9fafb',
+            border: 'none',
+            cursor: 'pointer',
+            fontSize: 16,
+          }}
+        >
+          ×
+        </button>
+      </header>
+      <div
+        role="tablist"
+        aria-label="Dev Panel sections"
+        style={{ display: 'flex', borderBottom: '1px solid #374151' }}
+      >
+        {TABS.map(tab => (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === tab.id}
+            data-testid={`panel-tab-${tab.id}`}
+            onClick={() => uiStore.getState().setActiveTab(tab.id)}
+            style={{
+              flex: 1,
+              padding: '8px 12px',
+              background: activeTab === tab.id ? '#1f2937' : 'transparent',
+              color: activeTab === tab.id ? '#f59e0b' : '#9ca3af',
+              border: 'none',
+              borderBottom: activeTab === tab.id ? '2px solid #f59e0b' : '2px solid transparent',
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+              fontSize: 11,
+            }}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div
+        role="tabpanel"
+        aria-labelledby={`panel-tab-${activeTab}`}
+        style={{ flex: 1, padding: 16, overflow: 'auto' }}
+      >
+        <p style={{ color: '#9ca3af', fontSize: 12 }}>
+          [{activeTab}] section content — coming in M
+          {activeTab === 'toggles'
+            ? '1'
+            : activeTab === 'scenarios' || activeTab === 'auth'
+              ? '2'
+              : '3'}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/dev-tools/panel/DevPanelMount.tsx
+++ b/apps/web/src/dev-tools/panel/DevPanelMount.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { DevPanel } from './DevPanel';
+import { useKeyboardShortcut } from './hooks/useKeyboardShortcut';
+import { useQueryStringPanelOpen } from './hooks/useQueryStringPanelOpen';
+
+import type { PanelUiState } from './stores/panelUiStore';
+import type { StoreApi } from 'zustand/vanilla';
+
+export interface DevPanelMountProps {
+  uiStore: StoreApi<PanelUiState>;
+}
+
+export function DevPanelMount({ uiStore }: DevPanelMountProps): React.JSX.Element {
+  useKeyboardShortcut({ ctrl: true, shift: true, key: 'm' }, () => {
+    uiStore.getState().toggle();
+  });
+  useQueryStringPanelOpen(uiStore);
+  return <DevPanel uiStore={uiStore} />;
+}

--- a/apps/web/src/dev-tools/panel/README.md
+++ b/apps/web/src/dev-tools/panel/README.md
@@ -1,0 +1,33 @@
+# dev-tools/panel
+
+Dev Panel sub-module for MeepleDev Phase 2. Provides a fixed right-side drawer with 4 tabs (Toggles, Scenarios, Auth, Inspector). Tab content is filled in M1-M3.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `DevPanel.tsx` | Drawer UI shell — inline styles only, no Tailwind, ARIA compliant |
+| `DevPanelMount.tsx` | Mounts DevPanel + wires keyboard shortcut (Ctrl+Shift+M) + URL param (`?devpanel=1`) |
+| `installPanel.ts` | Bootstrap function — creates panelUiStore, fires prefetch |
+| `index.ts` | Barrel export |
+| `api/devPanelErrors.ts` | `DevPanelClientError` class |
+| `api/devPanelClient.ts` | HTTP client for `/dev/toggles` (GET/PATCH/POST reset) |
+| `hooks/useStoreSlice.ts` | Zustand vanilla → React bridge |
+| `hooks/useKeyboardShortcut.ts` | Generic keyboard shortcut hook |
+| `hooks/useQueryStringPanelOpen.ts` | Opens panel when `?devpanel=1` is present in URL |
+| `stores/panelUiStore.ts` | Zustand vanilla store with sessionStorage persistence |
+
+## Architecture
+
+- **No global styles**: DevPanel uses inline styles to avoid polluting app CSS
+- **Vanilla Zustand**: `StoreApi<PanelUiState>` is passed as prop — no React context required
+- **Tree-shakeable**: entire panel module is dynamically imported by `mock-provider.tsx`
+- **Keyboard**: `Ctrl+Shift+M` (or `Cmd+Shift+M` on macOS) toggles the drawer
+- **URL**: `?devpanel=1` opens the drawer on load and cleans the query string
+
+## Usage
+
+```tsx
+// Automatically mounted by mock-provider.tsx when NEXT_PUBLIC_MOCK_MODE=true
+// Manual open: Ctrl+Shift+M or append ?devpanel=1 to any dev URL
+```

--- a/apps/web/src/dev-tools/panel/api/devPanelClient.ts
+++ b/apps/web/src/dev-tools/panel/api/devPanelClient.ts
@@ -1,0 +1,66 @@
+import type { BackendTogglesState } from '@/dev-tools/types';
+
+import { DevPanelClientError } from './devPanelErrors';
+
+export { DevPanelClientError };
+
+export interface PatchTogglesResponse {
+  updated: string[];
+  toggles: Record<string, boolean>;
+}
+
+const BASE_URL = '/dev/toggles';
+const INTERNAL_HEADER = { 'X-Meepledev-Internal': '1' } as const;
+const TIMEOUT_MS = 5000;
+
+async function fetchJson<T>(input: string, init: RequestInit): Promise<T> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const response = await fetch(input, {
+      ...init,
+      signal: controller.signal,
+      headers: { ...INTERNAL_HEADER, 'Content-Type': 'application/json', ...(init.headers ?? {}) },
+    });
+    if (!response.ok) {
+      let errorBody: { error?: string; message?: string } = {};
+      try {
+        errorBody = await response.json();
+      } catch {
+        /* ignore */
+      }
+      throw new DevPanelClientError(
+        errorBody.message ?? `${input} failed with status ${response.status}`,
+        response.status,
+        { traceId: response.headers.get('X-Trace-Id') ?? undefined }
+      );
+    }
+    return (await response.json()) as T;
+  } catch (err) {
+    if (err instanceof DevPanelClientError) throw err;
+    throw new DevPanelClientError(err instanceof Error ? err.message : String(err), 0, {
+      cause: err,
+    });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+export async function getToggles(): Promise<BackendTogglesState> {
+  return fetchJson<BackendTogglesState>(BASE_URL, { method: 'GET' });
+}
+
+export async function patchToggles(
+  toggles: Record<string, boolean>
+): Promise<PatchTogglesResponse> {
+  return fetchJson<PatchTogglesResponse>(BASE_URL, {
+    method: 'PATCH',
+    body: JSON.stringify({ toggles }),
+  });
+}
+
+export async function resetToggles(): Promise<BackendTogglesState> {
+  return fetchJson<BackendTogglesState>(`${BASE_URL}/reset`, { method: 'POST' });
+}
+
+export const devPanelClient = { getToggles, patchToggles, resetToggles } as const;

--- a/apps/web/src/dev-tools/panel/api/devPanelErrors.ts
+++ b/apps/web/src/dev-tools/panel/api/devPanelErrors.ts
@@ -1,0 +1,11 @@
+export class DevPanelClientError extends Error {
+  public readonly status: number;
+  public readonly traceId?: string;
+
+  constructor(message: string, status: number, options?: { cause?: unknown; traceId?: string }) {
+    super(message, options?.cause ? { cause: options.cause } : undefined);
+    this.name = 'DevPanelClientError';
+    this.status = status;
+    this.traceId = options?.traceId;
+  }
+}

--- a/apps/web/src/dev-tools/panel/hooks/useKeyboardShortcut.ts
+++ b/apps/web/src/dev-tools/panel/hooks/useKeyboardShortcut.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+
+export interface KeyboardShortcut {
+  ctrl?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+  key: string;
+}
+
+export function useKeyboardShortcut(combo: KeyboardShortcut, handler: () => void): void {
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key.toLowerCase() !== combo.key.toLowerCase()) return;
+      if (combo.ctrl && !event.ctrlKey && !event.metaKey) return;
+      if (combo.shift && !event.shiftKey) return;
+      if (combo.alt && !event.altKey) return;
+      handler();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, [combo.ctrl, combo.shift, combo.alt, combo.key, handler]);
+}

--- a/apps/web/src/dev-tools/panel/hooks/useQueryStringPanelOpen.ts
+++ b/apps/web/src/dev-tools/panel/hooks/useQueryStringPanelOpen.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+
+import type { PanelUiState } from '@/dev-tools/panel/stores/panelUiStore';
+
+import type { StoreApi } from 'zustand/vanilla';
+
+export function useQueryStringPanelOpen(store: StoreApi<PanelUiState>): void {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('devpanel') === '1') {
+      store.getState().setOpen(true);
+      params.delete('devpanel');
+      const newSearch = params.toString();
+      const newUrl =
+        window.location.pathname + (newSearch ? `?${newSearch}` : '') + window.location.hash;
+      window.history.replaceState({}, '', newUrl);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/apps/web/src/dev-tools/panel/hooks/useStoreSlice.ts
+++ b/apps/web/src/dev-tools/panel/hooks/useStoreSlice.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react';
+
+import type { StoreApi } from 'zustand/vanilla';
+
+export function useStoreSlice<T, U>(store: StoreApi<T>, selector: (state: T) => U): U {
+  const [slice, setSlice] = useState<U>(() => selector(store.getState()));
+  useEffect(() => {
+    return store.subscribe(state => {
+      setSlice(selector(state));
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [store]);
+  return slice;
+}

--- a/apps/web/src/dev-tools/panel/index.ts
+++ b/apps/web/src/dev-tools/panel/index.ts
@@ -1,0 +1,4 @@
+export { installPanel, type InstalledPanel } from './installPanel';
+export { DevPanel, type DevPanelProps } from './DevPanel';
+export { DevPanelMount, type DevPanelMountProps } from './DevPanelMount';
+export type { PanelUiState } from './stores/panelUiStore';

--- a/apps/web/src/dev-tools/panel/installPanel.ts
+++ b/apps/web/src/dev-tools/panel/installPanel.ts
@@ -1,0 +1,17 @@
+import { devPanelClient } from './api/devPanelClient';
+import { createPanelUiStore, type PanelUiState } from './stores/panelUiStore';
+
+import type { StoreApi } from 'zustand/vanilla';
+
+export interface InstalledPanel {
+  uiStore: StoreApi<PanelUiState>;
+}
+
+export function installPanel(): InstalledPanel {
+  const uiStore = createPanelUiStore();
+  void devPanelClient.getToggles().catch(() => {});
+  if (typeof console !== 'undefined') {
+    console.warn('[MeepleDev Phase 2] Dev Panel installed. Press Ctrl+Shift+M to open.');
+  }
+  return { uiStore };
+}

--- a/apps/web/src/dev-tools/panel/stores/panelUiStore.ts
+++ b/apps/web/src/dev-tools/panel/stores/panelUiStore.ts
@@ -1,0 +1,92 @@
+import { createStore, type StoreApi } from 'zustand/vanilla';
+
+import type { DevPanelTab } from '@/dev-tools/types';
+
+export interface PanelUiState {
+  isOpen: boolean;
+  collapsed: boolean;
+  activeTab: DevPanelTab;
+  drawerWidth: number;
+
+  setOpen: (open: boolean) => void;
+  toggle: () => void;
+  setCollapsed: (c: boolean) => void;
+  setActiveTab: (tab: DevPanelTab) => void;
+  setDrawerWidth: (w: number) => void;
+}
+
+const KEYS = {
+  isOpen: 'meepledev-panel-is-open',
+  collapsed: 'meepledev-panel-collapsed',
+  activeTab: 'meepledev-panel-active-tab',
+  drawerWidth: 'meepledev-panel-drawer-width',
+} as const;
+
+const VALID_TABS: DevPanelTab[] = ['toggles', 'scenarios', 'auth', 'inspector'];
+
+function safeRead(key: string): string | null {
+  try {
+    return typeof sessionStorage !== 'undefined' ? sessionStorage.getItem(key) : null;
+  } catch {
+    return null;
+  }
+}
+
+function safeWrite(key: string, value: string): void {
+  try {
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.setItem(key, value);
+    }
+  } catch {
+    /* quota exceeded — in-memory fallback */
+  }
+}
+
+function readBool(key: string, defaultValue: boolean): boolean {
+  const raw = safeRead(key);
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  return defaultValue;
+}
+
+function readTab(key: string, defaultValue: DevPanelTab): DevPanelTab {
+  const raw = safeRead(key);
+  return VALID_TABS.includes(raw as DevPanelTab) ? (raw as DevPanelTab) : defaultValue;
+}
+
+function readInt(key: string, defaultValue: number): number {
+  const raw = safeRead(key);
+  const parsed = raw ? parseInt(raw, 10) : NaN;
+  return Number.isFinite(parsed) ? parsed : defaultValue;
+}
+
+export function createPanelUiStore(): StoreApi<PanelUiState> {
+  return createStore<PanelUiState>((set, get) => ({
+    isOpen: readBool(KEYS.isOpen, false),
+    collapsed: readBool(KEYS.collapsed, false),
+    activeTab: readTab(KEYS.activeTab, 'toggles'),
+    drawerWidth: readInt(KEYS.drawerWidth, 420),
+
+    setOpen: (open: boolean) => {
+      safeWrite(KEYS.isOpen, String(open));
+      set({ isOpen: open });
+    },
+    toggle: () => {
+      const next = !get().isOpen;
+      safeWrite(KEYS.isOpen, String(next));
+      set({ isOpen: next });
+    },
+    setCollapsed: (c: boolean) => {
+      safeWrite(KEYS.collapsed, String(c));
+      set({ collapsed: c });
+    },
+    setActiveTab: (tab: DevPanelTab) => {
+      safeWrite(KEYS.activeTab, tab);
+      set({ activeTab: tab });
+    },
+    setDrawerWidth: (w: number) => {
+      safeWrite(KEYS.drawerWidth, String(w));
+      set({ drawerWidth: w });
+    },
+  }));
+}

--- a/apps/web/src/dev-tools/types.ts
+++ b/apps/web/src/dev-tools/types.ts
@@ -81,3 +81,28 @@ export interface ToggleConfig {
   groups: GroupToggles;
   overrides: EndpointOverrides;
 }
+
+// ============================================================================
+// Phase 2 — Dev Panel runtime types
+// ============================================================================
+
+/** Tab identifiers for the Dev Panel. */
+export type DevPanelTab = 'toggles' | 'scenarios' | 'auth' | 'inspector';
+
+/** Backend toggles state returned by GET /dev/toggles. */
+export interface BackendTogglesState {
+  toggles: Record<string, boolean>;
+  knownServices: string[];
+}
+
+/** Request inspector entry (ring buffer item). */
+export interface InspectorEntry {
+  id: string;
+  timestamp: number;
+  method: string;
+  url: string;
+  status: number;
+  durationMs: number;
+  isMock: boolean;
+  mockSource?: string;
+}


### PR DESCRIPTION
## Summary

Milestone M0 del piano Phase 2 MeepleDev: scaffold completo per il Dev Panel runtime UI + 3 backend HTTP endpoints.

- **Backend** (3 endpoint gated `env.IsDevelopment()`):
  - `GET /dev/toggles` — stato corrente toggle mock/real
  - `PATCH /dev/toggles` — batch update con validazione unknown keys
  - `POST /dev/toggles/reset` — reset a valori env bootstrap
  - `MockToggleStateProvider.ResetToDefaults()` con bootstrap cache
  - 4 integration tests + 3 unit tests nuovi

- **Frontend** (panel/ sub-module isolato):
  - `DevPanel.tsx` — drawer fisso destro (420px, dark theme, inline styles, ARIA dialog + tablist)
  - `panelUiStore` — Zustand vanilla + sessionStorage persistence (9 unit tests)
  - `useKeyboardShortcut` — Ctrl+Shift+M / Cmd+Shift+M toggle (6 tests)
  - `useQueryStringPanelOpen` — `?devpanel=1` auto-open + URL strip (4 tests)
  - `devPanelClient` — HTTP client con 5s abort timeout + `X-Meepledev-Internal` header (7 tests)
  - `useStoreSlice` — Zustand vanilla → React bridge
  - `installPanel` → `install.ts` → `mock-provider.tsx` wiring completo

Dopo M0: `Ctrl+Shift+M` apre un drawer vuoto con 4 tab nav (Toggles, Scenarios, Auth, Inspector).

## Test results

- Frontend: **70/70** test passano (12 file: dev-tools + mocks + integration)
- Backend: **14/14** DevTools test passano (10 unit + 4 integration)
- TypeScript: clean, 0 errori
- Build: frontend + backend prod OK

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test __tests__/dev-tools __tests__/mocks __tests__/integration/dev-tools` → 70/70
- [x] `dotnet test --filter "DevTools"` → 14/14
- [x] `pnpm build` (pre-push) → OK
- [x] `dotnet build -c Release` (pre-push) → OK
- [ ] E2E browser: `Ctrl+Shift+M` opens drawer (M4 e2e spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)