### PR TITLE
feat(dashboard): Hybrid redesign with entity zones and theme toggle

### DIFF
--- a/apps/web/src/__tests__/components/dashboard/EntityZone.test.tsx
+++ b/apps/web/src/__tests__/components/dashboard/EntityZone.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { EntityZone } from '@/components/dashboard/EntityZone';
+
+// Mock next/link
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('EntityZone', () => {
+  it('renders title and count', () => {
+    render(
+      <EntityZone entity="game" title="Giochi" count={12} viewAllHref="/games">
+        <div>children</div>
+      </EntityZone>
+    );
+    expect(screen.getByText('Giochi')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+  });
+
+  it('renders entity-colored dot', () => {
+    render(
+      <EntityZone entity="session" title="Sessioni" count={3}>
+        <div>children</div>
+      </EntityZone>
+    );
+    const dot = screen.getByTestId('entity-dot');
+    expect(dot).toBeInTheDocument();
+  });
+
+  it('renders "Vedi tutti" link when viewAllHref provided', () => {
+    render(
+      <EntityZone entity="game" title="Giochi" count={12} viewAllHref="/games">
+        <div>children</div>
+      </EntityZone>
+    );
+    expect(screen.getByText(/Vedi tutti/)).toBeInTheDocument();
+  });
+
+  it('does not render "Vedi tutti" when viewAllHref omitted', () => {
+    render(
+      <EntityZone entity="toolkit" title="Strumenti" count={4}>
+        <div>children</div>
+      </EntityZone>
+    );
+    expect(screen.queryByText(/Vedi tutti/)).not.toBeInTheDocument();
+  });
+
+  it('renders children', () => {
+    render(
+      <EntityZone entity="agent" title="Agenti" count={0}>
+        <div data-testid="child">hello</div>
+      </EntityZone>
+    );
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/__tests__/components/dashboard/GreetingStrip.test.tsx
+++ b/apps/web/src/__tests__/components/dashboard/GreetingStrip.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { GreetingStrip } from '@/components/dashboard/GreetingStrip';
+
+// Mock next/link
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('GreetingStrip', () => {
+  it('renders user display name', () => {
+    render(<GreetingStrip displayName="Aaron" stats={{ games: 12, sessions: 8, agents: 4 }} />);
+    expect(screen.getByText(/Ciao, Aaron/)).toBeInTheDocument();
+  });
+
+  it('renders stats summary', () => {
+    render(<GreetingStrip displayName="Aaron" stats={{ games: 12, sessions: 8, agents: 4 }} />);
+    expect(screen.getByText(/12 giochi/)).toBeInTheDocument();
+    expect(screen.getByText(/8 sessioni/)).toBeInTheDocument();
+  });
+
+  it('renders quick action buttons', () => {
+    render(<GreetingStrip displayName="Aaron" stats={{ games: 0, sessions: 0, agents: 0 }} />);
+    expect(screen.getByRole('link', { name: /Aggiungi gioco/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Nuova sessione/i })).toBeInTheDocument();
+  });
+
+  it('renders user initial in avatar', () => {
+    render(<GreetingStrip displayName="Aaron" stats={{ games: 0, sessions: 0, agents: 0 }} />);
+    expect(screen.getByTestId('greeting-avatar')).toHaveTextContent('A');
+  });
+
+  it('omits zero-count stats from summary', () => {
+    render(<GreetingStrip displayName="Test" stats={{ games: 5, sessions: 0, agents: 0 }} />);
+    expect(screen.getByText(/5 giochi/)).toBeInTheDocument();
+    expect(screen.queryByText(/0 sessioni/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(authenticated)/dashboard/DashboardClient.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/DashboardClient.tsx
@@ -48,16 +48,10 @@ const AGENTS_FILTERS: FilterChip[] = [
 // ---------------------------------------------------------------------------
 
 const TOOLKIT_TOOLS = [
-  { id: 'dice', icon: '🎲', name: 'Dado', desc: 'Lancia d4–d20', iconBg: 'bg-amber-100' },
-  { id: 'timer', icon: '⏳', name: 'Clessidra', desc: 'Timer per turno', iconBg: 'bg-sky-100' },
-  {
-    id: 'score',
-    icon: '📊',
-    name: 'Scoreboard',
-    desc: 'Punteggi multi-player',
-    iconBg: 'bg-purple-100',
-  },
-  { id: 'token', icon: '🪙', name: 'Token', desc: 'Contatori risorse', iconBg: 'bg-green-100' },
+  { id: 'dice', icon: '🎲', name: 'Dado', desc: 'Lancia d4–d20' },
+  { id: 'timer', icon: '⏳', name: 'Clessidra', desc: 'Timer per turno' },
+  { id: 'score', icon: '📊', name: 'Scoreboard', desc: 'Punteggi multi-player' },
+  { id: 'token', icon: '🪙', name: 'Token', desc: 'Contatori risorse' },
 ] as const;
 
 // ---------------------------------------------------------------------------
@@ -95,7 +89,7 @@ function EmptyCTA({
   return (
     <div
       className="flex flex-col items-center gap-3 py-6 px-4 text-center
-                 rounded-xl border border-dashed border-[rgba(180,130,80,0.25)]
+                 rounded-xl border border-dashed border-[rgba(180,130,80,0.25)] dark:border-[rgba(180,130,80,0.4)]
                  bg-card"
     >
       <span className="text-3xl">{icon}</span>
@@ -220,7 +214,7 @@ function CatalogGameCard({
           inLibrary
             ? 'mx-1.5 mb-1.5 h-[22px] rounded-lg text-[10px] font-bold font-[Quicksand] flex items-center justify-center gap-1 bg-muted text-muted-foreground/60 cursor-default'
             : adding
-              ? 'mx-1.5 mb-1.5 h-[22px] rounded-lg text-[10px] font-bold font-[Quicksand] flex items-center justify-center gap-1 bg-black/20 text-white cursor-wait'
+              ? 'mx-1.5 mb-1.5 h-[22px] rounded-lg text-[10px] font-bold font-[Quicksand] flex items-center justify-center gap-1 bg-black/20 dark:bg-white/20 text-white cursor-wait'
               : 'mx-1.5 mb-1.5 h-[22px] rounded-lg text-[10px] font-bold font-[Quicksand] flex items-center justify-center gap-1 bg-amber-600 text-white hover:opacity-90 active:scale-95 transition-transform'
         }
       >
@@ -576,7 +570,12 @@ export function DashboardClient() {
               actions={[{ label: '＋ Crea sessione', href: '/sessions/new', primary: true }]}
             />
           ) : (
-            <div className="flex gap-3.5 overflow-x-auto pb-2 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-border">
+            <div
+              role="region"
+              aria-label="Sessioni recenti"
+              tabIndex={0}
+              className="flex gap-3.5 overflow-x-auto pb-2 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-lg"
+            >
               {filteredSessionItems.map(item => (
                 <div key={item.id ?? item.title} className="w-[260px] shrink-0">
                   <MeepleCard {...item} />

--- a/apps/web/src/app/(authenticated)/dashboard/DashboardClient.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/DashboardClient.tsx
@@ -6,6 +6,8 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 import { useAuth } from '@/components/auth/AuthProvider';
+import { EntityZone } from '@/components/dashboard/EntityZone';
+import { GreetingStrip } from '@/components/dashboard/GreetingStrip';
 import { OwnershipConfirmDialog } from '@/components/dialogs/OwnershipConfirmDialog';
 import { HubLayout, type FilterChip } from '@/components/layout/HubLayout';
 import { MeepleCard } from '@/components/ui/data-display/meeple-card';
@@ -62,38 +64,11 @@ const TOOLKIT_TOOLS = [
 // Sub-components
 // ---------------------------------------------------------------------------
 
-function GreetingHeader({ displayName }: { displayName: string }) {
-  return (
-    <div className="pt-2 pb-1">
-      <h2 className="font-[Quicksand] font-bold text-2xl text-[var(--nh-text-primary,#1a1a1a)]">
-        Ciao, {displayName} 👋
-      </h2>
-      <p className="text-sm text-[var(--nh-text-secondary,#5a4a35)] mt-0.5">
-        La tua tavola da gioco
-      </p>
-    </div>
-  );
-}
-
-function HubBlock({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <section>
-      <h3
-        className="font-[Quicksand] font-bold text-sm uppercase tracking-wide
-                   text-[var(--nh-text-secondary,#5a4a35)] mb-2"
-      >
-        {title}
-      </h3>
-      {children}
-    </section>
-  );
-}
-
 function LoadingSkeleton({ count }: { count: number }) {
   return (
     <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
       {Array.from({ length: count }).map((_, i) => (
-        <div key={i} className="h-40 rounded-xl bg-black/5 animate-pulse" />
+        <div key={i} className="h-40 rounded-xl bg-muted animate-pulse" />
       ))}
     </div>
   );
@@ -121,14 +96,12 @@ function EmptyCTA({
     <div
       className="flex flex-col items-center gap-3 py-6 px-4 text-center
                  rounded-xl border border-dashed border-[rgba(180,130,80,0.25)]
-                 bg-[var(--nh-bg-card,white)]"
+                 bg-card"
     >
       <span className="text-3xl">{icon}</span>
       <div>
-        <p className="font-[Quicksand] font-bold text-sm text-[var(--nh-text-primary,#1a1a1a)]">
-          {title}
-        </p>
-        <p className="text-xs text-[var(--nh-text-muted,#94a3b8)] mt-1 max-w-[240px] mx-auto leading-relaxed">
+        <p className="font-[Quicksand] font-bold text-sm text-foreground">{title}</p>
+        <p className="text-xs text-muted-foreground/60 mt-1 max-w-[240px] mx-auto leading-relaxed">
           {sub}
         </p>
       </div>
@@ -164,7 +137,7 @@ function MeepleCardGrid({
   if (items.length === 0) {
     if (emptyNode) return <>{emptyNode}</>;
     return (
-      <div className="flex flex-col items-center gap-2 py-8 text-[var(--nh-text-muted,#94a3b8)]">
+      <div className="flex flex-col items-center gap-2 py-8 text-muted-foreground/60">
         <p className="text-sm font-medium">Nessun elemento.</p>
       </div>
     );
@@ -203,11 +176,11 @@ function CatalogGameCard({
 }) {
   return (
     <div
-      className="bg-[var(--nh-bg-card,white)] border border-[var(--nh-border,rgba(0,0,0,0.07))]
+      className="bg-card border border-border
                  rounded-xl shadow-sm overflow-hidden flex flex-col"
     >
       {/* Thumbnail */}
-      <div className="relative h-[68px] flex items-center justify-center bg-gradient-to-br from-[#fdf0e0] to-[#fce8cc] overflow-hidden flex-shrink-0">
+      <div className="relative h-[68px] flex items-center justify-center bg-gradient-to-br from-[#fdf0e0] to-[#fce8cc] dark:from-[hsl(25,20%,18%)] dark:to-[hsl(30,15%,15%)] overflow-hidden flex-shrink-0">
         {game.imageUrl ? (
           // eslint-disable-next-line @next/next/no-img-element
           <img src={game.imageUrl} alt={game.title} className="w-full h-full object-cover" />
@@ -216,7 +189,7 @@ function CatalogGameCard({
         )}
         {hasKb !== undefined && (
           <span
-            className={`absolute top-1 right-1 px-1.5 py-0.5 rounded text-[8px] font-extrabold font-[Quicksand] text-white leading-none ${hasKb ? 'bg-green-500' : 'bg-[var(--nh-text-muted,#94a3b8)]'}`}
+            className={`absolute top-1 right-1 px-1.5 py-0.5 rounded text-[8px] font-extrabold font-[Quicksand] text-white leading-none ${hasKb ? 'bg-green-500' : 'bg-muted-foreground/60'}`}
           >
             {hasKb ? 'KB ✓' : 'KB –'}
           </span>
@@ -227,14 +200,12 @@ function CatalogGameCard({
       <div className="px-2 pt-1.5 pb-1 flex-1 min-h-0">
         <p
           className="font-[Quicksand] font-bold text-[11px] leading-tight
-                     overflow-hidden line-clamp-2 text-[var(--nh-text-primary,#1a1a2e)]"
+                     overflow-hidden line-clamp-2 text-foreground"
         >
           {game.title}
         </p>
         {game.publisher && (
-          <p className="text-[10px] text-[var(--nh-text-secondary,#64748b)] mt-0.5 truncate">
-            {game.publisher}
-          </p>
+          <p className="text-[10px] text-muted-foreground mt-0.5 truncate">{game.publisher}</p>
         )}
       </div>
 
@@ -247,7 +218,7 @@ function CatalogGameCard({
         }
         className={
           inLibrary
-            ? 'mx-1.5 mb-1.5 h-[22px] rounded-lg text-[10px] font-bold font-[Quicksand] flex items-center justify-center gap-1 bg-black/5 text-[var(--nh-text-muted,#94a3b8)] cursor-default'
+            ? 'mx-1.5 mb-1.5 h-[22px] rounded-lg text-[10px] font-bold font-[Quicksand] flex items-center justify-center gap-1 bg-muted text-muted-foreground/60 cursor-default'
             : adding
               ? 'mx-1.5 mb-1.5 h-[22px] rounded-lg text-[10px] font-bold font-[Quicksand] flex items-center justify-center gap-1 bg-black/20 text-white cursor-wait'
               : 'mx-1.5 mb-1.5 h-[22px] rounded-lg text-[10px] font-bold font-[Quicksand] flex items-center justify-center gap-1 bg-amber-600 text-white hover:opacity-90 active:scale-95 transition-transform'
@@ -348,7 +319,7 @@ function NewUserGamesBlock({
         <LoadingSkeleton count={6} />
       ) : (
         <>
-          <p className="text-xs text-[var(--nh-text-muted,#94a3b8)] bg-amber-50 border border-amber-100 rounded-lg px-3 py-2 mb-3 font-medium">
+          <p className="text-xs text-muted-foreground/60 bg-amber-50 dark:bg-amber-950/30 border border-amber-100 dark:border-amber-900/50 rounded-lg px-3 py-2 mb-3 font-medium">
             💡 Libreria vuota — ecco i top giochi dal catalogo. Aggiungili per iniziare!
           </p>
           <div className="grid grid-cols-2 gap-2">
@@ -382,41 +353,23 @@ function NewUserGamesBlock({
   );
 }
 
-// ---------------------------------------------------------------------------
-// Toolkit carousel (always shown, static data)
-// ---------------------------------------------------------------------------
-
-function ToolkitCarousel() {
+function ToolkitGrid() {
   return (
-    <>
-      <p className="text-[10px] text-[var(--nh-text-muted,#94a3b8)] font-semibold mb-2">
-        Strumenti disponibili subito, senza libreria
-      </p>
-      <div className="flex gap-2 overflow-x-auto scrollbar-none pb-1 -mx-1 px-1">
-        {TOOLKIT_TOOLS.map(tool => (
-          <Link
-            key={tool.id}
-            href={`/toolkit?tool=${tool.id}`}
-            className="flex-shrink-0 w-[100px] bg-[var(--nh-bg-card,white)]
-                       border border-[var(--nh-border,rgba(0,0,0,0.07))]
-                       rounded-xl p-2.5 flex flex-col items-center gap-1.5
-                       hover:shadow-md transition-shadow"
-          >
-            <span
-              className={`w-[38px] h-[38px] rounded-[10px] flex items-center justify-center text-xl ${tool.iconBg}`}
-            >
-              {tool.icon}
-            </span>
-            <span className="font-[Quicksand] font-bold text-[11px] text-center leading-tight text-[var(--nh-text-primary,#1a1a1a)]">
-              {tool.name}
-            </span>
-            <span className="text-[9px] text-[var(--nh-text-muted,#94a3b8)] text-center leading-tight">
-              {tool.desc}
-            </span>
-          </Link>
-        ))}
-      </div>
-    </>
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      {TOOLKIT_TOOLS.map(tool => (
+        <Link
+          key={tool.id}
+          href={`/toolkit?tool=${tool.id}`}
+          className="flex flex-col items-center gap-1.5 rounded-xl border border-[hsl(142,30%,88%)] bg-[hsl(142,30%,96%)] p-4 text-center transition-all hover:-translate-y-0.5 hover:border-[hsl(142,70%,45%)] hover:shadow-md dark:border-[hsl(142,30%,25%)] dark:bg-[hsl(142,20%,12%)] dark:hover:border-[hsl(142,70%,40%)]"
+        >
+          <span className="text-[28px]">{tool.icon}</span>
+          <span className="font-quicksand text-[13px] font-bold text-[hsl(142,50%,30%)] dark:text-[hsl(142,50%,65%)]">
+            {tool.name}
+          </span>
+          <span className="text-[11px] text-muted-foreground">{tool.desc}</span>
+        </Link>
+      ))}
+    </div>
   );
 }
 
@@ -564,12 +517,19 @@ export function DashboardClient() {
   // Render
   // ---------------------------------------------------------------------------
 
-  return (
-    <div className="flex flex-col gap-6 px-4 pb-24 pt-4 max-w-[1440px] mx-auto">
-      <GreetingHeader displayName={displayName} />
+  // Build stats for greeting strip
+  const stats = {
+    games: gameItems.length,
+    sessions: sessionItems.length,
+    agents: agentItems.length,
+  };
 
-      {/* Block 1: Games */}
-      <HubBlock title="🎲 Giochi">
+  return (
+    <div className="mx-auto flex max-w-[1200px] flex-col gap-7 px-4 pb-24 pt-4">
+      <GreetingStrip displayName={displayName} stats={stats} />
+
+      {/* Games zone (orange) */}
+      <EntityZone entity="game" title="Giochi" count={gameItems.length} viewAllHref="/games">
         {isNewUser ? (
           <NewUserGamesBlock
             search={gamesSearch}
@@ -589,10 +549,15 @@ export function DashboardClient() {
             <MeepleCardGrid items={filteredGameItems} isLoading={libraryLoading} />
           </HubLayout>
         )}
-      </HubBlock>
+      </EntityZone>
 
-      {/* Block 2: Sessions */}
-      <HubBlock title="🎯 Sessioni">
+      {/* Sessions zone (indigo) — horizontal scroll */}
+      <EntityZone
+        entity="session"
+        title="Sessioni"
+        count={sessionItems.length}
+        viewAllHref="/sessions"
+      >
         <HubLayout
           searchPlaceholder="Filtra per stato..."
           searchValue={sessionsSearch}
@@ -601,23 +566,29 @@ export function DashboardClient() {
           activeFilterId={sessionsFilter}
           onFilterChange={setSessionsFilter}
         >
-          <MeepleCardGrid
-            items={filteredSessionItems}
-            isLoading={sessionsLoading}
-            emptyNode={
-              <EmptyCTA
-                icon="🎯"
-                title="Nessuna sessione"
-                sub="Inizia una nuova partita e traccia i tuoi progressi in tempo reale."
-                actions={[{ label: '＋ Crea sessione', href: '/sessions/new', primary: true }]}
-              />
-            }
-          />
+          {sessionsLoading ? (
+            <LoadingSkeleton count={4} />
+          ) : filteredSessionItems.length === 0 ? (
+            <EmptyCTA
+              icon="🎯"
+              title="Nessuna sessione"
+              sub="Inizia una nuova partita e traccia i tuoi progressi in tempo reale."
+              actions={[{ label: '＋ Crea sessione', href: '/sessions/new', primary: true }]}
+            />
+          ) : (
+            <div className="flex gap-3.5 overflow-x-auto pb-2 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-border">
+              {filteredSessionItems.map(item => (
+                <div key={item.id ?? item.title} className="w-[260px] shrink-0">
+                  <MeepleCard {...item} />
+                </div>
+              ))}
+            </div>
+          )}
         </HubLayout>
-      </HubBlock>
+      </EntityZone>
 
-      {/* Block 3: Agents */}
-      <HubBlock title="🤖 Agenti AI">
+      {/* Agents zone (amber) */}
+      <EntityZone entity="agent" title="Agenti AI" count={agentItems.length} viewAllHref="/agents">
         <HubLayout
           searchPlaceholder="Cerca agenti..."
           searchValue={agentsSearch}
@@ -642,12 +613,12 @@ export function DashboardClient() {
             }
           />
         </HubLayout>
-      </HubBlock>
+      </EntityZone>
 
-      {/* Block 4: Toolkit */}
-      <HubBlock title="🛠️ Toolkit">
-        <ToolkitCarousel />
-      </HubBlock>
+      {/* Toolkit zone (green) */}
+      <EntityZone entity="toolkit" title="Strumenti" count={TOOLKIT_TOOLS.length}>
+        <ToolkitGrid />
+      </EntityZone>
     </div>
   );
 }

--- a/apps/web/src/app/(authenticated)/dashboard/__tests__/DashboardClient.test.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/__tests__/DashboardClient.test.tsx
@@ -68,7 +68,7 @@ describe('DashboardClient', () => {
     expect(screen.getAllByText(/Giochi/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Sessioni/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Agenti/i).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/Toolkit/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Strumenti/i).length).toBeGreaterThan(0);
   });
 
   it('shows catalog hint for new user with empty library', () => {

--- a/apps/web/src/components/dashboard/EntityZone.tsx
+++ b/apps/web/src/components/dashboard/EntityZone.tsx
@@ -32,7 +32,7 @@ export function EntityZone({ entity, title, count, viewAllHref, children }: Enti
         {viewAllHref && (
           <Link
             href={viewAllHref}
-            className="ml-auto text-xs font-semibold text-[hsl(25,95%,45%)] hover:underline"
+            className="ml-auto text-xs font-semibold text-[hsl(25,95%,45%)] hover:underline dark:text-[hsl(25,95%,65%)]"
           >
             Vedi tutti →
           </Link>

--- a/apps/web/src/components/dashboard/EntityZone.tsx
+++ b/apps/web/src/components/dashboard/EntityZone.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import Link from 'next/link';
+
+import { entityHsl } from '@/components/ui/data-display/meeple-card';
+import type { MeepleEntityType } from '@/components/ui/data-display/meeple-card';
+
+interface EntityZoneProps {
+  entity: MeepleEntityType;
+  title: string;
+  count: number;
+  viewAllHref?: string;
+  children: React.ReactNode;
+}
+
+export function EntityZone({ entity, title, count, viewAllHref, children }: EntityZoneProps) {
+  const dotColor = entityHsl(entity);
+
+  return (
+    <section className="space-y-3">
+      {/* Zone header */}
+      <div className="flex items-center gap-2.5">
+        <div
+          data-testid="entity-dot"
+          className="h-2.5 w-2.5 rounded-full"
+          style={{ backgroundColor: dotColor }}
+        />
+        <h3 className="font-quicksand text-[13px] font-bold uppercase tracking-[0.08em] text-muted-foreground">
+          {title}
+        </h3>
+        <span className="text-[11px] tabular-nums text-muted-foreground/60">{count}</span>
+        {viewAllHref && (
+          <Link
+            href={viewAllHref}
+            className="ml-auto text-xs font-semibold text-[hsl(25,95%,45%)] hover:underline"
+          >
+            Vedi tutti →
+          </Link>
+        )}
+      </div>
+
+      {/* Zone content */}
+      {children}
+    </section>
+  );
+}

--- a/apps/web/src/components/dashboard/GreetingStrip.tsx
+++ b/apps/web/src/components/dashboard/GreetingStrip.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import Link from 'next/link';
+
+export interface GreetingStripStats {
+  games: number;
+  sessions: number;
+  agents: number;
+}
+
+interface GreetingStripProps {
+  displayName: string;
+  stats: GreetingStripStats;
+}
+
+export function GreetingStrip({ displayName, stats }: GreetingStripProps) {
+  const initial = displayName.charAt(0).toUpperCase();
+  const statsSummary = [
+    stats.games > 0 ? `${stats.games} giochi` : null,
+    stats.sessions > 0 ? `${stats.sessions} sessioni` : null,
+    stats.agents > 0 ? `${stats.agents} agenti` : null,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+
+  return (
+    <div className="flex items-center gap-5 rounded-2xl border border-[hsl(25,40%,85%)] bg-gradient-to-r from-[hsl(25,40%,94%)] to-[hsl(30,35%,91%)] px-7 py-6 dark:border-[hsl(25,30%,25%)] dark:from-[hsl(25,20%,14%)] dark:to-[hsl(30,15%,12%)]">
+      {/* Avatar */}
+      <div
+        data-testid="greeting-avatar"
+        className="grid h-[52px] w-[52px] shrink-0 place-items-center rounded-xl bg-gradient-to-br from-[hsl(25,95%,45%)] to-[hsl(25,95%,55%)] text-xl font-bold text-white"
+      >
+        {initial}
+      </div>
+
+      {/* Text */}
+      <div className="min-w-0">
+        <h1 className="font-quicksand text-[22px] font-bold text-foreground">
+          Ciao, {displayName} 👋
+        </h1>
+        <p className="mt-0.5 text-[13px] text-muted-foreground">
+          La tua tavola da gioco{statsSummary ? ` · ${statsSummary}` : ''}
+        </p>
+      </div>
+
+      {/* Quick Actions - desktop only */}
+      <div className="ml-auto flex shrink-0 gap-2 max-md:hidden">
+        <Link
+          href="/sessions/new"
+          className="inline-flex items-center gap-1.5 rounded-full border border-[var(--mc-border)] bg-card/70 px-4 py-2 text-xs font-semibold text-foreground transition-all hover:bg-card hover:shadow-sm"
+        >
+          📋 Nuova sessione
+        </Link>
+        <Link
+          href="/library?action=add"
+          className="inline-flex items-center gap-1.5 rounded-full bg-[hsl(25,95%,45%)] px-4 py-2 text-xs font-semibold text-white shadow-[0_2px_12px_rgba(210,105,30,0.25)] transition-all hover:bg-[hsl(25,95%,38%)]"
+        >
+          + Aggiungi gioco
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/GreetingStrip.tsx
+++ b/apps/web/src/components/dashboard/GreetingStrip.tsx
@@ -14,7 +14,7 @@ interface GreetingStripProps {
 }
 
 export function GreetingStrip({ displayName, stats }: GreetingStripProps) {
-  const initial = displayName.charAt(0).toUpperCase();
+  const initial = (displayName || '?').charAt(0).toUpperCase();
   const statsSummary = [
     stats.games > 0 ? `${stats.games} giochi` : null,
     stats.sessions > 0 ? `${stats.sessions} sessioni` : null,

--- a/apps/web/src/components/layout/UserShell/TopBarV2.tsx
+++ b/apps/web/src/components/layout/UserShell/TopBarV2.tsx
@@ -4,6 +4,7 @@ import { Menu, Search } from 'lucide-react';
 import Link from 'next/link';
 
 import { UserMenuDropdown } from '@/components/layout/UserMenuDropdown';
+import { ThemeToggle } from '@/components/ui/navigation/ThemeToggle';
 import { Button } from '@/components/ui/primitives/button';
 
 interface TopBarV2Props {
@@ -54,6 +55,8 @@ export function TopBarV2({ onHamburgerClick, onSearchClick, adminMode }: TopBarV
         <Button variant="ghost" size="icon" aria-label="Cerca" onClick={onSearchClick}>
           <Search className="h-5 w-5" />
         </Button>
+
+        <ThemeToggle size="sm" />
 
         <UserMenuDropdown />
       </div>


### PR DESCRIPTION
## Summary
- Redesign dashboard layout from flat grid to "Hybrid" style with entity-colored zones, greeting strip with avatar/stats/CTAs, and varied section layouts
- Add visible ThemeToggle to TopBarV2 for quick light/dark mode switching
- Clean up all legacy `--nh-*` CSS variables → Tailwind semantic tokens with dark mode support

## Changes
- **GreetingStrip**: New component with user avatar (initial), stats summary, quick action buttons (desktop)
- **EntityZone**: New component with entity-colored dot, title, count, "Vedi tutti" link
- **DashboardClient**: Rewritten layout — Games (grid), Sessions (horizontal scroll), Agents (grid), Toolkit (green-tinted grid)
- **TopBarV2**: Added ThemeToggle between Search and UserMenu
- **CSS cleanup**: All `--nh-*` vars replaced with `text-foreground`, `bg-card`, `border-border`, etc.
- **Dark mode**: Full `dark:` variants on all new components (GreetingStrip gradient, ToolkitGrid, CatalogGameCard)

## What's preserved
- MeepleCard component (untouched) — remains the core interaction surface
- ManaPips hook and component (untouched)
- All data hooks (useLibrary, useActiveSessions, useAgents)
- NewUserGamesBlock onboarding flow
- OwnershipConfirmDialog
- HubLayout search/filter

## Test plan
- [x] 10 new unit tests (GreetingStrip: 5, EntityZone: 5)
- [x] 9 existing DashboardClient tests pass (1 updated: Toolkit → Strumenti)
- [x] TypeScript typecheck passes
- [x] Pre-commit + pre-push hooks pass (lint, build)
- [ ] Visual verification: light mode dashboard layout
- [ ] Visual verification: dark mode dashboard layout
- [ ] Mobile responsive check (GreetingStrip CTAs hidden, grids collapse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
