### PR TITLE
feat(alpha): golden path UX gaps — invite link, library button, chat messages

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/SendInvitationCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/SendInvitationCommandHandler.cs
@@ -92,10 +92,10 @@ internal sealed class SendInvitationCommandHandler : ICommandHandler<SendInvitat
         }
 #pragma warning restore CA1031
 
-        return MapToDto(invitation);
+        return MapToDto(invitation, rawToken);
     }
 
-    internal static InvitationDto MapToDto(InvitationToken invitation)
+    internal static InvitationDto MapToDto(InvitationToken invitation, string? rawToken = null)
     {
         return new InvitationDto(
             Id: invitation.Id,
@@ -105,6 +105,7 @@ internal sealed class SendInvitationCommandHandler : ICommandHandler<SendInvitat
             ExpiresAt: invitation.ExpiresAt,
             CreatedAt: invitation.CreatedAt,
             AcceptedAt: invitation.AcceptedAt,
-            InvitedByUserId: invitation.InvitedByUserId);
+            InvitedByUserId: invitation.InvitedByUserId,
+            Token: rawToken);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/InvitationDto.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/InvitationDto.cs
@@ -14,4 +14,7 @@ public sealed record InvitationDto(
     DateTime? AcceptedAt,
     Guid InvitedByUserId,
     bool EmailSent = true,
-    List<GameSuggestionDto>? GameSuggestions = null);
+    List<GameSuggestionDto>? GameSuggestions = null,
+    // Raw token only populated on creation; not stored in DB (only hash persisted).
+    // Use to construct the accept-invite URL immediately after sending.
+    string? Token = null);

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/Invitation/GetInvitationsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/Invitation/GetInvitationsQueryHandler.cs
@@ -42,7 +42,7 @@ internal sealed class GetInvitationsQueryHandler
             totalCount = await _invitationRepo.CountAllAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var items = invitations.Select(SendInvitationCommandHandler.MapToDto).ToList();
+        var items = invitations.Select(inv => SendInvitationCommandHandler.MapToDto(inv)).ToList();
 
         return new GetInvitationsResponse(items, totalCount, query.Page, query.PageSize);
     }

--- a/apps/web/src/app/(authenticated)/games/[id]/__tests__/GameDetailPage.test.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/__tests__/GameDetailPage.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * GameDetailPage Tests
+ *
+ * Covers:
+ * - Shows "Aggiungi alla Libreria" button when game is NOT in library
+ * - Hides the button and shows "In libreria" badge when game IS in library
+ * - Renders loading skeleton while data is fetching
+ * - Renders error state when game is not found
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ============================================================================
+// Navigation mocks
+// ============================================================================
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: 'game-123' }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+// ============================================================================
+// Query mocks
+// ============================================================================
+
+let mockGame: Record<string, unknown> | null = null;
+let mockGameLoading = false;
+let mockLibraryStatus: { inLibrary: boolean } | null = null;
+let mockLibraryLoading = false;
+let mockManaPipsData: null = null;
+let mockPipsLoading = false;
+
+vi.mock('@/hooks/queries/useSharedGames', () => ({
+  useSharedGame: () => ({
+    data: mockGame,
+    isLoading: mockGameLoading,
+  }),
+}));
+
+vi.mock('@/hooks/queries/useLibrary', () => ({
+  useGameInLibraryStatus: () => ({
+    data: mockLibraryStatus,
+    isLoading: mockLibraryLoading,
+  }),
+}));
+
+vi.mock('@/hooks/queries/useGameManaPips', () => ({
+  useGameManaPips: () => ({
+    data: mockManaPipsData,
+    isLoading: mockPipsLoading,
+  }),
+  buildGameManaPips: () => [],
+}));
+
+// ============================================================================
+// Component mocks
+// ============================================================================
+
+vi.mock('@/components/library/AddToLibraryButton', () => ({
+  AddToLibraryButton: ({ gameId, gameTitle }: { gameId: string; gameTitle: string }) => (
+    <button data-testid="add-to-library-button" data-game-id={gameId} data-game-title={gameTitle}>
+      Aggiungi alla Collezione
+    </button>
+  ),
+}));
+
+vi.mock('@/components/ui/data-display/meeple-card', () => ({
+  MeepleCard: ({ badge }: { badge?: string }) => (
+    <div data-testid="meeple-card">{badge && <span data-testid="library-badge">{badge}</span>}</div>
+  ),
+}));
+
+// ============================================================================
+// Import under test (after mocks)
+// ============================================================================
+
+import GameDetailPage from '../page';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const GAME = {
+  id: 'game-123',
+  title: 'Catan',
+  publishers: [{ name: 'Kosmos' }],
+  yearPublished: 1995,
+  imageUrl: null,
+  averageRating: 7.5,
+};
+
+const resetDefaults = () => {
+  mockGame = GAME;
+  mockGameLoading = false;
+  mockLibraryStatus = { inLibrary: false };
+  mockLibraryLoading = false;
+  mockManaPipsData = null;
+  mockPipsLoading = false;
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('GameDetailPage', () => {
+  beforeEach(resetDefaults);
+
+  it('shows AddToLibraryButton when game is not in library', () => {
+    mockLibraryStatus = { inLibrary: false };
+
+    render(<GameDetailPage />);
+
+    expect(screen.getByTestId('add-to-library-button')).toBeInTheDocument();
+    expect(screen.queryByTestId('library-badge')).not.toBeInTheDocument();
+  });
+
+  it('hides AddToLibraryButton and shows badge when game is in library', () => {
+    mockLibraryStatus = { inLibrary: true };
+
+    render(<GameDetailPage />);
+
+    expect(screen.queryByTestId('add-to-library-button')).not.toBeInTheDocument();
+    expect(screen.getByTestId('library-badge')).toHaveTextContent('In libreria');
+  });
+
+  it('passes correct gameId and gameTitle to AddToLibraryButton', () => {
+    mockLibraryStatus = { inLibrary: false };
+
+    render(<GameDetailPage />);
+
+    const btn = screen.getByTestId('add-to-library-button');
+    expect(btn).toHaveAttribute('data-game-id', 'game-123');
+    expect(btn).toHaveAttribute('data-game-title', 'Catan');
+  });
+
+  it('renders loading skeleton while data is fetching', () => {
+    mockGameLoading = true;
+
+    render(<GameDetailPage />);
+
+    // Skeleton renders; neither button nor meeple-card should appear
+    expect(screen.queryByTestId('meeple-card')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('add-to-library-button')).not.toBeInTheDocument();
+  });
+
+  it('renders error state when game is not found', () => {
+    mockGame = null;
+
+    render(<GameDetailPage />);
+
+    expect(screen.getByText('Gioco non trovato.')).toBeInTheDocument();
+    expect(screen.queryByTestId('add-to-library-button')).not.toBeInTheDocument();
+  });
+
+  it('does not show AddToLibraryButton when libraryStatus is null (loading state)', () => {
+    // null status means the query hasn't resolved yet; treat as "not in library"
+    mockLibraryStatus = null;
+
+    render(<GameDetailPage />);
+
+    // null?.inLibrary === undefined, which is falsy — button should appear
+    expect(screen.getByTestId('add-to-library-button')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(authenticated)/games/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/page.tsx
@@ -13,6 +13,7 @@ import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 
+import { AddToLibraryButton } from '@/components/library/AddToLibraryButton';
 import { MeepleCard } from '@/components/ui/data-display/meeple-card';
 import { Alert, AlertDescription } from '@/components/ui/feedback/alert';
 import { Skeleton } from '@/components/ui/feedback/skeleton';
@@ -147,6 +148,13 @@ export default function GameDetailPage() {
             manaPips={manaPips}
           />
         </section>
+
+        {/* Library Action */}
+        {!libraryStatus?.inLibrary && (
+          <div className="mb-6 flex justify-center" data-testid="add-to-library-section">
+            <AddToLibraryButton gameId={id} gameTitle={game.title} size="lg" />
+          </div>
+        )}
 
         {/* Tab Navigation */}
         <GameTabNav gameId={id} />

--- a/apps/web/src/components/admin/invitations/InviteUserDialog.tsx
+++ b/apps/web/src/components/admin/invitations/InviteUserDialog.tsx
@@ -3,12 +3,15 @@
  *
  * Dialog for sending a single user invitation.
  * Admin enters email + selects role, then sends invitation via API.
+ * After a successful send, shows a copyable invite link (token is only
+ * available at creation time — not stored in plain text in the DB).
  */
 
 'use client';
 
 import { useState } from 'react';
 
+import { Check, Copy } from 'lucide-react';
 import { toast } from 'sonner';
 
 import {
@@ -44,11 +47,15 @@ export function InviteUserDialog({ open, onOpenChange, onSuccess }: InviteUserDi
   const [role, setRole] = useState<string>('User');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [inviteLink, setInviteLink] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
 
   function resetForm() {
     setEmail('');
     setRole('User');
     setError(null);
+    setInviteLink(null);
+    setCopied(false);
   }
 
   function handleOpenChange(nextOpen: boolean) {
@@ -56,6 +63,17 @@ export function InviteUserDialog({ open, onOpenChange, onSuccess }: InviteUserDi
       resetForm();
     }
     onOpenChange(nextOpen);
+  }
+
+  async function handleCopyLink() {
+    if (!inviteLink) return;
+    try {
+      await navigator.clipboard.writeText(inviteLink);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error('Failed to copy link');
+    }
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -75,11 +93,18 @@ export function InviteUserDialog({ open, onOpenChange, onSuccess }: InviteUserDi
 
     setIsSubmitting(true);
     try {
-      await api.invitations.sendInvitation(trimmedEmail, role);
+      const result = await api.invitations.sendInvitation(trimmedEmail, role);
       toast.success(`Invitation sent to ${trimmedEmail}`);
-      resetForm();
-      onOpenChange(false);
       onSuccess?.();
+
+      if (result.token) {
+        const encodedToken = encodeURIComponent(result.token);
+        setInviteLink(`${window.location.origin}/accept-invite?token=${encodedToken}`);
+      } else {
+        // No token in response (e.g. SMTP configured and token not exposed) — close normally
+        resetForm();
+        onOpenChange(false);
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to send invitation';
       setError(message);
@@ -100,56 +125,90 @@ export function InviteUserDialog({ open, onOpenChange, onSuccess }: InviteUserDi
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="invite-email">Email Address</Label>
-            <Input
-              id="invite-email"
-              type="email"
-              placeholder="user@example.com"
-              value={email}
-              onChange={e => setEmail(e.target.value)}
-              disabled={isSubmitting}
-              autoFocus
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="invite-role">Role</Label>
-            <Select value={role} onValueChange={setRole} disabled={isSubmitting}>
-              <SelectTrigger id="invite-role">
-                <SelectValue placeholder="Select a role" />
-              </SelectTrigger>
-              <SelectContent>
-                {INVITATION_ROLES.map(r => (
-                  <SelectItem key={r} value={r}>
-                    {r}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          {error && (
-            <p className="text-sm text-red-600" role="alert">
-              {error}
+        {inviteLink ? (
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Invitation sent. Copy the link below to share it manually if email is not configured.
             </p>
-          )}
+            <div className="space-y-2">
+              <Label htmlFor="invite-link">Invitation Link</Label>
+              <div className="flex gap-2">
+                <Input
+                  id="invite-link"
+                  readOnly
+                  value={inviteLink}
+                  className="text-xs"
+                  aria-label="Invitation link"
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  onClick={handleCopyLink}
+                  aria-label={copied ? 'Copied' : 'Copy invitation link'}
+                >
+                  {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                </Button>
+              </div>
+            </div>
+            <DialogFooter>
+              <Button type="button" onClick={() => handleOpenChange(false)}>
+                Done
+              </Button>
+            </DialogFooter>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="invite-email">Email Address</Label>
+              <Input
+                id="invite-email"
+                type="email"
+                placeholder="user@example.com"
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+                disabled={isSubmitting}
+                autoFocus
+              />
+            </div>
 
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => handleOpenChange(false)}
-              disabled={isSubmitting}
-            >
-              Cancel
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? 'Sending...' : 'Send Invitation'}
-            </Button>
-          </DialogFooter>
-        </form>
+            <div className="space-y-2">
+              <Label htmlFor="invite-role">Role</Label>
+              <Select value={role} onValueChange={setRole} disabled={isSubmitting}>
+                <SelectTrigger id="invite-role">
+                  <SelectValue placeholder="Select a role" />
+                </SelectTrigger>
+                <SelectContent>
+                  {INVITATION_ROLES.map(r => (
+                    <SelectItem key={r} value={r}>
+                      {r}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {error && (
+              <p className="text-sm text-red-600" role="alert">
+                {error}
+              </p>
+            )}
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+                disabled={isSubmitting}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? 'Sending...' : 'Send Invitation'}
+              </Button>
+            </DialogFooter>
+          </form>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/src/components/admin/invitations/__tests__/InviteUserDialog.test.tsx
+++ b/apps/web/src/components/admin/invitations/__tests__/InviteUserDialog.test.tsx
@@ -7,6 +7,7 @@ import { renderWithQuery } from '@/__tests__/utils/query-test-utils';
 import { InviteUserDialog } from '../InviteUserDialog';
 
 const mockSendInvitation = vi.hoisted(() => vi.fn());
+const mockWriteText = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('@/lib/api', () => ({
   api: {
@@ -33,6 +34,12 @@ describe('InviteUserDialog', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockWriteText.mockResolvedValue(undefined);
+    // Stub clipboard.writeText so we can assert on it without jsdom restrictions
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      clipboard: { writeText: mockWriteText },
+    });
   });
 
   it('renders the dialog with form fields', () => {
@@ -69,12 +76,13 @@ describe('InviteUserDialog', () => {
     });
   });
 
-  it('submits valid invitation and calls onSuccess', async () => {
+  it('submits valid invitation and calls onSuccess — no token in response closes dialog', async () => {
     mockSendInvitation.mockResolvedValueOnce({
       id: '123',
       email: 'test@example.com',
       role: 'User',
       status: 'Pending',
+      // no token field → dialog closes immediately
     });
 
     renderWithQuery(<InviteUserDialog {...defaultProps} />);
@@ -87,6 +95,86 @@ describe('InviteUserDialog', () => {
     });
 
     expect(defaultProps.onSuccess).toHaveBeenCalled();
+    expect(defaultProps.onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('shows copyable invitation link when token is returned', async () => {
+    mockSendInvitation.mockResolvedValueOnce({
+      id: '123',
+      email: 'test@example.com',
+      role: 'User',
+      status: 'Pending',
+      token: 'abc-def-ghi',
+    });
+
+    renderWithQuery(<InviteUserDialog {...defaultProps} />);
+
+    await user.type(screen.getByLabelText('Email Address'), 'test@example.com');
+    await user.click(screen.getByRole('button', { name: /send invitation/i }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Invitation link')).toBeInTheDocument();
+    });
+
+    const linkInput = screen.getByLabelText('Invitation link') as HTMLInputElement;
+    expect(linkInput.value).toContain('/accept-invite?token=');
+    expect(linkInput.value).toContain('abc-def-ghi');
+    expect(defaultProps.onSuccess).toHaveBeenCalled();
+
+    // Dialog should NOT have been closed yet
+    expect(defaultProps.onOpenChange).not.toHaveBeenCalledWith(false);
+
+    // Copy button should be present
+    expect(screen.getByRole('button', { name: /copy invitation link/i })).toBeInTheDocument();
+  });
+
+  it('copies invitation link to clipboard when copy button is clicked', async () => {
+    mockSendInvitation.mockResolvedValueOnce({
+      id: '123',
+      email: 'test@example.com',
+      role: 'User',
+      status: 'Pending',
+      token: 'my-test-token',
+    });
+
+    renderWithQuery(<InviteUserDialog {...defaultProps} />);
+
+    await user.type(screen.getByLabelText('Email Address'), 'test@example.com');
+    await user.click(screen.getByRole('button', { name: /send invitation/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /copy invitation link/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /copy invitation link/i }));
+
+    expect(mockWriteText).toHaveBeenCalledWith(expect.stringContaining('my-test-token'));
+
+    // Button label changes to "Copied"
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /copied/i })).toBeInTheDocument();
+    });
+  });
+
+  it('closes dialog via Done button after showing invite link', async () => {
+    mockSendInvitation.mockResolvedValueOnce({
+      id: '123',
+      email: 'test@example.com',
+      role: 'User',
+      status: 'Pending',
+      token: 'abc-def-ghi',
+    });
+
+    renderWithQuery(<InviteUserDialog {...defaultProps} />);
+
+    await user.type(screen.getByLabelText('Email Address'), 'test@example.com');
+    await user.click(screen.getByRole('button', { name: /send invitation/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /done/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /done/i }));
     expect(defaultProps.onOpenChange).toHaveBeenCalledWith(false);
   });
 

--- a/apps/web/src/hooks/__tests__/useAgentChatStream.test.ts
+++ b/apps/web/src/hooks/__tests__/useAgentChatStream.test.ts
@@ -10,7 +10,17 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
+import { toast } from 'sonner';
 import { useAgentChatStream } from '../useAgentChatStream';
+
+// Mock sonner toast
+vi.mock('sonner', () => ({
+  toast: {
+    info: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
 
 // ─── Helpers ─────────────────────────────────────────────
 
@@ -64,6 +74,7 @@ describe('useAgentChatStream', () => {
   beforeEach(() => {
     fetchMock = vi.fn();
     globalThis.fetch = fetchMock;
+    vi.mocked(toast.info).mockClear();
   });
 
   afterEach(() => {
@@ -503,6 +514,157 @@ describe('useAgentChatStream', () => {
     expect(result.current.state.modelDowngrade).not.toBeNull();
     expect(result.current.state.modelDowngrade!.isLocalFallback).toBe(false);
     expect(result.current.state.modelDowngrade!.upgradeMessage).toBeNull();
+  });
+
+  // ─── Task 3: Model Downgrade Toast ───────────────────────
+
+  it('shows rate_limited toast when ModelDowngrade reason is rate_limited', async () => {
+    const events = [
+      sseEvent(EventType.ModelDowngrade, {
+        originalModel: 'meta-llama/llama-3.3-70b-instruct:free',
+        fallbackModel: 'llama3:8b',
+        reason: 'rate_limited',
+        isLocalFallback: true,
+        upgradeMessage: null,
+      }),
+      sseEvent(EventType.Complete, { totalTokens: 5 }),
+    ];
+
+    const stream = createSSEStream(events);
+    fetchMock.mockResolvedValueOnce({ ok: true, body: stream });
+
+    const { result } = renderHook(() => useAgentChatStream());
+
+    await act(async () => {
+      result.current.sendMessage('agent-1', 'Hi');
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+
+    expect(toast.info).toHaveBeenCalledWith(
+      'Modello temporaneamente cambiato per limiti di utilizzo',
+      { duration: 5000 }
+    );
+  });
+
+  it('shows generic downgrade toast when ModelDowngrade reason is not rate_limited', async () => {
+    const events = [
+      sseEvent(EventType.ModelDowngrade, {
+        originalModel: 'anthropic/claude-3.5-haiku',
+        fallbackModel: 'openai/gpt-4o-mini',
+        reason: 'provider_unavailable',
+        isLocalFallback: false,
+        upgradeMessage: null,
+      }),
+      sseEvent(EventType.Complete, { totalTokens: 10 }),
+    ];
+
+    const stream = createSSEStream(events);
+    fetchMock.mockResolvedValueOnce({ ok: true, body: stream });
+
+    const { result } = renderHook(() => useAgentChatStream());
+
+    await act(async () => {
+      result.current.sendMessage('agent-1', 'Hi');
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+
+    expect(toast.info).toHaveBeenCalledWith(
+      'Modello alternativo in uso per garantire la risposta',
+      { duration: 5000 }
+    );
+  });
+
+  // ─── Task 4: Rate Limit User-Friendly Error Messages ─────
+
+  it('shows Italian rate_limited message for errorCode rate_limited', async () => {
+    const events = [
+      sseEvent(EventType.Error, {
+        errorMessage: 'Rate limit exceeded',
+        errorCode: 'rate_limited',
+      }),
+    ];
+
+    const stream = createSSEStream(events);
+    fetchMock.mockResolvedValueOnce({ ok: true, body: stream });
+
+    const onError = vi.fn();
+    const { result } = renderHook(() => useAgentChatStream({ onError }));
+
+    await act(async () => {
+      result.current.sendMessage('agent-1', 'Hi');
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+
+    expect(result.current.state.error).toBe(
+      'Hai raggiunto il limite di messaggi. Riprova tra qualche minuto.'
+    );
+    expect(onError).toHaveBeenCalledWith(
+      'Hai raggiunto il limite di messaggi. Riprova tra qualche minuto.'
+    );
+  });
+
+  it('shows Italian provider_unavailable message for errorCode provider_unavailable', async () => {
+    const events = [
+      sseEvent(EventType.Error, {
+        errorMessage: 'Provider temporarily unavailable',
+        errorCode: 'provider_unavailable',
+      }),
+    ];
+
+    const stream = createSSEStream(events);
+    fetchMock.mockResolvedValueOnce({ ok: true, body: stream });
+
+    const onError = vi.fn();
+    const { result } = renderHook(() => useAgentChatStream({ onError }));
+
+    await act(async () => {
+      result.current.sendMessage('agent-1', 'Hi');
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+
+    expect(result.current.state.error).toBe(
+      'Il servizio AI è temporaneamente non disponibile. Riprova tra poco.'
+    );
+    expect(onError).toHaveBeenCalledWith(
+      'Il servizio AI è temporaneamente non disponibile. Riprova tra poco.'
+    );
+  });
+
+  it('falls back to errorMessage for unknown errorCode', async () => {
+    const events = [
+      sseEvent(EventType.Error, {
+        errorMessage: 'Agent not found',
+        errorCode: 'AGENT_NOT_FOUND',
+      }),
+    ];
+
+    const stream = createSSEStream(events);
+    fetchMock.mockResolvedValueOnce({ ok: true, body: stream });
+
+    const { result } = renderHook(() => useAgentChatStream());
+
+    await act(async () => {
+      result.current.sendMessage('agent-1', 'Hi');
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+
+    expect(result.current.state.error).toBe('Agent not found');
+  });
+
+  it('uses generic Italian fallback when no errorMessage and unknown errorCode', async () => {
+    const events = [sseEvent(EventType.Error, { errorCode: 'SOME_UNKNOWN' })];
+
+    const stream = createSSEStream(events);
+    fetchMock.mockResolvedValueOnce({ ok: true, body: stream });
+
+    const { result } = renderHook(() => useAgentChatStream());
+
+    await act(async () => {
+      result.current.sendMessage('agent-1', 'Hi');
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+
+    expect(result.current.state.error).toBe('Si è verificato un errore. Riprova.');
   });
 
   it('resets modelDowngrade on new message send', async () => {

--- a/apps/web/src/hooks/useAgentChatStream.ts
+++ b/apps/web/src/hooks/useAgentChatStream.ts
@@ -8,6 +8,8 @@
 
 import { useState, useCallback, useEffect, useRef } from 'react';
 
+import { toast } from 'sonner';
+
 // StreamingEventType enum values from backend
 const StreamingEventType = {
   StateUpdate: 0,
@@ -360,7 +362,15 @@ export function useAgentChatStream(callbacks?: AgentChatStreamCallbacks) {
 
                 case StreamingEventType.Error: {
                   const data = event.data as { errorMessage?: string; errorCode?: string };
-                  const errorMsg = data?.errorMessage || 'Unknown error';
+                  let errorMsg: string;
+                  if (data?.errorCode === 'rate_limited') {
+                    errorMsg = 'Hai raggiunto il limite di messaggi. Riprova tra qualche minuto.';
+                  } else if (data?.errorCode === 'provider_unavailable') {
+                    errorMsg =
+                      'Il servizio AI è temporaneamente non disponibile. Riprova tra poco.';
+                  } else {
+                    errorMsg = data?.errorMessage || 'Si è verificato un errore. Riprova.';
+                  }
                   setState(prev => ({
                     ...prev,
                     error: errorMsg,
@@ -393,6 +403,11 @@ export function useAgentChatStream(callbacks?: AgentChatStreamCallbacks) {
                       upgradeMessage: data?.upgradeMessage ?? null,
                     },
                   }));
+                  const toastMessage =
+                    data?.reason === 'rate_limited'
+                      ? 'Modello temporaneamente cambiato per limiti di utilizzo'
+                      : 'Modello alternativo in uso per garantire la risposta';
+                  toast.info(toastMessage, { duration: 5000 });
                   break;
                 }
 

--- a/apps/web/src/lib/api/schemas/invitation.schemas.ts
+++ b/apps/web/src/lib/api/schemas/invitation.schemas.ts
@@ -34,6 +34,8 @@ export const InvitationDtoSchema = z.object({
   createdAt: z.string(),
   acceptedAt: z.string().nullable(),
   invitedByUserId: z.string().uuid(),
+  // Only present in the creation response. Not stored in the DB (hash only).
+  token: z.string().optional().nullable(),
 });
 
 export const InvitationStatsSchema = z.object({


### PR DESCRIPTION
## Summary

- **Copy invitation link**: Admin UI shows copyable link after sending invite (critical for alpha without SMTP)
- **Add to Library button**: Game detail page now shows "Aggiungi alla libreria" button when game not in library
- **Model downgrade toast**: Chat shows info toast when LLM falls back to alternative model
- **Rate limit messages**: Chat shows Italian user-friendly messages for rate_limited and provider_unavailable errors

## Changes

### Backend (2 files)
- `InvitationDto` gets optional `Token` field (only populated on creation, never in list queries)
- `SendInvitationCommandHandler` returns raw token in response

### Frontend (5 files)
- `InviteUserDialog`: shows copyable link field after successful invite send
- `games/[id]/page.tsx`: conditional AddToLibraryButton / badge
- `useAgentChatStream.ts`: toast on ModelDowngrade (type 21), Italian error messages on Error (type 5)
- `invitation.schemas.ts`: Zod schema updated for optional token

### Tests (3 files, +417 lines)
- InviteUserDialog: 4 new tests (link display, clipboard copy, done button)
- GameDetailPage: 6 new tests (button/badge conditional rendering)
- useAgentChatStream: 6 new tests (downgrade toast, error messages)

## Test plan

- [x] All new frontend tests pass
- [x] Frontend build passes (134 static pages)
- [x] Backend build passes (0 warnings)
- [ ] Manual: Admin sends invite → sees copyable link → tester opens link → activates account
- [ ] Manual: Browse game → click "Aggiungi alla libreria" → badge updates
- [ ] Manual: Chat with agent → verify error messages are Italian

🤖 Generated with [Claude Code](https://claude.com/claude-code)
