### PR TITLE
fix(seed): add badsworm demo user seeded from SEED_BADSWORM_PASSWORD secret

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedBadswormUserCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedBadswormUserCommand.cs
@@ -3,7 +3,8 @@ using Api.SharedKernel.Application.Interfaces;
 namespace Api.BoundedContexts.Administration.Application.Commands;
 
 /// <summary>
-/// Command to seed the badsworm demo user for development purposes.
+/// Command to seed the badsworm demo user account.
 /// Creates badsworm@alice.it with password from SEED_BADSWORM_PASSWORD secret.
+/// Runs in all environments (Dev, Staging, Prod) when the secret is present.
 /// </summary>
 public sealed record SeedBadswormUserCommand : ICommand;

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedBadswormUserCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedBadswormUserCommandHandler.cs
@@ -15,6 +15,8 @@ namespace Api.BoundedContexts.Administration.Application.Commands;
 /// Handler for SeedBadswormUserCommand.
 /// Creates demo user (badsworm@alice.it) with password from SEED_BADSWORM_PASSWORD secret.
 /// Idempotent: Only executes if user doesn't exist.
+/// Runs in all environments (Dev, Staging, Prod) when SEED_BADSWORM_PASSWORD secret is present.
+/// Remove or leave the secret absent in environments where this account should not exist.
 /// </summary>
 internal sealed class SeedBadswormUserCommandHandler : ICommandHandler<SeedBadswormUserCommand>
 {
@@ -69,7 +71,7 @@ internal sealed class SeedBadswormUserCommandHandler : ICommandHandler<SeedBadsw
             passwordHash: PasswordHash.Create(password),
             role: Role.User
         );
-        user.VerifyEmail();
+        user.VerifyEmail(); // Developer account: pre-verified, no email flow required
 
         await _userRepository.AddAsync(user, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/Infrastructure/Seeders/Core/CoreSeedLayer.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Core/CoreSeedLayer.cs
@@ -34,7 +34,7 @@ internal sealed class CoreSeedLayer : ISeedLayer
         await SafeExecute("staging demo user",
             () => mediator.Send(new SeedStagingDemoUserCommand(), cancellationToken), logger).ConfigureAwait(false);
 
-        // Non-fatal: badsworm demo user (requires SEED_BADSWORM_PASSWORD secret)
+        // Non-fatal: badsworm demo user (requires SEED_BADSWORM_PASSWORD secret — runs in all envs)
         await SafeExecute("badsworm user",
             () => mediator.Send(new SeedBadswormUserCommand(), cancellationToken), logger).ConfigureAwait(false);
 

--- a/apps/api/tests/Api.Tests/Administration/SeedBadswormUserCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/Administration/SeedBadswormUserCommandHandlerTests.cs
@@ -1,0 +1,123 @@
+using Api.BoundedContexts.Administration.Application.Commands;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.BoundedContexts.Authentication.Domain.ValueObjects;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.SharedKernel.Infrastructure.Persistence;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using Api.Tests.Constants;
+
+namespace Api.Tests.Administration.AutoConfiguration;
+
+[Trait("Category", TestCategories.Unit)]
+public sealed class SeedBadswormUserCommandHandlerTests
+{
+    private const string BadswormPassword = "BadswormSeed2026!xK"; // gitguardian:ignore
+
+    private readonly Mock<IUserRepository> _userRepositoryMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IConfiguration> _configurationMock;
+    private readonly Mock<ILogger<SeedBadswormUserCommandHandler>> _loggerMock;
+    private readonly SeedBadswormUserCommandHandler _handler;
+
+    public SeedBadswormUserCommandHandlerTests()
+    {
+        _userRepositoryMock = new Mock<IUserRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _loggerMock = new Mock<ILogger<SeedBadswormUserCommandHandler>>();
+        _configurationMock = new Mock<IConfiguration>();
+        _configurationMock.Setup(c => c["SEED_BADSWORM_PASSWORD"]).Returns(BadswormPassword);
+
+        _handler = new SeedBadswormUserCommandHandler(
+            _userRepositoryMock.Object,
+            _unitOfWorkMock.Object,
+            _configurationMock.Object,
+            _loggerMock.Object
+        );
+    }
+
+    [Fact]
+    public async Task Handle_WhenBadswormUserExists_ShouldSkipSeed()
+    {
+        _userRepositoryMock
+            .Setup(x => x.GetByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateBadswormUser());
+
+        await _handler.Handle(new SeedBadswormUserCommand(), CancellationToken.None);
+
+        _userRepositoryMock.Verify(x => x.AddAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Never);
+        _unitOfWorkMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoBadswormUserExists_ShouldCreateUser()
+    {
+        _userRepositoryMock
+            .Setup(x => x.GetByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        await _handler.Handle(new SeedBadswormUserCommand(), CancellationToken.None);
+
+        _userRepositoryMock.Verify(
+            x => x.AddAsync(It.Is<User>(u =>
+                u.Email.Value == "badsworm@alice.it" &&
+                u.DisplayName == "Badsworm" &&
+                u.Role == Role.User &&
+                u.EmailVerified
+            ), It.IsAny<CancellationToken>()),
+            Times.Once
+        );
+        _unitOfWorkMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenPasswordNotConfigured_ShouldSkipSeed()
+    {
+        var configMock = new Mock<IConfiguration>();
+        configMock.Setup(c => c["SEED_BADSWORM_PASSWORD"]).Returns((string?)null);
+
+        var handler = new SeedBadswormUserCommandHandler(
+            _userRepositoryMock.Object,
+            _unitOfWorkMock.Object,
+            configMock.Object,
+            _loggerMock.Object
+        );
+
+        await handler.Handle(new SeedBadswormUserCommand(), CancellationToken.None);
+
+        _userRepositoryMock.Verify(x => x.AddAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenPasswordTooShort_ShouldSkipSeed()
+    {
+        var configMock = new Mock<IConfiguration>();
+        configMock.Setup(c => c["SEED_BADSWORM_PASSWORD"]).Returns("short");
+
+        var handler = new SeedBadswormUserCommandHandler(
+            _userRepositoryMock.Object,
+            _unitOfWorkMock.Object,
+            configMock.Object,
+            _loggerMock.Object
+        );
+
+        await handler.Handle(new SeedBadswormUserCommand(), CancellationToken.None);
+
+        _userRepositoryMock.Verify(x => x.AddAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static User CreateBadswormUser()
+    {
+        return new User(
+            Guid.NewGuid(),
+            new Email("badsworm@alice.it"),
+            "Badsworm",
+            PasswordHash.Create(BadswormPassword),
+            Role.User
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `SeedBadswormUserCommand` + `SeedBadswormUserCommandHandler` to seed `badsworm@alice.it` as a demo user in all environments
- Password read exclusively from `SEED_BADSWORM_PASSWORD` secret via `SecretsHelper.GetSeedBadswormPassword()` — never hardcoded
- Wired in `CoreSeedLayer` as a non-fatal step (absent secret = no-op, logged as warning)
- Adds `GetSeedBadswormPassword()` helper to `SecretsHelper.cs`
- Updates `admin.secret.example` with `SEED_BADSWORM_PASSWORD` placeholder
- Also includes code review fixes (C1, C2, I2) from review of PR #405 that were missing from the squash merge

## Test Plan

- [ ] Verify build passes (frontend + backend)
- [ ] Confirm `badsworm@alice.it` is seeded when `SEED_BADSWORM_PASSWORD` is set in `admin.secret`
- [ ] Confirm no error is raised when `SEED_BADSWORM_PASSWORD` is absent (warning only)
- [ ] Verify `useEntityActions` passes `gameName` in session navigation URL
- [ ] Verify `useSearchParams` in `/sessions/new` is wrapped in `<Suspense>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)