### PR TITLE
fix(auth): return raw token in Resend and ProvisionAndInvite handlers

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ProvisionAndInviteUserCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ProvisionAndInviteUserCommandHandler.cs
@@ -130,10 +130,10 @@ internal sealed class ProvisionAndInviteUserCommandHandler : ICommandHandler<Pro
 #pragma warning restore CA1031
 
         // 9. Return InvitationDto with EmailSent status
-        return MapToDto(invitation, emailSent);
+        return MapToDto(invitation, emailSent, rawToken);
     }
 
-    private static InvitationDto MapToDto(InvitationToken invitation, bool emailSent)
+    private static InvitationDto MapToDto(InvitationToken invitation, bool emailSent, string? rawToken = null)
     {
         var gameSuggestions = invitation.GameSuggestions
             .Select(gs => new GameSuggestionDto(gs.GameId, gs.Type.ToString()))
@@ -149,6 +149,7 @@ internal sealed class ProvisionAndInviteUserCommandHandler : ICommandHandler<Pro
             AcceptedAt: invitation.AcceptedAt,
             InvitedByUserId: invitation.InvitedByUserId,
             EmailSent: emailSent,
-            GameSuggestions: gameSuggestions);
+            GameSuggestions: gameSuggestions,
+            Token: rawToken);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ResendInvitationCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ResendInvitationCommandHandler.cs
@@ -96,6 +96,6 @@ internal sealed class ResendInvitationCommandHandler : ICommandHandler<ResendInv
         }
 #pragma warning restore CA1031
 
-        return SendInvitationCommandHandler.MapToDto(newInvitation);
+        return SendInvitationCommandHandler.MapToDto(newInvitation, rawToken);
     }
 }


### PR DESCRIPTION
## Summary

- **ResendInvitationCommandHandler**: now passes `rawToken` to `MapToDto` so the copy-link UI works after resending an invite
- **ProvisionAndInviteUserCommandHandler**: now passes `rawToken` to its `MapToDto` so bulk invite flows also expose the token

Addresses code review findings from #468 (Important issues 1 & 2).

## Test plan

- [x] Backend builds with 0 errors
- [x] Frontend builds with 0 errors
- [ ] Manual: Resend invite from admin → verify response includes token
- [ ] Manual: Bulk invite → verify response includes token

🤖 Generated with [Claude Code](https://claude.com/claude-code)
