### PR TITLE
feat(agent-drawer): wire CardDetailModal + agent card opens drawer

### DIFF
--- a/apps/web/src/app/(authenticated)/agents/page.tsx
+++ b/apps/web/src/app/(authenticated)/agents/page.tsx
@@ -33,6 +33,7 @@ import { Input } from '@/components/ui/primitives/input';
 import { useAgents } from '@/hooks/queries/useAgents';
 import { useAgentSlots } from '@/hooks/queries/useAgentSlots';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import { useNavigation } from '@/hooks/useNavigation';
 import { useResponsive } from '@/hooks/useResponsive';
 import { useCardHand } from '@/stores/use-card-hand';
 
@@ -59,6 +60,7 @@ function AgentCard({
 
 export default function AgentsPage() {
   const router = useRouter();
+  const { openDetail } = useNavigation();
   const { drawCard } = useCardHand();
   const [searchQuery, setSearchQuery] = useState('');
   const [typeFilter, setTypeFilter] = useState<string>('all');
@@ -252,7 +254,7 @@ export default function AgentsPage() {
           <AgentCard
             key={agent.id}
             agent={agent}
-            onClick={() => router.push(`/agents/${agent.id}`)}
+            onClick={() => openDetail(agent.id, 'agent')}
           />
         ))}
         {isLoadingMore && <CardGridSkeletons count={4} />}

--- a/apps/web/src/components/layout/UserShell/UserShellClient.tsx
+++ b/apps/web/src/components/layout/UserShell/UserShellClient.tsx
@@ -3,6 +3,7 @@
 import { Suspense, type ReactNode } from 'react';
 
 import { DashboardEngineProvider } from '@/components/dashboard';
+import { CardDetailModal } from '@/components/features/common/CardDetailModal';
 import { BackToSessionFAB } from '@/components/session/BackToSessionFAB';
 
 import { DesktopShell } from './DesktopShell';
@@ -18,6 +19,7 @@ export function UserShellClient({ children }: UserShellClientProps) {
       <Suspense>
         <BackToSessionFAB />
       </Suspense>
+      <CardDetailModal />
     </DesktopShell>
   );
 }


### PR DESCRIPTION
## Summary

- Mount `CardDetailModal` in `UserShellClient` so the entity drawer is available on all authenticated pages
- Agent list page (`/agents`): click on agent card now calls `openDetail(agentId, 'agent')` which opens the new 2-column `AgentChatDrawerLayout` (PR #362) instead of navigating to `/agents/[id]`

## Files Changed (2)

- `apps/web/src/components/layout/UserShell/UserShellClient.tsx` — add `<CardDetailModal />`
- `apps/web/src/app/(authenticated)/agents/page.tsx` — import `useNavigation`, replace `router.push` with `openDetail`

## Test Plan

- [ ] Navigate to `/agents`, click any agent card — drawer opens from right (800px, 2-column layout)
- [ ] Drawer shows: sidebar (game context, new chat, recent chats, KB) + chat area
- [ ] Close drawer with X or Escape — returns to agent list
- [ ] Other entity drawers (game, chat, kb) still work on their respective pages

🤖 Generated with [Claude Code](https://claude.ai/claude-code)