### PR TITLE
fix(chat,api): QA stream routing and agent-slots endpoint (#415, #417)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetUserAgentSlotsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetUserAgentSlotsQueryHandler.cs
@@ -1,0 +1,70 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Domain;
+using Api.BoundedContexts.UserLibrary.Domain.Repositories;
+using MediatR;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Handles GetUserAgentSlotsQuery — returns user's agent slot allocation and usage.
+/// Issue #4771: Agent Slots Endpoint + Quota System.
+/// Issue #417: Frontend calls GET /api/v1/user/agent-slots → 404.
+/// </summary>
+internal sealed class GetUserAgentSlotsQueryHandler
+    : IRequestHandler<GetUserAgentSlotsQuery, UserAgentSlotsDto>
+{
+    private readonly IUserLibraryRepository _libraryRepository;
+
+    public GetUserAgentSlotsQueryHandler(IUserLibraryRepository libraryRepository)
+    {
+        _libraryRepository = libraryRepository ?? throw new ArgumentNullException(nameof(libraryRepository));
+    }
+
+    public async Task<UserAgentSlotsDto> Handle(
+        GetUserAgentSlotsQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var used = await _libraryRepository
+            .GetAgentConfigCountAsync(request.UserId, cancellationToken)
+            .ConfigureAwait(false);
+
+        var total = AgentTierLimits.GetMaxAgents(request.UserTier, request.UserRole);
+
+        // Cap total for display (Enterprise/Admin gets int.MaxValue — show a sensible number)
+        var displayTotal = total == int.MaxValue ? used + 100 : total;
+        var available = Math.Max(0, displayTotal - used);
+
+        // Build slot list: occupied slots (index 0..used-1) + available slots (used..total-1)
+        var slots = new List<AgentSlotDto>();
+        for (var i = 0; i < Math.Min(used, displayTotal); i++)
+        {
+            slots.Add(new AgentSlotDto(
+                SlotIndex: i,
+                AgentId: null,   // Individual agent details require a separate query
+                AgentName: null,
+                GameId: null,
+                Status: "active"
+            ));
+        }
+
+        for (var i = used; i < Math.Min(displayTotal, used + 20); i++)
+        {
+            slots.Add(new AgentSlotDto(
+                SlotIndex: i,
+                AgentId: null,
+                AgentName: null,
+                GameId: null,
+                Status: "available"
+            ));
+        }
+
+        return new UserAgentSlotsDto(
+            Total: displayTotal,
+            Used: used,
+            Available: available,
+            Slots: slots
+        );
+    }
+}

--- a/apps/api/src/Api/Routing/AiEndpoints.cs
+++ b/apps/api/src/Api/Routing/AiEndpoints.cs
@@ -43,6 +43,8 @@ internal static class AiEndpoints
 
         MapPlayerModeSuggestionEndpoint(group);
 
+        MapUserAgentSlotsEndpoint(group);
+
         // UI-01: Chat management endpoints
         return group;
     }
@@ -997,5 +999,33 @@ internal static class AiEndpoints
             await context.Response.WriteAsync($"data: {json}\n\n", ct).ConfigureAwait(false);
             await context.Response.Body.FlushAsync(ct).ConfigureAwait(false);
         }
+    }
+
+    // ─── Agent Slots ─────────────────────────────────────────────────────
+
+    private static void MapUserAgentSlotsEndpoint(RouteGroupBuilder group)
+    {
+        group.MapGet("/user/agent-slots", HandleGetUserAgentSlots)
+            .WithName("GetUserAgentSlots")
+            .WithDescription("Get user's agent slot allocation and usage (Issue #4771)")
+            .WithTags("AI Agents")
+            .Produces<UserAgentSlotsDto>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .RequireSession();
+    }
+
+    private static async Task<IResult> HandleGetUserAgentSlots(
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        var session = (SessionStatusDto)context.Items[nameof(SessionStatusDto)]!;
+        var userId = session.User!.Id;
+        var userTier = session.User!.Tier;
+        var userRole = session.User!.Role;
+
+        var query = new GetUserAgentSlotsQuery(userId, userTier, userRole);
+        var result = await mediator.Send(query, ct).ConfigureAwait(false);
+        return Results.Ok(result);
     }
 }

--- a/apps/api/tests/Api.Tests/Routing/EndpointContractTests.cs
+++ b/apps/api/tests/Api.Tests/Routing/EndpointContractTests.cs
@@ -100,6 +100,9 @@ public sealed class EndpointContractTests : IClassFixture<RouteContractTestFacto
         // Game Nights
         yield return ["GET", "/api/v1/game-nights"];
 
+        // Agent Slots (Issue #417)
+        yield return ["GET", "/api/v1/user/agent-slots"];
+
         // Contact (public, no auth)
         yield return ["POST", "/api/v1/contact"];
     }
@@ -118,7 +121,7 @@ public sealed class EndpointContractTests : IClassFixture<RouteContractTestFacto
         yield return ["GET",  "/api/v1/agent-typologies",                                                     "typology listing"];
         yield return ["GET",  "/api/v1/agents/recent?limit=10",                                               "recent agents"];
         yield return ["POST", "/api/v1/agents/user",                                                          "create user agent"];
-        yield return ["GET",  "/api/v1/user/agent-slots",                                                     "agent slots"];
+        // agent-slots: moved to KnownRoutes (Issue #417 — handler implemented)
         yield return ["POST", "/api/v1/agents/create-with-setup",                                             "create with setup"];
         yield return ["POST", "/api/v1/agents/quick-create",                                                  "quick create tutor"];
         yield return ["PUT",  "/api/v1/agents/00000000-0000-0000-0000-000000000001/configure",                "configure agent"];

--- a/apps/web/src/components/chat-unified/ChatThreadView.tsx
+++ b/apps/web/src/components/chat-unified/ChatThreadView.tsx
@@ -280,18 +280,10 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
       };
       setMessages(prev => [...prev, userMessage]);
 
-      // SSE path: stream via agent endpoint when agentId is available
-      if (thread?.agentId) {
-        // Issue #4780: Build proxy game context for OpenRouter proxy (if enabled)
-        const proxyCtx: ProxyGameContext | undefined =
-          game && thread.agentTypology
-            ? { gameName: game.title, agentTypology: thread.agentTypology }
-            : undefined;
-        sendViaSSE(thread.agentId, messageContent, threadId, proxyCtx);
-        return; // onComplete/onError callbacks handle the rest
-      }
-
-      // QA stream path: system agents (no agentId) with game context (#415)
+      // QA stream path: game context available → use RAG QA streaming (#415)
+      // Priority: gameId check FIRST because POST /agents/{id}/chat does not exist
+      // in the backend — the correct SSE endpoint is POST /agents/qa/stream which
+      // takes gameId+query and internally selects the right agent/strategy.
       if (thread?.gameId) {
         const assistantMsgId = `assistant-${Date.now()}`;
         const assistantMessage: ChatMessageItem = {
@@ -401,7 +393,18 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
         return;
       }
 
-      // REST fallback: no game context — just save message
+      // SSE agent path: for future per-agent chat endpoints (POST /agents/{id}/chat)
+      // Currently no backend route exists — kept as fallback for when it's implemented.
+      if (thread?.agentId && !thread?.gameId) {
+        const proxyCtx: ProxyGameContext | undefined =
+          game && thread.agentTypology
+            ? { gameName: game.title, agentTypology: thread.agentTypology }
+            : undefined;
+        sendViaSSE(thread.agentId, messageContent, threadId, proxyCtx);
+        return;
+      }
+
+      // REST fallback: no game context and no agent — just save message
       try {
         const response = await api.chat.addMessage(threadId, {
           content: messageContent,

--- a/apps/web/src/lib/api/clients/agentsClient.ts
+++ b/apps/web/src/lib/api/clients/agentsClient.ts
@@ -421,7 +421,7 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
     /**
      * Get user's agent slot allocation and usage
      * Issue #4771: Agent Slots Endpoint + Quota System
-     * @todo BACKEND MISSING: No route registered for GET /api/v1/user/agent-slots. Throws on null response. See: endpoint audit 2026-04-15
+     * Issue #417: Backend route registered in AiEndpoints.cs (GET /api/v1/user/agent-slots)
      */
     async getSlots(): Promise<{
       total: number;


### PR DESCRIPTION
## Summary

- **#415 (CRITICAL)**: Fix chat not triggering AI response — `ChatThreadView.handleSendMessage` checked `thread.agentId` before `thread.gameId`, routing to `POST /agents/{id}/chat` which doesn't exist in the backend. Reordered conditions so QA stream path (`POST /agents/qa/stream`) fires when gameId is available.
- **#417**: Implement `GetUserAgentSlotsQueryHandler` + `GET /api/v1/user/agent-slots` route with tier-based slot allocation via `AgentTierLimits`. Moved from `PendingBackendRoutes` to `KnownRoutes` in contract tests.
- **#416**: Already fixed in current codebase — frontend correctly calls `GET /api/v1/games/{id}/agents`.

## Files Changed

| File | Change |
|------|--------|
| `ChatThreadView.tsx` | Prioritize `gameId` check over `agentId` for QA stream |
| `AiEndpoints.cs` | Add `GET /user/agent-slots` route + handler |
| `GetUserAgentSlotsQueryHandler.cs` | New MediatR handler for agent slot quota |
| `EndpointContractTests.cs` | Move agent-slots to KnownRoutes |
| `agentsClient.ts` | Remove @todo BACKEND MISSING annotation |

## Test plan

- [ ] Verify chat sends AI response after message (navigate to game chat, send message, confirm SSE stream fires)
- [ ] Verify `GET /api/v1/user/agent-slots` returns 200 with slot data
- [ ] Verify agent slot counts match user tier limits
- [ ] Confirm no regressions on existing chat flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
