### PR TITLE
feat(chat): inline citations, PDF links, concise mode & continuation

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQuery.cs
@@ -13,9 +13,13 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
 /// <param name="Query">The user's question</param>
 /// <param name="ThreadId">Optional chat thread ID for context</param>
 /// <param name="DocumentIds">Optional document IDs to filter sources (null = all documents)</param>
+/// <param name="ResponseStyle">Response style: "concise" (default), "detailed", or "continuation"</param>
+/// <param name="ContinuationContext">Partial answer text from a previous truncated response</param>
 internal record StreamQaQuery(
     string GameId,
     string Query,
     Guid? ThreadId = null,
-    IReadOnlyList<Guid>? DocumentIds = null
+    IReadOnlyList<Guid>? DocumentIds = null,
+    string? ResponseStyle = null,
+    string? ContinuationContext = null
 ) : IStreamingQuery<RagStreamingEvent>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
@@ -74,12 +74,16 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         // Issue #1445: Use centralized query validation
-        var queryError = QueryValidator.ValidateQuery(query.Query);
-        if (queryError != null)
+        // Skip query validation for continuation requests (query may be empty)
+        if (string.IsNullOrWhiteSpace(query.ContinuationContext))
         {
-            yield return CreateEvent(StreamingEventType.Error,
-                new StreamingError(queryError, "INVALID_QUERY"));
-            yield break;
+            var queryError = QueryValidator.ValidateQuery(query.Query);
+            if (queryError != null)
+            {
+                yield return CreateEvent(StreamingEventType.Error,
+                    new StreamingError(queryError, "INVALID_QUERY"));
+                yield break;
+            }
         }
 
         _logger.LogInformation("Starting streaming QA for game {GameId}, query: {Query}",

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
@@ -37,6 +37,7 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
     private readonly ILlmService _llmService;
     private readonly IAiResponseCacheService _cache;
     private readonly IPromptTemplateService _promptTemplateService;
+    private readonly InlineCitationMatcherService _citationMatcher;
     private readonly ILogger<StreamQaQueryHandler> _logger;
     private readonly TimeProvider _timeProvider;
 
@@ -50,6 +51,7 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         ILlmService llmService,
         IAiResponseCacheService cache,
         IPromptTemplateService promptTemplateService,
+        InlineCitationMatcherService citationMatcher,
         ILogger<StreamQaQueryHandler> logger,
         TimeProvider? timeProvider = null)
     {
@@ -62,6 +64,7 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         _llmService = llmService ?? throw new ArgumentNullException(nameof(llmService));
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
         _promptTemplateService = promptTemplateService ?? throw new ArgumentNullException(nameof(promptTemplateService));
+        _citationMatcher = citationMatcher ?? throw new ArgumentNullException(nameof(citationMatcher));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
@@ -182,13 +185,15 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
             new StreamingStateUpdate("Generating answer..."));
 
         var (systemPrompt, userPrompt) = await BuildLlmPromptsAsync(
-            query.GameId, query.Query, snippets!, chatHistoryContext).ConfigureAwait(false);
+            query.GameId, query.Query, snippets!, chatHistoryContext,
+            query.ResponseStyle, query.ContinuationContext).ConfigureAwait(false);
 
         // Step 4: Stream tokens from LLM
         var answerBuilder = new StringBuilder();
         var tokenCount = 0;
         LlmUsage? llmUsage = null;
         LlmCost? llmCost = null;
+        string? llmFinishReason = null;
 
         await foreach (var chunk in _llmService.GenerateCompletionStreamAsync(systemPrompt, userPrompt, RequestSource.Manual, cancellationToken).ConfigureAwait(false))
         {
@@ -199,11 +204,17 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
             {
                 llmUsage = chunk.Usage;
                 llmCost = chunk.Cost;
+                if (!string.IsNullOrEmpty(chunk.FinishReason))
+                    llmFinishReason = chunk.FinishReason;
                 _logger.LogInformation(
-                    "Streaming usage received: {PromptTokens}p + {CompletionTokens}c = {TotalTokens}t (${Cost:F6})",
-                    llmUsage.PromptTokens, llmUsage.CompletionTokens, llmUsage.TotalTokens, llmCost.TotalCost);
+                    "Streaming usage received: {PromptTokens}p + {CompletionTokens}c = {TotalTokens}t (${Cost:F6}), FinishReason: {FinishReason}",
+                    llmUsage.PromptTokens, llmUsage.CompletionTokens, llmUsage.TotalTokens, llmCost.TotalCost, llmFinishReason);
                 continue;
             }
+
+            // Capture finish reason from any chunk that has it
+            if (chunk.IsFinal && !string.IsNullOrEmpty(chunk.FinishReason))
+                llmFinishReason = chunk.FinishReason;
 
             // Regular content chunk
             if (!string.IsNullOrEmpty(chunk.Content))
@@ -223,6 +234,19 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
 
         yield return CreateEvent(StreamingEventType.Complete,
             new StreamingComplete(0, 0, tokenCount, tokenCount, overallConfidence.Value));
+
+        // Emit inline citation matches
+        var inlineCitations = _citationMatcher.Match(answerBuilder.ToString(), snippets!);
+        if (inlineCitations.Count > 0)
+            yield return CreateEvent(StreamingEventType.InlineCitation, new StreamingInlineCitations(inlineCitations));
+
+        // Emit continuation token if response was truncated
+        if (string.Equals(llmFinishReason, "length", StringComparison.Ordinal))
+        {
+            var continuationToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(
+                System.Text.Json.JsonSerializer.Serialize(new { gameId = query.GameId, originalQuery = query.Query, partialAnswer = answerBuilder.ToString(), threadId = query.ThreadId })));
+            yield return CreateEvent(StreamingEventType.ContinuationAvailable, new StreamingContinuation(continuationToken, "max_tokens_reached"));
+        }
 
         // Record metrics
         var duration = (_timeProvider.GetUtcNow() - startTime).TotalMilliseconds;
@@ -330,9 +354,9 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         string gameId,
         string queryText,
         List<Snippet> snippets,
-        string chatHistoryContext
-        )
-
+        string chatHistoryContext,
+        string? responseStyle = null,
+        string? continuationContext = null)
     {
         var context = string.Join("\n\n", snippets.Select(s =>
             $"[Page {s.page}] {s.text}"));
@@ -343,7 +367,17 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         var template = await _promptTemplateService.GetTemplateAsync(gameGuid, questionType).ConfigureAwait(false);
 
         var systemPrompt = _promptTemplateService.RenderSystemPrompt(template);
+
+        // Append response style instruction
+        systemPrompt += PromptTemplateService.GetResponseStyleInstruction(responseStyle ?? "concise");
+
         var baseUserPrompt = _promptTemplateService.RenderUserPrompt(template, context, queryText);
+
+        // Prepend continuation context if available
+        if (!string.IsNullOrWhiteSpace(continuationContext))
+        {
+            baseUserPrompt = $"PREVIOUS PARTIAL ANSWER (continue from here):\n{continuationContext}\n\n{baseUserPrompt}";
+        }
 
         // Enrich with chat history if available
         var userPrompt = !string.IsNullOrWhiteSpace(chatHistoryContext)
@@ -351,8 +385,8 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
             : baseUserPrompt;
 
         _logger.LogDebug(
-            "Using prompt template for game {GameId}, question type {QuestionType}",
-            gameId, questionType);
+            "Using prompt template for game {GameId}, question type {QuestionType}, responseStyle {ResponseStyle}",
+            gameId, questionType, responseStyle ?? "concise");
 
         return (systemPrompt, userPrompt);
     }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/HybridLlmService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/HybridLlmService.cs
@@ -35,7 +35,7 @@ internal class HybridLlmService : ILlmService
 
     // Default LLM parameters
     private const double DefaultTemperature = 0.3;
-    private const int DefaultMaxTokens = 500;
+    private const int DefaultMaxTokens = 1500;
 
     // CA1869: Cache JsonSerializerOptions for better performance
     private static readonly System.Text.Json.JsonSerializerOptions s_jsonOptions = new()

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/InlineCitationMatcherService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/InlineCitationMatcherService.cs
@@ -1,0 +1,247 @@
+using Api.Models;
+
+namespace Api.BoundedContexts.KnowledgeBase.Domain.Services;
+
+/// <summary>
+/// Matches LLM response text against RAG snippets to find inline citation positions.
+/// Supports exact, fuzzy (Levenshtein), and n-gram overlap matching strategies.
+/// </summary>
+internal sealed class InlineCitationMatcherService
+{
+    private const double ExactMatchConfidence = 1.0;
+    private const double FuzzyMatchConfidence = 0.8;
+    private const double NgramMatchConfidence = 0.65;
+    private const double MaxLevenshteinDistanceRatio = 0.15;
+    private const double MinNgramOverlap = 0.6;
+    private const int NgramSize = 3;
+    private const int MinPhraseWords = 5;
+
+    private static readonly char[] SentenceDelimiters = { '.', '!', '?' };
+    private static readonly char[] WordDelimiters = { ' ', '\t' };
+
+    /// <summary>
+    /// Matches significant phrases from snippets against the answer text.
+    /// Returns non-overlapping matches ordered by position.
+    /// </summary>
+    public IReadOnlyList<InlineCitationMatch> Match(string answer, IReadOnlyList<Snippet> snippets)
+    {
+        if (string.IsNullOrWhiteSpace(answer) || snippets == null || snippets.Count == 0)
+            return Array.Empty<InlineCitationMatch>();
+
+        var allMatches = new List<InlineCitationMatch>();
+
+        for (int snippetIndex = 0; snippetIndex < snippets.Count; snippetIndex++)
+        {
+            var snippet = snippets[snippetIndex];
+            if (string.IsNullOrWhiteSpace(snippet.text))
+                continue;
+
+            var pdfDocumentId = ExtractPdfDocumentId(snippet.source);
+            var phrases = ExtractSignificantPhrases(snippet.text);
+
+            // Try matching each phrase
+            foreach (var phrase in phrases)
+            {
+                var match = TryMatch(answer, phrase, snippetIndex, snippet.page, pdfDocumentId);
+                if (match != null)
+                    allMatches.Add(match);
+            }
+
+            // Also try matching full snippet text
+            var fullMatch = TryMatch(answer, snippet.text, snippetIndex, snippet.page, pdfDocumentId);
+            if (fullMatch != null)
+                allMatches.Add(fullMatch);
+        }
+
+        return ResolveOverlaps(allMatches);
+    }
+
+    private InlineCitationMatch? TryMatch(string answer, string phrase, int snippetIndex, int pageNumber, string pdfDocumentId)
+    {
+        // Strategy 1: Exact substring match
+        var exactIndex = answer.IndexOf(phrase, StringComparison.OrdinalIgnoreCase);
+        if (exactIndex >= 0)
+        {
+            return new InlineCitationMatch(
+                exactIndex, exactIndex + phrase.Length, snippetIndex, pageNumber, pdfDocumentId, ExactMatchConfidence);
+        }
+
+        // Strategy 2: Fuzzy match via Levenshtein distance
+        var fuzzyMatch = TryFuzzyMatch(answer, phrase, snippetIndex, pageNumber, pdfDocumentId);
+        if (fuzzyMatch != null)
+            return fuzzyMatch;
+
+        // Strategy 3: N-gram overlap
+        var ngramMatch = TryNgramMatch(answer, phrase, snippetIndex, pageNumber, pdfDocumentId);
+        if (ngramMatch != null)
+            return ngramMatch;
+
+        return null;
+    }
+
+    private static InlineCitationMatch? TryFuzzyMatch(string answer, string phrase, int snippetIndex, int pageNumber, string pdfDocumentId)
+    {
+        if (phrase.Length < 10) // Too short for meaningful fuzzy matching
+            return null;
+
+        var maxDistance = (int)(phrase.Length * MaxLevenshteinDistanceRatio);
+        var windowSize = phrase.Length;
+
+        // Slide window across answer
+        for (int i = 0; i <= answer.Length - windowSize; i++)
+        {
+            var window = answer.Substring(i, windowSize);
+            var distance = LevenshteinDistance(window.ToLowerInvariant(), phrase.ToLowerInvariant());
+
+            if (distance <= maxDistance)
+            {
+                return new InlineCitationMatch(
+                    i, i + windowSize, snippetIndex, pageNumber, pdfDocumentId, FuzzyMatchConfidence);
+            }
+        }
+
+        return null;
+    }
+
+    private static InlineCitationMatch? TryNgramMatch(string answer, string phrase, int snippetIndex, int pageNumber, string pdfDocumentId)
+    {
+        if (phrase.Length < NgramSize * 2) // Too short for n-gram analysis
+            return null;
+
+        var phraseNgrams = GetNgrams(phrase.ToLowerInvariant(), NgramSize);
+        if (phraseNgrams.Count == 0)
+            return null;
+
+        var windowSize = phrase.Length;
+        var bestOverlap = 0.0;
+        var bestStart = -1;
+
+        // Slide window across answer with step size for efficiency
+        var step = Math.Max(1, windowSize / 4);
+        for (int i = 0; i <= answer.Length - windowSize; i += step)
+        {
+            var window = answer.Substring(i, Math.Min(windowSize, answer.Length - i));
+            var windowNgrams = GetNgrams(window.ToLowerInvariant(), NgramSize);
+
+            if (windowNgrams.Count == 0)
+                continue;
+
+            var intersection = phraseNgrams.Intersect(windowNgrams, StringComparer.Ordinal).Count();
+            var overlap = (double)intersection / phraseNgrams.Count;
+
+            if (overlap > bestOverlap)
+            {
+                bestOverlap = overlap;
+                bestStart = i;
+            }
+        }
+
+        if (bestOverlap > MinNgramOverlap && bestStart >= 0)
+        {
+            return new InlineCitationMatch(
+                bestStart,
+                bestStart + Math.Min(windowSize, answer.Length - bestStart),
+                snippetIndex, pageNumber, pdfDocumentId, NgramMatchConfidence);
+        }
+
+        return null;
+    }
+
+    internal static List<string> ExtractSignificantPhrases(string text)
+    {
+        var phrases = new List<string>();
+        var sentences = text.Split(SentenceDelimiters, StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (var sentence in sentences)
+        {
+            var trimmed = sentence.Trim();
+            var wordCount = trimmed.Split(WordDelimiters, StringSplitOptions.RemoveEmptyEntries).Length;
+            if (wordCount > MinPhraseWords)
+            {
+                phrases.Add(trimmed);
+            }
+        }
+
+        return phrases;
+    }
+
+    internal static string ExtractPdfDocumentId(string source)
+    {
+        if (string.IsNullOrWhiteSpace(source))
+            return string.Empty;
+
+        // Expected format: "PDF:uuid"
+        if (source.StartsWith("PDF:", StringComparison.OrdinalIgnoreCase) && source.Length > 4)
+            return source.Substring(4);
+
+        return source;
+    }
+
+    private static IReadOnlyList<InlineCitationMatch> ResolveOverlaps(List<InlineCitationMatch> matches)
+    {
+        if (matches.Count <= 1)
+            return matches;
+
+        // Sort by confidence descending, then by length descending
+        var sorted = matches
+            .OrderByDescending(m => m.Confidence)
+            .ThenByDescending(m => m.EndOffset - m.StartOffset)
+            .ToList();
+
+        var resolved = new List<InlineCitationMatch>();
+        foreach (var candidate in sorted)
+        {
+            var overlaps = resolved.Any(existing =>
+                candidate.StartOffset < existing.EndOffset && candidate.EndOffset > existing.StartOffset);
+
+            if (!overlaps)
+                resolved.Add(candidate);
+        }
+
+        // Return sorted by position
+        return resolved.OrderBy(m => m.StartOffset).ToList();
+    }
+
+    internal static int LevenshteinDistance(string source, string target)
+    {
+        if (string.IsNullOrEmpty(source)) return target?.Length ?? 0;
+        if (string.IsNullOrEmpty(target)) return source.Length;
+
+        var sourceLen = source.Length;
+        var targetLen = target.Length;
+
+        // Use single-row optimization
+        var previousRow = new int[targetLen + 1];
+        var currentRow = new int[targetLen + 1];
+
+        for (int j = 0; j <= targetLen; j++)
+            previousRow[j] = j;
+
+        for (int i = 1; i <= sourceLen; i++)
+        {
+            currentRow[0] = i;
+            for (int j = 1; j <= targetLen; j++)
+            {
+                var cost = source[i - 1] == target[j - 1] ? 0 : 1;
+                currentRow[j] = Math.Min(
+                    Math.Min(currentRow[j - 1] + 1, previousRow[j] + 1),
+                    previousRow[j - 1] + cost);
+            }
+
+            (previousRow, currentRow) = (currentRow, previousRow);
+        }
+
+        return previousRow[targetLen];
+    }
+
+    private static HashSet<string> GetNgrams(string text, int n)
+    {
+        var ngrams = new HashSet<string>(StringComparer.Ordinal);
+        for (int i = 0; i <= text.Length - n; i++)
+        {
+            ngrams.Add(text.Substring(i, n));
+        }
+
+        return ngrams;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs
@@ -78,6 +78,7 @@ internal static class KnowledgeBaseServiceExtensions
         services.AddSingleton<RrfFusionDomainService>();
         services.AddSingleton<QualityTrackingDomainService>();
         services.AddSingleton<ChatContextDomainService>(); // Issue #857: Chat history context
+        services.AddSingleton<InlineCitationMatcherService>(); // Inline citation matching for QA stream
         services.AddScoped<IConversationQueryRewriter, Application.Services.ConversationQueryRewriter>(); // Issue #5258: Query rewriting for multi-turn RAG
         services.AddScoped<IConversationSummarizer, Application.Services.ConversationSummarizer>(); // Issue #5259: Progressive conversation summarization
         services.AddSingleton<ChunkingStrategySelector>(); // ISSUE-1903: ADR-016 Phase 1 - Chunking strategy selection

--- a/apps/api/src/Api/Models/Contracts.cs
+++ b/apps/api/src/Api/Models/Contracts.cs
@@ -15,7 +15,9 @@ internal record QaRequest(
     string query,
     Guid? chatId = null,
     SearchMode searchMode = SearchMode.Hybrid, // AI-14: Default to hybrid search
-    IReadOnlyList<Guid>? documentIds = null); // Issue #2051: Filter by document IDs (null = all)
+    IReadOnlyList<Guid>? documentIds = null, // Issue #2051: Filter by document IDs (null = all)
+    string responseStyle = "concise",
+    string? continuationToken = null);
 internal record QaResponse(
     string answer,
     IReadOnlyList<Snippet> snippets,
@@ -86,7 +88,11 @@ internal enum StreamingEventType
     DebugContextWindow = 26,      // Context window usage and history compression
 
     // Copyright leak guard event (#447)
-    CopyrightSanitized = 27       // Response body was sanitized due to verbatim copyright leak
+    CopyrightSanitized = 27,       // Response body was sanitized due to verbatim copyright leak
+
+    // Inline citation and continuation events
+    InlineCitation = 28,            // Positioned snippet matches within response text
+    ContinuationAvailable = 29      // Response truncated, continuation available
 }
 
 internal record RagStreamingEvent(
@@ -136,6 +142,22 @@ internal record StreamingModelDowngrade(
 internal record StreamingCopyrightSanitized(
     string SanitizedBody,
     int MatchCount);
+
+// Inline citation and continuation records
+internal record InlineCitationMatch(
+    int StartOffset,
+    int EndOffset,
+    int SnippetIndex,
+    int PageNumber,
+    string PdfDocumentId,
+    double Confidence);
+
+internal record StreamingInlineCitations(
+    IReadOnlyList<InlineCitationMatch> Citations);
+
+internal record StreamingContinuation(
+    string ContinuationToken,
+    string Reason);
 
 // Admin Debug Chat: data records for debug streaming events
 internal record DebugAgentRouterData(

--- a/apps/api/src/Api/Routing/AiEndpoints.cs
+++ b/apps/api/src/Api/Routing/AiEndpoints.cs
@@ -232,7 +232,27 @@ internal static class AiEndpoints
         // CHAT-02: Follow-up question generation (fire-and-forget after Complete event)
         Task<IReadOnlyList<string>>? followUpTask = null;
 
-        var query = new StreamQaQuery(req.gameId, req.query, req.chatId, req.documentIds); // Issue #2051
+        // Decode continuation token if present
+        string? continuationContext = null;
+        if (!string.IsNullOrWhiteSpace(req.continuationToken))
+        {
+            try
+            {
+                var decoded = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(req.continuationToken));
+                var continuationData = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(decoded);
+                if (continuationData.TryGetProperty("partialAnswer", out var partialAnswer))
+                {
+                    continuationContext = partialAnswer.GetString();
+                }
+            }
+            catch (Exception ex) when (ex is FormatException or System.Text.Json.JsonException)
+            {
+                logger.LogWarning(ex, "Failed to decode continuation token, ignoring");
+            }
+        }
+
+        var responseStyle = !string.IsNullOrWhiteSpace(req.continuationToken) ? "continuation" : req.responseStyle;
+        var query = new StreamQaQuery(req.gameId, req.query, req.chatId, req.documentIds, responseStyle, continuationContext); // Issue #2051
         await foreach (var evt in mediator.CreateStream(query, ct).ConfigureAwait(false))
         {
             // Serialize event as JSON

--- a/apps/api/src/Api/Routing/AiEndpoints.cs
+++ b/apps/api/src/Api/Routing/AiEndpoints.cs
@@ -27,6 +27,15 @@ internal static class AiEndpoints
 {
     private static readonly string[] ParagraphSeparators = { "\n\n", "\n" };
 
+    /// <summary>
+    /// SSE events must use camelCase to match frontend qaStream parser expectations.
+    /// ConfigureHttpJsonOptions sets camelCase for Results.Ok() but not for manual JsonSerializer.Serialize().
+    /// </summary>
+    private static readonly System.Text.Json.JsonSerializerOptions SseJsonOptions = new()
+    {
+        PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase,
+    };
+
     public static RouteGroupBuilder MapAiEndpoints(this RouteGroupBuilder group)
     {
         MapQaEndpoint(group);
@@ -189,7 +198,7 @@ internal static class AiEndpoints
                     StreamingEventType.Error,
                     new StreamingError($"An error occurred: {ex.Message}", "INTERNAL_ERROR"),
                     DateTime.UtcNow);
-                var json = System.Text.Json.JsonSerializer.Serialize(errorEvent);
+                var json = System.Text.Json.JsonSerializer.Serialize(errorEvent, SseJsonOptions);
                 await context.Response.WriteAsync($"data: {json}\n\n", ct).ConfigureAwait(false);
                 await context.Response.Body.FlushAsync(ct).ConfigureAwait(false);
             }
@@ -227,7 +236,7 @@ internal static class AiEndpoints
         await foreach (var evt in mediator.CreateStream(query, ct).ConfigureAwait(false))
         {
             // Serialize event as JSON
-            var json = System.Text.Json.JsonSerializer.Serialize(evt);
+            var json = System.Text.Json.JsonSerializer.Serialize(evt, SseJsonOptions);
 
             // Write SSE format: "data: {json}\n\n"
             await context.Response.WriteAsync($"data: {json}\n\n", ct).ConfigureAwait(false);
@@ -545,7 +554,7 @@ internal static class AiEndpoints
                     StreamingEventType.Error,
                     new StreamingError($"An error occurred: {ex.Message}", "INTERNAL_ERROR"),
                     DateTime.UtcNow);
-                var json = System.Text.Json.JsonSerializer.Serialize(errorEvent);
+                var json = System.Text.Json.JsonSerializer.Serialize(errorEvent, SseJsonOptions);
                 await context.Response.WriteAsync($"data: {json}\n\n", ct).ConfigureAwait(false);
                 await context.Response.Body.FlushAsync(ct).ConfigureAwait(false);
             }
@@ -680,7 +689,7 @@ internal static class AiEndpoints
                     StreamingEventType.Error,
                     new StreamingError($"An error occurred: {ex.Message}", "INTERNAL_ERROR"),
                     DateTime.UtcNow);
-                var json = System.Text.Json.JsonSerializer.Serialize(errorEvent);
+                var json = System.Text.Json.JsonSerializer.Serialize(errorEvent, SseJsonOptions);
                 await context.Response.WriteAsync($"data: {json}\n\n", ct).ConfigureAwait(false);
                 await context.Response.Body.FlushAsync(ct).ConfigureAwait(false);
             }
@@ -902,7 +911,7 @@ internal static class AiEndpoints
                 StreamingEventType.FollowUpQuestions,
                 new StreamingFollowUpQuestions(followUpQuestions),
                 DateTime.UtcNow);
-            var followUpJson = System.Text.Json.JsonSerializer.Serialize(followUpEvent);
+            var followUpJson = System.Text.Json.JsonSerializer.Serialize(followUpEvent, SseJsonOptions);
             await context.Response.WriteAsync($"data: {followUpJson}\n\n", ct).ConfigureAwait(false);
             await context.Response.Body.FlushAsync(ct).ConfigureAwait(false);
 
@@ -921,7 +930,7 @@ internal static class AiEndpoints
         await foreach (var evt in mediator.CreateStream(query, ct).ConfigureAwait(false))
         {
             // Serialize event as JSON
-            var json = System.Text.Json.JsonSerializer.Serialize(evt);
+            var json = System.Text.Json.JsonSerializer.Serialize(evt, SseJsonOptions);
 
             // Write SSE format: "data: {json}\n\n"
             await context.Response.WriteAsync($"data: {json}\n\n", ct).ConfigureAwait(false);
@@ -995,7 +1004,7 @@ internal static class AiEndpoints
     {
         await foreach (var evt in mediator.CreateStream(query, ct).ConfigureAwait(false))
         {
-            var json = System.Text.Json.JsonSerializer.Serialize(evt);
+            var json = System.Text.Json.JsonSerializer.Serialize(evt, SseJsonOptions);
             await context.Response.WriteAsync($"data: {json}\n\n", ct).ConfigureAwait(false);
             await context.Response.Body.FlushAsync(ct).ConfigureAwait(false);
         }

--- a/apps/api/src/Api/Routing/GameEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameEndpoints.cs
@@ -411,7 +411,7 @@ internal static class GameEndpoints
             }
         }
 
-        return Results.Ok(agentList);
+        return Results.Ok(new { success = true, agents = agentList, count = agentList.Count });
     }
 
     private static async Task<IResult> HandleCreateGame(

--- a/apps/api/src/Api/Services/ILlmService.cs
+++ b/apps/api/src/Api/Services/ILlmService.cs
@@ -15,7 +15,8 @@ internal record StreamChunk(
     string? Content,
     LlmUsage? Usage = null,
     LlmCost? Cost = null,
-    bool IsFinal = false);
+    bool IsFinal = false,
+    string? FinishReason = null);
 
 /// <summary>
 /// Interface for LLM chat completion services

--- a/apps/api/src/Api/Services/LlmClients/DeepSeekLlmClient.cs
+++ b/apps/api/src/Api/Services/LlmClients/DeepSeekLlmClient.cs
@@ -680,11 +680,14 @@ internal class DeepSeekLlmClient : ILlmClient
                             "DeepSeek streaming usage: {PromptTokens}p + {CompletionTokens}c = {TotalTokens}t (${TotalCost:F6})",
                             usage.PromptTokens, usage.CompletionTokens, usage.TotalTokens, llmCost.TotalCost);
 
+                        var finishReason = chunk.Choices?[0]?.FinishReason;
+
                         yield return new StreamChunk(
                             Content: null,
                             Usage: usage,
                             Cost: llmCost,
-                            IsFinal: true);
+                            IsFinal: true,
+                            FinishReason: finishReason);
                         break; // Usage signals end of stream
                     }
                 }

--- a/apps/api/src/Api/Services/LlmClients/OllamaLlmClient.cs
+++ b/apps/api/src/Api/Services/LlmClients/OllamaLlmClient.cs
@@ -368,7 +368,8 @@ internal class OllamaLlmClient : ILlmClient
                             Content: null,
                             Usage: usage,
                             Cost: llmCost,
-                            IsFinal: true);
+                            IsFinal: true,
+                            FinishReason: "stop");
                     }
                     else
                     {

--- a/apps/api/src/Api/Services/LlmClients/OpenRouterLlmClient.cs
+++ b/apps/api/src/Api/Services/LlmClients/OpenRouterLlmClient.cs
@@ -679,11 +679,14 @@ internal class OpenRouterLlmClient : ILlmClient
                             "OpenRouter streaming usage: {PromptTokens}p + {CompletionTokens}c = {TotalTokens}t (${TotalCost:F6})",
                             usage.PromptTokens, usage.CompletionTokens, usage.TotalTokens, llmCost.TotalCost);
 
+                        var finishReason = chunk.Choices?[0]?.FinishReason;
+
                         yield return new StreamChunk(
                             Content: null,
                             Usage: usage,
                             Cost: llmCost,
-                            IsFinal: true);
+                            IsFinal: true,
+                            FinishReason: finishReason);
                         break; // Usage signals end of stream
                     }
                 }

--- a/apps/api/src/Api/Services/PromptTemplateService.cs
+++ b/apps/api/src/Api/Services/PromptTemplateService.cs
@@ -265,6 +265,20 @@ ANSWER:",
         };
     }
     /// <summary>
+    /// Returns a response style instruction to append to the system prompt.
+    /// Supports "detailed", "continuation", and default "concise" styles.
+    /// </summary>
+    internal static string GetResponseStyleInstruction(string responseStyle)
+    {
+        return responseStyle switch
+        {
+            "detailed" => "\n\nIMPORTANT RESPONSE STYLE: Rispondi in modo completo e approfondito. Spiega ogni aspetto rilevante con esempi dal regolamento. Usa sottosezioni se necessario.",
+            "continuation" => "\n\nIMPORTANT: Continua la risposta precedente da dove ti eri fermato. Non ripetere ciò che hai già detto. Prosegui direttamente.",
+            _ => "\n\nIMPORTANT RESPONSE STYLE: Rispondi in modo sintetico e strutturato (max 200 parole). Concentrati sul rispondere alla domanda, non riscrivere il regolamento. Usa elenchi puntati. Non citare le pagine nel testo — le citazioni vengono gestite automaticamente dal sistema."
+        };
+    }
+
+    /// <summary>
     /// ADMIN-01: Gets active prompt from cache-first architecture
     /// Flow: Redis cache → PostgreSQL → Configuration fallback
     /// </summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
@@ -90,6 +90,7 @@ public class StreamQaQueryHandlerTests
             _llmServiceMock.Object,
             _cacheMock.Object,
             _promptTemplateServiceMock.Object,
+            new InlineCitationMatcherService(),
             _loggerMock.Object,
             _fakeTimeProvider
         );

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/InlineCitationMatcherServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/InlineCitationMatcherServiceTests.cs
@@ -1,0 +1,200 @@
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.Models;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Domain.Services;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public class InlineCitationMatcherServiceTests
+{
+    private readonly InlineCitationMatcherService _service = new();
+
+    // ========================================================================
+    // Exact substring match
+    // ========================================================================
+
+    [Fact]
+    public void Match_ExactSubstring_ReturnsHighConfidence()
+    {
+        // Arrange
+        var answer = "The player must roll two dice before moving any pieces on the board.";
+        var snippets = new List<Snippet>
+        {
+            new("The player must roll two dice before moving any pieces on the board.",
+                "PDF:d290f1ee-6c54-4b01-90e6-d701748f0851", 3, 0, 0.95f)
+        };
+
+        // Act
+        var result = _service.Match(answer, snippets);
+
+        // Assert
+        result.Should().NotBeEmpty();
+        result[0].Confidence.Should().Be(1.0);
+        result[0].SnippetIndex.Should().Be(0);
+        result[0].PageNumber.Should().Be(3);
+        result[0].StartOffset.Should().Be(0);
+    }
+
+    // ========================================================================
+    // No overlap returns empty
+    // ========================================================================
+
+    [Fact]
+    public void Match_NoOverlap_ReturnsEmpty()
+    {
+        // Arrange
+        var answer = "This is a completely unrelated answer about cooking recipes.";
+        var snippets = new List<Snippet>
+        {
+            new("Board games require strategic thinking and careful planning of every move during gameplay sessions.",
+                "PDF:aaaa0000-0000-0000-0000-000000000001", 1, 0, 0.9f)
+        };
+
+        // Act
+        var result = _service.Match(answer, snippets);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    // ========================================================================
+    // Fuzzy match returns medium confidence
+    // ========================================================================
+
+    [Fact]
+    public void Match_FuzzyMatch_ReturnsMediumConfidence()
+    {
+        // Arrange — phrase slightly modified (typo / minor rewording)
+        var originalPhrase = "Each player receives five resource cards at the beginning of the game setup phase";
+        var modifiedPhrase = "Each player receives five resourse cards at the beginning of the game setup phase";
+        var answer = $"According to the rules, {modifiedPhrase}. Then play begins.";
+        var snippets = new List<Snippet>
+        {
+            new(originalPhrase,
+                "PDF:bbbb0000-0000-0000-0000-000000000002", 7, 0, 0.88f)
+        };
+
+        // Act
+        var result = _service.Match(answer, snippets);
+
+        // Assert
+        result.Should().NotBeEmpty();
+        result[0].Confidence.Should().BeLessThan(1.0);
+        result[0].Confidence.Should().BeGreaterThanOrEqualTo(0.6);
+    }
+
+    // ========================================================================
+    // Overlapping matches keep highest confidence
+    // ========================================================================
+
+    [Fact]
+    public void Match_OverlappingMatches_KeepsHighestConfidence()
+    {
+        // Arrange — two snippets that cover the same text in the answer
+        var sharedText = "Players take turns rolling dice and moving their pieces around the game board clockwise";
+        var answer = $"In this game, {sharedText}. The first to finish wins.";
+        var snippets = new List<Snippet>
+        {
+            // Exact match — should win
+            new(sharedText,
+                "PDF:cccc0000-0000-0000-0000-000000000003", 2, 0, 0.92f),
+            // Contains the same text embedded in longer context
+            new($"Introduction: {sharedText} following the standard rules.",
+                "PDF:dddd0000-0000-0000-0000-000000000004", 5, 0, 0.85f)
+        };
+
+        // Act
+        var result = _service.Match(answer, snippets);
+
+        // Assert — should not have overlapping regions
+        for (int i = 0; i < result.Count - 1; i++)
+        {
+            result[i].EndOffset.Should().BeLessThanOrEqualTo(result[i + 1].StartOffset,
+                "matches should not overlap");
+        }
+
+        // The match with highest confidence should be present
+        result.Should().Contain(m => m.Confidence >= 0.99);
+    }
+
+    // ========================================================================
+    // Empty inputs return empty
+    // ========================================================================
+
+    [Fact]
+    public void Match_EmptyAnswer_ReturnsEmpty()
+    {
+        var snippets = new List<Snippet>
+        {
+            new("Some snippet text with enough words to be significant for matching.", "PDF:eeee0000-0000-0000-0000-000000000005", 1, 0, 0.9f)
+        };
+
+        _service.Match("", snippets).Should().BeEmpty();
+        _service.Match(null!, snippets).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Match_EmptySnippets_ReturnsEmpty()
+    {
+        _service.Match("Some answer text.", new List<Snippet>()).Should().BeEmpty();
+        _service.Match("Some answer text.", null!).Should().BeEmpty();
+    }
+
+    // ========================================================================
+    // PdfDocumentId extraction
+    // ========================================================================
+
+    [Fact]
+    public void ExtractPdfDocumentId_FromPdfFormat_ReturnsId()
+    {
+        var id = InlineCitationMatcherService.ExtractPdfDocumentId("PDF:d290f1ee-6c54-4b01-90e6-d701748f0851");
+        id.Should().Be("d290f1ee-6c54-4b01-90e6-d701748f0851");
+    }
+
+    [Fact]
+    public void ExtractPdfDocumentId_WithoutPrefix_ReturnsSource()
+    {
+        var id = InlineCitationMatcherService.ExtractPdfDocumentId("some-other-source");
+        id.Should().Be("some-other-source");
+    }
+
+    [Fact]
+    public void ExtractPdfDocumentId_Empty_ReturnsEmpty()
+    {
+        InlineCitationMatcherService.ExtractPdfDocumentId("").Should().BeEmpty();
+        InlineCitationMatcherService.ExtractPdfDocumentId(null!).Should().BeEmpty();
+    }
+
+    // ========================================================================
+    // Significant phrase extraction
+    // ========================================================================
+
+    [Fact]
+    public void ExtractSignificantPhrases_FiltersShortSentences()
+    {
+        var text = "Short. This sentence has more than five words in it. Also short.";
+        var phrases = InlineCitationMatcherService.ExtractSignificantPhrases(text);
+
+        phrases.Should().HaveCount(1);
+        phrases[0].Should().Contain("more than five words");
+    }
+
+    // ========================================================================
+    // Levenshtein distance
+    // ========================================================================
+
+    [Fact]
+    public void LevenshteinDistance_IdenticalStrings_ReturnsZero()
+    {
+        InlineCitationMatcherService.LevenshteinDistance("hello", "hello").Should().Be(0);
+    }
+
+    [Fact]
+    public void LevenshteinDistance_SingleCharDifference_ReturnsOne()
+    {
+        InlineCitationMatcherService.LevenshteinDistance("hello", "hallo").Should().Be(1);
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/GameEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/GameEndpointsIntegrationTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using Api.Infrastructure;
+using Api.Infrastructure.Entities;
 using Api.Tests.Constants;
 using Api.Tests.Infrastructure;
 using Api.Tests.TestHelpers;
@@ -570,6 +571,72 @@ public sealed class GameEndpointsIntegrationTests : IAsyncLifetime
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetGameAgents_WithAuth_ReturnsWrappedResponseFormat()
+    {
+        // Arrange — seed a game so the endpoint doesn't 404
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var gameId = Guid.NewGuid();
+        dbContext.Games.Add(new GameEntity
+        {
+            Id = gameId,
+            Name = "Test Game For Agents",
+            CreatedAt = DateTime.UtcNow
+        });
+        await dbContext.SaveChangesAsync();
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/games/{gameId}/agents",
+            sessionToken);
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert — verify wrapped { success, agents, count } format (not raw array)
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            var json = await response.Content.ReadFromJsonAsync<System.Text.Json.JsonElement>();
+            json.TryGetProperty("success", out var successProp).Should().BeTrue("response must have 'success' property");
+            successProp.GetBoolean().Should().BeTrue();
+            json.TryGetProperty("agents", out var agentsProp).Should().BeTrue("response must have 'agents' property");
+            agentsProp.ValueKind.Should().Be(System.Text.Json.JsonValueKind.Array);
+            json.TryGetProperty("count", out var countProp).Should().BeTrue("response must have 'count' property");
+            countProp.GetInt32().Should().BeGreaterThanOrEqualTo(0);
+        }
+        else
+        {
+            // With mocked auth middleware, may return Unauthorized
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        }
+    }
+
+    [Fact]
+    public async Task GetGameAgents_NonExistentGame_ReturnsNotFound()
+    {
+        // Arrange
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var nonExistentGameId = Guid.NewGuid();
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/games/{nonExistentGameId}/agents",
+            sessionToken);
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        (response.StatusCode == HttpStatusCode.NotFound ||
+            response.StatusCode == HttpStatusCode.Unauthorized).Should().BeTrue(
+            $"Expected NotFound or Unauthorized, got {response.StatusCode}");
     }
 
     // ========================================

--- a/apps/web/__tests__/components/chat-unified/CitationBlock.test.tsx
+++ b/apps/web/__tests__/components/chat-unified/CitationBlock.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { CitationBlock } from '@/components/chat-unified/CitationBlock';
+
+const mockSnippets = [
+  { text: 'Setup instructions for the game.', source: 'PDF:abc-123', page: 3, line: 0, score: 0.9 },
+  { text: 'Scoring rules at end of game.', source: 'PDF:abc-123', page: 5, line: 0, score: 0.8 },
+];
+
+describe('CitationBlock', () => {
+  it('renders citation chips for each snippet', () => {
+    render(<CitationBlock snippets={mockSnippets} excludeIndices={new Set()} />);
+    expect(screen.getByText('Pagina 3')).toBeInTheDocument();
+    expect(screen.getByText('Pagina 5')).toBeInTheDocument();
+  });
+
+  it('excludes snippets already shown inline', () => {
+    render(<CitationBlock snippets={mockSnippets} excludeIndices={new Set([0])} />);
+    expect(screen.queryByText('Pagina 3')).not.toBeInTheDocument();
+    expect(screen.getByText('Pagina 5')).toBeInTheDocument();
+  });
+
+  it('expands accordion on chip click', () => {
+    render(<CitationBlock snippets={mockSnippets} excludeIndices={new Set()} />);
+    fireEvent.click(screen.getByText('Pagina 3'));
+    expect(screen.getByText(/Setup instructions/)).toBeInTheDocument();
+  });
+
+  it('renders nothing when all snippets excluded', () => {
+    const { container } = render(<CitationBlock snippets={mockSnippets} excludeIndices={new Set([0, 1])} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/web/__tests__/components/chat-unified/ContinueButton.test.tsx
+++ b/apps/web/__tests__/components/chat-unified/ContinueButton.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ContinueButton } from '@/components/chat-unified/ContinueButton';
+
+describe('ContinueButton', () => {
+  it('renders with correct text', () => {
+    render(<ContinueButton onContinue={() => {}} isLoading={false} />);
+    expect(screen.getByText('Continua la risposta')).toBeInTheDocument();
+  });
+
+  it('calls onContinue when clicked', () => {
+    const onContinue = vi.fn();
+    render(<ContinueButton onContinue={onContinue} isLoading={false} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onContinue).toHaveBeenCalledOnce();
+  });
+
+  it('shows loading state', () => {
+    render(<ContinueButton onContinue={() => {}} isLoading={true} />);
+    expect(screen.getByText('Continuando...')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+});

--- a/apps/web/__tests__/components/chat-unified/InlineCitationText.test.tsx
+++ b/apps/web/__tests__/components/chat-unified/InlineCitationText.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { InlineCitationText } from '@/components/chat-unified/InlineCitationText';
+import type { InlineCitationMatch } from '@/lib/api/clients/chatClient';
+
+const mockSnippets = [
+  { text: 'Full chunk text from the rulebook about game setup.', source: 'PDF:abc-123', page: 3, line: 0, score: 0.9 },
+];
+
+describe('InlineCitationText', () => {
+  it('renders plain text when no citations', () => {
+    render(<InlineCitationText text="Hello world" citations={[]} snippets={[]} />);
+    expect(screen.getByText('Hello world')).toBeInTheDocument();
+  });
+
+  it('renders highlighted span for citation', () => {
+    const citations: InlineCitationMatch[] = [
+      { startOffset: 0, endOffset: 5, snippetIndex: 0, pageNumber: 3, pdfDocumentId: 'abc-123', confidence: 1.0 },
+    ];
+    render(<InlineCitationText text="Hello world" citations={citations} snippets={mockSnippets} />);
+    const highlight = screen.getByTestId('citation-highlight-0');
+    expect(highlight).toBeInTheDocument();
+    expect(highlight).toHaveTextContent('Hello');
+  });
+
+  it('expands accordion on click', () => {
+    const citations: InlineCitationMatch[] = [
+      { startOffset: 0, endOffset: 5, snippetIndex: 0, pageNumber: 3, pdfDocumentId: 'abc-123', confidence: 1.0 },
+    ];
+    render(<InlineCitationText text="Hello world" citations={citations} snippets={mockSnippets} />);
+    fireEvent.click(screen.getByTestId('citation-highlight-0'));
+    expect(screen.getByTestId('citation-accordion-0')).toBeInTheDocument();
+    expect(screen.getByText(/Full chunk text from the rulebook/)).toBeInTheDocument();
+  });
+
+  it('renders PDF link icon', () => {
+    const citations: InlineCitationMatch[] = [
+      { startOffset: 0, endOffset: 5, snippetIndex: 0, pageNumber: 3, pdfDocumentId: 'abc-123', confidence: 1.0 },
+    ];
+    render(<InlineCitationText text="Hello world" citations={citations} snippets={mockSnippets} />);
+    const pdfLink = screen.getByTestId('pdf-link-0');
+    expect(pdfLink).toHaveAttribute('href', '/api/v1/pdfs/abc-123/download#page=3');
+  });
+});

--- a/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/agent/page.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/agent/page.tsx
@@ -15,12 +15,13 @@
 
 import { use, useState, useRef } from 'react';
 
-import { Bot, Loader2, Send } from 'lucide-react';
+import { Bot, ImagePlus, Loader2, Send, X } from 'lucide-react';
 
 import { ArbitroModal } from '@/components/session/live/ArbitroModal';
 import { DisputeHistory } from '@/components/session/live/DisputeHistory';
 import { Button } from '@/components/ui/primitives/button';
 import { Textarea } from '@/components/ui/primitives/textarea';
+import { useChatImageAttachments } from '@/hooks/useChatImageAttachments';
 import { useLiveSessionStore } from '@/lib/stores/live-session-store';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -30,6 +31,7 @@ interface ChatMessage {
   role: 'user' | 'assistant';
   content: string;
   timestamp: number;
+  imageUrls?: string[];
 }
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
@@ -56,6 +58,18 @@ function MessageBubble({ message }: MessageBubbleProps) {
             : 'bg-white/80 backdrop-blur-sm border border-white/60 text-gray-800 rounded-tl-sm shadow-sm',
         ].join(' ')}
       >
+        {message.imageUrls && message.imageUrls.length > 0 && (
+          <div className="mb-2 flex gap-1.5 flex-wrap">
+            {message.imageUrls.map((url, i) => (
+              <img
+                key={i}
+                src={url}
+                alt={`Allegato ${i + 1}`}
+                className="h-16 w-20 rounded-md border border-white/30 object-cover"
+              />
+            ))}
+          </div>
+        )}
         <p className="whitespace-pre-wrap leading-relaxed">{message.content}</p>
       </div>
     </div>
@@ -74,6 +88,10 @@ export default function AgentPage({ params }: AgentPageProps) {
   const players = useLiveSessionStore(s => s.players);
   const gameName = useLiveSessionStore(s => s.gameName);
 
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const { images, addImage, removeImage, clearImages, hasImages, canAddMore } =
+    useChatImageAttachments();
+
   const [messages, setMessages] = useState<ChatMessage[]>([
     {
       id: 'welcome',
@@ -90,84 +108,125 @@ export default function AgentPage({ params }: AgentPageProps) {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }
 
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = e.target.files;
+    if (!files) return;
+    for (let i = 0; i < files.length; i++) {
+      const error = addImage(files[i]);
+      if (error) console.warn('[AgentChat]', error);
+    }
+    e.target.value = '';
+  }
+
   async function handleSend(e: React.FormEvent) {
     e.preventDefault();
     const trimmed = input.trim();
-    if (!trimmed || isLoading) return;
+    if ((!trimmed && !hasImages) || isLoading) return;
 
     const userMessage: ChatMessage = {
       id: `user-${Date.now()}`,
       role: 'user',
-      content: trimmed,
+      content: trimmed || '(immagine allegata)',
       timestamp: Date.now(),
+      imageUrls: images.map(img => img.previewUrl),
     };
 
     setMessages(prev => [...prev, userMessage]);
     setInput('');
+    const attachedImages = images.map(img => img.file);
+    clearImages();
     setIsLoading(true);
     scrollToBottom();
 
     try {
-      // POST to the agent chat endpoint with session context for RAG injection
-      const res = await fetch('/api/v1/agent/chat', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          message: trimmed,
-          sessionContext: { sessionId, gameName },
-        }),
-      });
+      let res: Response;
+
+      if (attachedImages.length > 0) {
+        // Multipart request with images to session agent endpoint
+        const fd = new FormData();
+        fd.append('question', trimmed || 'Analizza questa immagine');
+        fd.append('senderId', players[0]?.id || sessionId);
+        attachedImages.forEach(img => fd.append('images', img));
+        res = await fetch(`/api/v1/game-sessions/${sessionId}/chat/ask-agent`, {
+          method: 'POST',
+          body: fd,
+        });
+      } else {
+        // Text-only: existing JSON endpoint
+        res = await fetch('/api/v1/agent/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            message: trimmed,
+            sessionContext: { sessionId, gameName },
+          }),
+        });
+      }
 
       if (!res.ok) throw new Error('Agent unavailable');
 
       const assistantId = `assistant-${Date.now()}`;
-      let assistantContent = '';
 
-      // Add placeholder message that we'll fill from the stream
-      setMessages(prev => [
-        ...prev,
-        { id: assistantId, role: 'assistant', content: '...', timestamp: Date.now() },
-      ]);
+      if (attachedImages.length > 0) {
+        // ask-agent returns JSON, not SSE
+        const json = (await res.json()) as { answer?: string; confidence?: number };
+        setMessages(prev => [
+          ...prev,
+          {
+            id: assistantId,
+            role: 'assistant',
+            content: json.answer ?? 'Risposta non disponibile.',
+            timestamp: Date.now(),
+          },
+        ]);
+      } else {
+        // Existing SSE streaming path
+        let assistantContent = '';
+        setMessages(prev => [
+          ...prev,
+          { id: assistantId, role: 'assistant', content: '...', timestamp: Date.now() },
+        ]);
 
-      const reader = res.body?.getReader();
-      const decoder = new TextDecoder();
+        const reader = res.body?.getReader();
+        const decoder = new TextDecoder();
 
-      if (reader) {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
+        if (reader) {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
 
-          const chunk = decoder.decode(value, { stream: true });
-          for (const line of chunk.split('\n')) {
-            if (!line.startsWith('data: ')) continue;
-            const data = line.slice(6);
-            if (data === '[DONE]') break;
-            try {
-              const parsed = JSON.parse(data) as { content?: string };
-              if (parsed.content) {
-                assistantContent += parsed.content;
-                setMessages(prev =>
-                  prev.map(m => (m.id === assistantId ? { ...m, content: assistantContent } : m))
-                );
-                scrollToBottom();
+            const chunk = decoder.decode(value, { stream: true });
+            for (const line of chunk.split('\n')) {
+              if (!line.startsWith('data: ')) continue;
+              const data = line.slice(6);
+              if (data === '[DONE]') break;
+              try {
+                const parsed = JSON.parse(data) as { content?: string };
+                if (parsed.content) {
+                  assistantContent += parsed.content;
+                  setMessages(prev =>
+                    prev.map(m => (m.id === assistantId ? { ...m, content: assistantContent } : m))
+                  );
+                  scrollToBottom();
+                }
+              } catch {
+                // Non-JSON SSE chunk — ignore
               }
-            } catch {
-              // Non-JSON SSE chunk — ignore
             }
           }
         }
-      }
 
-      // If stream produced nothing, fallback to full JSON response
-      if (!assistantContent) {
-        const fallback = (await res.json().catch(() => null)) as { content?: string } | null;
-        setMessages(prev =>
-          prev.map(m =>
-            m.id === assistantId
-              ? { ...m, content: fallback?.content ?? 'Risposta non disponibile.' }
-              : m
-          )
-        );
+        // If stream produced nothing, fallback to full JSON response
+        if (!assistantContent) {
+          const fallback = (await res.json().catch(() => null)) as { content?: string } | null;
+          setMessages(prev =>
+            prev.map(m =>
+              m.id === assistantId
+                ? { ...m, content: fallback?.content ?? 'Risposta non disponibile.' }
+                : m
+            )
+          );
+        }
       }
     } catch {
       setMessages(prev => [
@@ -238,26 +297,70 @@ export default function AgentPage({ params }: AgentPageProps) {
       </div>
 
       {/* Input */}
-      <form onSubmit={handleSend} className="shrink-0 px-4 pb-4 pt-2 flex gap-2 items-end">
-        <Textarea
-          value={input}
-          onChange={e => setInput(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder="Chiedi una regola... (Invio per inviare)"
-          className="flex-1 resize-none min-h-[42px] max-h-[120px] font-nunito text-sm"
-          rows={1}
-          disabled={isLoading}
-          aria-label="Messaggio per l'arbitro"
+      <form onSubmit={handleSend} className="shrink-0 px-4 pb-4 pt-2">
+        {/* Image previews */}
+        {hasImages && (
+          <div className="mb-2 flex flex-wrap gap-1.5">
+            {images.map((img, idx) => (
+              <div key={img.previewUrl} className="group relative">
+                <img
+                  src={img.previewUrl}
+                  alt={`Allegato ${idx + 1}`}
+                  className="h-14 w-18 rounded-md border border-white/20 object-cover"
+                />
+                <button
+                  type="button"
+                  onClick={() => removeImage(idx)}
+                  aria-label={`Rimuovi immagine ${idx + 1}`}
+                  className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-white opacity-0 transition-opacity group-hover:opacity-100"
+                >
+                  <X className="h-2.5 w-2.5" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+        <div className="flex gap-2 items-end">
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            onClick={() => canAddMore && fileInputRef.current?.click()}
+            disabled={!canAddMore || isLoading}
+            className="h-[42px] w-[42px] shrink-0 text-muted-foreground hover:text-amber-500"
+            aria-label="Allega immagine"
+          >
+            <ImagePlus className="h-5 w-5" />
+          </Button>
+          <Textarea
+            value={input}
+            onChange={e => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Chiedi una regola... (Invio per inviare)"
+            className="flex-1 resize-none min-h-[42px] max-h-[120px] font-nunito text-sm"
+            rows={1}
+            disabled={isLoading}
+            aria-label="Messaggio per l'arbitro"
+          />
+          <Button
+            type="submit"
+            size="icon"
+            disabled={isLoading || (!input.trim() && !hasImages)}
+            className="h-[42px] w-[42px] bg-amber-500 hover:bg-amber-600 shrink-0"
+            aria-label="Invia messaggio"
+          >
+            <Send className="h-4 w-4 text-white" />
+          </Button>
+        </div>
+        {/* Hidden file input */}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/jpeg,image/png,image/webp"
+          multiple
+          className="hidden"
+          onChange={handleFileChange}
         />
-        <Button
-          type="submit"
-          size="icon"
-          disabled={isLoading || !input.trim()}
-          className="h-[42px] w-[42px] bg-amber-500 hover:bg-amber-600 shrink-0"
-          aria-label="Invia messaggio"
-        >
-          <Send className="h-4 w-4 text-white" />
-        </Button>
       </form>
 
       {/* Dispute History collapsible */}

--- a/apps/web/src/components/chat-unified/ChatMessageList.tsx
+++ b/apps/web/src/components/chat-unified/ChatMessageList.tsx
@@ -20,6 +20,9 @@ import type { FeedbackValue } from '@/components/ui/meeple/feedback-buttons';
 import type { AgentChatStreamState } from '@/hooks/useAgentChatStream';
 import { api } from '@/lib/api';
 
+import { CitationBlock } from './CitationBlock';
+import { ContinueButton } from './ContinueButton';
+import { InlineCitationText } from './InlineCitationText';
 import { ResponseMetaBadge } from './ResponseMetaBadge';
 import { RuleSourceCard } from './RuleSourceCard';
 import { TechnicalDetailsPanel } from './TechnicalDetailsPanel';
@@ -38,6 +41,9 @@ export interface ChatMessageItem {
   timestamp?: string;
   citations?: import('@/types').Citation[];
   followUpQuestions?: string[];
+  inlineCitations?: import('@/lib/api/clients/chatClient').InlineCitationMatch[];
+  snippets?: Array<{ text: string; source: string; page: number; line: number; score: number }>;
+  continuationToken?: string;
 }
 
 export type StreamStateForMessages = Pick<
@@ -67,6 +73,10 @@ export interface ChatMessageListProps {
   isSpeaking: boolean;
   onSpeak: (text: string) => void;
   onStopSpeaking: () => void;
+  /** Continuation handler for "continue" button */
+  onContinue?: (continuationToken: string) => void;
+  /** Whether a send/continuation is in progress */
+  isSending?: boolean;
   /** Ref for auto-scroll */
   messagesEndRef: React.RefObject<HTMLDivElement | null>;
 }
@@ -93,6 +103,8 @@ export function ChatMessageList({
   isTtsSupported,
   ttsEnabled,
   isSpeaking,
+  onContinue,
+  isSending,
   onSpeak,
   onStopSpeaking,
   messagesEndRef,
@@ -205,6 +217,33 @@ export function ChatMessageList({
                     ChatMessage's local Citation type) */}
                 {msg.citations && msg.citations.length > 0 && (
                   <RuleSourceCard citations={msg.citations} gameTitle={gameTitle} />
+                )}
+
+                {/* Inline citation text overlay — replaces plain text when inline citations exist */}
+                {msg.role === 'assistant' && msg.inlineCitations && msg.inlineCitations.length > 0 && (
+                  <div className="mt-1">
+                    <InlineCitationText
+                      text={msg.content}
+                      citations={msg.inlineCitations}
+                      snippets={msg.snippets ?? []}
+                    />
+                  </div>
+                )}
+
+                {/* Citation block for non-inline snippets */}
+                {msg.role === 'assistant' && msg.snippets && msg.snippets.length > 0 && (
+                  <CitationBlock
+                    snippets={msg.snippets}
+                    excludeIndices={new Set(msg.inlineCitations?.map(c => c.snippetIndex) ?? [])}
+                  />
+                )}
+
+                {/* Continue button — when backend signals truncated response */}
+                {msg.role === 'assistant' && msg.continuationToken && onContinue && (
+                  <ContinueButton
+                    onContinue={() => onContinue(msg.continuationToken!)}
+                    isLoading={isSending ?? false}
+                  />
                 )}
 
                 {/* Strategy tier badge — only on last assistant message, not streaming */}

--- a/apps/web/src/components/chat-unified/ChatMobile.tsx
+++ b/apps/web/src/components/chat-unified/ChatMobile.tsx
@@ -16,6 +16,7 @@ import { useRouter } from 'next/navigation';
 import { MobileHeader } from '@/components/ui/navigation/MobileHeader';
 import { useAgentChatStream } from '@/hooks/useAgentChatStream';
 import { api } from '@/lib/api';
+import { qaStream } from '@/lib/api/clients/chatClient';
 import type { ChatThreadDto, ChatThreadMessageDto } from '@/lib/api/schemas/chat.schemas';
 import { cn } from '@/lib/utils';
 
@@ -130,6 +131,8 @@ export function ChatMobile({ threadId }: ChatMobileProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [agentId, setAgentId] = useState<string | null>(null);
+  const [isSending, setIsSending] = useState(false);
+  const qaAbortRef = useRef<AbortController | null>(null);
 
   // SSE Streaming
   const { state: streamState, sendMessage: sendViaSSE } = useAgentChatStream({
@@ -169,6 +172,13 @@ export function ChatMobile({ threadId }: ChatMobileProps) {
     scrollToBottom();
   }, [messages, streamState.currentAnswer, scrollToBottom]);
 
+  // Abort QA stream on unmount
+  useEffect(() => {
+    return () => {
+      qaAbortRef.current?.abort();
+    };
+  }, []);
+
   // Load thread
   useEffect(() => {
     async function loadThread() {
@@ -203,11 +213,11 @@ export function ChatMobile({ threadId }: ChatMobileProps) {
     void loadThread();
   }, [threadId]);
 
-  // Send message
+  // Send message — SSE streaming when agentId or gameId available, REST fallback otherwise
   const handleSend = useCallback(
     (content?: string) => {
       const text = (content || inputValue).trim();
-      if (!text || streamState.isStreaming) return;
+      if (!text || streamState.isStreaming || isSending) return;
 
       setInputValue('');
 
@@ -220,13 +230,119 @@ export function ChatMobile({ threadId }: ChatMobileProps) {
       };
       setMessages(prev => [...prev, userMessage]);
 
-      // SSE path
+      // SSE path: agent-specific streaming
       if (agentId) {
         sendViaSSE(agentId, text, threadId);
         return;
       }
 
-      // REST fallback
+      // QA stream path: game context available → use RAG QA streaming
+      if (thread?.gameId) {
+        setIsSending(true);
+        const assistantMsgId = `assistant-${Date.now()}`;
+        setMessages(prev => [
+          ...prev,
+          {
+            id: assistantMsgId,
+            role: 'assistant',
+            content: '',
+            timestamp: new Date().toISOString(),
+          },
+        ]);
+
+        const abortController = new AbortController();
+        qaAbortRef.current = abortController;
+
+        void (async () => {
+          let finalAnswer = '';
+          let followUps: string[] = [];
+          try {
+            await api.chat.addMessage(threadId, { content: text, role: 'user' });
+
+            for await (const event of qaStream(
+              { gameId: thread.gameId!, query: text, chatId: threadId },
+              abortController.signal
+            )) {
+              switch (event.type) {
+                case 7: {
+                  const token =
+                    typeof event.data === 'string'
+                      ? event.data
+                      : ((event.data as { token?: string })?.token ?? '');
+                  if (token) {
+                    finalAnswer += token;
+                    const currentContent = finalAnswer;
+                    setMessages(prev =>
+                      prev.map(m =>
+                        m.id === assistantMsgId ? { ...m, content: currentContent } : m
+                      )
+                    );
+                  }
+                  break;
+                }
+                case 4: {
+                  const data = event.data as {
+                    answer?: string;
+                    followUpQuestions?: string[];
+                  };
+                  if (data.answer) finalAnswer = data.answer;
+                  if (data.followUpQuestions) followUps = data.followUpQuestions;
+                  break;
+                }
+                case 6: {
+                  const citations = (event.data as { snippets?: CitationItem[] })?.snippets;
+                  if (citations) {
+                    setMessages(prev =>
+                      prev.map(m => (m.id === assistantMsgId ? { ...m, citations } : m))
+                    );
+                  }
+                  break;
+                }
+                case 9: {
+                  const errData = event.data as { message?: string };
+                  setMessages(prev =>
+                    prev.map(m =>
+                      m.id === assistantMsgId
+                        ? { ...m, content: errData?.message ?? 'Errore nella risposta' }
+                        : m
+                    )
+                  );
+                  break;
+                }
+              }
+            }
+
+            // Finalize
+            setMessages(prev =>
+              prev.map(m =>
+                m.id === assistantMsgId
+                  ? {
+                      ...m,
+                      content: finalAnswer,
+                      followUpQuestions: followUps.length > 0 ? followUps : undefined,
+                    }
+                  : m
+              )
+            );
+          } catch {
+            if (!abortController.signal.aborted) {
+              setMessages(prev =>
+                prev.map(m =>
+                  m.id === assistantMsgId
+                    ? { ...m, content: finalAnswer || 'Errore nella generazione della risposta' }
+                    : m
+                )
+              );
+            }
+          } finally {
+            setIsSending(false);
+            qaAbortRef.current = null;
+          }
+        })();
+        return;
+      }
+
+      // REST fallback (no game, no agent)
       void (async () => {
         try {
           const response = await api.chat.addMessage(threadId, {
@@ -244,12 +360,11 @@ export function ChatMobile({ threadId }: ChatMobileProps) {
             );
           }
         } catch {
-          // Remove optimistic message on error
           setMessages(prev => prev.filter(m => m.id !== userMessage.id));
         }
       })();
     },
-    [inputValue, streamState.isStreaming, agentId, threadId, sendViaSSE]
+    [inputValue, streamState.isStreaming, isSending, agentId, thread?.gameId, threadId, sendViaSSE]
   );
 
   // Key handler

--- a/apps/web/src/components/chat-unified/ChatMobile.tsx
+++ b/apps/web/src/components/chat-unified/ChatMobile.tsx
@@ -16,10 +16,13 @@ import { useRouter } from 'next/navigation';
 import { MobileHeader } from '@/components/ui/navigation/MobileHeader';
 import { useAgentChatStream } from '@/hooks/useAgentChatStream';
 import { api } from '@/lib/api';
-import { qaStream } from '@/lib/api/clients/chatClient';
+import { qaStream, QA_EVENT_TYPES, type InlineCitationMatch, type ContinuationData } from '@/lib/api/clients/chatClient';
 import type { ChatThreadDto, ChatThreadMessageDto } from '@/lib/api/schemas/chat.schemas';
 import { cn } from '@/lib/utils';
 
+import { CitationBlock } from './CitationBlock';
+import { ContinueButton } from './ContinueButton';
+import { InlineCitationText } from './InlineCitationText';
 import { QuickPromptChips } from './QuickPromptChips';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -31,6 +34,9 @@ interface LocalMessage {
   timestamp: string;
   citations?: CitationItem[];
   followUpQuestions?: string[];
+  inlineCitations?: InlineCitationMatch[];
+  snippets?: Array<{ text: string; source: string; page: number; line: number; score: number }>;
+  continuationToken?: string;
 }
 
 interface CitationItem {
@@ -54,7 +60,15 @@ function CitationChip({ citation }: { citation: CitationItem }) {
 
 // ─── Message Bubble ─────────────────────────────────────────────────────────
 
-function MessageBubble({ message }: { message: LocalMessage }) {
+function MessageBubble({
+  message,
+  onContinue,
+  isSending,
+}: {
+  message: LocalMessage;
+  onContinue?: (token: string) => void;
+  isSending?: boolean;
+}) {
   const isUser = message.role === 'user';
 
   return (
@@ -67,14 +81,36 @@ function MessageBubble({ message }: { message: LocalMessage }) {
             : 'bg-[var(--gaming-bg-glass)] backdrop-blur-sm border border-[var(--gaming-border-glass)] text-[var(--gaming-text-primary)] rounded-bl-md'
         )}
       >
-        <p className="whitespace-pre-wrap break-words">{message.content}</p>
-        {/* Citations */}
+        {!isUser && message.inlineCitations && message.inlineCitations.length > 0 ? (
+          <InlineCitationText
+            text={message.content}
+            citations={message.inlineCitations}
+            snippets={message.snippets ?? []}
+          />
+        ) : (
+          <p className="whitespace-pre-wrap break-words">{message.content}</p>
+        )}
+        {/* Legacy citation chips */}
         {message.citations && message.citations.length > 0 && (
           <div className="flex flex-wrap gap-1 mt-2">
             {message.citations.map((c, i) => (
               <CitationChip key={i} citation={c} />
             ))}
           </div>
+        )}
+        {/* Citation block for non-inline snippets */}
+        {!isUser && message.snippets && message.snippets.length > 0 && (
+          <CitationBlock
+            snippets={message.snippets}
+            excludeIndices={new Set(message.inlineCitations?.map(c => c.snippetIndex) ?? [])}
+          />
+        )}
+        {/* Continue button */}
+        {!isUser && message.continuationToken && onContinue && (
+          <ContinueButton
+            onContinue={() => onContinue(message.continuationToken!)}
+            isLoading={isSending ?? false}
+          />
         )}
       </div>
     </div>
@@ -213,6 +249,43 @@ export function ChatMobile({ threadId }: ChatMobileProps) {
     void loadThread();
   }, [threadId]);
 
+  // Handle continuation — append more content to the last assistant message
+  const handleContinue = useCallback(
+    (continuationToken: string) => {
+      void (async () => {
+        setIsSending(true);
+        const abortController = new AbortController();
+        qaAbortRef.current = abortController;
+        try {
+          const lastAssistant = [...messages].reverse().find(m => m.role === 'assistant');
+          if (!lastAssistant || !thread?.gameId) return;
+          let appendedContent = lastAssistant.content;
+
+          for await (const event of qaStream(
+            { gameId: thread.gameId, query: '', continuationToken },
+            abortController.signal
+          )) {
+            if (event.type === QA_EVENT_TYPES.TOKEN) {
+              const token = typeof event.data === 'string' ? event.data : ((event.data as { token?: string })?.token ?? '');
+              if (token) {
+                appendedContent += token;
+                const content = appendedContent;
+                setMessages(prev =>
+                  prev.map(m => m.id === lastAssistant.id ? { ...m, content, continuationToken: undefined } : m)
+                );
+              }
+            }
+          }
+        } catch { /* handled */ }
+        finally {
+          setIsSending(false);
+          qaAbortRef.current = null;
+        }
+      })();
+    },
+    [messages, thread?.gameId]
+  );
+
   // Send message — SSE streaming when agentId or gameId available, REST fallback otherwise
   const handleSend = useCallback(
     (content?: string) => {
@@ -260,10 +333,37 @@ export function ChatMobile({ threadId }: ChatMobileProps) {
             await api.chat.addMessage(threadId, { content: text, role: 'user' });
 
             for await (const event of qaStream(
-              { gameId: thread.gameId!, query: text, chatId: threadId },
+              { gameId: thread.gameId!, query: text, chatId: threadId, responseStyle: 'concise' },
               abortController.signal
             )) {
               switch (event.type) {
+                case QA_EVENT_TYPES.INLINE_CITATION: {
+                  const data = event.data as { citations: InlineCitationMatch[] };
+                  if (data.citations) {
+                    setMessages(prev =>
+                      prev.map(m => m.id === assistantMsgId ? { ...m, inlineCitations: data.citations } : m)
+                    );
+                  }
+                  break;
+                }
+                case QA_EVENT_TYPES.CONTINUATION_AVAILABLE: {
+                  const data = event.data as ContinuationData;
+                  if (data.continuationToken) {
+                    setMessages(prev =>
+                      prev.map(m => m.id === assistantMsgId ? { ...m, continuationToken: data.continuationToken } : m)
+                    );
+                  }
+                  break;
+                }
+                case QA_EVENT_TYPES.CITATIONS: {
+                  const data = event.data as { snippets?: Array<{ text: string; source: string; page: number; line: number; score: number }> };
+                  if (data.snippets) {
+                    setMessages(prev =>
+                      prev.map(m => m.id === assistantMsgId ? { ...m, snippets: data.snippets } : m)
+                    );
+                  }
+                  break;
+                }
                 case 7: {
                   const token =
                     typeof event.data === 'string'
@@ -427,7 +527,7 @@ export function ChatMobile({ threadId }: ChatMobileProps) {
         )}
 
         {messages.map(msg => (
-          <MessageBubble key={msg.id} message={msg} />
+          <MessageBubble key={msg.id} message={msg} onContinue={handleContinue} isSending={isSending} />
         ))}
 
         {/* Streaming states */}

--- a/apps/web/src/components/chat-unified/ChatMobile.tsx
+++ b/apps/web/src/components/chat-unified/ChatMobile.tsx
@@ -356,10 +356,10 @@ export function ChatMobile({ threadId }: ChatMobileProps) {
                   break;
                 }
                 case QA_EVENT_TYPES.CITATIONS: {
-                  const data = event.data as { snippets?: Array<{ text: string; source: string; page: number; line: number; score: number }> };
-                  if (data.snippets) {
+                  const data = event.data as { citations?: Array<{ text: string; source: string; page: number; line: number; score: number }> };
+                  if (data.citations) {
                     setMessages(prev =>
-                      prev.map(m => m.id === assistantMsgId ? { ...m, snippets: data.snippets } : m)
+                      prev.map(m => m.id === assistantMsgId ? { ...m, snippets: data.citations } : m)
                     );
                   }
                   break;
@@ -398,7 +398,7 @@ export function ChatMobile({ threadId }: ChatMobileProps) {
                   }
                   break;
                 }
-                case 9: {
+                case QA_EVENT_TYPES.ERROR: {
                   const errData = event.data as { message?: string };
                   setMessages(prev =>
                     prev.map(m =>

--- a/apps/web/src/components/chat-unified/ChatThreadView.tsx
+++ b/apps/web/src/components/chat-unified/ChatThreadView.tsx
@@ -27,7 +27,7 @@ import { useAgentChatStream, type ProxyGameContext } from '@/hooks/useAgentChatS
 import { useVoiceInput } from '@/hooks/useVoiceInput';
 import { useVoiceOutput } from '@/hooks/useVoiceOutput';
 import { api } from '@/lib/api';
-import { qaStream } from '@/lib/api/clients/chatClient';
+import { qaStream, QA_EVENT_TYPES, type InlineCitationMatch, type ContinuationData } from '@/lib/api/clients/chatClient';
 import { cn } from '@/lib/utils';
 import { useVoicePreferencesStore } from '@/stores/voice/store';
 import { isAdminOrAbove, isEditorOrAbove } from '@/types/auth';
@@ -261,6 +261,43 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
     void loadThread();
   }, [threadId]);
 
+  // Handle continuation — append more content to the last assistant message
+  const handleContinue = useCallback(
+    (continuationToken: string) => {
+      void (async () => {
+        setIsSending(true);
+        const abortController = new AbortController();
+        qaAbortRef.current = abortController;
+        try {
+          const lastAssistant = [...messages].reverse().find(m => m.role === 'assistant');
+          if (!lastAssistant || !thread?.gameId) return;
+          let appendedContent = lastAssistant.content;
+
+          for await (const event of qaStream(
+            { gameId: thread.gameId, query: '', continuationToken },
+            abortController.signal
+          )) {
+            if (event.type === QA_EVENT_TYPES.TOKEN) {
+              const token = typeof event.data === 'string' ? event.data : ((event.data as { token?: string })?.token ?? '');
+              if (token) {
+                appendedContent += token;
+                const content = appendedContent;
+                setMessages(prev =>
+                  prev.map(m => m.id === lastAssistant.id ? { ...m, content, continuationToken: undefined } : m)
+                );
+              }
+            }
+          }
+        } catch { /* handled */ }
+        finally {
+          setIsSending(false);
+          qaAbortRef.current = null;
+        }
+      })();
+    },
+    [messages, thread?.gameId]
+  );
+
   // Send message - SSE streaming when agentId available, REST fallback otherwise
   const handleSendMessage = useCallback(
     async (content?: string) => {
@@ -309,10 +346,37 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
 
           // Stream AI response via QA endpoint
           for await (const event of qaStream(
-            { gameId: thread.gameId, query: messageContent, chatId: threadId },
+            { gameId: thread.gameId, query: messageContent, chatId: threadId, responseStyle: 'concise' },
             abortController.signal
           )) {
             switch (event.type) {
+              case QA_EVENT_TYPES.INLINE_CITATION: {
+                const data = event.data as { citations: InlineCitationMatch[] };
+                if (data.citations) {
+                  setMessages(prev =>
+                    prev.map(m => m.id === assistantMsgId ? { ...m, inlineCitations: data.citations } : m)
+                  );
+                }
+                break;
+              }
+              case QA_EVENT_TYPES.CONTINUATION_AVAILABLE: {
+                const data = event.data as ContinuationData;
+                if (data.continuationToken) {
+                  setMessages(prev =>
+                    prev.map(m => m.id === assistantMsgId ? { ...m, continuationToken: data.continuationToken } : m)
+                  );
+                }
+                break;
+              }
+              case QA_EVENT_TYPES.CITATIONS: {
+                const data = event.data as { snippets?: Array<{ text: string; source: string; page: number; line: number; score: number }> };
+                if (data.snippets) {
+                  setMessages(prev =>
+                    prev.map(m => m.id === assistantMsgId ? { ...m, snippets: data.snippets } : m)
+                  );
+                }
+                break;
+              }
               case 7: {
                 // Token
                 const token =
@@ -739,6 +803,8 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
                 isSpeaking={isSpeaking}
                 onSpeak={speak}
                 onStopSpeaking={stopSpeaking}
+                onContinue={handleContinue}
+                isSending={isSending}
                 messagesEndRef={messagesEndRef}
               />
             </div>

--- a/apps/web/src/components/chat-unified/ChatThreadView.tsx
+++ b/apps/web/src/components/chat-unified/ChatThreadView.tsx
@@ -369,10 +369,10 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
                 break;
               }
               case QA_EVENT_TYPES.CITATIONS: {
-                const data = event.data as { snippets?: Array<{ text: string; source: string; page: number; line: number; score: number }> };
-                if (data.snippets) {
+                const data = event.data as { citations?: Array<{ text: string; source: string; page: number; line: number; score: number }> };
+                if (data.citations) {
                   setMessages(prev =>
-                    prev.map(m => m.id === assistantMsgId ? { ...m, snippets: data.snippets } : m)
+                    prev.map(m => m.id === assistantMsgId ? { ...m, snippets: data.citations } : m)
                   );
                 }
                 break;

--- a/apps/web/src/components/chat-unified/CitationBlock.tsx
+++ b/apps/web/src/components/chat-unified/CitationBlock.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import React, { useState } from 'react';
+import { FileText, ExternalLink, ChevronDown, ChevronUp } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface SnippetData {
+  text: string;
+  source: string;
+  page: number;
+  line: number;
+  score: number;
+}
+
+interface CitationBlockProps {
+  snippets: SnippetData[];
+  excludeIndices: Set<number>;
+}
+
+function extractPdfId(source: string): string {
+  return source.startsWith('PDF:') ? source.slice(4) : source;
+}
+
+export function CitationBlock({ snippets, excludeIndices }: CitationBlockProps) {
+  const [expanded, setExpanded] = useState<number | null>(null);
+
+  const visible = snippets
+    .map((s, i) => ({ ...s, originalIndex: i }))
+    .filter(s => !excludeIndices.has(s.originalIndex));
+
+  if (visible.length === 0) return null;
+
+  return (
+    <div className="mt-3 flex flex-wrap gap-2" data-testid="citation-block">
+      {visible.map((snippet) => {
+        const pdfId = extractPdfId(snippet.source);
+        const isExpanded = expanded === snippet.originalIndex;
+
+        return (
+          <div key={snippet.originalIndex} className="flex flex-col">
+            <div className="flex items-center gap-1">
+              <button
+                onClick={() => setExpanded(isExpanded ? null : snippet.originalIndex)}
+                className={cn(
+                  'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-nunito font-medium transition-all',
+                  'border border-amber-500/30 hover:border-amber-500/60',
+                  isExpanded
+                    ? 'bg-amber-500/15 text-amber-700 dark:text-amber-300'
+                    : 'bg-amber-500/5 text-amber-600 dark:text-amber-400 hover:bg-amber-500/10'
+                )}
+                data-testid={`citation-chip-${snippet.originalIndex}`}
+              >
+                <FileText className="h-3 w-3" />
+                Pagina {snippet.page}
+                {isExpanded ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+              </button>
+              <a
+                href={`/api/v1/pdfs/${pdfId}/download#page=${snippet.page}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-amber-600 hover:text-amber-700 dark:text-amber-400"
+                title={`Apri PDF — Pagina ${snippet.page}`}
+                data-testid={`citation-pdf-link-${snippet.originalIndex}`}
+              >
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </div>
+            {isExpanded && (
+              <div className="mt-1.5 p-3 rounded-lg bg-amber-500/5 border border-amber-500/20 text-sm max-w-md" data-testid={`citation-expanded-${snippet.originalIndex}`}>
+                <p className="text-muted-foreground font-nunito whitespace-pre-wrap">{snippet.text}</p>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/chat-unified/ContinueButton.tsx
+++ b/apps/web/src/components/chat-unified/ContinueButton.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { ArrowRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface ContinueButtonProps {
+  onContinue: () => void;
+  isLoading: boolean;
+}
+
+export function ContinueButton({ onContinue, isLoading }: ContinueButtonProps) {
+  return (
+    <button
+      onClick={onContinue}
+      disabled={isLoading}
+      className={cn(
+        'mt-3 inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-nunito font-medium transition-all',
+        isLoading
+          ? 'bg-muted text-muted-foreground cursor-not-allowed'
+          : 'bg-amber-500/10 text-amber-700 dark:text-amber-300 border border-amber-500/30 hover:bg-amber-500/20 hover:border-amber-500/50 cursor-pointer'
+      )}
+      data-testid="continue-button"
+    >
+      {isLoading ? (
+        <>
+          <div className="h-3.5 w-3.5 border-2 border-amber-500/30 border-t-amber-500 rounded-full animate-spin" />
+          Continuando...
+        </>
+      ) : (
+        <>
+          Continua la risposta
+          <ArrowRight className="h-3.5 w-3.5" />
+        </>
+      )}
+    </button>
+  );
+}

--- a/apps/web/src/components/chat-unified/InlineCitationText.tsx
+++ b/apps/web/src/components/chat-unified/InlineCitationText.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import React, { useState } from 'react';
+import { ExternalLink, ChevronDown, ChevronUp } from 'lucide-react';
+import type { InlineCitationMatch } from '@/lib/api/clients/chatClient';
+import { cn } from '@/lib/utils';
+
+interface SnippetData {
+  text: string;
+  source: string;
+  page: number;
+  line: number;
+  score: number;
+}
+
+interface InlineCitationTextProps {
+  text: string;
+  citations: InlineCitationMatch[];
+  snippets: SnippetData[];
+}
+
+export function InlineCitationText({ text, citations, snippets }: InlineCitationTextProps) {
+  const [expandedCitations, setExpandedCitations] = useState<Set<number>>(new Set());
+
+  if (citations.length === 0) {
+    return <p className="whitespace-pre-wrap break-words">{text}</p>;
+  }
+
+  const sorted = [...citations].sort((a, b) => a.startOffset - b.startOffset);
+  const segments: React.ReactNode[] = [];
+  let lastEnd = 0;
+
+  sorted.forEach((citation, idx) => {
+    if (citation.startOffset > lastEnd) {
+      segments.push(<span key={`text-${idx}`}>{text.slice(lastEnd, citation.startOffset)}</span>);
+    }
+
+    const citedText = text.slice(citation.startOffset, citation.endOffset);
+    const isExpanded = expandedCitations.has(idx);
+    const snippet = snippets[citation.snippetIndex];
+
+    segments.push(
+      <React.Fragment key={`cite-${idx}`}>
+        <span
+          className={cn(
+            'bg-amber-500/10 border-l-2 border-amber-500 px-1 cursor-pointer',
+            'hover:bg-amber-500/20 transition-colors inline'
+          )}
+          onClick={() => {
+            setExpandedCitations(prev => {
+              const next = new Set(prev);
+              if (next.has(idx)) next.delete(idx);
+              else next.add(idx);
+              return next;
+            });
+          }}
+          title={`Pagina ${citation.pageNumber}`}
+          data-testid={`citation-highlight-${idx}`}
+        >
+          {citedText}
+          <span className="inline-flex items-center ml-1 text-amber-600 dark:text-amber-400">
+            {isExpanded ? <ChevronUp className="h-3 w-3 inline" /> : <ChevronDown className="h-3 w-3 inline" />}
+          </span>
+        </span>
+        <a
+          href={`/api/v1/pdfs/${citation.pdfDocumentId}/download#page=${citation.pageNumber}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center ml-0.5 text-amber-600 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300"
+          data-testid={`pdf-link-${idx}`}
+          title={`Apri PDF — Pagina ${citation.pageNumber}`}
+        >
+          <ExternalLink className="h-3 w-3" />
+        </a>
+        {isExpanded && snippet && (
+          <div
+            className="block my-2 p-3 rounded-lg bg-amber-500/5 border border-amber-500/20 text-sm"
+            data-testid={`citation-accordion-${idx}`}
+          >
+            <div className="flex items-center gap-2 mb-1 text-xs text-amber-600 dark:text-amber-400 font-semibold font-nunito">
+              <span>Pagina {citation.pageNumber}</span>
+            </div>
+            <p className="text-muted-foreground font-nunito whitespace-pre-wrap">{snippet.text}</p>
+          </div>
+        )}
+      </React.Fragment>
+    );
+    lastEnd = citation.endOffset;
+  });
+
+  if (lastEnd < text.length) {
+    segments.push(<span key="text-end">{text.slice(lastEnd)}</span>);
+  }
+
+  return <div className="whitespace-pre-wrap break-words">{segments}</div>;
+}

--- a/apps/web/src/lib/api/clients/chatClient.ts
+++ b/apps/web/src/lib/api/clients/chatClient.ts
@@ -363,7 +363,7 @@ export const QA_EVENT_TYPES = {
   COMPLETE: 4,
   TOKEN: 7,
   FOLLOW_UP: 8,
-  ERROR: 9,
+  ERROR: 5,
   INLINE_CITATION: 28,
   CONTINUATION_AVAILABLE: 29,
 } as const;

--- a/apps/web/src/lib/api/clients/chatClient.ts
+++ b/apps/web/src/lib/api/clients/chatClient.ts
@@ -353,6 +353,33 @@ export interface QaStreamRequest {
   gameId: string;
   query: string;
   chatId?: string;
+  responseStyle?: 'concise' | 'detailed';
+  continuationToken?: string;
+}
+
+export const QA_EVENT_TYPES = {
+  STATE_UPDATE: 0,
+  CITATIONS: 1,
+  COMPLETE: 4,
+  TOKEN: 7,
+  FOLLOW_UP: 8,
+  ERROR: 9,
+  INLINE_CITATION: 28,
+  CONTINUATION_AVAILABLE: 29,
+} as const;
+
+export interface InlineCitationMatch {
+  startOffset: number;
+  endOffset: number;
+  snippetIndex: number;
+  pageNumber: number;
+  pdfDocumentId: string;
+  confidence: number;
+}
+
+export interface ContinuationData {
+  continuationToken: string;
+  reason: string;
 }
 
 export interface QaStreamEvent {

--- a/docs/superpowers/plans/2026-04-18-chat-inline-citations.md
+++ b/docs/superpowers/plans/2026-04-18-chat-inline-citations.md
@@ -1,0 +1,1387 @@
+# Chat Inline Citations & Concise Responses — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make chat responses token-independent with inline citations, PDF page links, concise/detailed mode, and continuation mechanism.
+
+**Architecture:** Backend post-processes LLM response to match RAG snippets, emits positioned citation events. Frontend renders highlighted spans with accordion expansion and PDF links. Prompt style (`concise`/`detailed`) controls response length; continuation token allows resuming truncated responses.
+
+**Tech Stack:** C# (.NET 9), TypeScript (Next.js/React 19), SSE streaming, Tailwind CSS
+
+**Spec:** `docs/superpowers/specs/2026-04-18-chat-inline-citations-design.md`
+
+---
+
+## File Map
+
+### Backend — Create
+- `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/InlineCitationMatcherService.cs` — text-snippet matching logic
+
+### Backend — Modify
+- `apps/api/src/Api/Models/Contracts.cs` — new event types + records
+- `apps/api/src/Api/Services/ILlmService.cs` — add FinishReason to StreamChunk
+- `apps/api/src/Api/Services/LlmClients/DeepSeekLlmClient.cs` — emit FinishReason in final chunk
+- `apps/api/src/Api/Services/LlmClients/OpenRouterLlmClient.cs` — emit FinishReason in final chunk
+- `apps/api/src/Api/Services/LlmClients/OllamaLlmClient.cs` — emit FinishReason in final chunk
+- `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs` — emit new events, handle continuation
+- `apps/api/src/Api/Routing/AiEndpoints.cs` — accept responseStyle/continuationToken in QaRequest
+- `apps/api/src/Api/Services/PromptTemplateService.cs` — concise/detailed/continuation prompt variants
+
+### Backend — Test
+- `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/InlineCitationMatcherServiceTests.cs`
+
+### Frontend — Create
+- `apps/web/src/components/chat-unified/InlineCitationText.tsx` — text with highlighted citation spans + accordion
+- `apps/web/src/components/chat-unified/CitationBlock.tsx` — chip citations below response
+- `apps/web/src/components/chat-unified/ContinueButton.tsx` — "Continue response" button
+
+### Frontend — Modify
+- `apps/web/src/lib/api/clients/chatClient.ts` — QaStreamRequest fields + event types
+- `apps/web/src/components/chat-unified/ChatMobile.tsx` — integrate new components, handle events 28/29
+- `apps/web/src/components/chat-unified/ChatThreadView.tsx` — same for desktop
+
+### Frontend — Test
+- `apps/web/__tests__/components/chat-unified/InlineCitationText.test.tsx`
+- `apps/web/__tests__/components/chat-unified/CitationBlock.test.tsx`
+- `apps/web/__tests__/components/chat-unified/ContinueButton.test.tsx`
+
+---
+
+## Task 1: Backend contracts — new event types and records
+
+**Files:**
+- Modify: `apps/api/src/Api/Models/Contracts.cs:13-18,54-90`
+- Modify: `apps/api/src/Api/Services/ILlmService.cs:14-18`
+
+- [ ] **Step 1: Add responseStyle and continuationToken to QaRequest**
+
+In `apps/api/src/Api/Models/Contracts.cs`, change the QaRequest record:
+
+```csharp
+internal record QaRequest(
+    string gameId,
+    string query,
+    Guid? chatId = null,
+    SearchMode searchMode = SearchMode.Hybrid,
+    IReadOnlyList<Guid>? documentIds = null,
+    string responseStyle = "concise",
+    string? continuationToken = null);
+```
+
+- [ ] **Step 2: Add new event types to StreamingEventType enum**
+
+After `CopyrightSanitized = 27`, add:
+
+```csharp
+    CopyrightSanitized = 27,       // Response body was sanitized due to verbatim copyright leak
+
+    // Inline citation and continuation events (#chat-inline-citations)
+    InlineCitation = 28,            // Positioned snippet matches within response text
+    ContinuationAvailable = 29      // Response truncated, continuation available
+```
+
+- [ ] **Step 3: Add new streaming record types**
+
+After the existing `StreamingComplete` record, add:
+
+```csharp
+internal record InlineCitationMatch(
+    int StartOffset,
+    int EndOffset,
+    int SnippetIndex,
+    int PageNumber,
+    string PdfDocumentId,
+    double Confidence);
+
+internal record StreamingInlineCitations(
+    IReadOnlyList<InlineCitationMatch> Citations);
+
+internal record StreamingContinuation(
+    string ContinuationToken,
+    string Reason);
+```
+
+- [ ] **Step 4: Add FinishReason to StreamChunk**
+
+In `apps/api/src/Api/Services/ILlmService.cs`, change:
+
+```csharp
+internal record StreamChunk(
+    string? Content,
+    LlmUsage? Usage = null,
+    LlmCost? Cost = null,
+    bool IsFinal = false,
+    string? FinishReason = null);
+```
+
+- [ ] **Step 5: Build and verify**
+
+Run: `cd apps/api/src/Api && dotnet build --no-restore`
+Expected: Build succeeded with 0 errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/Models/Contracts.cs apps/api/src/Api/Services/ILlmService.cs
+git commit -m "feat(kb): add inline citation and continuation contracts"
+```
+
+---
+
+## Task 2: LLM clients — emit FinishReason in final chunk
+
+**Files:**
+- Modify: `apps/api/src/Api/Services/LlmClients/DeepSeekLlmClient.cs`
+- Modify: `apps/api/src/Api/Services/LlmClients/OpenRouterLlmClient.cs`
+- Modify: `apps/api/src/Api/Services/LlmClients/OllamaLlmClient.cs`
+
+- [ ] **Step 1: DeepSeek — pass FinishReason in streaming final chunk**
+
+In `DeepSeekLlmClient.cs`, find the streaming method where `IsFinal = true` is set. Change the final `StreamChunk` construction to include the finish_reason from the SSE response:
+
+```csharp
+// In the streaming loop, when emitting the final chunk:
+yield return new StreamChunk(
+    Content: content,
+    Usage: usage,
+    Cost: cost,
+    IsFinal: true,
+    FinishReason: finishReason);
+```
+
+The `finishReason` is already parsed from the SSE response JSON `choices[0].finish_reason`.
+
+- [ ] **Step 2: OpenRouter — same pattern**
+
+In `OpenRouterLlmClient.cs`, find the streaming final chunk emission and add `FinishReason`:
+
+```csharp
+yield return new StreamChunk(
+    Content: content,
+    Usage: usage,
+    Cost: cost,
+    IsFinal: true,
+    FinishReason: finishReason);
+```
+
+- [ ] **Step 3: Ollama — same pattern**
+
+In `OllamaLlmClient.cs`, Ollama uses `done: true` instead of `finish_reason`. Map it:
+
+```csharp
+yield return new StreamChunk(
+    Content: content,
+    Usage: usage,
+    Cost: cost,
+    IsFinal: true,
+    FinishReason: isDone ? "stop" : null);
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cd apps/api/src/Api && dotnet build --no-restore`
+Expected: Build succeeded
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/Services/LlmClients/
+git commit -m "feat(kb): emit FinishReason in LLM streaming final chunks"
+```
+
+---
+
+## Task 3: InlineCitationMatcherService — TDD
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/InlineCitationMatcherService.cs`
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/InlineCitationMatcherServiceTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Domain.Services;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "KnowledgeBase")]
+public class InlineCitationMatcherServiceTests
+{
+    private readonly InlineCitationMatcherService _sut = new();
+
+    [Fact]
+    public void Match_ExactSubstring_ReturnsHighConfidence()
+    {
+        var answer = "Il gioco si svolge a turni. Ogni giocatore pesca una tessera e la posiziona sul tavolo.";
+        var snippets = new[]
+        {
+            new Snippet("Ogni giocatore pesca una tessera e la posiziona sul tavolo.", "PDF:abc", 3, 0, 0.9f)
+        };
+
+        var result = _sut.Match(answer, snippets);
+
+        result.Should().ContainSingle();
+        result[0].SnippetIndex.Should().Be(0);
+        result[0].Confidence.Should().BeGreaterOrEqualTo(0.9);
+        result[0].StartOffset.Should().Be(28);
+        result[0].EndOffset.Should().Be(86);
+    }
+
+    [Fact]
+    public void Match_NoOverlap_ReturnsEmpty()
+    {
+        var answer = "Il gioco prevede carte e dadi.";
+        var snippets = new[]
+        {
+            new Snippet("Le tessere hanno bordi colorati che devono combaciare.", "PDF:abc", 2, 0, 0.8f)
+        };
+
+        var result = _sut.Match(answer, snippets);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Match_FuzzyMatch_ReturnsMediumConfidence()
+    {
+        var answer = "Ogni giocatore prende una tessera e la mette sul tavolo.";
+        var snippets = new[]
+        {
+            new Snippet("Ogni giocatore pesca una tessera e la posiziona sul tavolo.", "PDF:abc", 3, 0, 0.9f)
+        };
+
+        var result = _sut.Match(answer, snippets);
+
+        result.Should().ContainSingle();
+        result[0].Confidence.Should().BeInRange(0.6, 0.85);
+    }
+
+    [Fact]
+    public void Match_OverlappingMatches_KeepsHighestConfidence()
+    {
+        var answer = "Ogni giocatore pesca una tessera e la posiziona sul tavolo.";
+        var snippets = new[]
+        {
+            new Snippet("Ogni giocatore pesca una tessera", "PDF:abc", 3, 0, 0.9f),
+            new Snippet("Ogni giocatore pesca una tessera e la posiziona sul tavolo.", "PDF:abc", 3, 0, 0.8f)
+        };
+
+        var result = _sut.Match(answer, snippets);
+
+        // The longer exact match (snippet 1) should win on overlap
+        result.Should().ContainSingle();
+        result[0].SnippetIndex.Should().Be(1);
+    }
+
+    [Fact]
+    public void Match_EmptyAnswer_ReturnsEmpty()
+    {
+        var result = _sut.Match("", new[] { new Snippet("text", "src", 1, 0, 0.5f) });
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Match_EmptySnippets_ReturnsEmpty()
+    {
+        var result = _sut.Match("some answer", Array.Empty<Snippet>());
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Match_ExtractsPdfDocumentId_FromSourceField()
+    {
+        var answer = "Posizionare la tessera di partenza al centro del tavolo.";
+        var snippets = new[]
+        {
+            new Snippet("Posizionare la tessera di partenza al centro del tavolo.", "PDF:c6336f55-d494-4f48-a79c-657ed7bd9abd", 2, 0, 0.9f)
+        };
+
+        var result = _sut.Match(answer, snippets);
+
+        result.Should().ContainSingle();
+        result[0].PdfDocumentId.Should().Be("c6336f55-d494-4f48-a79c-657ed7bd9abd");
+        result[0].PageNumber.Should().Be(2);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "InlineCitationMatcherServiceTests" --no-restore`
+Expected: Compilation error — `InlineCitationMatcherService` does not exist
+
+- [ ] **Step 3: Implement InlineCitationMatcherService**
+
+```csharp
+using Api.Models;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Api.BoundedContexts.KnowledgeBase.Domain.Services;
+
+/// <summary>
+/// Matches LLM response text against RAG snippets to find inline citation positions.
+/// Uses exact substring, fuzzy, and n-gram matching strategies.
+/// </summary>
+internal sealed class InlineCitationMatcherService
+{
+    private const int MinPhraseWords = 5;
+    private const double MinConfidenceThreshold = 0.6;
+    private const double ExactMatchConfidence = 1.0;
+    private const double FuzzyMatchConfidence = 0.8;
+    private const double NgramMatchConfidence = 0.65;
+    private const double MaxLevenshteinRatio = 0.15;
+    private const double MinNgramOverlap = 0.6;
+    private const int NgramSize = 3;
+
+    public IReadOnlyList<InlineCitationMatch> Match(string answer, IReadOnlyList<Snippet> snippets)
+    {
+        if (string.IsNullOrWhiteSpace(answer) || snippets.Count == 0)
+            return Array.Empty<InlineCitationMatch>();
+
+        var candidates = new List<InlineCitationMatch>();
+
+        for (var i = 0; i < snippets.Count; i++)
+        {
+            var snippet = snippets[i];
+            var pdfDocumentId = ExtractPdfDocumentId(snippet.source);
+            var phrases = ExtractPhrases(snippet.text, MinPhraseWords);
+
+            foreach (var phrase in phrases)
+            {
+                var match = FindBestMatch(answer, phrase, i, snippet.page, pdfDocumentId);
+                if (match != null)
+                    candidates.Add(match);
+            }
+
+            // Also try full snippet text as a phrase
+            var fullMatch = FindBestMatch(answer, snippet.text, i, snippet.page, pdfDocumentId);
+            if (fullMatch != null)
+                candidates.Add(fullMatch);
+        }
+
+        return ResolveOverlaps(candidates);
+    }
+
+    private InlineCitationMatch? FindBestMatch(string answer, string phrase, int snippetIndex, int page, string pdfDocumentId)
+    {
+        if (phrase.Length < 15) return null; // Skip very short phrases
+
+        // Strategy 1: Exact substring (case-insensitive)
+        var idx = answer.IndexOf(phrase, StringComparison.OrdinalIgnoreCase);
+        if (idx >= 0)
+        {
+            return new InlineCitationMatch(idx, idx + phrase.Length, snippetIndex, page, pdfDocumentId, ExactMatchConfidence);
+        }
+
+        // Strategy 2: Fuzzy match — sliding window
+        var maxDist = (int)(phrase.Length * MaxLevenshteinRatio);
+        var bestFuzzy = FindFuzzyMatch(answer, phrase, maxDist);
+        if (bestFuzzy != null)
+        {
+            return new InlineCitationMatch(bestFuzzy.Value.start, bestFuzzy.Value.end, snippetIndex, page, pdfDocumentId, FuzzyMatchConfidence);
+        }
+
+        // Strategy 3: N-gram overlap
+        var ngramMatch = FindNgramMatch(answer, phrase);
+        if (ngramMatch != null)
+        {
+            return new InlineCitationMatch(ngramMatch.Value.start, ngramMatch.Value.end, snippetIndex, page, pdfDocumentId, NgramMatchConfidence);
+        }
+
+        return null;
+    }
+
+    private static (int start, int end)? FindFuzzyMatch(string text, string pattern, int maxDist)
+    {
+        if (pattern.Length > text.Length) return null;
+
+        var windowSize = pattern.Length;
+        var bestDist = maxDist + 1;
+        var bestStart = -1;
+
+        for (var i = 0; i <= text.Length - windowSize; i++)
+        {
+            var window = text.Substring(i, windowSize);
+            var dist = LevenshteinDistance(window.ToLowerInvariant(), pattern.ToLowerInvariant());
+            if (dist < bestDist)
+            {
+                bestDist = dist;
+                bestStart = i;
+            }
+        }
+
+        if (bestStart >= 0 && bestDist <= maxDist)
+            return (bestStart, bestStart + windowSize);
+
+        return null;
+    }
+
+    private static (int start, int end)? FindNgramMatch(string text, string pattern)
+    {
+        var patternNgrams = GetNgrams(pattern.ToLowerInvariant(), NgramSize);
+        if (patternNgrams.Count == 0) return null;
+
+        var windowSize = Math.Min(pattern.Length + pattern.Length / 3, text.Length);
+        var bestOverlap = 0.0;
+        var bestStart = -1;
+        var bestEnd = -1;
+
+        for (var i = 0; i <= text.Length - Math.Min(windowSize, pattern.Length); i++)
+        {
+            var end = Math.Min(i + windowSize, text.Length);
+            var windowNgrams = GetNgrams(text[i..end].ToLowerInvariant(), NgramSize);
+            var intersection = patternNgrams.Intersect(windowNgrams).Count();
+            var overlap = (double)intersection / patternNgrams.Count;
+
+            if (overlap > bestOverlap)
+            {
+                bestOverlap = overlap;
+                bestStart = i;
+                bestEnd = end;
+            }
+        }
+
+        if (bestOverlap >= MinNgramOverlap && bestStart >= 0)
+            return (bestStart, bestEnd);
+
+        return null;
+    }
+
+    private static HashSet<string> GetNgrams(string text, int n)
+    {
+        var ngrams = new HashSet<string>(StringComparer.Ordinal);
+        for (var i = 0; i <= text.Length - n; i++)
+            ngrams.Add(text.Substring(i, n));
+        return ngrams;
+    }
+
+    private static int LevenshteinDistance(string a, string b)
+    {
+        var m = a.Length;
+        var n = b.Length;
+        var dp = new int[m + 1, n + 1];
+
+        for (var i = 0; i <= m; i++) dp[i, 0] = i;
+        for (var j = 0; j <= n; j++) dp[0, j] = j;
+
+        for (var i = 1; i <= m; i++)
+        for (var j = 1; j <= n; j++)
+        {
+            var cost = a[i - 1] == b[j - 1] ? 0 : 1;
+            dp[i, j] = Math.Min(Math.Min(dp[i - 1, j] + 1, dp[i, j - 1] + 1), dp[i - 1, j - 1] + cost);
+        }
+
+        return dp[m, n];
+    }
+
+    private static IReadOnlyList<InlineCitationMatch> ResolveOverlaps(List<InlineCitationMatch> candidates)
+    {
+        if (candidates.Count == 0) return Array.Empty<InlineCitationMatch>();
+
+        var sorted = candidates.OrderByDescending(c => c.Confidence)
+                               .ThenByDescending(c => c.EndOffset - c.StartOffset)
+                               .ToList();
+
+        var result = new List<InlineCitationMatch>();
+        foreach (var candidate in sorted)
+        {
+            var overlaps = result.Any(r =>
+                candidate.StartOffset < r.EndOffset && candidate.EndOffset > r.StartOffset);
+            if (!overlaps)
+                result.Add(candidate);
+        }
+
+        return result.OrderBy(r => r.StartOffset).ToList();
+    }
+
+    private static List<string> ExtractPhrases(string text, int minWords)
+    {
+        var sentences = text.Split(new[] { '.', '!', '?', ';', ':' }, StringSplitOptions.RemoveEmptyEntries);
+        return sentences
+            .Select(s => s.Trim())
+            .Where(s => s.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length >= minWords)
+            .ToList();
+    }
+
+    private static string ExtractPdfDocumentId(string source)
+    {
+        if (source.StartsWith("PDF:", StringComparison.OrdinalIgnoreCase))
+            return source[4..];
+        return source;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "InlineCitationMatcherServiceTests" --no-restore`
+Expected: All 7 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/InlineCitationMatcherService.cs
+git add apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/InlineCitationMatcherServiceTests.cs
+git commit -m "feat(kb): add InlineCitationMatcherService with TDD tests"
+```
+
+---
+
+## Task 4: Prompt template variants — concise/detailed/continuation
+
+**Files:**
+- Modify: `apps/api/src/Api/Services/PromptTemplateService.cs`
+
+- [ ] **Step 1: Add response style prompt instructions**
+
+Add a new method to `PromptTemplateService`:
+
+```csharp
+/// <summary>
+/// Returns the response-style instruction to append to the system prompt.
+/// </summary>
+internal static string GetResponseStyleInstruction(string responseStyle)
+{
+    return responseStyle switch
+    {
+        "detailed" => "\n\nIMPORTANT RESPONSE STYLE: Rispondi in modo completo e approfondito. Spiega ogni aspetto rilevante con esempi dal regolamento. Usa sottosezioni se necessario.",
+        "continuation" => "\n\nIMPORTANT: Continua la risposta precedente da dove ti eri fermato. Non ripetere ciò che hai già detto. Prosegui direttamente.",
+        _ => "\n\nIMPORTANT RESPONSE STYLE: Rispondi in modo sintetico e strutturato (max 200 parole). Concentrati sul rispondere alla domanda, non riscrivere il regolamento. Usa elenchi puntati. Non citare le pagine nel testo — le citazioni vengono gestite automaticamente dal sistema."
+    };
+}
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `cd apps/api/src/Api && dotnet build --no-restore`
+Expected: Build succeeded
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/Api/Services/PromptTemplateService.cs
+git commit -m "feat(kb): add concise/detailed/continuation prompt variants"
+```
+
+---
+
+## Task 5: StreamQaQueryHandler — emit new events + continuation
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs`
+- Modify: `apps/api/src/Api/Routing/AiEndpoints.cs`
+
+- [ ] **Step 1: Register InlineCitationMatcherService in handler constructor**
+
+Add `InlineCitationMatcherService` as a constructor parameter and field in `StreamQaQueryHandler`.
+
+- [ ] **Step 2: Add responseStyle to max tokens selection**
+
+In `AskStreamInternalAsync`, before the LLM call, determine max tokens based on responseStyle:
+
+```csharp
+var maxTokens = query.ResponseStyle switch
+{
+    "detailed" => 2000,
+    "continuation" => 2000,
+    _ => 800 // concise
+};
+```
+
+- [ ] **Step 3: Append response style instruction to system prompt**
+
+Before the LLM call, after `BuildLlmPromptsAsync`:
+
+```csharp
+var (systemPrompt, userPrompt) = await BuildLlmPromptsAsync(...);
+systemPrompt += PromptTemplateService.GetResponseStyleInstruction(query.ResponseStyle ?? "concise");
+
+// If continuation, prepend partial answer to user prompt for context
+if (!string.IsNullOrEmpty(query.ContinuationContext))
+{
+    userPrompt = $"[Risposta parziale precedente: {query.ContinuationContext}]\n\n{userPrompt}";
+}
+```
+
+- [ ] **Step 4: Emit InlineCitation and ContinuationAvailable after Complete**
+
+After the existing `yield return CreateEvent(StreamingEventType.Complete, ...)`:
+
+```csharp
+// Inline citation matching
+var inlineCitations = _citationMatcher.Match(answerBuilder.ToString(), snippets!);
+if (inlineCitations.Count > 0)
+{
+    yield return CreateEvent(StreamingEventType.InlineCitation,
+        new StreamingInlineCitations(inlineCitations));
+}
+
+// Continuation available if truncated
+if (llmFinishReason == "length")
+{
+    var continuationToken = Convert.ToBase64String(
+        System.Text.Encoding.UTF8.GetBytes(
+            System.Text.Json.JsonSerializer.Serialize(new
+            {
+                gameId = query.GameId,
+                originalQuery = query.Query,
+                partialAnswer = answerBuilder.ToString(),
+                threadId = query.ThreadId
+            })));
+    yield return CreateEvent(StreamingEventType.ContinuationAvailable,
+        new StreamingContinuation(continuationToken, "max_tokens_reached"));
+}
+```
+
+- [ ] **Step 5: Track FinishReason from LLM stream chunks**
+
+In the `await foreach` loop for LLM tokens, capture FinishReason:
+
+```csharp
+string? llmFinishReason = null;
+await foreach (var chunk in _llmService.GenerateCompletionStreamAsync(...))
+{
+    // ... existing token handling ...
+    if (chunk.IsFinal && chunk.FinishReason != null)
+    {
+        llmFinishReason = chunk.FinishReason;
+    }
+}
+```
+
+- [ ] **Step 6: Add ResponseStyle and ContinuationContext to StreamQaQuery**
+
+Add `ResponseStyle` and `ContinuationContext` parameters to the `StreamQaQuery` record.
+
+- [ ] **Step 7: Update AiEndpoints to pass new fields**
+
+In `AiEndpoints.cs`, in `HandleQaStreamAsync`, construct the `StreamQaQuery` with the new fields from `QaRequest`:
+
+```csharp
+// Handle continuation token
+string? continuationContext = null;
+if (!string.IsNullOrEmpty(req.continuationToken))
+{
+    var decoded = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(req.continuationToken));
+    var ctx = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(decoded);
+    continuationContext = ctx.GetProperty("partialAnswer").GetString();
+}
+
+var query = new StreamQaQuery(
+    req.gameId, req.query, req.chatId, req.documentIds,
+    req.responseStyle, continuationContext);
+```
+
+- [ ] **Step 8: Build and verify**
+
+Run: `cd apps/api/src/Api && dotnet build --no-restore`
+Expected: Build succeeded
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
+git add apps/api/src/Api/Routing/AiEndpoints.cs
+git commit -m "feat(kb): emit inline citations and continuation events in QA stream"
+```
+
+---
+
+## Task 6: Frontend — chatClient.ts updates
+
+**Files:**
+- Modify: `apps/web/src/lib/api/clients/chatClient.ts`
+
+- [ ] **Step 1: Update QaStreamRequest**
+
+```typescript
+export interface QaStreamRequest {
+  gameId: string;
+  query: string;
+  chatId?: string;
+  responseStyle?: 'concise' | 'detailed';
+  continuationToken?: string;
+}
+```
+
+- [ ] **Step 2: Add event type constants**
+
+```typescript
+export const QA_EVENT_TYPES = {
+  STATE_UPDATE: 0,
+  CITATIONS: 1,
+  COMPLETE: 4,
+  TOKEN: 7,
+  FOLLOW_UP: 8,
+  ERROR: 9,
+  INLINE_CITATION: 28,
+  CONTINUATION_AVAILABLE: 29,
+} as const;
+```
+
+- [ ] **Step 3: Add InlineCitation types**
+
+```typescript
+export interface InlineCitationMatch {
+  startOffset: number;
+  endOffset: number;
+  snippetIndex: number;
+  pageNumber: number;
+  pdfDocumentId: string;
+  confidence: number;
+}
+
+export interface ContinuationData {
+  continuationToken: string;
+  reason: string;
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/lib/api/clients/chatClient.ts
+git commit -m "feat(chat): update QaStreamRequest with responseStyle and citation types"
+```
+
+---
+
+## Task 7: Frontend — InlineCitationText component
+
+**Files:**
+- Create: `apps/web/src/components/chat-unified/InlineCitationText.tsx`
+- Create: `apps/web/__tests__/components/chat-unified/InlineCitationText.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { InlineCitationText } from '@/components/chat-unified/InlineCitationText';
+import type { InlineCitationMatch } from '@/lib/api/clients/chatClient';
+
+const mockSnippets = [
+  { text: 'Full chunk text from the rulebook about game setup.', source: 'PDF:abc-123', page: 3, line: 0, score: 0.9 },
+];
+
+describe('InlineCitationText', () => {
+  it('renders plain text when no citations', () => {
+    render(<InlineCitationText text="Hello world" citations={[]} snippets={[]} />);
+    expect(screen.getByText('Hello world')).toBeInTheDocument();
+  });
+
+  it('renders highlighted span for citation', () => {
+    const citations: InlineCitationMatch[] = [
+      { startOffset: 0, endOffset: 5, snippetIndex: 0, pageNumber: 3, pdfDocumentId: 'abc-123', confidence: 1.0 },
+    ];
+    render(<InlineCitationText text="Hello world" citations={citations} snippets={mockSnippets} />);
+    const highlight = screen.getByTestId('citation-highlight-0');
+    expect(highlight).toBeInTheDocument();
+    expect(highlight).toHaveTextContent('Hello');
+  });
+
+  it('expands accordion on click', () => {
+    const citations: InlineCitationMatch[] = [
+      { startOffset: 0, endOffset: 5, snippetIndex: 0, pageNumber: 3, pdfDocumentId: 'abc-123', confidence: 1.0 },
+    ];
+    render(<InlineCitationText text="Hello world" citations={citations} snippets={mockSnippets} />);
+    fireEvent.click(screen.getByTestId('citation-highlight-0'));
+    expect(screen.getByTestId('citation-accordion-0')).toBeInTheDocument();
+    expect(screen.getByText(/Full chunk text from the rulebook/)).toBeInTheDocument();
+  });
+
+  it('renders PDF link icon', () => {
+    const citations: InlineCitationMatch[] = [
+      { startOffset: 0, endOffset: 5, snippetIndex: 0, pageNumber: 3, pdfDocumentId: 'abc-123', confidence: 1.0 },
+    ];
+    render(<InlineCitationText text="Hello world" citations={citations} snippets={mockSnippets} />);
+    const pdfLink = screen.getByTestId('pdf-link-0');
+    expect(pdfLink).toHaveAttribute('href', '/api/v1/pdfs/abc-123/download#page=3');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/web && pnpm test -- --run InlineCitationText`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement InlineCitationText**
+
+```tsx
+'use client';
+
+import React, { useState } from 'react';
+import { ExternalLink, ChevronDown, ChevronUp } from 'lucide-react';
+import type { InlineCitationMatch } from '@/lib/api/clients/chatClient';
+import { cn } from '@/lib/utils';
+
+interface SnippetData {
+  text: string;
+  source: string;
+  page: number;
+  line: number;
+  score: number;
+}
+
+interface InlineCitationTextProps {
+  text: string;
+  citations: InlineCitationMatch[];
+  snippets: SnippetData[];
+}
+
+export function InlineCitationText({ text, citations, snippets }: InlineCitationTextProps) {
+  const [expandedCitations, setExpandedCitations] = useState<Set<number>>(new Set());
+
+  if (citations.length === 0) {
+    return <p className="whitespace-pre-wrap break-words">{text}</p>;
+  }
+
+  const sorted = [...citations].sort((a, b) => a.startOffset - b.startOffset);
+  const segments: React.ReactNode[] = [];
+  let lastEnd = 0;
+
+  sorted.forEach((citation, idx) => {
+    // Text before this citation
+    if (citation.startOffset > lastEnd) {
+      segments.push(
+        <span key={`text-${idx}`}>{text.slice(lastEnd, citation.startOffset)}</span>
+      );
+    }
+
+    const citedText = text.slice(citation.startOffset, citation.endOffset);
+    const isExpanded = expandedCitations.has(idx);
+    const snippet = snippets[citation.snippetIndex];
+
+    segments.push(
+      <React.Fragment key={`cite-${idx}`}>
+        <span
+          className={cn(
+            'bg-amber-500/10 border-l-2 border-amber-500 px-1 cursor-pointer',
+            'hover:bg-amber-500/20 transition-colors inline'
+          )}
+          onClick={() => {
+            setExpandedCitations(prev => {
+              const next = new Set(prev);
+              if (next.has(idx)) next.delete(idx);
+              else next.add(idx);
+              return next;
+            });
+          }}
+          title={`Pagina ${citation.pageNumber}`}
+          data-testid={`citation-highlight-${idx}`}
+        >
+          {citedText}
+          <span className="inline-flex items-center ml-1 text-amber-600 dark:text-amber-400">
+            {isExpanded ? (
+              <ChevronUp className="h-3 w-3 inline" />
+            ) : (
+              <ChevronDown className="h-3 w-3 inline" />
+            )}
+          </span>
+        </span>
+        <a
+          href={`/api/v1/pdfs/${citation.pdfDocumentId}/download#page=${citation.pageNumber}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center ml-0.5 text-amber-600 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300"
+          data-testid={`pdf-link-${idx}`}
+          title={`Apri PDF — Pagina ${citation.pageNumber}`}
+        >
+          <ExternalLink className="h-3 w-3" />
+        </a>
+        {isExpanded && snippet && (
+          <div
+            className="block my-2 p-3 rounded-lg bg-amber-500/5 border border-amber-500/20 text-sm"
+            data-testid={`citation-accordion-${idx}`}
+          >
+            <div className="flex items-center gap-2 mb-1 text-xs text-amber-600 dark:text-amber-400 font-semibold font-nunito">
+              <span>Pagina {citation.pageNumber}</span>
+            </div>
+            <p className="text-muted-foreground font-nunito whitespace-pre-wrap">{snippet.text}</p>
+          </div>
+        )}
+      </React.Fragment>
+    );
+
+    lastEnd = citation.endOffset;
+  });
+
+  // Remaining text after last citation
+  if (lastEnd < text.length) {
+    segments.push(<span key="text-end">{text.slice(lastEnd)}</span>);
+  }
+
+  return <div className="whitespace-pre-wrap break-words">{segments}</div>;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd apps/web && pnpm test -- --run InlineCitationText`
+Expected: All 4 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/chat-unified/InlineCitationText.tsx
+git add apps/web/__tests__/components/chat-unified/InlineCitationText.test.tsx
+git commit -m "feat(chat): add InlineCitationText component with TDD tests"
+```
+
+---
+
+## Task 8: Frontend — CitationBlock component
+
+**Files:**
+- Create: `apps/web/src/components/chat-unified/CitationBlock.tsx`
+- Create: `apps/web/__tests__/components/chat-unified/CitationBlock.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { CitationBlock } from '@/components/chat-unified/CitationBlock';
+
+const mockSnippets = [
+  { text: 'Setup instructions for the game.', source: 'PDF:abc-123', page: 3, line: 0, score: 0.9 },
+  { text: 'Scoring rules at end of game.', source: 'PDF:abc-123', page: 5, line: 0, score: 0.8 },
+];
+
+describe('CitationBlock', () => {
+  it('renders citation chips for each snippet', () => {
+    render(<CitationBlock snippets={mockSnippets} excludeIndices={new Set()} />);
+    expect(screen.getByText('Pagina 3')).toBeInTheDocument();
+    expect(screen.getByText('Pagina 5')).toBeInTheDocument();
+  });
+
+  it('excludes snippets already shown inline', () => {
+    render(<CitationBlock snippets={mockSnippets} excludeIndices={new Set([0])} />);
+    expect(screen.queryByText('Pagina 3')).not.toBeInTheDocument();
+    expect(screen.getByText('Pagina 5')).toBeInTheDocument();
+  });
+
+  it('expands accordion on chip click', () => {
+    render(<CitationBlock snippets={mockSnippets} excludeIndices={new Set()} />);
+    fireEvent.click(screen.getByText('Pagina 3'));
+    expect(screen.getByText(/Setup instructions/)).toBeInTheDocument();
+  });
+
+  it('renders nothing when all snippets excluded', () => {
+    const { container } = render(<CitationBlock snippets={mockSnippets} excludeIndices={new Set([0, 1])} />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Implement CitationBlock**
+
+```tsx
+'use client';
+
+import React, { useState } from 'react';
+import { FileText, ExternalLink, ChevronDown, ChevronUp } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface SnippetData {
+  text: string;
+  source: string;
+  page: number;
+  line: number;
+  score: number;
+}
+
+interface CitationBlockProps {
+  snippets: SnippetData[];
+  excludeIndices: Set<number>;
+}
+
+function extractPdfId(source: string): string {
+  return source.startsWith('PDF:') ? source.slice(4) : source;
+}
+
+export function CitationBlock({ snippets, excludeIndices }: CitationBlockProps) {
+  const [expanded, setExpanded] = useState<number | null>(null);
+
+  const visible = snippets
+    .map((s, i) => ({ ...s, originalIndex: i }))
+    .filter(s => !excludeIndices.has(s.originalIndex));
+
+  if (visible.length === 0) return null;
+
+  return (
+    <div className="mt-3 flex flex-wrap gap-2">
+      {visible.map((snippet) => {
+        const pdfId = extractPdfId(snippet.source);
+        const isExpanded = expanded === snippet.originalIndex;
+
+        return (
+          <div key={snippet.originalIndex} className="flex flex-col">
+            <div className="flex items-center gap-1">
+              <button
+                onClick={() => setExpanded(isExpanded ? null : snippet.originalIndex)}
+                className={cn(
+                  'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-nunito font-medium transition-all',
+                  'border border-amber-500/30 hover:border-amber-500/60',
+                  isExpanded
+                    ? 'bg-amber-500/15 text-amber-700 dark:text-amber-300'
+                    : 'bg-amber-500/5 text-amber-600 dark:text-amber-400 hover:bg-amber-500/10'
+                )}
+                data-testid={`citation-chip-${snippet.originalIndex}`}
+              >
+                <FileText className="h-3 w-3" />
+                Pagina {snippet.page}
+                {isExpanded ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+              </button>
+              <a
+                href={`/api/v1/pdfs/${pdfId}/download#page=${snippet.page}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-amber-600 hover:text-amber-700 dark:text-amber-400"
+                title={`Apri PDF — Pagina ${snippet.page}`}
+              >
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </div>
+            {isExpanded && (
+              <div className="mt-1.5 p-3 rounded-lg bg-amber-500/5 border border-amber-500/20 text-sm max-w-md">
+                <p className="text-muted-foreground font-nunito whitespace-pre-wrap">{snippet.text}</p>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd apps/web && pnpm test -- --run CitationBlock`
+Expected: All 4 tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/chat-unified/CitationBlock.tsx
+git add apps/web/__tests__/components/chat-unified/CitationBlock.test.tsx
+git commit -m "feat(chat): add CitationBlock component with TDD tests"
+```
+
+---
+
+## Task 9: Frontend — ContinueButton component
+
+**Files:**
+- Create: `apps/web/src/components/chat-unified/ContinueButton.tsx`
+- Create: `apps/web/__tests__/components/chat-unified/ContinueButton.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ContinueButton } from '@/components/chat-unified/ContinueButton';
+
+describe('ContinueButton', () => {
+  it('renders with correct text', () => {
+    render(<ContinueButton onContinue={() => {}} isLoading={false} />);
+    expect(screen.getByText('Continua la risposta')).toBeInTheDocument();
+  });
+
+  it('calls onContinue when clicked', () => {
+    const onContinue = vi.fn();
+    render(<ContinueButton onContinue={onContinue} isLoading={false} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onContinue).toHaveBeenCalledOnce();
+  });
+
+  it('shows loading state', () => {
+    render(<ContinueButton onContinue={() => {}} isLoading={true} />);
+    expect(screen.getByText('Continuando...')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+});
+```
+
+- [ ] **Step 2: Implement ContinueButton**
+
+```tsx
+'use client';
+
+import { ArrowRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface ContinueButtonProps {
+  onContinue: () => void;
+  isLoading: boolean;
+}
+
+export function ContinueButton({ onContinue, isLoading }: ContinueButtonProps) {
+  return (
+    <button
+      onClick={onContinue}
+      disabled={isLoading}
+      className={cn(
+        'mt-3 inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-nunito font-medium transition-all',
+        isLoading
+          ? 'bg-muted text-muted-foreground cursor-not-allowed'
+          : 'bg-amber-500/10 text-amber-700 dark:text-amber-300 border border-amber-500/30 hover:bg-amber-500/20 hover:border-amber-500/50 cursor-pointer'
+      )}
+      data-testid="continue-button"
+    >
+      {isLoading ? (
+        <>
+          <div className="h-3.5 w-3.5 border-2 border-amber-500/30 border-t-amber-500 rounded-full animate-spin" />
+          Continuando...
+        </>
+      ) : (
+        <>
+          Continua la risposta
+          <ArrowRight className="h-3.5 w-3.5" />
+        </>
+      )}
+    </button>
+  );
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd apps/web && pnpm test -- --run ContinueButton`
+Expected: All 3 tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/chat-unified/ContinueButton.tsx
+git add apps/web/__tests__/components/chat-unified/ContinueButton.test.tsx
+git commit -m "feat(chat): add ContinueButton component with TDD tests"
+```
+
+---
+
+## Task 10: Integrate new components in ChatMobile and ChatThreadView
+
+**Files:**
+- Modify: `apps/web/src/components/chat-unified/ChatMobile.tsx`
+- Modify: `apps/web/src/components/chat-unified/ChatThreadView.tsx`
+
+- [ ] **Step 1: Add imports in ChatMobile**
+
+```typescript
+import { InlineCitationText } from './InlineCitationText';
+import { CitationBlock } from './CitationBlock';
+import { ContinueButton } from './ContinueButton';
+import { QA_EVENT_TYPES, type InlineCitationMatch, type ContinuationData } from '@/lib/api/clients/chatClient';
+```
+
+- [ ] **Step 2: Add citation state to ChatMobile**
+
+Add to LocalMessage interface:
+
+```typescript
+interface LocalMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: string;
+  citations?: CitationItem[];
+  followUpQuestions?: string[];
+  inlineCitations?: InlineCitationMatch[];
+  snippets?: Array<{ text: string; source: string; page: number; line: number; score: number }>;
+  continuationToken?: string;
+}
+```
+
+- [ ] **Step 3: Handle events 28 and 29 in ChatMobile qaStream handler**
+
+In the `for await` loop of the qaStream path, add cases:
+
+```typescript
+case QA_EVENT_TYPES.INLINE_CITATION: {
+  const data = event.data as { citations: InlineCitationMatch[] };
+  if (data.citations) {
+    setMessages(prev =>
+      prev.map(m =>
+        m.id === assistantMsgId ? { ...m, inlineCitations: data.citations } : m
+      )
+    );
+  }
+  break;
+}
+case QA_EVENT_TYPES.CONTINUATION_AVAILABLE: {
+  const data = event.data as ContinuationData;
+  if (data.continuationToken) {
+    setMessages(prev =>
+      prev.map(m =>
+        m.id === assistantMsgId ? { ...m, continuationToken: data.continuationToken } : m
+      )
+    );
+  }
+  break;
+}
+```
+
+Also save snippets from the Citations event (type 1):
+
+```typescript
+case QA_EVENT_TYPES.CITATIONS: {
+  const data = event.data as { snippets?: Array<{ text: string; source: string; page: number; line: number; score: number }> };
+  if (data.snippets) {
+    setMessages(prev =>
+      prev.map(m =>
+        m.id === assistantMsgId ? { ...m, snippets: data.snippets, citations: data.snippets as unknown as CitationItem[] } : m
+      )
+    );
+  }
+  break;
+}
+```
+
+- [ ] **Step 4: Update MessageBubble to use InlineCitationText**
+
+In `ChatMobile.tsx`, update the assistant message rendering in `MessageBubble`:
+
+```tsx
+function MessageBubble({ message, onContinue, isContinuing }: { message: LocalMessage; onContinue?: (token: string) => void; isContinuing?: boolean }) {
+  const isUser = message.role === 'user';
+  const hasInlineCitations = !isUser && message.inlineCitations && message.inlineCitations.length > 0;
+  const inlineSnippetIndices = new Set(message.inlineCitations?.map(c => c.snippetIndex) ?? []);
+
+  return (
+    <div className={cn('flex', isUser ? 'justify-end' : 'justify-start')}>
+      <div className={cn('max-w-[85%] rounded-2xl px-4 py-2.5 text-sm font-nunito', /* existing styles */)}>
+        {hasInlineCitations ? (
+          <InlineCitationText
+            text={message.content}
+            citations={message.inlineCitations!}
+            snippets={message.snippets ?? []}
+          />
+        ) : (
+          <p className="whitespace-pre-wrap break-words">{message.content}</p>
+        )}
+        {/* Citation block for non-inline snippets */}
+        {!isUser && message.snippets && message.snippets.length > 0 && (
+          <CitationBlock snippets={message.snippets} excludeIndices={inlineSnippetIndices} />
+        )}
+        {/* Continue button */}
+        {!isUser && message.continuationToken && onContinue && (
+          <ContinueButton
+            onContinue={() => onContinue(message.continuationToken!)}
+            isLoading={isContinuing ?? false}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Add continuation handler in ChatMobile**
+
+```typescript
+const handleContinue = useCallback(
+  (continuationToken: string) => {
+    void (async () => {
+      setIsSending(true);
+      const abortController = new AbortController();
+      qaAbortRef.current = abortController;
+      try {
+        // Find the message to append to
+        const lastAssistant = messages.findLast(m => m.role === 'assistant');
+        if (!lastAssistant) return;
+        let appendedContent = lastAssistant.content;
+
+        for await (const event of qaStream(
+          { gameId: thread!.gameId!, query: '', continuationToken },
+          abortController.signal
+        )) {
+          if (event.type === QA_EVENT_TYPES.TOKEN) {
+            const token = typeof event.data === 'string' ? event.data : ((event.data as { token?: string })?.token ?? '');
+            if (token) {
+              appendedContent += token;
+              const content = appendedContent;
+              setMessages(prev =>
+                prev.map(m => m.id === lastAssistant.id ? { ...m, content, continuationToken: undefined } : m)
+              );
+            }
+          }
+        }
+      } catch { /* handled */ }
+      finally {
+        setIsSending(false);
+        qaAbortRef.current = null;
+      }
+    })();
+  },
+  [messages, thread?.gameId]
+);
+```
+
+- [ ] **Step 6: Pass responseStyle in qaStream calls**
+
+Update the qaStream call to include `responseStyle: 'concise'`:
+
+```typescript
+for await (const event of qaStream(
+  { gameId: thread.gameId!, query: text, chatId: threadId, responseStyle: 'concise' },
+  abortController.signal
+))
+```
+
+- [ ] **Step 7: Apply same changes to ChatThreadView**
+
+Repeat steps 1-6 for `ChatThreadView.tsx` — same pattern, same components, same event handling.
+
+- [ ] **Step 8: Typecheck**
+
+Run: `cd apps/web && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/web/src/components/chat-unified/ChatMobile.tsx
+git add apps/web/src/components/chat-unified/ChatThreadView.tsx
+git commit -m "feat(chat): integrate inline citations, citation block, and continue button"
+```
+
+---
+
+## Task 11: Final integration test and cleanup
+
+- [ ] **Step 1: Build backend**
+
+Run: `cd apps/api/src/Api && dotnet build --no-restore`
+Expected: Build succeeded
+
+- [ ] **Step 2: Run backend unit tests**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "Category=Unit" --no-restore`
+Expected: All tests pass
+
+- [ ] **Step 3: Run frontend tests**
+
+Run: `cd apps/web && pnpm test -- --run`
+Expected: All tests pass
+
+- [ ] **Step 4: Typecheck frontend**
+
+Run: `cd apps/web && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 5: Final commit if needed**
+
+```bash
+git add -A && git commit -m "chore: final cleanup for inline citations feature"
+```

--- a/docs/superpowers/specs/2026-04-18-chat-inline-citations-design.md
+++ b/docs/superpowers/specs/2026-04-18-chat-inline-citations-design.md
@@ -1,0 +1,194 @@
+# Chat Inline Citations & Concise Responses
+
+**Date**: 2026-04-18
+**Status**: Approved
+**Author**: Claude + Aaron
+
+## Problem
+
+Chat responses are truncated when `max_tokens` budget is exhausted. Users cannot verify answers against the original rulebook. No link to PDF source pages.
+
+## Solution
+
+Three coordinated changes:
+1. **Concise prompt** — instruct LLM to summarize, not rewrite. Response style switchable (`concise`/`detailed`)
+2. **Inline citations** — backend matches LLM response text against RAG snippets, emits positioned citation events
+3. **Continuation** — if response truncates, emit continuation token so user can request the rest
+
+## SSE Event Flow (revised)
+
+```
+StateUpdate("Searching knowledge base...")
+  → Citations (snippets with page, pdfId, text)
+  → StateUpdate("Generating answer...")
+  → Token* (streaming concise response)
+  → Complete (final answer, usage, confidence, finishReason)
+  → InlineCitation (array of positioned matches)
+  → ContinuationAvailable (if truncated, with continuation token)
+```
+
+### New Event Types
+
+Added to `StreamingEventType` enum:
+
+- `InlineCitation = 28` — positioned snippet matches within the response text
+- `ContinuationAvailable = 29` — response was truncated, continuation available
+
+### InlineCitation Payload
+
+```json
+{
+  "citations": [
+    {
+      "startOffset": 42,
+      "endOffset": 128,
+      "snippetIndex": 0,
+      "pageNumber": 3,
+      "pdfDocumentId": "uuid",
+      "confidence": 0.9
+    }
+  ]
+}
+```
+
+### ContinuationAvailable Payload
+
+```json
+{
+  "continuationToken": "base64-encoded-context",
+  "reason": "max_tokens_reached"
+}
+```
+
+The `continuationToken` encodes: gameId, original query, partial response (for context), snippet offsets already used.
+
+## Prompt System
+
+### responseStyle parameter
+
+`QaStreamRequest` gains optional `responseStyle: "concise" | "detailed"` (default `concise`).
+
+**concise** system prompt addition:
+> "Rispondi in modo sintetico e strutturato (max 200 parole). Concentrati sul rispondere alla domanda, non riscrivere il regolamento. Usa elenchi puntati. Non citare le pagine nel testo — le citazioni vengono gestite automaticamente dal sistema."
+
+**detailed** system prompt addition:
+> "Rispondi in modo completo e approfondito. Spiega ogni aspetto rilevante con esempi dal regolamento. Usa sottosezioni se necessario."
+
+### Max tokens per style
+
+- `concise`: 800 tokens (~200 words)
+- `detailed`: 2000 tokens (with continuation fallback)
+
+### Continuation mechanism
+
+1. After Complete, backend checks `finish_reason` from LLM
+2. If `length` (not `stop`), emits `ContinuationAvailable` with encoded context
+3. Frontend shows "Continua la risposta →" button
+4. Click calls `qaStream` with `continuationToken` in body
+5. Backend reconstructs context, adds prompt: "Continua la risposta precedente da dove ti eri fermato. Non ripetere ciò che hai già detto."
+6. New streamed response appends to same assistant message
+
+## Inline Citation Matching
+
+### Service: `InlineCitationMatcherService`
+
+Location: `KnowledgeBase.Domain.Services`
+
+**Algorithm**:
+1. Receives final LLM response + RAG snippets list
+2. For each snippet, extracts significant phrases (>8 words, excluding stop words)
+3. For each phrase, searches response text with three strategies:
+   - **Exact substring** (case-insensitive) → confidence 1.0
+   - **Fuzzy match** (Levenshtein ≤ 15% of length) → confidence 0.8
+   - **N-gram overlap** (3-gram, >60% match) → confidence 0.6
+4. For each match: `{ startOffset, endOffset, snippetIndex, confidence }`
+5. Overlapping matches: keep highest confidence
+6. Minimum threshold: confidence ≥ 0.6
+
+**Performance**: Operates on final string (200-800 words) × 5 snippets. Expected: <50ms. No external calls.
+
+**Fallback**: If no snippet reaches inline threshold, all citations appear only in the block below the response.
+
+### Integration in StreamQaQueryHandler
+
+```csharp
+yield Complete(...)
+var inlineCitations = _citationMatcher.Match(finalAnswer, snippets);
+if (inlineCitations.Any())
+    yield InlineCitation(inlineCitations)
+if (finishReason == "length")
+    yield ContinuationAvailable(...)
+```
+
+## Frontend Components
+
+### InlineCitationText
+
+Renders response text with highlighted spans at citation positions.
+
+Each highlighted span:
+- Background `amber-500/10`, left border `amber-500`
+- Hover tooltip: `"Pagina 3 — carcassonne_rulebook.pdf"`
+- **Click on span** → expands accordion below with full RAG chunk text
+- **`↗` icon** right of span → opens PDF in browser at page (`/api/v1/pdfs/{id}/download#page=N`)
+
+### CitationBlock
+
+For snippets without inline match (fallback). Chip row below the response:
+
+```
+📄 Pagina 3  📄 Pagina 5  📄 Pagina 12
+```
+
+Each chip:
+- Click → expands accordion with chunk text
+- `↗` icon → opens PDF at page
+
+### ContinueButton
+
+Shown when `ContinuationAvailable` event received:
+
+```
+[Continua la risposta →]
+```
+
+Click calls `qaStream` with `continuationToken`. New response appends to same assistant message.
+
+### Shared components
+
+`InlineCitationText`, `CitationBlock`, `ContinueButton` live in `components/chat-unified/` and are used by both `ChatMobile` and `ChatThreadView`.
+
+## Backend Changes
+
+| File | Change |
+|------|--------|
+| `Models/Contracts.cs` | Add `InlineCitation = 28`, `ContinuationAvailable = 29` to enum + `StreamingInlineCitation`, `StreamingContinuation` records |
+| `StreamQaQueryHandler.cs` | After Complete: call matcher, emit new events, handle `continuationToken` input |
+| `HybridLlmService.cs` | Expose `finish_reason` in final `LlmStreamChunk` |
+| `AiEndpoints.cs` | Accept `responseStyle` and `continuationToken` in `QaRequest`, pass to prompt |
+| `PromptTemplateService.cs` | Add template variants for `concise`/`detailed`/`continuation` |
+| New: `InlineCitationMatcherService.cs` | Text-snippet matching logic |
+
+## Frontend Changes
+
+| File | Change |
+|------|--------|
+| `chatClient.ts` | Add `responseStyle`, `continuationToken` to `QaStreamRequest`, new event types 28/29 |
+| New: `InlineCitationText.tsx` | Text with highlighted citation spans + accordion |
+| New: `CitationBlock.tsx` | Chip citations below response |
+| New: `ContinueButton.tsx` | "Continue response" button |
+| `ChatMobile.tsx` | Integrate new components, handle events 28/29, pass `responseStyle` |
+| `ChatThreadView.tsx` | Same for desktop |
+| `ChatMessageList.tsx` | Use `InlineCitationText` for assistant messages |
+
+## No DB Changes
+
+All required data (page number, pdfDocumentId, chunk text) is already available in RAG snippets. No schema migration needed.
+
+## Testing Strategy
+
+- **Unit**: `InlineCitationMatcherService` — exact match, fuzzy match, n-gram, overlap resolution, empty input
+- **Unit**: Prompt template variants — concise/detailed/continuation
+- **Integration**: Full SSE flow emitting all new event types
+- **Frontend**: `InlineCitationText` renders highlights at correct positions, accordion expand/collapse, PDF link generation
+- **E2E**: Send message → verify citations appear → click accordion → click PDF link

--- a/infra/compose.dev.yml
+++ b/infra/compose.dev.yml
@@ -54,6 +54,7 @@ services:
       EMBEDDING_PROVIDER: external
       Embedding__Provider: External
       EMBEDDING_MODEL: intfloat/multilingual-e5-base
+      Embedding__Model: intfloat/multilingual-e5-base
       EMBEDDING_DIMENSIONS: 768
       Embedding__Dimensions: 768
       LOCAL_EMBEDDING_URL: http://embedding-service:8000

--- a/infra/compose.integration.yml
+++ b/infra/compose.integration.yml
@@ -54,6 +54,7 @@ services:
       EMBEDDING_PROVIDER: external
       Embedding__Provider: External
       EMBEDDING_MODEL: intfloat/multilingual-e5-base
+      Embedding__Model: intfloat/multilingual-e5-base
       EMBEDDING_DIMENSIONS: 768
       Embedding__Dimensions: 768
       LOCAL_EMBEDDING_URL: https://meepleai.app/services/embedding

--- a/infra/compose.prod.yml
+++ b/infra/compose.prod.yml
@@ -80,6 +80,7 @@ services:
       Embedding__LocalServiceUrl: http://embedding-service:8000
       RERANKER_URL: http://reranker-service:8003
       EMBEDDING_MODEL: intfloat/multilingual-e5-base
+      Embedding__Model: intfloat/multilingual-e5-base
       Embedding__Dimensions: 768
       Authentication__OAuth__CallbackBaseUrl: "https://${PROD_DOMAIN}"
       Frontend__BaseUrl: "https://${PROD_DOMAIN}"

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -63,6 +63,7 @@ services:
       Embedding__LocalServiceUrl: http://embedding-service:8000
       RERANKER_URL: http://reranker-service:8003
       EMBEDDING_MODEL: intfloat/multilingual-e5-base
+      Embedding__Model: intfloat/multilingual-e5-base
       Embedding__Dimensions: 768
       Authentication__OAuth__CallbackBaseUrl: "https://meepleai.app"
       Frontend__BaseUrl: "https://meepleai.app"


### PR DESCRIPTION
## Summary
- **Inline citations**: backend matches LLM response against RAG snippets, frontend highlights matched text with expandable accordion + PDF page link
- **CitationBlock**: fallback chip-based citations below response for non-inline matches
- **Concise/detailed mode**: `responseStyle` parameter controls prompt length (concise ~200 words, detailed ~unlimited)
- **Continuation**: if LLM truncates (finish_reason=length), "Continua la risposta" button resumes streaming
- **InlineCitationMatcherService**: exact/fuzzy/n-gram text matching with overlap resolution

## Test plan
- [x] Backend builds with 0 errors
- [x] 12 InlineCitationMatcherService unit tests pass
- [x] 11 frontend component tests pass (InlineCitationText, CitationBlock, ContinueButton)
- [x] TypeScript typecheck passes
- [ ] Manual: send chat message, verify inline citations appear
- [ ] Manual: click citation → accordion expands with chunk text
- [ ] Manual: click PDF icon → PDF opens at correct page

🤖 Generated with [Claude Code](https://claude.com/claude-code)