### PR TITLE
fix(migrations): make DropPdfAndCollectionGameId idempotent vs schema drift

### DIFF
--- a/apps/api/src/Api/Infrastructure/Migrations/20260419155458_DropPdfAndCollectionGameId.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260419155458_DropPdfAndCollectionGameId.cs
@@ -10,105 +10,112 @@ namespace Api.Infrastructure.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            // NOTE: This migration is idempotent against actual schema state, not just
+            // __EFMigrationsHistory. Staging deploy run 24782673236 failed because the FK
+            // FK_pdf_documents_games_GameId had been dropped out-of-band (not tracked in
+            // migration history) — EF's generated DROP CONSTRAINT without IF EXISTS then
+            // raised ERROR 42704. Using raw Sql() with PostgreSQL IF EXISTS / IF NOT EXISTS
+            // clauses makes this migration safe to apply against DBs with partial drift.
+
             // ========= pdf_documents =========
 
-            // 1a. Backfill SharedGameId
+            // 1a. Backfill SharedGameId (guarded: only if GameId column still exists)
             migrationBuilder.Sql(@"
-                UPDATE pdf_documents p
-                SET ""SharedGameId"" = g.""SharedGameId""
-                FROM games g
-                WHERE p.""GameId"" = g.""Id""
-                  AND p.""SharedGameId"" IS NULL
-                  AND g.""SharedGameId"" IS NOT NULL;
+                DO $$
+                BEGIN
+                    IF EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'pdf_documents' AND column_name = 'GameId'
+                    ) THEN
+                        UPDATE pdf_documents p
+                        SET ""SharedGameId"" = g.""SharedGameId""
+                        FROM games g
+                        WHERE p.""GameId"" = g.""Id""
+                          AND p.""SharedGameId"" IS NULL
+                          AND g.""SharedGameId"" IS NOT NULL;
+                    END IF;
+                END $$;
             ");
 
-            // 1b. Drop FK + indices + column
-            migrationBuilder.DropForeignKey(
-                name: "FK_pdf_documents_games_GameId",
-                table: "pdf_documents");
+            // 1b. Drop FK + indices + column (idempotent)
+            migrationBuilder.Sql(@"
+                ALTER TABLE pdf_documents DROP CONSTRAINT IF EXISTS ""FK_pdf_documents_games_GameId"";
+                DROP INDEX IF EXISTS ""IX_pdf_documents_GameId_UploadedAt"";
+                DROP INDEX IF EXISTS ix_pdf_documents_content_hash_game_id;
+                ALTER TABLE pdf_documents DROP COLUMN IF EXISTS ""GameId"";
+            ");
 
-            migrationBuilder.DropIndex(
-                name: "IX_pdf_documents_GameId_UploadedAt",
-                table: "pdf_documents");
-
-            migrationBuilder.DropIndex(
-                name: "ix_pdf_documents_content_hash_game_id",
-                table: "pdf_documents");
-
-            migrationBuilder.DropColumn(
-                name: "GameId",
-                table: "pdf_documents");
-
-            // 1c. New indices on SharedGameId
-            migrationBuilder.CreateIndex(
-                name: "IX_pdf_documents_SharedGameId_UploadedAt",
-                table: "pdf_documents",
-                columns: new[] { "SharedGameId", "UploadedAt" });
-
-            migrationBuilder.CreateIndex(
-                name: "ix_pdf_documents_content_hash_shared_game_id",
-                table: "pdf_documents",
-                columns: new[] { "content_hash", "SharedGameId" });
+            // 1c. New indices on SharedGameId (idempotent)
+            migrationBuilder.Sql(@"
+                CREATE INDEX IF NOT EXISTS ""IX_pdf_documents_SharedGameId_UploadedAt""
+                    ON pdf_documents (""SharedGameId"", ""UploadedAt"");
+                CREATE INDEX IF NOT EXISTS ix_pdf_documents_content_hash_shared_game_id
+                    ON pdf_documents (content_hash, ""SharedGameId"");
+            ");
 
             // ========= document_collections (C1) =========
 
-            // 2a. Add nullable SharedGameId column (backfill target)
-            migrationBuilder.AddColumn<Guid>(
-                name: "SharedGameId",
-                table: "document_collections",
-                type: "uuid",
-                nullable: true);
-
-            // 2b. Backfill from games.SharedGameId
+            // 2a. Add nullable SharedGameId column (backfill target; idempotent)
             migrationBuilder.Sql(@"
-                UPDATE document_collections c
-                SET ""SharedGameId"" = g.""SharedGameId""
-                FROM games g
-                WHERE c.""GameId"" = g.""Id""
-                  AND g.""SharedGameId"" IS NOT NULL;
+                ALTER TABLE document_collections ADD COLUMN IF NOT EXISTS ""SharedGameId"" uuid;
+            ");
+
+            // 2b. Backfill from games.SharedGameId (guarded: only if GameId column still exists)
+            migrationBuilder.Sql(@"
+                DO $$
+                BEGIN
+                    IF EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'document_collections' AND column_name = 'GameId'
+                    ) THEN
+                        UPDATE document_collections c
+                        SET ""SharedGameId"" = g.""SharedGameId""
+                        FROM games g
+                        WHERE c.""GameId"" = g.""Id""
+                          AND g.""SharedGameId"" IS NOT NULL;
+                    END IF;
+                END $$;
             ");
 
             // 2c. Hard-cut orphans (Q2=D): collections without shared_game mapping are deleted
             //     Cascade rule applies — children (PDFs in collection) lose CollectionId (SetNull per PdfDocumentEntityConfiguration).
+            //     Naturally idempotent: re-running after NOT NULL is set finds zero rows.
             migrationBuilder.Sql(@"
                 DELETE FROM document_collections
                 WHERE ""SharedGameId"" IS NULL;
             ");
 
-            // 2d. Drop FK + index + column
-            migrationBuilder.DropForeignKey(
-                name: "FK_document_collections_games_GameId",
-                table: "document_collections");
-
-            migrationBuilder.DropIndex(
-                name: "IX_document_collections_GameId",
-                table: "document_collections");
-
-            migrationBuilder.DropColumn(
-                name: "GameId",
-                table: "document_collections");
+            // 2d. Drop FK + index + column (idempotent)
+            migrationBuilder.Sql(@"
+                ALTER TABLE document_collections DROP CONSTRAINT IF EXISTS ""FK_document_collections_games_GameId"";
+                DROP INDEX IF EXISTS ""IX_document_collections_GameId"";
+                ALTER TABLE document_collections DROP COLUMN IF EXISTS ""GameId"";
+            ");
 
             // 2e. Make SharedGameId required (after backfill + orphan cleanup)
-            //     EF's AlterColumn doesn't emit SET NOT NULL for nullable→required transitions
-            //     on newly added columns (same migration). Use raw SQL to guarantee NOT NULL.
+            //     PostgreSQL SET NOT NULL is naturally idempotent — no error if already NOT NULL.
             migrationBuilder.Sql(@"
                 ALTER TABLE document_collections
                 ALTER COLUMN ""SharedGameId"" SET NOT NULL;
             ");
 
-            // 2f. FK + index on SharedGameId (Cascade per spec Q5=A)
-            migrationBuilder.CreateIndex(
-                name: "IX_document_collections_SharedGameId",
-                table: "document_collections",
-                column: "SharedGameId");
+            // 2f. FK + index on SharedGameId (Cascade per spec Q5=A; idempotent)
+            migrationBuilder.Sql(@"
+                CREATE INDEX IF NOT EXISTS ""IX_document_collections_SharedGameId""
+                    ON document_collections (""SharedGameId"");
 
-            migrationBuilder.AddForeignKey(
-                name: "FK_document_collections_shared_games_SharedGameId",
-                table: "document_collections",
-                column: "SharedGameId",
-                principalTable: "shared_games",
-                principalColumn: "id",
-                onDelete: ReferentialAction.Cascade);
+                DO $$
+                BEGIN
+                    IF NOT EXISTS (
+                        SELECT 1 FROM pg_constraint
+                        WHERE conname = 'FK_document_collections_shared_games_SharedGameId'
+                    ) THEN
+                        ALTER TABLE document_collections
+                            ADD CONSTRAINT ""FK_document_collections_shared_games_SharedGameId""
+                            FOREIGN KEY (""SharedGameId"") REFERENCES shared_games (id) ON DELETE CASCADE;
+                    END IF;
+                END $$;
+            ");
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Summary

Staging deploy run [24782673236](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/24782673236) failed at the `Database Migration` step on `migrations.sql:8462`:

```
ERROR: constraint "FK_pdf_documents_games_GameId" of relation "pdf_documents" does not exist
CONTEXT: ALTER TABLE pdf_documents DROP CONSTRAINT "FK_pdf_documents_games_GameId"
```

## Root cause

The FK had been dropped out-of-band on the staging DB (not recorded in `__EFMigrationsHistory`). EF Core's generated DROP CONSTRAINT statements have no `IF EXISTS` clause, so `ON_ERROR_STOP=1` aborts the script.

EF's idempotent script wraps each migration body in a `__EFMigrationsHistory` guard, but that guard only protects against re-running an already-applied migration — it does **NOT** protect against schema drift within an unapplied migration. Inspection on staging confirmed:

- `pg_constraint` on `pdf_documents`: only 3 FKs present; `FK_pdf_documents_games_GameId` missing
- `information_schema.columns`: `pdf_documents.GameId` column still exists
- `__EFMigrationsHistory`: migration `20260419155458_DropPdfAndCollectionGameId` not yet applied

## Fix

Refactor the `Up()` method to use raw `Sql()` calls with PostgreSQL `IF EXISTS` / `IF NOT EXISTS` clauses:

| Operation | Before | After |
|---|---|---|
| FK drop | `migrationBuilder.DropForeignKey(...)` | `ALTER TABLE ... DROP CONSTRAINT IF EXISTS ...` |
| Index drop | `migrationBuilder.DropIndex(...)` | `DROP INDEX IF EXISTS ...` |
| Column drop | `migrationBuilder.DropColumn(...)` | `ALTER TABLE ... DROP COLUMN IF EXISTS ...` |
| Column add | `migrationBuilder.AddColumn<Guid>(...)` | `ALTER TABLE ... ADD COLUMN IF NOT EXISTS ...` |
| Index create | `migrationBuilder.CreateIndex(...)` | `CREATE INDEX IF NOT EXISTS ...` |
| FK add | `migrationBuilder.AddForeignKey(...)` | `DO $$ IF NOT EXISTS ... ADD CONSTRAINT ...` (PG has no ADD CONSTRAINT IF NOT EXISTS for FKs) |

Backfill `UPDATE` statements wrapped in a `DO` block checking `information_schema.columns` to handle the case where the source column has already been dropped.

`SET NOT NULL` on `document_collections.SharedGameId` left as-is — PostgreSQL is naturally idempotent for this operation.

`Down()` intentionally left unchanged: it assumes a complete `Up` state and rolls back from there; making it idempotent would mask incomplete rollbacks which is what you *want* to surface.

## Verification

- [x] `dotnet build` clean (0 warnings, 0 errors)
- [x] Migration ID unchanged (`20260419155458_DropPdfAndCollectionGameId`) — model snapshot valid
- [ ] Next staging deploy run applies migration successfully on drifted DB
- [ ] Follow-up: confirm `__EFMigrationsHistory` contains all 3 expected rows after deploy

## Blocker chain

1. PR #515 — `$HOME/.dotnet/tools` PATH fix ✅ merged (step 6 now reaches psql)
2. **This PR** — psql no longer aborts on out-of-band schema drift
3. After merge → staging deploy should complete → unblocks audit-pdf-storage.sh (#5) and Mechanic Extractor smoke test (#6)

## Test plan

- [ ] Merge to main-dev → sync to main-staging via usual PR
- [ ] Deploy-staging workflow picks up new migration body
- [ ] Monitor migrate-db step on the post-merge deploy run
- [ ] Verify `SELECT "MigrationId" FROM "__EFMigrationsHistory"` shows `20260419155458_DropPdfAndCollectionGameId` after deploy
- [ ] Verify `pdf_documents` no longer has `GameId` column
- [ ] Verify `document_collections` has `SharedGameId` NOT NULL + FK to `shared_games`

🤖 Generated with [Claude Code](https://claude.com/claude-code)