### PR TITLE
fix: PDF mapping + RAG retrieval quality (#422, #423)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/GenerateToolkitFromKbHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/GenerateToolkitFromKbHandler.cs
@@ -79,7 +79,7 @@ internal class GenerateToolkitFromKbHandler
             _hybridSearchService.SearchAsync(
                 q, command.GameId, SearchMode.Hybrid, MaxChunksPerQuery,
                 accessibleCardIds, vectorWeight: 0.7f, keywordWeight: 0.3f,
-                cancellationToken));
+                cancellationToken: cancellationToken));
 
         var allResults = await Task.WhenAll(searchTasks).ConfigureAwait(false);
 

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/GenerateToolkitFromKbHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/GenerateToolkitFromKbHandler.cs
@@ -79,6 +79,7 @@ internal class GenerateToolkitFromKbHandler
             _hybridSearchService.SearchAsync(
                 q, command.GameId, SearchMode.Hybrid, MaxChunksPerQuery,
                 accessibleCardIds, vectorWeight: 0.7f, keywordWeight: 0.3f,
+                keywordMinScore: 0.01,
                 cancellationToken: cancellationToken));
 
         var allResults = await Task.WhenAll(searchTasks).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs
@@ -178,12 +178,16 @@ internal class SearchQueryHandler : IQueryHandler<SearchQuery, List<SearchResult
             gameId, queryVector, topK, minScore, documentIds, cancellationToken).ConfigureAwait(false);
 
         // Keyword search (use HybridSearchService with Keyword mode)
+        // Issue #423: Pass keywordMinScore to filter low-relevance keyword matches (e.g., ToC entries)
+        // ts_rank_cd scores are typically 0-0.3; threshold of 0.01 filters noise while keeping real matches
+        const double KeywordMinScore = 0.01;
         var hybridSearchResults = await _hybridSearchService.SearchAsync(
             query,
             gameId,
             SearchMode.Keyword,
             topK,
             documentIds?.ToList(), // Issue #2051: Pass document filter
+            keywordMinScore: KeywordMinScore,
             cancellationToken: cancellationToken).ConfigureAwait(false);
 
         // Map keyword results to domain entities

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Reranking/ResilientRetrievalService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Reranking/ResilientRetrievalService.cs
@@ -131,6 +131,7 @@ internal sealed class ResilientRetrievalService : IRerankedRetrievalService, IDi
             request.GameId,
             mode,
             candidateCount,
+            keywordMinScore: 0.01,
             cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/ContextEngineering/HybridSearchEngine.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/ContextEngineering/HybridSearchEngine.cs
@@ -85,6 +85,7 @@ internal sealed class HybridSearchEngine : IHybridSearchEngine
                 documentIds: request.DocumentIds,
                 vectorWeight: vectorWeight,
                 keywordWeight: keywordWeight,
+                keywordMinScore: 0.01,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
             searchStopwatch.Stop();

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/PdfSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/PdfSeeder.cs
@@ -153,11 +153,20 @@ internal static class PdfSeeder
                     continue;
                 }
 
+                // Look up SharedGameId from the Games table
+                var sharedGameId = await db.Games
+                    .AsNoTracking()
+                    .Where(g => g.Id == gameId)
+                    .Select(g => g.SharedGameId)
+                    .FirstOrDefaultAsync(ct)
+                    .ConfigureAwait(false);
+
                 // Create PdfDocumentEntity in Pending state
                 var pdfEntity = new PdfDocumentEntity
                 {
                     Id = Guid.NewGuid(),
                     GameId = gameId,
+                    SharedGameId = sharedGameId,
                     FileName = fileName,
                     FilePath = result.FilePath ?? string.Empty,
                     FileSizeBytes = result.FileSizeBytes,

--- a/apps/api/src/Api/Services/HybridSearchService.cs
+++ b/apps/api/src/Api/Services/HybridSearchService.cs
@@ -48,6 +48,7 @@ internal class HybridSearchService : IHybridSearchService
         List<Guid>? documentIds = null,
         float vectorWeight = 0.7f,
         float keywordWeight = 0.3f,
+        double keywordMinScore = 0.0,
         CancellationToken cancellationToken = default)
     {
         // Issue #1445: Use centralized query validation
@@ -74,10 +75,10 @@ internal class HybridSearchService : IHybridSearchService
                     return await SearchSemanticOnlyAsync(query, gameId, safeLimit, documentIds, cancellationToken).ConfigureAwait(false);
 
                 case SearchMode.Keyword:
-                    return await SearchKeywordOnlyAsync(query, gameId, safeLimit, documentIds, cancellationToken).ConfigureAwait(false);
+                    return await SearchKeywordOnlyAsync(query, gameId, safeLimit, documentIds, keywordMinScore, cancellationToken).ConfigureAwait(false);
 
                 case SearchMode.Hybrid:
-                    return await SearchHybridAsync(query, gameId, safeLimit, vectorWeight, keywordWeight, documentIds, cancellationToken).ConfigureAwait(false);
+                    return await SearchHybridAsync(query, gameId, safeLimit, vectorWeight, keywordWeight, documentIds, keywordMinScore, cancellationToken).ConfigureAwait(false);
 
                 default:
                     throw new ArgumentException($"Unsupported search mode: {mode}", nameof(mode));
@@ -136,6 +137,7 @@ internal class HybridSearchService : IHybridSearchService
         Guid gameId,
         int limit,
         List<Guid>? documentIds,
+        double keywordMinScore,
         CancellationToken cancellationToken)
     {
         var keywordResults = await _keywordSearchService.SearchAsync(
@@ -144,6 +146,7 @@ internal class HybridSearchService : IHybridSearchService
             limit,
             phraseSearch: query.Contains('"'), // Enable phrase search if query has quotes
             boostTerms: _config.BoostTerms,
+            minScore: keywordMinScore,
             cancellationToken: cancellationToken).ConfigureAwait(false);
 
         // Issue #2051: Filter by document IDs if specified
@@ -184,6 +187,7 @@ internal class HybridSearchService : IHybridSearchService
         float vectorWeight,
         float keywordWeight,
         List<Guid>? documentIds,
+        double keywordMinScore,
         CancellationToken cancellationToken)
     {
         var fetchLimit = Math.Max(limit * 2, 20);
@@ -198,6 +202,7 @@ internal class HybridSearchService : IHybridSearchService
             fetchLimit,
             phraseSearch: query.Contains('"'),
             boostTerms: _config.BoostTerms,
+            minScore: keywordMinScore,
             cancellationToken: cancellationToken);
 
         await Task.WhenAll(vectorTask, keywordTask).ConfigureAwait(false);

--- a/apps/api/src/Api/Services/IHybridSearchService.cs
+++ b/apps/api/src/Api/Services/IHybridSearchService.cs
@@ -20,6 +20,7 @@ internal interface IHybridSearchService
     /// <param name="documentIds">Optional document IDs to filter sources (Issue #2051)</param>
     /// <param name="vectorWeight">Weight for vector search scores (default: 0.7)</param>
     /// <param name="keywordWeight">Weight for keyword search scores (default: 0.3)</param>
+    /// <param name="keywordMinScore">Minimum ts_rank_cd score for keyword results to filter low-relevance matches like ToC entries (default: 0.0)</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Hybrid search results with RRF-fused scores</returns>
     Task<List<HybridSearchResult>> SearchAsync(
@@ -30,6 +31,7 @@ internal interface IHybridSearchService
         List<Guid>? documentIds = null,
         float vectorWeight = 0.7f,
         float keywordWeight = 0.3f,
+        double keywordMinScore = 0.0,
         CancellationToken cancellationToken = default);
 }
 

--- a/apps/api/src/Api/Services/IKeywordSearchService.cs
+++ b/apps/api/src/Api/Services/IKeywordSearchService.cs
@@ -19,6 +19,7 @@ internal interface IKeywordSearchService
     /// <param name="phraseSearch">Enable exact phrase matching with proximity operators</param>
     /// <param name="boostTerms">Optional list of terms to boost in ranking (e.g., game-specific terminology)</param>
     /// <param name="language">Language code for FTS configuration: "it" → meepleai_italian, "en" → english (default: "it")</param>
+    /// <param name="minScore">Minimum ts_rank_cd score threshold to filter low-relevance results (default: 0.0, no filtering)</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>List of keyword search results with BM25-style relevance scores</returns>
     Task<List<KeywordSearchResult>> SearchAsync(
@@ -28,6 +29,7 @@ internal interface IKeywordSearchService
         bool phraseSearch = false,
         List<string>? boostTerms = null,
         string language = "it",
+        double minScore = 0.0,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/apps/api/src/Api/Services/KeywordSearchService.cs
+++ b/apps/api/src/Api/Services/KeywordSearchService.cs
@@ -50,6 +50,7 @@ internal class KeywordSearchService : IKeywordSearchService
         bool phraseSearch = false,
         List<string>? boostTerms = null,
         string language = "it",
+        double minScore = 0.0,
         CancellationToken cancellationToken = default)
     {
         // Issue #1445: Use centralized query validation
@@ -83,6 +84,7 @@ internal class KeywordSearchService : IKeywordSearchService
 
             // Execute PostgreSQL full-text search with ts_rank_cd scoring
             // Using FromSqlRaw for complex tsvector queries (EF Core limitation with tsvector operators)
+            // Issue #423: Add minScore filter to exclude low-relevance keyword matches (e.g., ToC entries)
             var sql = @"
                 SELECT
                     ""Id"",
@@ -96,6 +98,7 @@ internal class KeywordSearchService : IKeywordSearchService
                 WHERE
                     ""GameId"" = @gameId::uuid
                     AND search_vector @@ to_tsquery(@textSearchConfig::regconfig, @tsQuery)
+                    AND ts_rank_cd(search_vector, to_tsquery(@textSearchConfig::regconfig, @tsQuery), @normalization) >= @minScore
                 ORDER BY ""RelevanceScore"" DESC
                 LIMIT @limit";
 
@@ -110,6 +113,7 @@ internal class KeywordSearchService : IKeywordSearchService
                     new NpgsqlParameter("@tsQuery", tsQuery),
                     new NpgsqlParameter("@normalization", DefaultNormalization),
                     new NpgsqlParameter("@gameId", gameIdString),
+                    new NpgsqlParameter("@minScore", minScore),
                     new NpgsqlParameter("@limit", safeLimit)) // Use capped limit
                 .AsNoTracking()
                 .ToListAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/Services/KeywordSearchService.cs
+++ b/apps/api/src/Api/Services/KeywordSearchService.cs
@@ -85,20 +85,23 @@ internal class KeywordSearchService : IKeywordSearchService
             // Execute PostgreSQL full-text search with ts_rank_cd scoring
             // Using FromSqlRaw for complex tsvector queries (EF Core limitation with tsvector operators)
             // Issue #423: Add minScore filter to exclude low-relevance keyword matches (e.g., ToC entries)
+            // Perf: subquery avoids double ts_rank_cd evaluation (computed once in inner SELECT, filtered in outer WHERE)
             var sql = @"
-                SELECT
-                    ""Id"",
-                    ""Content"",
-                    ""PdfDocumentId"",
-                    ""GameId"",
-                    ""ChunkIndex"",
-                    ""PageNumber"",
-                    ts_rank_cd(search_vector, to_tsquery(@textSearchConfig::regconfig, @tsQuery), @normalization) AS ""RelevanceScore""
-                FROM text_chunks
-                WHERE
-                    ""GameId"" = @gameId::uuid
-                    AND search_vector @@ to_tsquery(@textSearchConfig::regconfig, @tsQuery)
-                    AND ts_rank_cd(search_vector, to_tsquery(@textSearchConfig::regconfig, @tsQuery), @normalization) >= @minScore
+                SELECT * FROM (
+                    SELECT
+                        ""Id"",
+                        ""Content"",
+                        ""PdfDocumentId"",
+                        ""GameId"",
+                        ""ChunkIndex"",
+                        ""PageNumber"",
+                        ts_rank_cd(search_vector, to_tsquery(@textSearchConfig::regconfig, @tsQuery), @normalization) AS ""RelevanceScore""
+                    FROM text_chunks
+                    WHERE
+                        ""GameId"" = @gameId::uuid
+                        AND search_vector @@ to_tsquery(@textSearchConfig::regconfig, @tsQuery)
+                ) ranked
+                WHERE ""RelevanceScore"" >= @minScore
                 ORDER BY ""RelevanceScore"" DESC
                 LIMIT @limit";
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Handlers/GenerateToolkitFromKbHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Handlers/GenerateToolkitFromKbHandlerTests.cs
@@ -184,6 +184,7 @@ public class GenerateToolkitFromKbHandlerTests
             .Setup(s => s.SearchAsync(
                 It.IsAny<string>(), GameId, SearchMode.Hybrid, It.IsAny<int>(),
                 It.IsAny<List<Guid>?>(), It.IsAny<float>(), It.IsAny<float>(),
+                It.IsAny<double>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(chunks);
 
@@ -225,6 +226,7 @@ public class GenerateToolkitFromKbHandlerTests
             .Setup(s => s.SearchAsync(
                 It.IsAny<string>(), GameId, SearchMode.Hybrid, It.IsAny<int>(),
                 It.IsAny<List<Guid>?>(), It.IsAny<float>(), It.IsAny<float>(),
+                It.IsAny<double>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<HybridSearchResult> { chunk });
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AskArbiterCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AskArbiterCommandHandlerTests.cs
@@ -68,6 +68,7 @@ public sealed class AskArbiterCommandHandlerTests : IDisposable
                 It.IsAny<List<Guid>?>(),
                 It.IsAny<float>(),
                 It.IsAny<float>(),
+                It.IsAny<double>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<HybridSearchResult>());
 
@@ -330,7 +331,7 @@ public sealed class AskArbiterCommandHandlerTests : IDisposable
         _mockHybridSearchService.Verify(
             s => s.SearchAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<SearchMode>(),
                 It.IsAny<int>(), It.IsAny<List<Guid>?>(), It.IsAny<float>(), It.IsAny<float>(),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<double>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AskQuestionQueryHandlerSecurityTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AskQuestionQueryHandlerSecurityTests.cs
@@ -102,6 +102,7 @@ public class AskQuestionQueryHandlerSecurityTests
                 It.IsAny<List<Guid>?>(),
                 It.IsAny<float>(),
                 It.IsAny<float>(),
+                It.IsAny<double>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<HybridSearchResult>());
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/PlaygroundChatCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/PlaygroundChatCommandHandlerTests.cs
@@ -450,7 +450,7 @@ public sealed class PlaygroundChatCommandHandlerTests
         _mockHybridSearchService
             .Setup(s => s.SearchAsync(
                 It.IsAny<string>(), gameId, SearchMode.Hybrid, 5,
-                null, 0.7f, 0.3f, It.IsAny<CancellationToken>()))
+                null, 0.7f, 0.3f, It.IsAny<double>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<HybridSearchResult>
             {
                 new()
@@ -516,7 +516,7 @@ public sealed class PlaygroundChatCommandHandlerTests
             s => s.SearchAsync(
                 It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<SearchMode>(),
                 It.IsAny<int>(), It.IsAny<List<Guid>?>(), It.IsAny<float>(),
-                It.IsAny<float>(), It.IsAny<CancellationToken>()),
+                It.IsAny<float>(), It.IsAny<double>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
@@ -248,7 +248,7 @@ public class StreamQaQueryHandlerTests
 
         // Should NOT call search or LLM
         _hybridSearchServiceMock.Verify(
-            x => x.SearchAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<SearchMode>(), It.IsAny<int>(), It.IsAny<List<Guid>?>(), It.IsAny<float>(), It.IsAny<float>(), It.IsAny<CancellationToken>()),
+            x => x.SearchAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<SearchMode>(), It.IsAny<int>(), It.IsAny<List<Guid>?>(), It.IsAny<float>(), It.IsAny<float>(), It.IsAny<double>(), It.IsAny<CancellationToken>()),
             Times.Never
         );
         _llmServiceMock.Verify(
@@ -446,7 +446,7 @@ public class StreamQaQueryHandlerTests
             });
 
         _hybridSearchServiceMock
-            .Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<SearchMode>(), It.IsAny<int>(), It.IsAny<List<Guid>?>(), It.IsAny<float>(), It.IsAny<float>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<SearchMode>(), It.IsAny<int>(), It.IsAny<List<Guid>?>(), It.IsAny<float>(), It.IsAny<float>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<HybridSearchResult>()); // Empty results
 
         // Act
@@ -613,7 +613,7 @@ public class StreamQaQueryHandlerTests
             .Returns(new List<DomainSearchResult> { lowScoreResult });
 
         _hybridSearchServiceMock
-            .Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<Guid>(), SearchMode.Keyword, It.IsAny<int>(), It.IsAny<List<Guid>?>(), It.IsAny<float>(), It.IsAny<float>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<Guid>(), SearchMode.Keyword, It.IsAny<int>(), It.IsAny<List<Guid>?>(), It.IsAny<float>(), It.IsAny<float>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<HybridSearchResult>());
 
         _rrfFusionServiceMock
@@ -714,7 +714,7 @@ public class StreamQaQueryHandlerTests
             .Returns(highQualityResults);
 
         _hybridSearchServiceMock
-            .Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<Guid>(), SearchMode.Keyword, It.IsAny<int>(), It.IsAny<List<Guid>?>(), It.IsAny<float>(), It.IsAny<float>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<Guid>(), SearchMode.Keyword, It.IsAny<int>(), It.IsAny<List<Guid>?>(), It.IsAny<float>(), It.IsAny<float>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<HybridSearchResult>());
 
         _rrfFusionServiceMock
@@ -820,6 +820,7 @@ public class StreamQaQueryHandlerTests
                 ),
                 It.IsAny<float>(),
                 It.IsAny<float>(),
+                It.IsAny<double>(),
                 It.IsAny<CancellationToken>()
             ),
             Times.Once,
@@ -987,6 +988,7 @@ public class StreamQaQueryHandlerTests
                 It.IsAny<List<Guid>?>(),
                 It.IsAny<float>(),
                 It.IsAny<float>(),
+                It.IsAny<double>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(keywordSearchResults);
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/Reranking/ResilientRetrievalServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/Reranking/ResilientRetrievalServiceTests.cs
@@ -81,6 +81,7 @@ public class ResilientRetrievalServiceTests
                 It.IsAny<List<Guid>?>(),
                 It.IsAny<float>(),
                 It.IsAny<float>(),
+                It.IsAny<double>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<HybridSearchResult>
             {
@@ -139,6 +140,7 @@ public class ResilientRetrievalServiceTests
                 It.IsAny<List<Guid>?>(),
                 It.IsAny<float>(),
                 It.IsAny<float>(),
+                It.IsAny<double>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<HybridSearchResult>());
 
@@ -175,6 +177,7 @@ public class ResilientRetrievalServiceTests
                 It.IsAny<List<Guid>?>(),
                 It.IsAny<float>(),
                 It.IsAny<float>(),
+                It.IsAny<double>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<HybridSearchResult>
             {
@@ -212,6 +215,7 @@ public class ResilientRetrievalServiceTests
                 It.IsAny<List<Guid>?>(),
                 It.IsAny<float>(),
                 It.IsAny<float>(),
+                It.IsAny<double>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<HybridSearchResult>
             {
@@ -254,6 +258,7 @@ public class ResilientRetrievalServiceTests
                 It.IsAny<List<Guid>?>(),
                 It.IsAny<float>(),
                 It.IsAny<float>(),
+                It.IsAny<double>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<HybridSearchResult>
             {
@@ -324,6 +329,7 @@ public class ResilientRetrievalServiceTests
                 It.IsAny<List<Guid>?>(),
                 It.IsAny<float>(),
                 It.IsAny<float>(),
+                It.IsAny<double>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<HybridSearchResult>
             {
@@ -393,6 +399,7 @@ public class ResilientRetrievalServiceTests
                 It.IsAny<List<Guid>?>(),
                 It.IsAny<float>(),
                 It.IsAny<float>(),
+                It.IsAny<double>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<HybridSearchResult>());
 
@@ -416,6 +423,7 @@ public class ResilientRetrievalServiceTests
                 It.IsAny<List<Guid>?>(),
                 It.IsAny<float>(),
                 It.IsAny<float>(),
+                It.IsAny<double>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/ContextEngineering/HybridSearchEngineTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/ContextEngineering/HybridSearchEngineTests.cs
@@ -154,6 +154,7 @@ public class HybridSearchEngineTests
                 It.IsAny<List<Guid>?>(),
                 It.IsAny<float>(),
                 It.IsAny<float>(),
+                It.IsAny<double>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(hybridResults);
 
@@ -196,6 +197,7 @@ public class HybridSearchEngineTests
                 It.IsAny<List<Guid>?>(),
                 It.IsAny<float>(),
                 It.IsAny<float>(),
+                It.IsAny<double>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<HybridSearchResult>());
 
@@ -233,6 +235,7 @@ public class HybridSearchEngineTests
                 It.IsAny<List<Guid>?>(),
                 It.IsAny<float>(),
                 It.IsAny<float>(),
+                It.IsAny<double>(),
                 It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Test error"));
 
@@ -285,9 +288,10 @@ public class HybridSearchEngineTests
                 It.IsAny<List<Guid>?>(),
                 It.IsAny<float>(),
                 It.IsAny<float>(),
+                It.IsAny<double>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<string, Guid, SearchMode, int, List<Guid>?, float, float, CancellationToken>(
-                (q, g, m, l, d, vw, kw, ct) =>
+            .Callback<string, Guid, SearchMode, int, List<Guid>?, float, float, double, CancellationToken>(
+                (q, g, m, l, d, vw, kw, ms, ct) =>
                 {
                     capturedVectorWeight = vw;
                     capturedKeywordWeight = kw;
@@ -334,9 +338,10 @@ public class HybridSearchEngineTests
                 It.IsAny<List<Guid>?>(),
                 It.IsAny<float>(),
                 It.IsAny<float>(),
+                It.IsAny<double>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<string, Guid, SearchMode, int, List<Guid>?, float, float, CancellationToken>(
-                (q, g, m, l, d, vw, kw, ct) => capturedVectorWeight = vw)
+            .Callback<string, Guid, SearchMode, int, List<Guid>?, float, float, double, CancellationToken>(
+                (q, g, m, l, d, vw, kw, ms, ct) => capturedVectorWeight = vw)
             .ReturnsAsync(new List<HybridSearchResult>());
 
         var engine = new HybridSearchEngine(
@@ -371,6 +376,7 @@ public class HybridSearchEngineTests
                 It.IsAny<List<Guid>?>(),
                 It.IsAny<float>(),
                 It.IsAny<float>(),
+                It.IsAny<double>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<HybridSearchResult>
             {

--- a/apps/api/tests/Api.Tests/Integration/Infrastructure/RagServiceIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Infrastructure/RagServiceIntegrationTests.cs
@@ -228,7 +228,7 @@ public sealed class RagServiceIntegrationTests : IAsyncLifetime
         };
 
         _hybridSearchServiceMock
-            .Setup(x => x.SearchAsync(query, Guid.Parse(gameId), SearchMode.Hybrid, 5, null, 0.7f, 0.3f, It.IsAny<CancellationToken>()))
+            .Setup(x => x.SearchAsync(query, Guid.Parse(gameId), SearchMode.Hybrid, 5, null, 0.7f, 0.3f, It.IsAny<double>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(hybridResults);
 
         _llmServiceMock
@@ -282,7 +282,7 @@ public sealed class RagServiceIntegrationTests : IAsyncLifetime
         };
 
         _hybridSearchServiceMock
-            .Setup(x => x.SearchAsync(query, Guid.Parse(gameId), SearchMode.Semantic, 5, null, 0.7f, 0.3f, It.IsAny<CancellationToken>()))
+            .Setup(x => x.SearchAsync(query, Guid.Parse(gameId), SearchMode.Semantic, 5, null, 0.7f, 0.3f, It.IsAny<double>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(semanticResults);
 
         _llmServiceMock
@@ -334,7 +334,7 @@ public sealed class RagServiceIntegrationTests : IAsyncLifetime
         };
 
         _hybridSearchServiceMock
-            .Setup(x => x.SearchAsync(query, Guid.Parse(gameId), SearchMode.Keyword, 5, null, 0.7f, 0.3f, It.IsAny<CancellationToken>()))
+            .Setup(x => x.SearchAsync(query, Guid.Parse(gameId), SearchMode.Keyword, 5, null, 0.7f, 0.3f, It.IsAny<double>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(keywordResults);
 
         _llmServiceMock
@@ -454,7 +454,7 @@ public sealed class RagServiceIntegrationTests : IAsyncLifetime
         };
 
         _hybridSearchServiceMock
-            .Setup(x => x.SearchAsync(query, Guid.Parse(gameId), SearchMode.Hybrid, 5, null, 0.7f, 0.3f, It.IsAny<CancellationToken>()))
+            .Setup(x => x.SearchAsync(query, Guid.Parse(gameId), SearchMode.Hybrid, 5, null, 0.7f, 0.3f, It.IsAny<double>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(hybridResults);
 
         _llmServiceMock
@@ -503,7 +503,7 @@ public sealed class RagServiceIntegrationTests : IAsyncLifetime
         };
 
         _hybridSearchServiceMock
-            .Setup(x => x.SearchAsync(query, Guid.Parse(gameId), SearchMode.Hybrid, 5, null, 0.7f, 0.3f, It.IsAny<CancellationToken>()))
+            .Setup(x => x.SearchAsync(query, Guid.Parse(gameId), SearchMode.Hybrid, 5, null, 0.7f, 0.3f, It.IsAny<double>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(hybridResults);
 
         var callCount = 0;
@@ -558,7 +558,7 @@ public sealed class RagServiceIntegrationTests : IAsyncLifetime
         };
 
         _hybridSearchServiceMock
-            .Setup(x => x.SearchAsync(query, Guid.Parse(gameId), It.IsAny<SearchMode>(), 5, null, 0.7f, 0.3f, It.IsAny<CancellationToken>()))
+            .Setup(x => x.SearchAsync(query, Guid.Parse(gameId), It.IsAny<SearchMode>(), 5, null, 0.7f, 0.3f, It.IsAny<double>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(hybridResults);
 
         var callCount = 0;
@@ -660,7 +660,7 @@ public sealed class RagServiceIntegrationTests : IAsyncLifetime
         var query = "Non-existent rule";
 
         _hybridSearchServiceMock
-            .Setup(x => x.SearchAsync(query, Guid.Parse(gameId), SearchMode.Hybrid, 5, null, 0.7f, 0.3f, It.IsAny<CancellationToken>()))
+            .Setup(x => x.SearchAsync(query, Guid.Parse(gameId), SearchMode.Hybrid, 5, null, 0.7f, 0.3f, It.IsAny<double>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<HybridSearchResult>());
 
         // Act

--- a/apps/api/tests/Api.Tests/Services/RagServiceIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Services/RagServiceIntegrationTests.cs
@@ -348,6 +348,7 @@ public sealed class RagServiceIntegrationTests : IDisposable
                 It.IsAny<List<Guid>?>(),
                 It.IsAny<float>(),
                 It.IsAny<float>(),
+                It.IsAny<double>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(dummyResults);
     }

--- a/apps/api/tests/Api.Tests/Services/RagServicePerformanceTests.cs
+++ b/apps/api/tests/Api.Tests/Services/RagServicePerformanceTests.cs
@@ -298,8 +298,9 @@ public sealed class RagServicePerformanceTests : IDisposable
                 It.IsAny<List<Guid>?>(),
                 It.IsAny<float>(),
                 It.IsAny<float>(),
+                It.IsAny<double>(),
                 It.IsAny<CancellationToken>()))
-            .Returns(async (string query, Guid gameId, SearchMode mode, int limit, List<Guid>? documentIds, float vw, float kw, CancellationToken ct) =>
+            .Returns(async (string query, Guid gameId, SearchMode mode, int limit, List<Guid>? documentIds, float vw, float kw, double minScore, CancellationToken ct) =>
             {
                 // Simulate test-optimized hybrid search latency: 30-80ms
                 // (Reduced from 150-250ms to ensure P95 <3000ms target)


### PR DESCRIPTION
## Summary

Fixes 2 bugs discovered during E2E testing of the chat RAG flow:

- **#422** PdfSeeder doesn't propagate `SharedGameId` from `GameEntity` → PDFs get mapped to wrong games. **Fix:** Look up `games.SharedGameId` before creating `PdfDocumentEntity`.
- **#423** Keyword search in hybrid RAG has no `minScore` filter → Table of Contents outranks actual content via RRF fusion. **Fix:** Propagate `minScore` (ts_rank_cd >= 0.01) through `HybridSearchService` → `KeywordSearchService` → SQL WHERE clause.

## Changes (17 files, +70 -22)

| File | Change |
|------|--------|
| `PdfSeeder.cs` | +SharedGameId lookup from GameEntity |
| `KeywordSearchService.cs` | +`minScore` param + SQL `ts_rank_cd >= @minScore` filter |
| `IKeywordSearchService.cs` | +`minScore` param (default 0.0) |
| `HybridSearchService.cs` | Propagate `keywordMinScore` to keyword path |
| `IHybridSearchService.cs` | +`keywordMinScore` param (default 0.0) |
| `SearchQueryHandler.cs` | Pass `keywordMinScore: 0.01` to hybrid search |
| 10 test files | Updated mock setups for new parameter |

## Test plan

- [x] Backend builds (pre-push verified)
- [x] All existing tests updated and passing
- [ ] Re-seed staging PDFs to verify SharedGameId propagation
- [ ] RAG query "explain the game setup" returns actual setup content (not ToC)

Closes #422, #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)