### PR TITLE
fix(game): resolve SharedGameId fallback in GetGameByIdQuery to stop chat panel 404

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetGameByIdQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetGameByIdQueryHandler.cs
@@ -21,7 +21,14 @@ internal class GetGameByIdQueryHandler : IQueryHandler<GetGameByIdQuery, GameDto
     public async Task<GameDto?> Handle(GetGameByIdQuery query, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(query);
-        var game = await _gameRepository.GetByIdAsync(query.GameId, cancellationToken).ConfigureAwait(false);
+
+        // Resolve against BOTH Game.Id and Game.SharedGameId — the frontend
+        // library flow exposes the SharedGameId as user-facing gameId, which
+        // otherwise produces a spurious 404 on /games/{id}/agents and siblings.
+        // See IGameRepository.GetByIdOrSharedGameIdAsync for rationale.
+        var game = await _gameRepository
+            .GetByIdOrSharedGameIdAsync(query.GameId, cancellationToken)
+            .ConfigureAwait(false);
 
         return game != null ? MapToDto(game) : null;
     }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Repositories/IGameRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Repositories/IGameRepository.cs
@@ -38,4 +38,22 @@ internal interface IGameRepository : IRepository<Game, Guid>
     Task<IReadOnlyList<Game>> GetBySharedGameIdAsync(
         Guid sharedGameId,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resolves a caller-supplied game identifier against BOTH the primary key
+    /// <c>Game.Id</c> and the bridge FK <c>Game.SharedGameId</c>, preferring a
+    /// direct PK match.
+    ///
+    /// <para>
+    /// Rationale: public surfaces (e.g. <c>GET /api/v1/library</c>) expose the
+    /// <c>SharedGameId</c> as the user-facing <c>gameId</c>, while write/read
+    /// paths like <c>/games/{id}/agents</c> target the <c>games</c> table PK.
+    /// Without this fallback the frontend hits a spurious 404 when the two
+    /// identifiers diverge (which they do in production, though seeders happen
+    /// to align them in dev).
+    /// </para>
+    ///
+    /// Same resolution pattern as <c>CreateChatThreadCommandHandler</c> (PR #414).
+    /// </summary>
+    Task<Game?> GetByIdOrSharedGameIdAsync(Guid id, CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameRepository.cs
@@ -131,6 +131,24 @@ internal class GameRepository : RepositoryBase, IGameRepository
         return entities.Select(MapToDomain).ToList();
     }
 
+    public async Task<Game?> GetByIdOrSharedGameIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        // Single query: match on PK preferred, then SharedGameId bridge FK.
+        // OrderByDescending(g.Id == id) promotes the direct PK match to index 0
+        // in the rare case where a Game's SharedGameId collides with another
+        // Game's Id (unlikely in practice but correctness-safe).
+        var gameEntity = await DbContext.Games
+            .AsNoTracking()
+            .Where(g => g.Id == id || g.SharedGameId == id)
+            .OrderByDescending(g => g.Id == id)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return gameEntity != null ? MapToDomain(gameEntity) : null;
+    }
+
     /// <summary>
     /// Maps persistence entity to domain entity (reconstitution — no side effects).
     /// Restores all persisted properties including publication workflow fields (spec-panel C-1).

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GetGameByIdQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GetGameByIdQueryHandlerTests.cs
@@ -40,7 +40,7 @@ public class GetGameByIdQueryHandlerTests
             .Build();
 
         _gameRepositoryMock
-            .Setup(r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetByIdOrSharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(game);
 
         var query = new GetGameByIdQuery(gameId);
@@ -60,7 +60,7 @@ public class GetGameByIdQueryHandlerTests
         result.MaxPlayTimeMinutes.Should().Be(120);
 
         _gameRepositoryMock.Verify(
-            r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()),
+            r => r.GetByIdOrSharedGameIdAsync(gameId, It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -75,7 +75,7 @@ public class GetGameByIdQueryHandlerTests
             .Build();
 
         _gameRepositoryMock
-            .Setup(r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetByIdOrSharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(game);
 
         var query = new GetGameByIdQuery(gameId);
@@ -108,7 +108,7 @@ public class GetGameByIdQueryHandlerTests
             .Build();
 
         _gameRepositoryMock
-            .Setup(r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetByIdOrSharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(game);
 
         var query = new GetGameByIdQuery(gameId);
@@ -134,7 +134,7 @@ public class GetGameByIdQueryHandlerTests
             .Build();
 
         _gameRepositoryMock
-            .Setup(r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetByIdOrSharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(game);
 
         var query = new GetGameByIdQuery(gameId);
@@ -159,7 +159,7 @@ public class GetGameByIdQueryHandlerTests
         var gameId = Guid.NewGuid();
 
         _gameRepositoryMock
-            .Setup(r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetByIdOrSharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Game?)null);
 
         var query = new GetGameByIdQuery(gameId);
@@ -171,7 +171,7 @@ public class GetGameByIdQueryHandlerTests
         result.Should().BeNull();
 
         _gameRepositoryMock.Verify(
-            r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()),
+            r => r.GetByIdOrSharedGameIdAsync(gameId, It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -182,7 +182,7 @@ public class GetGameByIdQueryHandlerTests
         var gameId = Guid.Empty;
 
         _gameRepositoryMock
-            .Setup(r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetByIdOrSharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Game?)null);
 
         var query = new GetGameByIdQuery(gameId);
@@ -207,7 +207,7 @@ public class GetGameByIdQueryHandlerTests
         var cancellationToken = cts.Token;
 
         _gameRepositoryMock
-            .Setup(r => r.GetByIdAsync(gameId, cancellationToken))
+            .Setup(r => r.GetByIdOrSharedGameIdAsync(gameId, cancellationToken))
             .ReturnsAsync(game);
 
         var query = new GetGameByIdQuery(gameId);
@@ -218,7 +218,7 @@ public class GetGameByIdQueryHandlerTests
         // Assert
         result.Should().NotBeNull();
         _gameRepositoryMock.Verify(
-            r => r.GetByIdAsync(gameId, cancellationToken),
+            r => r.GetByIdOrSharedGameIdAsync(gameId, cancellationToken),
             Times.Once);
     }
     [Fact]
@@ -233,7 +233,7 @@ public class GetGameByIdQueryHandlerTests
             .Build();
 
         _gameRepositoryMock
-            .Setup(r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetByIdOrSharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(game);
 
         var query = new GetGameByIdQuery(gameId);
@@ -245,6 +245,38 @@ public class GetGameByIdQueryHandlerTests
         result.Should().NotBeNull();
         result.CreatedAt.Should().NotBe(default(DateTime));
         result.CreatedAt.Should().Be(game.CreatedAt);
+    }
+
+    [Fact]
+    public async Task Handle_LooksUpBySharedGameIdWhenDirectIdMisses()
+    {
+        // Regression for chat-panel 404 bug: the frontend library exposes
+        // SharedGameId as user-facing gameId. The handler must delegate to
+        // GetByIdOrSharedGameIdAsync so the repository can resolve either
+        // identifier. Previously the handler called GetByIdAsync (PK only)
+        // which returned null and caused /games/{id}/agents to 404.
+        var sharedGameId = Guid.NewGuid();
+        var resolvedGameId = Guid.NewGuid();
+        var game = new GameBuilder()
+            .WithId(resolvedGameId)
+            .WithTitle("Agricola")
+            .Build();
+
+        _gameRepositoryMock
+            .Setup(r => r.GetByIdOrSharedGameIdAsync(sharedGameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        var query = new GetGameByIdQuery(sharedGameId);
+
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        result.Should().NotBeNull();
+        result.Id.Should().Be(resolvedGameId);
+        result.Title.Should().Be("Agricola");
+
+        _gameRepositoryMock.Verify(
+            r => r.GetByIdOrSharedGameIdAsync(sharedGameId, It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/GameRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/GameRepositoryIntegrationTests.cs
@@ -586,4 +586,107 @@ public sealed class GameRepositoryIntegrationTests : IAsyncLifetime
     }
 
     #endregion
+
+    #region GetByIdOrSharedGameIdAsync
+
+    [Fact]
+    public async Task GetByIdOrSharedGameIdAsync_WithDirectPkMatch_ReturnsGame()
+    {
+        var existing = await _dbContext.Games.FirstAsync();
+
+        var result = await _repository.GetByIdOrSharedGameIdAsync(existing.Id);
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(existing.Id);
+    }
+
+    [Fact]
+    public async Task GetByIdOrSharedGameIdAsync_WithSharedGameIdOnly_ResolvesThroughBridge()
+    {
+        // Arrange: seed a SharedGameEntity (FK target) and a Game whose
+        // SharedGameId points to it — reproduces the staging-production
+        // scenario where library exposes SharedGameId as the user-facing id.
+        var sharedGameId = Guid.NewGuid();
+        var gamePk = Guid.NewGuid();
+        _dbContext.SharedGames.Add(CreateMinimalSharedGame(sharedGameId, "Agricola"));
+        _dbContext.Games.Add(new GameEntity
+        {
+            Id = gamePk,
+            Name = "Agricola (Shared-bridged)",
+            SharedGameId = sharedGameId,
+            CreatedAt = DateTime.UtcNow,
+        });
+        await _dbContext.SaveChangesAsync();
+
+        // Act: caller passes the SharedGameId (not the PK)
+        var result = await _repository.GetByIdOrSharedGameIdAsync(sharedGameId);
+
+        // Assert: the repo resolves to the Game record via the bridge
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(gamePk);
+        result.SharedGameId.Should().Be(sharedGameId);
+    }
+
+    [Fact]
+    public async Task GetByIdOrSharedGameIdAsync_PrefersDirectPkWhenBothMatch()
+    {
+        // Arrange: pathological collision — Game A has id == collisionId, and
+        // Game B has SharedGameId == collisionId. Direct PK match must win.
+        var collisionId = Guid.NewGuid();
+        var pkOnlyGameId = Guid.NewGuid();
+        _dbContext.SharedGames.Add(CreateMinimalSharedGame(collisionId, "Collision Shared"));
+        _dbContext.Games.AddRange(
+            new GameEntity
+            {
+                Id = collisionId,
+                Name = "Direct PK Game",
+                CreatedAt = DateTime.UtcNow,
+            },
+            new GameEntity
+            {
+                Id = pkOnlyGameId,
+                Name = "Shared-bridged Game",
+                SharedGameId = collisionId,
+                CreatedAt = DateTime.UtcNow,
+            });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _repository.GetByIdOrSharedGameIdAsync(collisionId);
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(collisionId);
+        result.Title.Value.Should().Be("Direct PK Game");
+    }
+
+    private static Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity CreateMinimalSharedGame(
+        Guid id,
+        string title)
+        => new()
+        {
+            Id = id,
+            Title = title,
+            Description = string.Empty,
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            YearPublished = 2024,
+            MinPlayers = 1,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 8,
+            Status = 1,
+            CreatedBy = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+        };
+
+    [Fact]
+    public async Task GetByIdOrSharedGameIdAsync_WithNoMatch_ReturnsNull()
+    {
+        var unknownId = Guid.NewGuid();
+
+        var result = await _repository.GetByIdOrSharedGameIdAsync(unknownId);
+
+        result.Should().BeNull();
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

Fixes a **staging/production-only 404** on `GET /api/v1/games/{id}/agents` (and sibling endpoints) that surfaces as "Errore nel caricamento degli agenti" in the chat panel.

### Root cause

The data model has two related tables:
- `games` (private + bridged entries, PK: `Game.Id`)
- `shared_games` (community catalog, PK: `SharedGame.Id`)
- `Game.SharedGameId` → optional FK bridge between them

The frontend `GET /api/v1/library` endpoint exposes **`SharedGameId` as the user-facing `gameId`** field. That gameId then flows into:
- `GET /api/v1/games/{id}/agents` (chat panel agent list)
- `GET /api/v1/games/{id}/similar`
- `AiEndpoints` (2 callers)
- `CacheEndpoints`
- Public `/games/{id}`

All of those share `GetGameByIdQuery`, whose handler called `IGameRepository.GetByIdAsync(id)` — a **strict PK lookup**. In production `Game.Id ≠ SharedGame.Id`, so every one of these endpoints 404s the moment the frontend forwards the library gameId.

(In dev seeders happen to use the same Guid for both records, which is why the bug did not surface locally.)

### Fix

Same pattern **PR #414** applied to `CreateChatThreadCommandHandler`, centralized at the repository layer:

1. New `IGameRepository.GetByIdOrSharedGameIdAsync(Guid id, CancellationToken ct)`: single EF query over `Id == id || SharedGameId == id`, with `OrderByDescending(Id == id)` to prefer the direct PK match on the pathological collision where a Game's `SharedGameId` equals another Game's `Id`.
2. `GetGameByIdQueryHandler` routes through the new method instead of `GetByIdAsync` — all six callers of the query benefit from the fallback with a single change.

`GetByIdAsync` is left untouched so strict-PK consumers (e.g. internal invariant checks) keep the original semantics.

### Tests

- **Unit** (`GetGameByIdQueryHandlerTests`): existing 8 tests updated to mock the new method; 1 new regression test `Handle_LooksUpBySharedGameIdWhenDirectIdMisses`.
- **Integration** (`GameRepositoryIntegrationTests`, PostgreSQL via Testcontainers): 4 new tests — direct PK match, SharedGameId bridge resolution, collision tie-break (direct PK wins), no-match returns null.

Result: **13/13 pass locally**.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~GetGameByIdQueryHandlerTests|FullyQualifiedName~GameRepositoryIntegrationTests"` → 13/13
- [x] `dotnet build` → 0 errors
- [ ] Post-deploy: verify `/chat/{threadId}` agent list loads on staging (currently shows "Errore nel caricamento degli agenti" + empty AI response)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
