### PR TITLE
feat(kb): RAG admin onboarding — games grid + upload drawer + queue ETA/remove

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/GameWithoutKbDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/GameWithoutKbDto.cs
@@ -11,7 +11,7 @@ internal sealed record GameWithoutKbDto(
     string? ImageUrl,
     string PlayerCountLabel,
     int PdfCount,
-    bool HasFailedPdfs
+    int FailedPdfCount
 );
 
 internal sealed record GamesWithoutKbPagedResponse(

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/GameWithoutKbDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/GameWithoutKbDto.cs
@@ -1,0 +1,23 @@
+namespace Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+
+/// <summary>
+/// Game with no active Knowledge Base (HasKnowledgeBase = false).
+/// Used by the admin RAG onboarding flow.
+/// </summary>
+internal sealed record GameWithoutKbDto(
+    Guid GameId,
+    string Title,
+    string? Publisher,
+    string? ImageUrl,
+    string PlayerCountLabel,
+    int PdfCount,
+    bool HasFailedPdfs
+);
+
+internal sealed record GamesWithoutKbPagedResponse(
+    IReadOnlyList<GameWithoutKbDto> Items,
+    int Total,
+    int Page,
+    int PageSize,
+    int TotalPages
+);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetGamesWithoutKb/GetGamesWithoutKbQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetGamesWithoutKb/GetGamesWithoutKbQuery.cs
@@ -1,0 +1,14 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetGamesWithoutKb;
+
+/// <summary>
+/// Returns paginated SharedGames where HasKnowledgeBase = false (no indexed VectorDocument).
+/// Supports pagination and full-text search on Title.
+/// </summary>
+internal sealed record GetGamesWithoutKbQuery(
+    int Page = 1,
+    int PageSize = 20,
+    string? Search = null
+) : IQuery<GamesWithoutKbPagedResponse>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetGamesWithoutKb/GetGamesWithoutKbQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetGamesWithoutKb/GetGamesWithoutKbQueryHandler.cs
@@ -9,6 +9,7 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetGamesWithoutK
 /// <summary>
 /// Returns SharedGames where HasKnowledgeBase = false (admin RAG onboarding flow).
 /// Uses the denormalized flag for O(1) filtering without joining VectorDocuments.
+/// Aggregates PDF counts in a single batched query to avoid N+1 correlated subqueries.
 /// </summary>
 internal sealed class GetGamesWithoutKbQueryHandler
     : IQueryHandler<GetGamesWithoutKbQuery, GamesWithoutKbPagedResponse>
@@ -48,6 +49,7 @@ internal sealed class GetGamesWithoutKbQueryHandler
 
         var total = await baseQuery.CountAsync(cancellationToken).ConfigureAwait(false);
 
+        // Project the page of games (without PDF stats to avoid correlated subqueries).
         var games = await baseQuery
             .OrderBy(sg => sg.Title)
             .Skip((page - 1) * pageSize)
@@ -60,23 +62,43 @@ internal sealed class GetGamesWithoutKbQueryHandler
                 sg.MinPlayers,
                 sg.MaxPlayers,
                 Publishers = sg.Publishers.Select(p => p.Name).ToList(),
-                PdfCount = _dbContext.PdfDocuments
-                    .Count(pd => pd.SharedGameId == sg.Id),
-                HasFailedPdfs = _dbContext.PdfDocuments
-                    .Any(pd => pd.SharedGameId == sg.Id && pd.ProcessingState == FailedState)
             })
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        var items = games.Select(g => new GameWithoutKbDto(
-            GameId: g.Id,
-            Title: g.Title,
-            Publisher: g.Publishers.FirstOrDefault(),
-            ImageUrl: string.IsNullOrWhiteSpace(g.ImageUrl) ? null : g.ImageUrl,
-            PlayerCountLabel: FormatPlayerCount(g.MinPlayers, g.MaxPlayers),
-            PdfCount: g.PdfCount,
-            HasFailedPdfs: g.HasFailedPdfs
-        )).ToList();
+        var gameIds = games.Select(g => g.Id).ToArray();
+
+        // One batched aggregation query across all games in the page (avoids N+1).
+        var pdfStats = gameIds.Length == 0
+            ? new Dictionary<Guid, (int PdfCount, int FailedPdfCount)>()
+            : await _dbContext.PdfDocuments
+                .AsNoTracking()
+                .Where(pd => pd.SharedGameId != null && gameIds.Contains(pd.SharedGameId!.Value))
+                .GroupBy(pd => pd.SharedGameId!.Value)
+                .Select(g => new
+                {
+                    GameId = g.Key,
+                    PdfCount = g.Count(),
+                    FailedPdfCount = g.Count(pd => pd.ProcessingState == FailedState),
+                })
+                .ToDictionaryAsync(
+                    x => x.GameId,
+                    x => (x.PdfCount, x.FailedPdfCount),
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+        var items = games.Select(g =>
+        {
+            var stats = pdfStats.TryGetValue(g.Id, out var s) ? s : (PdfCount: 0, FailedPdfCount: 0);
+            return new GameWithoutKbDto(
+                GameId: g.Id,
+                Title: g.Title,
+                Publisher: g.Publishers.FirstOrDefault(),
+                ImageUrl: string.IsNullOrWhiteSpace(g.ImageUrl) ? null : g.ImageUrl,
+                PlayerCountLabel: FormatPlayerCount(g.MinPlayers, g.MaxPlayers),
+                PdfCount: stats.PdfCount,
+                FailedPdfCount: stats.FailedPdfCount);
+        }).ToList();
 
         var totalPages = total > 0 ? (int)Math.Ceiling((double)total / pageSize) : 0;
 

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetGamesWithoutKb/GetGamesWithoutKbQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetGamesWithoutKb/GetGamesWithoutKbQueryHandler.cs
@@ -1,0 +1,108 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetGamesWithoutKb;
+
+/// <summary>
+/// Returns SharedGames where HasKnowledgeBase = false (admin RAG onboarding flow).
+/// Uses the denormalized flag for O(1) filtering without joining VectorDocuments.
+/// </summary>
+internal sealed class GetGamesWithoutKbQueryHandler
+    : IQueryHandler<GetGamesWithoutKbQuery, GamesWithoutKbPagedResponse>
+{
+    private const int PublishedStatus = 1;
+    private const string FailedState = "Failed";
+
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetGamesWithoutKbQueryHandler> _logger;
+
+    public GetGamesWithoutKbQueryHandler(
+        MeepleAiDbContext dbContext,
+        ILogger<GetGamesWithoutKbQueryHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<GamesWithoutKbPagedResponse> Handle(
+        GetGamesWithoutKbQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var page = Math.Max(1, query.Page);
+        var pageSize = Math.Clamp(query.PageSize, 1, 100);
+
+        var baseQuery = _dbContext.SharedGames
+            .AsNoTracking()
+            .Where(sg => !sg.HasKnowledgeBase && sg.Status == PublishedStatus);
+
+        if (!string.IsNullOrWhiteSpace(query.Search))
+        {
+            var pattern = $"%{query.Search.Trim()}%";
+            baseQuery = baseQuery.Where(sg => EF.Functions.ILike(sg.Title, pattern));
+        }
+
+        var total = await baseQuery.CountAsync(cancellationToken).ConfigureAwait(false);
+
+        var games = await baseQuery
+            .OrderBy(sg => sg.Title)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(sg => new
+            {
+                sg.Id,
+                sg.Title,
+                sg.ImageUrl,
+                sg.MinPlayers,
+                sg.MaxPlayers,
+                Publishers = sg.Publishers.Select(p => p.Name).ToList(),
+                PdfCount = _dbContext.PdfDocuments
+                    .Count(pd => pd.SharedGameId == sg.Id),
+                HasFailedPdfs = _dbContext.PdfDocuments
+                    .Any(pd => pd.SharedGameId == sg.Id && pd.ProcessingState == FailedState)
+            })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var items = games.Select(g => new GameWithoutKbDto(
+            GameId: g.Id,
+            Title: g.Title,
+            Publisher: g.Publishers.FirstOrDefault(),
+            ImageUrl: string.IsNullOrWhiteSpace(g.ImageUrl) ? null : g.ImageUrl,
+            PlayerCountLabel: FormatPlayerCount(g.MinPlayers, g.MaxPlayers),
+            PdfCount: g.PdfCount,
+            HasFailedPdfs: g.HasFailedPdfs
+        )).ToList();
+
+        var totalPages = total > 0 ? (int)Math.Ceiling((double)total / pageSize) : 0;
+
+        _logger.LogDebug(
+            "GetGamesWithoutKb: found {Total} games, page {Page}/{TotalPages}",
+            total,
+            page,
+            totalPages);
+
+        return new GamesWithoutKbPagedResponse(
+            Items: items,
+            Total: total,
+            Page: page,
+            PageSize: pageSize,
+            TotalPages: totalPages);
+    }
+
+    private static string FormatPlayerCount(int min, int max)
+    {
+        if (min <= 0 && max <= 0)
+        {
+            return "—";
+        }
+
+        return min == max
+            ? $"{min} giocatori"
+            : $"{min}–{max} giocatori";
+    }
+}

--- a/apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.DocumentProcessing.Application.Queries.Queue;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.EstimateAgentCost;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetGamesWithoutKb;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
 using Api.Filters;
 using MediatR;
@@ -88,6 +89,27 @@ internal static class AdminKnowledgeBaseEndpoints
         .WithSummary("Estimate token cost before starting a RAG chat session")
         .WithDescription("Calculates estimated cost per query based on document chunks, model pricing, and retrieval strategy.")
         .Produces<AgentCostEstimateDto>();
+
+        // GET /api/v1/admin/kb/games/without-kb - Admin RAG onboarding: games missing a KB
+        kbGroup.MapGet("/games/without-kb", async (
+            IMediator mediator,
+            [FromQuery] int? page,
+            [FromQuery] int? pageSize,
+            [FromQuery] string? search,
+            CancellationToken cancellationToken) =>
+        {
+            var query = new GetGamesWithoutKbQuery(
+                Page: page ?? 1,
+                PageSize: pageSize ?? 20,
+                Search: search);
+
+            var result = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .WithName("GetGamesWithoutKb")
+        .WithSummary("List shared games with no active Knowledge Base (admin RAG onboarding)")
+        .WithDescription("Returns SharedGames where HasKnowledgeBase = false. Supports pagination and search on Title.")
+        .Produces<GamesWithoutKbPagedResponse>();
 
         // GET /api/v1/admin/shared-games (extended for admin - #4654, #4785)
         var gamesGroup = group.MapGroup("/admin/shared-games")

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetGamesWithoutKb/GetGamesWithoutKbQueryHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetGamesWithoutKb/GetGamesWithoutKbQueryHandlerIntegrationTests.cs
@@ -163,9 +163,10 @@ public sealed class GetGamesWithoutKbQueryHandlerIntegrationTests : IAsyncLifeti
     }
 
     [Fact(Timeout = 30000)]
-    public async Task Handle_PdfCountAndFailedFlag_AreCorrect()
+    public async Task Handle_PdfCountAndFailedCount_AreAccuratelySeparate()
     {
-        // Arrange: a game with 2 PDFs, 1 failed — seed uploader user first (FK constraint)
+        // Arrange: a game with 3 PDFs, only 1 failed — verifies that the failed
+        // count is distinct from the total PdfCount (regression for H3).
         var adminUserId = Guid.NewGuid();
         _dbContext!.Users.Add(CreateTestUser(adminUserId));
 
@@ -180,6 +181,17 @@ public sealed class GetGamesWithoutKbQueryHandlerIntegrationTests : IAsyncLifeti
                 FileName = "root.pdf",
                 FilePath = "/root.pdf",
                 FileSizeBytes = 1000,
+                ProcessingState = "Ready",
+                UploadedByUserId = adminUserId,
+                UploadedAt = DateTime.UtcNow
+            },
+            new PdfDocumentEntity
+            {
+                Id = Guid.NewGuid(),
+                SharedGameId = game.Id,
+                FileName = "root-supplement.pdf",
+                FilePath = "/root-supplement.pdf",
+                FileSizeBytes = 750,
                 ProcessingState = "Ready",
                 UploadedByUserId = adminUserId,
                 UploadedAt = DateTime.UtcNow
@@ -203,10 +215,28 @@ public sealed class GetGamesWithoutKbQueryHandlerIntegrationTests : IAsyncLifeti
             new GetGamesWithoutKbQuery(Search: "Root"),
             TestCancellationToken);
 
+        // Assert — total PdfCount (3) vs failed-only count (1) are distinct values
+        var item = result.Items.Should().ContainSingle().Subject;
+        item.PdfCount.Should().Be(3);
+        item.FailedPdfCount.Should().Be(1);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task Handle_ReturnsZeroStats_WhenGameHasNoPdfs()
+    {
+        // Arrange
+        _dbContext!.SharedGames.Add(CreateGame("BareGame", hasKb: false));
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+
+        // Act
+        var result = await _handler!.Handle(
+            new GetGamesWithoutKbQuery(Search: "BareGame"),
+            TestCancellationToken);
+
         // Assert
         var item = result.Items.Should().ContainSingle().Subject;
-        item.PdfCount.Should().Be(2);
-        item.HasFailedPdfs.Should().BeTrue();
+        item.PdfCount.Should().Be(0);
+        item.FailedPdfCount.Should().Be(0);
     }
 
     [Fact(Timeout = 30000)]

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetGamesWithoutKb/GetGamesWithoutKbQueryHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetGamesWithoutKb/GetGamesWithoutKbQueryHandlerIntegrationTests.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetGamesWithoutKb;
 using Api.Infrastructure;
+using Api.BoundedContexts.Authentication.Domain.Entities;
 using Api.Infrastructure.Entities;
 using Api.Infrastructure.Entities.SharedGameCatalog;
 using Api.Tests.Constants;
@@ -164,10 +165,12 @@ public sealed class GetGamesWithoutKbQueryHandlerIntegrationTests : IAsyncLifeti
     [Fact(Timeout = 30000)]
     public async Task Handle_PdfCountAndFailedFlag_AreCorrect()
     {
-        // Arrange: a game with 2 PDFs, 1 failed
+        // Arrange: a game with 2 PDFs, 1 failed — seed uploader user first (FK constraint)
         var adminUserId = Guid.NewGuid();
+        _dbContext!.Users.Add(CreateTestUser(adminUserId));
+
         var game = CreateGame("Root", hasKb: false);
-        _dbContext!.SharedGames.Add(game);
+        _dbContext.SharedGames.Add(game);
 
         _dbContext.PdfDocuments.AddRange(
             new PdfDocumentEntity
@@ -244,6 +247,19 @@ public sealed class GetGamesWithoutKbQueryHandlerIntegrationTests : IAsyncLifeti
         result.Total.Should().Be(0);
         result.TotalPages.Should().Be(0);
     }
+
+    private static UserEntity CreateTestUser(Guid userId)
+        => new()
+        {
+            Id = userId,
+            Email = $"test-{userId}@example.com",
+            DisplayName = "Test Admin",
+            PasswordHash = "hashed_password",
+            Role = "admin",
+            Tier = "free",
+            CreatedAt = DateTime.UtcNow,
+            IsTwoFactorEnabled = false
+        };
 
     private static SharedGameEntity CreateGame(string title, bool hasKb, bool isDeleted = false)
         => new()

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetGamesWithoutKb/GetGamesWithoutKbQueryHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetGamesWithoutKb/GetGamesWithoutKbQueryHandlerIntegrationTests.cs
@@ -1,0 +1,267 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetGamesWithoutKb;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries.GetGamesWithoutKb;
+
+/// <summary>
+/// Integration tests for <see cref="GetGamesWithoutKbQueryHandler"/>.
+/// Validates the admin RAG onboarding flow: returns paginated SharedGames where
+/// <c>HasKnowledgeBase = false</c>, counts PDFs and surfaces failed-state flag.
+/// </summary>
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class GetGamesWithoutKbQueryHandlerIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private GetGamesWithoutKbQueryHandler? _handler;
+    private ServiceProvider? _serviceProvider;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public GetGamesWithoutKbQueryHandlerIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_games_without_kb_{Guid.NewGuid():N}";
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(connectionString);
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await _dbContext.Database.MigrateAsync(TestCancellationToken);
+                break;
+            }
+            catch (NpgsqlException) when (attempt < 2)
+            {
+                await Task.Delay(TestConstants.Timing.RetryDelay, TestCancellationToken);
+            }
+        }
+
+        var logger = _serviceProvider.GetRequiredService<ILogger<GetGamesWithoutKbQueryHandler>>();
+        _handler = new GetGamesWithoutKbQueryHandler(_dbContext, logger);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_dbContext is not null)
+        {
+            await _dbContext.DisposeAsync();
+        }
+
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try { await _fixture.DropIsolatedDatabaseAsync(_databaseName); }
+            catch { /* best-effort cleanup */ }
+        }
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task Handle_ReturnsOnlyGamesWithoutKb()
+    {
+        // Arrange: 2 games without KB, 1 with KB
+        _dbContext!.SharedGames.AddRange(
+            CreateGame("Wingspan", hasKb: true),
+            CreateGame("Catan", hasKb: false),
+            CreateGame("Pandemic", hasKb: false)
+        );
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+
+        // Act
+        var result = await _handler!.Handle(new GetGamesWithoutKbQuery(), TestCancellationToken);
+
+        // Assert
+        result.Items.Should().HaveCount(2);
+        result.Items.Should().NotContain(i => i.Title == "Wingspan");
+        result.Items.Select(i => i.Title).Should().BeEquivalentTo(new[] { "Catan", "Pandemic" });
+        result.Total.Should().Be(2);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task Handle_FiltersDeletedGames()
+    {
+        // Arrange: soft-deleted game should never surface (global query filter)
+        _dbContext!.SharedGames.AddRange(
+            CreateGame("Visible", hasKb: false),
+            CreateGame("DeletedGame", hasKb: false, isDeleted: true)
+        );
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+
+        // Act
+        var result = await _handler!.Handle(new GetGamesWithoutKbQuery(), TestCancellationToken);
+
+        // Assert
+        result.Items.Should().ContainSingle(i => i.Title == "Visible");
+        result.Items.Should().NotContain(i => i.Title == "DeletedGame");
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task Handle_FiltersUnpublishedGames()
+    {
+        // Arrange: draft game should not appear (Status != 1)
+        var draft = CreateGame("DraftGame", hasKb: false);
+        draft.Status = 0; // Draft
+        _dbContext!.SharedGames.AddRange(
+            CreateGame("PublishedGame", hasKb: false),
+            draft
+        );
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+
+        // Act
+        var result = await _handler!.Handle(new GetGamesWithoutKbQuery(), TestCancellationToken);
+
+        // Assert
+        result.Items.Should().ContainSingle(i => i.Title == "PublishedGame");
+        result.Items.Should().NotContain(i => i.Title == "DraftGame");
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task Handle_SearchFilters_ByTitle_CaseInsensitive()
+    {
+        // Arrange
+        _dbContext!.SharedGames.AddRange(
+            CreateGame("Agricola", hasKb: false),
+            CreateGame("Terraforming Mars", hasKb: false)
+        );
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+
+        // Act
+        var result = await _handler!.Handle(
+            new GetGamesWithoutKbQuery(Search: "agricola"),
+            TestCancellationToken);
+
+        // Assert
+        result.Items.Should().ContainSingle(i => i.Title == "Agricola");
+        result.Items.Should().NotContain(i => i.Title == "Terraforming Mars");
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task Handle_PdfCountAndFailedFlag_AreCorrect()
+    {
+        // Arrange: a game with 2 PDFs, 1 failed
+        var adminUserId = Guid.NewGuid();
+        var game = CreateGame("Root", hasKb: false);
+        _dbContext!.SharedGames.Add(game);
+
+        _dbContext.PdfDocuments.AddRange(
+            new PdfDocumentEntity
+            {
+                Id = Guid.NewGuid(),
+                SharedGameId = game.Id,
+                FileName = "root.pdf",
+                FilePath = "/root.pdf",
+                FileSizeBytes = 1000,
+                ProcessingState = "Ready",
+                UploadedByUserId = adminUserId,
+                UploadedAt = DateTime.UtcNow
+            },
+            new PdfDocumentEntity
+            {
+                Id = Guid.NewGuid(),
+                SharedGameId = game.Id,
+                FileName = "root-ext.pdf",
+                FilePath = "/root-ext.pdf",
+                FileSizeBytes = 500,
+                ProcessingState = "Failed",
+                UploadedByUserId = adminUserId,
+                UploadedAt = DateTime.UtcNow
+            }
+        );
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+
+        // Act
+        var result = await _handler!.Handle(
+            new GetGamesWithoutKbQuery(Search: "Root"),
+            TestCancellationToken);
+
+        // Assert
+        var item = result.Items.Should().ContainSingle().Subject;
+        item.PdfCount.Should().Be(2);
+        item.HasFailedPdfs.Should().BeTrue();
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task Handle_Pagination_WorksCorrectly()
+    {
+        // Arrange: 5 games without KB
+        for (var i = 0; i < 5; i++)
+        {
+            _dbContext!.SharedGames.Add(CreateGame($"Game_{i:00}", hasKb: false));
+        }
+        await _dbContext!.SaveChangesAsync(TestCancellationToken);
+
+        // Act
+        var page1 = await _handler!.Handle(
+            new GetGamesWithoutKbQuery(Page: 1, PageSize: 3),
+            TestCancellationToken);
+        var page2 = await _handler!.Handle(
+            new GetGamesWithoutKbQuery(Page: 2, PageSize: 3),
+            TestCancellationToken);
+
+        // Assert
+        page1.Items.Should().HaveCount(3);
+        page2.Items.Should().HaveCount(2);
+        page1.Total.Should().Be(5);
+        page1.TotalPages.Should().Be(2);
+        page1.Page.Should().Be(1);
+        page2.Page.Should().Be(2);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task Handle_EmptyDatabase_ReturnsZeroResults()
+    {
+        // Act
+        var result = await _handler!.Handle(new GetGamesWithoutKbQuery(), TestCancellationToken);
+
+        // Assert
+        result.Items.Should().BeEmpty();
+        result.Total.Should().Be(0);
+        result.TotalPages.Should().Be(0);
+    }
+
+    private static SharedGameEntity CreateGame(string title, bool hasKb, bool isDeleted = false)
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            Title = title,
+            Description = string.Empty,
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            HasKnowledgeBase = hasKb,
+            IsDeleted = isDeleted,
+            Status = 1, // Published
+            YearPublished = 2024,
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            CreatedBy = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow
+        };
+}

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/games/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/games/page.tsx
@@ -21,12 +21,15 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 
+import { GamesWithoutKbSection } from '@/components/admin/knowledge-base/games-without-kb-section';
+import { UploadForGameDrawer } from '@/components/admin/knowledge-base/upload-for-game-drawer';
 import { Badge } from '@/components/ui/data-display/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/data-display/card';
 import { Button } from '@/components/ui/primitives/button';
 import { Input } from '@/components/ui/primitives/input';
 import { createAdminClient } from '@/lib/api/clients/adminClient';
 import { HttpClient } from '@/lib/api/core/httpClient';
+import type { GameWithoutKbDto } from '@/lib/api/kb-games-without-kb-api';
 import type { GameKbStatusItem } from '@/lib/api/schemas/admin-knowledge-base.schemas';
 
 const httpClient = new HttpClient();
@@ -141,6 +144,7 @@ function GameKbRow({ item }: { item: GameKbStatusItem }) {
 export default function KbGamesPage() {
   const [search, setSearch] = useState('');
   const [filter, setFilter] = useState<'all' | 'complete' | 'partial' | 'none'>('all');
+  const [uploadTarget, setUploadTarget] = useState<GameWithoutKbDto | null>(null);
 
   const { data, isLoading, error, refetch, isRefetching } = useQuery({
     queryKey: ['admin', 'kb-game-statuses'],
@@ -245,7 +249,11 @@ export default function KbGamesPage() {
           </CardTitle>
         </CardHeader>
         <CardContent className="px-2">
-          {isLoading ? (
+          {filter === 'none' ? (
+            <div className="p-2">
+              <GamesWithoutKbSection onUploadClick={setUploadTarget} />
+            </div>
+          ) : isLoading ? (
             <div className="space-y-1 p-2">
               {Array.from({ length: 6 }).map((_, i) => (
                 <div
@@ -273,6 +281,12 @@ export default function KbGamesPage() {
           )}
         </CardContent>
       </Card>
+
+      <UploadForGameDrawer
+        game={uploadTarget}
+        open={uploadTarget !== null}
+        onClose={() => setUploadTarget(null)}
+      />
     </div>
   );
 }

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/queue/components/queue-item-actions.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/queue/components/queue-item-actions.tsx
@@ -9,6 +9,7 @@ import {
   XCircleIcon,
   FileTextIcon,
   RefreshCwIcon,
+  Trash2Icon,
 } from 'lucide-react';
 
 import {
@@ -32,7 +33,7 @@ import { Button } from '@/components/ui/primitives/button';
 import { useToast } from '@/hooks/useToast';
 
 import { ExtractedTextPreviewModal } from './extracted-text-preview-modal';
-import { setPriority, cancelJob, retryJob } from '../lib/queue-api';
+import { setPriority, cancelJob, retryJob, removeJob } from '../lib/queue-api';
 
 import type { ProcessingJobDto, ProcessingPriority } from '../lib/queue-api';
 
@@ -44,6 +45,7 @@ export function QueueItemActions({ job }: QueueItemActionsProps) {
   const queryClient = useQueryClient();
   const { toast } = useToast();
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
+  const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
   const [textPreviewOpen, setTextPreviewOpen] = useState(false);
 
   const invalidate = useCallback(() => {
@@ -84,9 +86,26 @@ export function QueueItemActions({ job }: QueueItemActionsProps) {
     },
   });
 
+  const removeMutation = useMutation({
+    mutationFn: () => removeJob(job.id),
+    onSuccess: () => {
+      invalidate();
+      setRemoveDialogOpen(false);
+      toast({ title: 'Job rimosso dalla coda' });
+    },
+    onError: () => {
+      toast({
+        title: 'Errore',
+        description: 'Impossibile rimuovere il job.',
+        variant: 'destructive',
+      });
+    },
+  });
+
   const canBump = job.status === 'Queued';
   const canCancel = job.status === 'Queued' || job.status === 'Processing';
   const canRetry = job.status === 'Failed' && job.canRetry;
+  const canRemove = job.status === 'Queued';
 
   return (
     <>
@@ -128,6 +147,19 @@ export function QueueItemActions({ job }: QueueItemActionsProps) {
             </DropdownMenuItem>
           )}
 
+          {canRemove && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={() => setRemoveDialogOpen(true)}
+                className="text-orange-600 dark:text-orange-400"
+              >
+                <Trash2Icon className="h-4 w-4 mr-2" />
+                Rimuovi dalla coda
+              </DropdownMenuItem>
+            </>
+          )}
+
           {canCancel && (
             <>
               <DropdownMenuSeparator />
@@ -156,6 +188,28 @@ export function QueueItemActions({ job }: QueueItemActionsProps) {
             <AlertDialogCancel>Keep</AlertDialogCancel>
             <AlertDialogAction onClick={() => cancelMutation.mutate()}>
               Cancel Job
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Remove confirmation dialog */}
+      <AlertDialog open={removeDialogOpen} onOpenChange={setRemoveDialogOpen}>
+        <AlertDialogContent onClick={e => e.stopPropagation()}>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Rimuovere dalla coda?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Rimuove &quot;{job.pdfFileName}&quot; dalla coda. Il file non verrà eliminato. Potrai
+              accodarlo di nuovo.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Annulla</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => removeMutation.mutate()}
+              className="bg-orange-600 hover:bg-orange-700"
+            >
+              Rimuovi dalla coda
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/queue/components/queue-list.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/queue/components/queue-list.tsx
@@ -19,7 +19,7 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
 
 import { Skeleton } from '@/components/ui/feedback/skeleton';
@@ -28,7 +28,7 @@ import { ScrollArea } from '@/components/ui/primitives/scroll-area';
 import { useToast } from '@/hooks/useToast';
 
 import { QueueItem } from './queue-item';
-import { reorderQueue } from '../lib/queue-api';
+import { fetchBatchETA, reorderQueue } from '../lib/queue-api';
 
 import type { PaginatedQueueResponse, QueueFilters, ProcessingJobDto } from '../lib/queue-api';
 
@@ -108,6 +108,25 @@ export function QueueList({
 
   const jobs = useMemo(() => data?.jobs ?? [], [data?.jobs]);
 
+  // Per-job ETA (refreshed every 30s) — surfaces Queued/Processing remaining time
+  const { data: etaData } = useQuery({
+    queryKey: ['admin', 'queue', 'eta'],
+    queryFn: fetchBatchETA,
+    staleTime: 30_000,
+    refetchInterval: 30_000,
+  });
+
+  const etaSecondsByJobId = useMemo(() => {
+    const map = new Map<string, number | null>();
+    for (const eta of etaData?.jobs ?? []) {
+      map.set(
+        eta.jobId,
+        eta.estimatedMinutesRemaining != null ? eta.estimatedMinutesRemaining * 60 : null
+      );
+    }
+    return map;
+  }, [etaData]);
+
   // Separate queued (draggable) and non-queued items
   const queuedJobs = useMemo(() => jobs.filter(j => j.status === 'Queued'), [jobs]);
   const sortableIds = useMemo(() => queuedJobs.map(j => j.id), [queuedJobs]);
@@ -180,6 +199,7 @@ export function QueueList({
                   job={job}
                   isSelected={selectedJobId === job.id}
                   onSelect={onSelectJob}
+                  etaSeconds={etaSecondsByJobId.get(job.id) ?? null}
                 />
               ))}
             </div>

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/queue/components/queue-stats-bar.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/queue/components/queue-stats-bar.tsx
@@ -2,9 +2,10 @@
 
 import type { ComponentType } from 'react';
 
-import { ClockIcon, LoaderIcon, CheckCircle2Icon, XCircleIcon } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
+import { CheckCircle2Icon, ClockIcon, LoaderIcon, TimerIcon, XCircleIcon } from 'lucide-react';
 
-import { useQueueStats } from '../lib/queue-api';
+import { fetchBatchETA, useQueueStats } from '../lib/queue-api';
 
 interface StatItem {
   label: string;
@@ -49,12 +50,19 @@ const STAT_CONFIG: {
 export function QueueStatsBar() {
   const results = useQueueStats();
 
+  const { data: etaData } = useQuery({
+    queryKey: ['admin', 'queue', 'eta'],
+    queryFn: fetchBatchETA,
+    staleTime: 30_000,
+    refetchInterval: 30_000,
+  });
+
   const isLoading = results.some(r => r.isLoading);
 
   if (isLoading) {
     return (
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-        {Array.from({ length: 4 }).map((_, i) => (
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
+        {Array.from({ length: 5 }).map((_, i) => (
           <div
             key={i}
             className="h-16 bg-white/40 dark:bg-zinc-800/40 backdrop-blur-sm rounded-xl border border-slate-200/60 dark:border-zinc-700/40 animate-pulse"
@@ -69,8 +77,12 @@ export function QueueStatsBar() {
     value: results[i]?.data?.total ?? 0,
   }));
 
+  const etaMinutes = etaData?.totalDrainTimeMinutes;
+  const hasEta = etaMinutes != null && etaMinutes > 0;
+  const etaLabel = hasEta ? `~${Math.round(etaMinutes)} min` : '—';
+
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+    <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
       {stats.map(stat => {
         const Icon = stat.icon;
         return (
@@ -88,6 +100,19 @@ export function QueueStatsBar() {
           </div>
         );
       })}
+
+      <div
+        className="flex items-center gap-3 px-4 py-3 bg-white/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-xl border border-slate-200/50 dark:border-zinc-700/50"
+        aria-label="ETA totale per svuotare la coda"
+      >
+        <div className="p-1.5 rounded-lg bg-orange-50 dark:bg-orange-900/20">
+          <TimerIcon className="h-4 w-4 text-orange-600 dark:text-orange-400" />
+        </div>
+        <div>
+          <div className="text-lg font-semibold text-foreground tabular-nums">{etaLabel}</div>
+          <div className="text-xs text-muted-foreground">ETA totale</div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/admin/knowledge-base/__tests__/games-without-kb-section.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/__tests__/games-without-kb-section.test.tsx
@@ -18,7 +18,7 @@ const mockGames = [
     imageUrl: null,
     playerCountLabel: '3–4 giocatori',
     pdfCount: 0,
-    hasFailedPdfs: false,
+    failedPdfCount: 0,
   },
   {
     gameId: 'bbb-222',
@@ -26,8 +26,8 @@ const mockGames = [
     publisher: null,
     imageUrl: null,
     playerCountLabel: '2–4 giocatori',
-    pdfCount: 1,
-    hasFailedPdfs: true,
+    pdfCount: 3,
+    failedPdfCount: 2,
   },
 ];
 
@@ -48,7 +48,40 @@ describe('GamesWithoutKbSection', () => {
     expect(screen.getByText('Pandemic')).toBeInTheDocument();
   });
 
-  it('shows failed badge for games with failed PDFs', () => {
+  it('shows failed badge with plural form when multiple PDFs failed', () => {
+    // Pandemic has pdfCount=3, failedPdfCount=2 — badge must reflect the failed
+    // count (2), NOT the total, and use plural form "falliti" (regression for H3+M3).
+    const onUpload = vi.fn();
+    render(<GamesWithoutKbSection onUploadClick={onUpload} />);
+
+    expect(screen.getByText('2 falliti')).toBeInTheDocument();
+    expect(screen.queryByText('3 fallito')).not.toBeInTheDocument();
+    expect(screen.queryByText('3 falliti')).not.toBeInTheDocument();
+  });
+
+  it('uses singular form when exactly 1 PDF failed', () => {
+    vi.mocked(useGamesWithoutKb).mockReturnValue({
+      data: {
+        items: [
+          {
+            gameId: 'ccc-333',
+            title: 'Root',
+            publisher: null,
+            imageUrl: null,
+            playerCountLabel: '2–4 giocatori',
+            pdfCount: 1,
+            failedPdfCount: 1,
+          },
+        ],
+        total: 1,
+        page: 1,
+        pageSize: 20,
+        totalPages: 1,
+      },
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useGamesWithoutKb>);
+
     const onUpload = vi.fn();
     render(<GamesWithoutKbSection onUploadClick={onUpload} />);
 

--- a/apps/web/src/components/admin/knowledge-base/__tests__/games-without-kb-section.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/__tests__/games-without-kb-section.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GamesWithoutKbSection } from '../games-without-kb-section';
+
+vi.mock('@/lib/api/kb-games-without-kb-api', () => ({
+  useGamesWithoutKb: vi.fn(),
+}));
+
+import { useGamesWithoutKb } from '@/lib/api/kb-games-without-kb-api';
+
+const mockGames = [
+  {
+    gameId: 'aaa-111',
+    title: 'Catan',
+    publisher: 'Kosmos',
+    imageUrl: null,
+    playerCountLabel: '3–4 giocatori',
+    pdfCount: 0,
+    hasFailedPdfs: false,
+  },
+  {
+    gameId: 'bbb-222',
+    title: 'Pandemic',
+    publisher: null,
+    imageUrl: null,
+    playerCountLabel: '2–4 giocatori',
+    pdfCount: 1,
+    hasFailedPdfs: true,
+  },
+];
+
+describe('GamesWithoutKbSection', () => {
+  beforeEach(() => {
+    vi.mocked(useGamesWithoutKb).mockReturnValue({
+      data: { items: mockGames, total: 2, page: 1, pageSize: 20, totalPages: 1 },
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useGamesWithoutKb>);
+  });
+
+  it('renders a MeepleCard for each game', () => {
+    const onUpload = vi.fn();
+    render(<GamesWithoutKbSection onUploadClick={onUpload} />);
+
+    expect(screen.getByText('Catan')).toBeInTheDocument();
+    expect(screen.getByText('Pandemic')).toBeInTheDocument();
+  });
+
+  it('shows failed badge for games with failed PDFs', () => {
+    const onUpload = vi.fn();
+    render(<GamesWithoutKbSection onUploadClick={onUpload} />);
+
+    expect(screen.getByText('1 fallito')).toBeInTheDocument();
+  });
+
+  it('calls onUploadClick with the game when action button is clicked', async () => {
+    const onUpload = vi.fn();
+    render(<GamesWithoutKbSection onUploadClick={onUpload} />);
+
+    const buttons = screen.getAllByRole('button', { name: /aggiungi pdf/i });
+    await userEvent.click(buttons[0]);
+
+    expect(onUpload).toHaveBeenCalledWith(mockGames[0]);
+  });
+
+  it('shows loading skeletons when loading', () => {
+    vi.mocked(useGamesWithoutKb).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as ReturnType<typeof useGamesWithoutKb>);
+
+    const onUpload = vi.fn();
+    render(<GamesWithoutKbSection onUploadClick={onUpload} />);
+
+    expect(screen.getByTestId('games-without-kb-loading')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no games found', () => {
+    vi.mocked(useGamesWithoutKb).mockReturnValue({
+      data: { items: [], total: 0, page: 1, pageSize: 20, totalPages: 0 },
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useGamesWithoutKb>);
+
+    const onUpload = vi.fn();
+    render(<GamesWithoutKbSection onUploadClick={onUpload} />);
+
+    expect(screen.getByText(/tutti i giochi hanno una kb attiva/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/admin/knowledge-base/__tests__/upload-for-game-drawer.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/__tests__/upload-for-game-drawer.test.tsx
@@ -13,7 +13,7 @@ const mockGame: GameWithoutKbDto = {
   imageUrl: null,
   playerCountLabel: '1–5 giocatori',
   pdfCount: 0,
-  hasFailedPdfs: false,
+  failedPdfCount: 0,
 };
 
 describe('UploadForGameDrawer', () => {
@@ -44,10 +44,22 @@ describe('UploadForGameDrawer', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('shows drop zone with max file info', () => {
+  it('shows CTA linking to upload page with gameId pre-filled', () => {
     render(<UploadForGameDrawer game={mockGame} open={true} onClose={vi.fn()} />);
 
-    expect(screen.getByText(/trascina i pdf qui/i)).toBeInTheDocument();
-    expect(screen.getByText(/max 5 file/i)).toBeInTheDocument();
+    const cta = screen.getByRole('link', { name: /apri flusso di upload/i });
+    expect(cta).toHaveAttribute('href', '/admin/knowledge-base/upload?gameId=aaa-111');
+  });
+
+  it('surfaces failedPdfCount in metadata when > 0', () => {
+    const failed: GameWithoutKbDto = {
+      ...mockGame,
+      pdfCount: 3,
+      failedPdfCount: 2,
+    };
+    render(<UploadForGameDrawer game={failed} open={true} onClose={vi.fn()} />);
+
+    expect(screen.getByText('PDF falliti')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/admin/knowledge-base/__tests__/upload-for-game-drawer.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/__tests__/upload-for-game-drawer.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { GameWithoutKbDto } from '@/lib/api/kb-games-without-kb-api';
+
+import { UploadForGameDrawer } from '../upload-for-game-drawer';
+
+const mockGame: GameWithoutKbDto = {
+  gameId: 'aaa-111',
+  title: 'Wingspan',
+  publisher: 'Stonemaier Games',
+  imageUrl: null,
+  playerCountLabel: '1–5 giocatori',
+  pdfCount: 0,
+  hasFailedPdfs: false,
+};
+
+describe('UploadForGameDrawer', () => {
+  it('renders game title and publisher in the drawer', () => {
+    render(<UploadForGameDrawer game={mockGame} open={true} onClose={vi.fn()} />);
+
+    expect(screen.getByText(/Upload PDF — Wingspan/)).toBeInTheDocument();
+    expect(screen.getByText('Stonemaier Games')).toBeInTheDocument();
+  });
+
+  it('calls onClose when Annulla is clicked', async () => {
+    const onClose = vi.fn();
+    render(<UploadForGameDrawer game={mockGame} open={true} onClose={onClose} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /annulla/i }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('does not render content when open=false', () => {
+    render(<UploadForGameDrawer game={mockGame} open={false} onClose={vi.fn()} />);
+
+    expect(screen.queryByText(/Upload PDF — Wingspan/)).not.toBeInTheDocument();
+  });
+
+  it('returns null when no game is provided', () => {
+    const { container } = render(<UploadForGameDrawer game={null} open={true} onClose={vi.fn()} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows drop zone with max file info', () => {
+    render(<UploadForGameDrawer game={mockGame} open={true} onClose={vi.fn()} />);
+
+    expect(screen.getByText(/trascina i pdf qui/i)).toBeInTheDocument();
+    expect(screen.getByText(/max 5 file/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/admin/knowledge-base/games-without-kb-section.tsx
+++ b/apps/web/src/components/admin/knowledge-base/games-without-kb-section.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useState } from 'react';
+
+import { AlertCircle, CheckCircle2, Upload } from 'lucide-react';
+
+import { MeepleCard, MeepleCardSkeleton } from '@/components/ui/data-display/meeple-card';
+import { Input } from '@/components/ui/primitives/input';
+import { useGamesWithoutKb, type GameWithoutKbDto } from '@/lib/api/kb-games-without-kb-api';
+
+interface GamesWithoutKbSectionProps {
+  onUploadClick: (game: GameWithoutKbDto) => void;
+}
+
+/**
+ * Admin RAG onboarding — grid of SharedGames with no Knowledge Base yet.
+ * Each card exposes an "Aggiungi PDF" CTA that opens the upload drawer.
+ *
+ * See: docs/superpowers/plans/2026-04-11-rag-admin-onboarding.md (Task 5)
+ */
+export function GamesWithoutKbSection({ onUploadClick }: GamesWithoutKbSectionProps) {
+  const [search, setSearch] = useState('');
+  const [page, setPage] = useState(1);
+
+  const { data, isLoading } = useGamesWithoutKb({
+    page,
+    pageSize: 20,
+    search: search || undefined,
+  });
+
+  if (isLoading) {
+    return (
+      <div
+        data-testid="games-without-kb-loading"
+        className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
+      >
+        {Array.from({ length: 10 }).map((_, i) => (
+          <MeepleCardSkeleton key={i} variant="grid" />
+        ))}
+      </div>
+    );
+  }
+
+  const items = data?.items ?? [];
+  const totalPages = data?.totalPages ?? 0;
+
+  return (
+    <div className="space-y-4">
+      <Input
+        type="search"
+        placeholder="Cerca gioco senza KB..."
+        value={search}
+        onChange={e => {
+          setSearch(e.target.value);
+          setPage(1);
+        }}
+        className="max-w-sm"
+        aria-label="Cerca gioco senza Knowledge Base"
+      />
+
+      {items.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 py-16 text-slate-400 dark:text-zinc-500">
+          <CheckCircle2 className="h-10 w-10 text-emerald-400" />
+          <p className="text-sm">Tutti i giochi hanno una KB attiva</p>
+        </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+            {items.map(game => (
+              <div key={game.gameId} className="flex flex-col gap-2">
+                <MeepleCard
+                  entity="kb"
+                  variant="grid"
+                  title={game.title}
+                  subtitle={game.publisher ?? undefined}
+                  imageUrl={game.imageUrl ?? undefined}
+                  status={game.hasFailedPdfs ? 'failed' : 'idle'}
+                  badge={game.hasFailedPdfs ? `${game.pdfCount} fallito` : 'Nessuna KB'}
+                  metadata={[
+                    { label: 'Giocatori', value: game.playerCountLabel },
+                    ...(game.pdfCount > 0
+                      ? [{ label: 'PDF caricati', value: String(game.pdfCount) }]
+                      : []),
+                  ]}
+                />
+                <button
+                  type="button"
+                  onClick={() => onUploadClick(game)}
+                  className="flex items-center justify-center gap-2 rounded-md bg-orange-600 px-3 py-2 text-xs font-semibold text-white shadow-sm transition-colors hover:bg-orange-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-600"
+                  aria-label={`Aggiungi PDF per ${game.title}`}
+                >
+                  {game.hasFailedPdfs ? (
+                    <AlertCircle className="h-3.5 w-3.5" aria-hidden="true" />
+                  ) : (
+                    <Upload className="h-3.5 w-3.5" aria-hidden="true" />
+                  )}
+                  Aggiungi PDF
+                </button>
+              </div>
+            ))}
+          </div>
+
+          {totalPages > 1 && (
+            <nav
+              aria-label="Paginazione giochi senza KB"
+              className="flex justify-center gap-2 pt-2"
+            >
+              <button
+                type="button"
+                onClick={() => setPage(p => Math.max(1, p - 1))}
+                disabled={page === 1}
+                className="rounded border border-slate-200 px-3 py-1 text-sm disabled:opacity-40 dark:border-zinc-700"
+                aria-label="Pagina precedente"
+              >
+                ‹
+              </button>
+              <span
+                className="px-3 py-1 text-sm text-slate-500 dark:text-zinc-400"
+                aria-live="polite"
+              >
+                {page} / {totalPages}
+              </span>
+              <button
+                type="button"
+                onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+                disabled={page === totalPages}
+                className="rounded border border-slate-200 px-3 py-1 text-sm disabled:opacity-40 dark:border-zinc-700"
+                aria-label="Pagina successiva"
+              >
+                ›
+              </button>
+            </nav>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/knowledge-base/games-without-kb-section.tsx
+++ b/apps/web/src/components/admin/knowledge-base/games-without-kb-section.tsx
@@ -69,13 +69,17 @@ export function GamesWithoutKbSection({ onUploadClick }: GamesWithoutKbSectionPr
             {items.map(game => (
               <div key={game.gameId} className="flex flex-col gap-2">
                 <MeepleCard
-                  entity="kb"
+                  entity="game"
                   variant="grid"
                   title={game.title}
                   subtitle={game.publisher ?? undefined}
                   imageUrl={game.imageUrl ?? undefined}
-                  status={game.hasFailedPdfs ? 'failed' : 'idle'}
-                  badge={game.hasFailedPdfs ? `${game.pdfCount} fallito` : 'Nessuna KB'}
+                  status={game.failedPdfCount > 0 ? 'failed' : 'idle'}
+                  badge={
+                    game.failedPdfCount > 0
+                      ? `${game.failedPdfCount} ${game.failedPdfCount === 1 ? 'fallito' : 'falliti'}`
+                      : 'Nessuna KB'
+                  }
                   metadata={[
                     { label: 'Giocatori', value: game.playerCountLabel },
                     ...(game.pdfCount > 0
@@ -89,7 +93,7 @@ export function GamesWithoutKbSection({ onUploadClick }: GamesWithoutKbSectionPr
                   className="flex items-center justify-center gap-2 rounded-md bg-orange-600 px-3 py-2 text-xs font-semibold text-white shadow-sm transition-colors hover:bg-orange-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-600"
                   aria-label={`Aggiungi PDF per ${game.title}`}
                 >
-                  {game.hasFailedPdfs ? (
+                  {game.failedPdfCount > 0 ? (
                     <AlertCircle className="h-3.5 w-3.5" aria-hidden="true" />
                   ) : (
                     <Upload className="h-3.5 w-3.5" aria-hidden="true" />

--- a/apps/web/src/components/admin/knowledge-base/upload-for-game-drawer.tsx
+++ b/apps/web/src/components/admin/knowledge-base/upload-for-game-drawer.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+import { FileText, Upload, X } from 'lucide-react';
+
+import { MeepleCard } from '@/components/ui/data-display/meeple-card';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/navigation/sheet';
+import { Button } from '@/components/ui/primitives/button';
+import { useToast } from '@/hooks/useToast';
+import type { GameWithoutKbDto } from '@/lib/api/kb-games-without-kb-api';
+
+const MAX_FILES = 5;
+const MAX_SIZE_MB = 500;
+
+interface UploadForGameDrawerProps {
+  game: GameWithoutKbDto | null;
+  open: boolean;
+  onClose: () => void;
+}
+
+interface PendingFile {
+  file: File;
+  id: string;
+}
+
+/**
+ * Slide-over drawer that lets an admin upload PDFs targeting a specific
+ * SharedGame that currently has no Knowledge Base.
+ *
+ * On submit we navigate to the existing /admin/knowledge-base/upload page
+ * with `gameId` pre-filled — the existing UploadZone handles the actual
+ * ingestion pipeline.
+ *
+ * See: docs/superpowers/plans/2026-04-11-rag-admin-onboarding.md (Task 6)
+ */
+export function UploadForGameDrawer({ game, open, onClose }: UploadForGameDrawerProps) {
+  const { toast } = useToast();
+  const [pendingFiles, setPendingFiles] = useState<PendingFile[]>([]);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const addFiles = useCallback(
+    (files: File[]) => {
+      const valid = files.filter(f => {
+        const sizeMb = f.size / (1024 * 1024);
+        if (sizeMb > MAX_SIZE_MB) {
+          toast({
+            title: `${f.name} supera ${MAX_SIZE_MB}MB`,
+            variant: 'destructive',
+          });
+          return false;
+        }
+        return true;
+      });
+
+      setPendingFiles(prev => {
+        const available = MAX_FILES - prev.length;
+        if (available <= 0) {
+          toast({
+            title: `Massimo ${MAX_FILES} file per upload`,
+            variant: 'destructive',
+          });
+          return prev;
+        }
+        const toAdd = valid.slice(0, available).map(f => ({
+          file: f,
+          id: crypto.randomUUID(),
+        }));
+        return [...prev, ...toAdd];
+      });
+    },
+    [toast]
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setIsDragging(false);
+      const dropped = Array.from(e.dataTransfer.files).filter(f => f.type === 'application/pdf');
+      addFiles(dropped);
+    },
+    [addFiles]
+  );
+
+  const handleFileInput = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const selected = Array.from(e.target.files ?? []);
+      addFiles(selected);
+      e.target.value = '';
+    },
+    [addFiles]
+  );
+
+  function removeFile(id: string) {
+    setPendingFiles(prev => prev.filter(f => f.id !== id));
+  }
+
+  function handleClose() {
+    setPendingFiles([]);
+    onClose();
+  }
+
+  const handleUpload = useCallback(() => {
+    if (!game || pendingFiles.length === 0) return;
+    const params = new URLSearchParams({ gameId: game.gameId });
+    window.location.href = `/admin/knowledge-base/upload?${params.toString()}`;
+  }, [game, pendingFiles]);
+
+  if (!game) return null;
+
+  return (
+    <Sheet open={open} onOpenChange={next => !next && handleClose()}>
+      <SheetContent
+        side="right"
+        className="flex w-[420px] flex-col gap-0 p-0 sm:w-[480px] sm:max-w-[480px]"
+      >
+        <SheetHeader className="border-b border-slate-200 px-6 py-4 dark:border-zinc-700">
+          <SheetTitle className="text-base font-semibold">Upload PDF — {game.title}</SheetTitle>
+        </SheetHeader>
+
+        <div className="flex-1 space-y-4 overflow-y-auto px-6 py-4">
+          <MeepleCard
+            entity="kb"
+            variant="list"
+            title={game.title}
+            subtitle={game.publisher ?? undefined}
+            imageUrl={game.imageUrl ?? undefined}
+            status="idle"
+            metadata={[{ label: 'Giocatori', value: game.playerCountLabel }]}
+          />
+
+          <div
+            onDragOver={e => {
+              e.preventDefault();
+              setIsDragging(true);
+            }}
+            onDragLeave={() => setIsDragging(false)}
+            onDrop={handleDrop}
+            className={`relative cursor-pointer rounded-xl border-2 border-dashed p-8 text-center transition-colors ${
+              isDragging
+                ? 'border-blue-400 bg-blue-50 dark:bg-blue-900/20'
+                : 'border-slate-300 hover:border-slate-400 dark:border-zinc-600 dark:hover:border-zinc-500'
+            }`}
+          >
+            <input
+              type="file"
+              accept=".pdf,application/pdf"
+              multiple
+              onChange={handleFileInput}
+              className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+              aria-label="Seleziona file PDF"
+            />
+            <Upload
+              className="mx-auto mb-2 h-8 w-8 text-slate-400 dark:text-zinc-500"
+              aria-hidden="true"
+            />
+            <p className="text-sm font-medium text-slate-700 dark:text-zinc-300">
+              Trascina i PDF qui
+            </p>
+            <p className="mt-1 text-xs text-slate-400 dark:text-zinc-500">
+              Max {MAX_FILES} file · Max {MAX_SIZE_MB}MB ciascuno
+            </p>
+          </div>
+
+          {pendingFiles.length > 0 && (
+            <ul className="space-y-2">
+              {pendingFiles.map(({ file, id }) => (
+                <li
+                  key={id}
+                  className="flex items-center gap-3 rounded-lg bg-slate-50 px-3 py-2 dark:bg-zinc-800"
+                >
+                  <FileText
+                    className="h-4 w-4 shrink-0 text-slate-400 dark:text-zinc-500"
+                    aria-hidden="true"
+                  />
+                  <span className="flex-1 truncate text-sm text-slate-700 dark:text-zinc-300">
+                    {file.name}
+                  </span>
+                  <span className="shrink-0 text-xs text-slate-400 dark:text-zinc-500">
+                    {(file.size / (1024 * 1024)).toFixed(1)} MB
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => removeFile(id)}
+                    className="text-slate-400 transition-colors hover:text-red-500 dark:text-zinc-500 dark:hover:text-red-400"
+                    aria-label={`Rimuovi ${file.name}`}
+                  >
+                    <X className="h-4 w-4" aria-hidden="true" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-3 border-t border-slate-200 px-6 py-4 dark:border-zinc-700">
+          <Button variant="outline" onClick={handleClose}>
+            Annulla
+          </Button>
+          <Button onClick={handleUpload} disabled={pendingFiles.length === 0}>
+            <Upload className="mr-2 h-4 w-4" aria-hidden="true" />
+            Avvia upload ({pendingFiles.length} PDF)
+          </Button>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/web/src/components/admin/knowledge-base/upload-for-game-drawer.tsx
+++ b/apps/web/src/components/admin/knowledge-base/upload-for-game-drawer.tsx
@@ -1,17 +1,11 @@
 'use client';
 
-import { useCallback, useState } from 'react';
-
-import { FileText, Upload, X } from 'lucide-react';
+import { ArrowRightIcon, Upload } from 'lucide-react';
 
 import { MeepleCard } from '@/components/ui/data-display/meeple-card';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/navigation/sheet';
 import { Button } from '@/components/ui/primitives/button';
-import { useToast } from '@/hooks/useToast';
 import type { GameWithoutKbDto } from '@/lib/api/kb-games-without-kb-api';
-
-const MAX_FILES = 5;
-const MAX_SIZE_MB = 500;
 
 interface UploadForGameDrawerProps {
   game: GameWithoutKbDto | null;
@@ -19,97 +13,24 @@ interface UploadForGameDrawerProps {
   onClose: () => void;
 }
 
-interface PendingFile {
-  file: File;
-  id: string;
-}
-
 /**
- * Slide-over drawer that lets an admin upload PDFs targeting a specific
- * SharedGame that currently has no Knowledge Base.
+ * Slide-over drawer that previews the target game and hands the admin off to
+ * the dedicated upload page (`/admin/knowledge-base/upload?gameId=...`).
  *
- * On submit we navigate to the existing /admin/knowledge-base/upload page
- * with `gameId` pre-filled — the existing UploadZone handles the actual
- * ingestion pipeline.
+ * Previously this drawer also accepted files via drag-and-drop, but the files
+ * were silently dropped on navigation (the upload page owns its own selection
+ * state). The simplified flow avoids misleading UX: one clear CTA that lands
+ * the admin on the real upload form pre-filtered by game.
  *
  * See: docs/superpowers/plans/2026-04-11-rag-admin-onboarding.md (Task 6)
  */
 export function UploadForGameDrawer({ game, open, onClose }: UploadForGameDrawerProps) {
-  const { toast } = useToast();
-  const [pendingFiles, setPendingFiles] = useState<PendingFile[]>([]);
-  const [isDragging, setIsDragging] = useState(false);
-
-  const addFiles = useCallback(
-    (files: File[]) => {
-      const valid = files.filter(f => {
-        const sizeMb = f.size / (1024 * 1024);
-        if (sizeMb > MAX_SIZE_MB) {
-          toast({
-            title: `${f.name} supera ${MAX_SIZE_MB}MB`,
-            variant: 'destructive',
-          });
-          return false;
-        }
-        return true;
-      });
-
-      setPendingFiles(prev => {
-        const available = MAX_FILES - prev.length;
-        if (available <= 0) {
-          toast({
-            title: `Massimo ${MAX_FILES} file per upload`,
-            variant: 'destructive',
-          });
-          return prev;
-        }
-        const toAdd = valid.slice(0, available).map(f => ({
-          file: f,
-          id: crypto.randomUUID(),
-        }));
-        return [...prev, ...toAdd];
-      });
-    },
-    [toast]
-  );
-
-  const handleDrop = useCallback(
-    (e: React.DragEvent) => {
-      e.preventDefault();
-      setIsDragging(false);
-      const dropped = Array.from(e.dataTransfer.files).filter(f => f.type === 'application/pdf');
-      addFiles(dropped);
-    },
-    [addFiles]
-  );
-
-  const handleFileInput = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const selected = Array.from(e.target.files ?? []);
-      addFiles(selected);
-      e.target.value = '';
-    },
-    [addFiles]
-  );
-
-  function removeFile(id: string) {
-    setPendingFiles(prev => prev.filter(f => f.id !== id));
-  }
-
-  function handleClose() {
-    setPendingFiles([]);
-    onClose();
-  }
-
-  const handleUpload = useCallback(() => {
-    if (!game || pendingFiles.length === 0) return;
-    const params = new URLSearchParams({ gameId: game.gameId });
-    window.location.href = `/admin/knowledge-base/upload?${params.toString()}`;
-  }, [game, pendingFiles]);
+  const uploadHref = game ? `/admin/knowledge-base/upload?gameId=${game.gameId}` : undefined;
 
   if (!game) return null;
 
   return (
-    <Sheet open={open} onOpenChange={next => !next && handleClose()}>
+    <Sheet open={open} onOpenChange={next => !next && onClose()}>
       <SheetContent
         side="right"
         className="flex w-[420px] flex-col gap-0 p-0 sm:w-[480px] sm:max-w-[480px]"
@@ -120,86 +41,43 @@ export function UploadForGameDrawer({ game, open, onClose }: UploadForGameDrawer
 
         <div className="flex-1 space-y-4 overflow-y-auto px-6 py-4">
           <MeepleCard
-            entity="kb"
+            entity="game"
             variant="list"
             title={game.title}
             subtitle={game.publisher ?? undefined}
             imageUrl={game.imageUrl ?? undefined}
             status="idle"
-            metadata={[{ label: 'Giocatori', value: game.playerCountLabel }]}
+            metadata={[
+              { label: 'Giocatori', value: game.playerCountLabel },
+              ...(game.pdfCount > 0
+                ? [{ label: 'PDF caricati', value: String(game.pdfCount) }]
+                : []),
+              ...(game.failedPdfCount > 0
+                ? [{ label: 'PDF falliti', value: String(game.failedPdfCount) }]
+                : []),
+            ]}
           />
 
-          <div
-            onDragOver={e => {
-              e.preventDefault();
-              setIsDragging(true);
-            }}
-            onDragLeave={() => setIsDragging(false)}
-            onDrop={handleDrop}
-            className={`relative cursor-pointer rounded-xl border-2 border-dashed p-8 text-center transition-colors ${
-              isDragging
-                ? 'border-blue-400 bg-blue-50 dark:bg-blue-900/20'
-                : 'border-slate-300 hover:border-slate-400 dark:border-zinc-600 dark:hover:border-zinc-500'
-            }`}
-          >
-            <input
-              type="file"
-              accept=".pdf,application/pdf"
-              multiple
-              onChange={handleFileInput}
-              className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
-              aria-label="Seleziona file PDF"
-            />
-            <Upload
-              className="mx-auto mb-2 h-8 w-8 text-slate-400 dark:text-zinc-500"
-              aria-hidden="true"
-            />
-            <p className="text-sm font-medium text-slate-700 dark:text-zinc-300">
-              Trascina i PDF qui
-            </p>
-            <p className="mt-1 text-xs text-slate-400 dark:text-zinc-500">
-              Max {MAX_FILES} file · Max {MAX_SIZE_MB}MB ciascuno
+          <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700 dark:border-zinc-700 dark:bg-zinc-800/50 dark:text-zinc-300">
+            <p className="font-medium">Come procedere</p>
+            <p className="mt-1 text-xs text-slate-500 dark:text-zinc-400">
+              Aprirai il flusso di upload principale con il gioco già selezionato. Carica uno o più
+              PDF: l&apos;estrazione e l&apos;indicizzazione RAG partono automaticamente una volta
+              completato l&apos;upload.
             </p>
           </div>
-
-          {pendingFiles.length > 0 && (
-            <ul className="space-y-2">
-              {pendingFiles.map(({ file, id }) => (
-                <li
-                  key={id}
-                  className="flex items-center gap-3 rounded-lg bg-slate-50 px-3 py-2 dark:bg-zinc-800"
-                >
-                  <FileText
-                    className="h-4 w-4 shrink-0 text-slate-400 dark:text-zinc-500"
-                    aria-hidden="true"
-                  />
-                  <span className="flex-1 truncate text-sm text-slate-700 dark:text-zinc-300">
-                    {file.name}
-                  </span>
-                  <span className="shrink-0 text-xs text-slate-400 dark:text-zinc-500">
-                    {(file.size / (1024 * 1024)).toFixed(1)} MB
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => removeFile(id)}
-                    className="text-slate-400 transition-colors hover:text-red-500 dark:text-zinc-500 dark:hover:text-red-400"
-                    aria-label={`Rimuovi ${file.name}`}
-                  >
-                    <X className="h-4 w-4" aria-hidden="true" />
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
         </div>
 
         <div className="flex justify-end gap-3 border-t border-slate-200 px-6 py-4 dark:border-zinc-700">
-          <Button variant="outline" onClick={handleClose}>
+          <Button variant="outline" onClick={onClose}>
             Annulla
           </Button>
-          <Button onClick={handleUpload} disabled={pendingFiles.length === 0}>
-            <Upload className="mr-2 h-4 w-4" aria-hidden="true" />
-            Avvia upload ({pendingFiles.length} PDF)
+          <Button asChild>
+            <a href={uploadHref}>
+              <Upload className="mr-2 h-4 w-4" aria-hidden="true" />
+              Apri flusso di upload
+              <ArrowRightIcon className="ml-2 h-4 w-4" aria-hidden="true" />
+            </a>
           </Button>
         </div>
       </SheetContent>

--- a/apps/web/src/lib/api/kb-games-without-kb-api.ts
+++ b/apps/web/src/lib/api/kb-games-without-kb-api.ts
@@ -16,7 +16,7 @@ export interface GameWithoutKbDto {
   imageUrl: string | null;
   playerCountLabel: string;
   pdfCount: number;
-  hasFailedPdfs: boolean;
+  failedPdfCount: number;
 }
 
 export interface GamesWithoutKbPagedResponse {

--- a/apps/web/src/lib/api/kb-games-without-kb-api.ts
+++ b/apps/web/src/lib/api/kb-games-without-kb-api.ts
@@ -1,0 +1,65 @@
+/**
+ * Admin RAG onboarding: list of SharedGames with no active Knowledge Base.
+ *
+ * Matches backend endpoint: GET /api/v1/admin/kb/games/without-kb
+ * See: docs/superpowers/plans/2026-04-11-rag-admin-onboarding.md (Task 4)
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { apiClient } from '@/lib/api/client';
+
+export interface GameWithoutKbDto {
+  gameId: string;
+  title: string;
+  publisher: string | null;
+  imageUrl: string | null;
+  playerCountLabel: string;
+  pdfCount: number;
+  hasFailedPdfs: boolean;
+}
+
+export interface GamesWithoutKbPagedResponse {
+  items: GameWithoutKbDto[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+export interface GamesWithoutKbParams {
+  page?: number;
+  pageSize?: number;
+  search?: string;
+}
+
+const EMPTY_RESPONSE: GamesWithoutKbPagedResponse = {
+  items: [],
+  total: 0,
+  page: 1,
+  pageSize: 20,
+  totalPages: 0,
+};
+
+export async function fetchGamesWithoutKb(
+  params: GamesWithoutKbParams = {}
+): Promise<GamesWithoutKbPagedResponse> {
+  const qs = new URLSearchParams();
+  if (params.page !== undefined) qs.set('page', params.page.toString());
+  if (params.pageSize !== undefined) qs.set('pageSize', params.pageSize.toString());
+  if (params.search) qs.set('search', params.search);
+
+  const query = qs.toString();
+  const url = `/api/v1/admin/kb/games/without-kb${query ? `?${query}` : ''}`;
+
+  const result = await apiClient.get<GamesWithoutKbPagedResponse>(url);
+  return result ?? EMPTY_RESPONSE;
+}
+
+export function useGamesWithoutKb(params: GamesWithoutKbParams = {}) {
+  return useQuery({
+    queryKey: ['admin', 'kb', 'games-without-kb', params],
+    queryFn: () => fetchGamesWithoutKb(params),
+    staleTime: 30_000,
+  });
+}


### PR DESCRIPTION
## Summary

Implements the RAG admin onboarding flow per `docs/superpowers/plans/2026-04-11-rag-admin-onboarding.md`:

- **Backend**: `GetGamesWithoutKbQuery` + handler + endpoint `GET /api/v1/admin/kb/games/without-kb`
- **Frontend**: admin grid of SharedGames missing a KB + slide-over drawer for PDF upload
- **Queue UX**: per-job ETA badges + total ETA stat tile + "Rimuovi dalla coda" action

### What's new for admins

1. Filter "Senza KB" in `/admin/knowledge-base/games` now shows a MeepleCard grid with a CTA "Aggiungi PDF" per game
2. Clicking the CTA opens a right-side drawer pre-targeted at that game; upload kicks off via the existing `/admin/knowledge-base/upload` flow
3. Queue dashboard now surfaces ETA per job (Queued/Processing) and total drain time in the stats bar
4. Queued jobs get a "Rimuovi dalla coda" option in the actions dropdown (orange, distinct from red Cancel)

### Implementation notes

- Handler uses the denormalized `SharedGameEntity.HasKnowledgeBase` flag for O(1) filtering (no VectorDocuments join)
- `ILIKE` full-text search on Title, PostgreSQL-specific — tests run via Testcontainers
- `GetGamesWithoutKbQueryHandlerIntegrationTests` covers: KB filter, soft-delete, unpublished, case-insensitive search, PDF count + failed-flag, pagination, empty state (7 tests)
- Frontend tests use `vi.mock` on React Query hook — 10 new Vitest cases across `GamesWithoutKbSection` and `UploadForGameDrawer`

## Test plan

- [x] Backend: `dotnet test --filter "FullyQualifiedName~GetGamesWithoutKb"` → 7/7 pass
- [x] Frontend: `pnpm vitest run src/components/admin/knowledge-base/__tests__/` → 10/10 pass
- [x] `pnpm typecheck` → clean
- [x] `dotnet build` → 0 errors
- [ ] Manual: admin visits `/admin/knowledge-base/games`, filters "Senza KB", uploads PDF via drawer
- [ ] Manual: admin checks queue dashboard — ETA badges appear on Queued/Processing jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
