### PR TITLE
fix(frontend): reposition + indicator and Posseduto badge on MeepleCard

### DIFF
--- a/apps/web/src/__tests__/components/ui/data-display/meeple-card/parts/NavFooter.test.tsx
+++ b/apps/web/src/__tests__/components/ui/data-display/meeple-card/parts/NavFooter.test.tsx
@@ -53,3 +53,41 @@ describe('NavFooter href support', () => {
     expect(screen.getByRole('button')).toBeInTheDocument();
   });
 });
+
+describe('NavFooter plus-indicator position', () => {
+  it('renders the "+" button in the top-right corner of the icon (not bottom)', () => {
+    render(
+      <NavFooter
+        items={[
+          {
+            icon: <span>📚</span>,
+            label: 'KB',
+            entity: 'kb',
+            showPlus: true,
+          },
+        ]}
+      />
+    );
+    const plusButton = screen.getByLabelText('Aggiungi KB');
+    // Plus overlay must share the count-badge anchor (top-right) to stay above the icon.
+    expect(plusButton.className).toContain('-top-1');
+    expect(plusButton.className).toContain('-right-1');
+    expect(plusButton.className).not.toContain('-bottom-');
+  });
+
+  it('does not render "+" overlay when showPlus is false', () => {
+    render(
+      <NavFooter
+        items={[
+          {
+            icon: <span>📚</span>,
+            label: 'KB',
+            entity: 'kb',
+            count: 3,
+          },
+        ]}
+      />
+    );
+    expect(screen.queryByLabelText('Aggiungi KB')).toBeNull();
+  });
+});

--- a/apps/web/src/__tests__/components/ui/data-display/meeple-card/parts/StatusBadge.test.tsx
+++ b/apps/web/src/__tests__/components/ui/data-display/meeple-card/parts/StatusBadge.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { StatusBadge } from '@/components/ui/data-display/meeple-card/parts/StatusBadge';
+
+describe('StatusBadge', () => {
+  it('renders "Posseduto" label for owned status (Italian localization)', () => {
+    render(<StatusBadge status="owned" />);
+    expect(screen.getByText('Posseduto')).toBeInTheDocument();
+    expect(screen.queryByText('owned')).toBeNull();
+  });
+
+  it('falls back to raw status string when no localized label exists', () => {
+    render(<StatusBadge status="wishlist" />);
+    expect(screen.getByText('wishlist')).toBeInTheDocument();
+  });
+
+  it('renders null for unknown status (no color mapping)', () => {
+    const { container } = render(
+      // @ts-expect-error - intentionally invalid status to exercise null branch
+      <StatusBadge status="definitely-not-a-status" />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/web/src/components/library/MeepleLibraryGameCard.tsx
+++ b/apps/web/src/components/library/MeepleLibraryGameCard.tsx
@@ -31,7 +31,6 @@ import { AgentDrawerSheet } from './AgentDrawerSheet';
 import { ChatDrawerSheet } from './ChatDrawerSheet';
 import { DeclareOwnershipButton } from './DeclareOwnershipButton';
 import { KbDrawerSheet } from './KbDrawerSheet';
-import { RagAccessBadge } from './RagAccessBadge';
 import { SessionDrawerSheet } from './SessionDrawerSheet';
 
 // ============================================================================
@@ -72,8 +71,10 @@ export interface MeepleLibraryGameCardProps {
 // ============================================================================
 
 function mapGameStateToStatus(state: GameStateType | null | undefined): CardStatus | undefined {
-  if (!state) return undefined;
-  if (state === 'Owned' || state === 'Nuovo') return 'owned';
+  // "Posseduto" overlay only when the user has declared ownership.
+  // Drives copyright-safe citation rendering: owners see verbatim PDF quotes,
+  // non-owners get paraphrased snippets. 'Nuovo' = added but not yet declared.
+  if (state === 'Owned') return 'owned';
   if (state === 'Wishlist') return 'wishlist';
   return undefined;
 }
@@ -201,7 +202,6 @@ export function MeepleLibraryGameCard({
 
   const mappedStatus = mapGameStateToStatus(game.currentState);
   const badge = game.isFavorite ? '❤️ Preferito' : undefined;
-  const showRagBadge = game.hasKb || game.currentState === 'Owned';
 
   const navItems = useMemo(
     () =>
@@ -257,8 +257,8 @@ export function MeepleLibraryGameCard({
         data-testid={`library-game-card-${game.gameId}`}
       />
 
-      {/* Ownership + RAG Access indicators */}
-      {(game.currentState === 'Nuovo' || showRagBadge) && (
+      {/* Ownership declaration CTA (RAG access is now shown as status overlay on the card) */}
+      {game.currentState === 'Nuovo' && (
         <div className="flex items-center gap-2 mt-1 px-1">
           <DeclareOwnershipButton
             gameId={game.gameId}
@@ -266,7 +266,6 @@ export function MeepleLibraryGameCard({
             gameState={game.currentState}
             onOwnershipDeclared={handleOwnershipDeclared}
           />
-          {showRagBadge && <RagAccessBadge hasRagAccess={game.hasRagAccess} isRagPublic={false} />}
         </div>
       )}
 

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/NavFooter.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/NavFooter.tsx
@@ -71,7 +71,7 @@ export function NavFooter({ items, size = 'sm' }: NavFooterProps) {
                   e.stopPropagation();
                   item.onPlusClick?.();
                 }}
-                className="absolute -bottom-0.5 right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full text-[8px] font-extrabold text-white shadow-sm"
+                className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full text-[10px] font-extrabold text-white shadow-sm"
                 style={{ background: color }}
                 aria-label={`Aggiungi ${item.label}`}
               >

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/StatusBadge.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/StatusBadge.tsx
@@ -7,16 +7,22 @@ interface StatusBadgeProps {
   className?: string;
 }
 
+const statusLabels: Partial<Record<CardStatus, string>> = {
+  owned: 'Posseduto',
+};
+
 export function StatusBadge({ status, className = '' }: StatusBadgeProps) {
   const colors = statusColors[status];
   if (!colors) return null;
+
+  const label = statusLabels[status] ?? status;
 
   return (
     <span
       className={`absolute left-2.5 top-7 z-10 rounded-[5px] px-[7px] py-[1px] text-[9px] font-bold ${className}`}
       style={{ background: colors.bg, color: colors.text }}
     >
-      {status}
+      {label}
     </span>
   );
 }


### PR DESCRIPTION
## Summary

Correzione grafica su `MeepleCard` (libreria) a seguito di review visivo:

- **`+` dei nav-items** (KB/Agent/Chat/Sessioni) spostato dall'angolo in basso-destra all'angolo in alto-destra dell'icona. Condivide l'anchor del count badge (mutuamente esclusivi via `showPlus = count === 0`).
- **Label "Sbloccato"** rimosso dal render esterno sotto la card. Al suo posto un overlay **"Posseduto"** sulla cover tramite `StatusBadge` (localizzazione `owned` → "Posseduto").
- **Semantica allineata alla copyright compliance**: il badge ora riflette esattamente `currentState === 'Owned'`, che a livello backend corrisponde a `OwnershipDeclaredAt != null` — la condizione che sblocca `CopyrightTier.Full` e quindi le citazioni verbatim dai PDF. Prima il badge era legato a `hasRagAccess`, semanticamente più permissivo (RAG pubblico/admin) e non coerente col gate copyright.

## Changes

| File | Cambio |
|---|---|
| `parts/NavFooter.tsx` | `+` button: `-bottom-0.5 right-1 h-3.5 w-3.5 text-[8px]` → `-top-1 -right-1 h-4 w-4 text-[10px]` |
| `parts/StatusBadge.tsx` | Label map `{ owned: 'Posseduto' }`; fallback al raw status |
| `library/MeepleLibraryGameCard.tsx` | Rimosso `RagAccessBadge` esterno; `mapGameStateToStatus` ora basato solo su `currentState` con commento sul copyright rationale; condizione wrapper CTA semplificata a `currentState === 'Nuovo'` |

`RagAccessBadge` component **non rimosso** — è ancora usato da `GameTableZoneTools.tsx:288` (fuori scope).

## Tests

- **`StatusBadge.test.tsx`** (nuovo): 3 test — label "Posseduto" per owned, fallback per status senza mapping, null per status sconosciuto.
- **`NavFooter.test.tsx`** (esteso): +2 test — posizione `-top-1 -right-1` del `+`, assenza del `+` quando `count > 0`.

Tutti i 15 test verdi in locale. Typecheck OK. Lint 0 errori (14 warning pre-esistenti).

## Test plan

- [ ] CI verde (typecheck + lint + vitest)
- [ ] Verifica visiva in `make dev`: il `+` sporge in alto-dx di ogni icona del nav footer (test con gioco senza KB/Agent/Chat/Sessioni → tutti i `+` visibili)
- [ ] Verifica visiva: per un gioco con `currentState === 'Owned'` appare il badge "Posseduto" verde sulla cover (top-left). Per `currentState === 'Nuovo'` NON appare (si vede solo il CTA "Dichiara Possesso" sotto la card).
- [ ] Verifica sanity su `/games/<id>/kb`, `/games/<id>/chat` per conferma che il click sull'icona nav funziona come prima (change solo cosmetico)

## Follow-up

- #444 — Rinforzare il prompt LLM per paraphrase enforcement quando le citations includono tier `Protected` (safety net aggiuntivo contro verbatim leak nel response body).

## Context

Task utente: screenshot di errore (`meepleError.png`, non committato) mostrava il `+` sotto le icone di navigazione (sovrapposto al label) e il badge "Sbloccato" fuori dalla card. Durante il fix è emersa un'incongruenza semantica sul gate copyright, risolta allineando il badge a `currentState === 'Owned'`.