### PR TITLE
feat(sprint2): QuickView content wiring + Timer SSE broadcast

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/RandomToolHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/RandomToolHandlers.cs
@@ -5,6 +5,8 @@ using System.Collections.Concurrent;
 using System.Security.Cryptography;
 
 using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Domain.Events;
+using Api.BoundedContexts.SessionTracking.Domain.Services;
 
 using MediatR;
 
@@ -84,17 +86,20 @@ public sealed class TimerStateManager
 public sealed class StartTimerCommandHandler : IRequestHandler<StartTimerCommand, StartTimerResponse>
 {
     private readonly TimerStateManager _timerManager;
+    private readonly ISessionBroadcastService _broadcast;
     private readonly ILogger<StartTimerCommandHandler> _logger;
 
     public StartTimerCommandHandler(
         TimerStateManager timerManager,
+        ISessionBroadcastService broadcast,
         ILogger<StartTimerCommandHandler> logger)
     {
         _timerManager = timerManager;
+        _broadcast = broadcast;
         _logger = logger;
     }
 
-    public Task<StartTimerResponse> Handle(StartTimerCommand request, CancellationToken cancellationToken)
+    public async Task<StartTimerResponse> Handle(StartTimerCommand request, CancellationToken cancellationToken)
     {
         var timer = _timerManager.CreateTimer(
             request.SessionId,
@@ -108,28 +113,43 @@ public sealed class StartTimerCommandHandler : IRequestHandler<StartTimerCommand
             request.DurationSeconds,
             request.ParticipantName);
 
-        return Task.FromResult(new StartTimerResponse(
+        await _broadcast.PublishAsync(
+            request.SessionId,
+            new TimerStartedEvent(
+                request.SessionId,
+                timer.TimerId,
+                timer.DurationSeconds,
+                request.ParticipantId,
+                request.ParticipantName,
+                timer.StartedAt!.Value),
+            EventVisibility.Public,
+            cancellationToken).ConfigureAwait(false);
+
+        return new StartTimerResponse(
             request.SessionId,
             timer.TimerId,
             timer.DurationSeconds,
-            timer.StartedAt!.Value));
+            timer.StartedAt!.Value);
     }
 }
 
 public sealed class PauseTimerCommandHandler : IRequestHandler<PauseTimerCommand, TimerStatusResponse>
 {
     private readonly TimerStateManager _timerManager;
+    private readonly ISessionBroadcastService _broadcast;
     private readonly ILogger<PauseTimerCommandHandler> _logger;
 
     public PauseTimerCommandHandler(
         TimerStateManager timerManager,
+        ISessionBroadcastService broadcast,
         ILogger<PauseTimerCommandHandler> logger)
     {
         _timerManager = timerManager;
+        _broadcast = broadcast;
         _logger = logger;
     }
 
-    public Task<TimerStatusResponse> Handle(PauseTimerCommand request, CancellationToken cancellationToken)
+    public async Task<TimerStatusResponse> Handle(PauseTimerCommand request, CancellationToken cancellationToken)
     {
         var timer = _timerManager.GetTimer(request.SessionId);
         if (timer == null || !string.Equals(timer.Status, "running", StringComparison.Ordinal))
@@ -147,29 +167,42 @@ public sealed class PauseTimerCommandHandler : IRequestHandler<PauseTimerCommand
             request.SessionId,
             timer.RemainingSeconds);
 
-        return Task.FromResult(new TimerStatusResponse(
+        await _broadcast.PublishAsync(
+            request.SessionId,
+            new TimerPausedEvent(
+                request.SessionId,
+                timer.TimerId,
+                timer.RemainingSeconds,
+                timer.PausedAt.Value),
+            EventVisibility.Public,
+            cancellationToken).ConfigureAwait(false);
+
+        return new TimerStatusResponse(
             request.SessionId,
             timer.TimerId,
             timer.Status,
             timer.RemainingSeconds,
-            DateTime.UtcNow));
+            DateTime.UtcNow);
     }
 }
 
 public sealed class ResumeTimerCommandHandler : IRequestHandler<ResumeTimerCommand, TimerStatusResponse>
 {
     private readonly TimerStateManager _timerManager;
+    private readonly ISessionBroadcastService _broadcast;
     private readonly ILogger<ResumeTimerCommandHandler> _logger;
 
     public ResumeTimerCommandHandler(
         TimerStateManager timerManager,
+        ISessionBroadcastService broadcast,
         ILogger<ResumeTimerCommandHandler> logger)
     {
         _timerManager = timerManager;
+        _broadcast = broadcast;
         _logger = logger;
     }
 
-    public Task<TimerStatusResponse> Handle(ResumeTimerCommand request, CancellationToken cancellationToken)
+    public async Task<TimerStatusResponse> Handle(ResumeTimerCommand request, CancellationToken cancellationToken)
     {
         var timer = _timerManager.GetTimer(request.SessionId);
         if (timer == null || !string.Equals(timer.Status, "paused", StringComparison.Ordinal))
@@ -186,38 +219,64 @@ public sealed class ResumeTimerCommandHandler : IRequestHandler<ResumeTimerComma
             request.SessionId,
             timer.RemainingSeconds);
 
-        return Task.FromResult(new TimerStatusResponse(
+        await _broadcast.PublishAsync(
+            request.SessionId,
+            new TimerResumedEvent(
+                request.SessionId,
+                timer.TimerId,
+                timer.RemainingSeconds,
+                DateTime.UtcNow),
+            EventVisibility.Public,
+            cancellationToken).ConfigureAwait(false);
+
+        return new TimerStatusResponse(
             request.SessionId,
             timer.TimerId,
             timer.Status,
             timer.RemainingSeconds,
-            DateTime.UtcNow));
+            DateTime.UtcNow);
     }
 }
 
 public sealed class ResetTimerCommandHandler : IRequestHandler<ResetTimerCommand, TimerResetResponse>
 {
     private readonly TimerStateManager _timerManager;
+    private readonly ISessionBroadcastService _broadcast;
     private readonly ILogger<ResetTimerCommandHandler> _logger;
 
     public ResetTimerCommandHandler(
         TimerStateManager timerManager,
+        ISessionBroadcastService broadcast,
         ILogger<ResetTimerCommandHandler> logger)
     {
         _timerManager = timerManager;
+        _broadcast = broadcast;
         _logger = logger;
     }
 
-    public Task<TimerResetResponse> Handle(ResetTimerCommand request, CancellationToken cancellationToken)
+    public async Task<TimerResetResponse> Handle(ResetTimerCommand request, CancellationToken cancellationToken)
     {
+        var timer = _timerManager.GetTimer(request.SessionId);
         _timerManager.RemoveTimer(request.SessionId);
 
         _logger.LogInformation("Timer reset for session {SessionId}", request.SessionId);
 
-        return Task.FromResult(new TimerResetResponse(
+        if (timer != null)
+        {
+            await _broadcast.PublishAsync(
+                request.SessionId,
+                new TimerResetEvent(
+                    request.SessionId,
+                    timer.TimerId,
+                    DateTime.UtcNow),
+                EventVisibility.Public,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        return new TimerResetResponse(
             request.SessionId,
             true,
-            DateTime.UtcNow));
+            DateTime.UtcNow);
     }
 }
 

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/RandomToolHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/RandomToolHandlers.cs
@@ -7,6 +7,7 @@ using System.Security.Cryptography;
 using Api.BoundedContexts.SessionTracking.Application.Commands;
 using Api.BoundedContexts.SessionTracking.Domain.Events;
 using Api.BoundedContexts.SessionTracking.Domain.Services;
+using Api.Middleware.Exceptions;
 
 using MediatR;
 
@@ -154,7 +155,7 @@ public sealed class PauseTimerCommandHandler : IRequestHandler<PauseTimerCommand
         var timer = _timerManager.GetTimer(request.SessionId);
         if (timer == null || !string.Equals(timer.Status, "running", StringComparison.Ordinal))
         {
-            throw new InvalidOperationException("No running timer found for this session");
+            throw new ConflictException("No running timer found for this session");
         }
 
         // Calculate remaining time before pausing
@@ -207,7 +208,7 @@ public sealed class ResumeTimerCommandHandler : IRequestHandler<ResumeTimerComma
         var timer = _timerManager.GetTimer(request.SessionId);
         if (timer == null || !string.Equals(timer.Status, "paused", StringComparison.Ordinal))
         {
-            throw new InvalidOperationException("No paused timer found for this session");
+            throw new ConflictException("No paused timer found for this session");
         }
 
         timer.Status = "running";

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/RandomToolEvents.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/RandomToolEvents.cs
@@ -48,7 +48,7 @@ public sealed record TimerCompletedEvent(
     Guid SessionId,
     Guid TimerId,
     DateTime CompletedAt
-);
+) : INotification;
 
 /// <summary>
 /// Event when a timer is reset.

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/RandomToolEvents.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/RandomToolEvents.cs
@@ -1,6 +1,8 @@
 // SSE events for random tools (Issue #3345).
 // These events are broadcast to all session participants.
 
+using MediatR;
+
 namespace Api.BoundedContexts.SessionTracking.Domain.Events;
 
 // ============================================================================
@@ -17,7 +19,7 @@ public sealed record TimerStartedEvent(
     Guid StartedBy,
     string StartedByName,
     DateTime StartedAt
-);
+) : INotification;
 
 /// <summary>
 /// Event when a timer is paused.
@@ -27,7 +29,7 @@ public sealed record TimerPausedEvent(
     Guid TimerId,
     int RemainingSeconds,
     DateTime PausedAt
-);
+) : INotification;
 
 /// <summary>
 /// Event when a timer is resumed.
@@ -37,7 +39,7 @@ public sealed record TimerResumedEvent(
     Guid TimerId,
     int RemainingSeconds,
     DateTime ResumedAt
-);
+) : INotification;
 
 /// <summary>
 /// Event when a timer completes.
@@ -55,7 +57,7 @@ public sealed record TimerResetEvent(
     Guid SessionId,
     Guid TimerId,
     DateTime ResetAt
-);
+) : INotification;
 
 // ============================================================================
 // Coin Flip Events

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Services/SseEventTypeMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Services/SseEventTypeMapper.cs
@@ -75,6 +75,7 @@ public static class SseEventTypeMapper
         [typeof(TimerPausedEvent)] = "session:timer",
         [typeof(TimerResumedEvent)] = "session:timer",
         [typeof(TimerResetEvent)] = "session:timer",
+        [typeof(TimerCompletedEvent)] = "session:timer",
 
         // Game Night diary → session:gamenight
         [typeof(GameNightEvents.GameStartedInNightEvent)] = "session:gamenight",

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Services/SseEventTypeMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Services/SseEventTypeMapper.cs
@@ -70,6 +70,12 @@ public static class SseEventTypeMapper
         // Widget state → session:toolkit (P2-1: Widget State SSE Broadcast)
         [typeof(WidgetStateUpdatedEvent)] = "session:toolkit",
 
+        // Timer events → session:timer (Issue #3345)
+        [typeof(TimerStartedEvent)] = "session:timer",
+        [typeof(TimerPausedEvent)] = "session:timer",
+        [typeof(TimerResumedEvent)] = "session:timer",
+        [typeof(TimerResetEvent)] = "session:timer",
+
         // Game Night diary → session:gamenight
         [typeof(GameNightEvents.GameStartedInNightEvent)] = "session:gamenight",
         [typeof(GameNightEvents.GameCompletedInNightEvent)] = "session:gamenight",

--- a/apps/web/src/components/layout/QuickView/FaqContent.tsx
+++ b/apps/web/src/components/layout/QuickView/FaqContent.tsx
@@ -1,27 +1,90 @@
 'use client';
 
+import { useState, useEffect } from 'react';
+
 import { HelpCircle } from 'lucide-react';
+
+import { createSharedGamesClient } from '@/lib/api/clients/sharedGamesClient';
+import { HttpClient } from '@/lib/api/core/httpClient';
+import type { RulebookAnalysisDto } from '@/lib/api/schemas/shared-games.schemas';
+import { getCachedAnalyses, cacheRulebookAnalyses } from '@/lib/game-night/rules-cache';
 
 interface FaqContentProps {
   gameId: string | null;
 }
 
 export function FaqContent({ gameId }: FaqContentProps) {
-  return (
-    <div data-testid="faq-content" className="flex flex-col h-full">
-      {gameId === null ? (
+  const [analysis, setAnalysis] = useState<RulebookAnalysisDto | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!gameId) return;
+
+    const cached = getCachedAnalyses(gameId);
+    if (cached && cached.analyses.length > 0) {
+      setAnalysis(cached.analyses[0]);
+      return;
+    }
+
+    setLoading(true);
+
+    const client = createSharedGamesClient({ httpClient: new HttpClient() });
+    client
+      .getGameAnalysis(gameId)
+      .then(analyses => {
+        if (analyses.length > 0) {
+          cacheRulebookAnalyses(gameId, analyses);
+          setAnalysis(analyses[0]);
+        }
+      })
+      .catch(() => {
+        // leave analysis null → empty state
+      })
+      .finally(() => setLoading(false));
+  }, [gameId]);
+
+  if (!gameId) {
+    return (
+      <div data-testid="faq-content" className="flex flex-col h-full">
         <div className="flex flex-col items-center justify-center py-8 text-center">
           <HelpCircle className="h-8 w-8 text-muted-foreground/40 mb-3" />
           <p className="text-sm text-muted-foreground">Seleziona un gioco per vederne le FAQ</p>
         </div>
-      ) : (
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div data-testid="faq-content" className="flex flex-col h-full">
+        <div data-testid="faq-loading" className="flex items-center justify-center py-8">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        </div>
+      </div>
+    );
+  }
+
+  const faqs = analysis?.generatedFaqs ?? [];
+
+  if (faqs.length === 0) {
+    return (
+      <div data-testid="faq-content" className="flex flex-col h-full">
         <div className="flex flex-col items-center justify-center py-8 text-center">
           <HelpCircle className="h-8 w-8 text-muted-foreground/40 mb-3" />
-          <p className="text-sm text-muted-foreground">
-            Le FAQ verranno caricate dalla knowledge base del gioco
-          </p>
+          <p className="text-sm text-muted-foreground">FAQ non disponibili per questo gioco.</p>
         </div>
-      )}
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="faq-content" className="space-y-3 text-sm">
+      {faqs.map((faq, i) => (
+        <div key={i} className="space-y-1">
+          <p className="font-medium text-foreground">{faq.question}</p>
+          <p className="text-muted-foreground leading-relaxed">{faq.answer}</p>
+        </div>
+      ))}
     </div>
   );
 }

--- a/apps/web/src/components/layout/QuickView/FaqContent.tsx
+++ b/apps/web/src/components/layout/QuickView/FaqContent.tsx
@@ -16,6 +16,7 @@ interface FaqContentProps {
 export function FaqContent({ gameId }: FaqContentProps) {
   const [analysis, setAnalysis] = useState<RulebookAnalysisDto | null>(null);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
     if (!gameId) return;
@@ -27,6 +28,7 @@ export function FaqContent({ gameId }: FaqContentProps) {
     }
 
     setLoading(true);
+    setError(false);
 
     const client = createSharedGamesClient({ httpClient: new HttpClient() });
     client
@@ -37,9 +39,7 @@ export function FaqContent({ gameId }: FaqContentProps) {
           setAnalysis(analyses[0]);
         }
       })
-      .catch(() => {
-        // leave analysis null → empty state
-      })
+      .catch(() => setError(true))
       .finally(() => setLoading(false));
   }, [gameId]);
 
@@ -66,7 +66,7 @@ export function FaqContent({ gameId }: FaqContentProps) {
 
   const faqs = analysis?.generatedFaqs ?? [];
 
-  if (faqs.length === 0) {
+  if (error || faqs.length === 0) {
     return (
       <div data-testid="faq-content" className="flex flex-col h-full">
         <div className="flex flex-col items-center justify-center py-8 text-center">
@@ -80,7 +80,7 @@ export function FaqContent({ gameId }: FaqContentProps) {
   return (
     <div data-testid="faq-content" className="space-y-3 text-sm">
       {faqs.map((faq, i) => (
-        <div key={i} className="space-y-1">
+        <div key={faq.question || i} className="space-y-1">
           <p className="font-medium text-foreground">{faq.question}</p>
           <p className="text-muted-foreground leading-relaxed">{faq.answer}</p>
         </div>

--- a/apps/web/src/components/layout/QuickView/RulesContent.tsx
+++ b/apps/web/src/components/layout/QuickView/RulesContent.tsx
@@ -126,7 +126,7 @@ export function RulesContent({ gameId }: RulesContentProps) {
             {analysis.gamePhases
               .sort((a, b) => a.order - b.order)
               .map(phase => (
-                <li key={phase.name} className="text-muted-foreground">
+                <li key={phase.order} className="text-muted-foreground">
                   <span className="font-medium text-foreground">{phase.name}</span>
                   {' — '}
                   {phase.description}

--- a/apps/web/src/components/layout/QuickView/RulesContent.tsx
+++ b/apps/web/src/components/layout/QuickView/RulesContent.tsx
@@ -1,26 +1,142 @@
 'use client';
 
-import { BookOpen } from 'lucide-react';
+import { useState, useEffect } from 'react';
+
+import { BookOpen, Trophy, Zap, Layers } from 'lucide-react';
+
+import { createSharedGamesClient } from '@/lib/api/clients/sharedGamesClient';
+import { HttpClient } from '@/lib/api/core/httpClient';
+import type { RulebookAnalysisDto } from '@/lib/api/schemas/shared-games.schemas';
+import { getCachedAnalyses, cacheRulebookAnalyses } from '@/lib/game-night/rules-cache';
 
 interface RulesContentProps {
   gameId: string | null;
 }
 
 export function RulesContent({ gameId }: RulesContentProps) {
-  return (
-    <div data-testid="rules-content" className="flex flex-col h-full">
-      {gameId === null ? (
+  const [analysis, setAnalysis] = useState<RulebookAnalysisDto | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (!gameId) return;
+
+    // Try cache first
+    const cached = getCachedAnalyses(gameId);
+    if (cached && cached.analyses.length > 0) {
+      setAnalysis(cached.analyses[0]);
+      return;
+    }
+
+    // Fetch from API
+    setLoading(true);
+    setError(false);
+
+    const client = createSharedGamesClient({ httpClient: new HttpClient() });
+    client
+      .getGameAnalysis(gameId)
+      .then(analyses => {
+        if (analyses.length > 0) {
+          cacheRulebookAnalyses(gameId, analyses);
+          setAnalysis(analyses[0]);
+        }
+      })
+      .catch(() => setError(true))
+      .finally(() => setLoading(false));
+  }, [gameId]);
+
+  if (!gameId) {
+    return (
+      <div data-testid="rules-content" className="flex flex-col h-full">
         <div className="flex flex-col items-center justify-center py-8 text-center">
           <BookOpen className="h-8 w-8 text-muted-foreground/40 mb-3" />
           <p className="text-sm text-muted-foreground">Seleziona un gioco per vederne le regole</p>
         </div>
-      ) : (
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div data-testid="rules-content" className="flex flex-col h-full">
+        <div data-testid="rules-loading" className="flex items-center justify-center py-8">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !analysis) {
+    return (
+      <div data-testid="rules-content" className="flex flex-col h-full">
         <div className="flex flex-col items-center justify-center py-8 text-center">
           <BookOpen className="h-8 w-8 text-muted-foreground/40 mb-3" />
-          <p className="text-sm text-muted-foreground">
-            Le regole verranno caricate dalla knowledge base del gioco
-          </p>
+          <p className="text-sm text-muted-foreground">Regole non disponibili per questo gioco.</p>
         </div>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="rules-content" className="space-y-4 text-sm">
+      {/* Summary */}
+      <section>
+        <p className="text-muted-foreground leading-relaxed">{analysis.summary}</p>
+      </section>
+
+      {/* Victory conditions */}
+      {analysis.victoryConditions && (
+        <section>
+          <div className="flex items-center gap-1.5 mb-1.5 font-semibold text-foreground">
+            <Trophy className="h-3.5 w-3.5 text-amber-500" />
+            <span>Come si vince</span>
+          </div>
+          <p className="text-muted-foreground">{analysis.victoryConditions.primary}</p>
+        </section>
+      )}
+
+      {/* Key mechanics */}
+      {analysis.keyMechanics.length > 0 && (
+        <section>
+          <div className="flex items-center gap-1.5 mb-1.5 font-semibold text-foreground">
+            <Zap className="h-3.5 w-3.5 text-blue-500" />
+            <span>Meccaniche</span>
+          </div>
+          <div className="flex flex-wrap gap-1">
+            {analysis.keyMechanics.map(m => (
+              <span
+                key={m}
+                className="px-2 py-0.5 rounded-full bg-muted text-muted-foreground text-xs"
+              >
+                {m}
+              </span>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Game phases */}
+      {analysis.gamePhases.length > 0 && (
+        <section>
+          <div className="flex items-center gap-1.5 mb-1.5 font-semibold text-foreground">
+            <Layers className="h-3.5 w-3.5 text-purple-500" />
+            <span>Fasi di gioco</span>
+          </div>
+          <ol className="space-y-1">
+            {analysis.gamePhases
+              .sort((a, b) => a.order - b.order)
+              .map(phase => (
+                <li key={phase.name} className="text-muted-foreground">
+                  <span className="font-medium text-foreground">{phase.name}</span>
+                  {' — '}
+                  {phase.description}
+                  {phase.isOptional && (
+                    <span className="ml-1 text-xs text-muted-foreground">(opzionale)</span>
+                  )}
+                </li>
+              ))}
+          </ol>
+        </section>
       )}
     </div>
   );

--- a/apps/web/src/components/layout/QuickView/__tests__/FaqContent.test.tsx
+++ b/apps/web/src/components/layout/QuickView/__tests__/FaqContent.test.tsx
@@ -1,0 +1,151 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock rules-cache
+vi.mock('@/lib/game-night/rules-cache', () => ({
+  getCachedAnalyses: vi.fn().mockReturnValue(null),
+  cacheRulebookAnalyses: vi.fn(),
+}));
+
+const mockFaqs = [
+  {
+    question: 'Quanti punti servono per vincere?',
+    answer: 'Servono 10 punti vittoria.',
+    sourceSection: 'Vittoria',
+    confidence: 0.95,
+    tags: ['punti', 'vittoria'],
+  },
+  {
+    question: 'Posso costruire strade ovunque?',
+    answer: 'No, solo adiacenti alle tue strutture.',
+    sourceSection: 'Costruzione',
+    confidence: 0.9,
+    tags: ['strade'],
+  },
+];
+
+// Mock sharedGamesClient
+vi.mock('@/lib/api/clients/sharedGamesClient', () => ({
+  createSharedGamesClient: vi.fn(() => ({
+    getGameAnalysis: vi.fn().mockResolvedValue([
+      {
+        id: 'a1',
+        sharedGameId: 'g1',
+        gameTitle: 'Catan',
+        summary: 'Commercia e costruisci per vincere.',
+        keyMechanics: [],
+        victoryConditions: null,
+        resources: [],
+        gamePhases: [],
+        commonQuestions: ['Come si gioca il primo turno?'],
+        generatedFaqs: mockFaqs,
+        confidenceScore: 0.9,
+        version: 1,
+        isActive: true,
+        source: 'LLM',
+        analyzedAt: '2026-01-01T00:00:00Z',
+        createdBy: 'user1',
+        keyConcepts: [],
+        completionStatus: 'Complete',
+      },
+    ]),
+  })),
+}));
+
+// Mock HttpClient dependency
+vi.mock('@/lib/api/core/httpClient', () => ({
+  HttpClient: vi.fn().mockImplementation(() => ({})),
+}));
+
+import { FaqContent } from '../FaqContent';
+
+describe('FaqContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('mostra placeholder quando gameId è null', () => {
+    render(<FaqContent gameId={null} />);
+    expect(screen.getByText(/seleziona un gioco/i)).toBeInTheDocument();
+  });
+
+  it('mostra loading spinner durante fetch', () => {
+    render(<FaqContent gameId="g1" />);
+    expect(screen.getByTestId('faq-loading')).toBeInTheDocument();
+  });
+
+  it('mostra le FAQ generate dopo il fetch', async () => {
+    render(<FaqContent gameId="g1" />);
+    await waitFor(() => {
+      expect(screen.getByText('Quanti punti servono per vincere?')).toBeInTheDocument();
+      expect(screen.getByText('Servono 10 punti vittoria.')).toBeInTheDocument();
+    });
+  });
+
+  it('mostra tutte le FAQ', async () => {
+    render(<FaqContent gameId="g1" />);
+    await waitFor(() => {
+      expect(screen.getByText('Posso costruire strade ovunque?')).toBeInTheDocument();
+      expect(screen.getByText('No, solo adiacenti alle tue strutture.')).toBeInTheDocument();
+    });
+  });
+
+  it('usa la cache se disponibile senza fetching', async () => {
+    const { getCachedAnalyses } = await import('@/lib/game-night/rules-cache');
+    vi.mocked(getCachedAnalyses).mockReturnValue({
+      analyses: [
+        {
+          id: 'a1',
+          sharedGameId: 'g1',
+          gameTitle: 'Catan',
+          summary: 'Da cache.',
+          keyMechanics: [],
+          victoryConditions: null,
+          resources: [],
+          gamePhases: [],
+          commonQuestions: [],
+          generatedFaqs: [
+            {
+              question: 'FAQ da cache?',
+              answer: 'Sì, dalla cache.',
+              sourceSection: 'Cache',
+              confidence: 0.8,
+              tags: [],
+            },
+          ],
+          confidenceScore: 0.9,
+          version: 1,
+          isActive: true,
+          source: 'LLM',
+          analyzedAt: '2026-01-01T00:00:00Z',
+          createdBy: 'user1',
+          keyConcepts: [],
+          completionStatus: 'Complete',
+        } as any,
+      ],
+      cachedAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 3600000).toISOString(),
+      gameTitle: 'Catan',
+    });
+
+    render(<FaqContent gameId="g1" />);
+    await waitFor(() => {
+      expect(screen.getByText('FAQ da cache?')).toBeInTheDocument();
+    });
+  });
+
+  it('mostra messaggio se nessuna FAQ disponibile', async () => {
+    const { getCachedAnalyses } = await import('@/lib/game-night/rules-cache');
+    vi.mocked(getCachedAnalyses).mockReturnValue(null);
+
+    const { createSharedGamesClient } = await import('@/lib/api/clients/sharedGamesClient');
+    vi.mocked(createSharedGamesClient).mockReturnValue({
+      getGameAnalysis: vi.fn().mockResolvedValue([]),
+    } as any);
+
+    render(<FaqContent gameId="g1" />);
+    await waitFor(() => {
+      expect(screen.getByText(/non disponibili/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/layout/QuickView/__tests__/RulesContent.test.tsx
+++ b/apps/web/src/components/layout/QuickView/__tests__/RulesContent.test.tsx
@@ -1,28 +1,147 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock rules-cache
+vi.mock('@/lib/game-night/rules-cache', () => ({
+  getCachedAnalyses: vi.fn().mockReturnValue(null),
+  cacheRulebookAnalyses: vi.fn(),
+}));
+
+// Mock sharedGamesClient
+vi.mock('@/lib/api/clients/sharedGamesClient', () => ({
+  createSharedGamesClient: vi.fn(() => ({
+    getGameAnalysis: vi.fn().mockResolvedValue([
+      {
+        id: 'a1',
+        sharedGameId: 'g1',
+        gameTitle: 'Catan',
+        summary: 'Commercia e costruisci per vincere.',
+        keyMechanics: ['Scambio', 'Costruzione'],
+        victoryConditions: {
+          primary: 'Primi 10 punti',
+          alternatives: [],
+          isPointBased: true,
+          targetPoints: 10,
+        },
+        resources: [],
+        gamePhases: [
+          { name: 'Setup', description: 'Posiziona esagoni', order: 1, isOptional: false },
+        ],
+        commonQuestions: [],
+        generatedFaqs: [],
+        confidenceScore: 0.9,
+        version: '1',
+        isActive: true,
+        source: 'LLM',
+        analyzedAt: '2026-01-01T00:00:00Z',
+        createdBy: 'user1',
+        keyConcepts: [],
+        completionStatus: 'Complete',
+      },
+    ]),
+  })),
+}));
+
+// Mock HttpClient dependency
+vi.mock('@/lib/api/core/httpClient', () => ({
+  HttpClient: vi.fn().mockImplementation(() => ({})),
+}));
 
 import { RulesContent } from '../RulesContent';
 
 describe('RulesContent', () => {
-  it('renders the rules-content container', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('mostra placeholder quando gameId è null', () => {
     render(<RulesContent gameId={null} />);
-    expect(screen.getByTestId('rules-content')).toBeInTheDocument();
+    expect(screen.getByText(/seleziona un gioco/i)).toBeInTheDocument();
   });
 
-  it('shows placeholder when gameId is null', () => {
-    render(<RulesContent gameId={null} />);
-    expect(screen.getByText('Seleziona un gioco per vederne le regole')).toBeInTheDocument();
+  it('mostra loading spinner durante fetch', () => {
+    render(<RulesContent gameId="g1" />);
+    expect(screen.getByTestId('rules-loading')).toBeInTheDocument();
   });
 
-  it('shows KB placeholder when gameId is set', () => {
-    render(<RulesContent gameId="game-123" />);
-    expect(
-      screen.getByText('Le regole verranno caricate dalla knowledge base del gioco')
-    ).toBeInTheDocument();
+  it('mostra il summary dopo il fetch', async () => {
+    render(<RulesContent gameId="g1" />);
+    await waitFor(() => {
+      expect(screen.getByText('Commercia e costruisci per vincere.')).toBeInTheDocument();
+    });
   });
 
-  it('does not show null placeholder when gameId is set', () => {
-    render(<RulesContent gameId="game-123" />);
-    expect(screen.queryByText('Seleziona un gioco per vederne le regole')).not.toBeInTheDocument();
+  it('mostra le meccaniche chiave', async () => {
+    render(<RulesContent gameId="g1" />);
+    await waitFor(() => {
+      expect(screen.getByText('Scambio')).toBeInTheDocument();
+      expect(screen.getByText('Costruzione')).toBeInTheDocument();
+    });
+  });
+
+  it('mostra le fasi di gioco', async () => {
+    render(<RulesContent gameId="g1" />);
+    await waitFor(() => {
+      expect(screen.getByText('Setup')).toBeInTheDocument();
+    });
+  });
+
+  it('mostra le condizioni di vittoria', async () => {
+    render(<RulesContent gameId="g1" />);
+    await waitFor(() => {
+      expect(screen.getByText(/primi 10 punti/i)).toBeInTheDocument();
+    });
+  });
+
+  it('usa la cache se disponibile senza fetching', async () => {
+    const { getCachedAnalyses } = await import('@/lib/game-night/rules-cache');
+    vi.mocked(getCachedAnalyses).mockReturnValue({
+      analyses: [
+        {
+          id: 'a1',
+          sharedGameId: 'g1',
+          gameTitle: 'Catan',
+          summary: 'Da cache.',
+          keyMechanics: [],
+          victoryConditions: null,
+          resources: [],
+          gamePhases: [],
+          commonQuestions: [],
+          generatedFaqs: [],
+          confidenceScore: 0.9,
+          version: '1',
+          isActive: true,
+          source: 'LLM',
+          analyzedAt: '2026-01-01T00:00:00Z',
+          createdBy: 'user1',
+          keyConcepts: [],
+          completionStatus: 'Complete',
+        } as any,
+      ],
+      cachedAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 3600000).toISOString(),
+      gameTitle: 'Catan',
+    });
+
+    render(<RulesContent gameId="g1" />);
+    await waitFor(() => {
+      expect(screen.getByText('Da cache.')).toBeInTheDocument();
+    });
+  });
+
+  it('mostra messaggio se nessuna analisi disponibile', async () => {
+    // Reset cache mock to avoid bleeding from previous test
+    const { getCachedAnalyses } = await import('@/lib/game-night/rules-cache');
+    vi.mocked(getCachedAnalyses).mockReturnValue(null);
+
+    const { createSharedGamesClient } = await import('@/lib/api/clients/sharedGamesClient');
+    vi.mocked(createSharedGamesClient).mockReturnValue({
+      getGameAnalysis: vi.fn().mockResolvedValue([]),
+    } as any);
+
+    render(<RulesContent gameId="g1" />);
+    await waitFor(() => {
+      expect(screen.getByText(/non disponibili/i)).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/components/toolkit/Timer.tsx
+++ b/apps/web/src/components/toolkit/Timer.tsx
@@ -3,12 +3,15 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 
 import { Button } from '@/components/ui/primitives/button';
+import { useSessionStream, type TimerEventPayload } from '@/lib/domain-hooks/useSessionStream';
 
 interface TimerProps {
   name: string;
   defaultSeconds: number;
   type: 'countdown' | 'countup' | 'turn';
   onAction?: (action: string, seconds: number) => void;
+  /** When provided, timer state is synchronized with other participants via SSE. */
+  sessionId?: string;
 }
 
 const WARNING_THRESHOLD = 10;
@@ -83,15 +86,41 @@ function useLocalTimer(defaultSeconds: number) {
     }
   }, [seconds, running]);
 
-  return { seconds, running, start, pause, reset };
+  return { seconds, running, start, pause, reset, setSeconds, setRunning };
 }
 
 // ── Component ───────────────────────────────────────────────────────
 
-export function Timer({ name, defaultSeconds, type, onAction }: TimerProps) {
-  // Phase 1: always use local timer (standalone and in-session).
-  // Phase 2: when in-session, SSE timer_tick events will drive the display.
-  const { seconds, running, start, pause, reset } = useLocalTimer(defaultSeconds);
+export function Timer({ name, defaultSeconds, type, onAction, sessionId }: TimerProps) {
+  const { seconds, running, start, pause, reset, setSeconds, setRunning } =
+    useLocalTimer(defaultSeconds);
+
+  // Phase 2: sync timer state from SSE when in a session context
+  useSessionStream(sessionId ?? null, {
+    enabled: !!sessionId,
+    onTimerEvent: useCallback(
+      (payload: TimerEventPayload) => {
+        if (payload.durationSeconds !== undefined) {
+          // TimerStarted
+          setSeconds(payload.durationSeconds);
+          setRunning(true);
+        } else if (payload.pausedAt !== undefined && payload.remainingSeconds !== undefined) {
+          // TimerPaused
+          setSeconds(payload.remainingSeconds);
+          setRunning(false);
+        } else if (payload.resumedAt !== undefined && payload.remainingSeconds !== undefined) {
+          // TimerResumed
+          setSeconds(payload.remainingSeconds);
+          setRunning(true);
+        } else if (payload.resetAt !== undefined) {
+          // TimerReset
+          setSeconds(defaultSeconds);
+          setRunning(false);
+        }
+      },
+      [setSeconds, setRunning, defaultSeconds]
+    ),
+  });
 
   // Guard: alert fires at most once per timer run
   const alertFiredRef = useRef(false);

--- a/apps/web/src/components/toolkit/Timer.tsx
+++ b/apps/web/src/components/toolkit/Timer.tsx
@@ -95,6 +95,9 @@ export function Timer({ name, defaultSeconds, type, onAction, sessionId }: Timer
   const { seconds, running, start, pause, reset, setSeconds, setRunning } =
     useLocalTimer(defaultSeconds);
 
+  // Guard: alert fires at most once per timer run
+  const alertFiredRef = useRef(false);
+
   // Phase 2: sync timer state from SSE when in a session context
   useSessionStream(sessionId ?? null, {
     enabled: !!sessionId,
@@ -113,17 +116,15 @@ export function Timer({ name, defaultSeconds, type, onAction, sessionId }: Timer
           setSeconds(payload.remainingSeconds);
           setRunning(true);
         } else if (payload.resetAt !== undefined) {
-          // TimerReset
+          // TimerReset (remote)
           setSeconds(defaultSeconds);
           setRunning(false);
+          alertFiredRef.current = false;
         }
       },
       [setSeconds, setRunning, defaultSeconds]
     ),
   });
-
-  // Guard: alert fires at most once per timer run
-  const alertFiredRef = useRef(false);
 
   const isWarning = type === 'countdown' && seconds <= WARNING_THRESHOLD && seconds > 0;
   const isExpired = type === 'countdown' && seconds === 0;

--- a/apps/web/src/lib/domain-hooks/useSessionStream.ts
+++ b/apps/web/src/lib/domain-hooks/useSessionStream.ts
@@ -21,7 +21,8 @@ export type SessionSSEEventType =
   | 'session:score'
   | 'session:conflict'
   | 'session:toolkit'
-  | 'session:chat';
+  | 'session:chat'
+  | 'session:timer';
 
 export type ConnectionStatus =
   | 'disconnected'
@@ -79,6 +80,32 @@ export interface SessionStatePayload {
   status: string;
 }
 
+// ============ Timer Event Payloads ============
+
+/**
+ * Union of all timer SSE event shapes (all arrive as 'session:timer').
+ * Detect event type by field presence:
+ *  - has durationSeconds → TimerStarted
+ *  - has pausedAt        → TimerPaused
+ *  - has resumedAt       → TimerResumed
+ *  - has resetAt         → TimerReset
+ */
+export interface TimerEventPayload {
+  sessionId: string;
+  timerId: string;
+  // TimerStarted
+  durationSeconds?: number;
+  startedBy?: string;
+  startedByName?: string;
+  startedAt?: string;
+  // TimerPaused / TimerResumed
+  remainingSeconds?: number;
+  pausedAt?: string;
+  resumedAt?: string;
+  // TimerReset
+  resetAt?: string;
+}
+
 // ============ Hook Options ============
 
 export interface UseSessionStreamOptions {
@@ -90,6 +117,7 @@ export interface UseSessionStreamOptions {
   onSessionStateChanged?: (payload: SessionStatePayload) => void;
   onToolkitEvent?: (payload: unknown) => void;
   onChatMessage?: (payload: unknown) => void;
+  onTimerEvent?: (payload: TimerEventPayload) => void;
   onError?: (error: Error) => void;
   enabled?: boolean;
   maxReconnectAttempts?: number;
@@ -155,6 +183,9 @@ export function useSessionStream(
         case 'session:chat':
           cbs.onChatMessage?.(parsed.data);
           break;
+        case 'session:timer':
+          cbs.onTimerEvent?.(parsed.data as TimerEventPayload);
+          break;
         case 'session:conflict':
           // Conflict events handled via state update
           cbs.onSessionStateChanged?.(parsed.data as SessionStatePayload);
@@ -199,6 +230,7 @@ export function useSessionStream(
       es.addEventListener('session:score', handleMessage as EventListener);
       es.addEventListener('session:toolkit', handleMessage as EventListener);
       es.addEventListener('session:chat', handleMessage as EventListener);
+      es.addEventListener('session:timer', handleMessage as EventListener);
       es.addEventListener('session:conflict', handleMessage as EventListener);
 
       es.onerror = () => {


### PR DESCRIPTION
## Summary

- **RulesContent**: wire to `GET /api/v1/shared-games/{gameId}/analysis` with localStorage cache (cache-first, 8 unit tests)
- **FaqContent**: same API, displays `generatedFaqs` (question + answer list), 6 unit tests
- **Timer SSE backend**: inject `ISessionBroadcastService` into 4 timer handlers (Start/Pause/Resume/Reset); add `INotification` to domain events; map to `session:timer` in `SseEventTypeMapper`
- **Timer SSE frontend**: add `session:timer` event type + `TimerEventPayload` to `useSessionStream`; add `sessionId?` prop to `Timer.tsx` (Phase 2: sync timer state from SSE events)

## Test plan

- [x] `RulesContent.test.tsx` — 8 tests: null/loading/summary/mechanics/phases/victory/cache/empty
- [x] `FaqContent.test.tsx` — 6 tests: null/loading/faqs/all-faqs/cache/empty
- [x] `Timer.test.tsx` — 4 existing tests still pass
- [x] `useSessionStream.test.ts` — 11 existing tests still pass
- [x] Frontend typecheck clean (`pnpm typecheck`)
- [x] Backend build clean (0 errors, 0 warnings)
- [x] Full pre-push hook passed (Next.js build + dotnet build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)