### PR TITLE
fix(infra): harden seed-index scripts for cross-env portability

### DIFF
--- a/infra/scripts/seed-index-dump.sh
+++ b/infra/scripts/seed-index-dump.sh
@@ -21,7 +21,7 @@ TS=$(date -u +%Y%m%dT%H%M%SZ)
 COMMIT=$(git rev-parse --short=9 HEAD)
 
 EMBEDDING_MODEL=$(docker exec meepleai-api printenv EMBEDDING_MODEL 2>/dev/null || echo "unknown")
-EMBEDDING_DIM=$(docker exec meepleai-api printenv EMBEDDING_DIM 2>/dev/null || echo "0")
+EMBEDDING_DIM=$(docker exec meepleai-api printenv EMBEDDING_DIMENSIONS 2>/dev/null || docker exec meepleai-api printenv EMBEDDING_DIM 2>/dev/null || echo "0")
 MODEL_SLUG=$(echo "$EMBEDDING_MODEL" | tr '/' '_' | tr -cd 'A-Za-z0-9_.-')
 
 BASENAME="meepleai_seed_${TS}_${MODEL_SLUG}_${COMMIT}"
@@ -90,7 +90,13 @@ SELECT json_build_object(
   'failed_pdf_ids',    COALESCE((SELECT json_agg(\"Id\") FROM pdf_documents WHERE processing_state='Failed'), '[]'::json)
 );")
 
-MANIFEST_SHA=$(sha256sum apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml | awk '{print $1}')
+MANIFEST_PATH=""
+for f in apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml \
+         ../apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml; do
+    [ -f "$f" ] && { MANIFEST_PATH="$f"; break; }
+done
+[ -n "$MANIFEST_PATH" ] || fail "manifest dev.yml non trovato"
+MANIFEST_SHA=$(sha256sum "$MANIFEST_PATH" | awk '{print $1}')
 
 jq -n \
     --argjson stats "$STATS_JSON" \

--- a/infra/scripts/seed-index-preflight.sh
+++ b/infra/scripts/seed-index-preflight.sh
@@ -13,13 +13,21 @@ docker compose version >/dev/null || fail "docker compose non disponibile"
 # 2. jq (usato da dump/verify/fetch)
 command -v jq >/dev/null || fail "jq non installato"
 
-# 3. Manifest dev.yml presente
-MANIFEST="apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml"
-[ -f "$MANIFEST" ] || fail "manifest non trovato: $MANIFEST"
+# 3. Manifest dev.yml presente (supporta esecuzione da repo root o da infra/)
+MANIFEST=""
+for f in apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml \
+         ../apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml; do
+    [ -f "$f" ] && { MANIFEST="$f"; break; }
+done
+[ -n "$MANIFEST" ] || fail "manifest non trovato: apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml"
 
-# 4. Seed blob bucket configurato (opzionale ma senza di esso PdfSeeder è silenzioso)
-if [ ! -f infra/secrets/storage.secret ] || ! grep -q "^SEED_BLOB_" infra/secrets/storage.secret 2>/dev/null; then
-    log "WARNING: seed blob non configurato in infra/secrets/storage.secret — PdfSeeder non seederà PDF"
+# 4. Seed bucket configurato (opzionale ma senza di esso PdfSeeder è silenzioso)
+STORAGE_SECRET=""
+for f in infra/secrets/storage.secret secrets/storage.secret; do
+    [ -f "$f" ] && { STORAGE_SECRET="$f"; break; }
+done
+if [ -z "$STORAGE_SECRET" ] || ! grep -qE "^SEED_(BLOB|BUCKET)_" "$STORAGE_SECRET" 2>/dev/null; then
+    log "WARNING: seed bucket non configurato in storage.secret — PdfSeeder non seederà PDF"
     log "Procedo comunque (il bake può essere legittimo per testare il flusso su 0 PDF)"
 fi
 

--- a/infra/scripts/seed-index-wait.sh
+++ b/infra/scripts/seed-index-wait.sh
@@ -7,6 +7,8 @@ TIMEOUT_SECONDS=${SEED_INDEX_TIMEOUT:-10800}        # 3h
 POLL_INTERVAL=${SEED_INDEX_POLL:-15}                 # 15s
 FAILURE_THRESHOLD_PCT=${SEED_INDEX_FAILURE_PCT:-15}  # 15%
 ALLOW_PARTIAL=${SEED_INDEX_ALLOW_PARTIAL:-false}
+PG_USER="${POSTGRES_USER:-meepleai}"
+PG_DB="${POSTGRES_DB:-meepleai_staging}"
 
 log() { echo "[seed-index-wait] $*" >&2; }
 fail() { echo "::error:: $*" >&2; exit 1; }
@@ -14,7 +16,7 @@ fail() { echo "::error:: $*" >&2; exit 1; }
 start=$(date +%s)
 while :; do
     read -r total completed failed dlq queued running < <(
-        docker exec meepleai-postgres psql -U postgres -d meepleai -At -F' ' -c \
+        docker exec meepleai-postgres psql -U "$PG_USER" -d "$PG_DB" -At -F' ' -c \
         "SELECT
            COUNT(*),
            COUNT(*) FILTER (WHERE status='Completed'),
@@ -50,7 +52,7 @@ log "termine: $completed/$total OK, $fail_count falliti (${fail_pct}%)"
 
 if [ "$fail_pct" -gt "$FAILURE_THRESHOLD_PCT" ] && [ "$ALLOW_PARTIAL" != "true" ]; then
     log "fail rate ${fail_pct}% > soglia ${FAILURE_THRESHOLD_PCT}%"
-    docker exec meepleai-postgres psql -U postgres -d meepleai -c \
+    docker exec meepleai-postgres psql -U "$PG_USER" -d "$PG_DB" -c \
       "SELECT j.id, p.file_name, s.error_message
        FROM processing_jobs j
        JOIN pdf_documents p ON p.id = j.pdf_document_id


### PR DESCRIPTION
## Summary
- `seed-index-dump.sh`: prefer `EMBEDDING_DIMENSIONS` con fallback `EMBEDDING_DIM`; manifest path funziona sia da repo root che da `infra/`
- `seed-index-preflight.sh`: path flessibili per manifest e `storage.secret`; regex ora matcha sia `SEED_BLOB_*` che `SEED_BUCKET_*`
- `seed-index-wait.sh`: parametrizza `POSTGRES_USER` / `POSTGRES_DB` (default `meepleai` / `meepleai_staging`) invece di hardcoded `postgres` / `meepleai`

## Rationale
Sblocca lo snapshot workflow su ambienti dove gli script vengono invocati sia dalla repo root che da `infra/`, e si allinea con i nomi env var correnti (`EMBEDDING_DIMENSIONS`, `POSTGRES_USER`).

## Test plan
- [x] `make dev-from-snapshot` da repo root funziona
- [x] `make seed-index` da `infra/` genera dump + meta + sidecar corretti
- [ ] Verifica `seed-index-wait.sh` contro staging con env custom

🤖 Generated with [Claude Code](https://claude.com/claude-code)