### PR TITLE
ci(coverage): switch backend-unit to dotnet-coverage for reliable CI coverage (#236)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -31,7 +31,14 @@ coverage:
 
   # Track coverage by bounded context
   flags:
-    # Backend overall
+    # Backend unit (uploaded from backend-unit CI job)
+    backend-unit:
+      paths:
+        - apps/api/src/Api/BoundedContexts/**
+      carryforward: true
+      carryforward_mode: "all"
+
+    # Backend overall (combined unit + integration)
     backend:
       paths:
         - apps/api/src/Api/BoundedContexts/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,24 +137,30 @@ jobs:
           dotnet-version: '9.0.x'
           working-directory: apps/api
 
+      - name: Install dotnet-coverage
+        run: |
+          dotnet tool install --global dotnet-coverage
+          echo "$HOME/.dotnet/tools" >> $GITHUB_PATH
+
       - name: Build
         run: dotnet build --no-restore --configuration Release
 
-      - name: Run Unit Tests
+      - name: Run Unit Tests with Coverage
         timeout-minutes: 30
         env:
           CI: true
         run: |
-          echo "🧪 Running unit tests..."
-          dotnet test \
-            --filter "Category=Unit" \
-            --logger "console;verbosity=minimal" \
-            --no-build \
-            --configuration Release \
-            --blame-hang-timeout 5min \
-            -p:CollectCoverage=true \
-            -p:CoverletOutputFormat=cobertura \
-            -p:CoverletOutput=./coverage/unit-coverage.xml
+          echo "🧪 Running unit tests with dotnet-coverage..."
+          mkdir -p coverage
+          dotnet-coverage collect \
+            "dotnet test MeepleAI.Api.sln \
+              --filter Category=Unit \
+              --settings tests/Api.Tests/unit.runsettings \
+              --no-build \
+              --configuration Release \
+              --blame-hang-timeout 5min" \
+            -f cobertura \
+            -o coverage/unit-coverage.xml
           echo "✅ Unit tests passed"
 
       - name: Upload Coverage
@@ -162,7 +168,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: apps/api/coverage/unit-coverage.xml
-          flags: backend-unit
+          flags: backend-unit,backend
           token: ${{ secrets.CODECOV_TOKEN }}
         continue-on-error: true
 

--- a/apps/api/tests/Api.Tests/unit.runsettings
+++ b/apps/api/tests/Api.Tests/unit.runsettings
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Run settings for Unit tests with dotnet-coverage.
+  Used by: ci.yml backend-unit job.
+  Coverage thresholds are enforced by Codecov via .codecov.yml (backend flag: 90% target).
+-->
+<RunSettings>
+  <RunConfiguration>
+    <!-- Maximum time for entire test session: 20 minutes -->
+    <TestSessionTimeout>1200000</TestSessionTimeout>
+
+    <!-- Results directory -->
+    <ResultsDirectory>./TestResults</ResultsDirectory>
+
+    <!-- Parallel execution: unit tests are safe to parallelize -->
+    <MaxCpuCount>0</MaxCpuCount>
+    <DisableParallelization>false</DisableParallelization>
+  </RunConfiguration>
+
+  <LoggerRunSettings>
+    <Loggers>
+      <Logger friendlyName="console" enabled="True">
+        <Configuration>
+          <Verbosity>minimal</Verbosity>
+        </Configuration>
+      </Logger>
+    </Loggers>
+  </LoggerRunSettings>
+
+  <!-- xUnit specific settings -->
+  <xUnit>
+    <DiagnosticMessages>false</DiagnosticMessages>
+    <AppDomain>denied</AppDomain>
+  </xUnit>
+</RunSettings>

--- a/docs/testing/codecov-integration.md
+++ b/docs/testing/codecov-integration.md
@@ -59,7 +59,7 @@ Coverage is uploaded in `.github/workflows/ci.yml`:
 ### Frontend Upload
 ```yaml
 - name: Upload Coverage
-  uses: codecov/codecov-action@v4
+  uses: codecov/codecov-action@v5
   with:
     files: apps/web/coverage/lcov.info
     flags: frontend
@@ -67,14 +67,25 @@ Coverage is uploaded in `.github/workflows/ci.yml`:
 ```
 
 ### Backend Upload
+
+Coverage is collected with `dotnet-coverage` (Microsoft) to avoid DLL locking on Windows and provide more reliable profiling.
+
 ```yaml
+- name: Install dotnet-coverage
+  run: dotnet tool install --global dotnet-coverage
+
+- name: Run Unit Tests with Coverage
+  run: |
+    dotnet-coverage collect \
+      "dotnet test MeepleAI.Api.sln --filter 'Category=Unit' --no-build --configuration Release" \
+      -f cobertura \
+      -o coverage/unit-coverage.xml
+
 - name: Upload Coverage
-  uses: codecov/codecov-action@v4
+  uses: codecov/codecov-action@v5
   with:
-    files: |
-      apps/api/coverage/unit-coverage.xml
-      apps/api/coverage/integration-coverage.xml
-    flags: backend
+    files: apps/api/coverage/unit-coverage.xml
+    flags: backend-unit,backend
     token: ${{ secrets.CODECOV_TOKEN }}
 ```
 
@@ -123,8 +134,13 @@ pnpm test:coverage
 ### Backend
 ```bash
 cd apps/api
-dotnet test --collect:"XPlat Code Coverage"
-# View: apps/api/TestResults/*/coverage.cobertura.xml
+dotnet tool install --global dotnet-coverage  # Once per machine
+mkdir -p coverage
+dotnet-coverage collect \
+  "dotnet test MeepleAI.Api.sln --filter 'Category=Unit' --no-build --configuration Release" \
+  -f cobertura \
+  -o coverage/unit-coverage.xml
+# View: apps/api/coverage/unit-coverage.xml
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

- Replaces Coverlet MSBuild params in `backend-unit` CI job with `dotnet-coverage collect` (Microsoft's official tool) — avoids DLL locking issues and provides more reliable profiling on all platforms
- Fixes PATH export for the dotnet tool (consistent with `e2e` job pattern for `dotnet-ef`)
- Fixes Codecov flag upload: now uses `backend-unit,backend` matching `.codecov.yml` definitions
- Adds `backend-unit` flag to `.codecov.yml` with carryforward
- Adds `unit.runsettings` for unit test parallelization settings
- Updates `codecov-integration.md`: backend coverage docs + fixes `@v4`→`@v5`

## Test plan

- [ ] CI `backend-unit` job runs without errors
- [ ] `coverage/unit-coverage.xml` is generated at expected path (`apps/api/coverage/`)
- [ ] Codecov upload succeeds with both `backend-unit` and `backend` flags
- [ ] PR coverage comment appears on GitHub

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)