### PR TITLE
feat(vision): session vision AI — multimodal images for game state analysis

### DIFF
--- a/apps/api/src/Api/Api.csproj
+++ b/apps/api/src/Api/Api.csproj
@@ -62,6 +62,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="9.0.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageReference Include="SkiaSharp" Version="3.119.2" />
     <PackageReference Include="SlackNet" Version="0.17.9" />
     <PackageReference Include="StackExchange.Redis" Version="2.10.1" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.0" />

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/HybridLlmService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/HybridLlmService.cs
@@ -426,6 +426,151 @@ internal class HybridLlmService : ILlmService
         }
     }
 
+    /// <inheritdoc/>
+    public async Task<LlmCompletionResult> GenerateMultimodalCompletionAsync(
+        IReadOnlyList<LlmMessage> messages,
+        RequestSource source = RequestSource.Manual,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(messages);
+        if (messages.Count == 0)
+        {
+            return LlmCompletionResult.CreateFailure("No messages provided");
+        }
+
+        var needsVision = messages.Any(m => m.HasImages);
+
+        // Try to find a vision-capable provider first
+        if (needsVision)
+        {
+            var visionClient = _clients.FirstOrDefault(c => c.SupportsVision);
+            if (visionClient != null)
+            {
+                var selection = await _providerSelector.SelectProviderAsync(
+                    LlmUserContext.Anonymous, RagStrategy.Balanced, source, ct).ConfigureAwait(false);
+                var decision = selection.Decision;
+
+                // Prefer the routed provider if it supports vision, else use first vision provider
+                var client = selection.Client?.SupportsVision == true ? selection.Client : visionClient;
+
+                _logger.LogInformation(
+                    "Generating multimodal completion via {Provider} ({Model})",
+                    client.ProviderName, decision.ModelId);
+
+                var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+                try
+                {
+                    var result = await client.GenerateCompletionAsync(
+                        decision.ModelId, messages, DefaultTemperature, DefaultMaxTokens, ct).ConfigureAwait(false);
+
+                    stopwatch.Stop();
+
+                    if (result.Success)
+                    {
+                        _providerSelector.RecordSuccess(client.ProviderName, decision.ModelId, stopwatch.ElapsedMilliseconds, result);
+                        await _costService.LogSuccessAsync(result, LlmUserContext.Anonymous, stopwatch.ElapsedMilliseconds, source, ct).ConfigureAwait(false);
+                        return result;
+                    }
+
+                    _providerSelector.RecordFailure(client.ProviderName, decision.ModelId, stopwatch.ElapsedMilliseconds, result);
+                }
+                catch (Exception ex)
+                {
+                    stopwatch.Stop();
+                    _logger.LogError(ex, "Error generating multimodal completion with {Provider}", client.ProviderName);
+                    _providerSelector.RecordFailure(client.ProviderName, decision.ModelId, stopwatch.ElapsedMilliseconds);
+                }
+            }
+            else
+            {
+                _logger.LogWarning("No vision-capable provider available, falling back to text-only");
+            }
+        }
+
+        // Fallback: extract text from messages and use standard text-only completion
+        var systemParts = messages.Where(m => string.Equals(m.Role, "system", StringComparison.Ordinal))
+            .SelectMany(m => m.Content.OfType<TextContentPart>().Select(t => t.Text));
+        var userParts = messages.Where(m => string.Equals(m.Role, "user", StringComparison.Ordinal))
+            .SelectMany(m => m.Content.OfType<TextContentPart>().Select(t => t.Text));
+
+        var systemPrompt = string.Join("\n", systemParts);
+        var userPrompt = string.Join("\n", userParts);
+
+        if (string.IsNullOrWhiteSpace(userPrompt))
+        {
+            return LlmCompletionResult.CreateFailure("No text content found in messages");
+        }
+
+        return await GenerateCompletionAsync(systemPrompt, userPrompt, source, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+#pragma warning disable S3400 // Methods should not return constants - async iterator pattern requires this signature
+#pragma warning disable S4456 // Parameter validation on async iterator - validated before yield
+    public async IAsyncEnumerable<StreamChunk> GenerateMultimodalCompletionStreamAsync(
+        IReadOnlyList<LlmMessage> messages,
+        RequestSource source = RequestSource.Manual,
+        [EnumeratorCancellation] CancellationToken ct = default)
+#pragma warning restore S4456
+#pragma warning restore S3400
+    {
+        ArgumentNullException.ThrowIfNull(messages);
+        if (messages.Count == 0)
+        {
+            _logger.LogWarning("No messages provided for multimodal streaming");
+            yield break;
+        }
+
+        var needsVision = messages.Any(m => m.HasImages);
+
+        if (needsVision)
+        {
+            var visionClient = _clients.FirstOrDefault(c => c.SupportsVision);
+            if (visionClient != null)
+            {
+                var selection = await _providerSelector.SelectProviderAsync(
+                    LlmUserContext.Anonymous, RagStrategy.Balanced, source, ct).ConfigureAwait(false);
+                var decision = selection.Decision;
+
+                var client = selection.Client?.SupportsVision == true ? selection.Client : visionClient;
+
+                _logger.LogInformation(
+                    "Starting multimodal streaming via {Provider} ({Model})",
+                    client.ProviderName, decision.ModelId);
+
+                await foreach (var chunk in client.GenerateCompletionStreamAsync(
+                    decision.ModelId, messages, DefaultTemperature, DefaultMaxTokens, ct).ConfigureAwait(false))
+                {
+                    yield return chunk;
+                }
+
+                yield break;
+            }
+
+            _logger.LogWarning("No vision-capable provider available for streaming, falling back to text-only");
+        }
+
+        // Fallback: extract text and use standard streaming
+        var systemParts = messages.Where(m => string.Equals(m.Role, "system", StringComparison.Ordinal))
+            .SelectMany(m => m.Content.OfType<TextContentPart>().Select(t => t.Text));
+        var userParts = messages.Where(m => string.Equals(m.Role, "user", StringComparison.Ordinal))
+            .SelectMany(m => m.Content.OfType<TextContentPart>().Select(t => t.Text));
+
+        var systemPrompt = string.Join("\n", systemParts);
+        var userPrompt = string.Join("\n", userParts);
+
+        if (string.IsNullOrWhiteSpace(userPrompt))
+        {
+            _logger.LogWarning("No text content found in messages for streaming");
+            yield break;
+        }
+
+        await foreach (var chunk in GenerateCompletionStreamAsync(systemPrompt, userPrompt, source, ct).ConfigureAwait(false))
+        {
+            yield return chunk;
+        }
+    }
+
     private void AddRoutingMetadata(
         LlmCompletionResult result,
         LlmRoutingDecision decision,

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/VisionTierLimits.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/VisionTierLimits.cs
@@ -1,0 +1,33 @@
+namespace Api.BoundedContexts.KnowledgeBase.Domain;
+
+/// <summary>
+/// Configuration limits for vision features per user tier.
+/// </summary>
+internal record VisionTierConfig(
+    int MaxImagesPerMessage, int MaxSnapshotsPerSession,
+    int MaxImagesPerSnapshot, int MaxImageResolution,
+    bool GameStateExtractionEnabled);
+
+/// <summary>
+/// Static lookup for vision tier configurations.
+/// Maps user tier names to their vision feature limits.
+/// </summary>
+internal static class VisionTierLimits
+{
+    private static readonly IReadOnlyDictionary<string, VisionTierConfig> TierConfigs =
+        new Dictionary<string, VisionTierConfig>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["alpha"] = new(5, 20, 5, 2048, true),
+            ["free"] = new(2, 5, 3, 1024, false),
+            ["premium"] = new(5, 30, 10, 2048, true),
+        };
+
+    private static readonly VisionTierConfig DefaultConfig = TierConfigs["free"];
+
+    /// <summary>
+    /// Get the vision tier configuration for the given tier name.
+    /// Falls back to the "free" tier if the tier name is null or unrecognized.
+    /// </summary>
+    public static VisionTierConfig GetConfig(string? tier) =>
+        tier is null ? DefaultConfig : TierConfigs.GetValueOrDefault(tier, DefaultConfig);
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs
@@ -32,6 +32,7 @@ using Api.BoundedContexts.KnowledgeBase.Infrastructure.Scheduling;
 using Api.BoundedContexts.KnowledgeBase.Infrastructure.Services;
 using Api.Infrastructure.Seeders.Catalog.SeedBlob;
 using Api.Services;
+using Api.Services.ImageProcessing;
 using Api.Services.LlmClients;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Quartz;
@@ -218,6 +219,9 @@ internal static class KnowledgeBaseServiceExtensions
 
         // Issue #27: User region detection from Accept-Language header (Scoped - uses IHttpContextAccessor)
         services.AddScoped<IUserRegionDetector, UserRegionDetector>();
+
+        // Image preprocessing for vision-capable LLM models
+        services.AddSingleton<IImagePreprocessor, SkiaImagePreprocessor>();
 
         // Application Services - Hybrid LLM Service (Scoped - may use request context)
         // Issue #5487/#5489: Delegates to ILlmProviderSelector, ICircuitBreakerRegistry, ILlmCostService

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandHandlers.cs
@@ -1,10 +1,13 @@
 using MediatR;
 using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.Services;
 using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Events;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
 using Api.Middleware.Exceptions;
 using Api.Services;
+using Api.Services.ImageProcessing;
+using Api.Services.LlmClients;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.SessionTracking.Application.Commands;
@@ -96,6 +99,7 @@ public class SendSystemEventCommandHandler : IRequestHandler<SendSystemEventComm
 /// <summary>
 /// Handler for asking the RAG agent a question in session context.
 /// Issue #5313: Wired to real HybridLlmService for LLM completions.
+/// Supports optional image attachments for vision-based game state analysis.
 /// </summary>
 internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCommand, AskSessionAgentResult>
 {
@@ -103,6 +107,8 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
     private readonly ISessionChatRepository _chatRepository;
     private readonly IMediator _mediator;
     private readonly ILlmService _llmService;
+    private readonly IImagePreprocessor _imagePreprocessor;
+    private readonly IGameStateExtractor _gameStateExtractor;
     private readonly ILogger<AskSessionAgentCommandHandler> _logger;
 
     public AskSessionAgentCommandHandler(
@@ -110,12 +116,16 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
         ISessionChatRepository chatRepository,
         IMediator mediator,
         ILlmService llmService,
+        IImagePreprocessor imagePreprocessor,
+        IGameStateExtractor gameStateExtractor,
         ILogger<AskSessionAgentCommandHandler> logger)
     {
         _sessionRepository = sessionRepository;
         _chatRepository = chatRepository;
         _mediator = mediator;
         _llmService = llmService;
+        _imagePreprocessor = imagePreprocessor;
+        _gameStateExtractor = gameStateExtractor;
         _logger = logger;
     }
 
@@ -139,32 +149,88 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
         await _chatRepository.AddAsync(userMessage, cancellationToken).ConfigureAwait(false);
         await _chatRepository.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
-        // Call LLM for real response
+        // Extract game state from latest vision snapshot (non-blocking, returns cached if available)
+        var gameState = await _gameStateExtractor.ExtractIfNeededAsync(
+            request.SessionId, null, cancellationToken).ConfigureAwait(false);
+
+        // Build system prompt with optional game state context
         var agentType = "tutor";
         var systemPrompt = $"You are a helpful board game tutor assisting during a game session (Game ID: {session.GameId}). " +
                            "Answer questions about rules, strategy, and gameplay concisely.";
 
+        if (!string.IsNullOrWhiteSpace(gameState))
+        {
+            systemPrompt += $"\n\nCurrent game state from board analysis:\n{gameState}";
+        }
+
         string answer;
         float? confidence;
+        var hasImages = request.Images is { Count: > 0 };
 
         try
         {
-            var result = await _llmService.GenerateCompletionAsync(
-                systemPrompt,
-                request.Question,
-                RequestSource.AgentTask,
-                cancellationToken).ConfigureAwait(false);
-
-            if (result.Success)
+            if (hasImages)
             {
-                answer = result.Response;
-                confidence = 0.85f;
+                // Vision path: process images and build multimodal messages
+                var contentParts = new List<ContentPart>();
+
+                foreach (var img in request.Images!)
+                {
+                    var processed = await _imagePreprocessor.ProcessAsync(
+                        img.Data, img.MediaType).ConfigureAwait(false);
+                    var base64 = Convert.ToBase64String(processed.Data);
+                    contentParts.Add(new ImageContentPart(base64, processed.MediaType));
+                }
+
+                contentParts.Add(new TextContentPart(request.Question));
+
+                var messages = new List<LlmMessage>
+                {
+                    LlmMessage.FromText("system", systemPrompt),
+                    new("user", contentParts)
+                };
+
+                var result = await _llmService.GenerateMultimodalCompletionAsync(
+                    (IReadOnlyList<LlmMessage>)messages,
+                    RequestSource.AgentTask,
+                    cancellationToken).ConfigureAwait(false);
+
+                if (result.Success)
+                {
+                    answer = result.Response;
+                    confidence = 0.85f;
+                }
+                else
+                {
+                    _logger.LogWarning(
+                        "Multimodal LLM completion failed for session {SessionId}: {Error}",
+                        request.SessionId, result.ErrorMessage);
+                    answer = "I'm sorry, I couldn't analyze the image right now. Please try again.";
+                    confidence = null;
+                }
             }
             else
             {
-                _logger.LogWarning("LLM completion failed for session {SessionId}: {Error}", request.SessionId, result.ErrorMessage);
-                answer = "I'm sorry, I couldn't process your question right now. Please try again.";
-                confidence = null;
+                // Text-only path (existing behavior)
+                var result = await _llmService.GenerateCompletionAsync(
+                    systemPrompt,
+                    request.Question,
+                    RequestSource.AgentTask,
+                    cancellationToken).ConfigureAwait(false);
+
+                if (result.Success)
+                {
+                    answer = result.Response;
+                    confidence = 0.85f;
+                }
+                else
+                {
+                    _logger.LogWarning(
+                        "LLM completion failed for session {SessionId}: {Error}",
+                        request.SessionId, result.ErrorMessage);
+                    answer = "I'm sorry, I couldn't process your question right now. Please try again.";
+                    confidence = null;
+                }
             }
         }
         catch (Exception ex)

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandValidators.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandValidators.cs
@@ -24,12 +24,29 @@ public class SendSystemEventCommandValidator : AbstractValidator<SendSystemEvent
 
 public class AskSessionAgentCommandValidator : AbstractValidator<AskSessionAgentCommand>
 {
+    private const int MaxImages = 4;
+    private const long MaxImageBytes = 10_000_000; // 10 MB per image (pre-processing)
+
     public AskSessionAgentCommandValidator()
     {
         RuleFor(x => x.SessionId).NotEmpty().WithMessage("Session ID is required.");
         RuleFor(x => x.SenderId).NotEmpty().WithMessage("Sender ID is required.");
         RuleFor(x => x.Question).NotEmpty().MaximumLength(2000)
             .WithMessage("Question must be 1-2000 characters.");
+        RuleFor(x => x.Images)
+            .Must(imgs => imgs is null || imgs.Count <= MaxImages)
+            .WithMessage($"Maximum {MaxImages} images per request.");
+        RuleForEach(x => x.Images)
+            .ChildRules(img =>
+            {
+                img.RuleFor(i => i.Data)
+                    .NotEmpty().WithMessage("Image data must not be empty.")
+                    .Must(d => d.Length <= MaxImageBytes)
+                    .WithMessage($"Each image must be under {MaxImageBytes / 1_000_000} MB.");
+                img.RuleFor(i => i.MediaType)
+                    .NotEmpty().WithMessage("Image media type is required.");
+            })
+            .When(x => x.Images is { Count: > 0 });
     }
 }
 

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommands.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommands.cs
@@ -26,13 +26,20 @@ public record SendSystemEventCommand(
 ) : IRequest<SendChatMessageResult>;
 
 /// <summary>
+/// Image attachment for the ask-agent command (multipart upload).
+/// </summary>
+public record ChatImageAttachment(byte[] Data, string MediaType, string? FileName);
+
+/// <summary>
 /// Command to ask the RAG agent a question in session context.
+/// Supports optional image attachments for vision-based game state analysis.
 /// </summary>
 public record AskSessionAgentCommand(
     Guid SessionId,
     Guid SenderId,
     string Question,
-    int? TurnNumber
+    int? TurnNumber,
+    List<ChatImageAttachment>? Images = null
 ) : IRequest<AskSessionAgentResult>;
 
 public record AskSessionAgentResult(

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/VisionSnapshotCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/VisionSnapshotCommandHandler.cs
@@ -1,0 +1,133 @@
+using Api.BoundedContexts.KnowledgeBase.Domain;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.Services.ImageProcessing;
+using Api.Services.Pdf;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Handler for creating a vision snapshot with image upload, preprocessing, and storage.
+/// Session Vision AI feature.
+/// </summary>
+internal sealed class CreateVisionSnapshotCommandHandler
+    : IRequestHandler<CreateVisionSnapshotCommand, CreateVisionSnapshotResult>
+{
+    private readonly ISessionRepository _sessionRepository;
+    private readonly IVisionSnapshotRepository _snapshotRepository;
+    private readonly IImagePreprocessor _imagePreprocessor;
+    private readonly IBlobStorageService _blobStorageService;
+    private readonly ILogger<CreateVisionSnapshotCommandHandler> _logger;
+
+    public CreateVisionSnapshotCommandHandler(
+        ISessionRepository sessionRepository,
+        IVisionSnapshotRepository snapshotRepository,
+        IImagePreprocessor imagePreprocessor,
+        IBlobStorageService blobStorageService,
+        ILogger<CreateVisionSnapshotCommandHandler> logger)
+    {
+        _sessionRepository = sessionRepository;
+        _snapshotRepository = snapshotRepository;
+        _imagePreprocessor = imagePreprocessor;
+        _blobStorageService = blobStorageService;
+        _logger = logger;
+    }
+
+    public async Task<CreateVisionSnapshotResult> Handle(
+        CreateVisionSnapshotCommand request,
+        CancellationToken cancellationToken)
+    {
+        // 1. Validate session exists
+        _ = await _sessionRepository.GetByIdAsync(request.SessionId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {request.SessionId} not found");
+
+        // 2. Validate tier limits (hardcoded to "alpha" for now)
+        var tierConfig = VisionTierLimits.GetConfig("alpha");
+
+        var existingCount = await _snapshotRepository
+            .CountBySessionIdAsync(request.SessionId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (existingCount >= tierConfig.MaxSnapshotsPerSession)
+        {
+            throw new ConflictException(
+                $"Maximum snapshots per session reached ({tierConfig.MaxSnapshotsPerSession}).");
+        }
+
+        if (request.Images.Count == 0)
+        {
+            throw new BadRequestException("At least one image is required.");
+        }
+
+        if (request.Images.Count > tierConfig.MaxImagesPerSnapshot)
+        {
+            throw new BadRequestException(
+                $"Maximum {tierConfig.MaxImagesPerSnapshot} images per snapshot.");
+        }
+
+        // 3. Create snapshot entity
+        var snapshot = VisionSnapshot.Create(
+            request.SessionId,
+            request.UserId,
+            request.TurnNumber,
+            request.Caption);
+
+        // 4. Process and store each image
+        var gameIdForStorage = request.SessionId.ToString("N");
+
+        foreach (var imageUpload in request.Images)
+        {
+            try
+            {
+                // Preprocess image (resize, compress)
+                var processed = await _imagePreprocessor
+                    .ProcessAsync(imageUpload.Data, imageUpload.MediaType)
+                    .ConfigureAwait(false);
+
+                // Store in blob storage
+                using var stream = new MemoryStream(processed.Data);
+                var fileName = imageUpload.FileName ?? $"snapshot_{snapshot.Id:N}_{snapshot.Images.Count}.jpg";
+
+                var storageResult = await _blobStorageService
+                    .StoreAsync(stream, fileName, gameIdForStorage, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (!storageResult.Success || storageResult.FileId is null)
+                {
+                    _logger.LogWarning(
+                        "Failed to store vision snapshot image for session {SessionId}: {Error}",
+                        request.SessionId, storageResult.ErrorMessage);
+                    continue;
+                }
+
+                snapshot.AddImage(storageResult.FileId, processed.MediaType, processed.Width, processed.Height);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Error processing vision snapshot image for session {SessionId}",
+                    request.SessionId);
+                // Continue with remaining images — don't fail the whole snapshot
+            }
+        }
+
+        if (snapshot.Images.Count == 0)
+        {
+            throw new BadRequestException("No images could be processed successfully.");
+        }
+
+        // 5. Persist
+        await _snapshotRepository.AddAsync(snapshot, cancellationToken).ConfigureAwait(false);
+        await _snapshotRepository.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Created vision snapshot {SnapshotId} for session {SessionId} with {ImageCount} images",
+            snapshot.Id, request.SessionId, snapshot.Images.Count);
+
+        return new CreateVisionSnapshotResult(snapshot.Id, snapshot.Images.Count);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/VisionSnapshotCommands.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/VisionSnapshotCommands.cs
@@ -1,0 +1,25 @@
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Data for a single image being uploaded as part of a vision snapshot.
+/// </summary>
+internal record VisionSnapshotImageUpload(byte[] Data, string MediaType, string? FileName);
+
+/// <summary>
+/// Command to create a vision snapshot of the board state with uploaded images.
+/// Session Vision AI feature.
+/// </summary>
+internal record CreateVisionSnapshotCommand(
+    Guid SessionId,
+    Guid UserId,
+    int TurnNumber,
+    string? Caption,
+    List<VisionSnapshotImageUpload> Images
+) : IRequest<CreateVisionSnapshotResult>;
+
+/// <summary>
+/// Result of creating a vision snapshot.
+/// </summary>
+internal record CreateVisionSnapshotResult(Guid SnapshotId, int ImageCount);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/VisionSnapshotQueries.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/VisionSnapshotQueries.cs
@@ -1,0 +1,45 @@
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+/// <summary>
+/// DTO for a vision snapshot.
+/// </summary>
+internal record VisionSnapshotDto(
+    Guid Id,
+    Guid SessionId,
+    int TurnNumber,
+    string? Caption,
+    bool HasGameState,
+    DateTime CreatedAt,
+    List<VisionSnapshotImageDto> Images);
+
+/// <summary>
+/// DTO for a vision snapshot image.
+/// </summary>
+internal record VisionSnapshotImageDto(
+    Guid Id,
+    string? DownloadUrl,
+    string MediaType,
+    int Width,
+    int Height,
+    int OrderIndex);
+
+/// <summary>
+/// DTO for game state extraction result.
+/// </summary>
+internal record GameStateResult(
+    Guid SnapshotId,
+    string? GameStateJson,
+    bool IsExtracted,
+    DateTime SnapshotCreatedAt);
+
+/// <summary>
+/// Query to get all vision snapshots for a session.
+/// </summary>
+internal record GetVisionSnapshotsQuery(Guid SessionId) : IRequest<List<VisionSnapshotDto>>;
+
+/// <summary>
+/// Query to get the latest extracted game state for a session.
+/// </summary>
+internal record GetLatestGameStateQuery(Guid SessionId) : IRequest<GameStateResult?>;

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/VisionSnapshotQueryHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/VisionSnapshotQueryHandlers.cs
@@ -1,0 +1,100 @@
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Services.Pdf;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+/// <summary>
+/// Handler for listing vision snapshots with presigned image URLs.
+/// Session Vision AI feature.
+/// </summary>
+internal sealed class GetVisionSnapshotsQueryHandler
+    : IRequestHandler<GetVisionSnapshotsQuery, List<VisionSnapshotDto>>
+{
+    private readonly IVisionSnapshotRepository _snapshotRepository;
+    private readonly IBlobStorageService _blobStorageService;
+
+    public GetVisionSnapshotsQueryHandler(
+        IVisionSnapshotRepository snapshotRepository,
+        IBlobStorageService blobStorageService)
+    {
+        _snapshotRepository = snapshotRepository;
+        _blobStorageService = blobStorageService;
+    }
+
+    public async Task<List<VisionSnapshotDto>> Handle(
+        GetVisionSnapshotsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var snapshots = await _snapshotRepository
+            .GetBySessionIdAsync(request.SessionId, cancellationToken)
+            .ConfigureAwait(false);
+
+        var gameIdForStorage = request.SessionId.ToString("N");
+        var result = new List<VisionSnapshotDto>(snapshots.Count);
+
+        foreach (var snapshot in snapshots)
+        {
+            var imageDtos = new List<VisionSnapshotImageDto>(snapshot.Images.Count);
+
+            foreach (var image in snapshot.Images)
+            {
+                var downloadUrl = await _blobStorageService
+                    .GetPresignedDownloadUrlAsync(image.StorageKey, gameIdForStorage)
+                    .ConfigureAwait(false);
+
+                imageDtos.Add(new VisionSnapshotImageDto(
+                    image.Id,
+                    downloadUrl,
+                    image.MediaType,
+                    image.Width,
+                    image.Height,
+                    image.OrderIndex));
+            }
+
+            result.Add(new VisionSnapshotDto(
+                snapshot.Id,
+                snapshot.SessionId,
+                snapshot.TurnNumber,
+                snapshot.Caption,
+                snapshot.ExtractedGameState is not null,
+                snapshot.CreatedAt,
+                imageDtos));
+        }
+
+        return result;
+    }
+}
+
+/// <summary>
+/// Handler for getting the latest extracted game state for a session.
+/// Session Vision AI feature.
+/// </summary>
+internal sealed class GetLatestGameStateQueryHandler
+    : IRequestHandler<GetLatestGameStateQuery, GameStateResult?>
+{
+    private readonly IVisionSnapshotRepository _snapshotRepository;
+
+    public GetLatestGameStateQueryHandler(IVisionSnapshotRepository snapshotRepository)
+    {
+        _snapshotRepository = snapshotRepository;
+    }
+
+    public async Task<GameStateResult?> Handle(
+        GetLatestGameStateQuery request,
+        CancellationToken cancellationToken)
+    {
+        var latest = await _snapshotRepository
+            .GetLatestBySessionIdAsync(request.SessionId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (latest is null)
+            return null;
+
+        return new GameStateResult(
+            latest.Id,
+            latest.ExtractedGameState,
+            latest.ExtractedGameState is not null,
+            latest.CreatedAt);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Services/IGameStateExtractor.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Services/IGameStateExtractor.cs
@@ -1,0 +1,15 @@
+namespace Api.BoundedContexts.SessionTracking.Application.Services;
+
+/// <summary>
+/// Extracts structured game state from vision snapshot images using multimodal LLM.
+/// Session Vision AI feature.
+/// </summary>
+internal interface IGameStateExtractor
+{
+    /// <summary>
+    /// Extract game state from the latest snapshot for a session.
+    /// Returns null if extraction fails or confidence is too low (never blocks).
+    /// Idempotent: returns cached result if already extracted.
+    /// </summary>
+    Task<string?> ExtractIfNeededAsync(Guid sessionId, string? gameName, CancellationToken ct = default);
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/VisionSnapshot.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/VisionSnapshot.cs
@@ -1,0 +1,94 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Api.BoundedContexts.SessionTracking.Domain.Entities;
+
+/// <summary>
+/// A photo snapshot of the board state during a live session.
+/// Supports vision AI extraction of game state from images.
+/// Session Vision AI feature.
+/// </summary>
+public class VisionSnapshot
+{
+    private readonly List<VisionSnapshotImage> _images = [];
+
+    public Guid Id { get; private set; }
+    public Guid SessionId { get; private set; }
+    public Guid UserId { get; private set; }
+    public int TurnNumber { get; private set; }
+
+    [MaxLength(200)]
+    public string? Caption { get; private set; }
+
+    public string? ExtractedGameState { get; private set; }
+    public IReadOnlyList<VisionSnapshotImage> Images => _images.AsReadOnly();
+    public DateTime CreatedAt { get; private set; } = DateTime.UtcNow;
+    public DateTime? UpdatedAt { get; private set; }
+    public bool IsDeleted { get; private set; }
+    public DateTime? DeletedAt { get; private set; }
+
+    private VisionSnapshot() { }
+
+    public static VisionSnapshot Create(Guid sessionId, Guid userId, int turnNumber, string? caption)
+    {
+        if (sessionId == Guid.Empty) throw new ArgumentException("Session ID required.", nameof(sessionId));
+        if (userId == Guid.Empty) throw new ArgumentException("User ID required.", nameof(userId));
+        ArgumentOutOfRangeException.ThrowIfNegative(turnNumber);
+        if (caption?.Length > 200) throw new ArgumentException("Caption max 200 chars.", nameof(caption));
+
+        return new VisionSnapshot
+        {
+            Id = Guid.NewGuid(),
+            SessionId = sessionId,
+            UserId = userId,
+            TurnNumber = turnNumber,
+            Caption = caption
+        };
+    }
+
+    public void AddImage(string storageKey, string mediaType, int width, int height)
+    {
+        if (string.IsNullOrWhiteSpace(storageKey))
+            throw new ArgumentException("Storage key required.", nameof(storageKey));
+
+        _images.Add(new VisionSnapshotImage
+        {
+            Id = Guid.NewGuid(),
+            StorageKey = storageKey,
+            MediaType = mediaType,
+            Width = width,
+            Height = height,
+            OrderIndex = _images.Count
+        });
+    }
+
+    public void UpdateGameState(string gameStateJson)
+    {
+        ExtractedGameState = gameStateJson ?? throw new ArgumentNullException(nameof(gameStateJson));
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    public void SoftDelete()
+    {
+        IsDeleted = true;
+        DeletedAt = DateTime.UtcNow;
+    }
+}
+
+/// <summary>
+/// An image attached to a vision snapshot (photo of the board).
+/// </summary>
+public class VisionSnapshotImage
+{
+    public Guid Id { get; internal set; }
+
+    [MaxLength(500)]
+    public string StorageKey { get; internal set; } = string.Empty;
+
+    [MaxLength(50)]
+    public string MediaType { get; internal set; } = string.Empty;
+
+    public int Width { get; internal set; }
+    public int Height { get; internal set; }
+    public int OrderIndex { get; internal set; }
+    public Guid VisionSnapshotId { get; internal set; }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Repositories/IVisionSnapshotRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Repositories/IVisionSnapshotRepository.cs
@@ -1,0 +1,18 @@
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+
+namespace Api.BoundedContexts.SessionTracking.Domain.Repositories;
+
+/// <summary>
+/// Repository interface for VisionSnapshot persistence operations.
+/// Session Vision AI feature.
+/// </summary>
+internal interface IVisionSnapshotRepository
+{
+    Task<VisionSnapshot?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<List<VisionSnapshot>> GetBySessionIdAsync(Guid sessionId, CancellationToken ct = default);
+    Task<VisionSnapshot?> GetLatestBySessionIdAsync(Guid sessionId, CancellationToken ct = default);
+    Task AddAsync(VisionSnapshot snapshot, CancellationToken ct = default);
+    Task UpdateAsync(VisionSnapshot snapshot, CancellationToken ct = default);
+    Task<int> CountBySessionIdAsync(Guid sessionId, CancellationToken ct = default);
+    Task SaveChangesAsync(CancellationToken ct = default);
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/DependencyInjection/SessionTrackingServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/DependencyInjection/SessionTrackingServiceExtensions.cs
@@ -34,6 +34,7 @@ internal static class SessionTrackingServiceExtensions
         services.AddScoped<IToolkitSessionStateRepository, ToolkitSessionStateRepository>(); // ISSUE-5148: Epic B5
         services.AddScoped<ISessionEventRepository, SessionEventRepository>(); // ISSUE-276: Session Diary / Timeline
         services.AddScoped<ISessionCheckpointRepository, SessionCheckpointRepository>(); // ISSUE-278: Session Checkpoint / Deep Save
+        services.AddScoped<IVisionSnapshotRepository, VisionSnapshotRepository>(); // Session Vision AI
 
         // Register Unit of Work
         services.AddScoped<IUnitOfWork, EfCoreUnitOfWork>();
@@ -61,6 +62,9 @@ internal static class SessionTrackingServiceExtensions
         services.TryAddSingleton(TimeProvider.System);
         services.AddSingleton<IAutoSaveHealthTracker, AutoSaveHealthTracker>();
         services.AddHostedService<AutoSaveHealthLoggerService>();
+
+        // Session Vision AI
+        services.AddScoped<IGameStateExtractor, GameStateExtractor>();
 
         // MediatR handlers are auto-registered via assembly scanning in Program.cs
 

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/Configurations/VisionSnapshotConfiguration.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/Configurations/VisionSnapshotConfiguration.cs
@@ -1,0 +1,126 @@
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.BoundedContexts.SessionTracking.Infrastructure.Persistence.Configurations;
+
+/// <summary>
+/// EF Core configuration for VisionSnapshot.
+/// Uses direct domain entity mapping (no separate persistence entity).
+/// Session Vision AI feature.
+/// </summary>
+internal sealed class VisionSnapshotConfiguration : IEntityTypeConfiguration<VisionSnapshot>
+{
+    public void Configure(EntityTypeBuilder<VisionSnapshot> builder)
+    {
+        builder.ToTable("vision_snapshots");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id)
+            .HasColumnName("id")
+            .ValueGeneratedNever();
+
+        builder.Property(e => e.SessionId)
+            .HasColumnName("session_id")
+            .IsRequired();
+
+        builder.Property(e => e.UserId)
+            .HasColumnName("user_id")
+            .IsRequired();
+
+        builder.Property(e => e.TurnNumber)
+            .HasColumnName("turn_number")
+            .IsRequired();
+
+        builder.Property(e => e.Caption)
+            .HasColumnName("caption")
+            .HasMaxLength(200);
+
+        builder.Property(e => e.ExtractedGameState)
+            .HasColumnName("extracted_game_state")
+            .HasColumnType("jsonb");
+
+        builder.Property(e => e.CreatedAt)
+            .HasColumnName("created_at")
+            .IsRequired();
+
+        builder.Property(e => e.UpdatedAt)
+            .HasColumnName("updated_at");
+
+        builder.Property(e => e.IsDeleted)
+            .HasColumnName("is_deleted")
+            .HasDefaultValue(false)
+            .IsRequired();
+
+        builder.Property(e => e.DeletedAt)
+            .HasColumnName("deleted_at");
+
+        // Soft delete query filter
+        builder.HasQueryFilter(e => !e.IsDeleted);
+
+        // Navigation to images
+        builder.HasMany(e => e.Images)
+            .WithOne()
+            .HasForeignKey(e => e.VisionSnapshotId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Indexes
+        builder.HasIndex(e => e.SessionId)
+            .HasDatabaseName("ix_vision_snapshots_session_id");
+
+        builder.HasIndex(e => new { e.SessionId, e.TurnNumber })
+            .HasDatabaseName("ix_vision_snapshots_session_turn");
+
+        builder.HasIndex(e => e.IsDeleted)
+            .HasDatabaseName("ix_vision_snapshots_is_deleted");
+    }
+}
+
+/// <summary>
+/// EF Core configuration for VisionSnapshotImage.
+/// Session Vision AI feature.
+/// </summary>
+internal sealed class VisionSnapshotImageConfiguration : IEntityTypeConfiguration<VisionSnapshotImage>
+{
+    public void Configure(EntityTypeBuilder<VisionSnapshotImage> builder)
+    {
+        builder.ToTable("vision_snapshot_images");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id)
+            .HasColumnName("id")
+            .ValueGeneratedNever();
+
+        builder.Property(e => e.StorageKey)
+            .HasColumnName("storage_key")
+            .HasMaxLength(500)
+            .IsRequired();
+
+        builder.Property(e => e.MediaType)
+            .HasColumnName("media_type")
+            .HasMaxLength(50)
+            .IsRequired();
+
+        builder.Property(e => e.Width)
+            .HasColumnName("width")
+            .IsRequired();
+
+        builder.Property(e => e.Height)
+            .HasColumnName("height")
+            .IsRequired();
+
+        builder.Property(e => e.OrderIndex)
+            .HasColumnName("order_index")
+            .IsRequired();
+
+        builder.Property(e => e.VisionSnapshotId)
+            .HasColumnName("vision_snapshot_id")
+            .IsRequired();
+
+        // Indexes
+        builder.HasIndex(e => e.VisionSnapshotId)
+            .HasDatabaseName("ix_vision_snapshot_images_snapshot_id");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/VisionSnapshotRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/VisionSnapshotRepository.cs
@@ -1,0 +1,74 @@
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SessionTracking.Infrastructure.Persistence;
+
+/// <summary>
+/// EF Core implementation of IVisionSnapshotRepository.
+/// Uses direct domain entity mapping (no separate persistence entity).
+/// Session Vision AI feature.
+/// </summary>
+internal sealed class VisionSnapshotRepository : RepositoryBase, IVisionSnapshotRepository
+{
+    public VisionSnapshotRepository(MeepleAiDbContext dbContext, IDomainEventCollector eventCollector)
+        : base(dbContext, eventCollector)
+    {
+    }
+
+    public async Task<VisionSnapshot?> GetByIdAsync(Guid id, CancellationToken ct = default)
+    {
+        return await DbContext.VisionSnapshots
+            .Include(s => s.Images.OrderBy(i => i.OrderIndex))
+            .FirstOrDefaultAsync(s => s.Id == id, ct)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<List<VisionSnapshot>> GetBySessionIdAsync(Guid sessionId, CancellationToken ct = default)
+    {
+        return await DbContext.VisionSnapshots
+            .Include(s => s.Images.OrderBy(i => i.OrderIndex))
+            .Where(s => s.SessionId == sessionId)
+            .OrderByDescending(s => s.CreatedAt)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<VisionSnapshot?> GetLatestBySessionIdAsync(Guid sessionId, CancellationToken ct = default)
+    {
+        return await DbContext.VisionSnapshots
+            .Include(s => s.Images.OrderBy(i => i.OrderIndex))
+            .Where(s => s.SessionId == sessionId)
+            .OrderByDescending(s => s.CreatedAt)
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+    }
+
+    public async Task AddAsync(VisionSnapshot snapshot, CancellationToken ct = default)
+    {
+        await DbContext.VisionSnapshots
+            .AddAsync(snapshot, ct)
+            .ConfigureAwait(false);
+    }
+
+    public Task UpdateAsync(VisionSnapshot snapshot, CancellationToken ct = default)
+    {
+        DbContext.VisionSnapshots.Update(snapshot);
+        return Task.CompletedTask;
+    }
+
+    public async Task<int> CountBySessionIdAsync(Guid sessionId, CancellationToken ct = default)
+    {
+        return await DbContext.VisionSnapshots
+            .CountAsync(s => s.SessionId == sessionId, ct)
+            .ConfigureAwait(false);
+    }
+
+    public async Task SaveChangesAsync(CancellationToken ct = default)
+    {
+        await DbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Services/GameStateExtractor.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Services/GameStateExtractor.cs
@@ -1,0 +1,187 @@
+using System.Text.Json;
+using Api.BoundedContexts.SessionTracking.Application.Services;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Services;
+using Api.Services.LlmClients;
+using Api.Services.Pdf;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SessionTracking.Infrastructure.Services;
+
+/// <summary>
+/// Extracts structured game state from vision snapshot images using multimodal LLM.
+/// Session Vision AI feature.
+/// </summary>
+internal sealed class GameStateExtractor : IGameStateExtractor
+{
+    private const double MinConfidence = 0.4;
+
+    private static readonly string SystemPrompt = """
+        You are a board game vision analyzer. Analyze the photo(s) of a board game in progress
+        and extract the current game state as structured JSON.
+
+        Return ONLY valid JSON with this structure:
+        {
+          "confidence": 0.0-1.0,
+          "game_phase": "setup|early|mid|late|end",
+          "visible_elements": {
+            "board_state": "description of the board",
+            "player_positions": [],
+            "resources": {},
+            "score_indicators": {},
+            "cards_visible": [],
+            "tokens_pieces": []
+          },
+          "observations": "brief natural language summary of what you see",
+          "turn_estimate": null
+        }
+
+        Be honest about confidence. If the image is blurry, partially obscured, or you cannot
+        identify the game, set confidence low. Only include elements you can actually see.
+        """;
+
+    private readonly IVisionSnapshotRepository _snapshotRepository;
+    private readonly ILlmService _llmService;
+    private readonly IBlobStorageService _blobStorageService;
+    private readonly ILogger<GameStateExtractor> _logger;
+
+    public GameStateExtractor(
+        IVisionSnapshotRepository snapshotRepository,
+        ILlmService llmService,
+        IBlobStorageService blobStorageService,
+        ILogger<GameStateExtractor> logger)
+    {
+        _snapshotRepository = snapshotRepository;
+        _llmService = llmService;
+        _blobStorageService = blobStorageService;
+        _logger = logger;
+    }
+
+    public async Task<string?> ExtractIfNeededAsync(Guid sessionId, string? gameName, CancellationToken ct = default)
+    {
+        try
+        {
+            // 1. Get latest snapshot for session
+            var snapshot = await _snapshotRepository
+                .GetLatestBySessionIdAsync(sessionId, ct)
+                .ConfigureAwait(false);
+
+            if (snapshot is null)
+            {
+                _logger.LogDebug("No vision snapshots found for session {SessionId}", sessionId);
+                return null;
+            }
+
+            // 2. Idempotent: if already extracted, return cached result
+            if (snapshot.ExtractedGameState is not null)
+            {
+                return snapshot.ExtractedGameState;
+            }
+
+            if (snapshot.Images.Count == 0)
+            {
+                _logger.LogDebug("Vision snapshot {SnapshotId} has no images", snapshot.Id);
+                return null;
+            }
+
+            // 3. Load images from blob storage and build multimodal message
+            var gameIdForStorage = sessionId.ToString("N");
+            var contentParts = new List<ContentPart>();
+
+            var userPromptText = gameName is not null
+                ? $"Analyze this photo of a {gameName} game in progress. Extract the visible game state."
+                : "Analyze this photo of a board game in progress. Extract the visible game state.";
+
+            contentParts.Add(new TextContentPart(userPromptText));
+
+            foreach (var image in snapshot.Images)
+            {
+                using var stream = await _blobStorageService
+                    .RetrieveAsync(image.StorageKey, gameIdForStorage, ct)
+                    .ConfigureAwait(false);
+
+                if (stream is null)
+                {
+                    _logger.LogWarning(
+                        "Could not retrieve image {StorageKey} for snapshot {SnapshotId}",
+                        image.StorageKey, snapshot.Id);
+                    continue;
+                }
+
+                using var ms = new MemoryStream();
+                await stream.CopyToAsync(ms, ct).ConfigureAwait(false);
+                var base64 = Convert.ToBase64String(ms.ToArray());
+
+                contentParts.Add(new ImageContentPart(base64, image.MediaType));
+            }
+
+            if (contentParts.Count <= 1) // Only text, no images loaded
+            {
+                _logger.LogWarning(
+                    "Could not load any images for snapshot {SnapshotId}", snapshot.Id);
+                return null;
+            }
+
+            // 4. Call multimodal LLM
+            var messages = new List<LlmMessage>
+            {
+                LlmMessage.FromText("system", SystemPrompt),
+                new("user", contentParts)
+            };
+
+            var result = await _llmService
+                .GenerateMultimodalCompletionAsync(messages, RequestSource.AgentTask, ct)
+                .ConfigureAwait(false);
+
+            if (!result.Success || string.IsNullOrWhiteSpace(result.Response))
+            {
+                _logger.LogWarning(
+                    "LLM extraction failed for snapshot {SnapshotId}: {Error}",
+                    snapshot.Id, result.ErrorMessage);
+                return null;
+            }
+
+            // 5. Parse and validate confidence
+            try
+            {
+                using var doc = JsonDocument.Parse(result.Response);
+                var confidence = doc.RootElement.TryGetProperty("confidence", out var confProp)
+                    ? confProp.GetDouble()
+                    : 0.0;
+
+                if (confidence < MinConfidence)
+                {
+                    _logger.LogInformation(
+                        "Game state extraction confidence too low ({Confidence:F2}) for snapshot {SnapshotId}",
+                        confidence, snapshot.Id);
+                    return null;
+                }
+
+                // 6. Save to snapshot and return
+                snapshot.UpdateGameState(result.Response);
+                await _snapshotRepository.UpdateAsync(snapshot, ct).ConfigureAwait(false);
+                await _snapshotRepository.SaveChangesAsync(ct).ConfigureAwait(false);
+
+                _logger.LogInformation(
+                    "Extracted game state for snapshot {SnapshotId} with confidence {Confidence:F2}",
+                    snapshot.Id, confidence);
+
+                return result.Response;
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogWarning(ex,
+                    "Failed to parse LLM response as JSON for snapshot {SnapshotId}",
+                    snapshot.Id);
+                return null;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Unexpected error during game state extraction for session {SessionId}",
+                sessionId);
+            return null; // Never block — extraction failures are non-critical
+        }
+    }
+}

--- a/apps/api/src/Api/DevTools/MockImpls/MockLlmService.cs
+++ b/apps/api/src/Api/DevTools/MockImpls/MockLlmService.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Api.DevTools.Scenarios;
 using Api.Services;
+using Api.Services.LlmClients;
 
 namespace Api.DevTools.MockImpls;
 
@@ -74,6 +75,40 @@ internal sealed class MockLlmService : ILlmService
         catch
         {
             return Task.FromResult<T?>(null);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<LlmCompletionResult> GenerateMultimodalCompletionAsync(
+        IReadOnlyList<LlmMessage> messages,
+        RequestSource source = RequestSource.Manual,
+        CancellationToken ct = default)
+    {
+        // Extract text from messages for mock response
+        var userText = string.Join(" ", messages
+            .Where(m => string.Equals(m.Role, "user", System.StringComparison.Ordinal))
+            .SelectMany(m => m.Content.OfType<TextContentPart>().Select(t => t.Text)));
+        var systemText = string.Join(" ", messages
+            .Where(m => string.Equals(m.Role, "system", System.StringComparison.Ordinal))
+            .SelectMany(m => m.Content.OfType<TextContentPart>().Select(t => t.Text)));
+        return GenerateCompletionAsync(systemText, userText, source, ct);
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<StreamChunk> GenerateMultimodalCompletionStreamAsync(
+        IReadOnlyList<LlmMessage> messages,
+        RequestSource source = RequestSource.Manual,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        var userText = string.Join(" ", messages
+            .Where(m => string.Equals(m.Role, "user", System.StringComparison.Ordinal))
+            .SelectMany(m => m.Content.OfType<TextContentPart>().Select(t => t.Text)));
+        var systemText = string.Join(" ", messages
+            .Where(m => string.Equals(m.Role, "system", System.StringComparison.Ordinal))
+            .SelectMany(m => m.Content.OfType<TextContentPart>().Select(t => t.Text)));
+        await foreach (var chunk in GenerateCompletionStreamAsync(systemText, userText, source, ct).ConfigureAwait(false))
+        {
+            yield return chunk;
         }
     }
 

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -211,6 +211,8 @@ public class MeepleAiDbContext : DbContext
     public DbSet<BoundedContexts.AgentMemory.Infrastructure.Entities.GroupMemoryEntity> GroupMemories => Set<BoundedContexts.AgentMemory.Infrastructure.Entities.GroupMemoryEntity>(); // AgentMemory: play group memory
     public DbSet<BoundedContexts.AgentMemory.Infrastructure.Entities.PlayerMemoryEntity> PlayerMemories => Set<BoundedContexts.AgentMemory.Infrastructure.Entities.PlayerMemoryEntity>(); // AgentMemory: player statistics
     public DbSet<Api.Infrastructure.Entities.SessionTracking.SessionChatMessageEntity> SessionChatMessages => Set<Api.Infrastructure.Entities.SessionTracking.SessionChatMessageEntity>(); // ISSUE-4760
+    public DbSet<BoundedContexts.SessionTracking.Domain.Entities.VisionSnapshot> VisionSnapshots => Set<BoundedContexts.SessionTracking.Domain.Entities.VisionSnapshot>(); // Session Vision AI
+    public DbSet<BoundedContexts.SessionTracking.Domain.Entities.VisionSnapshotImage> VisionSnapshotImages => Set<BoundedContexts.SessionTracking.Domain.Entities.VisionSnapshotImage>(); // Session Vision AI
 
     // Issue #4220: Notification preferences
     public DbSet<Api.Infrastructure.Entities.UserNotifications.NotificationPreferencesEntity> NotificationPreferences => Set<Api.Infrastructure.Entities.UserNotifications.NotificationPreferencesEntity>();

--- a/apps/api/src/Api/Infrastructure/Migrations/20260417193010_AddVisionSnapshots.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260417193010_AddVisionSnapshots.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260417193010_AddVisionSnapshots")]
+    partial class AddVisionSnapshots
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260417193010_AddVisionSnapshots.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260417193010_AddVisionSnapshots.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddVisionSnapshots : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "vision_snapshots",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    session_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    turn_number = table.Column<int>(type: "integer", nullable: false),
+                    caption = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    extracted_game_state = table.Column<string>(type: "jsonb", nullable: true),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    is_deleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    deleted_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_vision_snapshots", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "vision_snapshot_images",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    storage_key = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    media_type = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    width = table.Column<int>(type: "integer", nullable: false),
+                    height = table.Column<int>(type: "integer", nullable: false),
+                    order_index = table.Column<int>(type: "integer", nullable: false),
+                    vision_snapshot_id = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_vision_snapshot_images", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_vision_snapshot_images_vision_snapshots_vision_snapshot_id",
+                        column: x => x.vision_snapshot_id,
+                        principalTable: "vision_snapshots",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_vision_snapshot_images_snapshot_id",
+                table: "vision_snapshot_images",
+                column: "vision_snapshot_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_vision_snapshots_is_deleted",
+                table: "vision_snapshots",
+                column: "is_deleted");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_vision_snapshots_session_id",
+                table: "vision_snapshots",
+                column: "session_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_vision_snapshots_session_turn",
+                table: "vision_snapshots",
+                columns: new[] { "session_id", "turn_number" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "vision_snapshot_images");
+
+            migrationBuilder.DropTable(
+                name: "vision_snapshots");
+        }
+    }
+}

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -744,6 +744,7 @@ if (!isAlphaMode)
     v1Api.MapGameNightEndpoints(); // Issue #46: Game Night Event endpoints
     v1Api.MapGameNightImprovvisataEndpoints(); // Game Night Improvvisata: E1-2 BGG import
     v1Api.MapRuleConflictFaqEndpoints(); // ISSUE-3966: Rule conflict FAQ management
+    v1Api.MapVisionSnapshotEndpoints(); // Session Vision AI: board photo snapshots + game state extraction
     v1Api.MapSessionTrackingEndpoints(); // GST-003: Session tracking real-time collaboration
     v1Api.MapSessionStatisticsEndpoints(); // P4: Session analytics dashboard
     v1Api.MapProposalMigrationEndpoints(); // Proposal migrations (Issue #3666)

--- a/apps/api/src/Api/Routing/SessionTracking/SessionPlayerActionsEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionTracking/SessionPlayerActionsEndpoints.cs
@@ -571,10 +571,56 @@ internal static class SessionPlayerActionsEndpoints
     {
         group.MapPost("/game-sessions/{sessionId:guid}/chat/ask-agent", async (
             Guid sessionId,
-            AskSessionAgentCommand command,
+            HttpRequest httpRequest,
             IMediator mediator,
             CancellationToken ct) =>
         {
+            AskSessionAgentCommand command;
+
+            if (httpRequest.HasFormContentType)
+            {
+                // Multipart form: supports image attachments
+                var form = await httpRequest.ReadFormAsync(ct).ConfigureAwait(false);
+
+                var questionStr = form["question"].ToString();
+                if (string.IsNullOrWhiteSpace(questionStr))
+                    return Results.BadRequest(new { error = "Question is required" });
+
+                if (!Guid.TryParse(form["senderId"].ToString(), out var senderId))
+                    return Results.BadRequest(new { error = "Valid senderId is required" });
+
+                int? turnNumber = int.TryParse(form["turnNumber"].ToString(), System.Globalization.CultureInfo.InvariantCulture, out var tn) ? tn : null;
+
+                var images = new List<ChatImageAttachment>();
+                foreach (var file in form.Files)
+                {
+                    if (file.Length == 0) continue;
+                    using var ms = new MemoryStream();
+                    await file.CopyToAsync(ms, ct).ConfigureAwait(false);
+                    images.Add(new ChatImageAttachment(
+                        ms.ToArray(),
+                        file.ContentType ?? "image/jpeg",
+                        file.FileName));
+                }
+
+                command = new AskSessionAgentCommand(
+                    sessionId,
+                    senderId,
+                    questionStr,
+                    turnNumber,
+                    images.Count > 0 ? images : null);
+            }
+            else
+            {
+                // JSON body: backward-compatible text-only path
+                var jsonCommand = await httpRequest.ReadFromJsonAsync<AskSessionAgentCommand>(ct)
+                    .ConfigureAwait(false);
+                if (jsonCommand is null)
+                    return Results.BadRequest(new { error = "Invalid request body" });
+
+                command = jsonCommand;
+            }
+
             if (sessionId != command.SessionId)
             {
                 return Results.BadRequest(new { error = "Session ID mismatch" });
@@ -584,10 +630,11 @@ internal static class SessionPlayerActionsEndpoints
             return Results.Ok(result);
         })
         .RequireAuthenticatedUser()
+        .DisableAntiforgery()
         .WithName("AskSessionAgent")
         .WithTags("SessionTracking", "Chat", "AI")
-        .WithSummary("Ask the RAG agent a question in session context [STUB]")
-        .WithDescription("Sends a question to the AI agent which answers using the game's knowledge base and session context. Currently returns a stub response pending RAG pipeline integration.")
+        .WithSummary("Ask the RAG agent a question in session context")
+        .WithDescription("Sends a question to the AI agent which answers using the game's knowledge base and session context. Supports multipart form with image attachments for vision analysis, or JSON body for text-only questions.")
         .Produces(200)
         .Produces(400)
         .Produces(401)

--- a/apps/api/src/Api/Routing/SessionTracking/VisionSnapshotEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionTracking/VisionSnapshotEndpoints.cs
@@ -1,0 +1,111 @@
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.Extensions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Routing;
+
+/// <summary>
+/// Vision snapshot endpoints for board photo capture and AI game state extraction.
+/// Session Vision AI feature.
+/// </summary>
+internal static class VisionSnapshotEndpoints
+{
+    public static RouteGroupBuilder MapVisionSnapshotEndpoints(this RouteGroupBuilder group)
+    {
+        var snapshotGroup = group.MapGroup("/live-sessions/{sessionId:guid}/vision-snapshots")
+            .WithTags("SessionTracking", "Vision");
+
+        // POST / — create snapshot (multipart form)
+        snapshotGroup.MapPost("", HandleCreateSnapshot)
+            .RequireAuthenticatedUser()
+            .DisableAntiforgery()
+            .Produces<CreateVisionSnapshotResult>(201)
+            .Produces(400)
+            .Produces(404)
+            .Produces(409)
+            .WithSummary("Upload board photo(s) to create a vision snapshot")
+            .WithDescription(
+                "Creates a vision snapshot with uploaded images. " +
+                "Accepts multipart/form-data with files and optional caption/turnNumber fields.");
+
+        // GET / — list snapshots
+        snapshotGroup.MapGet("", HandleGetSnapshots)
+            .RequireAuthenticatedUser()
+            .Produces<List<VisionSnapshotDto>>()
+            .WithSummary("List all vision snapshots for a session")
+            .WithDescription("Returns snapshots with presigned image download URLs.");
+
+        // GET /game-state — latest game state
+        snapshotGroup.MapGet("/game-state", HandleGetLatestGameState)
+            .RequireAuthenticatedUser()
+            .Produces<GameStateResult>()
+            .Produces(204)
+            .WithSummary("Get the latest extracted game state")
+            .WithDescription(
+                "Returns the most recent game state extracted from vision snapshots. " +
+                "Returns 204 if no snapshot or no extraction exists.");
+
+        return group;
+    }
+
+    private static async Task<IResult> HandleCreateSnapshot(
+        Guid sessionId,
+        HttpContext context,
+        IMediator mediator,
+        [FromForm] string? caption = null,
+        [FromForm] int turnNumber = 0)
+    {
+        var userId = context.User.GetUserId();
+        if (userId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
+        // Read uploaded files from multipart form
+        var form = await context.Request.ReadFormAsync().ConfigureAwait(false);
+        var images = new List<VisionSnapshotImageUpload>();
+
+        foreach (var file in form.Files)
+        {
+            if (file.Length == 0) continue;
+
+            using var ms = new MemoryStream();
+            await file.CopyToAsync(ms).ConfigureAwait(false);
+
+            images.Add(new VisionSnapshotImageUpload(
+                ms.ToArray(),
+                file.ContentType,
+                file.FileName));
+        }
+
+        var command = new CreateVisionSnapshotCommand(
+            sessionId,
+            userId,
+            turnNumber,
+            caption,
+            images);
+
+        var result = await mediator.Send(command).ConfigureAwait(false);
+        return Results.Created(
+            $"/api/v1/live-sessions/{sessionId}/vision-snapshots",
+            result);
+    }
+
+    private static async Task<IResult> HandleGetSnapshots(
+        Guid sessionId,
+        IMediator mediator)
+    {
+        var result = await mediator.Send(new GetVisionSnapshotsQuery(sessionId)).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleGetLatestGameState(
+        Guid sessionId,
+        IMediator mediator)
+    {
+        var result = await mediator.Send(new GetLatestGameStateQuery(sessionId)).ConfigureAwait(false);
+        return result is null ? Results.NoContent() : Results.Ok(result);
+    }
+}

--- a/apps/api/src/Api/Services/ILlmService.cs
+++ b/apps/api/src/Api/Services/ILlmService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Api.Services.LlmClients;
 
 #pragma warning disable MA0048 // File name must match type name - Contains Service with Configuration classes
 namespace Api.Services;
@@ -58,6 +59,24 @@ internal interface ILlmService
         string userPrompt,
         RequestSource source = RequestSource.Manual,
         CancellationToken ct = default) where T : class;
+
+    /// <summary>
+    /// Generate a multimodal (text + images) completion response.
+    /// Falls back to text-only if no vision-capable provider is available.
+    /// </summary>
+    Task<LlmCompletionResult> GenerateMultimodalCompletionAsync(
+        IReadOnlyList<LlmMessage> messages,
+        RequestSource source = RequestSource.Manual,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Generate a streaming multimodal (text + images) completion response.
+    /// Falls back to text-only if no vision-capable provider is available.
+    /// </summary>
+    IAsyncEnumerable<StreamChunk> GenerateMultimodalCompletionStreamAsync(
+        IReadOnlyList<LlmMessage> messages,
+        RequestSource source = RequestSource.Manual,
+        CancellationToken ct = default);
 
     /// <summary>
     /// Issue #4332: Generate completion with explicit model (bypassing routing strategy).

--- a/apps/api/src/Api/Services/ImageProcessing/IImagePreprocessor.cs
+++ b/apps/api/src/Api/Services/ImageProcessing/IImagePreprocessor.cs
@@ -1,0 +1,30 @@
+namespace Api.Services.ImageProcessing;
+
+/// <summary>
+/// Result of image preprocessing (resize, format conversion, quality reduction).
+/// </summary>
+internal record ProcessedImage(byte[] Data, string MediaType, int Width, int Height, long SizeBytes);
+
+/// <summary>
+/// Options for image preprocessing (max dimensions, size limits, format conversion).
+/// </summary>
+internal record ImageProcessingOptions(
+    int MaxWidth = 1024, int MaxHeight = 1024,
+    long MaxSizeBytes = 5_000_000, bool ConvertToJpeg = true);
+
+/// <summary>
+/// Preprocesses images for LLM vision input (resize, compress, format conversion).
+/// </summary>
+internal interface IImagePreprocessor
+{
+    /// <summary>
+    /// Process an image: resize if needed, convert format, enforce size limits.
+    /// </summary>
+    Task<ProcessedImage> ProcessAsync(byte[] imageData, string mediaType, ImageProcessingOptions? options = null);
+
+    /// <summary>
+    /// Detect the media type of an image from its magic bytes.
+    /// Returns null if the format is not recognized.
+    /// </summary>
+    string? DetectMediaType(byte[] data);
+}

--- a/apps/api/src/Api/Services/ImageProcessing/SkiaImagePreprocessor.cs
+++ b/apps/api/src/Api/Services/ImageProcessing/SkiaImagePreprocessor.cs
@@ -1,0 +1,119 @@
+using SkiaSharp;
+
+namespace Api.Services.ImageProcessing;
+
+/// <summary>
+/// SkiaSharp-based image preprocessor for LLM vision input.
+/// Handles resize, JPEG conversion, and size enforcement.
+/// </summary>
+internal class SkiaImagePreprocessor : IImagePreprocessor
+{
+    private const int FallbackJpegQuality = 60;
+    private const int DefaultJpegQuality = 85;
+
+    /// <inheritdoc/>
+    public Task<ProcessedImage> ProcessAsync(byte[] imageData, string mediaType, ImageProcessingOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(imageData);
+        if (imageData.Length == 0)
+        {
+            throw new ArgumentException("Image data is empty", nameof(imageData));
+        }
+
+        options ??= new ImageProcessingOptions();
+
+        using var original = SKBitmap.Decode(imageData)
+            ?? throw new InvalidOperationException("Failed to decode image data");
+
+        var targetWidth = original.Width;
+        var targetHeight = original.Height;
+
+        // Resize if exceeds max dimensions (maintain aspect ratio)
+        if (targetWidth > options.MaxWidth || targetHeight > options.MaxHeight)
+        {
+            var widthRatio = (double)options.MaxWidth / targetWidth;
+            var heightRatio = (double)options.MaxHeight / targetHeight;
+            var ratio = Math.Min(widthRatio, heightRatio);
+
+            targetWidth = (int)(targetWidth * ratio);
+            targetHeight = (int)(targetHeight * ratio);
+        }
+
+        using var resized = (targetWidth != original.Width || targetHeight != original.Height)
+            ? original.Resize(new SKImageInfo(targetWidth, targetHeight), SKSamplingOptions.Default)
+            : original;
+
+        if (resized == null)
+        {
+            throw new InvalidOperationException("Failed to resize image");
+        }
+
+        // Encode as JPEG (or original format if conversion not requested)
+        var encodeFormat = options.ConvertToJpeg ? SKEncodedImageFormat.Jpeg : GetFormat(mediaType);
+        var outputMediaType = options.ConvertToJpeg ? "image/jpeg" : mediaType;
+
+        using var image = SKImage.FromBitmap(resized);
+        var encoded = image.Encode(encodeFormat, DefaultJpegQuality);
+
+        // If still too large after resize, reduce quality
+        if (encoded.Size > options.MaxSizeBytes && encodeFormat == SKEncodedImageFormat.Jpeg)
+        {
+            encoded.Dispose();
+            encoded = image.Encode(SKEncodedImageFormat.Jpeg, FallbackJpegQuality);
+            outputMediaType = "image/jpeg";
+        }
+
+        var outputData = encoded.ToArray();
+
+        var result = new ProcessedImage(
+            outputData,
+            outputMediaType,
+            targetWidth,
+            targetHeight,
+            outputData.LongLength);
+
+        encoded.Dispose();
+
+        return Task.FromResult(result);
+    }
+
+    /// <inheritdoc/>
+    public string? DetectMediaType(byte[] data)
+    {
+        if (data == null || data.Length < 4)
+        {
+            return null;
+        }
+
+        // JPEG: FF D8 FF
+        if (data[0] == 0xFF && data[1] == 0xD8 && data[2] == 0xFF)
+        {
+            return "image/jpeg";
+        }
+
+        // PNG: 89 50 4E 47 (‰PNG)
+        if (data[0] == 0x89 && data[1] == 0x50 && data[2] == 0x4E && data[3] == 0x47)
+        {
+            return "image/png";
+        }
+
+        // WebP: RIFF....WEBP (bytes 0-3 = RIFF, bytes 8-11 = WEBP)
+        if (data.Length >= 12
+            && data[0] == 0x52 && data[1] == 0x49 && data[2] == 0x46 && data[3] == 0x46    // RIFF
+            && data[8] == 0x57 && data[9] == 0x45 && data[10] == 0x42 && data[11] == 0x50)  // WEBP
+        {
+            return "image/webp";
+        }
+
+        return null;
+    }
+
+    private static SKEncodedImageFormat GetFormat(string mediaType) =>
+        mediaType.ToLowerInvariant() switch
+        {
+            "image/png" => SKEncodedImageFormat.Png,
+            "image/webp" => SKEncodedImageFormat.Webp,
+            "image/gif" => SKEncodedImageFormat.Gif,
+            _ => SKEncodedImageFormat.Jpeg,
+        };
+}

--- a/apps/api/src/Api/Services/LlmClients/ContentPart.cs
+++ b/apps/api/src/Api/Services/LlmClients/ContentPart.cs
@@ -1,0 +1,39 @@
+namespace Api.Services.LlmClients;
+
+/// <summary>
+/// Base type for multimodal content parts in LLM messages.
+/// Supports text and image content for vision-capable models.
+/// </summary>
+#pragma warning disable S2094 // Abstract base record for sealed hierarchy (TextContentPart, ImageContentPart)
+internal abstract record ContentPart;
+#pragma warning restore S2094
+
+/// <summary>
+/// Text content part for LLM messages.
+/// </summary>
+internal record TextContentPart(string Text) : ContentPart;
+
+/// <summary>
+/// Image content part with base64-encoded data for vision-capable LLM models.
+/// </summary>
+internal record ImageContentPart(string Base64Data, string MediaType) : ContentPart
+{
+    public string ToDataUri() => $"data:{MediaType};base64,{Base64Data}";
+}
+
+/// <summary>
+/// Multimodal LLM message supporting mixed text and image content.
+/// </summary>
+internal record LlmMessage(string Role, IReadOnlyList<ContentPart> Content)
+{
+    /// <summary>
+    /// Create a text-only message (convenience factory).
+    /// </summary>
+    public static LlmMessage FromText(string role, string text) =>
+        new(role, [new TextContentPart(text)]);
+
+    /// <summary>
+    /// Whether this message contains any image content parts.
+    /// </summary>
+    public bool HasImages => Content.Any(c => c is ImageContentPart);
+}

--- a/apps/api/src/Api/Services/LlmClients/DeepSeekLlmClient.cs
+++ b/apps/api/src/Api/Services/LlmClients/DeepSeekLlmClient.cs
@@ -244,6 +244,220 @@ internal class DeepSeekLlmClient : ILlmClient
     }
 
     /// <inheritdoc/>
+    public bool SupportsVision => true;
+
+    /// <inheritdoc/>
+    public async Task<LlmCompletionResult> GenerateCompletionAsync(
+        string model,
+        IReadOnlyList<LlmMessage> messages,
+        double temperature,
+        int maxTokens,
+        CancellationToken ct = default)
+    {
+        if (!_isConfigured)
+        {
+            return LlmCompletionResult.CreateFailure("DeepSeek provider is not configured (missing API key)");
+        }
+
+        if (messages == null || messages.Count == 0)
+        {
+            return LlmCompletionResult.CreateFailure("No messages provided");
+        }
+
+        try
+        {
+            using var httpRequest = CreateMultimodalChatRequest(model, messages, temperature, maxTokens, stream: false);
+
+            _logger.LogInformation("Generating DeepSeek multimodal completion using {Model} (temp={Temperature}, max_tokens={MaxTokens})",
+                model, temperature, maxTokens);
+
+            using var response = await _httpClient.SendAsync(httpRequest, ct).ConfigureAwait(false);
+            return await HandleCompletionResponseAsync(response, model, ct).ConfigureAwait(false);
+        }
+        catch (TaskCanceledException ex)
+        {
+            _logger.LogError(ex, "DeepSeek multimodal completion timed out");
+            return LlmCompletionResult.CreateFailure("Request timed out");
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "HTTP request failed during DeepSeek multimodal completion");
+            return LlmCompletionResult.CreateFailure($"HTTP error: {ex.Message}");
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogError(ex, "Failed to deserialize DeepSeek multimodal response");
+            return LlmCompletionResult.CreateFailure("Invalid response format");
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+#pragma warning disable S125 // Sections of code should not be commented out
+        // SERVICE BOUNDARY: Wraps unexpected DeepSeek API errors into domain-friendly LlmCompletionResult
+#pragma warning restore S125
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error during DeepSeek multimodal completion");
+            return LlmCompletionResult.CreateFailure($"Error: {ex.Message}");
+        }
+#pragma warning restore CA1031
+    }
+
+    /// <inheritdoc/>
+    public async IAsyncEnumerable<StreamChunk> GenerateCompletionStreamAsync(
+        string model,
+        IReadOnlyList<LlmMessage> messages,
+        double temperature,
+        int maxTokens,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        if (!_isConfigured)
+        {
+            _logger.LogWarning("DeepSeek provider is not configured — multimodal streaming unavailable");
+            yield break;
+        }
+
+        if (messages == null || messages.Count == 0)
+        {
+            _logger.LogWarning("No messages provided for DeepSeek multimodal streaming");
+            yield break;
+        }
+
+        _logger.LogInformation("Starting DeepSeek multimodal streaming using {Model} (temp={Temperature}, max_tokens={MaxTokens})",
+            model, temperature, maxTokens);
+
+        const int maxRetries = 3;
+        int[] retryDelaysMs = [3000, 5000, 10000];
+        HttpResponseMessage? response = null;
+
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
+        {
+            using var httpRequest = CreateMultimodalChatRequest(model, messages, temperature, maxTokens, stream: true);
+            response = null;
+
+            try
+            {
+                response = await _httpClient.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    break;
+                }
+
+                var errorBody = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+                _logger.LogError("DeepSeek multimodal streaming API error: {Status} - {Body}", response.StatusCode, DataMasking.MaskResponseBody(errorBody));
+
+                if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests && attempt < maxRetries)
+                {
+                    var delay = retryDelaysMs[Math.Min(attempt, retryDelaysMs.Length - 1)];
+                    _logger.LogWarning("Rate limited (429), retrying in {Delay}ms (attempt {Next}/{Total})",
+                        delay, attempt + 2, maxRetries + 1);
+                    response.Dispose();
+                    response = null;
+                    await Task.Delay(delay, ct).ConfigureAwait(false);
+                    continue;
+                }
+
+                response.Dispose();
+                response = null;
+                yield break;
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogError(ex, "HTTP request failed initiating DeepSeek multimodal streaming");
+                response?.Dispose();
+                response = null;
+                yield break;
+            }
+            catch (TaskCanceledException ex)
+            {
+                _logger.LogError(ex, "DeepSeek multimodal streaming request timed out");
+                response?.Dispose();
+                response = null;
+                yield break;
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+#pragma warning disable S125 // Sections of code should not be commented out
+            // SERVICE BOUNDARY: Streaming generator boundary - must handle all errors gracefully
+#pragma warning restore S125
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected error initiating DeepSeek multimodal streaming");
+                response?.Dispose();
+                response = null;
+                yield break;
+            }
+#pragma warning restore CA1031
+        }
+
+        if (response == null || !response.IsSuccessStatusCode)
+        {
+            _logger.LogError("All {MaxRetries} multimodal streaming retry attempts exhausted", maxRetries + 1);
+            response?.Dispose();
+            yield break;
+        }
+
+        await foreach (var chunk in ProcessStreamResponseAsync(response, model, ct).ConfigureAwait(false))
+        {
+            yield return chunk;
+        }
+    }
+
+    private HttpRequestMessage CreateMultimodalChatRequest(
+        string model,
+        IReadOnlyList<LlmMessage> messages,
+        double temperature,
+        int maxTokens,
+        bool stream)
+    {
+        var apiMessages = new List<object>();
+
+        foreach (var message in messages)
+        {
+            if (!message.HasImages)
+            {
+                // Text-only message — use simple string content format
+                var textContent = string.Join("\n", message.Content.OfType<TextContentPart>().Select(t => t.Text));
+                apiMessages.Add(new { role = message.Role, content = textContent });
+            }
+            else
+            {
+                // Multimodal message — use content array format
+                var contentParts = new List<object>();
+                foreach (var part in message.Content)
+                {
+                    if (part is TextContentPart textPart)
+                    {
+                        contentParts.Add(new { type = "text", text = textPart.Text });
+                    }
+                    else if (part is ImageContentPart imagePart)
+                    {
+                        contentParts.Add(new
+                        {
+                            type = "image_url",
+                            image_url = new { url = imagePart.ToDataUri() }
+                        });
+                    }
+                }
+                apiMessages.Add(new { role = message.Role, content = contentParts });
+            }
+        }
+
+        var requestPayload = new Dictionary<string, object>(StringComparer.Ordinal)
+        {
+            ["model"] = model,
+            ["messages"] = apiMessages,
+            ["temperature"] = temperature,
+            ["max_tokens"] = maxTokens,
+            ["stream"] = stream
+        };
+
+        var json = JsonSerializer.Serialize(requestPayload);
+        return new HttpRequestMessage(HttpMethod.Post, "chat/completions")
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+
+    /// <inheritdoc/>
     public async Task<bool> CheckHealthAsync(CancellationToken ct = default)
     {
         if (!_isConfigured)

--- a/apps/api/src/Api/Services/LlmClients/ILlmClient.cs
+++ b/apps/api/src/Api/Services/LlmClients/ILlmClient.cs
@@ -62,4 +62,29 @@ internal interface ILlmClient
     /// Ollama: GET /api/tags — OpenRouter: GET /api/v1/models
     /// </summary>
     Task<bool> CheckHealthAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Whether this provider supports vision (image) content in messages.
+    /// </summary>
+    bool SupportsVision { get; }
+
+    /// <summary>
+    /// Generate a chat completion from multimodal messages (text + images).
+    /// </summary>
+    Task<LlmCompletionResult> GenerateCompletionAsync(
+        string model,
+        IReadOnlyList<LlmMessage> messages,
+        double temperature,
+        int maxTokens,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Generate a streaming chat completion from multimodal messages (text + images).
+    /// </summary>
+    IAsyncEnumerable<StreamChunk> GenerateCompletionStreamAsync(
+        string model,
+        IReadOnlyList<LlmMessage> messages,
+        double temperature,
+        int maxTokens,
+        CancellationToken ct = default);
 }

--- a/apps/api/src/Api/Services/LlmClients/OllamaLlmClient.cs
+++ b/apps/api/src/Api/Services/LlmClients/OllamaLlmClient.cs
@@ -384,6 +384,31 @@ internal class OllamaLlmClient : ILlmClient
     }
 
     /// <inheritdoc/>
+    public bool SupportsVision => false;
+
+    /// <inheritdoc/>
+    public Task<LlmCompletionResult> GenerateCompletionAsync(
+        string model,
+        IReadOnlyList<LlmMessage> messages,
+        double temperature,
+        int maxTokens,
+        CancellationToken ct = default)
+    {
+        throw new NotSupportedException("Ollama provider does not support multimodal (vision) messages");
+    }
+
+    /// <inheritdoc/>
+    public IAsyncEnumerable<StreamChunk> GenerateCompletionStreamAsync(
+        string model,
+        IReadOnlyList<LlmMessage> messages,
+        double temperature,
+        int maxTokens,
+        CancellationToken ct = default)
+    {
+        throw new NotSupportedException("Ollama provider does not support multimodal (vision) streaming");
+    }
+
+    /// <inheritdoc/>
     public async Task<bool> CheckHealthAsync(CancellationToken ct = default)
     {
         try

--- a/apps/api/src/Api/Services/LlmClients/OllamaLlmClient.cs
+++ b/apps/api/src/Api/Services/LlmClients/OllamaLlmClient.cs
@@ -394,18 +394,19 @@ internal class OllamaLlmClient : ILlmClient
         int maxTokens,
         CancellationToken ct = default)
     {
-        throw new NotSupportedException("Ollama provider does not support multimodal (vision) messages");
+        return Task.FromResult(LlmCompletionResult.CreateFailure("Ollama provider does not support multimodal (vision) messages"));
     }
 
     /// <inheritdoc/>
-    public IAsyncEnumerable<StreamChunk> GenerateCompletionStreamAsync(
+    public async IAsyncEnumerable<StreamChunk> GenerateCompletionStreamAsync(
         string model,
         IReadOnlyList<LlmMessage> messages,
         double temperature,
         int maxTokens,
-        CancellationToken ct = default)
+        [EnumeratorCancellation] CancellationToken ct = default)
     {
-        throw new NotSupportedException("Ollama provider does not support multimodal (vision) streaming");
+        yield return new StreamChunk(null, Usage: LlmUsage.Empty, IsFinal: true);
+        await Task.CompletedTask.ConfigureAwait(false); // Ollama does not support vision streaming
     }
 
     /// <inheritdoc/>

--- a/apps/api/src/Api/Services/LlmClients/OpenRouterLlmClient.cs
+++ b/apps/api/src/Api/Services/LlmClients/OpenRouterLlmClient.cs
@@ -262,6 +262,212 @@ internal class OpenRouterLlmClient : ILlmClient
     }
 
     /// <inheritdoc/>
+    public bool SupportsVision => true;
+
+    /// <inheritdoc/>
+    public async Task<LlmCompletionResult> GenerateCompletionAsync(
+        string model,
+        IReadOnlyList<LlmMessage> messages,
+        double temperature,
+        int maxTokens,
+        CancellationToken ct = default)
+    {
+        if (messages == null || messages.Count == 0)
+        {
+            return LlmCompletionResult.CreateFailure("No messages provided");
+        }
+
+        try
+        {
+            using var httpRequest = CreateMultimodalChatRequest(model, messages, temperature, maxTokens, stream: false);
+
+            _logger.LogInformation("Generating OpenRouter multimodal completion using {Model} (temp={Temperature}, max_tokens={MaxTokens})",
+                model, temperature, maxTokens);
+
+            using var response = await _httpClient.SendAsync(httpRequest, ct).ConfigureAwait(false);
+            return await HandleCompletionResponseAsync(response, model, ct).ConfigureAwait(false);
+        }
+        catch (TaskCanceledException ex)
+        {
+            _logger.LogError(ex, "OpenRouter multimodal completion timed out");
+            return LlmCompletionResult.CreateFailure("Request timed out");
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "HTTP request failed during OpenRouter multimodal completion");
+            return LlmCompletionResult.CreateFailure($"HTTP error: {ex.Message}");
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogError(ex, "Failed to deserialize OpenRouter multimodal response");
+            return LlmCompletionResult.CreateFailure("Invalid response format");
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+#pragma warning disable S125 // Sections of code should not be commented out
+        // SERVICE BOUNDARY: Wraps unexpected OpenRouter API errors into domain-friendly LlmCompletionResult
+#pragma warning restore S125
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error during OpenRouter multimodal completion");
+            return LlmCompletionResult.CreateFailure($"Error: {ex.Message}");
+        }
+#pragma warning restore CA1031
+    }
+
+    /// <inheritdoc/>
+    public async IAsyncEnumerable<StreamChunk> GenerateCompletionStreamAsync(
+        string model,
+        IReadOnlyList<LlmMessage> messages,
+        double temperature,
+        int maxTokens,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        if (messages == null || messages.Count == 0)
+        {
+            _logger.LogWarning("No messages provided for OpenRouter multimodal streaming");
+            yield break;
+        }
+
+        _logger.LogInformation("Starting OpenRouter multimodal streaming using {Model} (temp={Temperature}, max_tokens={MaxTokens})",
+            model, temperature, maxTokens);
+
+        const int maxRetries = 3;
+        int[] retryDelaysMs = [3000, 5000, 10000];
+        HttpResponseMessage? response = null;
+
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
+        {
+            using var httpRequest = CreateMultimodalChatRequest(model, messages, temperature, maxTokens, stream: true);
+            response = null;
+
+            try
+            {
+                response = await _httpClient.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    break;
+                }
+
+                var errorBody = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+                _logger.LogError("OpenRouter multimodal streaming API error: {Status} - {Body}", response.StatusCode, DataMasking.MaskResponseBody(errorBody));
+
+                if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests && attempt < maxRetries)
+                {
+                    var delay = retryDelaysMs[Math.Min(attempt, retryDelaysMs.Length - 1)];
+                    _logger.LogWarning("Rate limited (429), retrying in {Delay}ms (attempt {Next}/{Total})",
+                        delay, attempt + 2, maxRetries + 1);
+                    response.Dispose();
+                    response = null;
+                    await Task.Delay(delay, ct).ConfigureAwait(false);
+                    continue;
+                }
+
+                response.Dispose();
+                response = null;
+                yield break;
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogError(ex, "HTTP request failed initiating OpenRouter multimodal streaming");
+                response?.Dispose();
+                response = null;
+                yield break;
+            }
+            catch (TaskCanceledException ex)
+            {
+                _logger.LogError(ex, "OpenRouter multimodal streaming request timed out");
+                response?.Dispose();
+                response = null;
+                yield break;
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+#pragma warning disable S125 // Sections of code should not be commented out
+            // SERVICE BOUNDARY: Streaming generator boundary - must handle all errors gracefully
+#pragma warning restore S125
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected error initiating OpenRouter multimodal streaming");
+                response?.Dispose();
+                response = null;
+                yield break;
+            }
+#pragma warning restore CA1031
+        }
+
+        if (response == null || !response.IsSuccessStatusCode)
+        {
+            _logger.LogError("All {MaxRetries} multimodal streaming retry attempts exhausted", maxRetries + 1);
+            response?.Dispose();
+            yield break;
+        }
+
+        await foreach (var chunk in ProcessStreamResponseAsync(response, model, ct).ConfigureAwait(false))
+        {
+            yield return chunk;
+        }
+    }
+
+    private HttpRequestMessage CreateMultimodalChatRequest(
+        string model,
+        IReadOnlyList<LlmMessage> messages,
+        double temperature,
+        int maxTokens,
+        bool stream)
+    {
+        var apiMessages = new List<object>();
+
+        foreach (var message in messages)
+        {
+            if (!message.HasImages)
+            {
+                var textContent = string.Join("\n", message.Content.OfType<TextContentPart>().Select(t => t.Text));
+                apiMessages.Add(new { role = message.Role, content = textContent });
+            }
+            else
+            {
+                var contentParts = new List<object>();
+                foreach (var part in message.Content)
+                {
+                    if (part is TextContentPart textPart)
+                    {
+                        contentParts.Add(new { type = "text", text = textPart.Text });
+                    }
+                    else if (part is ImageContentPart imagePart)
+                    {
+                        contentParts.Add(new
+                        {
+                            type = "image_url",
+                            image_url = new { url = imagePart.ToDataUri() }
+                        });
+                    }
+                }
+                apiMessages.Add(new { role = message.Role, content = contentParts });
+            }
+        }
+
+        var requestPayload = new Dictionary<string, object>(StringComparer.Ordinal)
+        {
+            ["model"] = model,
+            ["messages"] = apiMessages,
+            ["temperature"] = temperature,
+            ["max_tokens"] = maxTokens,
+            ["stream"] = stream
+        };
+
+        if (stream)
+        {
+            requestPayload["usage"] = new { include = true };
+        }
+
+        var json = JsonSerializer.Serialize(requestPayload);
+        return new HttpRequestMessage(HttpMethod.Post, "chat/completions")
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+
+    /// <inheritdoc/>
     public async Task<bool> CheckHealthAsync(CancellationToken ct = default)
     {
         try

--- a/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/photos/page.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/photos/page.tsx
@@ -11,7 +11,9 @@ import { use, useRef, useState, useCallback, useEffect } from 'react';
 
 import { Camera, Image as ImageIcon, Trash2 } from 'lucide-react';
 
+import { SessionSnapshotPanel } from '@/components/session/SessionSnapshotPanel';
 import { Button } from '@/components/ui/primitives/button';
+import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
 import { addPhoto, listPhotos, deletePhoto, type StoredPhoto } from '@/lib/storage/photo-store';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -77,6 +79,7 @@ function toDisplay(stored: StoredPhoto): DisplayPhoto {
 
 export default function PhotosPage({ params }: PhotosPageProps) {
   const { sessionId } = use(params);
+  const { data: currentUser } = useCurrentUser();
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [photos, setPhotos] = useState<DisplayPhoto[]>([]);
@@ -193,6 +196,15 @@ export default function PhotosPage({ params }: PhotosPageProps) {
           ))}
         </div>
       )}
+
+      {/* Vision AI Snapshots */}
+      <div className="mt-6 border-t border-[var(--nh-border-default)] pt-6">
+        <SessionSnapshotPanel
+          sessionId={sessionId}
+          userId={currentUser?.id ?? ''}
+          currentTurn={1}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/chat/panel/ChatInputBar.tsx
+++ b/apps/web/src/components/chat/panel/ChatInputBar.tsx
@@ -1,20 +1,41 @@
 'use client';
 
-import { useState, type KeyboardEvent } from 'react';
+import { useState, useRef, type KeyboardEvent } from 'react';
+
+import { X } from 'lucide-react';
+
+import { useChatImageAttachments } from '@/hooks/useChatImageAttachments';
 
 interface ChatInputBarProps {
   placeholder?: string;
   onSend: (value: string) => void;
+  onSendWithImages?: (text: string, images: File[]) => void;
 }
 
-export function ChatInputBar({ placeholder = 'Chiedi una regola…', onSend }: ChatInputBarProps) {
+export function ChatInputBar({
+  placeholder = 'Chiedi una regola…',
+  onSend,
+  onSendWithImages,
+}: ChatInputBarProps) {
   const [value, setValue] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const { images, addImage, removeImage, clearImages, hasImages, canAddMore } =
+    useChatImageAttachments();
 
   const send = () => {
     const trimmed = value.trim();
-    if (trimmed.length === 0) return;
-    onSend(trimmed);
+    if (trimmed.length === 0 && !hasImages) return;
+
+    if (hasImages && onSendWithImages) {
+      onSendWithImages(
+        trimmed,
+        images.map(img => img.file)
+      );
+    } else {
+      onSend(trimmed);
+    }
     setValue('');
+    clearImages();
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -24,8 +45,45 @@ export function ChatInputBar({ placeholder = 'Chiedi una regola…', onSend }: C
     }
   };
 
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files) return;
+    for (let i = 0; i < files.length; i++) {
+      const error = addImage(files[i]);
+      if (error) {
+        // Could show a toast, for now silently skip
+        console.warn('[ChatInputBar]', error);
+      }
+    }
+    // Reset so same files can be re-selected
+    e.target.value = '';
+  };
+
   return (
     <div className="flex-shrink-0 border-t border-[var(--nh-border-default)] bg-[rgba(255,252,248,0.8)] px-5 py-4 backdrop-blur-md">
+      {/* Image previews */}
+      {hasImages && (
+        <div className="mb-3 flex flex-wrap gap-2">
+          {images.map((img, idx) => (
+            <div key={img.previewUrl} className="group relative">
+              <img
+                src={img.previewUrl}
+                alt={`Allegato ${idx + 1}`}
+                className="h-16 w-20 rounded-lg border border-[var(--nh-border-default)] object-cover shadow-sm"
+              />
+              <button
+                type="button"
+                onClick={() => removeImage(idx)}
+                aria-label={`Rimuovi immagine ${idx + 1}`}
+                className="absolute -right-1.5 -top-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-red-500 text-white opacity-0 shadow-sm transition-opacity group-hover:opacity-100"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
       <div className="flex items-end gap-2.5 rounded-2xl border border-[var(--nh-border-default)] bg-[var(--nh-bg-elevated)] py-2 pl-4 pr-2 shadow-[var(--shadow-warm-sm)] transition-all focus-within:border-[hsla(220,80%,55%,0.3)] focus-within:bg-white focus-within:shadow-[0_0_0_3px_hsla(220,80%,55%,0.1),var(--shadow-warm-md)]">
         <textarea
           value={value}
@@ -42,6 +100,15 @@ export function ChatInputBar({ placeholder = 'Chiedi una regola…', onSend }: C
             className="flex h-9 w-9 items-center justify-center rounded-[10px] text-[var(--nh-text-muted)] transition-all hover:bg-[var(--nh-bg-base)] hover:text-[var(--nh-text-primary)]"
           >
             📎
+          </button>
+          <button
+            type="button"
+            aria-label="Allega immagine"
+            onClick={() => canAddMore && fileInputRef.current?.click()}
+            className="flex h-9 w-9 items-center justify-center rounded-[10px] text-[var(--nh-text-muted)] transition-all hover:bg-[var(--nh-bg-base)] hover:text-[var(--nh-text-primary)] disabled:opacity-40"
+            disabled={!canAddMore}
+          >
+            🖼️
           </button>
           <button
             type="button"
@@ -64,6 +131,18 @@ export function ChatInputBar({ placeholder = 'Chiedi una regola…', onSend }: C
           </button>
         </div>
       </div>
+
+      {/* Hidden file input for image selection */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/webp"
+        multiple
+        className="hidden"
+        onChange={handleFileChange}
+        data-testid="chat-image-input"
+      />
+
       <div className="mt-2 flex items-center justify-between px-1.5 text-[0.68rem] text-[var(--nh-text-muted)]">
         <div className="flex gap-3">
           <span>

--- a/apps/web/src/components/chat/panel/ChatMessageBubble.tsx
+++ b/apps/web/src/components/chat/panel/ChatMessageBubble.tsx
@@ -9,6 +9,7 @@ interface ChatMessageBubbleProps {
   content: string;
   authorName: string;
   timestamp: string;
+  imageUrls?: string[];
 }
 
 function initials(name: string): string {
@@ -25,6 +26,7 @@ export function ChatMessageBubble({
   content,
   authorName,
   timestamp,
+  imageUrls,
 }: ChatMessageBubbleProps) {
   const isUser = role === 'user';
 
@@ -75,6 +77,19 @@ export function ChatMessageBubble({
               : undefined
           }
         >
+          {imageUrls && imageUrls.length > 0 && (
+            <div className="mb-2 flex flex-wrap gap-2">
+              {imageUrls.map((url, idx) => (
+                <a key={idx} href={url} target="_blank" rel="noopener noreferrer" className="block">
+                  <img
+                    src={url}
+                    alt={`Immagine ${idx + 1}`}
+                    className="h-15 w-20 cursor-pointer rounded-md border border-white/10 object-cover transition-opacity hover:opacity-80"
+                  />
+                </a>
+              ))}
+            </div>
+          )}
           <p className="whitespace-pre-wrap">{content}</p>
         </div>
       </div>

--- a/apps/web/src/components/session/GameStateDisplay.tsx
+++ b/apps/web/src/components/session/GameStateDisplay.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+/**
+ * GameStateDisplay — Renders parsed game state from Vision AI analysis.
+ *
+ * Session Vision AI — Task 15.1
+ */
+
+import { useMemo } from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface ParsedGameState {
+  board_description?: string;
+  notable_state?: string[];
+  confidence?: number;
+  [key: string]: unknown;
+}
+
+interface GameStateDisplayProps {
+  gameStateJson: string;
+  className?: string;
+}
+
+export function GameStateDisplay({ gameStateJson, className }: GameStateDisplayProps) {
+  const parsed = useMemo<ParsedGameState | null>(() => {
+    try {
+      return JSON.parse(gameStateJson);
+    } catch {
+      return null;
+    }
+  }, [gameStateJson]);
+
+  if (!parsed) {
+    return (
+      <div
+        className={cn(
+          'rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700',
+          className
+        )}
+      >
+        Impossibile interpretare lo stato della partita.
+      </div>
+    );
+  }
+
+  const confidence = typeof parsed.confidence === 'number' ? parsed.confidence : null;
+
+  return (
+    <div
+      className={cn(
+        'space-y-3 rounded-xl border border-[var(--nh-border-default)] bg-[var(--nh-bg-elevated)] p-4 shadow-sm',
+        className
+      )}
+    >
+      {/* Board description */}
+      {parsed.board_description && (
+        <div>
+          <h4 className="mb-1 font-quicksand text-xs font-bold uppercase tracking-wider text-[var(--nh-text-muted)]">
+            Stato del tavolo
+          </h4>
+          <p className="font-nunito text-sm leading-relaxed text-[var(--nh-text-primary)]">
+            {parsed.board_description}
+          </p>
+        </div>
+      )}
+
+      {/* Notable state */}
+      {parsed.notable_state && parsed.notable_state.length > 0 && (
+        <div>
+          <h4 className="mb-1.5 font-quicksand text-xs font-bold uppercase tracking-wider text-[var(--nh-text-muted)]">
+            Elementi rilevanti
+          </h4>
+          <ul className="space-y-1">
+            {parsed.notable_state.map((item, idx) => (
+              <li
+                key={idx}
+                className="flex items-start gap-2 font-nunito text-sm text-[var(--nh-text-primary)]"
+              >
+                <span className="mt-0.5 text-amber-500">&#8226;</span>
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Confidence */}
+      {confidence !== null && (
+        <div className="flex items-center gap-2 pt-1">
+          <div className="h-1.5 flex-1 rounded-full bg-stone-200">
+            <div
+              className={cn(
+                'h-1.5 rounded-full transition-all',
+                confidence >= 0.8
+                  ? 'bg-green-500'
+                  : confidence >= 0.5
+                    ? 'bg-amber-500'
+                    : 'bg-red-400'
+              )}
+              style={{ width: `${Math.round(confidence * 100)}%` }}
+            />
+          </div>
+          <span className="font-mono text-xs text-[var(--nh-text-muted)]">
+            {Math.round(confidence * 100)}%
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/session/SessionSnapshotPanel.tsx
+++ b/apps/web/src/components/session/SessionSnapshotPanel.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+/**
+ * SessionSnapshotPanel — Main panel for session snapshots with upload.
+ *
+ * Session Vision AI — Task 15.4
+ *
+ * Renders snapshot list, game state, upload dialog, and empty state.
+ */
+
+import { useState } from 'react';
+
+import { Camera, ImageOff } from 'lucide-react';
+
+import {
+  useSessionVisionSnapshots,
+  useLatestGameState,
+  useCreateSnapshot,
+} from '@/hooks/queries/useSessionSnapshots';
+import { cn } from '@/lib/utils';
+
+import { GameStateDisplay } from './GameStateDisplay';
+import { SnapshotCard } from './SnapshotCard';
+import { SnapshotUploadDialog } from './SnapshotUploadDialog';
+
+interface SessionSnapshotPanelProps {
+  sessionId: string;
+  userId: string;
+  currentTurn?: number;
+  className?: string;
+}
+
+export function SessionSnapshotPanel({
+  sessionId,
+  userId,
+  currentTurn = 1,
+  className,
+}: SessionSnapshotPanelProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const { data: snapshots, isLoading } = useSessionVisionSnapshots(sessionId);
+  const { data: gameState } = useLatestGameState(sessionId);
+  const createMutation = useCreateSnapshot(sessionId);
+
+  const handleUpload = (images: File[], caption: string, turnNumber: number) => {
+    createMutation.mutate(
+      { userId, turnNumber, images, caption: caption || undefined },
+      { onSuccess: () => setDialogOpen(false) }
+    );
+  };
+
+  const snapshotList = snapshots ?? [];
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="flex items-center gap-2 font-quicksand text-lg font-bold text-[var(--nh-text-primary)]">
+            <Camera className="h-5 w-5 text-amber-500" />
+            Stato Partita
+          </h2>
+          <p className="mt-0.5 font-nunito text-xs text-[var(--nh-text-muted)]">
+            {snapshotList.length === 0
+              ? 'Nessuno snapshot ancora'
+              : `${snapshotList.length} snapshot`}
+          </p>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setDialogOpen(true)}
+          className="flex items-center gap-1.5 rounded-xl bg-amber-500 px-3 py-2 font-nunito text-xs font-semibold text-white shadow-sm transition-colors hover:bg-amber-600"
+        >
+          + Nuovo Snapshot
+        </button>
+      </div>
+
+      {/* Latest game state */}
+      {gameState?.gameStateJson && <GameStateDisplay gameStateJson={gameState.gameStateJson} />}
+
+      {/* Loading */}
+      {isLoading && (
+        <p className="py-6 text-center font-nunito text-sm text-[var(--nh-text-muted)]">
+          Caricamento snapshot...
+        </p>
+      )}
+
+      {/* Empty state */}
+      {!isLoading && snapshotList.length === 0 && (
+        <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-stone-300 py-10">
+          <ImageOff className="h-10 w-10 text-stone-300" />
+          <p className="font-nunito text-sm text-[var(--nh-text-muted)]">
+            Scatta una foto del tavolo per analizzare lo stato della partita
+          </p>
+          <button
+            type="button"
+            onClick={() => setDialogOpen(true)}
+            className="rounded-lg border border-[var(--nh-border-default)] bg-white px-4 py-2 font-nunito text-xs font-medium text-[var(--nh-text-primary)] transition-colors hover:bg-stone-50"
+          >
+            <Camera className="mr-1.5 inline-block h-3.5 w-3.5" />
+            Primo snapshot
+          </button>
+        </div>
+      )}
+
+      {/* Snapshot list */}
+      {snapshotList.length > 0 && (
+        <div className="space-y-3">
+          {snapshotList
+            .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+            .map((snap, idx) => (
+              <SnapshotCard key={snap.id} snapshot={snap} isLatest={idx === 0} />
+            ))}
+        </div>
+      )}
+
+      {/* Upload dialog */}
+      <SnapshotUploadDialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        onUpload={handleUpload}
+        defaultTurnNumber={currentTurn}
+        isUploading={createMutation.isPending}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/session/SnapshotCard.tsx
+++ b/apps/web/src/components/session/SnapshotCard.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+/**
+ * SnapshotCard — Displays a single session snapshot with images and status.
+ *
+ * Session Vision AI — Task 15.2
+ */
+
+import type { SessionSnapshotDto } from '@/lib/api/clients/sessionSnapshotsClient';
+import { cn } from '@/lib/utils';
+
+interface SnapshotCardProps {
+  snapshot: SessionSnapshotDto;
+  isLatest?: boolean;
+  className?: string;
+}
+
+export function SnapshotCard({ snapshot, isLatest, className }: SnapshotCardProps) {
+  const date = new Date(snapshot.createdAt);
+  const timeLabel = date.toLocaleTimeString('it-IT', { hour: '2-digit', minute: '2-digit' });
+
+  return (
+    <div
+      className={cn(
+        'rounded-xl border bg-[var(--nh-bg-elevated)] p-3 shadow-sm transition-all',
+        isLatest ? 'border-amber-300 ring-1 ring-amber-200' : 'border-[var(--nh-border-default)]',
+        className
+      )}
+    >
+      {/* Header row */}
+      <div className="mb-2 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="font-quicksand text-sm font-bold text-[var(--nh-text-primary)]">
+            Turno {snapshot.turnNumber}
+          </span>
+          {isLatest && (
+            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-bold text-amber-700">
+              ULTIMO
+            </span>
+          )}
+        </div>
+
+        {/* Status badge */}
+        <span
+          className={cn(
+            'rounded-full px-2 py-0.5 text-[10px] font-semibold',
+            snapshot.hasGameState ? 'bg-green-100 text-green-700' : 'bg-amber-100 text-amber-700'
+          )}
+        >
+          {snapshot.hasGameState ? 'Analizzato' : 'Non analizzato'}
+        </span>
+      </div>
+
+      {/* Image thumbnails */}
+      {snapshot.images.length > 0 && (
+        <div className="mb-2 flex gap-2 overflow-x-auto">
+          {snapshot.images
+            .sort((a, b) => a.orderIndex - b.orderIndex)
+            .map(img => (
+              <a
+                key={img.id}
+                href={img.downloadUrl ?? '#'}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block flex-shrink-0"
+              >
+                <img
+                  src={img.downloadUrl ?? ''}
+                  alt={`Snapshot turno ${snapshot.turnNumber}`}
+                  className="h-16 w-20 rounded-lg border border-[var(--nh-border-default)] object-cover transition-opacity hover:opacity-80"
+                />
+              </a>
+            ))}
+        </div>
+      )}
+
+      {/* Caption + timestamp */}
+      <div className="flex items-end justify-between gap-2">
+        {snapshot.caption && (
+          <p className="flex-1 font-nunito text-xs text-[var(--nh-text-secondary)] line-clamp-2">
+            {snapshot.caption}
+          </p>
+        )}
+        <span className="shrink-0 font-mono text-[10px] text-[var(--nh-text-muted)]">
+          {timeLabel}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/session/SnapshotUploadDialog.tsx
+++ b/apps/web/src/components/session/SnapshotUploadDialog.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+/**
+ * SnapshotUploadDialog — Modal for uploading snapshot images.
+ *
+ * Session Vision AI — Task 15.3
+ */
+
+import { useState, useRef, useCallback } from 'react';
+
+import { Upload, X, ImagePlus } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+interface SnapshotUploadDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onUpload: (images: File[], caption: string, turnNumber: number) => void;
+  defaultTurnNumber?: number;
+  isUploading?: boolean;
+}
+
+interface PreviewImage {
+  file: File;
+  url: string;
+}
+
+export function SnapshotUploadDialog({
+  open,
+  onClose,
+  onUpload,
+  defaultTurnNumber = 1,
+  isUploading = false,
+}: SnapshotUploadDialogProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [previews, setPreviews] = useState<PreviewImage[]>([]);
+  const [caption, setCaption] = useState('');
+  const [turnNumber, setTurnNumber] = useState(defaultTurnNumber);
+
+  const handleFiles = useCallback((files: FileList | null) => {
+    if (!files) return;
+    const newPreviews: PreviewImage[] = [];
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i];
+      if (file.type.startsWith('image/')) {
+        newPreviews.push({ file, url: URL.createObjectURL(file) });
+      }
+    }
+    setPreviews(prev => [...prev, ...newPreviews]);
+  }, []);
+
+  const removePreview = useCallback((index: number) => {
+    setPreviews(prev => {
+      const removed = prev[index];
+      if (removed) URL.revokeObjectURL(removed.url);
+      return prev.filter((_, i) => i !== index);
+    });
+  }, []);
+
+  const handleSubmit = () => {
+    if (previews.length === 0) return;
+    onUpload(
+      previews.map(p => p.file),
+      caption.trim(),
+      turnNumber
+    );
+    // Cleanup
+    previews.forEach(p => URL.revokeObjectURL(p.url));
+    setPreviews([]);
+    setCaption('');
+  };
+
+  const handleClose = () => {
+    previews.forEach(p => URL.revokeObjectURL(p.url));
+    setPreviews([]);
+    setCaption('');
+    onClose();
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="mx-4 w-full max-w-md rounded-2xl border border-[var(--nh-border-default)] bg-white p-5 shadow-xl">
+        {/* Header */}
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="font-quicksand text-lg font-bold text-[var(--nh-text-primary)]">
+            Nuovo Snapshot
+          </h3>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="flex h-8 w-8 items-center justify-center rounded-lg text-[var(--nh-text-muted)] hover:bg-stone-100"
+            aria-label="Chiudi"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* File drop zone */}
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          className={cn(
+            'mb-4 flex w-full flex-col items-center gap-2 rounded-xl border-2 border-dashed p-6 transition-colors',
+            'border-stone-300 hover:border-amber-400 hover:bg-amber-50/50'
+          )}
+        >
+          <ImagePlus className="h-8 w-8 text-stone-400" />
+          <span className="font-nunito text-sm text-[var(--nh-text-muted)]">
+            Tocca per selezionare immagini
+          </span>
+        </button>
+
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/jpeg,image/png,image/webp"
+          multiple
+          className="hidden"
+          onChange={e => {
+            handleFiles(e.target.files);
+            e.target.value = '';
+          }}
+        />
+
+        {/* Previews */}
+        {previews.length > 0 && (
+          <div className="mb-4 flex flex-wrap gap-2">
+            {previews.map((p, idx) => (
+              <div key={p.url} className="group relative">
+                <img
+                  src={p.url}
+                  alt={`Anteprima ${idx + 1}`}
+                  className="h-16 w-20 rounded-lg border border-stone-200 object-cover"
+                />
+                <button
+                  type="button"
+                  onClick={() => removePreview(idx)}
+                  aria-label={`Rimuovi immagine ${idx + 1}`}
+                  className="absolute -right-1.5 -top-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-red-500 text-white opacity-0 shadow-sm transition-opacity group-hover:opacity-100"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Turn number */}
+        <div className="mb-3">
+          <label className="mb-1 block font-nunito text-xs font-semibold text-[var(--nh-text-muted)]">
+            Numero turno
+          </label>
+          <input
+            type="number"
+            min={1}
+            value={turnNumber}
+            onChange={e => setTurnNumber(Math.max(1, parseInt(e.target.value) || 1))}
+            className="w-full rounded-lg border border-[var(--nh-border-default)] bg-[var(--nh-bg-base)] px-3 py-2 font-nunito text-sm text-[var(--nh-text-primary)] outline-none focus:border-amber-400 focus:ring-1 focus:ring-amber-200"
+          />
+        </div>
+
+        {/* Caption */}
+        <div className="mb-4">
+          <label className="mb-1 block font-nunito text-xs font-semibold text-[var(--nh-text-muted)]">
+            Descrizione (opzionale)
+          </label>
+          <input
+            type="text"
+            value={caption}
+            onChange={e => setCaption(e.target.value)}
+            placeholder="Es. Fine del round 3, Alice in vantaggio"
+            className="w-full rounded-lg border border-[var(--nh-border-default)] bg-[var(--nh-bg-base)] px-3 py-2 font-nunito text-sm text-[var(--nh-text-primary)] outline-none placeholder:text-[var(--nh-text-muted)] focus:border-amber-400 focus:ring-1 focus:ring-amber-200"
+          />
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={handleClose}
+            className="flex-1 rounded-xl border border-[var(--nh-border-default)] bg-white py-2.5 font-nunito text-sm font-medium text-[var(--nh-text-primary)] transition-colors hover:bg-stone-50"
+          >
+            Annulla
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={previews.length === 0 || isUploading}
+            className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-amber-500 py-2.5 font-nunito text-sm font-semibold text-white transition-colors hover:bg-amber-600 disabled:opacity-50"
+          >
+            <Upload className="h-4 w-4" />
+            {isUploading ? 'Caricamento...' : 'Carica'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/queries/index.ts
+++ b/apps/web/src/hooks/queries/index.ts
@@ -225,6 +225,14 @@ export { useKbGameDocuments, kbGameDocumentKeys } from './useGameDocuments';
 
 // Next Session queries (Library Hero Banner)
 
+// Session Vision AI — Snapshots & Game State
+export {
+  useSessionVisionSnapshots,
+  useLatestGameState,
+  useCreateSnapshot,
+  snapshotKeys,
+} from './useSessionSnapshots';
+
 // Re-export from @tanstack/react-query for convenience
 export {
   useQuery,

--- a/apps/web/src/hooks/queries/useSessionSnapshots.ts
+++ b/apps/web/src/hooks/queries/useSessionSnapshots.ts
@@ -1,0 +1,49 @@
+'use client';
+
+/**
+ * useSessionSnapshots — React Query hooks for Session Vision AI snapshots
+ *
+ * Provides list, game-state, and create-mutation hooks for session snapshots.
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { createSessionSnapshotsClient } from '@/lib/api/clients/sessionSnapshotsClient';
+
+const client = createSessionSnapshotsClient();
+
+export const snapshotKeys = {
+  all: ['session-snapshots'] as const,
+  list: (sid: string) => [...snapshotKeys.all, 'list', sid] as const,
+  gameState: (sid: string) => [...snapshotKeys.all, 'game-state', sid] as const,
+};
+
+export function useSessionVisionSnapshots(sessionId: string, enabled = true) {
+  return useQuery({
+    queryKey: snapshotKeys.list(sessionId),
+    queryFn: () => client.getSnapshots(sessionId),
+    enabled: enabled && !!sessionId,
+    staleTime: 30_000,
+  });
+}
+
+export function useLatestGameState(sessionId: string, enabled = true) {
+  return useQuery({
+    queryKey: snapshotKeys.gameState(sessionId),
+    queryFn: () => client.getGameState(sessionId),
+    enabled: enabled && !!sessionId,
+    staleTime: 60_000,
+  });
+}
+
+export function useCreateSnapshot(sessionId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (args: { userId: string; turnNumber: number; images: File[]; caption?: string }) =>
+      client.createSnapshot(sessionId, args.userId, args.turnNumber, args.images, args.caption),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: snapshotKeys.list(sessionId) });
+      qc.invalidateQueries({ queryKey: snapshotKeys.gameState(sessionId) });
+    },
+  });
+}

--- a/apps/web/src/hooks/useChatImageAttachments.ts
+++ b/apps/web/src/hooks/useChatImageAttachments.ts
@@ -19,6 +19,7 @@ export function useChatImageAttachments(maxImages: number = 5) {
       if (!SUPPORTED_TYPES.includes(file.type))
         return 'Formato non supportato. Usa JPEG, PNG o WebP.';
       if (file.size > MAX_FILE_SIZE) return 'Immagine troppo grande. Massimo 10MB.';
+      if (images.length >= maxImages) return `Massimo ${maxImages} immagini per messaggio.`;
       setImages(prev => {
         if (prev.length >= maxImages) return prev;
         return [...prev, { file, previewUrl: URL.createObjectURL(file), mediaType: file.type }];

--- a/apps/web/src/hooks/useChatImageAttachments.ts
+++ b/apps/web/src/hooks/useChatImageAttachments.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+
+export interface ChatImagePreview {
+  file: File;
+  previewUrl: string;
+  mediaType: string;
+}
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024;
+const SUPPORTED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+
+export function useChatImageAttachments(maxImages: number = 5) {
+  const [images, setImages] = useState<ChatImagePreview[]>([]);
+
+  const addImage = useCallback(
+    (file: File): string | null => {
+      if (!SUPPORTED_TYPES.includes(file.type))
+        return 'Formato non supportato. Usa JPEG, PNG o WebP.';
+      if (file.size > MAX_FILE_SIZE) return 'Immagine troppo grande. Massimo 10MB.';
+      setImages(prev => {
+        if (prev.length >= maxImages) return prev;
+        return [...prev, { file, previewUrl: URL.createObjectURL(file), mediaType: file.type }];
+      });
+      return null;
+    },
+    [maxImages]
+  );
+
+  const removeImage = useCallback((index: number) => {
+    setImages(prev => {
+      const removed = prev[index];
+      if (removed) URL.revokeObjectURL(removed.previewUrl);
+      return prev.filter((_, i) => i !== index);
+    });
+  }, []);
+
+  const clearImages = useCallback(() => {
+    setImages(prev => {
+      prev.forEach(img => URL.revokeObjectURL(img.previewUrl));
+      return [];
+    });
+  }, []);
+
+  return {
+    images,
+    addImage,
+    removeImage,
+    clearImages,
+    hasImages: images.length > 0,
+    canAddMore: images.length < maxImages,
+  };
+}

--- a/apps/web/src/lib/api/clients/index.ts
+++ b/apps/web/src/lib/api/clients/index.ts
@@ -55,4 +55,5 @@ export * from './agentMemoryClient'; // AgentMemory — groups, game memory, pla
 export * from './agentDocumentsClient'; // User-scoped agent document selection
 export * from './infrastructureClient'; // AI Infrastructure Dashboard
 export * from './toolkit'; // Default Game Toolkit — session events & dice presets
+export * from './sessionSnapshotsClient'; // Session Vision AI — snapshot CRUD
 export * from '../session-flow'; // Session Flow v2.1 — typed client + DTOs

--- a/apps/web/src/lib/api/clients/sessionSnapshotsClient.ts
+++ b/apps/web/src/lib/api/clients/sessionSnapshotsClient.ts
@@ -1,0 +1,83 @@
+/**
+ * Session Snapshots API Client
+ *
+ * Session Vision AI: Frontend client for snapshot CRUD and game state retrieval.
+ *
+ * Uses native fetch (not httpClient.post) because multipart/form-data
+ * requires the browser to set the Content-Type boundary automatically.
+ */
+
+export interface SessionSnapshotDto {
+  id: string;
+  sessionId: string;
+  turnNumber: number;
+  caption: string | null;
+  hasGameState: boolean;
+  createdAt: string;
+  images: SnapshotImageDto[];
+}
+
+export interface SnapshotImageDto {
+  id: string;
+  downloadUrl: string | null;
+  mediaType: string;
+  width: number;
+  height: number;
+  orderIndex: number;
+}
+
+export interface GameStateResult {
+  snapshotId: string;
+  gameStateJson: string | null;
+  isExtracted: boolean;
+  snapshotCreatedAt: string;
+}
+
+export interface CreateSnapshotResult {
+  snapshotId: string;
+  imageCount: number;
+}
+
+export function createSessionSnapshotsClient() {
+  return {
+    async getSnapshots(sessionId: string): Promise<SessionSnapshotDto[]> {
+      const res = await fetch(`/api/v1/live-sessions/${encodeURIComponent(sessionId)}/snapshots`, {
+        credentials: 'include',
+      });
+      if (!res.ok) throw new Error(`Failed to fetch snapshots: ${res.status}`);
+      return res.json();
+    },
+
+    async getGameState(sessionId: string): Promise<GameStateResult | null> {
+      const res = await fetch(
+        `/api/v1/live-sessions/${encodeURIComponent(sessionId)}/snapshots/game-state`,
+        { credentials: 'include' }
+      );
+      if (res.status === 204) return null;
+      if (!res.ok) throw new Error(`Failed to fetch game state: ${res.status}`);
+      return res.json();
+    },
+
+    async createSnapshot(
+      sessionId: string,
+      userId: string,
+      turnNumber: number,
+      images: File[],
+      caption?: string
+    ): Promise<CreateSnapshotResult> {
+      const fd = new FormData();
+      fd.append('userId', userId);
+      fd.append('turnNumber', turnNumber.toString());
+      if (caption) fd.append('caption', caption);
+      images.forEach(img => fd.append('images', img));
+
+      const res = await fetch(`/api/v1/live-sessions/${encodeURIComponent(sessionId)}/snapshots`, {
+        method: 'POST',
+        credentials: 'include',
+        body: fd,
+      });
+      if (!res.ok) throw new Error(`Failed to create snapshot: ${res.status}`);
+      return res.json();
+    },
+  };
+}

--- a/apps/web/src/lib/api/clients/sessionSnapshotsClient.ts
+++ b/apps/web/src/lib/api/clients/sessionSnapshotsClient.ts
@@ -41,16 +41,19 @@ export interface CreateSnapshotResult {
 export function createSessionSnapshotsClient() {
   return {
     async getSnapshots(sessionId: string): Promise<SessionSnapshotDto[]> {
-      const res = await fetch(`/api/v1/live-sessions/${encodeURIComponent(sessionId)}/snapshots`, {
-        credentials: 'include',
-      });
+      const res = await fetch(
+        `/api/v1/live-sessions/${encodeURIComponent(sessionId)}/vision-snapshots`,
+        {
+          credentials: 'include',
+        }
+      );
       if (!res.ok) throw new Error(`Failed to fetch snapshots: ${res.status}`);
       return res.json();
     },
 
     async getGameState(sessionId: string): Promise<GameStateResult | null> {
       const res = await fetch(
-        `/api/v1/live-sessions/${encodeURIComponent(sessionId)}/snapshots/game-state`,
+        `/api/v1/live-sessions/${encodeURIComponent(sessionId)}/vision-snapshots/game-state`,
         { credentials: 'include' }
       );
       if (res.status === 204) return null;
@@ -71,11 +74,14 @@ export function createSessionSnapshotsClient() {
       if (caption) fd.append('caption', caption);
       images.forEach(img => fd.append('images', img));
 
-      const res = await fetch(`/api/v1/live-sessions/${encodeURIComponent(sessionId)}/snapshots`, {
-        method: 'POST',
-        credentials: 'include',
-        body: fd,
-      });
+      const res = await fetch(
+        `/api/v1/live-sessions/${encodeURIComponent(sessionId)}/vision-snapshots`,
+        {
+          method: 'POST',
+          credentials: 'include',
+          body: fd,
+        }
+      );
       if (!res.ok) throw new Error(`Failed to create snapshot: ${res.status}`);
       return res.json();
     },

--- a/docs/superpowers/plans/2026-04-17-session-vision-ai.md
+++ b/docs/superpowers/plans/2026-04-17-session-vision-ai.md
@@ -1,0 +1,2480 @@
+# Session Vision AI — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable users to upload images during game sessions so the AI agent can visually analyze board state and provide context-aware responses.
+
+**Architecture:** Extend `ILlmClient` with multimodal content parts (text + image). Add `IImagePreprocessor` for resize/optimization/fallback. New `SessionSnapshot` entity in SessionTracking BC for persistent board photos with lazy GameState extraction. Frontend: image attachments in ChatInputBar + dedicated SnapshotPanel.
+
+**Tech Stack:** .NET 9 (SkiaSharp for image processing), PostgreSQL (JSONB for GameState), Next.js 16 (React Query + Zustand), existing S3/local storage via `IBlobStorageService`.
+
+**Spec:** `docs/superpowers/specs/2026-04-17-session-vision-ai-design.md`
+
+---
+
+## File Structure
+
+### Backend — New Files
+| File | Responsibility |
+|------|---------------|
+| `Services/LlmClients/ContentPart.cs` | ContentPart types + LlmMessage record |
+| `Services/LlmClients/VisionCapability.cs` | `SupportsVision` extension, vision-aware model lists |
+| `Services/ImageProcessing/IImagePreprocessor.cs` | Interface + records (ProcessedImage, ImageProcessingOptions) |
+| `Services/ImageProcessing/SkiaImagePreprocessor.cs` | SkiaSharp implementation: resize, JPEG convert |
+| `BoundedContexts/SessionTracking/Domain/Entities/SessionSnapshot.cs` | Aggregate: SessionSnapshot + SnapshotImage |
+| `BoundedContexts/SessionTracking/Domain/Repositories/ISessionSnapshotRepository.cs` | Repository interface |
+| `BoundedContexts/SessionTracking/Infrastructure/Repositories/SessionSnapshotRepository.cs` | EF Core implementation |
+| `BoundedContexts/SessionTracking/Application/Commands/SnapshotCommands.cs` | CreateSessionSnapshotCommand + handler |
+| `BoundedContexts/SessionTracking/Application/Queries/SnapshotQueries.cs` | GetSessionSnapshots + GetLatestGameState queries + handlers |
+| `BoundedContexts/SessionTracking/Application/Services/IGameStateExtractor.cs` | Interface for lazy GameState extraction |
+| `BoundedContexts/SessionTracking/Application/Services/GameStateExtractor.cs` | Vision LLM call to extract structured game state |
+| `BoundedContexts/KnowledgeBase/Domain/VisionTierLimits.cs` | Tier-based limits for vision features |
+| `Routing/SessionTracking/SessionSnapshotEndpoints.cs` | Snapshot CRUD endpoints |
+
+### Backend — Modified Files
+| File | Changes |
+|------|---------|
+| `Services/LlmClients/ILlmClient.cs` | Add multimodal overloads + `SupportsVision` property |
+| `Services/LlmClients/DeepSeekLlmClient.cs` | Implement multimodal methods, `SupportsVision = true` |
+| `Services/LlmClients/OpenRouterLlmClient.cs` | Implement multimodal methods, `SupportsVision = true` |
+| `Services/LlmClients/OllamaLlmClient.cs` | Stub multimodal (throw), `SupportsVision = false` |
+| `Services/ILlmService.cs` | Add multimodal overloads on ILlmService |
+| `BoundedContexts/KnowledgeBase/Application/Services/HybridLlmService.cs` | Implement multimodal GenerateCompletion with vision routing |
+| `BoundedContexts/SessionTracking/Application/Commands/ChatCommandHandlers.cs` | Extend AskSessionAgentCommandHandler for images + lazy extraction |
+| `BoundedContexts/SessionTracking/Application/Commands/ChatCommandValidators.cs` | Add validation for images |
+| `BoundedContexts/SessionTracking/Infrastructure/DependencyInjection/SessionTrackingServiceExtensions.cs` | Register new services |
+| `BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs` | Register ImagePreprocessor |
+| `Infrastructure/MeepleAiDbContext.cs` | Add DbSet for SessionSnapshot + SnapshotImage |
+| `Routing/SessionTracking/SessionPlayerActionsEndpoints.cs` | Update ask-agent endpoint for multipart |
+
+### Frontend — New Files
+| File | Responsibility |
+|------|---------------|
+| `hooks/useChatImageAttachments.ts` | State management for ephemeral image attachments |
+| `hooks/queries/useSessionSnapshots.ts` | React Query hooks for snapshots + game state |
+| `lib/api/clients/sessionSnapshotsClient.ts` | API client for snapshot CRUD |
+| `components/session/SessionSnapshotPanel.tsx` | Main snapshot panel with timeline |
+| `components/session/SnapshotCard.tsx` | Individual snapshot card with status badge |
+| `components/session/SnapshotUploadDialog.tsx` | Upload dialog with caption input |
+| `components/session/GameStateDisplay.tsx` | Formatted GameState JSON display |
+
+### Frontend — Modified Files
+| File | Changes |
+|------|---------|
+| `components/chat/panel/ChatInputBar.tsx` | Add image button, preview thumbnails, multipart send |
+| `components/chat/panel/ChatMessageBubble.tsx` | Render image thumbnails in user messages |
+
+---
+
+## Task 1: ContentPart Types + LlmMessage
+
+**Files:**
+- Create: `apps/api/src/Api/Services/LlmClients/ContentPart.cs`
+
+- [ ] **Step 1: Create ContentPart types**
+
+```csharp
+// apps/api/src/Api/Services/LlmClients/ContentPart.cs
+namespace Api.Services.LlmClients;
+
+/// <summary>
+/// Base type for multimodal content parts in LLM messages.
+/// Follows the OpenAI content parts standard.
+/// </summary>
+internal abstract record ContentPart;
+
+/// <summary>
+/// Text content part for LLM messages.
+/// </summary>
+internal record TextContentPart(string Text) : ContentPart;
+
+/// <summary>
+/// Image content part with base64-encoded data.
+/// </summary>
+internal record ImageContentPart(string Base64Data, string MediaType) : ContentPart
+{
+    /// <summary>
+    /// Creates a data URI for the image (e.g., "data:image/jpeg;base64,...").
+    /// Used by OpenAI-compatible APIs.
+    /// </summary>
+    public string ToDataUri() => $"data:{MediaType};base64,{Base64Data}";
+}
+
+/// <summary>
+/// A message in an LLM conversation with multimodal content parts.
+/// </summary>
+internal record LlmMessage(string Role, IReadOnlyList<ContentPart> Content)
+{
+    /// <summary>
+    /// Creates a simple text-only message.
+    /// </summary>
+    public static LlmMessage FromText(string role, string text) =>
+        new(role, [new TextContentPart(text)]);
+
+    /// <summary>
+    /// Returns true if this message contains any image content parts.
+    /// </summary>
+    public bool HasImages => Content.Any(c => c is ImageContentPart);
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `cd apps/api/src/Api && dotnet build --no-restore 2>&1 | tail -5`
+Expected: Build succeeded.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/Api/Services/LlmClients/ContentPart.cs
+git commit -m "feat(vision): add ContentPart types and LlmMessage for multimodal LLM support"
+```
+
+---
+
+## Task 2: Extend ILlmClient with Multimodal Overloads
+
+**Files:**
+- Modify: `apps/api/src/Api/Services/LlmClients/ILlmClient.cs`
+
+- [ ] **Step 1: Add multimodal methods and SupportsVision to ILlmClient**
+
+Add these members to the `ILlmClient` interface after the existing methods:
+
+```csharp
+    /// <summary>
+    /// Whether this provider supports vision/image content parts.
+    /// Providers returning false will receive text-only fallback.
+    /// </summary>
+    bool SupportsVision { get; }
+
+    /// <summary>
+    /// Generate a multimodal chat completion with content parts (text + images).
+    /// </summary>
+    Task<LlmCompletionResult> GenerateCompletionAsync(
+        string model,
+        IReadOnlyList<LlmMessage> messages,
+        double temperature,
+        int maxTokens,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Generate a streaming multimodal chat completion.
+    /// </summary>
+    IAsyncEnumerable<StreamChunk> GenerateCompletionStreamAsync(
+        string model,
+        IReadOnlyList<LlmMessage> messages,
+        double temperature,
+        int maxTokens,
+        CancellationToken ct = default);
+```
+
+Add required using at top:
+
+```csharp
+using Api.Services.LlmClients;
+```
+
+- [ ] **Step 2: Verify build fails (providers don't implement yet)**
+
+Run: `cd apps/api/src/Api && dotnet build --no-restore 2>&1 | grep "error CS"`
+Expected: CS0535 errors for each provider not implementing the new members.
+
+- [ ] **Step 3: Implement multimodal on DeepSeekLlmClient**
+
+Add to `DeepSeekLlmClient.cs`:
+
+```csharp
+    public bool SupportsVision => true;
+
+    public async Task<LlmCompletionResult> GenerateCompletionAsync(
+        string model, IReadOnlyList<LlmMessage> messages,
+        double temperature, int maxTokens, CancellationToken ct = default)
+    {
+        var requestMessages = messages.Select(m => new
+        {
+            role = m.Role,
+            content = m.Content.Select<ContentPart, object>(c => c switch
+            {
+                TextContentPart t => new { type = "text", text = t.Text },
+                ImageContentPart img => new { type = "image_url", image_url = new { url = img.ToDataUri() } },
+                _ => new { type = "text", text = string.Empty }
+            }).ToArray()
+        }).ToArray();
+
+        var requestBody = new
+        {
+            model,
+            messages = requestMessages,
+            temperature,
+            max_tokens = maxTokens,
+            stream = false
+        };
+
+        return await SendCompletionRequestAsync(requestBody, model, ct).ConfigureAwait(false);
+    }
+
+    public async IAsyncEnumerable<StreamChunk> GenerateCompletionStreamAsync(
+        string model, IReadOnlyList<LlmMessage> messages,
+        double temperature, int maxTokens,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        var requestMessages = messages.Select(m => new
+        {
+            role = m.Role,
+            content = m.Content.Select<ContentPart, object>(c => c switch
+            {
+                TextContentPart t => new { type = "text", text = t.Text },
+                ImageContentPart img => new { type = "image_url", image_url = new { url = img.ToDataUri() } },
+                _ => new { type = "text", text = string.Empty }
+            }).ToArray()
+        }).ToArray();
+
+        var requestBody = new
+        {
+            model,
+            messages = requestMessages,
+            temperature,
+            max_tokens = maxTokens,
+            stream = true
+        };
+
+        await foreach (var chunk in SendStreamingRequestAsync(requestBody, model, ct).ConfigureAwait(false))
+        {
+            yield return chunk;
+        }
+    }
+```
+
+Note: `SendCompletionRequestAsync` and `SendStreamingRequestAsync` are private methods already in DeepSeekLlmClient that handle the HTTP call + response parsing. The multimodal methods reuse them — only the message format changes. If these private methods take the full request body as `object`, this works directly. If they take `(systemPrompt, userPrompt)`, refactor to extract the HTTP logic into a shared method that takes the request body object.
+
+- [ ] **Step 4: Implement multimodal on OpenRouterLlmClient**
+
+Same pattern as DeepSeek (OpenAI-compatible content parts format). Add:
+
+```csharp
+    public bool SupportsVision => true;
+```
+
+And implement the two multimodal methods with the same content-parts serialization pattern. OpenRouter uses the identical OpenAI message format.
+
+- [ ] **Step 5: Implement stub on OllamaLlmClient**
+
+```csharp
+    public bool SupportsVision => false;
+
+    public Task<LlmCompletionResult> GenerateCompletionAsync(
+        string model, IReadOnlyList<LlmMessage> messages,
+        double temperature, int maxTokens, CancellationToken ct = default)
+    {
+        throw new NotSupportedException("Ollama does not support multimodal/vision requests. Use a vision-capable provider.");
+    }
+
+    public IAsyncEnumerable<StreamChunk> GenerateCompletionStreamAsync(
+        string model, IReadOnlyList<LlmMessage> messages,
+        double temperature, int maxTokens, CancellationToken ct = default)
+    {
+        throw new NotSupportedException("Ollama does not support multimodal/vision requests. Use a vision-capable provider.");
+    }
+```
+
+- [ ] **Step 6: Verify build succeeds**
+
+Run: `cd apps/api/src/Api && dotnet build --no-restore 2>&1 | tail -5`
+Expected: Build succeeded.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/Services/LlmClients/
+git commit -m "feat(vision): extend ILlmClient with multimodal content parts and SupportsVision"
+```
+
+---
+
+## Task 3: Extend ILlmService + HybridLlmService with Multimodal
+
+**Files:**
+- Modify: `apps/api/src/Api/Services/ILlmService.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/HybridLlmService.cs`
+
+- [ ] **Step 1: Add multimodal methods to ILlmService**
+
+Add to `ILlmService` interface:
+
+```csharp
+    /// <summary>
+    /// Generate a multimodal completion with content parts (text + images).
+    /// Automatically routes to a vision-capable provider.
+    /// </summary>
+    Task<LlmCompletionResult> GenerateMultimodalCompletionAsync(
+        IReadOnlyList<LlmMessage> messages,
+        RequestSource source = RequestSource.Manual,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Generate a streaming multimodal completion.
+    /// </summary>
+    IAsyncEnumerable<StreamChunk> GenerateMultimodalCompletionStreamAsync(
+        IReadOnlyList<LlmMessage> messages,
+        RequestSource source = RequestSource.Manual,
+        CancellationToken ct = default);
+```
+
+Add at top of file:
+
+```csharp
+using Api.Services.LlmClients;
+```
+
+- [ ] **Step 2: Implement in HybridLlmService**
+
+Add to `HybridLlmService`:
+
+```csharp
+    public async Task<LlmCompletionResult> GenerateMultimodalCompletionAsync(
+        IReadOnlyList<LlmMessage> messages,
+        RequestSource source = RequestSource.Manual,
+        CancellationToken ct = default)
+    {
+        var userContext = LlmUserContextMapper.CreateDefault(source);
+        var selection = await _providerSelector.SelectProviderAsync(userContext, RagStrategy.Balanced, source, ct)
+            .ConfigureAwait(false);
+
+        bool requiresVision = messages.Any(m => m.HasImages);
+        var client = selection.Client;
+
+        // If vision required but provider doesn't support it, try fallback
+        if (requiresVision && !client.SupportsVision)
+        {
+            var fallback = await _providerSelector.GetNextFallbackAsync(
+                client.ProviderName, new HashSet<string>(StringComparer.Ordinal) { client.ProviderName }, ct)
+                .ConfigureAwait(false);
+
+            if (fallback?.Client.SupportsVision == true)
+                client = fallback.Client;
+            // else proceed with text-only (images will be ignored by caller)
+        }
+
+        if (requiresVision && client.SupportsVision)
+        {
+            return await client.GenerateCompletionAsync(
+                selection.ModelId, messages, DefaultTemperature, DefaultMaxTokens, ct)
+                .ConfigureAwait(false);
+        }
+
+        // Fallback: extract text only from messages
+        var systemPrompt = string.Join("\n",
+            messages.Where(m => m.Role == "system").SelectMany(m => m.Content.OfType<TextContentPart>()).Select(t => t.Text));
+        var userPrompt = string.Join("\n",
+            messages.Where(m => m.Role == "user").SelectMany(m => m.Content.OfType<TextContentPart>()).Select(t => t.Text));
+
+        return await GenerateCompletionAsync(systemPrompt, userPrompt, source, ct).ConfigureAwait(false);
+    }
+
+    public async IAsyncEnumerable<StreamChunk> GenerateMultimodalCompletionStreamAsync(
+        IReadOnlyList<LlmMessage> messages,
+        RequestSource source = RequestSource.Manual,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        var userContext = LlmUserContextMapper.CreateDefault(source);
+        var selection = await _providerSelector.SelectProviderAsync(userContext, RagStrategy.Balanced, source, ct)
+            .ConfigureAwait(false);
+
+        bool requiresVision = messages.Any(m => m.HasImages);
+        var client = selection.Client;
+
+        if (requiresVision && !client.SupportsVision)
+        {
+            var fallback = await _providerSelector.GetNextFallbackAsync(
+                client.ProviderName, new HashSet<string>(StringComparer.Ordinal) { client.ProviderName }, ct)
+                .ConfigureAwait(false);
+
+            if (fallback?.Client.SupportsVision == true)
+                client = fallback.Client;
+        }
+
+        if (requiresVision && client.SupportsVision)
+        {
+            await foreach (var chunk in client.GenerateCompletionStreamAsync(
+                selection.ModelId, messages, DefaultTemperature, DefaultMaxTokens, ct)
+                .ConfigureAwait(false))
+            {
+                yield return chunk;
+            }
+            yield break;
+        }
+
+        // Fallback: text-only
+        var systemPrompt = string.Join("\n",
+            messages.Where(m => m.Role == "system").SelectMany(m => m.Content.OfType<TextContentPart>()).Select(t => t.Text));
+        var userPrompt = string.Join("\n",
+            messages.Where(m => m.Role == "user").SelectMany(m => m.Content.OfType<TextContentPart>()).Select(t => t.Text));
+
+        await foreach (var chunk in GenerateCompletionStreamAsync(systemPrompt, userPrompt, source, ct)
+            .ConfigureAwait(false))
+        {
+            yield return chunk;
+        }
+    }
+```
+
+Note: Check that `DefaultTemperature` and `DefaultMaxTokens` constants exist in HybridLlmService (they should based on the existing code pattern). If not, use `0.3` and `500` directly.
+
+- [ ] **Step 3: Verify build**
+
+Run: `cd apps/api/src/Api && dotnet build --no-restore 2>&1 | tail -5`
+Expected: Build succeeded.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/Api/Services/ILlmService.cs apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/HybridLlmService.cs
+git commit -m "feat(vision): add multimodal methods to ILlmService and HybridLlmService"
+```
+
+---
+
+## Task 4: IImagePreprocessor + SkiaSharp Implementation
+
+**Files:**
+- Create: `apps/api/src/Api/Services/ImageProcessing/IImagePreprocessor.cs`
+- Create: `apps/api/src/Api/Services/ImageProcessing/SkiaImagePreprocessor.cs`
+
+- [ ] **Step 1: Create IImagePreprocessor interface**
+
+```csharp
+// apps/api/src/Api/Services/ImageProcessing/IImagePreprocessor.cs
+namespace Api.Services.ImageProcessing;
+
+internal record ProcessedImage(byte[] Data, string MediaType, int Width, int Height, long SizeBytes);
+
+internal record ImageProcessingOptions(
+    int MaxWidth = 1024,
+    int MaxHeight = 1024,
+    long MaxSizeBytes = 5_000_000,
+    bool ConvertToJpeg = true);
+
+internal interface IImagePreprocessor
+{
+    /// <summary>
+    /// Resize and optimize an image for vision API consumption.
+    /// </summary>
+    Task<ProcessedImage> ProcessAsync(byte[] imageData, string mediaType, ImageProcessingOptions? options = null);
+
+    /// <summary>
+    /// Validate that the given data is a supported image format.
+    /// Returns the detected media type or null if unsupported.
+    /// </summary>
+    string? DetectMediaType(byte[] data);
+}
+```
+
+- [ ] **Step 2: Create SkiaImagePreprocessor**
+
+```csharp
+// apps/api/src/Api/Services/ImageProcessing/SkiaImagePreprocessor.cs
+using SkiaSharp;
+
+namespace Api.Services.ImageProcessing;
+
+internal sealed class SkiaImagePreprocessor : IImagePreprocessor
+{
+    private static readonly ImageProcessingOptions DefaultOptions = new();
+
+    public Task<ProcessedImage> ProcessAsync(byte[] imageData, string mediaType, ImageProcessingOptions? options = null)
+    {
+        options ??= DefaultOptions;
+
+        using var original = SKBitmap.Decode(imageData)
+            ?? throw new ArgumentException("Unable to decode image data.");
+
+        int targetWidth = original.Width;
+        int targetHeight = original.Height;
+
+        // Scale down if exceeds max dimensions
+        if (targetWidth > options.MaxWidth || targetHeight > options.MaxHeight)
+        {
+            double scale = Math.Min(
+                (double)options.MaxWidth / targetWidth,
+                (double)options.MaxHeight / targetHeight);
+            targetWidth = (int)(targetWidth * scale);
+            targetHeight = (int)(targetHeight * scale);
+        }
+
+        using var resized = original.Resize(new SKImageInfo(targetWidth, targetHeight), SKFilterQuality.High);
+        if (resized is null)
+            throw new InvalidOperationException("Failed to resize image.");
+
+        using var image = SKImage.FromBitmap(resized);
+
+        var format = options.ConvertToJpeg ? SKEncodedImageFormat.Jpeg : SKEncodedImageFormat.Png;
+        var outputMediaType = options.ConvertToJpeg ? "image/jpeg" : mediaType;
+        int quality = 85;
+
+        using var encoded = image.Encode(format, quality);
+        var data = encoded.ToArray();
+
+        // If still too large, reduce quality
+        if (data.Length > options.MaxSizeBytes && options.ConvertToJpeg)
+        {
+            quality = 60;
+            using var reEncoded = image.Encode(SKEncodedImageFormat.Jpeg, quality);
+            data = reEncoded.ToArray();
+        }
+
+        return Task.FromResult(new ProcessedImage(data, outputMediaType, targetWidth, targetHeight, data.Length));
+    }
+
+    public string? DetectMediaType(byte[] data)
+    {
+        if (data.Length < 4) return null;
+
+        // JPEG: FF D8 FF
+        if (data[0] == 0xFF && data[1] == 0xD8 && data[2] == 0xFF)
+            return "image/jpeg";
+
+        // PNG: 89 50 4E 47
+        if (data[0] == 0x89 && data[1] == 0x50 && data[2] == 0x4E && data[3] == 0x47)
+            return "image/png";
+
+        // WebP: RIFF....WEBP
+        if (data.Length >= 12 && data[0] == 0x52 && data[1] == 0x49 && data[2] == 0x46 && data[3] == 0x46
+            && data[8] == 0x57 && data[9] == 0x45 && data[10] == 0x42 && data[11] == 0x50)
+            return "image/webp";
+
+        return null;
+    }
+}
+```
+
+- [ ] **Step 3: Add SkiaSharp NuGet package**
+
+Run: `cd apps/api/src/Api && dotnet add package SkiaSharp --version 2.88.*`
+
+- [ ] **Step 4: Register in DI**
+
+Add to `KnowledgeBaseServiceExtensions.cs` in the `AddLlmServices` method:
+
+```csharp
+    services.AddSingleton<IImagePreprocessor, SkiaImagePreprocessor>();
+```
+
+Add using: `using Api.Services.ImageProcessing;`
+
+- [ ] **Step 5: Verify build**
+
+Run: `cd apps/api/src/Api && dotnet build 2>&1 | tail -5`
+Expected: Build succeeded.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/Services/ImageProcessing/ apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs apps/api/src/Api/Api.csproj
+git commit -m "feat(vision): add IImagePreprocessor with SkiaSharp resize and format detection"
+```
+
+---
+
+## Task 5: VisionTierLimits
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/VisionTierLimits.cs`
+
+- [ ] **Step 1: Create VisionTierLimits**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/VisionTierLimits.cs
+namespace Api.BoundedContexts.KnowledgeBase.Domain;
+
+internal record VisionTierConfig(
+    int MaxImagesPerMessage,
+    int MaxSnapshotsPerSession,
+    int MaxImagesPerSnapshot,
+    int MaxImageResolution,
+    bool GameStateExtractionEnabled);
+
+internal static class VisionTierLimits
+{
+    private static readonly IReadOnlyDictionary<string, VisionTierConfig> TierConfigs =
+        new Dictionary<string, VisionTierConfig>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["alpha"] = new(MaxImagesPerMessage: 5, MaxSnapshotsPerSession: 20, MaxImagesPerSnapshot: 5, MaxImageResolution: 2048, GameStateExtractionEnabled: true),
+            ["free"] = new(MaxImagesPerMessage: 2, MaxSnapshotsPerSession: 5, MaxImagesPerSnapshot: 3, MaxImageResolution: 1024, GameStateExtractionEnabled: false),
+            ["premium"] = new(MaxImagesPerMessage: 5, MaxSnapshotsPerSession: 30, MaxImagesPerSnapshot: 10, MaxImageResolution: 2048, GameStateExtractionEnabled: true),
+        };
+
+    private static readonly VisionTierConfig DefaultConfig = TierConfigs["free"];
+
+    public static VisionTierConfig GetConfig(string? tier)
+    {
+        if (tier is null) return DefaultConfig;
+        return TierConfigs.GetValueOrDefault(tier, DefaultConfig);
+    }
+}
+```
+
+- [ ] **Step 2: Verify build + Commit**
+
+```bash
+cd apps/api/src/Api && dotnet build --no-restore 2>&1 | tail -3
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/VisionTierLimits.cs
+git commit -m "feat(vision): add VisionTierLimits with tier-based configuration"
+```
+
+---
+
+## Task 6: SessionSnapshot Entity + Repository
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/SessionSnapshot.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Repositories/ISessionSnapshotRepository.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Repositories/SessionSnapshotRepository.cs`
+
+- [ ] **Step 1: Create SessionSnapshot + SnapshotImage entities**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/SessionSnapshot.cs
+using System.ComponentModel.DataAnnotations;
+
+namespace Api.BoundedContexts.SessionTracking.Domain.Entities;
+
+/// <summary>
+/// Persistent snapshot of game board state with images.
+/// Supports lazy GameState extraction via vision AI.
+/// </summary>
+public class SessionSnapshot
+{
+    private readonly List<SnapshotImage> _images = [];
+
+    public Guid Id { get; private set; }
+    public Guid SessionId { get; private set; }
+    public Guid UserId { get; private set; }
+    public int TurnNumber { get; private set; }
+
+    [MaxLength(200)]
+    public string? Caption { get; private set; }
+
+    /// <summary>
+    /// JSON-structured game state extracted by vision AI. Null until lazy extraction runs.
+    /// </summary>
+    public string? ExtractedGameState { get; private set; }
+
+    public IReadOnlyList<SnapshotImage> Images => _images.AsReadOnly();
+
+    public DateTime CreatedAt { get; private set; } = DateTime.UtcNow;
+    public DateTime? UpdatedAt { get; private set; }
+    public bool IsDeleted { get; private set; }
+    public DateTime? DeletedAt { get; private set; }
+
+    private SessionSnapshot() { }
+
+    public static SessionSnapshot Create(Guid sessionId, Guid userId, int turnNumber, string? caption)
+    {
+        if (sessionId == Guid.Empty) throw new ArgumentException("Session ID required.", nameof(sessionId));
+        if (userId == Guid.Empty) throw new ArgumentException("User ID required.", nameof(userId));
+        if (turnNumber < 0) throw new ArgumentOutOfRangeException(nameof(turnNumber));
+        if (caption?.Length > 200) throw new ArgumentException("Caption max 200 chars.", nameof(caption));
+
+        return new SessionSnapshot
+        {
+            Id = Guid.NewGuid(),
+            SessionId = sessionId,
+            UserId = userId,
+            TurnNumber = turnNumber,
+            Caption = caption,
+        };
+    }
+
+    public void AddImage(string storageKey, string mediaType, int width, int height)
+    {
+        if (string.IsNullOrWhiteSpace(storageKey)) throw new ArgumentException("Storage key required.", nameof(storageKey));
+
+        _images.Add(new SnapshotImage
+        {
+            Id = Guid.NewGuid(),
+            StorageKey = storageKey,
+            MediaType = mediaType,
+            Width = width,
+            Height = height,
+            OrderIndex = _images.Count,
+        });
+    }
+
+    public void UpdateGameState(string gameStateJson)
+    {
+        ExtractedGameState = gameStateJson ?? throw new ArgumentNullException(nameof(gameStateJson));
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    public void SoftDelete()
+    {
+        IsDeleted = true;
+        DeletedAt = DateTime.UtcNow;
+    }
+}
+
+/// <summary>
+/// Individual image within a session snapshot.
+/// </summary>
+public class SnapshotImage
+{
+    public Guid Id { get; internal set; }
+
+    [MaxLength(500)]
+    public string StorageKey { get; internal set; } = string.Empty;
+
+    [MaxLength(50)]
+    public string MediaType { get; internal set; } = string.Empty;
+    public int Width { get; internal set; }
+    public int Height { get; internal set; }
+    public int OrderIndex { get; internal set; }
+
+    // Navigation — EF Core
+    public Guid SessionSnapshotId { get; internal set; }
+}
+```
+
+- [ ] **Step 2: Create repository interface**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Repositories/ISessionSnapshotRepository.cs
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+
+namespace Api.BoundedContexts.SessionTracking.Domain.Repositories;
+
+internal interface ISessionSnapshotRepository
+{
+    Task<SessionSnapshot?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<List<SessionSnapshot>> GetBySessionIdAsync(Guid sessionId, CancellationToken ct = default);
+    Task<SessionSnapshot?> GetLatestBySessionIdAsync(Guid sessionId, CancellationToken ct = default);
+    Task AddAsync(SessionSnapshot snapshot, CancellationToken ct = default);
+    Task UpdateAsync(SessionSnapshot snapshot, CancellationToken ct = default);
+    Task<int> CountBySessionIdAsync(Guid sessionId, CancellationToken ct = default);
+    Task SaveChangesAsync(CancellationToken ct = default);
+}
+```
+
+- [ ] **Step 3: Create EF Core repository implementation**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Repositories/SessionSnapshotRepository.cs
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SessionTracking.Infrastructure.Repositories;
+
+internal sealed class SessionSnapshotRepository : ISessionSnapshotRepository
+{
+    private readonly MeepleAiDbContext _db;
+
+    public SessionSnapshotRepository(MeepleAiDbContext db) => _db = db;
+
+    public async Task<SessionSnapshot?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
+        await _db.SessionSnapshots
+            .Include(s => s.Images.OrderBy(i => i.OrderIndex))
+            .FirstOrDefaultAsync(s => s.Id == id && !s.IsDeleted, ct)
+            .ConfigureAwait(false);
+
+    public async Task<List<SessionSnapshot>> GetBySessionIdAsync(Guid sessionId, CancellationToken ct = default) =>
+        await _db.SessionSnapshots
+            .Include(s => s.Images.OrderBy(i => i.OrderIndex))
+            .Where(s => s.SessionId == sessionId && !s.IsDeleted)
+            .OrderByDescending(s => s.TurnNumber)
+            .ThenByDescending(s => s.CreatedAt)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+    public async Task<SessionSnapshot?> GetLatestBySessionIdAsync(Guid sessionId, CancellationToken ct = default) =>
+        await _db.SessionSnapshots
+            .Include(s => s.Images.OrderBy(i => i.OrderIndex))
+            .Where(s => s.SessionId == sessionId && !s.IsDeleted)
+            .OrderByDescending(s => s.CreatedAt)
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+
+    public async Task AddAsync(SessionSnapshot snapshot, CancellationToken ct = default) =>
+        await _db.SessionSnapshots.AddAsync(snapshot, ct).ConfigureAwait(false);
+
+    public Task UpdateAsync(SessionSnapshot snapshot, CancellationToken ct = default)
+    {
+        _db.SessionSnapshots.Update(snapshot);
+        return Task.CompletedTask;
+    }
+
+    public async Task<int> CountBySessionIdAsync(Guid sessionId, CancellationToken ct = default) =>
+        await _db.SessionSnapshots.CountAsync(s => s.SessionId == sessionId && !s.IsDeleted, ct)
+            .ConfigureAwait(false);
+
+    public async Task SaveChangesAsync(CancellationToken ct = default) =>
+        await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+}
+```
+
+- [ ] **Step 4: Add DbSet to MeepleAiDbContext**
+
+Add to `Infrastructure/MeepleAiDbContext.cs`:
+
+```csharp
+    public DbSet<BoundedContexts.SessionTracking.Domain.Entities.SessionSnapshot> SessionSnapshots => Set<BoundedContexts.SessionTracking.Domain.Entities.SessionSnapshot>();
+```
+
+- [ ] **Step 5: Add EF configuration**
+
+Find or create the EF configuration file for SessionTracking and add configuration for SessionSnapshot + SnapshotImage. The configuration should include:
+- `HasColumnName("snake_case")` for all columns (per CLAUDE.md: always explicit snake_case)
+- `HasQueryFilter(s => !s.IsDeleted)` for soft delete
+- SnapshotImage as owned collection or separate table with FK
+
+- [ ] **Step 6: Register repository in DI**
+
+Add to `SessionTrackingServiceExtensions.cs`:
+
+```csharp
+    services.AddScoped<ISessionSnapshotRepository, SessionSnapshotRepository>();
+```
+
+Add required usings.
+
+- [ ] **Step 7: Create EF migration**
+
+Run: `cd apps/api/src/Api && dotnet ef migrations add AddSessionSnapshots`
+
+Review the generated migration SQL. Verify it creates `session_snapshots` and `snapshot_images` tables with correct column names and indexes.
+
+- [ ] **Step 8: Verify build + Commit**
+
+```bash
+cd apps/api/src/Api && dotnet build 2>&1 | tail -3
+git add apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/SessionSnapshot.cs apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Repositories/ISessionSnapshotRepository.cs apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Repositories/SessionSnapshotRepository.cs apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/DependencyInjection/SessionTrackingServiceExtensions.cs apps/api/src/Api/Infrastructure/Migrations/
+git commit -m "feat(vision): add SessionSnapshot entity, repository, and EF migration"
+```
+
+---
+
+## Task 7: Snapshot Commands + Handlers
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/SnapshotCommands.cs`
+
+- [ ] **Step 1: Create commands and handler**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/SnapshotCommands.cs
+using MediatR;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain;
+using Api.Middleware.Exceptions;
+using Api.Services.ImageProcessing;
+using Api.Services.Pdf;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+public record SnapshotImageUpload(byte[] Data, string MediaType, string? FileName);
+
+public record CreateSessionSnapshotCommand(
+    Guid SessionId,
+    Guid UserId,
+    int TurnNumber,
+    string? Caption,
+    List<SnapshotImageUpload> Images
+) : IRequest<CreateSnapshotResult>;
+
+public record CreateSnapshotResult(Guid SnapshotId, int ImageCount);
+
+internal sealed class CreateSessionSnapshotCommandHandler
+    : IRequestHandler<CreateSessionSnapshotCommand, CreateSnapshotResult>
+{
+    private readonly ISessionRepository _sessionRepository;
+    private readonly ISessionSnapshotRepository _snapshotRepository;
+    private readonly IImagePreprocessor _imagePreprocessor;
+    private readonly IBlobStorageService _blobStorage;
+
+    public CreateSessionSnapshotCommandHandler(
+        ISessionRepository sessionRepository,
+        ISessionSnapshotRepository snapshotRepository,
+        IImagePreprocessor imagePreprocessor,
+        IBlobStorageService blobStorage)
+    {
+        _sessionRepository = sessionRepository;
+        _snapshotRepository = snapshotRepository;
+        _imagePreprocessor = imagePreprocessor;
+        _blobStorage = blobStorage;
+    }
+
+    public async Task<CreateSnapshotResult> Handle(
+        CreateSessionSnapshotCommand request, CancellationToken ct)
+    {
+        var session = await _sessionRepository.GetByIdAsync(request.SessionId, ct).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {request.SessionId} not found");
+
+        // Validate tier limits
+        var tierConfig = VisionTierLimits.GetConfig("alpha"); // TODO: resolve user tier from session
+        var currentCount = await _snapshotRepository.CountBySessionIdAsync(request.SessionId, ct).ConfigureAwait(false);
+        if (currentCount >= tierConfig.MaxSnapshotsPerSession)
+            throw new ConflictException($"Maximum {tierConfig.MaxSnapshotsPerSession} snapshots per session reached.");
+
+        if (request.Images.Count > tierConfig.MaxImagesPerSnapshot)
+            throw new ConflictException($"Maximum {tierConfig.MaxImagesPerSnapshot} images per snapshot.");
+
+        if (request.Images.Count == 0)
+            throw new ConflictException("At least one image is required.");
+
+        var snapshot = SessionSnapshot.Create(request.SessionId, request.UserId, request.TurnNumber, request.Caption);
+
+        var options = new ImageProcessingOptions(
+            MaxWidth: tierConfig.MaxImageResolution,
+            MaxHeight: tierConfig.MaxImageResolution);
+
+        for (int i = 0; i < request.Images.Count; i++)
+        {
+            var img = request.Images[i];
+            var processed = await _imagePreprocessor.ProcessAsync(img.Data, img.MediaType, options).ConfigureAwait(false);
+
+            var fileName = $"img_{i}.jpg";
+            using var stream = new MemoryStream(processed.Data);
+            var storageResult = await _blobStorage.StoreAsync(
+                stream, fileName, $"snapshots/{request.SessionId}/{snapshot.Id}", ct).ConfigureAwait(false);
+
+            if (!storageResult.Success)
+                throw new InvalidOperationException($"Failed to store snapshot image: {storageResult.ErrorMessage}");
+
+            snapshot.AddImage(
+                storageResult.FilePath ?? $"snapshots/{request.SessionId}/{snapshot.Id}/{fileName}",
+                processed.MediaType,
+                processed.Width,
+                processed.Height);
+        }
+
+        await _snapshotRepository.AddAsync(snapshot, ct).ConfigureAwait(false);
+        await _snapshotRepository.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        return new CreateSnapshotResult(snapshot.Id, snapshot.Images.Count);
+    }
+}
+```
+
+- [ ] **Step 2: Verify build + Commit**
+
+```bash
+cd apps/api/src/Api && dotnet build --no-restore 2>&1 | tail -5
+git add apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/SnapshotCommands.cs
+git commit -m "feat(vision): add CreateSessionSnapshotCommand with image processing and storage"
+```
+
+---
+
+## Task 8: Snapshot Queries + GameState Extractor
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/SnapshotQueries.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Services/GameStateExtractor.cs`
+
+- [ ] **Step 1: Create queries and handlers**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/SnapshotQueries.cs
+using MediatR;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Services.Pdf;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+public record SessionSnapshotDto(
+    Guid Id, Guid SessionId, int TurnNumber, string? Caption,
+    bool HasGameState, DateTime CreatedAt,
+    List<SnapshotImageDto> Images);
+
+public record SnapshotImageDto(Guid Id, string? DownloadUrl, string MediaType, int Width, int Height, int OrderIndex);
+
+public record GameStateResult(Guid SnapshotId, string? GameStateJson, bool IsExtracted, DateTime SnapshotCreatedAt);
+
+// --- Get all snapshots for a session ---
+public record GetSessionSnapshotsQuery(Guid SessionId) : IRequest<List<SessionSnapshotDto>>;
+
+internal sealed class GetSessionSnapshotsQueryHandler
+    : IRequestHandler<GetSessionSnapshotsQuery, List<SessionSnapshotDto>>
+{
+    private readonly ISessionSnapshotRepository _repository;
+    private readonly IBlobStorageService _blobStorage;
+
+    public GetSessionSnapshotsQueryHandler(ISessionSnapshotRepository repository, IBlobStorageService blobStorage)
+    {
+        _repository = repository;
+        _blobStorage = blobStorage;
+    }
+
+    public async Task<List<SessionSnapshotDto>> Handle(GetSessionSnapshotsQuery request, CancellationToken ct)
+    {
+        var snapshots = await _repository.GetBySessionIdAsync(request.SessionId, ct).ConfigureAwait(false);
+        var result = new List<SessionSnapshotDto>();
+
+        foreach (var s in snapshots)
+        {
+            var images = new List<SnapshotImageDto>();
+            foreach (var img in s.Images)
+            {
+                var url = await _blobStorage.GetPresignedDownloadUrlAsync(
+                    img.StorageKey, $"snapshots/{s.SessionId}/{s.Id}").ConfigureAwait(false);
+                images.Add(new SnapshotImageDto(img.Id, url, img.MediaType, img.Width, img.Height, img.OrderIndex));
+            }
+            result.Add(new SessionSnapshotDto(s.Id, s.SessionId, s.TurnNumber, s.Caption,
+                s.ExtractedGameState is not null, s.CreatedAt, images));
+        }
+
+        return result;
+    }
+}
+
+// --- Get latest game state ---
+public record GetLatestGameStateQuery(Guid SessionId) : IRequest<GameStateResult?>;
+
+internal sealed class GetLatestGameStateQueryHandler
+    : IRequestHandler<GetLatestGameStateQuery, GameStateResult?>
+{
+    private readonly ISessionSnapshotRepository _repository;
+
+    public GetLatestGameStateQueryHandler(ISessionSnapshotRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<GameStateResult?> Handle(GetLatestGameStateQuery request, CancellationToken ct)
+    {
+        var latest = await _repository.GetLatestBySessionIdAsync(request.SessionId, ct).ConfigureAwait(false);
+        if (latest is null) return null;
+
+        return new GameStateResult(latest.Id, latest.ExtractedGameState,
+            latest.ExtractedGameState is not null, latest.CreatedAt);
+    }
+}
+```
+
+- [ ] **Step 2: Create GameStateExtractor service**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/SessionTracking/Application/Services/GameStateExtractor.cs
+using System.Text.Json;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Services;
+using Api.Services.LlmClients;
+using Api.Services.Pdf;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Services;
+
+internal interface IGameStateExtractor
+{
+    /// <summary>
+    /// Lazy-extract game state from the latest snapshot's images.
+    /// Returns the extracted JSON or null if extraction fails/not applicable.
+    /// Idempotent: skips if GameState already extracted for this snapshot.
+    /// </summary>
+    Task<string?> ExtractIfNeededAsync(Guid sessionId, string? gameName, CancellationToken ct = default);
+}
+
+internal sealed class GameStateExtractor : IGameStateExtractor
+{
+    private readonly ISessionSnapshotRepository _snapshotRepository;
+    private readonly IBlobStorageService _blobStorage;
+    private readonly ILlmService _llmService;
+    private readonly ILogger<GameStateExtractor> _logger;
+
+    public GameStateExtractor(
+        ISessionSnapshotRepository snapshotRepository,
+        IBlobStorageService blobStorage,
+        ILlmService llmService,
+        ILogger<GameStateExtractor> logger)
+    {
+        _snapshotRepository = snapshotRepository;
+        _blobStorage = blobStorage;
+        _llmService = llmService;
+        _logger = logger;
+    }
+
+    public async Task<string?> ExtractIfNeededAsync(Guid sessionId, string? gameName, CancellationToken ct = default)
+    {
+        var snapshot = await _snapshotRepository.GetLatestBySessionIdAsync(sessionId, ct).ConfigureAwait(false);
+        if (snapshot is null) return null;
+
+        // Idempotent: already extracted
+        if (snapshot.ExtractedGameState is not null) return snapshot.ExtractedGameState;
+
+        try
+        {
+            // Build multimodal messages for vision extraction
+            var contentParts = new List<ContentPart>();
+            foreach (var img in snapshot.Images)
+            {
+                var storageKey = img.StorageKey;
+                var gameId = $"snapshots/{snapshot.SessionId}/{snapshot.Id}";
+                using var stream = await _blobStorage.RetrieveAsync(storageKey, gameId, ct).ConfigureAwait(false);
+                if (stream is null) continue;
+
+                using var ms = new MemoryStream();
+                await stream.CopyToAsync(ms, ct).ConfigureAwait(false);
+                var base64 = Convert.ToBase64String(ms.ToArray());
+                contentParts.Add(new ImageContentPart(base64, img.MediaType));
+            }
+
+            if (contentParts.Count == 0)
+            {
+                _logger.LogWarning("No images could be loaded for snapshot {SnapshotId}", snapshot.Id);
+                return null;
+            }
+
+            var gameContext = gameName is not null ? $"The game is: {gameName}." : "Unknown board game.";
+
+            var systemPrompt = $"""
+                You are a board game image analyzer. Analyze the images and return structured JSON.
+                {gameContext}
+                Return ONLY valid JSON in this format:
+                {{
+                  "turn_estimate": null,
+                  "players": [],
+                  "board_description": "description of what you see",
+                  "notable_state": [],
+                  "confidence": 0.5
+                }}
+                """;
+
+            contentParts.Add(new TextContentPart("Extract the game state from these photos."));
+
+            var messages = new List<LlmMessage>
+            {
+                LlmMessage.FromText("system", systemPrompt),
+                new("user", contentParts)
+            };
+
+            var result = await _llmService.GenerateMultimodalCompletionAsync(messages, RequestSource.AgentTask, ct)
+                .ConfigureAwait(false);
+
+            if (!result.Success)
+            {
+                _logger.LogWarning("GameState extraction failed: {Error}", result.ErrorMessage);
+                return null;
+            }
+
+            // Validate JSON and check confidence
+            var response = result.Response.Trim();
+            // Strip markdown code fences if present
+            if (response.StartsWith("```", StringComparison.Ordinal))
+            {
+                var firstNewline = response.IndexOf('\n');
+                var lastFence = response.LastIndexOf("```", StringComparison.Ordinal);
+                if (firstNewline > 0 && lastFence > firstNewline)
+                    response = response[(firstNewline + 1)..lastFence].Trim();
+            }
+
+            using var doc = JsonDocument.Parse(response);
+            var confidence = doc.RootElement.TryGetProperty("confidence", out var conf) ? conf.GetDouble() : 0.0;
+
+            if (confidence < 0.4)
+            {
+                _logger.LogInformation("GameState extraction confidence {Confidence} below threshold for snapshot {SnapshotId}", confidence, snapshot.Id);
+                return null;
+            }
+
+            snapshot.UpdateGameState(response);
+            await _snapshotRepository.UpdateAsync(snapshot, ct).ConfigureAwait(false);
+            await _snapshotRepository.SaveChangesAsync(ct).ConfigureAwait(false);
+
+            return response;
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse GameState JSON for snapshot {SnapshotId}", snapshot.Id);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "GameState extraction error for snapshot {SnapshotId}", snapshot.Id);
+            return null;
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Register GameStateExtractor in DI**
+
+Add to `SessionTrackingServiceExtensions.cs`:
+
+```csharp
+    services.AddScoped<IGameStateExtractor, GameStateExtractor>();
+```
+
+- [ ] **Step 4: Verify build + Commit**
+
+```bash
+cd apps/api/src/Api && dotnet build --no-restore 2>&1 | tail -5
+git add apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/SnapshotQueries.cs apps/api/src/Api/BoundedContexts/SessionTracking/Application/Services/GameStateExtractor.cs apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/DependencyInjection/SessionTrackingServiceExtensions.cs
+git commit -m "feat(vision): add snapshot queries, GameStateExtractor with lazy extraction"
+```
+
+---
+
+## Task 9: Snapshot Endpoints
+
+**Files:**
+- Create: `apps/api/src/Api/Routing/SessionTracking/SessionSnapshotEndpoints.cs`
+
+- [ ] **Step 1: Create endpoint file**
+
+```csharp
+// apps/api/src/Api/Routing/SessionTracking/SessionSnapshotEndpoints.cs
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using MediatR;
+
+namespace Api.Routing.SessionTracking;
+
+internal static class SessionSnapshotEndpoints
+{
+    public static void MapSessionSnapshotEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/v1/live-sessions/{sessionId:guid}/snapshots")
+            .RequireAuthorization()
+            .WithTags("SessionTracking", "Vision");
+
+        group.MapPost("/", async (
+            Guid sessionId,
+            HttpContext httpContext,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var form = await httpContext.Request.ReadFormAsync(ct).ConfigureAwait(false);
+            var userId = Guid.Parse(form["userId"].ToString());
+            var turnNumber = int.Parse(form["turnNumber"].ToString());
+            var caption = form["caption"].ToString();
+
+            var images = new List<SnapshotImageUpload>();
+            foreach (var file in form.Files)
+            {
+                using var ms = new MemoryStream();
+                await file.CopyToAsync(ms, ct).ConfigureAwait(false);
+                images.Add(new SnapshotImageUpload(ms.ToArray(), file.ContentType, file.FileName));
+            }
+
+            var command = new CreateSessionSnapshotCommand(sessionId, userId, turnNumber,
+                string.IsNullOrWhiteSpace(caption) ? null : caption, images);
+            var result = await mediator.Send(command, ct).ConfigureAwait(false);
+            return Results.Created($"/api/v1/live-sessions/{sessionId}/snapshots/{result.SnapshotId}", result);
+        })
+        .DisableAntiforgery()
+        .WithName("CreateSessionSnapshot")
+        .WithSummary("Upload board state snapshot with images")
+        .Produces<CreateSnapshotResult>(201).Produces(400).Produces(404).Produces(409);
+
+        group.MapGet("/", async (Guid sessionId, IMediator mediator, CancellationToken ct) =>
+        {
+            var result = await mediator.Send(new GetSessionSnapshotsQuery(sessionId), ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .WithName("GetSessionSnapshots")
+        .WithSummary("List all snapshots for a session")
+        .Produces<List<SessionSnapshotDto>>(200);
+
+        group.MapGet("/game-state", async (Guid sessionId, IMediator mediator, CancellationToken ct) =>
+        {
+            var result = await mediator.Send(new GetLatestGameStateQuery(sessionId), ct).ConfigureAwait(false);
+            return result is null ? Results.NoContent() : Results.Ok(result);
+        })
+        .WithName("GetLatestGameState")
+        .WithSummary("Get latest extracted game state for a session")
+        .Produces<GameStateResult>(200).Produces(204);
+    }
+}
+```
+
+- [ ] **Step 2: Register endpoints in app startup**
+
+Find the file where session endpoints are mapped (search for `MapSessionPlayerActionsEndpoints` or similar) and add:
+
+```csharp
+app.MapSessionSnapshotEndpoints();
+```
+
+- [ ] **Step 3: Verify build + Commit**
+
+```bash
+cd apps/api/src/Api && dotnet build --no-restore 2>&1 | tail -5
+git add apps/api/src/Api/Routing/SessionTracking/SessionSnapshotEndpoints.cs
+git commit -m "feat(vision): add snapshot CRUD endpoints (upload, list, game-state)"
+```
+
+---
+
+## Task 10: Extend AskSessionAgent for Inline Images + Lazy Extraction
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandHandlers.cs`
+- Modify: `apps/api/src/Api/Routing/SessionTracking/SessionPlayerActionsEndpoints.cs`
+
+- [ ] **Step 1: Extend AskSessionAgentCommand**
+
+In `ChatCommandHandlers.cs`, find `public record AskSessionAgentCommand` and add the Images parameter. If the command is defined elsewhere, find it first:
+
+```csharp
+public record ChatImageAttachment(byte[] Data, string MediaType, string? FileName);
+
+public record AskSessionAgentCommand(
+    Guid SessionId,
+    Guid SenderId,
+    string Question,
+    int? TurnNumber,
+    List<ChatImageAttachment>? Images = null  // NEW - ephemeral inline images
+) : IRequest<AskSessionAgentResult>;
+```
+
+- [ ] **Step 2: Extend AskSessionAgentCommandHandler**
+
+Replace the handler to support vision:
+
+```csharp
+internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCommand, AskSessionAgentResult>
+{
+    private readonly ISessionRepository _sessionRepository;
+    private readonly ISessionChatRepository _chatRepository;
+    private readonly IMediator _mediator;
+    private readonly ILlmService _llmService;
+    private readonly IImagePreprocessor _imagePreprocessor;
+    private readonly IGameStateExtractor _gameStateExtractor;
+    private readonly ILogger<AskSessionAgentCommandHandler> _logger;
+
+    public AskSessionAgentCommandHandler(
+        ISessionRepository sessionRepository,
+        ISessionChatRepository chatRepository,
+        IMediator mediator,
+        ILlmService llmService,
+        IImagePreprocessor imagePreprocessor,
+        IGameStateExtractor gameStateExtractor,
+        ILogger<AskSessionAgentCommandHandler> logger)
+    {
+        _sessionRepository = sessionRepository;
+        _chatRepository = chatRepository;
+        _mediator = mediator;
+        _llmService = llmService;
+        _imagePreprocessor = imagePreprocessor;
+        _gameStateExtractor = gameStateExtractor;
+        _logger = logger;
+    }
+
+    public async Task<AskSessionAgentResult> Handle(AskSessionAgentCommand request, CancellationToken cancellationToken)
+    {
+        var session = await _sessionRepository.GetByIdAsync(request.SessionId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {request.SessionId} not found");
+
+        _ = session.Participants.FirstOrDefault(p => p.Id == request.SenderId)
+            ?? throw new NotFoundException($"Participant {request.SenderId} not found in session");
+
+        // Save user question
+        var userSeq = await _chatRepository.GetNextSequenceNumberAsync(request.SessionId, cancellationToken).ConfigureAwait(false);
+        var userMessage = SessionChatMessage.CreateTextMessage(
+            request.SessionId, request.SenderId, request.Question, userSeq, request.TurnNumber);
+        await _chatRepository.AddAsync(userMessage, cancellationToken).ConfigureAwait(false);
+        await _chatRepository.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // Lazy GameState extraction from snapshots
+        var gameState = await _gameStateExtractor.ExtractIfNeededAsync(
+            request.SessionId, null, cancellationToken).ConfigureAwait(false);
+
+        var agentType = "tutor";
+        string answer;
+        float? confidence;
+
+        try
+        {
+            var systemPrompt = $"You are a helpful board game tutor assisting during a game session (Game ID: {session.GameId}). " +
+                               "Answer questions about rules, strategy, and gameplay concisely.";
+
+            if (gameState is not null)
+                systemPrompt += $"\n\nCurrent game state (extracted from board photos):\n{gameState}";
+
+            bool hasImages = request.Images is { Count: > 0 };
+
+            if (hasImages)
+            {
+                // Build multimodal message with inline images
+                var userParts = new List<ContentPart>();
+                foreach (var img in request.Images!)
+                {
+                    var processed = await _imagePreprocessor.ProcessAsync(img.Data, img.MediaType).ConfigureAwait(false);
+                    var base64 = Convert.ToBase64String(processed.Data);
+                    userParts.Add(new ImageContentPart(base64, processed.MediaType));
+                }
+                userParts.Add(new TextContentPart(request.Question));
+
+                var messages = new List<LlmMessage>
+                {
+                    LlmMessage.FromText("system", systemPrompt),
+                    new("user", userParts)
+                };
+
+                var result = await _llmService.GenerateMultimodalCompletionAsync(
+                    messages, RequestSource.AgentTask, cancellationToken).ConfigureAwait(false);
+
+                answer = result.Success ? result.Response : "I'm sorry, I couldn't process your question right now. Please try again.";
+                confidence = result.Success ? 0.85f : null;
+            }
+            else
+            {
+                // Text-only path (existing behavior)
+                var result = await _llmService.GenerateCompletionAsync(
+                    systemPrompt, request.Question, RequestSource.AgentTask, cancellationToken).ConfigureAwait(false);
+
+                answer = result.Success ? result.Response : "I'm sorry, I couldn't process your question right now. Please try again.";
+                confidence = result.Success ? 0.85f : null;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "LLM service error for session {SessionId}", request.SessionId);
+            answer = "I'm sorry, an error occurred while processing your question. Please try again.";
+            confidence = null;
+        }
+
+        var agentSeq = await _chatRepository.GetNextSequenceNumberAsync(request.SessionId, cancellationToken).ConfigureAwait(false);
+        var agentMessage = SessionChatMessage.CreateAgentResponse(
+            request.SessionId, answer, agentSeq, agentType, confidence, null, request.TurnNumber);
+
+        await _chatRepository.AddAsync(agentMessage, cancellationToken).ConfigureAwait(false);
+        await _chatRepository.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        await _mediator.Publish(new SessionChatMessageSentEvent
+        {
+            SessionId = request.SessionId,
+            MessageId = agentMessage.Id,
+            SenderId = null,
+            MessageType = SessionChatMessageType.AgentResponse,
+            Content = answer,
+            TurnNumber = request.TurnNumber,
+        }, cancellationToken).ConfigureAwait(false);
+
+        return new AskSessionAgentResult(agentMessage.Id, answer, agentType, agentMessage.Confidence, null);
+    }
+}
+```
+
+- [ ] **Step 3: Update ask-agent endpoint for multipart**
+
+In `SessionPlayerActionsEndpoints.cs`, update the ask-agent endpoint to accept multipart form data with optional images:
+
+```csharp
+group.MapPost("/game-sessions/{sessionId:guid}/chat/ask-agent", async (
+    Guid sessionId,
+    HttpContext httpContext,
+    IMediator mediator,
+    CancellationToken ct) =>
+{
+    List<ChatImageAttachment>? images = null;
+    string question;
+    Guid senderId;
+    int? turnNumber = null;
+
+    if (httpContext.Request.HasFormContentType)
+    {
+        var form = await httpContext.Request.ReadFormAsync(ct).ConfigureAwait(false);
+        question = form["question"].ToString();
+        senderId = Guid.Parse(form["senderId"].ToString());
+        if (int.TryParse(form["turnNumber"].ToString(), out var tn)) turnNumber = tn;
+
+        if (form.Files.Count > 0)
+        {
+            images = [];
+            foreach (var file in form.Files)
+            {
+                using var ms = new MemoryStream();
+                await file.CopyToAsync(ms, ct).ConfigureAwait(false);
+                images.Add(new ChatImageAttachment(ms.ToArray(), file.ContentType, file.FileName));
+            }
+        }
+    }
+    else
+    {
+        var body = await httpContext.Request.ReadFromJsonAsync<AskSessionAgentCommand>(ct).ConfigureAwait(false)
+            ?? throw new BadHttpRequestException("Invalid request body");
+        question = body.Question;
+        senderId = body.SenderId;
+        turnNumber = body.TurnNumber;
+    }
+
+    var command = new AskSessionAgentCommand(sessionId, senderId, question, turnNumber, images);
+    var result = await mediator.Send(command, ct).ConfigureAwait(false);
+    return Results.Ok(result);
+})
+.DisableAntiforgery()
+.RequireAuthorization()
+.WithName("AskSessionAgent")
+.WithTags("SessionTracking", "Chat", "AI")
+.WithSummary("Ask the RAG agent a question in session context, optionally with images")
+.Produces<AskSessionAgentResult>(200).Produces(400).Produces(401).Produces(404);
+```
+
+- [ ] **Step 4: Verify build + Commit**
+
+```bash
+cd apps/api/src/Api && dotnet build --no-restore 2>&1 | tail -5
+git add apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandHandlers.cs apps/api/src/Api/Routing/SessionTracking/SessionPlayerActionsEndpoints.cs
+git commit -m "feat(vision): extend AskSessionAgent with inline images and lazy GameState extraction"
+```
+
+---
+
+## Task 11: Frontend — useChatImageAttachments Hook
+
+**Files:**
+- Create: `apps/web/src/hooks/useChatImageAttachments.ts`
+
+- [ ] **Step 1: Create the hook**
+
+```typescript
+// apps/web/src/hooks/useChatImageAttachments.ts
+'use client';
+
+import { useState, useCallback } from 'react';
+
+export interface ChatImagePreview {
+  file: File;
+  previewUrl: string;
+  mediaType: string;
+}
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+const SUPPORTED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+
+export function useChatImageAttachments(maxImages: number = 5) {
+  const [images, setImages] = useState<ChatImagePreview[]>([]);
+
+  const addImage = useCallback((file: File): string | null => {
+    if (!SUPPORTED_TYPES.includes(file.type)) {
+      return 'Formato non supportato. Usa JPEG, PNG o WebP.';
+    }
+    if (file.size > MAX_FILE_SIZE) {
+      return 'Immagine troppo grande. Massimo 10MB.';
+    }
+    setImages(prev => {
+      if (prev.length >= maxImages) return prev;
+      const previewUrl = URL.createObjectURL(file);
+      return [...prev, { file, previewUrl, mediaType: file.type }];
+    });
+    return null;
+  }, [maxImages]);
+
+  const removeImage = useCallback((index: number) => {
+    setImages(prev => {
+      const removed = prev[index];
+      if (removed) URL.revokeObjectURL(removed.previewUrl);
+      return prev.filter((_, i) => i !== index);
+    });
+  }, []);
+
+  const clearImages = useCallback(() => {
+    setImages(prev => {
+      prev.forEach(img => URL.revokeObjectURL(img.previewUrl));
+      return [];
+    });
+  }, []);
+
+  const hasImages = images.length > 0;
+  const canAddMore = images.length < maxImages;
+
+  return { images, addImage, removeImage, clearImages, hasImages, canAddMore };
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/web/src/hooks/useChatImageAttachments.ts
+git commit -m "feat(vision): add useChatImageAttachments hook for ephemeral image management"
+```
+
+---
+
+## Task 12: Frontend — Extend ChatInputBar with Image Support
+
+**Files:**
+- Modify: `apps/web/src/components/chat/panel/ChatInputBar.tsx`
+
+- [ ] **Step 1: Read current ChatInputBar.tsx and extend it**
+
+Add image button (🖼️), file input ref, preview thumbnails, and multipart send capability. Key changes:
+
+1. Import `useChatImageAttachments` hook
+2. Add hidden `<input type="file" accept="image/*" multiple>` with ref
+3. Add 🖼️ button next to existing 📎 button
+4. Show thumbnail previews with X remove button above the textarea when images are present
+5. Modify `onSend` prop to accept optional `FormData` or change to `onSendWithImages(text: string, images: File[])` callback
+6. On send: if images present, call `onSendWithImages(value, images.map(i => i.file))` then `clearImages()`
+
+The exact code depends on the current ChatInputBar structure. The worker should read the current file and make minimal, focused changes.
+
+- [ ] **Step 2: Verify dev build**
+
+Run: `cd apps/web && pnpm build 2>&1 | tail -10`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/chat/panel/ChatInputBar.tsx
+git commit -m "feat(vision): add image attachment button and preview to ChatInputBar"
+```
+
+---
+
+## Task 13: Frontend — Extend ChatMessageBubble for Image Display
+
+**Files:**
+- Modify: `apps/web/src/components/chat/panel/ChatMessageBubble.tsx`
+
+- [ ] **Step 1: Extend ChatMessageBubble to display images**
+
+Add optional `imageUrls?: string[]` prop. When present, render thumbnail grid above the text content:
+
+```tsx
+{imageUrls && imageUrls.length > 0 && (
+  <div className="flex gap-1.5 mb-2 flex-wrap">
+    {imageUrls.map((url, i) => (
+      <img
+        key={i}
+        src={url}
+        alt={`Attachment ${i + 1}`}
+        className="w-20 h-15 object-cover rounded-md border border-white/10 cursor-pointer"
+        onClick={() => window.open(url, '_blank')}
+      />
+    ))}
+  </div>
+)}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/web/src/components/chat/panel/ChatMessageBubble.tsx
+git commit -m "feat(vision): display image thumbnails in chat message bubbles"
+```
+
+---
+
+## Task 14: Frontend — Session Snapshots API Client + Hooks
+
+**Files:**
+- Create: `apps/web/src/lib/api/clients/sessionSnapshotsClient.ts`
+- Create: `apps/web/src/hooks/queries/useSessionSnapshots.ts`
+
+- [ ] **Step 1: Create API client**
+
+```typescript
+// apps/web/src/lib/api/clients/sessionSnapshotsClient.ts
+export interface SessionSnapshotDto {
+  id: string;
+  sessionId: string;
+  turnNumber: number;
+  caption: string | null;
+  hasGameState: boolean;
+  createdAt: string;
+  images: SnapshotImageDto[];
+}
+
+export interface SnapshotImageDto {
+  id: string;
+  downloadUrl: string | null;
+  mediaType: string;
+  width: number;
+  height: number;
+  orderIndex: number;
+}
+
+export interface GameStateResult {
+  snapshotId: string;
+  gameStateJson: string | null;
+  isExtracted: boolean;
+  snapshotCreatedAt: string;
+}
+
+export interface CreateSnapshotResult {
+  snapshotId: string;
+  imageCount: number;
+}
+
+export function createSessionSnapshotsClient() {
+  return {
+    async getSnapshots(sessionId: string): Promise<SessionSnapshotDto[]> {
+      const res = await fetch(`/api/v1/live-sessions/${sessionId}/snapshots`);
+      if (!res.ok) throw new Error(`Failed to fetch snapshots: ${res.status}`);
+      return res.json();
+    },
+
+    async getGameState(sessionId: string): Promise<GameStateResult | null> {
+      const res = await fetch(`/api/v1/live-sessions/${sessionId}/snapshots/game-state`);
+      if (res.status === 204) return null;
+      if (!res.ok) throw new Error(`Failed to fetch game state: ${res.status}`);
+      return res.json();
+    },
+
+    async createSnapshot(
+      sessionId: string,
+      userId: string,
+      turnNumber: number,
+      images: File[],
+      caption?: string
+    ): Promise<CreateSnapshotResult> {
+      const formData = new FormData();
+      formData.append('userId', userId);
+      formData.append('turnNumber', turnNumber.toString());
+      if (caption) formData.append('caption', caption);
+      images.forEach(img => formData.append('images', img));
+
+      const res = await fetch(`/api/v1/live-sessions/${sessionId}/snapshots`, {
+        method: 'POST',
+        body: formData,
+      });
+      if (!res.ok) throw new Error(`Failed to create snapshot: ${res.status}`);
+      return res.json();
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Create React Query hooks**
+
+```typescript
+// apps/web/src/hooks/queries/useSessionSnapshots.ts
+'use client';
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { createSessionSnapshotsClient } from '@/lib/api/clients/sessionSnapshotsClient';
+
+const client = createSessionSnapshotsClient();
+
+export const snapshotKeys = {
+  all: ['session-snapshots'] as const,
+  list: (sessionId: string) => [...snapshotKeys.all, 'list', sessionId] as const,
+  gameState: (sessionId: string) => [...snapshotKeys.all, 'game-state', sessionId] as const,
+};
+
+export function useSessionSnapshots(sessionId: string, enabled = true) {
+  return useQuery({
+    queryKey: snapshotKeys.list(sessionId),
+    queryFn: () => client.getSnapshots(sessionId),
+    enabled,
+    staleTime: 30_000, // 30s — snapshots change during active play
+  });
+}
+
+export function useLatestGameState(sessionId: string, enabled = true) {
+  return useQuery({
+    queryKey: snapshotKeys.gameState(sessionId),
+    queryFn: () => client.getGameState(sessionId),
+    enabled,
+    staleTime: 60_000, // 1min
+  });
+}
+
+export function useCreateSnapshot(sessionId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (args: { userId: string; turnNumber: number; images: File[]; caption?: string }) =>
+      client.createSnapshot(sessionId, args.userId, args.turnNumber, args.images, args.caption),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: snapshotKeys.list(sessionId) });
+      queryClient.invalidateQueries({ queryKey: snapshotKeys.gameState(sessionId) });
+    },
+  });
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/lib/api/clients/sessionSnapshotsClient.ts apps/web/src/hooks/queries/useSessionSnapshots.ts
+git commit -m "feat(vision): add session snapshots API client and React Query hooks"
+```
+
+---
+
+## Task 15: Frontend — Snapshot UI Components
+
+**Files:**
+- Create: `apps/web/src/components/session/GameStateDisplay.tsx`
+- Create: `apps/web/src/components/session/SnapshotCard.tsx`
+- Create: `apps/web/src/components/session/SnapshotUploadDialog.tsx`
+- Create: `apps/web/src/components/session/SessionSnapshotPanel.tsx`
+
+- [ ] **Step 1: Create GameStateDisplay**
+
+```tsx
+// apps/web/src/components/session/GameStateDisplay.tsx
+'use client';
+
+interface GameStateDisplayProps {
+  gameStateJson: string;
+}
+
+export function GameStateDisplay({ gameStateJson }: GameStateDisplayProps) {
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(gameStateJson);
+  } catch {
+    return <p className="text-xs text-muted-foreground">Dati non disponibili</p>;
+  }
+
+  const board = parsed.board_description as string | undefined;
+  const notable = parsed.notable_state as string[] | undefined;
+  const confidence = parsed.confidence as number | undefined;
+
+  return (
+    <div className="mt-2 p-2 bg-black/20 rounded text-xs text-muted-foreground space-y-1">
+      {board && <p>{board}</p>}
+      {notable && notable.length > 0 && (
+        <ul className="list-disc list-inside">
+          {notable.map((item, i) => <li key={i}>{item}</li>)}
+        </ul>
+      )}
+      {confidence !== undefined && (
+        <p className="text-emerald-500">Confidence: {(confidence * 100).toFixed(0)}%</p>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Create SnapshotCard**
+
+```tsx
+// apps/web/src/components/session/SnapshotCard.tsx
+'use client';
+
+import type { SessionSnapshotDto } from '@/lib/api/clients/sessionSnapshotsClient';
+import { GameStateDisplay } from './GameStateDisplay';
+
+interface SnapshotCardProps {
+  snapshot: SessionSnapshotDto;
+  isLatest?: boolean;
+}
+
+export function SnapshotCard({ snapshot, isLatest }: SnapshotCardProps) {
+  return (
+    <div className={`rounded-lg border p-3 ${isLatest ? 'border-emerald-500/30 bg-emerald-500/5' : 'border-white/10 bg-white/[0.02]'}`}>
+      <div className="flex items-center justify-between mb-2">
+        <span className={`text-xs font-semibold ${isLatest ? 'text-emerald-500' : 'text-muted-foreground'}`}>
+          Turno {snapshot.turnNumber} {isLatest && '— Ultimo'}
+        </span>
+        <span className={`text-[10px] px-2 py-0.5 rounded ${snapshot.hasGameState ? 'bg-emerald-500/15 text-emerald-500' : 'bg-amber-500/15 text-amber-500'}`}>
+          {snapshot.hasGameState ? '✓ Analizzato' : '⏳ Non analizzato'}
+        </span>
+      </div>
+      <div className="flex gap-1.5 mb-2">
+        {snapshot.images.map(img => (
+          <img
+            key={img.id}
+            src={img.downloadUrl ?? ''}
+            alt={`Snapshot img ${img.orderIndex}`}
+            className="w-16 h-12 object-cover rounded border border-white/10"
+          />
+        ))}
+      </div>
+      {snapshot.caption && (
+        <p className="text-xs text-muted-foreground italic">&ldquo;{snapshot.caption}&rdquo;</p>
+      )}
+      {snapshot.hasGameState && snapshot.images.length > 0 && (
+        <GameStateDisplay gameStateJson={/* fetched separately or embedded */""} />
+      )}
+    </div>
+  );
+}
+```
+
+Note: The GameState JSON is not included in the snapshot DTO for the list view (to keep payloads small). The GameStateDisplay can be populated from the `useLatestGameState` hook for the latest snapshot only, or added to the DTO if needed.
+
+- [ ] **Step 3: Create SnapshotUploadDialog**
+
+```tsx
+// apps/web/src/components/session/SnapshotUploadDialog.tsx
+'use client';
+
+import { useState, useRef } from 'react';
+
+interface SnapshotUploadDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onUpload: (images: File[], caption: string, turnNumber: number) => void;
+  currentTurn: number;
+}
+
+export function SnapshotUploadDialog({ open, onClose, onUpload, currentTurn }: SnapshotUploadDialogProps) {
+  const [caption, setCaption] = useState('');
+  const [turnNumber, setTurnNumber] = useState(currentTurn);
+  const [files, setFiles] = useState<File[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  if (!open) return null;
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) setFiles(Array.from(e.target.files));
+  };
+
+  const handleSubmit = () => {
+    if (files.length === 0) return;
+    onUpload(files, caption, turnNumber);
+    setFiles([]);
+    setCaption('');
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-card border border-white/10 rounded-xl p-6 w-full max-w-md space-y-4">
+        <h3 className="text-lg font-semibold">Nuovo Snapshot</h3>
+
+        <div>
+          <label className="text-sm text-muted-foreground">Immagini</label>
+          <input ref={inputRef} type="file" accept="image/*" multiple onChange={handleFileChange}
+            className="mt-1 block w-full text-sm" />
+          {files.length > 0 && <p className="text-xs text-muted-foreground mt-1">{files.length} immagini selezionate</p>}
+        </div>
+
+        <div>
+          <label className="text-sm text-muted-foreground">Turno</label>
+          <input type="number" value={turnNumber} min={0} onChange={e => setTurnNumber(Number(e.target.value))}
+            className="mt-1 block w-full rounded bg-white/5 border border-white/10 px-3 py-1.5 text-sm" />
+        </div>
+
+        <div>
+          <label className="text-sm text-muted-foreground">Descrizione (opzionale)</label>
+          <input type="text" value={caption} onChange={e => setCaption(e.target.value)} maxLength={200} placeholder="Es: Dopo aver costruito la città"
+            className="mt-1 block w-full rounded bg-white/5 border border-white/10 px-3 py-1.5 text-sm" />
+        </div>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button onClick={onClose} className="px-4 py-2 text-sm rounded border border-white/10">Annulla</button>
+          <button onClick={handleSubmit} disabled={files.length === 0}
+            className="px-4 py-2 text-sm rounded bg-amber-500 text-black font-medium disabled:opacity-50">
+            Carica
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Create SessionSnapshotPanel**
+
+```tsx
+// apps/web/src/components/session/SessionSnapshotPanel.tsx
+'use client';
+
+import { useState } from 'react';
+import { useSessionSnapshots, useCreateSnapshot } from '@/hooks/queries/useSessionSnapshots';
+import { SnapshotCard } from './SnapshotCard';
+import { SnapshotUploadDialog } from './SnapshotUploadDialog';
+
+interface SessionSnapshotPanelProps {
+  sessionId: string;
+  userId: string;
+  currentTurn: number;
+}
+
+export function SessionSnapshotPanel({ sessionId, userId, currentTurn }: SessionSnapshotPanelProps) {
+  const [uploadOpen, setUploadOpen] = useState(false);
+  const { data: snapshots, isLoading } = useSessionSnapshots(sessionId);
+  const createSnapshot = useCreateSnapshot(sessionId);
+
+  const handleUpload = (images: File[], caption: string, turnNumber: number) => {
+    createSnapshot.mutate({ userId, turnNumber, images, caption: caption || undefined });
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-amber-500">📸 Stato Partita</h3>
+          <p className="text-xs text-muted-foreground">{snapshots?.length ?? 0} snapshot salvati</p>
+        </div>
+        <button onClick={() => setUploadOpen(true)}
+          className="text-xs px-3 py-1.5 rounded-lg border border-amber-500/40 text-amber-500 hover:bg-amber-500/10">
+          + Nuovo Snapshot
+        </button>
+      </div>
+
+      {isLoading && <p className="text-xs text-muted-foreground">Caricamento...</p>}
+
+      <div className="space-y-2">
+        {snapshots?.map((s, i) => (
+          <SnapshotCard key={s.id} snapshot={s} isLatest={i === 0} />
+        ))}
+      </div>
+
+      {!isLoading && snapshots?.length === 0 && (
+        <p className="text-xs text-muted-foreground text-center py-4">
+          Nessuno snapshot. Scatta una foto del tavolo per iniziare.
+        </p>
+      )}
+
+      <SnapshotUploadDialog
+        open={uploadOpen}
+        onClose={() => setUploadOpen(false)}
+        onUpload={handleUpload}
+        currentTurn={currentTurn}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Verify build + Commit**
+
+```bash
+cd apps/web && pnpm build 2>&1 | tail -10
+git add apps/web/src/components/session/GameStateDisplay.tsx apps/web/src/components/session/SnapshotCard.tsx apps/web/src/components/session/SnapshotUploadDialog.tsx apps/web/src/components/session/SessionSnapshotPanel.tsx
+git commit -m "feat(vision): add SessionSnapshotPanel UI components (upload, cards, game state display)"
+```
+
+---
+
+## Task 16: Wire Snapshot Panel into Session Page
+
+**Files:**
+- Modify: The session play page or layout where tools/panels are shown
+
+- [ ] **Step 1: Find the session play page**
+
+Search for the session live/play page component. It's likely at `apps/web/src/app/(authenticated)/sessions/live/[sessionId]/page.tsx` or similar. Add `SessionSnapshotPanel` as a tab or section alongside existing session tools (DiceRoller, Scoreboard, etc.).
+
+- [ ] **Step 2: Import and render**
+
+```tsx
+import { SessionSnapshotPanel } from '@/components/session/SessionSnapshotPanel';
+
+// In the session page, add alongside other tools:
+<SessionSnapshotPanel
+  sessionId={sessionId}
+  userId={currentUserId}
+  currentTurn={currentTurn}
+/>
+```
+
+- [ ] **Step 3: Verify build + Commit**
+
+```bash
+cd apps/web && pnpm build 2>&1 | tail -10
+git add apps/web/src/app/
+git commit -m "feat(vision): wire SessionSnapshotPanel into session play page"
+```
+
+---
+
+## Task 17: Backend Unit Tests
+
+**Files:**
+- Create: Test files in `apps/api/tests/Api.Tests/`
+
+- [ ] **Step 1: Test ContentPart types**
+
+Create `apps/api/tests/Api.Tests/Services/LlmClients/ContentPartTests.cs`:
+
+```csharp
+using Api.Services.LlmClients;
+
+namespace Api.Tests.Services.LlmClients;
+
+public class ContentPartTests
+{
+    [Fact]
+    public void TextContentPart_stores_text()
+    {
+        var part = new TextContentPart("Hello");
+        Assert.Equal("Hello", part.Text);
+    }
+
+    [Fact]
+    public void ImageContentPart_generates_data_uri()
+    {
+        var part = new ImageContentPart("abc123", "image/jpeg");
+        Assert.Equal("data:image/jpeg;base64,abc123", part.ToDataUri());
+    }
+
+    [Fact]
+    public void LlmMessage_FromText_creates_text_only()
+    {
+        var msg = LlmMessage.FromText("user", "Hello");
+        Assert.Single(msg.Content);
+        Assert.IsType<TextContentPart>(msg.Content[0]);
+        Assert.False(msg.HasImages);
+    }
+
+    [Fact]
+    public void LlmMessage_HasImages_true_when_contains_image()
+    {
+        var msg = new LlmMessage("user", new ContentPart[]
+        {
+            new ImageContentPart("abc", "image/png"),
+            new TextContentPart("Describe this"),
+        });
+        Assert.True(msg.HasImages);
+    }
+}
+```
+
+- [ ] **Step 2: Test VisionTierLimits**
+
+Create `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/VisionTierLimitsTests.cs`:
+
+```csharp
+using Api.BoundedContexts.KnowledgeBase.Domain;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Domain;
+
+public class VisionTierLimitsTests
+{
+    [Fact]
+    public void Alpha_tier_has_generous_limits()
+    {
+        var config = VisionTierLimits.GetConfig("alpha");
+        Assert.Equal(5, config.MaxImagesPerMessage);
+        Assert.Equal(20, config.MaxSnapshotsPerSession);
+        Assert.True(config.GameStateExtractionEnabled);
+    }
+
+    [Fact]
+    public void Free_tier_has_conservative_limits()
+    {
+        var config = VisionTierLimits.GetConfig("free");
+        Assert.Equal(2, config.MaxImagesPerMessage);
+        Assert.Equal(5, config.MaxSnapshotsPerSession);
+        Assert.False(config.GameStateExtractionEnabled);
+    }
+
+    [Fact]
+    public void Null_tier_returns_free_defaults()
+    {
+        var config = VisionTierLimits.GetConfig(null);
+        Assert.Equal(2, config.MaxImagesPerMessage);
+    }
+
+    [Fact]
+    public void Unknown_tier_returns_free_defaults()
+    {
+        var config = VisionTierLimits.GetConfig("nonexistent");
+        Assert.Equal(2, config.MaxImagesPerMessage);
+    }
+}
+```
+
+- [ ] **Step 3: Test SessionSnapshot entity**
+
+Create `apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/SessionSnapshotTests.cs`:
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Domain;
+
+public class SessionSnapshotTests
+{
+    [Fact]
+    public void Create_sets_required_properties()
+    {
+        var sessionId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var snapshot = SessionSnapshot.Create(sessionId, userId, 3, "Turn 3 state");
+
+        Assert.Equal(sessionId, snapshot.SessionId);
+        Assert.Equal(userId, snapshot.UserId);
+        Assert.Equal(3, snapshot.TurnNumber);
+        Assert.Equal("Turn 3 state", snapshot.Caption);
+        Assert.Null(snapshot.ExtractedGameState);
+        Assert.Empty(snapshot.Images);
+        Assert.False(snapshot.IsDeleted);
+    }
+
+    [Fact]
+    public void Create_throws_on_empty_session_id()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            SessionSnapshot.Create(Guid.Empty, Guid.NewGuid(), 0, null));
+    }
+
+    [Fact]
+    public void AddImage_adds_with_correct_order()
+    {
+        var snapshot = SessionSnapshot.Create(Guid.NewGuid(), Guid.NewGuid(), 1, null);
+        snapshot.AddImage("key1", "image/jpeg", 800, 600);
+        snapshot.AddImage("key2", "image/png", 1024, 768);
+
+        Assert.Equal(2, snapshot.Images.Count);
+        Assert.Equal(0, snapshot.Images[0].OrderIndex);
+        Assert.Equal(1, snapshot.Images[1].OrderIndex);
+    }
+
+    [Fact]
+    public void UpdateGameState_sets_json_and_timestamp()
+    {
+        var snapshot = SessionSnapshot.Create(Guid.NewGuid(), Guid.NewGuid(), 1, null);
+        snapshot.UpdateGameState("{\"confidence\": 0.8}");
+
+        Assert.Equal("{\"confidence\": 0.8}", snapshot.ExtractedGameState);
+        Assert.NotNull(snapshot.UpdatedAt);
+    }
+
+    [Fact]
+    public void SoftDelete_marks_deleted()
+    {
+        var snapshot = SessionSnapshot.Create(Guid.NewGuid(), Guid.NewGuid(), 1, null);
+        snapshot.SoftDelete();
+
+        Assert.True(snapshot.IsDeleted);
+        Assert.NotNull(snapshot.DeletedAt);
+    }
+}
+```
+
+- [ ] **Step 4: Test SkiaImagePreprocessor**
+
+Create `apps/api/tests/Api.Tests/Services/ImageProcessing/SkiaImagePreprocessorTests.cs`:
+
+```csharp
+using Api.Services.ImageProcessing;
+using SkiaSharp;
+
+namespace Api.Tests.Services.ImageProcessing;
+
+public class SkiaImagePreprocessorTests
+{
+    private readonly SkiaImagePreprocessor _sut = new();
+
+    private static byte[] CreateTestImage(int width, int height)
+    {
+        using var bitmap = new SKBitmap(width, height);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(SKColors.Blue);
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Jpeg, 90);
+        return data.ToArray();
+    }
+
+    [Fact]
+    public async Task ProcessAsync_resizes_large_image()
+    {
+        var largeImage = CreateTestImage(4000, 3000);
+        var options = new ImageProcessingOptions(MaxWidth: 1024, MaxHeight: 1024);
+
+        var result = await _sut.ProcessAsync(largeImage, "image/jpeg", options);
+
+        Assert.True(result.Width <= 1024);
+        Assert.True(result.Height <= 1024);
+        Assert.Equal("image/jpeg", result.MediaType);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_preserves_small_image_dimensions()
+    {
+        var smallImage = CreateTestImage(640, 480);
+        var options = new ImageProcessingOptions(MaxWidth: 1024, MaxHeight: 1024);
+
+        var result = await _sut.ProcessAsync(smallImage, "image/jpeg", options);
+
+        Assert.Equal(640, result.Width);
+        Assert.Equal(480, result.Height);
+    }
+
+    [Fact]
+    public void DetectMediaType_jpeg()
+    {
+        var jpeg = CreateTestImage(10, 10);
+        Assert.Equal("image/jpeg", _sut.DetectMediaType(jpeg));
+    }
+
+    [Fact]
+    public void DetectMediaType_unknown_returns_null()
+    {
+        Assert.Null(_sut.DetectMediaType(new byte[] { 0x00, 0x01, 0x02, 0x03 }));
+    }
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~ContentPart|FullyQualifiedName~VisionTier|FullyQualifiedName~SessionSnapshot|FullyQualifiedName~SkiaImagePreprocessor" --verbosity normal 2>&1 | tail -20`
+
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/tests/Api.Tests/
+git commit -m "test(vision): add unit tests for ContentPart, VisionTierLimits, SessionSnapshot, ImagePreprocessor"
+```
+
+---
+
+## Task 18: Frontend Tests
+
+**Files:**
+- Create: `apps/web/__tests__/hooks/useChatImageAttachments.test.ts`
+
+- [ ] **Step 1: Test useChatImageAttachments hook**
+
+```typescript
+// apps/web/__tests__/hooks/useChatImageAttachments.test.ts
+import { renderHook, act } from '@testing-library/react';
+import { useChatImageAttachments } from '@/hooks/useChatImageAttachments';
+
+// Mock URL.createObjectURL / revokeObjectURL
+const mockCreateObjectURL = vi.fn(() => 'blob:mock-url');
+const mockRevokeObjectURL = vi.fn();
+Object.defineProperty(globalThis, 'URL', {
+  value: { createObjectURL: mockCreateObjectURL, revokeObjectURL: mockRevokeObjectURL },
+  writable: true,
+});
+
+function createMockFile(name: string, type: string, size: number): File {
+  const buffer = new ArrayBuffer(size);
+  return new File([buffer], name, { type });
+}
+
+describe('useChatImageAttachments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('starts with empty images', () => {
+    const { result } = renderHook(() => useChatImageAttachments());
+    expect(result.current.images).toHaveLength(0);
+    expect(result.current.hasImages).toBe(false);
+    expect(result.current.canAddMore).toBe(true);
+  });
+
+  it('adds a valid image', () => {
+    const { result } = renderHook(() => useChatImageAttachments());
+    const file = createMockFile('test.jpg', 'image/jpeg', 1000);
+
+    act(() => {
+      const error = result.current.addImage(file);
+      expect(error).toBeNull();
+    });
+
+    expect(result.current.images).toHaveLength(1);
+    expect(result.current.hasImages).toBe(true);
+  });
+
+  it('rejects unsupported file types', () => {
+    const { result } = renderHook(() => useChatImageAttachments());
+    const file = createMockFile('test.pdf', 'application/pdf', 1000);
+
+    act(() => {
+      const error = result.current.addImage(file);
+      expect(error).toContain('Formato non supportato');
+    });
+
+    expect(result.current.images).toHaveLength(0);
+  });
+
+  it('rejects oversized files', () => {
+    const { result } = renderHook(() => useChatImageAttachments());
+    const file = createMockFile('big.jpg', 'image/jpeg', 15 * 1024 * 1024);
+
+    act(() => {
+      const error = result.current.addImage(file);
+      expect(error).toContain('troppo grande');
+    });
+  });
+
+  it('respects max images limit', () => {
+    const { result } = renderHook(() => useChatImageAttachments(2));
+
+    act(() => {
+      result.current.addImage(createMockFile('1.jpg', 'image/jpeg', 100));
+      result.current.addImage(createMockFile('2.jpg', 'image/jpeg', 100));
+    });
+
+    expect(result.current.canAddMore).toBe(false);
+  });
+
+  it('removes an image and revokes URL', () => {
+    const { result } = renderHook(() => useChatImageAttachments());
+
+    act(() => {
+      result.current.addImage(createMockFile('1.jpg', 'image/jpeg', 100));
+    });
+
+    act(() => {
+      result.current.removeImage(0);
+    });
+
+    expect(result.current.images).toHaveLength(0);
+    expect(mockRevokeObjectURL).toHaveBeenCalled();
+  });
+
+  it('clearImages removes all and revokes URLs', () => {
+    const { result } = renderHook(() => useChatImageAttachments());
+
+    act(() => {
+      result.current.addImage(createMockFile('1.jpg', 'image/jpeg', 100));
+      result.current.addImage(createMockFile('2.jpg', 'image/jpeg', 100));
+    });
+
+    act(() => {
+      result.current.clearImages();
+    });
+
+    expect(result.current.images).toHaveLength(0);
+    expect(mockRevokeObjectURL).toHaveBeenCalledTimes(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run frontend tests**
+
+Run: `cd apps/web && pnpm test -- --run __tests__/hooks/useChatImageAttachments.test.ts 2>&1 | tail -20`
+Expected: All tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/__tests__/hooks/useChatImageAttachments.test.ts
+git commit -m "test(vision): add frontend tests for useChatImageAttachments hook"
+```
+
+---
+
+## Task 19: Final Build Verification + Lint
+
+- [ ] **Step 1: Backend full build**
+
+Run: `cd apps/api/src/Api && dotnet build 2>&1 | tail -5`
+Expected: Build succeeded.
+
+- [ ] **Step 2: Frontend full build**
+
+Run: `cd apps/web && pnpm build 2>&1 | tail -10`
+Expected: Build succeeded.
+
+- [ ] **Step 3: Frontend lint**
+
+Run: `cd apps/web && pnpm lint 2>&1 | tail -10`
+Fix any lint errors.
+
+- [ ] **Step 4: Frontend typecheck**
+
+Run: `cd apps/web && pnpm typecheck 2>&1 | tail -10`
+Fix any type errors.
+
+- [ ] **Step 5: Run backend unit tests**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "Category=Unit" --verbosity quiet 2>&1 | tail -10`
+Ensure no regressions.
+
+- [ ] **Step 6: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix(vision): resolve lint and type errors from vision AI integration"
+```

--- a/docs/superpowers/specs/2026-04-17-session-vision-ai-design.md
+++ b/docs/superpowers/specs/2026-04-17-session-vision-ai-design.md
@@ -1,0 +1,457 @@
+# Session Vision AI — Design Spec
+
+**Date**: 2026-04-17
+**Status**: Draft
+**Scope**: Integrare immagini caricate dall'utente durante sessioni di gioco per permettere all'agente AI di capire lo stato della partita tramite vision API.
+
+## Overview
+
+L'utente può fornire immagini all'agente AI in due modalità:
+1. **Inline chat** — allega 1+ immagini a un messaggio nella chat (effimere, non persistite)
+2. **Snapshot sessione** — carica foto come "stato corrente della partita" in un'area dedicata (persistenti in storage)
+
+L'agente usa modelli vision multimodali per:
+- **Descrizione libera** — rispondere nel contesto di ciò che vede nell'immagine
+- **Estrazione GameState strutturata** — estrarre dati di gioco (risorse, punteggi, posizioni) in JSON, best-effort
+
+## Decisioni Architetturali
+
+| Decisione | Scelta | Motivazione |
+|-----------|--------|-------------|
+| Flusso | Ibrido (inline chat + snapshot sessione) | Massima flessibilità per l'utente |
+| Analisi agente | Descrizione libera + GameState strutturato | Best-effort: non bloccante se l'extraction fallisce |
+| Provider | DeepSeek + OpenRouter | Routing esistente, accesso ai migliori modelli vision |
+| Limiti | Configurabili per tier utente | Segue pattern AgentTierLimits esistente |
+| Persistenza | Inline effimere, snapshot persistenti | Minimizza storage, snapshot hanno valore duraturo |
+| Extraction timing | Lazy (on-demand) | Zero costo LLM se l'utente non interagisce con l'agente |
+| Approccio architetturale | ILlmClient esteso + ImagePreprocessor | 1 chiamata LLM quando possibile, fallback testuale per provider solo-testo |
+
+## Data Model
+
+### ContentPart — Messaggi Multimodali
+
+```csharp
+public abstract record ContentPart;
+public record TextContentPart(string Text) : ContentPart;
+public record ImageContentPart(string Base64Data, string MediaType) : ContentPart;
+
+public record LlmMessage(string Role, List<ContentPart> Content);
+```
+
+Segue lo standard OpenAI content parts, compatibile con DeepSeek e OpenRouter.
+
+### ILlmClient — Estensione Interfaccia
+
+```csharp
+public interface ILlmClient
+{
+    // Esistenti (backward compat)
+    Task<LlmCompletionResult> GenerateCompletionAsync(
+        string model, string systemPrompt, string userPrompt,
+        float temperature, int maxTokens, CancellationToken ct = default);
+
+    IAsyncEnumerable<StreamChunk> GenerateCompletionStreamAsync(
+        string model, string systemPrompt, string userPrompt,
+        float temperature, int maxTokens, CancellationToken ct = default);
+
+    // Nuovi: multimodale
+    Task<LlmCompletionResult> GenerateCompletionAsync(
+        string model, List<LlmMessage> messages,
+        float temperature, int maxTokens, CancellationToken ct = default);
+
+    IAsyncEnumerable<StreamChunk> GenerateCompletionStreamAsync(
+        string model, List<LlmMessage> messages,
+        float temperature, int maxTokens, CancellationToken ct = default);
+
+    bool SupportsVision { get; }
+    bool SupportsModel(string modelId);
+    Task<bool> CheckHealthAsync(CancellationToken ct = default);
+}
+```
+
+### IImagePreprocessor
+
+```csharp
+public interface IImagePreprocessor
+{
+    Task<ProcessedImage> ProcessAsync(
+        byte[] imageData, string mediaType, ImageProcessingOptions options);
+
+    Task<string> DescribeImageAsync(byte[] imageData, string mediaType);
+}
+
+public record ProcessedImage(byte[] Data, string MediaType, int Width, int Height, long SizeBytes);
+
+public record ImageProcessingOptions(
+    int MaxWidth = 1024,
+    int MaxHeight = 1024,
+    long MaxSizeBytes = 5_000_000,
+    bool ConvertToJpeg = false);
+```
+
+`DescribeImageAsync` è il fallback: chiama il provider vision con il ranking più alto disponibile (anche se non è il provider primario scelto dalla strategia) per generare una descrizione testuale, che viene poi iniettata nel prompt del provider solo-testo primario. Se nessun provider vision è raggiungibile, l'immagine viene ignorata e l'agente risponde solo con contesto testuale, avvisando l'utente.
+
+### SessionSnapshot — Entità (SessionTracking BC)
+
+```csharp
+public class SessionSnapshot : AuditableEntity
+{
+    public Guid Id { get; private set; }
+    public Guid SessionId { get; private set; }
+    public Guid UserId { get; private set; }
+    public int TurnNumber { get; private set; }
+    public string? Caption { get; private set; }
+    public List<SnapshotImage> Images { get; private set; }
+    public string? ExtractedGameState { get; private set; }  // JSON, nullable
+
+    public static SessionSnapshot Create(
+        Guid sessionId, Guid userId, int turnNumber, string? caption);
+    public void AddImage(string storageKey, string mediaType, int width, int height);
+    public void UpdateGameState(string gameStateJson);
+}
+
+public class SnapshotImage : Entity
+{
+    public Guid Id { get; private set; }
+    public string StorageKey { get; private set; }
+    public string MediaType { get; private set; }
+    public int Width { get; private set; }
+    public int Height { get; private set; }
+    public int OrderIndex { get; private set; }
+}
+```
+
+### VisionTierLimits
+
+```csharp
+public record VisionTierLimits(
+    int MaxImagesPerMessage,
+    int MaxSnapshotsPerSession,
+    int MaxImagesPerSnapshot,
+    int MaxImageResolution,
+    bool GameStateExtractionEnabled);
+```
+
+| Tier | ImagesPerMsg | SnapshotsPerSession | ImagesPerSnapshot | MaxResolution | GameStateExtraction |
+|------|-------------|--------------------|--------------------|---------------|---------------------|
+| Alpha | 5 | 20 | 5 | 2048px | ON |
+| Free | 2 | 5 | 3 | 1024px | OFF |
+| Premium | 5 | 30 | 10 | 2048px | ON |
+
+## Flusso Inline Chat (Immagini Effimere)
+
+### Command
+
+```csharp
+public record AskSessionAgentCommand(
+    Guid SessionId,
+    Guid SenderId,
+    string Question,
+    int? TurnNumber,
+    List<ChatImageAttachment>? Images
+) : IRequest<AskSessionAgentResult>;
+
+public record ChatImageAttachment(byte[] Data, string MediaType, string? FileName);
+```
+
+### Endpoint
+
+```csharp
+app.MapPost("/api/v1/live-sessions/{sessionId}/agent/ask",
+    async (Guid sessionId, [FromForm] AskAgentWithImagesRequest request,
+           IMediator mediator) => ...);
+```
+
+Multipart form: `question` (string) + `turnNumber` (int?) + `images` (IFormFile[]).
+
+### Execution Flow
+
+```
+Utente allega immagini + domanda
+    │
+    ▼
+1. Valida tier limits (MaxImagesPerMessage)
+2. IImagePreprocessor.ProcessAsync() per ogni immagine (resize/optimize)
+3. Recupera ultimo GameState da snapshot (se presente) come contesto
+4. Assembla List<LlmMessage> con ContentPart (testo + immagini)
+5. LlmProviderSelector sceglie provider con SupportsVision=true
+6. Se nessun provider vision → DescribeImageAsync() fallback testuale
+7. ILlmClient.GenerateCompletionStreamAsync(messages)
+8. Salva risposta come SessionChatMessage (tipo AgentResponse)
+    │
+    ▼
+Immagini scartate — solo la risposta persiste
+```
+
+### Prompt Assembly
+
+```
+SYSTEM: {agent_prompt_template}
+        {rag_chunks_from_rulebook}
+        {latest_extracted_game_state_if_available}
+
+USER:   [Image1: base64] [Image2: base64]
+        "Ecco il tavolo, cosa mi consigli per il prossimo turno?"
+```
+
+## Flusso Snapshot Sessione (Immagini Persistenti)
+
+### Commands & Queries
+
+```csharp
+public record CreateSessionSnapshotCommand(
+    Guid SessionId, Guid UserId, int TurnNumber,
+    string? Caption, List<SnapshotImageUpload> Images
+) : IRequest<CreateSnapshotResult>;
+
+public record SnapshotImageUpload(byte[] Data, string MediaType, string? FileName);
+
+public record GetLatestGameStateQuery(Guid SessionId)
+    : IRequest<GameStateResult?>;
+
+public record GetSessionSnapshotsQuery(Guid SessionId)
+    : IRequest<List<SessionSnapshotDto>>;
+```
+
+### Endpoints
+
+```csharp
+app.MapPost("/api/v1/live-sessions/{sessionId}/snapshots", ...);   // upload
+app.MapGet("/api/v1/live-sessions/{sessionId}/snapshots", ...);    // list
+app.MapGet("/api/v1/live-sessions/{sessionId}/game-state", ...);   // latest state
+```
+
+### Lazy Extraction
+
+L'extraction del GameState avviene on-demand, alla prima domanda dell'utente dopo un upload:
+
+```
+Utente carica snapshot → immagini salvate in storage → DONE (zero costi LLM)
+    ...
+Utente chiede all'agente "Come sto messo?"
+    │
+    ▼
+Handler: c'è GameState estratto per l'ultimo snapshot?
+    │
+    ├─ SÌ → usa GameState nel system prompt
+    └─ NO → chiama vision LLM sulle immagini snapshot
+             salva ExtractedGameState nel DB
+             procede con la risposta
+             (+3-8s latenza sulla prima domanda)
+             Chiamate successive: GameState cachato
+```
+
+L'extraction è idempotente — non si rifa se già estratta. Si ricalcola solo con nuovo snapshot.
+
+### GameState Extraction Prompt
+
+```
+SYSTEM: Sei un analizzatore di immagini di giochi da tavolo.
+        Analizza le immagini e restituisci un JSON strutturato.
+        Il gioco è: {gameName}. Regole note: {ragContext}.
+
+USER:   [Image1] [Image2] [Image3]
+        Estrai lo stato del gioco da queste foto.
+        Restituisci SOLO JSON valido nel formato:
+        {
+          "turn_estimate": number | null,
+          "players": [{ "position": string, "resources": {}, "score": number | null }],
+          "board_description": string,
+          "notable_state": string[],
+          "confidence": number  // 0.0 - 1.0
+        }
+```
+
+GameState con `confidence < 0.4` non viene incluso nel system prompt dell'agente.
+
+### Storage Structure
+
+```
+snapshots/{sessionId}/{snapshotId}/img_0.jpg
+snapshots/{sessionId}/{snapshotId}/img_1.jpg
+```
+
+Usa il pattern `IStorageProvider` esistente (S3/local via factory).
+
+## Provider Vision & Fallback
+
+### Provider Support
+
+| Provider | SupportsVision | Modelli Vision |
+|----------|---------------|----------------|
+| DeepSeek | `true` | deepseek-chat (OpenAI-compatible) |
+| OpenRouter | `true` | claude-sonnet-4, gpt-4o, gemini-2.5-pro |
+| Ollama | `false` | modelli locali tipicamente solo-testo |
+
+### Fallback Chain
+
+```
+Richiesta con immagini
+    │
+    ▼
+Provider con SupportsVision=true disponibile?
+    │
+    ├─ SÌ → content parts nativi (1 chiamata LLM)
+    └─ NO → DescribeImageAsync via provider vision
+             → descrizione testuale iniettata nel prompt
+             → invio a provider solo-testo (2 chiamate LLM)
+```
+
+### LlmProviderSelector Esteso
+
+```csharp
+public class LlmProviderSelector : ILlmProviderSelector
+{
+    public async Task<ILlmClient> SelectProviderAsync(LlmRoutingContext context)
+    {
+        var candidates = _providers
+            .Where(p => p.IsHealthy)
+            .Where(p => !context.RequiresVision || p.SupportsVision)
+            .OrderBy(p => ScoreProvider(p, context.Strategy));
+
+        if (!candidates.Any() && context.RequiresVision)
+            return SelectWithTextFallback(context);
+
+        return candidates.First();
+    }
+}
+```
+
+## Frontend
+
+### Componenti
+
+| Componente | Path | Descrizione |
+|-----------|------|-------------|
+| ChatInputBar | `components/chat/panel/ChatInputBar.tsx` | Esteso: bottone 🖼️, preview immagini, rimozione |
+| ChatMessageBubble | `components/chat/panel/ChatMessageBubble.tsx` | Esteso: render thumbnail immagini nel messaggio |
+| SessionSnapshotPanel | `components/session/SessionSnapshotPanel.tsx` | NUOVO: area snapshot con timeline per turno |
+| SnapshotCard | `components/session/SnapshotCard.tsx` | NUOVO: card singolo snapshot con badge stato |
+| SnapshotUploadDialog | `components/session/SnapshotUploadDialog.tsx` | NUOVO: dialog upload con caption e turn number |
+| GameStateDisplay | `components/session/GameStateDisplay.tsx` | NUOVO: visualizzazione GameState JSON leggibile |
+
+### Hooks
+
+```typescript
+// Inline chat images (effimere)
+useChatImageAttachments()
+  → addImage(file) / removeImage(index) / clearImages()
+  → images: ChatImagePreview[]
+
+// Snapshot sessione
+useSessionSnapshots(sessionId)
+  → snapshots, isLoading, createSnapshot(files, caption, turnNumber)
+
+// Game state
+useLatestGameState(sessionId)
+  → gameState, isAnalyzed, isLoading
+```
+
+### UX Details
+
+- Bottone 🖼️ separato dal 📎 (PDF) nella ChatInputBar
+- Preview thumbnail con X per rimuovere prima dell'invio
+- Immagini nel bubble messaggio: thumbnail cliccabili per full-size
+- Snapshot panel: timeline per turno, badge "Analizzato" / "Non analizzato"
+- Mobile: picker nativo (fotocamera + galleria), HEIC → JPEG server-side
+
+## Error Handling
+
+### Upload Errors
+
+| Scenario | Handling |
+|----------|----------|
+| File non immagine | Validazione client + server: 400 Bad Request |
+| Immagine troppo grande | Reject: "Immagine max {X}MB per il tuo piano" |
+| Troppe immagini | Reject: "Max {N} immagini per messaggio" |
+| Upload network failure | Retry client-side (max 2), poi toast errore |
+| HEIC/WebP | Server converte a JPEG via preprocessor |
+
+### Vision Errors
+
+| Scenario | Handling |
+|----------|----------|
+| Nessun provider vision | Fallback testuale automatico |
+| Vision API timeout | Retry 1x, poi risposta senza contesto visivo + avviso |
+| GameState extraction fallisce | Snapshot valido con solo immagini, `ExtractedGameState = null` |
+| Confidence < 0.4 | GameState escluso dal system prompt, log per monitoring |
+| Immagine non è un gioco | Agente risponde "L'immagine non sembra un gioco da tavolo" |
+
+### Concorrenza
+
+| Scenario | Handling |
+|----------|----------|
+| 2 utenti caricano snapshot simultaneamente | Snapshot indipendenti, nessun conflitto |
+| Lazy extraction doppia | Optimistic lock: primo completa, secondo riusa |
+| Upload durante chat streaming | Endpoint indipendenti, nessun blocco |
+
+## Testing Strategy
+
+### Backend Unit Tests
+- ContentPart serialization/deserialization
+- ImagePreprocessor: resize, HEIC conversion, size limits
+- VisionTierLimits validation per ogni tier
+- GameState extraction prompt building
+- Provider selection con/senza SupportsVision
+- Fallback chain: vision → text description
+
+### Backend Integration Tests
+- Snapshot CRUD con storage reale (Testcontainers)
+- AskSessionAgentCommand con immagini mock
+- Lazy extraction trigger e caching
+- Tier limits enforcement
+
+### Frontend Unit Tests
+- useChatImageAttachments: add/remove/clear
+- ChatInputBar: render bottone 🖼️, preview, invio multipart
+- ChatMessageBubble: render immagini inline
+- SnapshotCard: badge stato, GameState display
+
+### Frontend E2E (Playwright)
+- Upload immagine inline e ricezione risposta agente
+- Upload snapshot, verifica persistenza, verifica badge
+- Tier limits: verificare reject quando superati
+- Mobile: fotocamera picker, HEIC handling
+
+## Migration
+
+```sql
+-- Nuova tabella SessionSnapshots
+CREATE TABLE session_snapshots (
+    id UUID PRIMARY KEY,
+    session_id UUID NOT NULL REFERENCES sessions(id),
+    user_id UUID NOT NULL,
+    turn_number INT NOT NULL,
+    caption TEXT,
+    extracted_game_state JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ,
+    created_by UUID,
+    updated_by UUID,
+    is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    deleted_at TIMESTAMPTZ
+);
+
+-- Nuova tabella SnapshotImages
+CREATE TABLE snapshot_images (
+    id UUID PRIMARY KEY,
+    snapshot_id UUID NOT NULL REFERENCES session_snapshots(id) ON DELETE CASCADE,
+    storage_key TEXT NOT NULL,
+    media_type VARCHAR(50) NOT NULL,
+    width INT NOT NULL,
+    height INT NOT NULL,
+    order_index INT NOT NULL DEFAULT 0
+);
+
+CREATE INDEX ix_session_snapshots_session_id ON session_snapshots(session_id);
+CREATE INDEX ix_session_snapshots_session_turn ON session_snapshots(session_id, turn_number);
+CREATE INDEX ix_snapshot_images_snapshot_id ON snapshot_images(snapshot_id);
+```
+
+## Out of Scope
+
+- Video upload / streaming
+- Real-time board tracking (continuous vision)
+- Collaborative snapshot editing tra partecipanti
+- OCR specifico per testi su carte/componenti (potrebbe essere un follow-up)
+- Training/fine-tuning modelli su giochi specifici


### PR DESCRIPTION
## Summary

- **Multimodal LLM support**: Extended `ILlmClient` and `ILlmService` with content parts (text + images). DeepSeek and OpenRouter support vision natively, Ollama falls back to text-only.
- **Image preprocessing**: `IImagePreprocessor` with SkiaSharp — resize, JPEG conversion, format detection. Configurable limits per user tier (`VisionTierLimits`).
- **VisionSnapshot entity**: New aggregate in SessionTracking BC for persistent board photos with lazy GameState extraction via vision AI.
- **Inline chat images**: Extended `AskSessionAgentCommand` to accept ephemeral image attachments. Multipart endpoint with backward-compatible JSON fallback.
- **Frontend**: Image attachment in ChatInputBar, thumbnail rendering in ChatMessageBubble, SessionSnapshotPanel with upload dialog and game state display.
- **35 new tests**: 28 backend unit tests + 7 frontend hook tests, all passing.

## Test plan

- [ ] Backend build: `cd apps/api/src/Api && dotnet build` — 0 errors
- [ ] Frontend build: `cd apps/web && pnpm build` — 0 errors
- [ ] Backend tests: `dotnet test --filter "ContentPart|VisionTier|VisionSnapshot|SkiaImagePreprocessor"` — 28 pass
- [ ] Frontend tests: `pnpm test -- --run useChatImageAttachments` — 7 pass
- [ ] Verify snapshot upload endpoint: POST `/api/v1/live-sessions/{id}/snapshots` with multipart form
- [ ] Verify ask-agent with images: POST `/game-sessions/{id}/chat/ask-agent` with multipart form
- [ ] Visual check: SessionSnapshotPanel renders in live session photos page

🤖 Generated with [Claude Code](https://claude.com/claude-code)