### PR TITLE
feat(dev): MeepleDev Phase 2 M1 — Toggles section (MSW + backend)

### DIFF
--- a/apps/web/__tests__/dev-tools/panel/useBackendTogglesMutation.test.ts
+++ b/apps/web/__tests__/dev-tools/panel/useBackendTogglesMutation.test.ts
@@ -1,25 +1,46 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
+import { DevPanelClientError } from '@/dev-tools/panel/api/devPanelErrors';
+
+// Mock the entire module so both named exports AND devPanelClient object methods are intercepted
+vi.mock('@/dev-tools/panel/api/devPanelClient', async () => {
+  const { DevPanelClientError: RealError } = await vi.importActual<
+    typeof import('@/dev-tools/panel/api/devPanelClient')
+  >('@/dev-tools/panel/api/devPanelClient');
+  return {
+    DevPanelClientError: RealError,
+    getToggles: vi.fn(),
+    patchToggles: vi.fn(),
+    resetToggles: vi.fn(),
+    devPanelClient: {
+      getToggles: vi.fn(),
+      patchToggles: vi.fn(),
+      resetToggles: vi.fn(),
+    },
+  };
+});
+
 import { useBackendTogglesMutation } from '@/dev-tools/panel/hooks/useBackendTogglesMutation';
-import * as client from '@/dev-tools/panel/api/devPanelClient';
+import { devPanelClient } from '@/dev-tools/panel/api/devPanelClient';
+
+const mockPatch = devPanelClient.patchToggles as ReturnType<typeof vi.fn>;
+const mockReset = devPanelClient.resetToggles as ReturnType<typeof vi.fn>;
 
 describe('useBackendTogglesMutation', () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
   afterEach(() => {
     vi.useRealTimers();
   });
 
   it('setToggle calls patchToggles', async () => {
-    const spy = vi
-      .spyOn(client, 'patchToggles')
-      .mockResolvedValue({ updated: ['llm'], toggles: { llm: false } });
+    mockPatch.mockResolvedValue({ updated: ['llm'], toggles: { llm: false } });
     const { result } = renderHook(() => useBackendTogglesMutation());
     await act(async () => {
       await result.current.setToggle('llm', false);
     });
-    expect(spy).toHaveBeenCalledWith({ llm: false });
+    expect(mockPatch).toHaveBeenCalledWith({ llm: false });
     expect(result.current.mutationError).toBeNull();
   });
 
@@ -30,7 +51,7 @@ describe('useBackendTogglesMutation', () => {
         resolveFirst = () => resolve({ updated: ['llm'], toggles: { llm: false } });
       }
     );
-    const spy = vi.spyOn(client, 'patchToggles').mockImplementation(() => firstPromise);
+    mockPatch.mockImplementation(() => firstPromise);
     const { result } = renderHook(() => useBackendTogglesMutation());
     void act(() => {
       void result.current.setToggle('llm', false);
@@ -38,12 +59,12 @@ describe('useBackendTogglesMutation', () => {
     await act(async () => {
       await result.current.setToggle('llm', true);
     });
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect(mockPatch).toHaveBeenCalledTimes(1);
     resolveFirst();
   });
 
   it('setToggle on different names does NOT block', async () => {
-    const spy = vi.spyOn(client, 'patchToggles').mockResolvedValue({ updated: [], toggles: {} });
+    mockPatch.mockResolvedValue({ updated: [], toggles: {} });
     const { result } = renderHook(() => useBackendTogglesMutation());
     await act(async () => {
       await Promise.all([
@@ -51,11 +72,11 @@ describe('useBackendTogglesMutation', () => {
         result.current.setToggle('embedding', true),
       ]);
     });
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect(mockPatch).toHaveBeenCalledTimes(2);
   });
 
   it('exposes mutationError on failure', async () => {
-    vi.spyOn(client, 'patchToggles').mockRejectedValue(new client.DevPanelClientError('boom', 500));
+    mockPatch.mockRejectedValue(new DevPanelClientError('boom', 500));
     const { result } = renderHook(() => useBackendTogglesMutation());
     await act(async () => {
       try {
@@ -69,13 +90,11 @@ describe('useBackendTogglesMutation', () => {
   });
 
   it('resetAll calls resetToggles', async () => {
-    const spy = vi
-      .spyOn(client, 'resetToggles')
-      .mockResolvedValue({ toggles: { llm: true }, knownServices: ['llm'] });
+    mockReset.mockResolvedValue({ toggles: { llm: true }, knownServices: ['llm'] });
     const { result } = renderHook(() => useBackendTogglesMutation());
     await act(async () => {
       await result.current.resetAll();
     });
-    expect(spy).toHaveBeenCalledOnce();
+    expect(mockReset).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/__tests__/dev-tools/panel/useBackendTogglesMutation.test.ts
+++ b/apps/web/__tests__/dev-tools/panel/useBackendTogglesMutation.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useBackendTogglesMutation } from '@/dev-tools/panel/hooks/useBackendTogglesMutation';
+import * as client from '@/dev-tools/panel/api/devPanelClient';
+
+describe('useBackendTogglesMutation', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('setToggle calls patchToggles', async () => {
+    const spy = vi
+      .spyOn(client, 'patchToggles')
+      .mockResolvedValue({ updated: ['llm'], toggles: { llm: false } });
+    const { result } = renderHook(() => useBackendTogglesMutation());
+    await act(async () => {
+      await result.current.setToggle('llm', false);
+    });
+    expect(spy).toHaveBeenCalledWith({ llm: false });
+    expect(result.current.mutationError).toBeNull();
+  });
+
+  it('setToggle ignores concurrent click on same name', async () => {
+    let resolveFirst: () => void = () => {};
+    const firstPromise = new Promise<{ updated: string[]; toggles: Record<string, boolean> }>(
+      resolve => {
+        resolveFirst = () => resolve({ updated: ['llm'], toggles: { llm: false } });
+      }
+    );
+    const spy = vi.spyOn(client, 'patchToggles').mockImplementation(() => firstPromise);
+    const { result } = renderHook(() => useBackendTogglesMutation());
+    void act(() => {
+      void result.current.setToggle('llm', false);
+    });
+    await act(async () => {
+      await result.current.setToggle('llm', true);
+    });
+    expect(spy).toHaveBeenCalledTimes(1);
+    resolveFirst();
+  });
+
+  it('setToggle on different names does NOT block', async () => {
+    const spy = vi.spyOn(client, 'patchToggles').mockResolvedValue({ updated: [], toggles: {} });
+    const { result } = renderHook(() => useBackendTogglesMutation());
+    await act(async () => {
+      await Promise.all([
+        result.current.setToggle('llm', false),
+        result.current.setToggle('embedding', true),
+      ]);
+    });
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('exposes mutationError on failure', async () => {
+    vi.spyOn(client, 'patchToggles').mockRejectedValue(new client.DevPanelClientError('boom', 500));
+    const { result } = renderHook(() => useBackendTogglesMutation());
+    await act(async () => {
+      try {
+        await result.current.setToggle('llm', false);
+      } catch {
+        /* expected */
+      }
+    });
+    expect(result.current.mutationError).not.toBeNull();
+    expect(result.current.mutationError?.status).toBe(500);
+  });
+
+  it('resetAll calls resetToggles', async () => {
+    const spy = vi
+      .spyOn(client, 'resetToggles')
+      .mockResolvedValue({ toggles: { llm: true }, knownServices: ['llm'] });
+    const { result } = renderHook(() => useBackendTogglesMutation());
+    await act(async () => {
+      await result.current.resetAll();
+    });
+    expect(spy).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/__tests__/dev-tools/panel/useBackendTogglesQuery.test.ts
+++ b/apps/web/__tests__/dev-tools/panel/useBackendTogglesQuery.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useBackendTogglesQuery } from '@/dev-tools/panel/hooks/useBackendTogglesQuery';
+import { devPanelClient, DevPanelClientError } from '@/dev-tools/panel/api/devPanelClient';
+
+describe('useBackendTogglesQuery', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fetches toggles on mount and exposes loading state', async () => {
+    vi.spyOn(devPanelClient, 'getToggles').mockResolvedValue({
+      toggles: { llm: true, embedding: false },
+      knownServices: ['llm', 'embedding'],
+    });
+    const { result } = renderHook(() => useBackendTogglesQuery());
+    expect(result.current.isLoading).toBe(true);
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.toggles.llm).toBe(true);
+    expect(result.current.toggles.embedding).toBe(false);
+    expect(result.current.knownServices).toEqual(['llm', 'embedding']);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('exposes error when fetch fails', async () => {
+    vi.spyOn(devPanelClient, 'getToggles').mockRejectedValue(
+      new DevPanelClientError('Backend down', 0)
+    );
+    const { result } = renderHook(() => useBackendTogglesQuery());
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.error?.status).toBe(0);
+  });
+
+  it('refetch fires a new request', async () => {
+    const spy = vi
+      .spyOn(devPanelClient, 'getToggles')
+      .mockResolvedValue({ toggles: { llm: true }, knownServices: ['llm'] });
+    const { result } = renderHook(() => useBackendTogglesQuery());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(spy).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await result.current.refetch();
+    });
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses exponential backoff on error (10s, 30s, 60s, 300s)', async () => {
+    vi.useFakeTimers();
+    let callCount = 0;
+    vi.spyOn(devPanelClient, 'getToggles').mockImplementation(() => {
+      callCount++;
+      return Promise.reject(new DevPanelClientError('down', 0));
+    });
+    renderHook(() => useBackendTogglesQuery());
+    await vi.advanceTimersByTimeAsync(0);
+    expect(callCount).toBe(1);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(callCount).toBe(2);
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(callCount).toBe(3);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(callCount).toBe(4);
+    await vi.advanceTimersByTimeAsync(300_000);
+    expect(callCount).toBe(5);
+    await vi.advanceTimersByTimeAsync(600_000);
+    expect(callCount).toBe(5); // stops after 5th
+  });
+});

--- a/apps/web/src/app/mock-provider.tsx
+++ b/apps/web/src/app/mock-provider.tsx
@@ -35,7 +35,12 @@ type DevBadgeComponent = ComponentType<{
   authStore: unknown;
 }>;
 
-type DevPanelMountComponent = ComponentType<{ uiStore: unknown }>;
+type DevPanelMountComponent = ComponentType<{
+  uiStore: unknown;
+  mockControlStore: unknown;
+  handlerGroups: Array<{ name: string; handlers: unknown[] }>;
+  worker: { resetHandlers: (...h: unknown[]) => void };
+}>;
 
 interface MockProviderProps {
   children: React.ReactNode;
@@ -88,6 +93,12 @@ export function MockProvider({ children }: MockProviderProps) {
   const [tools, setTools] = useState<DevToolsBundle | null>(null);
   const [DevBadge, setDevBadge] = useState<DevBadgeComponent | null>(null);
   const [DevPanelMountComp, setDevPanelMountComp] = useState<DevPanelMountComponent | null>(null);
+  const [mswWorker, setMswWorker] = useState<{ resetHandlers: (...h: unknown[]) => void } | null>(
+    null
+  );
+  const [handlerGroups, setHandlerGroups] = useState<Array<{ name: string; handlers: unknown[] }>>(
+    []
+  );
   // Track if panel mount has been loaded to avoid duplicate imports
   const panelMountLoaded = useRef(false);
 
@@ -112,10 +123,21 @@ export function MockProvider({ children }: MockProviderProps) {
         // Load DevPanelMount lazily (same bundle, just isolated via dynamic import)
         if (installed.panel && !panelMountLoaded.current) {
           panelMountLoaded.current = true;
-          import(`${'@'}/dev-tools/panel/DevPanelMount` as string)
-            .then(mod => {
+          Promise.all([
+            import(`${'@'}/dev-tools/panel/DevPanelMount` as string),
+            import(`${'@'}/mocks/browser` as string),
+            import(`${'@'}/mocks/handlers/registry` as string),
+          ])
+            .then(([mountMod, browserMod, registryMod]) => {
               setDevPanelMountComp(
-                () => (mod as { DevPanelMount: DevPanelMountComponent }).DevPanelMount
+                () => (mountMod as { DevPanelMount: DevPanelMountComponent }).DevPanelMount
+              );
+              setMswWorker(
+                (browserMod as { worker: { resetHandlers: (...h: unknown[]) => void } }).worker
+              );
+              setHandlerGroups(
+                (registryMod as { HANDLER_GROUPS: Array<{ name: string; handlers: unknown[] }> })
+                  .HANDLER_GROUPS
               );
             })
             .catch(() => {});
@@ -163,9 +185,13 @@ export function MockProvider({ children }: MockProviderProps) {
       {IS_DEV_MOCK &&
         tools &&
         DevPanelMountComp &&
+        mswWorker &&
         (tools as DevToolsBundle & { panel?: { uiStore: unknown } }).panel && (
           <DevPanelMountComp
             uiStore={(tools as DevToolsBundle & { panel?: { uiStore: unknown } }).panel!.uiStore}
+            mockControlStore={tools.controlStore}
+            handlerGroups={handlerGroups}
+            worker={mswWorker}
           />
         )}
     </>

--- a/apps/web/src/dev-tools/install.ts
+++ b/apps/web/src/dev-tools/install.ts
@@ -91,7 +91,11 @@ export function installDevTools(): InstalledDevTools {
     );
   }
 
-  const panel = installPanel();
+  const panel = installPanel({
+    mockControlStore: controlStore,
+    scenarioStore,
+    authStore,
+  });
 
   return { controlStore, scenarioStore, authStore, panel };
 }

--- a/apps/web/src/dev-tools/panel/DevPanel.tsx
+++ b/apps/web/src/dev-tools/panel/DevPanel.tsx
@@ -2,13 +2,19 @@
 
 import type { DevPanelTab } from '@/dev-tools/types';
 
+import { SectionErrorBoundary } from './components/SectionErrorBoundary';
 import { useStoreSlice } from './hooks/useStoreSlice';
+import { TogglesSection } from './sections/TogglesSection';
 
+import type { MockControlState, HandlerGroup } from './sections/TogglesSection';
 import type { PanelUiState } from './stores/panelUiStore';
 import type { StoreApi } from 'zustand/vanilla';
 
 export interface DevPanelProps {
   uiStore: StoreApi<PanelUiState>;
+  mockControlStore: StoreApi<MockControlState>;
+  handlerGroups: HandlerGroup[];
+  worker: { resetHandlers: (...handlers: unknown[]) => void };
 }
 
 const TABS: { id: DevPanelTab; label: string }[] = [
@@ -18,7 +24,12 @@ const TABS: { id: DevPanelTab; label: string }[] = [
   { id: 'inspector', label: 'Inspector' },
 ];
 
-export function DevPanel({ uiStore }: DevPanelProps): React.JSX.Element | null {
+export function DevPanel({
+  uiStore,
+  mockControlStore,
+  handlerGroups,
+  worker,
+}: DevPanelProps): React.JSX.Element | null {
   const isOpen = useStoreSlice(uiStore, s => s.isOpen);
   const activeTab = useStoreSlice(uiStore, s => s.activeTab);
   const drawerWidth = useStoreSlice(uiStore, s => s.drawerWidth);
@@ -105,14 +116,20 @@ export function DevPanel({ uiStore }: DevPanelProps): React.JSX.Element | null {
         aria-labelledby={`panel-tab-${activeTab}`}
         style={{ flex: 1, padding: 16, overflow: 'auto' }}
       >
-        <p style={{ color: '#9ca3af', fontSize: 12 }}>
-          [{activeTab}] section content — coming in M
-          {activeTab === 'toggles'
-            ? '1'
-            : activeTab === 'scenarios' || activeTab === 'auth'
-              ? '2'
-              : '3'}
-        </p>
+        {activeTab === 'toggles' ? (
+          <SectionErrorBoundary sectionName="Toggles">
+            <TogglesSection
+              mockControlStore={mockControlStore}
+              handlerGroups={handlerGroups}
+              worker={worker}
+            />
+          </SectionErrorBoundary>
+        ) : (
+          <p style={{ color: '#9ca3af', fontSize: 12 }}>
+            [{activeTab}] section content — coming in M
+            {activeTab === 'scenarios' || activeTab === 'auth' ? '2' : '3'}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/dev-tools/panel/DevPanelMount.tsx
+++ b/apps/web/src/dev-tools/panel/DevPanelMount.tsx
@@ -4,17 +4,33 @@ import { DevPanel } from './DevPanel';
 import { useKeyboardShortcut } from './hooks/useKeyboardShortcut';
 import { useQueryStringPanelOpen } from './hooks/useQueryStringPanelOpen';
 
+import type { MockControlState, HandlerGroup } from './sections/TogglesSection';
 import type { PanelUiState } from './stores/panelUiStore';
 import type { StoreApi } from 'zustand/vanilla';
 
 export interface DevPanelMountProps {
   uiStore: StoreApi<PanelUiState>;
+  mockControlStore: StoreApi<MockControlState>;
+  handlerGroups: HandlerGroup[];
+  worker: { resetHandlers: (...handlers: unknown[]) => void };
 }
 
-export function DevPanelMount({ uiStore }: DevPanelMountProps): React.JSX.Element {
+export function DevPanelMount({
+  uiStore,
+  mockControlStore,
+  handlerGroups,
+  worker,
+}: DevPanelMountProps): React.JSX.Element {
   useKeyboardShortcut({ ctrl: true, shift: true, key: 'm' }, () => {
     uiStore.getState().toggle();
   });
   useQueryStringPanelOpen(uiStore);
-  return <DevPanel uiStore={uiStore} />;
+  return (
+    <DevPanel
+      uiStore={uiStore}
+      mockControlStore={mockControlStore}
+      handlerGroups={handlerGroups}
+      worker={worker}
+    />
+  );
 }

--- a/apps/web/src/dev-tools/panel/components/SectionErrorBoundary.tsx
+++ b/apps/web/src/dev-tools/panel/components/SectionErrorBoundary.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import React, { Component, type ErrorInfo, type ReactNode } from 'react';
+
+export interface SectionErrorBoundaryProps {
+  sectionName: string;
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  errorMessage: string;
+}
+
+export class SectionErrorBoundary extends Component<SectionErrorBoundaryProps, State> {
+  constructor(props: SectionErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, errorMessage: '' };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, errorMessage: error.message };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    if (typeof console !== 'undefined') {
+      console.warn(`[MeepleDev] Section "${this.props.sectionName}" crashed:`, error, errorInfo);
+    }
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div
+          role="alert"
+          style={{
+            padding: 16,
+            background: '#7f1d1d',
+            color: '#fecaca',
+            borderRadius: 6,
+            fontSize: 11,
+          }}
+        >
+          <strong>{this.props.sectionName} section crashed</strong>
+          <div style={{ marginTop: 6, fontFamily: 'monospace' }}>{this.state.errorMessage}</div>
+          <button
+            type="button"
+            onClick={() => this.setState({ hasError: false, errorMessage: '' })}
+            style={{
+              marginTop: 8,
+              padding: '4px 8px',
+              background: '#f9fafb',
+              color: '#7f1d1d',
+              border: 'none',
+              borderRadius: 4,
+              cursor: 'pointer',
+              fontSize: 10,
+            }}
+          >
+            Retry
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/apps/web/src/dev-tools/panel/components/ToggleSwitch.tsx
+++ b/apps/web/src/dev-tools/panel/components/ToggleSwitch.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+export interface ToggleSwitchProps {
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  label: string;
+  description?: ReactNode;
+  disabled?: boolean;
+  testId?: string;
+}
+
+export function ToggleSwitch({
+  checked,
+  onChange,
+  label,
+  description,
+  disabled = false,
+  testId,
+}: ToggleSwitchProps): React.JSX.Element {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'space-between',
+        padding: '8px 12px',
+        gap: 12,
+        opacity: disabled ? 0.5 : 1,
+      }}
+    >
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 12, color: '#f9fafb', fontWeight: 500 }}>{label}</div>
+        {description ? (
+          <div style={{ fontSize: 10, color: '#9ca3af', marginTop: 2 }}>{description}</div>
+        ) : null}
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        aria-label={`Toggle ${label}`}
+        data-testid={testId}
+        data-state={checked ? 'on' : 'off'}
+        disabled={disabled}
+        onClick={() => onChange(!checked)}
+        style={{
+          width: 36,
+          height: 20,
+          borderRadius: 10,
+          background: checked ? '#10b981' : '#374151',
+          border: 'none',
+          cursor: disabled ? 'not-allowed' : 'pointer',
+          position: 'relative',
+          flexShrink: 0,
+          padding: 0,
+        }}
+      >
+        <span
+          style={{
+            position: 'absolute',
+            top: 2,
+            left: checked ? 18 : 2,
+            width: 16,
+            height: 16,
+            borderRadius: '50%',
+            background: '#f9fafb',
+            transition: 'left 100ms ease-out',
+          }}
+        />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/dev-tools/panel/hooks/useBackendTogglesMutation.ts
+++ b/apps/web/src/dev-tools/panel/hooks/useBackendTogglesMutation.ts
@@ -1,0 +1,49 @@
+import { useCallback, useRef, useState } from 'react';
+
+import { devPanelClient, DevPanelClientError } from '../api/devPanelClient';
+
+export interface UseBackendTogglesMutationResult {
+  setToggle: (name: string, value: boolean) => Promise<void>;
+  resetAll: () => Promise<void>;
+  isMutating: boolean;
+  mutationError: DevPanelClientError | null;
+}
+
+export function useBackendTogglesMutation(): UseBackendTogglesMutationResult {
+  const [isMutating, setIsMutating] = useState(false);
+  const [mutationError, setMutationError] = useState<DevPanelClientError | null>(null);
+  const inFlightToggles = useRef<Set<string>>(new Set());
+
+  const setToggle = useCallback(async (name: string, value: boolean) => {
+    if (inFlightToggles.current.has(name)) return;
+    inFlightToggles.current.add(name);
+    setIsMutating(true);
+    try {
+      await devPanelClient.patchToggles({ [name]: value });
+      setMutationError(null);
+    } catch (err) {
+      const e = err instanceof DevPanelClientError ? err : new DevPanelClientError(String(err), 0);
+      setMutationError(e);
+      throw e;
+    } finally {
+      inFlightToggles.current.delete(name);
+      setIsMutating(false);
+    }
+  }, []);
+
+  const resetAll = useCallback(async () => {
+    setIsMutating(true);
+    try {
+      await devPanelClient.resetToggles();
+      setMutationError(null);
+    } catch (err) {
+      const e = err instanceof DevPanelClientError ? err : new DevPanelClientError(String(err), 0);
+      setMutationError(e);
+      throw e;
+    } finally {
+      setIsMutating(false);
+    }
+  }, []);
+
+  return { setToggle, resetAll, isMutating, mutationError };
+}

--- a/apps/web/src/dev-tools/panel/hooks/useBackendTogglesQuery.ts
+++ b/apps/web/src/dev-tools/panel/hooks/useBackendTogglesQuery.ts
@@ -1,0 +1,66 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+
+import type { BackendTogglesState } from '@/dev-tools/types';
+
+import { devPanelClient, DevPanelClientError } from '../api/devPanelClient';
+
+const BACKOFF_DELAYS_MS = [10_000, 30_000, 60_000, 300_000] as const;
+
+export interface UseBackendTogglesQueryResult {
+  toggles: Record<string, boolean>;
+  knownServices: string[];
+  isLoading: boolean;
+  error: DevPanelClientError | null;
+  refetch: () => Promise<void>;
+}
+
+export function useBackendTogglesQuery(): UseBackendTogglesQueryResult {
+  const [state, setState] = useState<BackendTogglesState>({ toggles: {}, knownServices: [] });
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<DevPanelClientError | null>(null);
+  const retryCountRef = useRef(0);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const fetchOnce = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const data = await devPanelClient.getToggles();
+      setState(data);
+      setError(null);
+      retryCountRef.current = 0;
+    } catch (err) {
+      const e = err instanceof DevPanelClientError ? err : new DevPanelClientError(String(err), 0);
+      setError(e);
+      const idx = retryCountRef.current;
+      if (idx < BACKOFF_DELAYS_MS.length) {
+        const delay = BACKOFF_DELAYS_MS[idx];
+        retryCountRef.current = idx + 1;
+        retryTimerRef.current = setTimeout(() => {
+          void fetchOnce();
+        }, delay);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const refetch = useCallback(async () => {
+    if (retryTimerRef.current) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+    retryCountRef.current = 0;
+    await fetchOnce();
+  }, [fetchOnce]);
+
+  useEffect(() => {
+    void fetchOnce();
+    return () => {
+      if (retryTimerRef.current) {
+        clearTimeout(retryTimerRef.current);
+      }
+    };
+  }, [fetchOnce]);
+
+  return { toggles: state.toggles, knownServices: state.knownServices, isLoading, error, refetch };
+}

--- a/apps/web/src/dev-tools/panel/installPanel.ts
+++ b/apps/web/src/dev-tools/panel/installPanel.ts
@@ -3,15 +3,22 @@ import { createPanelUiStore, type PanelUiState } from './stores/panelUiStore';
 
 import type { StoreApi } from 'zustand/vanilla';
 
-export interface InstalledPanel {
-  uiStore: StoreApi<PanelUiState>;
+export interface PanelDependencies {
+  mockControlStore: StoreApi<unknown>;
+  scenarioStore: StoreApi<unknown>;
+  authStore: StoreApi<unknown>;
 }
 
-export function installPanel(): InstalledPanel {
+export interface InstalledPanel {
+  uiStore: StoreApi<PanelUiState>;
+  deps: PanelDependencies;
+}
+
+export function installPanel(deps: PanelDependencies): InstalledPanel {
   const uiStore = createPanelUiStore();
   void devPanelClient.getToggles().catch(() => {});
   if (typeof console !== 'undefined') {
     console.warn('[MeepleDev Phase 2] Dev Panel installed. Press Ctrl+Shift+M to open.');
   }
-  return { uiStore };
+  return { uiStore, deps };
 }

--- a/apps/web/src/dev-tools/panel/sections/TogglesSection.tsx
+++ b/apps/web/src/dev-tools/panel/sections/TogglesSection.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { useEffect, useMemo, useCallback } from 'react';
+
+import { ToggleSwitch } from '../components/ToggleSwitch';
+import { useBackendTogglesMutation } from '../hooks/useBackendTogglesMutation';
+import { useBackendTogglesQuery } from '../hooks/useBackendTogglesQuery';
+import { useStoreSlice } from '../hooks/useStoreSlice';
+
+import type { StoreApi } from 'zustand/vanilla';
+
+export interface MockControlState {
+  toggles: { groups: Record<string, boolean>; overrides: Record<string, boolean> };
+  setGroup: (name: string, value: boolean) => void;
+}
+
+export interface HandlerGroup {
+  name: string;
+  handlers: unknown[];
+}
+
+export interface TogglesSectionProps {
+  mockControlStore: StoreApi<MockControlState>;
+  handlerGroups: HandlerGroup[];
+  worker: { resetHandlers: (...handlers: unknown[]) => void };
+}
+
+export function TogglesSection({
+  mockControlStore,
+  handlerGroups,
+  worker,
+}: TogglesSectionProps): React.JSX.Element {
+  const groups = useStoreSlice(mockControlStore, s => s.toggles.groups);
+  const query = useBackendTogglesQuery();
+  const mutation = useBackendTogglesMutation();
+
+  const applyMswHandlers = useCallback(() => {
+    const active = handlerGroups.flatMap(g => (groups[g.name] !== false ? g.handlers : []));
+    worker.resetHandlers(...active);
+  }, [groups, handlerGroups, worker]);
+
+  useEffect(() => {
+    applyMswHandlers();
+  }, [applyMswHandlers]);
+
+  const handleMswToggle = (groupName: string, value: boolean): void => {
+    mockControlStore.getState().setGroup(groupName, value);
+  };
+
+  const handleBackendToggle = async (serviceName: string, value: boolean): Promise<void> => {
+    try {
+      await mutation.setToggle(serviceName, value);
+      await query.refetch();
+    } catch {
+      /* surfaced via error state */
+    }
+  };
+
+  const handleResetMsw = (): void => {
+    handlerGroups.forEach(g => mockControlStore.getState().setGroup(g.name, true));
+  };
+
+  const handleResetBackend = async (): Promise<void> => {
+    try {
+      await mutation.resetAll();
+      await query.refetch();
+    } catch {
+      /* surfaced */
+    }
+  };
+
+  const sortedGroups = useMemo(() => handlerGroups.map(g => g.name).sort(), [handlerGroups]);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <section>
+        <header
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginBottom: 8,
+          }}
+        >
+          <h3
+            style={{
+              fontSize: 11,
+              color: '#f59e0b',
+              textTransform: 'uppercase',
+              letterSpacing: 0.5,
+              margin: 0,
+            }}
+          >
+            Frontend (MSW) — {sortedGroups.length} groups
+          </h3>
+          <button
+            type="button"
+            onClick={handleResetMsw}
+            data-testid="toggles-reset-msw"
+            style={{
+              fontSize: 10,
+              padding: '4px 8px',
+              background: 'transparent',
+              color: '#9ca3af',
+              border: '1px solid #374151',
+              borderRadius: 4,
+              cursor: 'pointer',
+            }}
+          >
+            Reset all
+          </button>
+        </header>
+        {sortedGroups.map(groupName => (
+          <ToggleSwitch
+            key={`msw-${groupName}`}
+            checked={groups[groupName] !== false}
+            onChange={next => handleMswToggle(groupName, next)}
+            label={groupName}
+            testId={`toggle-msw-${groupName}`}
+          />
+        ))}
+      </section>
+
+      <section>
+        <header
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginBottom: 8,
+          }}
+        >
+          <h3
+            style={{
+              fontSize: 11,
+              color: '#f59e0b',
+              textTransform: 'uppercase',
+              letterSpacing: 0.5,
+              margin: 0,
+            }}
+          >
+            Backend services — {query.knownServices.length}
+          </h3>
+          {query.knownServices.length > 0 ? (
+            <button
+              type="button"
+              onClick={handleResetBackend}
+              data-testid="toggles-reset-backend"
+              disabled={mutation.isMutating}
+              style={{
+                fontSize: 10,
+                padding: '4px 8px',
+                background: 'transparent',
+                color: '#9ca3af',
+                border: '1px solid #374151',
+                borderRadius: 4,
+                cursor: mutation.isMutating ? 'not-allowed' : 'pointer',
+              }}
+            >
+              Reset all
+            </button>
+          ) : null}
+        </header>
+
+        {query.error ? (
+          <div
+            role="status"
+            style={{
+              padding: 12,
+              background: '#7f1d1d',
+              color: '#fecaca',
+              borderRadius: 6,
+              fontSize: 11,
+              marginBottom: 8,
+            }}
+          >
+            <strong>Backend unreachable</strong>
+            <div style={{ marginTop: 4 }}>{query.error.message}</div>
+            <button
+              type="button"
+              onClick={() => void query.refetch()}
+              style={{
+                marginTop: 6,
+                padding: '4px 8px',
+                background: '#f9fafb',
+                color: '#7f1d1d',
+                border: 'none',
+                borderRadius: 4,
+                cursor: 'pointer',
+                fontSize: 10,
+              }}
+            >
+              Retry
+            </button>
+          </div>
+        ) : null}
+
+        {query.isLoading && !query.knownServices.length ? (
+          <div style={{ fontSize: 11, color: '#9ca3af', padding: '8px 12px' }}>Loading...</div>
+        ) : null}
+
+        {query.knownServices.map(serviceName => (
+          <ToggleSwitch
+            key={`be-${serviceName}`}
+            checked={query.toggles[serviceName] === true}
+            onChange={next => void handleBackendToggle(serviceName, next)}
+            label={serviceName}
+            disabled={mutation.isMutating}
+            testId={`toggle-be-${serviceName}`}
+          />
+        ))}
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Milestone M1: **Toggles tab funzionante** nel Dev Panel. La killer feature di Phase 2.

- `useBackendTogglesQuery` — read hook con exponential backoff [10s, 30s, 60s, 300s]
- `useBackendTogglesMutation` — write hook con per-name lock (ignora concurrent click)
- `ToggleSwitch` — ARIA switch component (`role="switch"`, `aria-checked`)
- `SectionErrorBoundary` — error boundary per sezione con Retry
- `TogglesSection` — assembla MSW groups (13) + backend services, reset buttons
- Wiring completo: `DevPanel` → `TogglesSection` con `mockControlStore` + `worker` + `handlerGroups`

## Browser test verification (7 screenshot)

| Test | Result |
|---|---|
| DevBadge visible | ✅ |
| `Ctrl+Shift+M` opens drawer | ✅ |
| 4 tab navigation | ✅ |
| 13 MSW groups with toggles | ✅ |
| Toggle click disables group | ✅ |
| Backend unreachable banner | ✅ (rosso, .NET non running) |
| `×` closes panel | ✅ |
| `?devpanel=1` opens panel | ✅ + URL stripped |

## Test results

- Frontend: **79/79** test (14 file)
- Backend: **14/14** DevTools test
- TypeScript: clean
- Build: frontend + backend prod OK (pre-push hook)

## Test plan

- [x] `pnpm test __tests__/dev-tools __tests__/mocks __tests__/integration/dev-tools` → 79/79
- [x] `pnpm typecheck` clean
- [x] `pnpm build` OK
- [x] Browser manual test (Playwright): 7/7 scenari verificati
- [ ] E2E Playwright spec (M4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)