### PR TITLE
feat(session): S3+S4+S5 — inline AI chat, RAG quick links, functional tool sheet

### DIFF
--- a/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/play-mode-mobile.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/play-mode-mobile.tsx
@@ -29,6 +29,7 @@ import { OfflineBanner } from '@/components/session/live/OfflineBanner';
 import { TurnStateHeader } from '@/components/session/live/TurnStateHeader';
 import { QuickToolBar } from '@/components/session/QuickToolBar';
 import type { ToolId } from '@/components/session/QuickToolBar';
+import { RagQuickLinks } from '@/components/session/RagQuickLinks';
 import { ScoreNumpad } from '@/components/session/ScoreNumpad';
 import { MobileHeader } from '@/components/ui/navigation/MobileHeader';
 import { SessionBottomNav, type SessionTab } from '@/components/ui/navigation/SessionBottomNav';
@@ -318,6 +319,9 @@ export function PlayModeMobile({ sessionId }: PlayModeMobileProps) {
 
             {/* Quick tools */}
             <QuickToolBar activeTool={activeTool} onSelectTool={handleSelectTool} />
+
+            {/* S4 — RAG quick links from game KB */}
+            <RagQuickLinks gameId={session?.gameId} />
 
             {/* Scoreboard summary */}
             <div>

--- a/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/play-mode-mobile.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/play-mode-mobile.tsx
@@ -91,6 +91,7 @@ export function PlayModeMobile({ sessionId }: PlayModeMobileProps) {
   const {
     messages: chatMessages,
     isStreaming: chatStreaming,
+    error: chatError,
     send: sendChat,
   } = useSessionInlineChat(session?.gameId);
   const [sessionEnded, setSessionEnded] = useState(false);
@@ -374,7 +375,12 @@ export function PlayModeMobile({ sessionId }: PlayModeMobileProps) {
 
         {/* ——— Tab: Chiedi ——— */}
         {activeTab === 'chat' && (
-          <div className="p-4">
+          <div className="p-4 space-y-2">
+            {chatError && (
+              <p className="text-xs text-red-400 text-center" role="alert">
+                {chatError}
+              </p>
+            )}
             <SessionChatWidget
               messages={chatMessages}
               isStreaming={chatStreaming}

--- a/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/play-mode-mobile.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/play-mode-mobile.tsx
@@ -16,12 +16,13 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 
-import { Timer, MessageCircle, Crown, LogOut } from 'lucide-react';
+import { Timer, Crown, LogOut } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
 import { ChatSlideOverPanel } from '@/components/chat/panel/ChatSlideOverPanel';
 import { LiveScoreboard } from '@/components/game-night/LiveScoreboard';
 import type { LiveScoreboardPlayer } from '@/components/game-night/LiveScoreboard';
+import { SessionChatWidget } from '@/components/game-night/SessionChatWidget';
 import { GameOverModal } from '@/components/session/live/GameOverModal';
 import type { GameOverPlayer } from '@/components/session/live/GameOverModal';
 import { OfflineBanner } from '@/components/session/live/OfflineBanner';
@@ -29,11 +30,10 @@ import { TurnStateHeader } from '@/components/session/live/TurnStateHeader';
 import { QuickToolBar } from '@/components/session/QuickToolBar';
 import type { ToolId } from '@/components/session/QuickToolBar';
 import { ScoreNumpad } from '@/components/session/ScoreNumpad';
-import { GradientButton } from '@/components/ui/buttons/GradientButton';
 import { MobileHeader } from '@/components/ui/navigation/MobileHeader';
 import { SessionBottomNav, type SessionTab } from '@/components/ui/navigation/SessionBottomNav';
 import { BottomSheet } from '@/components/ui/overlays/BottomSheet';
-import { useChatPanel } from '@/hooks/useChatPanel';
+import { useSessionInlineChat } from '@/hooks/useSessionInlineChat';
 import { api } from '@/lib/api';
 import type { TurnPhasesDto } from '@/lib/api/schemas/live-sessions.schemas';
 import { PLAYER_COLOR_HEX } from '@/lib/constants/player-colors';
@@ -85,8 +85,12 @@ export function PlayModeMobile({ sessionId }: PlayModeMobileProps) {
   // End session confirm
   const [showEndConfirm, setShowEndConfirm] = useState(false);
 
-  // Chat panel (inline slide-over, no navigation)
-  const { open: openChat } = useChatPanel();
+  // S3 — inline chat state for Tab "Chiedi"
+  const {
+    messages: chatMessages,
+    isStreaming: chatStreaming,
+    send: sendChat,
+  } = useSessionInlineChat(session?.gameId);
   const [sessionEnded, setSessionEnded] = useState(false);
 
   // Turn phases
@@ -365,37 +369,13 @@ export function PlayModeMobile({ sessionId }: PlayModeMobileProps) {
 
         {/* ——— Tab: Chiedi ——— */}
         {activeTab === 'chat' && (
-          <div className="flex flex-col items-center justify-center p-8 space-y-6 min-h-[60vh]">
-            <div className="h-20 w-20 rounded-2xl bg-amber-500/10 flex items-center justify-center">
-              <MessageCircle className="h-10 w-10 text-amber-500" />
-            </div>
-            <div className="text-center space-y-2">
-              <h3 className="text-lg font-bold font-quicksand">Chiedi all&apos;assistente AI</h3>
-              <p className="text-sm text-muted-foreground max-w-xs">
-                Hai dubbi sulle regole? Chiedi al nostro assistente e ottieni risposte immediate.
-              </p>
-            </div>
-            <div className="w-full max-w-xs">
-              <GradientButton
-                fullWidth
-                size="lg"
-                onClick={() =>
-                  openChat(
-                    session?.gameId && session.gameName
-                      ? {
-                          id: session.gameId,
-                          name: session.gameName,
-                          pdfCount: 0,
-                          kbStatus: 'ready',
-                        }
-                      : undefined
-                  )
-                }
-                data-testid="open-chat-btn"
-              >
-                Apri Chat AI
-              </GradientButton>
-            </div>
+          <div className="p-4">
+            <SessionChatWidget
+              messages={chatMessages}
+              isStreaming={chatStreaming}
+              onSend={sendChat}
+              defaultExpanded
+            />
           </div>
         )}
 

--- a/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/play-mode-mobile.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/play-mode-mobile.tsx
@@ -31,6 +31,7 @@ import { QuickToolBar } from '@/components/session/QuickToolBar';
 import type { ToolId } from '@/components/session/QuickToolBar';
 import { RagQuickLinks } from '@/components/session/RagQuickLinks';
 import { ScoreNumpad } from '@/components/session/ScoreNumpad';
+import { ToolSheetContent } from '@/components/session/ToolSheetContent';
 import { MobileHeader } from '@/components/ui/navigation/MobileHeader';
 import { SessionBottomNav, type SessionTab } from '@/components/ui/navigation/SessionBottomNav';
 import { BottomSheet } from '@/components/ui/overlays/BottomSheet';
@@ -457,11 +458,7 @@ export function PlayModeMobile({ sessionId }: PlayModeMobileProps) {
         onOpenChange={setToolSheetOpen}
         title={activeTool ? activeTool.charAt(0).toUpperCase() + activeTool.slice(1) : 'Strumento'}
       >
-        <div className="flex items-center justify-center py-12">
-          <p className="text-sm text-muted-foreground">
-            Strumento: <span className="font-semibold">{activeTool}</span>
-          </p>
-        </div>
+        <ToolSheetContent activeTool={activeTool} />
       </BottomSheet>
 
       {/* Score Numpad BottomSheet */}

--- a/apps/web/src/components/session/RagQuickLinks.tsx
+++ b/apps/web/src/components/session/RagQuickLinks.tsx
@@ -22,9 +22,12 @@ export function RagQuickLinks({ gameId, className }: RagQuickLinksProps) {
 
   useEffect(() => {
     if (!gameId) return;
-    api.knowledgeBase.getQuickLinks(gameId).then(data => {
-      setLinks(data.slice(0, 4));
-    });
+    api.knowledgeBase
+      .getQuickLinks(gameId)
+      .then(data => {
+        setLinks(data.slice(0, 4));
+      })
+      .catch(() => {});
   }, [gameId]);
 
   if (!gameId || links.length === 0) return null;

--- a/apps/web/src/components/session/RagQuickLinks.tsx
+++ b/apps/web/src/components/session/RagQuickLinks.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+import { BookOpen } from 'lucide-react';
+
+import { BottomSheet } from '@/components/ui/overlays/BottomSheet';
+import { useChatPanel } from '@/hooks/useChatPanel';
+import { api } from '@/lib/api';
+import type { QuickLink } from '@/lib/api/clients/knowledgeBaseClient';
+import { cn } from '@/lib/utils';
+
+interface RagQuickLinksProps {
+  gameId: string | null | undefined;
+  className?: string;
+}
+
+export function RagQuickLinks({ gameId, className }: RagQuickLinksProps) {
+  const [links, setLinks] = useState<QuickLink[]>([]);
+  const [selected, setSelected] = useState<QuickLink | null>(null);
+  const { open: openChat } = useChatPanel();
+
+  useEffect(() => {
+    if (!gameId) return;
+    api.knowledgeBase.getQuickLinks(gameId).then(data => {
+      setLinks(data.slice(0, 4));
+    });
+  }, [gameId]);
+
+  if (!gameId || links.length === 0) return null;
+
+  return (
+    <div data-testid="rag-quick-links" className={cn('space-y-2', className)}>
+      <h4 className="text-xs font-semibold text-muted-foreground flex items-center gap-1.5">
+        <BookOpen className="h-3.5 w-3.5" aria-hidden="true" />
+        Dalla Knowledge Base
+      </h4>
+
+      <div className="flex flex-wrap gap-2">
+        {links.map(link => (
+          <button
+            key={link.id}
+            type="button"
+            onClick={() => setSelected(link)}
+            className={cn(
+              'px-3 py-1.5 rounded-full text-xs font-medium',
+              'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+              'border border-amber-500/20 hover:bg-amber-500/20 transition-colors'
+            )}
+          >
+            {link.title}
+          </button>
+        ))}
+      </div>
+
+      <BottomSheet
+        open={!!selected}
+        onOpenChange={open => {
+          if (!open) setSelected(null);
+        }}
+        title={selected?.title ?? ''}
+      >
+        <div className="space-y-4 py-2">
+          <p className="text-sm text-muted-foreground leading-relaxed">{selected?.snippet}</p>
+          <button
+            type="button"
+            onClick={() => {
+              openChat();
+              setSelected(null);
+            }}
+            className={cn(
+              'w-full py-3 rounded-xl text-sm font-semibold',
+              'bg-amber-600 text-white hover:bg-amber-700 transition-colors'
+            )}
+          >
+            Chiedi all&apos;agente
+          </button>
+        </div>
+      </BottomSheet>
+    </div>
+  );
+}

--- a/apps/web/src/components/session/RagQuickLinks.tsx
+++ b/apps/web/src/components/session/RagQuickLinks.tsx
@@ -27,7 +27,9 @@ export function RagQuickLinks({ gameId, className }: RagQuickLinksProps) {
       .then(data => {
         setLinks(data.slice(0, 4));
       })
-      .catch(() => {});
+      .catch(err => {
+        console.error('[RagQuickLinks] Failed to fetch quick links:', err);
+      });
   }, [gameId]);
 
   if (!gameId || links.length === 0) return null;

--- a/apps/web/src/components/session/ToolSheetContent.tsx
+++ b/apps/web/src/components/session/ToolSheetContent.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+
+import type { ToolId } from '@/components/session/QuickToolBar';
+import { cn } from '@/lib/utils';
+
+// ── Dadi ─────────────────────────────────────────────────────────────────────
+
+function DadoTool() {
+  const [value, setValue] = useState<number | null>(null);
+  const [rolling, setRolling] = useState(false);
+
+  const FACE = ['⚀', '⚁', '⚂', '⚃', '⚄', '⚅'] as const;
+
+  const roll = () => {
+    setRolling(true);
+    setTimeout(() => {
+      setValue(Math.floor(Math.random() * 6) + 1);
+      setRolling(false);
+    }, 400);
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-6 py-4">
+      <span className={cn('text-8xl select-none', rolling && 'animate-bounce')} aria-hidden="true">
+        {value !== null ? FACE[value - 1] : '🎲'}
+      </span>
+      {value !== null && (
+        <p className="text-2xl font-bold tabular-nums" aria-live="polite">
+          {value}
+        </p>
+      )}
+      <button
+        type="button"
+        onClick={roll}
+        disabled={rolling}
+        aria-label={value === null ? 'Lancia dado' : 'Rilancia dado'}
+        className="px-6 py-2 rounded-xl bg-amber-600 text-white text-sm font-semibold disabled:opacity-60"
+      >
+        {value === null ? 'Lancia' : 'Rilancia'}
+      </button>
+    </div>
+  );
+}
+
+// ── Moneta ────────────────────────────────────────────────────────────────────
+
+function MonetaTool() {
+  const [result, setResult] = useState<'testa' | 'croce' | null>(null);
+  const [flipping, setFlipping] = useState(false);
+
+  const flip = () => {
+    setFlipping(true);
+    setTimeout(() => {
+      setResult(Math.random() < 0.5 ? 'testa' : 'croce');
+      setFlipping(false);
+    }, 400);
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-6 py-4">
+      <span className={cn('text-8xl select-none', flipping && 'animate-spin')} aria-hidden="true">
+        {result === 'croce' ? '💰' : '🪙'}
+      </span>
+      {result && (
+        <p className="text-xl font-bold capitalize" aria-live="polite">
+          {result}
+        </p>
+      )}
+      <button
+        type="button"
+        onClick={flip}
+        disabled={flipping}
+        aria-label={result === null ? 'Lancia moneta' : 'Rilancia moneta'}
+        className="px-6 py-2 rounded-xl bg-amber-600 text-white text-sm font-semibold disabled:opacity-60"
+      >
+        {result === null ? 'Lancia' : 'Rilancia'}
+      </button>
+    </div>
+  );
+}
+
+// ── Contatore ─────────────────────────────────────────────────────────────────
+
+function ContatoTool() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div className="flex flex-col items-center gap-6 py-4">
+      <p className="text-6xl font-bold tabular-nums font-mono" aria-live="polite">
+        {count}
+      </p>
+      <div className="flex gap-4">
+        <button
+          type="button"
+          onClick={() => setCount(c => Math.max(0, c - 1))}
+          aria-label="Decrementa"
+          className="h-14 w-14 rounded-full bg-white/10 text-3xl font-bold flex items-center justify-center hover:bg-white/20 active:scale-95"
+        >
+          −
+        </button>
+        <button
+          type="button"
+          onClick={() => setCount(c => c + 1)}
+          aria-label="Incrementa"
+          className="h-14 w-14 rounded-full bg-amber-600 text-3xl font-bold text-white flex items-center justify-center hover:bg-amber-700 active:scale-95"
+        >
+          +
+        </button>
+      </div>
+      <button
+        type="button"
+        onClick={() => setCount(0)}
+        aria-label="Azzera"
+        className="text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+      >
+        Azzera
+      </button>
+    </div>
+  );
+}
+
+// ── Timer ─────────────────────────────────────────────────────────────────────
+
+function TimerTool() {
+  const [elapsed, setElapsed] = useState(0);
+  const [running, setRunning] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (running) {
+      intervalRef.current = setInterval(() => setElapsed(e => e + 1), 1000);
+    } else if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [running]);
+
+  const format = (s: number) => {
+    const m = Math.floor(s / 60);
+    const sec = s % 60;
+    return `${String(m).padStart(2, '0')}:${String(sec).padStart(2, '0')}`;
+  };
+
+  const reset = () => {
+    setRunning(false);
+    setElapsed(0);
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-6 py-4">
+      <p
+        className="text-5xl font-mono font-bold tabular-nums"
+        aria-live="off"
+        aria-label={`Timer: ${format(elapsed)}`}
+      >
+        {format(elapsed)}
+      </p>
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={() => setRunning(r => !r)}
+          aria-label={running ? 'Pausa' : 'Avvia'}
+          className="px-6 py-2 rounded-xl bg-amber-600 text-white text-sm font-semibold hover:bg-amber-700"
+        >
+          {running ? 'Pausa' : 'Avvia'}
+        </button>
+        <button
+          type="button"
+          onClick={reset}
+          aria-label="Reset"
+          className="px-6 py-2 rounded-xl bg-white/10 text-sm font-semibold hover:bg-white/20"
+        >
+          Reset
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Main export ───────────────────────────────────────────────────────────────
+
+interface ToolSheetContentProps {
+  activeTool: ToolId | null;
+}
+
+export function ToolSheetContent({ activeTool }: ToolSheetContentProps) {
+  if (activeTool === 'dadi') return <DadoTool />;
+  if (activeTool === 'moneta') return <MonetaTool />;
+  if (activeTool === 'contatore') return <ContatoTool />;
+  if (activeTool === 'timer') return <TimerTool />;
+  if (activeTool === 'carte') {
+    return (
+      <div className="flex flex-col items-center gap-4 py-8">
+        <span className="text-5xl" aria-hidden="true">
+          🃏
+        </span>
+        <p className="text-sm text-muted-foreground">Carte — disponibile prossimamente</p>
+      </div>
+    );
+  }
+  return null;
+}

--- a/apps/web/src/components/session/ToolSheetContent.tsx
+++ b/apps/web/src/components/session/ToolSheetContent.tsx
@@ -10,12 +10,19 @@ import { cn } from '@/lib/utils';
 function DadoTool() {
   const [value, setValue] = useState<number | null>(null);
   const [rolling, setRolling] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
 
   const FACE = ['⚀', '⚁', '⚂', '⚃', '⚄', '⚅'] as const;
 
   const roll = () => {
     setRolling(true);
-    setTimeout(() => {
+    timeoutRef.current = setTimeout(() => {
       setValue(Math.floor(Math.random() * 6) + 1);
       setRolling(false);
     }, 400);
@@ -49,10 +56,17 @@ function DadoTool() {
 function MonetaTool() {
   const [result, setResult] = useState<'testa' | 'croce' | null>(null);
   const [flipping, setFlipping] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
 
   const flip = () => {
     setFlipping(true);
-    setTimeout(() => {
+    timeoutRef.current = setTimeout(() => {
       setResult(Math.random() < 0.5 ? 'testa' : 'croce');
       setFlipping(false);
     }, 400);

--- a/apps/web/src/components/session/ToolSheetContent.tsx
+++ b/apps/web/src/components/session/ToolSheetContent.tsx
@@ -83,7 +83,7 @@ function MonetaTool() {
 
 // ── Contatore ─────────────────────────────────────────────────────────────────
 
-function ContatoTool() {
+function ContatoreTool() {
   const [count, setCount] = useState(0);
 
   return (
@@ -190,7 +190,7 @@ interface ToolSheetContentProps {
 export function ToolSheetContent({ activeTool }: ToolSheetContentProps) {
   if (activeTool === 'dadi') return <DadoTool />;
   if (activeTool === 'moneta') return <MonetaTool />;
-  if (activeTool === 'contatore') return <ContatoTool />;
+  if (activeTool === 'contatore') return <ContatoreTool />;
   if (activeTool === 'timer') return <TimerTool />;
   if (activeTool === 'carte') {
     return (

--- a/apps/web/src/components/session/__tests__/RagQuickLinks.test.tsx
+++ b/apps/web/src/components/session/__tests__/RagQuickLinks.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * RagQuickLinks — S4 RAG quick links pills + detail BottomSheet
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockApi = vi.hoisted(() => ({
+  knowledgeBase: {
+    getQuickLinks: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/api', () => ({ api: mockApi }));
+
+const mockOpenChat = vi.hoisted(() => vi.fn());
+vi.mock('@/hooks/useChatPanel', () => ({
+  useChatPanel: () => ({ open: mockOpenChat }),
+}));
+
+import { RagQuickLinks } from '../RagQuickLinks';
+
+const LINKS = [
+  { id: '1', title: 'Regole base', snippet: 'Il gioco si svolge in turni...' },
+  { id: '2', title: 'Punteggio', snippet: 'I punti si calcolano così...' },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockApi.knowledgeBase.getQuickLinks.mockResolvedValue(LINKS);
+});
+
+describe('RagQuickLinks', () => {
+  it('non renderizza nulla senza gameId', () => {
+    const { container } = render(<RagQuickLinks gameId={undefined} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('mostra le pill dopo il caricamento', async () => {
+    render(<RagQuickLinks gameId="game-abc" />);
+    await waitFor(() => {
+      expect(screen.getByText('Regole base')).toBeInTheDocument();
+      expect(screen.getByText('Punteggio')).toBeInTheDocument();
+    });
+  });
+
+  it('non mostra più di 4 pill', async () => {
+    const manyLinks = Array.from({ length: 6 }, (_, i) => ({
+      id: String(i),
+      title: `Link ${i}`,
+      snippet: `Snippet ${i}`,
+    }));
+    mockApi.knowledgeBase.getQuickLinks.mockResolvedValue(manyLinks);
+    render(<RagQuickLinks gameId="game-abc" />);
+    await waitFor(() => {
+      expect(screen.getAllByRole('button')).toHaveLength(4);
+    });
+  });
+
+  it('apre il BottomSheet con snippet al click', async () => {
+    render(<RagQuickLinks gameId="game-abc" />);
+    await waitFor(() => screen.getByText('Regole base'));
+    fireEvent.click(screen.getByText('Regole base'));
+    expect(screen.getByText('Il gioco si svolge in turni...')).toBeInTheDocument();
+  });
+
+  it("il tasto Chiedi all'agente nel BottomSheet chiama openChat", async () => {
+    render(<RagQuickLinks gameId="game-abc" />);
+    await waitFor(() => screen.getByText('Regole base'));
+    fireEvent.click(screen.getByText('Regole base'));
+    fireEvent.click(screen.getByText("Chiedi all'agente"));
+    expect(mockOpenChat).toHaveBeenCalled();
+  });
+
+  it('non mostra nulla se la lista è vuota', async () => {
+    mockApi.knowledgeBase.getQuickLinks.mockResolvedValue([]);
+    const { container } = render(<RagQuickLinks gameId="game-abc" />);
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="rag-quick-links"]')).toBeNull();
+    });
+  });
+});

--- a/apps/web/src/components/session/__tests__/ToolSheetContent.test.tsx
+++ b/apps/web/src/components/session/__tests__/ToolSheetContent.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * ToolSheetContent — S5 functional tool UIs
+ */
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { ToolSheetContent } from '../ToolSheetContent';
+
+describe('ToolSheetContent', () => {
+  it('renderizza null per activeTool null', () => {
+    const { container } = render(<ToolSheetContent activeTool={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  // ── Dadi ──────────────────────────────────────────────────────────────
+  describe('Dadi', () => {
+    beforeEach(() => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.5); // → value = 4
+    });
+    afterEach(() => vi.restoreAllMocks());
+
+    it('mostra tasto Lancia inizialmente', () => {
+      render(<ToolSheetContent activeTool="dadi" />);
+      expect(screen.getByRole('button', { name: /lancia/i })).toBeInTheDocument();
+    });
+
+    it('mostra il valore dopo il roll', async () => {
+      vi.useFakeTimers();
+      render(<ToolSheetContent activeTool="dadi" />);
+      fireEvent.click(screen.getByRole('button', { name: /lancia/i }));
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+      });
+      expect(screen.getByText('4')).toBeInTheDocument();
+      vi.useRealTimers();
+    });
+  });
+
+  // ── Moneta ────────────────────────────────────────────────────────────
+  describe('Moneta', () => {
+    it('mostra tasto Lancia inizialmente', () => {
+      render(<ToolSheetContent activeTool="moneta" />);
+      expect(screen.getByRole('button', { name: /lancia/i })).toBeInTheDocument();
+    });
+
+    it('mostra testa o croce dopo il lancio', async () => {
+      vi.useFakeTimers();
+      vi.spyOn(Math, 'random').mockReturnValue(0.1); // < 0.5 → testa
+      render(<ToolSheetContent activeTool="moneta" />);
+      fireEvent.click(screen.getByRole('button', { name: /lancia/i }));
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+      });
+      expect(screen.getByText(/testa|croce/i)).toBeInTheDocument();
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    });
+  });
+
+  // ── Contatore ─────────────────────────────────────────────────────────
+  describe('Contatore', () => {
+    it('mostra valore 0 inizialmente', () => {
+      render(<ToolSheetContent activeTool="contatore" />);
+      expect(screen.getByText('0')).toBeInTheDocument();
+    });
+
+    it('incrementa con +', () => {
+      render(<ToolSheetContent activeTool="contatore" />);
+      fireEvent.click(screen.getByRole('button', { name: /incrementa/i }));
+      expect(screen.getByText('1')).toBeInTheDocument();
+    });
+
+    it('decrementa con - ma non scende sotto 0', () => {
+      render(<ToolSheetContent activeTool="contatore" />);
+      fireEvent.click(screen.getByRole('button', { name: /decrementa/i }));
+      expect(screen.getByText('0')).toBeInTheDocument();
+    });
+
+    it('azzera il contatore', () => {
+      render(<ToolSheetContent activeTool="contatore" />);
+      fireEvent.click(screen.getByRole('button', { name: /incrementa/i }));
+      fireEvent.click(screen.getByRole('button', { name: /incrementa/i }));
+      fireEvent.click(screen.getByRole('button', { name: /azzera/i }));
+      expect(screen.getByText('0')).toBeInTheDocument();
+    });
+  });
+
+  // ── Timer ─────────────────────────────────────────────────────────────
+  describe('Timer', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('mostra 00:00 inizialmente', () => {
+      render(<ToolSheetContent activeTool="timer" />);
+      expect(screen.getByText('00:00')).toBeInTheDocument();
+    });
+
+    it('avvia il timer al click su Avvia', async () => {
+      render(<ToolSheetContent activeTool="timer" />);
+      fireEvent.click(screen.getByRole('button', { name: /avvia/i }));
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+      });
+      expect(screen.getByText('00:03')).toBeInTheDocument();
+    });
+
+    it('mette in pausa il timer', async () => {
+      render(<ToolSheetContent activeTool="timer" />);
+      fireEvent.click(screen.getByRole('button', { name: /avvia/i }));
+      await act(async () => {
+        vi.advanceTimersByTime(2000);
+      });
+      fireEvent.click(screen.getByRole('button', { name: /pausa/i }));
+      await act(async () => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(screen.getByText('00:02')).toBeInTheDocument();
+    });
+
+    it('resetta il timer', async () => {
+      render(<ToolSheetContent activeTool="timer" />);
+      fireEvent.click(screen.getByRole('button', { name: /avvia/i }));
+      await act(async () => {
+        vi.advanceTimersByTime(5000);
+      });
+      fireEvent.click(screen.getByRole('button', { name: /reset/i }));
+      expect(screen.getByText('00:00')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/hooks/__tests__/useSessionInlineChat.test.ts
+++ b/apps/web/src/hooks/__tests__/useSessionInlineChat.test.ts
@@ -1,0 +1,109 @@
+/**
+ * useSessionInlineChat — inline chat state management for PlayModeMobile
+ */
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockApi = vi.hoisted(() => ({
+  chat: {
+    createThread: vi.fn(),
+    addMessage: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/api', () => ({ api: mockApi }));
+
+import { useSessionInlineChat } from '../useSessionInlineChat';
+
+const THREAD = {
+  id: 'thread-1',
+  gameId: 'game-abc',
+  title: null,
+  createdAt: new Date().toISOString(),
+  lastMessageAt: new Date().toISOString(),
+  messageCount: 2,
+  messages: [
+    { content: 'Ciao', role: 'user', timestamp: new Date().toISOString() },
+    {
+      content: 'Come posso aiutarti?',
+      role: 'assistant',
+      timestamp: new Date().toISOString(),
+      backendMessageId: 'msg-1',
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockApi.chat.createThread.mockResolvedValue(THREAD);
+  mockApi.chat.addMessage.mockResolvedValue({
+    ...THREAD,
+    messages: [
+      ...THREAD.messages,
+      {
+        content: 'Seconda risposta',
+        role: 'assistant',
+        timestamp: new Date().toISOString(),
+        backendMessageId: 'msg-2',
+      },
+    ],
+  });
+});
+
+describe('useSessionInlineChat', () => {
+  it('starts with empty messages and not streaming', () => {
+    const { result } = renderHook(() => useSessionInlineChat('game-abc'));
+    expect(result.current.messages).toHaveLength(0);
+    expect(result.current.isStreaming).toBe(false);
+  });
+
+  it('adds user message immediately on send', async () => {
+    const { result } = renderHook(() => useSessionInlineChat('game-abc'));
+    await act(async () => {
+      result.current.send('Ciao');
+    });
+    expect(result.current.messages[0]).toMatchObject({ role: 'user', content: 'Ciao' });
+  });
+
+  it('calls createThread on first send with gameId', async () => {
+    const { result } = renderHook(() => useSessionInlineChat('game-abc'));
+    await act(async () => {
+      result.current.send('Prima domanda');
+    });
+    expect(mockApi.chat.createThread).toHaveBeenCalledWith(
+      expect.objectContaining({ gameId: 'game-abc', initialMessage: 'Prima domanda' })
+    );
+  });
+
+  it('appends assistant reply after first send', async () => {
+    const { result } = renderHook(() => useSessionInlineChat('game-abc'));
+    await act(async () => {
+      result.current.send('Ciao');
+    });
+    const assistantMsg = result.current.messages.find(m => m.role === 'assistant');
+    expect(assistantMsg).toMatchObject({ role: 'assistant', content: 'Come posso aiutarti?' });
+  });
+
+  it('calls addMessage (not createThread) on subsequent sends', async () => {
+    const { result } = renderHook(() => useSessionInlineChat('game-abc'));
+    await act(async () => {
+      result.current.send('Prima');
+    });
+    await act(async () => {
+      result.current.send('Seconda');
+    });
+    expect(mockApi.chat.createThread).toHaveBeenCalledTimes(1);
+    expect(mockApi.chat.addMessage).toHaveBeenCalledWith(
+      'thread-1',
+      expect.objectContaining({ content: 'Seconda', role: 'user' })
+    );
+  });
+
+  it('is not streaming after send completes', async () => {
+    const { result } = renderHook(() => useSessionInlineChat('game-abc'));
+    await act(async () => {
+      result.current.send('Ciao');
+    });
+    expect(result.current.isStreaming).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/__tests__/useSessionInlineChat.test.ts
+++ b/apps/web/src/hooks/__tests__/useSessionInlineChat.test.ts
@@ -106,4 +106,14 @@ describe('useSessionInlineChat', () => {
     });
     expect(result.current.isStreaming).toBe(false);
   });
+
+  it('imposta error quando createThread fallisce', async () => {
+    mockApi.chat.createThread.mockRejectedValueOnce(new Error('network error'));
+    const { result } = renderHook(() => useSessionInlineChat('game-abc'));
+    await act(async () => {
+      result.current.send('Ciao');
+    });
+    expect(result.current.error).toBeTruthy();
+    expect(result.current.isStreaming).toBe(false);
+  });
 });

--- a/apps/web/src/hooks/useSessionInlineChat.ts
+++ b/apps/web/src/hooks/useSessionInlineChat.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+
+import type { ChatMessage } from '@/components/game-night/SessionChatWidget';
+import { api } from '@/lib/api';
+
+interface UseSessionInlineChatReturn {
+  messages: ChatMessage[];
+  isStreaming: boolean;
+  send: (text: string) => void;
+}
+
+export function useSessionInlineChat(
+  gameId: string | null | undefined
+): UseSessionInlineChatReturn {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [threadId, setThreadId] = useState<string | null>(null);
+
+  const send = useCallback(
+    async (text: string) => {
+      const userMsg: ChatMessage = {
+        id: crypto.randomUUID(),
+        role: 'user',
+        content: text,
+        timestamp: new Date(),
+      };
+      setMessages(prev => [...prev, userMsg]);
+      setIsStreaming(true);
+
+      try {
+        let thread;
+        if (!threadId) {
+          thread = await api.chat.createThread({
+            gameId: gameId ?? null,
+            initialMessage: text,
+          });
+          setThreadId(thread.id);
+        } else {
+          thread = await api.chat.addMessage(threadId, { content: text, role: 'user' });
+        }
+
+        // Extract the last assistant message from the returned thread
+        const assistantMsgs = thread.messages.filter(
+          (m: { role: string }) => m.role === 'assistant'
+        );
+        const last = assistantMsgs[assistantMsgs.length - 1];
+        if (last) {
+          const assistantMsg: ChatMessage = {
+            id: last.backendMessageId ?? crypto.randomUUID(),
+            role: 'assistant',
+            content: last.content,
+            timestamp: new Date(last.timestamp),
+          };
+          setMessages(prev => [...prev, assistantMsg]);
+        }
+      } catch {
+        // Silent fail — user can retry
+      } finally {
+        setIsStreaming(false);
+      }
+    },
+    [gameId, threadId]
+  );
+
+  return { messages, isStreaming, send };
+}

--- a/apps/web/src/hooks/useSessionInlineChat.ts
+++ b/apps/web/src/hooks/useSessionInlineChat.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useRef, useCallback } from 'react';
 
 import type { ChatMessage } from '@/components/game-night/SessionChatWidget';
 import { api } from '@/lib/api';
@@ -8,7 +8,8 @@ import { api } from '@/lib/api';
 interface UseSessionInlineChatReturn {
   messages: ChatMessage[];
   isStreaming: boolean;
-  send: (text: string) => void;
+  error: string | null;
+  send: (text: string) => Promise<void>;
 }
 
 export function useSessionInlineChat(
@@ -16,10 +17,12 @@ export function useSessionInlineChat(
 ): UseSessionInlineChatReturn {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isStreaming, setIsStreaming] = useState(false);
-  const [threadId, setThreadId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const threadIdRef = useRef<string | null>(null);
 
   const send = useCallback(
     async (text: string) => {
+      setError(null);
       const userMsg: ChatMessage = {
         id: crypto.randomUUID(),
         role: 'user',
@@ -31,20 +34,18 @@ export function useSessionInlineChat(
 
       try {
         let thread;
-        if (!threadId) {
+        if (!threadIdRef.current) {
           thread = await api.chat.createThread({
             gameId: gameId ?? null,
             initialMessage: text,
           });
-          setThreadId(thread.id);
+          threadIdRef.current = thread.id;
         } else {
-          thread = await api.chat.addMessage(threadId, { content: text, role: 'user' });
+          thread = await api.chat.addMessage(threadIdRef.current!, { content: text, role: 'user' });
         }
 
         // Extract the last assistant message from the returned thread
-        const assistantMsgs = thread.messages.filter(
-          (m: { role: string }) => m.role === 'assistant'
-        );
+        const assistantMsgs = thread.messages.filter(m => m.role === 'assistant');
         const last = assistantMsgs[assistantMsgs.length - 1];
         if (last) {
           const assistantMsg: ChatMessage = {
@@ -56,13 +57,13 @@ export function useSessionInlineChat(
           setMessages(prev => [...prev, assistantMsg]);
         }
       } catch {
-        // Silent fail — user can retry
+        setError("Errore nell'invio del messaggio.");
       } finally {
         setIsStreaming(false);
       }
     },
-    [gameId, threadId]
+    [gameId]
   );
 
-  return { messages, isStreaming, send };
+  return { messages, isStreaming, error, send };
 }

--- a/apps/web/src/hooks/useSessionInlineChat.ts
+++ b/apps/web/src/hooks/useSessionInlineChat.ts
@@ -19,9 +19,12 @@ export function useSessionInlineChat(
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const threadIdRef = useRef<string | null>(null);
+  const isSendingRef = useRef(false);
 
   const send = useCallback(
     async (text: string) => {
+      if (isSendingRef.current) return;
+      isSendingRef.current = true;
       setError(null);
       const userMsg: ChatMessage = {
         id: crypto.randomUUID(),
@@ -60,6 +63,7 @@ export function useSessionInlineChat(
         setError("Errore nell'invio del messaggio.");
       } finally {
         setIsStreaming(false);
+        isSendingRef.current = false;
       }
     },
     [gameId]

--- a/apps/web/src/lib/api/clients/knowledgeBaseClient.ts
+++ b/apps/web/src/lib/api/clients/knowledgeBaseClient.ts
@@ -240,8 +240,9 @@ export function createKnowledgeBaseClient({ httpClient }: CreateKnowledgeBaseCli
      * @returns Array of quick link items (id, title, snippet)
      */
     async getQuickLinks(gameId: string): Promise<QuickLink[]> {
+      // Route: GET /api/v1/knowledge-base/{gameId}/quick-links (path param, consistent with other KB endpoints)
       const result = await httpClient.get(
-        `/api/v1/knowledge-base/quick-links?gameId=${encodeURIComponent(gameId)}`,
+        `/api/v1/knowledge-base/${encodeURIComponent(gameId)}/quick-links`,
         QuickLinksSchema
       );
       return result ?? [];

--- a/apps/web/src/lib/api/clients/knowledgeBaseClient.ts
+++ b/apps/web/src/lib/api/clients/knowledgeBaseClient.ts
@@ -45,6 +45,16 @@ export type GameKbSettingsPayload = Omit<GameKbSettings, 'gameId'>;
 
 import type { HttpClient } from '../core/httpClient';
 
+// ── Quick Links (S4) ────────────────────────────────────────────────────────
+
+export const QuickLinkSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  snippet: z.string(),
+});
+export const QuickLinksSchema = z.array(QuickLinkSchema);
+export type QuickLink = z.infer<typeof QuickLinkSchema>;
+
 export interface CreateKnowledgeBaseClientParams {
   httpClient: HttpClient;
 }
@@ -220,6 +230,19 @@ export function createKnowledgeBaseClient({ httpClient }: CreateKnowledgeBaseCli
       const result = await httpClient.get(
         `/api/v1/knowledge-base/${encodeURIComponent(gameId)}/documents`,
         z.array(GameDocumentSchema)
+      );
+      return result ?? [];
+    },
+
+    /**
+     * S4: Get RAG quick links for a game (max 4 from the game's KB)
+     * @param gameId Game ID (GUID format)
+     * @returns Array of quick link items (id, title, snippet)
+     */
+    async getQuickLinks(gameId: string): Promise<QuickLink[]> {
+      const result = await httpClient.get(
+        `/api/v1/knowledge-base/quick-links?gameId=${encodeURIComponent(gameId)}`,
+        QuickLinksSchema
       );
       return result ?? [];
     },


### PR DESCRIPTION
## Summary

- **S3 — Inline AI Chat (Tab Chiedi)**: sostituisce il CTA button con `SessionChatWidget` inline, guidato da `useSessionInlineChat` hook con `useRef` per threadId (no stale closure), gestione `error` con feedback visivo
- **S4 — RAG Quick Links**: aggiunge `RagQuickLinks` sotto `QuickToolBar` nella tab Gioco — fetcha max 4 link dalla KB del gioco, apre `BottomSheet` con snippet + "Chiedi all'agente"
- **S5 — Tool Sheet funzionale**: sostituisce il placeholder con UI reale: Dadi (d6 ⚀-⚅), Moneta (testa/croce), Contatore (+/-/azzera), Timer (start/stop/reset MM:SS) — tutti con `useRef`+`useEffect` cleanup per timeout/interval

## Nuovi file
- `src/hooks/useSessionInlineChat.ts` — hook S3
- `src/hooks/__tests__/useSessionInlineChat.test.ts` — 7 test
- `src/components/session/RagQuickLinks.tsx` — componente S4
- `src/components/session/__tests__/RagQuickLinks.test.tsx` — 6 test
- `src/components/session/ToolSheetContent.tsx` — 4 tool S5
- `src/components/session/__tests__/ToolSheetContent.test.tsx` — 13 test
- `src/lib/api/clients/knowledgeBaseClient.ts` — aggiunto `getQuickLinks()`

## Test Plan
- [ ] 26 nuovi test passano: `useSessionInlineChat` (7) + `RagQuickLinks` (6) + `ToolSheetContent` (13)
- [ ] Build frontend OK (Next.js + TypeScript)
- [ ] Build backend OK
- [ ] Tab "Chiedi" in play-mode mobile mostra la chat inline
- [ ] Tab "Gioco" mostra le pill RAG sotto la toolbar
- [ ] Tool sheet Dadi/Moneta/Timer/Contatore funzionanti
- [ ] Errore chat visualizzato con `role="alert"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)