### PR TITLE
release: merge main-dev to main-staging (chat 500 fix + health stability)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/OpenRouterUsageService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/OpenRouterUsageService.cs
@@ -163,11 +163,14 @@ internal sealed class OpenRouterUsageService : BackgroundService, IOpenRouterUsa
                 return;
             }
 
+            // Null limit means unlimited (paid tier); null usage defaults to 0. Balance only meaningful when limit is set.
+            var limit = apiResponse.Data.LimitUsd ?? 0m;
+            var usage = apiResponse.Data.Usage ?? 0m;
             var status = new OpenRouterAccountStatus
             {
-                BalanceUsd = apiResponse.Data.LimitUsd - apiResponse.Data.Usage,
-                LimitUsd = apiResponse.Data.LimitUsd,
-                UsageUsd = apiResponse.Data.Usage,
+                BalanceUsd = limit > 0 ? limit - usage : 0m,
+                LimitUsd = limit,
+                UsageUsd = usage,
                 IsFreeTier = apiResponse.Data.IsFreeTier,
                 RateLimitRequests = apiResponse.Data.RateLimit?.Requests ?? 0,
                 RateLimitInterval = apiResponse.Data.RateLimit?.Interval ?? string.Empty,
@@ -204,9 +207,9 @@ internal sealed class OpenRouterUsageService : BackgroundService, IOpenRouterUsa
     private sealed record AuthKeyApiResponse(AuthKeyData? Data);
 
     private sealed record AuthKeyData(
-        // OpenRouter returns "limit" (not "limit_usd")
-        [property: JsonPropertyName("limit")] decimal LimitUsd,
-        decimal Usage,
+        // OpenRouter returns "limit" (not "limit_usd"). Nullable: unlimited accounts return null.
+        [property: JsonPropertyName("limit")] decimal? LimitUsd,
+        decimal? Usage,
         [property: JsonPropertyName("is_free_tier")] bool IsFreeTier,
         [property: JsonPropertyName("rate_limit")] RateLimitInfo? RateLimit);
 

--- a/apps/api/src/Api/Infrastructure/Health/Checks/SmolDoclingHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/SmolDoclingHealthCheck.cs
@@ -25,6 +25,16 @@ public class SmolDoclingHealthCheck : IHealthCheck
         HealthCheckContext context,
         CancellationToken cancellationToken = default)
     {
+        // Skip active probe if this extractor is not the selected provider — avoids
+        // false Unhealthy for optional services that are intentionally not deployed.
+        var provider = _configuration["PdfProcessing:Extractor:Provider"] ?? "Orchestrator";
+        var usesSmolDocling = provider.Equals("Orchestrator", StringComparison.OrdinalIgnoreCase) ||
+                              provider.Equals("SmolDocling", StringComparison.OrdinalIgnoreCase);
+        if (!usesSmolDocling)
+        {
+            return HealthCheckResult.Degraded($"SmolDocling not in use (Provider={provider})");
+        }
+
         var smoldoclingUrl = _configuration["PdfProcessing:Extractor:SmolDocling:ApiUrl"];
         if (string.IsNullOrWhiteSpace(smoldoclingUrl))
         {

--- a/apps/api/src/Api/Infrastructure/Health/Checks/UnstructuredHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/UnstructuredHealthCheck.cs
@@ -25,6 +25,16 @@ public class UnstructuredHealthCheck : IHealthCheck
         HealthCheckContext context,
         CancellationToken cancellationToken = default)
     {
+        // Skip active probe if this extractor is not the selected provider — avoids
+        // false Unhealthy for optional services that are intentionally not deployed.
+        var provider = _configuration["PdfProcessing:Extractor:Provider"] ?? "Orchestrator";
+        var usesUnstructured = provider.Equals("Orchestrator", StringComparison.OrdinalIgnoreCase) ||
+                               provider.Equals("Unstructured", StringComparison.OrdinalIgnoreCase);
+        if (!usesUnstructured)
+        {
+            return HealthCheckResult.Degraded($"Unstructured not in use (Provider={provider})");
+        }
+
         var unstructuredUrl = _configuration["PdfProcessing:Extractor:Unstructured:ApiUrl"];
         if (string.IsNullOrWhiteSpace(unstructuredUrl))
         {

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -567,20 +567,56 @@ app.MapHealthChecks("/health", new Microsoft.AspNetCore.Diagnostics.HealthChecks
     ResponseWriter = async (context, report) =>
     {
         context.Response.ContentType = "application/json";
-        var result = System.Text.Json.JsonSerializer.Serialize(new
+
+        // Defensive serialization: isolate any single check's serialization failure
+        // to avoid crashing the whole /health endpoint with empty 500 body.
+        var logger = context.RequestServices.GetRequiredService<ILoggerFactory>().CreateLogger("HealthCheck");
+        var checks = new List<object>(capacity: report.Entries.Count);
+        foreach (var entry in report.Entries)
         {
-            status = report.Status.ToString(),
-            checks = report.Entries.Select(e => new
+            try
             {
-                name = e.Key,
-                status = e.Value.Status.ToString(),
-                description = e.Value.Description,
-                duration = e.Value.Duration.TotalMilliseconds,
-                tags = e.Value.Tags
-            }),
-            totalDuration = report.TotalDuration.TotalMilliseconds
-        });
-        await context.Response.WriteAsync(result).ConfigureAwait(false);
+                checks.Add(new
+                {
+                    name = entry.Key,
+                    status = entry.Value.Status.ToString(),
+                    description = entry.Value.Description,
+                    duration = entry.Value.Duration.TotalMilliseconds,
+                    tags = entry.Value.Tags
+                });
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to serialize health check entry {Name}", entry.Key);
+                checks.Add(new
+                {
+                    name = entry.Key,
+                    status = "SerializationError",
+                    description = ex.Message,
+                    duration = 0.0,
+                    tags = Array.Empty<string>()
+                });
+            }
+        }
+
+        try
+        {
+            var result = System.Text.Json.JsonSerializer.Serialize(new
+            {
+                status = report.Status.ToString(),
+                checks,
+                totalDuration = report.TotalDuration.TotalMilliseconds
+            });
+            await context.Response.WriteAsync(result).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to serialize /health response (entries: {Count})", checks.Count);
+            context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            await context.Response.WriteAsync(
+                $"{{\"status\":\"SerializationError\",\"error\":\"{ex.GetType().Name}: {ex.Message}\"}}")
+                .ConfigureAwait(false);
+        }
     }
 });
 

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -70,6 +70,10 @@ services:
       Authentication__SessionCookie__SameSite: "Lax"
       # Ollama disabled in staging — all LLM traffic goes to OpenRouter
       AI__Providers__Ollama__Enabled: "false"
+      # Unused optional AI services — PDF extraction uses local Docnet (Provider: Docnet).
+      # Empty URL makes health checks return Degraded instead of Unhealthy.
+      PdfProcessing__Extractor__SmolDocling__ApiUrl: ""
+      PdfProcessing__Extractor__Unstructured__ApiUrl: ""
     volumes:
       - ./secrets:/app/infra/secrets:ro
     labels:
@@ -158,7 +162,10 @@ services:
       - "traefik.http.middlewares.strip-services-reranker.stripprefix.prefixes=/services/reranker"
       - "traefik.http.services.reranker.loadbalancer.server.port=8003"
 
+  # Disabled in staging — PDF extraction uses local Docnet (see api.environment).
+  # Re-enable with profile 'pdf-cloud-extractors' if switching Extractor:Provider.
   unstructured-service:
+    profiles: [pdf-cloud-extractors]
     restart: always
     deploy:
       resources:
@@ -178,6 +185,7 @@ services:
       - "traefik.http.services.unstructured.loadbalancer.server.port=8001"
 
   smoldocling-service:
+    profiles: [pdf-cloud-extractors]
     restart: always
     deploy:
       resources:


### PR DESCRIPTION
## Summary
Promote 4 fixes from main-dev to staging.

## Commits
- fe51a7d75 — fix(health): skip active probe for unused PDF extractors (#434)
- 346fd507e — fix(infra): disable unused PDF services in staging (#433)
- 007f2a0cf — fix(health): defensive serialization for /health endpoint (#432)
- 2001456d9 — fix(kb): handle null limit/usage in OpenRouter auth/key response (#430)

Note: #429 (missing GetAllAgentsQueryHandler — the chat agent 500 fix) already on main-staging from earlier manual merge.

## Test plan
- [x] All 4 PRs merged to main-dev individually
- [x] Manual deploy verified on staging: /health returns 200 Degraded, chat agent works, 18GB free disk
- [ ] CI Deploy to Staging workflow runs cleanly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)