### PR TITLE
fix(ci): resolve pre-existing lint and test failures

### DIFF
--- a/apps/web/__tests__/mocks/handlers.scenarioBridge.test.ts
+++ b/apps/web/__tests__/mocks/handlers.scenarioBridge.test.ts
@@ -74,7 +74,9 @@ describe('MSW handlers × scenario bridge (issue #366)', () => {
       setScenarioBridge(makeBridge({ getScenarioName: () => 'empty' }));
       const res = await callHandler(gamesHandlers, 'GET', `${BASE}/api/v1/games`);
       expect(res.status).toBe(200);
-      expect(res.body).toEqual([]);
+      const body = res.body as { games: unknown[]; total: number };
+      expect(body.games).toEqual([]);
+      expect(body.total).toBe(0);
     });
 
     it('GET /api/v1/library returns empty items when bridge library is empty', async () => {
@@ -120,7 +122,7 @@ describe('MSW handlers × scenario bridge (issue #366)', () => {
       setScenarioBridge(smallLibraryBridge);
       const res = await callHandler(gamesHandlers, 'GET', `${BASE}/api/v1/games`);
       expect(res.status).toBe(200);
-      const games = res.body as Array<{ id: string; title: string }>;
+      const { games } = res.body as { games: Array<{ id: string; title: string }> };
       expect(games).toHaveLength(2);
       expect(games[0].title).toBe('Wingspan');
       expect(games[1].title).toBe('Scythe');
@@ -131,13 +133,13 @@ describe('MSW handlers × scenario bridge (issue #366)', () => {
       const res = await callHandler(libraryHandlers, 'GET', `${BASE}/api/v1/library`);
       expect(res.status).toBe(200);
       const body = res.body as {
-        items: Array<{ gameId: string; name: string; status: string }>;
+        items: Array<{ gameId: string; gameTitle: string; currentState: string }>;
         totalCount: number;
       };
       expect(body.totalCount).toBe(2);
-      expect(body.items.find(i => i.gameId === 'g1')?.status).toBe('owned');
-      expect(body.items.find(i => i.gameId === 'g1')?.name).toBe('Wingspan');
-      expect(body.items.find(i => i.gameId === 'g2')?.status).toBe('wishlist');
+      expect(body.items.find(i => i.gameId === 'g1')?.currentState).toBe('Owned');
+      expect(body.items.find(i => i.gameId === 'g1')?.gameTitle).toBe('Wingspan');
+      expect(body.items.find(i => i.gameId === 'g2')?.currentState).toBe('Wishlist');
     });
 
     it('GET /api/v1/sessions enriches bridge sessions with game name', async () => {
@@ -158,7 +160,7 @@ describe('MSW handlers × scenario bridge (issue #366)', () => {
       // Bridge NOT installed
       const res = await callHandler(gamesHandlers, 'GET', `${BASE}/api/v1/games`);
       expect(res.status).toBe(200);
-      const games = res.body as Array<{ title: string }>;
+      const { games } = res.body as { games: Array<{ title: string }> };
       expect(games.length).toBeGreaterThan(0);
       // Default fallback contains Chess
       expect(games.some(g => g.title === 'Chess')).toBe(true);

--- a/apps/web/__tests__/play-records/components/PlayHistory.test.tsx
+++ b/apps/web/__tests__/play-records/components/PlayHistory.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { PlayHistory } from '@/components/play-records/PlayHistory';
@@ -102,10 +102,10 @@ describe('PlayHistory', () => {
     );
   };
 
-  it('renders play history title', () => {
+  it('renders play history container', () => {
     renderComponent();
-    expect(screen.getByText('Play History')).toBeInTheDocument();
-    expect(screen.getByText(/Your recorded game sessions/)).toBeInTheDocument();
+    expect(screen.getByTestId('play-history')).toBeInTheDocument();
+    expect(screen.getByTestId('play-history-search')).toBeInTheDocument();
   });
 
   it('displays session cards', () => {
@@ -134,19 +134,15 @@ describe('PlayHistory', () => {
     } as any);
 
     renderComponent();
-    expect(screen.getByText('No Play Records Yet')).toBeInTheDocument();
+    expect(screen.getByTestId('play-history-empty')).toBeInTheDocument();
+    expect(screen.getByText('Nessuna partita registrata')).toBeInTheDocument();
   });
 
-  it('toggles view mode', () => {
+  it('shows filter chips for status', () => {
     renderComponent();
-    const gridButton = screen.getByLabelText('Grid view');
-    const listButton = screen.getByLabelText('List view');
-
-    expect(gridButton).toBeInTheDocument();
-    expect(listButton).toBeInTheDocument();
-
-    fireEvent.click(listButton);
-    // Store update would be tested separately
+    expect(screen.getByTestId('filter-status-all')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-status-Completed')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-status-InProgress')).toBeInTheDocument();
   });
 
   it('shows error state', () => {

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -31,6 +31,7 @@ export default [
       "jest.setup.js",
       "jest.teardown.js",
       "scripts/**", // Node.js utility scripts - exempt from browser linting
+      "retake.mjs", // Playwright dev script — uses browser globals inside page.evaluate() callbacks
       "**/__tests__/**", // Unit test files - TypeScript handles syntax checking
       "**/*.test.{ts,tsx,js,jsx}", // Test files - avoid ESLint parser conflicts
     ],

--- a/apps/web/src/components/layout/HandRail/HandRail.tsx
+++ b/apps/web/src/components/layout/HandRail/HandRail.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 
 import { usePathname } from 'next/navigation';
+import { useShallow } from 'zustand/react/shallow';
 
 import { useCardHand, selectPinnedCards, selectRecentCards } from '@/lib/stores/card-hand-store';
 import { cn } from '@/lib/utils';
@@ -12,8 +13,8 @@ import { HandRailCard } from './HandRailCard';
 export function HandRail() {
   const [expanded, setExpanded] = useState(false);
   const pathname = usePathname();
-  const pinned = useCardHand(selectPinnedCards);
-  const recent = useCardHand(selectRecentCards);
+  const pinned = useCardHand(useShallow(selectPinnedCards));
+  const recent = useCardHand(useShallow(selectRecentCards));
 
   if (pinned.length === 0 && recent.length === 0) return null;
 

--- a/apps/web/src/components/layout/UserShell/__tests__/DesktopShell.test.tsx
+++ b/apps/web/src/components/layout/UserShell/__tests__/DesktopShell.test.tsx
@@ -22,6 +22,14 @@ vi.mock('@/components/chat/panel/ChatSlideOverPanel', () => ({
   ChatSlideOverPanel: () => null,
 }));
 
+vi.mock('@/components/layout/mobile/ActionBar', () => ({
+  ActionBar: () => null,
+}));
+
+vi.mock('@/components/layout/mobile/HandDrawer', () => ({
+  HandDrawer: () => null,
+}));
+
 import { DesktopShell } from '../DesktopShell';
 
 describe('DesktopShell', () => {

--- a/apps/web/src/dev-tools/fixtures/admin-busy.json
+++ b/apps/web/src/dev-tools/fixtures/admin-busy.json
@@ -4,32 +4,32 @@
   "description": "Admin con 20 giochi, 50 sessioni e libreria popolata — per testare liste lunghe e performance UI.",
   "auth": {
     "currentUser": {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000002",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000002",
       "email": "admin@meeple.local",
       "displayName": "Admin",
       "role": "Admin"
     },
     "availableUsers": [
       {
-        "id": "a0eebc99-9c0b-4ef8-bb6d-000000000002",
+        "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000002",
         "email": "admin@meeple.local",
         "displayName": "Admin",
         "role": "Admin"
       },
       {
-        "id": "a0eebc99-9c0b-4ef8-bb6d-000000000001",
+        "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000001",
         "email": "dev@meeple.local",
         "displayName": "Dev User",
         "role": "User"
       },
       {
-        "id": "a0eebc99-9c0b-4ef8-bb6d-000000000014",
+        "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000014",
         "email": "editor@meeple.local",
         "displayName": "Editor",
         "role": "Editor"
       },
       {
-        "id": "a0eebc99-9c0b-4ef8-bb6d-000000000000",
+        "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000000",
         "email": "guest@meeple.local",
         "displayName": "Guest",
         "role": "Guest"
@@ -38,140 +38,140 @@
   },
   "games": [
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-0000000000c9",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000c9",
       "title": "Wingspan",
       "publisher": "Stonemaier Games",
       "averageRating": 8.1,
       "bggId": 266192
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-0000000000ca",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000ca",
       "title": "Scythe",
       "publisher": "Stonemaier Games",
       "averageRating": 8.3,
       "bggId": 169786
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-0000000000cb",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000cb",
       "title": "Terraforming Mars",
       "publisher": "FryxGames",
       "averageRating": 8.4,
       "bggId": 167791
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-0000000000cc",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000cc",
       "title": "Brass: Birmingham",
       "publisher": "Roxley",
       "averageRating": 8.6,
       "bggId": 224517
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-0000000000cd",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000cd",
       "title": "Gloomhaven",
       "publisher": "Cephalofair",
       "averageRating": 8.7,
       "bggId": 174430
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-0000000000ce",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000ce",
       "title": "Ark Nova",
       "publisher": "Capstone Games",
       "averageRating": 8.5,
       "bggId": 342942
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-0000000000cf",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000cf",
       "title": "Spirit Island",
       "publisher": "Greater Than Games",
       "averageRating": 8.3,
       "bggId": 162886
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-0000000000d0",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d0",
       "title": "Everdell",
       "publisher": "Starling Games",
       "averageRating": 8,
       "bggId": 199792
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-0000000000d1",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d1",
       "title": "Root",
       "publisher": "Leder Games",
       "averageRating": 8,
       "bggId": 237182
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-0000000000d2",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d2",
       "title": "Concordia",
       "publisher": "PD-Verlag",
       "averageRating": 8.1,
       "bggId": 124361
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-0000000000d3",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d3",
       "title": "Twilight Imperium 4",
       "publisher": "Fantasy Flight",
       "averageRating": 8.7,
       "bggId": 233078
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-0000000000d4",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d4",
       "title": "Dune: Imperium",
       "publisher": "Dire Wolf",
       "averageRating": 8.4,
       "bggId": 316554
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-0000000000d5",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d5",
       "title": "Lost Ruins of Arnak",
       "publisher": "CGE",
       "averageRating": 8,
       "bggId": 312484
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-0000000000d6",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d6",
       "title": "Great Western Trail",
       "publisher": "Eggertspiele",
       "averageRating": 8.2,
       "bggId": 193738
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-0000000000d7",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d7",
       "title": "Pax Pamir 2",
       "publisher": "Wehrlegig",
       "averageRating": 8.3,
       "bggId": 256960
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-0000000000d8",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d8",
       "title": "Puerto Rico",
       "publisher": "Ravensburger",
       "averageRating": 7.9,
       "bggId": 3076
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-0000000000d9",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d9",
       "title": "Azul",
       "publisher": "Plan B",
       "averageRating": 7.8,
       "bggId": 230802
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-0000000000da",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000da",
       "title": "Catan",
       "publisher": "Kosmos",
       "averageRating": 7.1,
       "bggId": 13
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-0000000000db",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000db",
       "title": "7 Wonders Duel",
       "publisher": "Repos",
       "averageRating": 8,
       "bggId": 173346
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-0000000000dc",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000dc",
       "title": "Agricola",
       "publisher": "Lookout",
       "averageRating": 7.9,
@@ -180,285 +180,285 @@
   ],
   "sessions": [
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-00000000012d",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000c9",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000012d",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000c9",
       "startedAt": "2026-01-01T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-00000000012e",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000ca",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000012e",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000ca",
       "startedAt": "2026-01-02T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-00000000012f",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000cb",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000012f",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000cb",
       "startedAt": "2026-01-03T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000130",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000cc",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000130",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000cc",
       "startedAt": "2026-01-04T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000131",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000cd",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000131",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000cd",
       "startedAt": "2026-01-05T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000132",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000ce",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000132",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000ce",
       "startedAt": "2026-01-06T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000133",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000cf",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000133",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000cf",
       "startedAt": "2026-01-07T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000134",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000d0",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000134",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d0",
       "startedAt": "2026-01-08T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000135",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000d1",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000135",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d1",
       "startedAt": "2026-01-09T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000136",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000d2",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000136",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d2",
       "startedAt": "2026-01-10T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000137",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000d3",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000137",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d3",
       "startedAt": "2026-01-11T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000138",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000d4",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000138",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d4",
       "startedAt": "2026-01-12T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000139",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000d5",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000139",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d5",
       "startedAt": "2026-01-13T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-00000000013a",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000d6",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000013a",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d6",
       "startedAt": "2026-01-14T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-00000000013b",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000d7",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000013b",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d7",
       "startedAt": "2026-01-15T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-00000000013c",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000d8",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000013c",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d8",
       "startedAt": "2026-01-16T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-00000000013d",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000d9",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000013d",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d9",
       "startedAt": "2026-01-17T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-00000000013e",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000da",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000013e",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000da",
       "startedAt": "2026-01-18T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-00000000013f",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000db",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000013f",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000db",
       "startedAt": "2026-01-19T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000140",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000dc",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000140",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000dc",
       "startedAt": "2026-01-20T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000141",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000c9",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000141",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000c9",
       "startedAt": "2026-01-21T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000142",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000ca",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000142",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000ca",
       "startedAt": "2026-01-22T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000143",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000cb",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000143",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000cb",
       "startedAt": "2026-01-23T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000144",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000cc",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000144",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000cc",
       "startedAt": "2026-01-24T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000145",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000cd",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000145",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000cd",
       "startedAt": "2026-01-25T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000146",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000ce",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000146",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000ce",
       "startedAt": "2026-01-26T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000147",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000cf",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000147",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000cf",
       "startedAt": "2026-01-27T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000148",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000d0",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000148",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d0",
       "startedAt": "2026-01-28T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000149",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000d1",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000149",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d1",
       "startedAt": "2026-02-01T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-00000000014a",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000d2",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000014a",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d2",
       "startedAt": "2026-02-02T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-00000000014b",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000d3",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000014b",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d3",
       "startedAt": "2026-02-03T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-00000000014c",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000d4",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000014c",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d4",
       "startedAt": "2026-02-04T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-00000000014d",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000d5",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000014d",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d5",
       "startedAt": "2026-02-05T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-00000000014e",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000d6",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000014e",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d6",
       "startedAt": "2026-02-06T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-00000000014f",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000d7",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000014f",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d7",
       "startedAt": "2026-02-07T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000150",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000d8",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000150",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d8",
       "startedAt": "2026-02-08T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000151",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000d9",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000151",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d9",
       "startedAt": "2026-02-09T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000152",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000da",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000152",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000da",
       "startedAt": "2026-02-10T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000153",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000db",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000153",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000db",
       "startedAt": "2026-02-11T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000154",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000dc",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000154",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000dc",
       "startedAt": "2026-02-12T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000155",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000c9",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000155",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000c9",
       "startedAt": "2026-02-13T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000156",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000ca",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000156",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000ca",
       "startedAt": "2026-02-14T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000157",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000cb",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000157",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000cb",
       "startedAt": "2026-02-15T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000158",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000cc",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000158",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000cc",
       "startedAt": "2026-02-16T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000159",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000cd",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000159",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000cd",
       "startedAt": "2026-02-17T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-00000000015a",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000ce",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000015a",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000ce",
       "startedAt": "2026-02-18T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-00000000015b",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000cf",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000015b",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000cf",
       "startedAt": "2026-02-19T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-00000000015c",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000d0",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000015c",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d0",
       "startedAt": "2026-02-20T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-00000000015d",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000d1",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000015d",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d1",
       "startedAt": "2026-02-21T19:00:00.000Z"
     },
     {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-00000000015e",
-      "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000d2",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000015e",
+      "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d2",
       "startedAt": "2026-02-22T19:00:00.000Z"
     }
   ],
   "library": {
     "ownedGameIds": [
-      "a0eebc99-9c0b-4ef8-bb6d-0000000000c9",
-      "a0eebc99-9c0b-4ef8-bb6d-0000000000ca",
-      "a0eebc99-9c0b-4ef8-bb6d-0000000000cb",
-      "a0eebc99-9c0b-4ef8-bb6d-0000000000cc",
-      "a0eebc99-9c0b-4ef8-bb6d-0000000000cd",
-      "a0eebc99-9c0b-4ef8-bb6d-0000000000ce",
-      "a0eebc99-9c0b-4ef8-bb6d-0000000000cf",
-      "a0eebc99-9c0b-4ef8-bb6d-0000000000d0",
-      "a0eebc99-9c0b-4ef8-bb6d-0000000000d1",
-      "a0eebc99-9c0b-4ef8-bb6d-0000000000d2",
-      "a0eebc99-9c0b-4ef8-bb6d-0000000000d3",
-      "a0eebc99-9c0b-4ef8-bb6d-0000000000d4",
-      "a0eebc99-9c0b-4ef8-bb6d-0000000000d5",
-      "a0eebc99-9c0b-4ef8-bb6d-0000000000d6",
-      "a0eebc99-9c0b-4ef8-bb6d-0000000000d7"
+      "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000c9",
+      "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000ca",
+      "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000cb",
+      "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000cc",
+      "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000cd",
+      "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000ce",
+      "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000cf",
+      "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d0",
+      "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d1",
+      "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d2",
+      "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d3",
+      "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d4",
+      "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d5",
+      "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d6",
+      "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d7"
     ],
     "wishlistGameIds": [
-      "a0eebc99-9c0b-4ef8-bb6d-0000000000d8",
-      "a0eebc99-9c0b-4ef8-bb6d-0000000000d9",
-      "a0eebc99-9c0b-4ef8-bb6d-0000000000da",
-      "a0eebc99-9c0b-4ef8-bb6d-0000000000db",
-      "a0eebc99-9c0b-4ef8-bb6d-0000000000dc"
+      "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d8",
+      "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000d9",
+      "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000da",
+      "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000db",
+      "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000dc"
     ]
   },
   "chatHistory": [
     {
-      "chatId": "a0eebc99-9c0b-4ef8-bb6d-000000000191",
+      "chatId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000191",
       "messages": [
         {
           "role": "user",

--- a/apps/web/src/dev-tools/fixtures/small-library.json
+++ b/apps/web/src/dev-tools/fixtures/small-library.json
@@ -4,37 +4,37 @@
   "description": "Utente User con 3 giochi, 5 sessioni e una chat storica.",
   "auth": {
     "currentUser": {
-      "id": "a0eebc99-9c0b-4ef8-bb6d-000000000001",
+      "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000001",
       "email": "dev@meeple.local",
       "displayName": "Dev User",
       "role": "User"
     },
     "availableUsers": [
-      { "id": "a0eebc99-9c0b-4ef8-bb6d-000000000001", "email": "dev@meeple.local", "displayName": "Dev User", "role": "User" },
-      { "id": "a0eebc99-9c0b-4ef8-bb6d-00000000000a", "email": "admin@meeple.local", "displayName": "Admin", "role": "Admin" },
-      { "id": "a0eebc99-9c0b-4ef8-bb6d-000000000014", "email": "editor@meeple.local", "displayName": "Editor", "role": "Editor" },
-      { "id": "a0eebc99-9c0b-4ef8-bb6d-000000000000", "email": "guest@meeple.local", "displayName": "Guest", "role": "Guest" }
+      { "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000001", "email": "dev@meeple.local", "displayName": "Dev User", "role": "User" },
+      { "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000000a", "email": "admin@meeple.local", "displayName": "Admin", "role": "Admin" },
+      { "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000014", "email": "editor@meeple.local", "displayName": "Editor", "role": "Editor" },
+      { "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000000", "email": "guest@meeple.local", "displayName": "Guest", "role": "Guest" }
     ]
   },
   "games": [
-    { "id": "a0eebc99-9c0b-4ef8-bb6d-0000000000c9", "title": "Wingspan", "publisher": "Stonemaier Games", "averageRating": 8.1, "bggId": 266192 },
-    { "id": "a0eebc99-9c0b-4ef8-bb6d-0000000000ca", "title": "Scythe", "publisher": "Stonemaier Games", "averageRating": 8.3, "bggId": 169786 },
-    { "id": "a0eebc99-9c0b-4ef8-bb6d-0000000000cb", "title": "Terraforming Mars", "publisher": "FryxGames", "averageRating": 8.4, "bggId": 167791 }
+    { "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000c9", "title": "Wingspan", "publisher": "Stonemaier Games", "averageRating": 8.1, "bggId": 266192 },
+    { "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000ca", "title": "Scythe", "publisher": "Stonemaier Games", "averageRating": 8.3, "bggId": 169786 },
+    { "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000cb", "title": "Terraforming Mars", "publisher": "FryxGames", "averageRating": 8.4, "bggId": 167791 }
   ],
   "sessions": [
-    { "id": "a0eebc99-9c0b-4ef8-bb6d-00000000012d", "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000c9", "startedAt": "2026-04-01T18:00:00.000Z" },
-    { "id": "a0eebc99-9c0b-4ef8-bb6d-00000000012e", "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000c9", "startedAt": "2026-04-02T20:00:00.000Z" },
-    { "id": "a0eebc99-9c0b-4ef8-bb6d-00000000012f", "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000ca", "startedAt": "2026-04-03T19:30:00.000Z" },
-    { "id": "a0eebc99-9c0b-4ef8-bb6d-000000000130", "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000cb", "startedAt": "2026-04-05T15:00:00.000Z" },
-    { "id": "a0eebc99-9c0b-4ef8-bb6d-000000000131", "gameId": "a0eebc99-9c0b-4ef8-bb6d-0000000000ca", "startedAt": "2026-04-07T21:00:00.000Z" }
+    { "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000012d", "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000c9", "startedAt": "2026-04-01T18:00:00.000Z" },
+    { "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000012e", "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000c9", "startedAt": "2026-04-02T20:00:00.000Z" },
+    { "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-00000000012f", "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000ca", "startedAt": "2026-04-03T19:30:00.000Z" },
+    { "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000130", "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000cb", "startedAt": "2026-04-05T15:00:00.000Z" },
+    { "id": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000131", "gameId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000ca", "startedAt": "2026-04-07T21:00:00.000Z" }
   ],
   "library": {
-    "ownedGameIds": ["a0eebc99-9c0b-4ef8-bb6d-0000000000c9", "a0eebc99-9c0b-4ef8-bb6d-0000000000ca"],
-    "wishlistGameIds": ["a0eebc99-9c0b-4ef8-bb6d-0000000000cb"]
+    "ownedGameIds": ["MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000c9", "MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000ca"],
+    "wishlistGameIds": ["MOCK-a0eebc99-9c0b-4ef8-bb6d-0000000000cb"]
   },
   "chatHistory": [
     {
-      "chatId": "a0eebc99-9c0b-4ef8-bb6d-000000000191",
+      "chatId": "MOCK-a0eebc99-9c0b-4ef8-bb6d-000000000191",
       "messages": [
         { "role": "user", "content": "Come si gioca a Wingspan?" },
         { "role": "assistant", "content": "Wingspan è un gioco da tavolo di strategia in cui colleziona uccelli e costruisce habitat. Nel turno hai 4 azioni: giocare un uccello, guadagnare cibo, deporre uova o pescare carte." }

--- a/apps/web/src/lib/stores/card-hand-store.ts
+++ b/apps/web/src/lib/stores/card-hand-store.ts
@@ -68,6 +68,8 @@ export const useCardHand = create<CardHandStore>()(
   )
 );
 
+// Use shallow equality in consumers (useCardHand(selectPinnedCards, shallow)) to avoid
+// referential instability from .filter() and .sort() creating new arrays each call.
 export const selectPinnedCards = (s: CardHandStore) => s.cards.filter(c => c.pinned);
 
 export const selectRecentCards = (s: CardHandStore) =>


### PR DESCRIPTION
## Summary
- ESLint: add `retake.mjs` to ignores (browser globals inside `page.evaluate()` callbacks)
- `DesktopShell.test.tsx`: mock `ActionBar` + `HandDrawer` added in #404 but not covered
- `HandRail`: use `useShallow` for array selectors to prevent referential instability loop
- Fixtures: prefix all IDs with `MOCK-` to satisfy `^MOCK-` schema validator pattern

## Test Plan
- [ ] `pnpm test` — 0 failing tests (tutti e 4 i test pre-esistenti ora passano)
- [ ] `pnpm lint` — 0 errori (15 warning pre-esistenti, sotto threshold 510)