### PR TITLE
feat(toolkit): Phase 1 gaps — timer in play page + sound/vibration alert

### DIFF
--- a/apps/web/src/app/(authenticated)/toolkit/play/page.tsx
+++ b/apps/web/src/app/(authenticated)/toolkit/play/page.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect } from 'react';
 import { CounterTool } from '@/components/toolkit/CounterTool';
 import { DiceRoller } from '@/components/toolkit/DiceRoller';
 import { Randomizer } from '@/components/toolkit/Randomizer';
+import { Timer } from '@/components/toolkit/Timer';
 import { DEFAULT_TOOLKIT } from '@/lib/config/default-toolkit';
 import type { ToolLogEntry } from '@/lib/types/standalone-toolkit';
 import { appendToolLog, generateLogId, clearOldEntries } from '@/lib/utils/toolkit-log';
@@ -62,6 +63,32 @@ export default function ToolkitPlayPage() {
           ))}
         </div>
       </section>
+
+      {/* Timer */}
+      {DEFAULT_TOOLKIT.timers.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-400">
+            Timer
+          </h2>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {DEFAULT_TOOLKIT.timers.map(config => (
+              <Timer
+                key={config.name}
+                name={config.name}
+                defaultSeconds={config.defaultSeconds}
+                type={config.type}
+                onAction={(action, seconds) =>
+                  addLog({
+                    toolType: 'timer',
+                    action,
+                    result: `${config.name}: ${action} @ ${seconds}s`,
+                  })
+                }
+              />
+            ))}
+          </div>
+        </section>
+      )}
 
       {/* Contatori */}
       <section>

--- a/apps/web/src/components/toolkit/Timer.tsx
+++ b/apps/web/src/components/toolkit/Timer.tsx
@@ -11,6 +11,38 @@ interface TimerProps {
   onAction?: (action: string, seconds: number) => void;
 }
 
+const WARNING_THRESHOLD = 10;
+
+// ── Alert: suono + vibrazione ───────────────────────────────────────
+
+function playAlertSound(): void {
+  try {
+    const ctx = new AudioContext();
+    const oscillator = ctx.createOscillator();
+    const gain = ctx.createGain();
+    oscillator.connect(gain);
+    gain.connect(ctx.destination);
+    oscillator.type = 'sine';
+    oscillator.frequency.setValueAtTime(880, ctx.currentTime);
+    gain.gain.setValueAtTime(0.3, ctx.currentTime);
+    gain.gain.linearRampToValueAtTime(0, ctx.currentTime + 0.4);
+    oscillator.start(ctx.currentTime);
+    oscillator.stop(ctx.currentTime + 0.4);
+    // Rilascia risorse dopo la riproduzione
+    setTimeout(() => void ctx.close(), 600);
+  } catch {
+    // AudioContext non disponibile (es. JSDOM) — fallback silenzioso
+  }
+}
+
+function triggerVibration(): void {
+  try {
+    navigator.vibrate?.([200, 100, 200]);
+  } catch {
+    // API vibrazione non disponibile — fallback silenzioso
+  }
+}
+
 // ── Local timer strategy ────────────────────────────────────────────
 
 function useLocalTimer(defaultSeconds: number) {
@@ -61,9 +93,22 @@ export function Timer({ name, defaultSeconds, type, onAction }: TimerProps) {
   // Phase 2: when in-session, SSE timer_tick events will drive the display.
   const { seconds, running, start, pause, reset } = useLocalTimer(defaultSeconds);
 
-  const warningThreshold = 10;
-  const isWarning = type === 'countdown' && seconds <= warningThreshold && seconds > 0;
+  // Guard: alert fires at most once per timer run
+  const alertFiredRef = useRef(false);
+
+  const isWarning = type === 'countdown' && seconds <= WARNING_THRESHOLD && seconds > 0;
   const isExpired = type === 'countdown' && seconds === 0;
+
+  // Fire sound + vibration once when countdown crosses the warning threshold
+  useEffect(() => {
+    if (type !== 'countdown') return;
+    if (!running) return;
+    if (seconds === WARNING_THRESHOLD && !alertFiredRef.current) {
+      alertFiredRef.current = true;
+      playAlertSound();
+      triggerVibration();
+    }
+  }, [seconds, running, type]);
 
   const handleStart = () => {
     start();
@@ -77,6 +122,7 @@ export function Timer({ name, defaultSeconds, type, onAction }: TimerProps) {
 
   const handleReset = () => {
     reset();
+    alertFiredRef.current = false; // permette all'alert di sparare di nuovo al prossimo avvio
     onAction?.('reset', defaultSeconds);
   };
 

--- a/apps/web/src/components/toolkit/__tests__/Timer.test.tsx
+++ b/apps/web/src/components/toolkit/__tests__/Timer.test.tsx
@@ -1,0 +1,111 @@
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { Timer } from '../Timer';
+
+// ── AudioContext stub ───────────────────────────────────────────────
+
+const mockOscillatorStart = vi.fn();
+const mockOscillatorStop = vi.fn();
+const mockOscillatorConnect = vi.fn();
+const mockGainConnect = vi.fn();
+const mockContextClose = vi.fn();
+
+function makeAudioContextMock() {
+  const gainNode = {
+    gain: { setValueAtTime: vi.fn(), linearRampToValueAtTime: vi.fn() },
+    connect: mockGainConnect,
+  };
+  const oscillator = {
+    type: 'sine' as OscillatorType,
+    frequency: { setValueAtTime: vi.fn() },
+    connect: mockOscillatorConnect,
+    start: mockOscillatorStart,
+    stop: mockOscillatorStop,
+  };
+  return {
+    createOscillator: vi.fn().mockReturnValue(oscillator),
+    createGain: vi.fn().mockReturnValue(gainNode),
+    destination: {},
+    currentTime: 0,
+    close: mockContextClose,
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal('AudioContext', vi.fn().mockImplementation(makeAudioContextMock));
+  vi.stubGlobal('navigator', { vibrate: vi.fn() });
+  mockOscillatorStart.mockClear();
+  mockOscillatorStop.mockClear();
+  mockOscillatorConnect.mockClear();
+  mockGainConnect.mockClear();
+  mockContextClose.mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('Timer — suono + vibrazione a 10s', () => {
+  it('chiama navigator.vibrate quando il countdown raggiunge 10s', () => {
+    // 12s timer: advance 2s → remaining = 10s → alert fires
+    const { getByRole } = render(<Timer name="Test" defaultSeconds={12} type="countdown" />);
+    act(() => {
+      getByRole('button', { name: /avvia/i }).click();
+    });
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(navigator.vibrate).toHaveBeenCalledWith([200, 100, 200]);
+  });
+
+  it('NON vibra se il tipo è countup', () => {
+    const { getByRole } = render(<Timer name="Test" defaultSeconds={0} type="countup" />);
+    act(() => {
+      getByRole('button', { name: /avvia/i }).click();
+    });
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(navigator.vibrate).not.toHaveBeenCalled();
+  });
+
+  it('NON vibra una seconda volta se già vibrato', () => {
+    const { getByRole } = render(<Timer name="Test" defaultSeconds={12} type="countdown" />);
+    act(() => {
+      getByRole('button', { name: /avvia/i }).click();
+    });
+    act(() => {
+      vi.advanceTimersByTime(2000); // → 10s, fires
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000); // → 9s, must NOT fire again
+    });
+    expect(navigator.vibrate).toHaveBeenCalledTimes(1);
+  });
+
+  it('ripristina alertFired dopo reset — alert può riscattarsi al prossimo avvio', () => {
+    const { getByRole } = render(<Timer name="Test" defaultSeconds={12} type="countdown" />);
+    // Prima run
+    act(() => {
+      getByRole('button', { name: /avvia/i }).click();
+    });
+    act(() => {
+      vi.advanceTimersByTime(2000); // → 10s, alert #1
+    });
+    // Reset
+    act(() => {
+      getByRole('button', { name: /reset/i }).click();
+    });
+    // Seconda run
+    act(() => {
+      getByRole('button', { name: /avvia/i }).click();
+    });
+    act(() => {
+      vi.advanceTimersByTime(2000); // → 10s, alert #2
+    });
+    expect(navigator.vibrate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/docs/specs/toolkit-game-utilities.md
+++ b/docs/specs/toolkit-game-utilities.md
@@ -2,7 +2,7 @@
 
 > **Version**: 0.2
 > **Date**: 2026-04-02
-> **Status**: Draft — revised after spec-panel review
+> **Status**: ✅ Phase 1 Complete — all OIs closed (2026-04-11)
 > **Bounded Contexts**: `GameToolkit`, `GameToolbox`, `SessionTracking`
 
 ---
@@ -374,10 +374,10 @@ POST /api/v1/sessions/{id}/tool-events (in-session)
 | OI-1 | ~~Verificare `DiceToolConfig` supporto `string[]` faces~~ — **CHIUSO** ✅ `CustomFaces: string[]?` già presente | — | — | — |
 | OI-2 | *(rimandato a Phase 2)* VirtualTable design | — | — | Phase 2 |
 | OI-3 | *(rimandato a Phase 2)* Transport annuncio dado | — | — | Phase 2 |
-| OI-4 | Schema localStorage `StandaloneToolLog` | FE Dev | 🟢 Bassa | — |
-| OI-5 | TimerTool offline fallback — validare con Sprint 2 SSE team | FE Dev | 🟡 Media | Timer in-session |
-| OI-6 | `POST /api/v1/sessions/{id}/tool-events` non esiste — **da creare** in `SessionTracking` BC come parte di questa feature | BE Dev | 🔴 Alta | Session log |
-| OI-7 | Player dropdown (§9.4) — Phase 1: free-text o lista in-memory locale, **non** accoppiato a `SharedContext`. Integrazione `SharedContext` rimandata a Phase 2 | FE Dev | 🟡 Media | UX turni |
+| OI-4 | ~~Schema localStorage `StandaloneToolLog`~~ — **CHIUSO** ✅ `ToolLogEntry` + `toolkit-log.ts` + tests | — | — | — |
+| OI-5 | TimerTool offline fallback — **DEFERRED Phase 2** ✅ (Timer.tsx usa sempre local timer in Phase 1) | — | — | Phase 2 |
+| OI-6 | ~~`POST /api/v1/sessions/{id}/tool-events` non esiste~~ — **CHIUSO** ✅ Implementato come `POST /game-sessions/{id}/events` + `useSessionToolLog` hook | — | — | — |
+| OI-7 | ~~Player dropdown (§9.4)~~ — **CHIUSO** ✅ Free-text "Chi gioca?" in `toolkit/play/page.tsx` | — | — | — |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add **Timer section** to standalone play page (\`toolkit/play/page.tsx\`) — renders \`DEFAULT_TOOLKIT.timers\` using the existing \`Timer\` component (closes spec REQ-TIMER-01, §3.1)
- Add **sound (AudioContext) + vibration** (\`navigator.vibrate\`) alert to \`Timer.tsx\` when countdown reaches 10s warning threshold (closes spec §4.2 / §9.3)

## OI Review (tutti chiusi)

| OI | Status |
|----|--------|
| OI-4 localStorage schema | ✅ Already done |
| OI-5 Timer offline fallback | ✅ Correctly deferred Phase 2 |
| OI-6 POST /game-sessions/{id}/events | ✅ Already done |
| OI-7 Player free-text input | ✅ Already done |

## Test plan

- [x] 4 new unit tests in \`Timer.test.tsx\` — all pass
- [x] \`pnpm test --run src/components/toolkit/\` — 15 files, 122 tests, no regressions
- [x] \`pnpm typecheck\` + \`pnpm build\` — 0 errors
- [ ] Manual: open \`/toolkit/play\`, verify Timer cards ("Timer", "Timer turno") appear
- [ ] Manual (mobile): start countdown, wait to 10s — verify color change + vibration

🤖 Generated with [Claude Code](https://claude.com/claude-code)