### PR TITLE
feat(mechanic-extractor): M1.1 schema & persistence (#523)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicAnalysis.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicAnalysis.cs
@@ -1,0 +1,520 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Exceptions;
+using Api.SharedKernel.Domain.Entities;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+
+/// <summary>
+/// Aggregate root for the AI-first Mechanic Extractor pipeline (ADR-051). Represents a single
+/// AI-generated analysis of a game's rulebook PDF, with a lifecycle state machine, per-claim
+/// review, suppression kill-switch (T5), and cost cap governance (T8).
+/// </summary>
+/// <remarks>
+/// Lifecycle state machine:
+/// <code>
+///   Draft (0) ──SubmitForReview──► InReview (1)
+///   InReview (1) ──Approve──────► Published (2)   (requires all claims Approved)
+///   InReview (1) ──Reject───────► Rejected (3)
+///   Rejected (3) ──SubmitForReview──► InReview (1) (re-submit after edits)
+/// </code>
+/// Suppression (<see cref="IsSuppressed"/>) is orthogonal to <see cref="Status"/>: a Published
+/// analysis may be suppressed without changing status. Global query filter hides suppressed rows
+/// from player-facing queries.
+/// </remarks>
+public sealed class MechanicAnalysis : AggregateRoot<Guid>
+{
+    private readonly List<MechanicClaim> _claims = new();
+
+    private static readonly Dictionary<MechanicAnalysisStatus, MechanicAnalysisStatus[]> ValidTransitions = new()
+    {
+        [MechanicAnalysisStatus.Draft] = new[] { MechanicAnalysisStatus.InReview },
+        [MechanicAnalysisStatus.InReview] = new[] { MechanicAnalysisStatus.Published, MechanicAnalysisStatus.Rejected },
+        [MechanicAnalysisStatus.Rejected] = new[] { MechanicAnalysisStatus.InReview },
+        [MechanicAnalysisStatus.Published] = Array.Empty<MechanicAnalysisStatus>()
+    };
+
+    // === Core identity / lineage ===
+
+    public Guid SharedGameId { get; private set; }
+    public Guid PdfDocumentId { get; private set; }
+    public string PromptVersion { get; private set; } = string.Empty;
+
+    // === Lifecycle ===
+
+    public MechanicAnalysisStatus Status { get; private set; }
+    public Guid CreatedBy { get; private set; }
+    public DateTime CreatedAt { get; private set; }
+    public Guid? ReviewedBy { get; private set; }
+    public DateTime? ReviewedAt { get; private set; }
+    public string? RejectionReason { get; private set; }
+
+    // === LLM execution snapshot ===
+
+    public int TotalTokensUsed { get; private set; }
+    public decimal EstimatedCostUsd { get; private set; }
+    public string ModelUsed { get; private set; } = string.Empty;
+    public string Provider { get; private set; } = string.Empty;
+
+    // === T8 cost governance (ADR-051) ===
+
+    public decimal CostCapUsd { get; private set; }
+    public DateTime? CostCapOverrideAt { get; private set; }
+    public Guid? CostCapOverrideBy { get; private set; }
+    public string? CostCapOverrideReason { get; private set; }
+
+    // === T5 takedown kill-switch ===
+
+    public bool IsSuppressed { get; private set; }
+    public DateTime? SuppressedAt { get; private set; }
+    public Guid? SuppressedBy { get; private set; }
+    public string? SuppressionReason { get; private set; }
+    public DateTime? SuppressionRequestedAt { get; private set; }
+    public SuppressionRequestSource? SuppressionRequestSource { get; private set; }
+
+    // === Children ===
+
+    public IReadOnlyList<MechanicClaim> Claims => _claims.AsReadOnly();
+
+    /// <summary>EF Core constructor.</summary>
+    private MechanicAnalysis() : base()
+    {
+    }
+
+    private MechanicAnalysis(
+        Guid id,
+        Guid sharedGameId,
+        Guid pdfDocumentId,
+        string promptVersion,
+        Guid createdBy,
+        DateTime createdAt,
+        string modelUsed,
+        string provider,
+        decimal costCapUsd)
+        : base(id)
+    {
+        SharedGameId = sharedGameId;
+        PdfDocumentId = pdfDocumentId;
+        PromptVersion = promptVersion;
+        Status = MechanicAnalysisStatus.Draft;
+        CreatedBy = createdBy;
+        CreatedAt = createdAt;
+        ModelUsed = modelUsed;
+        Provider = provider;
+        CostCapUsd = costCapUsd;
+        IsSuppressed = false;
+        TotalTokensUsed = 0;
+        EstimatedCostUsd = 0m;
+    }
+
+    /// <summary>
+    /// Creates a new analysis in <see cref="MechanicAnalysisStatus.Draft"/> status with the
+    /// initial set of claims produced by the AI pipeline. The claims list can be empty if the
+    /// caller plans to populate it via subsequent calls (but the state will not be valid until
+    /// at least one claim exists).
+    /// </summary>
+    public static MechanicAnalysis Create(
+        Guid sharedGameId,
+        Guid pdfDocumentId,
+        string promptVersion,
+        Guid createdBy,
+        DateTime createdAt,
+        string modelUsed,
+        string provider,
+        decimal costCapUsd,
+        IEnumerable<MechanicClaim>? initialClaims = null)
+    {
+        if (sharedGameId == Guid.Empty)
+        {
+            throw new ArgumentException("SharedGameId cannot be empty.", nameof(sharedGameId));
+        }
+
+        if (pdfDocumentId == Guid.Empty)
+        {
+            throw new ArgumentException("PdfDocumentId cannot be empty.", nameof(pdfDocumentId));
+        }
+
+        if (string.IsNullOrWhiteSpace(promptVersion))
+        {
+            throw new ArgumentException("PromptVersion is required for reproducibility (ADR-051 T7).", nameof(promptVersion));
+        }
+
+        if (createdBy == Guid.Empty)
+        {
+            throw new ArgumentException("CreatedBy cannot be empty.", nameof(createdBy));
+        }
+
+        if (string.IsNullOrWhiteSpace(modelUsed))
+        {
+            throw new ArgumentException("ModelUsed is required.", nameof(modelUsed));
+        }
+
+        if (string.IsNullOrWhiteSpace(provider))
+        {
+            throw new ArgumentException("Provider is required.", nameof(provider));
+        }
+
+        if (costCapUsd <= 0m)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(costCapUsd),
+                costCapUsd,
+                "CostCapUsd must be strictly positive (ADR-051 T8).");
+        }
+
+        var analysis = new MechanicAnalysis(
+            id: Guid.NewGuid(),
+            sharedGameId: sharedGameId,
+            pdfDocumentId: pdfDocumentId,
+            promptVersion: promptVersion.Trim(),
+            createdBy: createdBy,
+            createdAt: createdAt,
+            modelUsed: modelUsed.Trim(),
+            provider: provider.Trim(),
+            costCapUsd: costCapUsd);
+
+        if (initialClaims is not null)
+        {
+            foreach (var claim in initialClaims)
+            {
+                analysis._claims.Add(claim);
+            }
+        }
+
+        return analysis;
+    }
+
+    /// <summary>
+    /// Adds a claim to a Draft analysis. Useful for incremental generation (one section at a time).
+    /// </summary>
+    public void AddClaim(MechanicClaim claim)
+    {
+        ArgumentNullException.ThrowIfNull(claim);
+
+        if (Status != MechanicAnalysisStatus.Draft)
+        {
+            throw new InvalidMechanicAnalysisStateException(
+                Id,
+                Status,
+                "add claim",
+                MechanicAnalysisStatus.Draft);
+        }
+
+        if (claim.AnalysisId != Id)
+        {
+            throw new ArgumentException(
+                $"Claim's AnalysisId ({claim.AnalysisId}) does not match this analysis ({Id}).",
+                nameof(claim));
+        }
+
+        _claims.Add(claim);
+    }
+
+    /// <summary>
+    /// Records the LLM usage snapshot (tokens + actual cost) after generation completes.
+    /// Callable only in Draft — once submitted for review the snapshot is frozen.
+    /// </summary>
+    public void RecordUsage(int totalTokensUsed, decimal estimatedCostUsd)
+    {
+        if (Status != MechanicAnalysisStatus.Draft)
+        {
+            throw new InvalidMechanicAnalysisStateException(
+                Id,
+                Status,
+                "record LLM usage",
+                MechanicAnalysisStatus.Draft);
+        }
+
+        if (totalTokensUsed < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(totalTokensUsed), totalTokensUsed, "Must be non-negative.");
+        }
+
+        if (estimatedCostUsd < 0m)
+        {
+            throw new ArgumentOutOfRangeException(nameof(estimatedCostUsd), estimatedCostUsd, "Must be non-negative.");
+        }
+
+        TotalTokensUsed = totalTokensUsed;
+        EstimatedCostUsd = estimatedCostUsd;
+    }
+
+    // === State transitions ===
+
+    /// <summary>
+    /// Submits the analysis for admin review. Allowed from Draft (first submit) or Rejected
+    /// (resubmit after edits).
+    /// </summary>
+    public void SubmitForReview(Guid actorId, DateTime utcNow)
+    {
+        if (actorId == Guid.Empty)
+        {
+            throw new ArgumentException("ActorId cannot be empty.", nameof(actorId));
+        }
+
+        EnsureTransitionAllowed("submit for review", MechanicAnalysisStatus.InReview);
+
+        if (_claims.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Cannot submit MechanicAnalysis {Id} for review: no claims have been added.");
+        }
+
+        // Resubmission after rejection: reset claim statuses to Pending so the admin re-reviews them.
+        if (Status == MechanicAnalysisStatus.Rejected)
+        {
+            foreach (var claim in _claims)
+            {
+                claim.ResetToPending();
+            }
+
+            RejectionReason = null;
+        }
+
+        var previous = Status;
+        Status = MechanicAnalysisStatus.InReview;
+        ReviewedBy = null;
+        ReviewedAt = null;
+
+        AddDomainEvent(new MechanicAnalysisStatusChangedEvent(Id, previous, Status, actorId, note: null));
+    }
+
+    /// <summary>
+    /// Approves the analysis and transitions it to Published. Requires every claim to be Approved.
+    /// </summary>
+    public void Approve(Guid reviewerId, DateTime utcNow)
+    {
+        if (reviewerId == Guid.Empty)
+        {
+            throw new ArgumentException("ReviewerId cannot be empty.", nameof(reviewerId));
+        }
+
+        EnsureTransitionAllowed("approve", MechanicAnalysisStatus.Published);
+
+        if (_claims.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Cannot approve MechanicAnalysis {Id}: it has no claims.");
+        }
+
+        if (_claims.Any(c => c.Status != MechanicClaimStatus.Approved))
+        {
+            throw new InvalidOperationException(
+                $"Cannot approve MechanicAnalysis {Id}: not all claims are Approved " +
+                $"(Pending={_claims.Count(c => c.Status == MechanicClaimStatus.Pending)}, " +
+                $"Rejected={_claims.Count(c => c.Status == MechanicClaimStatus.Rejected)}).");
+        }
+
+        var previous = Status;
+        Status = MechanicAnalysisStatus.Published;
+        ReviewedBy = reviewerId;
+        ReviewedAt = utcNow;
+
+        AddDomainEvent(new MechanicAnalysisStatusChangedEvent(Id, previous, Status, reviewerId, note: null));
+    }
+
+    /// <summary>
+    /// Rejects the analysis with a reason. The analysis can later be resubmitted via
+    /// <see cref="SubmitForReview(Guid, DateTime)"/> after the author edits the claims.
+    /// </summary>
+    public void Reject(Guid reviewerId, string reason, DateTime utcNow)
+    {
+        if (reviewerId == Guid.Empty)
+        {
+            throw new ArgumentException("ReviewerId cannot be empty.", nameof(reviewerId));
+        }
+
+        if (string.IsNullOrWhiteSpace(reason))
+        {
+            throw new ArgumentException("Rejection reason is required.", nameof(reason));
+        }
+
+        EnsureTransitionAllowed("reject", MechanicAnalysisStatus.Rejected);
+
+        var previous = Status;
+        Status = MechanicAnalysisStatus.Rejected;
+        ReviewedBy = reviewerId;
+        ReviewedAt = utcNow;
+        RejectionReason = reason.Trim();
+
+        AddDomainEvent(new MechanicAnalysisStatusChangedEvent(Id, previous, Status, reviewerId, RejectionReason));
+    }
+
+    /// <summary>
+    /// Approves a single claim. Valid only while the analysis is InReview.
+    /// </summary>
+    public void ApproveClaim(Guid claimId, Guid reviewerId, DateTime utcNow)
+    {
+        var claim = RequireClaimUnderReview(claimId, "approve claim");
+        claim.Approve(reviewerId, utcNow);
+    }
+
+    /// <summary>
+    /// Rejects a single claim with a note. Valid only while the analysis is InReview.
+    /// </summary>
+    public void RejectClaim(Guid claimId, Guid reviewerId, string note, DateTime utcNow)
+    {
+        var claim = RequireClaimUnderReview(claimId, "reject claim");
+        claim.Reject(reviewerId, note, utcNow);
+    }
+
+    // === Suppression (T5 kill-switch) ===
+
+    /// <summary>
+    /// Applies a takedown (suppress) on the analysis. Allowed from any status — suppression is
+    /// orthogonal to lifecycle.
+    /// </summary>
+    public void Suppress(
+        Guid actorId,
+        string reason,
+        SuppressionRequestSource requestSource,
+        DateTime? requestedAt,
+        DateTime utcNow)
+    {
+        if (actorId == Guid.Empty)
+        {
+            throw new ArgumentException("ActorId cannot be empty.", nameof(actorId));
+        }
+
+        if (string.IsNullOrWhiteSpace(reason))
+        {
+            throw new ArgumentException("Suppression reason is required (legal evidence chain).", nameof(reason));
+        }
+
+        if (IsSuppressed)
+        {
+            throw new InvalidOperationException($"MechanicAnalysis {Id} is already suppressed.");
+        }
+
+        IsSuppressed = true;
+        SuppressedAt = utcNow;
+        SuppressedBy = actorId;
+        SuppressionReason = reason.Trim();
+        SuppressionRequestSource = requestSource;
+        SuppressionRequestedAt = requestedAt;
+
+        AddDomainEvent(new MechanicAnalysisSuppressedEvent(
+            Id,
+            actorId,
+            SuppressionReason,
+            requestSource,
+            requestedAt));
+    }
+
+    /// <summary>
+    /// Lifts the takedown. Clears all suppression tracking fields.
+    /// </summary>
+    public void Unsuppress(Guid actorId, string reason, DateTime utcNow)
+    {
+        if (actorId == Guid.Empty)
+        {
+            throw new ArgumentException("ActorId cannot be empty.", nameof(actorId));
+        }
+
+        if (string.IsNullOrWhiteSpace(reason))
+        {
+            throw new ArgumentException("Unsuppression reason is required.", nameof(reason));
+        }
+
+        if (!IsSuppressed)
+        {
+            throw new InvalidOperationException($"MechanicAnalysis {Id} is not suppressed.");
+        }
+
+        IsSuppressed = false;
+        SuppressedAt = null;
+        SuppressedBy = null;
+        SuppressionReason = null;
+        SuppressionRequestSource = null;
+        SuppressionRequestedAt = null;
+
+        AddDomainEvent(new MechanicAnalysisUnsuppressedEvent(Id, actorId, reason.Trim()));
+    }
+
+    // === T8 cost cap override ===
+
+    /// <summary>
+    /// Raises the cost cap with an admin justification. All three override fields are set
+    /// atomically (DB CHECK enforces all-or-none).
+    /// </summary>
+    public void OverrideCostCap(Guid actorId, decimal newCapUsd, string reason, DateTime utcNow)
+    {
+        if (actorId == Guid.Empty)
+        {
+            throw new ArgumentException("ActorId cannot be empty.", nameof(actorId));
+        }
+
+        if (string.IsNullOrWhiteSpace(reason))
+        {
+            throw new ArgumentException("Override reason is required.", nameof(reason));
+        }
+
+        if (newCapUsd <= 0m)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(newCapUsd),
+                newCapUsd,
+                "New cap must be strictly positive.");
+        }
+
+        if (newCapUsd <= CostCapUsd)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(newCapUsd),
+                newCapUsd,
+                $"New cap must be greater than the current cap ({CostCapUsd:C}).");
+        }
+
+        var previous = CostCapUsd;
+        CostCapUsd = newCapUsd;
+        CostCapOverrideAt = utcNow;
+        CostCapOverrideBy = actorId;
+        CostCapOverrideReason = reason.Trim();
+
+        AddDomainEvent(new MechanicAnalysisCostCapOverriddenEvent(
+            Id,
+            actorId,
+            previous,
+            newCapUsd,
+            CostCapOverrideReason));
+    }
+
+    // === Helpers ===
+
+    private void EnsureTransitionAllowed(string operation, MechanicAnalysisStatus target)
+    {
+        if (!ValidTransitions.TryGetValue(Status, out var allowedTargets) ||
+            Array.IndexOf(allowedTargets, target) < 0)
+        {
+            var allowedFrom = ValidTransitions
+                .Where(kv => kv.Value.Contains(target))
+                .Select(kv => kv.Key)
+                .ToArray();
+
+            throw new InvalidMechanicAnalysisStateException(
+                Id,
+                Status,
+                operation,
+                allowedFrom);
+        }
+    }
+
+    private MechanicClaim RequireClaimUnderReview(Guid claimId, string operation)
+    {
+        if (Status != MechanicAnalysisStatus.InReview)
+        {
+            throw new InvalidMechanicAnalysisStateException(
+                Id,
+                Status,
+                operation,
+                MechanicAnalysisStatus.InReview);
+        }
+
+        var claim = _claims.FirstOrDefault(c => c.Id == claimId)
+            ?? throw new InvalidOperationException(
+                $"Claim {claimId} does not belong to MechanicAnalysis {Id}.");
+
+        return claim;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicAnalysis.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicAnalysis.cs
@@ -77,7 +77,15 @@ public sealed class MechanicAnalysis : AggregateRoot<Guid>
 
     public IReadOnlyList<MechanicClaim> Claims => _claims.AsReadOnly();
 
-    /// <summary>EF Core constructor.</summary>
+    /// <summary>
+    /// Optimistic concurrency token — PostgreSQL's system <c>xmin</c> column value as seen at
+    /// load time. Round-tripped through the aggregate so detached <c>DbContext.Update</c> in the
+    /// repository preserves the original token (instead of defaulting to 0 and triggering a
+    /// spurious concurrency exception on every save).
+    /// </summary>
+    public uint XminVersion { get; private set; }
+
+    /// <summary>EF Core constructor / repository reconstitution.</summary>
     private MechanicAnalysis() : base()
     {
     }
@@ -180,6 +188,83 @@ public sealed class MechanicAnalysis : AggregateRoot<Guid>
             {
                 analysis._claims.Add(claim);
             }
+        }
+
+        return analysis;
+    }
+
+    /// <summary>
+    /// Rehydrates an aggregate from persistence. Used exclusively by the repository's
+    /// <c>MapToDomain</c>; bypasses validation because invariants were already enforced when
+    /// the aggregate was originally created. Does NOT raise domain events.
+    /// </summary>
+    /// <remarks>
+    /// Pre-loaded <paramref name="claims"/> are attached as-is; the repository is responsible
+    /// for materializing the full graph (Claim + Citations) before calling this factory.
+    /// </remarks>
+    public static MechanicAnalysis Reconstitute(
+        Guid id,
+        Guid sharedGameId,
+        Guid pdfDocumentId,
+        string promptVersion,
+        MechanicAnalysisStatus status,
+        Guid createdBy,
+        DateTime createdAt,
+        Guid? reviewedBy,
+        DateTime? reviewedAt,
+        string? rejectionReason,
+        int totalTokensUsed,
+        decimal estimatedCostUsd,
+        string modelUsed,
+        string provider,
+        decimal costCapUsd,
+        DateTime? costCapOverrideAt,
+        Guid? costCapOverrideBy,
+        string? costCapOverrideReason,
+        bool isSuppressed,
+        DateTime? suppressedAt,
+        Guid? suppressedBy,
+        string? suppressionReason,
+        DateTime? suppressionRequestedAt,
+        SuppressionRequestSource? suppressionRequestSource,
+        IEnumerable<MechanicClaim> claims,
+        uint xminVersion = 0)
+    {
+        ArgumentNullException.ThrowIfNull(claims);
+
+        var analysis = new MechanicAnalysis
+        {
+            XminVersion = xminVersion,
+            // Base Entity<Guid>.Id has a protected setter, accessible from this derived type.
+            Id = id,
+            SharedGameId = sharedGameId,
+            PdfDocumentId = pdfDocumentId,
+            PromptVersion = promptVersion,
+            Status = status,
+            CreatedBy = createdBy,
+            CreatedAt = createdAt,
+            ReviewedBy = reviewedBy,
+            ReviewedAt = reviewedAt,
+            RejectionReason = rejectionReason,
+            TotalTokensUsed = totalTokensUsed,
+            EstimatedCostUsd = estimatedCostUsd,
+            ModelUsed = modelUsed,
+            Provider = provider,
+            CostCapUsd = costCapUsd,
+            CostCapOverrideAt = costCapOverrideAt,
+            CostCapOverrideBy = costCapOverrideBy,
+            CostCapOverrideReason = costCapOverrideReason,
+            IsSuppressed = isSuppressed,
+            SuppressedAt = suppressedAt,
+            SuppressedBy = suppressedBy,
+            SuppressionReason = suppressionReason,
+            SuppressionRequestedAt = suppressionRequestedAt,
+            SuppressionRequestSource = suppressionRequestSource
+        };
+
+        foreach (var claim in claims)
+        {
+            analysis._claims.Add(claim);
         }
 
         return analysis;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/MechanicCitation.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/MechanicCitation.cs
@@ -131,6 +131,27 @@ public sealed class MechanicCitation : Entity<Guid>
             displayOrder: displayOrder);
     }
 
+    /// <summary>
+    /// Rehydrates a citation from persistence. Used exclusively by the repository's
+    /// <c>MapToDomain</c>; bypasses validation because invariants were enforced at creation time.
+    /// </summary>
+    public static MechanicCitation Reconstitute(
+        Guid id,
+        Guid claimId,
+        int pdfPage,
+        string quote,
+        Guid? chunkId,
+        int displayOrder)
+    {
+        return new MechanicCitation(
+            id: id,
+            claimId: claimId,
+            pdfPage: pdfPage,
+            quote: quote,
+            chunkId: chunkId,
+            displayOrder: displayOrder);
+    }
+
     private static readonly char[] WhitespaceSeparators =
         { ' ', '\t', '\n', '\r', '\f', '\v' };
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/MechanicCitation.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/MechanicCitation.cs
@@ -1,0 +1,147 @@
+using Api.SharedKernel.Domain.Entities;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+
+/// <summary>
+/// Attribution citation for a <see cref="MechanicClaim"/>: a verbatim short quote from the
+/// source rulebook PDF with a page pointer, plus an optional link to the originating text chunk.
+/// </summary>
+/// <remarks>
+/// Design rationale (ADR-051 + §2.1 of the M1.1 plan):
+/// - Separate table instead of EF <c>OwnsMany</c> because the side-panel navigation needs indexed
+///   lookups by <see cref="PdfPage"/>, and the chunk FK must be nullable with
+///   <c>ON DELETE SET NULL</c>.
+/// - Quote length is capped at 25 words at the DB level (T1 belt-and-braces CHECK constraint);
+///   the domain factory also enforces it so that invariants are audited before persistence.
+/// - <see cref="ChunkId"/> is nullable because text chunks may be re-indexed; losing the chunk
+///   reference is acceptable, losing the quote+page is not.
+/// </remarks>
+public sealed class MechanicCitation : Entity<Guid>
+{
+    /// <summary>Maximum number of words allowed inside <see cref="Quote"/> (ADR-051 T1).</summary>
+    public const int MaxQuoteWords = 25;
+
+    /// <summary>Maximum character budget for <see cref="Quote"/>.</summary>
+    /// <remarks>400 = 25 words × ~16 chars upper bound. Used to size the varchar column.</remarks>
+    public const int MaxQuoteChars = 400;
+
+    /// <summary>FK to the parent <see cref="MechanicClaim"/>.</summary>
+    public Guid ClaimId { get; private set; }
+
+    /// <summary>1-based page number in the originating PDF. Always &gt; 0.</summary>
+    public int PdfPage { get; private set; }
+
+    /// <summary>
+    /// Verbatim excerpt from the rulebook used as attribution for the parent claim.
+    /// Must be ≤ <see cref="MaxQuoteWords"/> words — enforced both here and by a DB CHECK constraint.
+    /// </summary>
+    public string Quote { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Optional reference to the originating text chunk (for side-panel navigation / re-verification).
+    /// Nullable because chunks may be re-indexed and set to NULL by ON DELETE SET NULL.
+    /// </summary>
+    public Guid? ChunkId { get; private set; }
+
+    /// <summary>Display order inside the claim's citation list (0-based).</summary>
+    public int DisplayOrder { get; private set; }
+
+    /// <summary>
+    /// EF Core constructor. Do not use directly.
+    /// </summary>
+    private MechanicCitation() : base()
+    {
+    }
+
+    private MechanicCitation(
+        Guid id,
+        Guid claimId,
+        int pdfPage,
+        string quote,
+        Guid? chunkId,
+        int displayOrder)
+        : base(id)
+    {
+        ClaimId = claimId;
+        PdfPage = pdfPage;
+        Quote = quote;
+        ChunkId = chunkId;
+        DisplayOrder = displayOrder;
+    }
+
+    /// <summary>
+    /// Factory that validates all invariants. Raises <see cref="ArgumentException"/> on violation
+    /// (caller is expected to be the aggregate root or a command handler with validated input).
+    /// </summary>
+    public static MechanicCitation Create(
+        Guid claimId,
+        int pdfPage,
+        string quote,
+        Guid? chunkId,
+        int displayOrder)
+    {
+        if (claimId == Guid.Empty)
+        {
+            throw new ArgumentException("ClaimId cannot be empty.", nameof(claimId));
+        }
+
+        if (pdfPage <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(pdfPage),
+                pdfPage,
+                "PdfPage must be a positive 1-based page number.");
+        }
+
+        if (string.IsNullOrWhiteSpace(quote))
+        {
+            throw new ArgumentException("Quote cannot be empty.", nameof(quote));
+        }
+
+        var trimmed = quote.Trim();
+        if (trimmed.Length > MaxQuoteChars)
+        {
+            throw new ArgumentException(
+                $"Quote exceeds {MaxQuoteChars} characters (ADR-051 T1 enforcement).",
+                nameof(quote));
+        }
+
+        var wordCount = CountWords(trimmed);
+        if (wordCount > MaxQuoteWords)
+        {
+            throw new ArgumentException(
+                $"Quote has {wordCount} words, exceeding the {MaxQuoteWords}-word cap (ADR-051 T1).",
+                nameof(quote));
+        }
+
+        if (displayOrder < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(displayOrder),
+                displayOrder,
+                "DisplayOrder must be non-negative.");
+        }
+
+        return new MechanicCitation(
+            id: Guid.NewGuid(),
+            claimId: claimId,
+            pdfPage: pdfPage,
+            quote: trimmed,
+            chunkId: chunkId,
+            displayOrder: displayOrder);
+    }
+
+    private static readonly char[] WhitespaceSeparators =
+        { ' ', '\t', '\n', '\r', '\f', '\v' };
+
+    /// <summary>Counts whitespace-separated tokens — mirrors the DB CHECK constraint logic.</summary>
+    internal static int CountWords(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return 0;
+        }
+
+        return value.Split(WhitespaceSeparators, StringSplitOptions.RemoveEmptyEntries).Length;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/MechanicClaim.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/MechanicClaim.cs
@@ -1,0 +1,169 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.SharedKernel.Domain.Entities;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+
+/// <summary>
+/// A single rephrased rule extracted from a rulebook, attached to a parent
+/// <see cref="Aggregates.MechanicAnalysis"/>. Carries its attribution citations and per-claim
+/// review status.
+/// </summary>
+/// <remarks>
+/// Lifecycle:
+/// - Created as <see cref="MechanicClaimStatus.Pending"/> when the AI produces it.
+/// - Moves to <see cref="MechanicClaimStatus.Approved"/> or <see cref="MechanicClaimStatus.Rejected"/>
+///   via admin review during the InReview phase of the parent analysis.
+/// - A parent analysis can only be promoted to <see cref="MechanicAnalysisStatus.Published"/>
+///   when every claim is <see cref="MechanicClaimStatus.Approved"/> (AC-10).
+///
+/// Invariants:
+/// - Must have at least one citation (ADR-051 T3).
+/// - Rejection requires a <see cref="RejectionNote"/>.
+/// </remarks>
+public sealed class MechanicClaim : Entity<Guid>
+{
+    private readonly List<MechanicCitation> _citations = new();
+
+    /// <summary>FK to the parent <see cref="Aggregates.MechanicAnalysis"/>.</summary>
+    public Guid AnalysisId { get; private set; }
+
+    /// <summary>Logical section of the rulebook this claim belongs to.</summary>
+    public MechanicSection Section { get; private set; }
+
+    /// <summary>Rephrased rule text (player-facing).</summary>
+    public string Text { get; private set; } = string.Empty;
+
+    /// <summary>Display order inside the section (0-based).</summary>
+    public int DisplayOrder { get; private set; }
+
+    /// <summary>Per-claim review status.</summary>
+    public MechanicClaimStatus Status { get; private set; }
+
+    /// <summary>Admin who last reviewed this claim (null until first review).</summary>
+    public Guid? ReviewedBy { get; private set; }
+
+    /// <summary>UTC timestamp of the last review action (null until first review).</summary>
+    public DateTime? ReviewedAt { get; private set; }
+
+    /// <summary>Reason the claim was rejected. Required when <see cref="Status"/> is Rejected.</summary>
+    public string? RejectionNote { get; private set; }
+
+    /// <summary>Attribution citations (minimum 1 — ADR-051 T3).</summary>
+    public IReadOnlyList<MechanicCitation> Citations => _citations.AsReadOnly();
+
+    /// <summary>EF Core constructor. Do not use directly.</summary>
+    private MechanicClaim() : base()
+    {
+    }
+
+    private MechanicClaim(
+        Guid id,
+        Guid analysisId,
+        MechanicSection section,
+        string text,
+        int displayOrder)
+        : base(id)
+    {
+        AnalysisId = analysisId;
+        Section = section;
+        Text = text;
+        DisplayOrder = displayOrder;
+        Status = MechanicClaimStatus.Pending;
+    }
+
+    /// <summary>
+    /// Factory that creates a new pending claim with its citations.
+    /// </summary>
+    /// <exception cref="ArgumentException">If <paramref name="text"/> is blank or citations is empty.</exception>
+    public static MechanicClaim Create(
+        Guid analysisId,
+        MechanicSection section,
+        string text,
+        int displayOrder,
+        IEnumerable<MechanicCitation> citations)
+    {
+        if (analysisId == Guid.Empty)
+        {
+            throw new ArgumentException("AnalysisId cannot be empty.", nameof(analysisId));
+        }
+
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            throw new ArgumentException("Claim text cannot be empty.", nameof(text));
+        }
+
+        if (displayOrder < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(displayOrder),
+                displayOrder,
+                "DisplayOrder must be non-negative.");
+        }
+
+        var citationList = citations?.ToList() ?? new List<MechanicCitation>();
+        if (citationList.Count == 0)
+        {
+            throw new ArgumentException(
+                "At least one citation is required (ADR-051 T3).",
+                nameof(citations));
+        }
+
+        var claim = new MechanicClaim(
+            id: Guid.NewGuid(),
+            analysisId: analysisId,
+            section: section,
+            text: text.Trim(),
+            displayOrder: displayOrder);
+
+        claim._citations.AddRange(citationList);
+        return claim;
+    }
+
+    /// <summary>
+    /// Approves the claim. Idempotent: re-approving is a no-op.
+    /// </summary>
+    internal void Approve(Guid reviewerId, DateTime utcNow)
+    {
+        if (reviewerId == Guid.Empty)
+        {
+            throw new ArgumentException("ReviewerId cannot be empty.", nameof(reviewerId));
+        }
+
+        Status = MechanicClaimStatus.Approved;
+        ReviewedBy = reviewerId;
+        ReviewedAt = utcNow;
+        RejectionNote = null;
+    }
+
+    /// <summary>
+    /// Rejects the claim with a reason. The claim stays attached but cannot be published.
+    /// </summary>
+    internal void Reject(Guid reviewerId, string note, DateTime utcNow)
+    {
+        if (reviewerId == Guid.Empty)
+        {
+            throw new ArgumentException("ReviewerId cannot be empty.", nameof(reviewerId));
+        }
+
+        if (string.IsNullOrWhiteSpace(note))
+        {
+            throw new ArgumentException("Rejection note is required when rejecting a claim.", nameof(note));
+        }
+
+        Status = MechanicClaimStatus.Rejected;
+        ReviewedBy = reviewerId;
+        ReviewedAt = utcNow;
+        RejectionNote = note.Trim();
+    }
+
+    /// <summary>
+    /// Moves the claim back to pending (used when the parent analysis transitions Rejected→InReview).
+    /// </summary>
+    internal void ResetToPending()
+    {
+        Status = MechanicClaimStatus.Pending;
+        ReviewedBy = null;
+        ReviewedAt = null;
+        RejectionNote = null;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/MechanicClaim.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/MechanicClaim.cs
@@ -120,6 +120,41 @@ public sealed class MechanicClaim : Entity<Guid>
     }
 
     /// <summary>
+    /// Rehydrates a claim from persistence. Used exclusively by the repository's
+    /// <c>MapToDomain</c>; bypasses validation because invariants were enforced at creation time.
+    /// </summary>
+    public static MechanicClaim Reconstitute(
+        Guid id,
+        Guid analysisId,
+        MechanicSection section,
+        string text,
+        int displayOrder,
+        MechanicClaimStatus status,
+        Guid? reviewedBy,
+        DateTime? reviewedAt,
+        string? rejectionNote,
+        IEnumerable<MechanicCitation> citations)
+    {
+        ArgumentNullException.ThrowIfNull(citations);
+
+        var claim = new MechanicClaim
+        {
+            Id = id,
+            AnalysisId = analysisId,
+            Section = section,
+            Text = text,
+            DisplayOrder = displayOrder,
+            Status = status,
+            ReviewedBy = reviewedBy,
+            ReviewedAt = reviewedAt,
+            RejectionNote = rejectionNote
+        };
+
+        claim._citations.AddRange(citations);
+        return claim;
+    }
+
+    /// <summary>
     /// Approves the claim. Idempotent: re-approving is a no-op.
     /// </summary>
     internal void Approve(Guid reviewerId, DateTime utcNow)

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/MechanicStatusAudit.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/MechanicStatusAudit.cs
@@ -1,0 +1,98 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.SharedKernel.Domain.Entities;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+
+/// <summary>
+/// Immutable audit row recording a lifecycle transition of a <see cref="Aggregates.MechanicAnalysis"/>
+/// (Draft → InReview → Published / Rejected).
+/// </summary>
+/// <remarks>
+/// Persisted by the SaveChanges interceptor in response to
+/// <see cref="Events.MechanicAnalysisStatusChangedEvent"/> events emitted by the aggregate.
+/// Append-only: there is no update surface.
+/// Suppression events are recorded separately in <see cref="MechanicSuppressionAudit"/> — this
+/// split keeps the schema strict (no nullable discriminator columns) and indices partial.
+/// </remarks>
+public sealed class MechanicStatusAudit : Entity<Guid>
+{
+    /// <summary>FK to the analysis that transitioned.</summary>
+    public Guid AnalysisId { get; private set; }
+
+    /// <summary>Status before the transition.</summary>
+    public MechanicAnalysisStatus FromStatus { get; private set; }
+
+    /// <summary>Status after the transition. Must differ from <see cref="FromStatus"/>.</summary>
+    public MechanicAnalysisStatus ToStatus { get; private set; }
+
+    /// <summary>User (admin / system bot) who performed the transition.</summary>
+    public Guid ActorId { get; private set; }
+
+    /// <summary>Optional explanation (e.g. rejection reason).</summary>
+    public string? Note { get; private set; }
+
+    /// <summary>UTC timestamp the transition actually took effect.</summary>
+    public DateTime OccurredAt { get; private set; }
+
+    /// <summary>EF Core constructor.</summary>
+    private MechanicStatusAudit() : base()
+    {
+    }
+
+    private MechanicStatusAudit(
+        Guid id,
+        Guid analysisId,
+        MechanicAnalysisStatus fromStatus,
+        MechanicAnalysisStatus toStatus,
+        Guid actorId,
+        string? note,
+        DateTime occurredAt)
+        : base(id)
+    {
+        AnalysisId = analysisId;
+        FromStatus = fromStatus;
+        ToStatus = toStatus;
+        ActorId = actorId;
+        Note = note;
+        OccurredAt = occurredAt;
+    }
+
+    /// <summary>
+    /// Creates a new status-transition audit row. Called from the SaveChanges interceptor
+    /// after it consumes a <see cref="Events.MechanicAnalysisStatusChangedEvent"/>.
+    /// </summary>
+    public static MechanicStatusAudit Create(
+        Guid analysisId,
+        MechanicAnalysisStatus fromStatus,
+        MechanicAnalysisStatus toStatus,
+        Guid actorId,
+        string? note,
+        DateTime occurredAt)
+    {
+        if (analysisId == Guid.Empty)
+        {
+            throw new ArgumentException("AnalysisId cannot be empty.", nameof(analysisId));
+        }
+
+        if (actorId == Guid.Empty)
+        {
+            throw new ArgumentException("ActorId cannot be empty.", nameof(actorId));
+        }
+
+        if (fromStatus == toStatus)
+        {
+            throw new ArgumentException(
+                $"Status transition cannot be a self-loop ({fromStatus} → {toStatus}).",
+                nameof(toStatus));
+        }
+
+        return new MechanicStatusAudit(
+            id: Guid.NewGuid(),
+            analysisId: analysisId,
+            fromStatus: fromStatus,
+            toStatus: toStatus,
+            actorId: actorId,
+            note: string.IsNullOrWhiteSpace(note) ? null : note.Trim(),
+            occurredAt: occurredAt);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/MechanicSuppressionAudit.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/MechanicSuppressionAudit.cs
@@ -1,0 +1,143 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.SharedKernel.Domain.Entities;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+
+/// <summary>
+/// Immutable audit row recording a suppression toggle (takedown) on a
+/// <see cref="Aggregates.MechanicAnalysis"/>. Separate from <see cref="MechanicStatusAudit"/>
+/// because suppression is orthogonal to status: a Published analysis can be Suppressed without
+/// changing its status (ADR-051 T5 kill-switch).
+/// </summary>
+/// <remarks>
+/// This table forms the legal evidence chain for DMCA / editor takedown requests:
+/// - <see cref="Reason"/> is required and holds the takedown reference (email subject, ticket, etc.).
+/// - <see cref="RequestedAt"/> + <see cref="OccurredAt"/> feed the SLA dashboard.
+/// - <see cref="RequestSource"/> disambiguates editor email vs. legal department vs. other.
+/// Append-only — no update surface.
+/// </remarks>
+public sealed class MechanicSuppressionAudit : Entity<Guid>
+{
+    /// <summary>FK to the analysis that was suppressed / unsuppressed.</summary>
+    public Guid AnalysisId { get; private set; }
+
+    /// <summary>Previous suppression state.</summary>
+    public bool FromSuppressed { get; private set; }
+
+    /// <summary>New suppression state. Must differ from <see cref="FromSuppressed"/>.</summary>
+    public bool ToSuppressed { get; private set; }
+
+    /// <summary>Admin who toggled suppression.</summary>
+    public Guid ActorId { get; private set; }
+
+    /// <summary>
+    /// Takedown reference (required). For suppress events: editor email subject / legal ticket.
+    /// For unsuppress events: justification for lifting the takedown.
+    /// </summary>
+    public string Reason { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Origin of the takedown request. Nullable because unsuppress events don't originate from
+    /// an external request.
+    /// </summary>
+    public SuppressionRequestSource? RequestSource { get; private set; }
+
+    /// <summary>When the takedown request was notified to us (null on unsuppress).</summary>
+    public DateTime? RequestedAt { get; private set; }
+
+    /// <summary>UTC timestamp when the suppression actually took effect.</summary>
+    public DateTime OccurredAt { get; private set; }
+
+    /// <summary>EF Core constructor.</summary>
+    private MechanicSuppressionAudit() : base()
+    {
+    }
+
+    private MechanicSuppressionAudit(
+        Guid id,
+        Guid analysisId,
+        bool fromSuppressed,
+        bool toSuppressed,
+        Guid actorId,
+        string reason,
+        SuppressionRequestSource? requestSource,
+        DateTime? requestedAt,
+        DateTime occurredAt)
+        : base(id)
+    {
+        AnalysisId = analysisId;
+        FromSuppressed = fromSuppressed;
+        ToSuppressed = toSuppressed;
+        ActorId = actorId;
+        Reason = reason;
+        RequestSource = requestSource;
+        RequestedAt = requestedAt;
+        OccurredAt = occurredAt;
+    }
+
+    /// <summary>
+    /// Creates a suppression audit row (takedown applied).
+    /// </summary>
+    public static MechanicSuppressionAudit CreateSuppress(
+        Guid analysisId,
+        Guid actorId,
+        string reason,
+        SuppressionRequestSource requestSource,
+        DateTime? requestedAt,
+        DateTime occurredAt)
+    {
+        ValidateCommon(analysisId, actorId, reason);
+
+        return new MechanicSuppressionAudit(
+            id: Guid.NewGuid(),
+            analysisId: analysisId,
+            fromSuppressed: false,
+            toSuppressed: true,
+            actorId: actorId,
+            reason: reason.Trim(),
+            requestSource: requestSource,
+            requestedAt: requestedAt,
+            occurredAt: occurredAt);
+    }
+
+    /// <summary>
+    /// Creates an unsuppression audit row (takedown lifted).
+    /// </summary>
+    public static MechanicSuppressionAudit CreateUnsuppress(
+        Guid analysisId,
+        Guid actorId,
+        string reason,
+        DateTime occurredAt)
+    {
+        ValidateCommon(analysisId, actorId, reason);
+
+        return new MechanicSuppressionAudit(
+            id: Guid.NewGuid(),
+            analysisId: analysisId,
+            fromSuppressed: true,
+            toSuppressed: false,
+            actorId: actorId,
+            reason: reason.Trim(),
+            requestSource: null,
+            requestedAt: null,
+            occurredAt: occurredAt);
+    }
+
+    private static void ValidateCommon(Guid analysisId, Guid actorId, string reason)
+    {
+        if (analysisId == Guid.Empty)
+        {
+            throw new ArgumentException("AnalysisId cannot be empty.", nameof(analysisId));
+        }
+
+        if (actorId == Guid.Empty)
+        {
+            throw new ArgumentException("ActorId cannot be empty.", nameof(actorId));
+        }
+
+        if (string.IsNullOrWhiteSpace(reason))
+        {
+            throw new ArgumentException("Suppression reason is required (legal evidence chain).", nameof(reason));
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/MechanicAnalysisStatus.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/MechanicAnalysisStatus.cs
@@ -1,0 +1,19 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+/// <summary>
+/// Lifecycle status of a MechanicAnalysis.
+/// Transitions (see <see cref="Aggregates.MechanicAnalysis"/> state machine):
+///   Draft (0) → InReview (1): SubmitForReview
+///   InReview (1) → Published (2): Approve (all claims approved)
+///   InReview (1) → Rejected (3): Reject
+///   Rejected (3) → InReview (1): SubmitForReview (after edits)
+/// Note: Suppressed is NOT a Status value — suppression is orthogonal via <see cref="Aggregates.MechanicAnalysis.IsSuppressed"/>.
+/// A Published analysis under takedown stays Published + IsSuppressed=true.
+/// </summary>
+public enum MechanicAnalysisStatus
+{
+    Draft = 0,
+    InReview = 1,
+    Published = 2,
+    Rejected = 3
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/MechanicClaimStatus.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/MechanicClaimStatus.cs
@@ -1,0 +1,12 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+/// <summary>
+/// Per-claim review status inside a MechanicAnalysis.
+/// A MechanicAnalysis transitions to Published only when all its claims are Approved (AC-10).
+/// </summary>
+public enum MechanicClaimStatus
+{
+    Pending = 0,
+    Approved = 1,
+    Rejected = 2
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/MechanicSection.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/MechanicSection.cs
@@ -1,0 +1,15 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+/// <summary>
+/// Logical section of the rulebook a MechanicClaim belongs to.
+/// Used both for UI grouping (reference cards) and prompt routing during extraction.
+/// </summary>
+public enum MechanicSection
+{
+    Summary = 0,
+    Mechanics = 1,
+    Victory = 2,
+    Resources = 3,
+    Phases = 4,
+    Faq = 5
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/SuppressionRequestSource.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/SuppressionRequestSource.cs
@@ -1,0 +1,12 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+/// <summary>
+/// Origin of a takedown request that triggered suppression of a MechanicAnalysis.
+/// Recorded in mechanic_suppression_audit for T5 kill-switch accountability (ADR-051).
+/// </summary>
+public enum SuppressionRequestSource
+{
+    Email = 1,
+    Legal = 2,
+    Other = 3
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Events/MechanicAnalysisCostCapOverriddenEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Events/MechanicAnalysisCostCapOverriddenEvent.cs
@@ -1,0 +1,34 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+
+/// <summary>
+/// Raised when an admin explicitly raises the cost cap for a <see cref="Aggregates.MechanicAnalysis"/>
+/// beyond the default (ADR-051 T8). Consumed by the SaveChanges interceptor for audit persistence.
+/// </summary>
+internal sealed class MechanicAnalysisCostCapOverriddenEvent : DomainEventBase
+{
+    public Guid AnalysisId { get; }
+
+    public Guid ActorId { get; }
+
+    public decimal PreviousCapUsd { get; }
+
+    public decimal NewCapUsd { get; }
+
+    public string Reason { get; }
+
+    public MechanicAnalysisCostCapOverriddenEvent(
+        Guid analysisId,
+        Guid actorId,
+        decimal previousCapUsd,
+        decimal newCapUsd,
+        string reason)
+    {
+        AnalysisId = analysisId;
+        ActorId = actorId;
+        PreviousCapUsd = previousCapUsd;
+        NewCapUsd = newCapUsd;
+        Reason = reason;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Events/MechanicAnalysisStatusChangedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Events/MechanicAnalysisStatusChangedEvent.cs
@@ -1,0 +1,39 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+
+/// <summary>
+/// Raised when a <see cref="Aggregates.MechanicAnalysis"/> lifecycle status transitions
+/// (Draft → InReview, InReview → Published, InReview → Rejected, Rejected → InReview).
+/// </summary>
+/// <remarks>
+/// Consumer: <c>MediatorSaveChangesInterceptor</c> writes a row into <c>mechanic_status_audit</c>
+/// in the same transaction as the aggregate's state change (atomicity invariant from §2.3 of the plan).
+/// </remarks>
+internal sealed class MechanicAnalysisStatusChangedEvent : DomainEventBase
+{
+    public Guid AnalysisId { get; }
+
+    public MechanicAnalysisStatus FromStatus { get; }
+
+    public MechanicAnalysisStatus ToStatus { get; }
+
+    public Guid ActorId { get; }
+
+    public string? Note { get; }
+
+    public MechanicAnalysisStatusChangedEvent(
+        Guid analysisId,
+        MechanicAnalysisStatus fromStatus,
+        MechanicAnalysisStatus toStatus,
+        Guid actorId,
+        string? note)
+    {
+        AnalysisId = analysisId;
+        FromStatus = fromStatus;
+        ToStatus = toStatus;
+        ActorId = actorId;
+        Note = note;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Events/MechanicAnalysisSuppressedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Events/MechanicAnalysisSuppressedEvent.cs
@@ -1,0 +1,36 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+
+/// <summary>
+/// Raised when a <see cref="Aggregates.MechanicAnalysis"/> is suppressed in response to a takedown request
+/// (ADR-051 T5 kill-switch). Consumed by the SaveChanges interceptor to persist a
+/// <see cref="Entities.MechanicSuppressionAudit"/> row in the same transaction.
+/// </summary>
+internal sealed class MechanicAnalysisSuppressedEvent : DomainEventBase
+{
+    public Guid AnalysisId { get; }
+
+    public Guid ActorId { get; }
+
+    public string Reason { get; }
+
+    public SuppressionRequestSource RequestSource { get; }
+
+    public DateTime? RequestedAt { get; }
+
+    public MechanicAnalysisSuppressedEvent(
+        Guid analysisId,
+        Guid actorId,
+        string reason,
+        SuppressionRequestSource requestSource,
+        DateTime? requestedAt)
+    {
+        AnalysisId = analysisId;
+        ActorId = actorId;
+        Reason = reason;
+        RequestSource = requestSource;
+        RequestedAt = requestedAt;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Events/MechanicAnalysisUnsuppressedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Events/MechanicAnalysisUnsuppressedEvent.cs
@@ -1,0 +1,24 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+
+/// <summary>
+/// Raised when a takedown on a <see cref="Aggregates.MechanicAnalysis"/> is lifted.
+/// Consumed by the SaveChanges interceptor to persist a
+/// <see cref="Entities.MechanicSuppressionAudit"/> row (toggle true→false).
+/// </summary>
+internal sealed class MechanicAnalysisUnsuppressedEvent : DomainEventBase
+{
+    public Guid AnalysisId { get; }
+
+    public Guid ActorId { get; }
+
+    public string Reason { get; }
+
+    public MechanicAnalysisUnsuppressedEvent(Guid analysisId, Guid actorId, string reason)
+    {
+        AnalysisId = analysisId;
+        ActorId = actorId;
+        Reason = reason;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Exceptions/InvalidMechanicAnalysisStateException.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Exceptions/InvalidMechanicAnalysisStateException.cs
@@ -1,0 +1,46 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.SharedKernel.Domain.Exceptions;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Exceptions;
+
+/// <summary>
+/// Thrown when a domain operation is invoked on a <see cref="Aggregates.MechanicAnalysis"/>
+/// whose current status does not permit that transition.
+/// </summary>
+public sealed class InvalidMechanicAnalysisStateException : DomainException
+{
+    public Guid AnalysisId { get; }
+
+    public MechanicAnalysisStatus CurrentStatus { get; }
+
+    public string AttemptedOperation { get; }
+
+    public MechanicAnalysisStatus[] AllowedStatuses { get; }
+
+    public InvalidMechanicAnalysisStateException(
+        Guid analysisId,
+        MechanicAnalysisStatus currentStatus,
+        string attemptedOperation,
+        params MechanicAnalysisStatus[] allowedStatuses)
+        : base(BuildMessage(analysisId, currentStatus, attemptedOperation, allowedStatuses))
+    {
+        AnalysisId = analysisId;
+        CurrentStatus = currentStatus;
+        AttemptedOperation = attemptedOperation;
+        AllowedStatuses = allowedStatuses;
+    }
+
+    private static string BuildMessage(
+        Guid analysisId,
+        MechanicAnalysisStatus currentStatus,
+        string operation,
+        MechanicAnalysisStatus[] allowedStatuses)
+    {
+        var allowed = allowedStatuses.Length == 0
+            ? "no status"
+            : string.Join(" or ", allowedStatuses);
+
+        return $"Cannot {operation} for MechanicAnalysis {analysisId} in {currentStatus} status. " +
+               $"Allowed: {allowed}.";
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IMechanicAnalysisRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IMechanicAnalysisRepository.cs
@@ -1,0 +1,59 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+
+/// <summary>
+/// Repository interface for the <see cref="MechanicAnalysis"/> aggregate (ADR-051).
+/// Returns the aggregate root with its child claims and citations eagerly loaded
+/// via <c>AsSplitQuery</c> to avoid cartesian explosion across the 1:N:N hierarchy.
+/// </summary>
+public interface IMechanicAnalysisRepository
+{
+    /// <summary>
+    /// Stages a new <see cref="MechanicAnalysis"/> for insertion. Persistence occurs
+    /// at <c>SaveChangesAsync</c>, which also dispatches any pending domain events.
+    /// </summary>
+    Task AddAsync(MechanicAnalysis analysis, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Loads a <see cref="MechanicAnalysis"/> by its primary key without eagerly loading
+    /// claims or citations. Intended for status-only operations (e.g. suppression toggle,
+    /// cost-cap override) where the child graph is not needed.
+    /// Honors the <see cref="MechanicAnalysis.IsSuppressed"/> query filter.
+    /// </summary>
+    Task<MechanicAnalysis?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Loads a <see cref="MechanicAnalysis"/> by its primary key with the full claim and
+    /// citation graph attached. Uses <c>AsSplitQuery</c> to avoid cartesian explosion.
+    /// Honors the <see cref="MechanicAnalysis.IsSuppressed"/> query filter.
+    /// </summary>
+    Task<MechanicAnalysis?> GetByIdWithClaimsAsync(
+        Guid id,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the currently published (non-suppressed) analysis for a shared game,
+    /// or <c>null</c> if none exists. At most one <see cref="Enums.MechanicAnalysisStatus.Published"/>
+    /// analysis may exist per shared game at a time (uniqueness enforced by partial index
+    /// in the EF migration per plan §2.2.1).
+    /// </summary>
+    Task<MechanicAnalysis?> GetPublishedForSharedGameAsync(
+        Guid sharedGameId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns all analyses currently in the admin review queue
+    /// (<see cref="Enums.MechanicAnalysisStatus.InReview"/>), including suppressed rows so
+    /// they stay visible to moderators. Ignores the global suppression filter.
+    /// </summary>
+    Task<IReadOnlyList<MechanicAnalysis>> GetReviewQueueAsync(
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Marks a previously loaded <see cref="MechanicAnalysis"/> as modified.
+    /// Intended for entities loaded as <c>AsNoTracking</c> or detached.
+    /// Tracked entities do not require an explicit call.
+    /// </summary>
+    void Update(MechanicAnalysis analysis);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -42,6 +42,7 @@ internal static class SharedGameCatalogServiceExtensions
         services.AddScoped<IGameStateTemplateRepository, GameStateTemplateRepository>(); // Issue #2400 Sprint 3
         services.AddScoped<IRulebookAnalysisRepository, RulebookAnalysisRepository>(); // Issue #2402 Sprint 3
         services.AddScoped<IMechanicDraftRepository, MechanicDraftRepository>(); // Mechanic Extractor: Variant C drafts
+        services.AddScoped<IMechanicAnalysisRepository, MechanicAnalysisRepository>(); // Issue #523: M1.1 Mechanic Analysis persistence
         services.AddScoped<IShareRequestRepository, ShareRequestRepository>(); // Issue #2724: CreateShareRequest
         services.AddScoped<IBadgeRepository, BadgeRepository>(); // Issue #2731: Badge gamification system
         services.AddScoped<IUserBadgeRepository, UserBadgeRepository>(); // Issue #2731: User badge awards

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicAnalysisRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicAnalysisRepository.cs
@@ -1,0 +1,302 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+
+/// <summary>
+/// Repository implementation for the <see cref="MechanicAnalysis"/> aggregate (ADR-051 / M1.1).
+/// </summary>
+/// <remarks>
+/// Audit-via-repository pattern: before clearing domain events via <see cref="RepositoryBase.CollectDomainEvents"/>,
+/// the repository inspects the aggregate's pending events and synthesizes corresponding rows in
+/// <c>mechanic_status_audit</c> / <c>mechanic_suppression_audit</c> into the same <see cref="DbContext"/>.
+/// Because all inserts share the same <see cref="DbContext.SaveChangesAsync(CancellationToken)"/>
+/// they commit atomically (plan §2.3 atomicity invariant), without requiring a SaveChanges interceptor.
+/// </remarks>
+internal sealed class MechanicAnalysisRepository : RepositoryBase, IMechanicAnalysisRepository
+{
+    public MechanicAnalysisRepository(MeepleAiDbContext dbContext, IDomainEventCollector eventCollector)
+        : base(dbContext, eventCollector)
+    {
+    }
+
+    public async Task AddAsync(MechanicAnalysis analysis, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(analysis);
+
+        var entity = MapToEntity(analysis);
+        await DbContext.MechanicAnalyses.AddAsync(entity, cancellationToken).ConfigureAwait(false);
+
+        SynthesizeAuditRows(analysis);
+        CollectDomainEvents(analysis);
+    }
+
+    public async Task<MechanicAnalysis?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.MechanicAnalyses
+            .AsNoTracking()
+            .FirstOrDefaultAsync(a => a.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entity is null ? null : MapToDomain(entity, claims: Array.Empty<MechanicClaimEntity>());
+    }
+
+    public async Task<MechanicAnalysis?> GetByIdWithClaimsAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.MechanicAnalyses
+            .AsNoTracking()
+            .AsSplitQuery()
+            .Include(a => a.Claims)
+                .ThenInclude(c => c.Citations)
+            .FirstOrDefaultAsync(a => a.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entity is null ? null : MapToDomain(entity, entity.Claims);
+    }
+
+    public async Task<MechanicAnalysis?> GetPublishedForSharedGameAsync(
+        Guid sharedGameId,
+        CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.MechanicAnalyses
+            .AsNoTracking()
+            .AsSplitQuery()
+            .Include(a => a.Claims)
+                .ThenInclude(c => c.Citations)
+            .Where(a => a.SharedGameId == sharedGameId
+                        && a.Status == (int)MechanicAnalysisStatus.Published)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return entity is null ? null : MapToDomain(entity, entity.Claims);
+    }
+
+    public async Task<IReadOnlyList<MechanicAnalysis>> GetReviewQueueAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var entities = await DbContext.MechanicAnalyses
+            .AsNoTracking()
+            .IgnoreQueryFilters()
+            .AsSplitQuery()
+            .Include(a => a.Claims)
+                .ThenInclude(c => c.Citations)
+            .Where(a => a.Status == (int)MechanicAnalysisStatus.InReview)
+            .OrderBy(a => a.CreatedAt)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return entities.Select(e => MapToDomain(e, e.Claims)).ToList();
+    }
+
+    public void Update(MechanicAnalysis analysis)
+    {
+        ArgumentNullException.ThrowIfNull(analysis);
+
+        var entity = MapToEntity(analysis);
+        DbContext.MechanicAnalyses.Update(entity);
+
+        SynthesizeAuditRows(analysis);
+        CollectDomainEvents(analysis);
+    }
+
+    // === Audit synthesis ===
+
+    /// <summary>
+    /// Projects pending domain events onto audit tables in the same DbContext so the audit rows
+    /// are written inside the same SaveChangesAsync transaction as the aggregate state change.
+    /// </summary>
+    private void SynthesizeAuditRows(MechanicAnalysis analysis)
+    {
+        foreach (var evt in analysis.DomainEvents)
+        {
+            switch (evt)
+            {
+                case MechanicAnalysisStatusChangedEvent statusEvt:
+                    DbContext.MechanicStatusAudits.Add(new MechanicStatusAuditEntity
+                    {
+                        Id = Guid.NewGuid(),
+                        AnalysisId = statusEvt.AnalysisId,
+                        FromStatus = (int)statusEvt.FromStatus,
+                        ToStatus = (int)statusEvt.ToStatus,
+                        ActorId = statusEvt.ActorId,
+                        Note = statusEvt.Note,
+                        OccurredAt = statusEvt.OccurredAt
+                    });
+                    break;
+
+                case MechanicAnalysisSuppressedEvent suppressedEvt:
+                    DbContext.MechanicSuppressionAudits.Add(new MechanicSuppressionAuditEntity
+                    {
+                        Id = Guid.NewGuid(),
+                        AnalysisId = suppressedEvt.AnalysisId,
+                        IsSuppressed = true,
+                        ActorId = suppressedEvt.ActorId,
+                        Reason = suppressedEvt.Reason,
+                        RequestSource = (int)suppressedEvt.RequestSource,
+                        RequestedAt = suppressedEvt.RequestedAt,
+                        OccurredAt = suppressedEvt.OccurredAt
+                    });
+                    break;
+
+                case MechanicAnalysisUnsuppressedEvent unsuppressedEvt:
+                    DbContext.MechanicSuppressionAudits.Add(new MechanicSuppressionAuditEntity
+                    {
+                        Id = Guid.NewGuid(),
+                        AnalysisId = unsuppressedEvt.AnalysisId,
+                        IsSuppressed = false,
+                        ActorId = unsuppressedEvt.ActorId,
+                        Reason = unsuppressedEvt.Reason,
+                        RequestSource = null,
+                        RequestedAt = null,
+                        OccurredAt = unsuppressedEvt.OccurredAt
+                    });
+                    break;
+
+                // MechanicAnalysisCostCapOverriddenEvent: no dedicated audit table in M1.1;
+                // the event is still dispatched by the base class for downstream handlers (admin UI, logs).
+            }
+        }
+    }
+
+    // === Mapping ===
+
+    private static MechanicAnalysis MapToDomain(
+        MechanicAnalysisEntity entity,
+        IEnumerable<MechanicClaimEntity> claims)
+    {
+        var domainClaims = claims.Select(MapClaimToDomain).ToList();
+
+        return MechanicAnalysis.Reconstitute(
+            id: entity.Id,
+            sharedGameId: entity.SharedGameId,
+            pdfDocumentId: entity.PdfDocumentId,
+            promptVersion: entity.PromptVersion,
+            status: (MechanicAnalysisStatus)entity.Status,
+            createdBy: entity.CreatedBy,
+            createdAt: entity.CreatedAt,
+            reviewedBy: entity.ReviewedBy,
+            reviewedAt: entity.ReviewedAt,
+            rejectionReason: entity.RejectionReason,
+            totalTokensUsed: entity.TotalTokensUsed,
+            estimatedCostUsd: entity.EstimatedCostUsd,
+            modelUsed: entity.ModelUsed,
+            provider: entity.Provider,
+            costCapUsd: entity.CostCapUsd,
+            costCapOverrideAt: entity.CostCapOverrideAt,
+            costCapOverrideBy: entity.CostCapOverrideBy,
+            costCapOverrideReason: entity.CostCapOverrideReason,
+            isSuppressed: entity.IsSuppressed,
+            suppressedAt: entity.SuppressedAt,
+            suppressedBy: entity.SuppressedBy,
+            suppressionReason: entity.SuppressionReason,
+            suppressionRequestedAt: entity.SuppressionRequestedAt,
+            suppressionRequestSource: entity.SuppressionRequestSource is null
+                ? null
+                : (SuppressionRequestSource)entity.SuppressionRequestSource.Value,
+            claims: domainClaims,
+            xminVersion: entity.Xmin);
+    }
+
+    private static MechanicClaim MapClaimToDomain(MechanicClaimEntity entity)
+    {
+        var citations = entity.Citations.Select(MapCitationToDomain).ToList();
+
+        return MechanicClaim.Reconstitute(
+            id: entity.Id,
+            analysisId: entity.AnalysisId,
+            section: (MechanicSection)entity.Section,
+            text: entity.Text,
+            displayOrder: entity.DisplayOrder,
+            status: (MechanicClaimStatus)entity.Status,
+            reviewedBy: entity.ReviewedBy,
+            reviewedAt: entity.ReviewedAt,
+            rejectionNote: entity.RejectionNote,
+            citations: citations);
+    }
+
+    private static MechanicCitation MapCitationToDomain(MechanicCitationEntity entity)
+    {
+        return MechanicCitation.Reconstitute(
+            id: entity.Id,
+            claimId: entity.ClaimId,
+            pdfPage: entity.PdfPage,
+            quote: entity.Quote,
+            chunkId: entity.ChunkId,
+            displayOrder: entity.DisplayOrder);
+    }
+
+    private static MechanicAnalysisEntity MapToEntity(MechanicAnalysis analysis)
+    {
+        return new MechanicAnalysisEntity
+        {
+            Id = analysis.Id,
+            SharedGameId = analysis.SharedGameId,
+            PdfDocumentId = analysis.PdfDocumentId,
+            PromptVersion = analysis.PromptVersion,
+            Status = (int)analysis.Status,
+            CreatedBy = analysis.CreatedBy,
+            CreatedAt = analysis.CreatedAt,
+            ReviewedBy = analysis.ReviewedBy,
+            ReviewedAt = analysis.ReviewedAt,
+            RejectionReason = analysis.RejectionReason,
+            TotalTokensUsed = analysis.TotalTokensUsed,
+            EstimatedCostUsd = analysis.EstimatedCostUsd,
+            ModelUsed = analysis.ModelUsed,
+            Provider = analysis.Provider,
+            CostCapUsd = analysis.CostCapUsd,
+            CostCapOverrideAt = analysis.CostCapOverrideAt,
+            CostCapOverrideBy = analysis.CostCapOverrideBy,
+            CostCapOverrideReason = analysis.CostCapOverrideReason,
+            IsSuppressed = analysis.IsSuppressed,
+            SuppressedAt = analysis.SuppressedAt,
+            SuppressedBy = analysis.SuppressedBy,
+            SuppressionReason = analysis.SuppressionReason,
+            SuppressionRequestedAt = analysis.SuppressionRequestedAt,
+            SuppressionRequestSource = analysis.SuppressionRequestSource is null
+                ? null
+                : (int)analysis.SuppressionRequestSource.Value,
+            Xmin = analysis.XminVersion,
+            Claims = analysis.Claims.Select(MapClaimToEntity).ToList()
+        };
+    }
+
+    private static MechanicClaimEntity MapClaimToEntity(MechanicClaim claim)
+    {
+        return new MechanicClaimEntity
+        {
+            Id = claim.Id,
+            AnalysisId = claim.AnalysisId,
+            Section = (int)claim.Section,
+            Text = claim.Text,
+            DisplayOrder = claim.DisplayOrder,
+            Status = (int)claim.Status,
+            ReviewedBy = claim.ReviewedBy,
+            ReviewedAt = claim.ReviewedAt,
+            RejectionNote = claim.RejectionNote,
+            Citations = claim.Citations.Select(MapCitationToEntity).ToList()
+        };
+    }
+
+    private static MechanicCitationEntity MapCitationToEntity(MechanicCitation citation)
+    {
+        return new MechanicCitationEntity
+        {
+            Id = citation.Id,
+            ClaimId = citation.ClaimId,
+            PdfPage = citation.PdfPage,
+            Quote = citation.Quote,
+            ChunkId = citation.ChunkId,
+            DisplayOrder = citation.DisplayOrder
+        };
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicAnalysisEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicAnalysisEntityConfiguration.cs
@@ -1,0 +1,133 @@
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.Configurations.SharedGameCatalog;
+
+/// <summary>
+/// EF configuration for <see cref="MechanicAnalysisEntity"/> (ADR-051 / M1.1).
+/// </summary>
+/// <remarks>
+/// Enforces at DB level:
+/// - Partial unique index: at most one <c>Status=Published AND IsSuppressed=false</c> per SharedGame.
+/// - CHECK (cost_cap_override all-or-none).
+/// - CHECK (suppression completeness — unsuppressed rows must have all suppression fields NULL;
+///   suppressed rows must have actor + reason + suppressed_at populated).
+/// - Global query filter hides suppressed rows from player-facing queries.
+/// </remarks>
+internal sealed class MechanicAnalysisEntityConfiguration : IEntityTypeConfiguration<MechanicAnalysisEntity>
+{
+    public void Configure(EntityTypeBuilder<MechanicAnalysisEntity> builder)
+    {
+        builder.ToTable("mechanic_analyses", t =>
+        {
+            t.HasCheckConstraint(
+                "ck_mechanic_analyses_cost_cap_override_all_or_none",
+                "(cost_cap_override_at IS NULL AND cost_cap_override_by IS NULL AND cost_cap_override_reason IS NULL) "
+                + "OR (cost_cap_override_at IS NOT NULL AND cost_cap_override_by IS NOT NULL AND cost_cap_override_reason IS NOT NULL)");
+
+            t.HasCheckConstraint(
+                "ck_mechanic_analyses_suppression_completeness",
+                "(is_suppressed = false AND suppressed_at IS NULL AND suppressed_by IS NULL "
+                + "AND suppression_reason IS NULL AND suppression_request_source IS NULL "
+                + "AND suppression_requested_at IS NULL) "
+                + "OR (is_suppressed = true AND suppressed_at IS NOT NULL AND suppressed_by IS NOT NULL "
+                + "AND suppression_reason IS NOT NULL)");
+
+            t.HasCheckConstraint(
+                "ck_mechanic_analyses_status_range",
+                "status BETWEEN 0 AND 3");
+
+            t.HasCheckConstraint(
+                "ck_mechanic_analyses_cost_cap_positive",
+                "cost_cap_usd > 0");
+        });
+
+        builder.HasKey(a => a.Id);
+
+        builder.Property(a => a.Id).HasColumnName("id").IsRequired();
+        builder.Property(a => a.SharedGameId).HasColumnName("shared_game_id").IsRequired();
+        builder.Property(a => a.PdfDocumentId).HasColumnName("pdf_document_id").IsRequired();
+
+        builder.Property(a => a.PromptVersion)
+            .HasColumnName("prompt_version")
+            .HasMaxLength(64)
+            .IsRequired();
+
+        builder.Property(a => a.Status).HasColumnName("status").IsRequired();
+        builder.Property(a => a.CreatedBy).HasColumnName("created_by").IsRequired();
+        builder.Property(a => a.CreatedAt).HasColumnName("created_at").IsRequired();
+        builder.Property(a => a.ReviewedBy).HasColumnName("reviewed_by");
+        builder.Property(a => a.ReviewedAt).HasColumnName("reviewed_at");
+
+        builder.Property(a => a.RejectionReason)
+            .HasColumnName("rejection_reason")
+            .HasMaxLength(2000);
+
+        builder.Property(a => a.TotalTokensUsed).HasColumnName("total_tokens_used").HasDefaultValue(0).IsRequired();
+
+        builder.Property(a => a.EstimatedCostUsd)
+            .HasColumnName("estimated_cost_usd")
+            .HasColumnType("numeric(12,6)")
+            .HasDefaultValue(0m)
+            .IsRequired();
+
+        builder.Property(a => a.ModelUsed).HasColumnName("model_used").HasMaxLength(128).IsRequired();
+        builder.Property(a => a.Provider).HasColumnName("provider").HasMaxLength(64).IsRequired();
+
+        builder.Property(a => a.CostCapUsd)
+            .HasColumnName("cost_cap_usd")
+            .HasColumnType("numeric(12,6)")
+            .IsRequired();
+
+        builder.Property(a => a.CostCapOverrideAt).HasColumnName("cost_cap_override_at");
+        builder.Property(a => a.CostCapOverrideBy).HasColumnName("cost_cap_override_by");
+        builder.Property(a => a.CostCapOverrideReason).HasColumnName("cost_cap_override_reason").HasMaxLength(2000);
+
+        builder.Property(a => a.IsSuppressed).HasColumnName("is_suppressed").HasDefaultValue(false).IsRequired();
+        builder.Property(a => a.SuppressedAt).HasColumnName("suppressed_at");
+        builder.Property(a => a.SuppressedBy).HasColumnName("suppressed_by");
+        builder.Property(a => a.SuppressionReason).HasColumnName("suppression_reason").HasMaxLength(2000);
+        builder.Property(a => a.SuppressionRequestedAt).HasColumnName("suppression_requested_at");
+        builder.Property(a => a.SuppressionRequestSource).HasColumnName("suppression_request_source");
+
+        // Optimistic concurrency via PostgreSQL's system `xmin` column, mapped to an explicit
+        // property on the entity so the repository can round-trip its value through the aggregate
+        // (preserving the original token on detached Update).
+        builder.Property(a => a.Xmin)
+            .HasColumnName("xmin")
+            .HasColumnType("xid")
+            .ValueGeneratedOnAddOrUpdate()
+            .IsConcurrencyToken();
+
+        // === Indexes ===
+        builder.HasIndex(a => a.SharedGameId).HasDatabaseName("ix_mechanic_analyses_shared_game_id");
+        builder.HasIndex(a => a.PdfDocumentId).HasDatabaseName("ix_mechanic_analyses_pdf_document_id");
+        builder.HasIndex(a => a.Status).HasDatabaseName("ix_mechanic_analyses_status");
+        builder.HasIndex(a => a.CreatedBy).HasDatabaseName("ix_mechanic_analyses_created_by");
+        builder.HasIndex(a => a.IsSuppressed)
+            .HasDatabaseName("ix_mechanic_analyses_is_suppressed")
+            .HasFilter("is_suppressed = true");
+
+        // One Published, non-suppressed analysis per shared game (plan §2.2.1).
+        builder.HasIndex(a => a.SharedGameId)
+            .HasDatabaseName("ux_mechanic_analyses_published_per_game")
+            .IsUnique()
+            .HasFilter("status = 2 AND is_suppressed = false");
+
+        // === FK to SharedGame ===
+        builder.HasOne(a => a.SharedGame)
+            .WithMany()
+            .HasForeignKey(a => a.SharedGameId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // === Children ===
+        builder.HasMany(a => a.Claims)
+            .WithOne(c => c.Analysis)
+            .HasForeignKey(c => c.AnalysisId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // === Suppression global query filter (T5) ===
+        builder.HasQueryFilter(a => !a.IsSuppressed);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicAnalysisEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicAnalysisEntityConfiguration.cs
@@ -115,6 +115,15 @@ internal sealed class MechanicAnalysisEntityConfiguration : IEntityTypeConfigura
             .IsUnique()
             .HasFilter("status = 2 AND is_suppressed = false");
 
+        // T7 reproducibility (plan §2.2 + §3.5): one non-rejected analysis per
+        // (SharedGameId, PdfDocumentId, PromptVersion) tuple. Excluding Rejected (status=3)
+        // lets users re-run the same prompt after a rejection without collision,
+        // while a new PromptVersion bump always produces a fresh row.
+        builder.HasIndex(a => new { a.SharedGameId, a.PdfDocumentId, a.PromptVersion })
+            .HasDatabaseName("ux_mechanic_analyses_shared_game_pdf_prompt")
+            .IsUnique()
+            .HasFilter("status <> 3");
+
         // === FK to SharedGame ===
         builder.HasOne(a => a.SharedGame)
             .WithMany()

--- a/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicCitationEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicCitationEntityConfiguration.cs
@@ -1,0 +1,71 @@
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.Configurations.SharedGameCatalog;
+
+/// <summary>
+/// EF configuration for <see cref="MechanicCitationEntity"/> (ADR-051 T1: quote ≤25 words).
+/// </summary>
+/// <remarks>
+/// The 25-word CHECK constraint is enforced at DB level via whitespace tokenisation, mirroring
+/// the domain factory's <c>MechanicCitation.CountWords</c>. Belt-and-braces defense: reject
+/// non-compliant rows even if a future code path bypasses the domain factory.
+/// </remarks>
+internal sealed class MechanicCitationEntityConfiguration : IEntityTypeConfiguration<MechanicCitationEntity>
+{
+    public void Configure(EntityTypeBuilder<MechanicCitationEntity> builder)
+    {
+        builder.ToTable("mechanic_citations", t =>
+        {
+            t.HasCheckConstraint(
+                "ck_mechanic_citations_page_positive",
+                "pdf_page > 0");
+
+            t.HasCheckConstraint(
+                "ck_mechanic_citations_quote_not_empty",
+                "char_length(btrim(quote)) > 0");
+
+            t.HasCheckConstraint(
+                "ck_mechanic_citations_quote_chars_cap",
+                "char_length(quote) <= 400");
+
+            // 25-word cap (ADR-051 T1). regexp_matches counts whitespace-separated tokens.
+            t.HasCheckConstraint(
+                "ck_mechanic_citations_quote_word_cap",
+                "array_length(regexp_split_to_array(btrim(quote), '\\s+'), 1) <= 25");
+
+            t.HasCheckConstraint(
+                "ck_mechanic_citations_display_order_non_negative",
+                "display_order >= 0");
+        });
+
+        builder.HasKey(c => c.Id);
+
+        builder.Property(c => c.Id).HasColumnName("id").IsRequired();
+        builder.Property(c => c.ClaimId).HasColumnName("claim_id").IsRequired();
+        builder.Property(c => c.PdfPage).HasColumnName("pdf_page").IsRequired();
+
+        builder.Property(c => c.Quote)
+            .HasColumnName("quote")
+            .HasMaxLength(400)
+            .IsRequired();
+
+        builder.Property(c => c.ChunkId).HasColumnName("chunk_id");
+        builder.Property(c => c.DisplayOrder).HasColumnName("display_order").IsRequired();
+
+        builder.HasIndex(c => c.ClaimId).HasDatabaseName("ix_mechanic_citations_claim_id");
+        builder.HasIndex(c => new { c.ClaimId, c.PdfPage })
+            .HasDatabaseName("ix_mechanic_citations_claim_page");
+        builder.HasIndex(c => c.ChunkId)
+            .HasDatabaseName("ix_mechanic_citations_chunk_id")
+            .HasFilter("chunk_id IS NOT NULL");
+
+        // FK to text_chunks — nullable, ON DELETE SET NULL so chunk re-indexing doesn't drop citations.
+        // Shadow-style relationship: the KB-owned TextChunk provides only the FK column here, not a navigation.
+        builder.HasOne<Api.Infrastructure.Entities.TextChunkEntity>()
+            .WithMany()
+            .HasForeignKey(c => c.ChunkId)
+            .OnDelete(DeleteBehavior.SetNull);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicClaimEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicClaimEntityConfiguration.cs
@@ -1,0 +1,64 @@
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.Configurations.SharedGameCatalog;
+
+/// <summary>
+/// EF configuration for <see cref="MechanicClaimEntity"/>.
+/// </summary>
+internal sealed class MechanicClaimEntityConfiguration : IEntityTypeConfiguration<MechanicClaimEntity>
+{
+    public void Configure(EntityTypeBuilder<MechanicClaimEntity> builder)
+    {
+        builder.ToTable("mechanic_claims", t =>
+        {
+            t.HasCheckConstraint(
+                "ck_mechanic_claims_status_range",
+                "status BETWEEN 0 AND 2");
+
+            t.HasCheckConstraint(
+                "ck_mechanic_claims_section_range",
+                "section BETWEEN 0 AND 5");
+
+            t.HasCheckConstraint(
+                "ck_mechanic_claims_display_order_non_negative",
+                "display_order >= 0");
+
+            // A rejected claim must have a rejection note; an approved claim has reviewer+timestamp.
+            t.HasCheckConstraint(
+                "ck_mechanic_claims_rejection_note_when_rejected",
+                "status <> 2 OR rejection_note IS NOT NULL");
+        });
+
+        builder.HasKey(c => c.Id);
+
+        builder.Property(c => c.Id).HasColumnName("id").IsRequired();
+        builder.Property(c => c.AnalysisId).HasColumnName("analysis_id").IsRequired();
+        builder.Property(c => c.Section).HasColumnName("section").IsRequired();
+
+        builder.Property(c => c.Text)
+            .HasColumnName("text")
+            .HasColumnType("text")
+            .IsRequired();
+
+        builder.Property(c => c.DisplayOrder).HasColumnName("display_order").IsRequired();
+        builder.Property(c => c.Status).HasColumnName("status").HasDefaultValue(0).IsRequired();
+        builder.Property(c => c.ReviewedBy).HasColumnName("reviewed_by");
+        builder.Property(c => c.ReviewedAt).HasColumnName("reviewed_at");
+
+        builder.Property(c => c.RejectionNote)
+            .HasColumnName("rejection_note")
+            .HasMaxLength(2000);
+
+        builder.HasIndex(c => c.AnalysisId).HasDatabaseName("ix_mechanic_claims_analysis_id");
+        builder.HasIndex(c => new { c.AnalysisId, c.Section, c.DisplayOrder })
+            .HasDatabaseName("ix_mechanic_claims_analysis_section_order");
+        builder.HasIndex(c => c.Status).HasDatabaseName("ix_mechanic_claims_status");
+
+        builder.HasMany(c => c.Citations)
+            .WithOne(ci => ci.Claim)
+            .HasForeignKey(ci => ci.ClaimId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicStatusAuditEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicStatusAuditEntityConfiguration.cs
@@ -1,0 +1,49 @@
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.Configurations.SharedGameCatalog;
+
+/// <summary>
+/// EF configuration for <see cref="MechanicStatusAuditEntity"/> (ADR-051 T6 audit trail).
+/// Append-only; rows are written by the repository in the same transaction as the analysis update.
+/// </summary>
+internal sealed class MechanicStatusAuditEntityConfiguration : IEntityTypeConfiguration<MechanicStatusAuditEntity>
+{
+    public void Configure(EntityTypeBuilder<MechanicStatusAuditEntity> builder)
+    {
+        builder.ToTable("mechanic_status_audit", t =>
+        {
+            t.HasCheckConstraint(
+                "ck_mechanic_status_audit_status_range",
+                "from_status BETWEEN 0 AND 3 AND to_status BETWEEN 0 AND 3");
+
+            t.HasCheckConstraint(
+                "ck_mechanic_status_audit_distinct_states",
+                "from_status <> to_status");
+        });
+
+        builder.HasKey(a => a.Id);
+
+        builder.Property(a => a.Id).HasColumnName("id").IsRequired();
+        builder.Property(a => a.AnalysisId).HasColumnName("analysis_id").IsRequired();
+        builder.Property(a => a.FromStatus).HasColumnName("from_status").IsRequired();
+        builder.Property(a => a.ToStatus).HasColumnName("to_status").IsRequired();
+        builder.Property(a => a.ActorId).HasColumnName("actor_id").IsRequired();
+
+        builder.Property(a => a.Note)
+            .HasColumnName("note")
+            .HasMaxLength(2000);
+
+        builder.Property(a => a.OccurredAt).HasColumnName("occurred_at").IsRequired();
+
+        builder.HasIndex(a => a.AnalysisId).HasDatabaseName("ix_mechanic_status_audit_analysis_id");
+        builder.HasIndex(a => new { a.AnalysisId, a.OccurredAt })
+            .HasDatabaseName("ix_mechanic_status_audit_analysis_time");
+
+        builder.HasOne(a => a.Analysis)
+            .WithMany()
+            .HasForeignKey(a => a.AnalysisId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicSuppressionAuditEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicSuppressionAuditEntityConfiguration.cs
@@ -1,0 +1,46 @@
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.Configurations.SharedGameCatalog;
+
+/// <summary>
+/// EF configuration for <see cref="MechanicSuppressionAuditEntity"/> (ADR-051 T5 + T6).
+/// </summary>
+internal sealed class MechanicSuppressionAuditEntityConfiguration : IEntityTypeConfiguration<MechanicSuppressionAuditEntity>
+{
+    public void Configure(EntityTypeBuilder<MechanicSuppressionAuditEntity> builder)
+    {
+        builder.ToTable("mechanic_suppression_audit", t =>
+        {
+            t.HasCheckConstraint(
+                "ck_mechanic_suppression_audit_request_source_range",
+                "request_source IS NULL OR request_source BETWEEN 0 AND 3");
+        });
+
+        builder.HasKey(a => a.Id);
+
+        builder.Property(a => a.Id).HasColumnName("id").IsRequired();
+        builder.Property(a => a.AnalysisId).HasColumnName("analysis_id").IsRequired();
+        builder.Property(a => a.IsSuppressed).HasColumnName("is_suppressed").IsRequired();
+        builder.Property(a => a.ActorId).HasColumnName("actor_id").IsRequired();
+
+        builder.Property(a => a.Reason)
+            .HasColumnName("reason")
+            .HasMaxLength(2000)
+            .IsRequired();
+
+        builder.Property(a => a.RequestSource).HasColumnName("request_source");
+        builder.Property(a => a.RequestedAt).HasColumnName("requested_at");
+        builder.Property(a => a.OccurredAt).HasColumnName("occurred_at").IsRequired();
+
+        builder.HasIndex(a => a.AnalysisId).HasDatabaseName("ix_mechanic_suppression_audit_analysis_id");
+        builder.HasIndex(a => new { a.AnalysisId, a.OccurredAt })
+            .HasDatabaseName("ix_mechanic_suppression_audit_analysis_time");
+
+        builder.HasOne(a => a.Analysis)
+            .WithMany()
+            .HasForeignKey(a => a.AnalysisId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicAnalysisEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicAnalysisEntity.cs
@@ -1,0 +1,57 @@
+namespace Api.Infrastructure.Entities.SharedGameCatalog;
+
+/// <summary>
+/// Persistence entity for <see cref="Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates.MechanicAnalysis"/>
+/// (ADR-051 / M1.1). Plain POCO — all invariants are enforced by the domain aggregate; this type
+/// exists only to be shaped by EF Core.
+/// </summary>
+public class MechanicAnalysisEntity
+{
+    public Guid Id { get; set; }
+
+    // === Core identity / lineage ===
+    public Guid SharedGameId { get; set; }
+    public Guid PdfDocumentId { get; set; }
+    public string PromptVersion { get; set; } = string.Empty;
+
+    // === Lifecycle ===
+    /// <summary>0=Draft, 1=InReview, 2=Published, 3=Rejected.</summary>
+    public int Status { get; set; }
+    public Guid CreatedBy { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public Guid? ReviewedBy { get; set; }
+    public DateTime? ReviewedAt { get; set; }
+    public string? RejectionReason { get; set; }
+
+    // === LLM execution snapshot ===
+    public int TotalTokensUsed { get; set; }
+    public decimal EstimatedCostUsd { get; set; }
+    public string ModelUsed { get; set; } = string.Empty;
+    public string Provider { get; set; } = string.Empty;
+
+    // === T8 cost governance ===
+    public decimal CostCapUsd { get; set; }
+    public DateTime? CostCapOverrideAt { get; set; }
+    public Guid? CostCapOverrideBy { get; set; }
+    public string? CostCapOverrideReason { get; set; }
+
+    // === T5 takedown kill-switch ===
+    public bool IsSuppressed { get; set; }
+    public DateTime? SuppressedAt { get; set; }
+    public Guid? SuppressedBy { get; set; }
+    public string? SuppressionReason { get; set; }
+    public DateTime? SuppressionRequestedAt { get; set; }
+    /// <summary>0=Publisher, 1=Legal, 2=Community, 3=Internal.</summary>
+    public int? SuppressionRequestSource { get; set; }
+
+    // === Optimistic concurrency ===
+    /// <summary>
+    /// PostgreSQL system column <c>xmin</c> mapped as <see cref="uint"/> (xid).
+    /// Marked as concurrency token in EF configuration; server-generated on add/update.
+    /// </summary>
+    public uint Xmin { get; set; }
+
+    // === Navigation ===
+    public SharedGameEntity SharedGame { get; set; } = default!;
+    public ICollection<MechanicClaimEntity> Claims { get; set; } = new List<MechanicClaimEntity>();
+}

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicCitationEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicCitationEntity.cs
@@ -1,0 +1,24 @@
+namespace Api.Infrastructure.Entities.SharedGameCatalog;
+
+/// <summary>
+/// Persistence entity for <see cref="Api.BoundedContexts.SharedGameCatalog.Domain.Entities.MechanicCitation"/>.
+/// </summary>
+public class MechanicCitationEntity
+{
+    public Guid Id { get; set; }
+    public Guid ClaimId { get; set; }
+
+    /// <summary>1-based page number in the originating PDF. Always &gt; 0 (enforced by CHECK).</summary>
+    public int PdfPage { get; set; }
+
+    /// <summary>Verbatim quote, max 400 chars / 25 words (ADR-051 T1). Word cap enforced by CHECK.</summary>
+    public string Quote { get; set; } = string.Empty;
+
+    /// <summary>Nullable: chunks may be re-indexed. ON DELETE SET NULL in FK.</summary>
+    public Guid? ChunkId { get; set; }
+
+    public int DisplayOrder { get; set; }
+
+    // === Navigation ===
+    public MechanicClaimEntity Claim { get; set; } = default!;
+}

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicClaimEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicClaimEntity.cs
@@ -1,0 +1,27 @@
+namespace Api.Infrastructure.Entities.SharedGameCatalog;
+
+/// <summary>
+/// Persistence entity for <see cref="Api.BoundedContexts.SharedGameCatalog.Domain.Entities.MechanicClaim"/>.
+/// </summary>
+public class MechanicClaimEntity
+{
+    public Guid Id { get; set; }
+    public Guid AnalysisId { get; set; }
+
+    /// <summary>0=Summary, 1=Mechanics, 2=Victory, 3=Resources, 4=Phases, 5=Questions.</summary>
+    public int Section { get; set; }
+
+    public string Text { get; set; } = string.Empty;
+    public int DisplayOrder { get; set; }
+
+    /// <summary>0=Pending, 1=Approved, 2=Rejected.</summary>
+    public int Status { get; set; }
+
+    public Guid? ReviewedBy { get; set; }
+    public DateTime? ReviewedAt { get; set; }
+    public string? RejectionNote { get; set; }
+
+    // === Navigation ===
+    public MechanicAnalysisEntity Analysis { get; set; } = default!;
+    public ICollection<MechanicCitationEntity> Citations { get; set; } = new List<MechanicCitationEntity>();
+}

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicStatusAuditEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicStatusAuditEntity.cs
@@ -1,0 +1,28 @@
+namespace Api.Infrastructure.Entities.SharedGameCatalog;
+
+/// <summary>
+/// Audit row for every <see cref="MechanicAnalysisEntity.Status"/> transition (ADR-051 T6).
+/// Written by the repository from the aggregate's collected <c>MechanicAnalysisStatusChangedEvent</c>s
+/// in the same <c>SaveChangesAsync</c> transaction as the analysis update, ensuring atomicity.
+/// </summary>
+public class MechanicStatusAuditEntity
+{
+    public Guid Id { get; set; }
+    public Guid AnalysisId { get; set; }
+
+    /// <summary>Previous lifecycle status code.</summary>
+    public int FromStatus { get; set; }
+
+    /// <summary>New lifecycle status code.</summary>
+    public int ToStatus { get; set; }
+
+    public Guid ActorId { get; set; }
+
+    /// <summary>Optional admin note (e.g. rejection reason).</summary>
+    public string? Note { get; set; }
+
+    public DateTime OccurredAt { get; set; }
+
+    // === Navigation ===
+    public MechanicAnalysisEntity Analysis { get; set; } = default!;
+}

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicSuppressionAuditEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicSuppressionAuditEntity.cs
@@ -1,0 +1,28 @@
+namespace Api.Infrastructure.Entities.SharedGameCatalog;
+
+/// <summary>
+/// Audit row for every suppression / unsuppression action on a <see cref="MechanicAnalysisEntity"/>
+/// (ADR-051 T5). Written atomically by the repository.
+/// </summary>
+public class MechanicSuppressionAuditEntity
+{
+    public Guid Id { get; set; }
+    public Guid AnalysisId { get; set; }
+
+    /// <summary>true = suppression applied, false = suppression lifted.</summary>
+    public bool IsSuppressed { get; set; }
+
+    public Guid ActorId { get; set; }
+
+    public string Reason { get; set; } = string.Empty;
+
+    /// <summary>Source code: 0=Publisher, 1=Legal, 2=Community, 3=Internal. Null when unsuppressing.</summary>
+    public int? RequestSource { get; set; }
+
+    public DateTime? RequestedAt { get; set; }
+
+    public DateTime OccurredAt { get; set; }
+
+    // === Navigation ===
+    public MechanicAnalysisEntity Analysis { get; set; } = default!;
+}

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -135,6 +135,11 @@ public class MeepleAiDbContext : DbContext
     public DbSet<GameStateTemplateEntity> GameStateTemplates => Set<GameStateTemplateEntity>(); // ISSUE-2400: Sprint 3 - Game state templates
     public DbSet<RulebookAnalysisEntity> RulebookAnalyses => Set<RulebookAnalysisEntity>(); // ISSUE-2402: Sprint 3 - Rulebook analysis service
     public DbSet<MechanicDraftEntity> MechanicDrafts => Set<MechanicDraftEntity>(); // Mechanic Extractor: Variant C draft workspace
+    public DbSet<MechanicAnalysisEntity> MechanicAnalyses => Set<MechanicAnalysisEntity>(); // ISSUE-523: Mechanic Extractor M1.1 — AI-first analysis aggregate
+    public DbSet<MechanicClaimEntity> MechanicClaims => Set<MechanicClaimEntity>(); // ISSUE-523: Child of MechanicAnalysis
+    public DbSet<MechanicCitationEntity> MechanicCitations => Set<MechanicCitationEntity>(); // ISSUE-523: Child of MechanicClaim (ADR-051 T1 quote cap)
+    public DbSet<MechanicStatusAuditEntity> MechanicStatusAudits => Set<MechanicStatusAuditEntity>(); // ISSUE-523: T6 audit trail for lifecycle transitions
+    public DbSet<MechanicSuppressionAuditEntity> MechanicSuppressionAudits => Set<MechanicSuppressionAuditEntity>(); // ISSUE-523: T5 audit trail for suppressions
     public DbSet<QuickQuestionEntity> QuickQuestions => Set<QuickQuestionEntity>(); // ISSUE-2401: Sprint 3 - Quick questions AI generation
     public DbSet<UserLibraryEntryEntity> UserLibraryEntries => Set<UserLibraryEntryEntity>(); // User Library feature
     public DbSet<WishlistItemEntity> WishlistItems => Set<WishlistItemEntity>(); // ISSUE-3917: Wishlist management

--- a/apps/api/src/Api/Infrastructure/Migrations/20260423072032_M1_1_MechanicAnalysisSchema.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260423072032_M1_1_MechanicAnalysisSchema.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260423072032_M1_1_MechanicAnalysisSchema")]
+    partial class M1_1_MechanicAnalysisSchema
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260423072032_M1_1_MechanicAnalysisSchema.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260423072032_M1_1_MechanicAnalysisSchema.Designer.cs
@@ -9572,6 +9572,11 @@ namespace Api.Infrastructure.Migrations
                     b.HasIndex("Status")
                         .HasDatabaseName("ix_mechanic_analyses_status");
 
+                    b.HasIndex("SharedGameId", "PdfDocumentId", "PromptVersion")
+                        .IsUnique()
+                        .HasDatabaseName("ux_mechanic_analyses_shared_game_pdf_prompt")
+                        .HasFilter("status <> 3");
+
                     b.ToTable("mechanic_analyses", null, t =>
                         {
                             t.HasCheckConstraint("ck_mechanic_analyses_cost_cap_override_all_or_none", "(cost_cap_override_at IS NULL AND cost_cap_override_by IS NULL AND cost_cap_override_reason IS NULL) OR (cost_cap_override_at IS NOT NULL AND cost_cap_override_by IS NOT NULL AND cost_cap_override_reason IS NOT NULL)");

--- a/apps/api/src/Api/Infrastructure/Migrations/20260423072032_M1_1_MechanicAnalysisSchema.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260423072032_M1_1_MechanicAnalysisSchema.cs
@@ -1,0 +1,269 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class M1_1_MechanicAnalysisSchema : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "mechanic_analyses",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    shared_game_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    pdf_document_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    prompt_version = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    status = table.Column<int>(type: "integer", nullable: false),
+                    created_by = table.Column<Guid>(type: "uuid", nullable: false),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    reviewed_by = table.Column<Guid>(type: "uuid", nullable: true),
+                    reviewed_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    rejection_reason = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    total_tokens_used = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    estimated_cost_usd = table.Column<decimal>(type: "numeric(12,6)", nullable: false, defaultValue: 0m),
+                    model_used = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    provider = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    cost_cap_usd = table.Column<decimal>(type: "numeric(12,6)", nullable: false),
+                    cost_cap_override_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    cost_cap_override_by = table.Column<Guid>(type: "uuid", nullable: true),
+                    cost_cap_override_reason = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    is_suppressed = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    suppressed_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    suppressed_by = table.Column<Guid>(type: "uuid", nullable: true),
+                    suppression_reason = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    suppression_requested_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    suppression_request_source = table.Column<int>(type: "integer", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_mechanic_analyses", x => x.id);
+                    table.CheckConstraint("ck_mechanic_analyses_cost_cap_override_all_or_none", "(cost_cap_override_at IS NULL AND cost_cap_override_by IS NULL AND cost_cap_override_reason IS NULL) OR (cost_cap_override_at IS NOT NULL AND cost_cap_override_by IS NOT NULL AND cost_cap_override_reason IS NOT NULL)");
+                    table.CheckConstraint("ck_mechanic_analyses_cost_cap_positive", "cost_cap_usd > 0");
+                    table.CheckConstraint("ck_mechanic_analyses_status_range", "status BETWEEN 0 AND 3");
+                    table.CheckConstraint("ck_mechanic_analyses_suppression_completeness", "(is_suppressed = false AND suppressed_at IS NULL AND suppressed_by IS NULL AND suppression_reason IS NULL AND suppression_request_source IS NULL AND suppression_requested_at IS NULL) OR (is_suppressed = true AND suppressed_at IS NOT NULL AND suppressed_by IS NOT NULL AND suppression_reason IS NOT NULL)");
+                    table.ForeignKey(
+                        name: "FK_mechanic_analyses_shared_games_shared_game_id",
+                        column: x => x.shared_game_id,
+                        principalTable: "shared_games",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "mechanic_claims",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    analysis_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    section = table.Column<int>(type: "integer", nullable: false),
+                    text = table.Column<string>(type: "text", nullable: false),
+                    display_order = table.Column<int>(type: "integer", nullable: false),
+                    status = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    reviewed_by = table.Column<Guid>(type: "uuid", nullable: true),
+                    reviewed_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    rejection_note = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_mechanic_claims", x => x.id);
+                    table.CheckConstraint("ck_mechanic_claims_display_order_non_negative", "display_order >= 0");
+                    table.CheckConstraint("ck_mechanic_claims_rejection_note_when_rejected", "status <> 2 OR rejection_note IS NOT NULL");
+                    table.CheckConstraint("ck_mechanic_claims_section_range", "section BETWEEN 0 AND 5");
+                    table.CheckConstraint("ck_mechanic_claims_status_range", "status BETWEEN 0 AND 2");
+                    table.ForeignKey(
+                        name: "FK_mechanic_claims_mechanic_analyses_analysis_id",
+                        column: x => x.analysis_id,
+                        principalTable: "mechanic_analyses",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "mechanic_status_audit",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    analysis_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    from_status = table.Column<int>(type: "integer", nullable: false),
+                    to_status = table.Column<int>(type: "integer", nullable: false),
+                    actor_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    note = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    occurred_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_mechanic_status_audit", x => x.id);
+                    table.CheckConstraint("ck_mechanic_status_audit_distinct_states", "from_status <> to_status");
+                    table.CheckConstraint("ck_mechanic_status_audit_status_range", "from_status BETWEEN 0 AND 3 AND to_status BETWEEN 0 AND 3");
+                    table.ForeignKey(
+                        name: "FK_mechanic_status_audit_mechanic_analyses_analysis_id",
+                        column: x => x.analysis_id,
+                        principalTable: "mechanic_analyses",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "mechanic_suppression_audit",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    analysis_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    is_suppressed = table.Column<bool>(type: "boolean", nullable: false),
+                    actor_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    reason = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: false),
+                    request_source = table.Column<int>(type: "integer", nullable: true),
+                    requested_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    occurred_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_mechanic_suppression_audit", x => x.id);
+                    table.CheckConstraint("ck_mechanic_suppression_audit_request_source_range", "request_source IS NULL OR request_source BETWEEN 0 AND 3");
+                    table.ForeignKey(
+                        name: "FK_mechanic_suppression_audit_mechanic_analyses_analysis_id",
+                        column: x => x.analysis_id,
+                        principalTable: "mechanic_analyses",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "mechanic_citations",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    claim_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    pdf_page = table.Column<int>(type: "integer", nullable: false),
+                    quote = table.Column<string>(type: "character varying(400)", maxLength: 400, nullable: false),
+                    chunk_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    display_order = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_mechanic_citations", x => x.id);
+                    table.CheckConstraint("ck_mechanic_citations_display_order_non_negative", "display_order >= 0");
+                    table.CheckConstraint("ck_mechanic_citations_page_positive", "pdf_page > 0");
+                    table.CheckConstraint("ck_mechanic_citations_quote_chars_cap", "char_length(quote) <= 400");
+                    table.CheckConstraint("ck_mechanic_citations_quote_not_empty", "char_length(btrim(quote)) > 0");
+                    table.CheckConstraint("ck_mechanic_citations_quote_word_cap", "array_length(regexp_split_to_array(btrim(quote), '\\s+'), 1) <= 25");
+                    table.ForeignKey(
+                        name: "FK_mechanic_citations_mechanic_claims_claim_id",
+                        column: x => x.claim_id,
+                        principalTable: "mechanic_claims",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_mechanic_citations_text_chunks_chunk_id",
+                        column: x => x.chunk_id,
+                        principalTable: "text_chunks",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_mechanic_analyses_created_by",
+                table: "mechanic_analyses",
+                column: "created_by");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_mechanic_analyses_is_suppressed",
+                table: "mechanic_analyses",
+                column: "is_suppressed",
+                filter: "is_suppressed = true");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_mechanic_analyses_pdf_document_id",
+                table: "mechanic_analyses",
+                column: "pdf_document_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_mechanic_analyses_status",
+                table: "mechanic_analyses",
+                column: "status");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_mechanic_analyses_published_per_game",
+                table: "mechanic_analyses",
+                column: "shared_game_id",
+                unique: true,
+                filter: "status = 2 AND is_suppressed = false");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_mechanic_citations_chunk_id",
+                table: "mechanic_citations",
+                column: "chunk_id",
+                filter: "chunk_id IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_mechanic_citations_claim_id",
+                table: "mechanic_citations",
+                column: "claim_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_mechanic_citations_claim_page",
+                table: "mechanic_citations",
+                columns: new[] { "claim_id", "pdf_page" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_mechanic_claims_analysis_id",
+                table: "mechanic_claims",
+                column: "analysis_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_mechanic_claims_analysis_section_order",
+                table: "mechanic_claims",
+                columns: new[] { "analysis_id", "section", "display_order" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_mechanic_claims_status",
+                table: "mechanic_claims",
+                column: "status");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_mechanic_status_audit_analysis_id",
+                table: "mechanic_status_audit",
+                column: "analysis_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_mechanic_status_audit_analysis_time",
+                table: "mechanic_status_audit",
+                columns: new[] { "analysis_id", "occurred_at" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_mechanic_suppression_audit_analysis_id",
+                table: "mechanic_suppression_audit",
+                column: "analysis_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_mechanic_suppression_audit_analysis_time",
+                table: "mechanic_suppression_audit",
+                columns: new[] { "analysis_id", "occurred_at" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "mechanic_citations");
+
+            migrationBuilder.DropTable(
+                name: "mechanic_status_audit");
+
+            migrationBuilder.DropTable(
+                name: "mechanic_suppression_audit");
+
+            migrationBuilder.DropTable(
+                name: "mechanic_claims");
+
+            migrationBuilder.DropTable(
+                name: "mechanic_analyses");
+        }
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Migrations/20260423072032_M1_1_MechanicAnalysisSchema.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260423072032_M1_1_MechanicAnalysisSchema.cs
@@ -195,6 +195,14 @@ namespace Api.Infrastructure.Migrations
                 unique: true,
                 filter: "status = 2 AND is_suppressed = false");
 
+            // T7 reproducibility: one non-rejected analysis per (game, pdf, prompt_version)
+            migrationBuilder.CreateIndex(
+                name: "ux_mechanic_analyses_shared_game_pdf_prompt",
+                table: "mechanic_analyses",
+                columns: new[] { "shared_game_id", "pdf_document_id", "prompt_version" },
+                unique: true,
+                filter: "status <> 3");
+
             migrationBuilder.CreateIndex(
                 name: "ix_mechanic_citations_chunk_id",
                 table: "mechanic_citations",

--- a/apps/api/src/Api/Infrastructure/Migrations/MeepleAiDbContextModelSnapshot.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/MeepleAiDbContextModelSnapshot.cs
@@ -9569,6 +9569,11 @@ namespace Api.Infrastructure.Migrations
                     b.HasIndex("Status")
                         .HasDatabaseName("ix_mechanic_analyses_status");
 
+                    b.HasIndex("SharedGameId", "PdfDocumentId", "PromptVersion")
+                        .IsUnique()
+                        .HasDatabaseName("ux_mechanic_analyses_shared_game_pdf_prompt")
+                        .HasFilter("status <> 3");
+
                     b.ToTable("mechanic_analyses", null, t =>
                         {
                             t.HasCheckConstraint("ck_mechanic_analyses_cost_cap_override_all_or_none", "(cost_cap_override_at IS NULL AND cost_cap_override_by IS NULL AND cost_cap_override_reason IS NULL) OR (cost_cap_override_at IS NOT NULL AND cost_cap_override_by IS NOT NULL AND cost_cap_override_reason IS NOT NULL)");

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicAnalysisTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicAnalysisTests.cs
@@ -1,0 +1,394 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Exceptions;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+
+/// <summary>
+/// Unit tests for the <see cref="MechanicAnalysis"/> aggregate root (Issue #523, M1.1).
+/// Covers aggregate invariants (AC-1..AC-3), state machine transitions (AC-10, AC-12),
+/// suppression kill-switch (T5), and cost cap override (T8).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class MechanicAnalysisTests
+{
+    // ============================================================
+    // Factory (Create)
+    // ============================================================
+
+    [Fact]
+    public void Create_WithValidInputs_ProducesDraftWithDefaults()
+    {
+        var analysis = NewAnalysisWithClaim();
+
+        analysis.Id.Should().NotBe(Guid.Empty);
+        analysis.Status.Should().Be(MechanicAnalysisStatus.Draft);
+        analysis.IsSuppressed.Should().BeFalse();
+        analysis.TotalTokensUsed.Should().Be(0);
+        analysis.EstimatedCostUsd.Should().Be(0m);
+        analysis.ReviewedBy.Should().BeNull();
+        analysis.ReviewedAt.Should().BeNull();
+        analysis.RejectionReason.Should().BeNull();
+        analysis.DomainEvents.Should().BeEmpty(); // Create() does not raise events.
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_WithBlankPromptVersion_Throws(string promptVersion)
+    {
+        var act = () => MechanicAnalysis.Create(
+            sharedGameId: Guid.NewGuid(),
+            pdfDocumentId: Guid.NewGuid(),
+            promptVersion: promptVersion,
+            createdBy: Guid.NewGuid(),
+            createdAt: DateTime.UtcNow,
+            modelUsed: "deepseek-chat",
+            provider: "deepseek",
+            costCapUsd: 1m);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*PromptVersion*");
+    }
+
+    [Fact]
+    public void Create_WithNonPositiveCostCap_Throws()
+    {
+        var act = () => MechanicAnalysis.Create(
+            sharedGameId: Guid.NewGuid(),
+            pdfDocumentId: Guid.NewGuid(),
+            promptVersion: "v1",
+            createdBy: Guid.NewGuid(),
+            createdAt: DateTime.UtcNow,
+            modelUsed: "m",
+            provider: "p",
+            costCapUsd: 0m);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    // ============================================================
+    // AC-3: at least one citation per claim (enforced by MechanicClaim factory)
+    // ============================================================
+
+    [Fact]
+    public void CreateClaim_WithoutCitations_Throws()
+    {
+        var analysisId = Guid.NewGuid();
+        var act = () => MechanicClaim.Create(
+            analysisId,
+            MechanicSection.Mechanics,
+            "A rule",
+            displayOrder: 0,
+            citations: Array.Empty<MechanicCitation>());
+
+        act.Should().Throw<ArgumentException>().WithMessage("*citation*");
+    }
+
+    // ============================================================
+    // AC-1: ≤25 word citation cap (T1)
+    // ============================================================
+
+    [Fact]
+    public void CreateCitation_WithQuoteOver25Words_Throws()
+    {
+        var tooLong = string.Join(' ', Enumerable.Repeat("word", 26));
+        var act = () => MechanicCitation.Create(
+            Guid.NewGuid(),
+            pdfPage: 1,
+            quote: tooLong,
+            chunkId: null,
+            displayOrder: 0);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*25*");
+    }
+
+    [Fact]
+    public void CreateCitation_WithQuoteExactly25Words_Succeeds()
+    {
+        var boundary = string.Join(' ', Enumerable.Repeat("word", 25));
+        var citation = MechanicCitation.Create(
+            Guid.NewGuid(),
+            pdfPage: 3,
+            quote: boundary,
+            chunkId: null,
+            displayOrder: 0);
+
+        citation.Quote.Should().Be(boundary);
+    }
+
+    // ============================================================
+    // State machine: SubmitForReview
+    // ============================================================
+
+    [Fact]
+    public void SubmitForReview_FromDraft_TransitionsToInReview_AndRaisesEvent()
+    {
+        var analysis = NewAnalysisWithClaim();
+        var actor = Guid.NewGuid();
+
+        analysis.SubmitForReview(actor, DateTime.UtcNow);
+
+        analysis.Status.Should().Be(MechanicAnalysisStatus.InReview);
+        analysis.DomainEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<MechanicAnalysisStatusChangedEvent>();
+    }
+
+    [Fact]
+    public void SubmitForReview_FromPublished_Throws()
+    {
+        var analysis = PublishedAnalysis(out _, out _);
+
+        var act = () => analysis.SubmitForReview(Guid.NewGuid(), DateTime.UtcNow);
+
+        act.Should().Throw<InvalidMechanicAnalysisStateException>();
+    }
+
+    [Fact]
+    public void SubmitForReview_WithNoClaims_Throws()
+    {
+        var analysis = MechanicAnalysis.Create(
+            sharedGameId: Guid.NewGuid(),
+            pdfDocumentId: Guid.NewGuid(),
+            promptVersion: "v1",
+            createdBy: Guid.NewGuid(),
+            createdAt: DateTime.UtcNow,
+            modelUsed: "m",
+            provider: "p",
+            costCapUsd: 1m);
+
+        var act = () => analysis.SubmitForReview(Guid.NewGuid(), DateTime.UtcNow);
+        act.Should().Throw<InvalidOperationException>().WithMessage("*no claims*");
+    }
+
+    // ============================================================
+    // AC-10: Approve requires ALL claims Approved
+    // ============================================================
+
+    [Fact]
+    public void Approve_WithPendingClaim_Throws()
+    {
+        var analysis = NewAnalysisWithClaim();
+        analysis.SubmitForReview(Guid.NewGuid(), DateTime.UtcNow);
+
+        var act = () => analysis.Approve(Guid.NewGuid(), DateTime.UtcNow);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*not all claims are Approved*");
+    }
+
+    [Fact]
+    public void Approve_AfterAllClaimsApproved_TransitionsToPublished()
+    {
+        var analysis = PublishedAnalysis(out var reviewerId, out var utcNow);
+
+        analysis.Status.Should().Be(MechanicAnalysisStatus.Published);
+        analysis.ReviewedBy.Should().Be(reviewerId);
+        analysis.ReviewedAt.Should().Be(utcNow);
+        analysis.DomainEvents.OfType<MechanicAnalysisStatusChangedEvent>()
+            .Should().ContainSingle(e => e.ToStatus == MechanicAnalysisStatus.Published);
+    }
+
+    // ============================================================
+    // Reject + Resubmit path
+    // ============================================================
+
+    [Fact]
+    public void Reject_FromInReview_TransitionsToRejected_WithReason()
+    {
+        var analysis = NewAnalysisWithClaim();
+        analysis.SubmitForReview(Guid.NewGuid(), DateTime.UtcNow);
+        analysis.ClearDomainEvents();
+
+        analysis.Reject(Guid.NewGuid(), "Missing evidence", DateTime.UtcNow);
+
+        analysis.Status.Should().Be(MechanicAnalysisStatus.Rejected);
+        analysis.RejectionReason.Should().Be("Missing evidence");
+        analysis.DomainEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<MechanicAnalysisStatusChangedEvent>();
+    }
+
+    [Fact]
+    public void SubmitForReview_AfterRejection_ResetsClaimsToPending_AndClearsRejectionReason()
+    {
+        var analysis = NewAnalysisWithClaim();
+        var adminId = Guid.NewGuid();
+        analysis.SubmitForReview(adminId, DateTime.UtcNow);
+        analysis.ApproveClaim(analysis.Claims[0].Id, adminId, DateTime.UtcNow);
+        analysis.Reject(adminId, "mistake", DateTime.UtcNow);
+
+        analysis.Claims[0].Status.Should().Be(MechanicClaimStatus.Approved);
+        analysis.RejectionReason.Should().Be("mistake");
+
+        analysis.SubmitForReview(adminId, DateTime.UtcNow);
+
+        analysis.Status.Should().Be(MechanicAnalysisStatus.InReview);
+        analysis.Claims[0].Status.Should().Be(MechanicClaimStatus.Pending);
+        analysis.RejectionReason.Should().BeNull();
+    }
+
+    // ============================================================
+    // ApproveClaim / RejectClaim: only in InReview
+    // ============================================================
+
+    [Fact]
+    public void ApproveClaim_WhileDraft_Throws()
+    {
+        var analysis = NewAnalysisWithClaim();
+        var act = () => analysis.ApproveClaim(analysis.Claims[0].Id, Guid.NewGuid(), DateTime.UtcNow);
+        act.Should().Throw<InvalidMechanicAnalysisStateException>();
+    }
+
+    [Fact]
+    public void RejectClaim_WithoutNote_Throws()
+    {
+        var analysis = NewAnalysisWithClaim();
+        analysis.SubmitForReview(Guid.NewGuid(), DateTime.UtcNow);
+
+        var act = () => analysis.RejectClaim(analysis.Claims[0].Id, Guid.NewGuid(), "  ", DateTime.UtcNow);
+        act.Should().Throw<ArgumentException>();
+    }
+
+    // ============================================================
+    // AC-12 / T5: Suppression kill-switch
+    // ============================================================
+
+    [Fact]
+    public void Suppress_FromPublished_SetsFields_AndRaisesEvent()
+    {
+        var analysis = PublishedAnalysis(out _, out _);
+        analysis.ClearDomainEvents();
+        var actor = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+
+        analysis.Suppress(actor, "DMCA", SuppressionRequestSource.Legal, requestedAt: now.AddHours(-2), utcNow: now);
+
+        analysis.IsSuppressed.Should().BeTrue();
+        analysis.SuppressedBy.Should().Be(actor);
+        analysis.SuppressedAt.Should().Be(now);
+        analysis.SuppressionReason.Should().Be("DMCA");
+        analysis.SuppressionRequestSource.Should().Be(SuppressionRequestSource.Legal);
+        analysis.Status.Should().Be(MechanicAnalysisStatus.Published); // orthogonal
+        analysis.DomainEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<MechanicAnalysisSuppressedEvent>();
+    }
+
+    [Fact]
+    public void Suppress_WhenAlreadySuppressed_Throws()
+    {
+        var analysis = PublishedAnalysis(out _, out _);
+        analysis.Suppress(Guid.NewGuid(), "r1", SuppressionRequestSource.Other, null, DateTime.UtcNow);
+
+        var act = () => analysis.Suppress(Guid.NewGuid(), "r2", SuppressionRequestSource.Other, null, DateTime.UtcNow);
+        act.Should().Throw<InvalidOperationException>().WithMessage("*already suppressed*");
+    }
+
+    [Fact]
+    public void Unsuppress_ClearsFields_AndRaisesEvent()
+    {
+        var analysis = PublishedAnalysis(out _, out _);
+        analysis.Suppress(Guid.NewGuid(), "r", SuppressionRequestSource.Other, null, DateTime.UtcNow);
+        analysis.ClearDomainEvents();
+
+        analysis.Unsuppress(Guid.NewGuid(), "appeal upheld", DateTime.UtcNow);
+
+        analysis.IsSuppressed.Should().BeFalse();
+        analysis.SuppressedBy.Should().BeNull();
+        analysis.SuppressedAt.Should().BeNull();
+        analysis.SuppressionReason.Should().BeNull();
+        analysis.SuppressionRequestSource.Should().BeNull();
+        analysis.SuppressionRequestedAt.Should().BeNull();
+        analysis.DomainEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<MechanicAnalysisUnsuppressedEvent>();
+    }
+
+    [Fact]
+    public void Unsuppress_WhenNotSuppressed_Throws()
+    {
+        var analysis = PublishedAnalysis(out _, out _);
+        var act = () => analysis.Unsuppress(Guid.NewGuid(), "reason", DateTime.UtcNow);
+        act.Should().Throw<InvalidOperationException>().WithMessage("*not suppressed*");
+    }
+
+    // ============================================================
+    // T8: Cost cap override
+    // ============================================================
+
+    [Fact]
+    public void OverrideCostCap_WithHigherCap_SetsAllThreeOverrideFields_AndRaisesEvent()
+    {
+        var analysis = NewAnalysisWithClaim(costCap: 1m);
+        var actor = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+
+        analysis.OverrideCostCap(actor, newCapUsd: 5m, reason: "high-cost game", utcNow: now);
+
+        analysis.CostCapUsd.Should().Be(5m);
+        analysis.CostCapOverrideAt.Should().Be(now);
+        analysis.CostCapOverrideBy.Should().Be(actor);
+        analysis.CostCapOverrideReason.Should().Be("high-cost game");
+        analysis.DomainEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<MechanicAnalysisCostCapOverriddenEvent>();
+    }
+
+    [Fact]
+    public void OverrideCostCap_WithLowerOrEqualCap_Throws()
+    {
+        var analysis = NewAnalysisWithClaim(costCap: 5m);
+        var act = () => analysis.OverrideCostCap(Guid.NewGuid(), newCapUsd: 5m, reason: "r", utcNow: DateTime.UtcNow);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    // ============================================================
+    // Helpers
+    // ============================================================
+
+    private static MechanicAnalysis NewAnalysisWithClaim(decimal costCap = 1m)
+    {
+        var analysis = MechanicAnalysis.Create(
+            sharedGameId: Guid.NewGuid(),
+            pdfDocumentId: Guid.NewGuid(),
+            promptVersion: "v1",
+            createdBy: Guid.NewGuid(),
+            createdAt: DateTime.UtcNow,
+            modelUsed: "deepseek-chat",
+            provider: "deepseek",
+            costCapUsd: costCap);
+
+        // MechanicCitation.Create validates ClaimId != Empty only (not relational integrity).
+        // The real DB FK is enforced by the EF configuration. For domain tests we reuse analysis.Id
+        // as a non-empty placeholder for ClaimId — MechanicClaim is created next and its real Id is
+        // independent, but the citation's ClaimId field is irrelevant for aggregate-level behavior.
+        var claim = MechanicClaim.Create(
+            analysisId: analysis.Id,
+            section: MechanicSection.Mechanics,
+            text: "Draw phase",
+            displayOrder: 0,
+            citations: new[]
+            {
+                MechanicCitation.Create(
+                    claimId: analysis.Id, // dummy — DB FK enforced at persistence, domain only checks non-empty
+                    pdfPage: 1,
+                    quote: "Each turn draw one card.",
+                    chunkId: null,
+                    displayOrder: 0)
+            });
+
+        analysis.AddClaim(claim);
+        return analysis;
+    }
+
+    private static MechanicAnalysis PublishedAnalysis(out Guid reviewerId, out DateTime utcNow)
+    {
+        var analysis = NewAnalysisWithClaim();
+        reviewerId = Guid.NewGuid();
+        utcNow = DateTime.UtcNow;
+        analysis.SubmitForReview(reviewerId, utcNow);
+        analysis.ApproveClaim(analysis.Claims[0].Id, reviewerId, utcNow);
+        analysis.Approve(reviewerId, utcNow);
+        return analysis;
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicAnalysisRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicAnalysisRepositoryIntegrationTests.cs
@@ -1,0 +1,412 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+
+/// <summary>
+/// Integration tests for <see cref="MechanicAnalysisRepository"/> against a real PostgreSQL
+/// database (Testcontainers). Covers Issue #523 acceptance criteria that require EF/DB behavior:
+/// partial unique index (AC-4), audit atomicity (AC-5), suppression query filter (AC-6),
+/// review queue visibility (AC-7), optimistic concurrency (AC-9), cascade deletes (AC-11).
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class MechanicAnalysisRepositoryIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private MeepleAiDbContext _dbContext = null!;
+    private MechanicAnalysisRepository _repository = null!;
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+
+    public MechanicAnalysisRepositoryIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_mechanic_{Guid.NewGuid():N}";
+        _connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        _dbContext = _fixture.CreateDbContext(_connectionString);
+        await _dbContext.Database.MigrateAsync();
+
+        var mockEventCollector = new Mock<IDomainEventCollector>();
+        mockEventCollector
+            .Setup(e => e.GetAndClearEvents())
+            .Returns(new List<Api.SharedKernel.Domain.Interfaces.IDomainEvent>().AsReadOnly());
+
+        _repository = new MechanicAnalysisRepository(_dbContext, mockEventCollector.Object);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    // ============================================================
+    // AC-4: Partial unique index — one Published+unsuppressed per SharedGame
+    // ============================================================
+
+    [Fact]
+    public async Task AC4_PartialUniqueIndex_AllowsSecondPublishedAfterFirstIsSuppressed()
+    {
+        // Arrange: seed two analyses for the same SharedGame.
+        // The partial unique index filters on `status=2 AND is_suppressed=false`,
+        // so suppressing the first Published should free the slot for a second one.
+        var sharedGameId = await SeedSharedGameAsync();
+
+        var first = await PersistPublishedAnalysisAsync(sharedGameId);
+
+        // Suppress the first → frees the unique slot.
+        var actorId = Guid.NewGuid();
+        first.Suppress(actorId, "Takedown", SuppressionRequestSource.Legal, DateTime.UtcNow, DateTime.UtcNow);
+        _repository.Update(first);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Act: publish a second analysis for the same SharedGame — should succeed.
+        var second = await PersistPublishedAnalysisAsync(sharedGameId);
+
+        // Assert: both rows coexist; only the unsuppressed one is visible via GetPublished.
+        _dbContext.ChangeTracker.Clear();
+        var total = await _dbContext.MechanicAnalyses
+            .IgnoreQueryFilters()
+            .CountAsync(a => a.SharedGameId == sharedGameId);
+        total.Should().Be(2);
+
+        var published = await _repository.GetPublishedForSharedGameAsync(sharedGameId);
+        published.Should().NotBeNull();
+        published!.Id.Should().Be(second.Id);
+    }
+
+    [Fact]
+    public async Task AC4_PartialUniqueIndex_RejectsSecondPublishedWhenFirstIsStillActive()
+    {
+        // Arrange: two Published+unsuppressed analyses for the same SharedGame should violate
+        // ux_mechanic_analyses_published_per_game.
+        var sharedGameId = await SeedSharedGameAsync();
+        await PersistPublishedAnalysisAsync(sharedGameId);
+
+        // Act + Assert: second publish raises a unique violation.
+        var act = async () => await PersistPublishedAnalysisAsync(sharedGameId);
+
+        await act.Should().ThrowAsync<DbUpdateException>()
+            .Where(ex => ex.InnerException != null
+                && ex.InnerException.Message.Contains("ux_mechanic_analyses_published_per_game",
+                    StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ============================================================
+    // AC-5: Audit rows written atomically with the aggregate state change
+    // ============================================================
+
+    [Fact]
+    public async Task AC5_StatusChange_WritesAuditRowInSameTransaction()
+    {
+        // Arrange
+        var sharedGameId = await SeedSharedGameAsync();
+        var analysis = BuildDraftAnalysisWithClaim(sharedGameId);
+        await _repository.AddAsync(analysis);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Act: SubmitForReview raises MechanicAnalysisStatusChangedEvent → repo must synthesize
+        // a mechanic_status_audit row.
+        var loaded = await _repository.GetByIdWithClaimsAsync(analysis.Id);
+        var actor = Guid.NewGuid();
+        var utcNow = DateTime.UtcNow;
+        loaded!.SubmitForReview(actor, utcNow);
+        _repository.Update(loaded);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Assert: status updated AND audit row exists with correct from/to status.
+        var entity = await _dbContext.MechanicAnalyses.AsNoTracking()
+            .FirstAsync(a => a.Id == analysis.Id);
+        entity.Status.Should().Be((int)MechanicAnalysisStatus.InReview);
+
+        var audits = await _dbContext.MechanicStatusAudits.AsNoTracking()
+            .Where(a => a.AnalysisId == analysis.Id)
+            .OrderBy(a => a.OccurredAt)
+            .ToListAsync();
+        audits.Should().HaveCount(1);
+        audits[0].FromStatus.Should().Be((int)MechanicAnalysisStatus.Draft);
+        audits[0].ToStatus.Should().Be((int)MechanicAnalysisStatus.InReview);
+        audits[0].ActorId.Should().Be(actor);
+    }
+
+    [Fact]
+    public async Task AC5_Suppress_WritesSuppressionAuditRow()
+    {
+        // Arrange
+        var sharedGameId = await SeedSharedGameAsync();
+        var published = await PersistPublishedAnalysisAsync(sharedGameId);
+
+        // Act: suppress → MechanicAnalysisSuppressedEvent → suppression audit row.
+        _dbContext.ChangeTracker.Clear();
+        var loaded = await _repository.GetByIdAsync(published.Id);
+        var actor = Guid.NewGuid();
+        loaded!.Suppress(actor, "Copyright claim", SuppressionRequestSource.Legal, DateTime.UtcNow, DateTime.UtcNow);
+        _repository.Update(loaded);
+        await _dbContext.SaveChangesAsync();
+
+        // Assert
+        var audits = await _dbContext.MechanicSuppressionAudits.AsNoTracking()
+            .Where(a => a.AnalysisId == published.Id)
+            .ToListAsync();
+        audits.Should().HaveCount(1);
+        audits[0].IsSuppressed.Should().BeTrue();
+        audits[0].ActorId.Should().Be(actor);
+        audits[0].Reason.Should().Be("Copyright claim");
+        audits[0].RequestSource.Should().Be((int)SuppressionRequestSource.Legal);
+    }
+
+    // ============================================================
+    // AC-6: Global query filter hides suppressed analyses
+    // ============================================================
+
+    [Fact]
+    public async Task AC6_SuppressedAnalysis_HiddenFromDefaultQueries()
+    {
+        // Arrange: publish, then suppress.
+        var sharedGameId = await SeedSharedGameAsync();
+        var analysis = await PersistPublishedAnalysisAsync(sharedGameId);
+
+        _dbContext.ChangeTracker.Clear();
+        var loaded = await _repository.GetByIdAsync(analysis.Id);
+        loaded!.Suppress(Guid.NewGuid(), "T5 takedown", SuppressionRequestSource.Email, DateTime.UtcNow, DateTime.UtcNow);
+        _repository.Update(loaded);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Act + Assert
+        // Player-facing query honors the filter → null.
+        var afterFilter = await _repository.GetPublishedForSharedGameAsync(sharedGameId);
+        afterFilter.Should().BeNull("global query filter hides IsSuppressed=true rows from player queries");
+
+        var byId = await _repository.GetByIdAsync(analysis.Id);
+        byId.Should().BeNull("GetByIdAsync honors the IsSuppressed filter per the interface contract");
+
+        // Direct IgnoreQueryFilters inspection confirms row still exists.
+        var rawExists = await _dbContext.MechanicAnalyses
+            .IgnoreQueryFilters()
+            .AnyAsync(a => a.Id == analysis.Id && a.IsSuppressed);
+        rawExists.Should().BeTrue();
+    }
+
+    // ============================================================
+    // AC-7: Review queue uses IgnoreQueryFilters and ordering
+    // ============================================================
+
+    [Fact]
+    public async Task AC7_GetReviewQueue_IncludesSuppressedInReviewItems_OrderedByCreatedAt()
+    {
+        // Arrange: three analyses — one Draft (excluded), two InReview (one suppressed).
+        var sharedGameId1 = await SeedSharedGameAsync();
+        var sharedGameId2 = await SeedSharedGameAsync();
+        var sharedGameId3 = await SeedSharedGameAsync();
+
+        var draft = BuildDraftAnalysisWithClaim(sharedGameId1);
+        await _repository.AddAsync(draft);
+        await _dbContext.SaveChangesAsync();
+
+        // InReview #1: oldest creation time
+        var inReviewOld = BuildDraftAnalysisWithClaim(sharedGameId2, createdAt: DateTime.UtcNow.AddMinutes(-10));
+        inReviewOld.SubmitForReview(Guid.NewGuid(), DateTime.UtcNow);
+        await _repository.AddAsync(inReviewOld);
+
+        // InReview #2: newer creation time, and suppressed — must still appear in queue.
+        var inReviewSuppressed = BuildDraftAnalysisWithClaim(sharedGameId3, createdAt: DateTime.UtcNow.AddMinutes(-1));
+        inReviewSuppressed.SubmitForReview(Guid.NewGuid(), DateTime.UtcNow);
+        inReviewSuppressed.Suppress(Guid.NewGuid(), "mod hold", SuppressionRequestSource.Other, DateTime.UtcNow, DateTime.UtcNow);
+        await _repository.AddAsync(inReviewSuppressed);
+
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Act
+        var queue = await _repository.GetReviewQueueAsync();
+
+        // Assert: 2 InReview rows, oldest first, suppressed included.
+        queue.Should().HaveCount(2);
+        queue[0].Id.Should().Be(inReviewOld.Id);
+        queue[1].Id.Should().Be(inReviewSuppressed.Id);
+        queue[1].IsSuppressed.Should().BeTrue();
+    }
+
+    // ============================================================
+    // AC-9: Optimistic concurrency via xmin RowVersion
+    // ============================================================
+
+    [Fact]
+    public async Task AC9_ConcurrentUpdate_ThrowsDbUpdateConcurrencyException()
+    {
+        // Arrange: persist analysis, then load two copies in separate contexts.
+        var sharedGameId = await SeedSharedGameAsync();
+        var analysis = BuildDraftAnalysisWithClaim(sharedGameId);
+        await _repository.AddAsync(analysis);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        await using var ctxA = _fixture.CreateDbContext(_connectionString);
+        await using var ctxB = _fixture.CreateDbContext(_connectionString);
+        var mockCollector = new Mock<IDomainEventCollector>();
+        mockCollector.Setup(e => e.GetAndClearEvents())
+            .Returns(new List<Api.SharedKernel.Domain.Interfaces.IDomainEvent>().AsReadOnly());
+        var repoA = new MechanicAnalysisRepository(ctxA, mockCollector.Object);
+        var repoB = new MechanicAnalysisRepository(ctxB, mockCollector.Object);
+
+        var copyA = await repoA.GetByIdWithClaimsAsync(analysis.Id);
+        var copyB = await repoB.GetByIdWithClaimsAsync(analysis.Id);
+
+        // Act: both copies mutate; first write wins.
+        copyA!.SubmitForReview(Guid.NewGuid(), DateTime.UtcNow);
+        repoA.Update(copyA);
+        await ctxA.SaveChangesAsync();
+
+        copyB!.SubmitForReview(Guid.NewGuid(), DateTime.UtcNow);
+        repoB.Update(copyB);
+
+        var act = async () => await ctxB.SaveChangesAsync();
+
+        // Assert
+        await act.Should().ThrowAsync<DbUpdateConcurrencyException>();
+    }
+
+    // ============================================================
+    // AC-11: Cascade delete — removing analysis cascades to claims + citations
+    // ============================================================
+
+    [Fact]
+    public async Task AC11_DeleteAnalysis_CascadesToClaimsAndCitations()
+    {
+        // Arrange
+        var sharedGameId = await SeedSharedGameAsync();
+        var analysis = BuildDraftAnalysisWithClaim(sharedGameId);
+        await _repository.AddAsync(analysis);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var claimsBefore = await _dbContext.MechanicClaims.CountAsync(c => c.AnalysisId == analysis.Id);
+        var citationsBefore = await _dbContext.MechanicCitations.CountAsync();
+        claimsBefore.Should().BeGreaterThan(0);
+        citationsBefore.Should().BeGreaterThan(0);
+
+        // Act: hard-delete the analysis row (simulates eventual purge after suppression).
+        var entity = await _dbContext.MechanicAnalyses.IgnoreQueryFilters()
+            .FirstAsync(a => a.Id == analysis.Id);
+        _dbContext.MechanicAnalyses.Remove(entity);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Assert: all children removed via ON DELETE CASCADE.
+        var claimsAfter = await _dbContext.MechanicClaims.CountAsync(c => c.AnalysisId == analysis.Id);
+        var citationsAfter = await _dbContext.MechanicCitations.CountAsync();
+        claimsAfter.Should().Be(0);
+        citationsAfter.Should().Be(0);
+    }
+
+    // ============================================================
+    // Helpers
+    // ============================================================
+
+    private async Task<Guid> SeedSharedGameAsync()
+    {
+        var sharedGameId = Guid.NewGuid();
+        _dbContext.SharedGames.Add(new SharedGameEntity
+        {
+            Id = sharedGameId,
+            Title = $"Test Game {sharedGameId:N}".Substring(0, 25),
+            Description = "Integration test game",
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            YearPublished = 2024,
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            Status = 1,
+            CreatedBy = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow
+        });
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+        return sharedGameId;
+    }
+
+    private static MechanicAnalysis BuildDraftAnalysisWithClaim(
+        Guid sharedGameId,
+        DateTime? createdAt = null)
+    {
+        var analysis = MechanicAnalysis.Create(
+            sharedGameId: sharedGameId,
+            pdfDocumentId: Guid.NewGuid(),
+            promptVersion: "v1",
+            createdBy: Guid.NewGuid(),
+            createdAt: createdAt ?? DateTime.UtcNow,
+            modelUsed: "deepseek-chat",
+            provider: "deepseek",
+            costCapUsd: 1m);
+
+        // Pre-allocate the claim Id so the citation's ClaimId matches the FK at persistence.
+        // MechanicClaim.Create() would generate a fresh Guid internally, breaking the FK link
+        // between mechanic_citations.claim_id and mechanic_claims.id.
+        var claimId = Guid.NewGuid();
+        var citation = MechanicCitation.Create(
+            claimId: claimId,
+            pdfPage: 1,
+            quote: "Each turn draw one card.",
+            chunkId: null,
+            displayOrder: 0);
+
+        var claim = MechanicClaim.Reconstitute(
+            id: claimId,
+            analysisId: analysis.Id,
+            section: MechanicSection.Mechanics,
+            text: "On each turn, draw one card.",
+            displayOrder: 0,
+            status: MechanicClaimStatus.Pending,
+            reviewedBy: null,
+            reviewedAt: null,
+            rejectionNote: null,
+            citations: new[] { citation });
+
+        analysis.AddClaim(claim);
+        return analysis;
+    }
+
+    private async Task<MechanicAnalysis> PersistPublishedAnalysisAsync(Guid sharedGameId)
+    {
+        var analysis = BuildDraftAnalysisWithClaim(sharedGameId);
+        var reviewer = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        analysis.SubmitForReview(reviewer, now);
+        analysis.ApproveClaim(analysis.Claims[0].Id, reviewer, now);
+        analysis.Approve(reviewer, now);
+
+        await _repository.AddAsync(analysis);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Reload so XminVersion reflects the DB-assigned xmin (server-generated on INSERT).
+        // Without this, subsequent repo.Update() on the returned aggregate would fail with a
+        // spurious DbUpdateConcurrencyException (original xmin=0 vs actual xmin).
+        var reloaded = await _repository.GetByIdWithClaimsAsync(analysis.Id);
+        return reloaded!;
+    }
+}

--- a/docs/architecture/adr/adr-051-mechanic-extractor-ip-policy.md
+++ b/docs/architecture/adr/adr-051-mechanic-extractor-ip-policy.md
@@ -1,0 +1,161 @@
+# ADR-051: Mechanic Extractor — IP Policy & AI-first Pipeline
+
+**Status**: Proposed
+**Date**: 2026-04-23
+**Issue**: Spec Panel Mechanic Extractor (2026-04-23) — evoluzione Variant C → AI-first
+**Decision Makers**: Product Lead, Engineering Lead
+**Related**: ADR-043 (LLM NFR), ADR-024 (PDF embedding pipeline), PR #517 (idempotent migrations pattern)
+
+---
+
+## Context
+
+Il Mechanic Extractor fu introdotto con il workflow **Variant C** ("human-authored, AI-assisted"): l'operatore scrive note sul regolamento, l'AI assiste trasformandole in draft, l'AI **non legge mai il testo originale del PDF**. Questa scelta era un **scudo preventivo di over-compliance** in assenza di consulenza IP formale: se l'AI non ha mai letto il testo, l'output non può essere derivato del testo originale.
+
+Al 2026-04-23 lo stato è:
+- Variant C implementato in `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/*`
+- Tabella `mechanic_drafts` in produzione con **0 righe** (nessuna estrazione mai finalizzata)
+- Footer UI dichiara esplicitamente *"L'AI non ha mai letto il testo del PDF originale"*
+- Frontend editor in `apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/`
+
+Due nuovi obiettivi di prodotto emergono dal Spec Panel 2026-04-23:
+
+1. **Specchietti di consultazione** — reference cards accurate per il giocatore al tavolo
+2. **Dimostrazione di comprensione AI** — artefatto che prova che l'AI comprende le regole con grounding visibile (citazioni al manuale)
+
+**Tensione con lo status quo**: entrambi gli obiettivi richiedono che l'**AI legga il PDF**, invertendo la premessa Variant C. Il footer attuale diventa tecnicamente falso e controproducente per il posizionamento "trust chain visibile".
+
+Driver della decisione:
+- L'utente carica un PDF che possiede legalmente (responsabilità downstream)
+- Le **regole funzionali** di un gioco (fatti) non sono tutelate da copyright: solo la *espressione testuale* lo è
+- Il diritto di citazione (art. 70 L.633/41 in Italia, fair use negli US) consente quote brevi con attribution
+- Senza AI-on-PDF, il purpose 2 (comprehension demo con citations) è irrealizzabile
+
+---
+
+## Decision
+
+**Sostituire il modello Variant C (AI-no-read)** con un **modello AI-first con citation enforcement e review gate umano**, formalizzando la IP policy tramite vincoli tecnici auto-applicati.
+
+### Policy di uso dei contenuti del manuale
+
+1. **Riformulazione obbligatoria**: ogni claim prodotto dall'AI deve essere **non-letterale**. Trascrizione o traduzione fedele del testo originale è **vietata**.
+2. **Quote cap**: ogni citation può contenere una `quote` testuale del manuale di **massimo 25 parole** (soglia fair use conservativa).
+3. **Citation obbligatoria**: ogni claim pubblicato deve avere almeno **una citation con `pdf_page`** e `quote ≤ 25 parole` a scopo di attribution.
+4. **Attribution visibile**: l'UI player-facing mostra copyright dell'editore originale e link al claim → citation.
+5. **Responsabilità di upload sull'utente**: il Terms of Service stabilisce che l'utente dichiara di possedere una copia legittima del PDF caricato (contratto esistente da rivedere).
+6. **Takedown policy**: un editore può richiedere la soppressione di `mechanic_cards` per i propri giochi; effetto immediato senza deploy via flag `is_suppressed`.
+7. **Review gate umano obbligatorio**: nessuna `mechanic_card` viene pubblicata senza approvazione esplicita di un admin (per-claim review); questo è anche un controllo di qualità, non solo IP.
+
+### Vincoli tecnici enforced dal sistema
+
+| # | Vincolo | Implementazione |
+|---|---------|-----------------|
+| T1 | Quote length ≤ 25 parole | Validator post-LLM: reject + re-prompt se violato |
+| T2 | Rejection sampling su copia letterale | Post-check: se una sequenza di output matcha > 10 parole consecutive del PDF source → reject + re-prompt |
+| T3 | Citation obbligatoria per claim | JSON schema enforcement nel prompt + validator applicativo |
+| T4 | Page reference verificabile | `citation.pdf_page` deve puntare a una pagina esistente nel PDF; `quote` deve essere substring del chunk associato |
+| T5 | Kill switch `is_suppressed` | Bool su `mechanic_cards`, indice parziale `WHERE is_suppressed = false` |
+| T6 | Audit log review | Ogni `status` transition su `mechanic_analyses` produce una riga in audit log con `reviewed_by`, `reviewed_at` |
+| T7 | Prompt versioning | `prompt_version` colonna + UNIQUE `(shared_game_id, pdf_document_id, prompt_version)` → riproducibilità |
+| T8 | Cost cap | Pre-flight estimate + hard cap default €2.00/analisi; override esplicito admin con reason |
+
+### Messaggio di attribution (UI)
+
+**Rimosso** (footer Variant C):
+> *"L'AI non ha mai letto il testo del PDF originale."*
+
+**Sostituito con** (footer unificato):
+> *"Analisi elaborata dall'AI sul manuale del gioco. Ogni affermazione è riformulata in parole originali e cita la pagina del regolamento. Copyright © degli editori per il testo originale del manuale."*
+
+### Deprecazione Variant C
+
+- `mechanic_drafts` e rotta editor esistente diventano **legacy/deprecated**
+- Banner deprecation sull'editor + redirect suggerito al nuovo flow AI-first
+- **Nessuna migrazione dati** (0 righe esistenti)
+- Codice rimosso post ≥ 6 mesi di sunset (tracked separatamente)
+
+---
+
+## Consequences
+
+### Positive
+
+- ✅ Sblocca purpose 1 (specchietti) e purpose 2 (comprehension demo) tecnicamente e legalmente
+- ✅ Pipeline unica (no dual-path Variant C + AI-first) → meno complessità, più coerenza
+- ✅ Citation visibile = differenziante competitivo vs LLM generici
+- ✅ Review gate = controllo qualità + IP safety in un unico step
+- ✅ Policy scritta → protegge in caso di dispute (ADR come evidenza di due diligence)
+- ✅ Pipeline condivisibile con chat RAG (stesso grounding, stessa policy quote cap)
+
+### Negative
+
+- ❌ Footer attuale va sostituito in UI esistente (breaking visuale)
+- ❌ Variant C effort speso diventa solo legacy (0 righe → zero valore prodotto perso, ma code to deprecate)
+- ❌ Review gate è un collo di bottiglia scalabilità (1 admin review ≈ 5-15 min/gioco)
+- ❌ T2 (rejection sampling letterale) può aumentare latency (retry) e cost (token ri-generati)
+
+### Rischi residui mitigati ma non eliminati
+
+- 🟡 **Takedown request da editore**: mitigazione via `is_suppressed` immediato; impossibile prevenire del tutto (serve diplomazia/partnership)
+- 🟡 **Quote cap 25 parole** è uno standard editoriale conservativo, non una soglia legale hard; un giudice potrebbe valutare diversamente in dispute
+- 🟡 **Player feedback come loop anti-hallucination**: dipende da volume utenti (cold start problem)
+- 🟡 **Responsabilità upload utente** copre solo dal lato civile; se l'utente carica un PDF piratato consapevolmente, MeepleAI potrebbe essere co-obbligata a vigilanza (richiede ToS review legale)
+
+### Follow-up obbligatori
+
+- **ToS review** con consulenza legale IP entro M2 (prima del lancio card pubbliche login-gated)
+- **Template takedown request** pubblicato su sito + email `takedown@meepleai.app`
+- **Periodico audit** (ogni 3 mesi) di campione `mechanic_cards` per verificare compliance T1-T4
+
+---
+
+## Alternatives Considered
+
+### A. Mantenere Variant C come unico path
+
+**Pro**: Zero rischio IP aggiuntivo
+**Contro**: Purpose 2 (comprehension demo con citation) impossibile senza AI-on-PDF. Purpose 1 (specchietto) limitato dalla velocità di input manuale umano. Effort di scrivere le note manualmente frena adozione.
+**Reject**: non soddisfa i goal del spec panel 2026-04-23.
+
+### B. AI-on-PDF senza vincoli di quote length o review gate
+
+**Pro**: Massima libertà, meno complessità implementativa
+**Contro**: Rischio IP alto (output può contenere copie letterali) + rischio reputazionale alto (hallucination pubblicate senza filtro).
+**Reject**: asimmetria di rischio (1 errore = 10 win annullati) rende indifendibile.
+
+### C. AI-on-PDF con guardrails tecnici + review gate ← **DECISIONE ADOTTATA**
+
+**Pro**: Bilancia apertura e safety. Sblocca entrambi i purpose. Protezione a strati (prompt → post-check → review umano → feedback loop).
+**Contro**: Più complessità (ma distribuita lungo il pipeline, non in un singolo layer).
+
+### D. Outsource compliance a modelli open-source on-prem
+
+**Pro**: Nessun terzo vede il PDF (DeepSeek/OpenRouter ricevono chunks)
+**Contro**: Cost & latency molto peggiori. Non sposta la sostanza del rischio IP (è l'output pubblicato, non il processing, a generare esposizione).
+**Reject**: trade-off non vale il complexity increase.
+
+---
+
+## References
+
+- Spec Panel Mechanic Extractor 2026-04-23 (interno, conversazione Claude)
+- ADR-043: LLM subsystem NFR (policy cost cap e fallback)
+- ADR-024: Advanced PDF embedding pipeline (chunking + pgvector)
+- [PR #517](https://github.com/meepleAi-app/meepleai-monorepo/pull/517) — Pattern idempotent migration
+- Legge italiana 633/1941 art. 70 (diritto di citazione)
+- 17 U.S.C. § 107 (Fair Use)
+- [Feist Publications v. Rural Telephone Service (1991)](https://supreme.justia.com/cases/federal/us/499/340/) — fatti non sono copyrightable
+- File attuale: `apps/api/src/Api/Routing/AdminMechanicExtractorEndpoints.cs`
+- File attuale: `apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/review/page.tsx`
+
+---
+
+## Target Games per M1 Testing
+
+| Gioco | SharedGameId | PDF status | Motivo |
+|-------|--------------|-----------|--------|
+| **Catan** | `6b76bdb3-424e-44bc-b02f-cb939ee9538b` | ✅ 1 PDF Ready | Gioco semplice (~20 pagine), noto globalmente, baseline |
+| **Mage Knight Board Game** | `8a9f8a90-594a-4316-a32e-daa43a4356fb` | ⚠️ **0 PDF Ready** | Gioco complesso (~100 pagine), stress test prompt + chunking. **Richiede upload PDF prima di M1.2** |
+
+**Gate M1**: per procedere al test su Mage Knight, occorre prima caricare un PDF Ready del manuale (responsabilità operatore, parte del setup M1.2).

--- a/docs/features/mechanic-extractor-ai-first-mockups.md
+++ b/docs/features/mechanic-extractor-ai-first-mockups.md
@@ -1,0 +1,481 @@
+# Mechanic Extractor AI-First — UI Mockups
+
+**Parent ADR**: [ADR-051](../architecture/adr/adr-051-mechanic-extractor-ip-policy.md)
+**Epic**: meepleAi-app/meepleai-monorepo#539
+**Date**: 2026-04-23
+**Status**: Draft for M1 implementation
+
+## Surfaces
+
+1. **Admin — Generation form** (new analysis trigger) → Issue #524
+2. **Admin — Review UI per-claim** → Issue #526
+3. **Admin — Publish confirm modal** → Issue #527
+4. **Player — Public card page** → Issue #528
+5. **Player — Citation side-panel** (M2 polish, see #530)
+
+All mockups use ASCII to keep them version-controllable. Visual design applies:
+- Palette Hybrid Warm-Modern (`--nh-bg-base`, amber accent)
+- Typography Quicksand (headings) + Nunito (body)
+- Component kit: `MeepleCard`, `Badge`, `Button`, `Skeleton`, `AlertDialog`
+
+---
+
+## 1. Admin — Generation Form (#524)
+
+**Route**: `/admin/knowledge-base/mechanic-analyses/new`
+
+**Purpose**: Trigger new AI analysis from a `(sharedGameId, pdfDocumentId)` pair.
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ ← Indietro                                    [ Admin / Knowledge Base ] │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  Nuova Analisi Meccaniche (AI-first)                                    │
+│  Genera card consultabile a partire dal manuale del gioco               │
+│                                                                         │
+│  ┌─────────────────────────────────────────────────────────────────┐   │
+│  │ Gioco                                                           │   │
+│  │ ┌───────────────────────────────────────────────────────────┐  │   │
+│  │ │ 🔍  Cerca gioco…                                          ▼ │  │   │
+│  │ └───────────────────────────────────────────────────────────┘  │   │
+│  │                                                                 │   │
+│  │ Catalogo community · 1.247 giochi                              │   │
+│  └─────────────────────────────────────────────────────────────────┘   │
+│                                                                         │
+│  ┌─────────────────────────────────────────────────────────────────┐   │
+│  │ Manuale PDF                                                     │   │
+│  │                                                                 │   │
+│  │ ○ 📄  catan-rules-4th-ed-EN.pdf    · 19 pagine · Ready          │   │
+│  │ ○ 📄  catan-rules-4th-ed-IT.pdf    · 22 pagine · Ready          │   │
+│  │                                                                 │   │
+│  │ ⚠️ Solo PDF con stato "Ready" sono eleggibili                  │   │
+│  └─────────────────────────────────────────────────────────────────┘   │
+│                                                                         │
+│  ┌─────────────────────────────────────────────────────────────────┐   │
+│  │ Configurazione avanzata                              ▶ Espandi │   │
+│  │                                                                 │   │
+│  │   Prompt version:  [ v1 (default) ▼ ]                          │   │
+│  │   Cost cap:        [ €2.00         ]   (max per analisi)       │   │
+│  │   Override:        ☐ Autorizza costo sopra cap (richiede motivo)│   │
+│  └─────────────────────────────────────────────────────────────────┘   │
+│                                                                         │
+│  ╔═════════════════════════════════════════════════════════════════╗   │
+│  ║  📊 Stima preliminare                                            ║   │
+│  ║  • Chunks da analizzare:      ~34                                ║   │
+│  ║  • Token input stimati:       ~18.000                            ║   │
+│  ║  • Costo stimato:             €0.42 (DeepSeek primary)           ║   │
+│  ║  • Tempo stimato:             ~45s                               ║   │
+│  ╚═════════════════════════════════════════════════════════════════╝   │
+│                                                                         │
+│                              [ Annulla ]  [ ⚡ Genera Analisi ]        │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### State variations
+
+- **Game not yet selected**: PDF selector disabled with hint "Seleziona prima il gioco"
+- **PDF exists but not Ready**: Shown greyed out with status badge (`Processing`, `Error`)
+- **No PDF available**: Empty state with CTA "Carica manuale"
+- **Cost estimate exceeds cap**: Red banner + require override + reason input
+- **Generation in progress**: Full-form skeleton + spinner + "Analisi in corso… ~45s" + link "Apri in background"
+
+---
+
+## 2. Admin — Review UI per-claim (#526)
+
+**Route**: `/admin/knowledge-base/mechanic-analyses/[analysisId]/review`
+
+**Purpose**: Admin approva/rifiuta ogni singolo claim, con citation viewer inline al PDF.
+
+### Header + summary
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ ← Indietro                                     [ Admin / Review ]       │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  Catan — Analisi Meccaniche                                             │
+│  Generated 2026-04-23 14:32 · DeepSeek v1 · 19 pagine · €0.38           │
+│                                                                         │
+│  [ ⏳ PENDING REVIEW ]   claims: 23  ·  citations: 31                   │
+│                                                                         │
+│  ┌─────────────────────────────────────────────────────────────────┐   │
+│  │ Guardrail status                                                │   │
+│  │                                                                 │   │
+│  │  ✅ T1 Quote length ≤ 25 parole   (31/31)                      │   │
+│  │  ✅ T2 No copie letterali         (0 rejection)                │   │
+│  │  ✅ T3 Citation per claim         (23/23)                      │   │
+│  │  ⚠️ T4 Pagine verificabili        (30/31 · 1 warning)          │   │
+│  │  ✅ T8 Costo entro cap            (€0.38 / €2.00)              │   │
+│  └─────────────────────────────────────────────────────────────────┘   │
+│                                                                         │
+│  Bulk actions:  [ Approva tutti ]  [ Rifiuta quote >20 parole ]        │
+│                 [ Filtra: ⚠️ solo warning ]                            │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### Two-column layout: claim list | PDF viewer
+
+```
+┌───────────────────────────────────┬─────────────────────────────────────┐
+│ CLAIM LIST (sticky, scrollable)   │ PDF VIEWER (synced to selected)     │
+├───────────────────────────────────┼─────────────────────────────────────┤
+│                                   │                                     │
+│ ╔═══════════════════════════════╗ │   [←] pag. 3 / 19    [→]  [100% ▼] │
+│ ║ § Sommario                    ║ │  ┌───────────────────────────────┐ │
+│ ║                               ║ │  │                               │ │
+│ ║ □ Claim 1 · ⚡                ║ │  │  Catan è un gioco di          │ │
+│ ║   Claim 1 text preview…       ║ │  │  commercio e colonizzazione   │ │
+│ ║   📍 p.1 · ✅ T1-T4 ok        ║ │  │  per 3-4 giocatori dove…      │ │
+│ ║   [ ✓ Approva ] [ ✗ Rifiuta ] ║ │  │                               │ │
+│ ║                               ║ │  │  [HIGHLIGHT: "commercio e     │ │
+│ ║ □ Claim 2                     ║ │  │   colonizzazione per 3-4"]    │ │
+│ ║   Durata partita: 60-90 min.  ║ │  │                               │ │
+│ ║   📍 p.2 · ✅ ok              ║ │  │  ...                          │ │
+│ ║                               ║ │  │                               │ │
+│ ╚═══════════════════════════════╝ │  │                               │ │
+│                                   │  │                               │ │
+│ ╔═══════════════════════════════╗ │  │                               │ │
+│ ║ § Meccaniche (6)              ║ │  │                               │ │
+│ ║                               ║ │  │                               │ │
+│ ║ □ Claim 3 · ⭐ SELECTED       ║ │  │                               │ │
+│ ║   "Il giocatore raccoglie     ║ │  │                               │ │
+│ ║    materie prime basate sul   ║ │  │                               │ │
+│ ║    tiro dei dadi"             ║ │  │                               │ │
+│ ║   📍 p.4 · ✅ ok              ║ │  │                               │ │
+│ ║                               ║ │  │                               │ │
+│ ║   └─ Citation [p.4]           ║ │  │                               │ │
+│ ║      "…ogni giocatore         ║ │  │                               │ │
+│ ║       riceve risorse dei      ║ │  │                               │ │
+│ ║       territori confinanti    ║ │  │                               │ │
+│ ║       al numero tirato"       ║ │  │                               │ │
+│ ║      (19 parole · ✅ T1)      ║ │  │                               │ │
+│ ║                               ║ │  │                               │ │
+│ ║   Note admin:                 ║ │  │                               │ │
+│ ║   [____________________]      ║ │  │                               │ │
+│ ║                               ║ │  │                               │ │
+│ ║   [ ✓ Approva ] [ ✗ Rifiuta ] ║ │  └───────────────────────────────┘ │
+│ ╚═══════════════════════════════╝ │                                     │
+│                                   │                                     │
+│ ╔═══════════════════════════════╗ │                                     │
+│ ║ § Vittoria                    ║ │                                     │
+│ ║ § Risorse (5)                 ║ │                                     │
+│ ║ § Fasi                        ║ │                                     │
+│ ║ § FAQ                         ║ │                                     │
+│ ╚═══════════════════════════════╝ │                                     │
+└───────────────────────────────────┴─────────────────────────────────────┘
+
+     Footer sticky:
+┌─────────────────────────────────────────────────────────────────────────┐
+│  Progresso review: 12/23 approvati · 1 rifiutato · 10 pending          │
+│                                                                         │
+│  [ Salva bozza ]              [ ← Richiedi modifiche ]  [ Approva → ]  │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### Claim status indicators
+
+| Badge | Significato |
+|-------|-------------|
+| ✅ T1-T4 ok | Tutti guardrail verdi |
+| ⚠️ T4 | Pagina citata non esiste (warning, non blocking) |
+| ❌ T1 | Quote >25 parole (auto-rejected, mostrato per audit) |
+| ⚡ | AI high-confidence |
+| 🔍 | AI low-confidence (richiede review attento) |
+
+### Interactions
+
+- Click su claim → sync PDF viewer + highlight quote sulla pagina
+- Click su citation badge `[p.N]` → stessa azione
+- Keyboard shortcuts: `j/k` navigate claims, `a` approve, `r` reject, `n` focus note field
+- Unsaved changes → `AlertDialog` "Sei sicuro di abbandonare?" on navigate away
+- Submit review → transition `pending_review` → `approved` (all approved) o `rejected` (any rejected + overall rejected)
+- Partial review → status resta `pending_review`, bozza salvata
+
+### Footer attribution (replaces Variant C footer)
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ Analisi elaborata dall'AI sul manuale del gioco. Ogni affermazione è    │
+│ riformulata in parole originali e cita la pagina del regolamento.       │
+│ Copyright © degli editori per il testo originale del manuale.           │
+│                                                                         │
+│ Modello: DeepSeek v1 · 4.823 token · €0.38                              │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. Admin — Publish confirm modal (#527)
+
+**Trigger**: Click "Approva →" con tutti claim approvati → apre modal conferma.
+
+```
+╔═════════════════════════════════════════════════════════════════════════╗
+║  Pubblica analisi come card?                                          × ║
+╠═════════════════════════════════════════════════════════════════════════╣
+║                                                                         ║
+║  Gioco:        Catan                                                    ║
+║  Analisi:      #a7f3-…-9bc2 · DeepSeek v1                              ║
+║  Claim:        23 approvati, 0 rifiutati                                ║
+║  Citations:    31 con pdf_page verificato                               ║
+║                                                                         ║
+║  La card sarà visibile a utenti loggati su:                             ║
+║  /games/catan/card                                                      ║
+║                                                                         ║
+║  ⚠️ Questa azione:                                                       ║
+║  • Pubblica immediatamente (nessun ulteriore gate)                      ║
+║  • Sostituisce eventuale card precedente (versione +1)                  ║
+║  • È tracciata in audit log                                             ║
+║                                                                         ║
+║  Titolo card:  [ Catan — Specchietto regole           ]                ║
+║                                                                         ║
+║                              [ Annulla ]   [ Pubblica ora ]            ║
+╚═════════════════════════════════════════════════════════════════════════╝
+```
+
+On success → toast "Card pubblicata su /games/catan/card" + link + redirect a pagina review con badge `PUBLISHED`.
+
+---
+
+## 4. Player — Public card page (#528)
+
+**Route**: `/games/[slug]/card` (login-gated in M1).
+
+**Purpose**: Specchietto consultabile al tavolo + comprehension demo per utenti.
+
+### Desktop layout
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  [Navbar MeepleAI]                                         [User menu] │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  ┌───────────────────────────────────────────────────────────────────┐ │
+│  │  Catan                                                             │ │
+│  │  Specchietto regole · versione 1 · pubblicata 23 apr 2026         │ │
+│  │                                                                    │ │
+│  │  [ 🤖 AI-generated · 👤 Human-reviewed ]   [ Come funziona? ]     │ │
+│  │                                                                    │ │
+│  │  🖨️ Stampa · 📤 Condividi · ⬇️ Download PDF                       │ │
+│  └───────────────────────────────────────────────────────────────────┘ │
+│                                                                         │
+│  ╔═══════════════════════════════════════════════════════════════════╗ │
+│  ║ 📖 Sommario                                                        ║ │
+│  ║                                                                    ║ │
+│  ║ Gioco di commercio e colonizzazione per 3-4 giocatori su isola    ║ │
+│  ║ modulare. Obiettivo: accumulare 10 punti vittoria tramite         ║ │
+│  ║ insediamenti, città e sviluppo territoriale.  [p.1] [p.2]         ║ │
+│  ║                                                                    ║ │
+│  ║ 🕐 60-90 min · 👥 3-4 giocatori · 🎯 Età 10+                      ║ │
+│  ╚═══════════════════════════════════════════════════════════════════╝ │
+│                                                                         │
+│  ╔═══════════════════════════════════════════════════════════════════╗ │
+│  ║ 🎲 Meccaniche principali                        6 meccaniche       ║ │
+│  ║                                                                    ║ │
+│  ║  • Raccolta risorse su tiro dadi  [p.4]                           ║ │
+│  ║  • Commercio tra giocatori  [p.6]                                 ║ │
+│  ║  • Costruzione strade/insediamenti  [p.5] [p.7]                   ║ │
+│  ║  • Carte sviluppo (cavaliere, progresso, vittoria)  [p.9]        ║ │
+│  ║  • Ladrone (blocco risorse + furto)  [p.8]                       ║ │
+│  ║  • Porto (commercio con banco a rapporto favorevole)  [p.6]      ║ │
+│  ╚═══════════════════════════════════════════════════════════════════╝ │
+│                                                                         │
+│  ╔═══════════════════════════════════════════════════════════════════╗ │
+│  ║ 🏆 Come si vince                                                   ║ │
+│  ║                                                                    ║ │
+│  ║  Il primo giocatore a raggiungere 10 punti vittoria nel proprio   ║ │
+│  ║ turno. [p.3]                                                       ║ │
+│  ║                                                                    ║ │
+│  ║  Fonti di punti:                                                   ║ │
+│  ║   • Insediamento:     1 PV                                         ║ │
+│  ║   • Città:            2 PV                                         ║ │
+│  ║   • Strada più lunga: 2 PV (bonus)                                ║ │
+│  ║   • Esercito grande:  2 PV (bonus)                                ║ │
+│  ║   • Carte vittoria:   1 PV ciascuna                               ║ │
+│  ╚═══════════════════════════════════════════════════════════════════╝ │
+│                                                                         │
+│  ╔═══════════════════════════════════════════════════════════════════╗ │
+│  ║ 📦 Risorse                                      5 tipi             ║ │
+│  ║                                                                    ║ │
+│  ║  ┌──────────┬──────────┬─────────────────────────┬─────────────┐  ║ │
+│  ║  │ Risorsa  │ Da       │ Serve per               │ Limitata    │  ║ │
+│  ║  ├──────────┼──────────┼─────────────────────────┼─────────────┤  ║ │
+│  ║  │ Legno    │ Foresta  │ Strade, insediamenti    │ No (banco)  │  ║ │
+│  ║  │ Argilla  │ Collina  │ Strade, insediamenti    │ No (banco)  │  ║ │
+│  ║  │ Grano    │ Campo    │ Insediamenti, città, C.S│ No (banco)  │  ║ │
+│  ║  │ Pecora   │ Pascolo  │ Insediamenti, C.Svil.   │ No (banco)  │  ║ │
+│  ║  │ Minerale │ Montagna │ Città, C.Svil.          │ No (banco)  │  ║ │
+│  ║  └──────────┴──────────┴─────────────────────────┴─────────────┘  ║ │
+│  ║                                                                    ║ │
+│  ║  Dettagli: [p.4] [p.5]                                             ║ │
+│  ╚═══════════════════════════════════════════════════════════════════╝ │
+│                                                                         │
+│  ╔═══════════════════════════════════════════════════════════════════╗ │
+│  ║ ▶ Fasi del turno                                                   ║ │
+│  ║                                                                    ║ │
+│  ║  ①  Tiro dei dadi       → raccolta risorse  [p.10]                ║ │
+│  ║  ②  Commercio           → marittimo/terrestre  [p.11]             ║ │
+│  ║  ③  Costruzione         → strade, insediamenti, città, carte      ║ │
+│  ║  ④  Fine turno          → passa al giocatore successivo           ║ │
+│  ╚═══════════════════════════════════════════════════════════════════╝ │
+│                                                                         │
+│  ╔═══════════════════════════════════════════════════════════════════╗ │
+│  ║ ❓ Domande frequenti                                               ║ │
+│  ║                                                                    ║ │
+│  ║  ▸ Cosa succede se esce il 7?                                     ║ │
+│  ║    Il ladrone si muove. Giocatori con >7 carte scartano metà.    ║ │
+│  ║    [p.8]                                                           ║ │
+│  ║                                                                    ║ │
+│  ║  ▸ Posso commerciare a qualunque rapporto?                        ║ │
+│  ║    Con altri giocatori sì. Con banco standard 4:1, con porto     ║ │
+│  ║    2:1 o 3:1.  [p.6]                                              ║ │
+│  ║                                                                    ║ │
+│  ║  ▸ Le strade si possono distruggere?                              ║ │
+│  ║    No, una volta costruite restano fino a fine partita.  [p.7]    ║ │
+│  ╚═══════════════════════════════════════════════════════════════════╝ │
+│                                                                         │
+│  ┌───────────────────────────────────────────────────────────────────┐ │
+│  │ Analisi elaborata dall'AI sul manuale del gioco. Ogni affermazione│ │
+│  │ è riformulata in parole originali e cita la pagina del regolamento│ │
+│  │                                                                    │ │
+│  │ Copyright © CATAN GmbH per il testo originale del manuale.        │ │
+│  │ MeepleAI analisi AI · v1 · 23 apr 2026                            │ │
+│  │                                                                    │ │
+│  │ 🚩 Segnala errore  ·  📧 Takedown request                         │ │
+│  └───────────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### Citation badge interaction
+
+- Hover `[p.4]` → tooltip `"ogni giocatore riceve risorse dei territori confinanti…" (19 parole)`
+- Click `[p.4]` → **side-panel** (see surface #5 below)
+
+### Mobile layout (portrait, ≤768px)
+
+```
+┌──────────────────────┐
+│ [≡] Catan        [👤]│
+├──────────────────────┤
+│                      │
+│  Catan               │
+│  Specchietto · v1    │
+│  🤖 AI · 👤 Review   │
+│                      │
+│  [🖨️] [📤] [⬇️]      │
+│                      │
+│  ━━━ 📖 Sommario ━━━ │
+│                      │
+│  Gioco di commercio  │
+│  e colonizzazione    │
+│  per 3-4 giocatori…  │
+│  [p.1] [p.2]        │
+│                      │
+│  🕐 60-90 min        │
+│  👥 3-4 giocatori    │
+│                      │
+│  ━━━ 🎲 Meccaniche ━━│
+│                      │
+│  • Raccolta risorse  │
+│    [p.4]             │
+│  • Commercio [p.6]   │
+│  ...                 │
+│                      │
+│  [Scroll per vedere  │
+│   tutte le sezioni]  │
+└──────────────────────┘
+```
+
+### Print layout
+
+- Stacked A4 con header gioco ripetuto su ogni pagina
+- Citation badge collassati a piè di pagina come note (`¹ p.4 · ² p.6`)
+- No background, no shadow, no interactive elements
+- Footer con copyright + MeepleAI analysis metadata
+
+---
+
+## 5. Player — Citation side-panel (#530, M2 polish)
+
+**Trigger**: Click su badge `[p.N]` dalla card pubblica.
+
+```
+┌──────────────────────────────────┬─────────────────────────────────┐
+│  (card pubblica, dimmed)         │  Citation · Pagina 4         × │
+│                                  │                                 │
+│                                  │ ┌─────────────────────────────┐ │
+│                                  │ │ 📄 PDF viewer               │ │
+│                                  │ │                             │ │
+│                                  │ │  ...                        │ │
+│                                  │ │                             │ │
+│                                  │ │  "ogni giocatore riceve     │ │
+│                                  │ │   risorse dei territori     │ │
+│                                  │ │   confinanti al numero      │ │
+│                                  │ │   tirato"                   │ │
+│                                  │ │  [HIGHLIGHTED]              │ │
+│                                  │ │                             │ │
+│                                  │ │  ...                        │ │
+│                                  │ │                             │ │
+│                                  │ └─────────────────────────────┘ │
+│                                  │                                 │
+│                                  │  📋 Copia citazione            │
+│                                  │  ⬇️ Apri PDF                    │
+│                                  │                                 │
+│                                  │  Quote: 19 parole               │
+│                                  │  © CATAN GmbH                   │
+└──────────────────────────────────┴─────────────────────────────────┘
+```
+
+### A11y
+
+- Focus trap su side-panel open
+- ESC chiude panel e ritorna focus al badge `[p.N]`
+- `aria-describedby` collega claim ↔ citation
+- Keyboard nav: `Tab` attraverso badges, `Enter` apre panel, `Shift+Tab` torna indietro
+
+---
+
+## Component map → code
+
+| UI element | Component | Path |
+|------------|-----------|------|
+| Outer layout | `DashboardShell` | `apps/web/src/components/shell/dashboard-shell.tsx` |
+| Review claim card | **NEW** `ClaimReviewCard` | `apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-analyses/_components/claim-review-card.tsx` |
+| Citation badge | **NEW** `CitationBadge` | `apps/web/src/components/shared/citation-badge.tsx` (riuso su admin + player) |
+| Citation side-panel | **NEW** `CitationSidePanel` | `apps/web/src/components/shared/citation-side-panel.tsx` |
+| PDF viewer (admin review) | Riuso esistente | `apps/web/src/components/pdf/pdf-viewer.tsx` |
+| Publish confirm modal | `AlertDialog` primitive | `apps/web/src/components/ui/overlays/alert-dialog-primitives` |
+| Card section | Riuso `Card` + `CardHeader` | `apps/web/src/components/ui/data-display/card.tsx` |
+| Guardrail status | **NEW** `GuardrailBadge` | `apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-analyses/_components/guardrail-badge.tsx` |
+| Stats row | Riuso `StatCard` (già in review/page.tsx) | promuovere a shared |
+
+## API calls map
+
+| UI action | Endpoint | Issue |
+|-----------|----------|-------|
+| Form submit "Genera" | `POST /api/v1/admin/mechanic-analyses` | #524 |
+| Load review data | `GET /api/v1/admin/mechanic-analyses/{id}` | #524 |
+| Submit review | `POST /api/v1/admin/mechanic-analyses/{id}/review` | #526 |
+| Publish | `POST /api/v1/admin/mechanic-analyses/{id}/publish` | #527 |
+| Load public card | `GET /api/v1/mechanic-cards?shared_game_slug=catan` | #528 |
+| Load PDF page for citation | `GET /api/v1/pdfs/{pdfId}/download` + page anchor | existing |
+
+## Design tokens usage
+
+- Card bg: `bg-white/70 backdrop-blur-md` (admin) / `bg-white` (public, più solido)
+- Section headers: `font-quicksand text-xl` + emoji-prefixed
+- Citation badge: `border-amber-300 bg-amber-50 text-amber-900` (hover: darker)
+- Guardrail verde: `bg-green-50 border-green-300 text-green-800`
+- Guardrail warning: `bg-amber-50 border-amber-300 text-amber-800`
+- Guardrail error: `bg-red-50 border-red-300 text-red-800`
+
+## Next steps
+
+Dopo validazione mockup → **Artifact 4** (piano tecnico M1.1-M1.3):
+- Schema classes C# + EF configurations
+- SQL idempotent migration completa
+- Prompt template v1 con JSON schema
+- Guardrail validators codice
+- Test fixtures (Catan subset)

--- a/docs/features/mechanic-extractor-ai-first-technical-plan.md
+++ b/docs/features/mechanic-extractor-ai-first-technical-plan.md
@@ -1,0 +1,1023 @@
+# Mechanic Extractor AI-first — Piano Tecnico M1.1–M1.3
+
+**Stato**: Proposta implementativa
+**Data**: 2026-04-23
+**Scope**: Milestone M1 — Core Pipeline (issue ME-M1.1 → ME-M1.3, #523-#525)
+**Related**: [ADR-051](../architecture/adr/adr-051-mechanic-extractor-ip-policy.md) · [Issue roadmap](../roadmap/mechanic-extractor-ai-first-issues.md) · [UI mockups](./mechanic-extractor-ai-first-mockups.md)
+
+> Questo documento traduce le tre issue fondamentali (schema, prompt+command, guardrails) in un piano concreto: file da creare, DDL idempotente, JSON schema, firme validator, test fixtures. Non include codice completo (ogni issue produce la sua PR) ma ne definisce i contratti.
+
+---
+
+## 1. Panoramica build order
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ ME-M1.1  Schema DB + EF                        #523          │
+│   ├─ MechanicAnalysis (aggregate root)                       │
+│   ├─ MechanicClaim (entity, child)                           │
+│   ├─ MechanicCitation (value object, owned)                  │
+│   └─ migration 20260428_AddMechanicAnalyses.cs               │
+├─────────────────────────────────────────────────────────────┤
+│ ME-M1.2  Command GenerateMechanicAnalysis      #524          │
+│   ├─ Prompt template v1 (system + user)                      │
+│   ├─ JSON schema output (claims[] with citations[])          │
+│   ├─ Handler: chunk retrieval → LLM → persist Draft          │
+│   └─ Rollback on validator failure (see M1.3)                │
+├─────────────────────────────────────────────────────────────┤
+│ ME-M1.3  Guardrails T1-T4, T8                  #525          │
+│   ├─ T1 QuoteLengthValidator (≤25 words)                     │
+│   ├─ T2 LiteralCopyValidator (>10 consecutive words)         │
+│   ├─ T3 CitationRequiredValidator                            │
+│   ├─ T4 CitationPageVerifier (substring + page exists)       │
+│   └─ T8 CostCapValidator (pre-flight € 2.00)                 │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Parallelizzabile**: M1.1 e prompt template di M1.2 possono procedere in parallelo. Il validator di M1.3 può essere stub-bed durante M1.2 (contract-first).
+
+---
+
+## 2. ME-M1.1 — Schema & Persistenza
+
+### 2.1 Entity layout (DDD)
+
+**Bounded context**: `SharedGameCatalog` (condiviso, come `MechanicDraft`)
+**Aggregate root**: `MechanicAnalysis`
+
+```
+MechanicAnalysis (aggregate root)
+├─ Id, SharedGameId, PdfDocumentId, PromptVersion, Status, CreatedBy, ReviewedBy, ReviewedAt
+├─ TotalTokensUsed, EstimatedCostUsd, ModelUsed, Provider
+│
+│  — T8 cost governance (ADR-051) —
+├─ CostCapUsd (decimal, default 2.0 from config MechanicExtractor:CostCapUsd)
+├─ CostCapOverrideAt, CostCapOverrideBy, CostCapOverrideReason (admin-only override trail)
+│
+│  — T5 takedown kill-switch + SLA tracking —
+├─ IsSuppressed (bool), SuppressedAt, SuppressedBy, SuppressionReason
+├─ SuppressionRequestedAt (nullable — when the takedown request arrived)
+├─ SuppressionRequestSource (nullable enum: Email=1 | Legal=2 | Other=3)
+│
+├─ [concurrency] xmin (PostgreSQL system column — NOT mapped as C# property;
+│                     configured via .UseXminAsConcurrencyToken() in EF)
+└─ Claims: IReadOnlyList<MechanicClaim>
+       ├─ Id, AnalysisId, Section (enum), Text, DisplayOrder, Status, ReviewedBy, ReviewedAt, RejectionNote
+       ├─ [concurrency] xmin (same pattern as parent)
+       └─ Citations: IReadOnlyList<MechanicCitation>  (child entity with Id, separate table — not OwnsMany
+                                                       because indexed lookup by PdfPage required for side-panel)
+              ├─ Id, ClaimId, DisplayOrder
+              ├─ PdfPage (int, CHECK > 0)
+              ├─ Quote (string, CHECK quote_word_count ≤ 25 at DB level — T1 belt-and-braces)
+              └─ ChunkId (Guid?, FK to text_chunks with ON DELETE SET NULL)
+```
+
+**Audit architecture decision** (Fowler P0-3): due tabelle separate invece di una tabella polimorfica con `EventType` discriminator. Rationale:
+
+- `mechanic_status_audit` (lifecycle: Draft→InReview→Published→Rejected)
+- `mechanic_suppression_audit` (IP kill-switch: takedown evidence chain)
+
+Ogni tabella ha schema stretto (no colonne nullable condizionali), indici propri, e consumer che sa esattamente quale storia sta leggendo. Join esplicito quando serve timeline unificata admin (query rara, overhead trascurabile). Alternative scartate: (A) tabella unica con EventType → fragile allo schema evolution, (B) event store generico con JSONB payload → perde type safety e indici partial.
+
+**File da creare**:
+
+| Path | Purpose |
+|------|---------|
+| `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicAnalysis.cs` | Aggregate root |
+| `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/MechanicClaim.cs` | Child entity |
+| `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/ValueObjects/MechanicCitation.cs` | Owned value object |
+| `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/MechanicAnalysisStatus.cs` | `Draft\|InReview\|Published\|Rejected\|Suppressed` |
+| `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/MechanicClaimStatus.cs` | `Pending\|Approved\|Rejected` |
+| `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/MechanicSection.cs` | `Summary\|Mechanics\|Victory\|Resources\|Phases\|Faq` |
+| `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IMechanicAnalysisRepository.cs` | Repo interface |
+| `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicAnalysisRepository.cs` | Impl |
+| `apps/api/src/Api/Infrastructure/EntityConfigurations/MechanicAnalysisConfiguration.cs` | EF config |
+| `apps/api/src/Api/Infrastructure/EntityConfigurations/MechanicClaimConfiguration.cs` | EF config |
+| `apps/api/src/Api/Infrastructure/Migrations/20260428XXXXXX_AddMechanicAnalyses.cs` | Migration |
+
+### 2.2 DDL idempotente (migration body)
+
+Pattern derivato da [PR #517](https://github.com/meepleAi-app/meepleai-monorepo/pull/517). **No `AddColumn`/`CreateTable` standard EF** — solo raw SQL con `IF NOT EXISTS` per resistere a drift staging.
+
+#### 2.2.0 Migration template (copy-paste ready)
+
+Il `Up()` della migrazione `AddMechanicAnalyses` deve avvolgere ogni DDL destruttivo in guardia di idempotenza. Template pronto all'uso (Hightower P1-5):
+
+```csharp
+// apps/api/src/Api/Infrastructure/Migrations/20260428XXXXXX_AddMechanicAnalyses.cs
+protected override void Up(MigrationBuilder migrationBuilder)
+{
+    // === mechanic_analyses ===
+    migrationBuilder.Sql(@"
+        CREATE TABLE IF NOT EXISTS mechanic_analyses (
+            /* ...colonne come §2.2.1... */
+        );
+    ");
+
+    // Aggiunta colonne incrementali (se la tabella già esiste in drift)
+    migrationBuilder.Sql(@"
+        DO $$
+        BEGIN
+            IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+                           WHERE table_name='mechanic_analyses' AND column_name='CostCapUsd') THEN
+                ALTER TABLE mechanic_analyses
+                    ADD COLUMN ""CostCapUsd"" numeric(10,4) NOT NULL DEFAULT 2.0;
+            END IF;
+        END $$;
+    ");
+
+    // Indici e CHECK constraints via guardia pg_constraint / pg_indexes
+    migrationBuilder.Sql(@"
+        DO $$
+        BEGIN
+            IF NOT EXISTS (SELECT 1 FROM pg_constraint
+                           WHERE conname = 'CK_mechanic_citations_quote_words') THEN
+                ALTER TABLE mechanic_citations
+                    ADD CONSTRAINT ""CK_mechanic_citations_quote_words""
+                    CHECK (array_length(regexp_split_to_array(trim(""Quote""), E'\\s+'), 1) <= 25);
+            END IF;
+        END $$;
+    ");
+
+    // ...(continuare per tutti i statement sotto §2.2.1-§2.2.4)
+}
+
+protected override void Down(MigrationBuilder migrationBuilder)
+{
+    // DROP IF EXISTS, simmetrico ma ordine inverso per FK
+    migrationBuilder.Sql(@"DROP TABLE IF EXISTS mechanic_suppression_audit CASCADE;");
+    migrationBuilder.Sql(@"DROP TABLE IF EXISTS mechanic_status_audit CASCADE;");
+    migrationBuilder.Sql(@"DROP TABLE IF EXISTS mechanic_citations CASCADE;");
+    migrationBuilder.Sql(@"DROP TABLE IF EXISTS mechanic_claims CASCADE;");
+    migrationBuilder.Sql(@"DROP TABLE IF EXISTS mechanic_analyses CASCADE;");
+}
+```
+
+**Vincolo di test idempotenza**: la migrazione deve passare 3 scenari CI:
+1. DB vuoto → crea tutto
+2. DB con schema completo → no-op (nessun errore)
+3. DB con schema parziale (es. solo `mechanic_analyses` senza `CostCapUsd`) → aggiunge colonne mancanti
+
+#### 2.2.1 mechanic_analyses
+
+```sql
+CREATE TABLE IF NOT EXISTS mechanic_analyses (
+    "Id" uuid PRIMARY KEY,
+    "SharedGameId" uuid NOT NULL REFERENCES shared_games(id) ON DELETE CASCADE,
+    "PdfDocumentId" uuid NOT NULL REFERENCES pdf_documents("Id") ON DELETE RESTRICT,
+    "PromptVersion" varchar(32) NOT NULL,
+    "Status" int NOT NULL DEFAULT 0,              -- Draft=0, InReview=1, Published=2, Rejected=3, Suppressed=4
+    "CreatedBy" uuid NOT NULL REFERENCES users("Id"),
+    "CreatedAt" timestamptz NOT NULL DEFAULT NOW(),
+    "ReviewedBy" uuid NULL REFERENCES users("Id"),
+    "ReviewedAt" timestamptz NULL,
+    "TotalTokensUsed" int NOT NULL DEFAULT 0,
+    "EstimatedCostUsd" numeric(10,4) NOT NULL DEFAULT 0,
+    "ModelUsed" varchar(128) NOT NULL,
+    "Provider" varchar(32) NOT NULL,              -- "deepseek" | "openrouter" | …
+
+    -- T8 cost governance (ADR-051)
+    "CostCapUsd" numeric(10,4) NOT NULL DEFAULT 2.0,
+    "CostCapOverrideAt" timestamptz NULL,
+    "CostCapOverrideBy" uuid NULL REFERENCES users("Id"),
+    "CostCapOverrideReason" text NULL,
+
+    -- T5 takedown kill-switch + SLA tracking
+    "IsSuppressed" boolean NOT NULL DEFAULT false,
+    "SuppressedAt" timestamptz NULL,
+    "SuppressedBy" uuid NULL REFERENCES users("Id"),
+    "SuppressionReason" text NULL,
+    "SuppressionRequestedAt" timestamptz NULL,
+    "SuppressionRequestSource" int NULL,          -- 1=Email, 2=Legal, 3=Other
+    "RejectionReason" text NULL,
+
+    -- Invariant: se override è presente, TUTTI i campi override devono esserlo
+    CONSTRAINT "CK_mechanic_analyses_cost_override_complete"
+        CHECK (
+            ("CostCapOverrideAt" IS NULL AND "CostCapOverrideBy" IS NULL AND "CostCapOverrideReason" IS NULL)
+         OR ("CostCapOverrideAt" IS NOT NULL AND "CostCapOverrideBy" IS NOT NULL AND "CostCapOverrideReason" IS NOT NULL)
+        ),
+    -- Invariant: se suppressed, SuppressedAt e SuppressedBy obbligatori
+    CONSTRAINT "CK_mechanic_analyses_suppression_complete"
+        CHECK (
+            ("IsSuppressed" = false)
+         OR ("IsSuppressed" = true AND "SuppressedAt" IS NOT NULL AND "SuppressedBy" IS NOT NULL)
+        )
+    -- NOTE: EF concurrency token is the PostgreSQL system column `xmin` (auto-present on every table).
+    --       Do NOT declare `xmin` explicitly — configure via `.UseXminAsConcurrencyToken()` in EF only.
+);
+
+-- Unique: one analysis per (game, pdf, prompt_version) — T7 reproducibility
+CREATE UNIQUE INDEX IF NOT EXISTS "UX_mechanic_analyses_shared_game_pdf_prompt"
+    ON mechanic_analyses ("SharedGameId", "PdfDocumentId", "PromptVersion")
+    WHERE "Status" <> 3;  -- exclude rejected so re-runs don't collide
+
+-- Player-facing lookup: only published + not suppressed
+CREATE INDEX IF NOT EXISTS "IX_mechanic_analyses_shared_game_published"
+    ON mechanic_analyses ("SharedGameId", "Status")
+    WHERE "Status" = 2 AND "IsSuppressed" = false;
+
+-- Admin review queue
+CREATE INDEX IF NOT EXISTS "IX_mechanic_analyses_status_created"
+    ON mechanic_analyses ("Status", "CreatedAt" DESC);
+
+-- Takedown SLA analytics (admin dashboard): time from request to effective suppression
+CREATE INDEX IF NOT EXISTS "IX_mechanic_analyses_suppression_sla"
+    ON mechanic_analyses ("SuppressionRequestedAt", "SuppressedAt")
+    WHERE "IsSuppressed" = true AND "SuppressionRequestedAt" IS NOT NULL;
+```
+
+#### 2.2.2 mechanic_claims (child entity)
+
+```sql
+CREATE TABLE IF NOT EXISTS mechanic_claims (
+    "Id" uuid PRIMARY KEY,
+    "AnalysisId" uuid NOT NULL REFERENCES mechanic_analyses("Id") ON DELETE CASCADE,
+    "Section" int NOT NULL,                      -- Summary=0, Mechanics=1, Victory=2, Resources=3, Phases=4, Faq=5
+    "Text" text NOT NULL,
+    "DisplayOrder" int NOT NULL DEFAULT 0,
+    "Status" int NOT NULL DEFAULT 0,             -- Pending=0, Approved=1, Rejected=2
+    "ReviewedBy" uuid NULL REFERENCES users("Id"),
+    "ReviewedAt" timestamptz NULL,
+    "RejectionNote" text NULL
+    -- NOTE: `xmin` system column used as concurrency token via EF `.UseXminAsConcurrencyToken()`.
+);
+
+CREATE INDEX IF NOT EXISTS "IX_mechanic_claims_analysis_section_order"
+    ON mechanic_claims ("AnalysisId", "Section", "DisplayOrder");
+
+CREATE INDEX IF NOT EXISTS "IX_mechanic_claims_pending"
+    ON mechanic_claims ("AnalysisId")
+    WHERE "Status" = 0;
+```
+
+#### 2.2.3 mechanic_citations
+
+```sql
+-- Decision: separate table — allows indexed page lookup for side-panel navigation
+CREATE TABLE IF NOT EXISTS mechanic_citations (
+    "Id" uuid PRIMARY KEY,
+    "ClaimId" uuid NOT NULL REFERENCES mechanic_claims("Id") ON DELETE CASCADE,
+    "PdfPage" int NOT NULL CHECK ("PdfPage" > 0),
+    "Quote" varchar(400) NOT NULL,               -- ~25 words * 16 chars upper bound
+    "ChunkId" uuid NULL REFERENCES text_chunks("Id") ON DELETE SET NULL,
+    "DisplayOrder" int NOT NULL DEFAULT 0,
+
+    -- T1 belt-and-braces: DB-level enforcement of 25-word cap
+    -- Tokenizza su whitespace dopo trim. Garantisce che anche un bug nel validator C#
+    -- non permetta di persistere quote > 25 parole (legal evidence chain integrity).
+    CONSTRAINT "CK_mechanic_citations_quote_words"
+        CHECK (array_length(regexp_split_to_array(trim("Quote"), E'\\s+'), 1) <= 25)
+);
+
+CREATE INDEX IF NOT EXISTS "IX_mechanic_citations_claim_page"
+    ON mechanic_citations ("ClaimId", "PdfPage");
+```
+
+#### 2.2.4 Audit tables (split architecture — Fowler P0-3)
+
+Due tabelle separate, una per tipo di evento. Rationale in §2.1.
+
+```sql
+-- Lifecycle audit: Draft→InReview→Published→Rejected transitions
+CREATE TABLE IF NOT EXISTS mechanic_status_audit (
+    "Id" uuid PRIMARY KEY,
+    "AnalysisId" uuid NOT NULL REFERENCES mechanic_analyses("Id") ON DELETE CASCADE,
+    "FromStatus" int NOT NULL,                    -- Draft=0, InReview=1, Published=2, Rejected=3
+    "ToStatus" int NOT NULL,
+    "ActorId" uuid NOT NULL REFERENCES users("Id"),
+    "Note" text NULL,                             -- es. rejection reason
+    "OccurredAt" timestamptz NOT NULL DEFAULT NOW(),
+    CONSTRAINT "CK_mechanic_status_audit_transition"
+        CHECK ("FromStatus" <> "ToStatus")        -- no self-loop
+);
+
+CREATE INDEX IF NOT EXISTS "IX_mechanic_status_audit_analysis_occurred"
+    ON mechanic_status_audit ("AnalysisId", "OccurredAt" DESC);
+
+-- Suppression audit: takedown evidence chain (legal/IP)
+-- Separata da status_audit perché IsSuppressed è ortogonale a Status
+-- (una Published può essere Suppressed senza cambiare Status).
+CREATE TABLE IF NOT EXISTS mechanic_suppression_audit (
+    "Id" uuid PRIMARY KEY,
+    "AnalysisId" uuid NOT NULL REFERENCES mechanic_analyses("Id") ON DELETE CASCADE,
+    "FromSuppressed" boolean NOT NULL,
+    "ToSuppressed" boolean NOT NULL,
+    "ActorId" uuid NOT NULL REFERENCES users("Id"),
+    "Reason" text NOT NULL,                       -- obbligatorio (takedown reference minimum)
+    "RequestSource" int NULL,                     -- 1=Email, 2=Legal, 3=Other (NULL solo per unsuppress)
+    "RequestedAt" timestamptz NULL,               -- quando il takedown fu notificato
+    "OccurredAt" timestamptz NOT NULL DEFAULT NOW(),
+    CONSTRAINT "CK_mechanic_suppression_audit_toggle"
+        CHECK ("FromSuppressed" <> "ToSuppressed")
+);
+
+CREATE INDEX IF NOT EXISTS "IX_mechanic_suppression_audit_analysis_occurred"
+    ON mechanic_suppression_audit ("AnalysisId", "OccurredAt" DESC);
+
+-- SLA analytics: quante ore tra richiesta e suppression effettiva
+CREATE INDEX IF NOT EXISTS "IX_mechanic_suppression_audit_sla"
+    ON mechanic_suppression_audit ("RequestedAt", "OccurredAt")
+    WHERE "ToSuppressed" = true AND "RequestedAt" IS NOT NULL;
+```
+
+**Idempotency wrapper**: avvolgere ogni statement che usa tipi nuovi (enum check, FK) in `DO $$ ... IF NOT EXISTS ... END $$;` come pattern PR #517 e template §2.2.0.
+
+### 2.3 EF configurations — punti chiave
+
+- `MechanicAnalysis`: `HasKey(x => x.Id)`; concurrency via `.UseXminAsConcurrencyToken()` — **NON** mappare `xmin` come proprietà C#, è system column auto-gestita (EF 9 read-only). `HasMany(a => a.Claims).WithOne().OnDelete(Cascade)`.
+- `MechanicClaim`: FK ad `AnalysisId` + `.OnDelete(DeleteBehavior.Cascade)`, navigation collection di `Citations`; concurrency identico via `.UseXminAsConcurrencyToken()`.
+- `MechanicCitation`: `HasKey(x => x.Id)`; indexed lookup su `ClaimId`. Value-object-like ma con Id per FK chunk (scelta pragmatica: separate table, non `OwnsMany` — vedi §2.1 rationale).
+- **Global query filter** su `MechanicAnalysis`: `.HasQueryFilter(a => !a.IsSuppressed)` — player non vede mai contenuti sotto takedown anche se un bug dimentica il check. Admin queries che devono vedere i suppressed: `.IgnoreQueryFilters()`.
+
+#### Audit trail — domain events pattern (Fowler P2-1)
+
+Preferenza: **domain events emessi dall'aggregato**, dispatcher nel `MediatorSaveChangesInterceptor` che è già in codebase (coerente con pattern `AggregateRoot.AddDomainEvent()`). Rifiutata soluzione pure-interceptor che legge ChangeTracker, perché rompe l'incapsulamento dell'aggregato.
+
+**Flusso**:
+
+```
+1. Endpoint → IMediator.Send(ApproveMechanicAnalysisCommand)
+2. Handler: analysis.Approve(actorId)
+   ├─ aggregate valida transizione + muta stato
+   └─ aggregate invoca this.AddDomainEvent(new MechanicAnalysisStatusChanged(id, from, to, actorId))
+3. Handler: repository.UpdateAsync(analysis); await unitOfWork.SaveChangesAsync()
+4. MediatorSaveChangesInterceptor (già registrato):
+   ├─ collect domain events da tutti gli aggregate tracked
+   ├─ persist audit row PRIMA di SaveChanges (stessa transaction)
+   └─ IMediator.Publish(event) DOPO SaveChanges (per side effects extra-aggregato, es. notifications)
+5. Handler ritorna result
+```
+
+**Eventi richiesti** (in `Domain/Events/`):
+
+| Evento | Trigger method | Audit table |
+|--------|----------------|-------------|
+| `MechanicAnalysisStatusChanged` | `SubmitForReview`, `Approve`, `Reject`, `Publish` | `mechanic_status_audit` |
+| `MechanicAnalysisSuppressed` | `Suppress(actorId, reason, requestedAt, source)` | `mechanic_suppression_audit` |
+| `MechanicAnalysisUnsuppressed` | `Unsuppress(actorId, reason)` | `mechanic_suppression_audit` |
+| `MechanicAnalysisCostCapOverridden` | `OverrideCostCap(actorId, newCapUsd, reason)` | `mechanic_status_audit` (o dedicata in M2) |
+
+**Invariante atomicità**: l'audit row e il state change dell'aggregato **devono** essere nella stessa transaction DB. Se la scrittura audit fallisce, l'intero SaveChanges rollbacks. Implementato via `SaveChangesInterceptor.SavingChangesAsync` (append rows al ChangeTracker prima del commit finale).
+
+### 2.4 Deprecazione Variant C — zero-risk sunset
+
+`mechanic_drafts` resta intatto, zero migrazione dati (0 righe). In M1.6 (issue separata):
+```sql
+-- Solo banner deprecation tracciato via config, nessuna DDL destruttiva fino a M6+
+COMMENT ON TABLE mechanic_drafts IS 'DEPRECATED 2026-04-28: superseded by mechanic_analyses. Removal: 2026-10+';
+```
+
+---
+
+## 3. ME-M1.2 — Command & Prompt
+
+### 3.1 Command contract
+
+**File da creare** in `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/`:
+
+```
+GenerateMechanicAnalysisCommand.cs          -- record (SharedGameId, PdfDocumentId, PromptVersion?, ForceRegenerate?)
+GenerateMechanicAnalysisCommandValidator.cs -- FluentValidation
+GenerateMechanicAnalysisCommandHandler.cs   -- pipeline: retrieval → prompt → LLM → parse → validate → persist
+GenerateMechanicAnalysisResult.cs           -- { AnalysisId, ClaimCount, TokensUsed, CostUsd, Warnings[] }
+```
+
+**Dependencies** (constructor injection):
+- `IMechanicAnalysisRepository`
+- `ISharedGameRepository` (game title + metadata)
+- `IPdfDocumentRepository` (verify access + page count)
+- `ITextChunkSearchService` (riuso da KB — retrieval per section)
+- `ILlmClient` via `ILlmProviderSelector` (DeepSeek primary, OpenRouter fallback)
+- `IMechanicOutputValidator` (M1.3 guardrails, contract-first — può essere stub)
+- `IAnalysisCostEstimator` (T8 pre-flight)
+- `ILogger<GenerateMechanicAnalysisCommandHandler>`
+- `TimeProvider`
+
+### 3.2 Pipeline handler (pseudo-flow)
+
+```
+1. Resolve game + pdf, verify pdf.Status = Ready
+2. Resolve effective cost cap (T8):
+   effectiveCapUsd = existingAnalysis?.CostCapUsd                         // re-run path: usa il cap della analysis esistente
+                  ?? config.MechanicExtractor.CostCapUsd                   // default da appsettings (seed della nuova entity)
+                  ?? 2.00m                                                 // hard fallback
+   pre-flight estimate:
+     estimated = Σ sections (K_chunks * avgTokensPerChunk + expectedClaims * avgTokensPerClaim) * modelPricing
+   decision matrix:
+     if estimated ≤ effectiveCapUsd                                 → proceed
+     if estimated > effectiveCapUsd AND command.CostCapOverride == null
+                                                                    → return 402 Payment Required
+     if estimated > effectiveCapUsd AND command.CostCapOverride != null:
+         - command.CostCapOverride must provide NewCapUsd + Reason (FluentValidation §3.1)
+         - operatore deve essere admin (authz layer)
+         - handler invoca analysis.OverrideCostCap(actorId, newCapUsd, reason)
+             → muta CostCapUsd + CostCapOverrideAt/By/Reason sull'aggregato
+             → aggregato emette MechanicAnalysisCostCapOverridden (§2.3) → audit row stessa transaction
+         - proceed con effectiveCapUsd = newCapUsd
+3. For each section in [Summary, Mechanics, Victory, Resources, Phases, Faq]:
+   a. retrieve top-K chunks (K=6) via hybrid search with section-specific query
+   b. build user prompt (§3.3) with retrieved chunks + section instructions
+   c. call LLM (temp=0.2, max_tokens=1500, JSON mode enforced)
+   d. parse JSON output → List<ClaimDraft>
+   e. run guardrails T1-T4 (M1.3) — on failure: retry once with reinforced prompt, then skip claim
+   f. accumulate tokens + cost
+   g. mid-generation guardrail:
+        if cumulativeCost > effectiveCapUsd * 1.5 → abort loop, go to step 4 with RejectionReason
+4. Persist MechanicAnalysis(Status=Draft) with all validated claims
+   - snapshot di CostCapUsd dal config/override (non più hardcoded)
+5. MechanicAnalysisStatusChanged(null → Draft) → audit row (via SaveChangesInterceptor)
+6. Return result (includes warnings for skipped claims + effectiveCapUsd + totalCostUsd)
+```
+
+**Key decisions**:
+- `CostCapUsd` è **persistito sull'aggregate**, non letto solo da config al volo: garantisce che un'analysis generata al cap €2.00 non cambi se il config sale a €5.00 in futuro (reproducibility + audit trail).
+- Override è una **transizione di dominio** (`OverrideCostCap`), non un flag nel command: audit trail via domain event evita che bug nel handler dimentichi di loggare.
+- Rollback mid-generation: se `cumulativeCost > effectiveCapUsd * 1.5`, persist partial con `RejectionReason = "cost cap breached at section X — estimated={est}, cap={cap}, actual={actual}"`.
+- Retry logic (max 1 retry per section) solo su guardrail failure, non su LLM network error (quello è ritentato dal client).
+- Temperature bassa (0.2) per deterministic output riducendo hallucination.
+
+### 3.3 Prompt template v1
+
+**File**: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractorPrompts.cs`
+
+#### System prompt (static)
+
+```
+You are an expert board game rulebook analyst. Your job is to extract structured
+reference claims from the provided rulebook excerpts and produce a JSON output
+that follows the exact schema below.
+
+HARD RULES (violating ANY means your output will be rejected):
+1. REPHRASE EVERY CLAIM — do NOT copy sentences verbatim from the excerpts.
+   Use your own words while preserving the rule's meaning precisely.
+2. Every claim MUST include at least one citation with:
+   - pdf_page: the page number in the rulebook
+   - quote: a short excerpt from the rulebook (≤ 25 words) to attribute the source
+3. The quote MUST be a verbatim substring of the excerpt (for verification),
+   but the claim text itself MUST be rephrased.
+4. If the excerpt does not contain clear evidence for a claim, do NOT invent it —
+   omit that claim entirely.
+5. Output MUST be valid JSON matching the schema — no prose before or after.
+
+Writing style:
+- Concise, player-friendly (Italian unless excerpts are exclusively English).
+- One rule per claim — do not stack multiple rules in a single claim.
+- Avoid jargon not present in the rulebook.
+```
+
+#### User prompt (per section, templated)
+
+```
+Game: {GameTitle}
+Section to extract: {SectionName}
+Section description: {SectionDescription}
+
+Rulebook excerpts (numbered, with page references):
+
+[Excerpt 1 — page {p1}]
+{chunk_1_text}
+
+[Excerpt 2 — page {p2}]
+{chunk_2_text}
+
+... (up to 6 excerpts)
+
+Produce claims for the "{SectionName}" section only.
+Target: {MinClaims}-{MaxClaims} claims.
+
+Return JSON with this structure:
+{
+  "section": "{SectionName}",
+  "claims": [
+    {
+      "text": "Rephrased rule in your own words",
+      "citations": [
+        {
+          "pdf_page": 12,
+          "quote": "verbatim snippet ≤ 25 words from the excerpt",
+          "excerpt_id": 1
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Section metadata** (drives `{SectionName}`, `{SectionDescription}`, `{MinClaims}`, `{MaxClaims}`):
+
+| Section | Description | Min | Max |
+|---------|-------------|-----|-----|
+| Summary | Scopo del gioco, 2-4 righe narrative sul flusso di gioco | 2 | 4 |
+| Mechanics | Meccaniche principali (es. drafting, worker placement) | 4 | 10 |
+| Victory | Condizione di vittoria + come si calcolano i punti | 1 | 4 |
+| Resources | Risorse e come si ottengono/spendono | 2 | 8 |
+| Phases | Fasi/round/turno sequenziali | 3 | 12 |
+| Faq | Domande frequenti o regole spesso fraintese | 0 | 6 |
+
+### 3.4 JSON schema (OpenAI/DeepSeek `response_format: json_schema`)
+
+```json
+{
+  "name": "mechanic_section_output",
+  "strict": true,
+  "schema": {
+    "type": "object",
+    "required": ["section", "claims"],
+    "additionalProperties": false,
+    "properties": {
+      "section": {
+        "type": "string",
+        "enum": ["Summary", "Mechanics", "Victory", "Resources", "Phases", "Faq"]
+      },
+      "claims": {
+        "type": "array",
+        "maxItems": 12,
+        "items": {
+          "type": "object",
+          "required": ["text", "citations"],
+          "additionalProperties": false,
+          "properties": {
+            "text": { "type": "string", "minLength": 10, "maxLength": 600 },
+            "citations": {
+              "type": "array",
+              "minItems": 1,
+              "maxItems": 3,
+              "items": {
+                "type": "object",
+                "required": ["pdf_page", "quote", "excerpt_id"],
+                "additionalProperties": false,
+                "properties": {
+                  "pdf_page": { "type": "integer", "minimum": 1 },
+                  "quote": { "type": "string", "minLength": 5, "maxLength": 300 },
+                  "excerpt_id": { "type": "integer", "minimum": 1 }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Schema enforcement**: provider passa via `ResponseFormat = JsonSchema(...)`. Se il provider (es. Ollama locale) non supporta strict JSON schema → fallback a `ResponseFormat.JsonObject` + validation C# side (già fatto da M1.3 T3).
+
+### 3.5 PromptVersion — riproducibilità
+
+- Valore costante in codice: `public const string MechanicExtractorPromptV1 = "v1.0.0";`
+- Cambio del prompt o dello schema → **bump semver** (es. `v1.1.0` se cambia solo wording, `v2.0.0` se cambia schema)
+- Stored in `mechanic_analyses.PromptVersion` + unique constraint (§2.2) consente re-run per stesso (game, pdf) con nuove versioni senza conflitti
+
+---
+
+## 4. ME-M1.3 — Guardrails T1-T4, T8
+
+### 4.1 Interface & orchestration
+
+**File**: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Services/IMechanicOutputValidator.cs`
+
+```csharp
+public interface IMechanicOutputValidator
+{
+    /// <summary>
+    /// Runs T1-T4 guardrails on a single claim. T8 runs separately at handler level.
+    /// Returns success if all checks pass, otherwise a failure with ordered reasons.
+    /// </summary>
+    MechanicValidationResult Validate(
+        ClaimDraft draft,
+        IReadOnlyList<RetrievedChunk> sourceChunks);
+}
+
+public sealed record MechanicValidationResult(
+    bool IsValid,
+    IReadOnlyList<MechanicValidationFailure> Failures);
+
+public sealed record MechanicValidationFailure(
+    string Rule,              // "T1", "T2", "T3", "T4"
+    string CitationRef,       // "citation[0]" or "claim.text"
+    string Message);
+```
+
+### 4.2 Individual validators (composition)
+
+**T1 — QuoteLength ≤ 25 words**
+```
+File: QuoteLengthValidator.cs
+Pure: input citation.quote → count words (split by whitespace after normalize) → ≤ 25
+Edge: hyphenated words "worker-placement" count as 1 (split by regex \s+, not \W+)
+Fail: FailureRule="T1", Message="Quote length N words exceeds cap 25"
+```
+
+**T2 — Literal copy > 10 consecutive words from source**
+```
+File: LiteralCopyValidator.cs
+Algorithm:
+  1. Normalize claim.text (lowercase, strip punctuation except intra-word)
+  2. Normalize all source chunks similarly
+  3. Sliding window on claim.text tokens (n=10):
+     for each 10-gram, check if it appears as substring in any source chunk
+  4. First match → fail
+Complexity: O(claim_tokens * source_total_chars) — acceptable for claims ≤ 600 chars
+Fail: FailureRule="T2", Message="Detected literal copy from source: '<offending 10-gram>'"
+```
+⚠️ Known false-positive: nomi propri di gioco (es. "il Mazzo Terreni del Nord") possono essere identici. Mitigazione v1: whitelist di frasi ≤ 3 parole (nomi dal `shared_games.Name` + expansions). v2 potenziale: n-gram overlap statistico invece di exact match.
+
+**T3 — Citation obbligatoria**
+```
+File: CitationRequiredValidator.cs
+Pure: citations.Count ≥ 1 (already enforced by JSON schema minItems:1, but double-check post-parse)
+Fail: FailureRule="T3", Message="Claim has no citations"
+```
+
+**T4 — Citation page + quote verifiable**
+```
+File: CitationPageVerifier.cs
+Deps: IPdfDocumentRepository (page count lookup)
+Algorithm for each citation:
+  1. Verify pdf_page ∈ [1, pdf.PageCount]
+  2. Find source chunk matching citation.excerpt_id (from retrieval context)
+  3. Verify citation.quote is a substring of that chunk's text (case-insensitive, whitespace-tolerant)
+Fail modes:
+  T4-a: "Page N does not exist (pdf has M pages)"
+  T4-b: "Quote not found in source excerpt ID E"
+  T4-c: "Excerpt ID E not in retrieval set"
+```
+
+**T8 — Cost cap pre-flight (handler-level, not per-claim)**
+```
+File: AnalysisCostEstimator.cs
+Input:
+  - sections.Count, avgChunkTokens, modelPricing (da IModelPricingCatalog)
+  - effectiveCapUsd (risolto dal handler, non hardcoded qui — vedi §3.2 step 2)
+Estimate:
+  inputTokens = sections * K_chunks * avgTokensPerChunk + sections * systemPromptTokens
+  outputTokens = sections * expectedClaimsPerSection * avgTokensPerClaim
+  estimatedUsd = (inputTokens * inputPricePerM + outputTokens * outputPricePerM) / 1_000_000
+Decision:
+  EstimateResult {
+      EstimatedUsd,
+      EffectiveCapUsd,
+      WithinCap : estimatedUsd ≤ effectiveCapUsd,
+      RequiresOverride : !WithinCap && !commandHasOverride
+  }
+Cap resolution order (handler-owned, estimator is pure):
+  1. re-run path       → existingAnalysis.CostCapUsd (persisted snapshot, reproducibility)
+  2. new analysis path → config MechanicExtractor:CostCapUsd (default 2.00 USD)
+  3. admin override    → analysis.OverrideCostCap(actorId, newCap, reason)
+                          → muta CostCapUsd + emette MechanicAnalysisCostCapOverridden
+                          → audit row (stessa transaction di SaveChanges)
+Fail-fast: command returns 402 Payment Required before any LLM call if
+           RequiresOverride == true && command.CostCapOverride == null
+```
+
+### 4.3 Retry policy — one-shot with reinforcement
+
+Quando `validator.Validate(...)` fallisce **solo per T1 o T2**:
+1. Build reinforcement suffix:
+   - T1 fail: `"Your previous quote was N words (limit: 25). Regenerate with shorter quotes."`
+   - T2 fail: `"Your previous claim contained verbatim copy: '<10-gram>'. Rephrase completely."`
+2. Single retry with appended instruction
+3. Second failure → skip claim, log warning, continue with rest
+
+T3/T4 failures = non retry-able (structural) → skip claim immediately.
+
+### 4.4 Where it plugs into pipeline
+
+```
+Handler.GenerateMechanicAnalysisAsync:
+    …
+    var response = await llmClient.GenerateCompletionAsync(…);
+    var parsed = JsonSerializer.Deserialize<SectionOutput>(response.Text);
+
+    foreach (var claimDraft in parsed.Claims)
+    {
+        var result = validator.Validate(claimDraft, retrievedChunks);
+        if (!result.IsValid && result.Failures.Any(f => f.Rule is "T1" or "T2"))
+        {
+            // retry once
+            var retried = await llmClient.GenerateCompletionAsync(reinforcedPrompt);
+            claimDraft = TryParseClaim(retried);
+            result = validator.Validate(claimDraft, retrievedChunks);
+        }
+
+        if (!result.IsValid)
+        {
+            warnings.Add($"Section {section}: skipped claim — {string.Join("; ", result.Failures)}");
+            continue;
+        }
+
+        validatedClaims.Add(claimDraft);
+    }
+    …
+```
+
+---
+
+## 5. Test fixtures & strategy
+
+### 5.1 Fixture dataset — Catan subset
+
+**Location**: `apps/api/tests/Api.Tests/Fixtures/MechanicExtractor/catan-subset/`
+
+| File | Content |
+|------|---------|
+| `catan-excerpt-setup.txt` | Pagina 4 — setup board |
+| `catan-excerpt-victory.txt` | Pagina 7 — 10 punti vittoria |
+| `catan-excerpt-resources.txt` | Pagina 5 — 5 risorse (wood, brick, sheep, wheat, ore) |
+| `catan-expected-claims.json` | Golden output (6 claims) per regression |
+
+### 5.2 Test layering
+
+**Unit tests** (`apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/`):
+- `QuoteLengthValidatorTests` — boundary: 24/25/26 parole, unicode normalization
+- `LiteralCopyValidatorTests` — exact match, case variation, whitespace tolerance, false-positive whitelist (game names)
+- `CitationPageVerifierTests` — page out of range, quote substring match, missing excerpt_id
+- `AnalysisCostEstimatorTests` — cost calculation, override path, model pricing lookup
+- `MechanicAnalysisTests` (aggregate) — state transitions Draft→InReview→Published, cannot mutate after Published, suppression
+- `GenerateMechanicAnalysisCommandValidatorTests` — FluentValidation rules
+
+**Integration tests** (with Testcontainers Postgres):
+- `MechanicAnalysisRepositoryTests` — persist + reload with Claims + Citations, concurrency (xmin), query filter (IsSuppressed)
+- `GenerateMechanicAnalysisCommandHandlerTests` — in-memory LLM fake that returns golden JSON → assert persisted structure matches expected
+
+**E2E / feature tests** (stubbed LLM):
+- `GenerateMechanicAnalysis_CatanFixture_ProducesValidAnalysis` — retrieval stub + LLM fake returning pre-canned response → end-to-end DB state
+- `GenerateMechanicAnalysis_CostCapExceeded_ReturnsPaymentRequired`
+- `GenerateMechanicAnalysis_LiteralCopy_RetriesOnce_ThenSkips`
+
+**No real LLM calls in CI.** Mage Knight fixture è manual-only (richiede PDF + chiave API + budget).
+
+### 5.3 Coverage gates (da CLAUDE.md: target 90%)
+
+- Validators: 95%+ (pure logic, no excuses)
+- Handler: 85%+ (pipeline branches + retry + cost cap)
+- Repository: 80%+ (EF-heavy, diminishing returns above)
+
+---
+
+## 6. Routing & endpoint (fuori scope M1 ma contratto)
+
+L'endpoint verrà aggiunto in **M1.4** (#526 — Admin Generation Form backend). Pattern CQRS:
+
+```csharp
+// apps/api/src/Api/Routing/AdminMechanicAnalysisEndpoints.cs (nuovo file)
+app.MapPost("/api/v1/admin/mechanic-analyses", async (
+    GenerateMechanicAnalysisCommand command,
+    IMediator mediator,
+    CancellationToken ct) =>
+{
+    var result = await mediator.Send(command, ct);
+    return Results.Created($"/api/v1/admin/mechanic-analyses/{result.AnalysisId}", result);
+})
+.RequireAuthorization("AdminOnly")
+.WithTags("Admin — Mechanic Extractor")
+.Produces<GenerateMechanicAnalysisResult>(StatusCodes.Status201Created)
+.Produces(StatusCodes.Status402PaymentRequired)
+.Produces<ValidationProblemDetails>(StatusCodes.Status400BadRequest);
+```
+
+---
+
+## 7. Rischi & mitigazioni
+
+| Rischio | Probabilità | Impatto | Mitigazione |
+|---------|-------------|---------|-------------|
+| T2 false-positive blocca troppi claim | Alta | Medio | Whitelist nomi propri + metrica "claims skipped" in telemetria; tuning threshold 10→12 parole se noise |
+| DeepSeek non supporta strict JSON schema | Media | Basso | Fallback ResponseFormat.JsonObject + schema validation C# — già previsto |
+| Pre-flight cost estimate sottovaluta | Bassa | Alto | Hard cutoff mid-generation se cumulative > 1.5x estimate; `CostCapUsd` è persistito sull'aggregato (re-run usa il cap originale) |
+| Concurrency token `xmin` mis-configurato (shadow column) | Bassa | Alto | DDL **non** dichiara `xmin` (system column); EF usa `.UseXminAsConcurrencyToken()` + AC-4 integration test copre collision |
+| `xmin` + logical replication / pglogical (P2-3) | Bassa | Medio | `xmin` è per-database: se in futuro si adotta logical replication verso una read-replica esterna, il valore può differire → concurrency check vale solo sulla primary. Mitigation: read-from-primary per admin review queue; in M2 valutare `uuid version` column custom se entra pglogical |
+| Idempotent migration su staging drift | Media | Alto | Pattern PR #517 (raw SQL IF NOT EXISTS) + template §2.2.0; CI deve eseguire i 3 scenari (vuoto / completo / parziale) |
+| Audit architecture — join cost su timeline unificata | Bassa | Basso | Scelta two-table (§2.1, §2.2.4): query admin "timeline completa di un'analysis" richiede UNION ALL fra `mechanic_status_audit` e `mechanic_suppression_audit` — query rara e indicizzata per `AnalysisId` in entrambe le tabelle |
+| Claims multilingua (regolamento IT vs EN) | Media | Basso | Language detection su chunks → passato al prompt come hint; fallback EN |
+
+---
+
+## 8. Checklist DoD per milestone M1.1–M1.3
+
+### M1.1 (#523) schema
+
+**Deliverables**
+- [ ] Aggregate root `MechanicAnalysis` + child entity `MechanicClaim` + child entity `MechanicCitation` + child entities `MechanicStatusAudit`/`MechanicSuppressionAudit` + enums
+- [ ] Domain methods: `Create`, `SubmitForReview`, `Approve`, `Reject`, `Publish`, `Suppress`, `Unsuppress`, `OverrideCostCap` (+ invalid-transition exceptions)
+- [ ] Domain events (§2.3): `MechanicAnalysisStatusChanged`, `MechanicAnalysisSuppressed`, `MechanicAnalysisUnsuppressed`, `MechanicAnalysisCostCapOverridden`
+- [ ] EF configurations con OnDelete + query filter `IsSuppressed` + `.UseXminAsConcurrencyToken()` + cost-override + suppression CHECK constraints
+- [ ] `SaveChangesInterceptor` (o estensione del `MediatorSaveChangesInterceptor` esistente) che proietta ogni evento in una audit row della tabella corretta, **nella stessa transaction**
+- [ ] Migration idempotente (pattern PR #517 + template §2.2.0); 3 scenari CI: DB vuoto, DB completo, DB con schema parziale
+- [ ] Repository interface + impl (`AsSplitQuery` per Claims+Citations)
+- [ ] Unit test aggregate (Create, state transitions, invariants, double-reject, publish-without-claims)
+- [ ] Integration test repository con Testcontainers Postgres (persist/reload/concurrency + audit + CHECK constraints + partial unique index)
+- [ ] `dotnet ef database update` verde su DB pulito + DB con schema parziale (drift test)
+- [ ] PR review approved + merge in `main-dev`
+
+**Acceptance Criteria (Gherkin, testabili)**
+
+AC-1..AC-8 coprono happy path e invarianti base; AC-9..AC-15 coprono edge cases e guardrails aggiunti dal review Wiegers/Adzic/Nygard.
+
+```gherkin
+AC-1 Creation with valid inputs:
+  Given uno SharedGame esistente e un PdfDocument Status=Ready per quel gioco
+  When chiamo MechanicAnalysis.Create(sharedGameId, pdfId, promptVersion="v1", createdBy=adminId)
+  Then l'aggregate viene creato con Status=Draft, IsSuppressed=false, Claims vuoto
+   And CostCapUsd viene inizializzato dal config MechanicExtractor:CostCapUsd (default 2.00)
+   And il concurrency token `xmin` è popolato dal DB dopo il primo SaveChanges
+
+AC-2 State machine — transizioni valide + audit (two-table):
+  Given un MechanicAnalysis con Status=Draft
+  When chiamo SubmitForReview(actorId)
+  Then Status diventa InReview
+   And l'aggregato emette MechanicAnalysisStatusChanged(from=Draft, to=InReview, actorId)
+   And una riga è creata in mechanic_status_audit con FromStatus=0, ToStatus=1, ActorId=actorId, OccurredAt=NOW()
+   And NESSUNA riga viene creata in mechanic_suppression_audit
+
+AC-3 State machine — transizione invalida:
+  Given un MechanicAnalysis con Status=Published
+  When chiamo SubmitForReview(actorId)
+  Then viene lanciata InvalidStateTransitionException
+   And nessuna riga viene creata in mechanic_status_audit né mechanic_suppression_audit
+
+AC-4 Optimistic concurrency (xmin):
+  Given due istanze simultanee A e B dello stesso MechanicAnalysis (Status=InReview)
+        caricate da due handler in transazioni separate
+  When A chiama Approve(actorId_A) e fa SaveChanges con successo
+   And B chiama Reject(actorId_B) e fa SaveChanges
+  Then il SaveChanges di B fallisce con DbUpdateConcurrencyException
+   And la riga DB ha Status=Approved (dal commit di A, NON Rejected di B)
+   And mechanic_status_audit contiene UNA sola riga (Draft→InReview→Approved path finale),
+       mai la transizione InReview→Rejected che è stata rigettata
+
+AC-5 Uniqueness constraint (T7 reproducibility) — esempio concreto:
+  Given SharedGameId="6b76bdb3-424e-44bc-b02f-cb939ee9538b" (Catan, da ADR-051)
+    And PdfDocumentId="<catan-pdf-id>" Status=Ready
+    And un MechanicAnalysis (Catan, catan-pdf, promptVersion="v1.0.0", Status=Published)
+  When provo a inserire un secondo MechanicAnalysis con gli stessi (Catan, catan-pdf, "v1.0.0") e Status=Draft
+  Then il DB solleva unique violation su UX_mechanic_analyses_shared_game_pdf_prompt
+
+  Given invece il primo record ha Status=Rejected
+  When inserisco il secondo con stessi (Catan, catan-pdf, "v1.0.0")
+  Then l'insert passa (il partial index WHERE Status <> 3 esclude i rejected)
+
+  Given un terzo caso: stesso Catan+catan-pdf, ma promptVersion="v1.1.0"
+  When inserisco mentre esiste già (Catan, catan-pdf, "v1.0.0", Published)
+  Then l'insert passa (PromptVersion è parte della uniqueness key)
+
+AC-6 Kill-switch query filter:
+  Given un MechanicAnalysis con Status=Published, IsSuppressed=true
+  When un player query via DbContext normale (no IgnoreQueryFilters)
+  Then il record NON viene restituito
+  When un admin query con .IgnoreQueryFilters()
+  Then il record viene restituito
+
+AC-7 Suppression audit (takedown evidence chain, two-table):
+  Given un MechanicAnalysis con IsSuppressed=false, Status=Published
+        e SharedGameId="8a9f8a90-594a-4316-a32e-daa43a4356fb" (Mage Knight, da ADR-051)
+  When chiamo Suppress(actorId, reason="takedown email from WizKids 2026-05-12",
+                       requestedAt="2026-05-10", source=SuppressionSource.Email)
+  Then IsSuppressed=true, SuppressedAt e SuppressedBy popolati
+   And SuppressionRequestedAt=2026-05-10, SuppressionRequestSource=1 (Email)
+   And Status RIMANE Published (suppression è ortogonale a status)
+   And l'aggregato emette MechanicAnalysisSuppressed
+   And una riga è creata in mechanic_suppression_audit con
+       FromSuppressed=false, ToSuppressed=true, Reason="takedown email from WizKids 2026-05-12",
+       RequestSource=1, RequestedAt=2026-05-10, OccurredAt=NOW()
+   And NESSUNA riga è creata in mechanic_status_audit
+   And la riga è recuperabile via IX_mechanic_suppression_audit_sla
+       (per SLA dashboard: OccurredAt - RequestedAt = latenza takedown)
+
+AC-8 Cascade integrity:
+  Given un MechanicAnalysis con 3 MechanicClaim, ognuno con 2 MechanicCitation,
+        5 righe in mechanic_status_audit e 2 in mechanic_suppression_audit
+  When l'aggregate viene cancellato (admin hard delete — non takedown)
+  Then tutti i claims e le citations vengono cancellati via FK cascade
+   And le righe di mechanic_status_audit e mechanic_suppression_audit associate
+       vengono cancellate via CASCADE on AnalysisId
+   And i text_chunks referenziati da Citations.ChunkId NON vengono toccati
+       (FK ON DELETE SET NULL su Citation.ChunkId)
+
+AC-9 Citation quote word cap — DB-level enforcement (T1 belt-and-braces):
+  Given un tentativo di persistere una MechanicCitation con Quote contenente 26 parole
+  When il SaveChanges viene inviato al DB (anche bypassando il validator C#)
+  Then il DB solleva CheckConstraintViolation su CK_mechanic_citations_quote_words
+   And la transazione rollback
+
+  Given una Quote con 25 parole (boundary)
+  When SaveChanges
+  Then il persist ha successo
+
+  Given una Quote con hyphenated compound "worker-placement" + 24 altre parole
+  When regexp_split_to_array(trim(Quote), E'\\s+') viene valutato
+  Then array_length = 25 (hyphen NON splitta, consistente col validator C#)
+
+AC-10 Publish senza claims solleva eccezione di dominio:
+  Given un MechanicAnalysis con Status=InReview e Claims vuoto
+  When chiamo Publish(actorId)
+  Then viene lanciata InvalidStateTransitionException con messaggio
+       "Cannot publish analysis without approved claims"
+   And nessuna riga è creata in mechanic_status_audit
+
+  Given un MechanicAnalysis con Status=InReview e 3 Claims, tutti Status=Pending
+  When chiamo Publish(actorId)
+  Then viene lanciata InvalidStateTransitionException con messaggio
+       "All claims must be Approved before publishing (2 pending)"
+
+AC-11 Cost cap override — domain + audit trail:
+  Given un MechanicAnalysis con CostCapUsd=2.00
+  When chiamo OverrideCostCap(actorId, newCapUsd=5.00, reason="Mage Knight 100pg richiede budget extra")
+  Then CostCapUsd=5.00
+   And CostCapOverrideAt, CostCapOverrideBy, CostCapOverrideReason popolati
+   And l'aggregato emette MechanicAnalysisCostCapOverridden
+   And una riga di audit viene creata (§2.3 decide destination table: status_audit o dedicata)
+   And il CHECK CK_mechanic_analyses_cost_override_complete passa (tutti i campi override popolati)
+
+  Given il tentativo di popolare CostCapOverrideAt ma lasciare CostCapOverrideReason NULL
+  When SaveChanges
+  Then il DB solleva CheckConstraintViolation su CK_mechanic_analyses_cost_override_complete
+
+AC-12 Double-reject idempotency:
+  Given un MechanicAnalysis con Status=InReview
+  When chiamo Reject(actorId, reason="hallucinations detected")
+  Then Status=Rejected, audit row creata
+
+  When chiamo Reject(actorId, reason="seconda rejection")
+  Then viene lanciata InvalidStateTransitionException (no self-loop)
+   And nessuna seconda audit row viene creata
+   And l'aggregato mantiene la prima reason
+
+AC-13 Suppress su Draft (policy decision — consentito):
+  Given un MechanicAnalysis con Status=Draft, IsSuppressed=false
+  When chiamo Suppress(actorId, reason="pre-emptive takedown during review", ...)
+  Then IsSuppressed=true (suppression è ortogonale a Status — can suppress at any stage)
+   And Status RIMANE Draft
+   And mechanic_suppression_audit contiene la riga
+   And il query filter nasconde il record anche ai player che non l'avrebbero visto (era Draft)
+       — coerente con principio "quando in dubbio, nascondi"
+
+AC-14 Query filter bypass documentato (regression guard):
+  Given 100 MechanicAnalysis in DB, di cui 10 con IsSuppressed=true
+  When un repository method usa ctx.MechanicAnalyses.ToListAsync() (no IgnoreQueryFilters)
+  Then la lista restituita ha esattamente 90 elementi
+  When un admin method usa ctx.MechanicAnalyses.IgnoreQueryFilters().ToListAsync()
+  Then la lista restituita ha esattamente 100 elementi
+   And un test di regressione verifica che TUTTI i metodi del repository
+       che tornano risultati player-facing NON usano IgnoreQueryFilters
+
+AC-15 Performance budget — split query on deep aggregate (Mage Knight scale):
+  Given un MechanicAnalysis con 50 Claims, ogni Claim con 3 Citations (150 citations totali)
+  When il repository carica analysis + claims + citations via AsSplitQuery
+  Then la query completa < 250ms su DB staging (p95)
+   And il numero di roundtrip SQL è 3 (non N+1)
+   And la memoria allocata è < 2MB per l'aggregate hydrato
+
+  NOTE: threshold indicativo — regola in base al profiling del primo run Mage Knight.
+        Obiettivo è prevenire N+1 regression, non garantire latenza hardcoded.
+```
+
+### M1.2 (#524) command + prompt
+- [ ] Prompt v1 file committato con versione costante
+- [ ] JSON schema file committato
+- [ ] Command + Validator + Handler + Result
+- [ ] Integration test con LLM fake (golden fixture)
+- [ ] Telemetria: tokens + cost + latency per sezione
+- [ ] DI registration in `SharedGameCatalogServiceExtensions`
+- [ ] PR review + merge
+
+### M1.3 (#525) guardrails
+- [ ] 4 validator + estimator impl + interface
+- [ ] Retry logic nel handler (plug da M1.2)
+- [ ] Unit test per ogni guardrail con boundary cases
+- [ ] Whitelist game names per T2
+- [ ] Documentazione runbook: come regolare threshold T2 in produzione
+- [ ] PR review + merge
+- [ ] **Gate M1** pronto: generate-and-review pipeline end-to-end su Catan
+
+---
+
+## 9. Glossario cross-reference
+
+| Simbolo | Significato |
+|---------|-------------|
+| T1–T8 | Technical constraints da ADR-051 §Policy |
+| Prompt v1.0.0 | Initial template, semver-tracked in `mechanic_analyses.PromptVersion` |
+| Section | One of {Summary, Mechanics, Victory, Resources, Phases, Faq} |
+| Claim | Una singola affermazione estratta, con ≥1 citation |
+| Citation | Coppia (pdf_page, quote ≤ 25 parole) |
+| Analysis | Aggregato di claims per (SharedGame × PdfDocument × PromptVersion) |
+
+---
+
+## Changelog
+
+- **2026-04-23** — Revisione post `/sc:spec-panel` (Wiegers, Fowler, Nygard, Adzic, Crispin, Hightower, Doumont).
+  - §2.1 Entity: aggiunte `CostCapUsd`, `CostCapOverride*`, `SuppressionRequestedAt`, `SuppressionRequestSource`; nota Quote CHECK; decisione architetturale audit split (Fowler P0-3).
+  - §2.2 DDL: §2.2.0 migration template idempotente (Hightower P1-5); CHECK constraints su override completeness, suppression completeness, quote word count; due tabelle audit separate (`mechanic_status_audit` + `mechanic_suppression_audit`) con partial index SLA.
+  - §2.3 EF: pattern ibrido domain events + SaveChangesInterceptor (Fowler P2-1); 4 eventi richiesti + mapping a audit table.
+  - §3.2 Pipeline: cost cap risolto come snapshot persistito sull'aggregato (reproducibility) + override come transizione di dominio; cutoff mid-generation 1.5× cap.
+  - §4.2 T8: estimator puro, cap resolution orchestrata dal handler (estimator non legge config).
+  - §7 Rischi: riga xmin + logical replication (P2-3) e nota costo join timeline audit two-table.
+  - §8 DoD: deliverables estesi con domain events + interceptor + 3 scenari CI migration; AC-2/4/5/7 rinforzati con esempi concreti (Catan `6b76bdb3...`, Mage Knight `8a9f8a90...` da ADR-051); aggiunti AC-9 (quote CHECK DB-level), AC-10 (publish senza claims), AC-11 (cost cap override + CHECK), AC-12 (double-reject idempotency), AC-13 (suppress su Draft), AC-14 (query filter regression), AC-15 (performance budget split query).
+
+---
+
+**End of Artifact 4.** Next actionable: implementare #523 (M1.1 schema) su branch `feature/issue-523-mechanic-schema`.

--- a/docs/roadmap/mechanic-extractor-ai-first-issues.md
+++ b/docs/roadmap/mechanic-extractor-ai-first-issues.md
@@ -1,0 +1,362 @@
+# Mechanic Extractor — AI-First Pipeline: Issue Decomposition
+
+**Parent ADR**: [ADR-051](../architecture/adr/adr-051-mechanic-extractor-ip-policy.md)
+**Date**: 2026-04-23
+**Epic tracking issue**: meepleAi-app/meepleai-monorepo#539
+**Target Games M1**: Catan (simple, `6b76bdb3-424e-44bc-b02f-cb939ee9538b`), Mage Knight Board Game (complex, `8a9f8a90-594a-4316-a32e-daa43a4356fb`)
+
+## Issue map (created on GitHub)
+
+| ID | Issue | URL |
+|----|-------|-----|
+| ME-M1.1 | Schema + migration | #523 |
+| ME-M1.2 | Command + prompt + DeepSeek | #524 |
+| ME-M1.3 | Guardrails | #525 |
+| ME-M1.4 | Admin review UI | #526 |
+| ME-M1.5 | Publish action | #527 |
+| ME-M1.6 | Public card page | #528 |
+| ME-M1.7 | Footer + takedown | #529 |
+| ME-M2.1 | Inline citation UX | #530 |
+| ME-M2.2 | Landing demo | #531 |
+| ME-M2.3 | Admin metrics | #532 |
+| ME-M3.1 | Player feedback | #533 |
+| ME-M3.2 | Auto-suppression | #534 |
+| ME-M3.3 | Admin notify | #535 |
+| ME-M4.1 | Deprecation banner | #536 |
+| ME-M4.2 | Hide legacy menu | #537 |
+| ME-M4.3 | Code removal | #538 |
+| EPIC | Tracking | #539 |
+
+## Milestone Overview
+
+| Milestone | Focus | # Issues | Gate |
+|-----------|-------|----------|------|
+| **M1** | Core pipeline (schema → extraction → review → publish → public card) | 7 | Catan card pubblicata + Mage Knight card pubblicata |
+| **M2** | Citation UX + trust chain | 3 | Citation UI live, admin metrics dashboard |
+| **M3** | Feedback loop | 3 | Auto-suppression funzionante su flag utenti |
+| **M4** | Variant C deprecation | 3 | Banner + redirect; rimozione codice tracked separatamente |
+
+---
+
+## M1 — Core Pipeline
+
+### M1.1 — Schema: `mechanic_analyses`, `mechanic_cards`, `mechanic_card_feedback` + migrazione idempotente
+
+**Labels**: `area:backend`, `bc:shared-game-catalog`, `type:schema`, `milestone:mechanic-extractor-m1`
+
+**Contesto**: ADR-051 richiede 3 nuove tabelle in `SharedGameCatalog`. Pattern migrazione idempotente come PR #517.
+
+**AC**:
+- [ ] Entity classes + EF configurations in `BoundedContexts/SharedGameCatalog/Domain` + `Infrastructure`
+- [ ] Tabella `mechanic_analyses`: `id, shared_game_id, pdf_document_id, model_used, prompt_version, generated_at, sections jsonb, citations jsonb, cost_usd, tokens_used, status, reviewed_by, reviewed_at, published_card_id, row_version`
+- [ ] Tabella `mechanic_cards`: `id, shared_game_id, origin_analysis_id, origin, content jsonb, version, published_at, published_by, is_suppressed, suppressed_reason, error_reports_count, feedback_score, row_version`
+- [ ] Tabella `mechanic_card_feedback`: `id, card_id, user_id, rating, error_claim_id, comment, created_at`
+- [ ] UNIQUE `(shared_game_id, pdf_document_id, prompt_version)` su `mechanic_analyses` (ADR T7)
+- [ ] Partial index `WHERE is_suppressed = false` su `mechanic_cards` (ADR T5)
+- [ ] Migrazione idempotente: raw SQL con `IF NOT EXISTS` / `DO $$ IF EXISTS` come in PR #517
+- [ ] FK con `ON DELETE CASCADE` verso `shared_games`
+- [ ] Test: migration applicabile 2x senza errori
+
+**Dependencies**: none
+
+---
+
+### M1.2 — Command `GenerateMechanicAnalysisCommand` + prompt v1 + integrazione DeepSeek
+
+**Labels**: `area:backend`, `bc:shared-game-catalog`, `type:feature`, `milestone:mechanic-extractor-m1`, `ai`
+
+**Contesto**: Endpoint admin che prende `(sharedGameId, pdfDocumentId)`, estrae chunks dal PDF, invia al LLM con schema JSON stretto, salva draft in `mechanic_analyses` status=`pending_review`.
+
+**AC**:
+- [ ] `POST /api/v1/admin/mechanic-analyses` (admin-only) con body `{ sharedGameId, pdfDocumentId, promptVersion? }`
+- [ ] `GenerateMechanicAnalysisCommand` + `Handler` + `Validator` (FluentValidation)
+- [ ] Retrieval chunks da `pdf_documents` via pgvector (riuso `IRetrievalService` esistente)
+- [ ] Prompt template v1 committato in `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/Prompts/MechanicAnalysisPromptV1.md`
+- [ ] JSON schema enforcement: claim/citation structure con `pdf_page` + `quote` (ADR T3)
+- [ ] LLM: DeepSeek primary, OpenRouter fallback (riuso `ILlmRoutingService`)
+- [ ] Pre-flight cost estimate + hard cap default €2.00 (ADR T8)
+- [ ] Salvataggio: `status='pending_review'`, token/cost tracked
+- [ ] Test integration: estrazione end-to-end su Catan PDF fixture
+
+**Dependencies**: M1.1
+
+---
+
+### M1.3 — Guardrails: quote length, rejection sampling, citation verification, cost cap
+
+**Labels**: `area:backend`, `bc:shared-game-catalog`, `type:feature`, `milestone:mechanic-extractor-m1`, `compliance:ip`
+
+**Contesto**: Vincoli tecnici T1-T4 dell'ADR-051. Post-processing dell'output LLM prima del salvataggio. Reject + re-prompt su violazione.
+
+**AC**:
+- [ ] Validator T1: ogni `citation.quote` ≤ 25 parole (conteggio word-tokenizer) → reject + re-prompt (max 2 retry)
+- [ ] Validator T2: rejection sampling letterale — se >10 parole consecutive matchano il chunk sorgente → reject + re-prompt
+- [ ] Validator T3: ogni `claim` deve avere almeno 1 `citation` con `pdf_page` valido
+- [ ] Validator T4: `citation.pdf_page` deve esistere nel PDF; `quote` deve essere substring del chunk associato
+- [ ] Validator T8: stop se cost estimate > cap (override admin solo con reason)
+- [ ] Logging strutturato: ogni rejection loggata con motivo + retry count per audit
+- [ ] Test unitari per ogni validator
+- [ ] Test integration: prompt intenzionalmente "buggy" viene bloccato
+
+**Dependencies**: M1.2
+
+---
+
+### M1.4 — Admin Review UI: per-claim approve/reject
+
+**Labels**: `area:frontend`, `type:feature`, `milestone:mechanic-extractor-m1`, `admin`
+
+**Contesto**: Sostituisce l'attuale review read-only. Admin vede ogni claim con citation highlight, può approvare/rifiutare per-claim, aggiungere note.
+
+**AC**:
+- [ ] Refactor `/admin/knowledge-base/mechanic-extractor/review` per consumare `mechanic_analyses` (non più `mechanic_drafts`)
+- [ ] Route: `/admin/knowledge-base/mechanic-analyses/[analysisId]/review`
+- [ ] Per ogni claim: checkbox approve/reject + campo note
+- [ ] Citation viewer: apre PDF viewer alla `pdf_page` evidenziando `quote`
+- [ ] Bulk actions: "Approve all", "Reject all con quote >20 parole"
+- [ ] Indicatori guardrail: badge verdi/rossi sui claim passati/falliti T1-T4
+- [ ] Submit → `POST /api/v1/admin/mechanic-analyses/{id}/review` con `{ claimApprovals: [...], reviewNotes }`
+- [ ] Status transition: `pending_review` → `approved` o `rejected`
+- [ ] Footer attribution aggiornato (rimossa dicitura Variant C, nuova da ADR-051)
+- [ ] Test E2E Playwright: review flow admin
+
+**Dependencies**: M1.2
+
+---
+
+### M1.5 — Publication action: promote approved analysis → `mechanic_card`
+
+**Labels**: `area:backend`, `bc:shared-game-catalog`, `type:feature`, `milestone:mechanic-extractor-m1`
+
+**Contesto**: Dopo review approvata, admin pubblica come `mechanic_card` visibile agli utenti loggati.
+
+**AC**:
+- [ ] `POST /api/v1/admin/mechanic-analyses/{id}/publish` con body `{ title? }`
+- [ ] `PublishMechanicCardCommand` + `Handler` + `Validator`
+- [ ] Solo analisi con `status='approved'` possono essere pubblicate
+- [ ] Crea riga `mechanic_cards` con `origin='ai_reviewed'`, `version=1`
+- [ ] Update `mechanic_analyses.published_card_id`
+- [ ] Audit log: `mechanic_card_audit_log(card_id, action='published', actor, timestamp, metadata)`
+- [ ] Riutilizza `SharedGameId` per unicità (una sola card attiva `WHERE !is_suppressed` per gioco)
+- [ ] Test integration: publish flow + verifica card visibile da endpoint player
+
+**Dependencies**: M1.4
+
+---
+
+### M1.6 — Public card page su `/games/{slug}/card` (login-gated)
+
+**Labels**: `area:frontend`, `type:feature`, `milestone:mechanic-extractor-m1`, `user-facing`
+
+**Contesto**: Specchietto pubblico dimostra comprensione AI. Login-gated in M1; rilassare ad alpha/public in fase successiva.
+
+**AC**:
+- [ ] Route: `/games/[slug]/card` — render `mechanic_card.content`
+- [ ] Middleware: redirect a login se non autenticato
+- [ ] Layout mobile-first, print-friendly (per player al tavolo)
+- [ ] Sezioni: Summary, Mechanics, Victory, Resources, Phases, FAQ (come review UI ma read-only)
+- [ ] Inline citations: ogni claim ha badge `[p.N]` cliccabile → opens modal/sidebar con `quote` + link al PDF
+- [ ] Footer attribution ADR-051 (editore + MeepleAI)
+- [ ] 404 se `is_suppressed=true` o nessuna card pubblicata
+- [ ] Badge "AI-generated, human-reviewed" con link a "come funziona" (landing M2.2)
+- [ ] Test E2E: apri card Catan, verifica citations
+
+**Dependencies**: M1.5
+
+---
+
+### M1.7 — Refactor footer Variant C + pagina takedown policy
+
+**Labels**: `area:frontend`, `type:chore`, `milestone:mechanic-extractor-m1`, `compliance:ip`
+
+**Contesto**: Footer attuale dichiara "AI non ha mai letto il testo" — tecnicamente falso con nuova pipeline. ADR-051 definisce nuovo testo.
+
+**AC**:
+- [ ] Rimosso testo Variant C in `review/page.tsx:262-265`
+- [ ] Nuovo footer (da ADR-051): *"Analisi elaborata dall'AI sul manuale del gioco. Ogni affermazione è riformulata in parole originali e cita la pagina del regolamento. Copyright © degli editori per il testo originale del manuale."*
+- [ ] Pagina `/legal/takedown` pubblica con template form
+- [ ] Email alias `takedown@meepleai.app` setup (infra task, tracked separatamente)
+- [ ] Link a `/legal/takedown` da footer card pubblica (M1.6)
+- [ ] Documento `docs/legal/takedown-policy.md` con SLA response + processo interno
+
+**Dependencies**: M1.6 (per link dalla card)
+
+---
+
+## M2 — Trust Chain
+
+### M2.1 — Inline citation UI su public card
+
+**Labels**: `area:frontend`, `type:enhancement`, `milestone:mechanic-extractor-m2`
+
+**Contesto**: M1.6 implementa citation base. M2 migliora UX con preview inline, highlight pagina PDF, copy-as-quote.
+
+**AC**:
+- [ ] Hover su badge `[p.N]` mostra tooltip con `quote` (primi 60 char)
+- [ ] Click apre side-panel con PDF viewer pre-scrollato alla pagina + quote evidenziata
+- [ ] Azione "Copia citazione" → clipboard con format APA-style
+- [ ] A11y: focus trap, ESC chiude panel, keyboard nav claim↔citation
+- [ ] Performance: lazy-load PDF.js solo on-demand
+
+**Dependencies**: M1.6
+
+---
+
+### M2.2 — Landing "Come funziona" con demo Catan
+
+**Labels**: `area:frontend`, `type:feature`, `milestone:mechanic-extractor-m2`, `marketing`
+
+**Contesto**: Asset pubblico per dimostrare comprensione AI + trust chain. Catan come esempio hero (scelto ADR).
+
+**AC**:
+- [ ] Route pubblica `/how-it-works/game-comprehension`
+- [ ] Sezione "Trust chain" in 4 step: PDF → AI reads → Review admin → Card con citations
+- [ ] Embed live della card Catan con citation interattiva
+- [ ] CTA: "Prova con il tuo gioco" → login
+- [ ] SEO: OG tags, structured data `LearningResource`
+- [ ] A11y: WCAG AA
+
+**Dependencies**: M1.6 (Catan pubblicato)
+
+---
+
+### M2.3 — Admin metrics dashboard: cost, review time, approval rate
+
+**Labels**: `area:frontend`, `area:backend`, `type:feature`, `milestone:mechanic-extractor-m2`, `admin`
+
+**Contesto**: Strumento operativo per monitorare qualità + costi pipeline AI.
+
+**AC**:
+- [ ] Route `/admin/mechanic-extractor/metrics`
+- [ ] KPI: avg cost/analisi, avg review time, approval rate, rejection reasons breakdown
+- [ ] Time series: costo giornaliero (7/30/90 giorni)
+- [ ] Tabella: analisi recenti con status + reviewer + cost
+- [ ] Filtri: per gioco, per reviewer, per status
+- [ ] Export CSV
+
+**Dependencies**: M1.5
+
+---
+
+## M3 — Feedback Loop
+
+### M3.1 — Player feedback UI: 👍/👎 + error report
+
+**Labels**: `area:frontend`, `type:feature`, `milestone:mechanic-extractor-m3`, `user-facing`
+
+**Contesto**: Utenti loggati possono segnalare errori su singoli claim. Feedback in `mechanic_card_feedback`.
+
+**AC**:
+- [ ] Per ogni claim nella card: pulsante 👍/👎
+- [ ] 👎 apre modal "Segnala errore" con: tipo (fattuale/ambiguo/contraddice regola), descrizione, citazione alla regola corretta (opzionale)
+- [ ] `POST /api/v1/mechanic-cards/{id}/feedback`
+- [ ] Rate limit: max 10 feedback/user/day
+- [ ] Idempotenza: un user può cambiare feedback ma non duplicare
+- [ ] UI conferma submit + "grazie" state
+
+**Dependencies**: M1.6
+
+---
+
+### M3.2 — Auto-suppression logic + re-processing queue
+
+**Labels**: `area:backend`, `bc:shared-game-catalog`, `type:feature`, `milestone:mechanic-extractor-m3`
+
+**Contesto**: Quando N error reports su stessa card superano soglia, auto-suppress + enqueue rigenerazione.
+
+**AC**:
+- [ ] Background job (Hangfire/cron) evalua feedback counts
+- [ ] Soglia default: `error_reports_count >= 5` AND `feedback_score < 0.5` → auto-suppress
+- [ ] `is_suppressed=true, suppressed_reason='auto_feedback'`
+- [ ] Enqueue nuova analisi con `promptVersion=current+1` (se disponibile), o alert admin per review manuale
+- [ ] Audit log su suppression
+- [ ] Config soglie via `SystemConfiguration` BC (admin tunable)
+
+**Dependencies**: M3.1
+
+---
+
+### M3.3 — Admin notification on suppression event
+
+**Labels**: `area:backend`, `bc:user-notifications`, `type:feature`, `milestone:mechanic-extractor-m3`
+
+**Contesto**: Admin deve sapere immediatamente quando una card viene soppressa (auto o manuale).
+
+**AC**:
+- [ ] Event `MechanicCardSuppressedEvent` pubblicato su suppression
+- [ ] Handler in `UserNotifications` BC crea notifica per tutti admin
+- [ ] Email opzionale (se admin ha `notify_on_card_suppression=true`)
+- [ ] Notifica include: gioco, motivo, link a metrics + re-process queue
+
+**Dependencies**: M3.2
+
+---
+
+## M4 — Variant C Deprecation
+
+### M4.1 — Deprecation banner + redirect sull'editor Variant C
+
+**Labels**: `area:frontend`, `type:chore`, `milestone:mechanic-extractor-m4`
+
+**AC**:
+- [ ] Banner giallo in alto su `/admin/knowledge-base/mechanic-extractor` (editor): "Questo flow è deprecato, usa il nuovo [AI Analysis]"
+- [ ] CTA primario → `/admin/knowledge-base/mechanic-analyses/new`
+- [ ] Banner persiste 6 mesi pre-rimozione
+
+**Dependencies**: M1.2
+
+---
+
+### M4.2 — Hide legacy menu items
+
+**Labels**: `area:frontend`, `type:chore`, `milestone:mechanic-extractor-m4`
+
+**AC**:
+- [ ] Sidebar admin: "Mechanic Extractor (legacy)" dietro feature flag `show_legacy_mechanic_extractor=false` (default)
+- [ ] Env override per staging/debug
+
+**Dependencies**: M4.1
+
+---
+
+### M4.3 — Code removal Variant C (tracked separately, +6 months)
+
+**Labels**: `area:backend`, `area:frontend`, `type:chore`, `milestone:mechanic-extractor-m4`, `deferred`
+
+**Contesto**: Issue placeholder per sunset code. NON chiudere fino a rimozione effettiva.
+
+**AC**:
+- [ ] Gate: >= 6 mesi da M4.1 merge
+- [ ] Rimossi: `MechanicExtractor` commands/queries legacy, `mechanic_drafts` table, route editor, componenti frontend Variant C
+- [ ] Migration drop table `mechanic_drafts` (idempotente)
+- [ ] Smoke test: nessun link rotto, no 500 su admin nav
+
+**Dependencies**: M4.2
+
+---
+
+## Ordine Esecuzione M1 (critical path)
+
+```
+M1.1 (schema) → M1.2 (command/prompt) → M1.3 (guardrails) → M1.4 (review UI)
+                                                               ↓
+                                    M1.7 (footer+takedown) ← M1.6 (public card) ← M1.5 (publish)
+```
+
+**Parallelizable**: M1.4 + M1.5 in parallelo (UI ≠ command backend); M1.7 dopo M1.6.
+
+## Gate criteria per M1 complete
+
+1. ✅ Catan card pubblicata su `/games/catan/card` (login-gated)
+2. ✅ Mage Knight PDF caricato su staging (prerequisito operatore, parte M1.2)
+3. ✅ Mage Knight card pubblicata su `/games/mage-knight/card`
+4. ✅ 0 citazioni con quote >25 parole (grep su `mechanic_cards.content`)
+5. ✅ Footer attribution nuovo live
+6. ✅ Takedown policy page pubblicata
+
+## Prerequisiti operativi (NON issue tecnica)
+
+- [ ] Upload PDF Mage Knight su staging (~100 pagine, ~15MB) — bloccante per M1.2 test
+- [ ] Conferma copia legittima per testing (Catan già OK)
+- [ ] ToS review con consulenza IP entro M2 (separato da questo roadmap)
+- [ ] Setup email `takedown@meepleai.app` (separato, M1.7)


### PR DESCRIPTION
## Summary

Implements M1.1 — schema & persistence layer for the MechanicAnalysis aggregate (issue #523).

- **Domain layer** (previous commit): `MechanicAnalysis` aggregate with `MechanicClaim` / `MechanicCitation` entities, status lifecycle (Draft → Ready → Published → Suppressed), versioning, and domain events.
- **Infrastructure layer** (this commit): EF Core entities, configurations, repository, EF migration, DI wiring.
- **Integration tests**: 8 Testcontainers tests covering AC-4..AC-9 + AC-11, plus 22 unit tests on the aggregate = 30 passing.

## Acceptance Criteria covered

| AC | Description | Status |
|----|-------------|--------|
| AC-4 | Partial unique index on `(SharedGameId, LatestVersion) WHERE NOT IsSuppressed AND Status=Published` | ✅ |
| AC-5 | Status transition + audit row atomic in a single `SaveChanges` | ✅ |
| AC-6 | Global query filter on `IsSuppressed` | ✅ |
| AC-7 | Review queue bypasses filter via `IgnoreQueryFilters()` | ✅ |
| AC-8 | Suppression creates audit row with actor + reason | ✅ |
| AC-9 | Optimistic concurrency via PostgreSQL `xmin` column | ✅ |
| AC-11 | Cascade delete: analysis → claims → citations → audit rows | ✅ |

## Key design decisions

### Optimistic concurrency via `xmin`
PostgreSQL's system `xmin` column (xid → `uint`) is mapped as an **explicit** `Xmin` property on the entity and plumbed through the aggregate as `XminVersion`. This is required because the repository uses the detached-Update pattern (`MapToDomain` → mutate → `MapToEntity` → `DbContext.Update`): without round-tripping the token through the aggregate, `Xmin` would default to 0 on every save and trigger a spurious `DbUpdateConcurrencyException`.

### Audit-via-repository
Status transitions and suppressions emit domain events; the repository synthesises audit rows from those events and persists them in the same `SaveChanges` call as the aggregate mutation. Atomicity is guaranteed by EF Core's single-transaction-per-SaveChanges behaviour.

### Query filter + review queue
The `MechanicAnalysis` entity has a global query filter `e => !e.IsSuppressed`. The review-queue query in the repository uses `IgnoreQueryFilters()` to surface suppressed rows for admin review.

## Test plan

- [x] `dotnet test --filter FullyQualifiedName~MechanicAnalysis` → 30/30 green locally
- [ ] CI pipeline green on this PR
- [ ] Code review via `/code-review:code-review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)