### PR TITLE
fix(admin-shell): restore ViewModeToggle in admin topbar

### DIFF
--- a/apps/web/src/components/layout/AdminShell/AdminShell.tsx
+++ b/apps/web/src/components/layout/AdminShell/AdminShell.tsx
@@ -6,6 +6,7 @@ import { Menu } from 'lucide-react';
 
 import { DashboardEngineProvider } from '@/components/dashboard';
 import { UserMenuDropdown } from '@/components/layout/UserMenuDropdown';
+import { ViewModeToggle } from '@/components/layout/ViewModeToggle';
 import { NotificationBell } from '@/components/notifications';
 import { useNavbarHeightStore } from '@/lib/stores/navbar-height-store';
 
@@ -48,6 +49,7 @@ export function AdminShell({ children }: AdminShellProps) {
             <Menu className="w-5 h-5" />
           </button>
           <div className="flex-1" />
+          <ViewModeToggle />
           <NotificationBell />
           <UserMenuDropdown />
         </header>


### PR DESCRIPTION
## Summary
- Ripristina il toggle admin/utente nell'header dell'AdminShell
- Il componente `ViewModeToggle` era stato perso durante la pulizia `UserTopNav` (PR #379)
- Il toggle è già completamente implementato e funzionante (fix proxy #391 appena mergiato)

## Test plan
- [ ] Aprire l'admin shell come superadmin
- [ ] Verificare che il toggle pill (⚙️/👤) sia visibile nell'header a destra
- [ ] Cliccare il toggle → naviga alla vista utente senza redirect loop
- [ ] Cliccare di nuovo → torna alla vista admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)