### PR TITLE
fix(infra): disable unused PDF services in staging

### DIFF
--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -70,6 +70,10 @@ services:
       Authentication__SessionCookie__SameSite: "Lax"
       # Ollama disabled in staging — all LLM traffic goes to OpenRouter
       AI__Providers__Ollama__Enabled: "false"
+      # Unused optional AI services — PDF extraction uses local Docnet (Provider: Docnet).
+      # Empty URL makes health checks return Degraded instead of Unhealthy.
+      PdfProcessing__Extractor__SmolDocling__ApiUrl: ""
+      PdfProcessing__Extractor__Unstructured__ApiUrl: ""
     volumes:
       - ./secrets:/app/infra/secrets:ro
     labels:
@@ -158,7 +162,10 @@ services:
       - "traefik.http.middlewares.strip-services-reranker.stripprefix.prefixes=/services/reranker"
       - "traefik.http.services.reranker.loadbalancer.server.port=8003"
 
+  # Disabled in staging — PDF extraction uses local Docnet (see api.environment).
+  # Re-enable with profile 'pdf-cloud-extractors' if switching Extractor:Provider.
   unstructured-service:
+    profiles: [pdf-cloud-extractors]
     restart: always
     deploy:
       resources:
@@ -178,6 +185,7 @@ services:
       - "traefik.http.services.unstructured.loadbalancer.server.port=8001"
 
   smoldocling-service:
+    profiles: [pdf-cloud-extractors]
     restart: always
     deploy:
       resources:


### PR DESCRIPTION
## Summary
Staging was running smoldocling (8.6GB) and unstructured (3.3GB) services despite Extractor:Provider=Docnet. Disk was at 99% full, blocking deploys.

## Changes
- Move both services to new profile \`pdf-cloud-extractors\` (opt-in only)
- Set empty URL env vars so health checks return Degraded, not Unhealthy

## Already done on staging
- Containers stopped and images removed (freed 19GB including ollama)
- Stale host-level Api process (PID 1368170) killed — it was hijacking localhost:8080 and serving old code

## Test plan
- [x] Build passes
- [ ] After deploy: verify /health returns proper JSON (not empty 500)
- [ ] Disk usage stays below 80%

🤖 Generated with [Claude Code](https://claude.com/claude-code)