### PR TITLE
fix(ci): add $HOME/.dotnet/tools to PATH in migrate-db job

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -448,6 +448,14 @@ jobs:
           else
             dotnet tool install --global dotnet-ef --version 9.*
           fi
+          # Self-hosted runners: $HOME/.dotnet/tools is where `dotnet tool
+          # install --global` places binaries, but this directory is NOT
+          # automatically added to PATH between steps. setup-dotnet only
+          # sets DOTNET_ROOT, not the user-global tools dir. Without this
+          # append, the next step's `dotnet ef ...` fails with "dotnet-ef
+          # not found on PATH" even though the tool is installed. Regression
+          # caught on staging deploy run 24779812732.
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
 
       - name: Restore and build API project
         working-directory: apps/api/src/Api


### PR DESCRIPTION
## Summary

Durable workflow fix for the `dotnet-ef not found on PATH` regression that blocked staging deploy run [24779812732](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/24779812732) (migrate-db job, step 6).

## Root cause

Self-hosted runners: `dotnet tool install --global` places binaries in `$HOME/.dotnet/tools`, but `setup-dotnet@v4` only exports `DOTNET_ROOT` — it does **not** append the user-global tools dir to PATH. The next step's `dotnet ef database update` then fails with "dotnet-ef not found on PATH" even though the tool is installed.

## Fix

Append `$HOME/.dotnet/tools` to `$GITHUB_PATH` right after the install step so it persists across subsequent steps in the job.

```yaml
echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
```

## Runtime workaround already applied

To unblock the current deploy without waiting for this PR cycle, a runtime PATH override was added to `/home/deploy/actions-runner/.env` on the staging runner and the service was restarted. This PR makes the fix durable in the workflow itself so:
- Fresh runners / rebuilt images work out of the box
- No reliance on undocumented runner-local state
- Fix survives runner recreation

## Test plan

- [x] Diff inspected — single additive line with explanatory comment
- [ ] Merge → next staging deploy run should pass migrate-db step without runner `.env` dependency
- [ ] After confirmation, clean up the runner-side `.env` PATH override

🤖 Generated with [Claude Code](https://claude.com/claude-code)