### PR TITLE
fix(ci): make dotnet-ef install idempotent for pre-installed runners

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -437,7 +437,17 @@ jobs:
           dotnet-version: '9.0.x'
 
       - name: Install dotnet-ef tool
-        run: dotnet tool install --global dotnet-ef --version 9.*
+        # Idempotent: use pre-installed tool if present (self-hosted runner may
+        # already have dotnet-ef from a newer SDK). `dotnet tool install` does
+        # not support downgrades, so skipping install when a compatible version
+        # exists avoids exit 1 on runners with ef 10.x already global.
+        run: |
+          if dotnet tool list --global | awk '{print $1}' | grep -qx 'dotnet-ef'; then
+            echo "dotnet-ef already installed globally — using existing version:"
+            dotnet tool list --global | grep '^dotnet-ef'
+          else
+            dotnet tool install --global dotnet-ef --version 9.*
+          fi
 
       - name: Restore and build API project
         working-directory: apps/api/src/Api


### PR DESCRIPTION
## Summary

- `dotnet tool install --version 9.*` fails on self-hosted runners that already have dotnet-ef 10.x globally installed (exit 1: *"The requested version 9.0.15 is lower than existing version 10.0.6"*)
- Fix: check-and-skip pattern — use existing tool if present, install 9.* only if missing
- Blocks PR #509 + #508 from reaching staging (deploy run 24710939981 aborted at this step)

## Context

Staging deploy 24710939981 (2026-04-21 07:57 UTC) failed immediately after build images, at the **Database Migration** job. The \`Install dotnet-ef tool\` step hit the downgrade-not-supported limitation of \`dotnet tool install\`.

dotnet-ef 10.x is backward compatible with the .NET 9 project used here — the migration SQL generation (\`dotnet ef migrations script --idempotent\`) is stable EF API since 6.x. No runtime risk from using the pre-installed 10.x.

## Test plan

- [ ] Merge → staging redeploy auto-triggers via workflow_run
- [ ] Verify **Database Migration** job succeeds (uses pre-installed 10.x)
- [ ] Verify migrations SQL applied on staging DB
- [ ] Smoke test Mechanic Extractor (separate follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)