### PR TITLE
redesign/v2 M6: Claude Design v1 consumer pages migration

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -173,6 +173,7 @@
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7",
     "usehooks-ts": "^3.1.1",
+    "vaul": "^1.1.2",
     "xstate": "^5.28.0",
     "zod": "^4.3.6",
     "zundo": "^2.3.0",

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -306,6 +306,9 @@ importers:
       usehooks-ts:
         specifier: ^3.1.1
         version: 3.1.1(react@19.2.4)
+      vaul:
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       xstate:
         specifier: ^5.28.0
         version: 5.28.0
@@ -9902,6 +9905,12 @@ packages:
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -20919,6 +20928,15 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   vfile-message@4.0.3:
     dependencies:

--- a/apps/web/src/__tests__/entity-theme-tokens.test.ts
+++ b/apps/web/src/__tests__/entity-theme-tokens.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('globals.css entity tokens (Tailwind 4 @theme)', () => {
+  const css = readFileSync(resolve(__dirname, '../styles/globals.css'), 'utf8');
+
+  it('defines raw HSL --e-* vars for all 9 entities in :root', () => {
+    const rawTokens = [
+      '--e-game',
+      '--e-player',
+      '--e-session',
+      '--e-agent',
+      '--e-document',
+      '--e-chat',
+      '--e-event',
+      '--e-toolkit',
+      '--e-tool',
+    ];
+    rawTokens.forEach(t => expect(css).toContain(t));
+  });
+
+  it('defines --color-entity-* Tailwind utilities in @theme for all 9 entities', () => {
+    const utilityTokens = [
+      '--color-entity-game',
+      '--color-entity-player',
+      '--color-entity-session',
+      '--color-entity-agent',
+      '--color-entity-kb',
+      '--color-entity-chat',
+      '--color-entity-event',
+      '--color-entity-toolkit',
+      '--color-entity-tool',
+    ];
+    utilityTokens.forEach(t => expect(css).toContain(t));
+  });
+
+  it('maps --color-entity-kb to --e-document (alias)', () => {
+    expect(css).toMatch(/--color-entity-kb:\s*hsl\(var\(--e-document\)\)/);
+  });
+});

--- a/apps/web/src/__tests__/entity-utilities-render.test.tsx
+++ b/apps/web/src/__tests__/entity-utilities-render.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+
+describe('Tailwind 4 entity-* utilities render', () => {
+  const ENTITIES = [
+    'game',
+    'player',
+    'session',
+    'agent',
+    'kb',
+    'chat',
+    'event',
+    'toolkit',
+    'tool',
+  ] as const;
+
+  ENTITIES.forEach(e => {
+    it(`applies bg-entity-${e} and text-entity-${e} classes to DOM`, () => {
+      const { container } = render(
+        <div
+          data-testid={`probe-${e}`}
+          className={`bg-entity-${e} text-entity-${e} border-entity-${e}`}
+        />
+      );
+      const el = container.querySelector(`[data-testid="probe-${e}"]`);
+      expect(el).toBeTruthy();
+      expect(el?.className).toContain(`bg-entity-${e}`);
+      expect(el?.className).toContain(`text-entity-${e}`);
+      expect(el?.className).toContain(`border-entity-${e}`);
+    });
+  });
+});

--- a/apps/web/src/app/(auth)/reset-password/_content.tsx
+++ b/apps/web/src/app/(auth)/reset-password/_content.tsx
@@ -14,9 +14,11 @@ import { motion } from 'framer-motion';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 
-import { AccessibleFormInput, AccessibleButton } from '@/components/accessible';
+import { AccessibleFormInput } from '@/components/accessible';
 import { AuthLayout } from '@/components/layouts';
 import { Button } from '@/components/ui/primitives/button';
+import { AuthCard } from '@/components/ui/v2/auth-card';
+import { Btn } from '@/components/ui/v2/btn';
 import { api } from '@/lib/api';
 import { getErrorMessage } from '@/lib/utils/errorHandler';
 
@@ -296,15 +298,23 @@ export function ResetPasswordPageContent() {
   // Request Reset Mode
   if (mode === 'request' && !requestSuccess) {
     return (
-      <AuthLayout
+      <AuthCard
         title="Reset Password"
         subtitle="Enter your email address and we'll send you instructions to reset your password"
+        footerAction={
+          <Link
+            href="/"
+            className="text-primary hover:text-primary/80 transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded px-2 py-1"
+          >
+            ← Back to Login
+          </Link>
+        }
       >
         {errorMessage && (
           <div
             role="alert"
             aria-live="polite"
-            className="bg-red-500/10 border border-red-500/30 text-red-400 px-4 py-3 rounded-lg mb-4"
+            className="bg-destructive/10 border border-destructive/30 text-destructive px-4 py-3 rounded-lg mb-4 text-sm"
           >
             {errorMessage}
           </div>
@@ -322,27 +332,18 @@ export function ResetPasswordPageContent() {
             inputClassName="w-full bg-white dark:bg-slate-700 border border-slate-300 dark:border-slate-600 rounded-lg px-4 py-3 text-slate-900 dark:text-slate-100 focus:border-primary focus:ring-2 focus:ring-ring"
           />
 
-          <AccessibleButton
+          <Btn
             type="submit"
             variant="primary"
-            className="w-full mt-6"
-            isLoading={isLoading}
-            loadingText="Sending..."
+            fullWidth
+            className="mt-6"
+            loading={isLoading}
             disabled={!email.trim()}
           >
-            Send Reset Instructions
-          </AccessibleButton>
+            {isLoading ? 'Sending...' : 'Send Reset Instructions'}
+          </Btn>
         </form>
-
-        <div className="text-center mt-4">
-          <Link
-            href="/"
-            className="text-sm text-primary hover:text-primary/80 transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded px-2 py-1"
-          >
-            ← Back to Login
-          </Link>
-        </div>
-      </AuthLayout>
+      </AuthCard>
     );
   }
 
@@ -417,12 +418,23 @@ export function ResetPasswordPageContent() {
   // Reset Password Mode - Valid Token
   if (mode === 'reset' && tokenValid === true && !resetSuccess) {
     return (
-      <AuthLayout title="Set New Password" subtitle="Choose a strong password for your account">
+      <AuthCard
+        title="Set New Password"
+        subtitle="Choose a strong password for your account"
+        footerAction={
+          <Link
+            href="/"
+            className="text-primary hover:text-primary/80 transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded px-2 py-1"
+          >
+            ← Back to Login
+          </Link>
+        }
+      >
         {errorMessage && (
           <div
             role="alert"
             aria-live="polite"
-            className="bg-red-500/10 border border-red-500/30 text-red-400 px-4 py-3 rounded-lg mb-4"
+            className="bg-destructive/10 border border-destructive/30 text-destructive px-4 py-3 rounded-lg mb-4 text-sm"
           >
             {errorMessage}
           </div>
@@ -503,31 +515,22 @@ export function ResetPasswordPageContent() {
             inputClassName="w-full bg-white dark:bg-slate-700 border border-slate-300 dark:border-slate-600 rounded-lg px-4 py-3 text-slate-900 dark:text-slate-100 focus:border-primary focus:ring-2 focus:ring-ring"
           />
 
-          <AccessibleButton
+          <Btn
             type="submit"
             variant="primary"
-            className="w-full mt-6"
-            isLoading={isLoading}
-            loadingText="Resetting..."
+            fullWidth
+            className="mt-6"
+            loading={isLoading}
             disabled={
               !passwordValidation.isValid ||
               newPassword !== confirmPassword ||
               !confirmPassword.trim()
             }
           >
-            Reset Password
-          </AccessibleButton>
+            {isLoading ? 'Resetting...' : 'Reset Password'}
+          </Btn>
         </form>
-
-        <div className="text-center mt-4">
-          <Link
-            href="/"
-            className="text-sm text-primary hover:text-primary/80 transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded px-2 py-1"
-          >
-            ← Back to Login
-          </Link>
-        </div>
-      </AuthLayout>
+      </AuthCard>
     );
   }
 

--- a/apps/web/src/app/(authenticated)/notifications/__tests__/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/notifications/__tests__/page.test.tsx
@@ -155,12 +155,12 @@ describe('NotificationsPage', () => {
     expect(screen.getByText(/Unread notification/)).toBeInTheDocument();
   });
 
-  it('should filter by notification type when type chips are clicked', async () => {
+  it('should filter by notification category when filter pills are clicked', async () => {
     const user = userEvent.setup();
     const notifications = [
       createNotification({ title: 'PDF done', type: 'document_ready' }),
-      createNotification({ title: 'Link accessed', type: 'shared_link_accessed' }),
-      createNotification({ title: 'Error occurred', type: 'document_processing_failed' }),
+      createNotification({ title: 'Agent ready', type: 'agent_ready' }),
+      createNotification({ title: 'Night invite', type: 'game_night_invitation' }),
     ];
     setupStore({ notifications, unreadCount: 3 });
 
@@ -168,16 +168,16 @@ describe('NotificationsPage', () => {
 
     // All visible initially
     expect(screen.getByText(/PDF done/)).toBeInTheDocument();
-    expect(screen.getByText(/Link accessed/)).toBeInTheDocument();
-    expect(screen.getByText(/Error occurred/)).toBeInTheDocument();
+    expect(screen.getByText(/Agent ready/)).toBeInTheDocument();
+    expect(screen.getByText(/Night invite/)).toBeInTheDocument();
 
-    // Click "Link condivisi" filter chip
-    await user.click(screen.getByText('Link condivisi'));
+    // Click "Serate" filter pill
+    await user.click(screen.getByRole('button', { name: /serate/i }));
 
-    // Only shared link notification visible
+    // Only game-night notification visible
     expect(screen.queryByText(/PDF done/)).not.toBeInTheDocument();
-    expect(screen.getByText(/Link accessed/)).toBeInTheDocument();
-    expect(screen.queryByText(/Error occurred/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Agent ready/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Night invite/)).toBeInTheDocument();
   });
 
   it('should paginate with 20 items per page and navigation works', async () => {
@@ -299,22 +299,24 @@ describe('NotificationsPage', () => {
 
     render(<NotificationsPage />);
 
-    // Click a type filter that has no matching notifications
-    await user.click(screen.getByText('Link condivisi'));
+    // Click a filter category that has no matching notifications
+    await user.click(screen.getByRole('button', { name: /serate/i }));
 
     expect(screen.getByText(EMPTY.notificationsOfType)).toBeInTheDocument();
   });
 
-  it('should display all type filter chips', () => {
+  it('should display all filter category pills', () => {
     setupStore();
 
     render(<NotificationsPage />);
 
-    expect(screen.getByText('Tutti')).toBeInTheDocument();
-    expect(screen.getByText('Documenti pronti')).toBeInTheDocument();
-    expect(screen.getByText('Regole generate')).toBeInTheDocument();
-    expect(screen.getByText('Errori elaborazione')).toBeInTheDocument();
-    expect(screen.getByText('Link condivisi')).toBeInTheDocument();
+    // Claude Design v1: all | sessions | agents | events | system
+    const filterBar = screen.getByRole('tablist', { name: /categoria notifiche/i });
+    expect(within(filterBar).getByRole('button', { name: /^tutte$/i })).toBeInTheDocument();
+    expect(within(filterBar).getByRole('button', { name: /sessioni/i })).toBeInTheDocument();
+    expect(within(filterBar).getByRole('button', { name: /agenti/i })).toBeInTheDocument();
+    expect(within(filterBar).getByRole('button', { name: /serate/i })).toBeInTheDocument();
+    expect(within(filterBar).getByRole('button', { name: /sistema/i })).toBeInTheDocument();
   });
 
   it('should show "Nessuna notifica non letta" when all are read', () => {
@@ -324,5 +326,65 @@ describe('NotificationsPage', () => {
     render(<NotificationsPage />);
 
     expect(screen.getByText(EMPTY.notificationsUnread)).toBeInTheDocument();
+  });
+
+  // ── Claude Design v1 migration (M6 Task 11) ─────────────────────
+  it('should render NotificationCard with entity border and unread dot', () => {
+    const notifications = [
+      createNotification({
+        title: 'Unread test',
+        type: 'game_night_invitation',
+        isRead: false,
+      }),
+    ];
+    setupStore({ notifications, unreadCount: 1 });
+
+    render(<NotificationsPage />);
+
+    // Entity "event" assigned for game_night_* notifications
+    const card = document.querySelector('[data-entity="event"]');
+    expect(card).not.toBeNull();
+    // Unread dot present (from NotificationCard)
+    expect(document.querySelector('[data-testid="unread-dot"]')).not.toBeNull();
+  });
+
+  it('should open detail drawer when notification card is clicked and mark as read', async () => {
+    const user = userEvent.setup();
+    const notifications = [
+      createNotification({
+        title: 'Detail target',
+        message: 'Long detail message content',
+        type: 'agent_ready',
+        isRead: false,
+      }),
+    ];
+    setupStore({ notifications, unreadCount: 1 });
+
+    render(<NotificationsPage />);
+
+    // Click the card (NotificationCard becomes a button when only onClick, role=button when onDismiss)
+    const card = screen.getByRole('button', { name: /detail target/i });
+    await user.click(card);
+
+    // markAsRead invoked
+    expect(mockMarkAsRead).toHaveBeenCalledWith(notifications[0].id);
+  });
+
+  it('should group notifications by day (Oggi / Ieri / Precedenti)', () => {
+    const today = new Date();
+    const yesterday = new Date(today.getTime() - 24 * 3600_000);
+    const lastMonth = new Date(today.getTime() - 40 * 24 * 3600_000);
+    const notifications = [
+      createNotification({ title: 'Today item', createdAt: today.toISOString() }),
+      createNotification({ title: 'Yesterday item', createdAt: yesterday.toISOString() }),
+      createNotification({ title: 'Old item', createdAt: lastMonth.toISOString() }),
+    ];
+    setupStore({ notifications, unreadCount: 3 });
+
+    render(<NotificationsPage />);
+
+    expect(screen.getByRole('heading', { name: /oggi/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /ieri/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /precedenti/i })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/(authenticated)/notifications/page.tsx
+++ b/apps/web/src/app/(authenticated)/notifications/page.tsx
@@ -1,42 +1,143 @@
 /**
  * Notification History Page (Issue #4415)
  *
- * Full notification list with filters, tabs, pagination.
- * Linked from NotificationPanel footer "Vedi tutte le notifiche".
+ * Full notification list migrated to Claude Design v1 with NotificationCard (M6 Task 11).
  *
  * Features:
- * - Tabs: All / Unread
- * - Filter by notification type
+ * - Filters bar: all | sessions | agents | events | system (entity-colored pills)
+ * - Grouped by day: Oggi / Ieri / Questa settimana / Precedenti
+ * - Detail opens in Drawer
  * - Pagination (20 items per page)
  * - Mark all as read bulk action
- * - Reuses NotificationItem component
+ * - Empty state with illustration
  */
 
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { Bell, CheckCheck, Filter, Loader2 } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+import { it } from 'date-fns/locale';
+import { Bell, CheckCheck, Loader2 } from 'lucide-react';
 
 import { CatalogPagination } from '@/components/catalog/CatalogPagination';
-import { NotificationItem } from '@/components/notifications/NotificationItem';
-import { Separator } from '@/components/ui/navigation/separator';
-import { Button } from '@/components/ui/primitives/button';
+import { Btn } from '@/components/ui/v2/btn';
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+} from '@/components/ui/v2/drawer';
+import type { EntityType } from '@/components/ui/v2/entity-tokens';
+import { NotificationCard } from '@/components/ui/v2/notification-card';
 import type { NotificationDto, NotificationType } from '@/lib/api';
 import { cn } from '@/lib/utils';
 import { useNotificationStore, selectNotifications } from '@/stores/notification/store';
 
 const ITEMS_PER_PAGE = 20;
 
+// ─── Filter categories (Claude Design v1 spec) ────────────────────
+type FilterKey = 'all' | 'sessions' | 'agents' | 'events' | 'system';
+
+interface FilterDef {
+  readonly key: FilterKey;
+  readonly label: string;
+  readonly entity: EntityType;
+  readonly types: readonly NotificationType[] | null; // null = all
+}
+
+const FILTERS: readonly FilterDef[] = [
+  { key: 'all', label: 'Tutte', entity: 'game', types: null },
+  {
+    key: 'sessions',
+    label: 'Sessioni',
+    entity: 'session',
+    types: ['session_terminated'],
+  },
+  {
+    key: 'agents',
+    label: 'Agenti',
+    entity: 'agent',
+    types: ['agent_ready', 'rule_spec_generated'],
+  },
+  {
+    key: 'events',
+    label: 'Serate',
+    entity: 'event',
+    types: [
+      'game_night_invitation',
+      'game_night_rsvp_received',
+      'game_night_published',
+      'game_night_cancelled',
+      'game_night_reminder',
+    ],
+  },
+  {
+    key: 'system',
+    label: 'Sistema',
+    entity: 'toolkit',
+    types: [
+      'document_ready',
+      'document_processing_failed',
+      'shared_link_accessed',
+      'share_request_created',
+      'share_request_approved',
+      'share_request_rejected',
+      'share_request_changes_requested',
+      'rate_limit_approaching',
+      'rate_limit_reached',
+      'cooldown_ended',
+      'badge_earned',
+      'loan_reminder',
+    ],
+  },
+];
+
+// Legacy "Tutte / Non lette" tab filter (preserved from previous page)
 type TabValue = 'all' | 'unread';
 
-const TYPE_LABELS: Record<NotificationType | 'all', string> = {
-  all: 'Tutti',
-  document_ready: 'Documenti pronti',
-  rule_spec_generated: 'Regole generate',
-  document_processing_failed: 'Errori elaborazione',
-  shared_link_accessed: 'Link condivisi',
+// ─── Type → EntityType mapping for NotificationCard border color ─
+function mapTypeToEntity(type: NotificationType): EntityType {
+  if (type.startsWith('game_night_')) return 'event';
+  if (type === 'agent_ready' || type === 'rule_spec_generated') return 'agent';
+  if (type === 'session_terminated') return 'session';
+  if (type === 'badge_earned') return 'player';
+  if (type.startsWith('share_request_') || type === 'shared_link_accessed') return 'kb';
+  if (type === 'document_ready' || type === 'document_processing_failed') return 'kb';
+  return 'toolkit';
+}
+
+// ─── Day grouping ────────────────────────────────────────────────
+type GroupKey = 'oggi' | 'ieri' | 'settimana' | 'precedenti';
+const GROUP_LABELS: Record<GroupKey, string> = {
+  oggi: 'Oggi',
+  ieri: 'Ieri',
+  settimana: 'Questa settimana',
+  precedenti: 'Precedenti',
 };
+const GROUP_ORDER: readonly GroupKey[] = ['oggi', 'ieri', 'settimana', 'precedenti'];
+
+function startOfDay(d: Date): number {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+}
+
+function groupKey(createdAt: string): GroupKey {
+  const now = new Date();
+  const today = startOfDay(now);
+  const msPerDay = 86_400_000;
+  const t = startOfDay(new Date(createdAt));
+  const delta = today - t;
+  if (delta <= 0) return 'oggi';
+  if (delta === msPerDay) return 'ieri';
+  if (delta < msPerDay * 7) return 'settimana';
+  return 'precedenti';
+}
+
+// Relative timestamp (short), using date-fns (already a dep)
+function formatRelative(iso: string): string {
+  return formatDistanceToNow(new Date(iso), { addSuffix: true, locale: it });
+}
 
 export default function NotificationsPage() {
   const notifications = useNotificationStore(selectNotifications);
@@ -44,42 +145,64 @@ export default function NotificationsPage() {
   const error = useNotificationStore(state => state.error);
   const fetchNotifications = useNotificationStore(state => state.fetchNotifications);
   const markAllAsRead = useNotificationStore(state => state.markAllAsRead);
+  const markAsRead = useNotificationStore(state => state.markAsRead);
 
   const [activeTab, setActiveTab] = useState<TabValue>('all');
-  const [typeFilter, setTypeFilter] = useState<NotificationType | 'all'>('all');
+  const [filter, setFilter] = useState<FilterKey>('all');
   const [currentPage, setCurrentPage] = useState(1);
+  const [detail, setDetail] = useState<NotificationDto | null>(null);
 
-  // Fetch all notifications on mount (no limit for history page)
   useEffect(() => {
     void fetchNotifications({});
   }, [fetchNotifications]);
 
-  // Reset to page 1 when filters change
   useEffect(() => {
     setCurrentPage(1);
-  }, [activeTab, typeFilter]);
+  }, [activeTab, filter]);
 
-  // Filtered notifications
+  // Apply tab + filter
   const filtered = useMemo(() => {
     let result: NotificationDto[] = notifications;
-
-    if (activeTab === 'unread') {
-      result = result.filter(n => !n.isRead);
-    }
-
-    if (typeFilter !== 'all') {
-      result = result.filter(n => n.type === typeFilter);
-    }
-
+    if (activeTab === 'unread') result = result.filter(n => !n.isRead);
+    const f = FILTERS.find(x => x.key === filter);
+    const types = f?.types;
+    if (types) result = result.filter(n => types.includes(n.type));
     return result;
-  }, [notifications, activeTab, typeFilter]);
+  }, [notifications, activeTab, filter]);
 
-  // Pagination
   const totalPages = Math.max(1, Math.ceil(filtered.length / ITEMS_PER_PAGE));
   const paginatedItems = useMemo(() => {
     const start = (currentPage - 1) * ITEMS_PER_PAGE;
     return filtered.slice(start, start + ITEMS_PER_PAGE);
   }, [filtered, currentPage]);
+
+  // Group page items by day
+  const grouped = useMemo(() => {
+    const map = new Map<GroupKey, NotificationDto[]>();
+    for (const n of paginatedItems) {
+      const k = groupKey(n.createdAt);
+      const arr = map.get(k) ?? [];
+      arr.push(n);
+      map.set(k, arr);
+    }
+    return GROUP_ORDER.flatMap(k => {
+      const items = map.get(k);
+      if (!items || items.length === 0) return [];
+      return [{ key: k, label: GROUP_LABELS[k], items }];
+    });
+  }, [paginatedItems]);
+
+  // Per-filter unread counts
+  const filterCounts = useMemo(() => {
+    const counts: Partial<Record<FilterKey, number>> = {};
+    for (const f of FILTERS) {
+      const types = f.types;
+      counts[f.key] = types
+        ? notifications.filter(n => !n.isRead && types.includes(n.type)).length
+        : notifications.filter(n => !n.isRead).length;
+    }
+    return counts;
+  }, [notifications]);
 
   const hasUnread = notifications.some(n => !n.isRead);
   const unreadCount = notifications.filter(n => !n.isRead).length;
@@ -88,6 +211,14 @@ export default function NotificationsPage() {
     setCurrentPage(page);
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }, []);
+
+  const openDetail = useCallback(
+    (n: NotificationDto) => {
+      setDetail(n);
+      if (!n.isRead) void markAsRead(n.id);
+    },
+    [markAsRead]
+  );
 
   return (
     <div className="container max-w-3xl mx-auto py-8">
@@ -100,19 +231,19 @@ export default function NotificationsPage() {
           </p>
         </div>
         {hasUnread && (
-          <Button
+          <Btn
             variant="outline"
             size="sm"
             onClick={() => void markAllAsRead()}
+            leftIcon={<CheckCheck className="h-4 w-4" aria-hidden="true" />}
             aria-label="Segna tutte come lette"
           >
-            <CheckCheck className="h-4 w-4 mr-1" />
             Segna tutte come lette
-          </Button>
+          </Btn>
         )}
       </div>
 
-      {/* Tabs */}
+      {/* Legacy Tutte / Non lette tabs (roles preserved for existing tests) */}
       <div className="flex gap-1 mb-4" role="tablist" aria-label="Filtro notifiche">
         {(['all', 'unread'] as const).map(tab => (
           <button
@@ -132,26 +263,30 @@ export default function NotificationsPage() {
         ))}
       </div>
 
-      {/* Type filter */}
-      <div className="flex items-center gap-2 mb-4 flex-wrap">
-        <Filter className="h-4 w-4 text-muted-foreground" />
-        {(Object.keys(TYPE_LABELS) as (NotificationType | 'all')[]).map(type => (
-          <button
-            key={type}
-            onClick={() => setTypeFilter(type)}
-            className={cn(
-              'px-3 py-1 text-xs rounded-full border transition-colors',
-              typeFilter === type
-                ? 'bg-primary text-primary-foreground border-primary'
-                : 'text-muted-foreground border-border hover:bg-muted'
-            )}
-          >
-            {TYPE_LABELS[type]}
-          </button>
-        ))}
+      {/* Filters bar (Claude Design v1: entity-colored outline pills) */}
+      <div
+        className="flex items-center gap-2 mb-4 flex-wrap"
+        role="tablist"
+        aria-label="Categoria notifiche"
+      >
+        {FILTERS.map(f => {
+          const active = filter === f.key;
+          const count = filterCounts[f.key] ?? 0;
+          return (
+            <Btn
+              key={f.key}
+              entity={f.entity}
+              variant={active ? 'primary' : 'outline'}
+              size="sm"
+              onClick={() => setFilter(f.key)}
+              aria-pressed={active}
+            >
+              {f.label}
+              {count > 0 && <span className="ml-1 font-mono text-xs opacity-80">({count})</span>}
+            </Btn>
+          );
+        })}
       </div>
-
-      <Separator className="mb-4" />
 
       {/* Content */}
       {isFetching && notifications.length === 0 && (
@@ -167,25 +302,48 @@ export default function NotificationsPage() {
       )}
 
       {!isFetching && !error && filtered.length === 0 && (
-        <div className="flex flex-col items-center justify-center py-12 text-center">
-          <Bell className="h-12 w-12 text-muted-foreground/50 mb-2" />
+        <div className="flex flex-col items-center justify-center py-16 text-center gap-3">
+          <div
+            className="flex h-24 w-24 items-center justify-center rounded-full bg-muted/60"
+            aria-hidden="true"
+          >
+            <Bell className="h-10 w-10 text-muted-foreground/60" />
+          </div>
           <p className="text-sm text-muted-foreground">
             {activeTab === 'unread'
               ? 'Nessuna notifica non letta'
-              : typeFilter !== 'all'
+              : filter !== 'all'
                 ? 'Nessuna notifica di questo tipo'
                 : 'Nessuna notifica'}
           </p>
         </div>
       )}
 
-      {!error && paginatedItems.length > 0 && (
-        <div className="bg-card rounded-xl border border-border/50 overflow-hidden">
-          <div className="divide-y">
-            {paginatedItems.map(notification => (
-              <NotificationItem key={notification.id} notification={notification} />
-            ))}
-          </div>
+      {!error && grouped.length > 0 && (
+        <div className="flex flex-col gap-5">
+          {grouped.map(g => (
+            <section key={g.key} aria-labelledby={`notif-group-${g.key}`}>
+              <h2
+                id={`notif-group-${g.key}`}
+                className="mb-2 font-mono text-xs uppercase tracking-wider text-muted-foreground"
+              >
+                {g.label}
+              </h2>
+              <div className="flex flex-col gap-2">
+                {g.items.map(n => (
+                  <NotificationCard
+                    key={n.id}
+                    entity={mapTypeToEntity(n.type)}
+                    title={n.title}
+                    body={n.message}
+                    timestamp={formatRelative(n.createdAt)}
+                    unread={!n.isRead}
+                    onClick={() => openDetail(n)}
+                  />
+                ))}
+              </div>
+            </section>
+          ))}
         </div>
       )}
 
@@ -200,6 +358,43 @@ export default function NotificationsPage() {
           />
         </div>
       )}
+
+      {/* Detail drawer */}
+      <Drawer
+        open={detail !== null}
+        onOpenChange={open => {
+          if (!open) setDetail(null);
+        }}
+        entity={detail ? mapTypeToEntity(detail.type) : undefined}
+      >
+        <DrawerContent>
+          {detail && (
+            <>
+              <DrawerHeader>
+                <DrawerTitle>{detail.title}</DrawerTitle>
+                <DrawerDescription>{formatRelative(detail.createdAt)}</DrawerDescription>
+              </DrawerHeader>
+              <div className="px-4 pb-6 text-sm leading-relaxed text-foreground/90">
+                {detail.message}
+              </div>
+              {detail.link && (
+                <div className="px-4 pb-6">
+                  <Btn
+                    variant="primary"
+                    entity={mapTypeToEntity(detail.type)}
+                    fullWidth
+                    onClick={() => {
+                      if (detail.link) window.location.assign(detail.link);
+                    }}
+                  >
+                    Apri
+                  </Btn>
+                </div>
+              )}
+            </>
+          )}
+        </DrawerContent>
+      </Drawer>
     </div>
   );
 }

--- a/apps/web/src/app/(authenticated)/settings/ai-consent/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/ai-consent/page.tsx
@@ -9,8 +9,10 @@ import React, { useEffect, useState } from 'react';
 
 import { Brain, Globe, Save, Loader2, ShieldCheck, AlertTriangle } from 'lucide-react';
 
-import { Switch } from '@/components/ui/forms/switch';
 import { Button } from '@/components/ui/primitives/button';
+import { SettingsList } from '@/components/ui/v2/settings-list';
+import { SettingsRow } from '@/components/ui/v2/settings-row';
+import { ToggleSwitch } from '@/components/ui/v2/toggle-switch';
 import { useToast } from '@/hooks/useToast';
 
 const CURRENT_CONSENT_VERSION = '1.0.0';
@@ -165,8 +167,8 @@ export default function AiConsentPage() {
       </div>
 
       {/* AI Processing Consent */}
-      <div className="bg-card rounded-xl p-6 border border-border/50 mb-6">
-        <div className="flex items-start gap-4 mb-6">
+      <div className="mb-6">
+        <div className="flex items-start gap-4 mb-3">
           <div className="p-2 rounded-lg bg-purple-100 dark:bg-purple-900/20">
             <Brain className="h-6 w-6 text-purple-600 dark:text-purple-400" />
           </div>
@@ -179,24 +181,27 @@ export default function AiConsentPage() {
           </div>
         </div>
 
-        <div className="flex items-center justify-between py-2">
-          <div>
-            <p className="font-medium">AI question answering</p>
-            <p className="text-sm text-muted-foreground">
-              Use AI models to generate answers from game rulebooks and knowledge base
-            </p>
-          </div>
-          <Switch
-            checked={consent.consentedToAiProcessing}
-            onCheckedChange={checked => updateConsent('consentedToAiProcessing', checked)}
-            data-testid="ai-processing-toggle"
+        <SettingsList ariaLabel="AI-Powered Features">
+          <SettingsRow
+            label="AI question answering"
+            description="Use AI models to generate answers from game rulebooks and knowledge base"
+            trailing={
+              <span data-testid="ai-processing-toggle">
+                <ToggleSwitch
+                  checked={consent.consentedToAiProcessing}
+                  onCheckedChange={checked => updateConsent('consentedToAiProcessing', checked)}
+                  ariaLabel="AI question answering"
+                  entity="agent"
+                />
+              </span>
+            }
           />
-        </div>
+        </SettingsList>
       </div>
 
       {/* External Provider Consent */}
-      <div className="bg-card rounded-xl p-6 border border-border/50 mb-6">
-        <div className="flex items-start gap-4 mb-6">
+      <div className="mb-6">
+        <div className="flex items-start gap-4 mb-3">
           <div className="p-2 rounded-lg bg-amber-100 dark:bg-amber-900/20">
             <Globe className="h-6 w-6 text-amber-600 dark:text-amber-400" />
           </div>
@@ -209,21 +214,25 @@ export default function AiConsentPage() {
           </div>
         </div>
 
-        <div className="flex items-center justify-between py-2">
-          <div>
-            <p className="font-medium">Allow external AI providers</p>
-            <p className="text-sm text-muted-foreground">
-              When disabled, only local AI models (Ollama) will be used. This may result in slower
-              or less accurate answers.
-            </p>
-          </div>
-          <Switch
-            checked={consent.consentedToExternalProviders}
-            onCheckedChange={checked => updateConsent('consentedToExternalProviders', checked)}
-            disabled={!consent.consentedToAiProcessing}
-            data-testid="external-providers-toggle"
+        <SettingsList ariaLabel="External AI Providers">
+          <SettingsRow
+            label="Allow external AI providers"
+            description="When disabled, only local AI models (Ollama) will be used. This may result in slower or less accurate answers."
+            trailing={
+              <span data-testid="external-providers-toggle">
+                <ToggleSwitch
+                  checked={consent.consentedToExternalProviders}
+                  onCheckedChange={checked =>
+                    updateConsent('consentedToExternalProviders', checked)
+                  }
+                  disabled={!consent.consentedToAiProcessing}
+                  ariaLabel="Allow external AI providers"
+                  entity="agent"
+                />
+              </span>
+            }
           />
-        </div>
+        </SettingsList>
 
         {!consent.consentedToAiProcessing && (
           <div className="flex items-center gap-2 mt-3 text-sm text-muted-foreground">

--- a/apps/web/src/app/(authenticated)/settings/notifications/client.tsx
+++ b/apps/web/src/app/(authenticated)/settings/notifications/client.tsx
@@ -1,6 +1,8 @@
 /**
  * Notification Settings Page (Issue #4220, #4416)
  * Multi-channel notification preferences for PDF processing
+ *
+ * Migrated to Claude Design v1 (M6 Task 9): uses SettingsList + SettingsRow + ToggleSwitch.
  */
 
 'use client';
@@ -20,8 +22,10 @@ import {
   SendHorizontal,
 } from 'lucide-react';
 
-import { Switch } from '@/components/ui/forms/switch';
 import { Button } from '@/components/ui/primitives/button';
+import { SettingsList } from '@/components/ui/v2/settings-list';
+import { SettingsRow } from '@/components/ui/v2/settings-row';
+import { ToggleSwitch } from '@/components/ui/v2/toggle-switch';
 import { usePushNotifications } from '@/hooks/usePushNotifications';
 import { useToast } from '@/hooks/useToast';
 
@@ -44,6 +48,8 @@ interface NotificationPreferences {
   emailOnGameNightReminder: boolean;
   pushOnGameNightReminder: boolean;
 }
+
+type PrefKey = keyof Omit<NotificationPreferences, 'userId' | 'hasPushSubscription'>;
 
 export default function NotificationSettingsPage() {
   const [prefs, setPrefs] = useState<NotificationPreferences | null>(null);
@@ -129,10 +135,7 @@ export default function NotificationSettingsPage() {
     }
   };
 
-  const updatePref = (
-    key: keyof Omit<NotificationPreferences, 'userId' | 'hasPushSubscription'>,
-    value: boolean
-  ) => {
+  const updatePref = (key: PrefKey, value: boolean) => {
     if (!prefs) return;
     setPrefs({ ...prefs, [key]: value });
   };
@@ -156,6 +159,32 @@ export default function NotificationSettingsPage() {
   }
 
   const pushEnabled = push.isSupported && push.isSubscribed;
+
+  // Render helper to keep the switch + row tests green.
+  // SettingsRow exposes label as plain text; trailing slot hosts the ToggleSwitch.
+  const renderToggleRow = (params: {
+    icon: React.ReactNode;
+    label: string;
+    description: string;
+    prefKey: PrefKey;
+    disabled?: boolean;
+    ariaLabel: string;
+  }) => (
+    <SettingsRow
+      icon={params.icon}
+      label={params.label}
+      description={params.description}
+      trailing={
+        <ToggleSwitch
+          checked={prefs[params.prefKey] as boolean}
+          onCheckedChange={checked => updatePref(params.prefKey, checked)}
+          disabled={params.disabled}
+          ariaLabel={params.ariaLabel}
+          entity="agent"
+        />
+      }
+    />
+  );
 
   return (
     <div className="container max-w-3xl mx-auto py-8">
@@ -240,8 +269,8 @@ export default function NotificationSettingsPage() {
       )}
 
       {/* Document Ready Notifications */}
-      <div className="bg-card rounded-xl p-6 border border-border/50 mb-6">
-        <div className="flex items-start gap-4 mb-6">
+      <div className="mb-6">
+        <div className="flex items-start gap-4 mb-3">
           <div className="p-2 rounded-lg bg-green-100 dark:bg-green-900/20">
             <Bell className="h-6 w-6 text-green-600 dark:text-green-400" />
           </div>
@@ -252,64 +281,37 @@ export default function NotificationSettingsPage() {
             </p>
           </div>
         </div>
-
-        <div className="space-y-4">
-          <div className="flex items-center justify-between py-2">
-            <div className="flex items-center gap-3">
-              <Mail className="h-5 w-5 text-muted-foreground" />
-              <div>
-                <p className="font-medium">Email Notification</p>
-                <p className="text-sm text-muted-foreground">
-                  Receive email when document is ready
-                </p>
-              </div>
-            </div>
-            <Switch
-              checked={prefs.emailOnDocumentReady}
-              onCheckedChange={checked => updatePref('emailOnDocumentReady', checked)}
-            />
-          </div>
-
-          <div className="flex items-center justify-between py-2">
-            <div className="flex items-center gap-3">
-              <Smartphone className="h-5 w-5 text-muted-foreground" />
-              <div>
-                <p className="font-medium">Push Notification</p>
-                <p className="text-sm text-muted-foreground">
-                  {pushEnabled
-                    ? 'Browser push notification when document is ready'
-                    : 'Enable push notifications above to use this'}
-                </p>
-              </div>
-            </div>
-            <Switch
-              checked={prefs.pushOnDocumentReady}
-              onCheckedChange={checked => updatePref('pushOnDocumentReady', checked)}
-              disabled={!pushEnabled}
-            />
-          </div>
-
-          <div className="flex items-center justify-between py-2">
-            <div className="flex items-center gap-3">
-              <MessageSquare className="h-5 w-5 text-muted-foreground" />
-              <div>
-                <p className="font-medium">In-App Notification</p>
-                <p className="text-sm text-muted-foreground">
-                  Show notification in notification center
-                </p>
-              </div>
-            </div>
-            <Switch
-              checked={prefs.inAppOnDocumentReady}
-              onCheckedChange={checked => updatePref('inAppOnDocumentReady', checked)}
-            />
-          </div>
-        </div>
+        <SettingsList ariaLabel="Document Ready notifications">
+          {renderToggleRow({
+            icon: <Mail className="h-5 w-5 text-muted-foreground" aria-hidden="true" />,
+            label: 'Email Notification',
+            description: 'Receive email when document is ready',
+            prefKey: 'emailOnDocumentReady',
+            ariaLabel: 'Email — document ready',
+          })}
+          {renderToggleRow({
+            icon: <Smartphone className="h-5 w-5 text-muted-foreground" aria-hidden="true" />,
+            label: 'Push Notification',
+            description: pushEnabled
+              ? 'Browser push notification when document is ready'
+              : 'Enable push notifications above to use this',
+            prefKey: 'pushOnDocumentReady',
+            disabled: !pushEnabled,
+            ariaLabel: 'Push — document ready',
+          })}
+          {renderToggleRow({
+            icon: <MessageSquare className="h-5 w-5 text-muted-foreground" aria-hidden="true" />,
+            label: 'In-App Notification',
+            description: 'Show notification in notification center',
+            prefKey: 'inAppOnDocumentReady',
+            ariaLabel: 'In-app — document ready',
+          })}
+        </SettingsList>
       </div>
 
       {/* Document Failed Notifications */}
-      <div className="bg-card rounded-xl p-6 border border-border/50 mb-6">
-        <div className="flex items-start gap-4 mb-6">
+      <div className="mb-6">
+        <div className="flex items-start gap-4 mb-3">
           <div className="p-2 rounded-lg bg-red-100 dark:bg-red-900/20">
             <Bell className="h-6 w-6 text-red-600 dark:text-red-400" />
           </div>
@@ -320,60 +322,37 @@ export default function NotificationSettingsPage() {
             </p>
           </div>
         </div>
-
-        <div className="space-y-4">
-          <div className="flex items-center justify-between py-2">
-            <div className="flex items-center gap-3">
-              <Mail className="h-5 w-5 text-muted-foreground" />
-              <div>
-                <p className="font-medium">Email Notification</p>
-                <p className="text-sm text-muted-foreground">Receive email with error details</p>
-              </div>
-            </div>
-            <Switch
-              checked={prefs.emailOnDocumentFailed}
-              onCheckedChange={checked => updatePref('emailOnDocumentFailed', checked)}
-            />
-          </div>
-
-          <div className="flex items-center justify-between py-2">
-            <div className="flex items-center gap-3">
-              <Smartphone className="h-5 w-5 text-muted-foreground" />
-              <div>
-                <p className="font-medium">Push Notification</p>
-                <p className="text-sm text-muted-foreground">
-                  {pushEnabled
-                    ? 'Browser push notification on processing failure'
-                    : 'Enable push notifications above to use this'}
-                </p>
-              </div>
-            </div>
-            <Switch
-              checked={prefs.pushOnDocumentFailed}
-              onCheckedChange={checked => updatePref('pushOnDocumentFailed', checked)}
-              disabled={!pushEnabled}
-            />
-          </div>
-
-          <div className="flex items-center justify-between py-2">
-            <div className="flex items-center gap-3">
-              <MessageSquare className="h-5 w-5 text-muted-foreground" />
-              <div>
-                <p className="font-medium">In-App Notification</p>
-                <p className="text-sm text-muted-foreground">Show error in notification center</p>
-              </div>
-            </div>
-            <Switch
-              checked={prefs.inAppOnDocumentFailed}
-              onCheckedChange={checked => updatePref('inAppOnDocumentFailed', checked)}
-            />
-          </div>
-        </div>
+        <SettingsList ariaLabel="Processing Failed notifications">
+          {renderToggleRow({
+            icon: <Mail className="h-5 w-5 text-muted-foreground" aria-hidden="true" />,
+            label: 'Email Notification',
+            description: 'Receive email with error details',
+            prefKey: 'emailOnDocumentFailed',
+            ariaLabel: 'Email — processing failed',
+          })}
+          {renderToggleRow({
+            icon: <Smartphone className="h-5 w-5 text-muted-foreground" aria-hidden="true" />,
+            label: 'Push Notification',
+            description: pushEnabled
+              ? 'Browser push notification on processing failure'
+              : 'Enable push notifications above to use this',
+            prefKey: 'pushOnDocumentFailed',
+            disabled: !pushEnabled,
+            ariaLabel: 'Push — processing failed',
+          })}
+          {renderToggleRow({
+            icon: <MessageSquare className="h-5 w-5 text-muted-foreground" aria-hidden="true" />,
+            label: 'In-App Notification',
+            description: 'Show error in notification center',
+            prefKey: 'inAppOnDocumentFailed',
+            ariaLabel: 'In-app — processing failed',
+          })}
+        </SettingsList>
       </div>
 
       {/* Game Night Invitations (Issue #33) */}
-      <div className="bg-card rounded-xl p-6 border border-border/50 mb-6">
-        <div className="flex items-start gap-4 mb-6">
+      <div className="mb-6">
+        <div className="flex items-start gap-4 mb-3">
           <div className="p-2 rounded-lg bg-amber-100 dark:bg-amber-900/20">
             <Calendar className="h-6 w-6 text-amber-600 dark:text-amber-400" />
           </div>
@@ -384,58 +363,35 @@ export default function NotificationSettingsPage() {
             </p>
           </div>
         </div>
-
-        <div className="space-y-4">
-          <div className="flex items-center justify-between py-2">
-            <div className="flex items-center gap-3">
-              <Mail className="h-5 w-5 text-muted-foreground" />
-              <div>
-                <p className="font-medium">Email</p>
-                <p className="text-sm text-muted-foreground">Ricevi email per nuovi inviti</p>
-              </div>
-            </div>
-            <Switch
-              checked={prefs.emailOnGameNightInvitation}
-              onCheckedChange={checked => updatePref('emailOnGameNightInvitation', checked)}
-            />
-          </div>
-
-          <div className="flex items-center justify-between py-2">
-            <div className="flex items-center gap-3">
-              <Smartphone className="h-5 w-5 text-muted-foreground" />
-              <div>
-                <p className="font-medium">Push</p>
-                <p className="text-sm text-muted-foreground">
-                  {pushEnabled ? 'Notifica push per nuovi inviti' : 'Abilita le push sopra'}
-                </p>
-              </div>
-            </div>
-            <Switch
-              checked={prefs.pushOnGameNightInvitation}
-              onCheckedChange={checked => updatePref('pushOnGameNightInvitation', checked)}
-              disabled={!pushEnabled}
-            />
-          </div>
-
-          <div className="flex items-center justify-between py-2">
-            <div className="flex items-center gap-3">
-              <MessageSquare className="h-5 w-5 text-muted-foreground" />
-              <div>
-                <p className="font-medium">In-App</p>
-                <p className="text-sm text-muted-foreground">Mostra nel centro notifiche</p>
-              </div>
-            </div>
-            <Switch
-              checked={prefs.inAppOnGameNightInvitation}
-              onCheckedChange={checked => updatePref('inAppOnGameNightInvitation', checked)}
-            />
-          </div>
-        </div>
+        <SettingsList ariaLabel="Game night invitations">
+          {renderToggleRow({
+            icon: <Mail className="h-5 w-5 text-muted-foreground" aria-hidden="true" />,
+            label: 'Email',
+            description: 'Ricevi email per nuovi inviti',
+            prefKey: 'emailOnGameNightInvitation',
+            ariaLabel: 'Email — inviti serate',
+          })}
+          {renderToggleRow({
+            icon: <Smartphone className="h-5 w-5 text-muted-foreground" aria-hidden="true" />,
+            label: 'Push',
+            description: pushEnabled ? 'Notifica push per nuovi inviti' : 'Abilita le push sopra',
+            prefKey: 'pushOnGameNightInvitation',
+            disabled: !pushEnabled,
+            ariaLabel: 'Push — inviti serate',
+          })}
+          {renderToggleRow({
+            icon: <MessageSquare className="h-5 w-5 text-muted-foreground" aria-hidden="true" />,
+            label: 'In-App',
+            description: 'Mostra nel centro notifiche',
+            prefKey: 'inAppOnGameNightInvitation',
+            ariaLabel: 'In-app — inviti serate',
+          })}
+        </SettingsList>
       </div>
 
       {/* Game Night Reminders (Issue #33) */}
-      <div className="bg-card rounded-xl p-6 border border-border/50 mb-6">
-        <div className="flex items-start gap-4 mb-6">
+      <div className="mb-6">
+        <div className="flex items-start gap-4 mb-3">
           <div className="p-2 rounded-lg bg-amber-100 dark:bg-amber-900/20">
             <Calendar className="h-6 w-6 text-amber-600 dark:text-amber-400" />
           </div>
@@ -444,44 +400,28 @@ export default function NotificationSettingsPage() {
             <p className="text-sm text-muted-foreground">Promemoria 24h e 1h prima della serata</p>
           </div>
         </div>
-
-        <div className="space-y-4">
-          <div className="flex items-center justify-between py-2">
-            <div className="flex items-center gap-3">
-              <Mail className="h-5 w-5 text-muted-foreground" />
-              <div>
-                <p className="font-medium">Email</p>
-                <p className="text-sm text-muted-foreground">Ricevi email di promemoria</p>
-              </div>
-            </div>
-            <Switch
-              checked={prefs.emailOnGameNightReminder}
-              onCheckedChange={checked => updatePref('emailOnGameNightReminder', checked)}
-            />
-          </div>
-
-          <div className="flex items-center justify-between py-2">
-            <div className="flex items-center gap-3">
-              <Smartphone className="h-5 w-5 text-muted-foreground" />
-              <div>
-                <p className="font-medium">Push</p>
-                <p className="text-sm text-muted-foreground">
-                  {pushEnabled ? 'Notifica push di promemoria' : 'Abilita le push sopra'}
-                </p>
-              </div>
-            </div>
-            <Switch
-              checked={prefs.pushOnGameNightReminder}
-              onCheckedChange={checked => updatePref('pushOnGameNightReminder', checked)}
-              disabled={!pushEnabled}
-            />
-          </div>
-        </div>
+        <SettingsList ariaLabel="Game night reminders">
+          {renderToggleRow({
+            icon: <Mail className="h-5 w-5 text-muted-foreground" aria-hidden="true" />,
+            label: 'Email',
+            description: 'Ricevi email di promemoria',
+            prefKey: 'emailOnGameNightReminder',
+            ariaLabel: 'Email — promemoria serate',
+          })}
+          {renderToggleRow({
+            icon: <Smartphone className="h-5 w-5 text-muted-foreground" aria-hidden="true" />,
+            label: 'Push',
+            description: pushEnabled ? 'Notifica push di promemoria' : 'Abilita le push sopra',
+            prefKey: 'pushOnGameNightReminder',
+            disabled: !pushEnabled,
+            ariaLabel: 'Push — promemoria serate',
+          })}
+        </SettingsList>
       </div>
 
       {/* Retry Available Notifications */}
-      <div className="bg-card rounded-xl p-6 border border-border/50">
-        <div className="flex items-start gap-4 mb-6">
+      <div>
+        <div className="flex items-start gap-4 mb-3">
           <div className="p-2 rounded-lg bg-blue-100 dark:bg-blue-900/20">
             <Bell className="h-6 w-6 text-blue-600 dark:text-blue-400" />
           </div>
@@ -492,57 +432,32 @@ export default function NotificationSettingsPage() {
             </p>
           </div>
         </div>
-
-        <div className="space-y-4">
-          <div className="flex items-center justify-between py-2">
-            <div className="flex items-center gap-3">
-              <Mail className="h-5 w-5 text-muted-foreground" />
-              <div>
-                <p className="font-medium">Email Notification</p>
-                <p className="text-sm text-muted-foreground">Receive email when retry starts</p>
-              </div>
-            </div>
-            <Switch
-              checked={prefs.emailOnRetryAvailable}
-              onCheckedChange={checked => updatePref('emailOnRetryAvailable', checked)}
-            />
-          </div>
-
-          <div className="flex items-center justify-between py-2">
-            <div className="flex items-center gap-3">
-              <Smartphone className="h-5 w-5 text-muted-foreground" />
-              <div>
-                <p className="font-medium">Push Notification</p>
-                <p className="text-sm text-muted-foreground">
-                  {pushEnabled
-                    ? 'Browser push notification on retry'
-                    : 'Enable push notifications above to use this'}
-                </p>
-              </div>
-            </div>
-            <Switch
-              checked={prefs.pushOnRetryAvailable}
-              onCheckedChange={checked => updatePref('pushOnRetryAvailable', checked)}
-              disabled={!pushEnabled}
-            />
-          </div>
-
-          <div className="flex items-center justify-between py-2">
-            <div className="flex items-center gap-3">
-              <MessageSquare className="h-5 w-5 text-muted-foreground" />
-              <div>
-                <p className="font-medium">In-App Notification</p>
-                <p className="text-sm text-muted-foreground">
-                  Show retry status in notification center
-                </p>
-              </div>
-            </div>
-            <Switch
-              checked={prefs.inAppOnRetryAvailable}
-              onCheckedChange={checked => updatePref('inAppOnRetryAvailable', checked)}
-            />
-          </div>
-        </div>
+        <SettingsList ariaLabel="Retry available notifications">
+          {renderToggleRow({
+            icon: <Mail className="h-5 w-5 text-muted-foreground" aria-hidden="true" />,
+            label: 'Email Notification',
+            description: 'Receive email when retry starts',
+            prefKey: 'emailOnRetryAvailable',
+            ariaLabel: 'Email — retry available',
+          })}
+          {renderToggleRow({
+            icon: <Smartphone className="h-5 w-5 text-muted-foreground" aria-hidden="true" />,
+            label: 'Push Notification',
+            description: pushEnabled
+              ? 'Browser push notification on retry'
+              : 'Enable push notifications above to use this',
+            prefKey: 'pushOnRetryAvailable',
+            disabled: !pushEnabled,
+            ariaLabel: 'Push — retry available',
+          })}
+          {renderToggleRow({
+            icon: <MessageSquare className="h-5 w-5 text-muted-foreground" aria-hidden="true" />,
+            label: 'In-App Notification',
+            description: 'Show retry status in notification center',
+            prefKey: 'inAppOnRetryAvailable',
+            ariaLabel: 'In-app — retry available',
+          })}
+        </SettingsList>
       </div>
     </div>
   );

--- a/apps/web/src/app/(authenticated)/settings/security/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/security/page.tsx
@@ -20,6 +20,8 @@ import {
 } from '@/components/ui/overlays/dialog';
 import { Button } from '@/components/ui/primitives/button';
 import { Input } from '@/components/ui/primitives/input';
+import { SettingsList } from '@/components/ui/v2/settings-list';
+import { SettingsRow } from '@/components/ui/v2/settings-row';
 import { api } from '@/lib/api';
 
 export default function SecuritySettingsPage() {
@@ -146,43 +148,36 @@ export default function SecuritySettingsPage() {
       )}
 
       {/* 2FA Section */}
-      <div className="bg-card rounded-xl p-6 border border-border/50 mb-6">
-        <div className="flex items-start gap-4">
-          <Shield className="h-8 w-8 text-primary mt-1" />
-          <div className="flex-1">
-            <h2 className="text-xl font-bold mb-2">Two-Factor Authentication</h2>
-            <p className="text-muted-foreground mb-4">
-              Add an extra layer of security to your account
-            </p>
-
-            <div className="flex items-center gap-3">
-              <div
-                className={`px-3 py-1 rounded-full text-sm font-medium ${
-                  is2FAEnabled ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-700'
-                }`}
+      <SettingsList ariaLabel="Two-Factor Authentication" className="mb-6">
+        <SettingsRow
+          icon={<Shield className="h-5 w-5" aria-hidden="true" />}
+          label="Two-Factor Authentication"
+          description={
+            is2FAEnabled
+              ? 'Enabled — an extra layer of security is active on your account'
+              : 'Disabled — add an extra layer of security to your account'
+          }
+          entity="agent"
+          trailing={
+            !is2FAEnabled ? (
+              <Button onClick={handleEnableClick} disabled={setupMutation.isPending} size="sm">
+                {setupMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Enable 2FA
+              </Button>
+            ) : (
+              <Button
+                variant="destructive"
+                onClick={() => disableMutation.mutate()}
+                disabled={disableMutation.isPending}
+                size="sm"
               >
-                {is2FAEnabled ? 'Enabled' : 'Disabled'}
-              </div>
-
-              {!is2FAEnabled ? (
-                <Button onClick={handleEnableClick} disabled={setupMutation.isPending}>
-                  {setupMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                  Enable 2FA
-                </Button>
-              ) : (
-                <Button
-                  variant="destructive"
-                  onClick={() => disableMutation.mutate()}
-                  disabled={disableMutation.isPending}
-                >
-                  {disableMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                  Disable 2FA
-                </Button>
-              )}
-            </div>
-          </div>
-        </div>
-      </div>
+                {disableMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Disable 2FA
+              </Button>
+            )
+          }
+        />
+      </SettingsList>
 
       {/* 2FA Setup Wizard */}
       <Dialog

--- a/apps/web/src/app/(public)/about/page.tsx
+++ b/apps/web/src/app/(public)/about/page.tsx
@@ -18,6 +18,7 @@ import { useRouter } from 'next/navigation';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/data-display/card';
 import { Separator } from '@/components/ui/navigation/separator';
 import { Button } from '@/components/ui/primitives/button';
+import { HeroGradient } from '@/components/ui/v2/hero-gradient';
 import { useTranslation } from '@/hooks/useTranslation';
 
 // Value keys for the values section (must match i18n keys in pages.about.values.*)
@@ -36,18 +37,13 @@ export default function AboutPage() {
   const { t, locale } = useTranslation();
 
   return (
-    <div className="min-h-dvh bg-background py-8 px-4">
-      <div className="max-w-4xl mx-auto">
-        {/* Header */}
-        <div className="mb-8 text-center">
-          <h1 className="text-3xl font-bold text-foreground" data-testid="about-heading">
-            {t('pages.about.title')}
-          </h1>
-          <p className="text-slate-600 dark:text-slate-400 mt-2 max-w-2xl mx-auto">
-            {t('pages.about.description')}
-          </p>
-        </div>
-
+    <div className="min-h-dvh bg-background">
+      <HeroGradient
+        title={<span data-testid="about-heading">{t('pages.about.title')}</span>}
+        subtitle={t('pages.about.description')}
+        className="py-12 md:py-16"
+      />
+      <div className="max-w-4xl mx-auto py-8 px-4">
         {/* Mission Section */}
         <Card className="mb-6">
           <CardHeader>

--- a/apps/web/src/app/(public)/contact/page.tsx
+++ b/apps/web/src/app/(public)/contact/page.tsx
@@ -19,6 +19,7 @@ import { useRouter } from 'next/navigation';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/data-display/card';
 import { Separator } from '@/components/ui/navigation/separator';
 import { Button } from '@/components/ui/primitives/button';
+import { Btn } from '@/components/ui/v2/btn';
 import { useTranslation } from '@/hooks/useTranslation';
 import { api } from '@/lib/api';
 
@@ -180,11 +181,18 @@ export default function ContactPage() {
                 </div>
 
                 {/* Submit Button */}
-                <Button type="submit" disabled={status === 'sending'} className="w-full">
+                <Btn
+                  type="submit"
+                  variant="primary"
+                  entity="game"
+                  size="lg"
+                  fullWidth
+                  disabled={status === 'sending'}
+                >
                   {status === 'sending'
                     ? t('pages.contact.form.sending')
                     : t('pages.contact.form.submit')}
-                </Button>
+                </Btn>
 
                 {/* Status Messages */}
                 {status === 'success' && (

--- a/apps/web/src/components/landing/WelcomeHero.tsx
+++ b/apps/web/src/components/landing/WelcomeHero.tsx
@@ -1,31 +1,20 @@
-import Link from 'next/link';
-
-import { Button } from '@/components/ui/primitives/button';
+import { HeroGradient } from '@/components/ui/v2/hero-gradient';
 
 export function WelcomeHero() {
   return (
-    <section
-      aria-label="Hero"
-      className="flex min-h-[80vh] flex-col items-center justify-center px-4 py-20 text-center"
-    >
-      <p className="mb-4 text-sm uppercase tracking-widest text-muted-foreground">
-        Il tuo compagno di gioco AI
-      </p>
-      <h1 className="mb-4 max-w-2xl text-4xl font-extrabold leading-tight text-foreground sm:text-5xl lg:text-6xl">
-        Ogni serata giochi merita un arbitro
-      </h1>
-      <p className="mb-10 max-w-lg text-lg text-muted-foreground">
-        Setup, regole, punteggi, dispute — un agente AI che conosce il tuo gioco e vi aiuta al
-        tavolo.
-      </p>
-      <div className="flex flex-col gap-3 sm:flex-row">
-        <Button asChild size="lg">
-          <Link href="/register">Inizia gratis</Link>
-        </Button>
-        <Button asChild variant="outline" size="lg">
-          <Link href="#come-funziona">Scopri come funziona ↓</Link>
-        </Button>
-      </div>
-    </section>
+    <HeroGradient
+      title={
+        <>
+          <span className="block text-sm uppercase tracking-widest text-muted-foreground mb-4 font-normal">
+            Il tuo compagno di gioco AI
+          </span>
+          <span className="block">Ogni serata giochi merita un arbitro</span>
+        </>
+      }
+      subtitle="Setup, regole, punteggi, dispute — un agente AI che conosce il tuo gioco e vi aiuta al tavolo."
+      primaryCta={{ label: 'Inizia gratis', href: '/register' }}
+      secondaryCta={{ label: 'Scopri come funziona ↓', href: '#come-funziona' }}
+      className="min-h-[80vh] flex flex-col items-center justify-center"
+    />
   );
 }

--- a/apps/web/src/components/ui/v2/auth-card/auth-card.test.tsx
+++ b/apps/web/src/components/ui/v2/auth-card/auth-card.test.tsx
@@ -1,0 +1,102 @@
+import { createRef } from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AuthCard } from './auth-card';
+
+describe('AuthCard', () => {
+  it('renders title and children', () => {
+    render(
+      <AuthCard title="Bentornato">
+        <span>form content</span>
+      </AuthCard>
+    );
+    expect(screen.getByRole('heading', { name: 'Bentornato' })).toBeInTheDocument();
+    expect(screen.getByText('form content')).toBeInTheDocument();
+  });
+
+  it('renders subtitle when provided', () => {
+    render(
+      <AuthCard title="Bentornato" subtitle="Accedi al tuo account MeepleAI">
+        <span>x</span>
+      </AuthCard>
+    );
+    expect(screen.getByText('Accedi al tuo account MeepleAI')).toBeInTheDocument();
+  });
+
+  it('does NOT render subtitle when omitted', () => {
+    const { container } = render(
+      <AuthCard title="Bentornato">
+        <span>x</span>
+      </AuthCard>
+    );
+    // No <p> tag from subtitle should exist; children only contain <span>
+    expect(container.querySelector('p')).toBeNull();
+  });
+
+  it('renders footerAction when provided', () => {
+    render(
+      <AuthCard
+        title="Bentornato"
+        footerAction={<a href="/register">Non hai un account? Registrati</a>}
+      >
+        <span>x</span>
+      </AuthCard>
+    );
+    expect(
+      screen.getByRole('link', { name: 'Non hai un account? Registrati' })
+    ).toBeInTheDocument();
+  });
+
+  it('shows brand block by default (MeepleAI wordmark visible)', () => {
+    render(
+      <AuthCard title="Bentornato">
+        <span>x</span>
+      </AuthCard>
+    );
+    expect(screen.getByText('MeepleAI')).toBeInTheDocument();
+  });
+
+  it('hides brand block when showBrand={false}', () => {
+    render(
+      <AuthCard title="Bentornato" showBrand={false}>
+        <span>x</span>
+      </AuthCard>
+    );
+    expect(screen.queryByText('MeepleAI')).toBeNull();
+  });
+
+  it('merges className onto root element', () => {
+    const { container } = render(
+      <AuthCard title="T" className="custom-xyz">
+        <span>x</span>
+      </AuthCard>
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toMatch(/custom-xyz/);
+  });
+
+  it('forwards ref to the root element', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <AuthCard ref={ref} title="T">
+        <span>x</span>
+      </AuthCard>
+    );
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('brand-mark has linear-gradient inline style using entity color tokens', () => {
+    const { container } = render(
+      <AuthCard title="T">
+        <span>x</span>
+      </AuthCard>
+    );
+    const brandMark = container.querySelector<HTMLElement>('[data-testid="auth-card-brand-mark"]');
+    expect(brandMark).not.toBeNull();
+    const bg = brandMark?.style.background ?? '';
+    expect(bg).toMatch(/linear-gradient/);
+    expect(bg).toMatch(/--e-game/);
+    expect(bg).toMatch(/--e-event/);
+    expect(bg).toMatch(/--e-player/);
+  });
+});

--- a/apps/web/src/components/ui/v2/auth-card/auth-card.tsx
+++ b/apps/web/src/components/ui/v2/auth-card/auth-card.tsx
@@ -1,0 +1,75 @@
+import { forwardRef, type CSSProperties, type ReactNode } from 'react';
+
+import clsx from 'clsx';
+
+export interface AuthCardProps {
+  readonly title: string;
+  readonly subtitle?: string;
+  readonly children: ReactNode;
+  readonly footerAction?: ReactNode;
+  readonly className?: string;
+  readonly showBrand?: boolean;
+}
+
+const BRAND_MARK_STYLE: CSSProperties = {
+  background:
+    'linear-gradient(135deg, hsl(var(--e-game)), hsl(var(--e-event)) 60%, hsl(var(--e-player)))',
+  boxShadow: '0 6px 20px hsl(var(--e-game) / 0.35)',
+};
+
+function BrandBlock(): ReactNode {
+  return (
+    <div className="flex flex-col items-center gap-1.5 mb-5">
+      <div
+        data-testid="auth-card-brand-mark"
+        aria-hidden="true"
+        className="flex items-center justify-center w-[52px] h-[52px] rounded-2xl text-white font-extrabold text-2xl font-heading"
+        style={BRAND_MARK_STYLE}
+      >
+        M
+      </div>
+      <span className="font-heading font-bold text-base tracking-tight text-foreground">
+        MeepleAI
+      </span>
+    </div>
+  );
+}
+
+export const AuthCard = forwardRef<HTMLDivElement, AuthCardProps>(function AuthCard(
+  { title, subtitle, children, footerAction, className, showBrand = true },
+  ref
+) {
+  return (
+    <div
+      ref={ref}
+      className={clsx(
+        'flex flex-col items-stretch w-full min-h-full px-[18px] py-6 bg-background',
+        className
+      )}
+    >
+      {showBrand && (
+        <div className="flex justify-center">
+          <BrandBlock />
+        </div>
+      )}
+
+      <div className="bg-card border border-border rounded-2xl shadow-lg p-6 sm:p-7">
+        <h1 className="font-heading font-bold text-2xl tracking-tight text-foreground m-0 mb-1">
+          {title}
+        </h1>
+        {subtitle && (
+          <p className="font-body text-sm text-muted-foreground leading-relaxed m-0 mb-4">
+            {subtitle}
+          </p>
+        )}
+        {children}
+      </div>
+
+      {footerAction && (
+        <div className="flex justify-center mt-5 text-sm text-muted-foreground font-body">
+          {footerAction}
+        </div>
+      )}
+    </div>
+  );
+});

--- a/apps/web/src/components/ui/v2/auth-card/index.ts
+++ b/apps/web/src/components/ui/v2/auth-card/index.ts
@@ -1,0 +1,2 @@
+export { AuthCard } from './auth-card';
+export type { AuthCardProps } from './auth-card';

--- a/apps/web/src/components/ui/v2/btn/btn.test.tsx
+++ b/apps/web/src/components/ui/v2/btn/btn.test.tsx
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { Btn } from './btn';
+
+expect.extend(toHaveNoViolations);
+
+describe('Btn', () => {
+  it('renders children', () => {
+    render(<Btn>Click me</Btn>);
+    expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument();
+  });
+
+  it('default variant is primary (bg-primary)', () => {
+    render(<Btn>x</Btn>);
+    expect(screen.getByRole('button')).toHaveClass('bg-primary');
+  });
+
+  it('default size is md (h-10)', () => {
+    render(<Btn>x</Btn>);
+    expect(screen.getByRole('button')).toHaveClass('h-10');
+  });
+
+  it('size sm produces h-8', () => {
+    render(<Btn size="sm">x</Btn>);
+    expect(screen.getByRole('button')).toHaveClass('h-8');
+  });
+
+  it('size lg produces h-12', () => {
+    render(<Btn size="lg">x</Btn>);
+    expect(screen.getByRole('button')).toHaveClass('h-12');
+  });
+
+  it('variant outline has border class', () => {
+    render(<Btn variant="outline">x</Btn>);
+    const btn = screen.getByRole('button');
+    expect(btn.className).toMatch(/\bborder\b/);
+  });
+
+  it('variant destructive has bg-destructive', () => {
+    render(<Btn variant="destructive">x</Btn>);
+    expect(screen.getByRole('button')).toHaveClass('bg-destructive');
+  });
+
+  it('variant secondary has bg-secondary', () => {
+    render(<Btn variant="secondary">x</Btn>);
+    expect(screen.getByRole('button')).toHaveClass('bg-secondary');
+  });
+
+  it('variant ghost has bg-transparent', () => {
+    render(<Btn variant="ghost">x</Btn>);
+    expect(screen.getByRole('button')).toHaveClass('bg-transparent');
+  });
+
+  it('entity prop applies entity background on primary variant', () => {
+    render(
+      <Btn variant="primary" entity="game">
+        x
+      </Btn>
+    );
+    const btn = screen.getByRole('button');
+    expect(btn.style.backgroundColor).toBe('hsl(var(--e-game))');
+  });
+
+  it('entity=kb maps to --e-document css variable', () => {
+    render(
+      <Btn variant="primary" entity="kb">
+        x
+      </Btn>
+    );
+    const btn = screen.getByRole('button');
+    expect(btn.style.backgroundColor).toBe('hsl(var(--e-document))');
+  });
+
+  it('entity prop applies entity border + color on outline variant', () => {
+    render(
+      <Btn variant="outline" entity="agent">
+        x
+      </Btn>
+    );
+    const btn = screen.getByRole('button');
+    expect(btn.style.borderColor).toBe('hsl(var(--e-agent))');
+    expect(btn.style.color).toBe('hsl(var(--e-agent))');
+  });
+
+  it('entity prop has no inline style effect on ghost/secondary/destructive', () => {
+    const { rerender } = render(
+      <Btn variant="ghost" entity="game">
+        x
+      </Btn>
+    );
+    expect(screen.getByRole('button').style.backgroundColor).toBe('');
+    rerender(
+      <Btn variant="secondary" entity="game">
+        x
+      </Btn>
+    );
+    expect(screen.getByRole('button').style.backgroundColor).toBe('');
+    rerender(
+      <Btn variant="destructive" entity="game">
+        x
+      </Btn>
+    );
+    expect(screen.getByRole('button').style.backgroundColor).toBe('');
+  });
+
+  it('leftIcon renders left of children', () => {
+    render(<Btn leftIcon={<span data-testid="left">L</span>}>label</Btn>);
+    const btn = screen.getByRole('button');
+    const left = screen.getByTestId('left');
+    expect(btn.firstChild).toBe(left);
+  });
+
+  it('rightIcon renders right of children', () => {
+    render(<Btn rightIcon={<span data-testid="right">R</span>}>label</Btn>);
+    const btn = screen.getByRole('button');
+    const right = screen.getByTestId('right');
+    expect(btn.lastChild).toBe(right);
+  });
+
+  it('loading shows spinner svg with animate-spin and hides leftIcon', () => {
+    render(
+      <Btn loading leftIcon={<span data-testid="left">L</span>}>
+        Submitting
+      </Btn>
+    );
+    const btn = screen.getByRole('button');
+    const spinner = btn.querySelector('svg.animate-spin');
+    expect(spinner).not.toBeNull();
+    expect(spinner).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.queryByTestId('left')).toBeNull();
+  });
+
+  it('loading sets aria-busy=true and disables button', () => {
+    render(<Btn loading>x</Btn>);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveAttribute('aria-busy', 'true');
+    expect(btn).toBeDisabled();
+  });
+
+  it('disabled prop sets disabled attr', () => {
+    render(<Btn disabled>x</Btn>);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('fullWidth adds w-full', () => {
+    render(<Btn fullWidth>x</Btn>);
+    expect(screen.getByRole('button')).toHaveClass('w-full');
+  });
+
+  it('onClick fires when not disabled or loading', async () => {
+    const onClick = vi.fn();
+    render(<Btn onClick={onClick}>go</Btn>);
+    await userEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('onClick does not fire when disabled', async () => {
+    const onClick = vi.fn();
+    render(
+      <Btn onClick={onClick} disabled>
+        go
+      </Btn>
+    );
+    await userEvent.click(screen.getByRole('button'));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('onClick does not fire when loading', async () => {
+    const onClick = vi.fn();
+    render(
+      <Btn onClick={onClick} loading>
+        go
+      </Btn>
+    );
+    await userEvent.click(screen.getByRole('button'));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('forwards className', () => {
+    render(<Btn className="custom-xyz">x</Btn>);
+    expect(screen.getByRole('button')).toHaveClass('custom-xyz');
+  });
+
+  it('default type is button', () => {
+    render(<Btn>x</Btn>);
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
+  });
+
+  it('asChild renders via Slot, applying classes to child element', () => {
+    render(
+      <Btn asChild variant="primary">
+        <a href="/foo" data-testid="link">
+          Go
+        </a>
+      </Btn>
+    );
+    const link = screen.getByTestId('link');
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveClass('bg-primary');
+    expect(link).toHaveAttribute('href', '/foo');
+  });
+
+  it('has no a11y violations', async () => {
+    const { container } = render(<Btn>Accessible</Btn>);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has no a11y violations when loading', async () => {
+    const { container } = render(<Btn loading>Loading</Btn>);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/ui/v2/btn/btn.tsx
+++ b/apps/web/src/components/ui/v2/btn/btn.tsx
@@ -1,0 +1,148 @@
+import type { CSSProperties, JSX, MouseEventHandler, ReactNode } from 'react';
+
+import { Slot } from '@radix-ui/react-slot';
+import clsx from 'clsx';
+
+import type { EntityType } from '../entity-tokens';
+
+// Map EntityType -> CSS variable key. Mirrors entity-card mapping
+// so `kb` resolves to `--e-document` (pre-existing naming from design tokens).
+const ENTITY_CSS_VAR_KEY: Record<EntityType, string> = {
+  game: 'game',
+  player: 'player',
+  session: 'session',
+  agent: 'agent',
+  kb: 'document',
+  chat: 'chat',
+  event: 'event',
+  toolkit: 'toolkit',
+  tool: 'tool',
+};
+
+export type BtnVariant = 'primary' | 'secondary' | 'outline' | 'ghost' | 'destructive';
+export type BtnSize = 'sm' | 'md' | 'lg';
+
+export interface BtnProps {
+  readonly variant?: BtnVariant;
+  readonly size?: BtnSize;
+  readonly entity?: EntityType;
+  readonly loading?: boolean;
+  readonly fullWidth?: boolean;
+  readonly leftIcon?: ReactNode;
+  readonly rightIcon?: ReactNode;
+  readonly asChild?: boolean;
+  readonly className?: string;
+  readonly children?: ReactNode;
+  readonly type?: 'button' | 'submit' | 'reset';
+  readonly disabled?: boolean;
+  readonly onClick?: MouseEventHandler<HTMLButtonElement>;
+}
+
+const SIZE_CLASSES: Record<BtnSize, string> = {
+  sm: 'h-8 px-3 text-xs',
+  md: 'h-10 px-4 text-sm',
+  lg: 'h-12 px-6 text-base',
+};
+
+const VARIANT_CLASSES: Record<BtnVariant, string> = {
+  primary: 'bg-primary text-primary-foreground hover:bg-primary/90',
+  secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+  outline: 'border border-border bg-transparent hover:bg-muted',
+  ghost: 'bg-transparent hover:bg-muted',
+  destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+};
+
+function Spinner(): JSX.Element {
+  return (
+    <svg
+      aria-hidden="true"
+      className="animate-spin h-4 w-4"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="12" cy="12" r="10" stroke="currentColor" strokeOpacity="0.25" strokeWidth="4" />
+      <path
+        d="M22 12a10 10 0 0 1-10 10"
+        stroke="currentColor"
+        strokeWidth="4"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+export function Btn({
+  variant = 'primary',
+  size = 'md',
+  entity,
+  loading = false,
+  fullWidth = false,
+  leftIcon,
+  rightIcon,
+  asChild = false,
+  className,
+  children,
+  type = 'button',
+  disabled = false,
+  onClick,
+}: BtnProps): JSX.Element {
+  const isDisabled = disabled || loading;
+
+  const classes = clsx(
+    'inline-flex items-center justify-center gap-2 font-semibold rounded-xl transition-colors',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+    'disabled:opacity-50 disabled:pointer-events-none',
+    SIZE_CLASSES[size],
+    VARIANT_CLASSES[variant],
+    fullWidth && 'w-full',
+    className
+  );
+
+  const style: CSSProperties | undefined = (() => {
+    if (!entity) return undefined;
+    const key = ENTITY_CSS_VAR_KEY[entity];
+    const color = `hsl(var(--e-${key}))`;
+    if (variant === 'primary') {
+      return { backgroundColor: color, color: 'white' };
+    }
+    if (variant === 'outline') {
+      return { borderColor: color, color };
+    }
+    return undefined;
+  })();
+
+  const content = (
+    <>
+      {loading ? <Spinner /> : leftIcon}
+      {children}
+      {rightIcon}
+    </>
+  );
+
+  if (asChild) {
+    return (
+      <Slot
+        className={classes}
+        style={style}
+        data-loading={loading || undefined}
+        aria-busy={loading || undefined}
+      >
+        {children as JSX.Element}
+      </Slot>
+    );
+  }
+
+  return (
+    <button
+      type={type}
+      className={classes}
+      style={style}
+      disabled={isDisabled}
+      aria-busy={loading || undefined}
+      onClick={onClick}
+    >
+      {content}
+    </button>
+  );
+}

--- a/apps/web/src/components/ui/v2/btn/index.ts
+++ b/apps/web/src/components/ui/v2/btn/index.ts
@@ -1,0 +1,2 @@
+export { Btn } from './btn';
+export type { BtnProps, BtnVariant, BtnSize } from './btn';

--- a/apps/web/src/components/ui/v2/drawer/drawer.test.tsx
+++ b/apps/web/src/components/ui/v2/drawer/drawer.test.tsx
@@ -1,0 +1,368 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe, toHaveNoViolations } from 'jest-axe';
+
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerClose,
+} from './drawer';
+
+expect.extend(toHaveNoViolations);
+
+type Listener = (e: MediaQueryListEvent) => void;
+
+interface MockMQL {
+  matches: boolean;
+  media: string;
+  addEventListener: (event: 'change', cb: Listener) => void;
+  removeEventListener: (event: 'change', cb: Listener) => void;
+  onchange: Listener | null;
+}
+
+function installMatchMedia(matches: boolean): MockMQL {
+  const listeners = new Set<Listener>();
+  const mql: MockMQL = {
+    matches,
+    media: '(min-width: 768px)',
+    addEventListener: (_e, cb) => listeners.add(cb),
+    removeEventListener: (_e, cb) => listeners.delete(cb),
+    onchange: null,
+  };
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockReturnValue(mql),
+  });
+  return mql;
+}
+
+// jsdom does not implement PointerEvent capture / scroll APIs that vaul uses.
+beforeEach(() => {
+  if (typeof Element.prototype.hasPointerCapture !== 'function') {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (typeof Element.prototype.setPointerCapture !== 'function') {
+    Element.prototype.setPointerCapture = () => {};
+  }
+  if (typeof Element.prototype.releasePointerCapture !== 'function') {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (typeof Element.prototype.scrollIntoView !== 'function') {
+    Element.prototype.scrollIntoView = () => {};
+  }
+  // Vaul reads `style.transform` from getComputedStyle on release; jsdom returns
+  // empty string which crashes its matrix parser. Provide a safe identity value.
+  const realGCS = window.getComputedStyle.bind(window);
+  vi.spyOn(window, 'getComputedStyle').mockImplementation((el: Element, pseudo?: string | null) => {
+    const cs = realGCS(el, pseudo ?? undefined);
+    if (!cs.transform) {
+      try {
+        Object.defineProperty(cs, 'transform', { configurable: true, value: 'none' });
+      } catch {
+        // ignore — already defined
+      }
+    }
+    return cs;
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Drawer (desktop / Radix)', () => {
+  beforeEach(() => {
+    installMatchMedia(true);
+  });
+
+  it('renders DrawerTitle and body when open', () => {
+    render(
+      <Drawer open onOpenChange={() => {}} side="desktop-right">
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>My title</DrawerTitle>
+            <DrawerDescription>desc text</DrawerDescription>
+          </DrawerHeader>
+          <p>body content</p>
+          <DrawerFooter>
+            <DrawerClose>Close</DrawerClose>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    );
+    expect(screen.getByText('My title')).toBeInTheDocument();
+    expect(screen.getByText('desc text')).toBeInTheDocument();
+    expect(screen.getByText('body content')).toBeInTheDocument();
+  });
+
+  it('does not render content when closed', () => {
+    render(
+      <Drawer open={false} onOpenChange={() => {}} side="desktop-right">
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>Hidden title</DrawerTitle>
+          </DrawerHeader>
+          <p>hidden body</p>
+        </DrawerContent>
+      </Drawer>
+    );
+    expect(screen.queryByText('Hidden title')).not.toBeInTheDocument();
+    expect(screen.queryByText('hidden body')).not.toBeInTheDocument();
+  });
+
+  it('DrawerClose triggers onOpenChange(false)', async () => {
+    const onOpenChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Drawer open onOpenChange={onOpenChange} side="desktop-right">
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>t</DrawerTitle>
+          </DrawerHeader>
+          <DrawerFooter>
+            <DrawerClose>Dismiss</DrawerClose>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    );
+    await user.click(screen.getByRole('button', { name: 'Dismiss' }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('ESC closes the drawer on desktop', async () => {
+    const onOpenChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Drawer open onOpenChange={onOpenChange} side="desktop-right">
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>t</DrawerTitle>
+          </DrawerHeader>
+          <p>body</p>
+        </DrawerContent>
+      </Drawer>
+    );
+    await user.keyboard('{Escape}');
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('uses Radix Dialog (role="dialog") on desktop', () => {
+    render(
+      <Drawer open onOpenChange={() => {}} side="desktop-right">
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>t</DrawerTitle>
+          </DrawerHeader>
+        </DrawerContent>
+      </Drawer>
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    // desktop content is fixed to right side
+    expect(dialog.className).toMatch(/right-0/);
+  });
+
+  it('renders entity accent on desktop when entity prop set', () => {
+    render(
+      <Drawer open onOpenChange={() => {}} side="desktop-right" entity="game">
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>t</DrawerTitle>
+          </DrawerHeader>
+        </DrawerContent>
+      </Drawer>
+    );
+    const dialog = screen.getByRole('dialog');
+    const accent = dialog.querySelector('[data-drawer-accent="game"]');
+    expect(accent).toBeInTheDocument();
+    expect(accent?.getAttribute('style')).toContain('hsl(var(--e-game))');
+  });
+
+  it('maps kb entity to --e-document on desktop accent', () => {
+    render(
+      <Drawer open onOpenChange={() => {}} side="desktop-right" entity="kb">
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>t</DrawerTitle>
+          </DrawerHeader>
+        </DrawerContent>
+      </Drawer>
+    );
+    const accent = screen.getByRole('dialog').querySelector('[data-drawer-accent="kb"]');
+    expect(accent?.getAttribute('style')).toContain('hsl(var(--e-document))');
+  });
+
+  it('has no a11y violations on desktop', async () => {
+    const { container } = render(
+      <Drawer open onOpenChange={() => {}} side="desktop-right">
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>Accessible title</DrawerTitle>
+            <DrawerDescription>Accessible desc</DrawerDescription>
+          </DrawerHeader>
+          <p>body</p>
+        </DrawerContent>
+      </Drawer>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('Drawer (mobile / vaul)', () => {
+  beforeEach(() => {
+    installMatchMedia(false);
+  });
+
+  it('renders DrawerTitle when open as bottom sheet', async () => {
+    render(
+      <Drawer open onOpenChange={() => {}} side="mobile-bottom">
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>Mobile title</DrawerTitle>
+          </DrawerHeader>
+          <p>mobile body</p>
+        </DrawerContent>
+      </Drawer>
+    );
+    // vaul mounts asynchronously via portal; queryByText handles both sync & async cases
+    expect(await screen.findByText('Mobile title')).toBeInTheDocument();
+    expect(screen.getByText('mobile body')).toBeInTheDocument();
+  });
+
+  it('uses vaul (data-vaul-drawer attribute on content)', async () => {
+    render(
+      <Drawer open onOpenChange={() => {}} side="mobile-bottom">
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>vaul check</DrawerTitle>
+          </DrawerHeader>
+        </DrawerContent>
+      </Drawer>
+    );
+    await screen.findByText('vaul check');
+    const vaulEl = document.querySelector('[data-vaul-drawer]');
+    expect(vaulEl).not.toBeNull();
+    expect(vaulEl?.getAttribute('data-vaul-drawer-direction')).toBe('bottom');
+  });
+
+  it('renders entity accent handle on mobile when entity prop set', async () => {
+    render(
+      <Drawer open onOpenChange={() => {}} side="mobile-bottom" entity="player">
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>player drawer</DrawerTitle>
+          </DrawerHeader>
+        </DrawerContent>
+      </Drawer>
+    );
+    await screen.findByText('player drawer');
+    const accent = document.querySelector('[data-drawer-accent="player"]');
+    expect(accent).not.toBeNull();
+    expect(accent?.getAttribute('style')).toContain('hsl(var(--e-player))');
+  });
+
+  it('DrawerClose triggers onOpenChange(false) on mobile', async () => {
+    const onOpenChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Drawer open onOpenChange={onOpenChange} side="mobile-bottom">
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>t</DrawerTitle>
+          </DrawerHeader>
+          <DrawerFooter>
+            <DrawerClose>Bye</DrawerClose>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    );
+    const btn = await screen.findByRole('button', { name: 'Bye' });
+    await user.click(btn);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});
+
+describe('Drawer (auto mode)', () => {
+  it('side="auto" picks bottom sheet on mobile', async () => {
+    installMatchMedia(false);
+    render(
+      <Drawer open onOpenChange={() => {}} side="auto">
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>auto-mobile</DrawerTitle>
+          </DrawerHeader>
+        </DrawerContent>
+      </Drawer>
+    );
+    await screen.findByText('auto-mobile');
+    expect(document.querySelector('[data-vaul-drawer]')).not.toBeNull();
+  });
+
+  it('side="auto" picks Radix dialog on desktop', () => {
+    installMatchMedia(true);
+    render(
+      <Drawer open onOpenChange={() => {}} side="auto">
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>auto-desktop</DrawerTitle>
+          </DrawerHeader>
+        </DrawerContent>
+      </Drawer>
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(document.querySelector('[data-vaul-drawer]')).toBeNull();
+  });
+
+  it('defaults side to "auto" when omitted', () => {
+    installMatchMedia(true);
+    render(
+      <Drawer open onOpenChange={() => {}}>
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>auto-default</DrawerTitle>
+          </DrawerHeader>
+        </DrawerContent>
+      </Drawer>
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('honours direction="bottom" alias for mobile-bottom', async () => {
+    installMatchMedia(true); // desktop matchMedia, but direction forces bottom
+    render(
+      <Drawer open onOpenChange={() => {}} direction="bottom">
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>direction-bottom</DrawerTitle>
+          </DrawerHeader>
+        </DrawerContent>
+      </Drawer>
+    );
+    await screen.findByText('direction-bottom');
+    expect(document.querySelector('[data-vaul-drawer]')).not.toBeNull();
+  });
+
+  it('honours direction="right" alias for desktop-right', () => {
+    installMatchMedia(false); // mobile matchMedia, but direction forces right
+    render(
+      <Drawer open onOpenChange={() => {}} direction="right">
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>direction-right</DrawerTitle>
+          </DrawerHeader>
+        </DrawerContent>
+      </Drawer>
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});
+
+// Touch act() to satisfy lint rules — used implicitly via user-event.
+void act;

--- a/apps/web/src/components/ui/v2/drawer/drawer.tsx
+++ b/apps/web/src/components/ui/v2/drawer/drawer.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import {
+  createContext,
+  forwardRef,
+  useContext,
+  useMemo,
+  type ButtonHTMLAttributes,
+  type CSSProperties,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react';
+
+import * as RadixDialog from '@radix-ui/react-dialog';
+import clsx from 'clsx';
+import { Drawer as VaulDrawer } from 'vaul';
+
+import { useDrawerBreakpoint } from './use-drawer-breakpoint';
+
+import type { EntityType } from '../entity-tokens';
+
+// Mirror EntityCard: `kb` -> `--e-document` (pre-existing token name).
+const ENTITY_CSS_VAR_KEY: Record<EntityType, string> = {
+  game: 'game',
+  player: 'player',
+  session: 'session',
+  agent: 'agent',
+  kb: 'document',
+  chat: 'chat',
+  event: 'event',
+  toolkit: 'toolkit',
+  tool: 'tool',
+};
+
+export type DrawerSide = 'auto' | 'mobile-bottom' | 'desktop-right';
+export type DrawerDirection = 'bottom' | 'right';
+type DrawerMode = 'mobile' | 'desktop';
+
+export interface DrawerProps {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly side?: DrawerSide;
+  /** Convenience alias: `bottom` -> `mobile-bottom`, `right` -> `desktop-right`. */
+  readonly direction?: DrawerDirection;
+  readonly entity?: EntityType;
+  readonly children: ReactNode;
+}
+
+interface DrawerContextValue {
+  readonly mode: DrawerMode;
+  readonly entity?: EntityType;
+}
+
+const DrawerContext = createContext<DrawerContextValue | null>(null);
+
+function useDrawerContext(component: string): DrawerContextValue {
+  const ctx = useContext(DrawerContext);
+  if (!ctx) throw new Error(`${component} must be rendered inside <Drawer>`);
+  return ctx;
+}
+
+function resolveMode(
+  side: DrawerSide,
+  direction: DrawerDirection | undefined,
+  breakpoint: DrawerMode
+): DrawerMode {
+  if (direction === 'bottom') return 'mobile';
+  if (direction === 'right') return 'desktop';
+  if (side === 'mobile-bottom') return 'mobile';
+  if (side === 'desktop-right') return 'desktop';
+  return breakpoint;
+}
+
+function entityAccentStyle(entity: EntityType | undefined): CSSProperties | undefined {
+  if (!entity) return undefined;
+  return { backgroundColor: `hsl(var(--e-${ENTITY_CSS_VAR_KEY[entity]}))` };
+}
+
+export function Drawer({
+  open,
+  onOpenChange,
+  side = 'auto',
+  direction,
+  entity,
+  children,
+}: DrawerProps): React.JSX.Element {
+  const breakpoint = useDrawerBreakpoint();
+  const mode = resolveMode(side, direction, breakpoint);
+  const ctx = useMemo<DrawerContextValue>(() => ({ mode, entity }), [mode, entity]);
+  const Root = mode === 'mobile' ? VaulDrawer.Root : RadixDialog.Root;
+  return (
+    <DrawerContext.Provider value={ctx}>
+      <Root open={open} onOpenChange={onOpenChange}>
+        {children}
+      </Root>
+    </DrawerContext.Provider>
+  );
+}
+
+const OVERLAY_CLS = 'fixed inset-0 z-40 bg-black/40 backdrop-blur-sm';
+const MOBILE_CONTENT_CLS =
+  'fixed inset-x-0 bottom-0 z-50 flex max-h-[90vh] flex-col rounded-t-2xl bg-card shadow-lg outline-none';
+const DESKTOP_CONTENT_CLS =
+  'fixed inset-y-0 right-0 z-50 flex w-[480px] max-w-full flex-col rounded-l-2xl bg-card shadow-lg outline-none';
+
+export interface DrawerContentProps extends HTMLAttributes<HTMLDivElement> {
+  readonly children: ReactNode;
+}
+
+export const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>(function DrawerContent(
+  { children, className, ...rest },
+  ref
+) {
+  const { mode, entity } = useDrawerContext('DrawerContent');
+  if (mode === 'mobile') {
+    return (
+      <VaulDrawer.Portal>
+        <VaulDrawer.Overlay className={OVERLAY_CLS} />
+        <VaulDrawer.Content ref={ref} className={clsx(MOBILE_CONTENT_CLS, className)} {...rest}>
+          <div
+            data-drawer-accent={entity}
+            aria-hidden="true"
+            className={clsx('mx-auto mt-2 h-1 w-12 rounded-full', !entity && 'bg-border')}
+            style={entityAccentStyle(entity)}
+          />
+          {children}
+        </VaulDrawer.Content>
+      </VaulDrawer.Portal>
+    );
+  }
+  return (
+    <RadixDialog.Portal>
+      <RadixDialog.Overlay className={OVERLAY_CLS} />
+      <RadixDialog.Content ref={ref} className={clsx(DESKTOP_CONTENT_CLS, className)} {...rest}>
+        {entity && (
+          <div
+            data-drawer-accent={entity}
+            aria-hidden="true"
+            className="absolute inset-y-0 left-0 w-1 rounded-l-2xl"
+            style={entityAccentStyle(entity)}
+          />
+        )}
+        {children}
+      </RadixDialog.Content>
+    </RadixDialog.Portal>
+  );
+});
+
+export interface DrawerHeaderProps extends HTMLAttributes<HTMLDivElement> {
+  readonly children: ReactNode;
+}
+export function DrawerHeader({
+  children,
+  className,
+  ...rest
+}: DrawerHeaderProps): React.JSX.Element {
+  return (
+    <div className={clsx('flex flex-col gap-1 p-4', className)} {...rest}>
+      {children}
+    </div>
+  );
+}
+
+export interface DrawerFooterProps extends HTMLAttributes<HTMLDivElement> {
+  readonly children: ReactNode;
+}
+export function DrawerFooter({
+  children,
+  className,
+  ...rest
+}: DrawerFooterProps): React.JSX.Element {
+  return (
+    <div className={clsx('mt-auto flex items-center justify-end gap-2 p-4', className)} {...rest}>
+      {children}
+    </div>
+  );
+}
+
+export interface DrawerTitleProps extends HTMLAttributes<HTMLHeadingElement> {
+  readonly children: ReactNode;
+}
+export const DrawerTitle = forwardRef<HTMLHeadingElement, DrawerTitleProps>(function DrawerTitle(
+  { children, className, ...rest },
+  ref
+) {
+  const { mode } = useDrawerContext('DrawerTitle');
+  const Cmp = mode === 'mobile' ? VaulDrawer.Title : RadixDialog.Title;
+  return (
+    <Cmp ref={ref} className={clsx('text-lg font-semibold text-foreground', className)} {...rest}>
+      {children}
+    </Cmp>
+  );
+});
+
+export interface DrawerDescriptionProps extends HTMLAttributes<HTMLParagraphElement> {
+  readonly children: ReactNode;
+}
+export const DrawerDescription = forwardRef<HTMLParagraphElement, DrawerDescriptionProps>(
+  function DrawerDescription({ children, className, ...rest }, ref) {
+    const { mode } = useDrawerContext('DrawerDescription');
+    const Cmp = mode === 'mobile' ? VaulDrawer.Description : RadixDialog.Description;
+    return (
+      <Cmp ref={ref} className={clsx('text-sm text-muted-foreground', className)} {...rest}>
+        {children}
+      </Cmp>
+    );
+  }
+);
+
+export interface DrawerCloseProps extends Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  'children'
+> {
+  readonly children: ReactNode;
+}
+export const DrawerClose = forwardRef<HTMLButtonElement, DrawerCloseProps>(function DrawerClose(
+  { children, className, ...rest },
+  ref
+) {
+  const { mode } = useDrawerContext('DrawerClose');
+  const Cmp = mode === 'mobile' ? VaulDrawer.Close : RadixDialog.Close;
+  const cls = clsx(
+    'inline-flex items-center justify-center rounded-md border border-border bg-card px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/40',
+    className
+  );
+  return (
+    <Cmp ref={ref} className={cls} {...rest}>
+      {children}
+    </Cmp>
+  );
+});

--- a/apps/web/src/components/ui/v2/drawer/index.ts
+++ b/apps/web/src/components/ui/v2/drawer/index.ts
@@ -1,0 +1,25 @@
+export {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerClose,
+  type DrawerProps,
+  type DrawerSide,
+  type DrawerDirection,
+  type DrawerContentProps,
+  type DrawerHeaderProps,
+  type DrawerTitleProps,
+  type DrawerDescriptionProps,
+  type DrawerFooterProps,
+  type DrawerCloseProps,
+} from './drawer';
+
+export {
+  useDrawerBreakpoint,
+  resolveDrawerBreakpoint,
+  getDrawerBreakpointSnapshot,
+  type DrawerBreakpoint,
+} from './use-drawer-breakpoint';

--- a/apps/web/src/components/ui/v2/drawer/use-drawer-breakpoint.test.ts
+++ b/apps/web/src/components/ui/v2/drawer/use-drawer-breakpoint.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { useDrawerBreakpoint } from './use-drawer-breakpoint';
+
+type Listener = (e: MediaQueryListEvent) => void;
+
+interface MockMQL {
+  matches: boolean;
+  media: string;
+  addEventListener: (event: 'change', cb: Listener) => void;
+  removeEventListener: (event: 'change', cb: Listener) => void;
+  // legacy API kept for safety
+  addListener?: (cb: Listener) => void;
+  removeListener?: (cb: Listener) => void;
+  dispatchEvent?: (e: Event) => boolean;
+  onchange: Listener | null;
+}
+
+function installMatchMedia(initialMatches: boolean) {
+  const listeners = new Set<Listener>();
+  const mql: MockMQL = {
+    matches: initialMatches,
+    media: '(min-width: 768px)',
+    addEventListener: (_e, cb) => listeners.add(cb),
+    removeEventListener: (_e, cb) => listeners.delete(cb),
+    onchange: null,
+  };
+  const matchMedia = vi.fn().mockReturnValue(mql);
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: matchMedia,
+  });
+  return {
+    mql,
+    fire(matches: boolean) {
+      mql.matches = matches;
+      const evt = { matches } as MediaQueryListEvent;
+      listeners.forEach(cb => cb(evt));
+    },
+  };
+}
+
+describe('useDrawerBreakpoint', () => {
+  let originalMatchMedia: typeof window.matchMedia | undefined;
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia;
+  });
+
+  afterEach(() => {
+    if (originalMatchMedia) {
+      Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        writable: true,
+        value: originalMatchMedia,
+      });
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('returns "mobile" when (min-width: 768px) does not match', () => {
+    installMatchMedia(false);
+    const { result } = renderHook(() => useDrawerBreakpoint());
+    expect(result.current).toBe('mobile');
+  });
+
+  it('returns "desktop" when (min-width: 768px) matches', () => {
+    installMatchMedia(true);
+    const { result } = renderHook(() => useDrawerBreakpoint());
+    expect(result.current).toBe('desktop');
+  });
+
+  it('updates when matchMedia change event fires', () => {
+    const m = installMatchMedia(false);
+    const { result } = renderHook(() => useDrawerBreakpoint());
+    expect(result.current).toBe('mobile');
+    act(() => {
+      m.fire(true);
+    });
+    expect(result.current).toBe('desktop');
+    act(() => {
+      m.fire(false);
+    });
+    expect(result.current).toBe('mobile');
+  });
+
+  it('is SSR safe — defaults to "mobile" when window is undefined', async () => {
+    // jsdom always defines `window`, so exercise the resolver directly.
+    const mod = await import('./use-drawer-breakpoint');
+    expect(mod.resolveDrawerBreakpoint(undefined)).toBe('mobile');
+  });
+
+  it('returns "mobile" when matchMedia is missing on window', async () => {
+    // Simulate environment without matchMedia (e.g. older SSR shims).
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+    const mod = await import('./use-drawer-breakpoint');
+    expect(mod.getDrawerBreakpointSnapshot()).toBe('mobile');
+  });
+});

--- a/apps/web/src/components/ui/v2/drawer/use-drawer-breakpoint.ts
+++ b/apps/web/src/components/ui/v2/drawer/use-drawer-breakpoint.ts
@@ -1,0 +1,33 @@
+import { useSyncExternalStore } from 'react';
+
+export type DrawerBreakpoint = 'mobile' | 'desktop';
+
+const QUERY = '(min-width: 768px)';
+
+type Win = (Window & typeof globalThis) | undefined;
+
+export function resolveDrawerBreakpoint(win: Win): DrawerBreakpoint {
+  if (!win || typeof win.matchMedia !== 'function') return 'mobile';
+  return win.matchMedia(QUERY).matches ? 'desktop' : 'mobile';
+}
+
+export function getDrawerBreakpointSnapshot(): DrawerBreakpoint {
+  return resolveDrawerBreakpoint(typeof window === 'undefined' ? undefined : window);
+}
+
+function subscribe(onChange: () => void): () => void {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return () => {};
+  }
+  const mql = window.matchMedia(QUERY);
+  mql.addEventListener('change', onChange);
+  return () => mql.removeEventListener('change', onChange);
+}
+
+function getServerSnapshot(): DrawerBreakpoint {
+  return 'mobile';
+}
+
+export function useDrawerBreakpoint(): DrawerBreakpoint {
+  return useSyncExternalStore(subscribe, () => getDrawerBreakpointSnapshot(), getServerSnapshot);
+}

--- a/apps/web/src/components/ui/v2/entity-card/entity-card.test.tsx
+++ b/apps/web/src/components/ui/v2/entity-card/entity-card.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { EntityCard } from './entity-card';
+
+expect.extend(toHaveNoViolations);
+
+describe('EntityCard', () => {
+  it('renders children', () => {
+    render(
+      <EntityCard entity="game">
+        <span>hello</span>
+      </EntityCard>
+    );
+    expect(screen.getByText('hello')).toBeInTheDocument();
+  });
+
+  it('sets data-entity attribute matching entity prop', () => {
+    const { container } = render(
+      <EntityCard entity="agent">
+        <span>x</span>
+      </EntityCard>
+    );
+    expect(container.querySelector('[data-entity="agent"]')).toBeInTheDocument();
+  });
+
+  it('applies entity-colored left border by default', () => {
+    const { container } = render(
+      <EntityCard entity="game">
+        <span>x</span>
+      </EntityCard>
+    );
+    const el = container.querySelector<HTMLElement>('[data-entity="game"]');
+    expect(el?.className).toMatch(/border-l-4/);
+    expect(el?.style.borderLeftColor).toBe('hsl(var(--e-game))');
+  });
+
+  it('maps kb entity to --e-document css variable', () => {
+    const { container } = render(
+      <EntityCard entity="kb">
+        <span>x</span>
+      </EntityCard>
+    );
+    const el = container.querySelector<HTMLElement>('[data-entity="kb"]');
+    expect(el?.style.borderLeftColor).toBe('hsl(var(--e-document))');
+  });
+
+  it('omits left border when entityBorder=false', () => {
+    const { container } = render(
+      <EntityCard entity="game" entityBorder={false}>
+        <span>x</span>
+      </EntityCard>
+    );
+    const el = container.querySelector<HTMLElement>('[data-entity="game"]');
+    expect(el?.className).not.toMatch(/border-l-4/);
+    expect(el?.style.borderLeftColor).toBe('');
+  });
+
+  it('variant=default applies border border-border classes', () => {
+    const { container } = render(
+      <EntityCard entity="game" variant="default">
+        <span>x</span>
+      </EntityCard>
+    );
+    const el = container.querySelector<HTMLElement>('[data-entity="game"]');
+    expect(el?.className).toMatch(/border-border/);
+  });
+
+  it('variant=elevated applies shadow-md class', () => {
+    const { container } = render(
+      <EntityCard entity="game" variant="elevated">
+        <span>x</span>
+      </EntityCard>
+    );
+    const el = container.querySelector<HTMLElement>('[data-entity="game"]');
+    expect(el?.className).toMatch(/shadow-md/);
+  });
+
+  it('variant=flat has no border-border and no shadow-md', () => {
+    const { container } = render(
+      <EntityCard entity="game" variant="flat" entityBorder={false}>
+        <span>x</span>
+      </EntityCard>
+    );
+    const el = container.querySelector<HTMLElement>('[data-entity="game"]');
+    expect(el?.className).not.toMatch(/border-border/);
+    expect(el?.className).not.toMatch(/shadow-md/);
+  });
+
+  it('renders as a button with aria-label when onClick is provided', async () => {
+    const onClick = vi.fn();
+    render(
+      <EntityCard entity="player" onClick={onClick} ariaLabel="Open player card">
+        <span>content</span>
+      </EntityCard>
+    );
+    const btn = screen.getByRole('button', { name: 'Open player card' });
+    expect(btn).toBeInTheDocument();
+    expect(btn.tagName).toBe('BUTTON');
+    expect(btn).toHaveAttribute('type', 'button');
+    await userEvent.click(btn);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders as a div when no onClick', () => {
+    const { container } = render(
+      <EntityCard entity="event">
+        <span>x</span>
+      </EntityCard>
+    );
+    const el = container.querySelector('[data-entity="event"]');
+    expect(el?.tagName).toBe('DIV');
+  });
+
+  describe('ariaLabel enforcement when clickable', () => {
+    let errSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      errSpy.mockRestore();
+    });
+
+    it('throws when onClick provided without ariaLabel', () => {
+      expect(() =>
+        render(
+          <EntityCard entity="game" onClick={() => {}}>
+            <span>x</span>
+          </EntityCard>
+        )
+      ).toThrow(/ariaLabel/i);
+    });
+  });
+
+  it('interactive=true adds cursor-pointer and hover class', () => {
+    const { container } = render(
+      <EntityCard entity="session" interactive>
+        <span>x</span>
+      </EntityCard>
+    );
+    const el = container.querySelector<HTMLElement>('[data-entity="session"]');
+    expect(el?.className).toMatch(/cursor-pointer/);
+    expect(el?.className).toMatch(/hover:/);
+  });
+
+  it('forwards className', () => {
+    const { container } = render(
+      <EntityCard entity="chat" className="custom-xyz">
+        <span>x</span>
+      </EntityCard>
+    );
+    const el = container.querySelector('[data-entity="chat"]');
+    expect(el?.className).toMatch(/custom-xyz/);
+  });
+
+  it('has no a11y violations as presentation div', async () => {
+    const { container } = render(
+      <EntityCard entity="game">
+        <p>Game summary</p>
+      </EntityCard>
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has no a11y violations as button', async () => {
+    const { container } = render(
+      <EntityCard entity="game" onClick={() => {}} ariaLabel="Open game">
+        <p>Game summary</p>
+      </EntityCard>
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/ui/v2/entity-card/entity-card.tsx
+++ b/apps/web/src/components/ui/v2/entity-card/entity-card.tsx
@@ -1,0 +1,85 @@
+import type { CSSProperties, JSX, ReactNode } from 'react';
+
+import clsx from 'clsx';
+
+import type { EntityType } from '../entity-tokens';
+
+// Map EntityType -> CSS variable key. Mirrors TAILWIND_KEY in entity-tokens.ts
+// so `kb` resolves to `--e-document` (pre-existing naming from design tokens).
+const ENTITY_CSS_VAR_KEY: Record<EntityType, string> = {
+  game: 'game',
+  player: 'player',
+  session: 'session',
+  agent: 'agent',
+  kb: 'document',
+  chat: 'chat',
+  event: 'event',
+  toolkit: 'toolkit',
+  tool: 'tool',
+};
+
+export type EntityCardVariant = 'default' | 'elevated' | 'flat';
+
+export interface EntityCardProps {
+  readonly entity: EntityType;
+  readonly variant?: EntityCardVariant;
+  readonly interactive?: boolean;
+  readonly onClick?: () => void;
+  readonly ariaLabel?: string;
+  readonly className?: string;
+  readonly entityBorder?: boolean;
+  readonly children: ReactNode;
+}
+
+export function EntityCard({
+  entity,
+  variant = 'default',
+  interactive = false,
+  onClick,
+  ariaLabel,
+  className,
+  entityBorder = true,
+  children,
+}: EntityCardProps): JSX.Element {
+  if (onClick && !ariaLabel) {
+    throw new Error(
+      'EntityCard: `ariaLabel` is required when `onClick` is provided for accessibility.'
+    );
+  }
+
+  const isInteractive = interactive || Boolean(onClick);
+
+  const classes = clsx(
+    'bg-card rounded-xl p-4 text-foreground transition-colors',
+    entityBorder && 'border-l-4',
+    variant === 'default' && 'border border-border',
+    variant === 'elevated' && 'shadow-md',
+    isInteractive && 'cursor-pointer transition-transform hover:-translate-y-0.5 hover:bg-muted/40',
+    className
+  );
+
+  const style: CSSProperties | undefined = entityBorder
+    ? { borderLeftColor: `hsl(var(--e-${ENTITY_CSS_VAR_KEY[entity]}))` }
+    : undefined;
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        data-entity={entity}
+        onClick={onClick}
+        className={clsx('block w-full text-left', classes)}
+        style={style}
+      >
+        {children}
+      </button>
+    );
+  }
+
+  return (
+    <div data-entity={entity} className={classes} style={style}>
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/v2/entity-card/index.ts
+++ b/apps/web/src/components/ui/v2/entity-card/index.ts
@@ -1,0 +1,2 @@
+export { EntityCard } from './entity-card';
+export type { EntityCardProps, EntityCardVariant } from './entity-card';

--- a/apps/web/src/components/ui/v2/entity-chip/entity-chip.test.tsx
+++ b/apps/web/src/components/ui/v2/entity-chip/entity-chip.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { EntityChip } from './entity-chip';
+
+expect.extend(toHaveNoViolations);
+
+describe('EntityChip', () => {
+  it('renders emoji and label', () => {
+    render(<EntityChip entity="game" label="Catan" />);
+    expect(screen.getByText('🎲')).toBeInTheDocument();
+    expect(screen.getByText('Catan')).toBeInTheDocument();
+  });
+
+  it('applies entity color class', () => {
+    const { container } = render(<EntityChip entity="session" label="Turno 1" />);
+    expect(container.querySelector('.bg-entity-session\\/10')).toBeInTheDocument();
+  });
+
+  it('renders size sm by default and md when prop set', () => {
+    const { container, rerender } = render(<EntityChip entity="agent" label="Rulebook AI" />);
+    expect(container.querySelector('.text-xs')).toBeInTheDocument();
+    rerender(<EntityChip entity="agent" label="Rulebook AI" size="md" />);
+    expect(container.querySelector('.text-sm')).toBeInTheDocument();
+  });
+
+  it('has no a11y violations', async () => {
+    const { container } = render(<EntityChip entity="player" label="Alice" />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/ui/v2/entity-chip/entity-chip.tsx
+++ b/apps/web/src/components/ui/v2/entity-chip/entity-chip.tsx
@@ -1,0 +1,22 @@
+import type { JSX } from 'react';
+
+import { getEntityToken, type EntityType } from '../entity-tokens';
+
+export interface EntityChipProps {
+  readonly entity: EntityType;
+  readonly label: string;
+  readonly size?: 'sm' | 'md';
+}
+
+export function EntityChip({ entity, label, size = 'sm' }: EntityChipProps): JSX.Element {
+  const t = getEntityToken(entity);
+  const sizeClasses = size === 'sm' ? 'text-xs px-2 py-0.5' : 'text-sm px-3 py-1';
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full ${t.bgSoft} ${t.text} ${sizeClasses} font-medium`}
+    >
+      <span aria-hidden="true">{t.emoji}</span>
+      <span>{label}</span>
+    </span>
+  );
+}

--- a/apps/web/src/components/ui/v2/entity-pip/entity-pip.test.tsx
+++ b/apps/web/src/components/ui/v2/entity-pip/entity-pip.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { EntityPip } from './entity-pip';
+
+expect.extend(toHaveNoViolations);
+
+describe('EntityPip', () => {
+  it('renders empty dot (no text) when count is not provided', () => {
+    const { container } = render(<EntityPip entity="game" />);
+    const pip = container.querySelector('[data-entity="game"]');
+    expect(pip).toBeInTheDocument();
+    expect(pip?.textContent).toBe('');
+  });
+
+  it('renders count when count > 0', () => {
+    render(<EntityPip entity="session" count={3} />);
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('applies entity color class via background token', () => {
+    const { container } = render(<EntityPip entity="session" count={2} />);
+    // bg-entity-<key> class from getEntityToken
+    expect(container.querySelector('.bg-entity-session')).toBeInTheDocument();
+  });
+
+  it('sets data-entity attribute', () => {
+    const { container } = render(<EntityPip entity="agent" count={1} />);
+    expect(container.querySelector('[data-entity="agent"]')).toBeInTheDocument();
+  });
+
+  it('renders as a button when onClick is provided', async () => {
+    const onClick = vi.fn();
+    render(<EntityPip entity="player" count={2} onClick={onClick} ariaLabel="2 players" />);
+    const btn = screen.getByRole('button', { name: '2 players' });
+    expect(btn).toBeInTheDocument();
+    expect(btn.tagName).toBe('BUTTON');
+    expect(btn).toHaveAttribute('type', 'button');
+    await userEvent.click(btn);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders as a span with role="presentation" when no onClick', () => {
+    const { container } = render(<EntityPip entity="event" count={1} />);
+    const el = container.querySelector('[data-entity="event"]');
+    expect(el?.tagName).toBe('SPAN');
+    expect(el).toHaveAttribute('role', 'presentation');
+  });
+
+  describe('ariaLabel enforcement when clickable', () => {
+    let errSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      errSpy.mockRestore();
+    });
+
+    it('throws when onClick provided without ariaLabel', () => {
+      expect(() => render(<EntityPip entity="player" count={2} onClick={() => {}} />)).toThrow(
+        /ariaLabel/i
+      );
+    });
+  });
+
+  it('shows ring when active', () => {
+    const { container } = render(<EntityPip entity="kb" count={5} active />);
+    const el = container.querySelector('[data-entity="kb"]');
+    expect(el?.className).toMatch(/ring-2/);
+  });
+
+  it('applies opacity-40 when count === 0', () => {
+    const { container } = render(<EntityPip entity="tool" count={0} />);
+    const el = container.querySelector('[data-entity="tool"]');
+    expect(el?.className).toMatch(/opacity-40/);
+  });
+
+  it('applies cursor-default when count === 0', () => {
+    const { container } = render(<EntityPip entity="tool" count={0} />);
+    const el = container.querySelector('[data-entity="tool"]');
+    expect(el?.className).toMatch(/cursor-default/);
+  });
+
+  it('forwards className', () => {
+    const { container } = render(<EntityPip entity="chat" count={1} className="custom-xyz" />);
+    const el = container.querySelector('[data-entity="chat"]');
+    expect(el?.className).toMatch(/custom-xyz/);
+  });
+
+  it('applies tabular-nums on count text', () => {
+    const { container } = render(<EntityPip entity="session" count={12} />);
+    const el = container.querySelector('[data-entity="session"]');
+    expect(el?.className).toMatch(/tabular-nums/);
+  });
+
+  it('size sm produces correct dimension classes for empty dot', () => {
+    const { container } = render(<EntityPip entity="game" size="sm" />);
+    const el = container.querySelector('[data-entity="game"]');
+    expect(el?.className).toMatch(/h-2\b/);
+    expect(el?.className).toMatch(/w-2\b/);
+  });
+
+  it('size md produces correct dimension classes for empty dot', () => {
+    const { container } = render(<EntityPip entity="game" size="md" />);
+    const el = container.querySelector('[data-entity="game"]');
+    expect(el?.className).toMatch(/h-2\.5/);
+    expect(el?.className).toMatch(/w-2\.5/);
+  });
+
+  it('size sm produces correct dimension classes with count', () => {
+    const { container } = render(<EntityPip entity="game" size="sm" count={2} />);
+    const el = container.querySelector('[data-entity="game"]');
+    expect(el?.className).toMatch(/h-4\b/);
+    expect(el?.className).toMatch(/min-w-4/);
+  });
+
+  it('size md produces correct dimension classes with count', () => {
+    const { container } = render(<EntityPip entity="game" size="md" count={3} />);
+    const el = container.querySelector('[data-entity="game"]');
+    expect(el?.className).toMatch(/h-5\b/);
+    expect(el?.className).toMatch(/min-w-5/);
+  });
+
+  it('has no a11y violations as presentation', async () => {
+    const { container } = render(<EntityPip entity="player" count={2} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has no a11y violations as button', async () => {
+    const { container } = render(
+      <EntityPip entity="player" count={2} onClick={() => {}} ariaLabel="2 players" />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/ui/v2/entity-pip/entity-pip.tsx
+++ b/apps/web/src/components/ui/v2/entity-pip/entity-pip.tsx
@@ -1,0 +1,80 @@
+import type { JSX } from 'react';
+
+import clsx from 'clsx';
+
+import { getEntityToken, type EntityType } from '../entity-tokens';
+
+export interface EntityPipProps {
+  readonly entity: EntityType;
+  readonly count?: number;
+  readonly active?: boolean;
+  readonly size?: 'sm' | 'md';
+  readonly onClick?: () => void;
+  readonly ariaLabel?: string;
+  readonly className?: string;
+}
+
+export function EntityPip({
+  entity,
+  count,
+  active = false,
+  size = 'sm',
+  onClick,
+  ariaLabel,
+  className,
+}: EntityPipProps): JSX.Element {
+  if (onClick && !ariaLabel) {
+    throw new Error(
+      'EntityPip: `ariaLabel` is required when `onClick` is provided for accessibility.'
+    );
+  }
+
+  const token = getEntityToken(entity);
+  const hasCount = typeof count === 'number';
+  const isEmpty = count === 0;
+
+  // Dot (no count) size classes
+  const dotSize = size === 'sm' ? 'h-2 w-2' : 'h-2.5 w-2.5';
+  // Pill (with count) size classes
+  const pillSize = size === 'sm' ? 'h-4 min-w-4 px-1 text-[10px]' : 'h-5 min-w-5 px-1.5 text-xs';
+
+  const tailwindKey = token.bg.replace('bg-entity-', '');
+
+  const baseClasses = clsx(
+    'inline-flex items-center justify-center rounded-full font-medium',
+    token.bg,
+    hasCount ? `${pillSize} text-white tabular-nums` : dotSize,
+    active && 'ring-2 ring-offset-1',
+    isEmpty && 'opacity-40 cursor-default',
+    className
+  );
+
+  // Use entity color at 0.35 alpha for ring via CSS variable in globals.css
+  const ringStyle = active
+    ? { boxShadow: `0 0 0 2px hsl(var(--e-${tailwindKey}) / 0.35)` }
+    : undefined;
+
+  const content = hasCount ? count : null;
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        data-entity={entity}
+        onClick={onClick}
+        disabled={isEmpty}
+        className={baseClasses}
+        style={ringStyle}
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return (
+    <span role="presentation" data-entity={entity} className={baseClasses} style={ringStyle}>
+      {content}
+    </span>
+  );
+}

--- a/apps/web/src/components/ui/v2/entity-pip/index.ts
+++ b/apps/web/src/components/ui/v2/entity-pip/index.ts
@@ -1,0 +1,2 @@
+export { EntityPip } from './entity-pip';
+export type { EntityPipProps } from './entity-pip';

--- a/apps/web/src/components/ui/v2/entity-tokens.test.ts
+++ b/apps/web/src/components/ui/v2/entity-tokens.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { ENTITY_TOKENS, getEntityToken, type EntityType } from './entity-tokens';
+
+describe('entity-tokens', () => {
+  it('provides 9 canonical entity types', () => {
+    const types: EntityType[] = [
+      'game',
+      'player',
+      'session',
+      'agent',
+      'kb',
+      'chat',
+      'event',
+      'toolkit',
+      'tool',
+    ];
+    types.forEach(t => {
+      const token = getEntityToken(t);
+      expect(token.bg).toContain('bg-entity-');
+      expect(token.text).toContain('text-entity-');
+      expect(token.emoji).toBeTruthy();
+      expect(token.label).toBeTruthy();
+    });
+  });
+
+  it('maps kb to document tailwind class', () => {
+    expect(getEntityToken('kb').bg).toBe('bg-entity-document');
+  });
+
+  it('returns emoji for toolkit as 🧰', () => {
+    expect(getEntityToken('toolkit').emoji).toBe('🧰');
+  });
+});

--- a/apps/web/src/components/ui/v2/entity-tokens.ts
+++ b/apps/web/src/components/ui/v2/entity-tokens.ts
@@ -1,0 +1,80 @@
+export type EntityType =
+  | 'game'
+  | 'player'
+  | 'session'
+  | 'agent'
+  | 'kb'
+  | 'chat'
+  | 'event'
+  | 'toolkit'
+  | 'tool';
+
+export interface EntityToken {
+  readonly bg: string;
+  readonly bgSoft: string;
+  readonly text: string;
+  readonly border: string;
+  readonly emoji: string;
+  readonly label: string;
+}
+
+// Map "kb" -> tailwind class "document" (pre-existing naming)
+const TAILWIND_KEY: Record<EntityType, string> = {
+  game: 'game',
+  player: 'player',
+  session: 'session',
+  agent: 'agent',
+  kb: 'document',
+  chat: 'chat',
+  event: 'event',
+  toolkit: 'toolkit',
+  tool: 'tool',
+};
+
+const EMOJI: Record<EntityType, string> = {
+  game: '🎲',
+  player: '👤',
+  session: '🎯',
+  agent: '🤖',
+  kb: '📚',
+  chat: '💬',
+  event: '🗓️',
+  toolkit: '🧰',
+  tool: '🔧',
+};
+
+const LABEL: Record<EntityType, string> = {
+  game: 'Gioco',
+  player: 'Giocatore',
+  session: 'Sessione',
+  agent: 'Agente',
+  kb: 'Base di conoscenza',
+  chat: 'Chat',
+  event: 'Evento',
+  toolkit: 'Toolkit',
+  tool: 'Tool',
+};
+
+export function getEntityToken(type: EntityType): EntityToken {
+  const k = TAILWIND_KEY[type];
+  return {
+    bg: `bg-entity-${k}`,
+    bgSoft: `bg-entity-${k}/10`,
+    text: `text-entity-${k}`,
+    border: `border-entity-${k}`,
+    emoji: EMOJI[type],
+    label: LABEL[type],
+  };
+}
+
+export const ENTITY_TOKENS: readonly EntityType[] = [
+  'game',
+  'player',
+  'session',
+  'agent',
+  'kb',
+  'chat',
+  'event',
+  'toolkit',
+  'tool',
+] as const;

--- a/apps/web/src/components/ui/v2/hero-gradient/hero-gradient.test.tsx
+++ b/apps/web/src/components/ui/v2/hero-gradient/hero-gradient.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { HeroGradient } from './hero-gradient';
+
+describe('HeroGradient', () => {
+  it('renders string title', () => {
+    render(<HeroGradient title="Il tuo assistente AI da tavolo" />);
+    expect(
+      screen.getByRole('heading', { name: /il tuo assistente ai da tavolo/i })
+    ).toBeInTheDocument();
+  });
+
+  it('renders ReactNode title with highlighted span', () => {
+    render(
+      <HeroGradient
+        title={
+          <>
+            Regole <span data-testid="highlight">chiare</span>
+          </>
+        }
+      />
+    );
+    expect(screen.getByTestId('highlight')).toHaveTextContent('chiare');
+  });
+
+  it('renders subtitle when provided', () => {
+    render(<HeroGradient title="Titolo" subtitle="Sottotitolo descrittivo" />);
+    expect(screen.getByText('Sottotitolo descrittivo')).toBeInTheDocument();
+  });
+
+  it('does NOT render subtitle when omitted', () => {
+    const { container } = render(<HeroGradient title="Titolo" />);
+    expect(container.querySelector('p')).toBeNull();
+  });
+
+  it('renders primaryCta button when provided', () => {
+    render(
+      <HeroGradient title="Titolo" primaryCta={{ label: 'Inizia ora', onClick: () => undefined }} />
+    );
+    expect(screen.getByRole('button', { name: 'Inizia ora' })).toBeInTheDocument();
+  });
+
+  it('renders secondaryCta button when provided', () => {
+    render(
+      <HeroGradient
+        title="Titolo"
+        secondaryCta={{ label: 'Scopri di più', onClick: () => undefined }}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Scopri di più' })).toBeInTheDocument();
+  });
+
+  it('fires primaryCta onClick', async () => {
+    const user = userEvent.setup();
+    const handler = vi.fn();
+    render(<HeroGradient title="Titolo" primaryCta={{ label: 'Go', onClick: handler }} />);
+    await user.click(screen.getByRole('button', { name: 'Go' }));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders primaryCta as link when href provided', () => {
+    render(<HeroGradient title="Titolo" primaryCta={{ label: 'Vai', href: '/signup' }} />);
+    const link = screen.getByRole('link', { name: 'Vai' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/signup');
+  });
+
+  it('renders secondaryCta as link when href provided', () => {
+    render(<HeroGradient title="Titolo" secondaryCta={{ label: 'Docs', href: '/docs' }} />);
+    expect(screen.getByRole('link', { name: 'Docs' })).toHaveAttribute('href', '/docs');
+  });
+
+  it('renders children when provided', () => {
+    render(
+      <HeroGradient title="Titolo">
+        <div data-testid="extras">extra content</div>
+      </HeroGradient>
+    );
+    expect(screen.getByTestId('extras')).toBeInTheDocument();
+  });
+
+  it('merges className onto root', () => {
+    const { container } = render(<HeroGradient title="Titolo" className="custom-root" />);
+    expect(container.firstChild).toHaveClass('custom-root');
+  });
+
+  it('applies gradient inline style on root', () => {
+    const { container } = render(<HeroGradient title="Titolo" />);
+    const root = container.firstChild as HTMLElement;
+    expect(root.style.background).toContain('linear-gradient');
+  });
+});

--- a/apps/web/src/components/ui/v2/hero-gradient/hero-gradient.tsx
+++ b/apps/web/src/components/ui/v2/hero-gradient/hero-gradient.tsx
@@ -1,0 +1,77 @@
+import type { CSSProperties, JSX, ReactNode } from 'react';
+
+import clsx from 'clsx';
+
+import { Btn } from '../btn';
+
+export interface HeroGradientCta {
+  readonly label: string;
+  readonly href?: string;
+  readonly onClick?: () => void;
+}
+
+export interface HeroGradientProps {
+  readonly title: ReactNode;
+  readonly subtitle?: string;
+  readonly primaryCta?: HeroGradientCta;
+  readonly secondaryCta?: HeroGradientCta;
+  readonly className?: string;
+  readonly children?: ReactNode;
+}
+
+const GRADIENT_STYLE: CSSProperties = {
+  background:
+    'linear-gradient(135deg, hsl(var(--e-game) / 0.08), hsl(var(--e-event) / 0.06), hsl(var(--e-player) / 0.08))',
+};
+
+function renderCta(cta: HeroGradientCta, variant: 'primary' | 'outline'): JSX.Element {
+  if (cta.href) {
+    return (
+      <Btn variant={variant} entity="game" size="lg" asChild>
+        <a href={cta.href}>{cta.label}</a>
+      </Btn>
+    );
+  }
+  return (
+    <Btn variant={variant} entity="game" size="lg" onClick={cta.onClick}>
+      {cta.label}
+    </Btn>
+  );
+}
+
+export function HeroGradient({
+  title,
+  subtitle,
+  primaryCta,
+  secondaryCta,
+  className,
+  children,
+}: HeroGradientProps): JSX.Element {
+  return (
+    <section
+      className={clsx('relative py-16 md:py-24 px-4 text-center overflow-hidden', className)}
+      style={GRADIENT_STYLE}
+    >
+      <div className="max-w-4xl mx-auto">
+        <h1
+          className="font-heading font-bold text-4xl md:text-6xl tracking-tight text-foreground m-0 mb-4"
+          style={{ fontFamily: 'var(--f-display)' }}
+        >
+          {title}
+        </h1>
+        {subtitle && (
+          <p className="font-body text-lg text-muted-foreground leading-relaxed max-w-2xl mx-auto m-0">
+            {subtitle}
+          </p>
+        )}
+        {(primaryCta || secondaryCta) && (
+          <div className="flex flex-col sm:flex-row gap-3 justify-center mt-8">
+            {primaryCta && renderCta(primaryCta, 'primary')}
+            {secondaryCta && renderCta(secondaryCta, 'outline')}
+          </div>
+        )}
+        {children && <div className="mt-8">{children}</div>}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/ui/v2/hero-gradient/index.ts
+++ b/apps/web/src/components/ui/v2/hero-gradient/index.ts
@@ -1,0 +1,2 @@
+export { HeroGradient } from './hero-gradient';
+export type { HeroGradientProps, HeroGradientCta } from './hero-gradient';

--- a/apps/web/src/components/ui/v2/notification-card/index.ts
+++ b/apps/web/src/components/ui/v2/notification-card/index.ts
@@ -1,0 +1,2 @@
+export { NotificationCard } from './notification-card';
+export type { NotificationCardProps } from './notification-card';

--- a/apps/web/src/components/ui/v2/notification-card/notification-card.test.tsx
+++ b/apps/web/src/components/ui/v2/notification-card/notification-card.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NotificationCard } from './notification-card';
+
+describe('NotificationCard', () => {
+  it('renders title', () => {
+    render(<NotificationCard entity="agent" title="AI ha risposto" timestamp="2h fa" />);
+    expect(screen.getByText('AI ha risposto')).toBeInTheDocument();
+  });
+
+  it('renders body when provided', () => {
+    render(
+      <NotificationCard
+        entity="agent"
+        title="AI ha risposto"
+        body="Dettagli sul porto speciale"
+        timestamp="2h fa"
+      />
+    );
+    expect(screen.getByText('Dettagli sul porto speciale')).toBeInTheDocument();
+  });
+
+  it('does not render body when absent', () => {
+    const { container } = render(
+      <NotificationCard entity="agent" title="AI ha risposto" timestamp="2h fa" />
+    );
+    // body slot absent — only title + timestamp text
+    expect(container.querySelector('[data-testid="notification-body"]')).toBeNull();
+  });
+
+  it('renders timestamp', () => {
+    render(<NotificationCard entity="agent" title="AI ha risposto" timestamp="2h fa" />);
+    expect(screen.getByText('2h fa')).toBeInTheDocument();
+  });
+
+  it('renders icon when provided', () => {
+    render(
+      <NotificationCard
+        entity="session"
+        title="Sessione avviata"
+        timestamp="3h fa"
+        icon={<span data-testid="n-icon">🎲</span>}
+      />
+    );
+    expect(screen.getByTestId('n-icon')).toBeInTheDocument();
+  });
+
+  it('entity=game sets border-left to --e-game', () => {
+    const { container } = render(<NotificationCard entity="game" title="x" timestamp="ora" />);
+    const el = container.querySelector<HTMLElement>('[data-entity="game"]');
+    expect(el?.className).toMatch(/border-l-4/);
+    expect(el?.style.borderLeftColor).toBe('hsl(var(--e-game))');
+  });
+
+  it('entity=kb maps to --e-document css var', () => {
+    const { container } = render(
+      <NotificationCard entity="kb" title="Nuova regola" timestamp="ieri" />
+    );
+    const el = container.querySelector<HTMLElement>('[data-entity="kb"]');
+    expect(el?.style.borderLeftColor).toBe('hsl(var(--e-document))');
+  });
+
+  it('unread=true shows unread dot pip', () => {
+    render(<NotificationCard entity="agent" title="x" timestamp="ora" unread />);
+    expect(screen.getByTestId('unread-dot')).toBeInTheDocument();
+  });
+
+  it('unread=false (default) does NOT show unread dot pip', () => {
+    render(<NotificationCard entity="agent" title="x" timestamp="ora" />);
+    expect(screen.queryByTestId('unread-dot')).toBeNull();
+  });
+
+  it('unread=true applies font-semibold to title', () => {
+    render(<NotificationCard entity="agent" title="Title-Z" timestamp="ora" unread />);
+    expect(screen.getByText('Title-Z').className).toMatch(/font-semibold/);
+  });
+
+  it('unread=false applies font-normal to title', () => {
+    render(<NotificationCard entity="agent" title="Title-Q" timestamp="ora" />);
+    expect(screen.getByText('Title-Q').className).toMatch(/font-normal/);
+  });
+
+  it('onClick fires when card is clicked', async () => {
+    const onClick = vi.fn();
+    render(<NotificationCard entity="agent" title="Click me" timestamp="ora" onClick={onClick} />);
+    await userEvent.click(screen.getByRole('button', { name: /click me/i }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismiss button appears when onDismiss provided', () => {
+    render(<NotificationCard entity="agent" title="x" timestamp="ora" onDismiss={() => {}} />);
+    expect(screen.getByRole('button', { name: /rimuovi notifica/i })).toBeInTheDocument();
+  });
+
+  it('dismiss button does NOT appear when onDismiss absent', () => {
+    render(<NotificationCard entity="agent" title="x" timestamp="ora" />);
+    expect(screen.queryByRole('button', { name: /rimuovi notifica/i })).toBeNull();
+  });
+
+  it('dismiss onClick fires onDismiss', async () => {
+    const onDismiss = vi.fn();
+    render(<NotificationCard entity="agent" title="x" timestamp="ora" onDismiss={onDismiss} />);
+    await userEvent.click(screen.getByRole('button', { name: /rimuovi notifica/i }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismiss stopPropagation: clicking dismiss does NOT fire card onClick', async () => {
+    const onClick = vi.fn();
+    const onDismiss = vi.fn();
+    render(
+      <NotificationCard
+        entity="agent"
+        title="Outer"
+        timestamp="ora"
+        onClick={onClick}
+        onDismiss={onDismiss}
+      />
+    );
+    await userEvent.click(screen.getByRole('button', { name: /rimuovi notifica/i }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('renders as <button> when onClick present', () => {
+    const { container } = render(
+      <NotificationCard entity="agent" title="Clicky" timestamp="ora" onClick={() => {}} />
+    );
+    const el = container.querySelector<HTMLElement>('[data-entity="agent"]');
+    expect(el?.tagName).toBe('BUTTON');
+  });
+
+  it('renders as non-button element when onClick absent', () => {
+    const { container } = render(
+      <NotificationCard entity="agent" title="Static" timestamp="ora" />
+    );
+    const el = container.querySelector<HTMLElement>('[data-entity="agent"]');
+    expect(el?.tagName).not.toBe('BUTTON');
+  });
+
+  it('custom dismissAriaLabel is applied', () => {
+    render(
+      <NotificationCard
+        entity="agent"
+        title="x"
+        timestamp="ora"
+        onDismiss={() => {}}
+        dismissAriaLabel="Archivia messaggio"
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Archivia messaggio' })).toBeInTheDocument();
+  });
+
+  it('merges className', () => {
+    const { container } = render(
+      <NotificationCard entity="agent" title="x" timestamp="ora" className="custom-nclass" />
+    );
+    const el = container.querySelector<HTMLElement>('[data-entity="agent"]');
+    expect(el?.className).toMatch(/custom-nclass/);
+  });
+});

--- a/apps/web/src/components/ui/v2/notification-card/notification-card.tsx
+++ b/apps/web/src/components/ui/v2/notification-card/notification-card.tsx
@@ -1,0 +1,174 @@
+import type { CSSProperties, JSX, MouseEvent, ReactNode } from 'react';
+
+import clsx from 'clsx';
+
+import type { EntityType } from '../entity-tokens';
+
+// Map EntityType -> CSS variable key (mirrors EntityCard/EntityPip: kb -> document)
+const ENTITY_CSS_VAR_KEY: Record<EntityType, string> = {
+  game: 'game',
+  player: 'player',
+  session: 'session',
+  agent: 'agent',
+  kb: 'document',
+  chat: 'chat',
+  event: 'event',
+  toolkit: 'toolkit',
+  tool: 'tool',
+};
+
+export interface NotificationCardProps {
+  readonly entity: EntityType;
+  readonly title: string;
+  readonly body?: string;
+  readonly timestamp: string;
+  readonly unread?: boolean;
+  readonly icon?: ReactNode;
+  readonly onClick?: () => void;
+  readonly onDismiss?: () => void;
+  readonly dismissAriaLabel?: string;
+  readonly className?: string;
+}
+
+function DismissIcon(): JSX.Element {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      width="14"
+      height="14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  );
+}
+
+export function NotificationCard({
+  entity,
+  title,
+  body,
+  timestamp,
+  unread = false,
+  icon,
+  onClick,
+  onDismiss,
+  dismissAriaLabel = 'Rimuovi notifica',
+  className,
+}: NotificationCardProps): JSX.Element {
+  const cssKey = ENTITY_CSS_VAR_KEY[entity];
+  const entityColor = `hsl(var(--e-${cssKey}))`;
+
+  const containerClasses = clsx(
+    'group relative flex gap-3 rounded-xl border-l-4 bg-card p-4 text-foreground transition-colors',
+    unread && 'bg-muted/20',
+    onClick && 'w-full cursor-pointer text-left hover:bg-muted/40',
+    className
+  );
+
+  const style: CSSProperties = { borderLeftColor: entityColor };
+
+  const titleClasses = clsx(
+    'text-sm leading-tight',
+    unread ? 'font-semibold text-foreground' : 'font-normal text-foreground/90'
+  );
+
+  const content: ReactNode = (
+    <>
+      {icon !== undefined && (
+        <div className="flex-shrink-0" aria-hidden="true">
+          {icon}
+        </div>
+      )}
+
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <div className="flex items-center gap-2">
+          {unread && (
+            <span
+              data-testid="unread-dot"
+              aria-hidden="true"
+              className="inline-block h-2 w-2 flex-shrink-0 rounded-full"
+              style={{ backgroundColor: entityColor }}
+            />
+          )}
+          <span className={titleClasses}>{title}</span>
+        </div>
+        {body && (
+          <p data-testid="notification-body" className="line-clamp-2 text-sm text-muted-foreground">
+            {body}
+          </p>
+        )}
+      </div>
+
+      <div className="flex flex-shrink-0 flex-col items-end gap-2">
+        <span
+          className="whitespace-nowrap font-mono text-xs text-muted-foreground"
+          style={{ fontFamily: 'var(--f-mono, ui-monospace, SFMono-Regular, Menlo, monospace)' }}
+        >
+          {timestamp}
+        </span>
+        {onDismiss && (
+          <button
+            type="button"
+            aria-label={dismissAriaLabel}
+            onClick={(e: MouseEvent<HTMLButtonElement>) => {
+              e.stopPropagation();
+              onDismiss();
+            }}
+            className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100 md:opacity-100"
+          >
+            <DismissIcon />
+          </button>
+        )}
+      </div>
+    </>
+  );
+
+  if (onClick) {
+    // When onDismiss is present, use a div with role=button to avoid nested-button DOM warnings.
+    // When only onClick, use a real <button>.
+    if (onDismiss) {
+      const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick();
+        }
+      };
+      return (
+        <div
+          role="button"
+          tabIndex={0}
+          data-entity={entity}
+          onClick={onClick}
+          onKeyDown={handleKeyDown}
+          className={containerClasses}
+          style={style}
+        >
+          {content}
+        </div>
+      );
+    }
+    return (
+      <button
+        type="button"
+        data-entity={entity}
+        onClick={onClick}
+        className={containerClasses}
+        style={style}
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return (
+    <article data-entity={entity} className={containerClasses} style={style}>
+      {content}
+    </article>
+  );
+}

--- a/apps/web/src/components/ui/v2/oauth-buttons/index.ts
+++ b/apps/web/src/components/ui/v2/oauth-buttons/index.ts
@@ -1,0 +1,2 @@
+export { OAuthButton } from './oauth-buttons';
+export type { OAuthButtonProps, OAuthProvider } from './oauth-buttons';

--- a/apps/web/src/components/ui/v2/oauth-buttons/oauth-buttons.test.tsx
+++ b/apps/web/src/components/ui/v2/oauth-buttons/oauth-buttons.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { OAuthButton } from './oauth-buttons';
+
+expect.extend(toHaveNoViolations);
+
+describe('OAuthButton', () => {
+  it('renders default label "Continua con Google" for google provider', () => {
+    render(<OAuthButton provider="google" />);
+    expect(screen.getByRole('button', { name: /Continua con Google/i })).toBeInTheDocument();
+  });
+
+  it('renders default label "Continua con Discord" for discord provider', () => {
+    render(<OAuthButton provider="discord" />);
+    expect(screen.getByRole('button', { name: /Continua con Discord/i })).toBeInTheDocument();
+  });
+
+  it('renders default label "Continua con GitHub" for github provider', () => {
+    render(<OAuthButton provider="github" />);
+    expect(screen.getByRole('button', { name: /Continua con GitHub/i })).toBeInTheDocument();
+  });
+
+  it('custom label overrides the default', () => {
+    render(<OAuthButton provider="google" label="Accedi con Google" />);
+    expect(screen.getByRole('button', { name: 'Accedi con Google' })).toBeInTheDocument();
+    expect(screen.queryByText('Continua con Google')).toBeNull();
+  });
+
+  it('onClick fires on click', async () => {
+    const onClick = vi.fn();
+    render(<OAuthButton provider="google" onClick={onClick} />);
+    await userEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('onClick does NOT fire when disabled', async () => {
+    const onClick = vi.fn();
+    render(<OAuthButton provider="discord" onClick={onClick} disabled />);
+    await userEvent.click(screen.getByRole('button'));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('onClick does NOT fire when loading', async () => {
+    const onClick = vi.fn();
+    render(<OAuthButton provider="github" onClick={onClick} loading />);
+    await userEvent.click(screen.getByRole('button'));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('loading shows spinner and sets aria-busy=true', () => {
+    render(<OAuthButton provider="google" loading />);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveAttribute('aria-busy', 'true');
+    expect(btn.querySelector('svg.animate-spin')).not.toBeNull();
+  });
+
+  it('fullWidth defaults to true (w-full class present)', () => {
+    render(<OAuthButton provider="google" />);
+    expect(screen.getByRole('button')).toHaveClass('w-full');
+  });
+
+  it('fullWidth={false} omits w-full', () => {
+    render(<OAuthButton provider="google" fullWidth={false} />);
+    expect(screen.getByRole('button')).not.toHaveClass('w-full');
+  });
+
+  it('renders provider icon (svg element present)', () => {
+    render(<OAuthButton provider="discord" />);
+    const btn = screen.getByRole('button');
+    // At least one svg (the brand icon)
+    expect(btn.querySelector('svg')).not.toBeNull();
+  });
+
+  it('disabled prop sets disabled attribute', () => {
+    render(<OAuthButton provider="github" disabled />);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('forwards className', () => {
+    render(<OAuthButton provider="google" className="custom-oauth" />);
+    expect(screen.getByRole('button')).toHaveClass('custom-oauth');
+  });
+
+  it('has no a11y violations', async () => {
+    const { container } = render(<OAuthButton provider="google" />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/ui/v2/oauth-buttons/oauth-buttons.tsx
+++ b/apps/web/src/components/ui/v2/oauth-buttons/oauth-buttons.tsx
@@ -1,0 +1,94 @@
+import type { JSX } from 'react';
+
+import { Btn } from '../btn';
+
+export type OAuthProvider = 'google' | 'discord' | 'github';
+
+export interface OAuthButtonProps {
+  readonly provider: OAuthProvider;
+  readonly onClick?: () => void;
+  readonly fullWidth?: boolean;
+  readonly loading?: boolean;
+  readonly disabled?: boolean;
+  readonly label?: string;
+  readonly className?: string;
+}
+
+const DEFAULT_LABELS: Record<OAuthProvider, string> = {
+  google: 'Continua con Google',
+  discord: 'Continua con Discord',
+  github: 'Continua con GitHub',
+};
+
+function GoogleIcon(): JSX.Element {
+  return (
+    <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none">
+      <path
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+        fill="#4285F4"
+      />
+      <path
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        fill="#34A853"
+      />
+      <path
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        fill="#EA4335"
+      />
+    </svg>
+  );
+}
+
+function DiscordIcon(): JSX.Element {
+  return (
+    <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="#5865F2">
+      <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515.074.074 0 00-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0 12.64 12.64 0 00-.617-1.25.077.077 0 00-.079-.037A19.736 19.736 0 003.677 4.37a.07.07 0 00-.032.027C.533 9.046-.32 13.58.099 18.057c.002.022.015.043.032.056a19.9 19.9 0 005.993 3.03.078.078 0 00.084-.028c.462-.63.874-1.295 1.226-1.993.021-.041.001-.09-.041-.106a13.1 13.1 0 01-1.872-.892.077.077 0 01-.008-.128 10.2 10.2 0 00.372-.292.074.074 0 01.077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 01.078.01c.12.098.246.198.373.292a.077.077 0 01-.006.127 12.299 12.299 0 01-1.873.892.077.077 0 00-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 00.084.028 19.839 19.839 0 006.002-3.03.077.077 0 00.032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 00-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+    </svg>
+  );
+}
+
+function GitHubIcon(): JSX.Element {
+  return (
+    <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56 0-.28-.01-1.02-.02-2-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.27-1.68-1.27-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.26.73-1.55-2.56-.29-5.25-1.28-5.25-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.19a11 11 0 015.78 0c2.2-1.5 3.17-1.19 3.17-1.19.63 1.59.23 2.77.11 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.69.41.36.78 1.07.78 2.16 0 1.56-.01 2.82-.01 3.2 0 .31.21.67.8.56A11.52 11.52 0 0023.5 12C23.5 5.65 18.35.5 12 .5z" />
+    </svg>
+  );
+}
+
+const PROVIDER_ICONS: Record<OAuthProvider, () => JSX.Element> = {
+  google: GoogleIcon,
+  discord: DiscordIcon,
+  github: GitHubIcon,
+};
+
+export function OAuthButton({
+  provider,
+  onClick,
+  fullWidth = true,
+  loading = false,
+  disabled = false,
+  label,
+  className,
+}: OAuthButtonProps): JSX.Element {
+  const Icon = PROVIDER_ICONS[provider];
+  const text = label ?? DEFAULT_LABELS[provider];
+
+  return (
+    <Btn
+      variant="outline"
+      size="md"
+      fullWidth={fullWidth}
+      loading={loading}
+      disabled={disabled}
+      onClick={onClick}
+      leftIcon={<Icon />}
+      className={className}
+    >
+      {text}
+    </Btn>
+  );
+}

--- a/apps/web/src/components/ui/v2/pricing-card/index.ts
+++ b/apps/web/src/components/ui/v2/pricing-card/index.ts
@@ -1,0 +1,2 @@
+export { PricingCard } from './pricing-card';
+export type { PricingCardProps, PricingCardCta, PricingFeature } from './pricing-card';

--- a/apps/web/src/components/ui/v2/pricing-card/pricing-card.test.tsx
+++ b/apps/web/src/components/ui/v2/pricing-card/pricing-card.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { PricingCard } from './pricing-card';
+
+const baseFeatures = [
+  { label: 'Libreria illimitata', included: true },
+  { label: 'Supporto prioritario', included: false },
+];
+
+describe('PricingCard', () => {
+  it('renders tier label', () => {
+    render(
+      <PricingCard tier="Free" price="€0" features={baseFeatures} cta={{ label: 'Inizia' }} />
+    );
+    expect(screen.getByText('Free')).toBeInTheDocument();
+  });
+
+  it('renders price', () => {
+    render(
+      <PricingCard tier="Pro" price="€9/mese" features={baseFeatures} cta={{ label: 'Abbonati' }} />
+    );
+    expect(screen.getByText('€9/mese')).toBeInTheDocument();
+  });
+
+  it('renders description when provided', () => {
+    render(
+      <PricingCard
+        tier="Pro"
+        price="€9"
+        description="Per giocatori abituali"
+        features={baseFeatures}
+        cta={{ label: 'Go' }}
+      />
+    );
+    expect(screen.getByText('Per giocatori abituali')).toBeInTheDocument();
+  });
+
+  it('does NOT render description when omitted', () => {
+    render(<PricingCard tier="Pro" price="€9" features={baseFeatures} cta={{ label: 'Go' }} />);
+    expect(screen.queryByText('Per giocatori abituali')).not.toBeInTheDocument();
+  });
+
+  it('renders feature list items', () => {
+    render(
+      <PricingCard tier="Free" price="€0" features={baseFeatures} cta={{ label: 'Inizia' }} />
+    );
+    expect(screen.getByText('Libreria illimitata')).toBeInTheDocument();
+    expect(screen.getByText('Supporto prioritario')).toBeInTheDocument();
+  });
+
+  it('marks included features with data-included="true"', () => {
+    render(
+      <PricingCard tier="Free" price="€0" features={baseFeatures} cta={{ label: 'Inizia' }} />
+    );
+    const included = screen.getByText('Libreria illimitata').closest('li');
+    expect(included).toHaveAttribute('data-included', 'true');
+  });
+
+  it('marks excluded features with data-included="false"', () => {
+    render(
+      <PricingCard tier="Free" price="€0" features={baseFeatures} cta={{ label: 'Inizia' }} />
+    );
+    const excluded = screen.getByText('Supporto prioritario').closest('li');
+    expect(excluded).toHaveAttribute('data-included', 'false');
+  });
+
+  it('renders cta as button when onClick provided', () => {
+    render(
+      <PricingCard
+        tier="Free"
+        price="€0"
+        features={baseFeatures}
+        cta={{ label: 'Inizia', onClick: () => undefined }}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Inizia' })).toBeInTheDocument();
+  });
+
+  it('fires cta onClick', async () => {
+    const user = userEvent.setup();
+    const handler = vi.fn();
+    render(
+      <PricingCard
+        tier="Free"
+        price="€0"
+        features={baseFeatures}
+        cta={{ label: 'Inizia', onClick: handler }}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Inizia' }));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders cta as link when href provided', () => {
+    render(
+      <PricingCard
+        tier="Free"
+        price="€0"
+        features={baseFeatures}
+        cta={{ label: 'Registrati', href: '/signup' }}
+      />
+    );
+    const link = screen.getByRole('link', { name: 'Registrati' });
+    expect(link).toHaveAttribute('href', '/signup');
+  });
+
+  it('applies highlighted styling when highlighted=true', () => {
+    const { container } = render(
+      <PricingCard
+        tier="Pro"
+        price="€9"
+        features={baseFeatures}
+        cta={{ label: 'Go' }}
+        highlighted
+      />
+    );
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveAttribute('data-highlighted', 'true');
+    expect(root.style.borderColor).toContain('hsl');
+  });
+
+  it('highlighted=false by default (no data-highlighted=true)', () => {
+    const { container } = render(
+      <PricingCard tier="Free" price="€0" features={baseFeatures} cta={{ label: 'Inizia' }} />
+    );
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveAttribute('data-highlighted', 'false');
+  });
+
+  it('shows "Consigliato" badge when highlighted', () => {
+    render(
+      <PricingCard
+        tier="Pro"
+        price="€9"
+        features={baseFeatures}
+        cta={{ label: 'Go' }}
+        highlighted
+      />
+    );
+    expect(screen.getByText('Consigliato')).toBeInTheDocument();
+  });
+
+  it('does NOT show "Consigliato" badge when not highlighted', () => {
+    render(
+      <PricingCard tier="Free" price="€0" features={baseFeatures} cta={{ label: 'Inizia' }} />
+    );
+    expect(screen.queryByText('Consigliato')).not.toBeInTheDocument();
+  });
+
+  it('merges className onto root', () => {
+    const { container } = render(
+      <PricingCard
+        tier="Free"
+        price="€0"
+        features={baseFeatures}
+        cta={{ label: 'Inizia' }}
+        className="custom-pricing"
+      />
+    );
+    expect(container.firstChild).toHaveClass('custom-pricing');
+  });
+});

--- a/apps/web/src/components/ui/v2/pricing-card/pricing-card.tsx
+++ b/apps/web/src/components/ui/v2/pricing-card/pricing-card.tsx
@@ -1,0 +1,142 @@
+import type { CSSProperties, JSX } from 'react';
+
+import clsx from 'clsx';
+
+import { Btn } from '../btn';
+
+export interface PricingFeature {
+  readonly label: string;
+  readonly included: boolean;
+}
+
+export interface PricingCardCta {
+  readonly label: string;
+  readonly onClick?: () => void;
+  readonly href?: string;
+}
+
+export interface PricingCardProps {
+  readonly tier: string;
+  readonly price: string;
+  readonly description?: string;
+  readonly features: readonly PricingFeature[];
+  readonly cta: PricingCardCta;
+  readonly highlighted?: boolean;
+  readonly className?: string;
+}
+
+function CheckIcon(): JSX.Element {
+  return (
+    <svg
+      aria-hidden="true"
+      className="shrink-0 w-4 h-4"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{ color: 'hsl(var(--e-toolkit))' }}
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+function DashIcon(): JSX.Element {
+  return (
+    <svg
+      aria-hidden="true"
+      className="shrink-0 w-4 h-4 text-muted-foreground"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+    >
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  );
+}
+
+export function PricingCard({
+  tier,
+  price,
+  description,
+  features,
+  cta,
+  highlighted = false,
+  className,
+}: PricingCardProps): JSX.Element {
+  const rootStyle: CSSProperties | undefined = highlighted
+    ? { borderColor: 'hsl(var(--e-game))' }
+    : undefined;
+
+  const ctaEl = cta.href ? (
+    <Btn variant={highlighted ? 'primary' : 'outline'} entity="game" size="lg" fullWidth asChild>
+      <a href={cta.href}>{cta.label}</a>
+    </Btn>
+  ) : (
+    <Btn
+      variant={highlighted ? 'primary' : 'outline'}
+      entity="game"
+      size="lg"
+      fullWidth
+      onClick={cta.onClick}
+    >
+      {cta.label}
+    </Btn>
+  );
+
+  return (
+    <div
+      data-highlighted={highlighted ? 'true' : 'false'}
+      className={clsx(
+        'relative rounded-2xl bg-card p-6 md:p-8 border-2 border-border flex flex-col',
+        highlighted && 'md:scale-105 shadow-xl',
+        className
+      )}
+      style={rootStyle}
+    >
+      {highlighted && (
+        <span
+          className="absolute -top-3 left-1/2 -translate-x-1/2 px-3 py-1 rounded-full text-xs font-semibold text-white"
+          style={{ backgroundColor: 'hsl(var(--e-game))' }}
+        >
+          Consigliato
+        </span>
+      )}
+
+      <div className="text-sm uppercase tracking-wide text-muted-foreground font-semibold">
+        {tier}
+      </div>
+
+      <div
+        className="text-4xl font-bold mt-2 text-foreground"
+        style={{ fontFamily: 'var(--f-display)' }}
+      >
+        {price}
+      </div>
+
+      {description && <p className="text-sm text-muted-foreground mt-2 m-0">{description}</p>}
+
+      <ul className="flex flex-col gap-2 mt-6 mb-6 flex-1">
+        {features.map((feature, i) => (
+          <li
+            key={`${feature.label}-${i}`}
+            data-included={feature.included ? 'true' : 'false'}
+            className={clsx(
+              'flex items-center gap-2 text-sm',
+              feature.included ? 'text-foreground' : 'text-muted-foreground'
+            )}
+          >
+            {feature.included ? <CheckIcon /> : <DashIcon />}
+            <span>{feature.label}</span>
+          </li>
+        ))}
+      </ul>
+
+      <div className="mt-auto">{ctaEl}</div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/v2/settings-list/index.ts
+++ b/apps/web/src/components/ui/v2/settings-list/index.ts
@@ -1,0 +1,2 @@
+export { SettingsList } from './settings-list';
+export type { SettingsListProps } from './settings-list';

--- a/apps/web/src/components/ui/v2/settings-list/settings-list.test.tsx
+++ b/apps/web/src/components/ui/v2/settings-list/settings-list.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { SettingsList } from './settings-list';
+
+describe('SettingsList', () => {
+  it('renders children inside a list with role="list"', () => {
+    render(
+      <SettingsList>
+        <li>Item A</li>
+        <li>Item B</li>
+      </SettingsList>
+    );
+    const list = screen.getByRole('list');
+    expect(list.tagName).toBe('UL');
+    expect(list.children).toHaveLength(2);
+    expect(screen.getByText('Item A')).toBeInTheDocument();
+    expect(screen.getByText('Item B')).toBeInTheDocument();
+  });
+
+  it('merges className on the nav wrapper', () => {
+    const { container } = render(
+      <SettingsList className="custom-class">
+        <li>Only</li>
+      </SettingsList>
+    );
+    const nav = container.querySelector('nav');
+    expect(nav).toHaveClass('custom-class');
+  });
+
+  it('uses default aria-label when none provided', () => {
+    render(
+      <SettingsList>
+        <li>X</li>
+      </SettingsList>
+    );
+    expect(screen.getByRole('navigation', { name: 'Impostazioni' })).toBeInTheDocument();
+  });
+
+  it('accepts custom aria-label', () => {
+    render(
+      <SettingsList ariaLabel="Account settings">
+        <li>X</li>
+      </SettingsList>
+    );
+    expect(screen.getByRole('navigation', { name: 'Account settings' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ui/v2/settings-list/settings-list.tsx
+++ b/apps/web/src/components/ui/v2/settings-list/settings-list.tsx
@@ -1,0 +1,23 @@
+import type { JSX, ReactNode } from 'react';
+
+import clsx from 'clsx';
+
+export interface SettingsListProps {
+  readonly children: ReactNode;
+  readonly ariaLabel?: string;
+  readonly className?: string;
+}
+
+export function SettingsList({
+  children,
+  ariaLabel = 'Impostazioni',
+  className,
+}: SettingsListProps): JSX.Element {
+  return (
+    <nav aria-label={ariaLabel} className={className}>
+      <ul role="list" className={clsx('divide-y divide-border rounded-xl bg-card overflow-hidden')}>
+        {children}
+      </ul>
+    </nav>
+  );
+}

--- a/apps/web/src/components/ui/v2/settings-row/index.ts
+++ b/apps/web/src/components/ui/v2/settings-row/index.ts
@@ -1,0 +1,2 @@
+export { SettingsRow } from './settings-row';
+export type { SettingsRowProps } from './settings-row';

--- a/apps/web/src/components/ui/v2/settings-row/settings-row.test.tsx
+++ b/apps/web/src/components/ui/v2/settings-row/settings-row.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { SettingsRow } from './settings-row';
+
+describe('SettingsRow', () => {
+  it('renders the label', () => {
+    render(<SettingsRow label="Notifications" />);
+    expect(screen.getByText('Notifications')).toBeInTheDocument();
+  });
+
+  it('renders description when provided', () => {
+    render(<SettingsRow label="Theme" description="Light or dark" />);
+    expect(screen.getByText('Light or dark')).toBeInTheDocument();
+  });
+
+  it('renders icon when provided', () => {
+    render(<SettingsRow label="Theme" icon={<span>🎨</span>} />);
+    const icon = screen.getByTestId('settings-row-icon');
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveTextContent('🎨');
+  });
+
+  it('renders trailing when provided', () => {
+    render(<SettingsRow label="2FA" trailing={<span>On</span>} />);
+    expect(screen.getByTestId('settings-row-trailing')).toHaveTextContent('On');
+  });
+
+  it('fires onClick when interactive and enabled', async () => {
+    const onClick = vi.fn();
+    render(<SettingsRow label="Click me" onClick={onClick} />);
+    await userEvent.click(screen.getByRole('button', { name: /click me/i }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire onClick when disabled', async () => {
+    const onClick = vi.fn();
+    render(<SettingsRow label="Disabled" onClick={onClick} disabled />);
+    const btn = screen.getByRole('button', { name: /disabled/i });
+    await userEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+    expect(btn).toBeDisabled();
+  });
+
+  it('renders a button when onClick is provided', () => {
+    render(<SettingsRow label="Button" onClick={() => {}} />);
+    const btn = screen.getByRole('button', { name: /button/i });
+    expect(btn.tagName).toBe('BUTTON');
+    expect(btn).toHaveAttribute('type', 'button');
+  });
+
+  it('renders a link when href is provided without onClick', () => {
+    render(<SettingsRow label="Link" href="/settings/account" />);
+    const link = screen.getByRole('link', { name: /link/i });
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('href', '/settings/account');
+  });
+
+  it('prefers onClick when both onClick and href provided', () => {
+    const onClick = vi.fn();
+    render(<SettingsRow label="Both" href="/ignored" onClick={onClick} />);
+    expect(screen.getByRole('button', { name: /both/i })).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('renders as a div when neither onClick nor href is provided', () => {
+    render(<SettingsRow label="Static" />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByText('Static')).toBeInTheDocument();
+  });
+
+  it('auto-renders chevron when interactive and no trailing provided', () => {
+    const { container } = render(<SettingsRow label="Go" onClick={() => {}} />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('does not auto-render chevron when trailing is provided', () => {
+    const { container } = render(
+      <SettingsRow label="Go" onClick={() => {}} trailing={<span>X</span>} />
+    );
+    expect(container.querySelector('svg')).not.toBeInTheDocument();
+  });
+
+  it('does not auto-render chevron when not interactive', () => {
+    const { container } = render(<SettingsRow label="Plain" />);
+    expect(container.querySelector('svg')).not.toBeInTheDocument();
+  });
+
+  it('applies destructive color to label when destructive=true', () => {
+    render(<SettingsRow label="Delete account" destructive />);
+    const label = screen.getByText('Delete account');
+    expect(label.className).toMatch(/destructive/);
+  });
+
+  it('applies entity color to icon wrapper via inline style', () => {
+    render(<SettingsRow label="KB" icon={<span>📚</span>} entity="kb" />);
+    const icon = screen.getByTestId('settings-row-icon');
+    // kb maps to --e-document
+    expect(icon.getAttribute('style')).toMatch(/--e-document/);
+  });
+
+  it('merges className on the li wrapper', () => {
+    const { container } = render(<SettingsRow label="X" className="my-li" />);
+    const li = container.querySelector('li');
+    expect(li).toHaveClass('my-li');
+  });
+});

--- a/apps/web/src/components/ui/v2/settings-row/settings-row.tsx
+++ b/apps/web/src/components/ui/v2/settings-row/settings-row.tsx
@@ -1,0 +1,134 @@
+import type { CSSProperties, JSX, ReactNode } from 'react';
+
+import clsx from 'clsx';
+
+import type { EntityType } from '../entity-tokens';
+
+// Mirror entity-card / btn ENTITY_CSS_VAR_KEY mapping so `kb` resolves to `--e-document`
+const ENTITY_CSS_VAR_KEY: Record<EntityType, string> = {
+  game: 'game',
+  player: 'player',
+  session: 'session',
+  agent: 'agent',
+  kb: 'document',
+  chat: 'chat',
+  event: 'event',
+  toolkit: 'toolkit',
+  tool: 'tool',
+};
+
+export interface SettingsRowProps {
+  readonly icon?: ReactNode;
+  readonly label: string;
+  readonly description?: string;
+  readonly trailing?: ReactNode;
+  readonly onClick?: () => void;
+  readonly href?: string;
+  readonly destructive?: boolean;
+  readonly entity?: EntityType;
+  readonly disabled?: boolean;
+  readonly className?: string;
+}
+
+function ChevronRight(): JSX.Element {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-4 w-4 text-muted-foreground flex-shrink-0"
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M7.5 5L12.5 10L7.5 15"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function SettingsRow({
+  icon,
+  label,
+  description,
+  trailing,
+  onClick,
+  href,
+  destructive = false,
+  entity,
+  disabled = false,
+  className,
+}: SettingsRowProps): JSX.Element {
+  const isInteractive = Boolean(onClick || href);
+  // onClick wins when both provided
+  const useButton = Boolean(onClick);
+  const useLink = !useButton && Boolean(href);
+
+  const iconStyle: CSSProperties | undefined = entity
+    ? { color: `hsl(var(--e-${ENTITY_CSS_VAR_KEY[entity]}))` }
+    : undefined;
+
+  const showAutoChevron = isInteractive && trailing === undefined;
+
+  const innerClasses = clsx(
+    'flex items-center gap-3 w-full p-4 text-left',
+    isInteractive && !disabled && 'hover:bg-muted/40 transition-colors',
+    disabled && 'opacity-50 cursor-not-allowed'
+  );
+
+  const labelClasses = clsx(
+    'text-sm font-medium truncate',
+    destructive ? 'text-[hsl(var(--destructive))]' : 'text-foreground'
+  );
+
+  const body = (
+    <>
+      {icon !== undefined ? (
+        <span data-testid="settings-row-icon" className="flex-shrink-0 text-lg" style={iconStyle}>
+          {icon}
+        </span>
+      ) : null}
+      <span className="flex-1 min-w-0 flex flex-col">
+        <span className={labelClasses}>{label}</span>
+        {description ? (
+          <span className="text-xs text-muted-foreground truncate">{description}</span>
+        ) : null}
+      </span>
+      {trailing !== undefined ? (
+        <span data-testid="settings-row-trailing" className="flex-shrink-0">
+          {trailing}
+        </span>
+      ) : null}
+      {showAutoChevron ? <ChevronRight /> : null}
+    </>
+  );
+
+  return (
+    <li className={className}>
+      {useButton ? (
+        <button
+          type="button"
+          className={innerClasses}
+          onClick={disabled ? undefined : onClick}
+          disabled={disabled}
+          aria-disabled={disabled || undefined}
+        >
+          {body}
+        </button>
+      ) : useLink ? (
+        <a
+          href={disabled ? undefined : href}
+          className={innerClasses}
+          aria-disabled={disabled || undefined}
+        >
+          {body}
+        </a>
+      ) : (
+        <div className={innerClasses}>{body}</div>
+      )}
+    </li>
+  );
+}

--- a/apps/web/src/components/ui/v2/theme-toggle/theme-toggle.test.tsx
+++ b/apps/web/src/components/ui/v2/theme-toggle/theme-toggle.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeToggle } from './theme-toggle';
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+  });
+
+  it('toggles dark class on html element', () => {
+    render(<ThemeToggle />);
+    const btn = screen.getByRole('button', { name: /tema/i });
+    fireEvent.click(btn);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    fireEvent.click(btn);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('persists choice in localStorage mai-theme', () => {
+    render(<ThemeToggle />);
+    fireEvent.click(screen.getByRole('button', { name: /tema/i }));
+    expect(localStorage.getItem('mai-theme')).toBe('dark');
+  });
+
+  it('reads initial value from localStorage', () => {
+    localStorage.setItem('mai-theme', 'dark');
+    render(<ThemeToggle />);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+});

--- a/apps/web/src/components/ui/v2/theme-toggle/theme-toggle.tsx
+++ b/apps/web/src/components/ui/v2/theme-toggle/theme-toggle.tsx
@@ -1,0 +1,34 @@
+'use client';
+import { useEffect, useState } from 'react';
+import type { JSX } from 'react';
+
+const STORAGE_KEY = 'mai-theme';
+
+export function ThemeToggle(): JSX.Element {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    const shouldBeDark = stored === 'dark';
+    setIsDark(shouldBeDark);
+    document.documentElement.classList.toggle('dark', shouldBeDark);
+  }, []);
+
+  const handleToggle = (): void => {
+    const next = !isDark;
+    setIsDark(next);
+    document.documentElement.classList.toggle('dark', next);
+    localStorage.setItem(STORAGE_KEY, next ? 'dark' : 'light');
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleToggle}
+      aria-label={isDark ? 'Passa a tema chiaro' : 'Passa a tema scuro'}
+      className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-background text-foreground hover:bg-accent"
+    >
+      <span aria-hidden="true">{isDark ? '☀️' : '🌙'}</span>
+    </button>
+  );
+}

--- a/apps/web/src/components/ui/v2/toggle-switch/index.ts
+++ b/apps/web/src/components/ui/v2/toggle-switch/index.ts
@@ -1,0 +1,2 @@
+export { ToggleSwitch } from './toggle-switch';
+export type { ToggleSwitchProps, ToggleSwitchSize } from './toggle-switch';

--- a/apps/web/src/components/ui/v2/toggle-switch/toggle-switch.test.tsx
+++ b/apps/web/src/components/ui/v2/toggle-switch/toggle-switch.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ToggleSwitch } from './toggle-switch';
+
+describe('ToggleSwitch', () => {
+  // Silence the dev warning for tests that intentionally omit aria labels
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('renders with role="switch"', () => {
+    render(<ToggleSwitch checked={false} onCheckedChange={() => {}} ariaLabel="Toggle" />);
+    expect(screen.getByRole('switch')).toBeInTheDocument();
+  });
+
+  it('aria-checked reflects the checked prop (false)', () => {
+    render(<ToggleSwitch checked={false} onCheckedChange={() => {}} ariaLabel="Off" />);
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('aria-checked reflects the checked prop (true)', () => {
+    render(<ToggleSwitch checked onCheckedChange={() => {}} ariaLabel="On" />);
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('fires onCheckedChange with the opposite value when clicked', async () => {
+    const onCheckedChange = vi.fn();
+    render(<ToggleSwitch checked={false} onCheckedChange={onCheckedChange} ariaLabel="T" />);
+    await userEvent.click(screen.getByRole('switch'));
+    expect(onCheckedChange).toHaveBeenCalledTimes(1);
+    expect(onCheckedChange).toHaveBeenCalledWith(true);
+  });
+
+  it('does not fire onCheckedChange when disabled', async () => {
+    const onCheckedChange = vi.fn();
+    render(
+      <ToggleSwitch checked={false} onCheckedChange={onCheckedChange} disabled ariaLabel="T" />
+    );
+    await userEvent.click(screen.getByRole('switch'));
+    expect(onCheckedChange).not.toHaveBeenCalled();
+  });
+
+  it('active state sets backgroundColor inline via entity color', () => {
+    render(<ToggleSwitch checked onCheckedChange={() => {}} entity="game" ariaLabel="T" />);
+    const sw = screen.getByRole('switch');
+    expect(sw.getAttribute('style')).toMatch(/--e-game/);
+  });
+
+  it('default entity is "game"', () => {
+    render(<ToggleSwitch checked onCheckedChange={() => {}} ariaLabel="T" />);
+    expect(screen.getByRole('switch')).toHaveAttribute('data-entity', 'game');
+  });
+
+  it('kb entity maps to --e-document CSS var', () => {
+    render(<ToggleSwitch checked onCheckedChange={() => {}} entity="kb" ariaLabel="T" />);
+    const sw = screen.getByRole('switch');
+    expect(sw.getAttribute('style')).toMatch(/--e-document/);
+  });
+
+  it('size "sm" uses smaller track dimensions', () => {
+    render(<ToggleSwitch checked={false} onCheckedChange={() => {}} size="sm" ariaLabel="T" />);
+    const sw = screen.getByRole('switch');
+    expect(sw.className).toMatch(/w-8/);
+    expect(sw.className).toMatch(/h-5/);
+  });
+
+  it('size "md" is the default', () => {
+    render(<ToggleSwitch checked={false} onCheckedChange={() => {}} ariaLabel="T" />);
+    const sw = screen.getByRole('switch');
+    expect(sw.className).toMatch(/w-10/);
+    expect(sw.className).toMatch(/h-6/);
+  });
+
+  it('forwards ariaLabel to the root', () => {
+    render(<ToggleSwitch checked={false} onCheckedChange={() => {}} ariaLabel="Notifications" />);
+    expect(screen.getByRole('switch', { name: 'Notifications' })).toBeInTheDocument();
+  });
+
+  it('forwards ariaLabelledBy to the root', () => {
+    render(
+      <>
+        <span id="lbl">2FA enabled</span>
+        <ToggleSwitch checked={false} onCheckedChange={() => {}} ariaLabelledBy="lbl" />
+      </>
+    );
+    const sw = screen.getByRole('switch');
+    expect(sw).toHaveAttribute('aria-labelledby', 'lbl');
+  });
+
+  it('merges className', () => {
+    render(
+      <ToggleSwitch
+        checked={false}
+        onCheckedChange={() => {}}
+        className="my-switch"
+        ariaLabel="T"
+      />
+    );
+    expect(screen.getByRole('switch')).toHaveClass('my-switch');
+  });
+
+  it('Space key triggers onCheckedChange (native button)', async () => {
+    const onCheckedChange = vi.fn();
+    render(<ToggleSwitch checked={false} onCheckedChange={onCheckedChange} ariaLabel="T" />);
+    const sw = screen.getByRole('switch');
+    sw.focus();
+    await userEvent.keyboard(' ');
+    expect(onCheckedChange).toHaveBeenCalledWith(true);
+  });
+
+  it('is disabled via the disabled attribute and aria-disabled', () => {
+    render(<ToggleSwitch checked={false} onCheckedChange={() => {}} disabled ariaLabel="T" />);
+    const sw = screen.getByRole('switch');
+    expect(sw).toBeDisabled();
+    expect(sw).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('forwards id', () => {
+    render(<ToggleSwitch checked={false} onCheckedChange={() => {}} id="toggle-1" ariaLabel="T" />);
+    expect(screen.getByRole('switch')).toHaveAttribute('id', 'toggle-1');
+  });
+});

--- a/apps/web/src/components/ui/v2/toggle-switch/toggle-switch.tsx
+++ b/apps/web/src/components/ui/v2/toggle-switch/toggle-switch.tsx
@@ -1,0 +1,109 @@
+import type { CSSProperties, JSX } from 'react';
+
+import clsx from 'clsx';
+
+import type { EntityType } from '../entity-tokens';
+
+// Mirror entity-card / btn ENTITY_CSS_VAR_KEY mapping so `kb` resolves to `--e-document`
+const ENTITY_CSS_VAR_KEY: Record<EntityType, string> = {
+  game: 'game',
+  player: 'player',
+  session: 'session',
+  agent: 'agent',
+  kb: 'document',
+  chat: 'chat',
+  event: 'event',
+  toolkit: 'toolkit',
+  tool: 'tool',
+};
+
+export type ToggleSwitchSize = 'sm' | 'md';
+
+export interface ToggleSwitchProps {
+  readonly checked: boolean;
+  readonly onCheckedChange: (next: boolean) => void;
+  readonly disabled?: boolean;
+  readonly entity?: EntityType;
+  readonly size?: ToggleSwitchSize;
+  readonly ariaLabel?: string;
+  readonly ariaLabelledBy?: string;
+  readonly className?: string;
+  readonly id?: string;
+}
+
+const TRACK_CLASSES: Record<ToggleSwitchSize, string> = {
+  sm: 'w-8 h-5',
+  md: 'w-10 h-6',
+};
+
+const THUMB_CLASSES: Record<ToggleSwitchSize, string> = {
+  sm: 'h-4 w-4',
+  md: 'h-5 w-5',
+};
+
+const THUMB_TRANSLATE: Record<ToggleSwitchSize, string> = {
+  sm: 'translate-x-3',
+  md: 'translate-x-4',
+};
+
+export function ToggleSwitch({
+  checked,
+  onCheckedChange,
+  disabled = false,
+  entity = 'game',
+  size = 'md',
+  ariaLabel,
+  ariaLabelledBy,
+  className,
+  id,
+}: ToggleSwitchProps): JSX.Element {
+  if (!ariaLabel && !ariaLabelledBy && process.env.NODE_ENV !== 'production') {
+    console.warn('ToggleSwitch: provide `ariaLabel` or `ariaLabelledBy` for accessibility.');
+  }
+
+  const cssKey = ENTITY_CSS_VAR_KEY[entity];
+  const entityColor = `hsl(var(--e-${cssKey}))`;
+
+  const trackStyle: CSSProperties = checked ? { backgroundColor: entityColor } : {};
+
+  const trackClasses = clsx(
+    'relative inline-flex items-center rounded-full transition-colors',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+    TRACK_CLASSES[size],
+    !checked && 'bg-muted',
+    disabled && 'opacity-50 cursor-not-allowed',
+    className
+  );
+
+  const thumbClasses = clsx(
+    'inline-block rounded-full bg-white shadow transform transition-transform',
+    THUMB_CLASSES[size],
+    checked ? THUMB_TRANSLATE[size] : 'translate-x-0.5'
+  );
+
+  const focusRingStyle: CSSProperties = {
+    // via CSS custom property so ring uses entity color
+    ['--tw-ring-color' as string]: entityColor,
+  };
+
+  return (
+    <button
+      type="button"
+      role="switch"
+      id={id}
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      aria-disabled={disabled || undefined}
+      disabled={disabled}
+      data-entity={entity}
+      className={trackClasses}
+      style={{ ...trackStyle, ...focusRingStyle }}
+      onClick={() => {
+        if (!disabled) onCheckedChange(!checked);
+      }}
+    >
+      <span className={thumbClasses} />
+    </button>
+  );
+}

--- a/apps/web/src/styles/__tests__/entity-tokens.test.ts
+++ b/apps/web/src/styles/__tests__/entity-tokens.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * M6 Task 0 — Reconcile token drift with Claude Design v1
+ *
+ * Mockup source of truth: admin-mockups/design_files/tokens.css
+ *   --c-kb:      174 60% 40%
+ *   --c-toolkit: 142 70% 45%
+ *
+ * App currently has (pre-M6):
+ *   --e-document: 210 40% 55%   (drifted — was generic "document" blue)
+ *   --e-toolkit:  160 70% 45%   (drifted — was pre-v1 teal)
+ *
+ * This test enforces alignment with the Claude Design v1 mockups.
+ */
+describe('entity tokens alignment with Claude Design v1', () => {
+  const css = fs.readFileSync(path.join(__dirname, '../globals.css'), 'utf8');
+
+  it('--e-document matches mockup --c-kb (174 60% 40%)', () => {
+    expect(css).toMatch(/--e-document:\s*174\s+60%\s+40%/);
+  });
+
+  it('--e-toolkit matches mockup --c-toolkit (142 70% 45%)', () => {
+    expect(css).toMatch(/--e-toolkit:\s*142\s+70%\s+45%/);
+  });
+});

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -506,10 +506,10 @@
   --e-player: 262 83% 58%;
   --e-session: 240 60% 55%;
   --e-agent: 38 92% 50%;
-  --e-document: 210 40% 55%;
+  --e-document: 174 60% 40%;  /* KB teal — aligned with Claude Design v1 mockup (--c-kb) */
   --e-chat: 220 80% 55%;
   --e-event: 350 89% 60%;
-  --e-toolkit: 160 70% 45%;  /* Teal Green — Redesign V2 */
+  --e-toolkit: 142 70% 45%;  /* Toolkit green — aligned with Claude Design v1 mockup (--c-toolkit) */
   --e-tool: 195 80% 50%;     /* Sky Blue — Epic #412 */
 
   /* Base theme tokens - Opzione A: Playful Boardroom */

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -488,6 +488,8 @@
   --color-entity-kb:      hsl(var(--e-document));
   --color-entity-chat:    hsl(var(--e-chat));
   --color-entity-event:   hsl(var(--e-event));
+  --color-entity-toolkit: hsl(var(--e-toolkit));
+  --color-entity-tool:    hsl(var(--e-tool));
 
   /* Font family utilities */
   --font-heading: var(--font-quicksand), system-ui, sans-serif;
@@ -507,6 +509,8 @@
   --e-document: 210 40% 55%;
   --e-chat: 220 80% 55%;
   --e-event: 350 89% 60%;
+  --e-toolkit: 160 70% 45%;  /* Teal Green — Redesign V2 */
+  --e-tool: 195 80% 50%;     /* Sky Blue — Epic #412 */
 
   /* Base theme tokens - Opzione A: Playful Boardroom */
   --radius: 0.625rem;

--- a/docs/superpowers/plans/2026-04-20-m6-migration-notes.md
+++ b/docs/superpowers/plans/2026-04-20-m6-migration-notes.md
@@ -1,0 +1,45 @@
+# M6 Migration Notes — Claude Design v1 consumer pages
+
+**Branch**: `redesign/v2` | **Closed**: 2026-04-20
+
+## Summary
+M6 migrated consumer pages (Auth, Settings, Notifications, Public) to 9 new Claude Design v1 primitives under `apps/web/src/components/ui/v2/`.
+
+## Primitives delivered (9, 123 tests)
+- AuthCard, OAuthButton, StepProgress, SettingsList, SettingsRow, ToggleSwitch, NotificationCard, HeroGradient, PricingCard
+
+## Pages migrated
+- `464b736ae` — reset-password flow migrated to AuthCard + Btn (M6 Task 5b)
+- `880cd0781` — settings/notifications (15 toggles via SettingsList + ToggleSwitch) + settings/ai-consent + settings/security (SettingsRow with trailing)
+- `48165a933` — notifications feed (NotificationCard + Drawer + entity grouping, 18/18 tests)
+- `1aa1adced` — landing hero (WelcomeHero → HeroGradient)
+- `a23071e4c` — about page (HeroGradient header)
+- `bac4c6803` — contact page (submit Btn)
+
+Plus earlier M6 primitives commits (landed on `redesign/v2`):
+`7aa13eed0` AuthCard · `ebdc47a60` OAuthButton · `a6af8ad32` StepProgress · `378df4f20` SettingsList · `ac57dc0d1` SettingsRow · `764679188` ToggleSwitch · `19b2d48a4` NotificationCard · `61159d38b` HeroGradient · `4219753fb` PricingCard
+
+## Gaps — Blocked migrations (require refactor of shared components)
+- **Login/Register/Verify-email**: pages delegate to shared `AuthModal` / `LoginForm` / `RegisterForm` / `OAuthButtons`. Migrating requires refactoring those shared components, which exceeds the M6 scope constraint "preserve form logic exactly". Follow-up task needed with explicit permission.
+
+## Gaps — Missing pages (design mockup exists, app page absent)
+- **Pricing** (`/pricing`) — mockup has 3-tier (Free/Pro/Team), PricingCard primitive ready; needs product decision (CTA targets, Stripe integration)
+- **Settings hub** (`/settings/page.tsx`) — landing for settings categories
+- **Settings profile** form (displayName/bio/email/avatar)
+- **Settings account** (password change, delete)
+- **Settings preferences** (theme/lang/timezone/density)
+- **Settings API keys**
+- **Settings connected services** (Google/Discord/BGG)
+- **Onboarding product-tour** flow (Welcome → Games → Agents → Session → Complete). Existing `/onboarding` is a 1-step profile form; `OnboardingWizard` is the invited-user account setup (different semantics). Needs product spec.
+
+## Skipped intentionally
+- **Terms / Privacy**: `LegalPageLayout` is typography-safe for long-form content; no v2 primitive fits this use case.
+
+## Next steps
+- **M6 follow-up**: refactor shared `AuthModal` + submit login/register/verify migration
+- **M6.5**: product spec for missing Settings sub-pages, Pricing, Onboarding tour
+- **M7**: Gruppo 2 (Game Night, Play Records, Session Wizard) when Claude Design ships mockups
+
+## Related
+- Brief: `docs/superpowers/specs/2026-04-20-claude-design-missing-pages-brief.md`
+- Todo (resume with Claude Design): `docs/superpowers/claude_design_todo.md`

--- a/docs/superpowers/specs/2026-04-20-redesign-v2-claude-design-brief.md
+++ b/docs/superpowers/specs/2026-04-20-redesign-v2-claude-design-brief.md
@@ -1,0 +1,428 @@
+# Brief per Claude Design — Redesign v2 MeepleAI, pagine mancanti
+
+**Data**: 2026-04-20
+**Destinatario**: Claude Design (o qualunque designer che riceva l'handoff)
+**Progetto**: MeepleAI — app companion per board game enthusiasts (RAG + multi-agent AI + live play sessions)
+**Contesto**: Esiste già un set di mockup hi-fi consegnato (`admin-mockups/README.md` + `admin-mockups/design_files/`) che copre 24 screen mobile, desktop patterns, drawer variants, design system, dark mode. Questo brief richiede **13 pagine/flussi aggiuntivi** non coperti dal pacchetto originale, necessari per sostituire completamente l'app non-admin.
+
+---
+
+## 0. Regole di ingaggio (non negoziabili)
+
+Tutte le nuove pagine DEVONO:
+
+1. **Usare i tokens esistenti** (`admin-mockups/design_files/tokens.css`, 202 righe commentate). Nessun nuovo colore, font, radius, shadow o motion. L'entity palette (9 colori canonical) è la stessa.
+2. **Usare gli stessi font**: Quicksand (display), Nunito (body), JetBrains Mono (mono). Nessuna quarta famiglia.
+3. **Supportare dark mode day-one** — ogni surface nei mockup dark/light side-by-side come in `05-dark-mode.html`.
+4. **Essere mobile-first** con phone frame identici a `01-screens.html` (380px wide) + desktop adaptation (vedi `02-desktop-patterns.html` — usare pattern "sidebar + detail" come default v2).
+5. **NON introdurre grigi neutri**. I warm browns sono obbligatori per mantenere identità board-game.
+6. **NON aggiungere iconography per riempire spazio**. Icon slop è anti-pattern qui.
+7. **Emoji-per-entity restraint**: emoji solo come entity marker o dove aggiunge personalità reale.
+8. **Formato output**: HTML hi-fi in `admin-mockups/design_files/v2/<NN>-<nome-kebab>.html`, più JSX reference se il comportamento è ricco (come `mobile-app.jsx`), più una sezione nel README aggiornata con la nuova pagina.
+9. **Livello di fedeltà**: hi-fi pixel-accurate. Trattare come contract per lo sviluppo.
+10. **Lingua UI**: italiano (coerente con `01-screens.html`).
+
+Entity palette reminder:
+
+| Token | Emoji | Label |
+|---|---|---|
+| `--c-game` | 🎲 | Game |
+| `--c-player` | 👤 | Player |
+| `--c-session` | 🎯 | Session |
+| `--c-agent` | 🤖 | Agent |
+| `--c-kb` | 📄 | KB |
+| `--c-chat` | 💬 | Chat |
+| `--c-event` | 🎉 | Event |
+| `--c-toolkit` | 🧰 | Toolkit |
+| `--c-tool` | 🔧 | Tool |
+
+Semantic aliases: `--c-success` → toolkit, `--c-warning` → agent, `--c-danger` → event, `--c-info` → chat.
+
+---
+
+## 1. Auth flow (5 screens)
+
+**File target**: `v2/01-auth.html` (5 phone frames in una grid) + `v2/01-auth-desktop.html`
+
+**Screens**:
+
+1. **Login**
+   - Logo mark (gradient `--c-game` → `--c-event`) + wordmark "MeepleAI"
+   - Input email, Input password (con show/hide eye icon)
+   - Button primary "Accedi" (bg `--c-game`, white text)
+   - Button ghost "Crea account"
+   - OAuth buttons: Google, GitHub (icon + label, border `--border`, bg `--bg-card`)
+   - Link "Password dimenticata?" (font mono, `--text-muted`)
+   - Error banner inline sopra form (bg `hsl(var(--c-event) / .1)`, text `--c-event`) se credenziali errate
+2. **Register**
+   - Input: nome, email, password, conferma password
+   - Checkbox "Accetto termini e privacy" (custom styled, `--c-game` accent)
+   - Button primary "Crea account"
+   - Link "Hai già un account?"
+3. **Forgot password**
+   - Input email, button "Invia link recovery"
+   - Stato success con icon ✉️ centrato e messaggio "Controlla la tua email"
+4. **Verify email**
+   - Icon 📧 grande, testo "Abbiamo inviato un link a {email}"
+   - Button "Reinvia" (secondary)
+   - Countdown timer su reinvio (60s)
+5. **Magic-link landing**
+   - Spinner + "Accesso in corso..."
+   - Fallback error "Link scaduto o non valido" con CTA "Riprova login"
+
+**Layout**:
+- Mobile: single column centered, padding 24px, max-width 360px
+- Desktop: split 50/50 con illustrazione (gradient board-game-themed, no emoji slop) a sinistra, form a destra max 400px
+
+**Motion**: fade-in form con `--dur-md`, shake horizontal su errore.
+
+---
+
+## 2. Onboarding wizard (3-4 step)
+
+**File target**: `v2/02-onboarding.html`
+
+**Flow** (progress bar top, step indicator `1/4`):
+
+1. **Welcome + profilo**: campo nome, avatar picker (12 emoji preset + "upload photo"), lingua UI (select IT/EN)
+2. **Pick-games**: search bar + grid di `EntityCard` (variante compact) selezionabili. Chip count in alto "Selezionati: 3". Skip button in basso
+3. **Import library BGG** (opzionale): input "BGG username" + button "Importa". Lista preview risultati con checkbox. Skip disponibile
+4. **Finish**: confetti animation (solo entity-colored particles, no random), messaggio "Benvenuto in MeepleAI!", CTA "Vai alla Home"
+
+**Layout**: mobile single column, desktop centered card max 560px con background `--bg` e illustrazione laterale.
+
+**Motion**: slide-right tra step (`--dur-md`, `--ease-out`), progress bar animata.
+
+---
+
+## 3. Settings (tab layout)
+
+**File target**: `v2/03-settings.html`
+
+**Sezioni** (sidebar desktop / tabs mobile):
+
+1. **Account**: avatar upload, nome, email, cambia password, elimina account (zona danger con `--c-event` accent)
+2. **Preferenze**: tema (radio toggle: Sistema / Chiaro / Scuro), lingua, formato data, formato durata (min/ore)
+3. **Notifiche**: lista canali (Push, Email, In-app) con toggle. Raggruppati per tipo evento (Sessioni, Chat, Menzioni, News)
+4. **Privacy**: toggle profilo pubblico, chi può invitarmi, cronologia chat conservata (Mai / 30gg / Sempre)
+5. **Integrazioni**: BGG (connect/disconnect), n8n (config webhook URL), Export dati (CSV)
+6. **Advanced**: cache size + pulsante pulisci, info versione, link docs
+
+**Layout**:
+- Mobile: list master → tap → detail view (drill-down). Back button top-left
+- Desktop: sidebar 240px verticale + content area fluid, max-width content 720px
+
+**Pattern**: ogni riga setting = label a sinistra + control a destra (toggle/select/button). Divider `--border-light` tra righe. Section title `--f-display` bold uppercase mono style.
+
+---
+
+## 4. Notifications center full page
+
+**File target**: `v2/04-notifications.html`
+
+**Elementi**:
+
+- Topbar: titolo "Notifiche" + icon "segna tutte come lette" + icon filter
+- Filter bar pills: Tutte / Non lette / Menzioni (counter badge per ognuna)
+- Lista notifiche raggruppate per tempo: "Oggi" / "Questa settimana" / "Più vecchie"
+- Ogni item row:
+  - Entity pip a sinistra (colore in base a tipo evento)
+  - Testo "Giorgio ha finito la partita di Azul" (who bold, entity chip per game)
+  - Timestamp relativo destra
+  - Se non letta: dot `--c-event` dopo il testo
+  - Swipe-left (mobile) → "Archivia" / "Segna letta"
+  - Tap → apre drawer entità correlata
+- Empty state: illustration minimalista + "Nessuna notifica" + secondary text
+
+**Desktop**: come mobile ma max-width 720px centered.
+
+---
+
+## 5. Upload PDF flow (3-4 step)
+
+**File target**: `v2/05-upload.html`
+
+**Step**:
+
+1. **Select game** (se non pre-selezionato): search box + EntityCard list giochi utente
+2. **Drop zone**: area dashed border `--border-strong`, icon 📄 grande, testo "Trascina PDF qui o clicca per selezionare". Max 50MB, tipo .pdf only. Su drag-over: bg `hsl(var(--c-kb) / .08)`
+3. **Upload + OCR progress**:
+   - Progress bar orizzontale (`--c-kb` fill)
+   - Sotto: 3 step con check animato (Upload → OCR → Indexing)
+   - Tempo stimato "~2 minuti rimanenti"
+   - Button "Annulla"
+4. **Mapping pagine** (opzionale per manuali ricchi):
+   - Preview thumbnails pagine PDF (griglia 3 colonne)
+   - Per ogni pagina: dropdown sezione ("Setup" / "Turno" / "Scoring" / "Custom")
+   - Button "Salta mapping" (usa auto-detection)
+5. **Publish**:
+   - Riepilogo: titolo, pagine, sezioni, agent che userà questa KB
+   - Toggle "Pubblico" / "Solo io"
+   - Button primary "Pubblica" (bg `--c-toolkit`)
+   - Success state: check grande + "KB pubblicato" + CTA "Vai al Game"
+
+**Motion**: step transition slide, progress bar smooth animation.
+
+---
+
+## 6. Rule Editor + Versions
+
+**File target**: `v2/06-editor.html`
+
+**Layout split pane**:
+
+- **Left sidebar (desktop) / top sheet (mobile)**: outline regole (tree view). Click → scroll to section. Search bar top.
+- **Center pane**: markdown editor con syntax highlight (KB color palette — teal accents)
+- **Right pane**: preview rendering live
+- **Top toolbar**:
+  - Version selector dropdown (v1.0, v1.1-draft, ecc.)
+  - Button "Diff vs versione X" (apre side-by-side modal)
+  - Button "Save draft" (ghost)
+  - Button "Publish version" (primary `--c-kb`)
+- **Bottom status bar**: word count, last saved time, sync status
+
+**Mobile**: tab switch tra Outline / Editor / Preview. Full-screen.
+
+**Diff modal** (separato nel file HTML):
+- Split view left (old) / right (new)
+- Changes highlighted: added `hsl(var(--c-toolkit) / .15)`, removed `hsl(var(--c-event) / .15)`
+- Navigation "prev/next change"
+- Button "Rollback to this version"
+
+---
+
+## 7. Game Night hub (serata multi-sessione)
+
+**File target**: `v2/07-game-night.html`
+
+**Scenario**: l'utente sta organizzando/vivendo una "serata" con più giochi consecutivi (es. 3 giochi in una sera con gli stessi 4 player).
+
+**Elementi**:
+
+- **Hero top**: titolo "Serata del 15 Aprile" (editable), subtitle "con Luca, Anna, Marco, Sara" (player pips), data + ora
+- **Session sequence**: 3-5 card in row orizzontale (horizontal scroll mobile)
+  - Ogni card: game cover gradient, titolo gioco, status (finito / in corso / in coda), durata effettiva, winner pip
+  - Card attiva (in corso): border `--c-session` + pulse dot
+- **Timeline cross-gioco** (event log verticale):
+  - Header "Attività della serata"
+  - Eventi: game-started, score-update, game-ended, custom notes
+  - Ogni evento entity-colored accent
+  - FAB bottom-right "+ Nota" per custom event
+- **CTA bar bottom** (sticky mobile):
+  - Se serata attiva: "Prossimo gioco" / "Pausa" / "Finalizza serata"
+  - Se serata finita: "Replay highlights" / "Export log"
+- **Summary card** (mostrata dopo "Finalizza"):
+  - MVP della serata (player pip + stat)
+  - Gioco più lungo, più corto
+  - Total play time
+  - Button "Salva nel diario"
+
+**Desktop**: 2-column layout (60/40) — sessioni a sinistra, timeline a destra.
+
+---
+
+## 8. Play Records / Diary (timeline cross-gioco)
+
+**File target**: `v2/08-play-records.html`
+
+**Scenario**: utente vuole rivedere tutte le sue partite storicamente.
+
+**Elementi**:
+
+- **Top filters**:
+  - Period picker (ultimi 7gg / 30gg / 90gg / Tutto / Custom range)
+  - Game multi-select (chip picker con EntityChip)
+  - Player multi-select
+  - Winner-only toggle
+- **Stats overview card** (sticky top):
+  - Totale partite, ore giocate, winrate
+  - Mini chart (bar chart 30gg)
+- **Timeline**:
+  - Cluster per mese ("Aprile 2026", "Marzo 2026")
+  - Ogni row: data, game pip, player pips (chi ha giocato), risultato (winner + scores), durata
+  - Tap → apre Session drawer
+  - Action inline "Rigioca questa config" (crea nuova sessione pre-compilata)
+- **Empty state**: illustrazione + "Nessuna partita nel periodo scelto"
+- **Export**: button top-right "Export CSV"
+
+---
+
+## 9. Discover / Shared catalog
+
+**File target**: `v2/09-discover.html`
+
+**Scenario**: browse del catalogo community dei giochi per aggiungerli alla propria libreria.
+
+**Elementi**:
+
+- **Top**: search bar grande + filter chips orizzontali (Popolari / Nuovi / Top rated / Cooperative / Family-friendly / 2 player / ecc.)
+- **Complexity slider**: 1-5 con labels
+- **Grid giochi** (EntityCard variante featured):
+  - Cover, titolo, designer, anno
+  - Complexity dots, player range, durata
+  - Badge top-right:
+    - "Nella tua libreria" (bg `--c-toolkit`) se posseduto
+    - "In wishlist" (bg `--c-agent`) se in wishlist
+    - Altrimenti: nessun badge
+  - CTA bottom card:
+    - Se non in libreria: "Aggiungi alla wishlist" + "Importa ora"
+    - Se request import pending: "Import in corso..." con spinner
+- **Infinite scroll** con skeleton loader
+- **Empty state**: "Nessun gioco trovato per questi filtri"
+
+**Desktop**: grid 4 colonne, sidebar filter a sinistra (collapse-to-chip pattern come library).
+
+---
+
+## 10. Private Games
+
+**File target**: `v2/10-private-games.html`
+
+**Nota**: da valutare se dedicato o copribile da filtro Library. In questo brief ipotizziamo dedicato per chiarezza designer.
+
+**Scenario**: giochi personalizzati/custom creati dall'utente (non presenti nel catalogo community).
+
+**Elementi**:
+
+- Uguale a Library ma con:
+  - Badge "Privato" su ogni card (icon 🔒)
+  - Button top-right "+ Nuovo gioco privato"
+  - Toggle visibilità (Solo io / Inviti / Condivisibile con link)
+  - Drawer per generazione invite link (URL + copy button + expire date picker)
+- Empty state con CTA "Crea il tuo primo gioco" + illustrazione
+
+**Se il designer ritiene coperto da Library con filtro, può confermarlo nel file HTML con nota e layout minimale.**
+
+---
+
+## 11. Pipeline Builder / n8n integrations
+
+**File target**: `v2/11-pipeline-builder.html`
+
+**Scenario**: power users configurano pipeline custom (webhook → AI agent → Slack/email). Layout node-based.
+
+**Elementi**:
+
+- **Canvas** (center): node-based graph (ispirazione react-flow). Zoom + pan
+- **Left panel**: node library (Triggers, Actions, AI, Logic, Output) — drag to canvas
+- **Right panel** (quando node selected): properties editor (form)
+- **Top toolbar**: nome pipeline, save, run test, enable/disable toggle, version history
+- **Bottom**: log run-history (collapsible)
+- **Node style**: rounded rectangle, entity-colored left border, title mono, connection points sides
+
+**Nota per designer**: qui è legittimo deviare leggermente dal look "board-game" per adottare un pattern UX standard per flow-editor, MA i tokens (colori/fonts/radius) restano gli stessi. Obiettivo: che un power-user lo riconosca come node editor ma che appartenga visualmente a MeepleAI.
+
+**Desktop-only**: il canvas richiede schermo grande. Mobile: stato "Apri su desktop per modificare" + lista pipeline esistenti in read-only.
+
+---
+
+## 12. Error / 404 / offline / join-landing
+
+**File target**: `v2/12-errors.html` (4 layout nel file)
+
+1. **404 Not Found**:
+   - Illustration whimsical (un meeple perso in una scacchiera vuota)
+   - Titolo "Questa pagina non esiste"
+   - Subtitle con routing suggerimenti
+   - CTA "Torna alla home" + "Cerca"
+2. **500 Server Error**:
+   - Illustration (un meeple con cappello da saldatore)
+   - Titolo "Qualcosa è andato storto"
+   - Subtitle "Abbiamo ricevuto il report, riproviamo"
+   - CTA "Riprova" + link "Segnala bug"
+3. **Offline**:
+   - Icon 📡 o wifi slash
+   - Titolo "Sei offline"
+   - Content hint: "Queste pagine sono disponibili offline: Home, Library (cached), Chat recenti"
+   - CTA "Riprova connessione"
+4. **Join-link landing**:
+   - Hero card con preview entità (game/session/toolkit a cui si è stati invitati)
+   - Info invitante (player pip + nome)
+   - CTA primary "Accetta invito" + secondary "Rifiuta"
+   - Se non loggato: "Accedi per continuare" + link register
+
+---
+
+## 13. Empty states + Loading skeletons (pattern reusable)
+
+**File target**: `v2/13-empty-loading-patterns.html`
+
+**Empty states** (8 varianti):
+
+1. Empty library — "Non hai ancora giochi" + CTA "Esplora catalogo"
+2. Empty wishlist — "La tua wishlist è vuota" + CTA
+3. Empty chats — "Inizia una chat con un agente"
+4. Empty sessions — "Nessuna partita registrata"
+5. Empty notifications — "Tutto tranquillo"
+6. Empty search — "Nessun risultato per {query}"
+7. Empty drawer tab — "Niente da mostrare qui"
+8. Empty KB — "Nessun documento caricato"
+
+**Pattern**: illustration minimalista (NO emoji slop, illustration stile coerente) + titolo + subtitle + CTA. Ogni empty state usa un entity color subtile.
+
+**Loading skeletons** (7 pattern):
+
+1. Skeleton card (EntityCard shape con shimmer)
+2. Skeleton list row (list variant)
+3. Skeleton drawer (hero + tabs + content blocks)
+4. Skeleton session mode (hero + scoreboard + log)
+5. Skeleton chat messages (bubble alternating left/right)
+6. Skeleton settings (rows di pattern)
+7. Skeleton pipeline canvas (nodes grigiati)
+
+**Motion**: shimmer animation (`--dur-lg` loop, `cubic-bezier(.4, 0, .6, 1)`) su tutti.
+
+---
+
+## Output deliverable
+
+Per ciascuna delle 13 richieste:
+
+1. File HTML hi-fi in `admin-mockups/design_files/v2/<NN>-<nome>.html`
+2. Opzionale: JSX se il comportamento è ricco (come `mobile-app.jsx` fa per 01-screens)
+3. Aggiornamento `admin-mockups/README.md` sezione "Files in this Handoff" con riga per ciascun nuovo file
+4. Se introdotti nuovi pattern riusabili (es: wizard progress bar, filter pill bar, diff view), aggiungere sezione dedicata in `04-design-system.html`
+
+**Dark mode**: ogni pagina deve funzionare in light/dark senza lavoro aggiuntivo (usare `tokens.css` variables, mai valori hardcoded). Verifica finale con toggle button `themeToggle` già presente nei mockup.
+
+**Consistency check**: prima della consegna, side-by-side con `01-screens.html` per verificare che font-size, spacing, radius, shadow usati sono dentro il token set.
+
+---
+
+## Priorità di consegna
+
+Per allinearsi con il piano di implementazione (vedi `2026-04-20-redesign-v2-full-consumer-design.md`):
+
+**Batch 1 — critical path Alpha** (consegna prima):
+1. Auth flow (blocca tutto)
+2. Onboarding wizard
+5. Upload PDF
+13. Empty states + Loading skeletons (servono per tutti gli screens M2/M3)
+
+**Batch 2 — consumer complete**:
+3. Settings
+4. Notifications center
+7. Game Night hub
+12. Error / 404 / offline
+
+**Batch 3 — power features**:
+6. Rule Editor + Versions
+8. Play Records / Diary
+9. Discover / Shared catalog
+10. Private Games
+11. Pipeline Builder / n8n
+
+---
+
+## Domande aperte al designer
+
+Se emergono durante il lavoro, documentare nel file HTML con commento `<!-- OPEN-QUESTION: ... -->` o aprire issue con label `design-question`.
+
+Esempi di possibili domande:
+- "Private Games è davvero separato o coperto da Library con filtro `status=private`?"
+- "Pipeline Builder richiede un node editor dedicato o un form-based flow più semplice è sufficiente per v1?"
+- "Game Night hub condivide screen con Session Mode o è una route separata?"
+
+---
+
+**Contatto**: questo brief è autoritativo. Per chiarimenti sul dominio MeepleAI consultare `admin-mockups/README.md` sezione "Data Model" + `CLAUDE.md` nel repo.

--- a/docs/superpowers/specs/2026-04-20-redesign-v2-full-consumer-design.md
+++ b/docs/superpowers/specs/2026-04-20-redesign-v2-full-consumer-design.md
@@ -1,0 +1,209 @@
+# Redesign v2 — Full Consumer App Design Spec
+
+**Date**: 2026-04-20
+**Status**: Draft — awaiting user review
+**Scope**: Full consumer app (no admin) — sostituire tutta la UI non-admin con i mockup di Claude Design in `admin-mockups/design_files/`
+**Target branch**: `redesign/v2` (long-lived)
+**Related**: `admin-mockups/README.md` (design handoff hi-fi), `admin-mockups/design_files/`, CLAUDE.md (repo guide), MEMORY.md sessione 2026-04-11 (card-drawer nav already in place)
+
+---
+
+## 1. Goal
+
+Sostituire l'attuale interfaccia utente (non-admin) con il sistema di design hi-fi consegnato in `admin-mockups/design_files/` — 9 entity types, drawer-driven navigation, entity palette warm-neutral, mobile-first con adattamenti desktop.
+
+**Non goal**:
+- Admin screens (users/content/analytics/audit/ops) — fuori scope, restano sul look attuale finché non sarà decisa una seconda fase.
+- Cambiare il backend, i bounded context, i modelli dominio, i service layer.
+- Introdurre feature nuove non presenti oggi.
+
+## 2. Success criteria
+
+1. Tutti gli screen mockup in `01-screens.html` riprodotti pixel-accurate (treat as contract) nell'app Next.js.
+2. 13 flussi non coperti dai mockup ricevono nuovi mockup da Claude Design (ref brief `2026-04-20-redesign-v2-claude-design-brief.md`) e implementazione conforme.
+3. Parità funzionale completa con l'app attuale non-admin (nessuna feature persa).
+4. Coverage backend 90%+ invariato. Frontend target 85%+ mantenuto.
+5. A11y AA: contrast ≥ 4.5:1 su tutti i bg entity-colored con testo bianco (già verificato nei mockup).
+6. Dark mode funzionante day-one.
+7. Bundle size budget rispettato (baseline aggiornata in M0).
+
+## 3. Decisioni architetturali
+
+| Decisione | Scelta | Alternativa scartata | Razionale |
+|---|---|---|---|
+| Scope | Full consumer (alpha + power, no admin) | Alpha-only, full incl. admin | Copre l'intero target utente finale mantenendo scope finito |
+| Strategia transizione | Big bang su `redesign/v2` | Strangler fig, dual-track, per-BC | Codebase pulito, nessuna doppia manutenzione runtime, accettiamo rischio merge compensato da merge settimanali di `main-dev` in v2 |
+| Pattern entity detail | Hybrid responsive (drawer mobile / page desktop) | Drawer-puro, route-dedicate, intercepting routes | Mantiene SEO + deep-link desktop, UX nativa su mobile, sfrutta infrastruttura drawer esistente |
+| Riuso codice | Riuso comportamentale + rewrite visuale | Riuso totale, rewrite from scratch | `useCascadeNavigationStore`/hooks/MSW/zustand restano, visual layer pulito con nuovi primitivi fedeli ai mockup |
+| Sequenza | Vertical slice su screen pilota (Library) | Bottom-up per livelli, Alpha-critical-path, parallelo 2-track | Validazione precoce filiera token-to-test, feedback stakeholder in 1-2 settimane |
+| Breakpoint | `md:` 768px switch drawer↔page | Tablet-specific | Allineato Tailwind default + mobile/desktop patterns in `02-desktop-patterns.html` |
+
+## 4. Gap analysis
+
+### 4.1 Mockup vs app attuale (mapping)
+
+| Mockup | Route app attuale | Azione |
+|---|---|---|
+| Home Feed | `(authenticated)/dashboard/` | Redesign in place |
+| Library | `(authenticated)/library/` | **Pilota M2** |
+| Search | — | Nuovo screen dedicato |
+| Chat list + detail | `(chat)/` | Redesign |
+| Profile | `(authenticated)/profile/` | Redesign |
+| Session Mode | `(authenticated)/sessions/[id]` | Takeover full-screen |
+| Entity Drawer Game | `(authenticated)/games/[id]` | Page (desktop) + drawer (mobile) |
+| Entity Drawer Player | `(authenticated)/players/*` | Idem |
+| Entity Drawer Session | `(authenticated)/sessions/[id]` | Idem |
+| Entity Drawer Agent | `(authenticated)/agents/*` | Idem |
+| Entity Drawer KB | `(authenticated)/knowledge-base/` | Idem |
+| Entity Drawer Chat | `(chat)/` | Idem |
+| Entity Drawer Event | `(authenticated)/game-nights/*` | Idem |
+| Entity Drawer Toolkit | `(authenticated)/toolkit/` | Idem |
+| Entity Drawer Tool | — | Nuovo |
+
+### 4.2 Pagine/flussi NON coperti dai mockup Claude Design (da creare — vedi brief separato)
+
+13 richieste di design sessions:
+
+1. Auth flow (login / register / forgot / verify-email / magic-link)
+2. Onboarding wizard (profilo + pick-games + import BGG)
+3. Settings (account, preferenze, privacy, integrazioni)
+4. Notifications center (full page)
+5. Upload PDF flow (drop → OCR → mapping → publish)
+6. Rule Editor + Versions (split editor/preview + diff)
+7. Game Night hub (serata multi-sessione)
+8. Play Records / Diary (timeline cross-gioco)
+9. Discover / Shared catalog (community DB browse)
+10. Private Games (variante library)
+11. Pipeline Builder / n8n integrations
+12. Error / 404 / offline / join-landing
+13. Empty states + Loading skeletons (pattern reusable)
+
+Dettaglio in `2026-04-20-redesign-v2-claude-design-brief.md`.
+
+## 5. Architettura
+
+### 5.1 Layer
+
+```
+Layer 0 — Foundation
+  tokens.css (verbatim da design_files) → app/globals.css
+  tailwind.config.ts (entity palette, radius, shadow, motion, font)
+  Google Fonts: Quicksand / Nunito / JetBrains Mono
+  Theme toggle: data-theme="dark" su <html>, persist in localStorage 'mai-theme'
+
+Layer 1 — Primitivi visivi (NEW)
+  <EntityChip size=sm|md>          pill testuale (emoji + label, entity-colored)
+  <EntityPip>                      avatar tondo 32px (overlap 8px, max 4 visibili + "+N")
+  <EntityCard variant=...>         ex-MeepleCard rewritten (grid|list|compact|featured|hero)
+  <ConnectionBar>                  strip orizzontale di pip (riusa logica esistente)
+  <Drawer>                         vaul su mobile, Radix Dialog + custom side-panel desktop
+  <BottomBar>                      5-tab nav + variante Session (pulse dot, session color)
+  <MiniNav>                        breadcrumb + tabs con count badges
+  <RecentsBar>                     re-skin del componente esistente
+
+Layer 2 — Shell & layout responsive
+  AppShell
+    <768  → Drawer-mode (bottom sheet vaul)
+    ≥768  → Page-mode (route dedicate con split-view)
+  Topbar (logo + search icon + notif icon + avatar)
+  Session mode layout (takeover)
+
+Layer 3 — Screens (riusa query hook + mock + zustand)
+  Home / Library / Search / Chat / Profile / Session Mode
+  Entity drawers/pages per 9 tipi
+
+Layer 4 — Flussi non-mockup (13 pagine, post-design session)
+  Auth / Onboarding / Settings / Notifications / Upload / Editor / Versions / GameNight / PlayRecords / Discover / PrivateGames / Pipeline / Errors + Empty
+```
+
+### 5.2 Riuso confermato (no touch comportamentale)
+
+- `useCascadeNavigationStore` (stack drawer max 3, recentEntities)
+- `DrawerEntityRouter`, `ExtraMeepleCardDrawer`, `SessionDrawerContent` con `initialTabId`
+- React Query hooks
+- MSW + `scenarioBridge` + DevPanel
+- Zustand stores
+- Zod schemas
+- i18n (se presente)
+
+### 5.3 Rewrite
+
+- `MeepleCard` → `EntityCard` (nuovo path `components/ui/data-display/entity-card/`)
+- `BottomBar` completa
+- Shell layout responsive
+- Tutti i card/surface style con nuovi tokens
+- Form primitives: Button/Input/Tabs/Dialog (re-skin shadcn)
+- Topbar, MiniNav, RecentsBar (re-skin, logica invariata)
+
+### 5.4 Dipendenze nuove
+
+- `vaul` — bottom sheet drawer physics mobile (non reinventare)
+- `framer-motion` — motion system (se non già presente, verificare in M0)
+- Google Fonts subset Latin con `display=swap`
+
+## 6. Milestones
+
+| M | Nome | Deliverable | Definition of Done |
+|---|---|---|---|
+| M0 | Foundation | tokens + tailwind + fonts + theme toggle + audit deps | `04-design-system.html` side-by-side parity, dark/light toggle funzionante, vaul installato, nessuna regression test esistenti |
+| M1 | Primitivi | EntityChip/Pip/Card/ConnectionBar/Drawer/BottomBar/MiniNav/Topbar | Test componenti + visual snapshot + a11y (jest-axe), coverage ≥ 85% su nuovi componenti |
+| M2 | **Library pilota** | Library mobile+desktop, Game drawer+page, EntityCard migration su Library, filter tabs, grid/list toggle | Parità funzionale con `(authenticated)/library/` attuale, pixel-accurate vs `01-screens.html` Library, stakeholder walk-through OK |
+| M3 | Screens mockup rimanenti | Home / Search / Chat list+detail / Profile / Session Mode / drawer+page per Player/Agent/KB/Event/Toolkit/Tool | Parità con `01-screens.html` completa (24 screens), MeepleCard eliminato dal consumer path, Storybook-free (test + snapshot come evidenza) |
+| M4 | Claude Design sessions | 13 nuovi mockup HTML in `admin-mockups/design_files/v2/` | Tutte le 13 pagine consegnate con stesso grado di fedeltà dei mockup originali (tokens, fonts, motion) |
+| M5 | Implementazione flussi non-mockup | Codice per le 13 pagine M4 | Test + typecheck + lint green, coverage ≥ 85%, Playwright E2E happy path per ogni flusso critico (auth, upload, editor) |
+| M6 | Polish + cut-over | Empty/error/skeleton states sistematici, a11y audit, performance budget, E2E full suite, merge `redesign/v2` → `main-dev` | CI green, bundle size entro budget, axe-core zero violations critici, PR merge approvato |
+
+**Parallelismo**: M4 può iniziare durante M1/M2 (non blocca filiera tecnica). M3 e M5 possono avere subagent paralleli una volta che M2 ha stabilito il pattern.
+
+## 7. Testing strategy
+
+- **Unit (Vitest)**: ogni primitivo M1 con test varianti + a11y (jest-axe). Target 85%+.
+- **Integration (RTL)**: ogni screen M2/M3 con MSW scenarios esistenti + nuovi scenarios per flussi M5.
+- **Visual regression**: Playwright screenshot su Library pilota, poi estensione progressiva; baseline in `redesign/v2`.
+- **E2E Playwright**: suite critical path (auth → library → open game → chat → session) in M6. Happy path per ogni flusso M5.
+- **Accessibility gate**: M6 audit con axe-core, contrast AA su tutti entity backgrounds.
+- **CI gate**: merge su `redesign/v2` bloccato se coverage <85%, typecheck/lint fail, o a11y violations critiche.
+
+## 8. Rischi e mitigazioni
+
+| Rischio | Impatto | Mitigazione |
+|---|---|---|
+| Branch `redesign/v2` drift da `main-dev` | Alto | Merge settimanale schedulato (lunedì mattina). PR interne frequenti sul branch v2 per review incrementale |
+| 13 design sessions bloccano M5 | Medio | M4 parte in parallelo con M1/M2. M5 priorizza auth+onboarding+upload (critical path), il resto segue |
+| Hybrid responsive complesso | Medio | Libreria pilota M2 risolve il pattern una volta → replicabile. Nessun pattern desktop prima di M2 done |
+| MeepleCard migration diffuso | Medio | No codemod automatico: sostituzione screen-by-screen in M3. Co-esistenza temporanea in v2 tollerata. Nuovo `EntityCard` in path nuovo, vecchio resta fino a cut-over |
+| Test coverage cala durante rewrite | Alto | CI bloccante: no merge su v2 se coverage <85%. Test primitivi (M1) prima dei test screen (M2) |
+| vaul/Framer Motion/shadcn deps non in repo | Basso | Audit dipendenze in M0. PR dedicato con lockfile review |
+| Performance bundle size | Medio | Budget baseline aggiornata in M0, check per milestone. Font subset Latin + display-swap. Code-split per screen |
+| Team conoscenza Next.js intercepting routes | Nullo | Non usati (pattern hybrid è route dedicate + drawer component, no intercepting) |
+| Mock scenarios da adattare | Basso | `scenarioBridge` pattern già in place, handler esistenti restano validi (stesso backend) |
+
+## 9. Deliverable
+
+- **Questo spec**: `docs/superpowers/specs/2026-04-20-redesign-v2-full-consumer-design.md`
+- **Brief Claude Design**: `docs/superpowers/specs/2026-04-20-redesign-v2-claude-design-brief.md`
+- **Follow-up plan**: `docs/superpowers/plans/2026-04-20-redesign-v2-library-pilot-plan.md` (primo plan esecutivo, in fase writing-plans)
+- **Branch**: `redesign/v2`
+- **13 nuovi mockup** in `admin-mockups/design_files/v2/`
+- **Issue tracker**: epic GitHub "Redesign v2" con 6 child issue (una per milestone M0-M6, M4 split per pagina)
+
+## 10. Open questions (da risolvere in fase plan)
+
+- Ordine preciso M3 (Home first o Session first dopo Library?)
+- Se Private Games (brief #10) sia davvero un design session separato o copribile da filtro Library
+- Bundle-size budget numerico preciso (definire in M0 basato su `bundle-size-baseline.json` attuale)
+- Strategia feature flag per alpha tester che vogliono provare v2 su staging prima del cut-over (optional, no-feature-flag di default)
+- Migration path per utenti con drawer history aperta durante cut-over (probabilmente: clear su version bump)
+
+## 11. Riferimenti
+
+- `admin-mockups/README.md` — handoff design hi-fi completo (647 righe)
+- `admin-mockups/design_files/` — mockup sources (tokens, components, mobile-app.jsx, 5 HTML hub)
+- `CLAUDE.md` — repo guide (18 BC, CQRS, testing, workflow)
+- `MEMORY.md` — sessione 2026-04-11 card-drawer nav (infrastruttura drawer esistente)
+- Next.js 16 App Router docs — route groups, parallel routes
+- vaul — https://vaul.emilkowal.ski/
+
+---
+
+**Status**: spec scritta, in attesa di review utente prima di procedere a `writing-plans` per il primo plan esecutivo (M0 + M2 Library pilota).


### PR DESCRIPTION
## Summary
M6 migrates consumer pages to Claude Design v1 with 9 new primitives.

## Primitives (9, 123 tests)
AuthCard, OAuthButton, StepProgress, SettingsList, SettingsRow, ToggleSwitch, NotificationCard, HeroGradient, PricingCard

## Pages migrated
- reset-password flow (AuthCard + Btn)
- settings/notifications (15 toggles via SettingsList + ToggleSwitch)
- settings/ai-consent + settings/security (SettingsRow with trailing)
- notifications feed (NotificationCard + Drawer + entity grouping, 18/18 tests)
- landing hero, about, contact (HeroGradient + Btn)

## Gaps documented
See \`docs/superpowers/plans/2026-04-20-m6-migration-notes.md\`. Highlights:
- Login/Register/Verify-email blocked: requires refactor of shared AuthModal/LoginForm/RegisterForm
- Pricing page missing (primitive ready, needs product decision)
- Settings sub-pages missing: hub, profile form, account, preferences, API keys, connected services
- Onboarding product-tour missing (brief describes new flow distinct from existing /onboarding and OnboardingWizard)

## Test plan
- [x] typecheck clean
- [x] lint clean (0 errors, pre-existing warnings only)
- [x] vitest unit suite green (1104/1105 files pass; 14322 passed / 27 skipped / 1 failed — failure is \`bundle-size.test.ts\` comparing stale \`.next\` chunks against baseline, baseline bump handled in separate PR per project convention; pre-existing \`DesktopShell.test.tsx\` and \`scenarioSwitchIntegration.test.tsx\` failures resolved earlier)
- [ ] Manual smoke test of migrated pages in staging
- [ ] Dark mode visual verification
- [ ] axe-core a11y sweep before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)