### PR TITLE
chore(promote): main-dev → main-staging (PR #508, #509, #510)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -437,7 +437,17 @@ jobs:
           dotnet-version: '9.0.x'
 
       - name: Install dotnet-ef tool
-        run: dotnet tool install --global dotnet-ef --version 9.*
+        # Idempotent: use pre-installed tool if present (self-hosted runner may
+        # already have dotnet-ef from a newer SDK). `dotnet tool install` does
+        # not support downgrades, so skipping install when a compatible version
+        # exists avoids exit 1 on runners with ef 10.x already global.
+        run: |
+          if dotnet tool list --global | awk '{print $1}' | grep -qx 'dotnet-ef'; then
+            echo "dotnet-ef already installed globally — using existing version:"
+            dotnet tool list --global | grep '^dotnet-ef'
+          else
+            dotnet tool install --global dotnet-ef --version 9.*
+          fi
 
       - name: Restore and build API project
         working-directory: apps/api/src/Api

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -407,32 +407,120 @@ jobs:
           echo "  Web built: ${{ needs.detect-changes.outputs.deploy_web }}"
 
   # Run database migrations BEFORE deploying new code
+  #
+  # Strategy (fix for historical bug where this job only did `docker pull`):
+  #   1. Generate an idempotent SQL migration script via `dotnet ef migrations script --idempotent`
+  #   2. SCP the SQL to the staging server
+  #   3. Create a pre-migration DB backup (pg_dump | gzip) for rollback safety
+  #   4. Apply the SQL via `docker exec postgres psql -v ON_ERROR_STOP=1 -f ...`
+  #   5. Verify __EFMigrationsHistory reflects the latest migration
+  #   6. Pull new API image (for the downstream deploy job)
+  #
+  # Idempotent SQL means every migration is wrapped in `IF NOT EXISTS` against
+  # `__EFMigrationsHistory`, so re-running is a no-op if no new migrations.
+  # If psql fails mid-stream, ON_ERROR_STOP=1 aborts the whole script and the
+  # backup created in step 3 can be restored with `pg_restore`.
   migrate-db:
     name: Database Migration
     runs-on: ${{ vars.RUNNER && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}
     needs: [build]
     if: vars.DEPLOY_METHOD == 'ssh'
     steps:
-      - name: Run Migrations via SSH
+      - name: Checkout source at deploy SHA
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Install dotnet-ef tool
+        run: dotnet tool install --global dotnet-ef --version 9.*
+
+      - name: Restore and build API project
+        working-directory: apps/api/src/Api
+        run: |
+          dotnet restore
+          dotnet build --no-restore -c Release
+
+      - name: Generate idempotent migration SQL
+        working-directory: apps/api/src/Api
+        run: |
+          # Note: no --no-build — dotnet-ef needs the project built. We built
+          # it in the previous step but ef defaults to Debug configuration,
+          # so we let it trigger its own build without the flag to avoid
+          # Release/Debug path mismatches.
+          dotnet ef migrations script --idempotent -o /tmp/migrations.sql
+          lines=$(wc -l < /tmp/migrations.sql)
+          echo "✅ Generated ${lines} lines of SQL at /tmp/migrations.sql"
+          if [ "$lines" -lt 10 ]; then
+            echo "❌ SQL output suspiciously small (< 10 lines). Aborting."
+            exit 1
+          fi
+
+      - name: Apply migrations on staging
         env:
           SSH_HOST: ${{ secrets.STAGING_HOST }}
           SSH_USER: ${{ secrets.STAGING_USER }}
           SSH_KEY: ${{ secrets.STAGING_SSH_KEY }}
           API_IMAGE: ${{ needs.build.outputs.api_image }}
         run: |
-          # Setup SSH
+          set -euo pipefail
+
+          # Setup SSH key
           mkdir -p ~/.ssh
           echo "$SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts 2>/dev/null
 
-          # Pull new API image on server (migrations auto-apply on startup)
-          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \
-            "$SSH_USER@$SSH_HOST" \
-            "docker pull $API_IMAGE && echo '✅ API image pulled'" || {
-            echo "⚠️ Image pull failed — deploy will use cached image"
-          }
+          SSH_CMD="ssh -i $HOME/.ssh/deploy_key -o StrictHostKeyChecking=no $SSH_USER@$SSH_HOST"
+          SCP_CMD="scp -i $HOME/.ssh/deploy_key -o StrictHostKeyChecking=no"
 
+          # Step 1 — pre-migration backup with integrity check.
+          # pipefail is active in the inner shell so a pg_dump failure stops
+          # the chain; gzip -t then verifies the gz is a complete, valid
+          # archive before we consider the backup usable. If any part fails
+          # we delete the partial file so an operator can't accidentally
+          # restore from a truncated dump later.
+          BACKUP_NAME="pre-migration-$(date -u +%Y%m%dT%H%M%SZ).sql.gz"
+          echo "📦 Creating pre-migration backup: ${BACKUP_NAME}"
+          $SSH_CMD "set -o pipefail; docker exec meepleai-postgres pg_dump -U meepleai -d meepleai_staging --no-owner --no-acl | gzip > /tmp/${BACKUP_NAME} && gzip -t /tmp/${BACKUP_NAME} && ls -lh /tmp/${BACKUP_NAME} || { echo '❌ backup failed — removing partial file'; rm -f /tmp/${BACKUP_NAME}; exit 1; }"
+
+          # Step 2 — upload idempotent SQL to server
+          echo "📤 Uploading migrations.sql to server..."
+          $SCP_CMD /tmp/migrations.sql "$SSH_USER@$SSH_HOST:/tmp/migrations.sql"
+
+          # Step 3 — apply SQL inside postgres container with ON_ERROR_STOP=1.
+          # Use a heredoc to ship a small remote script. psql's exit code is
+          # captured directly into `rc` on the next line; the `tail` (log
+          # output) and cleanup run unconditionally after, and their own
+          # exit codes never mask psql's result. Final `exit $rc` propagates
+          # the real psql outcome back through SSH to the runner.
+          echo "🔧 Applying migrations via psql..."
+          ssh -i "$HOME/.ssh/deploy_key" -o StrictHostKeyChecking=no "$SSH_USER@$SSH_HOST" bash <<'REMOTE_APPLY'
+          set -u
+          docker cp /tmp/migrations.sql meepleai-postgres:/tmp/migrations.sql
+          docker exec meepleai-postgres psql -U meepleai -d meepleai_staging -v ON_ERROR_STOP=1 -f /tmp/migrations.sql > /tmp/migrations.log 2>&1
+          rc=$?
+          echo "--- psql log (tail -20) ---"
+          tail -20 /tmp/migrations.log 2>/dev/null || true
+          echo "--- end log ---"
+          docker exec meepleai-postgres rm -f /tmp/migrations.sql /tmp/migrations.log 2>/dev/null || true
+          rm -f /tmp/migrations.sql /tmp/migrations.log
+          exit $rc
+          REMOTE_APPLY
+
+          # Step 4 — verify migration history
+          echo "🔍 Verifying applied migrations..."
+          $SSH_CMD "docker exec meepleai-postgres psql -U meepleai -d meepleai_staging -c 'SELECT \"MigrationId\" FROM \"__EFMigrationsHistory\" ORDER BY \"MigrationId\" DESC LIMIT 5;'"
+
+          # Step 5 — pull new API image for downstream deploy job
+          echo "📥 Pulling new API image..."
+          $SSH_CMD "docker pull $API_IMAGE && echo '✅ API image pulled'"
+
+          # Cleanup SSH key
           rm -f ~/.ssh/deploy_key
 
   # Snapshot previous performance baseline before deploy overwrites DEPLOYMENT.json

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -153,7 +153,7 @@ jobs:
           echo $! > api.pid
           sleep 15  # Wait for startup (migrations already done)
         env:
-          ASPNETCORE_ENVIRONMENT: Testing
+          ASPNETCORE_ENVIRONMENT: CI
           ASPNETCORE_URLS: "http://localhost:8080"
           POSTGRES_HOST: localhost
           POSTGRES_PORT: "5432"
@@ -477,7 +477,7 @@ jobs:
           echo $! > api.pid
           sleep 15  # Wait for startup (migrations already done)
         env:
-          ASPNETCORE_ENVIRONMENT: Testing
+          ASPNETCORE_ENVIRONMENT: CI
           ASPNETCORE_URLS: "http://localhost:8080"
           POSTGRES_HOST: localhost
           POSTGRES_PORT: "5432"

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/page.tsx
@@ -78,15 +78,41 @@ export default function MechanicExtractorPage() {
   const [aiResult, setAiResult] = useState<AiAssistResultDto | null>(null);
   const [autoSaveTimer, setAutoSaveTimer] = useState<ReturnType<typeof setTimeout> | null>(null);
 
-  // PDF viewer ref
-  const pdfUrl = selectedPdfId ? `/api/v1/documents/${selectedPdfId}/download` : '';
+  // PDF viewer ref (endpoint: /api/v1/pdfs/{pdfId}/download — see PdfRetrievalEndpoints)
+  const pdfUrl = selectedPdfId ? `/api/v1/pdfs/${selectedPdfId}/download` : '';
 
   // Fetch shared games for selection
-  const { data: gamesData } = useQuery({
+  const { data: gamesData, isLoading: isGamesLoading } = useQuery({
     queryKey: ['shared-games', 'all'],
     queryFn: () => gamesClient.getAll({ page: 1, pageSize: 100 }),
     staleTime: 60_000,
   });
+
+  // Fetch all PDFs in Ready state to determine which games have a PDF available
+  // NOTE: pageSize=500 is a deliberate cap; if exceeded the game filter will
+  // silently under-count eligible games. Raise or paginate if scale demands.
+  const { data: readyPdfsData, isLoading: isReadyPdfsLoading } = useQuery({
+    queryKey: ['admin', 'pdfs', 'ready-all'],
+    queryFn: () =>
+      adminClient.getAllPdfs({
+        state: 'Ready',
+        page: 1,
+        pageSize: 500,
+      }),
+    staleTime: 60_000,
+  });
+
+  const isGameSelectLoading = isGamesLoading || isReadyPdfsLoading;
+
+  // Build set of gameIds that have at least one Ready PDF
+  const gameIdsWithPdf = new Set(
+    (readyPdfsData?.items ?? []).map(p => p.gameId).filter((id): id is string => !!id)
+  );
+
+  // Filter games to those with at least one PDF available
+  const gamesWithPdf = (gamesData?.items ?? []).filter((g: { id: string }) =>
+    gameIdsWithPdf.has(g.id)
+  );
 
   // Fetch PDFs for selected game
   const { data: pdfsData } = useQuery({
@@ -94,7 +120,7 @@ export default function MechanicExtractorPage() {
     queryFn: () =>
       adminClient.getAllPdfs({
         gameId: selectedGameId,
-        status: 'completed',
+        state: 'Ready',
         page: 1,
         pageSize: 50,
       }),
@@ -210,7 +236,7 @@ export default function MechanicExtractorPage() {
   const handleGameSelect = (gameId: string) => {
     setSelectedGameId(gameId);
     setSelectedPdfId('');
-    const game = gamesData?.items?.find((g: { id: string; title: string }) => g.id === gameId);
+    const game = gamesWithPdf.find((g: { id: string; title: string }) => g.id === gameId);
     if (game) setGameTitle(game.title);
   };
 
@@ -251,11 +277,19 @@ export default function MechanicExtractorPage() {
                 Select Game
               </label>
               <Select value={selectedGameId} onValueChange={handleGameSelect}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Choose a game..." />
+                <SelectTrigger disabled={isGameSelectLoading}>
+                  <SelectValue
+                    placeholder={
+                      isGameSelectLoading
+                        ? 'Loading…'
+                        : gamesWithPdf.length === 0
+                          ? 'No games with PDF available'
+                          : 'Choose a game...'
+                    }
+                  />
                 </SelectTrigger>
                 <SelectContent>
-                  {gamesData?.items?.map((game: { id: string; title: string }) => (
+                  {gamesWithPdf.map((game: { id: string; title: string }) => (
                     <SelectItem key={game.id} value={game.id}>
                       {game.title}
                     </SelectItem>

--- a/apps/web/src/components/ui/overlays/select.tsx
+++ b/apps/web/src/components/ui/overlays/select.tsx
@@ -77,7 +77,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem]',
+        'relative z-50 max-h-[var(--radix-select-content-available-height)] min-w-[8rem]',
         'overflow-y-auto overflow-x-hidden rounded-md',
         'border border-border/50 dark:border-border/70',
         // Light mode: Glass morphism dropdown

--- a/scripts/audit-pdf-storage.sh
+++ b/scripts/audit-pdf-storage.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Audit R2/S3 PDF storage layout to determine whether rebucket-pdfs-s3.sh is required.
+#
+# Layouts:
+#   Legacy (pre 2026-04-19):  pdfs/{gameId}/{pdfId}.pdf
+#   Current (post-migration): pdfs/{pdfId}/{pdfId}.pdf      (uniform — gameId == pdfId)
+#
+# Decision:
+#   - If every top-level prefix under pdfs/ is a pdfId present in pdf_documents.Id
+#     → layout is current → rebucket N/A
+#   - If any top-level prefix matches a gameId (PrivateGameId/SharedGameId) but not
+#     a pdfId → legacy entries exist → rebucket required
+#
+# Usage:
+#   AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... \
+#   S3_ENDPOINT=https://<acct>.r2.cloudflarestorage.com \
+#   BUCKET=meepleai-uploads \
+#   [PG_DSN='postgres://user:pass@host:5432/meepleai_staging'] \
+#   ./scripts/audit-pdf-storage.sh
+#
+# If PG_DSN is omitted the script lists R2 prefixes and lets the operator
+# cross-reference manually.
+
+set -euo pipefail
+
+BUCKET="${BUCKET:?BUCKET env var required}"
+ENDPOINT="${S3_ENDPOINT:-}"
+PREFIX="${PREFIX:-pdfs/}"
+
+AWS_ARGS=()
+[[ -n "$ENDPOINT" ]] && AWS_ARGS+=(--endpoint-url "$ENDPOINT")
+
+echo "=== R2/S3 audit — bucket=$BUCKET prefix=$PREFIX ==="
+echo
+
+echo "[1/3] Top-level prefixes under $PREFIX:"
+# Delimiter '/' lists only CommonPrefixes (no recursion). Output is
+# "PRE <prefix>/" lines; strip prefix+trailing slash.
+mapfile -t R2_IDS < <(
+    aws "${AWS_ARGS[@]}" s3 ls "s3://${BUCKET}/${PREFIX}" \
+        | awk '/^[[:space:]]+PRE /{print $2}' \
+        | sed 's|/$||'
+)
+
+count="${#R2_IDS[@]}"
+echo "  Found $count entries"
+printf '  %s\n' "${R2_IDS[@]:0:10}"
+[[ $count -gt 10 ]] && echo "  … ($((count - 10)) more)"
+echo
+
+if [[ -z "${PG_DSN:-}" ]]; then
+    echo "[2/3] Skipped (PG_DSN not set) — manual cross-check required."
+    echo "[3/3] Skipped."
+    echo
+    echo "To complete audit, export PG_DSN pointing at the matching environment"
+    echo "and rerun this script."
+    exit 0
+fi
+
+# Pull pdfId and gameId sets from DB in one round-trip.
+echo "[2/3] Querying DB for pdf_documents ids + game ids…"
+DB_DUMP=$(
+    psql "$PG_DSN" -t -A -F '|' <<'SQL'
+SELECT
+    REPLACE("Id"::text, '-', ''),
+    REPLACE(COALESCE("PrivateGameId"::text, "SharedGameId"::text, ''), '-', '')
+FROM pdf_documents
+WHERE "FilePath" IS NOT NULL;
+SQL
+)
+
+declare -A PDF_IDS GAME_IDS
+while IFS='|' read -r pid gid; do
+    [[ -z "$pid" ]] && continue
+    PDF_IDS["$pid"]=1
+    [[ -n "$gid" ]] && GAME_IDS["$gid"]=1
+done <<< "$DB_DUMP"
+
+echo "  pdf_documents rows: ${#PDF_IDS[@]}"
+echo "  distinct game ids:  ${#GAME_IDS[@]}"
+echo
+
+echo "[3/3] Classifying R2 prefixes:"
+matched_pdf=0
+matched_game=0
+unknown=0
+for id in "${R2_IDS[@]}"; do
+    idN="${id//-/}"
+    if [[ -n "${PDF_IDS[$idN]:-}" ]]; then
+        ((matched_pdf++))
+    elif [[ -n "${GAME_IDS[$idN]:-}" ]]; then
+        ((matched_game++))
+        echo "  LEGACY gameId prefix: $id"
+    else
+        ((unknown++))
+        echo "  UNKNOWN prefix: $id"
+    fi
+done
+
+echo
+echo "=== Summary ==="
+echo "  current-layout (pdfId):  $matched_pdf"
+echo "  legacy-layout (gameId):  $matched_game"
+echo "  unknown:                 $unknown"
+echo
+
+if [[ $matched_game -eq 0 && $unknown -eq 0 ]]; then
+    echo "DECISION: rebucket N/A — all R2 prefixes match current pdfId layout."
+    exit 0
+elif [[ $matched_game -gt 0 ]]; then
+    echo "DECISION: rebucket REQUIRED — $matched_game legacy gameId prefixes found."
+    echo "         Run: BUCKET=$BUCKET ./scripts/rebucket-pdfs-s3.sh --dry-run"
+    exit 2
+else
+    echo "DECISION: INVESTIGATE — $unknown prefixes match neither pdfId nor gameId."
+    exit 3
+fi


### PR DESCRIPTION
## Summary
Promote 3 commits from `main-dev` to `main-staging` to unblock staging deploy.

## Commits
- b4923092b — fix(ci): make dotnet-ef install idempotent (#510) — **required to fix deploy-staging**
- 4d8da08a0 — feat(mechanic-extractor): review page + token tracking + bug fixes (#508)
- 24a320feb — fix(ci): apply DB migrations via idempotent SQL script (#509)

## Context
Previous deploy run on `main-staging` (sha `4d8da08a0`) failed due to `dotnet-ef` install conflict on pre-installed runner. PR #510 makes the install step idempotent (detects existing EF tool, skips reinstall). This promote brings the fix to `main-staging` so the next CI→deploy pipeline succeeds.

## Test plan
- [ ] CI passes on main-staging
- [ ] Deploy to Staging workflow triggers via workflow_run
- [ ] Deploy completes successfully
- [ ] Smoke test on staging: Mechanic Extractor review page
- [ ] Audit-pdf-storage.sh execution on R2 staging