### PR TITLE
fix(ci): use CI environment for test-e2e.yml backend subprocess

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -153,7 +153,7 @@ jobs:
           echo $! > api.pid
           sleep 15  # Wait for startup (migrations already done)
         env:
-          ASPNETCORE_ENVIRONMENT: Testing
+          ASPNETCORE_ENVIRONMENT: CI
           ASPNETCORE_URLS: "http://localhost:8080"
           POSTGRES_HOST: localhost
           POSTGRES_PORT: "5432"
@@ -477,7 +477,7 @@ jobs:
           echo $! > api.pid
           sleep 15  # Wait for startup (migrations already done)
         env:
-          ASPNETCORE_ENVIRONMENT: Testing
+          ASPNETCORE_ENVIRONMENT: CI
           ASPNETCORE_URLS: "http://localhost:8080"
           POSTGRES_HOST: localhost
           POSTGRES_PORT: "5432"


### PR DESCRIPTION
## Summary
- Fix E2E test failures caused by DI misconfiguration in backend subprocess
- Change `ASPNETCORE_ENVIRONMENT` from `Testing` → `CI` in both Start Backend API steps

## Root Cause
`InfrastructureServiceExtensions.cs:57` gates `MeepleAiDbContext` registration on non-Testing environments (assuming `WebApplicationFactory` would override DI in tests). But `test-e2e.yml` launches the API as a **subprocess via `dotnet run`**, not through WebApplicationFactory, so nothing overrides DI. Result: `MeepleAiDbContext` never registered, causing:

1. `ServiceCallLoggingHandler` DI scope resolution failures
2. `SessionFlowEndpoints` parameter binding inference: `MeepleAiDbContext db` fell through to Body inference → fatal at startup

## Fix
Align with `ci.yml` and `test-performance.yml` which already use `ASPNETCORE_ENVIRONMENT=CI` for the same subprocess pattern.

## Test plan
- [ ] E2E workflow triggers on this PR and passes
- [ ] After merge, rebase PR #511 and verify E2E passes there
- [ ] PR #511 merge triggers deploy-staging successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)