### PR TITLE
fix(tests): align exception assertions with DDD domain exceptions (#2568)

### DIFF
--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/EnableAlertRuleCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/EnableAlertRuleCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.Administration.Application.Commands.AlertRules;
 using Api.BoundedContexts.Administration.Domain.Aggregates.AlertRules;
 using Api.BoundedContexts.Administration.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.Tests.Constants;
 using FluentAssertions;
 using Moq;
@@ -98,7 +99,7 @@ public class EnableAlertRuleCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WhenAlertRuleNotFound_ThrowsInvalidOperationException()
+    public async Task Handle_WhenAlertRuleNotFound_ThrowsNotFoundException()
     {
         // Arrange
         var ruleId = Guid.NewGuid();
@@ -110,7 +111,7 @@ public class EnableAlertRuleCommandHandlerTests
         // Act & Assert
         var act = () =>
             _handler.Handle(command, CancellationToken.None);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<NotFoundException>()).Which;
 
         exception.Message.Should().Contain(ruleId.ToString());
         exception.Message.Should().Contain("not found");

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/GetAlertConfigurationQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/GetAlertConfigurationQueryHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.Administration.Application.Commands.AlertConfiguration
 using Api.BoundedContexts.Administration.Application.Queries.AlertConfiguration;
 using Api.BoundedContexts.Administration.Domain.Aggregates.AlertConfigurations;
 using Api.BoundedContexts.Administration.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.Tests.Constants;
 using FluentAssertions;
 using Moq;
@@ -91,7 +92,7 @@ public class GetAlertConfigurationQueryHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithEmptyCategory_ThrowsInvalidOperationException()
+    public async Task Handle_WithEmptyCategory_ThrowsNotFoundException()
     {
         // Arrange
         var query = new GetAlertConfigurationQuery("PagerDuty");
@@ -102,9 +103,8 @@ public class GetAlertConfigurationQueryHandlerTests
         // Act & Assert
         var act = () =>
             _handler.Handle(query, CancellationToken.None);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<NotFoundException>()).Which;
 
-        exception.Message.Should().Contain("No configuration found");
         exception.Message.Should().Contain("PagerDuty");
 
         _mockRepository.Verify(r => r.GetByCategoryAsync(ConfigCategory.PagerDuty, It.IsAny<CancellationToken>()), Times.Once);

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/PromptHandlers/CreatePromptTemplateCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/PromptHandlers/CreatePromptTemplateCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.Administration.Application.Commands;
 using Api.BoundedContexts.Administration.Application.Queries;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Services;
 using Api.SharedKernel.Domain.Interfaces;
 using Api.Tests.Constants;
@@ -86,7 +87,7 @@ public class CreatePromptTemplateCommandHandlerTests : IDisposable
     }
 
     [Fact]
-    public async Task Handle_WithDuplicateName_ShouldThrowInvalidOperationException()
+    public async Task Handle_WithDuplicateName_ShouldThrowConflictException()
     {
         // Arrange
         var userId = Guid.NewGuid();
@@ -125,7 +126,7 @@ public class CreatePromptTemplateCommandHandlerTests : IDisposable
         // Act & Assert
         var act = () =>
             _handler.Handle(command, CancellationToken.None);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<ConflictException>()).Which;
 
         exception.Message.Should().Contain("already exists");
 
@@ -135,7 +136,7 @@ public class CreatePromptTemplateCommandHandlerTests : IDisposable
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentUser_ShouldThrowInvalidOperationException()
+    public async Task Handle_WithNonExistentUser_ShouldThrowNotFoundException()
     {
         // Arrange
         var userId = Guid.NewGuid();
@@ -152,7 +153,7 @@ public class CreatePromptTemplateCommandHandlerTests : IDisposable
         // Act & Assert
         var act = () =>
             _handler.Handle(command, CancellationToken.None);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<NotFoundException>()).Which;
 
         exception.Message.Should().Contain("not found");
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/PromptHandlers/CreatePromptVersionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/PromptHandlers/CreatePromptVersionCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.Administration.Application.Commands;
 using Api.BoundedContexts.Administration.Application.Queries;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Services;
 using Api.SharedKernel.Domain.Interfaces;
 using Api.Tests.Constants;
@@ -165,7 +166,7 @@ public class CreatePromptVersionCommandHandlerTests : IDisposable
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentTemplate_ShouldThrowInvalidOperationException()
+    public async Task Handle_WithNonExistentTemplate_ShouldThrowNotFoundException()
     {
         // Arrange
         var templateId = Guid.NewGuid();
@@ -181,7 +182,7 @@ public class CreatePromptVersionCommandHandlerTests : IDisposable
         // Act & Assert
         var act = () =>
             _handler.Handle(command, CancellationToken.None);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<NotFoundException>()).Which;
 
         exception.Message.Should().Contain("not found");
 
@@ -191,7 +192,7 @@ public class CreatePromptVersionCommandHandlerTests : IDisposable
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentUser_ShouldThrowInvalidOperationException()
+    public async Task Handle_WithNonExistentUser_ShouldThrowNotFoundException()
     {
         // Arrange
         var templateId = Guid.NewGuid();
@@ -232,7 +233,7 @@ public class CreatePromptVersionCommandHandlerTests : IDisposable
         // Act & Assert
         var act = () =>
             _handler.Handle(command, CancellationToken.None);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<NotFoundException>()).Which;
 
         exception.Message.Should().Contain("not found");
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/UpdateAlertRuleCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/UpdateAlertRuleCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.Administration.Application.Commands.AlertRules;
 using Api.BoundedContexts.Administration.Domain.Aggregates.AlertRules;
 using Api.BoundedContexts.Administration.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.Tests.Constants;
 using FluentAssertions;
 using Moq;
@@ -72,7 +73,7 @@ public class UpdateAlertRuleCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WhenAlertRuleNotFound_ThrowsInvalidOperationException()
+    public async Task Handle_WhenAlertRuleNotFound_ThrowsNotFoundException()
     {
         // Arrange
         var ruleId = Guid.NewGuid();
@@ -93,7 +94,7 @@ public class UpdateAlertRuleCommandHandlerTests
         // Act & Assert
         var act = () =>
             _handler.Handle(command, CancellationToken.None);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<NotFoundException>()).Which;
 
         exception.Message.Should().Contain(ruleId.ToString());
         exception.Message.Should().Contain("not found");

--- a/apps/api/tests/Api.Tests/BoundedContexts/AgentMemory/Application/Handlers/AddHouseRuleCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/AgentMemory/Application/Handlers/AddHouseRuleCommandHandlerTests.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.AgentMemory.Application.Queries;
 using Api.BoundedContexts.AgentMemory.Domain.Entities;
 using Api.BoundedContexts.AgentMemory.Domain.Enums;
 using Api.BoundedContexts.AgentMemory.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.Services;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
@@ -104,7 +105,7 @@ public class AddHouseRuleCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_FeatureDisabled_ThrowsInvalidOperationException()
+    public async Task Handle_FeatureDisabled_ThrowsConflictException()
     {
         // Arrange
         _featureFlagsMock
@@ -115,6 +116,6 @@ public class AddHouseRuleCommandHandlerTests
 
         // Act & Assert
         var act = () => _handler.Handle(command, CancellationToken.None);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<ConflictException>();
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/AgentMemory/Application/Handlers/AddMemoryNoteCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/AgentMemory/Application/Handlers/AddMemoryNoteCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.AgentMemory.Application.Commands;
 using Api.BoundedContexts.AgentMemory.Domain.Entities;
 using Api.BoundedContexts.AgentMemory.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.Services;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
@@ -94,7 +95,7 @@ public class AddMemoryNoteCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_FeatureDisabled_ThrowsInvalidOperationException()
+    public async Task Handle_FeatureDisabled_ThrowsConflictException()
     {
         // Arrange
         _featureFlagsMock
@@ -104,7 +105,7 @@ public class AddMemoryNoteCommandHandlerTests
         var command = new AddMemoryNoteCommand(Guid.NewGuid(), Guid.NewGuid(), "Some note");
 
         // Act & Assert
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<ConflictException>(
             () => _handler.Handle(command, CancellationToken.None));
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/AgentMemory/Application/Handlers/ClaimGuestPlayerCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/AgentMemory/Application/Handlers/ClaimGuestPlayerCommandHandlerTests.cs
@@ -102,7 +102,7 @@ public class ClaimGuestPlayerCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_FeatureDisabled_ThrowsInvalidOperationException()
+    public async Task Handle_FeatureDisabled_ThrowsConflictException()
     {
         // Arrange
         _featureFlagsMock
@@ -113,6 +113,6 @@ public class ClaimGuestPlayerCommandHandlerTests
 
         // Act & Assert
         var act3 = () => _handler.Handle(command, CancellationToken.None);
-        await act3.Should().ThrowAsync<InvalidOperationException>();
+        await act3.Should().ThrowAsync<ConflictException>();
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/AgentMemory/Application/Handlers/CreateGroupMemoryCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/AgentMemory/Application/Handlers/CreateGroupMemoryCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.AgentMemory.Application.Commands;
 using Api.BoundedContexts.AgentMemory.Application.Queries;
 using Api.BoundedContexts.AgentMemory.Domain.Entities;
 using Api.BoundedContexts.AgentMemory.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.Services;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
@@ -146,7 +147,7 @@ public class CreateGroupMemoryCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_FeatureDisabled_ThrowsInvalidOperationException()
+    public async Task Handle_FeatureDisabled_ThrowsConflictException()
     {
         // Arrange
         _featureFlagsMock
@@ -157,6 +158,6 @@ public class CreateGroupMemoryCommandHandlerTests
 
         // Act & Assert
         var act = () => _handler.Handle(command, CancellationToken.None);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<ConflictException>();
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/AgentMemory/Application/Handlers/UpdateGroupPreferencesCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/AgentMemory/Application/Handlers/UpdateGroupPreferencesCommandHandlerTests.cs
@@ -77,7 +77,7 @@ public class UpdateGroupPreferencesCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_FeatureDisabled_ThrowsInvalidOperationException()
+    public async Task Handle_FeatureDisabled_ThrowsConflictException()
     {
         // Arrange
         _featureFlagsMock
@@ -87,7 +87,7 @@ public class UpdateGroupPreferencesCommandHandlerTests
         var command = new UpdateGroupPreferencesCommand(Guid.NewGuid(), null, null, null);
 
         // Act & Assert
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<ConflictException>(
             () => _handler.Handle(command, CancellationToken.None));
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Validators/UploadPrivatePdfCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Validators/UploadPrivatePdfCommandValidatorTests.cs
@@ -137,18 +137,18 @@ public class UploadPrivatePdfCommandValidatorTests
     [Fact]
     public void Validate_WithOversizedFile_FailsValidation()
     {
-        // Arrange - 51 MB file (exceeds 50 MB limit)
+        // Arrange - 101 MB file (exceeds 100 MB limit)
         var command = new UploadPrivatePdfCommand(
             Guid.NewGuid(),
             Guid.NewGuid(),
-            CreateMockPdfFormFile("oversized.pdf", 53_428_800)); // ~51 MB
+            CreateMockPdfFormFile("oversized.pdf", 105_906_176)); // ~101 MB
 
         // Act
         var result = _validator.TestValidate(command);
 
         // Assert
         result.ShouldHaveValidationErrorFor(x => x.PdfFile.Length)
-            .WithErrorMessage("PDF file size cannot exceed 50 MB.");
+            .WithErrorMessage("PDF file size cannot exceed 100 MB.");
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/AbandonGameSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/AbandonGameSessionCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.GameManagement.Application.Commands;
 using Api.BoundedContexts.GameManagement.Application.Queries;
 using Api.BoundedContexts.GameManagement.Domain.Entities;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.BoundedContexts.GameManagement.TestHelpers;
 using Moq;
@@ -225,7 +226,7 @@ public class AbandonGameSessionCommandHandlerTests
         result.Players.Count.Should().Be(4);
     }
     [Fact]
-    public async Task Handle_NonExistentSession_ThrowsInvalidOperationException()
+    public async Task Handle_NonExistentSession_ThrowsNotFoundException()
     {
         // Arrange
         var sessionId = Guid.NewGuid();
@@ -241,9 +242,9 @@ public class AbandonGameSessionCommandHandlerTests
         // Act & Assert
         var act =
             () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<NotFoundException>()).Which;
 
-        exception.Message.Should().ContainEquivalentOf($"Session with ID {sessionId} not found");
+        exception.Message.Should().ContainEquivalentOf(sessionId.ToString());
 
         // Verify save was NOT called
         _unitOfWorkMock.Verify(

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/ResumeGameSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/ResumeGameSessionCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.GameManagement.Application.Commands;
 using Api.BoundedContexts.GameManagement.Application.Queries;
 using Api.BoundedContexts.GameManagement.Domain.Entities;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.BoundedContexts.GameManagement.TestHelpers;
 using Moq;
@@ -178,7 +179,7 @@ public class ResumeGameSessionCommandHandlerTests
         result.Status.Should().Be("InProgress");
     }
     [Fact]
-    public async Task Handle_NonExistentSession_ThrowsInvalidOperationException()
+    public async Task Handle_NonExistentSession_ThrowsNotFoundException()
     {
         // Arrange
         var sessionId = Guid.NewGuid();
@@ -192,9 +193,9 @@ public class ResumeGameSessionCommandHandlerTests
         // Act & Assert
         var act =
             () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<NotFoundException>()).Which;
 
-        exception.Message.Should().ContainEquivalentOf($"Session with ID {sessionId} not found");
+        exception.Message.Should().ContainEquivalentOf(sessionId.ToString());
 
         // Verify save was NOT called
         _unitOfWorkMock.Verify(

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/StartGameSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/StartGameSessionCommandHandlerTests.cs
@@ -6,6 +6,7 @@ using Api.BoundedContexts.GameManagement.Domain.Entities;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
 using Api.BoundedContexts.GameManagement.Domain.Services;
 using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Moq;
 using Xunit;
@@ -293,7 +294,7 @@ public class StartGameSessionCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_NonExistentGame_ThrowsInvalidOperationException()
+    public async Task Handle_NonExistentGame_ThrowsNotFoundException()
     {
         // Arrange
         var gameId = Guid.NewGuid();
@@ -312,9 +313,9 @@ public class StartGameSessionCommandHandlerTests
         // Act & Assert
         var act =
             () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<NotFoundException>()).Which;
 
-        exception.Message.Should().ContainEquivalentOf($"Game with ID {gameId} not found");
+        exception.Message.Should().ContainEquivalentOf(gameId.ToString());
 
         // Verify session was NOT created
         _sessionRepositoryMock.Verify(

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/GetLedgerHistoryQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/GetLedgerHistoryQueryHandlerTests.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.GameManagement.Domain.Entities;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Application.Commands;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.Middleware.Exceptions;
 using Api.Tests.Constants;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
@@ -44,7 +45,7 @@ public class GetLedgerHistoryQueryHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentSession_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentSession_ThrowsNotFoundException()
     {
         // Arrange
         var sessionId = Guid.NewGuid();
@@ -55,7 +56,7 @@ public class GetLedgerHistoryQueryHandlerTests
 
         // Act & Assert
         Func<Task> act = async () => await _handler.Handle(query, TestCancellationToken);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<NotFoundException>()).Which;
 
         exception.Message.Should().Contain(sessionId.ToString());
     }


### PR DESCRIPTION
## Summary

Backend unit tests (`17` failures on PR #480 CI) still asserted
`InvalidOperationException` after handlers were refactored per Issue
#2568 to throw `NotFoundException` (HTTP 404) / `ConflictException`
(HTTP 409) from `Api.Middleware.Exceptions`. This PR re-aligns the
assertions across **15 test classes** in 5 bounded contexts.

## Changes

- **NotFoundException** assertions for missing entities (games,
  sessions, alert rules, groups, ledger history, prompt templates,
  email configs)
- **ConflictException** assertions for feature-disabled paths and
  duplicate-name conflicts
- **InvalidOperationException preserved** for legitimate domain
  invariant violations (already-claimed guest, session state machine
  transitions) — these correctly map to 500
- **`Validate_WithOversizedFile_FailsValidation`**: threshold updated
  `50 MB → 100 MB` to match the current
  `UploadPrivatePdfCommandValidator.MaxFileSizeBytes`

## Bounded contexts touched

`Administration`, `AgentMemory`, `DocumentProcessing`,
`GameManagement`, `KnowledgeBase`

## Test plan

- [x] `dotnet test` on all 15 modified classes → **107/107 green**
- [x] All 17 originally failing tests now pass
- [x] No handler code changed — tests-only PR
- [ ] CI green on push

Refs #2568