### PR TITLE
feat(dev): MeepleDev Phase 2 M2 — Scenarios + Auth + scenarioSwitcher

### DIFF
--- a/admin-mockups/meeple-card-drawer-tabs-mockup.html
+++ b/admin-mockups/meeple-card-drawer-tabs-mockup.html
@@ -1,0 +1,352 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+<title>MeepleAI — Card Page + Drawer Tabs Mockup</title>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700;800&family=Nunito:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<!--
+  NOTE: This is a static design mockup for internal use only.
+  All data is hardcoded mock content — no user input is processed.
+  innerHTML usage is safe here as all content is developer-authored constants.
+  This file is NOT served to end users or deployed to production.
+-->
+<style>
+:root {
+  --bg: #faf8f5;
+  --bg-card: rgba(255,255,255,0.92);
+  --bg-muted: #f1ede8;
+  --text: #1a1a2e;
+  --text-sec: #64748b;
+  --text-muted: #94a3b8;
+  --border: rgba(0,0,0,0.07);
+  --border-light: rgba(0,0,0,0.04);
+  --shadow-warm-sm: 0 1px 3px rgba(180,130,80,0.06), 0 1px 2px rgba(180,130,80,0.04);
+  --shadow-warm-md: 0 4px 12px rgba(180,130,80,0.08), 0 2px 4px rgba(180,130,80,0.04);
+  --shadow-warm-lg: 0 10px 30px rgba(180,130,80,0.12), 0 4px 8px rgba(180,130,80,0.06);
+  --shadow-warm-xl: 0 20px 50px rgba(180,130,80,0.16), 0 8px 16px rgba(180,130,80,0.08);
+  --phone-w: 390px; --phone-h: 844px;
+}
+* { margin:0; padding:0; box-sizing:border-box; }
+body { font-family:'Nunito',sans-serif; background:#e8e4df; color:var(--text); min-height:100vh; display:flex; flex-direction:column; align-items:center; padding:24px 16px; }
+h1,h2,h3,h4,h5 { font-family:'Quicksand',sans-serif; }
+.page-title { text-align:center; margin-bottom:16px; }
+.page-title h1 { font-size:1.4rem; }
+.page-title p { color:var(--text-sec); font-size:0.8rem; margin-top:4px; }
+.entity-switcher { display:flex; gap:6px; flex-wrap:wrap; justify-content:center; margin-bottom:20px; max-width:800px; }
+.entity-btn { padding:6px 14px; border-radius:20px; border:2px solid var(--border); background:var(--bg-card); font-family:'Quicksand',sans-serif; font-size:11px; font-weight:700; cursor:pointer; color:var(--text-sec); transition:all 0.25s; display:flex; align-items:center; gap:5px; }
+.entity-btn:hover { transform:translateY(-1px); box-shadow:var(--shadow-warm-md); }
+.entity-btn.active { color:white; border-color:transparent; box-shadow:var(--shadow-warm-lg); }
+.entity-btn .dot { width:8px; height:8px; border-radius:50%; flex-shrink:0; }
+.mockup-row { display:flex; gap:32px; flex-wrap:wrap; justify-content:center; align-items:flex-start; }
+.mockup-col { display:flex; flex-direction:column; align-items:center; gap:8px; }
+.mockup-label { font-family:'Quicksand',sans-serif; font-weight:700; font-size:0.8rem; color:var(--text-sec); text-transform:uppercase; letter-spacing:0.08em; }
+.phone { width:var(--phone-w); height:var(--phone-h); background:var(--bg); border-radius:40px; border:3px solid #c8c0b5; box-shadow: 0 30px 80px rgba(0,0,0,0.15), 0 8px 24px rgba(0,0,0,0.1), inset 0 0 0 1px rgba(255,255,255,0.4); overflow:hidden; position:relative; display:flex; flex-direction:column; }
+.status-bar { height:48px; display:flex; align-items:flex-end; justify-content:space-between; padding:0 28px 6px; font-size:12px; font-weight:600; flex-shrink:0; }
+.status-bar .time { font-weight:700; }
+.status-bar .icons { display:flex; gap:4px; font-size:11px; }
+.navbar { height:52px; display:flex; align-items:center; padding:0 16px; background:var(--bg-card); backdrop-filter:blur(12px) saturate(180%); border-bottom:1px solid var(--border); flex-shrink:0; gap:10px; }
+.navbar .back-btn { width:32px; height:32px; border-radius:50%; background:var(--bg-muted); border:none; cursor:pointer; display:flex; align-items:center; justify-content:center; font-size:14px; color:var(--text-sec); }
+.navbar .nav-title { font-family:'Quicksand',sans-serif; font-weight:700; font-size:0.95rem; flex:1; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.navbar .nav-action { width:32px; height:32px; border-radius:50%; background:var(--bg-muted); border:none; cursor:pointer; display:flex; align-items:center; justify-content:center; font-size:14px; color:var(--text-sec); }
+.page-content { flex:1; overflow-y:auto; scrollbar-width:none; }
+.page-content::-webkit-scrollbar { display:none; }
+.hero-section { position:relative; height:200px; overflow:hidden; }
+.hero-img { width:100%; height:100%; display:flex; align-items:center; justify-content:center; font-size:80px; }
+.hero-gradient { position:absolute; bottom:0; left:0; right:0; height:80px; background:linear-gradient(to top, var(--bg) 0%, transparent 100%); }
+.hero-badge { position:absolute; top:12px; left:16px; padding:4px 12px; border-radius:20px; font-family:'Quicksand',sans-serif; font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:0.06em; color:white; backdrop-filter:blur(8px); }
+.hero-rating { position:absolute; top:12px; right:16px; padding:4px 10px; border-radius:12px; background:rgba(0,0,0,0.5); backdrop-filter:blur(8px); color:#fbbf24; font-size:12px; font-weight:700; display:flex; align-items:center; gap:4px; }
+.card-info { padding:16px; }
+.card-info .title { font-family:'Quicksand',sans-serif; font-size:1.3rem; font-weight:700; line-height:1.2; }
+.card-info .subtitle { font-size:0.82rem; color:var(--text-sec); margin-top:2px; }
+.card-info .meta-row { display:flex; flex-wrap:wrap; gap:6px; margin-top:10px; }
+.meta-chip { display:flex; align-items:center; gap:4px; font-size:11px; color:var(--text-sec); background:var(--bg-muted); padding:4px 10px; border-radius:16px; font-weight:600; }
+.quick-actions-row { display:flex; gap:8px; padding:0 16px 12px; }
+.qa-pill { padding:8px 16px; border-radius:20px; border:1px solid var(--border); background:var(--bg-card); font-family:'Quicksand',sans-serif; font-size:12px; font-weight:700; cursor:pointer; color:var(--text-sec); transition:all 0.2s; display:flex; align-items:center; gap:6px; }
+.qa-pill.primary { color:white; border-color:transparent; }
+.card-nav-footer { display:flex; align-items:center; justify-content:center; gap:6px; padding:8px 16px; border-top:1px solid var(--border-light); border-bottom:1px solid var(--border-light); background:var(--bg-card); }
+.nav-item { display:flex; flex-direction:column; align-items:center; gap:2px; cursor:pointer; padding:4px 10px; border-radius:10px; transition:background 0.2s; }
+.nav-item:hover { background:var(--bg-muted); }
+.nav-item .nav-icon { width:28px; height:28px; border-radius:50%; display:flex; align-items:center; justify-content:center; font-size:13px; border:1px solid var(--border); background:var(--bg-card); position:relative; }
+.nav-item .nav-label { font-size:8px; font-weight:700; color:var(--text-sec); font-family:'Quicksand',sans-serif; text-transform:uppercase; }
+.nav-badge { position:absolute; top:-3px; right:-3px; min-width:14px; height:14px; border-radius:7px; font-size:7px; font-weight:800; color:white; display:flex; align-items:center; justify-content:center; padding:0 3px; }
+.section { padding:16px; }
+.section-title { font-family:'Quicksand',sans-serif; font-size:0.85rem; font-weight:700; margin-bottom:8px; display:flex; align-items:center; gap:6px; }
+.info-row { display:flex; justify-content:space-between; padding:8px 0; border-bottom:1px solid var(--border-light); font-size:12px; }
+.info-row .label { color:var(--text-muted); }
+.info-row .value { font-weight:600; }
+.stat-grid { display:grid; grid-template-columns:1fr 1fr; gap:8px; margin-bottom:12px; }
+.stat-box { padding:10px; border-radius:10px; background:var(--bg-muted); text-align:center; }
+.stat-box .stat-val { font-size:1.2rem; font-weight:800; font-family:'Quicksand',sans-serif; }
+.stat-box .stat-label { font-size:9px; color:var(--text-muted); font-weight:600; text-transform:uppercase; letter-spacing:0.05em; }
+.mini-list { display:flex; flex-direction:column; gap:6px; }
+.mini-item { display:flex; align-items:center; gap:10px; padding:8px 10px; background:var(--bg-card); border:1px solid var(--border); border-radius:10px; box-shadow:var(--shadow-warm-sm); }
+.mini-item .mi-icon { width:36px; height:36px; border-radius:8px; display:flex; align-items:center; justify-content:center; font-size:16px; flex-shrink:0; }
+.mini-item .mi-text { flex:1; }
+.mini-item .mi-title { font-size:12px; font-weight:700; }
+.mini-item .mi-sub { font-size:10px; color:var(--text-sec); }
+.mini-item .mi-badge { padding:3px 8px; border-radius:10px; font-size:9px; font-weight:700; color:white; }
+.drawer-overlay { position:absolute; inset:0; z-index:50; pointer-events:none; transition:background 0.35s; }
+.drawer-overlay.open { background:rgba(0,0,0,0.35); pointer-events:auto; }
+.drawer-panel { position:absolute; left:0; right:0; bottom:0; height:60%; background:var(--bg-card); backdrop-filter:blur(16px) saturate(180%); border-top:1px solid var(--border); box-shadow:0 -8px 32px rgba(0,0,0,0.12); border-radius:20px 20px 0 0; transform:translateY(105%); transition:transform 0.4s cubic-bezier(0.4,0,0.2,1); display:flex; flex-direction:column; overflow:hidden; z-index:51; }
+.drawer-overlay.open .drawer-panel { transform:translateY(0); }
+.drawer-handle-area { display:flex; align-items:center; justify-content:center; padding:8px 0 4px; flex-shrink:0; cursor:grab; }
+.drawer-handle { width:36px; height:4px; border-radius:2px; background:var(--border); }
+.drawer-header { display:flex; align-items:center; gap:8px; padding:4px 16px 8px; flex-shrink:0; }
+.drawer-header .dh-icon { width:28px; height:28px; border-radius:8px; display:flex; align-items:center; justify-content:center; color:white; font-size:13px; font-weight:700; }
+.drawer-header .dh-title { font-family:'Quicksand',sans-serif; font-size:0.9rem; font-weight:700; }
+.drawer-header .dh-close { margin-left:auto; width:28px; height:28px; border-radius:50%; background:var(--bg-muted); border:none; cursor:pointer; display:flex; align-items:center; justify-content:center; font-size:12px; color:var(--text-sec); }
+.drawer-tabs { display:flex; padding:0 12px; gap:0; border-bottom:1px solid var(--border); flex-shrink:0; overflow-x:auto; scrollbar-width:none; }
+.drawer-tabs::-webkit-scrollbar { display:none; }
+.drawer-tab { padding:8px 12px; font-size:11px; font-weight:700; font-family:'Quicksand',sans-serif; color:var(--text-muted); cursor:pointer; border-bottom:2px solid transparent; transition:color 0.2s, border-color 0.2s; background:transparent; border-top:none; border-left:none; border-right:none; white-space:nowrap; display:flex; align-items:center; gap:5px; flex-shrink:0; }
+.drawer-tab.active { border-bottom-color:currentColor; }
+.drawer-tab:hover { color:var(--text); }
+.drawer-tab .tab-badge { min-width:16px; height:16px; border-radius:8px; font-size:8px; font-weight:800; color:white; display:flex; align-items:center; justify-content:center; padding:0 4px; }
+.drawer-content { flex:1; padding:12px 16px; overflow-y:auto; font-size:13px; color:var(--text-sec); line-height:1.6; scrollbar-width:none; }
+.drawer-content::-webkit-scrollbar { display:none; }
+.drawer-content h4 { font-size:13px; color:var(--text); margin-bottom:6px; font-family:'Quicksand',sans-serif; }
+.progress-bar { height:6px; border-radius:3px; background:var(--bg-muted); overflow:hidden; margin:4px 0; }
+.progress-fill { height:100%; border-radius:3px; }
+.chat-bubble { padding:8px 12px; border-radius:12px; font-size:12px; line-height:1.5; max-width:85%; margin-bottom:6px; }
+.chat-bubble.user { background:var(--bg-muted); margin-left:auto; border-bottom-right-radius:4px; }
+.chat-bubble.assistant { border:1px solid var(--border); border-bottom-left-radius:4px; }
+.chat-bubble .cb-time { font-size:9px; color:var(--text-muted); margin-top:2px; }
+.photo-grid { display:grid; grid-template-columns:1fr 1fr 1fr; gap:6px; }
+.photo-thumb { aspect-ratio:1; border-radius:8px; display:flex; align-items:center; justify-content:center; font-size:20px; }
+.timeline-item { display:flex; gap:8px; padding:6px 0; border-bottom:1px solid var(--border-light); }
+.timeline-dot { width:8px; height:8px; border-radius:50%; margin-top:4px; flex-shrink:0; }
+.timeline-text { font-size:11px; }
+.timeline-text .tl-time { color:var(--text-muted); font-size:10px; }
+.action-group { display:flex; flex-direction:column; gap:6px; }
+.action-btn { display:flex; align-items:center; gap:8px; padding:10px 12px; border-radius:10px; background:var(--bg-muted); border:none; cursor:pointer; font-family:'Nunito',sans-serif; font-size:12px; font-weight:600; width:100%; text-align:left; }
+.action-btn.danger { color:hsl(0,70%,50%); }
+.config-row { display:flex; justify-content:space-between; align-items:center; padding:8px 12px; background:var(--bg-muted); border-radius:8px; margin-bottom:4px; font-size:12px; }
+.config-row .ck { font-family:monospace; color:var(--text-sec); font-size:11px; }
+.config-row .cv { font-weight:700; }
+.tool-preview { padding:12px; border-radius:12px; background:var(--bg-muted); text-align:center; margin:8px 0; }
+.tool-preview .tp-display { font-size:2rem; font-weight:800; font-family:'Quicksand',sans-serif; margin:8px 0; }
+.tool-preview .tp-controls { display:flex; gap:8px; justify-content:center; margin-top:8px; }
+.tool-preview .tp-btn { padding:6px 16px; border-radius:16px; border:1px solid var(--border); background:var(--bg-card); font-size:11px; font-weight:700; cursor:pointer; font-family:'Quicksand',sans-serif; }
+.tool-preview .tp-btn.primary { color:white; border-color:transparent; }
+.status-dot { width:6px; height:6px; border-radius:50%; display:inline-block; margin-right:4px; }
+.status-dot.green { background:hsl(142,70%,45%); }
+.status-dot.amber { background:hsl(38,92%,50%); }
+.status-dot.blue { background:hsl(220,80%,55%); }
+.bottom-bar { height:52px; flex-shrink:0; display:flex; align-items:center; justify-content:space-around; padding:0 16px 12px; background:var(--bg-card); backdrop-filter:blur(16px) saturate(180%); border-top:1px solid var(--border); }
+.bottom-item { display:flex; flex-direction:column; align-items:center; gap:1px; cursor:pointer; font-size:18px; }
+.bottom-item .bl { font-size:8px; font-weight:700; color:var(--text-sec); font-family:'Quicksand',sans-serif; }
+@media (max-width:480px) { .phone { width:100%; height:100vh; border-radius:0; border:none; } body { padding:0; } .page-title, .entity-switcher, .mockup-label { display:none; } }
+</style>
+</head>
+<body>
+<div class="page-title">
+  <h1>MeepleAI — Card Page + Drawer Tabs</h1>
+  <p>Ogni entity ha una pagina detail e un drawer con tab specifici. Seleziona un entity type per esplorare.</p>
+</div>
+<div class="entity-switcher" id="entity-switcher"></div>
+<div class="mockup-row">
+  <div class="mockup-col">
+    <span class="mockup-label" id="phone1-label">Card Page</span>
+    <div class="phone" id="phone-page">
+      <div class="status-bar"><span class="time">14:32</span><div class="icons"><span>📶</span><span>🔋</span></div></div>
+      <div class="navbar" id="page-navbar"></div>
+      <div class="page-content" id="page-content"></div>
+      <div class="bottom-bar">
+        <div class="bottom-item"><span>🏠</span><span class="bl">Home</span></div>
+        <div class="bottom-item"><span>🔍</span><span class="bl">Cerca</span></div>
+        <div class="bottom-item"><span>📚</span><span class="bl">Libreria</span></div>
+        <div class="bottom-item"><span>💬</span><span class="bl">Chat</span></div>
+        <div class="bottom-item"><span>👤</span><span class="bl">Profilo</span></div>
+      </div>
+    </div>
+  </div>
+  <div class="mockup-col">
+    <span class="mockup-label" id="phone2-label">Drawer View</span>
+    <div class="phone" id="phone-drawer">
+      <div class="status-bar"><span class="time">14:32</span><div class="icons"><span>📶</span><span>🔋</span></div></div>
+      <div class="navbar" id="drawer-navbar"></div>
+      <div class="page-content" id="drawer-page-bg" style="opacity:0.3;filter:blur(1px);pointer-events:none;"></div>
+      <div class="drawer-overlay open" id="drawer-overlay">
+        <div class="drawer-panel" onclick="event.stopPropagation()">
+          <div class="drawer-handle-area"><div class="drawer-handle"></div></div>
+          <div class="drawer-header" id="drawer-header"></div>
+          <div class="drawer-tabs" id="drawer-tabs"></div>
+          <div class="drawer-content" id="drawer-content"></div>
+        </div>
+      </div>
+      <div class="bottom-bar" style="opacity:0.3;">
+        <div class="bottom-item"><span>🏠</span><span class="bl">Home</span></div>
+        <div class="bottom-item"><span>🔍</span><span class="bl">Cerca</span></div>
+        <div class="bottom-item"><span>📚</span><span class="bl">Libreria</span></div>
+        <div class="bottom-item"><span>💬</span><span class="bl">Chat</span></div>
+        <div class="bottom-item"><span>👤</span><span class="bl">Profilo</span></div>
+      </div>
+    </div>
+  </div>
+</div>
+<div style="max-width:960px;margin:32px auto 16px;">
+  <h2 style="font-size:1rem;text-align:center;margin-bottom:4px;">Drawer Tab Specification</h2>
+  <p style="text-align:center;font-size:0.75rem;color:var(--text-sec);margin-bottom:12px;" id="spec-table-sub">Tab configuration per entity type selezionato</p>
+</div>
+<table id="spec-table" style="width:100%;max-width:900px;margin:0 auto 40px;border-collapse:collapse;font-size:12px;">
+  <thead><tr id="spec-thead-row" style="color:white;font-family:'Quicksand',sans-serif;font-size:11px;text-transform:uppercase;letter-spacing:0.05em;">
+    <th style="padding:10px 12px;text-align:left;">#</th><th style="padding:10px 12px;text-align:left;">Tab ID</th><th style="padding:10px 12px;text-align:left;">Label</th><th style="padding:10px 12px;text-align:left;">Icona</th><th style="padding:10px 12px;text-align:left;">Contenuto</th><th style="padding:10px 12px;text-align:left;">Badge</th>
+  </tr></thead>
+  <tbody id="spec-table-body"></tbody>
+</table>
+
+<script>
+/*
+ * STATIC MOCKUP — All content is developer-authored constants.
+ * No user input is processed. DOM manipulation uses only hardcoded strings.
+ */
+var ENTITIES={game:{color:{h:25,s:95,l:45},emoji:"\u{1F3B2}",label:"Game",title:"Azul",subtitle:"Plan B Games \u00B7 2017",cover:"linear-gradient(135deg, #1e88e5 0%, #0d47a1 50%, #ffc107 100%)",coverEmoji:"\u{1F537}",rating:7.8,badge:"In Libreria",meta:[{icon:"\u{1F465}",val:"2\u20134"},{icon:"\u23F1\uFE0F",val:"30\u201345m"},{icon:"\u{1F9E9}",val:"1.77"}],navItems:[{icon:"\u{1F4DA}",label:"KB",entity:"kb",count:3},{icon:"\u{1F916}",label:"Agent",entity:"agent",count:1},{icon:"\u{1F4AC}",label:"Chat",entity:"chat",count:5},{icon:"\u{1F3AF}",label:"Sessioni",entity:"session",count:23}],actions:["\u25B6\uFE0F Gioca","\u{1F916} Chiedi AI","\u2764\uFE0F Wishlist"],tabs:[{id:"details",label:"Dettagli",icon:"\u2139\uFE0F",specIcon:"Info",desc:"Publisher, anno, players, durata, complessita"},{id:"rules",label:"Regole",icon:"\u{1F4D6}",specIcon:"BookOpen",badge:12,desc:"FAQ count, documenti regole, link a KB docs",badgeLabel:"faqCount"},{id:"stats",label:"Statistiche",icon:"\u{1F4CA}",specIcon:"BarChart3",badge:23,desc:"Partite giocate, win rate, ultimo giocato",badgeLabel:"totalPlays"},{id:"kb",label:"KB",icon:"\u{1F4C4}",specIcon:"FileText",badge:3,desc:"Documenti indicizzati, stato indexing",badgeLabel:"kbDocCount"},{id:"agent",label:"Agente",icon:"\u{1F916}",specIcon:"Bot",desc:"Agente associato, stato, invocazioni"}]},player:{color:{h:262,s:83,l:58},emoji:"\u{1F464}",label:"Player",title:"Marco R.",subtitle:"Membro dal Gen 2025 \u00B7 89 partite",cover:"linear-gradient(135deg, hsl(262,83%,58%), hsl(262,60%,35%))",coverEmoji:"\u{1F464}",badge:"Pro Player",meta:[{icon:"\u{1F3C6}",val:"47 vittorie"},{icon:"\u{1F3B2}",val:"89 partite"},{icon:"\u{1F4CA}",val:"52.8%"}],navItems:[{icon:"\u{1F3C6}",label:"Vittorie",entity:"player",count:47},{icon:"\u{1F3AF}",label:"Partite",entity:"session",count:89},{icon:"\u2B50",label:"Preferiti",entity:"game",count:5},{icon:"\u{1F3C5}",label:"Trofei",entity:"player",count:8}],actions:["\u{1F4CA} Confronta","\u{1F4AC} Messaggio"],tabs:[{id:"overview",label:"Profilo",icon:"\u{1F464}",specIcon:"User",desc:"Nome, avatar, giochi preferiti, membro dal"},{id:"stats",label:"Statistiche",icon:"\u{1F3C6}",specIcon:"Trophy",badge:47,desc:"Vittorie, partite, win rate, distribuzione giochi",badgeLabel:"totalWins"},{id:"history",label:"Cronologia",icon:"\u{1F4DC}",specIcon:"History",badge:89,desc:"Ultime 10 partite con risultato e punteggio",badgeLabel:"totalSessions"},{id:"achievements",label:"Trofei",icon:"\u{1F3C5}",specIcon:"Award",badge:8,desc:"Badge sbloccati, progresso achievement",badgeLabel:"achievementCount"}]},session:{color:{h:240,s:60,l:55},emoji:"\u{1F3AF}",label:"Session",title:"Serata Azul",subtitle:"Azul \u00B7 Casa di Marco \u00B7 In corso",cover:"linear-gradient(135deg, hsl(240,60%,55%), hsl(240,40%,30%))",coverEmoji:"\u{1F3AF}",badge:"In Corso",meta:[{icon:"\u{1F465}",val:"4 giocatori"},{icon:"\u23F1\uFE0F",val:"45 min"},{icon:"\u{1F4CA}",val:"Turno 3/5"}],navItems:[{icon:"\u{1F465}",label:"Giocatori",entity:"player",count:4},{icon:"\u{1F4DD}",label:"Note",entity:"session",count:1},{icon:"\u{1F527}",label:"Tools",entity:"tool",count:3},{icon:"\u{1F4F7}",label:"Foto",entity:"session",count:4}],actions:["\u25B6\uFE0F Riprendi","\u{1F9F0} Toolkit","\u{1F4E4} Condividi"],tabs:[{id:"overview",label:"Overview",icon:"\u{1F4CB}",specIcon:"Layers",desc:"Gioco, stato, turno, durata, codice sessione"},{id:"scoreboard",label:"Classifica",icon:"\u{1F3C6}",specIcon:"Trophy",badge:4,desc:"Punteggi per round, ranking giocatori",badgeLabel:"playerCount"},{id:"toolkit",label:"Toolkit",icon:"\u{1F527}",specIcon:"Wrench",badge:3,desc:"Dadi, carte, timer, contatori attivi",badgeLabel:"toolCount"},{id:"notes",label:"Note",icon:"\u{1F4DD}",specIcon:"FileText",desc:"Note di sessione, eventi timeline"},{id:"media",label:"Media",icon:"\u{1F4F7}",specIcon:"Camera",badge:4,desc:"Foto, screenshot della sessione",badgeLabel:"photoCount"}]},agent:{color:{h:38,s:92,l:50},emoji:"\u{1F916}",label:"Agent",title:"Azul Rules Expert",subtitle:"RAG Strategy \u00B7 GPT-4o-mini \u00B7 Attivo",cover:"linear-gradient(135deg, hsl(38,92%,50%), hsl(38,70%,30%))",coverEmoji:"\u{1F916}",badge:"Attivo",meta:[{icon:"\u{1F4AC}",val:"342 invocazioni"},{icon:"\u{1F4DA}",val:"3 documenti"},{icon:"\u26A1",val:"1.2s"}],navItems:[{icon:"\u{1F4AC}",label:"Chat",entity:"chat",count:5},{icon:"\u{1F4DA}",label:"KB",entity:"kb",count:3},{icon:"\u{1F9E0}",label:"Memorie",entity:"agent"},{icon:"\u2699\uFE0F",label:"Config",entity:"agent"}],actions:["\u{1F4AC} Chat","\u{1F4CA} Stats","\u2699\uFE0F Config"],tabs:[{id:"overview",label:"Overview",icon:"\u{1F916}",specIcon:"Bot",desc:"Nome, tipo, strategia, modello, stato, gioco collegato"},{id:"stats",label:"Statistiche",icon:"\u26A1",specIcon:"Zap",badge:342,desc:"Invocazioni, latenza media, ultima invocazione",badgeLabel:"invocationCount"},{id:"kb",label:"KB",icon:"\u{1F4C4}",specIcon:"FileText",badge:3,desc:"Documenti associati, stato indexing",badgeLabel:"kbDocCount"},{id:"config",label:"Config",icon:"\u2699\uFE0F",specIcon:"Settings",desc:"Parametri strategia, temperatura, max tokens (read-only)"}]},kb:{color:{h:174,s:60,l:40},emoji:"\u{1F4C4}",label:"KB",title:"azul-regole-ita.pdf",subtitle:"2.4 MB \u00B7 12 pagine \u00B7 Indicizzato",cover:"linear-gradient(135deg, hsl(174,60%,40%), hsl(174,40%,25%))",coverEmoji:"\u{1F4C4}",badge:"Indicizzato",meta:[{icon:"\u{1F4CA}",val:"47 chunks"},{icon:"\u{1F4C4}",val:"12 pagine"},{icon:"\u{1F4BE}",val:"2.4 MB"}],navItems:[{icon:"\u{1F4CA}",label:"Chunks",entity:"kb",count:47},{icon:"\u{1F504}",label:"Reindex",entity:"kb"},{icon:"\u{1F441}\uFE0F",label:"Anteprima",entity:"kb"},{icon:"\u2B07\uFE0F",label:"Download",entity:"kb"}],actions:["\u{1F441}\uFE0F Anteprima","\u{1F504} Reindex","\u2B07\uFE0F Download"],tabs:[{id:"overview",label:"Overview",icon:"\u{1F4C4}",specIcon:"FileText",desc:"Filename, size, pages, stato, date upload/process"},{id:"preview",label:"Anteprima",icon:"\u{1F441}\uFE0F",specIcon:"Eye",desc:"Prime 500 parole del contenuto estratto"},{id:"chunks",label:"Chunks",icon:"\u{1F4CA}",specIcon:"Layers",badge:47,desc:"Chunk count, distribuzione, qualita embedding",badgeLabel:"chunkCount"}]},chat:{color:{h:220,s:80,l:55},emoji:"\u{1F4AC}",label:"Chat",title:"Come si gioca ad Azul?",subtitle:"Azul Rules Expert \u00B7 12 messaggi",cover:"linear-gradient(135deg, hsl(220,80%,55%), hsl(220,60%,35%))",coverEmoji:"\u{1F4AC}",badge:"Attiva",meta:[{icon:"\u{1F4AC}",val:"12 messaggi"},{icon:"\u23F1\uFE0F",val:"5 min fa"},{icon:"\u{1F916}",val:"GPT-4o-mini"}],navItems:[{icon:"\u{1F4AC}",label:"Messaggi",entity:"chat",count:12},{icon:"\u{1F4DA}",label:"Sources",entity:"kb"},{icon:"\u{1F916}",label:"Agente",entity:"agent"},{icon:"\u{1F4E6}",label:"Archivia",entity:"chat"}],actions:["\u{1F4AC} Continua","\u{1F4E4} Esporta"],tabs:[{id:"messages",label:"Messaggi",icon:"\u{1F4AC}",specIcon:"MessageSquare",badge:12,desc:"Ultimi 10 messaggi con scroll",badgeLabel:"messageCount"},{id:"context",label:"Contesto",icon:"\u{1F3AE}",specIcon:"Gamepad2",desc:"Gioco collegato, agente, parametri LLM"},{id:"actions",label:"Azioni",icon:"\u2699\uFE0F",specIcon:"Settings",desc:"Archivia, esporta, elimina, riapri"}]},event:{color:{h:350,s:89,l:60},emoji:"\u{1F4C5}",label:"Event",title:"Serata Giochi da Marco",subtitle:"15 Mar 2026 \u00B7 19:00 \u00B7 Casa di Marco",cover:"linear-gradient(135deg, hsl(350,89%,60%), hsl(350,70%,40%))",coverEmoji:"\u{1F389}",badge:"Confermato",meta:[{icon:"\u{1F465}",val:"5 partecipanti"},{icon:"\u{1F3B2}",val:"3 giochi"},{icon:"\u{1F4CD}",val:"Casa Marco"}],navItems:[{icon:"\u{1F465}",label:"Partecipanti",entity:"player",count:5},{icon:"\u{1F4CD}",label:"Luogo",entity:"event"},{icon:"\u{1F3B2}",label:"Giochi",entity:"game",count:3},{icon:"\u{1F4C5}",label:"Data",entity:"event"}],actions:["\u2705 Conferma","\u{1F4E4} Invita","\u{1F4DD} Note"],tabs:[{id:"overview",label:"Overview",icon:"\u{1F4C5}",specIcon:"Calendar",desc:"Nome, data, orario, luogo, organizzatore"},{id:"participants",label:"Partecipanti",icon:"\u{1F465}",specIcon:"Users",badge:5,desc:"Lista giocatori confermati/pendenti",badgeLabel:"participantCount"},{id:"games",label:"Giochi",icon:"\u{1F3B2}",specIcon:"Dices",badge:3,desc:"Giochi pianificati/giocati nella serata",badgeLabel:"gameCount"},{id:"diary",label:"Diario",icon:"\u{1F4D6}",specIcon:"BookOpen",desc:"Timeline cross-game, foto, momenti"}]},toolkit:{color:{h:142,s:70,l:45},emoji:"\u{1F9F0}",label:"Toolkit",title:"Azul Toolkit v2",subtitle:"Pubblicato \u00B7 3 strumenti \u00B7 Azul",cover:"linear-gradient(135deg, hsl(142,70%,45%), hsl(142,50%,28%))",coverEmoji:"\u{1F9F0}",badge:"Pubblicato",meta:[{icon:"\u{1F527}",val:"3 tools"},{icon:"\u{1F0CF}",val:"1 deck"},{icon:"\u23F1\uFE0F",val:"1 timer"}],navItems:[{icon:"\u{1F527}",label:"Tools",entity:"tool",count:3},{icon:"\u{1F0CF}",label:"Decks",entity:"toolkit",count:1},{icon:"\u23F1\uFE0F",label:"Phases",entity:"toolkit",count:3},{icon:"\u{1F4DC}",label:"Storico",entity:"session",count:12}],actions:["\u25B6\uFE0F Usa","\u270F\uFE0F Modifica","\u{1F4CB} Duplica"],tabs:[{id:"overview",label:"Overview",icon:"\u{1F9F0}",specIcon:"Wrench",desc:"Nome, versione, stato pubblicazione, gioco associato"},{id:"tools",label:"Strumenti",icon:"\u{1F527}",specIcon:"Layers",badge:3,desc:"Lista: dadi, carte, timer, contatori con config",badgeLabel:"toolCount"},{id:"templates",label:"Template",icon:"\u{1F4D0}",specIcon:"Layout",desc:"Scoring template, turn template, phases"},{id:"history",label:"Storico",icon:"\u{1F4DC}",specIcon:"History",badge:12,desc:"Utilizzi recenti, sessioni che hanno usato il toolkit",badgeLabel:"useCount"}]},tool:{color:{h:195,s:80,l:50},emoji:"\u{1F527}",label:"Tool",title:"Timer Turno Azul",subtitle:"Timer \u00B7 5:00 \u00B7 Per giocatore \u00B7 Auto-start",cover:"linear-gradient(135deg, hsl(195,80%,50%), hsl(195,60%,30%))",coverEmoji:"\u23F1\uFE0F",badge:"Attivo",meta:[{icon:"\u23F1\uFE0F",val:"5:00"},{icon:"\u{1F465}",val:"Per giocatore"},{icon:"\u{1F4CA}",val:"23 utilizzi"}],navItems:[{icon:"\u25B6\uFE0F",label:"Usa",entity:"tool"},{icon:"\u270F\uFE0F",label:"Modifica",entity:"tool"},{icon:"\u{1F4CB}",label:"Duplica",entity:"tool"},{icon:"\u{1F4DC}",label:"Storico",entity:"tool"}],actions:["\u25B6\uFE0F Start","\u23F8\uFE0F Pausa","\u{1F504} Reset"],tabs:[{id:"overview",label:"Dettaglio",icon:"\u{1F527}",specIcon:"Wrench",desc:"Nome, tipo, config completa"},{id:"usage",label:"Utilizzo",icon:"\u25B6\uFE0F",specIcon:"Play",desc:"Preview interattiva: start, pause, reset"},{id:"history",label:"Storico",icon:"\u{1F4DC}",specIcon:"History",desc:"Log utilizzi recenti con timestamp e sessione"}]}};
+
+/* Tab content templates — all hardcoded, no user input */
+var TAB_CONTENT = {
+  game: {
+    details: '<h4>Dettagli Gioco</h4><div class="info-row"><span class="label">Editore</span><span class="value">Plan B Games</span></div><div class="info-row"><span class="label">Anno</span><span class="value">2017</span></div><div class="info-row"><span class="label">Giocatori</span><span class="value">2\u20134</span></div><div class="info-row"><span class="label">Durata</span><span class="value">30\u201345 min</span></div><div class="info-row"><span class="label">Complessita</span><span class="value">\u25CF\u25CF\u25CB\u25CB\u25CB (1.77)</span></div><div class="info-row"><span class="label">Categoria</span><span class="value">Astratto, Piazzamento tessere</span></div><p style="margin-top:10px;font-size:12px;line-height:1.6;">Azul sfida i giocatori a decorare le pareti del Palazzo Reale di Evora selezionando le tessere piu belle dalla fabbrica...</p>',
+    rules: '<h4>\u{1F4D6} Regole &amp; FAQ</h4><div class="mini-list"><div class="mini-item"><div class="mi-icon" style="background:hsla(25,95%,45%,0.1);">\u2753</div><div class="mi-text"><div class="mi-title">Posso spostare tessere gia piazzate?</div><div class="mi-sub">No, una volta piazzate sono permanenti \u00B7 \u{1F44D} 47</div></div></div><div class="mini-item"><div class="mi-icon" style="background:hsla(25,95%,45%,0.1);">\u2753</div><div class="mi-text"><div class="mi-title">Cosa succede se la fabbrica e vuota?</div><div class="mi-sub">Il round termina e si procede al punteggio \u00B7 \u{1F44D} 31</div></div></div><div class="mini-item"><div class="mi-icon" style="background:hsla(25,95%,45%,0.1);">\u{1F4C4}</div><div class="mi-text"><div class="mi-title">azul-regole-ita.pdf</div><div class="mi-sub">12 pagine \u00B7 Indicizzato \u00B7 Caricato 15 Gen</div></div></div></div>',
+    stats: '<h4>\u{1F4CA} Statistiche</h4><div class="stat-grid"><div class="stat-box"><div class="stat-val" style="color:hsl(25,95%,45%);">23</div><div class="stat-label">Partite</div></div><div class="stat-box"><div class="stat-val" style="color:hsl(142,70%,45%);">65%</div><div class="stat-label">Win Rate</div></div><div class="stat-box"><div class="stat-val" style="color:hsl(220,80%,55%);">72</div><div class="stat-label">Avg Score</div></div><div class="stat-box"><div class="stat-val" style="color:hsl(262,83%,58%);">2g</div><div class="stat-label">Ultimo</div></div></div><h4 style="margin-top:8px;">Ultime 5 partite</h4><div class="info-row"><span class="label">11 Mar</span><span class="value" style="color:hsl(142,70%,35%);">Vittoria (72 pt)</span></div><div class="info-row"><span class="label">8 Mar</span><span class="value">2\u00B0 posto (61 pt)</span></div><div class="info-row"><span class="label">2 Mar</span><span class="value" style="color:hsl(142,70%,35%);">Vittoria (78 pt)</span></div>',
+    kb: '<h4>\u{1F4C4} Knowledge Base</h4><div class="mini-list"><div class="mini-item"><div class="mi-icon" style="background:hsla(174,60%,40%,0.1);">\u{1F4C4}</div><div class="mi-text"><div class="mi-title">azul-regole-ita.pdf</div><div class="mi-sub">47 chunks \u00B7 Indicizzato</div></div><div class="mi-badge" style="background:hsl(142,70%,45%);">\u2713</div></div><div class="mini-item"><div class="mi-icon" style="background:hsla(174,60%,40%,0.1);">\u{1F4C4}</div><div class="mi-text"><div class="mi-title">azul-strategie.pdf</div><div class="mi-sub">23 chunks \u00B7 Indicizzato</div></div><div class="mi-badge" style="background:hsl(142,70%,45%);">\u2713</div></div><div class="mini-item"><div class="mi-icon" style="background:hsla(38,92%,50%,0.1);">\u{1F4C4}</div><div class="mi-text"><div class="mi-title">azul-espansione.pdf</div><div class="mi-sub">In elaborazione...</div></div><div class="mi-badge" style="background:hsl(38,92%,50%);">\u27F3</div></div></div>',
+    agent: '<h4>\u{1F916} Agente AI</h4><div class="mini-item" style="margin-bottom:12px;"><div class="mi-icon" style="background:hsla(38,92%,50%,0.15);">\u{1F916}</div><div class="mi-text"><div class="mi-title">Azul Rules Expert</div><div class="mi-sub"><span class="status-dot green"></span>Attivo \u00B7 RAG Strategy \u00B7 GPT-4o-mini</div></div></div><div class="stat-grid"><div class="stat-box"><div class="stat-val" style="color:hsl(38,92%,50%);">342</div><div class="stat-label">Invocazioni</div></div><div class="stat-box"><div class="stat-val" style="color:hsl(38,92%,50%);">1.2s</div><div class="stat-label">Latenza</div></div></div><div class="info-row"><span class="label">Ultimo utilizzo</span><span class="value">5 min fa</span></div>'
+  },
+  player: {
+    overview: '<h4>Profilo Giocatore</h4><div style="display:flex;align-items:center;gap:12px;margin-bottom:12px;"><div style="width:48px;height:48px;border-radius:50%;background:linear-gradient(135deg,hsl(262,83%,58%),hsl(262,60%,35%));display:flex;align-items:center;justify-content:center;color:white;font-size:18px;font-weight:800;font-family:Quicksand,sans-serif;">MR</div><div><div style="font-weight:700;font-size:14px;">Marco Rossi</div><div style="font-size:11px;color:var(--text-sec);">Membro dal Gennaio 2025</div></div></div><div class="info-row"><span class="label">Gioco preferito</span><span class="value">Azul (23 partite)</span></div><div class="info-row"><span class="label">Genere preferito</span><span class="value">Astratto</span></div><div class="info-row"><span class="label">Gruppi</span><span class="value">2 (Game Night Club, Ufficio)</span></div>',
+    stats: '<h4>\u{1F3C6} Statistiche</h4><div class="stat-grid"><div class="stat-box"><div class="stat-val" style="color:hsl(262,83%,58%);">47</div><div class="stat-label">Vittorie</div></div><div class="stat-box"><div class="stat-val" style="color:hsl(262,83%,58%);">89</div><div class="stat-label">Partite</div></div><div class="stat-box"><div class="stat-val" style="color:hsl(142,70%,45%);">52.8%</div><div class="stat-label">Win Rate</div></div><div class="stat-box"><div class="stat-val" style="color:hsl(262,83%,58%);">15</div><div class="stat-label">Giochi</div></div></div><h4>Top 3</h4><div class="info-row"><span class="label">\u{1F947} Azul</span><span class="value">23 partite (65%)</span></div><div class="info-row"><span class="label">\u{1F948} Catan</span><span class="value">18 partite (44%)</span></div><div class="info-row"><span class="label">\u{1F949} Wingspan</span><span class="value">12 partite (58%)</span></div>',
+    history: '<h4>\u{1F4DC} Ultime Partite</h4><div class="info-row"><span class="label">11 Mar \u00B7 Azul</span><span class="value" style="color:hsl(142,70%,35%);">\u{1F3C6} 72 pt</span></div><div class="info-row"><span class="label">8 Mar \u00B7 Catan</span><span class="value">2\u00B0 \u00B7 8 pt</span></div><div class="info-row"><span class="label">2 Mar \u00B7 Azul</span><span class="value" style="color:hsl(142,70%,35%);">\u{1F3C6} 78 pt</span></div><div class="info-row"><span class="label">24 Feb \u00B7 Root</span><span class="value">3\u00B0 \u00B7 12 pt</span></div><div class="info-row"><span class="label">18 Feb \u00B7 Azul</span><span class="value" style="color:hsl(142,70%,35%);">\u{1F3C6} 69 pt</span></div>',
+    achievements: '<h4>\u{1F3C5} Trofei</h4><div class="mini-list"><div class="mini-item"><div class="mi-icon" style="background:hsla(45,100%,50%,0.15);">\u{1F3C5}</div><div class="mi-text"><div class="mi-title">Maestro di Azul</div><div class="mi-sub">50+ partite ad Azul</div></div></div><div class="mini-item"><div class="mi-icon" style="background:hsla(45,100%,50%,0.15);">\u{1F525}</div><div class="mi-text"><div class="mi-title">Streak vincente</div><div class="mi-sub">5 vittorie consecutive</div></div></div><div class="mini-item"><div class="mi-icon" style="background:hsla(45,100%,50%,0.15);">\u{1F3AF}</div><div class="mi-text"><div class="mi-title">Primo gioco</div><div class="mi-sub">Prima partita completata</div></div></div></div><div style="margin-top:10px;font-size:11px;color:var(--text-muted);">8/24 trofei</div><div class="progress-bar"><div class="progress-fill" style="width:33%;background:hsl(262,83%,58%);"></div></div>'
+  },
+  session: {
+    overview: '<h4>Overview Sessione</h4><div class="info-row"><span class="label">Gioco</span><span class="value">Azul</span></div><div class="info-row"><span class="label">Stato</span><span class="value"><span class="status-dot green"></span>In Corso</span></div><div class="info-row"><span class="label">Turno</span><span class="value">3 / 5</span></div><div class="info-row"><span class="label">Durata</span><span class="value">45 min</span></div><div class="info-row"><span class="label">Codice</span><span class="value" style="font-family:monospace;">AZL-7X2K</span></div><h4 style="margin-top:10px;">Giocatori</h4><div class="info-row"><span class="label">\u{1F947} Marco</span><span class="value" style="color:hsl(142,70%,35%);">72 pt</span></div><div class="info-row"><span class="label">\u{1F948} Sara</span><span class="value">61 pt</span></div><div class="info-row"><span class="label">\u{1F949} Luca</span><span class="value">54 pt</span></div><div class="info-row"><span class="label">4. Elena</span><span class="value">48 pt</span></div>',
+    scoreboard: '<h4>\u{1F3C6} Classifica</h4><div style="overflow-x:auto;"><table style="width:100%;font-size:11px;border-collapse:collapse;"><tr style="border-bottom:2px solid var(--border);"><th style="padding:6px;text-align:left;">Giocatore</th><th style="padding:6px;">R1</th><th style="padding:6px;">R2</th><th style="padding:6px;">R3</th><th style="padding:6px;font-weight:800;">Tot</th></tr><tr style="background:hsla(142,70%,45%,0.08);"><td style="padding:6px;font-weight:700;">\u{1F947} Marco</td><td style="padding:6px;text-align:center;">24</td><td style="padding:6px;text-align:center;">26</td><td style="padding:6px;text-align:center;">22</td><td style="padding:6px;text-align:center;font-weight:800;">72</td></tr><tr><td style="padding:6px;">\u{1F948} Sara</td><td style="padding:6px;text-align:center;">21</td><td style="padding:6px;text-align:center;">18</td><td style="padding:6px;text-align:center;">22</td><td style="padding:6px;text-align:center;font-weight:800;">61</td></tr><tr><td style="padding:6px;">\u{1F949} Luca</td><td style="padding:6px;text-align:center;">18</td><td style="padding:6px;text-align:center;">20</td><td style="padding:6px;text-align:center;">16</td><td style="padding:6px;text-align:center;font-weight:800;">54</td></tr></table></div>',
+    toolkit: '<h4>\u{1F527} Toolkit Attivi</h4><div class="mini-list"><div class="mini-item"><div class="mi-icon" style="background:hsla(240,60%,55%,0.1);">\u23F1\uFE0F</div><div class="mi-text"><div class="mi-title">Timer Turno</div><div class="mi-sub"><span class="status-dot green"></span>In esecuzione \u00B7 3:42</div></div></div><div class="mini-item"><div class="mi-icon" style="background:hsla(240,60%,55%,0.1);">\u{1F522}</div><div class="mi-text"><div class="mi-title">Contatore Parete</div><div class="mi-sub">Marco: 12 \u00B7 Sara: 9 \u00B7 Luca: 7</div></div></div><div class="mini-item"><div class="mi-icon" style="background:hsla(240,60%,55%,0.1);">\u{1F3B2}</div><div class="mi-text"><div class="mi-title">Selettore Primo Giocatore</div><div class="mi-sub">Turno corrente: Sara</div></div></div></div>',
+    notes: '<h4>\u{1F4DD} Timeline</h4><div class="timeline-item"><div class="timeline-dot" style="background:hsl(240,60%,55%);"></div><div class="timeline-text"><div>Sessione avviata</div><div class="tl-time">19:00</div></div></div><div class="timeline-item"><div class="timeline-dot" style="background:hsl(142,70%,45%);"></div><div class="timeline-text"><div>Round 1 \u2014 Marco in testa (24pt)</div><div class="tl-time">19:18</div></div></div><div class="timeline-item"><div class="timeline-dot" style="background:hsl(142,70%,45%);"></div><div class="timeline-text"><div>Round 2 \u2014 Marco consolida (50pt)</div><div class="tl-time">19:35</div></div></div><div class="timeline-item"><div class="timeline-dot" style="background:hsl(38,92%,50%);"></div><div class="timeline-text"><div>Nota: &quot;Sara completa riga blu&quot;</div><div class="tl-time">19:42</div></div></div>',
+    media: '<h4>\u{1F4F7} Media</h4><div class="photo-grid"><div class="photo-thumb" style="background:linear-gradient(135deg,#e3f2fd,#bbdefb);">\u{1F4F7}</div><div class="photo-thumb" style="background:linear-gradient(135deg,#f3e5f5,#e1bee7);">\u{1F4F7}</div><div class="photo-thumb" style="background:linear-gradient(135deg,#e8f5e9,#c8e6c9);">\u{1F4F7}</div><div class="photo-thumb" style="background:linear-gradient(135deg,#fff3e0,#ffe0b2);">\u{1F4F7}</div></div><p style="margin-top:8px;font-size:11px;color:var(--text-muted);">4 foto</p>'
+  },
+  agent: {
+    overview: '<h4>Overview Agente</h4><div class="info-row"><span class="label">Nome</span><span class="value">Azul Rules Expert</span></div><div class="info-row"><span class="label">Tipo</span><span class="value">QA (Rules Assistant)</span></div><div class="info-row"><span class="label">Strategia</span><span class="value">hybrid-rag</span></div><div class="info-row"><span class="label">Modello</span><span class="value">GPT-4o-mini</span></div><div class="info-row"><span class="label">Stato</span><span class="value"><span class="status-dot green"></span>Attivo</span></div><div class="info-row"><span class="label">Gioco</span><span class="value">Azul</span></div>',
+    stats: '<h4>\u26A1 Statistiche</h4><div class="stat-grid"><div class="stat-box"><div class="stat-val" style="color:hsl(38,92%,50%);">342</div><div class="stat-label">Invocazioni</div></div><div class="stat-box"><div class="stat-val" style="color:hsl(38,92%,50%);">1.2s</div><div class="stat-label">Latenza Media</div></div><div class="stat-box"><div class="stat-val" style="color:hsl(38,92%,50%);">5m</div><div class="stat-label">Ultimo Uso</div></div><div class="stat-box"><div class="stat-val" style="color:hsl(38,92%,50%);">97%</div><div class="stat-label">Uptime</div></div></div>',
+    kb: '<h4>\u{1F4C4} Documenti KB</h4><div class="mini-list"><div class="mini-item"><div class="mi-icon" style="background:hsla(174,60%,40%,0.1);">\u{1F4C4}</div><div class="mi-text"><div class="mi-title">azul-regole-ita.pdf</div><div class="mi-sub">47 chunks \u00B7 Indicizzato</div></div><div class="mi-badge" style="background:hsl(142,70%,45%);">\u2713</div></div><div class="mini-item"><div class="mi-icon" style="background:hsla(174,60%,40%,0.1);">\u{1F4C4}</div><div class="mi-text"><div class="mi-title">azul-strategie.pdf</div><div class="mi-sub">23 chunks \u00B7 Indicizzato</div></div><div class="mi-badge" style="background:hsl(142,70%,45%);">\u2713</div></div></div>',
+    config: '<h4>\u2699\uFE0F Configurazione</h4><div class="config-row"><span class="ck">temperature</span><span class="cv">0.7</span></div><div class="config-row"><span class="ck">maxTokens</span><span class="cv">2048</span></div><div class="config-row"><span class="ck">topK</span><span class="cv">5</span></div><div class="config-row"><span class="ck">strategy</span><span class="cv">hybrid-rag</span></div><div class="config-row"><span class="ck">rerankEnabled</span><span class="cv">true</span></div><p style="margin-top:10px;font-size:10px;color:var(--text-muted);">Sola lettura. Modifica dalla pagina Agente.</p>'
+  },
+  kb: {
+    overview: '<h4>Overview Documento</h4><div class="info-row"><span class="label">File</span><span class="value">azul-regole-ita.pdf</span></div><div class="info-row"><span class="label">Dimensione</span><span class="value">2.4 MB</span></div><div class="info-row"><span class="label">Pagine</span><span class="value">12</span></div><div class="info-row"><span class="label">Caratteri</span><span class="value">24,567</span></div><div class="info-row"><span class="label">Stato</span><span class="value"><span class="status-dot green"></span>Indicizzato</span></div><div class="info-row"><span class="label">Caricato</span><span class="value">15 Gen 2026</span></div><div class="info-row"><span class="label">Gioco</span><span class="value">Azul</span></div>',
+    preview: '<h4>\u{1F441}\uFE0F Anteprima</h4><div style="padding:10px;background:var(--bg-muted);border-radius:10px;font-size:12px;line-height:1.7;"><p><strong>AZUL \u2014 Regole del gioco</strong></p><p style="margin-top:6px;">Azul e un gioco astratto per 2-4 giocatori creato da Michael Kiesling. Il gioco e ispirato alle azulejos, le famose piastrelle decorative portoghesi.</p><p style="margin-top:6px;"><strong>Preparazione:</strong> Posizionate le fabbriche circolari al centro del tavolo...</p><p style="margin-top:8px;font-size:10px;color:var(--text-muted);">500/24,567 caratteri</p></div>',
+    chunks: '<h4>\u{1F4CA} Chunks</h4><div class="stat-grid"><div class="stat-box"><div class="stat-val" style="color:hsl(174,60%,40%);">47</div><div class="stat-label">Chunks</div></div><div class="stat-box"><div class="stat-val" style="color:hsl(174,60%,40%);">312</div><div class="stat-label">Avg Tokens</div></div></div><div class="info-row"><span class="label">Similarita media</span><span class="value">0.82</span></div><div class="info-row"><span class="label">Modello</span><span class="value">e5-base (768d)</span></div>'
+  },
+  chat: {
+    messages: '<h4>\u{1F4AC} Conversazione</h4><div style="display:flex;flex-direction:column;gap:6px;"><div class="chat-bubble user">Come si gioca ad Azul?<div class="cb-time">14:20</div></div><div class="chat-bubble assistant">Azul e un gioco di piazzamento tessere per 2-4 giocatori. Ogni turno scegli tessere colorate dalle fabbriche...<div class="cb-time">14:20</div></div><div class="chat-bubble user">Come funziona il punteggio?<div class="cb-time">14:22</div></div><div class="chat-bubble assistant">Quando piazzi una tessera sulla parete, guadagni 1 punto per ogni tessera adiacente. I bonus premiano righe e colonne complete...<div class="cb-time">14:22</div></div><div class="chat-bubble user">E le penalita?<div class="cb-time">14:25</div></div><div class="chat-bubble assistant">Le tessere non piazzate vanno nella floor line: -1, -1, -2, -2, -2, -3, -3.<div class="cb-time">14:25</div></div></div>',
+    context: '<h4>\u{1F3AE} Contesto Chat</h4><div class="info-row"><span class="label">Gioco</span><span class="value">Azul</span></div><div class="info-row"><span class="label">Agente</span><span class="value">Azul Rules Expert</span></div><div class="info-row"><span class="label">Modello</span><span class="value">GPT-4o-mini</span></div><div class="info-row"><span class="label">Temperatura</span><span class="value">0.7</span></div><div class="info-row"><span class="label">Iniziata</span><span class="value">14:20 \u00B7 10 Apr 2026</span></div>',
+    actions: '<h4>\u2699\uFE0F Azioni</h4><div class="action-group"><button class="action-btn"><span class="ab-icon">\u{1F4E6}</span>Archivia conversazione</button><button class="action-btn"><span class="ab-icon">\u{1F4E4}</span>Esporta come TXT</button><button class="action-btn"><span class="ab-icon">\u{1F4CB}</span>Copia link</button><button class="action-btn danger"><span class="ab-icon">\u{1F5D1}\uFE0F</span>Elimina conversazione</button></div>'
+  },
+  event: {
+    overview: '<h4>Overview Evento</h4><div class="info-row"><span class="label">Nome</span><span class="value">Serata Giochi da Marco</span></div><div class="info-row"><span class="label">Data</span><span class="value">15 Marzo 2026</span></div><div class="info-row"><span class="label">Orario</span><span class="value">19:00 \u2013 23:00</span></div><div class="info-row"><span class="label">Luogo</span><span class="value">\u{1F4CD} Casa di Marco</span></div><div class="info-row"><span class="label">Organizzatore</span><span class="value">Marco R.</span></div><div class="info-row"><span class="label">Note</span><span class="value">Portare snack! Pizza alle 21</span></div>',
+    participants: '<h4>\u{1F465} Partecipanti</h4><div class="mini-list"><div class="mini-item"><div class="mi-icon" style="background:hsla(262,83%,58%,0.1);">\u{1F464}</div><div class="mi-text"><div class="mi-title">Marco R.</div><div class="mi-sub">Organizzatore</div></div><div class="mi-badge" style="background:hsl(142,70%,45%);">\u2713</div></div><div class="mini-item"><div class="mi-icon" style="background:hsla(262,83%,58%,0.1);">\u{1F464}</div><div class="mi-text"><div class="mi-title">Sara B.</div><div class="mi-sub">Confermata</div></div><div class="mi-badge" style="background:hsl(142,70%,45%);">\u2713</div></div><div class="mini-item"><div class="mi-icon" style="background:hsla(262,83%,58%,0.1);">\u{1F464}</div><div class="mi-text"><div class="mi-title">Luca M.</div><div class="mi-sub">Confermato</div></div><div class="mi-badge" style="background:hsl(142,70%,45%);">\u2713</div></div><div class="mini-item"><div class="mi-icon" style="background:hsla(38,92%,50%,0.1);">\u{1F464}</div><div class="mi-text"><div class="mi-title">Giulia T.</div><div class="mi-sub">In attesa</div></div><div class="mi-badge" style="background:hsl(38,92%,50%);">?</div></div></div>',
+    games: '<h4>\u{1F3B2} Giochi</h4><div class="mini-list"><div class="mini-item"><div class="mi-icon" style="background:hsla(25,95%,45%,0.1);">\u{1F537}</div><div class="mi-text"><div class="mi-title">Azul</div><div class="mi-sub"><span class="status-dot green"></span>Completato \u00B7 Marco vince</div></div></div><div class="mini-item"><div class="mi-icon" style="background:hsla(25,95%,45%,0.1);">\u{1F3DD}\uFE0F</div><div class="mi-text"><div class="mi-title">Catan</div><div class="mi-sub"><span class="status-dot blue"></span>In corso</div></div></div><div class="mini-item"><div class="mi-icon" style="background:hsla(25,95%,45%,0.1);">\u{1F426}</div><div class="mi-text"><div class="mi-title">Wingspan</div><div class="mi-sub"><span class="status-dot amber"></span>Pianificato</div></div></div></div>',
+    diary: '<h4>\u{1F4D6} Diario</h4><div class="timeline-item"><div class="timeline-dot" style="background:hsl(350,89%,60%);"></div><div class="timeline-text"><div>\u{1F3E0} Arrivo ospiti</div><div class="tl-time">19:00</div></div></div><div class="timeline-item"><div class="timeline-dot" style="background:hsl(25,95%,45%);"></div><div class="timeline-text"><div>\u{1F537} Inizio Azul</div><div class="tl-time">19:15</div></div></div><div class="timeline-item"><div class="timeline-dot" style="background:hsl(142,70%,45%);"></div><div class="timeline-text"><div>\u{1F3C6} Marco vince Azul!</div><div class="tl-time">20:00</div></div></div><div class="timeline-item"><div class="timeline-dot" style="background:hsl(25,95%,45%);"></div><div class="timeline-text"><div>\u{1F3DD}\uFE0F Inizio Catan</div><div class="tl-time">20:15</div></div></div><div class="timeline-item"><div class="timeline-dot" style="background:hsl(350,89%,60%);"></div><div class="timeline-text"><div>\u{1F355} Pausa pizza!</div><div class="tl-time">21:00</div></div></div>'
+  },
+  toolkit: {
+    overview: '<h4>Overview Toolkit</h4><div class="info-row"><span class="label">Nome</span><span class="value">Azul Toolkit v2</span></div><div class="info-row"><span class="label">Versione</span><span class="value">2</span></div><div class="info-row"><span class="label">Stato</span><span class="value"><span class="status-dot green"></span>Pubblicato</span></div><div class="info-row"><span class="label">Gioco</span><span class="value">Azul</span></div><div class="info-row"><span class="label">Strumenti</span><span class="value">3 (timer, counter, dice)</span></div><div class="info-row"><span class="label">Usato in</span><span class="value">12 sessioni</span></div>',
+    tools: '<h4>\u{1F527} Strumenti</h4><div class="mini-list"><div class="mini-item"><div class="mi-icon" style="background:hsla(142,70%,45%,0.1);">\u23F1\uFE0F</div><div class="mi-text"><div class="mi-title">Timer Turno</div><div class="mi-sub">5:00 \u00B7 Per giocatore \u00B7 Auto-start</div></div></div><div class="mini-item"><div class="mi-icon" style="background:hsla(142,70%,45%,0.1);">\u{1F522}</div><div class="mi-text"><div class="mi-title">Contatore Parete</div><div class="mi-sub">0\u201325 \u00B7 Per giocatore</div></div></div><div class="mini-item"><div class="mi-icon" style="background:hsla(142,70%,45%,0.1);">\u{1F3B2}</div><div class="mi-text"><div class="mi-title">Selettore 1\u00B0 Giocatore</div><div class="mi-sub">1d4 \u00B7 Colori fazione</div></div></div></div>',
+    templates: '<h4>\u{1F4D0} Template</h4><h4 style="margin-top:8px;font-size:12px;">Scoring</h4><div class="info-row"><span class="label">Dimensioni</span><span class="value">Righe, Colonne, Set</span></div><div class="info-row"><span class="label">Tipo</span><span class="value">Additivo</span></div><h4 style="margin-top:12px;font-size:12px;">Fasi di turno</h4><div style="display:flex;gap:4px;flex-wrap:wrap;margin-top:4px;"><span style="padding:4px 10px;border-radius:12px;background:hsla(142,70%,45%,0.1);font-size:11px;font-weight:700;color:hsl(142,70%,45%);">1. Selezione</span><span style="padding:4px 10px;border-radius:12px;background:hsla(142,70%,45%,0.1);font-size:11px;font-weight:700;color:hsl(142,70%,45%);">2. Piazzamento</span><span style="padding:4px 10px;border-radius:12px;background:hsla(142,70%,45%,0.1);font-size:11px;font-weight:700;color:hsl(142,70%,45%);">3. Punteggio</span></div>',
+    history: '<h4>\u{1F4DC} Storico</h4><div class="info-row"><span class="label">11 Mar \u00B7 Serata Azul</span><span class="value">4 giocatori</span></div><div class="info-row"><span class="label">8 Mar \u00B7 Torneo</span><span class="value">3 giocatori</span></div><div class="info-row"><span class="label">2 Mar \u00B7 Casual</span><span class="value">2 giocatori</span></div><p style="margin-top:8px;font-size:10px;color:var(--text-muted);">12 utilizzi totali</p>'
+  },
+  tool: {
+    overview: '<h4>Dettaglio Strumento</h4><div class="info-row"><span class="label">Nome</span><span class="value">Timer Turno Azul</span></div><div class="info-row"><span class="label">Tipo</span><span class="value">Timer</span></div><div class="info-row"><span class="label">Durata</span><span class="value">5:00 (300s)</span></div><div class="info-row"><span class="label">Per giocatore</span><span class="value">Si</span></div><div class="info-row"><span class="label">Auto-start</span><span class="value">Si</span></div><div class="info-row"><span class="label">Warning</span><span class="value">30s (diventa rosso)</span></div><div class="info-row"><span class="label">Toolkit</span><span class="value">Azul Toolkit v2</span></div>',
+    usage: '<h4>\u25B6\uFE0F Preview</h4><div class="tool-preview"><div style="font-size:11px;color:var(--text-muted);text-transform:uppercase;font-weight:700;">Timer Turno</div><div class="tp-display" style="color:hsl(195,80%,50%);">4:12</div><div class="progress-bar"><div class="progress-fill" style="width:84%;background:hsl(195,80%,50%);"></div></div><div class="tp-controls"><button class="tp-btn">\u23F8\uFE0F Pausa</button><button class="tp-btn primary" style="background:hsl(195,80%,50%);">\u{1F504} Reset</button></div></div><p style="margin-top:8px;font-size:10px;color:var(--text-muted);text-align:center;">Giocatore: Marco \u00B7 Media: 4:12</p>',
+    history: '<h4>\u{1F4DC} Log</h4><div class="info-row"><span class="label">11 Mar 19:15</span><span class="value">Marco \u2014 4:42</span></div><div class="info-row"><span class="label">11 Mar 19:20</span><span class="value">Sara \u2014 3:58</span></div><div class="info-row"><span class="label">11 Mar 19:25</span><span class="value">Luca \u2014 5:00 (scaduto!)</span></div><div class="stat-grid" style="margin-top:10px;"><div class="stat-box"><div class="stat-val" style="color:hsl(195,80%,50%);">23</div><div class="stat-label">Utilizzi</div></div><div class="stat-box"><div class="stat-val" style="color:hsl(195,80%,50%);">4:12</div><div class="stat-label">Media</div></div></div>'
+  }
+};
+
+var currentEntity = 'game';
+var currentTabIdx = 0;
+
+function ec(e) { var c=ENTITIES[e].color; return 'hsl('+c.h+','+c.s+'%,'+c.l+'%)'; }
+function eca(e,a) { var c=ENTITIES[e].color; return 'hsla('+c.h+','+c.s+'%,'+c.l+'%,'+a+')'; }
+
+function setHtml(id, html) { document.getElementById(id).innerHTML = html; }
+
+function renderAll() {
+  var e = ENTITIES[currentEntity];
+  var color = ec(currentEntity);
+  currentTabIdx = 0;
+
+  // Switcher
+  var sw = '';
+  Object.keys(ENTITIES).forEach(function(key) {
+    var v = ENTITIES[key];
+    var act = key === currentEntity;
+    sw += '<button class="entity-btn' + (act ? ' active' : '') + '" onclick="switchEntity(\'' + key + '\')" style="' + (act ? 'background:' + ec(key) + ';color:white;border-color:transparent;' : '') + '">';
+    sw += '<span class="dot" style="background:' + (act ? 'white' : ec(key)) + ';"></span>';
+    sw += v.emoji + ' ' + v.label + '</button>';
+  });
+  setHtml('entity-switcher', sw);
+
+  document.getElementById('phone1-label').textContent = e.emoji + ' ' + e.title + ' \u2014 Page';
+  document.getElementById('phone2-label').textContent = e.emoji + ' ' + e.title + ' \u2014 Drawer';
+
+  var navHtml = '<button class="back-btn" title="Indietro">\u2039</button><span class="nav-title">' + e.title + '</span><button class="nav-action" title="Opzioni">\u22EF</button>';
+  setHtml('page-navbar', navHtml);
+  setHtml('drawer-navbar', navHtml);
+
+  // Page
+  var navItemsHtml = e.navItems.map(function(n) {
+    return '<div class="nav-item"><div class="nav-icon" style="color:' + ec(n.entity) + ';">' + n.icon + (n.count ? '<span class="nav-badge" style="background:' + ec(n.entity) + ';">' + n.count + '</span>' : '') + '</div><span class="nav-label">' + n.label + '</span></div>';
+  }).join('');
+
+  var metaHtml = e.meta.map(function(m) { return '<span class="meta-chip"><span class="icon">' + m.icon + '</span>' + m.val + '</span>'; }).join('');
+  metaHtml += '<span class="meta-chip" style="background:' + eca(currentEntity, 0.1) + ';color:' + color + ';font-weight:700;">' + e.badge + '</span>';
+
+  var actionsHtml = e.actions.map(function(a, i) {
+    return '<button class="qa-pill' + (i === 0 ? ' primary' : '') + '" style="' + (i === 0 ? 'background:' + color + ';border-color:transparent;' : 'color:' + color + ';') + '">' + a + '</button>';
+  }).join('');
+
+  var statHtml = '<div class="section"><div class="stat-grid"><div class="stat-box"><div class="stat-val" style="color:' + color + ';">' + (e.meta[0] ? e.meta[0].val : '') + '</div><div class="stat-label">' + (e.navItems[0] ? e.navItems[0].label : '') + '</div></div><div class="stat-box"><div class="stat-val" style="color:' + color + ';">' + (e.meta[1] ? e.meta[1].val : '') + '</div><div class="stat-label">' + (e.navItems[1] ? e.navItems[1].label : '') + '</div></div></div></div>';
+
+  var pageHtml = '<div class="hero-section"><div class="hero-img" style="background:' + e.cover + ';">' + e.coverEmoji + '</div><div class="hero-gradient"></div><div class="hero-badge" style="background:' + eca(currentEntity, 0.85) + ';">' + e.label + '</div>' + (e.rating ? '<div class="hero-rating">\u2B50 ' + e.rating + '</div>' : '') + '</div><div class="card-info"><div class="title">' + e.title + '</div><div class="subtitle">' + e.subtitle + '</div><div class="meta-row">' + metaHtml + '</div></div><div class="quick-actions-row">' + actionsHtml + '</div><div class="card-nav-footer">' + navItemsHtml + '</div>' + statHtml;
+
+  setHtml('page-content', pageHtml);
+  setHtml('drawer-page-bg', pageHtml);
+
+  renderDrawer();
+  renderSpecTable();
+}
+
+function renderDrawer() {
+  var e = ENTITIES[currentEntity];
+  var color = ec(currentEntity);
+  var tabs = e.tabs;
+
+  setHtml('drawer-header', '<div class="dh-icon" style="background:' + color + ';">' + e.emoji + '</div><span class="dh-title">' + e.title + '</span><button class="dh-close" title="Chiudi">\u2715</button>');
+
+  var tabsHtml = tabs.map(function(t, i) {
+    var act = i === currentTabIdx;
+    return '<button class="drawer-tab' + (act ? ' active' : '') + '" style="' + (act ? 'color:' + color + ';border-bottom-color:' + color + ';' : '') + '" onclick="switchTab(' + i + ')"><span class="tab-icon">' + t.icon + '</span>' + t.label + (t.badge ? '<span class="tab-badge" style="background:' + color + ';">' + t.badge + '</span>' : '') + '</button>';
+  }).join('');
+  setHtml('drawer-tabs', tabsHtml);
+
+  var tabId = tabs[currentTabIdx].id;
+  var content = (TAB_CONTENT[currentEntity] && TAB_CONTENT[currentEntity][tabId]) || '<p style="color:var(--text-muted);text-align:center;padding:20px;">Contenuto non disponibile</p>';
+  setHtml('drawer-content', content);
+}
+
+function renderSpecTable() {
+  var e = ENTITIES[currentEntity];
+  var color = ec(currentEntity);
+  document.getElementById('spec-thead-row').style.background = color;
+  document.getElementById('spec-table-sub').textContent = e.emoji + ' ' + e.label + ' \u2014 ' + e.tabs.length + ' tab';
+
+  var rows = e.tabs.map(function(t, i) {
+    return '<tr style="' + (i % 2 === 1 ? 'background:rgba(180,130,80,0.04);' : '') + '"><td style="padding:8px 12px;font-weight:700;color:' + color + ';">' + (i + 1) + '</td><td style="padding:8px 12px;font-family:monospace;font-size:11px;color:' + color + ';font-weight:600;">' + t.id + '</td><td style="padding:8px 12px;font-weight:700;">' + t.icon + ' ' + t.label + '</td><td style="padding:8px 12px;font-family:monospace;font-size:11px;color:var(--text-sec);">' + t.specIcon + '</td><td style="padding:8px 12px;color:var(--text-sec);">' + t.desc + '</td><td style="padding:8px 12px;">' + (t.badge ? '<span style="padding:2px 8px;border-radius:8px;background:' + eca(currentEntity, 0.15) + ';color:' + color + ';font-size:10px;font-weight:700;">' + (t.badgeLabel || '') + '</span>' : '<span style="color:var(--text-muted);">\u2014</span>') + '</td></tr>';
+  }).join('');
+  setHtml('spec-table-body', rows);
+}
+
+function switchEntity(key) { currentEntity = key; renderAll(); document.getElementById('page-content').scrollTop = 0; }
+function switchTab(idx) { currentTabIdx = idx; renderDrawer(); }
+
+renderAll();
+</script>
+</body>
+</html>

--- a/apps/web/__tests__/dev-tools/scenarioSwitcher.test.ts
+++ b/apps/web/__tests__/dev-tools/scenarioSwitcher.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
+import { switchScenario, resetSwitcherForTests } from '@/dev-tools/scenarioSwitcher';
+import { createScenarioStore } from '@/dev-tools/scenarioStore';
+import { createMockAuthStore } from '@/dev-tools/mockAuthStore';
+import { SCENARIO_MANIFEST } from '@/dev-tools/scenarioManifest';
+
+const initialScenario = SCENARIO_MANIFEST.empty as Parameters<typeof createScenarioStore>[0];
+
+describe('scenarioSwitcher', () => {
+  beforeEach(() => {
+    resetSwitcherForTests();
+  });
+
+  it('happy path: switches scenario, fires CustomEvent, invalidates queries', async () => {
+    const scenarioStore = createScenarioStore(initialScenario);
+    const authStore = createMockAuthStore({
+      scenarioUser: initialScenario.auth.currentUser,
+      availableUsers: initialScenario.auth.availableUsers,
+      envRole: null,
+      queryStringRole: null,
+    });
+    const queryClient = new QueryClient();
+    const cancelSpy = vi.spyOn(queryClient, 'cancelQueries');
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    let eventFired = false;
+    window.addEventListener('meepledev:scenario-switch-begin', () => {
+      eventFired = true;
+    });
+
+    await switchScenario('small-library', { scenarioStore, authStore, queryClient });
+
+    expect(scenarioStore.getState().scenario.name).toBe('small-library');
+    expect(scenarioStore.getState().isSwitching).toBe(false);
+    expect(eventFired).toBe(true);
+    expect(cancelSpy).toHaveBeenCalled();
+    expect(invalidateSpy).toHaveBeenCalled();
+  });
+
+  it('rejects unknown scenario name without leaving isSwitching=true', async () => {
+    const scenarioStore = createScenarioStore(initialScenario);
+    const authStore = createMockAuthStore({
+      scenarioUser: initialScenario.auth.currentUser,
+      availableUsers: initialScenario.auth.availableUsers,
+      envRole: null,
+      queryStringRole: null,
+    });
+    const queryClient = new QueryClient();
+
+    await expect(
+      switchScenario('non-existent', { scenarioStore, authStore, queryClient })
+    ).rejects.toThrow();
+    expect(scenarioStore.getState().isSwitching).toBe(false);
+    expect(scenarioStore.getState().scenario.name).toBe('empty');
+  });
+
+  it('last-click-wins: rapid switches converge to final selection', async () => {
+    const scenarioStore = createScenarioStore(initialScenario);
+    const authStore = createMockAuthStore({
+      scenarioUser: initialScenario.auth.currentUser,
+      availableUsers: initialScenario.auth.availableUsers,
+      envRole: null,
+      queryStringRole: null,
+    });
+    const queryClient = new QueryClient();
+
+    const p1 = switchScenario('small-library', { scenarioStore, authStore, queryClient });
+    const p2 = switchScenario('admin-busy', { scenarioStore, authStore, queryClient });
+    const p3 = switchScenario('empty', { scenarioStore, authStore, queryClient });
+
+    await Promise.allSettled([p1, p2, p3]);
+
+    expect(scenarioStore.getState().scenario.name).toBe('empty');
+    expect(scenarioStore.getState().isSwitching).toBe(false);
+  });
+
+  it('try/finally guarantees endSwitch even on exception', async () => {
+    const scenarioStore = createScenarioStore(initialScenario);
+    const authStore = createMockAuthStore({
+      scenarioUser: initialScenario.auth.currentUser,
+      availableUsers: initialScenario.auth.availableUsers,
+      envRole: null,
+      queryStringRole: null,
+    });
+    const queryClient = new QueryClient();
+    vi.spyOn(queryClient, 'invalidateQueries').mockImplementation(() => {
+      throw new Error('boom');
+    });
+
+    await expect(
+      switchScenario('small-library', { scenarioStore, authStore, queryClient })
+    ).rejects.toThrow('boom');
+    expect(scenarioStore.getState().isSwitching).toBe(false);
+  });
+});

--- a/apps/web/__tests__/integration/dev-tools/panel/scenarioSwitchIntegration.test.tsx
+++ b/apps/web/__tests__/integration/dev-tools/panel/scenarioSwitchIntegration.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ScenariosSection } from '@/dev-tools/panel/sections/ScenariosSection';
+import { createScenarioStore } from '@/dev-tools/scenarioStore';
+import { createMockAuthStore } from '@/dev-tools/mockAuthStore';
+import { resetSwitcherForTests } from '@/dev-tools/scenarioSwitcher';
+import { SCENARIO_MANIFEST } from '@/dev-tools/scenarioManifest';
+import type { Scenario } from '@/dev-tools/types';
+
+describe('Scenario switch integration', () => {
+  it('full switch flow: select → store updates → invalidateQueries called', async () => {
+    resetSwitcherForTests();
+    const initial = SCENARIO_MANIFEST.empty as Scenario;
+    const scenarioStore = createScenarioStore(initial);
+    const authStore = createMockAuthStore({
+      scenarioUser: initial.auth.currentUser,
+      availableUsers: initial.auth.availableUsers,
+      envRole: null,
+      queryStringRole: null,
+    });
+    const queryClient = new QueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const user = userEvent.setup();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ScenariosSection
+          scenarioStore={scenarioStore}
+          authStore={authStore}
+          queryClient={queryClient}
+        />
+      </QueryClientProvider>
+    );
+
+    const select = screen.getByTestId('scenario-select');
+    await user.selectOptions(select, 'small-library');
+
+    await waitFor(() => {
+      expect(scenarioStore.getState().scenario.name).toBe('small-library');
+    });
+    expect(invalidateSpy).toHaveBeenCalled();
+    expect(scenarioStore.getState().isSwitching).toBe(false);
+  });
+
+  it('scenario switch fires CustomEvent for SSE cleanup', async () => {
+    resetSwitcherForTests();
+    const initial = SCENARIO_MANIFEST.empty as Scenario;
+    const scenarioStore = createScenarioStore(initial);
+    const authStore = createMockAuthStore({
+      scenarioUser: initial.auth.currentUser,
+      availableUsers: initial.auth.availableUsers,
+      envRole: null,
+      queryStringRole: null,
+    });
+    const queryClient = new QueryClient();
+
+    let eventFired = false;
+    window.addEventListener('meepledev:scenario-switch-begin', () => {
+      eventFired = true;
+    });
+
+    const user = userEvent.setup();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ScenariosSection
+          scenarioStore={scenarioStore}
+          authStore={authStore}
+          queryClient={queryClient}
+        />
+      </QueryClientProvider>
+    );
+
+    await user.selectOptions(screen.getByTestId('scenario-select'), 'admin-busy');
+
+    await waitFor(() => {
+      expect(eventFired).toBe(true);
+    });
+  });
+});

--- a/apps/web/src/app/mock-provider.tsx
+++ b/apps/web/src/app/mock-provider.tsx
@@ -13,6 +13,8 @@
 
 import { useEffect, useRef, useState, type ComponentType } from 'react';
 
+import { QueryClient } from '@tanstack/react-query';
+
 const IS_DEV_MOCK =
   process.env.NODE_ENV === 'development' && process.env.NEXT_PUBLIC_MOCK_MODE === 'true';
 
@@ -40,11 +42,22 @@ type DevPanelMountComponent = ComponentType<{
   mockControlStore: unknown;
   handlerGroups: Array<{ name: string; handlers: unknown[] }>;
   worker: { resetHandlers: (...h: unknown[]) => void };
+  scenarioStore: unknown;
+  authStore: unknown;
+  queryClient: unknown;
 }>;
 
 interface MockProviderProps {
   children: React.ReactNode;
 }
+
+/**
+ * Dedicated QueryClient for the DevPanel (scenario switching, auth invalidation).
+ * Created outside the component so it's a stable singleton across re-renders.
+ * MockProvider renders outside the app's QueryClientProvider, so we can't use
+ * useQueryClient() here — a dedicated instance is the correct approach.
+ */
+const devQueryClient = new QueryClient();
 
 /**
  * Unregister any service workers that are not MSW's mockServiceWorker.js.
@@ -192,6 +205,9 @@ export function MockProvider({ children }: MockProviderProps) {
             mockControlStore={tools.controlStore}
             handlerGroups={handlerGroups}
             worker={mswWorker}
+            scenarioStore={tools.scenarioStore}
+            authStore={tools.authStore}
+            queryClient={devQueryClient}
           />
         )}
     </>

--- a/apps/web/src/dev-tools/panel/DevPanel.tsx
+++ b/apps/web/src/dev-tools/panel/DevPanel.tsx
@@ -1,13 +1,18 @@
 'use client';
 
+import type { MockAuthState } from '@/dev-tools/mockAuthStore';
+import type { ScenarioState } from '@/dev-tools/scenarioStore';
 import type { DevPanelTab } from '@/dev-tools/types';
 
 import { SectionErrorBoundary } from './components/SectionErrorBoundary';
 import { useStoreSlice } from './hooks/useStoreSlice';
+import { AuthSection } from './sections/AuthSection';
+import { ScenariosSection } from './sections/ScenariosSection';
 import { TogglesSection } from './sections/TogglesSection';
 
 import type { MockControlState, HandlerGroup } from './sections/TogglesSection';
 import type { PanelUiState } from './stores/panelUiStore';
+import type { QueryClient } from '@tanstack/react-query';
 import type { StoreApi } from 'zustand/vanilla';
 
 export interface DevPanelProps {
@@ -15,6 +20,9 @@ export interface DevPanelProps {
   mockControlStore: StoreApi<MockControlState>;
   handlerGroups: HandlerGroup[];
   worker: { resetHandlers: (...handlers: unknown[]) => void };
+  scenarioStore: StoreApi<ScenarioState>;
+  authStore: StoreApi<MockAuthState>;
+  queryClient: QueryClient;
 }
 
 const TABS: { id: DevPanelTab; label: string }[] = [
@@ -29,6 +37,9 @@ export function DevPanel({
   mockControlStore,
   handlerGroups,
   worker,
+  scenarioStore,
+  authStore,
+  queryClient,
 }: DevPanelProps): React.JSX.Element | null {
   const isOpen = useStoreSlice(uiStore, s => s.isOpen);
   const activeTab = useStoreSlice(uiStore, s => s.activeTab);
@@ -124,12 +135,24 @@ export function DevPanel({
               worker={worker}
             />
           </SectionErrorBoundary>
-        ) : (
-          <p style={{ color: '#9ca3af', fontSize: 12 }}>
-            [{activeTab}] section content — coming in M
-            {activeTab === 'scenarios' || activeTab === 'auth' ? '2' : '3'}
-          </p>
-        )}
+        ) : null}
+        {activeTab === 'scenarios' ? (
+          <SectionErrorBoundary sectionName="Scenarios">
+            <ScenariosSection
+              scenarioStore={scenarioStore}
+              authStore={authStore}
+              queryClient={queryClient}
+            />
+          </SectionErrorBoundary>
+        ) : null}
+        {activeTab === 'auth' ? (
+          <SectionErrorBoundary sectionName="Auth">
+            <AuthSection authStore={authStore} queryClient={queryClient} />
+          </SectionErrorBoundary>
+        ) : null}
+        {activeTab === 'inspector' ? (
+          <p style={{ color: '#9ca3af', fontSize: 12 }}>[inspector] section coming in M3</p>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/web/src/dev-tools/panel/DevPanelMount.tsx
+++ b/apps/web/src/dev-tools/panel/DevPanelMount.tsx
@@ -1,11 +1,15 @@
 'use client';
 
+import type { MockAuthState } from '@/dev-tools/mockAuthStore';
+import type { ScenarioState } from '@/dev-tools/scenarioStore';
+
 import { DevPanel } from './DevPanel';
 import { useKeyboardShortcut } from './hooks/useKeyboardShortcut';
 import { useQueryStringPanelOpen } from './hooks/useQueryStringPanelOpen';
 
 import type { MockControlState, HandlerGroup } from './sections/TogglesSection';
 import type { PanelUiState } from './stores/panelUiStore';
+import type { QueryClient } from '@tanstack/react-query';
 import type { StoreApi } from 'zustand/vanilla';
 
 export interface DevPanelMountProps {
@@ -13,6 +17,9 @@ export interface DevPanelMountProps {
   mockControlStore: StoreApi<MockControlState>;
   handlerGroups: HandlerGroup[];
   worker: { resetHandlers: (...handlers: unknown[]) => void };
+  scenarioStore: StoreApi<ScenarioState>;
+  authStore: StoreApi<MockAuthState>;
+  queryClient: QueryClient;
 }
 
 export function DevPanelMount({
@@ -20,6 +27,9 @@ export function DevPanelMount({
   mockControlStore,
   handlerGroups,
   worker,
+  scenarioStore,
+  authStore,
+  queryClient,
 }: DevPanelMountProps): React.JSX.Element {
   useKeyboardShortcut({ ctrl: true, shift: true, key: 'm' }, () => {
     uiStore.getState().toggle();
@@ -31,6 +41,9 @@ export function DevPanelMount({
       mockControlStore={mockControlStore}
       handlerGroups={handlerGroups}
       worker={worker}
+      scenarioStore={scenarioStore}
+      authStore={authStore}
+      queryClient={queryClient}
     />
   );
 }

--- a/apps/web/src/dev-tools/panel/installPanel.ts
+++ b/apps/web/src/dev-tools/panel/installPanel.ts
@@ -20,5 +20,9 @@ export function installPanel(deps: PanelDependencies): InstalledPanel {
   if (typeof console !== 'undefined') {
     console.warn('[MeepleDev Phase 2] Dev Panel installed. Press Ctrl+Shift+M to open.');
   }
+  if (typeof window !== 'undefined') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).__meepledev_stores__ = deps;
+  }
   return { uiStore, deps };
 }

--- a/apps/web/src/dev-tools/panel/sections/AuthSection.tsx
+++ b/apps/web/src/dev-tools/panel/sections/AuthSection.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import type { MockAuthState } from '@/dev-tools/mockAuthStore';
+import type { UserRole } from '@/dev-tools/types';
+
+import { useStoreSlice } from '../hooks/useStoreSlice';
+
+import type { QueryClient } from '@tanstack/react-query';
+import type { StoreApi } from 'zustand/vanilla';
+
+export interface AuthSectionProps {
+  authStore: StoreApi<MockAuthState>;
+  queryClient: QueryClient;
+}
+
+export function AuthSection({ authStore, queryClient }: AuthSectionProps): React.JSX.Element {
+  const currentUser = useStoreSlice(authStore, s => s.currentUser);
+  const availableUsers = useStoreSlice(authStore, s => s.availableUsers);
+
+  const handleRoleChange = async (newRole: string): Promise<void> => {
+    authStore.getState().setRole(newRole as UserRole);
+    await queryClient.invalidateQueries({ queryKey: ['auth', 'me'] });
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <section>
+        <h3
+          style={{
+            fontSize: 11,
+            color: '#f59e0b',
+            textTransform: 'uppercase',
+            letterSpacing: 0.5,
+            marginTop: 0,
+            marginBottom: 8,
+          }}
+        >
+          Current user
+        </h3>
+        <div style={{ fontSize: 12, color: '#f9fafb' }}>{currentUser.displayName}</div>
+        <div style={{ fontSize: 10, color: '#9ca3af', marginTop: 2 }}>
+          {currentUser.email} · <strong>{currentUser.role}</strong>
+        </div>
+      </section>
+      <section>
+        <label
+          htmlFor="role-select"
+          style={{ fontSize: 11, color: '#9ca3af', display: 'block', marginBottom: 4 }}
+        >
+          Switch role:
+        </label>
+        <select
+          id="role-select"
+          data-testid="role-select"
+          value={currentUser.role}
+          onChange={e => void handleRoleChange(e.target.value)}
+          style={{
+            width: '100%',
+            padding: '6px 8px',
+            background: '#1f2937',
+            color: '#f9fafb',
+            border: '1px solid #374151',
+            borderRadius: 4,
+            fontSize: 12,
+            fontFamily: 'inherit',
+          }}
+        >
+          {availableUsers.map(u => (
+            <option key={u.id} value={u.role}>
+              {u.role} ({u.displayName})
+            </option>
+          ))}
+        </select>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/dev-tools/panel/sections/ScenariosSection.tsx
+++ b/apps/web/src/dev-tools/panel/sections/ScenariosSection.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useState } from 'react';
+
+import type { MockAuthState } from '@/dev-tools/mockAuthStore';
+import { SCENARIO_MANIFEST } from '@/dev-tools/scenarioManifest';
+import type { ScenarioState } from '@/dev-tools/scenarioStore';
+import { switchScenario } from '@/dev-tools/scenarioSwitcher';
+
+import { useStoreSlice } from '../hooks/useStoreSlice';
+
+import type { QueryClient } from '@tanstack/react-query';
+import type { StoreApi } from 'zustand/vanilla';
+
+export interface ScenariosSectionProps {
+  scenarioStore: StoreApi<ScenarioState>;
+  authStore: StoreApi<MockAuthState>;
+  queryClient: QueryClient;
+}
+
+export function ScenariosSection({
+  scenarioStore,
+  authStore,
+  queryClient,
+}: ScenariosSectionProps): React.JSX.Element {
+  const currentScenario = useStoreSlice(scenarioStore, s => s.scenario);
+  const isSwitching = useStoreSlice(scenarioStore, s => s.isSwitching);
+  const [error, setError] = useState<string | null>(null);
+  const scenarios = Object.keys(SCENARIO_MANIFEST).sort();
+
+  const handleChange = async (newName: string): Promise<void> => {
+    if (newName === currentScenario.name) return;
+    setError(null);
+    try {
+      await switchScenario(newName, { scenarioStore, authStore, queryClient });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <section>
+        <h3
+          style={{
+            fontSize: 11,
+            color: '#f59e0b',
+            textTransform: 'uppercase',
+            letterSpacing: 0.5,
+            marginTop: 0,
+            marginBottom: 8,
+          }}
+        >
+          Active scenario
+        </h3>
+        <div style={{ fontSize: 12, color: '#f9fafb', marginBottom: 4 }}>
+          {currentScenario.name}
+        </div>
+        <div style={{ fontSize: 10, color: '#9ca3af' }}>{currentScenario.description}</div>
+      </section>
+      <section>
+        <label
+          htmlFor="scenario-select"
+          style={{ fontSize: 11, color: '#9ca3af', display: 'block', marginBottom: 4 }}
+        >
+          Switch to:
+        </label>
+        <select
+          id="scenario-select"
+          data-testid="scenario-select"
+          value={currentScenario.name}
+          disabled={isSwitching}
+          onChange={e => void handleChange(e.target.value)}
+          style={{
+            width: '100%',
+            padding: '6px 8px',
+            background: '#1f2937',
+            color: '#f9fafb',
+            border: '1px solid #374151',
+            borderRadius: 4,
+            fontSize: 12,
+            fontFamily: 'inherit',
+          }}
+        >
+          {scenarios.map(name => (
+            <option key={name} value={name}>
+              {name}
+            </option>
+          ))}
+        </select>
+        {isSwitching ? (
+          <div style={{ fontSize: 10, color: '#f59e0b', marginTop: 6 }}>Switching...</div>
+        ) : null}
+        {error ? (
+          <div role="alert" style={{ fontSize: 10, color: '#fecaca', marginTop: 6 }}>
+            {error}
+          </div>
+        ) : null}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/dev-tools/scenarioSwitcher.ts
+++ b/apps/web/src/dev-tools/scenarioSwitcher.ts
@@ -1,0 +1,76 @@
+import { SCENARIO_MANIFEST } from './scenarioManifest';
+import { validateScenario } from './scenarioValidator';
+
+import type { MockAuthState } from './mockAuthStore';
+import type { ScenarioState } from './scenarioStore';
+import type { Scenario } from './types';
+import type { QueryClient } from '@tanstack/react-query';
+import type { StoreApi } from 'zustand/vanilla';
+
+export interface SwitchScenarioDeps {
+  scenarioStore: StoreApi<ScenarioState>;
+  authStore: StoreApi<MockAuthState>;
+  queryClient: QueryClient;
+}
+
+let currentSwitchController: AbortController | null = null;
+
+export function resetSwitcherForTests(): void {
+  currentSwitchController = null;
+}
+
+export async function switchScenario(
+  scenarioName: string,
+  deps: SwitchScenarioDeps
+): Promise<void> {
+  const { scenarioStore, authStore, queryClient } = deps;
+
+  if (currentSwitchController !== null) {
+    currentSwitchController.abort();
+  }
+  const myController = new AbortController();
+  currentSwitchController = myController;
+  const { signal } = myController;
+
+  scenarioStore.getState().beginSwitch();
+
+  try {
+    await queryClient.cancelQueries({ type: 'active' });
+    if (signal.aborted) return;
+
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('meepledev:scenario-switch-begin'));
+    }
+    if (signal.aborted) return;
+
+    const raw = SCENARIO_MANIFEST[scenarioName];
+    if (raw === undefined) {
+      throw new Error(`Unknown scenario: ${scenarioName}`);
+    }
+    const validation = validateScenario(raw);
+    if (!validation.valid) {
+      throw new Error(`Scenario "${scenarioName}" is invalid: ${validation.errors.join('; ')}`);
+    }
+    if (signal.aborted) return;
+
+    const newScenario = raw as Scenario;
+    scenarioStore.getState().loadScenario(newScenario);
+
+    authStore.setState({
+      currentUser: newScenario.auth.currentUser,
+      availableUsers: newScenario.auth.availableUsers,
+    });
+
+    scenarioStore.getState().endSwitch();
+
+    if (signal.aborted) return;
+    await queryClient.invalidateQueries();
+  } finally {
+    if (scenarioStore.getState().isSwitching) {
+      scenarioStore.getState().endSwitch();
+    }
+    if (currentSwitchController === myController) {
+      currentSwitchController = null;
+    }
+  }
+}

--- a/apps/web/src/hooks/useAgentChatStream.ts
+++ b/apps/web/src/hooks/useAgentChatStream.ts
@@ -6,7 +6,7 @@
  * Parses RagStreamingEvent format (numeric StreamingEventType enum)
  */
 
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 
 // StreamingEventType enum values from backend
 const StreamingEventType = {
@@ -174,6 +174,20 @@ export function useAgentChatStream(callbacks?: AgentChatStreamCallbacks) {
     stopStreaming();
     setState(INITIAL_STATE);
   }, [stopStreaming]);
+
+  // Close the active stream when a dev-tools scenario switch begins (dev only).
+  useEffect(() => {
+    const onScenarioSwitch = (): void => {
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+        abortControllerRef.current = null;
+      }
+    };
+    window.addEventListener('meepledev:scenario-switch-begin', onScenarioSwitch);
+    return () => {
+      window.removeEventListener('meepledev:scenario-switch-begin', onScenarioSwitch);
+    };
+  }, []);
 
   const sendMessage = useCallback(
     (

--- a/apps/web/src/mocks/handlers/_shared.ts
+++ b/apps/web/src/mocks/handlers/_shared.ts
@@ -1,0 +1,18 @@
+import { HttpResponse } from 'msw';
+
+/**
+ * Returns 503 if a scenario switch is in progress.
+ * Uses the scenario bridge to check isSwitching without coupling to dev-tools.
+ */
+export function guardScenarioSwitching(): Response | null {
+  if (typeof window === 'undefined') return null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const meepledev = (window as any).__meepledev_stores__;
+  if (meepledev?.scenarioStore?.getState?.().isSwitching === true) {
+    return HttpResponse.json(
+      { error: 'scenario-switching', message: 'Scenario switch in progress, retry shortly' },
+      { status: 503 }
+    ) as unknown as Response;
+  }
+  return null;
+}

--- a/apps/web/src/mocks/handlers/chat.handlers.ts
+++ b/apps/web/src/mocks/handlers/chat.handlers.ts
@@ -9,6 +9,7 @@
 
 import { http, HttpResponse } from 'msw';
 
+import { guardScenarioSwitching } from './_shared';
 import {
   createMockChat,
   createMockChatMessage,
@@ -42,6 +43,8 @@ let chats = [
 export const chatHandlers = [
   // GET /api/v1/chat/threads - List chat threads
   http.get(`${API_BASE}/api/v1/chat/threads`, () => {
+    const guard = guardScenarioSwitching();
+    if (guard) return guard;
     return HttpResponse.json(chats, {
       headers: {
         'X-Correlation-Id': `test-correlation-${Date.now()}`,

--- a/apps/web/src/mocks/handlers/games.handlers.ts
+++ b/apps/web/src/mocks/handlers/games.handlers.ts
@@ -23,6 +23,7 @@ import {
   HANDLER_BASE,
 } from '../data/factories';
 import { getScenarioBridge, type BridgeMockGame } from '../scenarioBridge';
+import { guardScenarioSwitching } from './_shared';
 
 const API_BASE = HANDLER_BASE;
 
@@ -80,6 +81,8 @@ function removeGameFromStore(id: string): boolean {
 export const gamesHandlers = [
   // GET /api/v1/games - List all games
   http.get(`${API_BASE}/api/v1/games`, () => {
+    const guard = guardScenarioSwitching();
+    if (guard) return guard;
     return HttpResponse.json(currentGames(), {
       headers: {
         'X-Correlation-Id': `test-correlation-${Date.now()}`,

--- a/apps/web/src/mocks/handlers/library.handlers.ts
+++ b/apps/web/src/mocks/handlers/library.handlers.ts
@@ -12,6 +12,7 @@ import { http, HttpResponse } from 'msw';
 
 import { mockId, HANDLER_BASE } from '../data/factories';
 import { getScenarioBridge } from '../scenarioBridge';
+import { guardScenarioSwitching } from './_shared';
 
 const API_BASE = HANDLER_BASE;
 
@@ -114,6 +115,8 @@ let fallbackLibrary: LibraryItem[] = [
 
 export const libraryHandlers = [
   http.get(`${API_BASE}/api/v1/library/stats`, () => {
+    const guard = guardScenarioSwitching();
+    if (guard) return guard;
     const items = currentLibrary();
     const ratedItems = items.filter(i => i.rating);
     return HttpResponse.json({

--- a/apps/web/src/mocks/handlers/sessions.handlers.ts
+++ b/apps/web/src/mocks/handlers/sessions.handlers.ts
@@ -19,6 +19,7 @@ import { http, HttpResponse } from 'msw';
 
 import { mockId, HANDLER_BASE } from '../data/factories';
 import { getScenarioBridge } from '../scenarioBridge';
+import { guardScenarioSwitching } from './_shared';
 
 const API_BASE = HANDLER_BASE;
 
@@ -72,6 +73,8 @@ const fallbackSessions: SessionData[] = [
 
 export const sessionsHandlers = [
   http.get(`${API_BASE}/api/v1/sessions`, ({ request }) => {
+    const guard = guardScenarioSwitching();
+    if (guard) return guard;
     const items = currentSessions();
     const url = new URL(request.url);
     const status = url.searchParams.get('status');

--- a/docs/superpowers/plans/2026-04-10-card-drawer-navigation-redesign.md
+++ b/docs/superpowers/plans/2026-04-10-card-drawer-navigation-redesign.md
@@ -1,0 +1,1827 @@
+# Card Drawer + Navigation Redesign — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign the shell layout and drawer system for a Page-first navigation flow: remove CardHand + MyHand sidebars, add MiniNav recents, ConnectionBar, drawer tabs for all 9 entity types, and mobile Session Mode.
+
+**Architecture:** Remove 3 navigation layers (CardHand rail, MyHand sidebar, MyHand bottom bar) and replace with 2 simpler primitives: RecentsBar in MiniNav + ConnectionBar on entity pages. The existing ExtraMeepleCardDrawer pattern is extended (not replaced) — each entity gets a DrawerContent component with 2-3 tabs and a conditional ActionFooter. A drawer stack (max 3) enables cross-entity navigation. Session Mode toggles the mobile bottom bar during active game sessions.
+
+**Tech Stack:** Next.js 16 App Router, React 19, Zustand (stores), Radix UI Sheet (drawer), Tailwind 4, Lucide icons, Vitest (tests)
+
+**Spec:** `docs/superpowers/specs/2026-04-10-card-drawer-navigation-redesign-design.md`
+
+---
+
+## Milestone Overview
+
+| M | Milestone | Tasks | Outcome |
+|---|-----------|-------|---------|
+| **M0** | Recents store + RecentsBar | 1-3 | MiniNav shows recent entity pills, sessionStorage persisted |
+| **M1** | Shell cleanup | 4-6 | CardHand + MyHand removed, DesktopShell simplified, consumers migrated |
+| **M2** | ConnectionBar | 7-9 | Interactive ManaPip bar on entity pages, wired to cascade navigation |
+| **M3** | DrawerActionFooter + drawer stack | 10-12 | Conditional action footer, push/pop drawer stack |
+| **M4** | Entity drawer content (5 new) | 13-17 | Player, Session, Event, Toolkit, Tool drawer content components |
+| **M5** | Session Mode | 18-20 | MobileBottomBar dual-state, SessionBanner desktop |
+| **M6** | Integration + cleanup | 21-22 | Wire everything, final test pass, dead code removal |
+
+---
+
+## M0 — Recents Store + RecentsBar
+
+### Task 1: RecentsStore (Zustand)
+
+**Files:**
+- Create: `apps/web/src/stores/use-recents.ts`
+- Test: `apps/web/src/stores/__tests__/use-recents.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// apps/web/src/stores/__tests__/use-recents.test.ts
+import { act } from 'react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useRecentsStore } from '../use-recents';
+import type { MeepleEntityType } from '@/components/ui/data-display/meeple-card';
+
+function makeRecent(id: string, entity: MeepleEntityType = 'game') {
+  return { id, entity, title: `Title ${id}`, href: `/games/${id}` };
+}
+
+describe('useRecentsStore', () => {
+  beforeEach(() => {
+    act(() => useRecentsStore.getState().clear());
+    sessionStorage.clear();
+  });
+
+  it('starts empty', () => {
+    expect(useRecentsStore.getState().items).toEqual([]);
+  });
+
+  it('push adds an item with visitedAt timestamp', () => {
+    act(() => useRecentsStore.getState().push(makeRecent('g1')));
+    const items = useRecentsStore.getState().items;
+    expect(items).toHaveLength(1);
+    expect(items[0].id).toBe('g1');
+    expect(items[0].visitedAt).toBeGreaterThan(0);
+  });
+
+  it('push promotes existing item to front', () => {
+    act(() => {
+      useRecentsStore.getState().push(makeRecent('g1'));
+      useRecentsStore.getState().push(makeRecent('g2'));
+      useRecentsStore.getState().push(makeRecent('g1')); // re-visit
+    });
+    const items = useRecentsStore.getState().items;
+    expect(items).toHaveLength(2);
+    expect(items[0].id).toBe('g1'); // most recent first
+  });
+
+  it('evicts oldest when exceeding max 4', () => {
+    act(() => {
+      useRecentsStore.getState().push(makeRecent('g1'));
+      useRecentsStore.getState().push(makeRecent('g2'));
+      useRecentsStore.getState().push(makeRecent('g3'));
+      useRecentsStore.getState().push(makeRecent('g4'));
+      useRecentsStore.getState().push(makeRecent('g5'));
+    });
+    const items = useRecentsStore.getState().items;
+    expect(items).toHaveLength(4);
+    expect(items.find(i => i.id === 'g1')).toBeUndefined(); // evicted
+  });
+
+  it('remove deletes by id', () => {
+    act(() => {
+      useRecentsStore.getState().push(makeRecent('g1'));
+      useRecentsStore.getState().push(makeRecent('g2'));
+      useRecentsStore.getState().remove('g1');
+    });
+    expect(useRecentsStore.getState().items).toHaveLength(1);
+  });
+
+  it('clear empties the list', () => {
+    act(() => {
+      useRecentsStore.getState().push(makeRecent('g1'));
+      useRecentsStore.getState().clear();
+    });
+    expect(useRecentsStore.getState().items).toEqual([]);
+  });
+
+  it('persists to sessionStorage', () => {
+    act(() => useRecentsStore.getState().push(makeRecent('g1')));
+    const stored = sessionStorage.getItem('meeple-recents');
+    expect(stored).toBeTruthy();
+    expect(JSON.parse(stored!)).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Note: the `stores/__tests__/` directory is new — it will be created when writing the test file. Vitest's `include` glob covers `src/**/*.test.ts` so the path is valid.
+
+Run: `cd apps/web && pnpm vitest run src/stores/__tests__/use-recents.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement store**
+
+```typescript
+// apps/web/src/stores/use-recents.ts
+'use client';
+
+import { create } from 'zustand';
+
+import type { MeepleEntityType } from '@/components/ui/data-display/meeple-card';
+
+const MAX_RECENTS = 4;
+const STORAGE_KEY = 'meeple-recents';
+
+export interface RecentItem {
+  id: string;
+  entity: MeepleEntityType;
+  title: string;
+  href: string;
+  visitedAt: number;
+}
+
+interface RecentsState {
+  items: RecentItem[];
+  push: (item: Omit<RecentItem, 'visitedAt'>) => void;
+  remove: (id: string) => void;
+  clear: () => void;
+}
+
+function readStorage(): RecentItem[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as RecentItem[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeStorage(items: RecentItem[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  } catch {
+    /* full or unavailable */
+  }
+}
+
+export const useRecentsStore = create<RecentsState>((set, get) => ({
+  items: readStorage(),
+
+  push: (item) => {
+    const now = Date.now();
+    const current = get().items.filter(i => i.id !== item.id);
+    const next = [{ ...item, visitedAt: now }, ...current].slice(0, MAX_RECENTS);
+    writeStorage(next);
+    set({ items: next });
+  },
+
+  remove: (id) => {
+    const next = get().items.filter(i => i.id !== id);
+    writeStorage(next);
+    set({ items: next });
+  },
+
+  clear: () => {
+    writeStorage([]);
+    set({ items: [] });
+  },
+}));
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/web && pnpm vitest run src/stores/__tests__/use-recents.test.ts`
+Expected: all 7 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/stores/use-recents.ts apps/web/src/stores/__tests__/use-recents.test.ts
+git commit -m "feat(nav): add RecentsStore with sessionStorage persistence"
+```
+
+---
+
+### Task 2: RecentsBar component
+
+**Files:**
+- Create: `apps/web/src/components/layout/UserShell/RecentsBar.tsx`
+- Test: `apps/web/src/components/layout/UserShell/__tests__/RecentsBar.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// apps/web/src/components/layout/UserShell/__tests__/RecentsBar.test.tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { act } from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { RecentsBar } from '../RecentsBar';
+import { useRecentsStore } from '@/stores/use-recents';
+
+// Mock next/navigation
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => '/games/g1',
+}));
+
+function seedRecents() {
+  act(() => {
+    useRecentsStore.getState().push({ id: 'g2', entity: 'game', title: 'Catan', href: '/games/g2' });
+    useRecentsStore.getState().push({ id: 'a1', entity: 'agent', title: 'Azul Expert', href: '/agents/a1' });
+  });
+}
+
+describe('RecentsBar', () => {
+  beforeEach(() => {
+    act(() => useRecentsStore.getState().clear());
+    mockPush.mockClear();
+  });
+
+  it('renders nothing when no recents', () => {
+    const { container } = render(<RecentsBar />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders pills for each recent (excluding current path)', () => {
+    seedRecents();
+    render(<RecentsBar />);
+    // g2 and a1 are visible; current path is /games/g1 so no exclusion happens here
+    expect(screen.getAllByTestId(/^recent-pill-/)).toHaveLength(2);
+  });
+
+  it('excludes the current pathname from display', () => {
+    act(() => {
+      useRecentsStore.getState().push({ id: 'g1', entity: 'game', title: 'Azul', href: '/games/g1' });
+      useRecentsStore.getState().push({ id: 'g2', entity: 'game', title: 'Catan', href: '/games/g2' });
+    });
+    render(<RecentsBar />);
+    // /games/g1 is current path, should be excluded
+    expect(screen.queryByTestId('recent-pill-g1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('recent-pill-g2')).toBeInTheDocument();
+  });
+
+  it('navigates on click', async () => {
+    seedRecents();
+    render(<RecentsBar />);
+    await userEvent.click(screen.getByTestId('recent-pill-g2'));
+    expect(mockPush).toHaveBeenCalledWith('/games/g2');
+  });
+
+  it('shows tooltip with title on hover', async () => {
+    seedRecents();
+    render(<RecentsBar />);
+    const pill = screen.getByTestId('recent-pill-g2');
+    expect(pill).toHaveAttribute('title', 'Catan');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/__tests__/RecentsBar.test.tsx`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement RecentsBar**
+
+```tsx
+// apps/web/src/components/layout/UserShell/RecentsBar.tsx
+'use client';
+
+import { usePathname, useRouter } from 'next/navigation';
+
+import { entityHsl } from '@/components/ui/data-display/meeple-card';
+import { useRecentsStore } from '@/stores/use-recents';
+
+/**
+ * RecentsBar — shows recent entity pills in the MiniNav right area.
+ * Max 3 pills visible (4 on large screens via CSS).
+ * Current page is excluded from display.
+ * Hidden on mobile (< md).
+ */
+export function RecentsBar() {
+  const items = useRecentsStore(s => s.items);
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const visible = items.filter(i => i.href !== pathname).slice(0, 3);
+
+  if (visible.length === 0) return null;
+
+  return (
+    <div className="hidden md:flex items-center gap-1.5" data-testid="recents-bar">
+      {visible.map(item => {
+        const color = entityHsl(item.entity);
+        return (
+          <button
+            key={item.id}
+            type="button"
+            data-testid={`recent-pill-${item.id}`}
+            title={item.title}
+            onClick={() => router.push(item.href)}
+            className="flex h-7 w-7 items-center justify-center rounded-full text-[11px] font-bold transition-all duration-200 hover:scale-110 hover:shadow-md"
+            style={{
+              backgroundColor: `hsla(${color}, 0.1)`,
+              color: `hsl(${color})`,
+              outline: '1.5px solid transparent',
+            }}
+            onMouseEnter={e => {
+              (e.currentTarget as HTMLElement).style.outlineColor = `hsla(${color}, 0.4)`;
+            }}
+            onMouseLeave={e => {
+              (e.currentTarget as HTMLElement).style.outlineColor = 'transparent';
+            }}
+          >
+            {item.title.charAt(0).toUpperCase()}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/__tests__/RecentsBar.test.tsx`
+Expected: all 5 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/layout/UserShell/RecentsBar.tsx apps/web/src/components/layout/UserShell/__tests__/RecentsBar.test.tsx
+git commit -m "feat(nav): add RecentsBar component for MiniNav"
+```
+
+---
+
+### Task 3: Wire RecentsBar into MiniNavSlot
+
+**Files:**
+- Modify: `apps/web/src/components/layout/UserShell/MiniNavSlot.tsx`
+
+- [ ] **Step 1: Add RecentsBar import and render it between flex-1 spacer and primaryAction**
+
+In `MiniNavSlot.tsx`, add after `<div className="flex-1" />` and before the `primaryAction` button:
+
+```tsx
+// Add import at top
+import { RecentsBar } from './RecentsBar';
+
+// In the JSX, after <div className="flex-1" /> :
+<RecentsBar />
+```
+
+The full modified section (lines 54-69 of MiniNavSlot.tsx):
+
+```tsx
+      <div className="flex-1" />
+      <RecentsBar />
+      {config.primaryAction && (
+        <button
+          type="button"
+          onClick={config.primaryAction.onClick}
+          // ... rest unchanged
+```
+
+- [ ] **Step 2: Run existing MiniNavSlot tests + RecentsBar tests**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/UserShell/`
+Expected: all PASS
+
+- [ ] **Step 3: Export RecentsBar from barrel**
+
+Add to `apps/web/src/components/layout/UserShell/index.ts`:
+
+```typescript
+export { RecentsBar } from './RecentsBar';
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/layout/UserShell/MiniNavSlot.tsx apps/web/src/components/layout/UserShell/index.ts apps/web/src/components/layout/UserShell/RecentsBar.tsx
+git commit -m "feat(nav): wire RecentsBar into MiniNavSlot"
+```
+
+---
+
+## M1 — Shell Cleanup (Remove CardHand + MyHand)
+
+### Task 4: Migrate use-card-hand consumers to use-recents
+
+**Files:**
+- Modify: ~31 files importing `useCardHand` or `use-card-hand`
+- Remove: `apps/web/src/stores/use-card-hand.ts`
+
+This is a bulk migration. The pattern for each consumer:
+
+- [ ] **Step 1: Generate full consumer list**
+
+Run: `cd apps/web && grep -rl "useCardHand\|use-card-hand" src/ --include="*.ts" --include="*.tsx" | grep -v __tests__ | grep -v node_modules | sort`
+
+For each file in the list:
+
+- If the file calls `drawCard(...)`: replace with `useRecentsStore.getState().push({ id, entity, title, href })`
+- If the file reads `cards[]` for display (HandRail, DeckTrackerSync): mark for deletion in Task 5
+- If the file reads `focusedIdx`, `pinnedIds`, `expandedStack`, `isHandCollapsed`: remove those usages
+
+- [ ] **Step 2: Perform the migration file by file**
+
+For **page-level drawCard calls** (e.g., `DashboardClient.tsx`, `LibraryHub.tsx`, etc.), the pattern is:
+
+```typescript
+// BEFORE
+import { useCardHand } from '@/stores/use-card-hand';
+// in component:
+const drawCard = useCardHand(s => s.drawCard);
+useEffect(() => {
+  drawCard({ id: game.id, entity: 'game', title: game.title, href: `/games/${game.id}` });
+}, [game.id]);
+
+// AFTER
+import { useRecentsStore } from '@/stores/use-recents';
+// in component:
+useEffect(() => {
+  useRecentsStore.getState().push({ id: game.id, entity: 'game', title: game.title, href: `/games/${game.id}` });
+}, [game.id]);
+```
+
+For **components that render hand cards** (DesktopHandRail, HandRailItem, DeckTrackerSync, quick-cards-carousel): these are deleted in Task 5, so skip them here.
+
+- [ ] **Step 3: Migrate test files**
+
+Run: `cd apps/web && grep -rl "useCardHand\|use-card-hand" src/ --include="*.test.*" | sort`
+
+For each test file: replace `useCardHand` mocks with `useRecentsStore` mocks.
+
+- [ ] **Step 4: Delete store file**
+
+Delete `apps/web/src/stores/use-card-hand.ts`.
+
+- [ ] **Step 5: Verify no broken imports**
+
+Run: `cd apps/web && pnpm typecheck`
+Expected: no errors referencing `use-card-hand`
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `cd apps/web && pnpm vitest run`
+Expected: all PASS (some tests may need mock updates)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(nav): migrate use-card-hand consumers to use-recents"
+```
+
+---
+
+### Task 5: Remove CardHand + MyHand components from shell
+
+**Files:**
+- Remove: `apps/web/src/components/layout/UserShell/DesktopHandRail.tsx`
+- Remove: `apps/web/src/components/layout/UserShell/HandRailItem.tsx`
+- Remove: `apps/web/src/components/layout/UserShell/HandRailToolbar.tsx`
+- Remove: `apps/web/src/components/layout/MyHand/MyHandSidebar.tsx`
+- Remove: `apps/web/src/components/layout/MyHand/MyHandBottomBar.tsx`
+- Remove: `apps/web/src/components/layout/MyHand/MyHandSlot.tsx`
+- Remove: `apps/web/src/components/layout/MyHand/MyHandSlotPicker.tsx`
+- Remove: `apps/web/src/components/layout/MyHand/MyHandProvider.tsx`
+- Modify: `apps/web/src/components/layout/UserShell/index.ts`
+- Modify: `apps/web/src/components/layout/MyHand/index.ts`
+
+- [ ] **Step 1: Update barrel exports**
+
+`apps/web/src/components/layout/UserShell/index.ts` — remove lines:
+```typescript
+export { DesktopHandRail } from './DesktopHandRail';
+export { HandRailItem } from './HandRailItem';
+export { HandRailToolbar } from './HandRailToolbar';
+```
+
+`apps/web/src/components/layout/MyHand/index.ts` — remove all exports (file becomes empty or delete entirely).
+
+- [ ] **Step 2: Delete component files**
+
+Delete all 8 files listed above.
+
+- [ ] **Step 3: Delete related test files**
+
+Search and delete any test files in `__tests__/` directories for the removed components.
+
+- [ ] **Step 4: Verify typecheck**
+
+Run: `cd apps/web && pnpm typecheck`
+Fix any remaining imports of removed components.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(nav): remove CardHand rail + MyHand sidebar components"
+```
+
+---
+
+### Task 6: Simplify DesktopShell layout
+
+**Files:**
+- Modify: `apps/web/src/components/layout/UserShell/DesktopShell.tsx`
+
+- [ ] **Step 1: Rewrite DesktopShell**
+
+```tsx
+// apps/web/src/components/layout/UserShell/DesktopShell.tsx
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { ChatSlideOverPanel } from '@/components/chat/panel/ChatSlideOverPanel';
+
+import { MiniNavSlot } from './MiniNavSlot';
+import { TopBar } from './TopBar';
+
+interface DesktopShellProps {
+  children: ReactNode;
+}
+
+/**
+ * DesktopShell — Page-first layout.
+ *
+ * Layout:
+ *   ┌───────────────────────────────┐
+ *   │ TopBar (64px sticky)          │
+ *   ├───────────────────────────────┤
+ *   │ MiniNavSlot (48px, optional)  │
+ *   ├───────────────────────────────┤
+ *   │ main content (full width)     │
+ *   └───────────────────────────────┘
+ *
+ * SessionBanner and MobileBottomBar added in M5.
+ */
+export function DesktopShell({ children }: DesktopShellProps) {
+  return (
+    <div className="min-h-dvh flex flex-col bg-[var(--nh-bg-base)]">
+      <TopBar />
+      <MiniNavSlot />
+      <main className="flex-1 min-w-0 overflow-y-auto">{children}</main>
+      <ChatSlideOverPanel />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `cd apps/web && pnpm build`
+Expected: compiles without errors (some pages may show warnings if they still reference MyHand — fix in Task 4)
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd apps/web && pnpm vitest run`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/layout/UserShell/DesktopShell.tsx
+git commit -m "refactor(nav): simplify DesktopShell — full-width, no sidebars"
+```
+
+---
+
+## M2 — ConnectionBar
+
+### Task 7: ConnectionBar types + component
+
+**Files:**
+- Create: `apps/web/src/components/ui/data-display/connection-bar/types.ts`
+- Create: `apps/web/src/components/ui/data-display/connection-bar/ConnectionBar.tsx`
+- Create: `apps/web/src/components/ui/data-display/connection-bar/index.ts`
+- Test: `apps/web/src/components/ui/data-display/connection-bar/__tests__/ConnectionBar.test.tsx`
+
+- [ ] **Step 1: Create types**
+
+```typescript
+// apps/web/src/components/ui/data-display/connection-bar/types.ts
+import type { LucideIcon } from 'lucide-react';
+import type { MeepleEntityType } from '@/components/ui/data-display/meeple-card';
+
+export interface ConnectionPip {
+  entityType: MeepleEntityType;
+  count: number;
+  label: string;
+  icon: LucideIcon;
+  /** True when count === 0 or connection is unavailable — shows "+" create indicator */
+  isEmpty: boolean;
+}
+
+export interface ConnectionBarProps {
+  connections: ConnectionPip[];
+  onPipClick: (pip: ConnectionPip, anchorRect: DOMRect) => void;
+  className?: string;
+  'data-testid'?: string;
+}
+```
+
+- [ ] **Step 2: Write failing tests**
+
+```tsx
+// apps/web/src/components/ui/data-display/connection-bar/__tests__/ConnectionBar.test.tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { Bot, FileText, MessageCircle, Dices } from 'lucide-react';
+import { ConnectionBar } from '../ConnectionBar';
+import type { ConnectionPip } from '../types';
+
+const mockPips: ConnectionPip[] = [
+  { entityType: 'agent', count: 1, label: 'Agent', icon: Bot },
+  { entityType: 'kb', count: 3, label: 'KB', icon: FileText },
+  { entityType: 'chat', count: 0, label: 'Chat', icon: MessageCircle },
+  { entityType: 'session', count: 23, label: 'Sessioni', icon: Dices },
+];
+
+describe('ConnectionBar', () => {
+  it('renders a pill for each connection', () => {
+    render(<ConnectionBar connections={mockPips} onPipClick={vi.fn()} />);
+    expect(screen.getByText('Agent')).toBeInTheDocument();
+    expect(screen.getByText('KB')).toBeInTheDocument();
+    expect(screen.getByText('Chat')).toBeInTheDocument();
+    expect(screen.getByText('Sessioni')).toBeInTheDocument();
+  });
+
+  it('shows count badge when count > 0', () => {
+    render(<ConnectionBar connections={mockPips} onPipClick={vi.fn()} />);
+    expect(screen.getByText('3')).toBeInTheDocument();  // KB count
+    expect(screen.getByText('23')).toBeInTheDocument(); // Session count
+  });
+
+  it('shows "+" indicator when count is 0', () => {
+    render(<ConnectionBar connections={mockPips} onPipClick={vi.fn()} />);
+    const chatPip = screen.getByTestId('connection-pip-chat');
+    expect(chatPip).toHaveTextContent('+');
+  });
+
+  it('calls onPipClick with pip and anchorRect', async () => {
+    const handler = vi.fn();
+    render(<ConnectionBar connections={mockPips} onPipClick={handler} />);
+    await userEvent.click(screen.getByTestId('connection-pip-kb'));
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0].entityType).toBe('kb');
+    expect(handler.mock.calls[0][1]).toBeInstanceOf(DOMRect);
+  });
+
+  it('renders nothing when connections array is empty', () => {
+    const { container } = render(<ConnectionBar connections={[]} onPipClick={vi.fn()} />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 3: Implement ConnectionBar**
+
+```tsx
+// apps/web/src/components/ui/data-display/connection-bar/ConnectionBar.tsx
+'use client';
+
+import { useRef } from 'react';
+
+import { Plus } from 'lucide-react';
+
+import { entityHsl } from '@/components/ui/data-display/meeple-card';
+import { cn } from '@/lib/utils';
+
+import type { ConnectionBarProps, ConnectionPip } from './types';
+
+export function ConnectionBar({
+  connections,
+  onPipClick,
+  className,
+  'data-testid': testId,
+}: ConnectionBarProps) {
+  if (connections.length === 0) return null;
+
+  return (
+    <div
+      className={cn('flex items-center gap-2 overflow-x-auto py-2', className)}
+      data-testid={testId ?? 'connection-bar'}
+    >
+      {connections.map(pip => (
+        <ConnectionPipButton key={pip.entityType} pip={pip} onClick={onPipClick} />
+      ))}
+    </div>
+  );
+}
+
+function ConnectionPipButton({
+  pip,
+  onClick,
+}: {
+  pip: ConnectionPip;
+  onClick: ConnectionBarProps['onPipClick'];
+}) {
+  const ref = useRef<HTMLButtonElement>(null);
+  const color = entityHsl(pip.entityType);
+  const Icon = pip.icon;
+  const isEmpty = pip.isEmpty;
+
+  const handleClick = () => {
+    if (!ref.current) return;
+    onClick(pip, ref.current.getBoundingClientRect());
+  };
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      data-testid={`connection-pip-${pip.entityType}`}
+      onClick={handleClick}
+      className={cn(
+        'flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-bold transition-all duration-200',
+        'hover:scale-[1.03] hover:shadow-md',
+        isEmpty && 'border border-dashed opacity-60'
+      )}
+      style={{
+        backgroundColor: isEmpty ? 'transparent' : `hsla(${color}, 0.1)`,
+        color: `hsl(${color})`,
+        borderColor: isEmpty ? `hsla(${color}, 0.3)` : 'transparent',
+      }}
+    >
+      <Icon className="h-3.5 w-3.5" strokeWidth={2} />
+      {isEmpty ? (
+        <Plus className="h-3 w-3" strokeWidth={2.5} />
+      ) : (
+        <span className="tabular-nums">{pip.count}</span>
+      )}
+      <span>{pip.label}</span>
+    </button>
+  );
+}
+```
+
+- [ ] **Step 4: Create barrel export**
+
+```typescript
+// apps/web/src/components/ui/data-display/connection-bar/index.ts
+export { ConnectionBar } from './ConnectionBar';
+export type { ConnectionPip, ConnectionBarProps } from './types';
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd apps/web && pnpm vitest run src/components/ui/data-display/connection-bar/`
+Expected: all 5 tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/connection-bar/
+git commit -m "feat(nav): add ConnectionBar component with entity-colored pills"
+```
+
+---
+
+### Task 8: ConnectionBar config builders per entity type
+
+**Files:**
+- Create: `apps/web/src/components/ui/data-display/connection-bar/build-connections.ts`
+- Test: `apps/web/src/components/ui/data-display/connection-bar/__tests__/build-connections.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// apps/web/src/components/ui/data-display/connection-bar/__tests__/build-connections.test.ts
+import { describe, it, expect } from 'vitest';
+import { buildGameConnections, buildSessionConnections } from '../build-connections';
+
+describe('buildGameConnections', () => {
+  it('returns 4 pips: agent, kb, chat, session', () => {
+    const pips = buildGameConnections({ agentCount: 1, kbCount: 3, chatCount: 5, sessionCount: 23 });
+    expect(pips).toHaveLength(4);
+    expect(pips.map(p => p.entityType)).toEqual(['agent', 'kb', 'chat', 'session']);
+  });
+
+  it('sets count correctly', () => {
+    const pips = buildGameConnections({ agentCount: 0, kbCount: 2, chatCount: 0, sessionCount: 1 });
+    expect(pips[0].count).toBe(0); // agent
+    expect(pips[1].count).toBe(2); // kb
+  });
+});
+
+describe('buildSessionConnections', () => {
+  it('returns 4 pips: game, player, tool, agent', () => {
+    const pips = buildSessionConnections({ gameCount: 1, playerCount: 4, toolCount: 3, agentCount: 1 });
+    expect(pips).toHaveLength(4);
+    expect(pips.map(p => p.entityType)).toEqual(['game', 'player', 'tool', 'agent']);
+  });
+});
+```
+
+- [ ] **Step 2: Implement builders for all 9 entity types**
+
+```typescript
+// apps/web/src/components/ui/data-display/connection-bar/build-connections.ts
+import {
+  Bot, BookOpen, Calendar, Dices, FileText, Gamepad2,
+  MessageCircle, Star, Users, Wrench,
+} from 'lucide-react';
+
+import type { ConnectionPip } from './types';
+
+export function buildGameConnections(counts: {
+  agentCount: number; kbCount: number; chatCount: number; sessionCount: number;
+}): ConnectionPip[] {
+  return [
+    { entityType: 'agent', count: counts.agentCount, label: 'Agent', icon: Bot, isEmpty: counts.agentCount === 0 },
+    { entityType: 'kb', count: counts.kbCount, label: 'KB', icon: FileText, isEmpty: counts.kbCount === 0 },
+    { entityType: 'chat', count: counts.chatCount, label: 'Chat', icon: MessageCircle, isEmpty: counts.chatCount === 0 },
+    { entityType: 'session', count: counts.sessionCount, label: 'Sessioni', icon: Dices, isEmpty: counts.sessionCount === 0 },
+  ];
+}
+
+export function buildPlayerConnections(counts: {
+  sessionCount: number; favoriteGameCount: number;
+}): ConnectionPip[] {
+  return [
+    { entityType: 'session', count: counts.sessionCount, label: 'Sessioni', icon: Dices },
+    { entityType: 'game', count: counts.favoriteGameCount, label: 'Preferiti', icon: Star },
+  ];
+}
+
+export function buildSessionConnections(counts: {
+  gameCount: number; playerCount: number; toolCount: number; agentCount: number;
+}): ConnectionPip[] {
+  return [
+    { entityType: 'game', count: counts.gameCount, label: 'Gioco', icon: Gamepad2 },
+    { entityType: 'player', count: counts.playerCount, label: 'Giocatori', icon: Users },
+    { entityType: 'tool', count: counts.toolCount, label: 'Tools', icon: Wrench },
+    { entityType: 'agent', count: counts.agentCount, label: 'Agente', icon: Bot },
+  ];
+}
+
+export function buildAgentConnections(counts: {
+  gameCount: number; kbCount: number; chatCount: number;
+}): ConnectionPip[] {
+  return [
+    { entityType: 'game', count: counts.gameCount, label: 'Gioco', icon: Gamepad2 },
+    { entityType: 'kb', count: counts.kbCount, label: 'KB', icon: FileText },
+    { entityType: 'chat', count: counts.chatCount, label: 'Chat', icon: MessageCircle },
+  ];
+}
+
+export function buildKbConnections(counts: {
+  gameCount: number; agentCount: number;
+}): ConnectionPip[] {
+  return [
+    { entityType: 'game', count: counts.gameCount, label: 'Gioco', icon: Gamepad2 },
+    { entityType: 'agent', count: counts.agentCount, label: 'Agente', icon: Bot },
+  ];
+}
+
+export function buildChatConnections(counts: {
+  agentCount: number; gameCount: number;
+}): ConnectionPip[] {
+  return [
+    { entityType: 'agent', count: counts.agentCount, label: 'Agente', icon: Bot },
+    { entityType: 'game', count: counts.gameCount, label: 'Gioco', icon: Gamepad2 },
+  ];
+}
+
+export function buildEventConnections(counts: {
+  participantCount: number; gameCount: number; sessionCount: number;
+}): ConnectionPip[] {
+  return [
+    { entityType: 'player', count: counts.participantCount, label: 'Partecipanti', icon: Users },
+    { entityType: 'game', count: counts.gameCount, label: 'Giochi', icon: Dices },
+    { entityType: 'session', count: counts.sessionCount, label: 'Sessioni', icon: Dices },
+  ];
+}
+
+export function buildToolkitConnections(counts: {
+  gameCount: number; toolCount: number; sessionCount: number;
+}): ConnectionPip[] {
+  return [
+    { entityType: 'game', count: counts.gameCount, label: 'Gioco', icon: Gamepad2 },
+    { entityType: 'tool', count: counts.toolCount, label: 'Tools', icon: Wrench },
+    { entityType: 'session', count: counts.sessionCount, label: 'Sessioni', icon: Dices },
+  ];
+}
+
+export function buildToolConnections(counts: {
+  toolkitCount: number;
+}): ConnectionPip[] {
+  return [
+    { entityType: 'toolkit', count: counts.toolkitCount, label: 'Toolkit', icon: Wrench },
+  ];
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd apps/web && pnpm vitest run src/components/ui/data-display/connection-bar/`
+Expected: all PASS
+
+- [ ] **Step 4: Export builders from barrel**
+
+Add to `connection-bar/index.ts`:
+```typescript
+export {
+  buildGameConnections,
+  buildPlayerConnections,
+  buildSessionConnections,
+  buildAgentConnections,
+  buildKbConnections,
+  buildChatConnections,
+  buildEventConnections,
+  buildToolkitConnections,
+  buildToolConnections,
+} from './build-connections';
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/connection-bar/
+git commit -m "feat(nav): add ConnectionBar config builders for all 9 entity types"
+```
+
+---
+
+### Task 9: Wire ConnectionBar to cascade navigation
+
+**Files:**
+- Create: `apps/web/src/hooks/useConnectionBarNav.ts`
+- Test: `apps/web/src/hooks/__tests__/useConnectionBarNav.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// apps/web/src/hooks/__tests__/useConnectionBarNav.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useConnectionBarNav } from '../useConnectionBarNav';
+import { useCascadeNavigationStore } from '@/lib/stores/cascade-navigation-store';
+
+describe('useConnectionBarNav', () => {
+  beforeEach(() => {
+    act(() => useCascadeNavigationStore.getState().closeCascade());
+  });
+
+  it('opens DeckStack when count === 1 (DeckStack auto-resolves single item to drawer)', () => {
+    const { result } = renderHook(() => useConnectionBarNav('game-123'));
+    const pip = { entityType: 'agent' as const, count: 1, label: 'Agent', icon: vi.fn(), isEmpty: false };
+    const rect = new DOMRect(100, 200, 50, 30);
+
+    act(() => result.current.handlePipClick(pip, rect));
+
+    const state = useCascadeNavigationStore.getState();
+    // Hook opens DeckStack; the DeckStack component auto-resolves single-item to drawer.
+    // The hook can't call openDrawer directly because it doesn't know the target entityId.
+    expect(state.state).toBe('deckStack');
+    expect(state.activeEntityType).toBe('agent');
+    expect(state.sourceEntityId).toBe('game-123');
+  });
+
+  it('opens DeckStack when count >= 2', () => {
+    const { result } = renderHook(() => useConnectionBarNav('game-123'));
+    const pip = { entityType: 'kb' as const, count: 3, label: 'KB', icon: vi.fn() };
+    const rect = new DOMRect(100, 200, 50, 30);
+
+    act(() => result.current.handlePipClick(pip, rect));
+
+    const state = useCascadeNavigationStore.getState();
+    expect(state.state).toBe('deckStack');
+    expect(state.activeEntityType).toBe('kb');
+    expect(state.sourceEntityId).toBe('game-123');
+  });
+});
+```
+
+- [ ] **Step 2: Implement hook**
+
+```typescript
+// apps/web/src/hooks/useConnectionBarNav.ts
+'use client';
+
+import { useCallback } from 'react';
+
+import { useCascadeNavigationStore } from '@/lib/stores/cascade-navigation-store';
+
+import type { ConnectionPip } from '@/components/ui/data-display/connection-bar';
+
+/**
+ * Hook that wires ConnectionBar pip clicks to the cascade navigation store.
+ * Rules (from spec):
+ *   count === 0 → create action (handled by caller via onCreateEntity)
+ *   count === 1 → drawer opens directly
+ *   count >= 2  → DeckStack fan → click → drawer
+ */
+export function useConnectionBarNav(sourceEntityId: string) {
+  const openDeckStack = useCascadeNavigationStore(s => s.openDeckStack);
+  const openDrawer = useCascadeNavigationStore(s => s.openDrawer);
+
+  const handlePipClick = useCallback(
+    (pip: ConnectionPip, anchorRect: DOMRect) => {
+      if (pip.isEmpty) {
+        // count === 0: create action — caller handles via onCreateEntity callback
+        return;
+      }
+      if (pip.count === 1) {
+        // Single entity: open drawer directly (no DeckStack intermediate)
+        // The actual entityId must be resolved by the page — this opens the DeckStack
+        // which auto-resolves to drawer when it has exactly 1 item.
+        openDeckStack(pip.entityType, sourceEntityId, anchorRect);
+        return;
+      }
+      // count >= 2: show DeckStack fan
+      openDeckStack(pip.entityType, sourceEntityId, anchorRect);
+    },
+    [sourceEntityId, openDeckStack, openDrawer]
+  );
+
+  return { handlePipClick };
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd apps/web && pnpm vitest run src/hooks/__tests__/useConnectionBarNav.test.ts`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/hooks/useConnectionBarNav.ts apps/web/src/hooks/__tests__/useConnectionBarNav.test.ts
+git commit -m "feat(nav): add useConnectionBarNav hook wiring pips to cascade store"
+```
+
+---
+
+## M3 — DrawerActionFooter + Drawer Stack
+
+### Task 10: DrawerActionFooter component
+
+**Files:**
+- Create: `apps/web/src/components/ui/data-display/extra-meeple-card/DrawerActionFooter.tsx`
+- Test: `apps/web/src/components/ui/data-display/extra-meeple-card/__tests__/DrawerActionFooter.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+```tsx
+// apps/web/src/components/ui/data-display/extra-meeple-card/__tests__/DrawerActionFooter.test.tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { Play, ExternalLink } from 'lucide-react';
+import { DrawerActionFooter } from '../DrawerActionFooter';
+
+describe('DrawerActionFooter', () => {
+  it('renders enabled actions', () => {
+    render(
+      <DrawerActionFooter actions={[
+        { icon: Play, label: 'Gioca', onClick: vi.fn(), variant: 'primary', enabled: true },
+        { icon: ExternalLink, label: 'Apri', onClick: vi.fn(), variant: 'secondary', enabled: true },
+      ]} />
+    );
+    expect(screen.getByText('Gioca')).toBeInTheDocument();
+    expect(screen.getByText('Apri')).toBeInTheDocument();
+  });
+
+  it('hides disabled actions', () => {
+    render(
+      <DrawerActionFooter actions={[
+        { icon: Play, label: 'Gioca', onClick: vi.fn(), variant: 'primary', enabled: false },
+        { icon: ExternalLink, label: 'Apri', onClick: vi.fn(), variant: 'secondary', enabled: true },
+      ]} />
+    );
+    expect(screen.queryByText('Gioca')).not.toBeInTheDocument();
+    expect(screen.getByText('Apri')).toBeInTheDocument();
+  });
+
+  it('calls onClick when action clicked', async () => {
+    const handler = vi.fn();
+    render(
+      <DrawerActionFooter actions={[
+        { icon: Play, label: 'Gioca', onClick: handler, variant: 'primary', enabled: true },
+      ]} />
+    );
+    await userEvent.click(screen.getByText('Gioca'));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders nothing when all actions disabled', () => {
+    const { container } = render(
+      <DrawerActionFooter actions={[
+        { icon: Play, label: 'Gioca', onClick: vi.fn(), variant: 'primary', enabled: false },
+      ]} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Implement DrawerActionFooter**
+
+```tsx
+// apps/web/src/components/ui/data-display/extra-meeple-card/DrawerActionFooter.tsx
+'use client';
+
+import type { LucideIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+export interface DrawerAction {
+  icon: LucideIcon;
+  label: string;
+  onClick: () => void;
+  variant: 'primary' | 'secondary' | 'danger';
+  enabled: boolean;
+}
+
+interface DrawerActionFooterProps {
+  actions: DrawerAction[];
+  className?: string;
+}
+
+const variantStyles: Record<DrawerAction['variant'], string> = {
+  primary:
+    'bg-[var(--nh-bg-surface)] text-[var(--nh-text-primary)] font-bold hover:bg-[var(--nh-bg-surface-hover)]',
+  secondary:
+    'bg-transparent text-[var(--nh-text-secondary)] hover:bg-[var(--nh-bg-surface)]',
+  danger:
+    'bg-transparent text-red-600 hover:bg-red-50 dark:hover:bg-red-950/20',
+};
+
+export function DrawerActionFooter({ actions, className }: DrawerActionFooterProps) {
+  const visible = actions.filter(a => a.enabled);
+  if (visible.length === 0) return null;
+
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-2 border-t border-[var(--nh-border-default)] px-4 py-3',
+        className
+      )}
+      data-testid="drawer-action-footer"
+    >
+      {visible.map(action => {
+        const Icon = action.icon;
+        return (
+          <button
+            key={action.label}
+            type="button"
+            onClick={action.onClick}
+            className={cn(
+              'flex items-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold transition-colors',
+              variantStyles[action.variant]
+            )}
+          >
+            <Icon className="h-3.5 w-3.5" />
+            {action.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Run tests, verify PASS**
+
+Run: `cd apps/web && pnpm vitest run src/components/ui/data-display/extra-meeple-card/__tests__/DrawerActionFooter.test.tsx`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/extra-meeple-card/DrawerActionFooter.tsx apps/web/src/components/ui/data-display/extra-meeple-card/__tests__/DrawerActionFooter.test.tsx
+git commit -m "feat(drawer): add DrawerActionFooter with conditional actions"
+```
+
+---
+
+### Task 11: Update cascade-navigation-store with drawer stack
+
+**Files:**
+- Modify: `apps/web/src/lib/stores/cascade-navigation-store.ts`
+- Test: `apps/web/src/lib/stores/__tests__/cascade-navigation-store.test.ts`
+
+- [ ] **Step 1: Write failing tests for new actions**
+
+```typescript
+// apps/web/src/lib/stores/__tests__/cascade-navigation-store.test.ts
+// Add to existing test file or create new:
+import { act } from 'react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useCascadeNavigationStore } from '../cascade-navigation-store';
+
+describe('drawer stack', () => {
+  beforeEach(() => {
+    act(() => useCascadeNavigationStore.getState().closeCascade());
+  });
+
+  it('pushDrawer pushes current onto stack and opens new', () => {
+    const store = useCascadeNavigationStore;
+    act(() => store.getState().openDrawer('game', 'g1'));
+    act(() => store.getState().pushDrawer('agent', 'a1'));
+
+    const state = store.getState();
+    expect(state.state).toBe('drawer');
+    expect(state.activeEntityType).toBe('agent');
+    expect(state.activeEntityId).toBe('a1');
+    expect(state.drawerStack).toHaveLength(1);
+    expect(state.drawerStack[0].entityType).toBe('game');
+    expect(state.drawerStack[0].entityId).toBe('g1');
+  });
+
+  it('popDrawer restores previous drawer from stack', () => {
+    const store = useCascadeNavigationStore;
+    act(() => store.getState().openDrawer('game', 'g1'));
+    act(() => store.getState().pushDrawer('agent', 'a1'));
+    act(() => store.getState().popDrawer());
+
+    const state = store.getState();
+    expect(state.state).toBe('drawer');
+    expect(state.activeEntityType).toBe('game');
+    expect(state.activeEntityId).toBe('g1');
+    expect(state.drawerStack).toHaveLength(0);
+  });
+
+  it('popDrawer closes drawer when stack is empty', () => {
+    const store = useCascadeNavigationStore;
+    act(() => store.getState().openDrawer('game', 'g1'));
+    act(() => store.getState().popDrawer());
+
+    expect(store.getState().state).toBe('closed');
+  });
+
+  it('drawer stack max depth is 3', () => {
+    const store = useCascadeNavigationStore;
+    act(() => store.getState().openDrawer('game', 'g1'));
+    act(() => store.getState().pushDrawer('agent', 'a1'));
+    act(() => store.getState().pushDrawer('kb', 'k1'));
+    act(() => store.getState().pushDrawer('chat', 'c1'));
+    act(() => store.getState().pushDrawer('session', 's1')); // exceeds 3
+
+    const state = store.getState();
+    expect(state.drawerStack).toHaveLength(3);
+    // oldest (game g1) was evicted
+    expect(state.drawerStack[0].entityType).toBe('agent');
+  });
+
+  it('openDrawer accepts optional tabId', () => {
+    const store = useCascadeNavigationStore;
+    act(() => store.getState().openDrawer('session', 's1', 'toolkit'));
+
+    expect(store.getState().activeTabId).toBe('toolkit');
+  });
+
+  it('closeCascade clears the stack', () => {
+    const store = useCascadeNavigationStore;
+    act(() => store.getState().openDrawer('game', 'g1'));
+    act(() => store.getState().pushDrawer('agent', 'a1'));
+    act(() => store.getState().closeCascade());
+
+    expect(store.getState().drawerStack).toHaveLength(0);
+    expect(store.getState().state).toBe('closed');
+  });
+});
+```
+
+- [ ] **Step 2: Update store implementation**
+
+Add to `CascadeNavigationState` interface:
+```typescript
+activeTabId: string | null;
+drawerStack: DrawerStackEntry[];
+pushDrawer: (entityType: MeepleEntityType, entityId: string) => void;
+popDrawer: () => void;
+```
+
+Add `DrawerStackEntry` type:
+```typescript
+interface DrawerStackEntry {
+  entityType: MeepleEntityType;
+  entityId: string;
+  activeTabId?: string;
+}
+```
+
+Update `initialState`:
+```typescript
+activeTabId: null as string | null,
+drawerStack: [] as DrawerStackEntry[],
+```
+
+Update `openDrawer` to accept optional `tabId`:
+```typescript
+openDrawer: (entityType: MeepleEntityType, entityId: string, tabId?: string) => {
+  const current = get();
+  const skipped = current.state !== 'deckStack';
+  set({
+    state: 'drawer',
+    activeEntityType: entityType,
+    activeEntityId: entityId,
+    activeTabId: tabId ?? null,
+    deckStackSkipped: skipped,
+  }, false, 'openDrawer');
+},
+```
+
+Add `pushDrawer`:
+```typescript
+pushDrawer: (entityType: MeepleEntityType, entityId: string) => {
+  const current = get();
+  const entry: DrawerStackEntry = {
+    entityType: current.activeEntityType!,
+    entityId: current.activeEntityId!,
+    activeTabId: current.activeTabId ?? undefined,
+  };
+  const stack = [...current.drawerStack, entry].slice(-3); // max 3
+  set({
+    state: 'drawer',
+    activeEntityType: entityType,
+    activeEntityId: entityId,
+    activeTabId: null,
+    drawerStack: stack,
+  }, false, 'pushDrawer');
+},
+```
+
+Add `popDrawer`:
+```typescript
+popDrawer: () => {
+  const current = get();
+  if (current.drawerStack.length === 0) {
+    get().closeDrawer();
+    return;
+  }
+  const stack = [...current.drawerStack];
+  const prev = stack.pop()!;
+  set({
+    state: 'drawer',
+    activeEntityType: prev.entityType,
+    activeEntityId: prev.entityId,
+    activeTabId: prev.activeTabId ?? null,
+    drawerStack: stack,
+  }, false, 'popDrawer');
+},
+```
+
+Update `closeCascade` to clear stack:
+```typescript
+closeCascade: () => {
+  set({ ...initialState }, false, 'closeCascade');
+},
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd apps/web && pnpm vitest run src/lib/stores/__tests__/cascade-navigation-store.test.ts`
+Expected: all PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/lib/stores/cascade-navigation-store.ts apps/web/src/lib/stores/__tests__/cascade-navigation-store.test.ts
+git commit -m "feat(nav): add drawer stack (push/pop) to cascade navigation store"
+```
+
+---
+
+### Task 12: Update ExtraMeepleCardDrawer with stack nav + action footer slot
+
+**Files:**
+- Modify: `apps/web/src/components/ui/data-display/extra-meeple-card/ExtraMeepleCardDrawer.tsx`
+- Modify: `apps/web/src/components/ui/data-display/extra-meeple-card/drawer-test-ids.ts`
+
+- [ ] **Step 1: Add back button to drawer header when stack has entries**
+
+In `ExtraMeepleCardDrawer.tsx`, import and use the cascade store:
+
+```typescript
+import { useCascadeNavigationStore } from '@/lib/stores/cascade-navigation-store';
+```
+
+In the header section, before the Icon:
+```tsx
+const drawerStack = useCascadeNavigationStore(s => s.drawerStack);
+const popDrawer = useCascadeNavigationStore(s => s.popDrawer);
+const hasStack = drawerStack.length > 0;
+
+// In JSX, before <Icon>:
+{hasStack && (
+  <button
+    onClick={popDrawer}
+    className="flex h-7 w-7 items-center justify-center rounded-full bg-white/20 text-white transition-colors hover:bg-white/30"
+    aria-label="Indietro"
+    data-testid="drawer-back-button"
+  >
+    <ChevronLeft className="h-3.5 w-3.5" />
+  </button>
+)}
+```
+
+- [ ] **Step 2: Update drawer-test-ids.ts**
+
+```typescript
+// apps/web/src/components/ui/data-display/extra-meeple-card/drawer-test-ids.ts
+export const DRAWER_TEST_IDS = {
+  ENTITY_LABEL: 'drawer-entity-label',
+  LOADING_SKELETON: 'drawer-loading-skeleton',
+  ERROR_STATE: 'drawer-error-state',
+  BACK_BUTTON: 'drawer-back-button',
+  ACTION_FOOTER: 'drawer-action-footer',
+} as const;
+```
+
+- [ ] **Step 3: Verify build + existing tests**
+
+Run: `cd apps/web && pnpm typecheck && pnpm vitest run src/components/ui/data-display/extra-meeple-card/`
+Expected: PASS (some tests may need COMING_SOON removal — update those tests to expect new behavior)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/extra-meeple-card/ExtraMeepleCardDrawer.tsx apps/web/src/components/ui/data-display/extra-meeple-card/drawer-test-ids.ts
+git commit -m "feat(drawer): add stack nav back button + update test IDs"
+```
+
+---
+
+## M4 — Entity Drawer Content (5 new components)
+
+### Task 13: PlayerDrawerContent
+
+**Files:**
+- Create: `apps/web/src/components/ui/data-display/extra-meeple-card/entities/PlayerDrawerContent.tsx`
+- Test: `apps/web/src/components/ui/data-display/extra-meeple-card/entities/__tests__/PlayerDrawerContent.test.tsx`
+
+Implement the 3-tab player drawer (Profilo, Stats, Storico) with DrawerActionFooter. Follow the pattern of existing `GameExtraMeepleCard.tsx` — use `ENTITY_COLORS`, `EntityHeader`, `EntityTabTrigger`, `StatCard` from `shared.tsx`. Use Tabs/TabsList/TabsContent from `@/components/ui/navigation/tabs`.
+
+Footer actions: `[📊 Confronta]` (enabled conditionally) + `[↗ Apri]` (always).
+
+- [ ] **Step 1: Write failing tests** (render, tabs, footer conditions)
+- [ ] **Step 2: Implement component**
+- [ ] **Step 3: Wire into DrawerEntityRouter** (replace `DrawerComingSoon` for `player` case)
+- [ ] **Step 4: Remove old PlayerExtraMeepleCard** — delete `entities/PlayerExtraMeepleCard.tsx` and remove its re-export from `EntityExtraMeepleCard.tsx`
+- [ ] **Step 5: Run tests, verify PASS** (fix any imports of old component)
+- [ ] **Step 6: Commit**: `feat(drawer): add PlayerDrawerContent, remove old PlayerExtraMeepleCard`
+
+---
+
+### Task 14: SessionDrawerContent
+
+**Files:**
+- Create: `apps/web/src/components/ui/data-display/extra-meeple-card/entities/SessionDrawerContent.tsx`
+- Test: `apps/web/src/components/ui/data-display/extra-meeple-card/entities/__tests__/SessionDrawerContent.test.tsx`
+- Remove: `apps/web/src/components/ui/data-display/extra-meeple-card/ExtraMeepleCard.tsx` (after wiring)
+
+3-tab session drawer (Live, Toolkit*, Timeline). Toolkit tab hidden if no toolkit.
+Footer: `[▶️ Riprendi]` if in-progress · `[📊 Risultati]` if completed · `[↗ Apri]` always.
+
+Player rows in Live tab are clickable → call `pushDrawer('player', playerId)`.
+
+- [ ] **Step 1: Write failing tests**
+- [ ] **Step 2: Implement component**
+- [ ] **Step 3: Wire into DrawerEntityRouter** (replace `DrawerComingSoon` for `session` case)
+- [ ] **Step 4: Remove old `ExtraMeepleCard.tsx`** (session-specific, now superseded)
+- [ ] **Step 5: Update any imports of old ExtraMeepleCard** (grep and fix)
+- [ ] **Step 6: Run tests, verify PASS**
+- [ ] **Step 7: Commit**: `feat(drawer): add SessionDrawerContent, remove old ExtraMeepleCard`
+
+---
+
+### Task 15: EventExtraMeepleCard
+
+**Files:**
+- Create: `apps/web/src/components/ui/data-display/extra-meeple-card/entities/EventExtraMeepleCard.tsx`
+- Test: `apps/web/src/components/ui/data-display/extra-meeple-card/entities/__tests__/EventExtraMeepleCard.test.tsx`
+
+2-tab event drawer (Overview, Programma).
+Footer: `[✅ Conferma]` conditional · `[📤 Invita]` if organizer · `[↗ Apri]` always.
+
+- [ ] **Step 1-5: TDD cycle + wire into DrawerEntityRouter**
+- [ ] **Step 6: Commit**: `feat(drawer): add EventExtraMeepleCard with 2 tabs`
+
+---
+
+### Task 16: ToolkitExtraMeepleCard
+
+**Files:**
+- Create: `apps/web/src/components/ui/data-display/extra-meeple-card/entities/ToolkitExtraMeepleCard.tsx`
+- Test: `apps/web/src/components/ui/data-display/extra-meeple-card/entities/__tests__/ToolkitExtraMeepleCard.test.tsx`
+
+3-tab toolkit drawer (Overview, Template, Storico).
+Footer: `[▶️ Usa in sessione]` if published · `[✏️ Modifica]` if owner · `[↗ Apri]` always.
+
+- [ ] **Step 1-5: TDD cycle + wire into DrawerEntityRouter**
+- [ ] **Step 6: Commit**: `feat(drawer): add ToolkitExtraMeepleCard with 3 tabs`
+
+---
+
+### Task 17: ToolExtraMeepleCard
+
+**Files:**
+- Create: `apps/web/src/components/ui/data-display/extra-meeple-card/entities/ToolExtraMeepleCard.tsx`
+- Test: `apps/web/src/components/ui/data-display/extra-meeple-card/entities/__tests__/ToolExtraMeepleCard.test.tsx`
+
+2-tab tool drawer (Dettaglio, Preview).
+Footer: `[▶️ Usa]` if active session · `[✏️ Modifica]` if owner · `[↗ Apri]` always.
+
+- [ ] **Step 1-5: TDD cycle + wire into DrawerEntityRouter**
+- [ ] **Step 6: Commit**: `feat(drawer): add ToolExtraMeepleCard with 2 tabs`
+
+---
+
+## M5 — Session Mode
+
+### Task 18: MobileBottomBar with Normal/Session dual state
+
+**Files:**
+- Create: `apps/web/src/components/layout/MobileBottomBar.tsx`
+- Test: `apps/web/src/components/layout/__tests__/MobileBottomBar.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+```tsx
+// apps/web/src/components/layout/__tests__/MobileBottomBar.test.tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { MobileBottomBar } from '../MobileBottomBar';
+
+// Mock useDashboardMode
+vi.mock('@/components/dashboard', () => ({
+  useDashboardMode: vi.fn(),
+}));
+
+import { useDashboardMode } from '@/components/dashboard';
+
+describe('MobileBottomBar', () => {
+  it('renders normal mode tabs when no session active', () => {
+    (useDashboardMode as ReturnType<typeof vi.fn>).mockReturnValue({
+      isGameMode: false,
+      activeSessionId: null,
+    });
+    render(<MobileBottomBar />);
+    expect(screen.getByText('Home')).toBeInTheDocument();
+    expect(screen.getByText('Libreria')).toBeInTheDocument();
+    expect(screen.getByText('Chat')).toBeInTheDocument();
+  });
+
+  it('renders session mode when session is active', () => {
+    (useDashboardMode as ReturnType<typeof vi.fn>).mockReturnValue({
+      isGameMode: true,
+      activeSessionId: 'session-123',
+    });
+    render(<MobileBottomBar />);
+    expect(screen.getByText('Classifica')).toBeInTheDocument();
+    expect(screen.queryByText('Libreria')).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Implement MobileBottomBar**
+
+```tsx
+// apps/web/src/components/layout/MobileBottomBar.tsx
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+import {
+  BarChart3, ChevronLeft, Home, Library, MessageCircle,
+  MoreHorizontal, Search, User, Wrench,
+} from 'lucide-react';
+
+import { useDashboardMode } from '@/components/dashboard';
+import { useCascadeNavigationStore } from '@/lib/stores/cascade-navigation-store';
+import { cn } from '@/lib/utils';
+
+const NORMAL_TABS = [
+  { href: '/dashboard', icon: Home, label: 'Home' },
+  { href: '/discover', icon: Search, label: 'Cerca' },
+  { href: '/library', icon: Library, label: 'Libreria' },
+  { href: '/chat', icon: MessageCircle, label: 'Chat' },
+  { href: '/profile', icon: User, label: 'Profilo' },
+] as const;
+
+export function MobileBottomBar() {
+  const pathname = usePathname();
+  const { isGameMode, activeSessionId } = useDashboardMode();
+  const inSession = isGameMode && !!activeSessionId;
+
+  if (inSession) {
+    return <SessionModeBar sessionId={activeSessionId!} />;
+  }
+
+  return (
+    <nav
+      className="fixed bottom-0 left-0 right-0 z-30 flex items-center justify-around border-t border-border bg-background/95 px-2 pb-[env(safe-area-inset-bottom)] pt-1.5 backdrop-blur-md md:hidden"
+      data-testid="mobile-bottom-bar"
+    >
+      {NORMAL_TABS.map(tab => {
+        const active = pathname.startsWith(tab.href);
+        const Icon = tab.icon;
+        return (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            className={cn(
+              'flex min-w-[48px] flex-col items-center gap-0.5 py-1 text-[10px] font-bold',
+              active ? 'text-[hsl(25,95%,45%)]' : 'text-muted-foreground'
+            )}
+          >
+            <Icon className="h-5 w-5" />
+            <span>{tab.label}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
+function SessionModeBar({ sessionId }: { sessionId: string }) {
+  const openDrawer = useCascadeNavigationStore(s => s.openDrawer);
+
+  return (
+    <nav
+      className="fixed bottom-0 left-0 right-0 z-30 flex items-center justify-around border-t-2 border-indigo-400/60 bg-background/95 px-2 pb-[env(safe-area-inset-bottom)] pt-1.5 backdrop-blur-md md:hidden"
+      data-testid="mobile-bottom-bar-session"
+    >
+      <button
+        type="button"
+        onClick={() => window.history.back()}
+        className="flex min-w-[48px] flex-col items-center gap-0.5 py-1 text-[10px] font-bold text-muted-foreground"
+      >
+        <ChevronLeft className="h-5 w-5" />
+        <span>Back</span>
+      </button>
+      <button
+        type="button"
+        onClick={() => openDrawer('session', sessionId, 'live')}
+        className="flex min-w-[48px] flex-col items-center gap-0.5 py-1 text-[10px] font-bold text-indigo-600"
+      >
+        <BarChart3 className="h-5 w-5" />
+        <span>Classifica</span>
+      </button>
+      <button
+        type="button"
+        onClick={() => openDrawer('session', sessionId, 'toolkit')}
+        className="flex min-w-[48px] flex-col items-center gap-0.5 py-1 text-[10px] font-bold text-muted-foreground"
+      >
+        <Wrench className="h-5 w-5" />
+        <span>Toolkit</span>
+      </button>
+      <button
+        type="button"
+        onClick={() => {/* open agent chat drawer */}}
+        className="flex min-w-[48px] flex-col items-center gap-0.5 py-1 text-[10px] font-bold text-muted-foreground"
+      >
+        <MessageCircle className="h-5 w-5" />
+        <span>AI</span>
+      </button>
+      <button
+        type="button"
+        className="flex min-w-[48px] flex-col items-center gap-0.5 py-1 text-[10px] font-bold text-muted-foreground"
+      >
+        <MoreHorizontal className="h-5 w-5" />
+        <span>Altro</span>
+      </button>
+    </nav>
+  );
+}
+```
+
+- [ ] **Step 3: Run tests, PASS**
+- [ ] **Step 4: Commit**: `feat(nav): add MobileBottomBar with Normal/Session dual state`
+
+---
+
+### Task 19: SessionBanner (desktop)
+
+**Files:**
+- Create: `apps/web/src/components/layout/UserShell/SessionBanner.tsx`
+- Test: `apps/web/src/components/layout/UserShell/__tests__/SessionBanner.test.tsx`
+
+32px bar between MiniNav and content. Shows session name, turn, quick-access buttons.
+
+- [ ] **Step 1: Write failing tests** (renders when session active, hidden otherwise, buttons open drawers)
+- [ ] **Step 2: Implement SessionBanner**
+- [ ] **Step 3: Wire into DesktopShell** (add `<SessionBanner />` between `<MiniNavSlot />` and `<main>`)
+- [ ] **Step 4: Run tests, PASS**
+- [ ] **Step 5: Commit**: `feat(nav): add SessionBanner for desktop session context`
+
+---
+
+### Task 20: Wire MobileBottomBar into DesktopShell
+
+**Files:**
+- Modify: `apps/web/src/components/layout/UserShell/DesktopShell.tsx`
+
+- [ ] **Step 1: Add MobileBottomBar import and render**
+
+```tsx
+import { MobileBottomBar } from '@/components/layout/MobileBottomBar';
+
+// In JSX, after </main> and before <ChatSlideOverPanel />:
+<div className="md:hidden">
+  <MobileBottomBar />
+</div>
+```
+
+- [ ] **Step 2: Verify build + tests**
+- [ ] **Step 3: Commit**: `feat(nav): wire MobileBottomBar + SessionBanner into DesktopShell`
+
+---
+
+## Note: KB↔Chat Citation Pills (Deferred)
+
+The spec defines inline citation pills in chat messages (`[📄 p.12 §3]`) that link to KB drawers, and a bidirectional KB.Citazioni ↔ Chat.Fonti tab system. This requires:
+- Backend API changes to expose chunk page/paragraph metadata in chat responses
+- A `CitationPill` component for inline rendering in chat bubbles
+- Aggregation logic for the Fonti and Citazioni tabs
+
+This is **deferred to a follow-up plan** because it depends on backend API changes not in scope for this frontend redesign. The Chat drawer (already implemented) and KB drawer (already implemented) will have placeholder content for these tabs until the API is ready. The `Citazioni` tab in KB and `Fonti` tab in Chat should render empty states with "Disponibile prossimamente" text.
+
+---
+
+## M6 — Integration + Cleanup
+
+### Task 21: Wire ConnectionBar into entity pages
+
+**Files:**
+- Modify: game detail page, agent detail page, session detail page (and others as needed)
+
+For each entity page that has a detail view:
+1. Import `ConnectionBar` + the appropriate `build{Entity}Connections` builder
+2. Fetch connection counts from existing API data
+3. Render `<ConnectionBar>` below the title/meta section
+4. Use `useConnectionBarNav` to handle pip clicks
+
+- [ ] **Step 1: Wire game detail page** as the reference implementation
+- [ ] **Step 2: Wire remaining entity pages** following the same pattern
+- [ ] **Step 3: Run full test suite**
+- [ ] **Step 4: Commit**: `feat(nav): wire ConnectionBar into entity detail pages`
+
+---
+
+### Task 22: Dead code cleanup + final validation
+
+**Files:**
+- Modify: `apps/web/src/config/component-registry.ts` — remove entries for deleted components
+- Remove: any remaining dead imports, unused test files
+- Modify: `apps/web/src/components/ui/data-display/extra-meeple-card/EntityExtraMeepleCard.tsx` — update exports
+
+- [ ] **Step 1: Clean component-registry.ts and component-map.ts**
+
+Remove entries referencing `HandRailItem`, `HandRailToolbar`, `DesktopHandRail` from:
+- `apps/web/src/config/component-registry.ts`
+- `apps/web/src/components/admin/ui-library/component-map.ts`
+
+- [ ] **Step 2: Final grep for dead imports**
+
+Run: `cd apps/web && pnpm typecheck`
+Fix any remaining errors.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `cd apps/web && pnpm vitest run`
+Expected: all PASS
+
+- [ ] **Step 4: Run lint**
+
+Run: `cd apps/web && pnpm lint`
+Expected: no new errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "chore(nav): dead code cleanup after navigation redesign"
+```
+
+---
+
+## Dependency Graph
+
+```
+M0: Task 1 → Task 2 → Task 3
+M1: Task 4 → Task 5 → Task 6  (depends on M0 for recents store)
+M2: Task 7 → Task 8 → Task 9  (independent of M1, can run in parallel)
+M3: Task 10 → Task 11 → Task 12 (depends on M2 for cascade store updates)
+M4: Task 13, 14, 15, 16, 17   (depends on M3, tasks are independent of each other)
+M5: Task 18, 19 → Task 20     (depends on M1 for shell cleanup + M3/Task 11 for openDrawer tabId signature)
+M6: Task 21 → Task 22         (depends on M2, M3, M4, M5)
+```
+
+**Parallelizable**: M0+M2 can run simultaneously. Within M4, all 5 entity tasks are independent.

--- a/docs/superpowers/specs/2026-04-10-card-drawer-navigation-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-10-card-drawer-navigation-redesign-design.md
@@ -1,0 +1,476 @@
+# MeepleCard Drawer + Navigation Redesign — Design Spec
+
+**Date**: 2026-04-10
+**Status**: Draft
+**Scope**: Shell layout, drawer tabs, cascade navigation, ManaPip, session mode
+
+## Summary
+
+Redesign the MeepleAI navigation and drawer system around a **Page-first** flow. The user lands on an entity page and explores related entities via drawers — without leaving the page. Removes the CardHand left rail, transforms MyHand into lightweight recents, and introduces a ConnectionBar, conditional action footer, and mobile Session Mode.
+
+## Decisions Log
+
+| Question | Decision | Rationale |
+|----------|----------|-----------|
+| Primary flow | **Page-first** | User lands on entity page, drawer for related entities |
+| CardHand (left rail) | **Remove** | Redundant with Page-first + recents |
+| MyHand (4 fixed slots) | **Transform** → generic recents (A) + session-context (D) | Fixed slots too rigid; recents + session mode covers both needs |
+| Cascade: ManaPip click | **Smart**: 1 → drawer direct, 2+ → DeckStack (B) | Saves clicks when choice is obvious |
+| Cascade: NavFooter click | **Always drawer direct** (D) | NavFooter = intentional action; drawer shows picker if 2+ |
+| Drawer interactivity | **Read + quick actions** (B) | Light actions in footer; complex editing on full page |
+| Layout | **MiniNav potenziato, no sidebars** (C) | Full-width content, recents in MiniNav, session mode in bottom bar |
+| ManaPip | **Dual role** (D) | Small indicators on cards in lists; interactive ConnectionBar on pages |
+
+## 1. Shell Layout
+
+### What Gets Removed
+
+| Component | File | Reason |
+|-----------|------|--------|
+| `DesktopHandRail` | `components/layout/UserShell/DesktopHandRail.tsx` | Replaced by MiniNav recents |
+| `use-card-hand.ts` store | `stores/use-card-hand.ts` | No longer needed |
+| `MyHandSidebar` | `components/layout/MyHand/MyHandSidebar.tsx` | Replaced by recents + session mode |
+| `MyHandBottomBar` | `components/layout/MyHand/MyHandBottomBar.tsx` | Replaced by MobileTabBar + session mode |
+| `MyHandSlot`, `MyHandSlotPicker` | `components/layout/MyHand/` | No more fixed slots |
+| `my-hand/` store + API | `stores/my-hand/`, `lib/api/my-hand.ts` | Backend API can stay for backward compat, frontend stops using it |
+
+### New DesktopShell
+
+```
+┌──────────────────────────────────────────────┐
+│ TopBar (64px)   [Logo] [Search] [Notif] [Av] │
+├──────────────────────────────────────────────┤
+│ MiniNav (48px)                               │
+│ [← Breadcrumb] [Tab1] [Tab2]    [R1][R2][R3]│
+├──────────────────────────────────────────────┤
+│ SessionBanner (32px, only when active)       │
+├──────────────────────────────────────────────┤
+│                                              │
+│         main content (full width)            │
+│                                              │
+└──────────────────────────────────────────────┘
+```
+
+```tsx
+// New DesktopShell composition
+function DesktopShell({ children }) {
+  return (
+    <div className="min-h-dvh flex flex-col">
+      <TopBar />
+      <MiniNavSlot />        {/* existing, enhanced with recents */}
+      <SessionBanner />      {/* NEW: only when activeSessionId */}
+      <main className="flex-1 min-w-0 overflow-y-auto">
+        {children}
+      </main>
+      <div className="md:hidden">
+        <MobileBottomBar />  {/* NEW: replaces MyHandBottomBar */}
+      </div>
+      <ChatSlideOverPanel />
+    </div>
+  );
+}
+```
+
+## 2. MiniNav Recents
+
+### Store
+
+```typescript
+interface RecentItem {
+  id: string;
+  entity: MeepleEntityType;
+  title: string;
+  href: string;
+  visitedAt: number;
+}
+
+interface RecentsStore {
+  items: RecentItem[];        // max 4, FIFO
+  push: (item: Omit<RecentItem, 'visitedAt'>) => void;
+  remove: (id: string) => void;
+  clear: () => void;
+}
+```
+
+- Persisted in `sessionStorage` (resets on tab close)
+- Current page excluded from display
+- Max 3 visible (4 on screens > 1280px)
+
+### Rendering
+
+- 28px circle, entity-colored background alpha 10%, entity icon (Lucide, 14px)
+- Hover: tooltip "Azul (Game)", glow ring
+- Click: `router.push(href)`
+- New pill enters fade+slide from right, oldest exits left
+- **Mobile**: not shown in MiniNav (insufficient width)
+
+## 3. ConnectionBar (ManaPip Evolved)
+
+### Dual Role
+
+**On cards in lists** (ShelfCard, MeepleCard grid): ManaPip stays as-is — small 4-8px colored dots indicating related entities exist. Not clickable on the card itself.
+
+**On entity pages**: ConnectionBar appears below title/meta as interactive pills.
+
+### ConnectionBar Component
+
+```typescript
+interface ConnectionPip {
+  entityType: MeepleEntityType;
+  count: number;
+  label: string;
+  icon: LucideIcon;
+  isEmpty: boolean;             // count === 0: show "+" to create
+}
+
+interface ConnectionBarProps {
+  connections: ConnectionPip[];
+  onPipClick: (pip: ConnectionPip, anchorRect: DOMRect) => void;
+}
+```
+
+### Click Behavior
+
+| Trigger | Count | Action |
+|---------|-------|--------|
+| ConnectionBar pip | 0 | "Create" action (e.g., "Crea Agente per Azul") |
+| ConnectionBar pip | 1 | Drawer opens directly |
+| ConnectionBar pip | 2+ | DeckStack fan → click → Drawer |
+| NavFooter on MeepleCard | any | Drawer opens directly. If 2+ entities of that type exist, drawer shows a compact picker list as first view (entity mini-cards, click one to load full detail in same drawer). |
+
+### Connections per Entity Type
+
+| Entity Page | Shows connections to |
+|-------------|---------------------|
+| game | Agent, KB, Chat, Sessions |
+| player | Sessions, Favorite Games |
+| session | Game, Players, Tools, Agent |
+| agent | Game, KB, Chat |
+| kb | Game, Agent |
+| chat | Agent, Game |
+| event | Participants, Games, Sessions |
+| toolkit | Game, Tools, Sessions |
+| tool | Toolkit |
+
+### Rendering
+
+- Horizontal pills, entity-colored (bg alpha 10%, text entity color)
+- Icon (14px) + count + label
+- Hover: glow ring entity-colored
+- `isEmpty`: dashed border, "+" icon, dimmed
+- Mobile: horizontal scroll if needed, ~36px height
+
+## 4. Drawer System
+
+### Architecture (Unchanged Pattern)
+
+```
+ExtraMeepleCardDrawer (Sheet wrapper)
+  └── DrawerEntityRouter (switch on entityType)
+       └── {Entity}DrawerContent (fetches data, renders tabs)
+            ├── Tab content area (scrollable)
+            └── ActionFooter (fixed bottom, conditional actions)
+```
+
+Drawer opens `side="right"` on desktop, `side="bottom"` on mobile (future enhancement).
+
+### Drawer Action Footer
+
+Fixed bar at bottom of drawer. Actions are **conditional** — hidden or disabled based on state.
+
+```typescript
+interface DrawerAction {
+  icon: LucideIcon;
+  label: string;
+  onClick: () => void;
+  variant: 'primary' | 'secondary' | 'danger';
+  /** If false, action is hidden entirely (not just disabled) */
+  enabled: boolean;
+}
+```
+
+Every drawer includes `[↗ Apri pagina]` as the last action — the escape hatch to the full page.
+
+### Drawer Stack Navigation
+
+When clicking a linked entity inside a drawer (e.g., a session row in Game Storico), the current drawer is pushed to a stack and the new drawer opens. A back button in the drawer header returns to the previous drawer.
+
+```typescript
+interface DrawerStackEntry {
+  entityType: DrawerEntityType;
+  entityId: string;
+  activeTabId?: string;
+  scrollPosition?: number;
+}
+```
+
+Max stack depth: 3. Beyond that, the oldest entry is discarded.
+
+### Tab Definitions per Entity
+
+#### GAME — 3 tabs (1 if zero plays)
+
+| Tab | ID | Icon | Badge | Content |
+|-----|----|------|-------|---------|
+| Info | `info` | `Info` | — | Publisher, year, players, duration, complexity, description |
+| Stats | `stats` | `BarChart3` | `totalPlays` | Plays, win rate, avg score, trend. **Hidden if user has 0 plays.** |
+| Storico | `history` | `History` | — | Last plays: date, players, result, score. Each row links to session drawer. **Hidden if 0 plays.** |
+
+Footer: `[▶️ Gioca]` always · `[🤖 Chiedi AI]` if agent exists and active · `[↗ Apri]` always
+
+#### PLAYER — 3 tabs
+
+> **Migration note**: The existing `PlayerExtraMeepleCard.tsx` has Profile/Achievements/History tabs. `PlayerDrawerContent.tsx` replaces it with Profilo/Stats/Storico — achievements folded into Stats. The old component is removed.
+
+| Tab | ID | Icon | Badge | Content |
+|-----|----|------|-------|---------|
+| Profilo | `profile` | `User` | — | Avatar, name, member since, favorite game, groups |
+| Stats | `stats` | `Trophy` | `totalWins` | Wins, plays, win rate, top 3 games |
+| Storico | `history` | `History` | `totalSessions` | Last sessions: game, date, result, score. Each row links to session + game drawer. |
+
+Footer: `[📊 Confronta]` if common games exist · `[↗ Apri]` always
+
+#### SESSION — 3 tabs (2 if no toolkit)
+
+> **Migration note**: The existing `ExtraMeepleCard.tsx` is a session-specific component with 6 tabs (Overview, Toolkit, Scoreboard, History, Media, AI). `SessionDrawerContent.tsx` replaces it with a simplified 3-tab drawer version (Live, Toolkit, Timeline). The old component is removed; any standalone usage (e.g., session detail page) should use the page's own tab system, not the drawer component.
+
+| Tab | ID | Icon | Badge | Content |
+|-----|----|------|-------|---------|
+| Live | `live` | `Layers` | — | Status, turn, duration, player ranking with scores. Each player links to player drawer. |
+| Toolkit | `toolkit` | `Wrench` | `toolCount` | Active tools with state (timer running, counter values). **Hidden if no toolkit.** |
+| Timeline | `timeline` | `Clock` | — | Chrono feed: events + notes + inline photos |
+
+Footer: `[▶️ Riprendi]` if in-progress/paused · `[📊 Risultati]` if completed · `[📤 Condividi]` if completed · `[↗ Apri]` always
+
+#### AGENT — 3 tabs (2 if never invoked)
+
+| Tab | ID | Icon | Badge | Content |
+|-----|----|------|-------|---------|
+| Overview | `overview` | `Bot` | — | Name, type, strategy, model, status, linked game, KB doc count |
+| Storico | `history` | `History` | `invocationCount` | Last invocations: date, query type, latency. Each row links to chat thread. **Hidden if 0 invocations.** |
+| Config | `config` | `Settings` | — | Read-only parameters: temperature, maxTokens, topK, strategy, rerank |
+
+Footer: `[💬 Chat]` if agent active and KB populated · `[🔄 Riavvia]` if agent in error/idle · `[↗ Apri]` always
+
+#### KB — 3 tabs
+
+| Tab | ID | Icon | Badge | Content |
+|-----|----|------|-------|---------|
+| Overview | `overview` | `FileText` | — | Filename, size, pages, indexing status, dates, game, embedding model, chunk count |
+| Anteprima | `preview` | `Eye` | — | First ~500 words of extracted content |
+| Citazioni | `citations` | `MessageCircle` | citationCount | Chat threads that cited this document: thread title, date, cited passage with **page/paragraph reference**. Each row links to chat drawer. Empty state: "No citations yet — start a chat to use this document." |
+
+Footer: `[🔄 Reindex]` if status = indexed or failed (not during processing) · `[⬇️ Download]` always · `[↗ Apri]` always
+
+#### CHAT — 2 tabs
+
+| Tab | ID | Icon | Badge | Content |
+|-----|----|------|-------|---------|
+| Messaggi | `messages` | `MessageSquare` | `messageCount` | Compact header (agent badge + game badge), last 6-8 messages bubble UI. Agent responses with citations show clickable pills `[📄 p.12 §3]` that open KB drawer at cited position. |
+| Fonti | `sources` | `FileText` | — | KB documents cited in this chat: doc name, citation count, referenced pages/paragraphs. Each row links to KB drawer. |
+
+Footer: `[💬 Continua]` if chat active · `[📦 Archivia]` if chat active · `[🔓 Riapri]` if chat archived · `[↗ Apri]` always
+
+#### EVENT — 2 tabs
+
+| Tab | ID | Icon | Badge | Content |
+|-----|----|------|-------|---------|
+| Overview | `overview` | `Calendar` | — | Date, time, location, organizer, notes, participant list with status (confirmed/pending/declined) |
+| Programma | `program` | `Dices` | `gameCount` | Games with status (completed/in-progress/planned) + diary timeline if event is past/ongoing |
+
+Footer: `[✅ Conferma]` if user hasn't confirmed · `[❌ Declina]` if user confirmed (toggle) · `[📤 Invita]` if user is organizer · `[↗ Apri]` always
+
+#### TOOLKIT — 3 tabs
+
+| Tab | ID | Icon | Badge | Content |
+|-----|----|------|-------|---------|
+| Overview | `overview` | `Wrench` | — | Name, version, published status, game, tool list with type and config summary |
+| Template | `template` | `Layout` | — | Scoring dimensions, turn phases |
+| Storico | `history` | `History` | `useCount` | Sessions that used this toolkit: date, players, duration. Each row links to session drawer. |
+
+Footer: `[▶️ Usa in sessione]` if published · `[✏️ Modifica]` if user is owner · `[↗ Apri]` always
+
+#### TOOL — 2 tabs
+
+| Tab | ID | Icon | Badge | Content |
+|-----|----|------|-------|---------|
+| Dettaglio | `detail` | `Wrench` | — | Name, type, full config, parent toolkit, color |
+| Preview | `preview` | `Play` | — | Interactive: timer countdown / dice roll / card draw |
+
+Footer: `[▶️ Usa]` if in active session with this toolkit · `[✏️ Modifica]` if user is owner of parent toolkit · `[↗ Apri]` always
+
+## 5. Cross-Entity Links in Drawers
+
+Drawer content contains clickable references to other entities. Clicking pushes the current drawer onto a stack and opens the target drawer.
+
+### Link Graph
+
+```
+Game ←→ Session   (Game.Storico rows / Session.Live game link)
+Game ←→ Agent     (Game ConnectionBar / Agent.Overview game link)
+Game ←→ KB        (Game ConnectionBar / KB.Overview game link)
+Player ←→ Session (Player.Storico rows / Session.Live player rows)
+Agent ←→ Chat     (Agent.Storico rows / Chat.Messaggi agent badge)
+KB ←→ Chat        (KB.Citazioni rows / Chat.Fonti rows + message citation pills)
+Session ←→ Toolkit (Session.Toolkit tab / Toolkit.Storico rows)
+Session ←→ Player  (Session.Live player rows / Player.Storico session rows)
+Toolkit ←→ Session (Toolkit.Storico rows / Session.Toolkit)
+Event ←→ Game     (Event.Programma game rows)
+Event ←→ Player   (Event.Overview participant rows)
+```
+
+### KB ↔ Chat Citation Detail
+
+KB documents store chunk metadata with page/paragraph references. When an agent response cites a chunk:
+
+1. **In Chat.Messaggi**: citation appears as an inline pill: `[📄 azul-regole.pdf p.12 §3]`
+   - Click → opens KB drawer, scrolls Anteprima tab to approximate position
+2. **In Chat.Fonti tab**: aggregated by document, listing all pages/paragraphs cited
+3. **In KB.Citazioni tab**: lists all chat threads that referenced this doc, with cited passages
+
+## 6. Session Mode
+
+### Activation
+
+Session Mode activates when `useDashboardMode().isGameMode === true` and `activeSessionId` is present.
+
+### Mobile Bottom Bar
+
+**Normal Mode** (no active session):
+```
+[🏠 Home] [🔍 Cerca] [📚 Libreria] [💬 Chat] [👤 Profilo]
+```
+
+**Session Mode** (active session):
+```
+[◀ Back] [📊 Classifica] [🧰 Toolkit*] [💬 AI*] [⋯ Altro]
+```
+
+| Slot | Action | Condition |
+|------|--------|-----------|
+| ◀ Back | Navigate back (does not close session) | Always |
+| 📊 Classifica | Opens session drawer, tab "Live" | Always |
+| 🧰 Toolkit | Opens session drawer, tab "Toolkit" | Only if session has toolkit |
+| 💬 AI | Opens agent/chat drawer for session's agent | Only if game has active agent |
+| ⋯ Altro | Popup menu: Share, Notes, Photos, Exit session | Always |
+
+- Transition: crossfade 300ms between modes
+- Session indicator: subtle indigo top border, slow pulse
+
+### Desktop Session Banner
+
+32px bar between MiniNav and content. Only appears when session is active.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ 🟣 Sessione attiva: Serata Azul · Turno 3/5             │
+│                    [📊 Classifica] [🧰 Toolkit] [💬 AI] [✕]│
+└──────────────────────────────────────────────────────────┘
+```
+
+- Background: indigo alpha 8%, border-bottom indigo alpha 20%
+- Buttons open session-related drawers
+- `[✕]` exits session (with confirmation dialog)
+- On unrelated pages: compact mode — just text + "Torna alla sessione" link
+
+### Session Context in Drawers
+
+When a drawer is opened from Session Mode:
+- Drawer header shows subtle indigo top accent (2px)
+- Footer includes extra action: `[↩ Torna a sessione]` → navigates to `/sessions/[id]/play`
+
+## 7. Cascade Navigation Store (Updated)
+
+The existing `cascade-navigation-store.ts` is updated to support the drawer stack:
+
+```typescript
+interface CascadeNavigationState {
+  state: 'closed' | 'deckStack' | 'drawer';
+  
+  // Current drawer
+  activeEntityType: MeepleEntityType | null;
+  activeEntityId: string | null;
+  activeTabId: string | null;
+  
+  // DeckStack
+  sourceEntityId: string | null;
+  anchorRect: DOMRect | null;
+  
+  // Drawer stack (max 3)
+  drawerStack: DrawerStackEntry[];
+  
+  // Actions
+  openDeckStack: (entityType, sourceEntityId, anchor?) => void;
+  openDrawer: (entityType, entityId, tabId?) => void;
+  pushDrawer: (entityType, entityId) => void;   // NEW: push current, open new
+  popDrawer: () => void;                         // NEW: back to previous
+  closeDrawer: () => void;
+  closeCascade: () => void;
+}
+
+interface DrawerStackEntry {
+  entityType: MeepleEntityType;
+  entityId: string;
+  activeTabId?: string;
+  scrollPosition?: number;
+}
+```
+
+## 8. Files Affected
+
+### Remove
+- `components/layout/UserShell/DesktopHandRail.tsx`
+- `components/layout/UserShell/HandRailItem.tsx`
+- `components/layout/UserShell/HandRailToolbar.tsx`
+- `stores/use-card-hand.ts`
+- `components/layout/MyHand/MyHandSidebar.tsx`
+- `components/layout/MyHand/MyHandBottomBar.tsx`
+- `components/layout/MyHand/MyHandSlot.tsx`
+- `components/layout/MyHand/MyHandSlotPicker.tsx`
+- `components/layout/MyHand/MyHandProvider.tsx`
+- `stores/my-hand/` (entire directory)
+- `components/ui/data-display/extra-meeple-card/ExtraMeepleCard.tsx` (superseded by SessionDrawerContent)
+- `components/ui/data-display/extra-meeple-card/entities/PlayerExtraMeepleCard.tsx` (superseded by PlayerDrawerContent)
+
+### Create
+- `stores/use-recents.ts` — RecentsStore
+- `components/layout/UserShell/RecentsBar.tsx` — pill bar for MiniNav
+- `components/ui/data-display/connection-bar/ConnectionBar.tsx`
+- `components/ui/data-display/connection-bar/types.ts`
+- `components/layout/UserShell/SessionBanner.tsx`
+- `components/layout/MobileBottomBar.tsx` — unified mobile nav with session mode
+- `components/ui/data-display/extra-meeple-card/DrawerActionFooter.tsx`
+- `components/ui/data-display/extra-meeple-card/entities/EventExtraMeepleCard.tsx`
+- `components/ui/data-display/extra-meeple-card/entities/ToolkitExtraMeepleCard.tsx`
+- `components/ui/data-display/extra-meeple-card/entities/ToolExtraMeepleCard.tsx`
+- `components/ui/data-display/extra-meeple-card/entities/SessionDrawerContent.tsx`
+- `components/ui/data-display/extra-meeple-card/entities/PlayerDrawerContent.tsx`
+
+### Modify
+- `components/layout/UserShell/DesktopShell.tsx` — remove HandRail + MyHand imports, add SessionBanner + MobileBottomBar
+- `components/layout/UserShell/index.ts` — remove exports for DesktopHandRail, HandRailItem, HandRailToolbar
+- `components/layout/MyHand/index.ts` — remove export for MyHandProvider (or delete barrel if empty)
+- `components/layout/UserShell/MiniNavSlot.tsx` — add RecentsBar slot on the right side
+- `lib/stores/cascade-navigation-store.ts` — add `activeTabId: string | null` to state, update `openDrawer` signature to accept optional `tabId`, add `DrawerStackEntry` type, `drawerStack: DrawerStackEntry[]`, `pushDrawer`, `popDrawer` actions
+- `components/ui/data-display/extra-meeple-card/ExtraMeepleCardDrawer.tsx` — update DrawerEntityRouter for all 9 entities (remove DrawerComingSoon branches), add stack nav back button, integrate DrawerActionFooter
+- `components/ui/data-display/extra-meeple-card/drawer-states.tsx` — remove DrawerComingSoon component (all entities now have dedicated content)
+- `components/ui/data-display/extra-meeple-card/drawer-test-ids.ts` — remove COMING_SOON factory, add test-ids for new drawer content components
+- `components/ui/data-display/extra-meeple-card/EntityExtraMeepleCard.tsx` — remove re-export of PlayerExtraMeepleCard, update exports for new entity components
+- `components/dashboard/SessionPanel.tsx` — use ConnectionBar instead of inline mana pips
+- `config/component-registry.ts` — remove entries for HandRailItem, HandRailToolbar, DesktopHandRail
+
+### Consumer Migration (use-card-hand.ts removal)
+
+~31 files import `useCardHand` or `drawCard()`. These must be migrated:
+- **Page-level `drawCard()` calls** (DashboardClient, LibraryHub, sessions/_content, agents/page, etc.): replace with `useRecents().push()` — same entity data, different store
+- **Components reading `cards[]` for display** (DeckTrackerSync, quick-cards-carousel, session-quick-actions): remove or replace with recents-based logic
+- **Test files** (~20): update mocks from useCardHand to useRecents
+- Full consumer list to be generated during implementation via `grep -r "useCardHand\|use-card-hand" apps/web/src/`
+
+## 9. Out of Scope
+
+- Drawer `side="bottom"` on mobile (future enhancement, current right-side works)
+- Backend API changes for MyHand (keep for backward compat, just stop using)
+- ShelfCard ManaPip visual redesign (stays as-is)
+- DeckStack component redesign (stays as-is, just wired differently)
+- Full chat inline in drawer (drawer shows messages read-only; "Continua" navigates to full chat page)


### PR DESCRIPTION
## Summary

Milestone M2: **Scenario switching + role switching live** nel Dev Panel.

- **scenarioSwitcher.ts** — AbortController mutex (last-click-wins), CustomEvent SSE cleanup, query cancel + invalidate, try/finally safety (4 unit tests)
- **ScenariosSection** — dropdown 3 scenari (empty, small-library, admin-busy), "Switching..." state, error banner
- **AuthSection** — current user info + role dropdown, invalidates auth queries on switch
- **DevPanel wiring** — scenarioStore + authStore + queryClient threaded through DevPanelMount → DevPanel → sections
- **503 guard** — 4 handler GET (games, library, sessions, chat) return 503 during scenario switch via `window.__meepledev_stores__`
- **SSE cleanup** — `useAgentChatStream.ts` aborts fetch stream on `meepledev:scenario-switch-begin` CustomEvent
- **Integration test** — 2 tests: full switch flow + CustomEvent dispatch verification

## Test results

- Frontend: **85/85** test (16 file)
- TypeScript: clean
- Build: frontend + backend prod OK (pre-push hook)

## Test plan

- [x] `pnpm test __tests__/dev-tools __tests__/mocks __tests__/integration/dev-tools` → 85/85
- [x] `pnpm typecheck` clean
- [x] `pnpm build` OK
- [x] `dotnet build -c Release` OK
- [ ] Browser test: scenario switch changes data (M4 E2E)
- [ ] Browser test: role switch changes navbar (M4 E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)