### PR TITLE
fix(routing): endpoint audit fixes — route mismatch, orphan annotations, contract tests

### DIFF
--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -778,6 +778,7 @@ if (!isAlphaMode)
     v1Api.MapNotificationPreferencesEndpoints(); // Notification preferences (Issue #4220)
     v1Api.MapSlackIntegrationEndpoints();        // Slack OAuth connect/disconnect/status
     v1Api.MapUnsubscribeEndpoints();       // Issue #38: GDPR-compliant email unsubscribe
+    v1Api.MapContactEndpoints();           // Public contact form (no auth required)
 
     // Library extended
     v1Api.MapEntityLinkUserEndpoints();    // Entity link user endpoints (Issue #5137)

--- a/apps/api/src/Api/Routing/UserLibrary/UserLibraryCoreEndpoints.cs
+++ b/apps/api/src/Api/Routing/UserLibrary/UserLibraryCoreEndpoints.cs
@@ -38,7 +38,7 @@ internal static class UserLibraryCoreEndpoints
 
         // Agent configuration endpoints
         MapGetGameAgentConfigEndpoint(group);
-        MapConfigureGameAgentEndpoint(group);
+        MapUpdateAgentConfigEndpoint(group);
         MapResetGameAgentEndpoint(group);
         MapSaveAgentConfigEndpoint(group);
         MapCreateGameAgentEndpoint(group);
@@ -415,9 +415,9 @@ internal static class UserLibraryCoreEndpoints
         .WithOpenApi();
     }
 
-    private static void MapConfigureGameAgentEndpoint(RouteGroupBuilder group)
+    private static void MapUpdateAgentConfigEndpoint(RouteGroupBuilder group)
     {
-        group.MapPut("/library/games/{gameId:guid}/agent", async (
+        group.MapPut("/library/games/{gameId:guid}/agent-config", async (
             Guid gameId,
             [FromBody] AgentConfigDto agentConfig,
             IMediator mediator,
@@ -449,8 +449,8 @@ internal static class UserLibraryCoreEndpoints
         .Produces(401)
         .Produces(404)
         .WithTags("Library")
-        .WithSummary("Configure custom AI agent")
-        .WithDescription("Configures a custom AI agent for a game in user's library. Replaces any existing configuration.")
+        .WithSummary("Update AI agent configuration")
+        .WithDescription("Updates the custom AI agent configuration for a game in user's library. Replaces any existing configuration.")
         .WithOpenApi();
     }
 

--- a/apps/api/tests/Api.Tests/Integration/UserLibrary/UserLibraryEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/UserLibrary/UserLibraryEndpointsIntegrationTests.cs
@@ -484,7 +484,7 @@ public sealed class UserLibraryEndpointsIntegrationTests : IAsyncLifetime
         var gameId = Guid.NewGuid();
 
         // Act
-        var response = await _client.GetAsync($"/api/v1/library/games/{gameId}/agent");
+        var response = await _client.GetAsync($"/api/v1/library/games/{gameId}/agent-config");
 
         // Assert - May return MethodNotAllowed, NotFound, or Unauthorized
         (response.StatusCode == HttpStatusCode.Unauthorized ||

--- a/apps/api/tests/Api.Tests/Routing/EndpointContractTests.cs
+++ b/apps/api/tests/Api.Tests/Routing/EndpointContractTests.cs
@@ -1,0 +1,316 @@
+using System.Net;
+using Api.Infrastructure;
+using Api.Models;
+using Api.Services;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Api.Tests.Routing;
+
+/// <summary>
+/// Endpoint contract test: verifies frontend API URLs resolve to backend routes.
+///
+/// Strategy:
+/// - KnownRoutes: routes the frontend calls that MUST exist on the backend.
+///   They should return 401 (unauthenticated) or any non-404/405, proving the route is registered.
+/// - PendingBackendRoutes: routes the frontend calls but the backend has NOT yet implemented.
+///   They must return 404/405; when they stop doing so, move them to KnownRoutes.
+///
+/// Uses a minimal in-process test server (no real DB, no containers) so this test
+/// runs fast as part of the unit / CI pipeline without external dependencies.
+///
+/// See: endpoint-audit-2026-04-15, agentsClient.ts BACKEND MISSING annotations.
+/// </summary>
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "Routing")]
+public sealed class EndpointContractTests : IClassFixture<RouteContractTestFactory>
+{
+    private readonly HttpClient _client;
+
+    public EndpointContractTests(RouteContractTestFactory factory)
+    {
+        _client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // Known routes — frontend calls these, backend must have them registered.
+    // Expected status: anything except 404 / 405 (typically 401 Unauthorized).
+    // -----------------------------------------------------------------------
+    public static IEnumerable<object[]> KnownRoutes()
+    {
+        // Auth
+        yield return ["POST", "/api/v1/auth/login"];
+        yield return ["POST", "/api/v1/auth/register"];
+        yield return ["GET",  "/api/v1/auth/me"];
+        yield return ["GET",  "/api/v1/auth/session/status"];
+
+        // Library
+        yield return ["GET",  "/api/v1/library"];
+        yield return ["GET",  "/api/v1/library/games/00000000-0000-0000-0000-000000000001/agent-config"];
+        yield return ["PUT",  "/api/v1/library/games/00000000-0000-0000-0000-000000000001/agent-config"];
+        yield return ["POST", "/api/v1/library/games/00000000-0000-0000-0000-000000000001/agent-config"];
+
+        // PDF / ingest
+        yield return ["GET",  "/api/v1/pdfs/00000000-0000-0000-0000-000000000001/progress"];
+        yield return ["POST", "/api/v1/ingest/pdf"];
+
+        // Knowledge Base
+        yield return ["GET",  "/api/v1/knowledge-base/00000000-0000-0000-0000-000000000001/status"];
+        yield return ["POST", "/api/v1/knowledge-base/search"];
+
+        // Sessions
+        yield return ["GET", "/api/v1/sessions/active"];
+        yield return ["GET", "/api/v1/sessions/history"];
+
+        // Chat
+        yield return ["GET", "/api/v1/chat-threads"];
+
+        // Models
+        yield return ["GET", "/api/v1/models"];
+
+        // Games
+        yield return ["GET", "/api/v1/games"];
+
+        // Notifications
+        yield return ["GET", "/api/v1/notifications"];
+
+        // Wishlist
+        yield return ["GET", "/api/v1/wishlist"];
+
+        // Playlists
+        yield return ["GET", "/api/v1/playlists"];
+
+        // Play Records
+        yield return ["GET", "/api/v1/play-records/history"];
+
+        // Game Nights
+        yield return ["GET", "/api/v1/game-nights"];
+
+        // Contact (public endpoint — expects 200 or 400, not 404)
+        yield return ["POST", "/api/v1/contact"];
+    }
+
+    // -----------------------------------------------------------------------
+    // Pending routes — frontend calls these but NO backend implementation exists.
+    // Expected status: 404 or 405 (route not registered).
+    // When a route starts returning something else, move it to KnownRoutes!
+    // -----------------------------------------------------------------------
+    public static IEnumerable<object[]> PendingBackendRoutes()
+    {
+        // Agent CRUD — agentsClient.ts marks these as BACKEND MISSING (audit 2026-04-15).
+        yield return ["GET",  "/api/v1/agents",                                                                "agent listing"];
+        yield return ["GET",  "/api/v1/agents/00000000-0000-0000-0000-000000000001",                          "agent by id"];
+        yield return ["GET",  "/api/v1/agents/00000000-0000-0000-0000-000000000001/status",                   "agent status"];
+        yield return ["GET",  "/api/v1/agent-typologies",                                                     "typology listing"];
+        yield return ["GET",  "/api/v1/agents/recent?limit=10",                                               "recent agents"];
+        yield return ["POST", "/api/v1/agents/user",                                                          "create user agent"];
+        yield return ["GET",  "/api/v1/user/agent-slots",                                                     "agent slots"];
+        yield return ["POST", "/api/v1/agents/create-with-setup",                                             "create with setup"];
+        yield return ["POST", "/api/v1/agents/quick-create",                                                  "quick create tutor"];
+        yield return ["PUT",  "/api/v1/agents/00000000-0000-0000-0000-000000000001/configure",                "configure agent"];
+        yield return ["GET",  "/api/v1/agents/00000000-0000-0000-0000-000000000001/configuration",            "get agent config"];
+        yield return ["PATCH", "/api/v1/agents/00000000-0000-0000-0000-000000000001/configuration",           "update agent config"];
+    }
+
+    [Theory]
+    [MemberData(nameof(KnownRoutes))]
+    public async Task KnownRoute_ShouldNotReturn404(string method, string url)
+    {
+        var request = new HttpRequestMessage(new HttpMethod(method), url);
+        if (method is "POST" or "PUT" or "PATCH")
+            request.Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json");
+
+        var response = await _client.SendAsync(request);
+
+        // Any status except 404/405 = route is registered (typically 401 unauthenticated)
+        Assert.NotEqual(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.NotEqual(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+    }
+
+    [Theory]
+    [MemberData(nameof(PendingBackendRoutes))]
+    public async Task PendingRoute_ShouldReturn404UntilImplemented(
+        string method, string url, string description)
+    {
+        var request = new HttpRequestMessage(new HttpMethod(method), url);
+        if (method is "POST" or "PUT" or "PATCH")
+            request.Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json");
+
+        var response = await _client.SendAsync(request);
+
+        // If this assertion starts FAILING, the route was implemented!
+        // → Move the row from PendingBackendRoutes to KnownRoutes.
+        Assert.True(
+            response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.MethodNotAllowed,
+            $"Route {method} {url} ({description}) now returns {(int)response.StatusCode} {response.StatusCode}. " +
+            "Backend implementation detected — move this entry from PendingBackendRoutes to KnownRoutes.");
+    }
+}
+
+/// <summary>
+/// Lightweight WebApplicationFactory for endpoint contract tests.
+///
+/// Uses SQLite InMemory instead of Postgres (no Testcontainers needed),
+/// mocks all external services (Redis, embeddings, cache), and strips
+/// hosted background services so startup is fast and dependency-free.
+///
+/// This factory is intentionally minimal: we only need the ASP.NET routing
+/// pipeline to start so we can probe HTTP status codes.
+/// </summary>
+public sealed class RouteContractTestFactory : WebApplicationFactory<Program>
+{
+    static RouteContractTestFactory()
+    {
+        Environment.SetEnvironmentVariable("DISABLE_RATE_LIMITING", "true");
+        Environment.SetEnvironmentVariable("RateLimiting__Enabled", "false");
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Testing");
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+
+        builder.ConfigureAppConfiguration((_, configBuilder) =>
+        {
+            configBuilder.Sources.Clear();
+            configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                // Use SQLite InMemory — no external DB required
+                ["ConnectionStrings:DefaultConnection"] = "DataSource=:memory:",
+                ["ConnectionStrings:Postgres"]          = "DataSource=:memory:",
+                // JWT (required so auth middleware can start)
+                ["Jwt:Secret"]    = "contract-test-secret-key-minimum-32-characters-long",
+                ["Jwt:Issuer"]    = "MeepleAI-ContractTest",
+                ["Jwt:Audience"]  = "MeepleAI-ContractTest",
+                // OpenRouter placeholder
+                ["OpenRouter:ApiKey"]  = "contract-test-key",
+                ["OpenRouter:BaseUrl"] = "https://test.local",
+                // Disable all external services
+                ["BoardGameGeek:Enabled"] = "false",
+                ["Embedding:Enabled"]     = "false",
+                ["Embedding:Url"]         = "http://localhost:8000",
+                ["Qdrant:Enabled"]        = "false",
+                ["Qdrant:Host"]           = "localhost",
+                ["Qdrant:Port"]           = "6333",
+                ["Redis:Enabled"]         = "false",
+                ["Redis:ConnectionString"] = "localhost:6379",
+                // Session config
+                ["Authentication:SessionManagement:SessionExpirationDays"] = "30",
+                // Admin seed (skipped because hosted services are removed)
+                ["Admin:Email"]       = "admin@test.local",
+                ["Admin:Password"]    = "TestAdmin123!",
+                ["Admin:DisplayName"] = "Test Admin",
+                ["INITIAL_ADMIN_EMAIL"]        = "admin@test.local",
+                ["INITIAL_ADMIN_PASSWORD"]     = "TestAdmin123!",
+                ["INITIAL_ADMIN_DISPLAY_NAME"] = "Test Admin",
+                // Observability off
+                ["Observability:Enabled"]          = "false",
+                ["OTEL_EXPORTER_OTLP_ENDPOINT"]    = "",
+                // Rate limiting off
+                ["RateLimiting:Enabled"] = "false",
+                // CORS
+                ["Cors:Origins:0"] = "http://localhost:3000",
+            });
+        });
+
+        builder.ConfigureServices(services =>
+        {
+            // Remove all background services — prevents startup failures for services
+            // that need real DB / Redis / external endpoints.
+            var hostedServiceDescriptors = services
+                .Where(d => d.ServiceType == typeof(IHostedService))
+                .ToList();
+            foreach (var descriptor in hostedServiceDescriptors)
+                services.Remove(descriptor);
+
+            // Replace EF DbContext with SQLite InMemory (pgvector-free)
+            services.RemoveAll<DbContextOptions<MeepleAiDbContext>>();
+            services.RemoveAll<MeepleAiDbContext>();
+            services.RemoveAll<IDomainEventCollector>();
+
+            services.AddScoped<IDomainEventCollector, DomainEventCollector>();
+
+            services.AddDbContext<MeepleAiDbContext>(options =>
+            {
+                options.UseSqlite("DataSource=:memory:");
+                options.EnableSensitiveDataLogging();
+            });
+        });
+
+        builder.ConfigureTestServices(services =>
+        {
+            // Mock Redis
+            services.RemoveAll(typeof(IConnectionMultiplexer));
+            var mockRedis = new Mock<IConnectionMultiplexer>();
+            var mockDatabase = new Mock<IDatabase>();
+            mockRedis.Setup(r => r.GetDatabase(It.IsAny<int>(), It.IsAny<object>()))
+                     .Returns(mockDatabase.Object);
+            services.AddSingleton(mockRedis.Object);
+
+            // Mock embedding service
+            services.RemoveAll(typeof(IEmbeddingService));
+            services.AddScoped<IEmbeddingService>(_ => Mock.Of<IEmbeddingService>());
+
+            // Pass-through hybrid cache (no Redis needed)
+            services.RemoveAll(typeof(IHybridCacheService));
+            services.AddScoped<IHybridCacheService, ContractTestHybridCacheService>();
+
+            // Mock configuration service — returns sensible defaults
+            services.RemoveAll(typeof(IConfigurationService));
+            var mockConfigService = new Mock<IConfigurationService>();
+            mockConfigService
+                .Setup(c => c.GetValueAsync<bool?>(It.IsAny<string>(), It.IsAny<bool?>(), It.IsAny<string?>()))
+                .ReturnsAsync((string _, bool? def, string? __) => def);
+            mockConfigService
+                .Setup(c => c.GetValueAsync<int?>(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string?>()))
+                .ReturnsAsync((string _, int? def, string? __) => def);
+            mockConfigService
+                .Setup(c => c.GetValueAsync<string?>(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()))
+                .ReturnsAsync((string _, string? def, string? __) => def);
+            mockConfigService
+                .Setup(c => c.GetConfigurationByKeyAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((SystemConfigurationDto?)null);
+            services.AddScoped<IConfigurationService>(_ => mockConfigService.Object);
+        });
+    }
+}
+
+/// <summary>
+/// No-op IHybridCacheService: always executes the factory without caching.
+/// </summary>
+internal sealed class ContractTestHybridCacheService : IHybridCacheService
+{
+    public async Task<T> GetOrCreateAsync<T>(
+        string cacheKey,
+        Func<CancellationToken, Task<T>> factory,
+        string[]? tags = null,
+        TimeSpan? expiration = null,
+        CancellationToken ct = default) where T : class
+        => await factory(ct).ConfigureAwait(false);
+
+    public Task RemoveAsync(string cacheKey, CancellationToken ct = default)
+        => Task.CompletedTask;
+
+    public Task<int> RemoveByTagAsync(string tag, CancellationToken ct = default)
+        => Task.FromResult(0);
+
+    public Task<int> RemoveByTagsAsync(string[] tags, CancellationToken ct = default)
+        => Task.FromResult(0);
+
+    public Task<HybridCacheStats> GetStatsAsync(CancellationToken ct = default)
+        => Task.FromResult(new HybridCacheStats());
+}

--- a/apps/api/tests/Api.Tests/Routing/EndpointContractTests.cs
+++ b/apps/api/tests/Api.Tests/Routing/EndpointContractTests.cs
@@ -100,7 +100,8 @@ public sealed class EndpointContractTests : IClassFixture<RouteContractTestFacto
         // Game Nights
         yield return ["GET", "/api/v1/game-nights"];
 
-        // Contact: REMOVED — MapContactEndpoints defined but never called in routing setup.
+        // Contact (public, no auth)
+        yield return ["POST", "/api/v1/contact"];
     }
 
     // -----------------------------------------------------------------------
@@ -124,8 +125,6 @@ public sealed class EndpointContractTests : IClassFixture<RouteContractTestFacto
         yield return ["GET",  "/api/v1/agents/00000000-0000-0000-0000-000000000001/configuration",            "get agent config"];
         yield return ["PATCH", "/api/v1/agents/00000000-0000-0000-0000-000000000001/configuration",           "update agent config"];
 
-        // Contact — MapContactEndpoints defined but never wired in endpoint registration
-        yield return ["POST", "/api/v1/contact",                                                              "contact form (not wired)"];
     }
 
     [Theory]

--- a/apps/api/tests/Api.Tests/Routing/EndpointContractTests.cs
+++ b/apps/api/tests/Api.Tests/Routing/EndpointContractTests.cs
@@ -100,8 +100,7 @@ public sealed class EndpointContractTests : IClassFixture<RouteContractTestFacto
         // Game Nights
         yield return ["GET", "/api/v1/game-nights"];
 
-        // Contact (public endpoint — expects 200 or 400, not 404)
-        yield return ["POST", "/api/v1/contact"];
+        // Contact: REMOVED — MapContactEndpoints defined but never called in routing setup.
     }
 
     // -----------------------------------------------------------------------
@@ -124,6 +123,9 @@ public sealed class EndpointContractTests : IClassFixture<RouteContractTestFacto
         yield return ["PUT",  "/api/v1/agents/00000000-0000-0000-0000-000000000001/configure",                "configure agent"];
         yield return ["GET",  "/api/v1/agents/00000000-0000-0000-0000-000000000001/configuration",            "get agent config"];
         yield return ["PATCH", "/api/v1/agents/00000000-0000-0000-0000-000000000001/configuration",           "update agent config"];
+
+        // Contact — MapContactEndpoints defined but never wired in endpoint registration
+        yield return ["POST", "/api/v1/contact",                                                              "contact form (not wired)"];
     }
 
     [Theory]

--- a/apps/web/src/lib/api/clients/agentsClient.ts
+++ b/apps/web/src/lib/api/clients/agentsClient.ts
@@ -62,6 +62,7 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
      * Implements GetAllAgentsQuery from backend
      * @param activeOnly If true, only return active agents
      * @param type Optional agent type filter
+     * @todo BACKEND MISSING: No route registered for GET /api/v1/agents. Returns empty array via fallback. See: endpoint audit 2026-04-15
      */
     async getAll(activeOnly?: boolean, type?: string): Promise<AgentDto[]> {
       const params = new URLSearchParams();
@@ -112,6 +113,7 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
      * Get agent by ID
      * Implements GetAgentByIdQuery from backend
      * @param id Agent ID (GUID format)
+     * @todo BACKEND MISSING: No route registered for GET /api/v1/agents/{id}. Returns null via fallback. See: endpoint audit 2026-04-15
      */
     async getById(id: string): Promise<AgentDto | null> {
       return httpClient.get(`/api/v1/agents/${encodeURIComponent(id)}`, AgentDtoSchema);
@@ -121,6 +123,7 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
      * Get agent chat readiness status
      * Validates KB populated and RAG initialized
      * @param id Agent ID (GUID format)
+     * @todo BACKEND MISSING: No route registered for GET /api/v1/agents/{id}/status. Throws on null response. See: endpoint audit 2026-04-15
      */
     async getStatus(id: string): Promise<{
       agentId: string;
@@ -156,6 +159,7 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
      * Get approved agent typologies (authenticated endpoint)
      * Issue #3186 (AGT-012): Agent Config Modal
      * @param status Filter by status (default: 'Approved')
+     * @todo BACKEND MISSING: No route registered for GET /api/v1/agent-typologies. Returns empty array via fallback. See: endpoint audit 2026-04-15
      */
     async getTypologies(status: 'Approved' = 'Approved'): Promise<Typology[]> {
       const params = new URLSearchParams();
@@ -181,6 +185,7 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
     /**
      * Get recent agents for dashboard widget
      * Issue #4126: API Integration
+     * @todo BACKEND MISSING: No route registered for GET /api/v1/agents/recent. Returns empty array via fallback. See: endpoint audit 2026-04-15
      */
     async getRecent(limit: number = 10): Promise<AgentDto[]> {
       const response = await httpClient.get<AgentDto[]>(
@@ -197,6 +202,7 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
      * Implements InvokeAgentCommand from backend
      * @param id Agent ID (GUID format)
      * @param request Invocation request with query and optional context
+     * @todo BACKEND MISSING: No route registered for POST /api/v1/agents/{id}/invoke. Throws on null response. See: endpoint audit 2026-04-15
      */
     async invoke(id: string, request: InvokeAgentRequest): Promise<AgentResponseDto> {
       const response = await httpClient.post<AgentResponseDto>(
@@ -216,6 +222,7 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
      * Create a new agent (Admin only)
      * Implements CreateAgentCommand from backend
      * @param request Agent creation request
+     * @todo BACKEND MISSING: No route registered for POST /api/v1/agents. Throws on null response. See: endpoint audit 2026-04-15
      */
     async create(request: CreateAgentRequest): Promise<AgentDto> {
       const response = await httpClient.post<AgentDto>('/api/v1/agents', request, AgentDtoSchema);
@@ -232,6 +239,7 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
      * Implements ConfigureAgentCommand from backend
      * @param id Agent ID (GUID format)
      * @param request Configuration request
+     * @todo BACKEND MISSING: No route registered for PUT /api/v1/agents/{id}/configure. Throws on null response. See: endpoint audit 2026-04-15
      */
     async configure(id: string, request: ConfigureAgentRequest): Promise<ConfigureAgentResponse> {
       const response = await httpClient.put<ConfigureAgentResponse>(
@@ -390,6 +398,7 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
      * Create a user-owned agent with tier-aware configuration
      * Issue #4683: User Agent CRUD Endpoints
      * @param request Agent creation params (gameId, agentType, name, etc.)
+     * @todo BACKEND MISSING: No route registered for POST /api/v1/agents/user. Throws on null response. See: endpoint audit 2026-04-15
      */
     async createUserAgent(request: {
       gameId: string;
@@ -417,6 +426,7 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
     /**
      * Get user's agent slot allocation and usage
      * Issue #4771: Agent Slots Endpoint + Quota System
+     * @todo BACKEND MISSING: No route registered for GET /api/v1/user/agent-slots. Throws on null response. See: endpoint audit 2026-04-15
      */
     async getSlots(): Promise<{
       total: number;
@@ -453,6 +463,7 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
     /**
      * Orchestrated agent creation with auto-setup
      * Issue #4772: Agent Creation Orchestration Flow
+     * @todo BACKEND MISSING: No route registered for POST /api/v1/agents/create-with-setup. Throws on null response. See: endpoint audit 2026-04-15
      */
     async createWithSetup(request: {
       gameId: string;
@@ -517,6 +528,7 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
      * Update a user-owned agent (name, strategy)
      * PUT /api/v1/agents/{id}/user
      * Issue #4683: User Agent CRUD Endpoints
+     * @todo BACKEND MISSING: No route registered for PUT /api/v1/agents/{id}/user. Throws on null response. See: endpoint audit 2026-04-15
      */
     async updateUserAgent(
       agentId: string,
@@ -628,7 +640,10 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
       return response?.models ?? [];
     },
 
-    /** Get current LLM configuration for an agent */
+    /**
+     * Get current LLM configuration for an agent
+     * @todo BACKEND MISSING: No route registered for GET /api/v1/agents/{id}/configuration. Throws on null response. See: endpoint audit 2026-04-15
+     */
     async getAgentConfiguration(agentId: string): Promise<BackendAgentConfigurationDto> {
       const response = await httpClient.get<BackendAgentConfigurationDto>(
         `/api/v1/agents/${agentId}/configuration`
@@ -639,7 +654,10 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
       return response;
     },
 
-    /** Patch LLM configuration for an agent (partial update) */
+    /**
+     * Patch LLM configuration for an agent (partial update)
+     * @todo BACKEND MISSING: No route registered for PATCH /api/v1/agents/{id}/configuration. Throws on null response. See: endpoint audit 2026-04-15
+     */
     async updateAgentConfiguration(
       agentId: string,
       config: UpdateAgentConfigurationRequest
@@ -677,6 +695,7 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
      * POST /api/v1/agents/quick-create
      * @param gameId - Game UUID
      * @param sharedGameId - Optional shared game UUID for catalog-linked games
+     * @todo BACKEND MISSING: No route registered for POST /api/v1/agents/quick-create. Throws on null response. See: endpoint audit 2026-04-15
      */
     async quickCreateTutor(gameId: string, sharedGameId?: string): Promise<QuickCreateResult> {
       const body: { gameId: string; sharedGameId?: string } = { gameId };

--- a/docs/superpowers/plans/2026-04-15-endpoint-audit-fixes.md
+++ b/docs/superpowers/plans/2026-04-15-endpoint-audit-fixes.md
@@ -1,0 +1,443 @@
+# Endpoint Audit Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the 1 route mismatch found in the backend↔frontend endpoint audit, document 12+ orphan frontend agent methods with no backend route, and add a contract test to prevent future drift.
+
+**Architecture:** Three surgical changes: (1) rename one backend route to match its siblings, (2) add JSDoc `@todo` annotations on frontend client methods whose backend endpoints don't exist yet, (3) add a single integration test that verifies all frontend API URLs resolve to a registered backend route.
+
+**Tech Stack:** C# ASP.NET Minimal API, TypeScript/Next.js, xUnit
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|---------------|
+| Modify | `apps/api/src/Api/Routing/UserLibrary/UserLibraryCoreEndpoints.cs:420` | Fix PUT route `/agent` → `/agent-config` |
+| Modify | `apps/web/src/lib/api/clients/agentsClient.ts` | Add `@todo` annotations on 12 orphan methods |
+| Create | `tests/Api.Tests/Routing/EndpointContractTests.cs` | Contract test: every frontend URL must match a backend route |
+
+---
+
+### Task 1: Fix PUT Route Mismatch (P0)
+
+The backend defines `PUT /library/games/{gameId}/agent` but the frontend calls `PUT /library/games/{gameId}/agent-config`. The sibling endpoints (GET, POST) already use `/agent-config`. The fix is to rename the backend PUT route to `/agent-config` for consistency.
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/UserLibrary/UserLibraryCoreEndpoints.cs:420`
+
+- [ ] **Step 1: Verify current backend route**
+
+Run:
+```bash
+grep -n "MapPut.*library/games.*agent" apps/api/src/Api/Routing/UserLibrary/UserLibraryCoreEndpoints.cs
+```
+Expected output:
+```
+420:        group.MapPut("/library/games/{gameId:guid}/agent", async (
+```
+
+- [ ] **Step 2: Change the route from `/agent` to `/agent-config`**
+
+In `apps/api/src/Api/Routing/UserLibrary/UserLibraryCoreEndpoints.cs`, line 420, change:
+
+```csharp
+// BEFORE
+group.MapPut("/library/games/{gameId:guid}/agent", async (
+```
+
+to:
+
+```csharp
+// AFTER
+group.MapPut("/library/games/{gameId:guid}/agent-config", async (
+```
+
+- [ ] **Step 3: Update the method name for clarity**
+
+In the same file, rename the method (line 418):
+
+```csharp
+// BEFORE
+private static void MapConfigureGameAgentEndpoint(RouteGroupBuilder group)
+```
+
+to:
+
+```csharp
+// AFTER
+private static void MapUpdateAgentConfigEndpoint(RouteGroupBuilder group)
+```
+
+Also update the call site in the same file where this method is invoked. Search for `MapConfigureGameAgentEndpoint` and rename to `MapUpdateAgentConfigEndpoint`.
+
+- [ ] **Step 4: Update the OpenAPI metadata**
+
+Change `.WithSummary` and `.WithDescription` to reflect the `/agent-config` path:
+
+```csharp
+.WithSummary("Update AI agent configuration")
+.WithDescription("Updates the custom AI agent configuration for a game in user's library. Replaces any existing configuration.")
+```
+
+- [ ] **Step 5: Verify the sibling routes are consistent**
+
+Run:
+```bash
+grep -n "agent-config\|/agent\"" apps/api/src/Api/Routing/UserLibrary/UserLibraryCoreEndpoints.cs
+```
+
+Expected: all three endpoints (GET, POST, PUT) should now use `/agent-config`. The DELETE endpoint at `/agent` is intentionally different (it resets the agent entirely, not just the config).
+
+- [ ] **Step 6: Build to verify no compilation errors**
+
+```bash
+cd apps/api/src/Api && dotnet build
+```
+
+Expected: Build succeeded.
+
+- [ ] **Step 7: Run existing library tests**
+
+```bash
+cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~UserLibrary" --no-build
+```
+
+Expected: All pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/UserLibrary/UserLibraryCoreEndpoints.cs
+git commit -m "fix(routing): rename PUT /library/games/{gameId}/agent to /agent-config
+
+Aligns the PUT route with the sibling GET and POST endpoints that already
+use /agent-config. The frontend was calling /agent-config but the backend
+had /agent, causing 404/405 at runtime.
+
+Discovered during endpoint audit spec-panel review.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Annotate Orphan Frontend Agent Methods (P1)
+
+12+ methods in `agentsClient.ts` call backend URLs that have no registered route. These are actively used by UI components (hooks, pages) but return empty/null via error handling fallbacks. Rather than deleting them (which would break UI), annotate each with `@todo` documenting the missing backend endpoint.
+
+**Files:**
+- Modify: `apps/web/src/lib/api/clients/agentsClient.ts`
+
+**Active UI consumers per orphan method:**
+
+| Method | Frontend Consumer | Backend Route Needed |
+|--------|------------------|---------------------|
+| `getAll()` | `useAgents.ts:13` | `GET /agents` |
+| `getById()` | `agents/[id]/page.tsx:23` | `GET /agents/{id}` |
+| `getStatus()` | `useAgentStatus.ts:38` | `GET /agents/{id}/status` |
+| `getTypologies()` | `useAgentConfigModal.ts:142` | `GET /agent-typologies` |
+| `getRecent()` | `useRecentAgents.ts:13` | `GET /agents/recent` |
+| `create()` | (admin) | `POST /agents` |
+| `configure()` | (admin) | `PUT /agents/{id}/configure` |
+| `createUserAgent()` | `AgentCreationWizard.tsx:615`, `FirstAgentStep.tsx:42` | `POST /agents/user` |
+| `getSlots()` | `useAgentSlots.ts:33` | `GET /user/agent-slots` |
+| `createWithSetup()` | `useCreateAgentFlow.ts:51` | `POST /agents/create-with-setup` |
+| `quickCreateTutor()` | `OwnershipConfirmationDialog.tsx:57` | `POST /agents/quick-create` |
+| `getModels()` | `useModels.ts:19` | `GET /models` ← **this one EXISTS** (ModelEndpoints.cs) |
+| `getAgentConfiguration()` | `useModels.ts:28` | `GET /agents/{id}/configuration` |
+| `updateAgentConfiguration()` | `useModels.ts:39` | `PATCH /agents/{id}/configuration` |
+| `updateUserAgent()` | (unused in UI search) | `PUT /agents/{id}/user` |
+| `testTypology()` | (test flows) | `POST /agent-typologies/{id}/test` |
+
+**Note:** `getModels()` calling `GET /models` is NOT orphan — `ModelEndpoints.cs` defines this route. Skip annotation for that method.
+
+- [ ] **Step 1: Add `@todo` annotation to each orphan method**
+
+For each method listed above (except `getModels`), add a JSDoc `@todo` tag. Example pattern:
+
+```typescript
+    /**
+     * Get all agents with optional filtering
+     * Implements GetAllAgentsQuery from backend
+     * @todo BACKEND MISSING: No route registered for GET /api/v1/agents.
+     *       Returns empty array via error fallback. Needs KnowledgeBase BC endpoint.
+     *       See: endpoint audit 2026-04-15
+     */
+```
+
+Apply this pattern to all 15 orphan methods. The annotation must include:
+- `@todo BACKEND MISSING:` prefix (searchable)
+- The exact HTTP method + URL that has no backend route
+- Brief note on fallback behavior (returns null, empty array, throws)
+- Reference: `endpoint audit 2026-04-15`
+
+- [ ] **Step 2: Verify no functional changes**
+
+```bash
+cd apps/web && pnpm typecheck
+```
+
+Expected: No errors (JSDoc comments don't affect types).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/lib/api/clients/agentsClient.ts
+git commit -m "docs(agents-client): annotate 15 methods with missing backend routes
+
+Marks methods in agentsClient.ts that call backend URLs with no
+registered route. These degrade gracefully (return null/empty) but
+need backend implementation. Each tagged @todo BACKEND MISSING for
+easy grep discovery.
+
+Found during endpoint audit spec-panel review 2026-04-15.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Add Route Contract Test (P2)
+
+Create a test that extracts all URL patterns from the frontend API clients and verifies each one resolves to a registered ASP.NET route. This prevents future drift.
+
+**Files:**
+- Create: `tests/Api.Tests/Routing/EndpointContractTests.cs`
+
+- [ ] **Step 1: Create the contract test file**
+
+```csharp
+using System.Net;
+using System.Net.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Api.Tests.Routing;
+
+/// <summary>
+/// Verifies that all frontend API URLs resolve to registered backend routes.
+/// Prevents drift between frontend clients and backend routing.
+/// 
+/// How to maintain: when adding a new backend endpoint, add its route
+/// pattern to the KnownRoutes list below. The test ensures no route
+/// returns 404 due to missing registration (as opposed to missing data).
+/// 
+/// Discovered routes that intentionally have no backend yet are listed
+/// in PendingBackendRoutes with a tracking reference.
+/// </summary>
+[Trait("Category", "Integration")]
+[Trait("BoundedContext", "Routing")]
+public class EndpointContractTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+
+    public EndpointContractTests(WebApplicationFactory<Program> factory)
+    {
+        _client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+    }
+
+    /// <summary>
+    /// Routes that MUST be registered in the backend.
+    /// A 404 here means the route is missing (not that the resource doesn't exist).
+    /// We expect 401 (unauthenticated) or 400/200 — anything except 404.
+    /// </summary>
+    public static IEnumerable<object[]> KnownRoutes()
+    {
+        // Authentication
+        yield return new object[] { "POST", "/api/v1/auth/login" };
+        yield return new object[] { "POST", "/api/v1/auth/register" };
+        yield return new object[] { "POST", "/api/v1/auth/logout" };
+        yield return new object[] { "GET", "/api/v1/auth/me" };
+        yield return new object[] { "GET", "/api/v1/auth/session/status" };
+        yield return new object[] { "POST", "/api/v1/auth/session/extend" };
+
+        // Library
+        yield return new object[] { "GET", "/api/v1/library" };
+        yield return new object[] { "GET", "/api/v1/library/games/00000000-0000-0000-0000-000000000001/status" };
+        yield return new object[] { "GET", "/api/v1/library/games/00000000-0000-0000-0000-000000000001/agent-config" };
+        yield return new object[] { "PUT", "/api/v1/library/games/00000000-0000-0000-0000-000000000001/agent-config" };
+        yield return new object[] { "POST", "/api/v1/library/games/00000000-0000-0000-0000-000000000001/agent-config" };
+
+        // PDF
+        yield return new object[] { "GET", "/api/v1/pdfs/00000000-0000-0000-0000-000000000001/progress" };
+        yield return new object[] { "POST", "/api/v1/ingest/pdf" };
+
+        // Knowledge Base
+        yield return new object[] { "GET", "/api/v1/knowledge-base/00000000-0000-0000-0000-000000000001/status" };
+        yield return new object[] { "POST", "/api/v1/knowledge-base/search" };
+
+        // Sessions
+        yield return new object[] { "GET", "/api/v1/sessions/active" };
+        yield return new object[] { "GET", "/api/v1/sessions/history" };
+
+        // Chat
+        yield return new object[] { "GET", "/api/v1/chat-threads" };
+
+        // Models (exists in ModelEndpoints.cs)
+        yield return new object[] { "GET", "/api/v1/models" };
+
+        // Games
+        yield return new object[] { "GET", "/api/v1/games" };
+
+        // BGG
+        yield return new object[] { "GET", "/api/v1/bgg/search?q=catan" };
+
+        // Contact
+        yield return new object[] { "POST", "/api/v1/contact" };
+
+        // Notifications
+        yield return new object[] { "GET", "/api/v1/notifications" };
+
+        // Wishlist
+        yield return new object[] { "GET", "/api/v1/wishlist" };
+
+        // Playlists
+        yield return new object[] { "GET", "/api/v1/playlists" };
+
+        // Play Records
+        yield return new object[] { "GET", "/api/v1/play-records/history" };
+
+        // Game Nights
+        yield return new object[] { "GET", "/api/v1/game-nights" };
+    }
+
+    /// <summary>
+    /// Routes called by the frontend that intentionally have NO backend route yet.
+    /// These are tracked and expected to return 404 until implemented.
+    /// When implementing one, move it from here to KnownRoutes.
+    /// </summary>
+    public static IEnumerable<object[]> PendingBackendRoutes()
+    {
+        // Agent CRUD — frontend agentsClient.ts calls these, no backend route exists.
+        // See: endpoint audit 2026-04-15, @todo BACKEND MISSING annotations
+        yield return new object[] { "GET", "/api/v1/agents", "GET /agents — agent listing" };
+        yield return new object[] { "GET", "/api/v1/agents/00000000-0000-0000-0000-000000000001", "GET /agents/{id}" };
+        yield return new object[] { "GET", "/api/v1/agents/00000000-0000-0000-0000-000000000001/status", "GET /agents/{id}/status" };
+        yield return new object[] { "GET", "/api/v1/agent-typologies", "GET /agent-typologies" };
+        yield return new object[] { "GET", "/api/v1/agents/recent?limit=10", "GET /agents/recent" };
+        yield return new object[] { "POST", "/api/v1/agents/user", "POST /agents/user" };
+        yield return new object[] { "GET", "/api/v1/user/agent-slots", "GET /user/agent-slots" };
+        yield return new object[] { "POST", "/api/v1/agents/create-with-setup", "POST /agents/create-with-setup" };
+        yield return new object[] { "POST", "/api/v1/agents/quick-create", "POST /agents/quick-create" };
+        yield return new object[] { "PUT", "/api/v1/agents/00000000-0000-0000-0000-000000000001/configure", "PUT /agents/{id}/configure" };
+        yield return new object[] { "GET", "/api/v1/agents/00000000-0000-0000-0000-000000000001/configuration", "GET /agents/{id}/configuration" };
+        yield return new object[] { "PATCH", "/api/v1/agents/00000000-0000-0000-0000-000000000001/configuration", "PATCH /agents/{id}/configuration" };
+    }
+
+    [Theory]
+    [MemberData(nameof(KnownRoutes))]
+    public async Task KnownRoute_ShouldNotReturn404(string method, string url)
+    {
+        // Arrange
+        var request = new HttpRequestMessage(new HttpMethod(method), url);
+
+        // For POST/PUT/PATCH, add empty JSON body to avoid 415
+        if (method is "POST" or "PUT" or "PATCH")
+        {
+            request.Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json");
+        }
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert — any status except 404/405 means the route is registered.
+        // 401 (unauthenticated) is expected and valid.
+        Assert.NotEqual(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.NotEqual(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+    }
+
+    [Theory]
+    [MemberData(nameof(PendingBackendRoutes))]
+    public async Task PendingRoute_ShouldReturn404UntilImplemented(
+        string method, string url, string description)
+    {
+        // Arrange
+        var request = new HttpRequestMessage(new HttpMethod(method), url);
+        if (method is "POST" or "PUT" or "PATCH")
+        {
+            request.Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json");
+        }
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert — if this starts passing (not 404), the route was implemented.
+        // Move it from PendingBackendRoutes to KnownRoutes and celebrate!
+        Assert.True(
+            response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.MethodNotAllowed,
+            $"Route {method} {url} ({description}) is no longer 404! " +
+            $"Move it from PendingBackendRoutes to KnownRoutes in this test. " +
+            $"Status: {response.StatusCode}");
+    }
+}
+```
+
+- [ ] **Step 2: Verify the test compiles**
+
+```bash
+cd apps/api/src/Api && dotnet build ../../../tests/Api.Tests/
+```
+
+Expected: Build succeeded.
+
+- [ ] **Step 3: Run the contract tests**
+
+```bash
+cd apps/api/src/Api && dotnet test ../../../tests/Api.Tests/ --filter "FullyQualifiedName~EndpointContractTests" --no-build
+```
+
+Expected:
+- `KnownRoute_ShouldNotReturn404` — all pass (routes exist, return 401)
+- `PendingRoute_ShouldReturn404UntilImplemented` — all pass (routes return 404)
+
+- [ ] **Step 4: Fix any failures**
+
+If a KnownRoute returns 404, investigate: either the route pattern is wrong in the test or the endpoint is missing. Fix the test data.
+
+If a PendingRoute returns non-404, the endpoint was already implemented elsewhere. Move it to KnownRoutes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/Api.Tests/Routing/EndpointContractTests.cs
+git commit -m "test(routing): add endpoint contract tests for frontend↔backend alignment
+
+Verifies that all frontend API URLs resolve to registered backend routes.
+Tracks 12 pending agent endpoints with no backend route yet.
+When a pending route gets implemented, the test will tell you to move it
+from PendingBackendRoutes to KnownRoutes.
+
+Part of endpoint audit spec-panel 2026-04-15.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Final Verification & PR
+
+- [ ] **Step 1: Run full backend build + tests**
+
+```bash
+cd apps/api/src/Api && dotnet build && dotnet test --no-build
+```
+
+- [ ] **Step 2: Run frontend typecheck**
+
+```bash
+cd apps/web && pnpm typecheck
+```
+
+- [ ] **Step 3: Create branch and PR**
+
+```bash
+git checkout -b fix/endpoint-audit-2026-04-15
+git push -u origin fix/endpoint-audit-2026-04-15
+```
+
+PR to `main-dev` with summary of changes.


### PR DESCRIPTION
## Summary

- **P0 fix**: Renamed backend PUT `/library/games/{gameId}/agent` to `/agent-config` to match frontend and sibling GET/POST endpoints (was causing 404)
- **P1 docs**: Added `@todo BACKEND MISSING` annotations on 15 frontend agent client methods that call non-existent backend routes
- **P2 test**: Created `EndpointContractTests.cs` with 23 KnownRoutes + 12 PendingRoutes verifying frontend-backend alignment
- **Bonus fix**: Wired `MapContactEndpoints()` in Program.cs (endpoint was defined but never registered, `POST /contact` returned 404)
- **Code review fix**: Updated stale integration test using old `/agent` route

## Test plan

- [x] 35/35 contract tests passing
- [x] Frontend typecheck passes
- [x] Backend build: 0 errors
- [x] Pre-commit + pre-push hooks pass

Generated with Claude Code
