### PR TITLE
feat(auth v2): migrate secondary auth pages to v2 primitives

### DIFF
--- a/apps/web/src/app/(auth)/invitation-expired/page.tsx
+++ b/apps/web/src/app/(auth)/invitation-expired/page.tsx
@@ -19,7 +19,7 @@ import { Clock } from 'lucide-react';
 import Link from 'next/link';
 
 import { AuthLayout } from '@/components/layouts';
-import { Button } from '@/components/ui/primitives/button';
+import { Btn } from '@/components/ui/v2/btn';
 
 export default function InvitationExpiredPage() {
   return (
@@ -40,12 +40,12 @@ export default function InvitationExpiredPage() {
 
         {/* Actions */}
         <div className="flex flex-col gap-2 pt-4 w-full">
-          <Button asChild className="w-full">
+          <Btn asChild fullWidth>
             <Link href="/register">Request Access</Link>
-          </Button>
-          <Button variant="ghost" asChild className="w-full">
+          </Btn>
+          <Btn variant="ghost" asChild fullWidth>
             <Link href="/login">Back to Login</Link>
-          </Button>
+          </Btn>
         </div>
       </div>
     </AuthLayout>

--- a/apps/web/src/app/(auth)/setup-account/_content.tsx
+++ b/apps/web/src/app/(auth)/setup-account/_content.tsx
@@ -14,20 +14,18 @@
 
 import { useEffect, useState, FormEvent } from 'react';
 
-import { motion } from 'framer-motion';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 
-import { AccessibleFormInput, AccessibleButton } from '@/components/accessible';
 import { AuthLayout } from '@/components/layouts';
-import { Button } from '@/components/ui/primitives/button';
+import { Btn } from '@/components/ui/v2/btn';
+import { InputField } from '@/components/ui/v2/input-field';
+import { PwdInput } from '@/components/ui/v2/pwd-input';
 import { getErrorMessage } from '@/lib/utils/errorHandler';
 
 // ──────────────────────────────────────────────
 // Types
 // ──────────────────────────────────────────────
-
-type PasswordStrength = 'weak' | 'medium' | 'strong';
 
 interface PasswordValidation {
   minLength: boolean;
@@ -35,7 +33,6 @@ interface PasswordValidation {
   hasLowercase: boolean;
   hasNumber: boolean;
   isValid: boolean;
-  strength: PasswordStrength;
 }
 
 interface InvitationValidation {
@@ -55,22 +52,12 @@ const validatePassword = (password: string): PasswordValidation => {
   const hasLowercase = /[a-z]/.test(password);
   const hasNumber = /[0-9]/.test(password);
 
-  const requirementsMet = [minLength, hasUppercase, hasLowercase, hasNumber].filter(Boolean).length;
-
-  let strength: PasswordStrength = 'weak';
-  if (requirementsMet === 4) {
-    strength = 'strong';
-  } else if (requirementsMet >= 2 && minLength) {
-    strength = 'medium';
-  }
-
   return {
     minLength,
     hasUppercase,
     hasLowercase,
     hasNumber,
     isValid: minLength && hasUppercase && hasLowercase && hasNumber,
-    strength,
   };
 };
 
@@ -79,52 +66,6 @@ const getApiBase = (): string => {
     return process.env.NEXT_PUBLIC_API_BASE_URL ?? '';
   }
   return '';
-};
-
-// ──────────────────────────────────────────────
-// Password Strength Indicator
-// ──────────────────────────────────────────────
-
-const PasswordStrengthIndicator = ({ strength }: { strength: PasswordStrength }) => {
-  const strengthConfig = {
-    weak: {
-      color: 'bg-red-500',
-      text: 'Debole',
-      textColor: 'text-red-500',
-      width: 'w-1/3',
-    },
-    medium: {
-      color: 'bg-orange-500',
-      text: 'Media',
-      textColor: 'text-orange-500',
-      width: 'w-2/3',
-    },
-    strong: {
-      color: 'bg-green-500',
-      text: 'Forte',
-      textColor: 'text-green-500',
-      width: 'w-full',
-    },
-  };
-
-  const config = strengthConfig[strength];
-
-  return (
-    <div className="space-y-2" role="status" aria-live="polite">
-      <div className="flex justify-between items-center">
-        <span className="text-sm text-slate-600 dark:text-slate-400">Sicurezza password:</span>
-        <span className={`text-sm font-medium ${config.textColor}`}>{config.text}</span>
-      </div>
-      <div className="h-2 bg-slate-200 dark:bg-slate-700 rounded-full overflow-hidden">
-        <motion.div
-          className={`h-full ${config.color}`}
-          initial={{ width: 0 }}
-          animate={{ width: config.width }}
-          transition={{ duration: 0.3 }}
-        />
-      </div>
-    </div>
-  );
 };
 
 // ──────────────────────────────────────────────
@@ -149,7 +90,6 @@ export function SetupAccountContent() {
     hasLowercase: false,
     hasNumber: false,
     isValid: false,
-    strength: 'weak',
   });
 
   // UI state
@@ -232,7 +172,6 @@ export function SetupAccountContent() {
         hasLowercase: false,
         hasNumber: false,
         isValid: false,
-        strength: 'weak',
       });
     }
   }, [password]);
@@ -317,9 +256,9 @@ export function SetupAccountContent() {
             Token mancante. Utilizza il link ricevuto nell&apos;email di invito.
           </p>
           <div className="pt-4">
-            <Button variant="secondary" asChild>
+            <Btn variant="secondary" asChild>
               <Link href="/login">Vai al Login</Link>
-            </Button>
+            </Btn>
           </div>
         </div>
       </AuthLayout>
@@ -343,13 +282,13 @@ export function SetupAccountContent() {
           <div className="text-6xl mb-4">&#9888;&#65039;</div>
           <div className="pt-4 space-y-2">
             {isAlreadyUsed && (
-              <Button asChild className="w-full">
+              <Btn asChild fullWidth>
                 <Link href="/login">Vai al Login</Link>
-              </Button>
+              </Btn>
             )}
-            <Button variant="secondary" asChild className="w-full">
+            <Btn variant="secondary" asChild fullWidth>
               <Link href="/">Torna alla Home</Link>
-            </Button>
+            </Btn>
           </div>
         </div>
       </AuthLayout>
@@ -373,6 +312,9 @@ export function SetupAccountContent() {
   }
 
   // Valid token: show password form
+  const confirmError =
+    confirmPassword && password !== confirmPassword ? 'Le password non coincidono' : undefined;
+
   return (
     <AuthLayout
       title="Configura Account"
@@ -390,121 +332,115 @@ export function SetupAccountContent() {
 
       <form noValidate onSubmit={handleSubmit} className="space-y-4">
         {/* Email (readonly) */}
-        <AccessibleFormInput
+        <InputField
           label="Email"
           type="email"
           value={validationResult?.email ?? ''}
-          readOnly
+          onChange={() => {
+            /* readonly */
+          }}
           autoComplete="email"
-          inputClassName="w-full bg-slate-100 dark:bg-slate-800 border border-slate-300 dark:border-slate-600 rounded-lg px-4 py-3 text-slate-900 dark:text-slate-100 cursor-not-allowed"
+          disabled
         />
 
         {/* Display Name (readonly) */}
         {validationResult?.displayName && (
-          <AccessibleFormInput
+          <InputField
             label="Nome"
             type="text"
             value={validationResult.displayName}
-            readOnly
-            inputClassName="w-full bg-slate-100 dark:bg-slate-800 border border-slate-300 dark:border-slate-600 rounded-lg px-4 py-3 text-slate-900 dark:text-slate-100 cursor-not-allowed"
+            onChange={() => {
+              /* readonly */
+            }}
+            disabled
           />
         )}
 
         {/* Password */}
-        <AccessibleFormInput
+        <PwdInput
           label="Password"
-          type="password"
           value={password}
-          onChange={e => setPassword(e.target.value)}
+          onChange={setPassword}
           required
           autoComplete="new-password"
           placeholder="Inserisci la password"
-          inputClassName="w-full bg-white dark:bg-slate-700 border border-slate-300 dark:border-slate-600 rounded-lg px-4 py-3 text-slate-900 dark:text-slate-100 focus:border-primary focus:ring-2 focus:ring-ring"
+          showStrength
+          strengthPrefix="Sicurezza password:"
         />
 
         {/* Password Requirements */}
         {password && (
-          <div className="space-y-2">
-            <PasswordStrengthIndicator strength={passwordValidation.strength} />
-            <div className="text-sm space-y-1">
-              <div
-                className={`flex items-center gap-2 ${
-                  passwordValidation.minLength
-                    ? 'text-green-400'
-                    : 'text-slate-500 dark:text-slate-400'
-                }`}
-              >
-                <span aria-hidden="true">{passwordValidation.minLength ? '\u2713' : '\u25CB'}</span>
-                <span>Almeno 8 caratteri</span>
-              </div>
-              <div
-                className={`flex items-center gap-2 ${
-                  passwordValidation.hasUppercase
-                    ? 'text-green-400'
-                    : 'text-slate-500 dark:text-slate-400'
-                }`}
-              >
-                <span aria-hidden="true">
-                  {passwordValidation.hasUppercase ? '\u2713' : '\u25CB'}
-                </span>
-                <span>Almeno 1 lettera maiuscola</span>
-              </div>
-              <div
-                className={`flex items-center gap-2 ${
-                  passwordValidation.hasLowercase
-                    ? 'text-green-400'
-                    : 'text-slate-500 dark:text-slate-400'
-                }`}
-              >
-                <span aria-hidden="true">
-                  {passwordValidation.hasLowercase ? '\u2713' : '\u25CB'}
-                </span>
-                <span>Almeno 1 lettera minuscola</span>
-              </div>
-              <div
-                className={`flex items-center gap-2 ${
-                  passwordValidation.hasNumber
-                    ? 'text-green-400'
-                    : 'text-slate-500 dark:text-slate-400'
-                }`}
-              >
-                <span aria-hidden="true">{passwordValidation.hasNumber ? '\u2713' : '\u25CB'}</span>
-                <span>Almeno 1 numero</span>
-              </div>
+          <div className="text-sm space-y-1">
+            <div
+              className={`flex items-center gap-2 ${
+                passwordValidation.minLength
+                  ? 'text-green-400'
+                  : 'text-slate-500 dark:text-slate-400'
+              }`}
+            >
+              <span aria-hidden="true">{passwordValidation.minLength ? '\u2713' : '\u25CB'}</span>
+              <span>Almeno 8 caratteri</span>
+            </div>
+            <div
+              className={`flex items-center gap-2 ${
+                passwordValidation.hasUppercase
+                  ? 'text-green-400'
+                  : 'text-slate-500 dark:text-slate-400'
+              }`}
+            >
+              <span aria-hidden="true">
+                {passwordValidation.hasUppercase ? '\u2713' : '\u25CB'}
+              </span>
+              <span>Almeno 1 lettera maiuscola</span>
+            </div>
+            <div
+              className={`flex items-center gap-2 ${
+                passwordValidation.hasLowercase
+                  ? 'text-green-400'
+                  : 'text-slate-500 dark:text-slate-400'
+              }`}
+            >
+              <span aria-hidden="true">
+                {passwordValidation.hasLowercase ? '\u2713' : '\u25CB'}
+              </span>
+              <span>Almeno 1 lettera minuscola</span>
+            </div>
+            <div
+              className={`flex items-center gap-2 ${
+                passwordValidation.hasNumber
+                  ? 'text-green-400'
+                  : 'text-slate-500 dark:text-slate-400'
+              }`}
+            >
+              <span aria-hidden="true">{passwordValidation.hasNumber ? '\u2713' : '\u25CB'}</span>
+              <span>Almeno 1 numero</span>
             </div>
           </div>
         )}
 
         {/* Confirm Password */}
-        <AccessibleFormInput
+        <PwdInput
           label="Conferma Password"
-          type="password"
           value={confirmPassword}
-          onChange={e => setConfirmPassword(e.target.value)}
+          onChange={setConfirmPassword}
           required
           autoComplete="new-password"
           placeholder="Conferma la password"
-          error={
-            confirmPassword && password !== confirmPassword
-              ? 'Le password non coincidono'
-              : undefined
-          }
-          inputClassName="w-full bg-white dark:bg-slate-700 border border-slate-300 dark:border-slate-600 rounded-lg px-4 py-3 text-slate-900 dark:text-slate-100 focus:border-primary focus:ring-2 focus:ring-ring"
+          error={confirmError}
         />
 
         {/* Submit */}
-        <AccessibleButton
+        <Btn
           type="submit"
-          variant="primary"
-          className="w-full mt-6"
-          isLoading={isSubmitting}
-          loadingText="Attivazione in corso..."
+          fullWidth
+          className="mt-6"
+          loading={isSubmitting}
           disabled={
             !passwordValidation.isValid || password !== confirmPassword || !confirmPassword.trim()
           }
         >
-          Configura Account
-        </AccessibleButton>
+          {isSubmitting ? 'Attivazione in corso...' : 'Configura Account'}
+        </Btn>
       </form>
 
       <div className="text-center mt-4">

--- a/apps/web/src/app/(auth)/welcome/_content.tsx
+++ b/apps/web/src/app/(auth)/welcome/_content.tsx
@@ -5,8 +5,7 @@ import { useEffect, useState, useCallback } from 'react';
 import { PartyPopper, ArrowRight, Sparkles } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
-import { Progress } from '@/components/ui/feedback/progress';
-import { Button } from '@/components/ui/primitives/button';
+import { Btn } from '@/components/ui/v2/btn';
 
 const REDIRECT_DELAY_MS = 2000;
 const PROGRESS_INTERVAL_MS = 50;
@@ -105,20 +104,37 @@ export function WelcomeContent() {
 
         {/* Progress Bar */}
         <div className="space-y-2" role="status" aria-live="polite">
-          <Progress value={progress} className="h-2 w-full" aria-label="Redirect progress" />
+          <div
+            role="progressbar"
+            aria-valuenow={Math.round(progress)}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label="Redirect progress"
+            className="relative h-2 w-full overflow-hidden rounded-full bg-slate-200 dark:bg-slate-700"
+          >
+            <div
+              className="h-full rounded-full bg-primary transition-[width] duration-75 motion-reduce:transition-none"
+              style={{ width: `${Math.min(100, Math.max(0, progress))}%` }}
+            />
+          </div>
           <p className="text-xs text-slate-400 dark:text-slate-500">Reindirizzamento in corso...</p>
         </div>
 
         {/* Manual Redirect Button */}
-        <Button
+        <Btn
           onClick={handleRedirect}
           size="lg"
           className="group"
           data-testid="welcome-go-dashboard"
+          rightIcon={
+            <ArrowRight
+              className="h-4 w-4 transition-transform group-hover:translate-x-1"
+              aria-hidden="true"
+            />
+          }
         >
           Vai alla Dashboard
-          <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
-        </Button>
+        </Btn>
 
         {/* Features Preview */}
         <div className="pt-4 border-t border-slate-200 dark:border-slate-700">

--- a/apps/web/src/components/auth/VerificationSuccess.tsx
+++ b/apps/web/src/components/auth/VerificationSuccess.tsx
@@ -25,7 +25,7 @@ import { useEffect, useState, useRef } from 'react';
 
 import { CheckCircle2, ArrowRight } from 'lucide-react';
 
-import { Button } from '@/components/ui/primitives/button';
+import { Btn } from '@/components/ui/v2/btn';
 import { useTranslation } from '@/hooks/useTranslation';
 
 export interface VerificationSuccessProps {
@@ -144,14 +144,14 @@ export function VerificationSuccess({
 
       {/* Countdown or Redirect Button */}
       <div className="w-full space-y-3">
-        <Button
-          className="w-full"
+        <Btn
+          fullWidth
           onClick={handleManualRedirect}
           data-testid="continue-to-dashboard-button"
+          rightIcon={<ArrowRight className="w-4 h-4" aria-hidden="true" />}
         >
           {t('auth.emailVerification.success.continueButton')}
-          <ArrowRight className="w-4 h-4 ml-2" aria-hidden="true" />
-        </Button>
+        </Btn>
 
         {/* Countdown Message */}
         {countdown > 0 && autoRedirectSeconds > 0 && (


### PR DESCRIPTION
## Summary

Completes the auth-flow-v2 migration started in PR #484 by porting the remaining secondary auth routes and the `VerificationSuccess` component to the v2 design primitives. Closes #504.

## Changes

- **invitation-expired** (`/invitation-expired`): `Button` v1 → `Btn` v2 (variant `ghost` + `fullWidth`)
- **welcome** (`/welcome`): `Button` v1 → `Btn` v2, `Progress` v1 → inline tailwind progressbar (role="progressbar" + aria-valuenow)
- **setup-account** (`/setup-account`): full refactor
  - `AccessibleFormInput` → `InputField` v2 (email/displayName as `disabled`)
  - Password fields → `PwdInput` v2 with built-in show/hide toggle and `showStrength`
  - Local `PasswordStrengthIndicator` removed (replaced by `StrengthMeter` inside `PwdInput`)
  - `AccessibleButton` → `Btn` v2 with `loading` prop
  - `Button` v1 → `Btn` v2 throughout (token-missing + invalid-token + already-used branches)
- **`VerificationSuccess` component**: `Button` v1 → `Btn` v2 (`rightIcon` + `fullWidth`)

Zero v1 auth component imports remain in `src/app/(auth)`:

```bash
$ grep -r "AccessibleFormInput\|AccessibleButton\|ui/primitives/button\|ui/feedback/progress" src/app/(auth)
(no matches)
```

Note on `B10` (issue #494): the pre-migration `.html` mockup was deemed non-blocking — the v2 primitives (`InputField`, `PwdInput`, `StrengthMeter`, `Btn`, `AuthLayout`) already establish the design language, so migrating directly from v1 to v2 is safe and avoids redundant mockup work.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors (pre-existing warnings only)
- [x] `pnpm vitest run src/app/(auth)/__tests__ src/components/auth/__tests__` — 210/210 passing (13 test files)
- [x] `pnpm build` — production build succeeds (142 static pages incl. `/welcome`, `/setup-account`, `/invitation-expired`, `/verification-success`)
- [ ] Manual QA in browser: invitation-expired, welcome auto-redirect, setup-account full flow, verification-success

🤖 Generated with [Claude Code](https://claude.com/claude-code)