### PR TITLE
feat(theme): desktop dark theme unification

### DIFF
--- a/apps/web/src/components/layout/AdminShell/AdminShell.tsx
+++ b/apps/web/src/components/layout/AdminShell/AdminShell.tsx
@@ -27,7 +27,7 @@ export function AdminShell({ children }: AdminShellProps) {
   }, [setNavbarHeight]);
 
   return (
-    <div className="flex h-dvh bg-background">
+    <div className="flex h-dvh bg-[var(--bg-base)]">
       <a
         href="#main-content"
         className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:px-4 focus:py-2 focus:bg-background focus:text-foreground focus:rounded-md"
@@ -39,7 +39,7 @@ export function AdminShell({ children }: AdminShellProps) {
       <div className="flex flex-col flex-1 min-w-0">
         <header
           role="banner"
-          className="sticky top-0 z-40 h-[52px] flex items-center gap-3 px-4 border-b bg-background/95 backdrop-blur-md shrink-0"
+          className="sticky top-0 z-40 h-[52px] flex items-center gap-3 px-4 border-b border-[var(--border-glass)] bg-[var(--bg-elevated)]/95 backdrop-blur-[16px] shrink-0"
         >
           <button
             aria-label="Apri menu"

--- a/apps/web/src/components/layout/CardRack/CardRack.tsx
+++ b/apps/web/src/components/layout/CardRack/CardRack.tsx
@@ -54,8 +54,8 @@ export function CardRack({ className }: CardRackProps) {
         'fixed left-0 z-40',
         'top-[var(--top-bar-height,48px)]',
         'h-[calc(100vh-var(--top-bar-height,48px))]',
-        'bg-sidebar text-sidebar-foreground',
-        'border-r border-sidebar-border',
+        'bg-[var(--bg-base)] text-[var(--text-primary)]',
+        'border-r border-[var(--border-glass)]',
         'transition-[width] duration-200 ease-in-out motion-reduce:transition-none',
         isExpanded ? 'w-[var(--card-rack-hover-width,240px)]' : 'w-[var(--card-rack-width,64px)]',
         className
@@ -74,7 +74,7 @@ export function CardRack({ className }: CardRackProps) {
         ))}
       </div>
 
-      <hr className="mx-3 border-sidebar-border" />
+      <hr className="mx-3 border-[var(--border-glass)]" />
 
       <div className="flex flex-col gap-0.5 px-2 py-3">
         {BOTTOM_ITEMS.map(item => (

--- a/apps/web/src/components/layout/ContextualHand/ContextualHandBottomBar.tsx
+++ b/apps/web/src/components/layout/ContextualHand/ContextualHandBottomBar.tsx
@@ -2,21 +2,10 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-import {
-  BookOpen,
-  Gamepad2,
-  Bot,
-  Wrench,
-  Hash,
-  X,
-} from 'lucide-react';
+import { BookOpen, Gamepad2, Bot, Wrench, Hash, X } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
-import {
-  useContextualHandStore,
-  selectContext,
-  selectIsLoading,
-} from '@/stores/contextual-hand';
+import { useContextualHandStore, selectContext, selectIsLoading } from '@/stores/contextual-hand';
 
 import { ContextualHandSlot, type HandSlotType } from './ContextualHandSlot';
 
@@ -62,9 +51,9 @@ export function ContextualHandBottomBar() {
         aria-label="Azioni partita"
         className={cn(
           'md:hidden fixed bottom-0 inset-x-0 z-30',
-          'border-t border-[var(--nh-border-default)]',
-          'bg-[var(--nh-bg-base)]/95 backdrop-blur-sm',
-          'supports-[backdrop-filter]:bg-[var(--nh-bg-base)]/60'
+          'border-t border-[var(--border-glass)]',
+          'bg-[var(--bg-base)]/95 backdrop-blur-sm',
+          'supports-[backdrop-filter]:bg-[var(--bg-base)]/60'
         )}
         style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
       >
@@ -107,20 +96,20 @@ export function ContextualHandBottomBar() {
           <div
             className={cn(
               'absolute bottom-0 inset-x-0 max-h-[50vh] rounded-t-2xl',
-              'border-t border-[var(--nh-border-default)] bg-[var(--nh-bg-base)]',
+              'border-t border-[var(--border-glass)] bg-[var(--bg-base)]',
               'animate-in slide-in-from-bottom duration-300',
               'overflow-y-auto'
             )}
             style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
           >
             {/* Drag handle */}
-            <div className="sticky top-0 z-10 flex items-center justify-center bg-[var(--nh-bg-base)] pt-3 pb-1">
+            <div className="sticky top-0 z-10 flex items-center justify-center bg-[var(--bg-base)] pt-3 pb-1">
               <div className="h-1.5 w-12 rounded-full bg-muted-foreground/25" />
             </div>
 
             {/* Header */}
             <div className="flex items-center justify-between px-4 pb-2">
-              <h3 className="font-quicksand text-sm font-semibold text-[var(--nh-text-default)]">
+              <h3 className="font-quicksand text-sm font-semibold text-[var(--text-primary)]">
                 {TABS.find(t => t.type === expandedTab)?.label}
               </h3>
               <button

--- a/apps/web/src/components/layout/ContextualHand/ContextualHandSidebar.tsx
+++ b/apps/web/src/components/layout/ContextualHand/ContextualHandSidebar.tsx
@@ -40,17 +40,17 @@ export function ContextualHandSidebar() {
       aria-label="La mia mano"
       className={cn(
         'hidden md:flex flex-col shrink-0 sticky top-0 h-dvh z-30',
-        'border-l border-[var(--nh-border-default)] bg-[var(--nh-bg-base)]',
+        'border-l border-[var(--border-glass)] bg-[var(--bg-base)]',
         'transition-[width] duration-200 ease-out',
         isCollapsed ? 'w-[52px]' : 'w-[280px]'
       )}
     >
       {/* ── Header ───────────────────────────────────────────────── */}
-      <div className="flex items-center gap-2 border-b border-[var(--nh-border-default)] px-2 py-2.5">
+      <div className="flex items-center gap-2 border-b border-[var(--border-glass)] px-2 py-2.5">
         {!isCollapsed && (
           <>
             <Hand className="h-4 w-4 text-primary" />
-            <span className="font-quicksand text-sm font-semibold text-[var(--nh-text-default)]">
+            <span className="font-quicksand text-sm font-semibold text-[var(--text-primary)]">
               La Mia Mano
             </span>
           </>

--- a/apps/web/src/components/layout/HandRail/HandRail.tsx
+++ b/apps/web/src/components/layout/HandRail/HandRail.tsx
@@ -25,19 +25,19 @@ export function HandRail() {
       className={cn(
         'hidden md:flex flex-col flex-shrink-0',
         'h-[calc(100dvh-56px)] sticky top-[56px]',
-        'bg-[hsl(220,15%,11%)] border-r border-white/5',
+        'bg-[var(--bg-base)]/95 border-r border-[var(--border-glass)]',
         'transition-[width] duration-200 ease-out overflow-hidden',
         expanded ? 'w-[200px]' : 'w-[64px]'
       )}
       onMouseEnter={() => setExpanded(true)}
       onMouseLeave={() => setExpanded(false)}
     >
-      <div className="flex flex-col gap-1 p-[5px] flex-1 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      <div className="flex flex-col gap-1 p-2 flex-1 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         {pinned.length > 0 && (
           <>
             <span
               className={cn(
-                'text-[7.5px] font-[800] tracking-[0.1em] uppercase text-white/28 px-[3px] mt-1',
+                'text-[7.5px] font-[800] tracking-[0.1em] uppercase text-[var(--text-tertiary)] px-[3px] mt-1',
                 'transition-opacity duration-150',
                 expanded ? 'opacity-100' : 'opacity-0'
               )}
@@ -52,7 +52,7 @@ export function HandRail() {
                 active={pathname === card.href || pathname.startsWith(card.href + '/')}
               />
             ))}
-            <div className="h-px bg-white/5 my-1" />
+            <div className="h-px bg-[var(--border-glass)] my-1" />
           </>
         )}
 
@@ -60,7 +60,7 @@ export function HandRail() {
           <>
             <span
               className={cn(
-                'text-[7.5px] font-[800] tracking-[0.1em] uppercase text-white/28 px-[3px]',
+                'text-[7.5px] font-[800] tracking-[0.1em] uppercase text-[var(--text-tertiary)] px-[3px]',
                 'transition-opacity duration-150',
                 expanded ? 'opacity-100' : 'opacity-0'
               )}

--- a/apps/web/src/components/layout/UserShell/DesktopShell.tsx
+++ b/apps/web/src/components/layout/UserShell/DesktopShell.tsx
@@ -34,7 +34,7 @@ interface DesktopShellProps {
  */
 export function DesktopShell({ children }: DesktopShellProps) {
   return (
-    <div className="min-h-dvh flex flex-col bg-[var(--nh-bg-base)]">
+    <div className="min-h-dvh flex flex-col bg-[var(--bg-base)]">
       <TopBar />
       <div className="flex flex-1 min-h-0">
         <HandRail />

--- a/apps/web/src/components/layout/UserShell/MiniNavSlot.tsx
+++ b/apps/web/src/components/layout/UserShell/MiniNavSlot.tsx
@@ -18,9 +18,9 @@ export function MiniNavSlot() {
   return (
     <div
       data-testid="mini-nav-slot"
-      className="h-12 flex items-center gap-1 px-7 pl-[104px] border-b border-[var(--nh-border-default)] bg-[var(--nh-bg-base)]"
+      className="h-12 flex items-center gap-1 px-7 pl-[104px] border-b border-[var(--border-glass)] bg-[var(--bg-base)]"
     >
-      <div className="text-xs font-semibold text-[var(--nh-text-muted)] mr-5">
+      <div className="text-xs font-semibold text-[var(--text-tertiary)] mr-5">
         <span aria-hidden>›</span> {config.breadcrumb}
       </div>
       {config.tabs.map(tab => {
@@ -33,13 +33,13 @@ export function MiniNavSlot() {
             className={cn(
               'relative px-3.5 py-2 rounded-lg text-[0.78rem] font-bold flex items-center gap-1.5 transition-colors',
               active
-                ? 'text-[var(--nh-text-primary)]'
-                : 'text-[var(--nh-text-secondary)] hover:bg-[var(--nh-bg-surface)]'
+                ? 'text-[var(--text-primary)]'
+                : 'text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)]'
             )}
           >
             {tab.label}
             {tab.count !== undefined && (
-              <span className="px-1.5 py-0.5 rounded text-[10px] font-extrabold bg-[rgba(160,120,60,0.1)] text-[var(--nh-text-secondary)]">
+              <span className="px-1.5 py-0.5 rounded text-[10px] font-extrabold bg-[var(--bg-glass)] text-[var(--text-secondary)]">
                 {tab.count}
               </span>
             )}

--- a/apps/web/src/components/layout/UserShell/TopBar.tsx
+++ b/apps/web/src/components/layout/UserShell/TopBar.tsx
@@ -33,8 +33,8 @@ export function TopBar({ onOpenChat, onOpenSearch }: TopBarProps) {
   return (
     <header
       data-testid="top-bar"
-      className="sticky top-0 z-40 h-16 flex items-center gap-4 px-6 border-b border-[var(--nh-border-default)] backdrop-blur-md"
-      style={{ background: 'rgba(255, 252, 248, 0.85)' }}
+      className="sticky top-0 z-40 h-16 flex items-center gap-4 px-6 border-b border-[var(--border-glass)] backdrop-blur-[16px]"
+      style={{ background: 'color-mix(in srgb, var(--bg-elevated) 95%, transparent)' }}
     >
       <TopBarLogo />
       <TopBarNavLinks />

--- a/apps/web/src/components/layout/UserShell/TopBarChatButton.tsx
+++ b/apps/web/src/components/layout/UserShell/TopBarChatButton.tsx
@@ -23,7 +23,7 @@ export function TopBarChatButton({ onOpen, hasUnread = false }: TopBarChatButton
       type="button"
       aria-label="Chat agente"
       onClick={handleClick}
-      className="relative flex h-10 w-10 items-center justify-center rounded-[10px] border border-[var(--nh-border-default)] bg-[var(--nh-bg-surface)] text-base shrink-0 hover:bg-white hover:shadow-[var(--shadow-warm-sm)] hover:-translate-y-px transition-all"
+      className="relative flex h-10 w-10 items-center justify-center rounded-[10px] border border-[var(--border-glass)] bg-[var(--bg-elevated)] text-base shrink-0 hover:bg-[var(--bg-glass)] hover:shadow-[var(--shadow-warm-sm)] hover:-translate-y-px transition-all"
     >
       <span aria-hidden>💬</span>
       {hasUnread && (
@@ -33,7 +33,7 @@ export function TopBarChatButton({ onOpen, hasUnread = false }: TopBarChatButton
           className="absolute top-[7px] right-[7px] h-2 w-2 rounded-full"
           style={{
             background: 'hsl(350 89% 58%)',
-            boxShadow: '0 0 0 2px var(--nh-bg-surface)',
+            boxShadow: '0 0 0 2px var(--bg-elevated)',
           }}
         />
       )}

--- a/apps/web/src/components/layout/UserShell/TopBarLogo.tsx
+++ b/apps/web/src/components/layout/UserShell/TopBarLogo.tsx
@@ -19,7 +19,7 @@ export function TopBarLogo() {
       >
         ◆
       </span>
-      <span className="text-[var(--nh-text-primary)]">Meeple</span>
+      <span className="text-[var(--text-primary)]">Meeple</span>
       <span className="-ml-2.5" style={{ color: 'hsl(25 95% 42%)' }}>
         Ai
       </span>

--- a/apps/web/src/components/layout/UserShell/TopBarNavLinks.tsx
+++ b/apps/web/src/components/layout/UserShell/TopBarNavLinks.tsx
@@ -45,7 +45,7 @@ export function TopBarNavLinks() {
               'px-3.5 py-2 rounded-[10px] font-nunito font-bold text-[0.82rem] transition-colors',
               active
                 ? 'text-[hsl(25_95%_38%)] shadow-[inset_0_0_0_1px_hsla(25,95%,45%,0.25)]'
-                : 'text-[var(--nh-text-secondary)] hover:bg-[var(--nh-bg-surface)] hover:text-[var(--nh-text-primary)]'
+                : 'text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]'
             )}
             style={active ? { background: 'hsla(25, 95%, 45%, 0.1)' } : undefined}
           >

--- a/apps/web/src/components/layout/UserShell/TopBarSearchPill.tsx
+++ b/apps/web/src/components/layout/UserShell/TopBarSearchPill.tsx
@@ -31,14 +31,14 @@ export function TopBarSearchPill({
         type="button"
         aria-label="Search"
         onClick={() => onOpen?.()}
-        className="w-full flex items-center gap-3 px-5 py-[11px] rounded-xl border border-[var(--nh-border-default)] bg-[var(--nh-bg-surface)] text-left text-[0.82rem] text-[var(--nh-text-muted)] hover:bg-white hover:border-[rgba(160,120,60,0.2)] hover:shadow-[var(--shadow-warm-sm)] transition-all"
+        className="w-full flex items-center gap-3 px-5 py-[11px] rounded-xl border border-[var(--border-glass)] bg-[var(--bg-elevated)] text-left text-[0.82rem] text-[var(--text-tertiary)] hover:bg-[var(--bg-glass)] hover:border-[var(--border-glass-hover)] hover:shadow-[var(--shadow-warm-sm)] transition-all"
       >
         <span className="shrink-0 text-sm" aria-hidden>
           🔍
         </span>
         <span className="flex-1 truncate">{placeholder}</span>
         <span
-          className="shrink-0 px-2 py-0.5 rounded-[5px] border border-[var(--nh-border-default)] bg-[rgba(160,120,60,0.08)] text-[10px] font-mono font-bold text-[var(--nh-text-secondary)]"
+          className="shrink-0 px-2 py-0.5 rounded-[5px] border border-[var(--border-glass)] bg-[var(--bg-glass)] text-[10px] font-mono font-bold text-[var(--text-secondary)]"
           aria-hidden
         >
           ⌘K

--- a/apps/web/src/components/providers/ThemeProvider.tsx
+++ b/apps/web/src/components/providers/ThemeProvider.tsx
@@ -22,7 +22,7 @@ export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
   return (
     <NextThemesProvider
       attribute="class"
-      defaultTheme="light"
+      defaultTheme="dark"
       enableSystem
       disableTransitionOnChange={false}
       {...props}

--- a/apps/web/src/components/session/MobileScorebar.tsx
+++ b/apps/web/src/components/session/MobileScorebar.tsx
@@ -20,7 +20,7 @@ export function MobileScorebar({ players }: MobileScorebarProps) {
       {players.map(p => (
         <div
           key={p.id}
-          className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-card border border-border shrink-0"
+          className="flex items-center gap-2 px-3 py-1.5 rounded-[var(--radius-btn)] bg-[var(--bg-glass)] border border-[var(--border-glass)] shrink-0"
         >
           <div className="h-6 w-6 rounded-full bg-primary/20 flex items-center justify-center text-[10px] font-bold">
             {p.name[0]}

--- a/apps/web/src/components/session/MobileStatusBar.tsx
+++ b/apps/web/src/components/session/MobileStatusBar.tsx
@@ -20,7 +20,7 @@ export function MobileStatusBar({ gameName, currentPlayer }: MobileStatusBarProp
       className={cn(
         'flex items-center justify-between px-3 lg:hidden',
         'h-[var(--mobile-status-bar-height,36px)]',
-        'bg-card border-b border-border text-sm'
+        'bg-[var(--bg-glass)] border-b border-[var(--border-glass)] text-sm text-[var(--text-primary)]'
       )}
     >
       <div className="flex items-center gap-2 min-w-0">
@@ -41,11 +41,11 @@ export function MobileStatusBar({ gameName, currentPlayer }: MobileStatusBarProp
           </span>
         )}
         <span className="font-medium truncate">{gameName}</span>
-        <span className="text-xs text-muted-foreground truncate">· {currentPlayer}</span>
+        <span className="text-xs text-[var(--text-secondary)] truncate">· {currentPlayer}</span>
       </div>
 
       <div className="flex items-center gap-3 shrink-0">
-        <span className="text-xs text-muted-foreground">Turno {currentTurn}</span>
+        <span className="text-xs text-[var(--text-secondary)]">Turno {currentTurn}</span>
         {isLive && (
           <button
             onClick={togglePause}

--- a/apps/web/src/styles/design-tokens.css
+++ b/apps/web/src/styles/design-tokens.css
@@ -163,10 +163,29 @@
     --texture-parchment: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E");
 
     /* ============================================================================
-     * HYBRID WARM-MODERN PALETTE
-     * Warm-neutral visual identity (spec: 2026-03-25-library-visual-redesign)
-     * Light mode values (default); dark overrides in .dark {} block below
+     * UNIFIED THEME TOKENS
+     * Dark mode (default) — matches mobile Premium Gaming theme
+     * Light overrides via .light class on <html>
      * ============================================================================ */
+
+    /* Unified tokens (dark = default, consumed by all components) */
+    --bg-base: var(--gaming-bg-base);
+    --bg-elevated: var(--gaming-bg-elevated);
+    --bg-glass: var(--gaming-bg-glass);
+    --border-glass: var(--gaming-border-glass);
+    --border-glass-hover: var(--gaming-border-glass-hover);
+    --text-primary: var(--gaming-text-primary);
+    --text-secondary: var(--gaming-text-secondary);
+    --text-tertiary: var(--gaming-text-tertiary);
+    --text-accent: var(--gaming-text-accent);
+
+    /* Border-radius hierarchy */
+    --radius-sheet: 1.25rem;   /* 20px — sheets/drawers top-only */
+    --radius-card: 1rem;       /* 16px — cards */
+    --radius-btn: 0.75rem;     /* 12px — buttons/inputs */
+    --radius-pill: 3.125rem;   /* 50px — chips/pills */
+
+    /* Legacy aliases (backwards compat — remove after full migration) */
     --nh-bg-base: #faf8f5;
     --nh-bg-surface: #fffcf8;
     --nh-bg-surface-end: #f5f0e8;
@@ -571,6 +590,19 @@
     --mc-shadow-lg: 0 10px 30px rgba(0, 0, 0, 0.25), 0 4px 8px rgba(0, 0, 0, 0.15);
     --mc-shadow-xl: 0 20px 50px rgba(0, 0, 0, 0.30), 0 8px 16px rgba(0, 0, 0, 0.18);
     --mc-shadow-2xl: 0 25px 60px rgba(0, 0, 0, 0.35), 0 12px 24px rgba(0, 0, 0, 0.22);
+  }
+
+  /* Light mode overrides — apply via class="light" on <html> */
+  .light {
+    --bg-base: #faf8f5;
+    --bg-elevated: #fffcf8;
+    --bg-glass: rgba(160, 120, 60, 0.04);
+    --border-glass: rgba(160, 120, 60, 0.08);
+    --border-glass-hover: rgba(160, 120, 60, 0.14);
+    --text-primary: #1a1a1a;
+    --text-secondary: #5a4a35;
+    --text-tertiary: #8a7a65;
+    --text-accent: hsl(25, 95%, 38%);
   }
 }
 

--- a/apps/web/src/styles/design-tokens.css
+++ b/apps/web/src/styles/design-tokens.css
@@ -174,6 +174,8 @@
     --bg-glass: var(--gaming-bg-glass);
     --border-glass: var(--gaming-border-glass);
     --border-glass-hover: var(--gaming-border-glass-hover);
+    --bg-glass-hover: rgba(255, 255, 255, 0.08);
+    --border-glass-strong: rgba(255, 255, 255, 0.18);
     --text-primary: var(--gaming-text-primary);
     --text-secondary: var(--gaming-text-secondary);
     --text-tertiary: var(--gaming-text-tertiary);
@@ -599,6 +601,8 @@
     --bg-glass: rgba(160, 120, 60, 0.04);
     --border-glass: rgba(160, 120, 60, 0.08);
     --border-glass-hover: rgba(160, 120, 60, 0.14);
+    --bg-glass-hover: rgba(160, 120, 60, 0.07);
+    --border-glass-strong: rgba(160, 120, 60, 0.22);
     --text-primary: #1a1a1a;
     --text-secondary: #5a4a35;
     --text-tertiary: #8a7a65;

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -175,14 +175,16 @@
   }
 
   body {
-    @apply bg-background text-foreground antialiased;
+    @apply antialiased;
     font-family: var(--font-nunito, var(--font-sans));
     position: relative;
+    background: var(--bg-base);
+    color: var(--text-primary);
   }
 
   /* MeepleAI Background Texture System - Issue #2905 */
-  /* Subtle Wood/Paper Texture */
-  body::before {
+  /* Subtle Wood/Paper Texture — light mode only */
+  .light body::before {
     content: '';
     position: fixed;
     inset: 0;
@@ -194,8 +196,8 @@
     opacity: 0.6;
   }
 
-  /* Subtle warm gradient overlay */
-  body::after {
+  /* Subtle warm gradient overlay — light mode only */
+  .light body::after {
     content: '';
     position: fixed;
     inset: 0;

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -562,17 +562,16 @@
   --color-neutral-400: hsl(30 12% 72%);
   --color-neutral-600: hsl(30 12% 45%);
 
-  --bg-primary: hsl(var(--background));
+  /* NOTE: --bg-base, --bg-elevated, --text-primary, --text-secondary, --text-tertiary
+     are now unified tokens defined in design-tokens.css (dark-first).
+     Do NOT redefine them here. Use the unified tokens directly. */
+  --bg-primary: var(--bg-base);
   --bg-secondary: hsl(30 20% 94%);
   --bg-tertiary: hsl(30 18% 90%);
-  --bg-elevated: hsl(var(--card));
 
   --border-primary: hsl(var(--border));
   --border-secondary: hsl(30 12% 75%);
 
-  --text-primary: hsl(var(--foreground));
-  --text-secondary: hsl(var(--muted-foreground));
-  --text-tertiary: hsl(30 10% 55%);
   --text-inverse: hsl(var(--primary-foreground));
 
   --font-display: var(--font-quicksand, var(--font-sans));
@@ -646,17 +645,15 @@
   --color-neutral-400: hsl(0 0% 34%);
   --color-neutral-600: hsl(0 0% 46%);
 
-  --bg-primary: hsl(var(--background));       /* #1a1a1a */
-  --bg-secondary: hsl(0 0% 15%);              /* Slightly lighter than bg */
-  --bg-tertiary: hsl(0 0% 20%);               /* Lighter variant */
-  --bg-elevated: hsl(var(--card));            /* #2d2d2d */
+  /* NOTE: --bg-base, --bg-elevated, --text-primary, --text-secondary, --text-tertiary
+     are unified tokens from design-tokens.css. Do NOT redefine here. */
+  --bg-primary: var(--bg-base);
+  --bg-secondary: hsl(0 0% 15%);
+  --bg-tertiary: hsl(0 0% 20%);
 
   --border-primary: hsl(var(--border));
-  --border-secondary: hsl(0 0% 30%);          /* Lighter border variant */
+  --border-secondary: hsl(0 0% 30%);
 
-  --text-primary: hsl(var(--foreground));     /* #e8e4d8 */
-  --text-secondary: hsl(0 0% 60%);            /* #999999 - Muted text */
-  --text-tertiary: hsl(0 0% 50%);             /* Dimmer text */
   --text-inverse: hsl(var(--primary-foreground));
 
   --font-display: var(--font-quicksand, var(--font-sans));


### PR DESCRIPTION
## Summary

- Unify desktop authenticated pages with mobile's Dark Premium Gaming theme
- Add `--bg-*`, `--border-*`, `--text-*`, `--radius-*` unified CSS tokens on `:root` (dark-first), aliasing existing `--gaming-*` values
- Prepare `.light` class override for future light/dark toggle
- Update 17 files: shell (DesktopShell, TopBar, HandRail), navigation (MiniNav, TopBar children), sidebars (CardRack, ContextualHand), session components (MobileStatusBar, MobileScorebar), AdminShell
- Remove conflicting shadcn token overrides in globals.css that were blocking dark theme
- Set `defaultTheme="dark"` in next-themes ThemeProvider
- Body texture overlays scoped to `.light` only

## Deferred (follow-up)

- Layer 4: MeepleCard `--mc-*` token migration
- Layer 5: GameTableLayout hardcoded hex colors (`#0d1117` etc.)
- `tailwind.config.js` token mapping for cleaner class names
- Light/dark toggle button UI

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] Pre-commit hooks pass (lint, prettier, tsc)
- [ ] Visual check: desktop library page renders dark theme
- [ ] Visual check: TopBar, HandRail, MiniNav all dark and coherent
- [ ] Visual check: mobile layout unchanged (already uses `--gaming-*`)
- [ ] Verify landing/login pages unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
