### PR TITLE
fix(kb): add missing GetAllAgentsQueryHandler (chat 500)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetAllAgentsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetAllAgentsQueryHandler.cs
@@ -1,0 +1,69 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using MediatR;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Handler for GetAllAgentsQuery — returns lightweight AgentDto list for user-facing endpoints.
+/// Used by GET /api/v1/games/{id}/agents (chat panel agent resolution).
+/// </summary>
+internal sealed class GetAllAgentsQueryHandler
+    : IRequestHandler<GetAllAgentsQuery, List<AgentDto>>
+{
+    private readonly IAgentDefinitionRepository _repository;
+
+    public GetAllAgentsQueryHandler(IAgentDefinitionRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public async Task<List<AgentDto>> Handle(
+        GetAllAgentsQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var agents = request.ActiveOnly == true
+            ? await _repository.GetAllActiveAsync(cancellationToken).ConfigureAwait(false)
+            : await _repository.GetAllAsync(cancellationToken).ConfigureAwait(false);
+
+        // Apply optional Type filter
+        if (!string.IsNullOrWhiteSpace(request.Type))
+        {
+            agents = agents
+                .Where(a => string.Equals(a.Type.Value, request.Type, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        }
+
+        // Apply optional GameId filter
+        if (request.GameId.HasValue)
+        {
+            agents = agents.Where(a => a.GameId == request.GameId.Value).ToList();
+        }
+
+        return agents.Select(MapToDto).ToList();
+    }
+
+    private static AgentDto MapToDto(Domain.Entities.AgentDefinition agent)
+    {
+        var recentThreshold = DateTime.UtcNow.AddHours(-24);
+        var idleThreshold = DateTime.UtcNow.AddDays(-7);
+
+        return new AgentDto(
+            Id: agent.Id,
+            Name: agent.Name,
+            Type: agent.Type.Value,
+            StrategyName: agent.Strategy.Name,
+            StrategyParameters: agent.Strategy.Parameters,
+            IsActive: agent.IsActive,
+            CreatedAt: agent.CreatedAt,
+            LastInvokedAt: agent.LastInvokedAt,
+            InvocationCount: agent.InvocationCount,
+            IsRecentlyUsed: agent.LastInvokedAt.HasValue && agent.LastInvokedAt.Value > recentThreshold,
+            IsIdle: !agent.LastInvokedAt.HasValue || agent.LastInvokedAt.Value < idleThreshold,
+            GameId: agent.GameId,
+            CreatedByUserId: null
+        );
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/GetAllAgentsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/GetAllAgentsQueryHandlerTests.cs
@@ -1,0 +1,120 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+using AgentDefinitionEntity = Api.BoundedContexts.KnowledgeBase.Domain.Entities.AgentDefinition;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Handlers;
+
+/// <summary>
+/// Unit tests for GetAllAgentsQueryHandler — used by GET /api/v1/games/{id}/agents.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class GetAllAgentsQueryHandlerTests
+{
+    private readonly Mock<IAgentDefinitionRepository> _mockRepository;
+    private readonly GetAllAgentsQueryHandler _handler;
+
+    public GetAllAgentsQueryHandlerTests()
+    {
+        _mockRepository = new Mock<IAgentDefinitionRepository>();
+        _handler = new GetAllAgentsQueryHandler(_mockRepository.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ActiveOnly_ShouldCallGetAllActiveAsync()
+    {
+        // Arrange
+        var agents = new List<AgentDefinitionEntity>
+        {
+            CreateAgent("QA Agent"),
+            CreateAgent("Rules Agent")
+        };
+
+        _mockRepository
+            .Setup(r => r.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agents);
+
+        var query = new GetAllAgentsQuery(ActiveOnly: true);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Should().AllSatisfy(a => a.Should().BeOfType<AgentDto>());
+        _mockRepository.Verify(r => r.GetAllActiveAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NoFilter_ShouldCallGetAllAsync()
+    {
+        // Arrange
+        _mockRepository
+            .Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AgentDefinitionEntity>());
+
+        var query = new GetAllAgentsQuery();
+
+        // Act
+        await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        _mockRepository.Verify(r => r.GetAllAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _mockRepository.Verify(r => r.GetAllActiveAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_MapsFieldsCorrectly()
+    {
+        // Arrange
+        var agent = CreateAgent("Test Agent");
+        _mockRepository
+            .Setup(r => r.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AgentDefinitionEntity> { agent });
+
+        var query = new GetAllAgentsQuery(ActiveOnly: true);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().ContainSingle();
+        var dto = result[0];
+        dto.Name.Should().Be("Test Agent");
+        dto.Type.Should().NotBeNullOrEmpty();
+        dto.StrategyName.Should().NotBeNullOrEmpty();
+        dto.IsActive.Should().BeFalse(); // AgentDefinition.Create sets IsActive=false
+    }
+
+    [Fact]
+    public async Task Handle_EmptyResult_ShouldReturnEmptyList()
+    {
+        // Arrange
+        _mockRepository
+            .Setup(r => r.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AgentDefinitionEntity>());
+
+        var query = new GetAllAgentsQuery(ActiveOnly: true);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    private static AgentDefinitionEntity CreateAgent(string name)
+    {
+        return AgentDefinitionEntity.Create(
+            name,
+            $"Description for {name}",
+            AgentType.RagAgent,
+            AgentDefinitionConfig.Default());
+    }
+}

--- a/apps/api/tests/Api.Tests/Routing/EndpointContractTests.cs
+++ b/apps/api/tests/Api.Tests/Routing/EndpointContractTests.cs
@@ -55,21 +55,21 @@ public sealed class EndpointContractTests : IClassFixture<RouteContractTestFacto
         // Auth
         yield return ["POST", "/api/v1/auth/login"];
         yield return ["POST", "/api/v1/auth/register"];
-        yield return ["GET",  "/api/v1/auth/me"];
-        yield return ["GET",  "/api/v1/auth/session/status"];
+        yield return ["GET", "/api/v1/auth/me"];
+        yield return ["GET", "/api/v1/auth/session/status"];
 
         // Library
-        yield return ["GET",  "/api/v1/library"];
-        yield return ["GET",  "/api/v1/library/games/00000000-0000-0000-0000-000000000001/agent-config"];
-        yield return ["PUT",  "/api/v1/library/games/00000000-0000-0000-0000-000000000001/agent-config"];
+        yield return ["GET", "/api/v1/library"];
+        yield return ["GET", "/api/v1/library/games/00000000-0000-0000-0000-000000000001/agent-config"];
+        yield return ["PUT", "/api/v1/library/games/00000000-0000-0000-0000-000000000001/agent-config"];
         yield return ["POST", "/api/v1/library/games/00000000-0000-0000-0000-000000000001/agent-config"];
 
         // PDF / ingest
-        yield return ["GET",  "/api/v1/pdfs/00000000-0000-0000-0000-000000000001/progress"];
+        yield return ["GET", "/api/v1/pdfs/00000000-0000-0000-0000-000000000001/progress"];
         yield return ["POST", "/api/v1/ingest/pdf"];
 
         // Knowledge Base
-        yield return ["GET",  "/api/v1/knowledge-base/00000000-0000-0000-0000-000000000001/status"];
+        yield return ["GET", "/api/v1/knowledge-base/00000000-0000-0000-0000-000000000001/status"];
         yield return ["POST", "/api/v1/knowledge-base/search"];
 
         // Sessions
@@ -112,18 +112,18 @@ public sealed class EndpointContractTests : IClassFixture<RouteContractTestFacto
     public static IEnumerable<object[]> PendingBackendRoutes()
     {
         // Agent CRUD — agentsClient.ts marks these as BACKEND MISSING (audit 2026-04-15).
-        yield return ["GET",  "/api/v1/agents",                                                                "agent listing"];
-        yield return ["GET",  "/api/v1/agents/00000000-0000-0000-0000-000000000001",                          "agent by id"];
-        yield return ["GET",  "/api/v1/agents/00000000-0000-0000-0000-000000000001/status",                   "agent status"];
-        yield return ["GET",  "/api/v1/agent-typologies",                                                     "typology listing"];
-        yield return ["GET",  "/api/v1/agents/recent?limit=10",                                               "recent agents"];
-        yield return ["POST", "/api/v1/agents/user",                                                          "create user agent"];
-        yield return ["GET",  "/api/v1/user/agent-slots",                                                     "agent slots"];
-        yield return ["POST", "/api/v1/agents/create-with-setup",                                             "create with setup"];
-        yield return ["POST", "/api/v1/agents/quick-create",                                                  "quick create tutor"];
-        yield return ["PUT",  "/api/v1/agents/00000000-0000-0000-0000-000000000001/configure",                "configure agent"];
-        yield return ["GET",  "/api/v1/agents/00000000-0000-0000-0000-000000000001/configuration",            "get agent config"];
-        yield return ["PATCH", "/api/v1/agents/00000000-0000-0000-0000-000000000001/configuration",           "update agent config"];
+        yield return ["GET", "/api/v1/agents", "agent listing"];
+        yield return ["GET", "/api/v1/agents/00000000-0000-0000-0000-000000000001", "agent by id"];
+        yield return ["GET", "/api/v1/agents/00000000-0000-0000-0000-000000000001/status", "agent status"];
+        yield return ["GET", "/api/v1/agent-typologies", "typology listing"];
+        yield return ["GET", "/api/v1/agents/recent?limit=10", "recent agents"];
+        yield return ["POST", "/api/v1/agents/user", "create user agent"];
+        yield return ["GET", "/api/v1/user/agent-slots", "agent slots"];
+        yield return ["POST", "/api/v1/agents/create-with-setup", "create with setup"];
+        yield return ["POST", "/api/v1/agents/quick-create", "quick create tutor"];
+        yield return ["PUT", "/api/v1/agents/00000000-0000-0000-0000-000000000001/configure", "configure agent"];
+        yield return ["GET", "/api/v1/agents/00000000-0000-0000-0000-000000000001/configuration", "get agent config"];
+        yield return ["PATCH", "/api/v1/agents/00000000-0000-0000-0000-000000000001/configuration", "update agent config"];
 
     }
 
@@ -192,35 +192,35 @@ public sealed class RouteContractTestFactory : WebApplicationFactory<Program>
             {
                 // Use SQLite InMemory — no external DB required
                 ["ConnectionStrings:DefaultConnection"] = "DataSource=:memory:",
-                ["ConnectionStrings:Postgres"]          = "DataSource=:memory:",
+                ["ConnectionStrings:Postgres"] = "DataSource=:memory:",
                 // JWT (required so auth middleware can start)
-                ["Jwt:Secret"]    = "contract-test-secret-key-minimum-32-characters-long",
-                ["Jwt:Issuer"]    = "MeepleAI-ContractTest",
-                ["Jwt:Audience"]  = "MeepleAI-ContractTest",
+                ["Jwt:Secret"] = "contract-test-secret-key-minimum-32-characters-long",
+                ["Jwt:Issuer"] = "MeepleAI-ContractTest",
+                ["Jwt:Audience"] = "MeepleAI-ContractTest",
                 // OpenRouter placeholder
-                ["OpenRouter:ApiKey"]  = "contract-test-key",
+                ["OpenRouter:ApiKey"] = "contract-test-key",
                 ["OpenRouter:BaseUrl"] = "https://test.local",
                 // Disable all external services
                 ["BoardGameGeek:Enabled"] = "false",
-                ["Embedding:Enabled"]     = "false",
-                ["Embedding:Url"]         = "http://localhost:8000",
-                ["Qdrant:Enabled"]        = "false",
-                ["Qdrant:Host"]           = "localhost",
-                ["Qdrant:Port"]           = "6333",
-                ["Redis:Enabled"]         = "false",
+                ["Embedding:Enabled"] = "false",
+                ["Embedding:Url"] = "http://localhost:8000",
+                ["Qdrant:Enabled"] = "false",
+                ["Qdrant:Host"] = "localhost",
+                ["Qdrant:Port"] = "6333",
+                ["Redis:Enabled"] = "false",
                 ["Redis:ConnectionString"] = "localhost:6379",
                 // Session config
                 ["Authentication:SessionManagement:SessionExpirationDays"] = "30",
                 // Admin seed (skipped because hosted services are removed)
-                ["Admin:Email"]       = "admin@test.local",
-                ["Admin:Password"]    = "TestAdmin123!",
+                ["Admin:Email"] = "admin@test.local",
+                ["Admin:Password"] = "TestAdmin123!",
                 ["Admin:DisplayName"] = "Test Admin",
-                ["INITIAL_ADMIN_EMAIL"]        = "admin@test.local",
-                ["INITIAL_ADMIN_PASSWORD"]     = "TestAdmin123!",
+                ["INITIAL_ADMIN_EMAIL"] = "admin@test.local",
+                ["INITIAL_ADMIN_PASSWORD"] = "TestAdmin123!",
                 ["INITIAL_ADMIN_DISPLAY_NAME"] = "Test Admin",
                 // Observability off
-                ["Observability:Enabled"]          = "false",
-                ["OTEL_EXPORTER_OTLP_ENDPOINT"]    = "",
+                ["Observability:Enabled"] = "false",
+                ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "",
                 // Rate limiting off
                 ["RateLimiting:Enabled"] = "false",
                 // CORS


### PR DESCRIPTION
## Summary
- **Root cause**: `GetAllAgentsQuery` had no MediatR handler, causing `GET /api/v1/games/{id}/agents` to return 500
- **Impact**: Chat panel from navbar was completely broken — couldn't resolve agentId for SSE streaming
- **Fix**: Added `GetAllAgentsQueryHandler` + 4 unit tests (all passing, 1825 KB tests green)

## Evidence
Reproduced on meepleai.app via Chrome DevTools:
- `GET /api/v1/games/273b8f6c-.../agents` → **500** (this fix)
- `GET /api/v1/knowledge-base/273b8f6c-.../status` → 200 (unaffected)

## Test plan
- [x] `GetAllAgentsQueryHandler` unit tests (4/4 passing)
- [x] KnowledgeBase BC unit tests (1825/1825 passing)
- [x] `dotnet build` clean (0 errors, 0 warnings)
- [ ] Deploy to staging and verify chat panel resolves agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)