### PR TITLE
fix(ui): eliminate horizontal scroll on mobile viewports

### DIFF
--- a/apps/web/e2e/mobile-shell-viewport.spec.ts
+++ b/apps/web/e2e/mobile-shell-viewport.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * Regression: mobile viewport must not overflow horizontally.
+ *
+ * Original bug (2026-04-16): DesktopShell's TopBar had desktop-only layout
+ * with shrink-0 NavLinks + desktop-sized SearchPill + trailing group,
+ * producing ~105px horizontal overflow at 485px viewport.
+ *
+ * Fix: hamburger menu below md breakpoint, icon-only search pill on mobile,
+ * compact logo, responsive MiniNavSlot padding, overflow-x-clip safety nets
+ * on body + shell <main>.
+ */
+import { test, expect } from '@playwright/test';
+
+import { checkNoHorizontalOverflow } from './helpers/responsive-utils';
+
+// Run in the mobile-chrome project where viewport is 390×844
+test.describe('Mobile shell — no horizontal overflow', () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock auth to bypass login/middleware for authenticated routes
+    await page.context().route('**/api/v1/auth/me', async route => {
+      await route.fulfill({
+        json: {
+          id: 'test-user',
+          email: 'test@example.com',
+          displayName: 'Test User',
+          role: 'User',
+          tier: 'free',
+        },
+      });
+    });
+
+    // Minimal data mocks so pages render without errors
+    await page.context().route('**/api/v1/library/*', async route => {
+      await route.fulfill({ json: { items: [], total: 0 } });
+    });
+    await page.context().route('**/api/v1/games*', async route => {
+      await route.fulfill({ json: { games: [], total: 0 } });
+    });
+    await page.context().route('**/api/v1/sessions/active*', async route => {
+      await route.fulfill({ json: { sessions: [] } });
+    });
+    await page.context().route('**/api/v1/agents*', async route => {
+      await route.fulfill({ json: [] });
+    });
+  });
+
+  for (const path of ['/dashboard', '/library']) {
+    test(`no page scrollbar on ${path}`, async ({ page }) => {
+      await page.goto(path);
+      // Wait for the UserShell TopBar to hydrate
+      await expect(page.locator('[data-testid="top-bar"]')).toBeVisible();
+
+      // Primary assertion: scrollWidth must equal clientWidth on html
+      const { scrollW, clientW } = await page.evaluate(() => ({
+        scrollW: document.documentElement.scrollWidth,
+        clientW: document.documentElement.clientWidth,
+      }));
+      expect(
+        scrollW,
+        `horizontal overflow of ${scrollW - clientW}px on ${path}`
+      ).toBeLessThanOrEqual(clientW);
+
+      // Secondary assertion via shared helper (body + main containers)
+      await checkNoHorizontalOverflow(page);
+    });
+  }
+
+  test('hamburger menu button is visible on mobile', async ({ page }) => {
+    await page.goto('/dashboard');
+    const hamburger = page.getByRole('button', { name: /apri menu/i });
+    await expect(hamburger).toBeVisible();
+  });
+
+  test('desktop primary nav is hidden on mobile', async ({ page }) => {
+    await page.goto('/dashboard');
+    const desktopNav = page.locator('nav[aria-label="Primary"]');
+    // Element is in DOM but hidden via CSS (`hidden md:flex`)
+    await expect(desktopNav).toBeHidden();
+  });
+});

--- a/apps/web/src/components/layout/AdminShell/AdminShell.tsx
+++ b/apps/web/src/components/layout/AdminShell/AdminShell.tsx
@@ -57,7 +57,7 @@ export function AdminShell({ children }: AdminShellProps) {
         <AdminMobileDrawer open={drawerOpen} onOpenChange={setDrawerOpen} />
 
         <DashboardEngineProvider>
-          <main id="main-content" className="flex-1 overflow-y-auto">
+          <main id="main-content" className="flex-1 overflow-y-auto overflow-x-clip">
             {children}
           </main>
         </DashboardEngineProvider>

--- a/apps/web/src/components/layout/UserShell/DesktopShell.tsx
+++ b/apps/web/src/components/layout/UserShell/DesktopShell.tsx
@@ -41,7 +41,7 @@ export function DesktopShell({ children }: DesktopShellProps) {
         <div className="flex flex-col flex-1 min-w-0">
           <MiniNavSlot />
           <SessionBanner />
-          <main className="flex-1 min-w-0 overflow-y-auto">{children}</main>
+          <main className="flex-1 min-w-0 overflow-y-auto overflow-x-clip">{children}</main>
           <ActionPill />
         </div>
       </div>

--- a/apps/web/src/components/layout/UserShell/MiniNavSlot.tsx
+++ b/apps/web/src/components/layout/UserShell/MiniNavSlot.tsx
@@ -18,9 +18,9 @@ export function MiniNavSlot() {
   return (
     <div
       data-testid="mini-nav-slot"
-      className="h-12 flex items-center gap-1 px-7 pl-[104px] border-b border-[var(--border-glass)] bg-[var(--bg-base)]"
+      className="h-12 flex items-center gap-1 px-3 md:px-7 md:pl-[104px] border-b border-[var(--border-glass)] bg-[var(--bg-base)] overflow-x-auto md:overflow-x-visible [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
     >
-      <div className="text-xs font-semibold text-[var(--text-tertiary)] mr-5">
+      <div className="text-xs font-semibold text-[var(--text-tertiary)] mr-3 md:mr-5 shrink-0">
         <span aria-hidden>›</span> {config.breadcrumb}
       </div>
       {config.tabs.map(tab => {

--- a/apps/web/src/components/layout/UserShell/TopBar.tsx
+++ b/apps/web/src/components/layout/UserShell/TopBar.tsx
@@ -6,6 +6,7 @@ import { useChatPanel } from '@/hooks/useChatPanel';
 
 import { TopBarChatButton } from './TopBarChatButton';
 import { TopBarLogo } from './TopBarLogo';
+import { TopBarMobileMenu } from './TopBarMobileMenu';
 import { TopBarNavLinks } from './TopBarNavLinks';
 import { TopBarSearchPill } from './TopBarSearchPill';
 
@@ -33,13 +34,14 @@ export function TopBar({ onOpenChat, onOpenSearch }: TopBarProps) {
   return (
     <header
       data-testid="top-bar"
-      className="sticky top-0 z-40 h-16 flex items-center gap-4 px-6 border-b border-[var(--border-glass)] backdrop-blur-[16px]"
+      className="sticky top-0 z-40 h-16 flex items-center gap-2 md:gap-4 px-3 md:px-6 border-b border-[var(--border-glass)] backdrop-blur-[16px]"
       style={{ background: 'color-mix(in srgb, var(--bg-elevated) 95%, transparent)' }}
     >
+      <TopBarMobileMenu />
       <TopBarLogo />
       <TopBarNavLinks />
       <TopBarSearchPill onOpen={onOpenSearch} />
-      <div className="flex items-center gap-2.5 shrink-0">
+      <div className="flex items-center gap-1.5 md:gap-2.5 shrink-0">
         {onOpenChat ? <TopBarChatButton onOpen={onOpenChat} /> : <TopBarChatButtonConnected />}
         <NotificationBell />
         <UserMenuDropdown />

--- a/apps/web/src/components/layout/UserShell/TopBarLogo.tsx
+++ b/apps/web/src/components/layout/UserShell/TopBarLogo.tsx
@@ -19,8 +19,8 @@ export function TopBarLogo() {
       >
         ◆
       </span>
-      <span className="text-[var(--text-primary)]">Meeple</span>
-      <span className="-ml-2.5" style={{ color: 'hsl(25 95% 42%)' }}>
+      <span className="hidden sm:inline text-[var(--text-primary)]">Meeple</span>
+      <span className="hidden sm:inline -ml-2.5" style={{ color: 'hsl(25 95% 42%)' }}>
         Ai
       </span>
     </Link>

--- a/apps/web/src/components/layout/UserShell/TopBarMobileMenu.tsx
+++ b/apps/web/src/components/layout/UserShell/TopBarMobileMenu.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { Menu } from 'lucide-react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/navigation/sheet';
+import { cn } from '@/lib/utils';
+
+interface NavLink {
+  href: string;
+  label: string;
+  isActive: (pathname: string) => boolean;
+}
+
+const LINKS: NavLink[] = [
+  {
+    href: '/',
+    label: 'Home',
+    isActive: p => p === '/' || p === '/dashboard' || p?.startsWith('/dashboard') || false,
+  },
+  {
+    href: '/library',
+    label: 'Libreria',
+    isActive: p => p?.startsWith('/library') || false,
+  },
+  {
+    href: '/sessions',
+    label: 'Sessioni',
+    isActive: p => p?.startsWith('/sessions') || false,
+  },
+];
+
+/**
+ * Hamburger menu shown below the md breakpoint.
+ * Opens a Sheet drawer with the same primary links as TopBarNavLinks.
+ * Closes automatically on navigation.
+ */
+export function TopBarMobileMenu() {
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname() ?? '';
+
+  useEffect(() => {
+    if (open) setOpen(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname]);
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label="Apri menu"
+        aria-expanded={open}
+        aria-controls="topbar-mobile-drawer"
+        onClick={() => setOpen(true)}
+        className="md:hidden inline-flex h-10 w-10 items-center justify-center rounded-lg text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)] transition-colors shrink-0"
+      >
+        <Menu className="h-5 w-5" aria-hidden />
+      </button>
+
+      {open && (
+        <Sheet open={open} onOpenChange={setOpen}>
+          <SheetContent side="left" className="w-[260px] p-0" id="topbar-mobile-drawer">
+            <SheetHeader className="sr-only">
+              <SheetTitle>Navigazione</SheetTitle>
+            </SheetHeader>
+            <nav aria-label="Primary mobile" className="flex flex-col gap-1 p-4 pt-8">
+              {LINKS.map(link => {
+                const active = link.isActive(pathname);
+                return (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    aria-current={active ? 'page' : undefined}
+                    className={cn(
+                      'px-4 py-3 rounded-lg font-nunito font-bold text-[0.95rem] transition-colors',
+                      active
+                        ? 'text-[hsl(25_95%_38%)] bg-[hsla(25,95%,45%,0.1)] shadow-[inset_0_0_0_1px_hsla(25,95%,45%,0.25)]'
+                        : 'text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]'
+                    )}
+                  >
+                    {link.label}
+                  </Link>
+                );
+              })}
+            </nav>
+          </SheetContent>
+        </Sheet>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/components/layout/UserShell/TopBarNavLinks.tsx
+++ b/apps/web/src/components/layout/UserShell/TopBarNavLinks.tsx
@@ -33,7 +33,7 @@ export function TopBarNavLinks() {
   const pathname = usePathname() ?? '';
 
   return (
-    <nav className="flex items-center gap-1 ml-3 shrink-0" aria-label="Primary">
+    <nav className="hidden md:flex items-center gap-1 ml-3 shrink-0" aria-label="Primary">
       {LINKS.map(link => {
         const active = link.isActive(pathname);
         return (

--- a/apps/web/src/components/layout/UserShell/TopBarSearchPill.tsx
+++ b/apps/web/src/components/layout/UserShell/TopBarSearchPill.tsx
@@ -26,19 +26,19 @@ export function TopBarSearchPill({
   }, [onOpen]);
 
   return (
-    <div className="flex-1 min-w-0 px-2 max-w-[420px]">
+    <div className="flex-1 min-w-0 md:px-2 md:max-w-[420px] flex md:block justify-end">
       <button
         type="button"
         aria-label="Search"
         onClick={() => onOpen?.()}
-        className="w-full flex items-center gap-3 px-5 py-[11px] rounded-xl border border-[var(--border-glass)] bg-[var(--bg-elevated)] text-left text-[0.82rem] text-[var(--text-tertiary)] hover:bg-[var(--bg-glass)] hover:border-[var(--border-glass-hover)] hover:shadow-[var(--shadow-warm-sm)] transition-all"
+        className="md:w-full inline-flex md:flex items-center md:gap-3 h-10 w-10 md:h-auto md:w-auto justify-center md:justify-start md:px-5 md:py-[11px] rounded-full md:rounded-xl border border-[var(--border-glass)] bg-[var(--bg-elevated)] md:text-left text-[0.82rem] text-[var(--text-tertiary)] hover:bg-[var(--bg-glass)] hover:border-[var(--border-glass-hover)] hover:shadow-[var(--shadow-warm-sm)] transition-all"
       >
         <span className="shrink-0 text-sm" aria-hidden>
           🔍
         </span>
-        <span className="flex-1 truncate">{placeholder}</span>
+        <span className="hidden md:inline flex-1 truncate">{placeholder}</span>
         <span
-          className="shrink-0 px-2 py-0.5 rounded-[5px] border border-[var(--border-glass)] bg-[var(--bg-glass)] text-[10px] font-mono font-bold text-[var(--text-secondary)]"
+          className="hidden md:inline-block shrink-0 px-2 py-0.5 rounded-[5px] border border-[var(--border-glass)] bg-[var(--bg-glass)] text-[10px] font-mono font-bold text-[var(--text-secondary)]"
           aria-hidden
         >
           ⌘K

--- a/apps/web/src/components/layout/UserShell/__tests__/TopBar.test.tsx
+++ b/apps/web/src/components/layout/UserShell/__tests__/TopBar.test.tsx
@@ -30,11 +30,17 @@ describe('TopBar', () => {
   it('renders logo, nav links, search, chat button, and user menu', () => {
     render(<TopBar />);
     expect(screen.getByRole('link', { name: /meepleai home/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Home' })).toBeInTheDocument();
+    // Desktop NavLinks + mobile drawer both render the same labels (media-query hidden, still in DOM)
+    expect(screen.getAllByRole('link', { name: 'Home' }).length).toBeGreaterThan(0);
     expect(screen.getByRole('button', { name: /search/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /chat agente/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /notifications/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /user menu/i })).toBeInTheDocument();
+  });
+
+  it('renders mobile hamburger menu button', () => {
+    render(<TopBar />);
+    expect(screen.getByRole('button', { name: /apri menu/i })).toBeInTheDocument();
   });
 
   it('is 64px tall and sticky', () => {

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -180,6 +180,8 @@
     position: relative;
     background: var(--bg-base);
     color: var(--text-primary);
+    /* Safety net: prevent horizontal page scroll on mobile viewports */
+    overflow-x: clip;
   }
 
   /* MeepleAI Background Texture System - Issue #2905 */


### PR DESCRIPTION
## Summary

- Removed ~105px horizontal overflow that affected every authenticated route on mobile (≤~768px). The DesktopShell's `TopBar` was laid out desktop-first with `shrink-0` children totalling ~680px minimum, pushing the trailing action group off the viewport.
- Replaced the inline primary nav with a hamburger + Sheet drawer below `md`, compacted the logo/search/trailing group on small viewports, made `MiniNavSlot` responsive (drop the `pl-[104px]` HandRail offset on mobile + internal tab scroll), and added `overflow-x: clip` safety nets on both shells and the `body`.

## Evidence

Before (staging, viewport 485px):

| Metric | Value |
|---|---|
| `document.documentElement.scrollWidth` | 590 |
| `clientWidth` | 485 |
| Overflow | **105px** |
| Offender | `<div class="flex items-center gap-2.5 shrink-0">` (Chat + Notif + UserMenu trailing group) |

After (local production build, viewport 388px):

| Metric | Value |
|---|---|
| `scrollWidth` | 388 |
| `clientWidth` | 388 |
| Overflow | **0** |
| `getComputedStyle(body).overflowX` | `clip` |
| Hamburger visible | ✅ |
| Desktop nav (`nav[aria-label="Primary"]`) | `display: none` |

## Files changed

- `src/components/layout/UserShell/TopBar.tsx` — `px-3 md:px-6`, `gap-2 md:gap-4`, tighter trailing gap, mount new hamburger
- `src/components/layout/UserShell/TopBarMobileMenu.tsx` *(new)* — hamburger button + Sheet drawer (mirrors TopBarNavLinks), closes on route change
- `src/components/layout/UserShell/TopBarNavLinks.tsx` — `hidden md:flex` (DOM preserved for existing tests)
- `src/components/layout/UserShell/TopBarLogo.tsx` — wordmark `hidden sm:inline`, icon-only below sm
- `src/components/layout/UserShell/TopBarSearchPill.tsx` — 40px round icon button on mobile, full pill on md+
- `src/components/layout/UserShell/MiniNavSlot.tsx` — `px-3 md:px-7`, drop `pl-[104px]` below md, `overflow-x-auto md:overflow-x-visible`, breadcrumb `shrink-0`
- `src/components/layout/UserShell/DesktopShell.tsx` — `<main>` gains `overflow-x-clip`
- `src/components/layout/AdminShell/AdminShell.tsx` — `<main>` gains `overflow-x-clip`
- `src/styles/globals.css` — `body { overflow-x: clip; }` safety net

## Regression test

New `e2e/mobile-shell-viewport.spec.ts` (mobile-chrome @ 390×844):

- `no page scrollbar on /dashboard`
- `no page scrollbar on /library`
- `hamburger menu button is visible on mobile`
- `desktop primary nav is hidden on mobile`

Also verified the existing unit suites still pass:

- `TopBar.test.tsx` (+1 hamburger test), `TopBarLogo`, `TopBarNavLinks`, `TopBarSearchPill`, `DesktopShell`, `MiniNavSlot` — all green.
- `tsc --noEmit` clean.

## Test plan

- [x] Playwright regression `e2e/mobile-shell-viewport.spec.ts` — 4/4 passed on `mobile-chrome`
- [x] `pnpm vitest run` on touched component suites — 22/22 passed
- [x] `pnpm typecheck` — clean
- [ ] CI Playwright suite (mobile + desktop projects)
- [ ] Manual smoke on staging after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)