### PR TITLE
fix(health): skip active probe for unused PDF extractors

### DIFF
--- a/apps/api/src/Api/Infrastructure/Health/Checks/SmolDoclingHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/SmolDoclingHealthCheck.cs
@@ -25,6 +25,16 @@ public class SmolDoclingHealthCheck : IHealthCheck
         HealthCheckContext context,
         CancellationToken cancellationToken = default)
     {
+        // Skip active probe if this extractor is not the selected provider — avoids
+        // false Unhealthy for optional services that are intentionally not deployed.
+        var provider = _configuration["PdfProcessing:Extractor:Provider"] ?? "Orchestrator";
+        var usesSmolDocling = provider.Equals("Orchestrator", StringComparison.OrdinalIgnoreCase) ||
+                              provider.Equals("SmolDocling", StringComparison.OrdinalIgnoreCase);
+        if (!usesSmolDocling)
+        {
+            return HealthCheckResult.Degraded($"SmolDocling not in use (Provider={provider})");
+        }
+
         var smoldoclingUrl = _configuration["PdfProcessing:Extractor:SmolDocling:ApiUrl"];
         if (string.IsNullOrWhiteSpace(smoldoclingUrl))
         {

--- a/apps/api/src/Api/Infrastructure/Health/Checks/UnstructuredHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/UnstructuredHealthCheck.cs
@@ -25,6 +25,16 @@ public class UnstructuredHealthCheck : IHealthCheck
         HealthCheckContext context,
         CancellationToken cancellationToken = default)
     {
+        // Skip active probe if this extractor is not the selected provider — avoids
+        // false Unhealthy for optional services that are intentionally not deployed.
+        var provider = _configuration["PdfProcessing:Extractor:Provider"] ?? "Orchestrator";
+        var usesUnstructured = provider.Equals("Orchestrator", StringComparison.OrdinalIgnoreCase) ||
+                               provider.Equals("Unstructured", StringComparison.OrdinalIgnoreCase);
+        if (!usesUnstructured)
+        {
+            return HealthCheckResult.Degraded($"Unstructured not in use (Provider={provider})");
+        }
+
         var unstructuredUrl = _configuration["PdfProcessing:Extractor:Unstructured:ApiUrl"];
         if (string.IsNullOrWhiteSpace(unstructuredUrl))
         {

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -70,10 +70,6 @@ services:
       Authentication__SessionCookie__SameSite: "Lax"
       # Ollama disabled in staging — all LLM traffic goes to OpenRouter
       AI__Providers__Ollama__Enabled: "false"
-      # Unused optional AI services — PDF extraction uses local Docnet (Provider: Docnet).
-      # Empty URL makes health checks return Degraded instead of Unhealthy.
-      PdfProcessing__Extractor__SmolDocling__ApiUrl: ""
-      PdfProcessing__Extractor__Unstructured__ApiUrl: ""
     volumes:
       - ./secrets:/app/infra/secrets:ro
     labels:

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -70,6 +70,10 @@ services:
       Authentication__SessionCookie__SameSite: "Lax"
       # Ollama disabled in staging — all LLM traffic goes to OpenRouter
       AI__Providers__Ollama__Enabled: "false"
+      # Unused optional AI services — PDF extraction uses local Docnet (Provider: Docnet).
+      # Empty URL makes health checks return Degraded instead of Unhealthy.
+      PdfProcessing__Extractor__SmolDocling__ApiUrl: ""
+      PdfProcessing__Extractor__Unstructured__ApiUrl: ""
     volumes:
       - ./secrets:/app/infra/secrets:ro
     labels:
@@ -158,7 +162,10 @@ services:
       - "traefik.http.middlewares.strip-services-reranker.stripprefix.prefixes=/services/reranker"
       - "traefik.http.services.reranker.loadbalancer.server.port=8003"
 
+  # Disabled in staging — PDF extraction uses local Docnet (see api.environment).
+  # Re-enable with profile 'pdf-cloud-extractors' if switching Extractor:Provider.
   unstructured-service:
+    profiles: [pdf-cloud-extractors]
     restart: always
     deploy:
       resources:
@@ -178,6 +185,7 @@ services:
       - "traefik.http.services.unstructured.loadbalancer.server.port=8001"
 
   smoldocling-service:
+    profiles: [pdf-cloud-extractors]
     restart: always
     deploy:
       resources:


### PR DESCRIPTION
Follow-up to #433. Health checks now return Degraded (not Unhealthy) when the Extractor:Provider setting doesn't use that service. Avoids false alarms when smoldocling/unstructured aren't deployed (Provider=Docnet in staging).