### PR TITLE
fix(kb): reword comment to avoid SonarQube S125 false positive

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
@@ -426,7 +426,7 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
             }
         }
 
-        // Emit SSE event and apply recovery OUTSIDE try-catch (yield return restriction)
+        // #447: Leak detection result handling (placed here due to C# iterator method constraints)
         if (leakResult?.HasLeak == true)
         {
             foreach (var match in leakResult.Matches)


### PR DESCRIPTION
One-line fix: rewording comment that triggered Sonar S125 (commented-out code) in Docker Release build. Fixes deploy-staging Build Images failure.