### PR TITLE
fix(a11y): add landmarks and skip link to AdminShell (#254)

### DIFF
--- a/apps/web/src/components/layout/AdminShell/AdminShell.tsx
+++ b/apps/web/src/components/layout/AdminShell/AdminShell.tsx
@@ -27,10 +27,19 @@ export function AdminShell({ children }: AdminShellProps) {
 
   return (
     <div className="flex h-dvh bg-background">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:px-4 focus:py-2 focus:bg-background focus:text-foreground focus:rounded-md"
+      >
+        Salta al contenuto
+      </a>
       <AdminTabSidebar />
 
       <div className="flex flex-col flex-1 min-w-0">
-        <header className="sticky top-0 z-40 h-[52px] flex items-center gap-3 px-4 border-b bg-background/95 backdrop-blur-md shrink-0">
+        <header
+          role="banner"
+          className="sticky top-0 z-40 h-[52px] flex items-center gap-3 px-4 border-b bg-background/95 backdrop-blur-md shrink-0"
+        >
           <button
             aria-label="Apri menu"
             onClick={() => setDrawerOpen(true)}
@@ -46,7 +55,9 @@ export function AdminShell({ children }: AdminShellProps) {
         <AdminMobileDrawer open={drawerOpen} onOpenChange={setDrawerOpen} />
 
         <DashboardEngineProvider>
-          <main className="flex-1 overflow-y-auto">{children}</main>
+          <main id="main-content" className="flex-1 overflow-y-auto">
+            {children}
+          </main>
         </DashboardEngineProvider>
       </div>
     </div>

--- a/apps/web/src/components/layout/AdminShell/AdminTabSidebar.tsx
+++ b/apps/web/src/components/layout/AdminShell/AdminTabSidebar.tsx
@@ -20,7 +20,9 @@ export function AdminTabSidebar({ forceVisible }: AdminTabSidebarProps) {
   const activeSection = getActiveSection(pathname);
 
   return (
-    <div
+    <nav
+      role="navigation"
+      aria-label="Navigazione admin"
       className={cn(
         forceVisible
           ? 'flex flex-col h-full w-full'
@@ -83,6 +85,6 @@ export function AdminTabSidebar({ forceVisible }: AdminTabSidebarProps) {
           );
         })}
       </div>
-    </div>
+    </nav>
   );
 }


### PR DESCRIPTION
## Summary

- **AdminShell.tsx**: add skip link (`<a href="#main-content">` sr-only/visible-on-focus) before sidebar, add `role="banner"` to `<header>`, add `id="main-content"` to `<main>`
- **AdminTabSidebar.tsx**: convert outer `<div>` to `<nav role="navigation" aria-label="Navigazione admin">`

Resolves axe-core warnings on `/admin/agents`:
- `landmark-one-main` — main landmark now explicit
- `region` — navigation landmark now present  
- `bypass` — skip link now available for keyboard users

## Test plan

- [x] Build passes (TypeScript + Next.js)
- [x] Skip link visible on keyboard focus, hidden otherwise
- [x] `#main-content` target matches skip link href
- [x] `role="banner"` on `<header>` inside `<div>` root (not `<body>`)

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)