### PR TITLE
feat(session-ux): StartSessionSheet + inline agent chat from game card

### DIFF
--- a/apps/web/src/app/(authenticated)/library/games/[gameId]/game-detail-mobile.tsx
+++ b/apps/web/src/app/(authenticated)/library/games/[gameId]/game-detail-mobile.tsx
@@ -18,6 +18,7 @@ import { useRouter } from 'next/navigation';
 import { FocusedGameCard } from '@/components/game-detail/mobile/FocusedGameCard';
 import { GameDetailsDrawer } from '@/components/game-detail/mobile/GameDetailsDrawer';
 import { type GameTabId } from '@/components/game-detail/tabs';
+import { StartSessionSheet } from '@/components/session/StartSessionSheet';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/feedback/alert';
 import { Button } from '@/components/ui/primitives/button';
 import { useLibraryGameDetail } from '@/hooks/queries/useLibrary';
@@ -31,6 +32,7 @@ export default function GameDetailMobile({ gameId }: GameDetailMobileProps) {
   const { data: game, isLoading, error } = useLibraryGameDetail(gameId);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [initialTab, setInitialTab] = useState<GameTabId>('info');
+  const [sessionSheetOpen, setSessionSheetOpen] = useState(false);
 
   const handleOpenDrawer = () => {
     setInitialTab('info');
@@ -84,13 +86,23 @@ export default function GameDetailMobile({ gameId }: GameDetailMobileProps) {
 
   return (
     <div className="flex h-full flex-col" data-testid="game-detail-mobile">
-      <FocusedGameCard game={game} onOpenDrawer={handleOpenDrawer} />
+      <FocusedGameCard
+        game={game}
+        onOpenDrawer={handleOpenDrawer}
+        onStartSession={() => setSessionSheetOpen(true)}
+      />
       <GameDetailsDrawer
         open={drawerOpen}
         onOpenChange={setDrawerOpen}
         gameId={gameId}
         initialTab={initialTab}
         isNotInLibrary={false}
+      />
+      <StartSessionSheet
+        open={sessionSheetOpen}
+        onOpenChange={setSessionSheetOpen}
+        gameId={gameId}
+        gameName={game.gameTitle}
       />
     </div>
   );

--- a/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/play-mode-mobile.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/play-mode-mobile.tsx
@@ -506,12 +506,14 @@ export function PlayModeMobile({ sessionId }: PlayModeMobileProps) {
           </p>
           <div className="flex gap-3">
             <button
+              type="button"
               onClick={() => setShowEndConfirm(false)}
               className="flex-1 rounded-xl bg-white/10 py-3 text-sm font-medium hover:bg-white/20"
             >
               Annulla
             </button>
             <button
+              type="button"
               onClick={handleEndSession}
               className="flex-1 rounded-xl bg-red-500 py-3 text-sm font-medium text-white hover:bg-red-600"
             >

--- a/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/play-mode-mobile.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/play-mode-mobile.tsx
@@ -17,9 +17,9 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 
 import { Timer, MessageCircle, Crown, LogOut } from 'lucide-react';
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
+import { ChatSlideOverPanel } from '@/components/chat/panel/ChatSlideOverPanel';
 import { LiveScoreboard } from '@/components/game-night/LiveScoreboard';
 import type { LiveScoreboardPlayer } from '@/components/game-night/LiveScoreboard';
 import { GameOverModal } from '@/components/session/live/GameOverModal';
@@ -33,6 +33,7 @@ import { GradientButton } from '@/components/ui/buttons/GradientButton';
 import { MobileHeader } from '@/components/ui/navigation/MobileHeader';
 import { SessionBottomNav, type SessionTab } from '@/components/ui/navigation/SessionBottomNav';
 import { BottomSheet } from '@/components/ui/overlays/BottomSheet';
+import { useChatPanel } from '@/hooks/useChatPanel';
 import { api } from '@/lib/api';
 import type { TurnPhasesDto } from '@/lib/api/schemas/live-sessions.schemas';
 import { PLAYER_COLOR_HEX } from '@/lib/constants/player-colors';
@@ -83,6 +84,9 @@ export function PlayModeMobile({ sessionId }: PlayModeMobileProps) {
 
   // End session confirm
   const [showEndConfirm, setShowEndConfirm] = useState(false);
+
+  // Chat panel (inline slide-over, no navigation)
+  const { open: openChat } = useChatPanel();
   const [sessionEnded, setSessionEnded] = useState(false);
 
   // Turn phases
@@ -371,14 +375,27 @@ export function PlayModeMobile({ sessionId }: PlayModeMobileProps) {
                 Hai dubbi sulle regole? Chiedi al nostro assistente e ottieni risposte immediate.
               </p>
             </div>
-            <Link
-              href={session?.gameId ? `/chat?gameId=${session.gameId}` : '/chat'}
-              className="w-full max-w-xs"
-            >
-              <GradientButton fullWidth size="lg">
+            <div className="w-full max-w-xs">
+              <GradientButton
+                fullWidth
+                size="lg"
+                onClick={() =>
+                  openChat(
+                    session?.gameId && session.gameName
+                      ? {
+                          id: session.gameId,
+                          name: session.gameName,
+                          pdfCount: 0,
+                          kbStatus: 'ready',
+                        }
+                      : undefined
+                  )
+                }
+                data-testid="open-chat-btn"
+              >
                 Apri Chat AI
               </GradientButton>
-            </Link>
+            </div>
           </div>
         )}
 
@@ -503,6 +520,9 @@ export function PlayModeMobile({ sessionId }: PlayModeMobileProps) {
           </div>
         </div>
       </BottomSheet>
+
+      {/* Chat slide-over — keeps user in session, no navigation */}
+      <ChatSlideOverPanel />
     </div>
   );
 }

--- a/apps/web/src/components/game-detail/mobile/FocusedGameCard.tsx
+++ b/apps/web/src/components/game-detail/mobile/FocusedGameCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FileText } from 'lucide-react';
+import { FileText, Play } from 'lucide-react';
 
 import { MeepleCard } from '@/components/ui/data-display/meeple-card/MeepleCard';
 import type { MeepleCardMetadata } from '@/components/ui/data-display/meeple-card/types';
@@ -10,6 +10,7 @@ import type { LibraryGameDetail } from '@/hooks/queries/useLibrary';
 interface FocusedGameCardProps {
   game: LibraryGameDetail;
   onOpenDrawer: () => void;
+  onStartSession: () => void;
 }
 
 /**
@@ -21,7 +22,7 @@ interface FocusedGameCardProps {
  *
  * Reference: docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md §4.5
  */
-export function FocusedGameCard({ game, onOpenDrawer }: FocusedGameCardProps) {
+export function FocusedGameCard({ game, onOpenDrawer, onStartSession }: FocusedGameCardProps) {
   const metadata: MeepleCardMetadata[] = [];
   if (game.gameYearPublished) {
     metadata.push({ label: String(game.gameYearPublished) });
@@ -53,16 +54,29 @@ export function FocusedGameCard({ game, onOpenDrawer }: FocusedGameCardProps) {
         />
       </div>
 
-      <Button
-        type="button"
-        onClick={onOpenDrawer}
-        size="lg"
-        className="w-full gap-2"
-        data-testid="focused-game-details-button"
-      >
-        <FileText className="h-4 w-4" />
-        Dettagli
-      </Button>
+      <div className="flex gap-2">
+        <Button
+          type="button"
+          onClick={onStartSession}
+          size="lg"
+          className="flex-1 gap-2 bg-[hsl(142,70%,45%)] text-white hover:bg-[hsl(142,70%,40%)]"
+          data-testid="focused-game-start-button"
+        >
+          <Play className="h-4 w-4" />
+          Avvia Partita
+        </Button>
+        <Button
+          type="button"
+          onClick={onOpenDrawer}
+          size="lg"
+          variant="outline"
+          className="gap-2"
+          data-testid="focused-game-details-button"
+        >
+          <FileText className="h-4 w-4" />
+          Dettagli
+        </Button>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/session/StartSessionSheet.tsx
+++ b/apps/web/src/components/session/StartSessionSheet.tsx
@@ -1,0 +1,349 @@
+'use client';
+
+/**
+ * StartSessionSheet — 2-step bottom sheet to start a session from a library game card.
+ *
+ * Step 1 — Giocatori: add/remove players with name + color
+ * Step 2 — Ordine turni: drag to reorder turn order → Avvia Partita
+ *
+ * Game is pre-selected (passed as prop). Navigates to /sessions/live/{id} on start.
+ */
+
+import { useCallback, useState } from 'react';
+
+import { GripVertical, Plus, Trash2, X } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+
+import { GradientButton } from '@/components/ui/buttons/GradientButton';
+import { BottomSheet } from '@/components/ui/overlays/BottomSheet';
+import { Button } from '@/components/ui/primitives/button';
+import { Input } from '@/components/ui/primitives/input';
+import { api } from '@/lib/api';
+import type { PlayerColor } from '@/lib/api/schemas/live-sessions.schemas';
+import { cn } from '@/lib/utils';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface SheetPlayer {
+  id: string;
+  name: string;
+  color: PlayerColor;
+}
+
+type SheetStep = 'players' | 'order';
+
+interface StartSessionSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  gameId: string;
+  gameName: string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const COLOR_OPTIONS: { value: PlayerColor; hex: string; label: string }[] = [
+  { value: 'Red', hex: '#ef4444', label: 'Rosso' },
+  { value: 'Blue', hex: '#3b82f6', label: 'Blu' },
+  { value: 'Green', hex: '#22c55e', label: 'Verde' },
+  { value: 'Yellow', hex: '#eab308', label: 'Giallo' },
+  { value: 'Purple', hex: '#a855f7', label: 'Viola' },
+  { value: 'Orange', hex: '#f97316', label: 'Arancione' },
+];
+
+const STEP_LABELS: Record<SheetStep, string> = {
+  players: 'Giocatori',
+  order: 'Ordine turni',
+};
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function StartSessionSheet({
+  open,
+  onOpenChange,
+  gameId,
+  gameName,
+}: StartSessionSheetProps) {
+  const router = useRouter();
+
+  const [step, setStep] = useState<SheetStep>('players');
+  const [players, setPlayers] = useState<SheetPlayer[]>([
+    { id: `p-${Date.now()}`, name: 'Giocatore 1', color: 'Red' },
+  ]);
+  const [newName, setNewName] = useState('');
+  const [isCreating, setIsCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Drag state for step 2
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+
+  const usedColors = players.map(p => p.color);
+  const nextColor =
+    COLOR_OPTIONS.find(c => !usedColors.includes(c.value))?.value ?? COLOR_OPTIONS[0].value;
+
+  const handleClose = () => {
+    onOpenChange(false);
+    // Reset after close animation
+    setTimeout(() => {
+      setStep('players');
+      setPlayers([{ id: `p-${Date.now()}`, name: 'Giocatore 1', color: 'Red' }]);
+      setNewName('');
+      setError(null);
+    }, 300);
+  };
+
+  // ── Players step ────────────────────────────────────────────────────────────
+
+  const addPlayer = useCallback(() => {
+    const trimmed = newName.trim();
+    if (!trimmed) return;
+    setPlayers(prev => [...prev, { id: `p-${Date.now()}`, name: trimmed, color: nextColor }]);
+    setNewName('');
+  }, [newName, nextColor]);
+
+  const removePlayer = (id: string) => setPlayers(prev => prev.filter(p => p.id !== id));
+
+  const setColor = (id: string, color: PlayerColor) =>
+    setPlayers(prev => prev.map(p => (p.id === id ? { ...p, color } : p)));
+
+  // ── Order step ──────────────────────────────────────────────────────────────
+
+  const handleDragStart = (idx: number) => setDragIndex(idx);
+  const handleDragOver = (e: React.DragEvent) => e.preventDefault();
+  const handleDrop = (targetIdx: number) => {
+    if (dragIndex === null || dragIndex === targetIdx) {
+      setDragIndex(null);
+      return;
+    }
+    const reordered = [...players];
+    const [moved] = reordered.splice(dragIndex, 1);
+    reordered.splice(targetIdx, 0, moved);
+    setPlayers(reordered);
+    setDragIndex(null);
+  };
+
+  // ── Start session ───────────────────────────────────────────────────────────
+
+  const handleStart = useCallback(async () => {
+    if (players.length === 0) return;
+    setIsCreating(true);
+    setError(null);
+
+    try {
+      const sessionId = await api.liveSessions.createSession({
+        gameName,
+        gameId,
+      });
+
+      for (const player of players) {
+        try {
+          await api.liveSessions.addPlayer(sessionId, {
+            displayName: player.name,
+            color: player.color,
+          });
+        } catch {
+          // Non-blocking — continue with remaining players
+        }
+      }
+
+      router.push(`/sessions/live/${sessionId}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Impossibile avviare la sessione.');
+      setIsCreating(false);
+    }
+  }, [players, gameId, gameName, router]);
+
+  // ── Render ──────────────────────────────────────────────────────────────────
+
+  const title = step === 'players' ? 'Aggiungi giocatori' : 'Ordine dei turni';
+
+  return (
+    <BottomSheet open={open} onOpenChange={handleClose} title={title} height="full">
+      {/* Step indicator */}
+      <div className="flex items-center gap-2 mb-4 -mt-1" data-testid="step-indicator">
+        {(['players', 'order'] as SheetStep[]).map((s, i) => (
+          <div key={s} className="flex items-center gap-2">
+            {i > 0 && <div className="h-px w-6 bg-white/20" />}
+            <div
+              className={cn(
+                'flex items-center gap-1.5 text-xs font-medium',
+                step === s ? 'text-white' : 'text-white/40'
+              )}
+            >
+              <span
+                className={cn(
+                  'flex h-5 w-5 items-center justify-center rounded-full text-[10px] font-bold',
+                  step === s
+                    ? 'bg-[hsl(142,70%,45%)] text-white'
+                    : s === 'players' && step === 'order'
+                      ? 'bg-white/20 text-white/60'
+                      : 'bg-white/10 text-white/40'
+                )}
+              >
+                {i + 1}
+              </span>
+              {STEP_LABELS[s]}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* ── Step 1: Players ── */}
+      {step === 'players' && (
+        <div className="flex flex-col gap-4" data-testid="players-step">
+          {/* Player list */}
+          <div className="flex flex-col gap-2">
+            {players.map(p => (
+              <div
+                key={p.id}
+                className="flex items-center gap-2 rounded-xl bg-white/5 px-3 py-2.5"
+                data-testid={`player-row-${p.id}`}
+              >
+                {/* Name */}
+                <span className="flex-1 text-sm font-medium text-white">{p.name}</span>
+
+                {/* Color picker */}
+                <div className="flex items-center gap-1">
+                  {COLOR_OPTIONS.map(c => (
+                    <button
+                      key={c.value}
+                      type="button"
+                      aria-label={c.label}
+                      onClick={() => setColor(p.id, c.value)}
+                      className={cn(
+                        'h-5 w-5 rounded-full transition-transform',
+                        p.color === c.value ? 'scale-125 ring-2 ring-white/60' : 'opacity-60'
+                      )}
+                      style={{ backgroundColor: c.hex }}
+                    />
+                  ))}
+                </div>
+
+                {/* Remove */}
+                <button
+                  type="button"
+                  onClick={() => removePlayer(p.id)}
+                  disabled={players.length <= 1}
+                  aria-label={`Rimuovi ${p.name}`}
+                  className="text-white/40 hover:text-red-400 disabled:opacity-20"
+                  data-testid={`remove-player-${p.id}`}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+
+          {/* Add player form */}
+          <div className="flex gap-2">
+            <Input
+              value={newName}
+              onChange={e => setNewName(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') addPlayer();
+              }}
+              placeholder="Nome giocatore…"
+              className="flex-1 bg-white/10 border-white/20 text-white placeholder:text-white/40"
+              data-testid="new-player-input"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              onClick={addPlayer}
+              disabled={!newName.trim()}
+              aria-label="Aggiungi giocatore"
+              className="border-white/20 text-white hover:bg-white/10"
+              data-testid="add-player-btn"
+            >
+              <Plus className="h-4 w-4" />
+            </Button>
+          </div>
+
+          {/* Next step */}
+          <GradientButton
+            fullWidth
+            disabled={players.length === 0}
+            onClick={() => setStep('order')}
+            data-testid="next-step-btn"
+          >
+            Continua →
+          </GradientButton>
+        </div>
+      )}
+
+      {/* ── Step 2: Turn order ── */}
+      {step === 'order' && (
+        <div className="flex flex-col gap-4" data-testid="order-step">
+          <p className="text-xs text-white/50">
+            Trascina per cambiare l&apos;ordine dei turni. Il primo in lista inizia.
+          </p>
+
+          {/* Draggable list */}
+          <div className="flex flex-col gap-2">
+            {players.map((p, idx) => {
+              const colorHex = COLOR_OPTIONS.find(c => c.value === p.color)?.hex ?? '#888';
+              return (
+                <div
+                  key={p.id}
+                  draggable
+                  onDragStart={() => handleDragStart(idx)}
+                  onDragOver={handleDragOver}
+                  onDrop={() => handleDrop(idx)}
+                  className={cn(
+                    'flex items-center gap-3 rounded-xl bg-white/5 px-3 py-3 cursor-grab',
+                    dragIndex === idx && 'opacity-40'
+                  )}
+                  data-testid={`order-row-${p.id}`}
+                >
+                  <span className="text-sm font-bold tabular-nums text-white/40 w-4">
+                    {idx + 1}
+                  </span>
+                  <span
+                    className="h-3 w-3 rounded-full shrink-0"
+                    style={{ backgroundColor: colorHex }}
+                  />
+                  <span className="flex-1 text-sm font-medium text-white">{p.name}</span>
+                  <GripVertical className="h-4 w-4 text-white/30" />
+                </div>
+              );
+            })}
+          </div>
+
+          {error && (
+            <p className="text-xs text-red-400" data-testid="session-error">
+              {error}
+            </p>
+          )}
+
+          {/* Actions */}
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              className="border-white/20 text-white hover:bg-white/10"
+              onClick={() => setStep('players')}
+              data-testid="back-btn"
+            >
+              <X className="h-4 w-4 mr-1" />
+              Indietro
+            </Button>
+            <GradientButton
+              fullWidth
+              disabled={isCreating}
+              onClick={handleStart}
+              data-testid="start-session-btn"
+            >
+              {isCreating ? 'Avvio…' : '▶ Avvia Partita'}
+            </GradientButton>
+          </div>
+        </div>
+      )}
+    </BottomSheet>
+  );
+}

--- a/apps/web/src/components/session/StartSessionSheet.tsx
+++ b/apps/web/src/components/session/StartSessionSheet.tsx
@@ -9,7 +9,7 @@
  * Game is pre-selected (passed as prop). Navigates to /sessions/live/{id} on start.
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { GripVertical, Plus, Trash2, X } from 'lucide-react';
 import { useRouter } from 'next/navigation';
@@ -81,15 +81,20 @@ export function StartSessionSheet({
 
   // Drag state for step 2
   const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const usedColors = players.map(p => p.color);
-  const nextColor =
-    COLOR_OPTIONS.find(c => !usedColors.includes(c.value))?.value ?? COLOR_OPTIONS[0].value;
+  // Cleanup close-animation timer on unmount
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current !== null) clearTimeout(closeTimerRef.current);
+    };
+  }, []);
 
   const handleClose = () => {
     onOpenChange(false);
     // Reset after close animation
-    setTimeout(() => {
+    if (closeTimerRef.current !== null) clearTimeout(closeTimerRef.current);
+    closeTimerRef.current = setTimeout(() => {
       setStep('players');
       setPlayers([{ id: `p-${Date.now()}`, name: 'Giocatore 1', color: 'Red' }]);
       setNewName('');
@@ -102,9 +107,15 @@ export function StartSessionSheet({
   const addPlayer = useCallback(() => {
     const trimmed = newName.trim();
     if (!trimmed) return;
-    setPlayers(prev => [...prev, { id: `p-${Date.now()}`, name: trimmed, color: nextColor }]);
+    setPlayers(prev => {
+      // Derive nextColor from current snapshot to avoid stale closure on rapid add
+      const usedInPrev = prev.map(p => p.color);
+      const color =
+        COLOR_OPTIONS.find(c => !usedInPrev.includes(c.value))?.value ?? COLOR_OPTIONS[0].value;
+      return [...prev, { id: `p-${Date.now()}`, name: trimmed, color }];
+    });
     setNewName('');
-  }, [newName, nextColor]);
+  }, [newName]);
 
   const removePlayer = (id: string) => setPlayers(prev => prev.filter(p => p.id !== id));
 
@@ -140,15 +151,38 @@ export function StartSessionSheet({
         gameId,
       });
 
+      // Add players in turn order; collect the server-assigned IDs
+      const addedPlayerIds: string[] = [];
+      let failCount = 0;
       for (const player of players) {
         try {
-          await api.liveSessions.addPlayer(sessionId, {
+          const playerId = await api.liveSessions.addPlayer(sessionId, {
             displayName: player.name,
             color: player.color,
           });
+          addedPlayerIds.push(playerId);
         } catch {
-          // Non-blocking — continue with remaining players
+          failCount++;
         }
+      }
+
+      if (addedPlayerIds.length === 0) {
+        setError('Impossibile aggiungere i giocatori. Riprova.');
+        setIsCreating(false);
+        return;
+      }
+
+      // Persist the dragged turn order
+      try {
+        await api.liveSessions.updateTurnOrder(sessionId, { playerIds: addedPlayerIds });
+      } catch {
+        // Non-blocking — session is still playable without persisted order
+      }
+
+      if (failCount > 0) {
+        // Partial failure: show warning but still navigate
+        setError(`${failCount} giocatore/i non aggiunto/i. Continuo…`);
+        await new Promise(r => setTimeout(r, 1500));
       }
 
       router.push(`/sessions/live/${sessionId}`);


### PR DESCRIPTION
## Summary

- **StartSessionSheet** (nuovo): bottom sheet 2-step aperto da \`FocusedGameCard\` con bottone "▶ Avvia Partita". Step 1 — aggiungi/rimuovi giocatori con color picker; Step 2 — drag-to-reorder ordine turni + CTA Avvia. Chiama \`liveSessions.createSession\` + \`addPlayer\` per ogni player, poi naviga a \`/sessions/live/{id}\`.
- **FocusedGameCard**: aggiunto bottone "Avvia Partita" (verde, primary) affianco a "Dettagli". Nuova prop \`onStartSession\`.
- **GameDetailMobile**: stato \`sessionSheetOpen\` + render \`<StartSessionSheet>\`.
- **PlayModeMobile — Chiedi tab**: rimosso \`<Link href="/chat">\` che navigava via dalla sessione. Sostituito con button che chiama \`useChatPanel().open()\`. \`<ChatSlideOverPanel />\` reso inline nello stesso componente — l'utente resta in sessione.

## Test plan

- [ ] `/library/games/{gameId}` (mobile) — bottone "Avvia Partita" visibile nella card
- [ ] Click "Avvia Partita" → \`StartSessionSheet\` si apre con step 1 (Giocatori)
- [ ] Aggiungi 3 giocatori con nomi e colori diversi → lista aggiornata
- [ ] Rimuovi un giocatore → disabled se rimane 1 solo
- [ ] Click "Continua →" → step 2 (Ordine turni) con numerazione e drag handles
- [ ] Drag per riordinare → ordine cambia
- [ ] Click "Indietro" → torna step 1 con giocatori preservati
- [ ] Click "▶ Avvia Partita" → spinner mentre crea sessione → naviga a \`/sessions/live/{id}\`
- [ ] `/sessions/live/{id}` (mobile) — tab "Chiedi": click "Apri Chat AI" → \`ChatSlideOverPanel\` si apre senza navigare via
- [ ] Chiudi chat panel → schermata sessione rimane visibile

🤖 Generated with [Claude Code](https://claude.com/claude-code)