### PR TITLE
fix(kb): handle null limit/usage in OpenRouter auth/key response

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/OpenRouterUsageService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/OpenRouterUsageService.cs
@@ -163,11 +163,14 @@ internal sealed class OpenRouterUsageService : BackgroundService, IOpenRouterUsa
                 return;
             }
 
+            // Null limit means unlimited (paid tier); null usage defaults to 0. Balance only meaningful when limit is set.
+            var limit = apiResponse.Data.LimitUsd ?? 0m;
+            var usage = apiResponse.Data.Usage ?? 0m;
             var status = new OpenRouterAccountStatus
             {
-                BalanceUsd = apiResponse.Data.LimitUsd - apiResponse.Data.Usage,
-                LimitUsd = apiResponse.Data.LimitUsd,
-                UsageUsd = apiResponse.Data.Usage,
+                BalanceUsd = limit > 0 ? limit - usage : 0m,
+                LimitUsd = limit,
+                UsageUsd = usage,
                 IsFreeTier = apiResponse.Data.IsFreeTier,
                 RateLimitRequests = apiResponse.Data.RateLimit?.Requests ?? 0,
                 RateLimitInterval = apiResponse.Data.RateLimit?.Interval ?? string.Empty,
@@ -204,9 +207,9 @@ internal sealed class OpenRouterUsageService : BackgroundService, IOpenRouterUsa
     private sealed record AuthKeyApiResponse(AuthKeyData? Data);
 
     private sealed record AuthKeyData(
-        // OpenRouter returns "limit" (not "limit_usd")
-        [property: JsonPropertyName("limit")] decimal LimitUsd,
-        decimal Usage,
+        // OpenRouter returns "limit" (not "limit_usd"). Nullable: unlimited accounts return null.
+        [property: JsonPropertyName("limit")] decimal? LimitUsd,
+        decimal? Usage,
         [property: JsonPropertyName("is_free_tier")] bool IsFreeTier,
         [property: JsonPropertyName("rate_limit")] RateLimitInfo? RateLimit);
 


### PR DESCRIPTION
## Summary
OpenRouter `/auth/key` returns `null` for `limit`/`usage` on unlimited paid accounts, causing `JsonException` every 60s in `PollAccountStatusAsync` on staging logs.

## Fix
- Made `AuthKeyData.LimitUsd` and `Usage` nullable (`decimal?`)
- Defaults to `0m` when null (semantically: unlimited / no usage)
- `BalanceUsd` only computed when `limit > 0` (prevents meaningless negative balance)

## Test plan
- [x] Build passes (0 errors, 0 warnings)
- [x] 14/14 existing OpenRouterUsageService tests pass
- [ ] Verify on staging: no more JsonException in logs after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)