### PR TITLE
feat(kb): dynamic retrieval profile + multilingual classifier

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
@@ -839,13 +839,12 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
         bool hasExpansions, bool hasProtectedCitations, string agentLanguage)
         => BuildSystemPrompt(agentTypology, gameTitle, gameState, ragContext, hasExpansions, hasProtectedCitations, agentLanguage);
 
-    private static LlmUserTier MapToLlmUserTier(UserTier? userTier) => userTier?.Value?.ToLowerInvariant() switch
+    private static LlmUserTier MapToLlmUserTier(UserTier? userTier) => userTier?.Value switch
     {
-        "anonymous" => LlmUserTier.Anonymous,
-        "user" => LlmUserTier.User,
-        "editor" => LlmUserTier.Editor,
-        "admin" => LlmUserTier.Admin,
-        "premium" => LlmUserTier.Premium,
+        "free" => LlmUserTier.Anonymous,
+        "normal" => LlmUserTier.User,
+        "premium" or "pro" => LlmUserTier.Premium,
+        "enterprise" => LlmUserTier.Admin,
         null => LlmUserTier.Anonymous,
         _ => LlmUserTier.User
     };

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
@@ -10,6 +10,7 @@ using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.Models;
 using Api.Observability;
 using Api.Services;
+using Api.SharedKernel.Domain.Enums;
 using Api.SharedKernel.Domain.ValueObjects;
 using Microsoft.Extensions.Logging;
 
@@ -35,10 +36,6 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
     private readonly IGraphRetrievalService _graphRetrievalService;
     private readonly ILogger<RagPromptAssemblyService> _logger;
 
-    // RAG search parameters
-    private const int RerankedTopK = 5;  // Final chunk count after reranking
-    private const float DefaultMinScore = 0.55f;
-
     // Issue #5588: Expansion priority boost factor
     internal const float ExpansionBoostFactor = 1.3f;
 
@@ -55,11 +52,7 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
         "not certain", "it might", "it could"
     ];
 
-    // Sentence window
-    private const int SentenceWindowRadius = 1; // ±1 adjacent chunks
-
     // Hybrid search (RRF)
-    private const int FtsTopK = 10; // Full-text search results to feed into RRF
     private const int RrfK = 60;    // Standard RRF constant
 
     // Query expansion
@@ -173,6 +166,7 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
         try
         {
             // === ADAPTIVE RAG ===
+            var profile = RetrievalProfile.Default;
             var activeEnhancements = RagEnhancement.None;
             if (userTier != null)
             {
@@ -192,9 +186,16 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
                 _logger.LogInformation("Adaptive RAG: {Level} (confidence: {Confidence:F2})",
                     complexity.Level, complexity.Confidence);
 
+                // Resolve dynamic retrieval profile from complexity × tier
+                profile = RetrievalProfileResolver.Resolve(complexity, MapToLlmUserTier(userTier));
+                _logger.LogInformation("Retrieval profile: TopK={TopK}, MinScore={MinScore:F2}, FtsTopK={FtsTopK} (complexity={Level}, tier={Tier})",
+                    profile.TopK, profile.MinScore, profile.FtsTopK, complexity.Level, userTier?.Value ?? "anonymous");
+
                 MeepleAiMetrics.RagAdaptiveRoutingDecisions.Add(1,
                     new KeyValuePair<string, object?>("level", complexity.Level.ToString()),
-                    new KeyValuePair<string, object?>("skipped_retrieval", (!complexity.RequiresRetrieval).ToString()));
+                    new KeyValuePair<string, object?>("skipped_retrieval", (!complexity.RequiresRetrieval).ToString()),
+                    new KeyValuePair<string, object?>("topk", profile.TopK.ToString(CultureInfo.InvariantCulture)),
+                    new KeyValuePair<string, object?>("min_score", profile.MinScore.ToString("F2", CultureInfo.InvariantCulture)));
 
                 debugCollector?.Add(StreamingEventType.DebugAdaptiveRouting,
                     new DebugAdaptiveRoutingData(
@@ -253,13 +254,13 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
             }
 
             // Step 2b: Hybrid search — PostgreSQL FTS + RRF fusion (graceful degradation)
-            allChunks = await TryHybridSearchAsync(userQuestion, gameId, allChunks, ct).ConfigureAwait(false);
+            allChunks = await TryHybridSearchAsync(userQuestion, gameId, allChunks, profile, ct).ConfigureAwait(false);
 
             // Deduplicate by PdfId+ChunkIndex, keep highest score
             var filteredChunks = allChunks
                 .GroupBy(r => $"{r.PdfId}:{r.ChunkIndex}", StringComparer.Ordinal)
                 .Select(g => g.OrderByDescending(r => r.Score).First())
-                .Where(r => r.Score >= DefaultMinScore)
+                .Where(r => r.Score >= profile.MinScore)
                 .OrderByDescending(r => r.Score)
                 .ToList();
 
@@ -271,7 +272,7 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
 
             if (filteredChunks.Count == 0)
             {
-                _logger.LogInformation("No chunks above minScore {MinScore} for game {GameId}", DefaultMinScore, gameId);
+                _logger.LogInformation("No chunks above minScore {MinScore} for game {GameId}", profile.MinScore, gameId);
                 return (string.Empty, citations);
             }
 
@@ -281,7 +282,7 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
                 filteredChunks[0].Score);
 
             // Step 3: Rerank if available (graceful degradation)
-            filteredChunks = await TryRerankAsync(userQuestion, filteredChunks, ct).ConfigureAwait(false);
+            filteredChunks = await TryRerankAsync(userQuestion, filteredChunks, profile, ct).ConfigureAwait(false);
 
             // === CRAG: Evaluate retrieval relevance ===
             if (activeEnhancements.HasFlag(RagEnhancement.CragEvaluation) && filteredChunks.Count > 0)
@@ -305,7 +306,7 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
                     var expandedQuery = await ExpandQueryAsync(userQuestion, ct).ConfigureAwait(false);
                     var expandedChunks = await TryHybridSearchAsync(
                         expandedQuery.FirstOrDefault() ?? userQuestion,
-                        gameId, new List<SearchResultItem>(), ct).ConfigureAwait(false);
+                        gameId, new List<SearchResultItem>(), profile, ct).ConfigureAwait(false);
 
                     if (evaluation.UseRetrievedDocuments)
                     {
@@ -315,21 +316,21 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
                             .GroupBy(c => $"{c.PdfId}:{c.ChunkIndex}", StringComparer.Ordinal)
                             .Select(g => g.OrderByDescending(c => c.Score).First())
                             .OrderByDescending(c => c.Score)
-                            .Take(RerankedTopK * 2)
+                            .Take(profile.TopK * 2)
                             .ToList();
                     }
                     else
                     {
                         // Incorrect: replace with expanded results
                         filteredChunks = expandedChunks
-                            .Where(c => c.Score >= DefaultMinScore)
+                            .Where(c => c.Score >= profile.MinScore)
                             .OrderByDescending(c => c.Score)
-                            .Take(RerankedTopK)
+                            .Take(profile.TopK)
                             .ToList();
                     }
 
                     // Re-rerank the merged results
-                    filteredChunks = await TryRerankAsync(userQuestion, filteredChunks, ct)
+                    filteredChunks = await TryRerankAsync(userQuestion, filteredChunks, profile, ct)
                         .ConfigureAwait(false);
                 }
 
@@ -365,7 +366,7 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
 
                     filteredChunks = filteredChunks
                         .OrderByDescending(c => c.Score)
-                        .Take(RerankedTopK + 2) // Allow slightly more chunks when RAPTOR active
+                        .Take(profile.TopK + 2) // Allow slightly more chunks when RAPTOR active
                         .ToList();
 
                     _logger.LogInformation("RAPTOR: added {Count} summary chunks to context", raptorChunks.Count);
@@ -373,7 +374,7 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
             }
 
             // Step 4: Sentence window expansion — include adjacent chunks for more context
-            filteredChunks = await TrySentenceWindowExpansionAsync(filteredChunks, ct).ConfigureAwait(false);
+            filteredChunks = await TrySentenceWindowExpansionAsync(filteredChunks, profile, ct).ConfigureAwait(false);
 
             // Format chunks and track citations (with copyright annotation)
             var sb = new StringBuilder();
@@ -448,10 +449,10 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
     }
 
     private async Task<List<SearchResultItem>> TryRerankAsync(
-        string userQuestion, List<SearchResultItem> chunks, CancellationToken ct)
+        string userQuestion, List<SearchResultItem> chunks, RetrievalProfile profile, CancellationToken ct)
     {
-        if (chunks.Count <= RerankedTopK)
-            return chunks.Take(RerankedTopK).ToList();
+        if (chunks.Count <= profile.TopK)
+            return chunks.Take(profile.TopK).ToList();
 
         try
         {
@@ -461,7 +462,7 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
                 OriginalScore: c.Score
             )).ToList();
 
-            var result = await _reranker.RerankAsync(userQuestion, rerankChunks, RerankedTopK, ct).ConfigureAwait(false);
+            var result = await _reranker.RerankAsync(userQuestion, rerankChunks, profile.TopK, ct).ConfigureAwait(false);
 
             _logger.LogInformation("Reranked {Input} → {Output} chunks in {TimeMs:F1}ms",
                 chunks.Count, result.Chunks.Count, result.ProcessingTimeMs);
@@ -475,17 +476,17 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Reranker failed, using raw Qdrant scores (top {TopK})", RerankedTopK);
-            return chunks.Take(RerankedTopK).ToList();
+            _logger.LogWarning(ex, "Reranker failed, using raw scores (top {TopK})", profile.TopK);
+            return chunks.Take(profile.TopK).ToList();
         }
     }
 
     private async Task<List<SearchResultItem>> TryHybridSearchAsync(
-        string userQuestion, Guid gameId, List<SearchResultItem> vectorChunks, CancellationToken ct)
+        string userQuestion, Guid gameId, List<SearchResultItem> vectorChunks, RetrievalProfile profile, CancellationToken ct)
     {
         try
         {
-            var ftsResults = await _textSearch.FullTextSearchAsync(gameId, userQuestion, FtsTopK, ct).ConfigureAwait(false);
+            var ftsResults = await _textSearch.FullTextSearchAsync(gameId, userQuestion, profile.FtsTopK, ct).ConfigureAwait(false);
             if (ftsResults.Count == 0)
                 return vectorChunks;
 
@@ -549,7 +550,7 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
     }
 
     private async Task<List<SearchResultItem>> TrySentenceWindowExpansionAsync(
-        List<SearchResultItem> chunks, CancellationToken ct)
+        List<SearchResultItem> chunks, RetrievalProfile profile, CancellationToken ct)
     {
         if (chunks.Count == 0)
             return chunks;
@@ -567,7 +568,7 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
                     continue;
 
                 var adjacent = await _textSearch.GetAdjacentChunksAsync(
-                    pdfDocumentId, chunk.ChunkIndex, SentenceWindowRadius, ct).ConfigureAwait(false);
+                    pdfDocumentId, chunk.ChunkIndex, profile.WindowRadius, ct).ConfigureAwait(false);
 
                 foreach (var adj in adjacent)
                 {
@@ -837,4 +838,15 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
         string agentTypology, string gameTitle, GameState? gameState, string ragContext,
         bool hasExpansions, bool hasProtectedCitations, string agentLanguage)
         => BuildSystemPrompt(agentTypology, gameTitle, gameState, ragContext, hasExpansions, hasProtectedCitations, agentLanguage);
+
+    private static LlmUserTier MapToLlmUserTier(UserTier? userTier) => userTier?.Value?.ToLowerInvariant() switch
+    {
+        "anonymous" => LlmUserTier.Anonymous,
+        "user" => LlmUserTier.User,
+        "editor" => LlmUserTier.Editor,
+        "admin" => LlmUserTier.Admin,
+        "premium" => LlmUserTier.Premium,
+        null => LlmUserTier.Anonymous,
+        _ => LlmUserTier.User
+    };
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/Enhancements/QueryComplexityClassifier.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/Enhancements/QueryComplexityClassifier.cs
@@ -15,16 +15,34 @@ internal sealed class QueryComplexityClassifier : IQueryComplexityClassifier
 
     private static readonly string[] SimplePatterns =
     [
+        // English
         "what is", "what's", "define", "who is", "who's",
-        "how many", "when was", "when did", "where is", "where's"
+        "how many", "when was", "when did", "where is", "where's",
+        // Italian
+        "cos'è", "che cos'è", "quanti", "quante", "quando",
+        "dove", "chi è", "chi ha"
     ];
 
     private static readonly string[] ComplexIndicators =
     [
-        "compare", "after", "before", "if", "should i",
-        "can i", "expansion", "strategy", "versus", "vs",
-        "difference between", "pros and cons", "better than",
-        "recommend", "best way"
+        // English — strategy/comparison
+        "compare", "versus", "vs", "difference between",
+        "pros and cons", "better than", "recommend", "best way",
+        "expansion", "strategy",
+        // English — rule interactions
+        "interaction", "triggers", "resolve", "resolution order",
+        "in combination with", "simultaneously", "at the same time",
+        "sequence of", "priority", "override", "conflict between",
+        // Italian — strategy/comparison
+        "confronta", "differenza tra", "meglio", "consiglia",
+        "pro e contro", "rispetto a", "espansione",
+        // Italian — rule interactions
+        "interazione", "innesca", "si attiva", "si risolve",
+        "in combinazione con", "contemporaneamente", "nello stesso momento",
+        "in che ordine", "priorità", "sovrascrive", "conflitto tra",
+        // Shared conditional patterns (both languages)
+        "if ", "should i", "can i", "after", "before",
+        " se ", "posso", "devo", "durante"
     ];
 
     public QueryComplexityClassifier(ILlmService llmService, ILogger<QueryComplexityClassifier> logger)
@@ -61,6 +79,18 @@ internal sealed class QueryComplexityClassifier : IQueryComplexityClassifier
         if (complexCount >= 2)
             return QueryComplexity.Complex($"Multiple complex indicators ({complexCount})", 0.85f);
 
+        // Structural complexity: long multi-clause queries (language-agnostic)
+        var commaCount = normalized.Count(c => c == ',');
+        var hasConditional = normalized.Contains(" se ", StringComparison.Ordinal)
+                          || normalized.StartsWith("se ", StringComparison.Ordinal)
+                          || normalized.Contains("if ", StringComparison.Ordinal);
+
+        if (wordCount >= 25 && commaCount >= 3 && hasConditional)
+            return QueryComplexity.Complex("Long multi-clause conditional query", 0.80f);
+
+        if (wordCount >= 20 && complexCount >= 1 && commaCount >= 2)
+            return QueryComplexity.Complex("Structural complexity with interaction indicator", 0.80f);
+
         // No strong signal -> null means fall through to LLM
         return null;
     }
@@ -69,10 +99,12 @@ internal sealed class QueryComplexityClassifier : IQueryComplexityClassifier
     {
         const string systemPrompt = """
             Classify the complexity of the following board-game question.
+            The question may be in any language (Italian, English, or others). Classify regardless of language.
             Respond with JSON: {"Level":"Simple|Moderate|Complex","Confidence":0.0-1.0,"Reason":"brief reason"}
-            - Simple: single-fact lookup (e.g. "What is the max player count?")
-            - Moderate: needs context retrieval from rules (e.g. "How does scoring work?")
-            - Complex: multi-step reasoning, comparisons, or strategy advice
+            - Simple: single-fact lookup (e.g. "What is the max player count?" / "Quanti giocatori al massimo?")
+            - Moderate: needs context retrieval from rules (e.g. "How does scoring work?" / "Come funziona il punteggio?")
+            - Complex: multi-step reasoning, rule interactions, comparisons, or strategy advice
+              (e.g. "If I play card X and it triggers effect Y during combat, how does it resolve with Z?")
             """;
 
         try

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/Enhancements/RetrievalProfileResolver.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/Enhancements/RetrievalProfileResolver.cs
@@ -1,0 +1,47 @@
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.SharedKernel.Domain.Enums;
+
+namespace Api.BoundedContexts.KnowledgeBase.Domain.Services.Enhancements;
+
+/// <summary>
+/// Resolves retrieval parameters from query complexity and user tier.
+/// Pure static function — no dependencies, no state, fully testable.
+/// </summary>
+internal static class RetrievalProfileResolver
+{
+    public static RetrievalProfile Resolve(QueryComplexity complexity, LlmUserTier? tier)
+    {
+        var effectiveTier = tier ?? LlmUserTier.Anonymous;
+
+        if (complexity.Level == QueryComplexityLevel.Simple)
+            return RetrievalProfile.Default;
+
+        if (effectiveTier == LlmUserTier.Anonymous)
+            return RetrievalProfile.Default;
+
+        var tierBucket = effectiveTier switch
+        {
+            LlmUserTier.User => TierBucket.Standard,
+            _ => TierBucket.Elevated
+        };
+
+        return (complexity.Level, tierBucket) switch
+        {
+            (QueryComplexityLevel.Moderate, TierBucket.Standard) =>
+                new RetrievalProfile(TopK: 8, MinScore: 0.50f, FtsTopK: 15, WindowRadius: 1),
+
+            (QueryComplexityLevel.Moderate, TierBucket.Elevated) =>
+                new RetrievalProfile(TopK: 10, MinScore: 0.45f, FtsTopK: 20, WindowRadius: 1),
+
+            (QueryComplexityLevel.Complex, TierBucket.Standard) =>
+                new RetrievalProfile(TopK: 10, MinScore: 0.45f, FtsTopK: 20, WindowRadius: 1),
+
+            (QueryComplexityLevel.Complex, TierBucket.Elevated) =>
+                new RetrievalProfile(TopK: 15, MinScore: 0.40f, FtsTopK: 25, WindowRadius: 2),
+
+            _ => RetrievalProfile.Default
+        };
+    }
+
+    private enum TierBucket { Standard, Elevated }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/ValueObjects/RetrievalProfile.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/ValueObjects/RetrievalProfile.cs
@@ -1,0 +1,15 @@
+namespace Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+
+/// <summary>
+/// Immutable retrieval parameters resolved from query complexity and user tier.
+/// Replaces hardcoded RAG search constants for adaptive retrieval depth.
+/// </summary>
+internal sealed record RetrievalProfile(
+    int TopK,
+    float MinScore,
+    int FtsTopK,
+    int WindowRadius)
+{
+    /// <summary>Baseline profile matching the original hardcoded constants.</summary>
+    public static RetrievalProfile Default => new(TopK: 5, MinScore: 0.55f, FtsTopK: 10, WindowRadius: 1);
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/ValueObjects/RetrievalProfile.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/ValueObjects/RetrievalProfile.cs
@@ -10,6 +10,8 @@ internal sealed record RetrievalProfile(
     int FtsTopK,
     int WindowRadius)
 {
+    private static readonly RetrievalProfile _default = new(TopK: 5, MinScore: 0.55f, FtsTopK: 10, WindowRadius: 1);
+
     /// <summary>Baseline profile matching the original hardcoded constants.</summary>
-    public static RetrievalProfile Default => new(TopK: 5, MinScore: 0.55f, FtsTopK: 10, WindowRadius: 1);
+    public static RetrievalProfile Default => _default;
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/QueryComplexityClassifierTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/QueryComplexityClassifierTests.cs
@@ -194,4 +194,80 @@ public class QueryComplexityClassifierTests
 
         result.Should().BeNull();
     }
+
+    // --- Italian heuristics: Simple ---
+
+    [Theory]
+    [InlineData("cos'è Catan?")]
+    [InlineData("quanti giocatori?")]
+    [InlineData("quando esce?")]
+    [InlineData("dove si compra?")]
+    [InlineData("chi è l'autore?")]
+    public async Task ClassifyAsync_ItalianShortSimpleQuery_ShouldReturnSimple(string query)
+    {
+        var result = await _sut.ClassifyAsync(query);
+        result.Level.Should().Be(QueryComplexityLevel.Simple);
+        (result.Confidence >= 0.9f).Should().BeTrue();
+        _llmServiceMock.VerifyNoOtherCalls();
+    }
+
+    // --- Italian heuristics: Complex (interaction patterns) ---
+
+    [Theory]
+    [InlineData("se gioco una carta e si attiva un effetto durante il mio turno, come si risolve l'interazione?")]
+    [InlineData("confronta le strategie e dimmi quale conviene se ho poche risorse")]
+    [InlineData("quando pesco una carta che innesca un effetto combinato con il turno extra, in che ordine si risolvono?")]
+    public async Task ClassifyAsync_ItalianComplexInteraction_ShouldReturnComplex(string query)
+    {
+        var result = await _sut.ClassifyAsync(query);
+        result.Level.Should().Be(QueryComplexityLevel.Complex);
+        (result.Confidence >= 0.8f).Should().BeTrue();
+        _llmServiceMock.VerifyNoOtherCalls();
+    }
+
+    // --- English interaction patterns (new) ---
+
+    [Theory]
+    [InlineData("if I play a card that triggers an effect during combat, how does the interaction resolve with sustain damage?")]
+    [InlineData("when I activate this ability and it triggers another effect simultaneously, what is the resolution order?")]
+    public async Task ClassifyAsync_EnglishInteractionPatterns_ShouldReturnComplex(string query)
+    {
+        var result = await _sut.ClassifyAsync(query);
+        result.Level.Should().Be(QueryComplexityLevel.Complex);
+        (result.Confidence >= 0.8f).Should().BeTrue();
+        _llmServiceMock.VerifyNoOtherCalls();
+    }
+
+    // --- Structural complexity (language-agnostic) ---
+
+    [Theory]
+    [InlineData("Se uso la carta azione, pesco 2 carte, una innesca un effetto immediato che modifica i punti, e nel frattempo il turno extra si attiva, come funziona tutto?")]
+    [InlineData("If I use the action card, draw 2 cards, one triggers an immediate effect that modifies points, and meanwhile the extra turn activates, how does everything work?")]
+    public async Task ClassifyAsync_LongMultiClauseQuery_ShouldReturnComplex(string query)
+    {
+        var result = await _sut.ClassifyAsync(query);
+        result.Level.Should().Be(QueryComplexityLevel.Complex);
+        _llmServiceMock.VerifyNoOtherCalls();
+    }
+
+    // --- Multilingual LLM prompt verification ---
+
+    [Fact]
+    public async Task ClassifyAsync_ItalianAmbiguousQuery_ShouldCallLlmWithMultilingualPrompt()
+    {
+        _llmServiceMock
+            .Setup(x => x.GenerateJsonAsync<ComplexityClassification>(
+                It.Is<string>(s => s.Contains("any language", StringComparison.OrdinalIgnoreCase)),
+                It.IsAny<string>(), It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ComplexityClassification("Complex", 0.85f, "Multi-step rule interaction"));
+
+        var result = await _sut.ClassifyAsync("Come funziona il punteggio con l'espansione attiva?");
+
+        result.Level.Should().Be(QueryComplexityLevel.Complex);
+        _llmServiceMock.Verify(
+            x => x.GenerateJsonAsync<ComplexityClassification>(
+                It.Is<string>(s => s.Contains("any language", StringComparison.OrdinalIgnoreCase)),
+                It.IsAny<string>(), RequestSource.RagClassification, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/RetrievalProfileResolverTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/RetrievalProfileResolverTests.cs
@@ -1,0 +1,114 @@
+using Api.BoundedContexts.KnowledgeBase.Domain.Services.Enhancements;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.SharedKernel.Domain.Enums;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Unit;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public class RetrievalProfileResolverTests
+{
+    [Fact]
+    public void Default_ShouldHaveBaselineValues()
+    {
+        var profile = RetrievalProfile.Default;
+
+        profile.TopK.Should().Be(5);
+        profile.MinScore.Should().Be(0.55f);
+        profile.FtsTopK.Should().Be(10);
+        profile.WindowRadius.Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData(LlmUserTier.Anonymous)]
+    [InlineData(LlmUserTier.User)]
+    [InlineData(LlmUserTier.Premium)]
+    public void Resolve_SimpleQuery_AnyTier_ShouldReturnDefault(LlmUserTier tier)
+    {
+        var complexity = QueryComplexity.Simple("test", 0.9f);
+        var profile = RetrievalProfileResolver.Resolve(complexity, tier);
+        profile.TopK.Should().Be(5);
+        profile.MinScore.Should().Be(0.55f);
+    }
+
+    [Fact]
+    public void Resolve_ModerateQuery_AnonymousTier_ShouldReturnDefault()
+    {
+        var complexity = QueryComplexity.Moderate("test", 0.8f);
+        var profile = RetrievalProfileResolver.Resolve(complexity, LlmUserTier.Anonymous);
+        profile.TopK.Should().Be(5);
+        profile.MinScore.Should().Be(0.55f);
+    }
+
+    [Fact]
+    public void Resolve_ModerateQuery_UserTier_ShouldScaleUp()
+    {
+        var complexity = QueryComplexity.Moderate("test", 0.8f);
+        var profile = RetrievalProfileResolver.Resolve(complexity, LlmUserTier.User);
+        profile.TopK.Should().Be(8);
+        profile.MinScore.Should().Be(0.50f);
+        profile.FtsTopK.Should().Be(15);
+    }
+
+    [Fact]
+    public void Resolve_ModerateQuery_PremiumTier_ShouldScaleHigher()
+    {
+        var complexity = QueryComplexity.Moderate("test", 0.8f);
+        var profile = RetrievalProfileResolver.Resolve(complexity, LlmUserTier.Premium);
+        profile.TopK.Should().Be(10);
+        profile.MinScore.Should().Be(0.45f);
+        profile.FtsTopK.Should().Be(20);
+    }
+
+    [Fact]
+    public void Resolve_ComplexQuery_AnonymousTier_ShouldReturnDefault()
+    {
+        var complexity = QueryComplexity.Complex("test", 0.85f);
+        var profile = RetrievalProfileResolver.Resolve(complexity, LlmUserTier.Anonymous);
+        profile.TopK.Should().Be(5);
+        profile.MinScore.Should().Be(0.55f);
+    }
+
+    [Fact]
+    public void Resolve_ComplexQuery_UserTier_ShouldScaleSignificantly()
+    {
+        var complexity = QueryComplexity.Complex("test", 0.85f);
+        var profile = RetrievalProfileResolver.Resolve(complexity, LlmUserTier.User);
+        profile.TopK.Should().Be(10);
+        profile.MinScore.Should().Be(0.45f);
+        profile.FtsTopK.Should().Be(20);
+    }
+
+    [Fact]
+    public void Resolve_ComplexQuery_PremiumTier_ShouldMaximize()
+    {
+        var complexity = QueryComplexity.Complex("test", 0.85f);
+        var profile = RetrievalProfileResolver.Resolve(complexity, LlmUserTier.Premium);
+        profile.TopK.Should().Be(15);
+        profile.MinScore.Should().Be(0.40f);
+        profile.FtsTopK.Should().Be(25);
+        profile.WindowRadius.Should().Be(2);
+    }
+
+    [Theory]
+    [InlineData(LlmUserTier.Editor)]
+    [InlineData(LlmUserTier.Admin)]
+    public void Resolve_ComplexQuery_ElevatedTiers_ShouldMatchPremium(LlmUserTier tier)
+    {
+        var complexity = QueryComplexity.Complex("test", 0.85f);
+        var profile = RetrievalProfileResolver.Resolve(complexity, tier);
+        profile.TopK.Should().Be(15);
+        profile.MinScore.Should().Be(0.40f);
+    }
+
+    [Fact]
+    public void Resolve_NullTier_ShouldTreatAsAnonymous()
+    {
+        var complexity = QueryComplexity.Moderate("test", 0.8f);
+        var profile = RetrievalProfileResolver.Resolve(complexity, null);
+        profile.TopK.Should().Be(5);
+    }
+}


### PR DESCRIPTION
## Summary

- **Dynamic Retrieval Profile**: Replace hardcoded `RerankedTopK=5`, `DefaultMinScore=0.55`, `FtsTopK=10` with `RetrievalProfile` value object resolved from `QueryComplexity × LlmUserTier` via `RetrievalProfileResolver`
- **Multilingual Query Classifier**: Extend `QueryComplexityClassifier` with Italian+English heuristic patterns, structural complexity detection (multi-clause conditionals), and multilingual LLM fallback prompt
- **Tier-aware retrieval depth**: Complex questions from Premium/Enterprise users get up to 15 chunks (vs baseline 5), with lower score thresholds and wider sentence windows

## Retrieval Matrix

| Complexity \ Tier | Free | Normal | Premium/Pro/Enterprise |
|-------------------|------|--------|----------------------|
| **Simple** | 5 / 0.55 | 5 / 0.55 | 5 / 0.55 |
| **Moderate** | 5 / 0.55 | 8 / 0.50 | 10 / 0.45 |
| **Complex** | 5 / 0.55 | 10 / 0.45 | 15 / 0.40 |

Format: TopK / MinScore

## Key Design Decisions

- Feature-flag gated: when `AdaptiveRouting` is disabled, `RetrievalProfile.Default` preserves exact original behavior
- Pure static resolver — zero dependencies, fully unit-testable
- `UserTier` → `LlmUserTier` mapping uses actual domain values (free/normal/premium/pro/enterprise)

## Test plan

- [x] 13 unit tests for `RetrievalProfileResolver` — all tier×complexity combinations
- [x] 34 unit tests for `QueryComplexityClassifier` — IT+EN patterns, structural, LLM fallback
- [x] 1884 KnowledgeBase unit tests pass (0 failures)
- [ ] Manual verification in staging with complex multi-section game questions


🤖 Generated with [Claude Code](https://claude.com/claude-code)
