### PR TITLE
feat(meeple-card/nav): Piano 3 — ManaPips + FocusCard + drawCard + href navItems

### DIFF
--- a/apps/web/src/__tests__/components/ui/data-display/meeple-card/nav-items/buildGameNavItems.test.ts
+++ b/apps/web/src/__tests__/components/ui/data-display/meeple-card/nav-items/buildGameNavItems.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { buildGameNavItems } from '@/components/ui/data-display/meeple-card/nav-items/buildGameNavItems';
+
+const counts = { kbCount: 3, agentCount: 1, chatCount: 0, sessionCount: 5 };
+const handlers = {};
+
+describe('buildGameNavItems', () => {
+  it('returns 4 items always', () => {
+    expect(buildGameNavItems(counts, handlers).length).toBe(4);
+  });
+
+  it('sets href on each item when gameId provided', () => {
+    const items = buildGameNavItems(counts, handlers, 'abc123');
+    expect(items.find(i => i.entity === 'kb')?.href).toBe('/games/abc123/kb');
+    expect(items.find(i => i.entity === 'session')?.href).toBe('/games/abc123/sessions');
+    expect(items.find(i => i.entity === 'agent')?.href).toBe('/games/abc123/agent');
+    expect(items.find(i => i.entity === 'chat')?.href).toBe('/games/abc123/chat');
+  });
+
+  it('href is undefined when no gameId', () => {
+    const items = buildGameNavItems(counts, handlers);
+    expect(items.every(i => i.href === undefined)).toBe(true);
+  });
+
+  it('shows count when count > 0', () => {
+    const items = buildGameNavItems(counts, handlers);
+    expect(items.find(i => i.entity === 'kb')?.count).toBe(3);
+    expect(items.find(i => i.entity === 'session')?.count).toBe(5);
+  });
+
+  it('count is undefined when count === 0', () => {
+    const items = buildGameNavItems(counts, handlers);
+    expect(items.find(i => i.entity === 'chat')?.count).toBeUndefined();
+  });
+});

--- a/apps/web/src/__tests__/components/ui/data-display/meeple-card/parts/ManaPips.test.tsx
+++ b/apps/web/src/__tests__/components/ui/data-display/meeple-card/parts/ManaPips.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ManaPips } from '@/components/ui/data-display/meeple-card/parts/ManaPips';
+import type { ManaPip } from '@/components/ui/data-display/meeple-card/parts/ManaPips';
+
+const pips: ManaPip[] = [
+  { entityType: 'session', count: 5 },
+  { entityType: 'kb', count: 2 },
+  { entityType: 'agent', count: 1 },
+];
+
+describe('ManaPips', () => {
+  it('renders up to 3 pips', () => {
+    const { container } = render(<ManaPips pips={pips} />);
+    const dots = container.querySelectorAll('[data-pip]');
+    expect(dots).toHaveLength(3);
+  });
+
+  it('shows +N overflow when more than 3 pips', () => {
+    const fourPips: ManaPip[] = [
+      { entityType: 'session', count: 5 },
+      { entityType: 'kb', count: 2 },
+      { entityType: 'agent', count: 1 },
+      { entityType: 'toolkit', count: 3 },
+    ];
+    render(<ManaPips pips={fourPips} />);
+    expect(screen.getByText('+1')).toBeInTheDocument();
+  });
+
+  it('shows count badge when size=md and count > 0', () => {
+    render(<ManaPips pips={[{ entityType: 'session', count: 5 }]} size="md" />);
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('does not show badge when size=sm', () => {
+    render(<ManaPips pips={[{ entityType: 'session', count: 5 }]} size="sm" />);
+    expect(screen.queryByText('5')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when pips array is empty', () => {
+    const { container } = render(<ManaPips pips={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/web/src/__tests__/components/ui/data-display/meeple-card/parts/NavFooter.test.tsx
+++ b/apps/web/src/__tests__/components/ui/data-display/meeple-card/parts/NavFooter.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [k: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import { NavFooter } from '@/components/ui/data-display/meeple-card/parts/NavFooter';
+
+describe('NavFooter href support', () => {
+  it('renders link with correct href when href is provided', () => {
+    render(
+      <NavFooter
+        items={[
+          {
+            icon: <span>🎮</span>,
+            label: 'Sessioni',
+            entity: 'session',
+            href: '/games/abc/sessions',
+          },
+        ]}
+      />
+    );
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/games/abc/sessions');
+  });
+
+  it('renders div role=button when no href', () => {
+    render(
+      <NavFooter
+        items={[
+          {
+            icon: <span>🎮</span>,
+            label: 'Sessioni',
+            entity: 'session',
+          },
+        ]}
+      />
+    );
+    expect(screen.queryByRole('link')).toBeNull();
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/__tests__/components/ui/data-display/meeple-card/variants/FocusCard.test.tsx
+++ b/apps/web/src/__tests__/components/ui/data-display/meeple-card/variants/FocusCard.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [k: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import { FocusCard } from '@/components/ui/data-display/meeple-card/variants/FocusCard';
+
+const baseProps = {
+  entity: 'game' as const,
+  title: 'Catan',
+  subtitle: 'Klaus Teuber',
+  imageUrl: '/catan.jpg',
+  rating: 7.5,
+  ratingMax: 10,
+};
+
+describe('FocusCard', () => {
+  it('renders title and subtitle', () => {
+    render(<FocusCard {...baseProps} />);
+    expect(screen.getByText('Catan')).toBeInTheDocument();
+    expect(screen.getByText('Klaus Teuber')).toBeInTheDocument();
+  });
+
+  it('renders navItem chips when provided', () => {
+    render(
+      <FocusCard
+        {...baseProps}
+        navItems={[
+          {
+            icon: <span>🎮</span>,
+            label: 'Sessioni',
+            entity: 'session',
+            count: 5,
+            href: '/games/1/sessions',
+          },
+          { icon: <span>📚</span>, label: 'Docs', entity: 'kb', count: 2, href: '/games/1/kb' },
+        ]}
+      />
+    );
+    expect(screen.getByText('Sessioni')).toBeInTheDocument();
+    expect(screen.getByText('Docs')).toBeInTheDocument();
+  });
+
+  it('renders navItem count when provided', () => {
+    render(
+      <FocusCard
+        {...baseProps}
+        navItems={[
+          {
+            icon: <span>🎮</span>,
+            label: 'Sessioni',
+            entity: 'session',
+            count: 12,
+            href: '/games/1/sessions',
+          },
+        ]}
+      />
+    );
+    expect(screen.getByText('12')).toBeInTheDocument();
+  });
+
+  it('applies data-testid', () => {
+    render(<FocusCard {...baseProps} data-testid="focus-card-test" />);
+    expect(screen.getByTestId('focus-card-test')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/__tests__/hooks/useDrawCard.test.ts
+++ b/apps/web/src/__tests__/hooks/useDrawCard.test.ts
@@ -1,0 +1,36 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockDrawCard = vi.fn();
+vi.mock('@/lib/stores/card-hand-store', () => ({
+  useCardHand: (selector: (s: { drawCard: typeof mockDrawCard }) => unknown) =>
+    selector({ drawCard: mockDrawCard }),
+}));
+
+import { useDrawCard } from '@/hooks/useDrawCard';
+
+describe('useDrawCard', () => {
+  beforeEach(() => mockDrawCard.mockClear());
+
+  it('calls drawCard on mount with the provided card', () => {
+    renderHook(() =>
+      useDrawCard({
+        id: 'game:abc',
+        entityType: 'game',
+        entityId: 'abc',
+        label: 'Catan',
+        href: '/games/abc',
+        pinned: false,
+      })
+    );
+    expect(mockDrawCard).toHaveBeenCalledOnce();
+    expect(mockDrawCard).toHaveBeenCalledWith(
+      expect.objectContaining({ entityType: 'game', entityId: 'abc' })
+    );
+  });
+
+  it('does not call drawCard when card is null', () => {
+    renderHook(() => useDrawCard(null));
+    expect(mockDrawCard).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/ui/data-display/meeple-card/MeepleCard.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/MeepleCard.tsx
@@ -4,6 +4,7 @@ import { memo } from 'react';
 
 import { CompactCard } from './variants/CompactCard';
 import { FeaturedCard } from './variants/FeaturedCard';
+import { FocusCard } from './variants/FocusCard';
 import { GridCard } from './variants/GridCard';
 import { HeroCard } from './variants/HeroCard';
 import { ListCard } from './variants/ListCard';
@@ -16,6 +17,7 @@ const variantMap = {
   compact: CompactCard,
   featured: FeaturedCard,
   hero: HeroCard,
+  focus: FocusCard,
 } as const;
 
 export const MeepleCard = memo(function MeepleCard(props: MeepleCardProps) {

--- a/apps/web/src/components/ui/data-display/meeple-card/nav-items/buildGameNavItems.ts
+++ b/apps/web/src/components/ui/data-display/meeple-card/nav-items/buildGameNavItems.ts
@@ -24,13 +24,15 @@ export interface GameNavHandlers {
  * Build the canonical 4-slot nav-footer for game entity cards.
  *
  * Slots: KB | Agent | Chat | Sessioni
+ * - gameId provided → items get href for direct Link navigation
  * - count > 0 → shows count badge
  * - count === 0 → shows plus indicator that fires onPlusClick
  * - missing handler → slot rendered disabled
  */
 export function buildGameNavItems(
   counts: GameNavCounts,
-  handlers: GameNavHandlers
+  handlers: GameNavHandlers,
+  gameId?: string
 ): NavFooterItem[] {
   return [
     {
@@ -39,9 +41,10 @@ export function buildGameNavItems(
       entity: 'kb',
       count: counts.kbCount > 0 ? counts.kbCount : undefined,
       showPlus: counts.kbCount === 0,
-      disabled: !handlers.onKbClick,
+      disabled: !handlers.onKbClick && !gameId,
       onClick: handlers.onKbClick,
       onPlusClick: handlers.onKbPlus,
+      href: gameId ? `/games/${gameId}/kb` : undefined,
     },
     {
       icon: navIcons.agent,
@@ -49,9 +52,10 @@ export function buildGameNavItems(
       entity: 'agent',
       count: counts.agentCount > 0 ? counts.agentCount : undefined,
       showPlus: counts.agentCount === 0,
-      disabled: !handlers.onAgentClick,
+      disabled: !handlers.onAgentClick && !gameId,
       onClick: handlers.onAgentClick,
       onPlusClick: handlers.onAgentPlus,
+      href: gameId ? `/games/${gameId}/agent` : undefined,
     },
     {
       icon: navIcons.chat,
@@ -59,9 +63,10 @@ export function buildGameNavItems(
       entity: 'chat',
       count: counts.chatCount > 0 ? counts.chatCount : undefined,
       showPlus: counts.chatCount === 0,
-      disabled: !handlers.onChatClick,
+      disabled: !handlers.onChatClick && !gameId,
       onClick: handlers.onChatClick,
       onPlusClick: handlers.onChatPlus,
+      href: gameId ? `/games/${gameId}/chat` : undefined,
     },
     {
       icon: navIcons.session,
@@ -69,9 +74,10 @@ export function buildGameNavItems(
       entity: 'session',
       count: counts.sessionCount > 0 ? counts.sessionCount : undefined,
       showPlus: counts.sessionCount === 0,
-      disabled: !handlers.onSessionClick,
+      disabled: !handlers.onSessionClick && !gameId,
       onClick: handlers.onSessionClick,
       onPlusClick: handlers.onSessionPlus,
+      href: gameId ? `/games/${gameId}/sessions` : undefined,
     },
   ];
 }

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/Cover.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/Cover.tsx
@@ -17,6 +17,7 @@ const aspectRatioClass: Record<MeepleCardVariant, string> = {
   compact: 'aspect-square',
   featured: 'aspect-video',
   hero: 'aspect-video',
+  focus: 'aspect-[7/10]',
 };
 
 export function Cover({ entity, variant, imageUrl, alt }: CoverProps) {

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/ManaPips.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/ManaPips.tsx
@@ -1,0 +1,60 @@
+import { entityHsl } from '../tokens';
+
+import type { MeepleEntityType } from '../types';
+
+export interface ManaPip {
+  entityType: MeepleEntityType;
+  count?: number;
+}
+
+interface ManaPipsProps {
+  pips: ManaPip[];
+  /** sm = 6px pip no badge (compact); md = 8px pip with count badge (grid) */
+  size?: 'sm' | 'md';
+}
+
+const MAX_VISIBLE = 3;
+
+export function ManaPips({ pips, size = 'md' }: ManaPipsProps) {
+  if (pips.length === 0) return null;
+
+  const visible = pips.slice(0, MAX_VISIBLE);
+  const overflow = pips.length - MAX_VISIBLE;
+  const dotSize = size === 'md' ? 8 : 6;
+
+  return (
+    <div className="flex items-center gap-1 px-3 pb-2 pt-0.5">
+      {visible.map((pip, i) => {
+        const color = entityHsl(pip.entityType);
+        return (
+          <span
+            key={i}
+            data-pip
+            title={pip.entityType}
+            className="relative inline-flex items-center justify-center rounded-full"
+            style={{
+              width: dotSize,
+              height: dotSize,
+              background: color,
+              flexShrink: 0,
+            }}
+          >
+            {size === 'md' && pip.count !== undefined && pip.count > 0 && (
+              <span
+                className="absolute -top-2 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-full px-1 text-[7px] font-bold text-white"
+                style={{ background: color, lineHeight: '10px', minWidth: 12, textAlign: 'center' }}
+              >
+                {pip.count}
+              </span>
+            )}
+          </span>
+        );
+      })}
+      {overflow > 0 && (
+        <span className="text-[9px] font-semibold text-[var(--mc-text-muted,#94a3b8)]">
+          +{overflow}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/NavFooter.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/NavFooter.tsx
@@ -2,6 +2,8 @@
 
 import type { KeyboardEvent } from 'react';
 
+import Link from 'next/link';
+
 import { entityHsl } from '../tokens';
 
 import type { NavFooterItem } from '../types';
@@ -37,28 +39,8 @@ export function NavFooter({ items, size = 'sm' }: NavFooterProps) {
           }
         };
 
-        return (
-          <div
-            key={i}
-            role="button"
-            tabIndex={item.disabled ? -1 : 0}
-            aria-disabled={item.disabled}
-            aria-label={item.label}
-            title={item.label}
-            onClick={e => {
-              e.stopPropagation();
-              handleActivate();
-            }}
-            onKeyDown={handleKeyDown}
-            className={`group/nav relative flex flex-col items-center gap-0.5 outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-[var(--nav-hover-border)] ${
-              item.disabled ? 'cursor-not-allowed opacity-45' : 'cursor-pointer'
-            }`}
-            style={
-              {
-                '--nav-hover-border': borderHover,
-              } as React.CSSProperties
-            }
-          >
+        const innerContent = (
+          <>
             <div
               className={`relative flex ${iconSize} items-center justify-center rounded-full border border-[var(--mc-nav-icon-border)] bg-[var(--mc-nav-icon-bg)] transition-all duration-200 group-hover/nav:scale-[1.08] group-hover/nav:border-[var(--nav-hover-border)] group-hover/nav:bg-[var(--nav-hover-bg)] group-hover/nav:shadow-[var(--nav-hover-shadow)] group-active/nav:scale-95 group-active/nav:shadow-[inset_0_1px_2px_rgba(0,0,0,0.1)]`}
               style={
@@ -100,6 +82,50 @@ export function NavFooter({ items, size = 'sm' }: NavFooterProps) {
             <span className="text-[7px] font-semibold uppercase tracking-wide text-[var(--mc-text-muted)] transition-colors group-hover/nav:text-[var(--mc-text-secondary)]">
               {item.label}
             </span>
+          </>
+        );
+
+        const commonClassName = `group/nav relative flex flex-col items-center gap-0.5 outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-[var(--nav-hover-border)] ${
+          item.disabled ? 'cursor-not-allowed opacity-45' : 'cursor-pointer'
+        }`;
+        const commonStyle = { '--nav-hover-border': borderHover } as React.CSSProperties;
+
+        if (item.href && !item.disabled) {
+          return (
+            <Link
+              key={i}
+              href={item.href}
+              className={commonClassName}
+              style={commonStyle}
+              aria-label={item.label}
+              title={item.label}
+              onClick={e => {
+                e.stopPropagation();
+                item.onClick?.();
+              }}
+            >
+              {innerContent}
+            </Link>
+          );
+        }
+
+        return (
+          <div
+            key={i}
+            role="button"
+            tabIndex={item.disabled ? -1 : 0}
+            aria-disabled={item.disabled}
+            aria-label={item.label}
+            title={item.label}
+            onClick={e => {
+              e.stopPropagation();
+              handleActivate();
+            }}
+            onKeyDown={handleKeyDown}
+            className={commonClassName}
+            style={commonStyle}
+          >
+            {innerContent}
           </div>
         );
       })}

--- a/apps/web/src/components/ui/data-display/meeple-card/skeleton.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/skeleton.tsx
@@ -11,6 +11,7 @@ const skeletonHeight: Record<MeepleCardVariant, string> = {
   compact: 'h-[48px]',
   featured: 'h-[340px]',
   hero: 'h-[320px]',
+  focus: 'h-[378px]',
 };
 
 export function MeepleCardSkeleton({ variant = 'grid', className = '' }: MeepleCardSkeletonProps) {

--- a/apps/web/src/components/ui/data-display/meeple-card/types.ts
+++ b/apps/web/src/components/ui/data-display/meeple-card/types.ts
@@ -38,6 +38,7 @@ export interface NavFooterItem {
   disabled?: boolean;
   onClick?: () => void;
   onPlusClick?: () => void;
+  href?: string;
 }
 
 export type CardStatus =

--- a/apps/web/src/components/ui/data-display/meeple-card/types.ts
+++ b/apps/web/src/components/ui/data-display/meeple-card/types.ts
@@ -1,5 +1,7 @@
 import type { ReactNode } from 'react';
 
+import type { ManaPip } from './parts/ManaPips';
+
 // 9 entity types only
 export type MeepleEntityType =
   | 'game'
@@ -12,8 +14,8 @@ export type MeepleEntityType =
   | 'toolkit'
   | 'tool';
 
-// 5 variants only
-export type MeepleCardVariant = 'grid' | 'list' | 'compact' | 'featured' | 'hero';
+// 6 variants
+export type MeepleCardVariant = 'grid' | 'list' | 'compact' | 'featured' | 'hero' | 'focus';
 
 export interface MeepleCardMetadata {
   icon?: ReactNode;
@@ -76,6 +78,7 @@ export interface MeepleCardProps {
   coverLabels?: CoverLabel[];
   actions?: MeepleCardAction[];
   navItems?: NavFooterItem[];
+  manaPips?: ManaPip[];
   onClick?: () => void;
   flippable?: boolean;
   flipBackContent?: ReactNode;

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/CompactCard.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/CompactCard.tsx
@@ -1,11 +1,12 @@
 'use client';
 
+import { ManaPips } from '../parts/ManaPips';
 import { entityHsl } from '../tokens';
 
 import type { MeepleCardProps } from '../types';
 
 export function CompactCard(props: MeepleCardProps) {
-  const { entity, title, badge, onClick, className = '' } = props;
+  const { entity, title, badge, manaPips, onClick, className = '' } = props;
   const testId = props['data-testid'];
 
   return (
@@ -32,6 +33,7 @@ export function CompactCard(props: MeepleCardProps) {
           {badge}
         </span>
       )}
+      {manaPips && manaPips.length > 0 && <ManaPips pips={manaPips} size="sm" />}
     </div>
   );
 }

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/FocusCard.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/FocusCard.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import Link from 'next/link';
+
+import { AccentBorder } from '../parts/AccentBorder';
+import { Cover } from '../parts/Cover';
+import { MetaChips } from '../parts/MetaChips';
+import { Rating } from '../parts/Rating';
+import { entityHsl } from '../tokens';
+
+import type { MeepleCardProps } from '../types';
+
+/** Full-width entity header card. NavItems render as horizontal chips. */
+export function FocusCard(props: MeepleCardProps) {
+  const {
+    entity,
+    title,
+    subtitle,
+    imageUrl,
+    rating,
+    ratingMax,
+    metadata = [],
+    navItems = [],
+    onClick,
+    className = '',
+  } = props;
+  const testId = props['data-testid'];
+
+  return (
+    <div
+      className={`relative w-full overflow-hidden rounded-2xl border border-[var(--mc-border)] bg-[var(--mc-bg-card)] shadow-[var(--mc-shadow-sm)] backdrop-blur-[12px] ${className}`}
+      data-entity={entity}
+      data-testid={testId}
+      onClick={onClick}
+    >
+      <AccentBorder entity={entity} />
+
+      {/* Hero row: cover + info */}
+      <div className="flex gap-4 p-4">
+        <div className="h-24 w-24 shrink-0 overflow-hidden rounded-xl">
+          <Cover entity={entity} variant="compact" imageUrl={imageUrl} alt={title} />
+        </div>
+
+        <div className="flex min-w-0 flex-1 flex-col justify-center gap-1">
+          <h2 className="font-[var(--font-quicksand)] text-xl font-bold leading-tight text-[var(--mc-text-primary)]">
+            {title}
+          </h2>
+          {subtitle && <p className="text-sm text-[var(--mc-text-secondary)]">{subtitle}</p>}
+          {rating !== undefined && <Rating value={rating} max={ratingMax} />}
+          {metadata.length > 0 && <MetaChips metadata={metadata} />}
+        </div>
+      </div>
+
+      {/* NavItem chip row */}
+      {navItems.length > 0 && (
+        <div className="flex flex-wrap gap-2 border-t border-[var(--mc-border-light)] px-4 py-3">
+          {navItems.map((item, i) => {
+            const color = entityHsl(item.entity);
+            const chipContent = (
+              <>
+                <span className="text-[13px] leading-none">{item.icon}</span>
+                <span className="text-xs font-semibold">{item.label}</span>
+                {item.count !== undefined && item.count > 0 && (
+                  <span
+                    className="ml-0.5 rounded-full px-1.5 py-0.5 text-[9px] font-bold text-white"
+                    style={{ background: color }}
+                  >
+                    {item.count}
+                  </span>
+                )}
+              </>
+            );
+
+            const chipClass =
+              'flex items-center gap-1.5 rounded-xl border px-2.5 py-1.5 text-[var(--mc-text-primary)] transition-all duration-200 hover:scale-[1.03] active:scale-95';
+            const chipStyle = {
+              borderColor: entityHsl(item.entity, 0.3),
+              background: entityHsl(item.entity, 0.06),
+            };
+
+            if (item.href && !item.disabled) {
+              return (
+                <Link
+                  key={i}
+                  href={item.href}
+                  className={chipClass}
+                  style={chipStyle}
+                  onClick={e => {
+                    e.stopPropagation();
+                    item.onClick?.();
+                  }}
+                  aria-label={item.label}
+                >
+                  {chipContent}
+                </Link>
+              );
+            }
+
+            return (
+              <button
+                key={i}
+                type="button"
+                onClick={e => {
+                  e.stopPropagation();
+                  if (!item.disabled) item.onClick?.();
+                }}
+                disabled={item.disabled}
+                className={`${chipClass} ${item.disabled ? 'cursor-not-allowed opacity-40' : ''}`}
+                style={chipStyle}
+                aria-label={item.label}
+              >
+                {chipContent}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/GridCard.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/GridCard.tsx
@@ -3,6 +3,7 @@
 import { AccentBorder } from '../parts/AccentBorder';
 import { Cover } from '../parts/Cover';
 import { EntityBadge } from '../parts/EntityBadge';
+import { ManaPips } from '../parts/ManaPips';
 import { MetaChips } from '../parts/MetaChips';
 import { NavFooter } from '../parts/NavFooter';
 import { QuickActions } from '../parts/QuickActions';
@@ -27,6 +28,7 @@ export function GridCard(props: MeepleCardProps) {
     badge,
     actions = [],
     navItems = [],
+    manaPips,
     showQuickActions,
     onClick,
     className = '',
@@ -73,6 +75,7 @@ export function GridCard(props: MeepleCardProps) {
         {rating !== undefined && <Rating value={rating} max={ratingMax} />}
         {metadata.length > 0 && <MetaChips metadata={metadata} />}
       </div>
+      {manaPips && manaPips.length > 0 && <ManaPips pips={manaPips} size="md" />}
       {navItems.length > 0 && <NavFooter items={navItems} />}
     </div>
   );

--- a/apps/web/src/hooks/useDrawCard.ts
+++ b/apps/web/src/hooks/useDrawCard.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import type { HandCard } from '@/lib/stores/card-hand-store';
+import { useCardHand } from '@/lib/stores/card-hand-store';
+
+type DrawCardInput = Omit<HandCard, 'addedAt'>;
+
+/**
+ * Deals a card into the hand on mount.
+ * Pass `null` to skip (useful when entity data is still loading).
+ */
+export function useDrawCard(card: DrawCardInput | null) {
+  const drawCard = useCardHand(s => s.drawCard);
+
+  useEffect(() => {
+    if (card) {
+      drawCard(card);
+    }
+    // drawCard is stable (Zustand store method)
+    // card?.id as dep to re-draw if entityId changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [card?.id]);
+}


### PR DESCRIPTION
## Summary
- **ManaPips**: pip colorati (8px/6px) per varianti `grid` e `compact` — max 3 pips + `+N` overflow
- **FocusCard**: variante full-width con hero cover + navItem chips cliccabili (usa `<Link>` via `href`)
- **NavFooter href**: `NavFooterItem.href?` — renderizza `<Link>` per navigazione diretta
- **useDrawCard hook**: aggiunge carta alla mano on-mount nelle entity page
- **buildGameNavItems**: aggiornato con `href` per ogni nav item (opzionale `gameId`)
- **Registrazione variante `focus`** in `types.ts` e `MeepleCard.tsx`

## Test Plan
- [x] ManaPips: 5 unit test pass
- [x] NavFooter: 2 test (href → Link, no href → div[role=button]) pass
- [x] FocusCard: 4 test pass
- [x] MeepleCard focus variant registrata (Cover + skeleton aggiornati)
- [x] useDrawCard: 2 test pass
- [x] buildGameNavItems: 5 test pass
- [x] `pnpm typecheck` 0 errori
- [x] `pnpm test --run` 0 FAIL (pre-existing failures esclusi)

🤖 Piano 3 — Navigation Redesign
