### PR TITLE
fix(health): defensive serialization for /health endpoint

### DIFF
--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -567,20 +567,56 @@ app.MapHealthChecks("/health", new Microsoft.AspNetCore.Diagnostics.HealthChecks
     ResponseWriter = async (context, report) =>
     {
         context.Response.ContentType = "application/json";
-        var result = System.Text.Json.JsonSerializer.Serialize(new
+
+        // Defensive serialization: isolate any single check's serialization failure
+        // to avoid crashing the whole /health endpoint with empty 500 body.
+        var logger = context.RequestServices.GetRequiredService<ILoggerFactory>().CreateLogger("HealthCheck");
+        var checks = new List<object>(capacity: report.Entries.Count);
+        foreach (var entry in report.Entries)
         {
-            status = report.Status.ToString(),
-            checks = report.Entries.Select(e => new
+            try
             {
-                name = e.Key,
-                status = e.Value.Status.ToString(),
-                description = e.Value.Description,
-                duration = e.Value.Duration.TotalMilliseconds,
-                tags = e.Value.Tags
-            }),
-            totalDuration = report.TotalDuration.TotalMilliseconds
-        });
-        await context.Response.WriteAsync(result).ConfigureAwait(false);
+                checks.Add(new
+                {
+                    name = entry.Key,
+                    status = entry.Value.Status.ToString(),
+                    description = entry.Value.Description,
+                    duration = entry.Value.Duration.TotalMilliseconds,
+                    tags = entry.Value.Tags
+                });
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to serialize health check entry {Name}", entry.Key);
+                checks.Add(new
+                {
+                    name = entry.Key,
+                    status = "SerializationError",
+                    description = ex.Message,
+                    duration = 0.0,
+                    tags = Array.Empty<string>()
+                });
+            }
+        }
+
+        try
+        {
+            var result = System.Text.Json.JsonSerializer.Serialize(new
+            {
+                status = report.Status.ToString(),
+                checks,
+                totalDuration = report.TotalDuration.TotalMilliseconds
+            });
+            await context.Response.WriteAsync(result).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to serialize /health response (entries: {Count})", checks.Count);
+            context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            await context.Response.WriteAsync(
+                $"{{\"status\":\"SerializationError\",\"error\":\"{ex.GetType().Name}: {ex.Message}\"}}")
+                .ConfigureAwait(false);
+        }
     }
 });
 


### PR DESCRIPTION
## Summary
`/health` returns 500 with empty body on staging, breaking ops visibility. Root cause hidden by unhandled exception in the ResponseWriter.

## Fix
- Per-entry try/catch isolates individual check serialization failures
- Top-level try/catch logs the underlying exception and returns diagnostic JSON instead of empty body

Once deployed, staging logs will reveal the actual cause of the serialization failure for a follow-up root-cause fix.

## Test plan
- [x] Build passes (0 errors, 0 warnings)
- [ ] After deploy: check staging logs for "Failed to serialize /health response" to identify remaining root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)