### PR TITLE
feat(toolkit): timer, dice player-CTA, diary structured form

### DIFF
--- a/admin-mockups/toolkit-mobile-mockup.html
+++ b/admin-mockups/toolkit-mobile-mockup.html
@@ -1,0 +1,667 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+<title>MeepleAI — Toolkit Drawer Mobile Mockup</title>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700;800&family=Nunito:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<!--
+  Static design mockup for internal use only.
+  Shows: Toolkit Drawer in 4 states across two tabs (Dice + Scores).
+  US covered:
+    US2 — Roll 3d6+6, see result, re-roll / roll for next player
+    US3 — Quick manual roll log
+    US4 — Win tracker (players × games)
+-->
+<style>
+:root{
+  --bg:#faf8f5;--bg-card:rgba(255,255,255,0.94);--bg-muted:#f1ede8;
+  --text:#1a1a2e;--text-sec:#64748b;--text-muted:#94a3b8;
+  --border:rgba(0,0,0,0.07);
+  --shadow-sm:0 1px 3px rgba(180,130,80,.06),0 1px 2px rgba(180,130,80,.04);
+  --shadow-md:0 4px 12px rgba(180,130,80,.08),0 2px 4px rgba(180,130,80,.04);
+  --shadow-lg:0 10px 30px rgba(180,130,80,.12);
+  --green:hsl(142,70%,45%);--green-dark:hsl(142,70%,38%);
+  --green-bg:hsl(142,70%,95%);--green-border:hsl(142,60%,80%);
+  --phone-w:390px;--phone-h:844px;
+}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:'Nunito',sans-serif;background:#e8e4df;color:var(--text);min-height:100vh;display:flex;flex-direction:column;align-items:center;padding:24px 16px 48px}
+h1,h2,h3,h4{font-family:'Quicksand',sans-serif}
+
+/* Page header */
+.pg-title{text-align:center;margin-bottom:10px}
+.pg-title h1{font-size:1.25rem;font-weight:800}
+.pg-title p{color:var(--text-sec);font-size:.72rem;margin-top:3px;max-width:750px}
+
+/* State switcher */
+.state-switch{display:flex;gap:6px;flex-wrap:wrap;justify-content:center;margin-bottom:20px}
+.s-btn{padding:5px 14px;border-radius:18px;border:2px solid var(--border);background:var(--bg-card);font-family:'Quicksand',sans-serif;font-size:10px;font-weight:700;cursor:pointer;color:var(--text-sec);transition:all .2s}
+.s-btn.active{background:var(--green);color:white;border-color:transparent;box-shadow:0 2px 8px hsla(142,70%,45%,.35)}
+
+/* Layout grid */
+.mock-grid{display:flex;gap:28px;flex-wrap:wrap;justify-content:center;align-items:flex-start}
+.mock-col{display:flex;flex-direction:column;align-items:center;gap:8px}
+.mock-label{font-family:'Quicksand',sans-serif;font-weight:700;font-size:.68rem;color:var(--text-sec);text-transform:uppercase;letter-spacing:.1em;text-align:center}
+
+/* Phone shell */
+.phone{width:var(--phone-w);height:var(--phone-h);background:var(--bg);border-radius:42px;border:3px solid #c8c0b5;box-shadow:0 30px 80px rgba(0,0,0,.15),0 8px 24px rgba(0,0,0,.1),inset 0 0 0 1px rgba(255,255,255,.4);overflow:hidden;position:relative;display:flex;flex-direction:column}
+
+/* Status bar */
+.sbar{height:44px;display:flex;align-items:flex-end;justify-content:space-between;padding:0 28px 5px;font-size:11px;font-weight:600;flex-shrink:0}
+.sbar .t{font-weight:700}.sbar .i{display:flex;gap:3px;font-size:10px}
+
+/* Top bar */
+.topbar{height:48px;display:flex;align-items:center;padding:0 14px;background:var(--bg-card);backdrop-filter:blur(12px) saturate(180%);border-bottom:1px solid var(--border);flex-shrink:0;gap:8px}
+.topbar .logo{font-family:'Quicksand',sans-serif;font-weight:800;font-size:.9rem;color:hsl(25,95%,45%);display:flex;align-items:center;gap:5px}
+.topbar .logo .dice-icon{width:24px;height:24px;background:hsl(25,95%,45%);border-radius:5px;display:flex;align-items:center;justify-content:center;color:white;font-size:11px;font-weight:800}
+.topbar .spacer{flex:1}
+.topbar .tb-btn{width:30px;height:30px;border-radius:50%;background:var(--bg-muted);border:none;cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:13px;color:var(--text-sec)}
+.topbar .avatar{width:28px;height:28px;border-radius:50%;background:linear-gradient(135deg,hsl(262,83%,58%),hsl(262,60%,35%));color:white;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;font-family:'Quicksand',sans-serif;border:2px solid white}
+
+/* Page content */
+.pgc{flex:1;overflow-y:auto;scrollbar-width:none;background:var(--bg)}
+.pgc::-webkit-scrollbar{display:none}
+
+/* ===================== TOOLKIT DRAWER ===================== */
+.overlay{position:absolute;inset:0;background:rgba(0,0,0,.3);z-index:10}
+.drawer{position:absolute;inset-x:0;top:0;z-index:20;display:flex;flex-direction:column;background:rgba(255,255,255,.96);backdrop-filter:blur(20px);border-radius:0 0 24px 24px;box-shadow:0 20px 50px rgba(0,0,0,.18);max-height:82%}
+
+/* Drag handle */
+.drag-handle{display:flex;justify-content:center;padding:10px 0 6px}
+.drag-handle span{width:40px;height:4px;border-radius:2px;background:#d1d5db}
+
+/* Tab bar */
+.tab-bar{display:flex;border-bottom:1px solid #e5e7eb;padding:0 8px;flex-shrink:0}
+.tab{flex:1;display:flex;flex-direction:column;align-items:center;gap:2px;padding:8px 0 10px;font-size:10px;font-weight:600;color:#9ca3af;cursor:pointer;transition:color .2s;border-bottom:2px solid transparent;margin-bottom:-1px}
+.tab.active{color:var(--green);border-bottom-color:var(--green)}
+.tab .ti{font-size:15px}
+
+/* Tab content */
+.tab-content{flex:1;overflow-y:auto;padding:14px 14px 10px;scrollbar-width:none}
+.tab-content::-webkit-scrollbar{display:none}
+
+/* Section header */
+.sec-h{font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:#9ca3af;margin-bottom:6px}
+
+/* ── DICE TAB ── */
+.preset-row{display:flex;gap:6px;flex-wrap:wrap}
+.preset-chip{padding:4px 10px;border-radius:14px;border:1.5px solid #e5e7eb;font-family:'Quicksand',sans-serif;font-size:10px;font-weight:700;color:#6b7280;cursor:pointer}
+.preset-chip.active{background:var(--green);color:white;border-color:var(--green)}
+
+.pool-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:6px;margin-top:2px}
+.die-row{display:flex;align-items:center;justify-content:space-between;border:1px solid #e5e7eb;border-radius:10px;padding:6px 8px}
+.die-label{font-family:'Quicksand',sans-serif;font-size:11px;font-weight:700;color:#374151}
+.die-stepper{display:flex;align-items:center;gap:4px}
+.die-stepper button{width:18px;height:18px;border-radius:6px;border:none;background:#f3f4f6;font-size:11px;font-weight:700;color:#6b7280;cursor:pointer;display:flex;align-items:center;justify-content:center}
+.die-stepper .cnt{font-size:11px;font-weight:700;width:14px;text-align:center;color:var(--green)}
+
+.modifier-row{display:flex;align-items:center;gap:6px;font-size:11px;color:#6b7280;margin-top:4px}
+.modifier-row .mod-val{font-weight:700;color:var(--green);width:28px;text-align:center;font-family:'Quicksand',sans-serif}
+.modifier-row button{width:18px;height:18px;border-radius:6px;border:none;background:#f3f4f6;font-size:11px;font-weight:700;color:#6b7280;cursor:pointer;display:flex;align-items:center;justify-content:center}
+
+.formula-preview{text-align:center;font-family:'Quicksand',sans-serif;font-size:13px;font-weight:700;color:#374151;margin:6px 0}
+
+.roll-btn{width:100%;padding:10px;border-radius:12px;border:none;background:var(--green);color:white;font-family:'Quicksand',sans-serif;font-size:13px;font-weight:800;cursor:pointer;letter-spacing:.04em}
+
+/* Result display */
+.result-card{background:#f9fafb;border-radius:14px;padding:12px;display:flex;flex-direction:column;align-items:center;gap:6px;margin-top:8px}
+.result-dice{display:flex;gap:5px;flex-wrap:wrap;justify-content:center}
+.die-face{width:30px;height:30px;border-radius:8px;border:1px solid #e5e7eb;background:white;display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;color:#374151}
+.modifier-chip{display:flex;align-items:center;padding:0 4px;font-size:12px;font-weight:600;color:#6b7280}
+.result-total{font-size:36px;font-weight:800;color:#111827;font-family:'Quicksand',sans-serif;line-height:1}
+.result-for{font-size:10px;color:#9ca3af;display:flex;align-items:center;gap:4px}
+.result-for .player-dot{width:8px;height:8px;border-radius:50%;background:hsl(262,70%,55%)}
+.result-formula{font-size:10px;color:#d1d5db}
+
+/* CTA row after result */
+.result-cta{display:flex;gap:8px;margin-top:2px;width:100%}
+.cta-btn{flex:1;padding:8px 4px;border-radius:10px;border:none;cursor:pointer;font-family:'Quicksand',sans-serif;font-size:11px;font-weight:700;display:flex;align-items:center;justify-content:center;gap:4px;transition:all .15s}
+.cta-btn.reroll{background:#f3f4f6;color:#374151}
+.cta-btn.next-player{background:var(--green-bg);color:var(--green-dark);border:1px solid var(--green-border)}
+.cta-btn.next-player .np-avatar{width:16px;height:16px;border-radius:50%;background:hsl(38,90%,50%);display:inline-flex;align-items:center;justify-content:center;font-size:8px;color:white;font-weight:800}
+
+/* Quick log manual */
+.quick-log-row{display:flex;align-items:center;justify-content:center;margin-top:6px}
+.quick-log-link{font-size:10px;color:#9ca3af;text-decoration:underline;cursor:pointer;display:flex;align-items:center;gap:3px}
+
+/* Quick log modal (overlaid inside drawer) */
+.quick-log-modal{background:white;border-radius:14px;border:1px solid #e5e7eb;padding:12px;margin-top:8px;box-shadow:0 4px 16px rgba(0,0,0,.1)}
+.quick-log-modal .ql-title{font-family:'Quicksand',sans-serif;font-size:11px;font-weight:700;color:#374151;margin-bottom:8px;display:flex;align-items:center;gap:4px}
+.field-group{display:flex;flex-direction:column;gap:2px;margin-bottom:6px}
+.field-group label{font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:#9ca3af}
+.field-group select,.field-group input{border:1px solid #e5e7eb;border-radius:8px;padding:6px 8px;font-size:12px;color:#374151;outline:none;width:100%;font-family:'Nunito',sans-serif}
+.field-group select:focus,.field-group input:focus{border-color:var(--green)}
+.ql-actions{display:flex;gap:6px;margin-top:4px}
+.ql-btn{flex:1;padding:7px;border-radius:8px;border:none;cursor:pointer;font-family:'Quicksand',sans-serif;font-size:11px;font-weight:700}
+.ql-btn.cancel{background:#f3f4f6;color:#6b7280}
+.ql-btn.save{background:var(--green);color:white}
+
+/* ── SCORES TAB (Win Tracker) ── */
+.score-controls{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px}
+.add-game-btn{display:flex;align-items:center;gap:3px;padding:4px 8px;border-radius:8px;border:1.5px dashed #d1d5db;font-size:9px;font-weight:700;color:#9ca3af;cursor:pointer}
+
+.score-table{width:100%;border-collapse:collapse;font-size:11px}
+.score-table thead th{padding:4px 6px;text-align:center;font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:#6b7280;border-bottom:1px solid #e5e7eb}
+.score-table thead th:first-child{text-align:left;color:#374151;min-width:80px}
+.score-table thead th .th-avatar{width:20px;height:20px;border-radius:50%;margin:0 auto 2px;display:flex;align-items:center;justify-content:center;font-size:8px;font-weight:800;color:white}
+.score-table tbody tr{border-bottom:1px solid #f3f4f6}
+.score-table tbody tr.active-turn{background:hsl(142,70%,97%)}
+.score-table tbody td{padding:6px 4px;text-align:center;vertical-align:middle}
+.score-table tbody td:first-child{text-align:left;padding-left:2px}
+.drag-icon{font-size:10px;color:#d1d5db;margin-right:3px;cursor:grab}
+.player-row-name{font-size:11px;font-weight:600;color:#374151;display:flex;align-items:center;gap:2px;white-space:nowrap}
+.turn-dot{width:7px;height:7px;border-radius:50%;background:var(--green);flex-shrink:0}
+
+/* Score cell: stepper in cell */
+.score-cell{display:flex;align-items:center;justify-content:center;gap:2px}
+.cell-minus,.cell-plus{width:16px;height:16px;border-radius:4px;border:none;background:#f3f4f6;font-size:10px;font-weight:700;cursor:pointer;color:#6b7280;display:flex;align-items:center;justify-content:center}
+.cell-val{font-size:12px;font-weight:700;color:#374151;min-width:14px;text-align:center}
+
+/* Win total column */
+.win-total{font-size:13px;font-weight:800;color:var(--green)}
+
+/* Ranking bar */
+.ranking-bar{margin-top:8px;display:flex;gap:3px;height:28px;border-radius:8px;overflow:hidden}
+.rank-seg{display:flex;align-items:center;justify-content:center;font-size:9px;font-weight:800;color:rgba(255,255,255,.9);font-family:'Quicksand',sans-serif;transition:width .4s ease}
+
+/* Round row */
+.round-row{display:flex;align-items:center;justify-content:space-between;margin-top:8px;font-size:10px}
+.round-label{color:#9ca3af;font-weight:600}
+.advance-btn{padding:5px 10px;border-radius:8px;border:1px solid #e5e7eb;background:white;font-family:'Quicksand',sans-serif;font-size:10px;font-weight:700;color:#374151;cursor:pointer}
+
+/* Reset link */
+.reset-link{display:flex;justify-content:flex-end;margin-top:6px}
+.reset-link button{font-size:9px;color:#9ca3af;border:none;background:none;cursor:pointer;text-decoration:underline}
+
+/* ── PLAYER BAR ── */
+.player-bar{flex-shrink:0;border-top:1px solid #e5e7eb;background:rgba(255,255,255,.92);padding:8px 10px}
+.pb-inner{display:flex;align-items:center;gap:8px}
+.pb-avatars{display:flex;flex:1;gap:6px;overflow-x:auto;scrollbar-width:none}
+.pb-avatars::-webkit-scrollbar{display:none}
+.p-avatar-wrap{position:relative;display:flex;flex-direction:column;align-items:center;gap:1px}
+.p-avatar{width:32px;height:32px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:800;color:white;font-family:'Quicksand',sans-serif;border:2.5px solid white;box-shadow:0 1px 4px rgba(0,0,0,.15)}
+.p-avatar.active{border-color:var(--green);box-shadow:0 0 0 2px var(--green-bg)}
+.p-name{font-size:8px;font-weight:600;color:#6b7280;white-space:nowrap}
+.p-turn-dot{position:absolute;bottom:-2px;left:50%;transform:translateX(-50%);width:5px;height:5px;border-radius:50%;background:var(--green);border:1.5px solid white}
+.pb-add{width:28px;height:28px;border-radius:50%;border:2px dashed #d1d5db;background:none;display:flex;align-items:center;justify-content:center;font-size:14px;color:#9ca3af;cursor:pointer;flex-shrink:0}
+.pb-session-btn{flex-shrink:0;padding:4px 8px;border-radius:8px;border:1px solid #e5e7eb;font-size:9px;font-weight:700;color:#6b7280;background:white;cursor:pointer;font-family:'Quicksand',sans-serif}
+
+/* ── STATES visibility ── */
+.state-default .state-result{display:none}
+.state-default .state-quick-log{display:none}
+.state-result .state-builder{display:none}
+.state-result .state-quick-log{display:none}
+.state-quicklog .state-builder{display:none}
+.state-quicklog .state-result{display:none}
+</style>
+</head>
+<body>
+
+<div class="pg-title">
+  <h1>Toolkit Drawer — Mobile Mockup</h1>
+  <p>US2 · US3 · US4 — Dadi attributiti al giocatore · Quick log manuale · Win Tracker</p>
+</div>
+
+<div class="state-switch">
+  <button class="s-btn active" onclick="setView('all')">Tutti i pannelli</button>
+  <button class="s-btn" onclick="setView('dice-build')">🎲 Dadi – build 3d6+6</button>
+  <button class="s-btn" onclick="setView('dice-result')">🎲 Dadi – risultato + CTA</button>
+  <button class="s-btn" onclick="setView('dice-log')">📋 Quick log manuale</button>
+  <button class="s-btn" onclick="setView('scores')">🏆 Win Tracker</button>
+</div>
+
+<div class="mock-grid" id="grid">
+
+  <!-- ═══════════ PHONE 1: DICE BUILD ═══════════ -->
+  <div class="mock-col" id="panel-dice-build">
+    <div class="mock-label">🎲 Dadi — Pool builder<br>3d6 + modificatore +6</div>
+    <div class="phone">
+      <div class="sbar"><span class="t">9:41</span><div class="i"><span>▲▲▲</span><span>●●●</span><span>🔋</span></div></div>
+      <div class="topbar">
+        <div class="logo"><div class="dice-icon">🎲</div>MeepleAI</div>
+        <div class="spacer"></div>
+        <button class="tb-btn">🔔</button>
+        <div class="avatar">M</div>
+      </div>
+      <!-- Page behind overlay -->
+      <div class="pgc" style="display:flex;align-items:center;justify-content:center;color:#9ca3af;font-size:13px;">
+        Dashboard
+      </div>
+      <div class="overlay"></div>
+      <div class="drawer">
+        <div class="drag-handle"><span></span></div>
+        <div class="tab-bar">
+          <div class="tab"><span class="ti">🎲</span>Dadi</div>
+          <div class="tab active"><span class="ti">🎲</span>Dadi</div>
+          <div class="tab"><span class="ti">⏱️</span>Timer</div>
+          <div class="tab"><span class="ti">📝</span>Note</div>
+          <div class="tab"><span class="ti">📖</span>Diario</div>
+          <div class="tab"><span class="ti">🏆</span>Punti</div>
+        </div>
+        <!-- Only first tab shown; force active to Dadi -->
+        <style>
+          #panel-dice-build .tab-bar .tab:first-child{display:none}
+          #panel-dice-build .tab-bar .tab:nth-child(2){color:var(--green);border-bottom:2px solid var(--green)}
+        </style>
+        <div class="tab-content">
+          <!-- Preset row -->
+          <div class="sec-h">Preset rapidi</div>
+          <div class="preset-row" style="margin-bottom:12px">
+            <div class="preset-chip">1d6</div>
+            <div class="preset-chip">2d6</div>
+            <div class="preset-chip">1d20</div>
+            <div class="preset-chip">3d6</div>
+            <div class="preset-chip">1d100</div>
+          </div>
+          <!-- Pool builder -->
+          <div class="sec-h">Pool dadi</div>
+          <div class="pool-grid">
+            <div class="die-row"><span class="die-label">d4</span><div class="die-stepper"><button>-</button><span class="cnt" style="color:#d1d5db">0</span><button>+</button></div></div>
+            <div class="die-row" style="border-color:var(--green-border);background:var(--green-bg)"><span class="die-label" style="color:var(--green-dark)">d6</span><div class="die-stepper"><button>-</button><span class="cnt">3</span><button>+</button></div></div>
+            <div class="die-row"><span class="die-label">d8</span><div class="die-stepper"><button>-</button><span class="cnt" style="color:#d1d5db">0</span><button>+</button></div></div>
+            <div class="die-row"><span class="die-label">d10</span><div class="die-stepper"><button>-</button><span class="cnt" style="color:#d1d5db">0</span><button>+</button></div></div>
+            <div class="die-row"><span class="die-label">d12</span><div class="die-stepper"><button>-</button><span class="cnt" style="color:#d1d5db">0</span><button>+</button></div></div>
+            <div class="die-row"><span class="die-label">d20</span><div class="die-stepper"><button>-</button><span class="cnt" style="color:#d1d5db">0</span><button>+</button></div></div>
+          </div>
+          <!-- Modifier -->
+          <div class="modifier-row" style="margin-top:10px">
+            <span>Modificatore</span>
+            <button>-</button>
+            <span class="mod-val">+6</span>
+            <button>+</button>
+          </div>
+          <!-- Formula preview -->
+          <div class="formula-preview">3d6+6</div>
+          <!-- Roll button -->
+          <button class="roll-btn">LANCIA</button>
+        </div>
+        <!-- Player bar -->
+        <div class="player-bar">
+          <div class="pb-inner">
+            <div class="pb-avatars">
+              <div class="p-avatar-wrap">
+                <div class="p-avatar active" style="background:hsl(262,70%,55%)">M</div>
+                <div class="p-name">Marco</div>
+                <div class="p-turn-dot"></div>
+              </div>
+              <div class="p-avatar-wrap">
+                <div class="p-avatar" style="background:hsl(38,90%,50%)">A</div>
+                <div class="p-name">Alice</div>
+              </div>
+              <div class="p-avatar-wrap">
+                <div class="p-avatar" style="background:hsl(346,70%,55%)">B</div>
+                <div class="p-name">Bob</div>
+              </div>
+              <button class="pb-add">+</button>
+            </div>
+            <button class="pb-session-btn">Sessione</button>
+          </div>
+        </div>
+      </div><!-- /drawer -->
+    </div><!-- /phone -->
+  </div><!-- /col -->
+
+
+  <!-- ═══════════ PHONE 2: DICE RESULT + CTA ═══════════ -->
+  <div class="mock-col" id="panel-dice-result">
+    <div class="mock-label">🎲 Dadi — Risultato 3d6+6<br>CTA: Ritira / Prossimo giocatore</div>
+    <div class="phone">
+      <div class="sbar"><span class="t">9:41</span><div class="i"><span>▲▲▲</span><span>●●●</span><span>🔋</span></div></div>
+      <div class="topbar">
+        <div class="logo"><div class="dice-icon">🎲</div>MeepleAI</div>
+        <div class="spacer"></div>
+        <button class="tb-btn">🔔</button>
+        <div class="avatar">M</div>
+      </div>
+      <div class="pgc" style="display:flex;align-items:center;justify-content:center;color:#9ca3af;font-size:13px;">Dashboard</div>
+      <div class="overlay"></div>
+      <div class="drawer">
+        <div class="drag-handle"><span></span></div>
+        <div class="tab-bar">
+          <div class="tab active"><span class="ti">🎲</span>Dadi</div>
+          <div class="tab"><span class="ti">⏱️</span>Timer</div>
+          <div class="tab"><span class="ti">📝</span>Note</div>
+          <div class="tab"><span class="ti">📖</span>Diario</div>
+          <div class="tab"><span class="ti">🏆</span>Punti</div>
+        </div>
+        <div class="tab-content">
+          <!-- Preset row (compact) -->
+          <div class="preset-row" style="margin-bottom:8px">
+            <div class="preset-chip">1d6</div><div class="preset-chip">2d6</div><div class="preset-chip">1d20</div><div class="preset-chip active">3d6+6</div><div class="preset-chip">1d100</div>
+          </div>
+          <!-- Pool builder (compact, collapsed) -->
+          <div style="font-size:10px;color:#9ca3af;text-align:center;margin-bottom:6px;cursor:pointer">▸ Modifica pool (3d6 · +6)</div>
+          <!-- Formula preview -->
+          <div class="formula-preview">3d6+6</div>
+          <!-- Roll button -->
+          <button class="roll-btn">LANCIA</button>
+
+          <!-- RESULT CARD (NEW) -->
+          <div class="result-card">
+            <!-- Who rolled -->
+            <div class="result-for">
+              <span class="player-dot"></span>
+              <span style="font-weight:700;color:#374151">Marco</span>
+              <span style="color:#d1d5db">·</span>
+              <span>3d6+6</span>
+            </div>
+            <!-- Dice faces -->
+            <div class="result-dice">
+              <div class="die-face">5</div>
+              <div class="die-face">3</div>
+              <div class="die-face">4</div>
+              <div class="modifier-chip">+6</div>
+            </div>
+            <!-- Total -->
+            <div class="result-total">18</div>
+            <div class="result-formula">3d6+6</div>
+
+            <!-- CTA row (NEW) -->
+            <div class="result-cta">
+              <button class="cta-btn reroll">↺ Ritira</button>
+              <button class="cta-btn next-player">
+                <span class="np-avatar">A</span>
+                → Alice
+              </button>
+            </div>
+          </div>
+
+          <!-- Quick log link -->
+          <div class="quick-log-row">
+            <span class="quick-log-link">📋 Registra tiro manuale</span>
+          </div>
+
+          <!-- Custom presets section -->
+          <div style="margin-top:10px">
+            <div class="sec-h">I miei preset</div>
+            <div class="preset-row">
+              <div class="preset-chip active" style="background:var(--green-bg);border-color:var(--green-border);color:var(--green-dark)">3d6+6</div>
+              <div class="preset-chip active" style="background:var(--green-bg);border-color:var(--green-border);color:var(--green-dark)">2d10</div>
+            </div>
+          </div>
+        </div>
+        <!-- Player bar -->
+        <div class="player-bar">
+          <div class="pb-inner">
+            <div class="pb-avatars">
+              <div class="p-avatar-wrap">
+                <div class="p-avatar active" style="background:hsl(262,70%,55%)">M</div>
+                <div class="p-name">Marco</div>
+                <div class="p-turn-dot"></div>
+              </div>
+              <div class="p-avatar-wrap">
+                <div class="p-avatar" style="background:hsl(38,90%,50%)">A</div>
+                <div class="p-name">Alice</div>
+              </div>
+              <div class="p-avatar-wrap">
+                <div class="p-avatar" style="background:hsl(346,70%,55%)">B</div>
+                <div class="p-name">Bob</div>
+              </div>
+              <button class="pb-add">+</button>
+            </div>
+            <button class="pb-session-btn">Sessione</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+
+  <!-- ═══════════ PHONE 3: QUICK LOG MANUALE ═══════════ -->
+  <div class="mock-col" id="panel-dice-log">
+    <div class="mock-label">📋 Quick log manuale<br>Seleziona giocatore + formula + totale</div>
+    <div class="phone">
+      <div class="sbar"><span class="t">9:41</span><div class="i"><span>▲▲▲</span><span>●●●</span><span>🔋</span></div></div>
+      <div class="topbar">
+        <div class="logo"><div class="dice-icon">🎲</div>MeepleAI</div>
+        <div class="spacer"></div>
+        <button class="tb-btn">🔔</button>
+        <div class="avatar">M</div>
+      </div>
+      <div class="pgc" style="display:flex;align-items:center;justify-content:center;color:#9ca3af;font-size:13px;">Dashboard</div>
+      <div class="overlay"></div>
+      <div class="drawer">
+        <div class="drag-handle"><span></span></div>
+        <div class="tab-bar">
+          <div class="tab active"><span class="ti">🎲</span>Dadi</div>
+          <div class="tab"><span class="ti">⏱️</span>Timer</div>
+          <div class="tab"><span class="ti">📝</span>Note</div>
+          <div class="tab"><span class="ti">📖</span>Diario</div>
+          <div class="tab"><span class="ti">🏆</span>Punti</div>
+        </div>
+        <div class="tab-content">
+          <!-- Compact preset row -->
+          <div class="preset-row" style="margin-bottom:8px">
+            <div class="preset-chip">1d6</div><div class="preset-chip">2d6</div><div class="preset-chip active">3d6+6</div>
+          </div>
+          <div class="formula-preview">3d6+6</div>
+          <button class="roll-btn" style="margin-bottom:8px">LANCIA</button>
+
+          <!-- QUICK LOG MODAL -->
+          <div class="quick-log-modal">
+            <div class="ql-title">📋 Registra tiro</div>
+            <div class="field-group">
+              <label>Giocatore</label>
+              <select>
+                <option>Marco (turno)</option>
+                <option>Alice</option>
+                <option>Bob</option>
+              </select>
+            </div>
+            <div class="field-group">
+              <label>Formula</label>
+              <select>
+                <option>3d6+6</option>
+                <option>2d6</option>
+                <option>1d20</option>
+                <option>Custom…</option>
+              </select>
+            </div>
+            <div class="field-group">
+              <label>Totale ottenuto</label>
+              <input type="number" placeholder="es. 18" value="18">
+            </div>
+            <div class="ql-actions">
+              <button class="ql-btn cancel">Annulla</button>
+              <button class="ql-btn save">Salva nel diario</button>
+            </div>
+          </div>
+
+          <!-- Quick log link -->
+          <div class="quick-log-row" style="margin-top:6px">
+            <span class="quick-log-link" style="color:var(--green)">✕ Chiudi log manuale</span>
+          </div>
+        </div>
+        <!-- Player bar -->
+        <div class="player-bar">
+          <div class="pb-inner">
+            <div class="pb-avatars">
+              <div class="p-avatar-wrap">
+                <div class="p-avatar active" style="background:hsl(262,70%,55%)">M</div>
+                <div class="p-name">Marco</div>
+                <div class="p-turn-dot"></div>
+              </div>
+              <div class="p-avatar-wrap">
+                <div class="p-avatar" style="background:hsl(38,90%,50%)">A</div>
+                <div class="p-name">Alice</div>
+              </div>
+              <div class="p-avatar-wrap">
+                <div class="p-avatar" style="background:hsl(346,70%,55%)">B</div>
+                <div class="p-name">Bob</div>
+              </div>
+              <button class="pb-add">+</button>
+            </div>
+            <button class="pb-session-btn">Sessione</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+
+  <!-- ═══════════ PHONE 4: WIN TRACKER (Scores tab) ═══════════ -->
+  <div class="mock-col" id="panel-scores">
+    <div class="mock-label">🏆 Win Tracker<br>Righe = giocatori · Colonne = partite giocate</div>
+    <div class="phone">
+      <div class="sbar"><span class="t">9:41</span><div class="i"><span>▲▲▲</span><span>●●●</span><span>🔋</span></div></div>
+      <div class="topbar">
+        <div class="logo"><div class="dice-icon">🎲</div>MeepleAI</div>
+        <div class="spacer"></div>
+        <button class="tb-btn">🔔</button>
+        <div class="avatar">M</div>
+      </div>
+      <div class="pgc" style="display:flex;align-items:center;justify-content:center;color:#9ca3af;font-size:13px;">Dashboard</div>
+      <div class="overlay"></div>
+      <div class="drawer">
+        <div class="drag-handle"><span></span></div>
+        <div class="tab-bar">
+          <div class="tab"><span class="ti">🎲</span>Dadi</div>
+          <div class="tab"><span class="ti">⏱️</span>Timer</div>
+          <div class="tab"><span class="ti">📝</span>Note</div>
+          <div class="tab"><span class="ti">📖</span>Diario</div>
+          <div class="tab active"><span class="ti">🏆</span>Punti</div>
+        </div>
+        <div class="tab-content">
+          <!-- Header row -->
+          <div class="score-controls">
+            <div class="sec-h" style="margin-bottom:0">Partite</div>
+            <div class="add-game-btn">+ Aggiungi partita</div>
+          </div>
+
+          <!-- Score table: rows=players, cols=games + total -->
+          <div style="overflow-x:auto">
+            <table class="score-table">
+              <thead>
+                <tr>
+                  <th style="text-align:left">Giocatore</th>
+                  <th>
+                    <div class="th-avatar" style="background:hsl(25,80%,55%)">🎲</div>
+                    Catan
+                  </th>
+                  <th>
+                    <div class="th-avatar" style="background:hsl(195,70%,45%)">🚂</div>
+                    TtR
+                  </th>
+                  <th>
+                    <div class="th-avatar" style="background:hsl(280,60%,50%)">👑</div>
+                    Dom.
+                  </th>
+                  <th style="color:var(--green)">Vinte</th>
+                </tr>
+              </thead>
+              <tbody>
+                <!-- Marco (turno corrente) -->
+                <tr class="active-turn">
+                  <td>
+                    <div class="player-row-name">
+                      <span class="turn-dot"></span>
+                      <span class="p-avatar" style="width:18px;height:18px;font-size:8px;background:hsl(262,70%,55%)">M</span>
+                      Marco
+                    </div>
+                  </td>
+                  <td><div class="score-cell"><button class="cell-minus">-</button><span class="cell-val">1</span><button class="cell-plus">+</button></div></td>
+                  <td><div class="score-cell"><button class="cell-minus">-</button><span class="cell-val">0</span><button class="cell-plus">+</button></div></td>
+                  <td><div class="score-cell"><button class="cell-minus">-</button><span class="cell-val">1</span><button class="cell-plus">+</button></div></td>
+                  <td><div class="win-total">2</div></td>
+                </tr>
+                <!-- Alice -->
+                <tr>
+                  <td>
+                    <div class="player-row-name">
+                      <span style="width:7px;display:inline-block"></span>
+                      <span class="p-avatar" style="width:18px;height:18px;font-size:8px;background:hsl(38,90%,50%)">A</span>
+                      Alice
+                    </div>
+                  </td>
+                  <td><div class="score-cell"><button class="cell-minus">-</button><span class="cell-val">0</span><button class="cell-plus">+</button></div></td>
+                  <td><div class="score-cell"><button class="cell-minus">-</button><span class="cell-val">1</span><button class="cell-plus">+</button></div></td>
+                  <td><div class="score-cell"><button class="cell-minus">-</button><span class="cell-val">0</span><button class="cell-plus">+</button></div></td>
+                  <td><div class="win-total">1</div></td>
+                </tr>
+                <!-- Bob -->
+                <tr>
+                  <td>
+                    <div class="player-row-name">
+                      <span style="width:7px;display:inline-block"></span>
+                      <span class="p-avatar" style="width:18px;height:18px;font-size:8px;background:hsl(346,70%,55%)">B</span>
+                      Bob
+                    </div>
+                  </td>
+                  <td><div class="score-cell"><button class="cell-minus">-</button><span class="cell-val">0</span><button class="cell-plus">+</button></div></td>
+                  <td><div class="score-cell"><button class="cell-minus">-</button><span class="cell-val">0</span><button class="cell-plus">+</button></div></td>
+                  <td><div class="score-cell"><button class="cell-minus">-</button><span class="cell-val">1</span><button class="cell-plus">+</button></div></td>
+                  <td><div class="win-total">1</div></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Ranking bar -->
+          <div style="font-size:9px;color:#9ca3af;font-weight:700;text-transform:uppercase;letter-spacing:.08em;margin-top:10px;margin-bottom:4px">Classifica vinte</div>
+          <div class="ranking-bar">
+            <div class="rank-seg" style="width:50%;background:hsl(262,70%,55%)">M 2</div>
+            <div class="rank-seg" style="width:25%;background:hsl(38,90%,50%)">A 1</div>
+            <div class="rank-seg" style="width:25%;background:hsl(346,70%,55%)">B 1</div>
+          </div>
+
+          <!-- Round / advance -->
+          <div class="round-row">
+            <span class="round-label">Partita corrente: 3</span>
+            <button class="advance-btn">+ Avanza partita</button>
+          </div>
+
+          <!-- Reset -->
+          <div class="reset-link">
+            <button>🔄 Reset punteggi</button>
+          </div>
+        </div>
+        <!-- Player bar -->
+        <div class="player-bar">
+          <div class="pb-inner">
+            <div class="pb-avatars">
+              <div class="p-avatar-wrap">
+                <div class="p-avatar active" style="background:hsl(262,70%,55%)">M</div>
+                <div class="p-name">Marco</div>
+                <div class="p-turn-dot"></div>
+              </div>
+              <div class="p-avatar-wrap">
+                <div class="p-avatar" style="background:hsl(38,90%,50%)">A</div>
+                <div class="p-name">Alice</div>
+              </div>
+              <div class="p-avatar-wrap">
+                <div class="p-avatar" style="background:hsl(346,70%,55%)">B</div>
+                <div class="p-name">Bob</div>
+              </div>
+              <button class="pb-add">+</button>
+            </div>
+            <button class="pb-session-btn">Sessione</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div><!-- /grid -->
+
+<script>
+function setView(state) {
+  document.querySelectorAll('.s-btn').forEach(b => b.classList.remove('active'));
+  event.target.classList.add('active');
+  const all = ['dice-build','dice-result','dice-log','scores'];
+  if (state === 'all') {
+    all.forEach(id => {
+      const el = document.getElementById('panel-' + id);
+      if (el) el.style.display = '';
+    });
+  } else {
+    all.forEach(id => {
+      const el = document.getElementById('panel-' + id);
+      if (!el) return;
+      el.style.display = id === state ? '' : 'none';
+    });
+  }
+}
+</script>
+</body>
+</html>

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts';
+import './.next/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/src/components/toolkit-drawer/ToolkitDrawer.tsx
+++ b/apps/web/src/components/toolkit-drawer/ToolkitDrawer.tsx
@@ -14,21 +14,53 @@
  * Tab content is placeholder until individual tab components are implemented.
  */
 
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 
 import { AnimatePresence, motion } from 'framer-motion';
 
 import { lockScroll, unlockScroll } from '@/lib/scroll-lock';
 import { cn } from '@/lib/utils';
+import { getTimerStore } from '@/stores/toolkit-timer-store';
 
 import { PlayerBar } from './shared/PlayerBar';
 import { DiceRollerTab } from './tabs/DiceRollerTab';
 import { EventDiaryTab } from './tabs/EventDiaryTab';
 import { NotesTab } from './tabs/NotesTab';
 import { ScoreboardTab } from './tabs/ScoreboardTab';
+import { TimerTab } from './tabs/TimerTab';
 import { ToolkitDrawerProvider, useToolkitDrawer } from './ToolkitDrawerProvider';
 
 import type { ToolkitDrawerProps, ToolkitTab } from './types';
+
+// ============================================================================
+// Web Audio — timer-end beep (three ascending tones)
+// ============================================================================
+
+function playTimerEndSound() {
+  if (typeof window === 'undefined') return;
+  try {
+    const AudioCtxClass =
+      window.AudioContext ??
+      (window as Window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!AudioCtxClass) return;
+    const ctx = new AudioCtxClass();
+    [0, 0.35, 0.7].forEach(delay => {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.type = 'sine';
+      osc.frequency.setValueAtTime(880, ctx.currentTime + delay);
+      osc.frequency.exponentialRampToValueAtTime(440, ctx.currentTime + delay + 0.25);
+      gain.gain.setValueAtTime(0.35, ctx.currentTime + delay);
+      gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + delay + 0.28);
+      osc.start(ctx.currentTime + delay);
+      osc.stop(ctx.currentTime + delay + 0.3);
+    });
+  } catch {
+    // Web Audio not supported or blocked
+  }
+}
 
 // ============================================================================
 // Tab Configuration
@@ -43,6 +75,7 @@ interface TabConfig {
 
 const TABS: TabConfig[] = [
   { key: 'dice', label: 'Dadi', icon: '\uD83C\uDFB2', testId: 'toolkit-tab-dice' },
+  { key: 'timer', label: 'Timer', icon: '\u23F1\uFE0F', testId: 'toolkit-tab-timer' },
   { key: 'notes', label: 'Note', icon: '\uD83D\uDCDD', testId: 'toolkit-tab-notes' },
   { key: 'diary', label: 'Diario', icon: '\uD83D\uDCD6', testId: 'toolkit-tab-diary' },
   { key: 'scores', label: 'Punti', icon: '\uD83C\uDFC6', testId: 'toolkit-tab-scores' },
@@ -65,9 +98,9 @@ export function ToolkitDrawer({ gameId, sessionId, onClose, defaultTab }: Toolki
 // ============================================================================
 
 function ToolkitDrawerInner({ onClose }: { onClose: () => void }) {
-  const { activeTab, setActiveTab } = useToolkitDrawer();
+  const { activeTab, setActiveTab, gameId, store, logEvent } = useToolkitDrawer();
 
-  // Escape key handler
+  // ── Escape key handler ────────────────────────────────────────────────────
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose();
@@ -85,6 +118,33 @@ function ToolkitDrawerInner({ onClose }: { onClose: () => void }) {
       unlockScroll();
     };
   }, [handleKeyDown]);
+
+  // ── Timer end: sound + diary log (fires from any active tab) ─────────────
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const { gameId: endedId } = (e as CustomEvent<{ gameId: string }>).detail;
+      if (endedId !== gameId) return;
+      playTimerEndSound();
+      const total = getTimerStore(gameId).getState().totalSeconds;
+      logEvent('timer_end', { durationSeconds: total });
+    };
+    window.addEventListener('toolkit:timer-end', handler);
+    return () => window.removeEventListener('toolkit:timer-end', handler);
+  }, [gameId, logEvent]);
+
+  // ── Auto-reset timer on turn advance (when checkbox is enabled) ──────────
+  const currentTurnIndex = store(s => s.currentTurnIndex);
+  const isFirstTurnMount = useRef(true);
+  useEffect(() => {
+    if (isFirstTurnMount.current) {
+      isFirstTurnMount.current = false;
+      return;
+    }
+    const timerStore = getTimerStore(gameId);
+    if (timerStore.getState().autoResetOnTurn) {
+      timerStore.getState().reset();
+    }
+  }, [currentTurnIndex, gameId]);
 
   return (
     <AnimatePresence>
@@ -171,6 +231,8 @@ function TabContent({ tab }: { tab: ToolkitTab }) {
   switch (tab) {
     case 'dice':
       return <DiceRollerTab />;
+    case 'timer':
+      return <TimerTab />;
     case 'notes':
       return <NotesTab />;
     case 'diary':

--- a/apps/web/src/components/toolkit-drawer/ToolkitDrawer.tsx
+++ b/apps/web/src/components/toolkit-drawer/ToolkitDrawer.tsx
@@ -20,7 +20,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 
 import { lockScroll, unlockScroll } from '@/lib/scroll-lock';
 import { cn } from '@/lib/utils';
-import { getTimerStore } from '@/stores/toolkit-timer-store';
+import { destroyTimerStore, getTimerStore } from '@/stores/toolkit-timer-store';
 
 import { PlayerBar } from './shared/PlayerBar';
 import { DiceRollerTab } from './tabs/DiceRollerTab';
@@ -44,7 +44,8 @@ function playTimerEndSound() {
       (window as Window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
     if (!AudioCtxClass) return;
     const ctx = new AudioCtxClass();
-    [0, 0.35, 0.7].forEach(delay => {
+    const delays = [0, 0.35, 0.7];
+    delays.forEach((delay, i) => {
       const osc = ctx.createOscillator();
       const gain = ctx.createGain();
       osc.connect(gain);
@@ -56,6 +57,9 @@ function playTimerEndSound() {
       gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + delay + 0.28);
       osc.start(ctx.currentTime + delay);
       osc.stop(ctx.currentTime + delay + 0.3);
+      if (i === delays.length - 1) {
+        osc.onended = () => ctx.close().catch(() => {});
+      }
     });
   } catch {
     // Web Audio not supported or blocked
@@ -108,7 +112,7 @@ function ToolkitDrawerInner({ onClose }: { onClose: () => void }) {
     [onClose]
   );
 
-  // Escape key + scroll lock lifecycle
+  // Escape key + scroll lock + timer cleanup lifecycle
   useEffect(() => {
     document.addEventListener('keydown', handleKeyDown);
     lockScroll();
@@ -116,8 +120,9 @@ function ToolkitDrawerInner({ onClose }: { onClose: () => void }) {
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
       unlockScroll();
+      destroyTimerStore(gameId);
     };
-  }, [handleKeyDown]);
+  }, [handleKeyDown, gameId]);
 
   // ── Timer end: sound + diary log (fires from any active tab) ─────────────
   useEffect(() => {

--- a/apps/web/src/components/toolkit-drawer/tabs/DiaryEventRow.tsx
+++ b/apps/web/src/components/toolkit-drawer/tabs/DiaryEventRow.tsx
@@ -17,6 +17,7 @@ const EVENT_ICON: Record<DiaryEventType, string> = {
   player_joined: '👤',
   round_advance: '🔔',
   score_reset: '♻️',
+  timer_end: '⏱️',
 };
 
 function formatTime(timestamp: number): string {
@@ -66,6 +67,14 @@ function describeEvent(event: DiaryEvent): string {
     }
     case 'score_reset': {
       return 'Punteggi azzerati';
+    }
+    case 'timer_end': {
+      const dur = payload.durationSeconds as number | undefined;
+      if (!dur) return 'Timer scaduto';
+      const m = Math.floor(dur / 60);
+      const s = dur % 60;
+      const label = m > 0 ? `${m}m${s > 0 ? ` ${s}s` : ''}` : `${s}s`;
+      return `Timer scaduto (${label})`;
     }
     default:
       return JSON.stringify(payload);

--- a/apps/web/src/components/toolkit-drawer/tabs/DiceRollerTab.tsx
+++ b/apps/web/src/components/toolkit-drawer/tabs/DiceRollerTab.tsx
@@ -2,7 +2,9 @@
 
 /**
  * DiceRollerTab — Main dice tab composing preset rows, pool builder,
- * and result display. Logs every roll to the session diary.
+ * and result display. Logs every roll to the session diary with player
+ * attribution. Provides CTA buttons to re-roll or pass to the next
+ * player, and an inline form for manually recording a roll result.
  */
 
 import React, { useCallback, useState } from 'react';
@@ -16,20 +18,128 @@ import { DicePoolBuilder } from './DicePoolBuilder';
 import { DicePresetRow } from './DicePresetRow';
 import { DiceResultDisplay } from './DiceResultDisplay';
 
-import type { DicePreset, DiceResult } from '../types';
+import type { DicePreset, DiceResult, LocalPlayer } from '../types';
 
 // ============================================================================
-// Component
+// Quick Log Form — inline manual roll entry
+// ============================================================================
+
+interface DiceQuickLogFormProps {
+  players: LocalPlayer[];
+  defaultPlayerId?: string;
+  onSave: (playerId: string | null, formula: string, total: number) => void;
+  onCancel: () => void;
+}
+
+function DiceQuickLogForm({ players, defaultPlayerId, onSave, onCancel }: DiceQuickLogFormProps) {
+  const [selectedPlayerId, setSelectedPlayerId] = useState(defaultPlayerId ?? players[0]?.id ?? '');
+  const [formula, setFormula] = useState('');
+  const [totalStr, setTotalStr] = useState('');
+
+  const canSubmit = formula.trim() !== '' && totalStr !== '';
+
+  const handleSubmit = () => {
+    const total = parseInt(totalStr, 10);
+    if (isNaN(total) || !formula.trim()) return;
+    onSave(selectedPlayerId || null, formula.trim(), total);
+  };
+
+  return (
+    <div
+      className="flex flex-col gap-2.5 rounded-xl border border-gray-200 bg-gray-50 p-3"
+      data-testid="dice-quick-log-form"
+    >
+      <h4 className="text-xs font-semibold text-gray-600">Registra tiro manuale</h4>
+
+      {players.length > 0 && (
+        <select
+          value={selectedPlayerId}
+          onChange={e => setSelectedPlayerId(e.target.value)}
+          className="rounded-lg border border-gray-300 px-2 py-1.5 text-xs outline-none focus:border-[hsl(142,70%,45%)]"
+          data-testid="quick-log-player"
+        >
+          <option value="">— nessun giocatore —</option>
+          {players.map(p => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      )}
+
+      <input
+        type="text"
+        placeholder="Formula (es. 3d6+6)"
+        value={formula}
+        onChange={e => setFormula(e.target.value)}
+        onKeyDown={e => {
+          if (e.key === 'Enter' && canSubmit) handleSubmit();
+        }}
+        className="rounded-lg border border-gray-300 px-2 py-1.5 text-xs outline-none focus:border-[hsl(142,70%,45%)]"
+        data-testid="quick-log-formula"
+      />
+
+      <input
+        type="number"
+        placeholder="Totale ottenuto"
+        value={totalStr}
+        onChange={e => setTotalStr(e.target.value)}
+        onKeyDown={e => {
+          if (e.key === 'Enter' && canSubmit) handleSubmit();
+        }}
+        className="rounded-lg border border-gray-300 px-2 py-1.5 text-xs outline-none focus:border-[hsl(142,70%,45%)]"
+        data-testid="quick-log-total"
+      />
+
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="flex-1 rounded-lg border border-gray-300 py-1.5 text-xs font-medium text-gray-500 hover:bg-gray-100"
+          data-testid="quick-log-cancel"
+        >
+          Annulla
+        </button>
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+          className={cn(
+            'flex-1 rounded-lg py-1.5 text-xs font-medium transition-colors',
+            canSubmit
+              ? 'bg-[hsl(142,70%,45%)] text-white hover:bg-[hsl(142,70%,40%)]'
+              : 'cursor-not-allowed bg-gray-200 text-gray-400'
+          )}
+          data-testid="quick-log-save"
+        >
+          Salva
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// DiceRollerTab
 // ============================================================================
 
 export function DiceRollerTab() {
   const { store, logEvent } = useToolkitDrawer();
   const customPresets = store(s => s.customDicePresets);
+  const players = store(s => s.players);
+  const currentTurnIndex = store(s => s.currentTurnIndex);
+  const currentRound = store(s => s.currentRound);
   const { roll, lastResult, isRolling } = useDiceRoller();
+
+  // Current player and next player (for CTA row attribution)
+  const currentPlayer = players[currentTurnIndex] ?? null;
+  const nextPlayerIndex = players.length > 1 ? (currentTurnIndex + 1) % players.length : -1;
+  const nextPlayer = nextPlayerIndex >= 0 ? (players[nextPlayerIndex] ?? null) : null;
 
   // Collapsible sections
   const [showAiPresets, setShowAiPresets] = useState(false);
   const [showCustomPresets, setShowCustomPresets] = useState(true);
+  const [showQuickLog, setShowQuickLog] = useState(false);
 
   // Save-preset inline form
   const [saveName, setSaveName] = useState('');
@@ -38,20 +148,74 @@ export function DiceRollerTab() {
   // AI presets placeholder — will be populated from toolkit config in the future
   const aiPresets: DicePreset[] = [];
 
+  // ── Roll with player attribution ─────────────────────────────────────────
+
   const handleRoll = useCallback(
     (formula: string) => {
       const result: DiceResult = roll(formula);
       setLastFormula(formula);
 
-      logEvent('dice_roll', {
+      logEvent(
+        'dice_roll',
+        {
+          formula: result.formula,
+          rolls: result.rolls,
+          modifier: result.modifier,
+          total: result.total,
+        },
+        currentPlayer
+          ? { playerId: currentPlayer.id, playerName: currentPlayer.name, round: currentRound }
+          : undefined
+      );
+    },
+    [roll, logEvent, currentPlayer, currentRound]
+  );
+
+  // ── Re-roll same formula for same player ─────────────────────────────────
+
+  const handleReroll = useCallback(() => {
+    if (lastFormula && lastFormula !== '0') handleRoll(lastFormula);
+  }, [handleRoll, lastFormula]);
+
+  // ── Advance turn, then roll same formula for the new current player ──────
+
+  const handleRollNext = useCallback(() => {
+    if (!lastFormula || lastFormula === '0') return;
+    store.getState().advanceTurn();
+    // Read fresh state synchronously after mutation
+    const state = store.getState();
+    const newPlayer = state.players[state.currentTurnIndex] ?? null;
+    const result = roll(lastFormula);
+    logEvent(
+      'dice_roll',
+      {
         formula: result.formula,
         rolls: result.rolls,
         modifier: result.modifier,
         total: result.total,
-      });
+      },
+      newPlayer
+        ? { playerId: newPlayer.id, playerName: newPlayer.name, round: state.currentRound }
+        : undefined
+    );
+  }, [lastFormula, roll, logEvent, store]);
+
+  // ── Manual quick log ─────────────────────────────────────────────────────
+
+  const handleQuickLogSave = useCallback(
+    (playerId: string | null, formula: string, total: number) => {
+      const player = players.find(p => p.id === playerId) ?? null;
+      logEvent(
+        'dice_roll',
+        { formula, rolls: [], modifier: 0, total },
+        player ? { playerId: player.id, playerName: player.name, round: currentRound } : undefined
+      );
+      setShowQuickLog(false);
     },
-    [roll, logEvent]
+    [players, logEvent, currentRound]
   );
+
+  // ── Save preset ───────────────────────────────────────────────────────────
 
   const handleSavePreset = () => {
     const name = saveName.trim();
@@ -64,6 +228,8 @@ export function DiceRollerTab() {
     });
     setSaveName('');
   };
+
+  const hasResult = !!lastResult && !!lastFormula && lastFormula !== '0';
 
   return (
     <div className="flex flex-col gap-4" data-testid="dice-roller-tab">
@@ -152,6 +318,49 @@ export function DiceRollerTab() {
 
       {/* Result display */}
       <DiceResultDisplay result={lastResult} isRolling={isRolling} />
+
+      {/* CTA row — re-roll or pass to next player */}
+      {hasResult && !showQuickLog && (
+        <div className="flex items-center justify-center gap-2" data-testid="dice-cta-row">
+          <button
+            type="button"
+            onClick={handleReroll}
+            className="flex items-center gap-1.5 rounded-xl border border-gray-200 bg-white px-3 py-2 text-xs font-semibold text-gray-700 shadow-sm transition-colors hover:border-[hsl(142,70%,45%)] hover:text-[hsl(142,70%,45%)]"
+            data-testid="dice-reroll-btn"
+          >
+            ↺ Ritira
+          </button>
+          {nextPlayer && (
+            <button
+              type="button"
+              onClick={handleRollNext}
+              className="flex items-center gap-1.5 rounded-xl bg-[hsl(142,70%,45%)] px-3 py-2 text-xs font-semibold text-white shadow-sm transition-colors hover:bg-[hsl(142,70%,40%)]"
+              data-testid="dice-roll-next-btn"
+            >
+              → {nextPlayer.name}
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Quick log — inline manual entry form or trigger link */}
+      {showQuickLog ? (
+        <DiceQuickLogForm
+          players={players}
+          defaultPlayerId={currentPlayer?.id}
+          onSave={handleQuickLogSave}
+          onCancel={() => setShowQuickLog(false)}
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={() => setShowQuickLog(true)}
+          className="text-center text-xs text-gray-400 underline-offset-2 hover:text-gray-600 hover:underline"
+          data-testid="dice-quick-log-btn"
+        >
+          📝 Registra tiro manuale
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/toolkit-drawer/tabs/EventDiaryTab.tsx
+++ b/apps/web/src/components/toolkit-drawer/tabs/EventDiaryTab.tsx
@@ -1,16 +1,312 @@
 'use client';
 
 /**
- * EventDiaryTab — Chronological log of game events with filters and manual entries.
+ * EventDiaryTab — Chronological log of game events with filters.
+ *
+ * Manual entry modes:
+ *  1. Quick note: plain text input (manual_entry, current player)
+ *  2. Structured form: player + event type + type-specific value fields
  */
 
 import React, { useMemo, useState } from 'react';
+
+import { cn } from '@/lib/utils';
 
 import { useToolkitDrawer } from '../ToolkitDrawerProvider';
 import { DiaryEventRow } from './DiaryEventRow';
 import { DiaryFilters } from './DiaryFilters';
 
-import type { DiaryEvent, DiaryEventType } from '../types';
+import type { DiaryEvent, DiaryEventType, LocalPlayer } from '../types';
+
+// ============================================================================
+// Supported manual event types + their labels
+// ============================================================================
+
+interface ManualEventOption {
+  type: DiaryEventType;
+  label: string;
+  icon: string;
+}
+
+const MANUAL_EVENT_OPTIONS: ManualEventOption[] = [
+  { type: 'manual_entry', label: 'Nota', icon: '✍️' },
+  { type: 'dice_roll', label: 'Dado', icon: '🎲' },
+  { type: 'score_change', label: 'Punti', icon: '🏆' },
+  { type: 'turn_change', label: 'Turno', icon: '🔄' },
+  { type: 'round_advance', label: 'Round', icon: '🔔' },
+];
+
+// ============================================================================
+// Structured form — player + type + dynamic value fields
+// ============================================================================
+
+interface DiaryEventFormProps {
+  players: LocalPlayer[];
+  scoreCategories: string[];
+  currentRound: number;
+  onSubmit: (
+    type: DiaryEventType,
+    payload: Record<string, unknown>,
+    extra?: { playerId?: string; playerName?: string; round?: number }
+  ) => void;
+  onCancel: () => void;
+}
+
+function DiaryEventForm({
+  players,
+  scoreCategories,
+  currentRound,
+  onSubmit,
+  onCancel,
+}: DiaryEventFormProps) {
+  const [selectedType, setSelectedType] = useState<DiaryEventType>('manual_entry');
+  const [selectedPlayerId, setSelectedPlayerId] = useState(players[0]?.id ?? '');
+
+  // manual_entry
+  const [noteText, setNoteText] = useState('');
+
+  // dice_roll
+  const [diceFormula, setDiceFormula] = useState('');
+  const [diceTotal, setDiceTotal] = useState('');
+
+  // score_change
+  const [scoreCategory, setScoreCategory] = useState(scoreCategories[0] ?? '');
+  const [scoreDelta, setScoreDelta] = useState('');
+
+  // turn_change
+  const [nextPlayerId, setNextPlayerId] = useState(players[1]?.id ?? players[0]?.id ?? '');
+
+  // round_advance — uses currentRound+1 (no user input needed)
+
+  const player = players.find(p => p.id === selectedPlayerId) ?? null;
+
+  const canSubmit = (): boolean => {
+    switch (selectedType) {
+      case 'manual_entry':
+        return noteText.trim() !== '';
+      case 'dice_roll':
+        return diceFormula.trim() !== '' && diceTotal !== '' && !isNaN(parseInt(diceTotal, 10));
+      case 'score_change':
+        return scoreCategory.trim() !== '' && scoreDelta !== '' && !isNaN(parseInt(scoreDelta, 10));
+      case 'turn_change':
+        return !!nextPlayerId;
+      case 'round_advance':
+        return true;
+      default:
+        return false;
+    }
+  };
+
+  const handleSubmit = () => {
+    if (!canSubmit()) return;
+
+    const extra = player
+      ? { playerId: player.id, playerName: player.name, round: currentRound }
+      : { round: currentRound };
+
+    switch (selectedType) {
+      case 'manual_entry':
+        onSubmit('manual_entry', { text: noteText.trim() }, extra);
+        break;
+      case 'dice_roll': {
+        const total = parseInt(diceTotal, 10);
+        onSubmit(
+          'dice_roll',
+          { formula: diceFormula.trim(), rolls: [], modifier: 0, total },
+          extra
+        );
+        break;
+      }
+      case 'score_change': {
+        const delta = parseInt(scoreDelta, 10);
+        // newTotal not available in manual entry; DiaryEventRow shows '?' gracefully
+        onSubmit('score_change', { category: scoreCategory.trim(), delta }, extra);
+        break;
+      }
+      case 'turn_change': {
+        const nextPlayer = players.find(p => p.id === nextPlayerId);
+        onSubmit(
+          'turn_change',
+          { nextPlayerName: nextPlayer?.name ?? '' },
+          nextPlayer
+            ? { playerId: nextPlayer.id, playerName: nextPlayer.name, round: currentRound }
+            : extra
+        );
+        break;
+      }
+      case 'round_advance':
+        onSubmit('round_advance', { round: currentRound + 1 }, { round: currentRound + 1 });
+        break;
+    }
+  };
+
+  return (
+    <div
+      className="flex flex-col gap-2.5 rounded-xl border border-gray-200 bg-gray-50 p-3"
+      data-testid="diary-event-form"
+    >
+      {/* Type selector */}
+      <div className="flex gap-1.5 overflow-x-auto pb-0.5" role="group" aria-label="Tipo evento">
+        {MANUAL_EVENT_OPTIONS.map(opt => (
+          <button
+            key={opt.type}
+            type="button"
+            onClick={() => setSelectedType(opt.type)}
+            className={cn(
+              'flex shrink-0 items-center gap-1 rounded-full px-2.5 py-1 text-[10px] font-semibold transition-colors',
+              selectedType === opt.type
+                ? 'bg-[hsl(142,70%,45%)] text-white'
+                : 'border border-gray-300 text-gray-600 hover:border-[hsl(142,70%,45%)]'
+            )}
+            data-testid={`diary-form-type-${opt.type}`}
+          >
+            <span>{opt.icon}</span>
+            <span>{opt.label}</span>
+          </button>
+        ))}
+      </div>
+
+      {/* Player selector (hidden for turn_change and round_advance) */}
+      {selectedType !== 'turn_change' && selectedType !== 'round_advance' && players.length > 0 && (
+        <select
+          value={selectedPlayerId}
+          onChange={e => setSelectedPlayerId(e.target.value)}
+          className="rounded-lg border border-gray-300 px-2 py-1.5 text-xs outline-none focus:border-[hsl(142,70%,45%)]"
+          data-testid="diary-form-player"
+        >
+          <option value="">— nessun giocatore —</option>
+          {players.map(p => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      )}
+
+      {/* Dynamic value fields */}
+      {selectedType === 'manual_entry' && (
+        <input
+          type="text"
+          placeholder="Testo nota…"
+          value={noteText}
+          onChange={e => setNoteText(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter' && canSubmit()) handleSubmit();
+          }}
+          autoFocus
+          className="rounded-lg border border-gray-300 px-2 py-1.5 text-xs outline-none focus:border-[hsl(142,70%,45%)]"
+          data-testid="diary-form-note-text"
+        />
+      )}
+
+      {selectedType === 'dice_roll' && (
+        <div className="flex gap-2">
+          <input
+            type="text"
+            placeholder="Formula (es. 3d6+6)"
+            value={diceFormula}
+            onChange={e => setDiceFormula(e.target.value)}
+            className="flex-1 rounded-lg border border-gray-300 px-2 py-1.5 text-xs outline-none focus:border-[hsl(142,70%,45%)]"
+            data-testid="diary-form-dice-formula"
+          />
+          <input
+            type="number"
+            placeholder="Totale"
+            value={diceTotal}
+            onChange={e => setDiceTotal(e.target.value)}
+            className="w-20 rounded-lg border border-gray-300 px-2 py-1.5 text-xs outline-none focus:border-[hsl(142,70%,45%)]"
+            data-testid="diary-form-dice-total"
+          />
+        </div>
+      )}
+
+      {selectedType === 'score_change' && (
+        <div className="flex gap-2">
+          {scoreCategories.length > 0 ? (
+            <select
+              value={scoreCategory}
+              onChange={e => setScoreCategory(e.target.value)}
+              className="flex-1 rounded-lg border border-gray-300 px-2 py-1.5 text-xs outline-none focus:border-[hsl(142,70%,45%)]"
+              data-testid="diary-form-score-category"
+            >
+              {scoreCategories.map(cat => (
+                <option key={cat} value={cat}>
+                  {cat}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <input
+              type="text"
+              placeholder="Categoria"
+              value={scoreCategory}
+              onChange={e => setScoreCategory(e.target.value)}
+              className="flex-1 rounded-lg border border-gray-300 px-2 py-1.5 text-xs outline-none focus:border-[hsl(142,70%,45%)]"
+              data-testid="diary-form-score-category"
+            />
+          )}
+          <input
+            type="number"
+            placeholder="±punti"
+            value={scoreDelta}
+            onChange={e => setScoreDelta(e.target.value)}
+            className="w-20 rounded-lg border border-gray-300 px-2 py-1.5 text-xs outline-none focus:border-[hsl(142,70%,45%)]"
+            data-testid="diary-form-score-delta"
+          />
+        </div>
+      )}
+
+      {selectedType === 'turn_change' && players.length > 1 && (
+        <select
+          value={nextPlayerId}
+          onChange={e => setNextPlayerId(e.target.value)}
+          className="rounded-lg border border-gray-300 px-2 py-1.5 text-xs outline-none focus:border-[hsl(142,70%,45%)]"
+          data-testid="diary-form-turn-next"
+        >
+          {players.map(p => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      )}
+
+      {selectedType === 'round_advance' && (
+        <p className="text-xs text-gray-500">Registra inizio Round {currentRound + 1}</p>
+      )}
+
+      {/* Actions */}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="flex-1 rounded-lg border border-gray-300 py-1.5 text-xs font-medium text-gray-500 hover:bg-gray-100"
+          data-testid="diary-form-cancel"
+        >
+          Annulla
+        </button>
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={!canSubmit()}
+          className={cn(
+            'flex-1 rounded-lg py-1.5 text-xs font-medium transition-colors',
+            canSubmit()
+              ? 'bg-[hsl(142,70%,45%)] text-white hover:bg-[hsl(142,70%,40%)]'
+              : 'cursor-not-allowed bg-gray-200 text-gray-400'
+          )}
+          data-testid="diary-form-submit"
+        >
+          Salva
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Round group helper
+// ============================================================================
 
 function groupByRound(events: DiaryEvent[]): Array<{ round: number | null; events: DiaryEvent[] }> {
   const groups: Array<{ round: number | null; events: DiaryEvent[] }> = [];
@@ -34,18 +330,24 @@ function groupByRound(events: DiaryEvent[]): Array<{ round: number | null; event
   return groups;
 }
 
+// ============================================================================
+// EventDiaryTab
+// ============================================================================
+
 export function EventDiaryTab() {
   const { store, logEvent } = useToolkitDrawer();
   const diary = store(s => s.diary);
   const players = store(s => s.players);
+  const scoreCategories = store(s => s.scoreCategories);
   const currentTurnIndex = store(s => s.currentTurnIndex);
+  const currentRound = store(s => s.currentRound);
   const currentPlayer = players[currentTurnIndex];
 
   const [activeFilters, setActiveFilters] = useState<DiaryEventType[]>([]);
-  const [manualText, setManualText] = useState('');
+  const [quickText, setQuickText] = useState('');
+  const [showStructuredForm, setShowStructuredForm] = useState(false);
 
   const filteredEvents = useMemo(() => {
-    // Sort by timestamp desc (most recent first)
     const sorted = [...diary].sort((a, b) => b.timestamp - a.timestamp);
     if (activeFilters.length === 0) return sorted;
     return sorted.filter(e => activeFilters.includes(e.type));
@@ -61,8 +363,9 @@ export function EventDiaryTab() {
 
   const handleReset = () => setActiveFilters([]);
 
-  const handleSubmitManual = () => {
-    const trimmed = manualText.trim();
+  // Quick plain-text note (existing behavior)
+  const handleSubmitQuick = () => {
+    const trimmed = quickText.trim();
     if (!trimmed) return;
     logEvent(
       'manual_entry',
@@ -70,10 +373,20 @@ export function EventDiaryTab() {
       {
         playerId: currentPlayer?.id,
         playerName: currentPlayer?.name,
-        round: store.getState().currentRound,
+        round: currentRound,
       }
     );
-    setManualText('');
+    setQuickText('');
+  };
+
+  // Structured form submit
+  const handleStructuredSubmit = (
+    type: DiaryEventType,
+    payload: Record<string, unknown>,
+    extra?: { playerId?: string; playerName?: string; round?: number }
+  ) => {
+    logEvent(type, payload, extra);
+    setShowStructuredForm(false);
   };
 
   return (
@@ -105,29 +418,51 @@ export function EventDiaryTab() {
         )}
       </div>
 
-      {/* Manual entry input */}
-      <div className="flex items-center gap-2 border-t border-gray-200 pt-2">
-        <input
-          type="text"
-          value={manualText}
-          onChange={e => setManualText(e.target.value)}
-          onKeyDown={e => {
-            if (e.key === 'Enter') handleSubmitManual();
-          }}
-          placeholder="✍️ Aggiungi nota al diario"
-          className="flex-1 rounded-lg border border-gray-300 px-3 py-1.5 text-xs outline-none focus:border-[hsl(142,70%,45%)]"
-          data-testid="diary-manual-input"
+      {/* Bottom entry area */}
+      {showStructuredForm ? (
+        <DiaryEventForm
+          players={players}
+          scoreCategories={scoreCategories}
+          currentRound={currentRound}
+          onSubmit={handleStructuredSubmit}
+          onCancel={() => setShowStructuredForm(false)}
         />
-        <button
-          type="button"
-          onClick={handleSubmitManual}
-          disabled={!manualText.trim()}
-          className="rounded-lg bg-[hsl(142,70%,45%)] px-3 py-1.5 text-xs font-medium text-white disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400"
-          data-testid="diary-manual-submit"
-        >
-          +
-        </button>
-      </div>
+      ) : (
+        <div className="flex flex-col gap-1.5 border-t border-gray-200 pt-2">
+          {/* Quick text note */}
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={quickText}
+              onChange={e => setQuickText(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') handleSubmitQuick();
+              }}
+              placeholder="✍️ Nota rapida…"
+              className="flex-1 rounded-lg border border-gray-300 px-3 py-1.5 text-xs outline-none focus:border-[hsl(142,70%,45%)]"
+              data-testid="diary-manual-input"
+            />
+            <button
+              type="button"
+              onClick={handleSubmitQuick}
+              disabled={!quickText.trim()}
+              className="rounded-lg bg-[hsl(142,70%,45%)] px-3 py-1.5 text-xs font-medium text-white disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400"
+              data-testid="diary-manual-submit"
+            >
+              +
+            </button>
+          </div>
+          {/* Toggle structured form */}
+          <button
+            type="button"
+            onClick={() => setShowStructuredForm(true)}
+            className="text-center text-[10px] text-gray-400 underline-offset-2 hover:text-gray-600 hover:underline"
+            data-testid="diary-structured-form-btn"
+          >
+            + Registra evento strutturato
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/toolkit-drawer/tabs/EventDiaryTab.tsx
+++ b/apps/web/src/components/toolkit-drawer/tabs/EventDiaryTab.tsx
@@ -80,7 +80,7 @@ function DiaryEventForm({
 
   const player = players.find(p => p.id === selectedPlayerId) ?? null;
 
-  const canSubmit = (): boolean => {
+  const canSubmit = useMemo(() => {
     switch (selectedType) {
       case 'manual_entry':
         return noteText.trim() !== '';
@@ -95,10 +95,10 @@ function DiaryEventForm({
       default:
         return false;
     }
-  };
+  }, [selectedType, noteText, diceFormula, diceTotal, scoreCategory, scoreDelta, nextPlayerId]);
 
   const handleSubmit = () => {
-    if (!canSubmit()) return;
+    if (!canSubmit) return;
 
     const extra = player
       ? { playerId: player.id, playerName: player.name, round: currentRound }
@@ -191,7 +191,7 @@ function DiaryEventForm({
           value={noteText}
           onChange={e => setNoteText(e.target.value)}
           onKeyDown={e => {
-            if (e.key === 'Enter' && canSubmit()) handleSubmit();
+            if (e.key === 'Enter' && canSubmit) handleSubmit();
           }}
           autoFocus
           className="rounded-lg border border-gray-300 px-2 py-1.5 text-xs outline-none focus:border-[hsl(142,70%,45%)]"
@@ -288,10 +288,10 @@ function DiaryEventForm({
         <button
           type="button"
           onClick={handleSubmit}
-          disabled={!canSubmit()}
+          disabled={!canSubmit}
           className={cn(
             'flex-1 rounded-lg py-1.5 text-xs font-medium transition-colors',
-            canSubmit()
+            canSubmit
               ? 'bg-[hsl(142,70%,45%)] text-white hover:bg-[hsl(142,70%,40%)]'
               : 'cursor-not-allowed bg-gray-200 text-gray-400'
           )}

--- a/apps/web/src/components/toolkit-drawer/tabs/ScoreboardTab.tsx
+++ b/apps/web/src/components/toolkit-drawer/tabs/ScoreboardTab.tsx
@@ -56,7 +56,7 @@ function AddCategoryButton({ onAdd }: { onAdd: (name: string) => void }) {
           if (e.key === 'Enter') submit();
           if (e.key === 'Escape') setOpen(false);
         }}
-        placeholder="Nome"
+        placeholder="es. Catan"
         className="w-20 rounded border border-[hsl(142,70%,45%)] px-1 text-[10px] outline-none"
         data-testid="add-category-input"
       />
@@ -178,7 +178,7 @@ export function ScoreboardTab() {
     <div className="flex flex-col gap-3" data-testid="scoreboard-tab">
       {/* Categories row */}
       <div className="flex items-center justify-between">
-        <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-400">Categorie</h3>
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-400">Partite</h3>
         <AddCategoryButton onAdd={handleAddCategory} />
       </div>
 

--- a/apps/web/src/components/toolkit-drawer/tabs/TimerDisplay.tsx
+++ b/apps/web/src/components/toolkit-drawer/tabs/TimerDisplay.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+/**
+ * TimerDisplay — Circular countdown ring with color transitions and
+ * shake animation in the last 10 seconds.
+ *
+ * Stateless: receives remaining/total/status as props so it
+ * can be tested independently from the store.
+ */
+
+import React from 'react';
+
+import { motion } from 'framer-motion';
+
+import type { TimerStatus } from '@/stores/toolkit-timer-store';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+export function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+}
+
+function ringColor(progress: number, status: TimerStatus): string {
+  if (status === 'ended') return '#ef4444';
+  if (progress > 0.5) return 'hsl(142,70%,45%)';
+  if (progress > 0.2) return '#f59e0b';
+  return '#ef4444';
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+interface TimerDisplayProps {
+  remaining: number;
+  total: number;
+  status: TimerStatus;
+}
+
+const RADIUS = 52;
+const SIZE = 144;
+const CENTER = SIZE / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+export function TimerDisplay({ remaining, total, status }: TimerDisplayProps) {
+  const progress = total > 0 ? Math.min(1, remaining / total) : 0;
+  const color = ringColor(progress, status);
+  const dashOffset = CIRCUMFERENCE * (1 - progress);
+
+  const isShaking = status === 'running' && remaining > 0 && remaining <= 10;
+
+  return (
+    <motion.div
+      className="relative flex items-center justify-center mx-auto"
+      style={{ width: SIZE, height: SIZE }}
+      data-testid="timer-display-wrapper"
+      animate={isShaking ? { x: [-3, 3, -3, 3, -2, 2, -1, 1, 0] } : { x: 0 }}
+      transition={
+        isShaking ? { duration: 0.5, repeat: Infinity, repeatType: 'loop' } : { duration: 0.1 }
+      }
+    >
+      {/* Circular progress ring (SVG rotated so arc starts at 12 o'clock) */}
+      <svg
+        className="absolute inset-0"
+        width={SIZE}
+        height={SIZE}
+        viewBox={`0 0 ${SIZE} ${SIZE}`}
+        style={{ transform: 'rotate(-90deg)' }}
+        aria-hidden="true"
+      >
+        {/* Track */}
+        <circle cx={CENTER} cy={CENTER} r={RADIUS} fill="none" stroke="#e5e7eb" strokeWidth="9" />
+        {/* Progress arc */}
+        <circle
+          cx={CENTER}
+          cy={CENTER}
+          r={RADIUS}
+          fill="none"
+          stroke={color}
+          strokeWidth="9"
+          strokeLinecap="round"
+          strokeDasharray={CIRCUMFERENCE}
+          strokeDashoffset={dashOffset}
+          style={{
+            transition: 'stroke-dashoffset 0.45s linear, stroke 0.6s ease',
+          }}
+        />
+      </svg>
+
+      {/* Time label */}
+      <div className="z-10 flex flex-col items-center gap-0.5 select-none">
+        <span
+          className="text-3xl font-bold font-mono tabular-nums leading-none"
+          style={{ color, transition: 'color 0.6s ease' }}
+          data-testid="timer-display"
+        >
+          {formatTime(remaining)}
+        </span>
+        {status === 'ended' && (
+          <span className="text-[11px] font-bold tracking-wide text-red-500 animate-pulse">
+            Tempo!
+          </span>
+        )}
+        {status === 'paused' && (
+          <span className="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">
+            Pausa
+          </span>
+        )}
+      </div>
+    </motion.div>
+  );
+}

--- a/apps/web/src/components/toolkit-drawer/tabs/TimerPresetRow.tsx
+++ b/apps/web/src/components/toolkit-drawer/tabs/TimerPresetRow.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+/**
+ * TimerPresetRow — Row of quick-select preset durations.
+ */
+
+import React from 'react';
+
+import { cn } from '@/lib/utils';
+
+// ============================================================================
+// Presets
+// ============================================================================
+
+const PRESETS = [
+  { label: '30s', seconds: 30 },
+  { label: '1m', seconds: 60 },
+  { label: '2m', seconds: 120 },
+  { label: '3m', seconds: 180 },
+  { label: '5m', seconds: 300 },
+  { label: '10m', seconds: 600 },
+] as const;
+
+// ============================================================================
+// Component
+// ============================================================================
+
+interface TimerPresetRowProps {
+  /** Currently selected duration in seconds (matches totalSeconds in store). */
+  selected: number;
+  onSelect: (seconds: number) => void;
+}
+
+export function TimerPresetRow({ selected, onSelect }: TimerPresetRowProps) {
+  return (
+    <div className="flex flex-wrap justify-center gap-2" data-testid="timer-preset-row">
+      {PRESETS.map(p => {
+        const isActive = selected === p.seconds;
+        return (
+          <button
+            key={p.seconds}
+            type="button"
+            onClick={() => onSelect(p.seconds)}
+            className={cn(
+              'min-w-[42px] rounded-lg px-3 py-1.5 text-xs font-bold transition-colors',
+              isActive
+                ? 'bg-[hsl(142,70%,45%)] text-white shadow-sm'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+            )}
+            aria-pressed={isActive}
+            data-testid={`timer-preset-${p.seconds}`}
+          >
+            {p.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/toolkit-drawer/tabs/TimerTab.tsx
+++ b/apps/web/src/components/toolkit-drawer/tabs/TimerTab.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+/**
+ * TimerTab — Countdown timer tab for the Default Game Toolkit.
+ *
+ * State lives in the module-level `toolkit-timer-store` (survives drawer
+ * close/reopen). Sound and diary logging are handled in ToolkitDrawerInner
+ * (always mounted while the drawer is open) so they fire even when the user
+ * is on a different tab.
+ *
+ * Layout:
+ *   [Preset row: 30s 1m 2m 3m 5m 10m]
+ *   [Circular countdown ring]
+ *   [−1m]  [▶/⏸/↺]  [+1m]
+ *   [Reset]
+ *   [☑ Reset automatico al cambio turno]
+ */
+
+import React, { useCallback } from 'react';
+
+import { cn } from '@/lib/utils';
+import { getTimerStore } from '@/stores/toolkit-timer-store';
+
+import { useToolkitDrawer } from '../ToolkitDrawerProvider';
+import { TimerDisplay } from './TimerDisplay';
+import { TimerPresetRow } from './TimerPresetRow';
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function TimerTab() {
+  const { gameId } = useToolkitDrawer();
+  const timerStore = getTimerStore(gameId);
+
+  const remaining = timerStore(s => s.remaining);
+  const total = timerStore(s => s.totalSeconds);
+  const status = timerStore(s => s.status);
+  const autoReset = timerStore(s => s.autoResetOnTurn);
+
+  const handlePreset = useCallback(
+    (seconds: number) => timerStore.getState().setDuration(seconds),
+    [timerStore]
+  );
+
+  const handlePlayPause = useCallback(() => {
+    const s = timerStore.getState();
+    if (s.status === 'running') {
+      s.pause();
+    } else if (s.status === 'ended') {
+      s.reset(); // first click resets; user presses play again to start
+    } else {
+      s.start();
+    }
+  }, [timerStore]);
+
+  const handleReset = useCallback(() => timerStore.getState().reset(), [timerStore]);
+
+  const handleMinus = useCallback(() => timerStore.getState().adjustTime(-60), [timerStore]);
+  const handlePlus = useCallback(() => timerStore.getState().adjustTime(60), [timerStore]);
+
+  const handleAutoReset = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) =>
+      timerStore.getState().setAutoResetOnTurn(e.target.checked),
+    [timerStore]
+  );
+
+  const isPlaying = status === 'running';
+  const isEnded = status === 'ended';
+
+  return (
+    <div className="flex flex-col items-center gap-5 py-2" data-testid="timer-tab">
+      {/* Preset row */}
+      <TimerPresetRow selected={total} onSelect={handlePreset} />
+
+      {/* Circular ring display */}
+      <TimerDisplay remaining={remaining} total={total} status={status} />
+
+      {/* Adjust ± 1 minute + main control */}
+      <div className="flex items-center gap-4">
+        <button
+          type="button"
+          onClick={handleMinus}
+          disabled={remaining <= 0}
+          className="w-12 rounded-xl bg-gray-100 py-2 text-sm font-bold text-gray-600 hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-40 transition-colors"
+          aria-label="Rimuovi 1 minuto"
+          data-testid="timer-minus-1m"
+        >
+          −1m
+        </button>
+
+        {/* Play / Pause / Restart */}
+        <button
+          type="button"
+          onClick={handlePlayPause}
+          className={cn(
+            'flex h-16 w-16 items-center justify-center rounded-full text-2xl font-bold shadow-md transition-all active:scale-95',
+            isEnded
+              ? 'bg-red-500 text-white hover:bg-red-600'
+              : 'bg-[hsl(142,70%,45%)] text-white hover:bg-[hsl(142,70%,40%)]'
+          )}
+          aria-label={isEnded ? 'Ricomincia' : isPlaying ? 'Pausa' : 'Avvia'}
+          data-testid="timer-play-pause"
+        >
+          {isEnded ? '↺' : isPlaying ? '⏸' : '▶'}
+        </button>
+
+        <button
+          type="button"
+          onClick={handlePlus}
+          className="w-12 rounded-xl bg-gray-100 py-2 text-sm font-bold text-gray-600 hover:bg-gray-200 transition-colors"
+          aria-label="Aggiungi 1 minuto"
+          data-testid="timer-plus-1m"
+        >
+          +1m
+        </button>
+      </div>
+
+      {/* Reset link */}
+      <button
+        type="button"
+        onClick={handleReset}
+        className="text-xs text-gray-400 underline-offset-2 hover:text-gray-600 hover:underline"
+        data-testid="timer-reset"
+      >
+        Reset
+      </button>
+
+      {/* Auto-reset on turn toggle */}
+      <label className="flex cursor-pointer items-center gap-2 rounded-xl border border-gray-200 bg-gray-50 px-4 py-2.5">
+        <input
+          type="checkbox"
+          checked={autoReset}
+          onChange={handleAutoReset}
+          className="h-4 w-4 accent-[hsl(142,70%,45%)]"
+          data-testid="timer-auto-reset-checkbox"
+        />
+        <span className="text-xs text-gray-600">Reset automatico al cambio turno</span>
+      </label>
+    </div>
+  );
+}

--- a/apps/web/src/components/toolkit-drawer/types.ts
+++ b/apps/web/src/components/toolkit-drawer/types.ts
@@ -9,7 +9,7 @@
 // Tab Navigation
 // ============================================================================
 
-export type ToolkitTab = 'dice' | 'notes' | 'diary' | 'scores';
+export type ToolkitTab = 'dice' | 'timer' | 'notes' | 'diary' | 'scores';
 
 // ============================================================================
 // Diary Event Types
@@ -23,7 +23,8 @@ export type DiaryEventType =
   | 'manual_entry'
   | 'player_joined'
   | 'round_advance'
-  | 'score_reset';
+  | 'score_reset'
+  | 'timer_end';
 
 // ============================================================================
 // Player

--- a/apps/web/src/stores/toolkit-timer-store.ts
+++ b/apps/web/src/stores/toolkit-timer-store.ts
@@ -114,9 +114,11 @@ export function getTimerStore(gameId: string): UseBoundStore<StoreApi<TimerStore
       },
 
       adjustTime(deltaSec: number) {
-        set(s => ({
-          remaining: Math.max(0, Math.min(s.remaining + deltaSec, 5999)),
-        }));
+        set(s => {
+          const newRemaining = Math.max(0, Math.min(s.remaining + deltaSec, 5999));
+          const newStatus = s.status === 'ended' && newRemaining > 0 ? 'paused' : s.status;
+          return { remaining: newRemaining, status: newStatus };
+        });
       },
 
       setAutoResetOnTurn(enabled: boolean) {
@@ -128,4 +130,13 @@ export function getTimerStore(gameId: string): UseBoundStore<StoreApi<TimerStore
   }
 
   return storeRegistry.get(gameId)!;
+}
+
+/**
+ * Destroys the timer store for a given gameId, clearing the interval and
+ * removing it from the registry. Call when the ToolkitDrawer unmounts.
+ */
+export function destroyTimerStore(gameId: string): void {
+  clearTimerInterval(gameId);
+  storeRegistry.delete(gameId);
 }

--- a/apps/web/src/stores/toolkit-timer-store.ts
+++ b/apps/web/src/stores/toolkit-timer-store.ts
@@ -1,0 +1,131 @@
+'use client';
+
+/**
+ * Toolkit Timer Store — Module-level singleton per gameId
+ *
+ * The store and the `setInterval` live outside React's lifecycle so the
+ * countdown continues even when the ToolkitDrawer is closed.
+ * Callers (ToolkitDrawerInner, TimerTab) subscribe via Zustand selectors.
+ *
+ * Module-level registries:
+ *  - intervalRegistry: stores the active setInterval ID per gameId
+ *  - storeRegistry:    stores the Zustand store instance per gameId
+ */
+
+import { create } from 'zustand';
+
+import type { StoreApi, UseBoundStore } from 'zustand';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type TimerStatus = 'idle' | 'running' | 'paused' | 'ended';
+
+export interface TimerStoreState {
+  totalSeconds: number;
+  remaining: number;
+  status: TimerStatus;
+  autoResetOnTurn: boolean;
+}
+
+export interface TimerStoreActions {
+  start: () => void;
+  pause: () => void;
+  reset: () => void;
+  setDuration: (seconds: number) => void;
+  /** Add/subtract seconds from remaining (does NOT change totalSeconds). */
+  adjustTime: (deltaSec: number) => void;
+  setAutoResetOnTurn: (enabled: boolean) => void;
+}
+
+export type TimerStore = TimerStoreState & TimerStoreActions;
+
+// ============================================================================
+// Module-level registries (survive React unmounts)
+// ============================================================================
+
+const intervalRegistry = new Map<string, ReturnType<typeof setInterval>>();
+const storeRegistry = new Map<string, UseBoundStore<StoreApi<TimerStore>>>();
+
+function clearTimerInterval(gameId: string) {
+  const id = intervalRegistry.get(gameId);
+  if (id !== undefined) {
+    clearInterval(id);
+    intervalRegistry.delete(gameId);
+  }
+}
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+/**
+ * Returns (or lazily creates) the timer store for a given gameId.
+ * Safe to call multiple times — always returns the same instance.
+ */
+export function getTimerStore(gameId: string): UseBoundStore<StoreApi<TimerStore>> {
+  if (!storeRegistry.has(gameId)) {
+    const store = create<TimerStore>()((set, get) => ({
+      totalSeconds: 60,
+      remaining: 60,
+      status: 'idle',
+      autoResetOnTurn: false,
+
+      start() {
+        const { status, remaining } = get();
+        if (status === 'running' || remaining <= 0) return;
+
+        set({ status: 'running' });
+        clearTimerInterval(gameId); // guard against double-start
+
+        const id = setInterval(() => {
+          const { remaining: rem } = get();
+          if (rem <= 1) {
+            clearTimerInterval(gameId);
+            set({ remaining: 0, status: 'ended' });
+            if (typeof window !== 'undefined') {
+              window.dispatchEvent(new CustomEvent('toolkit:timer-end', { detail: { gameId } }));
+            }
+          } else {
+            set({ remaining: rem - 1 });
+          }
+        }, 1000);
+
+        intervalRegistry.set(gameId, id);
+      },
+
+      pause() {
+        if (get().status !== 'running') return;
+        clearTimerInterval(gameId);
+        set({ status: 'paused' });
+      },
+
+      reset() {
+        clearTimerInterval(gameId);
+        set(s => ({ remaining: s.totalSeconds, status: 'idle' }));
+      },
+
+      setDuration(seconds: number) {
+        clearTimerInterval(gameId);
+        // Clamp: 5 s – 99m59s
+        const clamped = Math.max(5, Math.min(seconds, 5999));
+        set({ totalSeconds: clamped, remaining: clamped, status: 'idle' });
+      },
+
+      adjustTime(deltaSec: number) {
+        set(s => ({
+          remaining: Math.max(0, Math.min(s.remaining + deltaSec, 5999)),
+        }));
+      },
+
+      setAutoResetOnTurn(enabled: boolean) {
+        set({ autoResetOnTurn: enabled });
+      },
+    }));
+
+    storeRegistry.set(gameId, store);
+  }
+
+  return storeRegistry.get(gameId)!;
+}


### PR DESCRIPTION
## Summary

- **TimerTab** (nuovo): countdown con preset 30s-10m, anello SVG circolare con transizioni colore green→amber→red, shake animation <10s, Web Audio 3-beep a scadenza, auto-reset al cambio turno. Store module-level () sopravvive a drawer close/reopen
- **DiceRollerTab**: ogni tiro ora attribuisce il giocatore corrente nel diario (); CTA row post-risultato con  (stessa formula) e  (avanza turno + ritira); form inline  (giocatore + formula + totale)
- **EventDiaryTab**: form strutturato  con type picker (nota/dado/punti/turno/round), giocatore selector, campi dinamici per tipo; la nota rapida esistente rimane invariata
- **ScoreboardTab**: label  →  per guidare il win-tracking (US4)
- **Mockup mobile** : 4 panel per US2/US3/US4

## Test plan

- [ ] TimerTab: seleziona preset → anello si aggiorna; play → countdown scende; pausa → riprende; reset → torna a totalSeconds; drawer chiuso e riaperto → timer continua
- [ ] Timer <10s → shake animation visibile; scadenza → beep + evento  nel diario
- [ ] Auto-reset checkbox → avanzare turno dalla PlayerBar resetta il timer
- [ ] DiceRollerTab: tira dado con giocatore configurato → evento diario mostra nome giocatore
- [ ] CTA  → ri-tira stessa formula, stessa player attribution
- [ ] CTA  → avanza turno, ri-tira, evento diario attribuito ad Alice
- [ ]  → form aperto → salva → evento nel diario con formula/totale
- [ ] EventDiaryTab: click  → form aperto
- [ ] Seleziona tipo Dado → formula + totale; tipo Punti → categoria + delta; tipo Turno → select giocatore
- [ ] Salva → evento appare nel diario con icona e descrizione corretti
- [ ] ScoreboardTab: label colonna titolo = Partite; placeholder input nuovo = es. Catan

🤖 Generated with [Claude Code](https://claude.com/claude-code)