### PR TITLE
test(vision): add unit tests for session vision AI

### DIFF
--- a/apps/api/tests/Api.Tests/Api.Tests.csproj
+++ b/apps/api/tests/Api.Tests/Api.Tests.csproj
@@ -32,6 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.105.0" />
+    <PackageReference Include="SkiaSharp" Version="3.119.2" />
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.11" />

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/VisionTierLimitsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/VisionTierLimitsTests.cs
@@ -1,0 +1,69 @@
+using Api.BoundedContexts.KnowledgeBase.Domain;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Domain;
+
+/// <summary>
+/// Unit tests for VisionTierLimits static lookup.
+/// Session Vision AI feature.
+/// </summary>
+public class VisionTierLimitsTests
+{
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void AlphaTier_HasExpectedLimits()
+    {
+        var config = VisionTierLimits.GetConfig("alpha");
+
+        config.MaxImagesPerMessage.Should().Be(5);
+        config.MaxSnapshotsPerSession.Should().Be(20);
+        config.GameStateExtractionEnabled.Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void FreeTier_HasExpectedLimits()
+    {
+        var config = VisionTierLimits.GetConfig("free");
+
+        config.MaxImagesPerMessage.Should().Be(2);
+        config.MaxSnapshotsPerSession.Should().Be(5);
+        config.GameStateExtractionEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void NullTier_ReturnsFreeDefaults()
+    {
+        var config = VisionTierLimits.GetConfig(null);
+
+        config.MaxImagesPerMessage.Should().Be(2);
+        config.MaxSnapshotsPerSession.Should().Be(5);
+        config.GameStateExtractionEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void UnknownTier_ReturnsFreeDefaults()
+    {
+        var config = VisionTierLimits.GetConfig("nonexistent-tier");
+
+        config.MaxImagesPerMessage.Should().Be(2);
+        config.MaxSnapshotsPerSession.Should().Be(5);
+        config.GameStateExtractionEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void TierLookup_IsCaseInsensitive()
+    {
+        var lower = VisionTierLimits.GetConfig("alpha");
+        var upper = VisionTierLimits.GetConfig("ALPHA");
+        var mixed = VisionTierLimits.GetConfig("Alpha");
+
+        lower.Should().Be(upper);
+        lower.Should().Be(mixed);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs
@@ -4,6 +4,8 @@ using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
 using Api.Middleware.Exceptions;
 using Api.Services;
+using Api.BoundedContexts.SessionTracking.Application.Services;
+using Api.Services.ImageProcessing;
 using Api.Tests.Constants;
 using MediatR;
 using Microsoft.Extensions.Logging;
@@ -175,6 +177,8 @@ public class AskSessionAgentCommandHandlerTests
             _mockChatRepo.Object,
             _mockMediator.Object,
             _mockLlmService.Object,
+            new Mock<IImagePreprocessor>().Object,
+            new Mock<IGameStateExtractor>().Object,
             new Mock<ILogger<AskSessionAgentCommandHandler>>().Object);
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/VisionSnapshotTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/VisionSnapshotTests.cs
@@ -1,0 +1,143 @@
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Domain;
+
+/// <summary>
+/// Unit tests for VisionSnapshot aggregate.
+/// Session Vision AI feature.
+/// </summary>
+public class VisionSnapshotTests
+{
+    private static readonly Guid ValidSessionId = Guid.NewGuid();
+    private static readonly Guid ValidUserId = Guid.NewGuid();
+
+    // ─── Create ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void Create_SetsRequiredProperties()
+    {
+        var snapshot = VisionSnapshot.Create(ValidSessionId, ValidUserId, 3, "Turn 3 state");
+
+        snapshot.Id.Should().NotBeEmpty();
+        snapshot.SessionId.Should().Be(ValidSessionId);
+        snapshot.UserId.Should().Be(ValidUserId);
+        snapshot.TurnNumber.Should().Be(3);
+        snapshot.Caption.Should().Be("Turn 3 state");
+        snapshot.IsDeleted.Should().BeFalse();
+        snapshot.Images.Should().BeEmpty();
+        snapshot.ExtractedGameState.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void Create_WithEmptySessionId_Throws()
+    {
+        var act = () => VisionSnapshot.Create(Guid.Empty, ValidUserId, 1, null);
+
+        act.Should().Throw<ArgumentException>().WithParameterName("sessionId");
+    }
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void Create_WithEmptyUserId_Throws()
+    {
+        var act = () => VisionSnapshot.Create(ValidSessionId, Guid.Empty, 1, null);
+
+        act.Should().Throw<ArgumentException>().WithParameterName("userId");
+    }
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void Create_WithNegativeTurnNumber_Throws()
+    {
+        var act = () => VisionSnapshot.Create(ValidSessionId, ValidUserId, -1, null);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void Create_WithTooLongCaption_Throws()
+    {
+        var longCaption = new string('x', 201);
+
+        var act = () => VisionSnapshot.Create(ValidSessionId, ValidUserId, 1, longCaption);
+
+        act.Should().Throw<ArgumentException>().WithParameterName("caption");
+    }
+
+    // ─── AddImage ───────────────────────────────────────────────────────────
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void AddImage_AddsWithCorrectOrderIndex()
+    {
+        var snapshot = VisionSnapshot.Create(ValidSessionId, ValidUserId, 1, null);
+
+        snapshot.AddImage("storage/img1.jpg", "image/jpeg", 800, 600);
+        snapshot.AddImage("storage/img2.png", "image/png", 1024, 768);
+
+        snapshot.Images.Should().HaveCount(2);
+        snapshot.Images[0].StorageKey.Should().Be("storage/img1.jpg");
+        snapshot.Images[0].OrderIndex.Should().Be(0);
+        snapshot.Images[1].StorageKey.Should().Be("storage/img2.png");
+        snapshot.Images[1].OrderIndex.Should().Be(1);
+    }
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void AddImage_WithEmptyStorageKey_Throws()
+    {
+        var snapshot = VisionSnapshot.Create(ValidSessionId, ValidUserId, 1, null);
+
+        var act = () => snapshot.AddImage("", "image/jpeg", 800, 600);
+
+        act.Should().Throw<ArgumentException>().WithParameterName("storageKey");
+    }
+
+    // ─── UpdateGameState ────────────────────────────────────────────────────
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void UpdateGameState_SetsJsonAndTimestamp()
+    {
+        var snapshot = VisionSnapshot.Create(ValidSessionId, ValidUserId, 1, null);
+        var json = """{"score": {"player1": 10}}""";
+
+        snapshot.UpdateGameState(json);
+
+        snapshot.ExtractedGameState.Should().Be(json);
+        snapshot.UpdatedAt.Should().NotBeNull();
+        snapshot.UpdatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void UpdateGameState_WithNull_Throws()
+    {
+        var snapshot = VisionSnapshot.Create(ValidSessionId, ValidUserId, 1, null);
+
+        var act = () => snapshot.UpdateGameState(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    // ─── SoftDelete ─────────────────────────────────────────────────────────
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void SoftDelete_MarksDeleted()
+    {
+        var snapshot = VisionSnapshot.Create(ValidSessionId, ValidUserId, 1, null);
+
+        snapshot.SoftDelete();
+
+        snapshot.IsDeleted.Should().BeTrue();
+        snapshot.DeletedAt.Should().NotBeNull();
+        snapshot.DeletedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(2));
+    }
+}

--- a/apps/api/tests/Api.Tests/Services/ImageProcessing/SkiaImagePreprocessorTests.cs
+++ b/apps/api/tests/Api.Tests/Services/ImageProcessing/SkiaImagePreprocessorTests.cs
@@ -1,0 +1,120 @@
+using Api.Services.ImageProcessing;
+using Api.Tests.Constants;
+using FluentAssertions;
+using SkiaSharp;
+using Xunit;
+
+namespace Api.Tests.Services.ImageProcessing;
+
+/// <summary>
+/// Unit tests for SkiaImagePreprocessor.
+/// Session Vision AI feature.
+/// </summary>
+public class SkiaImagePreprocessorTests
+{
+    private readonly SkiaImagePreprocessor _sut = new();
+
+    // ─── ProcessAsync — resize ──────────────────────────────────────────────
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public async Task ProcessAsync_ResizesLargeImage()
+    {
+        // Arrange: create a 4000x3000 JPEG
+        var imageData = CreateTestJpeg(4000, 3000);
+
+        // Act
+        var result = await _sut.ProcessAsync(imageData, "image/jpeg");
+
+        // Assert: default max is 1024
+        result.Width.Should().BeLessThanOrEqualTo(1024);
+        result.Height.Should().BeLessThanOrEqualTo(1024);
+        result.Data.Should().NotBeEmpty();
+        result.MediaType.Should().Be("image/jpeg");
+    }
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public async Task ProcessAsync_PreservesSmallImageDimensions()
+    {
+        // Arrange: create a 400x300 JPEG (under the 1024 default limit)
+        var imageData = CreateTestJpeg(400, 300);
+
+        // Act
+        var result = await _sut.ProcessAsync(imageData, "image/jpeg");
+
+        // Assert: dimensions should remain unchanged
+        result.Width.Should().Be(400);
+        result.Height.Should().Be(300);
+    }
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public async Task ProcessAsync_WithEmptyData_Throws()
+    {
+        var act = () => _sut.ProcessAsync([], "image/jpeg");
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    // ─── DetectMediaType ────────────────────────────────────────────────────
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void DetectMediaType_IdentifiesJpeg()
+    {
+        // JPEG magic bytes: FF D8 FF
+        var jpegHeader = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10 };
+
+        var result = _sut.DetectMediaType(jpegHeader);
+
+        result.Should().Be("image/jpeg");
+    }
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void DetectMediaType_IdentifiesPng()
+    {
+        // PNG magic bytes: 89 50 4E 47
+        var pngHeader = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A };
+
+        var result = _sut.DetectMediaType(pngHeader);
+
+        result.Should().Be("image/png");
+    }
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void DetectMediaType_ReturnsNullForUnknownData()
+    {
+        var unknownData = new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05 };
+
+        var result = _sut.DetectMediaType(unknownData);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void DetectMediaType_ReturnsNullForTooShortData()
+    {
+        var shortData = new byte[] { 0xFF, 0xD8 };
+
+        var result = _sut.DetectMediaType(shortData);
+
+        result.Should().BeNull();
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────────
+
+    private static byte[] CreateTestJpeg(int width, int height)
+    {
+        using var bitmap = new SKBitmap(width, height);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(SKColors.CornflowerBlue);
+
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Jpeg, 75);
+        return data.ToArray();
+    }
+}

--- a/apps/api/tests/Api.Tests/Services/LlmClients/ContentPartTests.cs
+++ b/apps/api/tests/Api.Tests/Services/LlmClients/ContentPartTests.cs
@@ -1,0 +1,85 @@
+using Api.Services.LlmClients;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Services.LlmClients;
+
+/// <summary>
+/// Unit tests for ContentPart, TextContentPart, ImageContentPart, and LlmMessage.
+/// Session Vision AI feature.
+/// </summary>
+public class ContentPartTests
+{
+    // ─── TextContentPart ────────────────────────────────────────────────────
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void TextContentPart_StoresText()
+    {
+        var part = new TextContentPart("Hello world");
+
+        part.Text.Should().Be("Hello world");
+    }
+
+    // ─── ImageContentPart ───────────────────────────────────────────────────
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void ImageContentPart_ToDataUri_GeneratesCorrectFormat()
+    {
+        var part = new ImageContentPart("abc123==", "image/jpeg");
+
+        var uri = part.ToDataUri();
+
+        uri.Should().Be("data:image/jpeg;base64,abc123==");
+    }
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void ImageContentPart_StoresBase64DataAndMediaType()
+    {
+        var part = new ImageContentPart("data==", "image/png");
+
+        part.Base64Data.Should().Be("data==");
+        part.MediaType.Should().Be("image/png");
+    }
+
+    // ─── LlmMessage.FromText ────────────────────────────────────────────────
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void FromText_CreatesTextOnlyMessage()
+    {
+        var message = LlmMessage.FromText("user", "Hello");
+
+        message.Role.Should().Be("user");
+        message.Content.Should().HaveCount(1);
+        message.Content[0].Should().BeOfType<TextContentPart>()
+            .Which.Text.Should().Be("Hello");
+    }
+
+    // ─── LlmMessage.HasImages ───────────────────────────────────────────────
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void HasImages_WithImageContentPart_ReturnsTrue()
+    {
+        var message = new LlmMessage("user", new ContentPart[]
+        {
+            new TextContentPart("Look at this:"),
+            new ImageContentPart("abc==", "image/jpeg")
+        });
+
+        message.HasImages.Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public void HasImages_WithOnlyTextContentParts_ReturnsFalse()
+    {
+        var message = LlmMessage.FromText("user", "Just text");
+
+        message.HasImages.Should().BeFalse();
+    }
+}

--- a/apps/web/__tests__/hooks/useChatImageAttachments.test.ts
+++ b/apps/web/__tests__/hooks/useChatImageAttachments.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for useChatImageAttachments hook.
+ * Session Vision AI feature.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { useChatImageAttachments } from '@/hooks/useChatImageAttachments';
+
+// Mock URL.createObjectURL / revokeObjectURL
+const mockCreateObjectURL = vi.fn((file: Blob) => `blob:mock-${Math.random()}`);
+const mockRevokeObjectURL = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  globalThis.URL.createObjectURL = mockCreateObjectURL;
+  globalThis.URL.revokeObjectURL = mockRevokeObjectURL;
+});
+
+function createMockFile(name: string, size: number, type: string): File {
+  const buffer = new ArrayBuffer(size);
+  return new File([buffer], name, { type });
+}
+
+describe('useChatImageAttachments', () => {
+  it('starts with empty images', () => {
+    const { result } = renderHook(() => useChatImageAttachments());
+
+    expect(result.current.images).toEqual([]);
+    expect(result.current.hasImages).toBe(false);
+    expect(result.current.canAddMore).toBe(true);
+  });
+
+  it('adds valid image and returns null error', () => {
+    const { result } = renderHook(() => useChatImageAttachments());
+    const file = createMockFile('photo.jpg', 1024, 'image/jpeg');
+
+    let error: string | null = null;
+    act(() => {
+      error = result.current.addImage(file);
+    });
+
+    expect(error).toBeNull();
+    expect(result.current.images).toHaveLength(1);
+    expect(result.current.images[0].file).toBe(file);
+    expect(result.current.images[0].mediaType).toBe('image/jpeg');
+    expect(result.current.hasImages).toBe(true);
+    expect(mockCreateObjectURL).toHaveBeenCalledOnce();
+  });
+
+  it('rejects unsupported file types with error string', () => {
+    const { result } = renderHook(() => useChatImageAttachments());
+    const file = createMockFile('doc.pdf', 1024, 'application/pdf');
+
+    let error: string | null = null;
+    act(() => {
+      error = result.current.addImage(file);
+    });
+
+    expect(error).toBeTypeOf('string');
+    expect(error).toBeTruthy();
+    expect(result.current.images).toHaveLength(0);
+  });
+
+  it('rejects oversized files', () => {
+    const { result } = renderHook(() => useChatImageAttachments());
+    // 11MB exceeds the 10MB limit
+    const file = createMockFile('huge.jpg', 11 * 1024 * 1024, 'image/jpeg');
+
+    let error: string | null = null;
+    act(() => {
+      error = result.current.addImage(file);
+    });
+
+    expect(error).toBeTypeOf('string');
+    expect(error).toBeTruthy();
+    expect(result.current.images).toHaveLength(0);
+  });
+
+  it('respects max limit and canAddMore becomes false', () => {
+    const { result } = renderHook(() => useChatImageAttachments(2));
+
+    act(() => {
+      result.current.addImage(createMockFile('a.jpg', 100, 'image/jpeg'));
+    });
+    act(() => {
+      result.current.addImage(createMockFile('b.jpg', 100, 'image/jpeg'));
+    });
+
+    expect(result.current.images).toHaveLength(2);
+    expect(result.current.canAddMore).toBe(false);
+
+    // Adding a third should not increase the count (state update capped in the hook)
+    act(() => {
+      result.current.addImage(createMockFile('c.jpg', 100, 'image/jpeg'));
+    });
+    expect(result.current.images).toHaveLength(2);
+  });
+
+  it('removeImage revokes URL', () => {
+    const { result } = renderHook(() => useChatImageAttachments());
+
+    act(() => {
+      result.current.addImage(createMockFile('a.jpg', 100, 'image/jpeg'));
+      result.current.addImage(createMockFile('b.jpg', 100, 'image/png'));
+    });
+
+    const previewUrl = result.current.images[0].previewUrl;
+
+    act(() => {
+      result.current.removeImage(0);
+    });
+
+    expect(mockRevokeObjectURL).toHaveBeenCalledWith(previewUrl);
+    expect(result.current.images).toHaveLength(1);
+  });
+
+  it('clearImages revokes all URLs', () => {
+    const { result } = renderHook(() => useChatImageAttachments());
+
+    act(() => {
+      result.current.addImage(createMockFile('a.jpg', 100, 'image/jpeg'));
+      result.current.addImage(createMockFile('b.jpg', 100, 'image/png'));
+    });
+
+    expect(result.current.images).toHaveLength(2);
+
+    act(() => {
+      result.current.clearImages();
+    });
+
+    expect(mockRevokeObjectURL).toHaveBeenCalledTimes(2);
+    expect(result.current.images).toHaveLength(0);
+    expect(result.current.hasImages).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- 35 new tests for the session vision AI feature (#466)
- Backend: ContentPart, VisionTierLimits, VisionSnapshot entity, SkiaImagePreprocessor
- Frontend: useChatImageAttachments hook
- Fixes existing ChatCommandHandlerTests for new constructor deps

## Test plan

- [ ] `dotnet test --filter "ContentPart|VisionTier|VisionSnapshot|SkiaImagePreprocessor"` — 28 pass
- [ ] `pnpm test -- --run useChatImageAttachments` — 7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)