### PR TITLE
feat(mechanic-extractor): review page + token tracking + bug fixes

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/page.tsx
@@ -78,8 +78,8 @@ export default function MechanicExtractorPage() {
   const [aiResult, setAiResult] = useState<AiAssistResultDto | null>(null);
   const [autoSaveTimer, setAutoSaveTimer] = useState<ReturnType<typeof setTimeout> | null>(null);
 
-  // PDF viewer ref
-  const pdfUrl = selectedPdfId ? `/api/v1/documents/${selectedPdfId}/download` : '';
+  // PDF viewer ref (endpoint: /api/v1/pdfs/{pdfId}/download — see PdfRetrievalEndpoints)
+  const pdfUrl = selectedPdfId ? `/api/v1/pdfs/${selectedPdfId}/download` : '';
 
   // Fetch shared games for selection
   const { data: gamesData } = useQuery({
@@ -88,13 +88,35 @@ export default function MechanicExtractorPage() {
     staleTime: 60_000,
   });
 
+  // Fetch all PDFs in Ready state to determine which games have a PDF available
+  const { data: readyPdfsData } = useQuery({
+    queryKey: ['admin', 'pdfs', 'ready-all'],
+    queryFn: () =>
+      adminClient.getAllPdfs({
+        state: 'Ready',
+        page: 1,
+        pageSize: 500,
+      }),
+    staleTime: 60_000,
+  });
+
+  // Build set of gameIds that have at least one Ready PDF
+  const gameIdsWithPdf = new Set(
+    (readyPdfsData?.items ?? []).map(p => p.gameId).filter((id): id is string => !!id)
+  );
+
+  // Filter games to those with at least one PDF available
+  const gamesWithPdf = (gamesData?.items ?? []).filter((g: { id: string }) =>
+    gameIdsWithPdf.has(g.id)
+  );
+
   // Fetch PDFs for selected game
   const { data: pdfsData } = useQuery({
     queryKey: ['admin', 'pdfs', { gameId: selectedGameId }],
     queryFn: () =>
       adminClient.getAllPdfs({
         gameId: selectedGameId,
-        status: 'completed',
+        state: 'Ready',
         page: 1,
         pageSize: 50,
       }),
@@ -210,7 +232,7 @@ export default function MechanicExtractorPage() {
   const handleGameSelect = (gameId: string) => {
     setSelectedGameId(gameId);
     setSelectedPdfId('');
-    const game = gamesData?.items?.find((g: { id: string; title: string }) => g.id === gameId);
+    const game = gamesWithPdf.find((g: { id: string; title: string }) => g.id === gameId);
     if (game) setGameTitle(game.title);
   };
 
@@ -252,10 +274,14 @@ export default function MechanicExtractorPage() {
               </label>
               <Select value={selectedGameId} onValueChange={handleGameSelect}>
                 <SelectTrigger>
-                  <SelectValue placeholder="Choose a game..." />
+                  <SelectValue
+                    placeholder={
+                      gamesWithPdf.length === 0 ? 'No games with PDF available' : 'Choose a game...'
+                    }
+                  />
                 </SelectTrigger>
                 <SelectContent>
-                  {gamesData?.items?.map((game: { id: string; title: string }) => (
+                  {gamesWithPdf.map((game: { id: string; title: string }) => (
                     <SelectItem key={game.id} value={game.id}>
                       {game.title}
                     </SelectItem>

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/page.tsx
@@ -82,14 +82,16 @@ export default function MechanicExtractorPage() {
   const pdfUrl = selectedPdfId ? `/api/v1/pdfs/${selectedPdfId}/download` : '';
 
   // Fetch shared games for selection
-  const { data: gamesData } = useQuery({
+  const { data: gamesData, isLoading: isGamesLoading } = useQuery({
     queryKey: ['shared-games', 'all'],
     queryFn: () => gamesClient.getAll({ page: 1, pageSize: 100 }),
     staleTime: 60_000,
   });
 
   // Fetch all PDFs in Ready state to determine which games have a PDF available
-  const { data: readyPdfsData } = useQuery({
+  // NOTE: pageSize=500 is a deliberate cap; if exceeded the game filter will
+  // silently under-count eligible games. Raise or paginate if scale demands.
+  const { data: readyPdfsData, isLoading: isReadyPdfsLoading } = useQuery({
     queryKey: ['admin', 'pdfs', 'ready-all'],
     queryFn: () =>
       adminClient.getAllPdfs({
@@ -99,6 +101,8 @@ export default function MechanicExtractorPage() {
       }),
     staleTime: 60_000,
   });
+
+  const isGameSelectLoading = isGamesLoading || isReadyPdfsLoading;
 
   // Build set of gameIds that have at least one Ready PDF
   const gameIdsWithPdf = new Set(
@@ -273,10 +277,14 @@ export default function MechanicExtractorPage() {
                 Select Game
               </label>
               <Select value={selectedGameId} onValueChange={handleGameSelect}>
-                <SelectTrigger>
+                <SelectTrigger disabled={isGameSelectLoading}>
                   <SelectValue
                     placeholder={
-                      gamesWithPdf.length === 0 ? 'No games with PDF available' : 'Choose a game...'
+                      isGameSelectLoading
+                        ? 'Loading…'
+                        : gamesWithPdf.length === 0
+                          ? 'No games with PDF available'
+                          : 'Choose a game...'
                     }
                   />
                 </SelectTrigger>

--- a/apps/web/src/components/ui/overlays/select.tsx
+++ b/apps/web/src/components/ui/overlays/select.tsx
@@ -77,7 +77,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem]',
+        'relative z-50 max-h-[var(--radix-select-content-available-height)] min-w-[8rem]',
         'overflow-y-auto overflow-x-hidden rounded-md',
         'border border-border/50 dark:border-border/70',
         // Light mode: Glass morphism dropdown


### PR DESCRIPTION
## Summary

Completa il flusso admin del Mechanic Extractor con review page, token tracking e fix critici emersi durante lo smoke test su staging.

### Feature (5 commits)

- **feat**: token tracking (`TokensPrompt`/`TokensCompletion`) + `RowVersion` (optimistic concurrency) + copyright firewall test
- **feat**: review page UI con token display e frontend schemas Zod
- **docs**: smoke test checklist (TC-01 → TC-12) + R2 rebucket script (`scripts/rebucket-pdfs-s3.sh`)
- **revert**: restore legacy rebucket-pdfs-s3.sh (script già esistente su main-dev)
- **fix**: 3 bug critici scoperti live su `meepleai.app` staging

### Bug fix dettagli (ultimo commit)

1. **PDF download URL wrong path** (404)
   - Era: `/api/v1/documents/{id}/download`
   - Ora: `/api/v1/pdfs/{id}/download` (match `PdfRetrievalEndpoints` routing)

2. **Game dropdown mostra giochi senza PDF**
   - Aggiunto `useQuery` per `adminClient.getAllPdfs({ state: 'Ready' })` con filtro client-side via `Set<gameId>`
   - Placeholder empty-state: `"No games with PDF available"`

3. **Filter state corretto**
   - Era: `status: 'Completed'` (solo lowercase mappato)
   - Ora: `state: 'Ready'` (direct `ProcessingState` match)

4. **Select dropdown non scrollabile con 100+ giochi** (Tailwind v4)
   - Era: `max-h-[--radix-select-content-available-height]` (syntax rejected)
   - Ora: `max-h-[var(--radix-select-content-available-height)]`

## Test plan

- [x] `pnpm vitest run mechanic-extractor/__tests__/page.test.tsx` → 9/9 passed
- [x] `pnpm vitest run src/components/ui/overlays` → 38/38 passed
- [x] `pnpm typecheck` → OK
- [x] Pre-commit lint-staged + backend build OK
- [ ] Post-deploy smoke test TC-01 → TC-12 su staging
- [ ] Rebucket R2 staging (dry-run → apply) — task separato

## Post-merge actions (tracked in task list)

- [ ] Eseguire `BUCKET=<staging> ./scripts/rebucket-pdfs-s3.sh --dry-run`
- [ ] Backup DB staging prima apply migration
- [ ] Smoke test completo

🤖 Generated with [Claude Code](https://claude.com/claude-code)