### PR TITLE
fix(ui): clip horizontal page overflow on all shells

### DIFF
--- a/apps/web/e2e/mobile-shell-viewport.spec.ts
+++ b/apps/web/e2e/mobile-shell-viewport.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * Regression: mobile viewport must not produce a horizontal page scrollbar.
+ *
+ * Background (2026-04-16): on current DesktopShell (TopBar legacy) the primary
+ * nav links were `shrink-0` and the trailing Chat+Notif+UserMenu cluster was
+ * also `shrink-0`, producing ~105px overflow at ≤~485px viewport, observed on
+ * staging `meepleai.app`. A follow-up navigation refactor (PR #431, TopBarV2)
+ * replaces the top bar with a mobile-first hamburger layout, but the underlying
+ * defense — `overflow-x: clip` on `body` and the shell `<main>` — is valuable
+ * for both architectures: any future component that mis-sizes content on a
+ * narrow viewport should not leak into a page-level horizontal scrollbar.
+ *
+ * This test asserts only the cross-architecture contract (no page-level
+ * horizontal scroll), not the internal shell composition.
+ */
+import { test, expect } from '@playwright/test';
+
+import { checkNoHorizontalOverflow } from './helpers/responsive-utils';
+
+// Runs in the `mobile-chrome` project (Pixel 5, 390×844).
+test.describe('Mobile shell — no horizontal page scrollbar', () => {
+  test.beforeEach(async ({ page }) => {
+    // Bypass auth via mocks so pages render under PLAYWRIGHT_AUTH_BYPASS
+    await page.context().route('**/api/v1/auth/me', async route => {
+      await route.fulfill({
+        json: {
+          id: 'test-user',
+          email: 'test@example.com',
+          displayName: 'Test User',
+          role: 'User',
+          tier: 'free',
+        },
+      });
+    });
+
+    // Minimal data mocks — pages render empty states without errors
+    await page.context().route('**/api/v1/library/*', async route => {
+      await route.fulfill({ json: { items: [], total: 0 } });
+    });
+    await page.context().route('**/api/v1/games*', async route => {
+      await route.fulfill({ json: { games: [], total: 0 } });
+    });
+    await page.context().route('**/api/v1/sessions/active*', async route => {
+      await route.fulfill({ json: { sessions: [] } });
+    });
+    await page.context().route('**/api/v1/agents*', async route => {
+      await route.fulfill({ json: [] });
+    });
+  });
+
+  for (const path of ['/dashboard', '/library']) {
+    test(`no page scrollbar on ${path}`, async ({ page }) => {
+      await page.goto(path);
+      // Wait for any sticky top navigation to be visible (shell-agnostic).
+      await page.waitForLoadState('domcontentloaded');
+
+      const { scrollW, clientW } = await page.evaluate(() => ({
+        scrollW: document.documentElement.scrollWidth,
+        clientW: document.documentElement.clientWidth,
+      }));
+      expect(
+        scrollW,
+        `horizontal overflow of ${scrollW - clientW}px on ${path}`
+      ).toBeLessThanOrEqual(clientW);
+
+      // Belt-and-braces: body + main containers
+      await checkNoHorizontalOverflow(page);
+    });
+  }
+});

--- a/apps/web/src/components/layout/AdminShell/AdminShell.tsx
+++ b/apps/web/src/components/layout/AdminShell/AdminShell.tsx
@@ -23,7 +23,7 @@ export function AdminShell({ children }: AdminShellProps) {
         adminMode
       />
 
-      <main id="main-content" className="flex-1 overflow-y-auto">
+      <main id="main-content" className="flex-1 overflow-y-auto overflow-x-clip">
         <DashboardEngineProvider>{children}</DashboardEngineProvider>
       </main>
 

--- a/apps/web/src/components/layout/UserShell/DesktopShell.tsx
+++ b/apps/web/src/components/layout/UserShell/DesktopShell.tsx
@@ -27,7 +27,7 @@ export function DesktopShell({ children }: DesktopShellProps) {
 
       <SessionBanner />
 
-      <main className="flex-1 overflow-y-auto">{children}</main>
+      <main className="flex-1 overflow-y-auto overflow-x-clip">{children}</main>
 
       <MobileCTAPill />
       <ChatSlideOverPanel />

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -180,6 +180,8 @@
     position: relative;
     background: var(--bg-base);
     color: var(--text-primary);
+    /* Safety net: prevent horizontal page scroll on mobile viewports */
+    overflow-x: clip;
   }
 
   /* MeepleAI Background Texture System - Issue #2905 */


### PR DESCRIPTION
## Summary

- Safety net against mobile horizontal page scroll: `overflow-x: clip` on `body` and on the `<main>` element of both `DesktopShell` and `AdminShell`.
- Shell-agnostic and minimal (4 files, 8 lines): lands cleanly on current `main-dev` (legacy `TopBar`) and remains correct after #431 ships the `TopBarV2` + `SideDrawer` refactor.
- Does **not** rewrite any navigation component — intentionally separate from the nav-simplification refactor in #431.

## Context

Observed on staging (`meepleai.app`) at viewport 485px on 2026-04-16:

| Route | `documentElement.scrollWidth` | `clientWidth` | Overflow |
|---|---|---|---|
| `/dashboard` | 590 | 485 | **105px** |
| `/library` | 590 | 485 | **105px** |

Offender (legacy shell): `<div class="flex items-center gap-2.5 shrink-0">` in `TopBar.tsx` wrapping `TopBarChatButton + NotificationBell + UserMenuDropdown` (148px wide, `shrink-0`, pushed off-viewport by equally non-shrinking `TopBarLogo` + `TopBarNavLinks`).

## Why this scope

Closed #436 earlier: ~75% of that patch rewrote components (`TopBar*`, `MiniNavSlot`) that #431 removes outright in favor of `TopBarV2` + `SideDrawer` + `MobileCTAPill`. Keeping only the three `overflow-x: clip` safety nets + regression — all of which:

- fix the visible symptom today (legacy shell),
- remain valuable after #431 merges (guards any future mis-sized descendant in either shell).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `FORCE_PRODUCTION_SERVER=true pnpm exec playwright test e2e/mobile-shell-viewport.spec.ts --project=mobile-chrome` — 2/2 passed (Pixel 5, 390×844)
- [ ] CI full Playwright (desktop + mobile + tablet projects)
- [ ] Manual smoke on staging after merge

🤖 Generated with [Claude Code](https://claude.ai/code)