### PR TITLE
fix(sw): prevent /admin redirect loop by never caching authenticated navigations

### DIFF
--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -7,11 +7,37 @@
  * - Session data: StaleWhileRevalidate
  */
 
-const CACHE_VERSION = 'meepleai-v3'; // Bumped: Fix menu flickering (removed aggressive default caching)
+const CACHE_VERSION = 'meepleai-v4'; // Bumped: Fix /admin redirect loop (never cache authenticated navigations)
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const DYNAMIC_CACHE = `${CACHE_VERSION}-dynamic`;
 const API_CACHE = `${CACHE_VERSION}-api`;
 const RULES_CACHE = `${CACHE_VERSION}-rules`;
+
+// Authenticated app routes: navigation responses MUST NOT be cached.
+// Their payload depends on cookies the SW cannot observe, so any cached
+// body replays stale state and can break server-side redirects
+// (e.g. /admin → /admin/overview producing /admin keyed to /admin/overview body).
+const AUTHENTICATED_NAV_PREFIXES = [
+  '/admin',
+  '/library',
+  '/chat',
+  '/sessions',
+  '/games',
+  '/agents',
+  '/upload',
+  '/editor',
+  '/settings',
+  '/play-records',
+  '/game-nights',
+  '/dashboard',
+  '/profile',
+];
+
+function isAuthenticatedNavigation(url) {
+  return AUTHENTICATED_NAV_PREFIXES.some(
+    prefix => url.pathname === prefix || url.pathname.startsWith(`${prefix}/`)
+  );
+}
 
 // Assets to cache on install
 const STATIC_ASSETS = [
@@ -242,17 +268,39 @@ async function staleWhileRevalidateStrategy(request) {
 
 /**
  * Navigation strategy with offline fallback
+ *
+ * Authenticated app routes (see AUTHENTICATED_NAV_PREFIXES) are always
+ * network-only: their payload depends on cookies the SW cannot read, so any
+ * cached body would replay stale state and can cause redirect loops when the
+ * server responds with 3xx (fetch follows redirects and response.url may
+ * differ from request.url, producing mismatched cache entries).
  */
 async function navigationStrategy(request) {
+  const url = new URL(request.url);
+  const isAuthNav = isAuthenticatedNavigation(url);
+
   try {
     const response = await fetch(request);
-    if (response.ok) {
+
+    // Only cache public navigations whose final URL matches the requested URL.
+    // This prevents storing redirected bodies under the original key.
+    if (!isAuthNav && response.ok && !response.redirected && response.url === request.url) {
       const cache = await caches.open(DYNAMIC_CACHE);
       cache.put(request, response.clone());
     }
+
     return response;
   } catch {
-    // Try cached version
+    // Never serve stale navigation for authenticated routes — fall through to
+    // the offline page so the user sees a clear offline state instead of
+    // potentially-stale authenticated content.
+    if (isAuthNav) {
+      const offlinePage = await caches.match('/offline');
+      if (offlinePage) return offlinePage;
+      return new Response('Offline', { status: 503 });
+    }
+
+    // Try cached version for public navigations
     const cached = await caches.match(request);
     if (cached) {
       return cached;


### PR DESCRIPTION
## Summary

Fixes an infinite redirect loop observed on `/admin/overview` where the URL oscillated between `/admin` and `/admin/overview` with hundreds of network calls per minute.

**Root cause** — the service worker's `navigationStrategy` cached every `response.ok` navigation. But `fetch(mode:'navigate')` follows redirects by default, so a request for `GET /admin` (which is a Next.js server-side `redirect('/admin/overview')` → 307) returned a final 200 with `response.url === '/admin/overview'`. The SW then stored the `/admin/overview` body **keyed under `/admin`** in `DYNAMIC_CACHE`. On subsequent navigations the mismatched cache entry replayed stale content, breaking the server-side redirect chain and causing the client router to oscillate.

### Reproduction evidence (Playwright + DevTools)
- `document.cookie === ""` (HttpOnly session cookie — normal)
- 453 GET `/admin/overview?_rsc=…`, all 200
- 284 GET `/admin`, **all 200 (never 307)** — smoking gun: the SW was serving cached bodies
- 229 GET `/api/v1/auth/me` — AuthProvider remounting per hard navigation

## Changes

- Introduce `AUTHENTICATED_NAV_PREFIXES` covering all authenticated app routes (`/admin`, `/library`, `/chat`, `/sessions`, `/games`, `/agents`, `/upload`, `/editor`, `/settings`, `/play-records`, `/game-nights`, `/dashboard`, `/profile`). Navigation responses for these routes depend on cookies the SW cannot observe, so caching them is inherently unsafe.
- `navigationStrategy`:
  - Skip `cache.put` entirely for authenticated navigations.
  - Even for public navigations, require `!response.redirected && response.url === request.url` before caching — prevents mismatched key/body pairs when redirects happen.
  - On network failure for authenticated routes, fall through to `/offline` (never serve potentially-stale authenticated content).
- Bump `CACHE_VERSION` `v3` → `v4` to invalidate stale `DYNAMIC_CACHE` entries for users already impacted.

## Test plan

- [ ] Deploy to staging/dev, hard-reload `/admin/overview` with an admin account — confirm no oscillation
- [ ] Users already affected: after deploy, bump activates automatically on next SW update; manual recovery path still available via `navigator.serviceWorker.getRegistrations() + caches.keys()` if needed
- [ ] Verify public routes (`/`, `/login`, `/about`) still cache normally and work offline
- [ ] Verify `/offline` page shown when authenticated route is requested while offline (previously: stale cached body)
- [ ] No regressions in static asset caching, API caching, rules/FAQ caching

## Notes

- `AuthProvider` already clears `localStorage.meepleai_has_session` on 401/null (lines 90–95), so no change needed there.
- The 229 `/auth/me` calls were a symptom of hard-navigation remount driven by the cache mismatch — not an independent bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)