### PR TITLE
feat(mechanic-extractor): M1.2 generate command + async pipeline (#524)

### DIFF
--- a/apps/api/src/Api/Api.csproj
+++ b/apps/api/src/Api/Api.csproj
@@ -103,6 +103,8 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Infrastructure\Seeders\Catalog\Manifests\*.yml" />
+    <!-- ISSUE-524 / M1.2: MechanicExtractor prompts (ADR-051, B4=A: versioned via git) -->
+    <EmbeddedResource Include="BoundedContexts\SharedGameCatalog\Infrastructure\Prompts\MechanicExtractor\v1\*.md" />
   </ItemGroup>
   <!-- MeepleDev: exclude dev tools from Release builds -->
   <ItemGroup Condition="'$(Configuration)' == 'Release'">

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/GenerateMechanicAnalysisCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/GenerateMechanicAnalysisCommand.cs
@@ -1,0 +1,39 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+
+/// <summary>
+/// Kicks off an AI-generated mechanic analysis for a shared game's PDF rulebook (ISSUE-524 / M1.2,
+/// ADR-051). The handler creates a <c>Draft</c> <see cref="Domain.Aggregates.MechanicAnalysis"/>
+/// aggregate and schedules the LLM pipeline to run asynchronously (B5=B). The endpoint returns
+/// 202 Accepted.
+/// </summary>
+/// <param name="SharedGameId">Target shared game whose rulebook will be analyzed.</param>
+/// <param name="PdfDocumentId">The specific PDF document version to analyze. Must be linked to
+///   <paramref name="SharedGameId"/> via <c>shared_game_documents</c>.</param>
+/// <param name="RequestedBy">User id of the admin triggering the run. Recorded as
+///   <c>CreatedBy</c> on the aggregate and, on mid-run abort, as <c>ReviewedBy</c> for audit.</param>
+/// <param name="CostCapUsd">Hard USD cap for this run (T8 cost governance). The pipeline aborts
+///   via <c>AutoRejectFromDraft</c> if cumulative cost exceeds the effective cap mid-run.</param>
+/// <param name="CostCapOverride">Optional planning-time override (B3=A). When present, the handler
+///   raises the aggregate's cap to <see cref="CostCapOverrideInput.NewCapUsd"/> immediately after
+///   creation, preserving the override reason on the aggregate's audit fields
+///   (<c>CostCapOverrideAt</c>/<c>CostCapOverrideBy</c>/<c>CostCapOverrideReason</c>).</param>
+internal record GenerateMechanicAnalysisCommand(
+    Guid SharedGameId,
+    Guid PdfDocumentId,
+    Guid RequestedBy,
+    decimal CostCapUsd,
+    CostCapOverrideInput? CostCapOverride = null) : ICommand<MechanicAnalysisGenerationResponseDto>;
+
+/// <summary>
+/// Admin-initiated raise of the default cost cap at planning time. Required when the cost
+/// estimator projects a total cost above the submitted <c>CostCapUsd</c> and the admin decides
+/// to proceed anyway with a justified, auditable override.
+/// </summary>
+/// <param name="NewCapUsd">New cap in USD. Must be strictly greater than the original
+///   <c>CostCapUsd</c>.</param>
+/// <param name="Reason">Free-form justification (20-500 chars). Persisted into
+///   <c>MechanicAnalysis.CostCapOverrideReason</c> for audit (T6).</param>
+internal record CostCapOverrideInput(decimal NewCapUsd, string Reason);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/GenerateMechanicAnalysisCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/GenerateMechanicAnalysisCommandHandler.cs
@@ -1,0 +1,357 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+
+/// <summary>
+/// Handler for <see cref="GenerateMechanicAnalysisCommand"/> (ISSUE-524 / M1.2, ADR-051).
+/// </summary>
+/// <remarks>
+/// Synchronous portion (blocks the HTTP request):
+/// <list type="number">
+/// <item><description>Verify <c>SharedGame</c> exists → <see cref="NotFoundException"/> otherwise.</description></item>
+/// <item><description>Verify the PDF is linked to the game via <c>shared_game_documents</c> → <see cref="NotFoundException"/> otherwise.</description></item>
+/// <item><description>T7 idempotency: if a non-<c>Rejected</c> analysis already exists for (SharedGameId, PdfDocumentId, PromptVersion), short-circuit and return its state with <c>IsExistingAnalysis=true</c>.</description></item>
+/// <item><description>Project cost via <see cref="IAnalysisCostEstimator"/>. If the projection exceeds the submitted cap and no override is provided, throw <see cref="ConflictException"/> (HTTP 409).</description></item>
+/// <item><description>Create the aggregate in <c>Draft</c>, optionally applying <c>OverrideCostCap</c> for auditable cap raises (B3=A), and persist via <c>IUnitOfWork.SaveChangesAsync</c>.</description></item>
+/// </list>
+/// Asynchronous portion (fire-and-forget): enqueue the pipeline run via
+/// <see cref="IBackgroundTaskService.ExecuteWithCancellation"/>. The background job owns its own
+/// DI scope (via <see cref="IServiceScopeFactory"/>) so this handler's scope can exit cleanly.
+/// The endpoint returns <c>202 Accepted</c> with <c>StatusUrl</c>.
+/// </remarks>
+internal sealed class GenerateMechanicAnalysisCommandHandler
+    : ICommandHandler<GenerateMechanicAnalysisCommand, MechanicAnalysisGenerationResponseDto>
+{
+    // B4=A: prompts v1 target DeepSeek. These defaults align with ADR-007 routing.
+    private const string DefaultProvider = "DeepSeek";
+    private const string DefaultModel = "deepseek-chat";
+
+    // Conservative DeepSeek list pricing as of 2026-04 (project_deepseek_llm memory).
+    // Runtime cost is captured per-section from the actual LlmCompletionResult, so any drift
+    // affects only the planning estimate — the hard cap still bites based on real spend.
+    private const decimal DefaultInputCostPerMillion = 0.14m;
+    private const decimal DefaultOutputCostPerMillion = 0.28m;
+
+    // Hard ceiling on retrieved context shipped into the pipeline. DeepSeek-chat tolerates
+    // ~64K context; we stay under that with room for prompt + completion. Conversion: ~4
+    // chars per token — good enough for a planning budget.
+    private const int MaxRetrievedCharacters = 240_000;
+
+    // Section fan-out for M1.2 (all six sections generated in one run).
+    private static readonly IReadOnlyList<MechanicSection> AllSections = new[]
+    {
+        MechanicSection.Summary,
+        MechanicSection.Mechanics,
+        MechanicSection.Victory,
+        MechanicSection.Resources,
+        MechanicSection.Phases,
+        MechanicSection.Faq
+    };
+
+    private readonly IMechanicAnalysisRepository _analysisRepository;
+    private readonly ISharedGameRepository _sharedGameRepository;
+    private readonly ISharedGameDocumentRepository _documentRepository;
+
+    // Read-side-only DbContext access for TextChunks (DocumentProcessing BC). We intentionally do
+    // not introduce a cross-BC repository for what is a projection used exclusively to assemble
+    // prompt input. All writes go through repositories + IUnitOfWork.
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly IMechanicPromptProvider _promptProvider;
+    private readonly IAnalysisCostEstimator _costEstimator;
+    private readonly IBackgroundTaskService _backgroundTaskService;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly TimeProvider _timeProvider;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<GenerateMechanicAnalysisCommandHandler> _logger;
+
+    public GenerateMechanicAnalysisCommandHandler(
+        IMechanicAnalysisRepository analysisRepository,
+        ISharedGameRepository sharedGameRepository,
+        ISharedGameDocumentRepository documentRepository,
+        MeepleAiDbContext dbContext,
+        IMechanicPromptProvider promptProvider,
+        IAnalysisCostEstimator costEstimator,
+        IBackgroundTaskService backgroundTaskService,
+        IServiceScopeFactory scopeFactory,
+        TimeProvider timeProvider,
+        IUnitOfWork unitOfWork,
+        ILogger<GenerateMechanicAnalysisCommandHandler> logger)
+    {
+        _analysisRepository = analysisRepository ?? throw new ArgumentNullException(nameof(analysisRepository));
+        _sharedGameRepository = sharedGameRepository ?? throw new ArgumentNullException(nameof(sharedGameRepository));
+        _documentRepository = documentRepository ?? throw new ArgumentNullException(nameof(documentRepository));
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _promptProvider = promptProvider ?? throw new ArgumentNullException(nameof(promptProvider));
+        _costEstimator = costEstimator ?? throw new ArgumentNullException(nameof(costEstimator));
+        _backgroundTaskService = backgroundTaskService ?? throw new ArgumentNullException(nameof(backgroundTaskService));
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<MechanicAnalysisGenerationResponseDto> Handle(
+        GenerateMechanicAnalysisCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var promptVersion = _promptProvider.PromptVersion;
+
+        // 1. SharedGame existence (404 if missing).
+        var sharedGame = await _sharedGameRepository
+            .GetByIdAsync(request.SharedGameId, cancellationToken)
+            .ConfigureAwait(false);
+        if (sharedGame is null)
+        {
+            throw new NotFoundException(
+                resourceType: "SharedGame",
+                resourceId: request.SharedGameId.ToString());
+        }
+
+        // 2. PDF linkage (404 if the PDF is not associated with the game). Goes through the
+        //    domain repository so the handler stays decoupled from EF entity projections.
+        var pdfLinked = await _documentRepository
+            .IsPdfLinkedToGameAsync(request.SharedGameId, request.PdfDocumentId, cancellationToken)
+            .ConfigureAwait(false);
+        if (!pdfLinked)
+        {
+            throw new NotFoundException(
+                resourceType: "SharedGameDocument",
+                resourceId: $"{request.SharedGameId}/{request.PdfDocumentId}");
+        }
+
+        // 3. T7 idempotency — return the existing non-rejected analysis unchanged.
+        var existing = await _analysisRepository
+            .FindByPromptVersionAsync(request.SharedGameId, request.PdfDocumentId, promptVersion, cancellationToken)
+            .ConfigureAwait(false);
+        if (existing is not null)
+        {
+            _logger.LogInformation(
+                "Mechanic analysis idempotent short-circuit: existing {ExistingId} for (SharedGame={SharedGame}, Pdf={Pdf}, PromptVersion={Version}, Status={Status}).",
+                existing.Id,
+                request.SharedGameId,
+                request.PdfDocumentId,
+                promptVersion,
+                existing.Status);
+
+            return BuildResponse(
+                existing.Id,
+                existing.Status,
+                promptVersion,
+                effectiveCostCap: existing.CostCapUsd,
+                estimatedCost: 0m,
+                projectedTotalTokens: 0,
+                costCapOverrideApplied: existing.CostCapOverrideBy is not null,
+                isExisting: true);
+        }
+
+        // 4. Load retrieval context. M1.2 ships the same bundled rulebook content to every
+        //    section (the section prompt itself narrows the focus). M1.3 will introduce a
+        //    semantic retriever keyed on section intent.
+        var retrievalContext = await LoadRetrievalContextAsync(request.PdfDocumentId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(retrievalContext))
+        {
+            throw new ConflictException(
+                $"PDF {request.PdfDocumentId} has no indexed text chunks. Re-run extraction before generating a mechanic analysis.");
+        }
+
+        // 5. Cost projection (T8). Token count uses a 4-char/token heuristic consistent with
+        //    the estimator's calibration in AnalysisCostEstimator.
+        var retrievedPromptTokens = retrievalContext.Length / 4;
+        var estimate = _costEstimator.Estimate(new AnalysisCostEstimateInput(
+            PromptVersion: promptVersion,
+            Provider: DefaultProvider,
+            Model: DefaultModel,
+            Sections: AllSections,
+            TotalRetrievedPromptTokens: retrievedPromptTokens,
+            InputCostPerMillionTokens: DefaultInputCostPerMillion,
+            OutputCostPerMillionTokens: DefaultOutputCostPerMillion));
+
+        var hasOverride = request.CostCapOverride is not null;
+        var effectiveCostCap = hasOverride ? request.CostCapOverride!.NewCapUsd : request.CostCapUsd;
+
+        // B2=A: hard cap × 1.0. Projected cost must fit under the effective cap up-front;
+        // we do not authorise any overshoot at planning time.
+        if (estimate.ProjectedCostUsd > effectiveCostCap)
+        {
+            _logger.LogWarning(
+                "Mechanic analysis rejected at planning: projected cost {Projected:F4} USD > cap {Cap:F4} USD (override={HasOverride}).",
+                estimate.ProjectedCostUsd,
+                effectiveCostCap,
+                hasOverride);
+
+            throw new ConflictException(
+                $"Projected cost {estimate.ProjectedCostUsd:F4} USD exceeds the effective cap {effectiveCostCap:F4} USD. "
+                + "Supply a CostCapOverride with justification or reduce the rulebook scope.");
+        }
+
+        // 6. Create aggregate in Draft, then optionally raise the cap for audit. The order
+        //    matters: Create() enforces costCapUsd > 0; OverrideCostCap() requires the new
+        //    cap to exceed the current one.
+        var utcNow = _timeProvider.GetUtcNow().UtcDateTime;
+        var analysis = MechanicAnalysis.Create(
+            sharedGameId: request.SharedGameId,
+            pdfDocumentId: request.PdfDocumentId,
+            promptVersion: promptVersion,
+            createdBy: request.RequestedBy,
+            createdAt: utcNow,
+            modelUsed: DefaultModel,
+            provider: DefaultProvider,
+            costCapUsd: request.CostCapUsd);
+
+        if (hasOverride)
+        {
+            analysis.OverrideCostCap(
+                actorId: request.RequestedBy,
+                newCapUsd: request.CostCapOverride!.NewCapUsd,
+                reason: request.CostCapOverride.Reason,
+                utcNow: utcNow);
+        }
+
+        await _analysisRepository.AddAsync(analysis, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            // Extremely narrow window: concurrent admin submitted the same (game, pdf, version).
+            // Re-query and short-circuit to the winner.
+            var winner = await _analysisRepository
+                .FindByPromptVersionAsync(request.SharedGameId, request.PdfDocumentId, promptVersion, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (winner is not null)
+            {
+                _logger.LogInformation(
+                    ex,
+                    "Mechanic analysis create lost race; returning concurrent winner {WinnerId}.", winner.Id);
+
+                return BuildResponse(
+                    winner.Id,
+                    winner.Status,
+                    promptVersion,
+                    effectiveCostCap: winner.CostCapUsd,
+                    estimatedCost: 0m,
+                    projectedTotalTokens: 0,
+                    costCapOverrideApplied: winner.CostCapOverrideBy is not null,
+                    isExisting: true);
+            }
+
+            throw;
+        }
+
+        _logger.LogInformation(
+            "Mechanic analysis {AnalysisId} queued for execution (SharedGame={SharedGame}, Pdf={Pdf}, ProjectedCost={Cost:F4}, EffectiveCap={Cap:F4}).",
+            analysis.Id,
+            request.SharedGameId,
+            request.PdfDocumentId,
+            estimate.ProjectedCostUsd,
+            effectiveCostCap);
+
+        // 7. Enqueue background execution. The callback must not capture the request-scoped
+        //    services — it creates a fresh scope so the pipeline can run past the HTTP
+        //    response.
+        var analysisId = analysis.Id;
+        _backgroundTaskService.ExecuteWithCancellation(
+            taskId: BuildTaskId(analysisId),
+            taskFactory: async ct =>
+            {
+                using var scope = _scopeFactory.CreateScope();
+                var executor = scope.ServiceProvider.GetRequiredService<IMechanicAnalysisExecutor>();
+                await executor.ExecuteAsync(analysisId, ct).ConfigureAwait(false);
+            });
+
+        return BuildResponse(
+            analysisId,
+            analysis.Status,
+            promptVersion,
+            effectiveCostCap: effectiveCostCap,
+            estimatedCost: estimate.ProjectedCostUsd,
+            projectedTotalTokens: estimate.ProjectedTotalTokens,
+            costCapOverrideApplied: hasOverride,
+            isExisting: false);
+    }
+
+    private async Task<string> LoadRetrievalContextAsync(Guid pdfDocumentId, CancellationToken ct)
+    {
+        // Pull chunks in document order. Ordering matters for the LLM — we want a coherent
+        // flow of the rulebook, not shuffled fragments. AsNoTracking() since we never mutate.
+        var chunks = await _dbContext.TextChunks
+            .AsNoTracking()
+            .Where(c => c.PdfDocumentId == pdfDocumentId)
+            .OrderBy(c => c.ChunkIndex)
+            .Select(c => new { c.ChunkIndex, c.PageNumber, c.Content })
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        if (chunks.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        // Concatenate with page markers to preserve provenance. Budget-capped so the prompt
+        // stays inside the model context window even for long rulebooks.
+        var builder = new System.Text.StringBuilder();
+        foreach (var chunk in chunks)
+        {
+            var header = chunk.PageNumber.HasValue
+                ? $"[chunk #{chunk.ChunkIndex} · page {chunk.PageNumber}]"
+                : $"[chunk #{chunk.ChunkIndex}]";
+
+            if (builder.Length + header.Length + chunk.Content.Length + 8 > MaxRetrievedCharacters)
+            {
+                break;
+            }
+
+            if (builder.Length > 0)
+            {
+                builder.Append("\n\n---\n\n");
+            }
+
+            builder.Append(header).Append('\n').Append(chunk.Content);
+        }
+
+        return builder.ToString();
+    }
+
+    private static MechanicAnalysisGenerationResponseDto BuildResponse(
+        Guid id,
+        MechanicAnalysisStatus status,
+        string promptVersion,
+        decimal effectiveCostCap,
+        decimal estimatedCost,
+        int projectedTotalTokens,
+        bool costCapOverrideApplied,
+        bool isExisting) =>
+        new(
+            Id: id,
+            Status: status,
+            PromptVersion: promptVersion,
+            CostCapUsd: effectiveCostCap,
+            EstimatedCostUsd: estimatedCost,
+            ProjectedTotalTokens: projectedTotalTokens,
+            CostCapOverrideApplied: costCapOverrideApplied,
+            StatusUrl: $"/api/v1/admin/mechanic-analyses/{id}/status",
+            IsExistingAnalysis: isExisting);
+
+    /// <summary>
+    /// Task id used by <see cref="IBackgroundTaskService"/> for cancellation correlation.
+    /// Stable per analysis so an operator can later invoke <c>CancelTask</c> if needed.
+    /// </summary>
+    internal static string BuildTaskId(Guid analysisId) => $"mechanic-analysis:{analysisId:D}";
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/GenerateMechanicAnalysisCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/GenerateMechanicAnalysisCommandValidator.cs
@@ -1,0 +1,56 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+
+/// <summary>
+/// FluentValidation rules for <see cref="GenerateMechanicAnalysisCommand"/>. These checks cover
+/// pre-conditions that are cheap to verify without hitting the DB or LLM. Cross-entity checks
+/// (game exists, PDF linked to game, idempotency) are delegated to the handler where the
+/// repository is available and exceptions can be mapped to proper HTTP status codes.
+/// </summary>
+internal sealed class GenerateMechanicAnalysisCommandValidator
+    : AbstractValidator<GenerateMechanicAnalysisCommand>
+{
+    /// <summary>
+    /// Sanity ceiling for the submitted cap. Prevents accidental typos like <c>"100.0"</c>
+    /// instead of <c>"1.00"</c> from pre-authorizing catastrophic spend. Admins who genuinely
+    /// need a higher cap should set <c>CostCapUsd</c> lower and supply a <c>CostCapOverride</c>
+    /// to make the intent auditable.
+    /// </summary>
+    private const decimal MaxCostCapUsd = 10.0m;
+
+    public GenerateMechanicAnalysisCommandValidator()
+    {
+        RuleFor(c => c.SharedGameId)
+            .NotEmpty().WithMessage("SharedGameId is required.");
+
+        RuleFor(c => c.PdfDocumentId)
+            .NotEmpty().WithMessage("PdfDocumentId is required.");
+
+        RuleFor(c => c.RequestedBy)
+            .NotEmpty().WithMessage("RequestedBy is required.");
+
+        RuleFor(c => c.CostCapUsd)
+            .GreaterThan(0m).WithMessage("CostCapUsd must be strictly positive (ADR-051 T8).")
+            .LessThanOrEqualTo(MaxCostCapUsd)
+                .WithMessage($"CostCapUsd must be ≤ {MaxCostCapUsd:F2} USD. Higher caps require an explicit override with justification.");
+
+        When(c => c.CostCapOverride is not null, () =>
+        {
+            RuleFor(c => c.CostCapOverride!.NewCapUsd)
+                .GreaterThan(0m).WithMessage("CostCapOverride.NewCapUsd must be strictly positive.")
+                .LessThanOrEqualTo(MaxCostCapUsd * 2)
+                    .WithMessage($"CostCapOverride.NewCapUsd must be ≤ {MaxCostCapUsd * 2:F2} USD.");
+
+            RuleFor(c => c.CostCapOverride!.Reason)
+                .NotEmpty().WithMessage("CostCapOverride.Reason is required when overriding the cap.")
+                .MinimumLength(20).WithMessage("CostCapOverride.Reason must be at least 20 characters to force deliberate justification.")
+                .MaximumLength(500).WithMessage("CostCapOverride.Reason must not exceed 500 characters.");
+
+            RuleFor(c => c)
+                .Must(c => c.CostCapOverride!.NewCapUsd > c.CostCapUsd)
+                    .WithMessage("CostCapOverride.NewCapUsd must be greater than the submitted CostCapUsd.")
+                    .WithName("CostCapOverride.NewCapUsd");
+        });
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicAnalysisGenerationResponseDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicAnalysisGenerationResponseDto.cs
@@ -1,0 +1,40 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+
+/// <summary>
+/// Response returned by <c>POST /api/v1/admin/mechanic-analyses</c> (ISSUE-524 / M1.2).
+/// The generation pipeline is asynchronous (B5=B): the endpoint returns 202 Accepted with
+/// this body immediately after the Draft aggregate is persisted and the background job is
+/// enqueued. Clients should poll <see cref="StatusUrl"/> (or subscribe to SignalR) to learn
+/// when the analysis transitions out of <see cref="MechanicAnalysisStatus.Draft"/>.
+/// </summary>
+/// <param name="Id">The newly-created (or pre-existing, on idempotent retry) analysis id.</param>
+/// <param name="Status">Aggregate status at the moment the endpoint responded. Always <c>Draft</c>
+///   for a brand-new run; on idempotent short-circuit this reflects the persisted state of the
+///   existing analysis (<c>Draft</c>, <c>InReview</c>, or <c>Published</c>).</param>
+/// <param name="PromptVersion">Prompt version used for generation (e.g. <c>"v1.0.0"</c>).</param>
+/// <param name="CostCapUsd">Effective cost cap in USD enforced for this run. If a
+///   <c>CostCapOverride</c> was supplied, this equals the override amount; otherwise the original
+///   admin-submitted cap.</param>
+/// <param name="EstimatedCostUsd">Conservative upper-bound projection computed by the cost
+///   estimator before the run starts. Real cost (captured on per-section runs) is typically lower.</param>
+/// <param name="ProjectedTotalTokens">Projected total tokens (prompt + completion) for all six
+///   sections. Informational only — not a hard limit.</param>
+/// <param name="CostCapOverrideApplied">True when the admin explicitly overrode the default cap
+///   at planning time, carrying the admin's justification into the aggregate's audit trail.</param>
+/// <param name="StatusUrl">Relative URL the client should poll to observe pipeline progress,
+///   e.g. <c>/api/v1/admin/mechanic-analyses/{id}/status</c>.</param>
+/// <param name="IsExistingAnalysis">True when T7 idempotency short-circuited a duplicate request;
+///   callers should treat the response as "already running / already completed" rather than a new
+///   run.</param>
+public sealed record MechanicAnalysisGenerationResponseDto(
+    Guid Id,
+    MechanicAnalysisStatus Status,
+    string PromptVersion,
+    decimal CostCapUsd,
+    decimal EstimatedCostUsd,
+    int ProjectedTotalTokens,
+    bool CostCapOverrideApplied,
+    string StatusUrl,
+    bool IsExistingAnalysis);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicAnalysisStatusDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicAnalysisStatusDto.cs
@@ -1,0 +1,61 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+
+/// <summary>
+/// Lightweight projection of a <see cref="Domain.Aggregates.MechanicAnalysis"/> returned by
+/// <c>GET /api/v1/admin/mechanic-analyses/{id}/status</c> (ISSUE-524 / M1.2). Admin callers use
+/// this endpoint to poll a background-running analysis after receiving <c>202 Accepted</c> from
+/// the generate endpoint. The payload includes per-section run telemetry (provider/model/tokens/
+/// latency) so operators can diagnose mid-pipeline failures without digging through logs.
+/// </summary>
+public sealed record MechanicAnalysisStatusDto(
+    Guid Id,
+    Guid SharedGameId,
+    Guid PdfDocumentId,
+    string PromptVersion,
+    MechanicAnalysisStatus Status,
+    string? RejectionReason,
+    Guid CreatedBy,
+    DateTime CreatedAt,
+    Guid? ReviewedBy,
+    DateTime? ReviewedAt,
+    string Provider,
+    string ModelUsed,
+    int TotalTokensUsed,
+    decimal EstimatedCostUsd,
+    decimal CostCapUsd,
+    bool CostCapOverrideApplied,
+    DateTime? CostCapOverrideAt,
+    Guid? CostCapOverrideBy,
+    string? CostCapOverrideReason,
+    bool IsSuppressed,
+    DateTime? SuppressedAt,
+    Guid? SuppressedBy,
+    string? SuppressionReason,
+    int ClaimsCount,
+    IReadOnlyList<MechanicSectionRunSummaryDto> SectionRuns);
+
+/// <summary>
+/// Per-section execution summary persisted in <c>mechanic_analysis_section_runs</c> (B6=C).
+/// One row per section attempt; rerunning the pipeline creates a new analysis with its own set
+/// of section runs. Exposed on the status endpoint for operator observability.
+/// <para>
+/// <c>Section</c> values: 0=Summary, 1=Mechanics, 2=Victory, 3=Resources, 4=Phases, 5=Faq.
+/// <c>Status</c> values: 0=Succeeded, 1=Failed, 2=SkippedDueToCostCap.
+/// </para>
+/// </summary>
+public sealed record MechanicSectionRunSummaryDto(
+    int Section,
+    int RunOrder,
+    string Provider,
+    string ModelUsed,
+    int PromptTokens,
+    int CompletionTokens,
+    int TotalTokens,
+    decimal EstimatedCostUsd,
+    int LatencyMs,
+    int Status,
+    string? ErrorMessage,
+    DateTime StartedAt,
+    DateTime CompletedAt);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetMechanicAnalysisStatusQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetMechanicAnalysisStatusQuery.cs
@@ -1,0 +1,13 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicExtractor;
+
+/// <summary>
+/// Loads the current status of an AI-generated mechanic analysis (ISSUE-524 / M1.2). Admin
+/// clients poll this endpoint after receiving <c>202 Accepted</c> from
+/// <c>POST /api/v1/admin/mechanic-analyses</c> to observe transitions out of <c>Draft</c>.
+/// </summary>
+/// <param name="AnalysisId">Primary key of the analysis to load.</param>
+internal sealed record GetMechanicAnalysisStatusQuery(Guid AnalysisId)
+    : IQuery<MechanicAnalysisStatusDto?>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetMechanicAnalysisStatusQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetMechanicAnalysisStatusQueryHandler.cs
@@ -1,0 +1,101 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicExtractor;
+
+/// <summary>
+/// Handler for <see cref="GetMechanicAnalysisStatusQuery"/> (ISSUE-524 / M1.2).
+/// Projects the aggregate + its section runs into a lightweight status DTO for admin polling.
+/// Bypasses the <c>IsSuppressed</c> global query filter so moderators can inspect suppressed
+/// analyses without losing visibility.
+/// </summary>
+internal sealed class GetMechanicAnalysisStatusQueryHandler
+    : IQueryHandler<GetMechanicAnalysisStatusQuery, MechanicAnalysisStatusDto?>
+{
+    private readonly MeepleAiDbContext _dbContext;
+
+    public GetMechanicAnalysisStatusQueryHandler(MeepleAiDbContext dbContext)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+    }
+
+    public async Task<MechanicAnalysisStatusDto?> Handle(
+        GetMechanicAnalysisStatusQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var analysis = await _dbContext.MechanicAnalyses
+            .AsNoTracking()
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(a => a.Id == request.AnalysisId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (analysis is null)
+        {
+            return null;
+        }
+
+        var claimsCount = await _dbContext.MechanicClaims
+            .AsNoTracking()
+            .IgnoreQueryFilters()
+            .CountAsync(c => c.AnalysisId == request.AnalysisId, cancellationToken)
+            .ConfigureAwait(false);
+
+        var sectionRunEntities = await _dbContext.MechanicAnalysisSectionRuns
+            .AsNoTracking()
+            .Where(r => r.AnalysisId == request.AnalysisId)
+            .OrderBy(r => r.RunOrder)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var sectionRuns = sectionRunEntities.Select(MapSectionRun).ToList();
+
+        return new MechanicAnalysisStatusDto(
+            Id: analysis.Id,
+            SharedGameId: analysis.SharedGameId,
+            PdfDocumentId: analysis.PdfDocumentId,
+            PromptVersion: analysis.PromptVersion,
+            Status: (MechanicAnalysisStatus)analysis.Status,
+            RejectionReason: analysis.RejectionReason,
+            CreatedBy: analysis.CreatedBy,
+            CreatedAt: analysis.CreatedAt,
+            ReviewedBy: analysis.ReviewedBy,
+            ReviewedAt: analysis.ReviewedAt,
+            Provider: analysis.Provider,
+            ModelUsed: analysis.ModelUsed,
+            TotalTokensUsed: analysis.TotalTokensUsed,
+            EstimatedCostUsd: analysis.EstimatedCostUsd,
+            CostCapUsd: analysis.CostCapUsd,
+            CostCapOverrideApplied: analysis.CostCapOverrideBy is not null,
+            CostCapOverrideAt: analysis.CostCapOverrideAt,
+            CostCapOverrideBy: analysis.CostCapOverrideBy,
+            CostCapOverrideReason: analysis.CostCapOverrideReason,
+            IsSuppressed: analysis.IsSuppressed,
+            SuppressedAt: analysis.SuppressedAt,
+            SuppressedBy: analysis.SuppressedBy,
+            SuppressionReason: analysis.SuppressionReason,
+            ClaimsCount: claimsCount,
+            SectionRuns: sectionRuns);
+    }
+
+    private static MechanicSectionRunSummaryDto MapSectionRun(MechanicAnalysisSectionRunEntity entity) =>
+        new(
+            Section: entity.Section,
+            RunOrder: entity.RunOrder,
+            Provider: entity.Provider,
+            ModelUsed: entity.ModelUsed,
+            PromptTokens: entity.PromptTokens,
+            CompletionTokens: entity.CompletionTokens,
+            TotalTokens: entity.TotalTokens,
+            EstimatedCostUsd: entity.EstimatedCostUsd,
+            LatencyMs: entity.LatencyMs,
+            Status: entity.Status,
+            ErrorMessage: entity.ErrorMessage,
+            StartedAt: entity.StartedAt,
+            CompletedAt: entity.CompletedAt);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/AnalysisCostEstimator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/AnalysisCostEstimator.cs
@@ -1,0 +1,62 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
+
+/// <summary>
+/// Default heuristic cost estimator for Mechanic Extractor pipelines (ISSUE-524 / M1.2).
+/// </summary>
+/// <remarks>
+/// Token budgets were calibrated against the v1 prompts:
+/// <list type="bullet">
+/// <item><description>System prompt (IP policy): ~700 tokens, shared by every section.</description></item>
+/// <item><description>Section user prompt (schema + instructions): ~350 tokens/section.</description></item>
+/// <item><description>Retrieved context: supplied by caller via <see cref="AnalysisCostEstimateInput.TotalRetrievedPromptTokens"/>.</description></item>
+/// <item><description>Output budget: 800 tokens for structured sections, 1400 for FAQ (5-10 Q&amp;A pairs).</description></item>
+/// </list>
+/// The estimator purposely over-projects so that cost caps bite early rather than mid-run.
+/// </remarks>
+internal sealed class AnalysisCostEstimator : IAnalysisCostEstimator
+{
+    private const int SystemPromptTokens = 700;
+    private const int SectionInstructionTokens = 350;
+    private const int DefaultSectionOutputTokens = 800;
+    private const int FaqOutputTokens = 1400;
+
+    public AnalysisCostEstimate Estimate(AnalysisCostEstimateInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        if (input.Sections.Count == 0)
+        {
+            throw new ArgumentException("At least one section must be targeted.", nameof(input));
+        }
+
+        var chunksPerSection = Math.Max(0, input.TotalRetrievedPromptTokens) / input.Sections.Count;
+
+        var perSection = new Dictionary<MechanicSection, SectionCostProjection>(input.Sections.Count);
+        var totalPromptTokens = 0;
+        var totalCompletionTokens = 0;
+        decimal totalCost = 0m;
+
+        foreach (var section in input.Sections)
+        {
+            var promptTokens = SystemPromptTokens + SectionInstructionTokens + chunksPerSection;
+            var completionTokens = section == MechanicSection.Faq ? FaqOutputTokens : DefaultSectionOutputTokens;
+
+            var inputCost = promptTokens / 1_000_000m * input.InputCostPerMillionTokens;
+            var outputCost = completionTokens / 1_000_000m * input.OutputCostPerMillionTokens;
+            var sectionCost = decimal.Round(inputCost + outputCost, 6, MidpointRounding.AwayFromZero);
+
+            perSection[section] = new SectionCostProjection(promptTokens, completionTokens, sectionCost);
+            totalPromptTokens += promptTokens;
+            totalCompletionTokens += completionTokens;
+            totalCost += sectionCost;
+        }
+
+        return new AnalysisCostEstimate(
+            ProjectedPromptTokens: totalPromptTokens,
+            ProjectedCompletionTokens: totalCompletionTokens,
+            ProjectedTotalTokens: totalPromptTokens + totalCompletionTokens,
+            ProjectedCostUsd: decimal.Round(totalCost, 6, MidpointRounding.AwayFromZero),
+            PerSection: perSection);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/EmbeddedMechanicPromptProvider.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/EmbeddedMechanicPromptProvider.cs
@@ -1,0 +1,51 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
+
+/// <summary>
+/// Loads Mechanic Extractor prompts from embedded markdown resources shipped with the API
+/// assembly. Lazily reads each file on first use and caches the text for the lifetime of
+/// the process. ISSUE-524 / M1.2 — prompts are versioned via git (B4=A).
+/// </summary>
+internal sealed class EmbeddedMechanicPromptProvider : IMechanicPromptProvider
+{
+    private const string ResourcePrefix = "Api.BoundedContexts.SharedGameCatalog.Infrastructure.Prompts.MechanicExtractor.v1.";
+    private static readonly Assembly Assembly = typeof(EmbeddedMechanicPromptProvider).Assembly;
+    private readonly ConcurrentDictionary<string, string> _cache = new(StringComparer.Ordinal);
+
+    public string PromptVersion => "v1.0.0";
+
+    public string GetSystemPrompt() => LoadResource("system.md");
+
+    public string GetSectionPrompt(MechanicSection section)
+    {
+        var fileName = section switch
+        {
+            MechanicSection.Summary => "summary.md",
+            MechanicSection.Mechanics => "mechanics.md",
+            MechanicSection.Victory => "victory.md",
+            MechanicSection.Resources => "resources.md",
+            MechanicSection.Phases => "phases.md",
+            MechanicSection.Faq => "faq.md",
+            _ => throw new ArgumentOutOfRangeException(nameof(section), section, "Unknown Mechanic section.")
+        };
+
+        return LoadResource(fileName);
+    }
+
+    private string LoadResource(string fileName)
+    {
+        return _cache.GetOrAdd(fileName, static name =>
+        {
+            var resourceName = ResourcePrefix + name;
+            using var stream = Assembly.GetManifestResourceStream(resourceName)
+                ?? throw new FileNotFoundException(
+                    $"Embedded Mechanic Extractor prompt not found: {resourceName}. " +
+                    "Ensure Api.csproj includes the BoundedContexts/SharedGameCatalog/Infrastructure/Prompts/MechanicExtractor/v1/*.md EmbeddedResource glob.");
+            using var reader = new StreamReader(stream);
+            return reader.ReadToEnd();
+        });
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/IAnalysisCostEstimator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/IAnalysisCostEstimator.cs
@@ -1,0 +1,48 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
+
+/// <summary>
+/// Estimates the USD cost of a Mechanic Extractor pipeline run ahead of actual LLM calls.
+/// Used by <c>GenerateMechanicAnalysisCommandHandler</c> to honour ADR-051 T8 cost caps:
+/// if the projected cost exceeds <c>CostCapUsd × 1.0</c> and no runtime override is provided,
+/// the command fails fast before any tokens are spent.
+/// </summary>
+/// <remarks>
+/// ISSUE-524 / M1.2. The estimator intentionally operates on heuristics (average chunk token
+/// counts, per-section output budgets) rather than a precise dry-run tokenization — the goal
+/// is a conservative upper bound, not a prediction.
+/// </remarks>
+public interface IAnalysisCostEstimator
+{
+    AnalysisCostEstimate Estimate(AnalysisCostEstimateInput input);
+}
+
+/// <summary>
+/// Input to cost projection. Caller supplies the planned sections and the retrieved chunk
+/// inventory (token counts already known from the retrieval step).
+/// </summary>
+public sealed record AnalysisCostEstimateInput(
+    string PromptVersion,
+    string Provider,
+    string Model,
+    IReadOnlyCollection<MechanicSection> Sections,
+    int TotalRetrievedPromptTokens,
+    decimal InputCostPerMillionTokens,
+    decimal OutputCostPerMillionTokens);
+
+/// <summary>
+/// Projected cost breakdown for a full pipeline run.
+/// </summary>
+public sealed record AnalysisCostEstimate(
+    int ProjectedPromptTokens,
+    int ProjectedCompletionTokens,
+    int ProjectedTotalTokens,
+    decimal ProjectedCostUsd,
+    IReadOnlyDictionary<MechanicSection, SectionCostProjection> PerSection);
+
+/// <summary>Per-section projection of tokens and cost.</summary>
+public sealed record SectionCostProjection(
+    int PromptTokens,
+    int CompletionTokens,
+    decimal CostUsd);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/IMechanicAnalysisExecutor.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/IMechanicAnalysisExecutor.cs
@@ -1,0 +1,29 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
+
+/// <summary>
+/// Background executor that runs the full Mechanic Extractor pipeline for a persisted
+/// <c>Draft</c> aggregate (ISSUE-524 / M1.2 decision B5=B — async 202 Accepted flow).
+/// </summary>
+/// <remarks>
+/// The command handler creates the aggregate, persists it as <c>Draft</c>, then enqueues a
+/// call to <see cref="ExecuteAsync"/> via <see cref="Api.Services.IBackgroundTaskService"/>.
+/// The executor owns its own DI scope (obtained from <c>IServiceScopeFactory</c>) so the
+/// HTTP request's scope can complete while the pipeline runs. All mutations — claim/citation
+/// persistence, section-run rows, status transitions, cost-cap abort — are made against a
+/// freshly-loaded aggregate and committed in a single <c>SaveChangesAsync</c> call, which
+/// also publishes the domain events (InReview / Rejected).
+/// </remarks>
+public interface IMechanicAnalysisExecutor
+{
+    /// <summary>
+    /// Runs the six-section pipeline for the given analysis id. Idempotent with respect to
+    /// aggregate state: if the aggregate has already transitioned out of <c>Draft</c> (e.g.,
+    /// due to a prior execution short-circuit), the method exits without further work.
+    /// </summary>
+    /// <param name="analysisId">Primary key of the <c>Draft</c> aggregate to process.</param>
+    /// <param name="cancellationToken">Cancellation token supplied by the background task
+    /// service. When cancelled, the executor marks the aggregate as <c>Rejected</c> with
+    /// reason <c>LlmGenerationFailed</c> so operators see a terminal state rather than a
+    /// stuck draft.</param>
+    Task ExecuteAsync(Guid analysisId, CancellationToken cancellationToken);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/IMechanicAnalysisPipeline.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/IMechanicAnalysisPipeline.cs
@@ -1,0 +1,74 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
+
+/// <summary>
+/// Orchestrates the per-section LLM calls of a Mechanic Extractor run (ISSUE-524 / M1.2).
+/// The pipeline is stateless — state is carried by the caller (handler) which holds the
+/// <c>MechanicAnalysis</c> aggregate and the DbContext.
+/// </summary>
+/// <remarks>
+/// <b>Failure semantics</b> (ADR-051):
+/// <list type="bullet">
+/// <item><description>If the <i>cumulative</i> cost after a section exceeds the effective cost cap, the pipeline returns <see cref="MechanicPipelineAbortReason.CostCapExceeded"/> mid-run.</description></item>
+/// <item><description>If an LLM call hard-fails after provider fallback, the pipeline returns <see cref="MechanicPipelineAbortReason.LlmGenerationFailed"/>.</description></item>
+/// <item><description>If validator rejects output after retries, returns <see cref="MechanicPipelineAbortReason.ValidationFailedBeyondRetry"/>.</description></item>
+/// </list>
+/// Each section attempt — success or failure — produces a <see cref="MechanicAnalysisSectionRunEntity"/>
+/// row so operators can audit spend and diagnose provider behaviour (B6=C).
+/// </remarks>
+public interface IMechanicAnalysisPipeline
+{
+    Task<MechanicPipelineResult> RunAsync(MechanicPipelineRequest request, CancellationToken cancellationToken);
+}
+
+/// <summary>Input to a pipeline run.</summary>
+public sealed record MechanicPipelineRequest(
+    Guid AnalysisId,
+    Guid SharedGameId,
+    Guid PdfDocumentId,
+    string PromptVersion,
+    IReadOnlyList<MechanicSection> Sections,
+    IReadOnlyDictionary<MechanicSection, string> RetrievedContextBySection,
+    string Provider,
+    string Model,
+    decimal EffectiveCostCapUsd,
+    decimal InputCostPerMillionTokens,
+    decimal OutputCostPerMillionTokens);
+
+/// <summary>Outcome of a pipeline run.</summary>
+public sealed record MechanicPipelineResult(
+    MechanicPipelineOutcome Outcome,
+    IReadOnlyList<MechanicAnalysisSectionRunEntity> SectionRuns,
+    IReadOnlyDictionary<MechanicSection, string> SectionOutputs,
+    int TotalPromptTokens,
+    int TotalCompletionTokens,
+    decimal TotalCostUsd,
+    string? AbortDetail)
+{
+    public bool IsSuccess => Outcome == MechanicPipelineOutcome.Succeeded;
+
+    public MechanicPipelineAbortReason? AbortReason => Outcome switch
+    {
+        MechanicPipelineOutcome.AbortedCostCap => MechanicPipelineAbortReason.CostCapExceeded,
+        MechanicPipelineOutcome.AbortedLlmFailed => MechanicPipelineAbortReason.LlmGenerationFailed,
+        MechanicPipelineOutcome.AbortedValidation => MechanicPipelineAbortReason.ValidationFailedBeyondRetry,
+        _ => null
+    };
+}
+
+public enum MechanicPipelineOutcome
+{
+    Succeeded = 0,
+    AbortedCostCap = 1,
+    AbortedLlmFailed = 2,
+    AbortedValidation = 3
+}
+
+public enum MechanicPipelineAbortReason
+{
+    CostCapExceeded = 0,
+    LlmGenerationFailed = 1,
+    ValidationFailedBeyondRetry = 2
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/IMechanicOutputValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/IMechanicOutputValidator.cs
@@ -1,0 +1,36 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
+
+/// <summary>
+/// Validates LLM output against ADR-051 guardrails T1-T4 (quote cap, no long verbatim,
+/// citation required, grounding). ISSUE-524 / M1.2 ships a stub that only enforces the
+/// cheap checks (quote word count, presence of citations) — the deeper guardrails
+/// (semantic grounding via embedding similarity, long-sequence detection against source)
+/// land in M1.3.
+/// </summary>
+public interface IMechanicOutputValidator
+{
+    /// <summary>
+    /// Validate a raw JSON section output.
+    /// </summary>
+    /// <param name="section">Target section of this output.</param>
+    /// <param name="rawJson">Raw JSON text as returned by the LLM.</param>
+    /// <returns>Aggregated validation result — <see cref="MechanicValidationResult.IsValid"/>
+    /// is <c>false</c> if any violation is detected.</returns>
+    MechanicValidationResult Validate(MechanicSection section, string rawJson);
+}
+
+/// <summary>Outcome of validation — either valid or a list of violations.</summary>
+public sealed record MechanicValidationResult(bool IsValid, IReadOnlyList<MechanicValidationViolation> Violations)
+{
+    public static MechanicValidationResult Valid() => new(true, Array.Empty<MechanicValidationViolation>());
+
+    public static MechanicValidationResult Invalid(IReadOnlyList<MechanicValidationViolation> violations) =>
+        new(false, violations);
+}
+
+public sealed record MechanicValidationViolation(
+    string Rule,
+    string Message,
+    string? Path = null);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/IMechanicPromptProvider.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/IMechanicPromptProvider.cs
@@ -1,0 +1,20 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
+
+/// <summary>
+/// Loads Mechanic Extractor prompts (system + per-section user instructions) from embedded
+/// resources. ISSUE-524 / M1.2 — decision B4=A: prompts live as <c>.md</c> files checked
+/// into git and compiled as <c>&lt;EmbeddedResource&gt;</c>.
+/// </summary>
+public interface IMechanicPromptProvider
+{
+    /// <summary>Canonical prompt version, e.g. <c>"v1.0.0"</c>.</summary>
+    string PromptVersion { get; }
+
+    /// <summary>Returns the shared system prompt (IP policy).</summary>
+    string GetSystemPrompt();
+
+    /// <summary>Returns the user prompt for the given section.</summary>
+    string GetSectionPrompt(MechanicSection section);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicAnalysisExecutor.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicAnalysisExecutor.cs
@@ -1,0 +1,365 @@
+using System.Text;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Infrastructure;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
+
+/// <summary>
+/// Default <see cref="IMechanicAnalysisExecutor"/>. Loads the <c>Draft</c> aggregate, runs the
+/// six-section LLM pipeline, parses the per-section JSON envelopes into
+/// <see cref="MechanicClaim"/>+<see cref="MechanicCitation"/> children, persists the
+/// <c>mechanic_analysis_section_runs</c> rows, and transitions the aggregate to
+/// <c>InReview</c> on success or auto-rejects it on pipeline abort.
+/// </summary>
+/// <remarks>
+/// The executor is intentionally scoped per background run — the command handler passes it the
+/// analysis id after creating a fresh <see cref="IServiceScope"/> via
+/// <see cref="IServiceScopeFactory"/>. All writes (section runs + aggregate state + audit rows
+/// synthesised by the repository) commit atomically via a single
+/// <see cref="IUnitOfWork.SaveChangesAsync(CancellationToken)"/>.
+///
+/// Idempotency: if the aggregate is not in <see cref="MechanicAnalysisStatus.Draft"/> when the
+/// executor fires (e.g., a prior run already moved it to InReview / Rejected), the method exits
+/// without touching state. This covers retries triggered by
+/// <see cref="Api.Services.IBackgroundTaskService"/> as well as concurrent operator actions.
+/// </remarks>
+internal sealed class MechanicAnalysisExecutor : IMechanicAnalysisExecutor
+{
+    // Mirrors the handler's budget. Kept in sync because the context bundle is the same shape
+    // shipped to every section in M1.2 (M1.3 introduces per-section semantic retrieval).
+    private const int MaxRetrievedCharacters = 240_000;
+
+    // DeepSeek list pricing as of 2026-04 (see memory/project_deepseek_llm.md). Used only when
+    // the LLM result does not attribute its own cost; the pipeline's RecordUsage below prefers
+    // the real spend coming back from the LlmCompletionResult.
+    private const decimal DefaultInputCostPerMillion = 0.14m;
+    private const decimal DefaultOutputCostPerMillion = 0.28m;
+
+    // The six mechanic sections covered by M1.2. The pipeline fans out one LLM call per section.
+    private static readonly IReadOnlyList<MechanicSection> AllSections = new[]
+    {
+        MechanicSection.Summary,
+        MechanicSection.Mechanics,
+        MechanicSection.Victory,
+        MechanicSection.Resources,
+        MechanicSection.Phases,
+        MechanicSection.Faq
+    };
+
+    private readonly IMechanicAnalysisRepository _analysisRepository;
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly IMechanicAnalysisPipeline _pipeline;
+    private readonly IMechanicPromptProvider _promptProvider;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<MechanicAnalysisExecutor> _logger;
+
+    public MechanicAnalysisExecutor(
+        IMechanicAnalysisRepository analysisRepository,
+        MeepleAiDbContext dbContext,
+        IMechanicAnalysisPipeline pipeline,
+        IMechanicPromptProvider promptProvider,
+        IUnitOfWork unitOfWork,
+        TimeProvider timeProvider,
+        ILogger<MechanicAnalysisExecutor> logger)
+    {
+        _analysisRepository = analysisRepository ?? throw new ArgumentNullException(nameof(analysisRepository));
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _pipeline = pipeline ?? throw new ArgumentNullException(nameof(pipeline));
+        _promptProvider = promptProvider ?? throw new ArgumentNullException(nameof(promptProvider));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task ExecuteAsync(Guid analysisId, CancellationToken cancellationToken)
+    {
+        if (analysisId == Guid.Empty)
+        {
+            throw new ArgumentException("AnalysisId cannot be empty.", nameof(analysisId));
+        }
+
+        var analysis = await _analysisRepository
+            .GetByIdWithClaimsAsync(analysisId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (analysis is null)
+        {
+            _logger.LogWarning(
+                "Mechanic analysis {AnalysisId} not found when background executor fired; skipping.",
+                analysisId);
+            return;
+        }
+
+        if (analysis.Status != MechanicAnalysisStatus.Draft)
+        {
+            _logger.LogInformation(
+                "Mechanic analysis {AnalysisId} is in status {Status}; executor exits idempotently.",
+                analysisId, analysis.Status);
+            return;
+        }
+
+        try
+        {
+            await RunPipelineAsync(analysis, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
+        {
+            // Cooperative cancellation: reload and auto-reject so the aggregate ends in a
+            // terminal state rather than stuck in Draft. We swallow the exception on purpose
+            // so the background task service sees a completed (not cancelled) run in its
+            // telemetry and downstream notifications fire.
+            _logger.LogWarning(
+                ex,
+                "Mechanic analysis {AnalysisId} execution cancelled; auto-rejecting to terminal state.",
+                analysisId);
+            await HandleCancellationAsync(analysisId).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Mechanic analysis {AnalysisId} pipeline crashed unexpectedly; auto-rejecting.",
+                analysisId);
+            await HandleUnexpectedFailureAsync(analysisId, ex).ConfigureAwait(false);
+        }
+    }
+
+    private async Task RunPipelineAsync(MechanicAnalysis analysis, CancellationToken cancellationToken)
+    {
+        var retrievalContext = await LoadRetrievalContextAsync(analysis.PdfDocumentId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(retrievalContext))
+        {
+            _logger.LogWarning(
+                "Mechanic analysis {AnalysisId} aborted: PDF {PdfId} has no indexed chunks at execution time.",
+                analysis.Id, analysis.PdfDocumentId);
+
+            var utcNow = _timeProvider.GetUtcNow().UtcDateTime;
+            analysis.AutoRejectFromDraft(
+                MechanicAnalysis.AutoRejectionReasons.LlmGenerationFailed,
+                analysis.CreatedBy,
+                utcNow);
+            _analysisRepository.Update(analysis);
+            await _unitOfWork.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+            return;
+        }
+
+        // M1.2 ships the same rulebook bundle to every section. M1.3 will swap this for per-
+        // section semantic retrieval.
+        var contextBySection = AllSections.ToDictionary(s => s, _ => retrievalContext);
+
+        var request = new MechanicPipelineRequest(
+            AnalysisId: analysis.Id,
+            SharedGameId: analysis.SharedGameId,
+            PdfDocumentId: analysis.PdfDocumentId,
+            PromptVersion: _promptProvider.PromptVersion,
+            Sections: AllSections,
+            RetrievedContextBySection: contextBySection,
+            Provider: analysis.Provider,
+            Model: analysis.ModelUsed,
+            EffectiveCostCapUsd: analysis.CostCapUsd,
+            InputCostPerMillionTokens: DefaultInputCostPerMillion,
+            OutputCostPerMillionTokens: DefaultOutputCostPerMillion);
+
+        var result = await _pipeline.RunAsync(request, cancellationToken).ConfigureAwait(false);
+
+        // Persist section-run telemetry first. We do this regardless of outcome so operators
+        // always have a trace row per section attempt (T6 auditability).
+        if (result.SectionRuns.Count > 0)
+        {
+            await _dbContext.MechanicAnalysisSectionRuns
+                .AddRangeAsync(result.SectionRuns, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+
+        if (result.Outcome == MechanicPipelineOutcome.Succeeded)
+        {
+            await ApplySuccessAsync(analysis, result, now).ConfigureAwait(false);
+        }
+        else
+        {
+            ApplyAbort(analysis, result, now);
+        }
+
+        _analysisRepository.Update(analysis);
+
+        // Use CancellationToken.None for the final commit: if the caller cancels after the LLM
+        // has already run we still want the aggregate state (and section-run audit rows) to
+        // reach disk so we don't lose the spend record.
+        await _unitOfWork.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Mechanic analysis {AnalysisId} finished: outcome={Outcome}, claims={Claims}, tokens={Tokens}, cost={Cost:F4} USD.",
+            analysis.Id, result.Outcome, analysis.Claims.Count, result.TotalPromptTokens + result.TotalCompletionTokens, result.TotalCostUsd);
+    }
+
+    private async Task ApplySuccessAsync(MechanicAnalysis analysis, MechanicPipelineResult result, DateTime utcNow)
+    {
+        var parsed = MechanicOutputParser.Parse(analysis.Id, result.SectionOutputs);
+
+        if (parsed.Count == 0)
+        {
+            _logger.LogWarning(
+                "Mechanic analysis {AnalysisId} pipeline succeeded but parser produced no claims; auto-rejecting.",
+                analysis.Id);
+            analysis.RecordUsage(
+                result.TotalPromptTokens + result.TotalCompletionTokens,
+                result.TotalCostUsd);
+            analysis.AutoRejectFromDraft(
+                MechanicAnalysis.AutoRejectionReasons.ValidationFailedBeyondRetry,
+                analysis.CreatedBy,
+                utcNow);
+            return;
+        }
+
+        foreach (var claim in parsed)
+        {
+            analysis.AddClaim(claim);
+        }
+
+        analysis.RecordUsage(
+            result.TotalPromptTokens + result.TotalCompletionTokens,
+            result.TotalCostUsd);
+
+        // Transition Draft → InReview. CreatedBy is used as the actor because M1.2 treats the
+        // AI author as the submitter; human review starts in the subsequent phase.
+        analysis.SubmitForReview(analysis.CreatedBy, utcNow);
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+
+    private static void ApplyAbort(MechanicAnalysis analysis, MechanicPipelineResult result, DateTime utcNow)
+    {
+        var reason = result.Outcome switch
+        {
+            MechanicPipelineOutcome.AbortedCostCap => MechanicAnalysis.AutoRejectionReasons.CostCapExceeded,
+            MechanicPipelineOutcome.AbortedValidation => MechanicAnalysis.AutoRejectionReasons.ValidationFailedBeyondRetry,
+            MechanicPipelineOutcome.AbortedLlmFailed => MechanicAnalysis.AutoRejectionReasons.LlmGenerationFailed,
+            _ => MechanicAnalysis.AutoRejectionReasons.LlmGenerationFailed
+        };
+
+        analysis.RecordUsage(
+            result.TotalPromptTokens + result.TotalCompletionTokens,
+            result.TotalCostUsd);
+        analysis.AutoRejectFromDraft(reason, analysis.CreatedBy, utcNow);
+    }
+
+    private async Task HandleCancellationAsync(Guid analysisId)
+    {
+        try
+        {
+            // Clear any entities the pipeline may have staged on this scoped DbContext before the
+            // cancellation fired (e.g. partial section runs added mid-pipeline). The cancellation
+            // commit MUST only persist the aggregate's Rejected transition + its audit row — not
+            // partial telemetry the pipeline hadn't yet decided to keep. The fresh detached
+            // reload below (AsNoTracking via the repository) plus Update() reattaches only the
+            // aggregate root.
+            _dbContext.ChangeTracker.Clear();
+
+            var analysis = await _analysisRepository
+                .GetByIdWithClaimsAsync(analysisId, CancellationToken.None)
+                .ConfigureAwait(false);
+
+            if (analysis is null || analysis.Status != MechanicAnalysisStatus.Draft)
+            {
+                return;
+            }
+
+            analysis.AutoRejectFromDraft(
+                MechanicAnalysis.AutoRejectionReasons.LlmGenerationFailed,
+                analysis.CreatedBy,
+                _timeProvider.GetUtcNow().UtcDateTime);
+            _analysisRepository.Update(analysis);
+            await _unitOfWork.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Mechanic analysis {AnalysisId} could not be auto-rejected after cancellation.",
+                analysisId);
+        }
+    }
+
+    private async Task HandleUnexpectedFailureAsync(Guid analysisId, Exception originalException)
+    {
+        try
+        {
+            // Same rationale as HandleCancellationAsync: a pipeline crash may leave half-staged
+            // entities on the scoped DbContext. Clear before the rejection commit so we only
+            // persist the terminal aggregate transition + its audit row.
+            _dbContext.ChangeTracker.Clear();
+
+            var analysis = await _analysisRepository
+                .GetByIdWithClaimsAsync(analysisId, CancellationToken.None)
+                .ConfigureAwait(false);
+
+            if (analysis is null || analysis.Status != MechanicAnalysisStatus.Draft)
+            {
+                return;
+            }
+
+            analysis.AutoRejectFromDraft(
+                MechanicAnalysis.AutoRejectionReasons.LlmGenerationFailed,
+                analysis.CreatedBy,
+                _timeProvider.GetUtcNow().UtcDateTime);
+            _analysisRepository.Update(analysis);
+            await _unitOfWork.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception cleanupEx)
+        {
+            _logger.LogError(
+                cleanupEx,
+                "Mechanic analysis {AnalysisId} failed to transition to Rejected after pipeline crash. " +
+                "Original exception: {OriginalMessage}",
+                analysisId, originalException.Message);
+        }
+    }
+
+    private async Task<string> LoadRetrievalContextAsync(Guid pdfDocumentId, CancellationToken cancellationToken)
+    {
+        var chunks = await _dbContext.TextChunks
+            .AsNoTracking()
+            .Where(c => c.PdfDocumentId == pdfDocumentId)
+            .OrderBy(c => c.ChunkIndex)
+            .Select(c => new { c.ChunkIndex, c.PageNumber, c.Content })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (chunks.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder();
+        foreach (var chunk in chunks)
+        {
+            var header = chunk.PageNumber.HasValue
+                ? $"[chunk #{chunk.ChunkIndex} · page {chunk.PageNumber}]"
+                : $"[chunk #{chunk.ChunkIndex}]";
+
+            if (builder.Length + header.Length + chunk.Content.Length + 8 > MaxRetrievedCharacters)
+            {
+                break;
+            }
+
+            if (builder.Length > 0)
+            {
+                builder.Append("\n\n---\n\n");
+            }
+
+            builder.Append(header).Append('\n').Append(chunk.Content);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicAnalysisPipeline.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicAnalysisPipeline.cs
@@ -1,0 +1,273 @@
+using System.Diagnostics;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
+
+/// <summary>
+/// Default <see cref="IMechanicAnalysisPipeline"/>. Runs the per-section loop with:
+/// prompt assembly → <see cref="ILlmService"/> call (JSON output) → validation →
+/// cumulative cost check → <see cref="MechanicAnalysisSectionRunEntity"/> emission.
+/// </summary>
+/// <remarks>
+/// Provider selection is delegated to <see cref="ILlmService"/>; the pipeline simply asks
+/// for the requested model and records the metadata. In M1.3 we will switch to explicit
+/// JSON schema strict mode via <c>ILlmClient</c> to reduce parse failures.
+/// </remarks>
+internal sealed class MechanicAnalysisPipeline : IMechanicAnalysisPipeline
+{
+    private const int MaxValidationRetries = 1;
+    // NOTE: Temperature (target 0.2) and per-section MaxOutputTokens (target 1500) will be
+    // threaded through via ILlmClient strict-mode in M1.3; the current ILlmService surface
+    // does not expose these knobs.
+
+    private readonly ILlmService _llmService;
+    private readonly IMechanicPromptProvider _promptProvider;
+    private readonly IMechanicOutputValidator _validator;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<MechanicAnalysisPipeline> _logger;
+
+    public MechanicAnalysisPipeline(
+        ILlmService llmService,
+        IMechanicPromptProvider promptProvider,
+        IMechanicOutputValidator validator,
+        TimeProvider timeProvider,
+        ILogger<MechanicAnalysisPipeline> logger)
+    {
+        _llmService = llmService ?? throw new ArgumentNullException(nameof(llmService));
+        _promptProvider = promptProvider ?? throw new ArgumentNullException(nameof(promptProvider));
+        _validator = validator ?? throw new ArgumentNullException(nameof(validator));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<MechanicPipelineResult> RunAsync(MechanicPipelineRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var sectionRuns = new List<MechanicAnalysisSectionRunEntity>(request.Sections.Count);
+        var outputs = new Dictionary<MechanicSection, string>(request.Sections.Count);
+        var totalPromptTokens = 0;
+        var totalCompletionTokens = 0;
+        decimal totalCostUsd = 0m;
+        var runOrder = 0;
+
+        var systemPrompt = _promptProvider.GetSystemPrompt();
+
+        foreach (var section in request.Sections)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var sectionPrompt = _promptProvider.GetSectionPrompt(section);
+            var context = request.RetrievedContextBySection.TryGetValue(section, out var ctx) ? ctx : string.Empty;
+            var userPrompt = BuildUserPrompt(sectionPrompt, context);
+
+            var (sectionRun, sectionOutput, sectionAbort) = await RunSectionAsync(
+                request,
+                section,
+                runOrder,
+                systemPrompt,
+                userPrompt,
+                cancellationToken).ConfigureAwait(false);
+
+            runOrder++;
+            sectionRuns.Add(sectionRun);
+
+            totalPromptTokens += sectionRun.PromptTokens;
+            totalCompletionTokens += sectionRun.CompletionTokens;
+            totalCostUsd += sectionRun.EstimatedCostUsd;
+
+            if (sectionAbort is not null)
+            {
+                return BuildAbortResult(sectionAbort.Value, sectionRun.ErrorMessage, sectionRuns, outputs,
+                    totalPromptTokens, totalCompletionTokens, totalCostUsd);
+            }
+
+            if (totalCostUsd > request.EffectiveCostCapUsd)
+            {
+                _logger.LogWarning(
+                    "Mechanic pipeline {AnalysisId} aborted at section {Section}: cumulative cost {Cost:F4} > cap {Cap:F4}.",
+                    request.AnalysisId, section, totalCostUsd, request.EffectiveCostCapUsd);
+
+                return BuildAbortResult(
+                    MechanicPipelineOutcome.AbortedCostCap,
+                    $"Cumulative cost {totalCostUsd:F6} USD exceeded effective cap {request.EffectiveCostCapUsd:F6} USD after section '{section}'.",
+                    sectionRuns, outputs, totalPromptTokens, totalCompletionTokens, totalCostUsd);
+            }
+
+            if (sectionOutput is not null)
+            {
+                outputs[section] = sectionOutput;
+            }
+        }
+
+        return new MechanicPipelineResult(
+            Outcome: MechanicPipelineOutcome.Succeeded,
+            SectionRuns: sectionRuns,
+            SectionOutputs: outputs,
+            TotalPromptTokens: totalPromptTokens,
+            TotalCompletionTokens: totalCompletionTokens,
+            TotalCostUsd: decimal.Round(totalCostUsd, 6, MidpointRounding.AwayFromZero),
+            AbortDetail: null);
+    }
+
+    private async Task<(MechanicAnalysisSectionRunEntity Run, string? Output, MechanicPipelineOutcome? Abort)>
+        RunSectionAsync(
+            MechanicPipelineRequest request,
+            MechanicSection section,
+            int runOrder,
+            string systemPrompt,
+            string userPrompt,
+            CancellationToken cancellationToken)
+    {
+        var startedAt = _timeProvider.GetUtcNow().UtcDateTime;
+        var stopwatch = Stopwatch.StartNew();
+        string? lastValidationError = null;
+        var attempts = MaxValidationRetries + 1;
+
+        for (var attempt = 1; attempt <= attempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var result = await _llmService.GenerateCompletionWithModelAsync(
+                explicitModel: request.Model,
+                systemPrompt: systemPrompt,
+                userPrompt: userPrompt,
+                source: RequestSource.Manual,
+                ct: cancellationToken).ConfigureAwait(false);
+
+            if (!result.Success)
+            {
+                stopwatch.Stop();
+                var completedAt = _timeProvider.GetUtcNow().UtcDateTime;
+                return (BuildFailedRun(
+                    request,
+                    section,
+                    runOrder,
+                    result,
+                    startedAt,
+                    completedAt,
+                    stopwatch.ElapsedMilliseconds,
+                    sectionStatus: 1,
+                    errorMessage: result.ErrorMessage ?? "LLM call failed without a specific error."),
+                    Output: null,
+                    Abort: MechanicPipelineOutcome.AbortedLlmFailed);
+            }
+
+            var validation = _validator.Validate(section, result.Response);
+            if (validation.IsValid)
+            {
+                stopwatch.Stop();
+                var completedAt = _timeProvider.GetUtcNow().UtcDateTime;
+                var run = new MechanicAnalysisSectionRunEntity
+                {
+                    Id = Guid.NewGuid(),
+                    AnalysisId = request.AnalysisId,
+                    Section = (int)section,
+                    RunOrder = runOrder,
+                    Provider = string.IsNullOrWhiteSpace(result.Cost.Provider) ? request.Provider : result.Cost.Provider,
+                    ModelUsed = string.IsNullOrWhiteSpace(result.Cost.ModelId) ? request.Model : result.Cost.ModelId,
+                    PromptTokens = result.Usage.PromptTokens,
+                    CompletionTokens = result.Usage.CompletionTokens,
+                    TotalTokens = result.Usage.TotalTokens,
+                    EstimatedCostUsd = decimal.Round(result.Cost.TotalCost, 6, MidpointRounding.AwayFromZero),
+                    LatencyMs = (int)Math.Min(int.MaxValue, stopwatch.ElapsedMilliseconds),
+                    Status = 0,
+                    ErrorMessage = null,
+                    StartedAt = startedAt,
+                    CompletedAt = completedAt
+                };
+                return (run, result.Response, Abort: null);
+            }
+
+            lastValidationError = string.Join("; ",
+                validation.Violations.Select(v => $"[{v.Rule}] {v.Message}{(v.Path is null ? string.Empty : $" ({v.Path})")}"));
+
+            _logger.LogWarning(
+                "Mechanic section '{Section}' attempt {Attempt}/{Total} failed validation: {Error}",
+                section, attempt, attempts, lastValidationError);
+        }
+
+        stopwatch.Stop();
+        var completedAtValidationFail = _timeProvider.GetUtcNow().UtcDateTime;
+        var validationFailureRun = new MechanicAnalysisSectionRunEntity
+        {
+            Id = Guid.NewGuid(),
+            AnalysisId = request.AnalysisId,
+            Section = (int)section,
+            RunOrder = runOrder,
+            Provider = request.Provider,
+            ModelUsed = request.Model,
+            PromptTokens = 0,
+            CompletionTokens = 0,
+            TotalTokens = 0,
+            EstimatedCostUsd = 0m,
+            LatencyMs = (int)Math.Min(int.MaxValue, stopwatch.ElapsedMilliseconds),
+            Status = 1,
+            ErrorMessage = $"Validation failed after {attempts} attempts: {lastValidationError}",
+            StartedAt = startedAt,
+            CompletedAt = completedAtValidationFail
+        };
+        return (validationFailureRun, Output: null, Abort: MechanicPipelineOutcome.AbortedValidation);
+    }
+
+    private static MechanicAnalysisSectionRunEntity BuildFailedRun(
+        MechanicPipelineRequest request,
+        MechanicSection section,
+        int runOrder,
+        LlmCompletionResult result,
+        DateTime startedAt,
+        DateTime completedAt,
+        long latencyMs,
+        int sectionStatus,
+        string errorMessage)
+    {
+        return new MechanicAnalysisSectionRunEntity
+        {
+            Id = Guid.NewGuid(),
+            AnalysisId = request.AnalysisId,
+            Section = (int)section,
+            RunOrder = runOrder,
+            Provider = string.IsNullOrWhiteSpace(result.Cost.Provider) ? request.Provider : result.Cost.Provider,
+            ModelUsed = string.IsNullOrWhiteSpace(result.Cost.ModelId) ? request.Model : result.Cost.ModelId,
+            PromptTokens = result.Usage.PromptTokens,
+            CompletionTokens = result.Usage.CompletionTokens,
+            TotalTokens = result.Usage.TotalTokens,
+            EstimatedCostUsd = decimal.Round(result.Cost.TotalCost, 6, MidpointRounding.AwayFromZero),
+            LatencyMs = (int)Math.Min(int.MaxValue, latencyMs),
+            Status = sectionStatus,
+            ErrorMessage = errorMessage,
+            StartedAt = startedAt,
+            CompletedAt = completedAt
+        };
+    }
+
+    private static MechanicPipelineResult BuildAbortResult(
+        MechanicPipelineOutcome outcome,
+        string? detail,
+        IReadOnlyList<MechanicAnalysisSectionRunEntity> runs,
+        IReadOnlyDictionary<MechanicSection, string> outputs,
+        int totalPromptTokens,
+        int totalCompletionTokens,
+        decimal totalCostUsd) =>
+        new(
+            Outcome: outcome,
+            SectionRuns: runs,
+            SectionOutputs: outputs,
+            TotalPromptTokens: totalPromptTokens,
+            TotalCompletionTokens: totalCompletionTokens,
+            TotalCostUsd: decimal.Round(totalCostUsd, 6, MidpointRounding.AwayFromZero),
+            AbortDetail: detail);
+
+    private static string BuildUserPrompt(string sectionPrompt, string retrievedContext)
+    {
+        if (string.IsNullOrWhiteSpace(retrievedContext))
+        {
+            return sectionPrompt;
+        }
+
+        return $"{sectionPrompt}\n\n## Retrieved rulebook chunks\n\n{retrievedContext}\n";
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicOutputParser.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicOutputParser.cs
@@ -1,0 +1,522 @@
+using System.Text.Json;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
+
+/// <summary>
+/// Parses the six section-level JSON envelopes emitted by the Mechanic Extractor pipeline
+/// into a flat list of <see cref="MechanicClaim"/> entities ready to be attached to a
+/// <see cref="Domain.Aggregates.MechanicAnalysis"/> aggregate.
+/// </summary>
+/// <remarks>
+/// The parser is intentionally defensive:
+/// <list type="bullet">
+/// <item><description>Malformed JSON for a section is skipped (no claims emitted for that section)
+/// rather than aborting the whole analysis — validation already ran per-section upstream.</description></item>
+/// <item><description>Items lacking a non-empty <c>citations</c> array are dropped (domain factory
+/// requires ≥1 citation per ADR-051 T3).</description></item>
+/// <item><description>Citations whose <c>pdf_page</c> is missing/non-positive or whose <c>quote</c>
+/// violates the 25-word cap are dropped before the claim factory runs, so a single bad citation
+/// doesn't disqualify the rest of a well-formed item.</description></item>
+/// <item><description>Claim Ids are pre-allocated so each <see cref="MechanicCitation.ClaimId"/>
+/// equals the real <c>MechanicClaim.Id</c> at persistence time — matching the explicit FK
+/// wiring in <c>MechanicClaimEntityConfiguration</c>. Because of this constraint we build claims
+/// via <see cref="MechanicClaim.Reconstitute"/> with the pre-allocated Id, and enforce the
+/// non-blank text and ≥1 citation invariants here in the parser.</description></item>
+/// </list>
+/// </remarks>
+internal static class MechanicOutputParser
+{
+    /// <summary>
+    /// Parses each section envelope into a flattened list of <see cref="MechanicClaim"/> entities.
+    /// The returned list preserves the section order supplied in <paramref name="sectionOutputs"/>
+    /// and assigns a contiguous <c>displayOrder</c> per section (0-based).
+    /// </summary>
+    public static IReadOnlyList<MechanicClaim> Parse(
+        Guid analysisId,
+        IReadOnlyDictionary<MechanicSection, string> sectionOutputs)
+    {
+        ArgumentNullException.ThrowIfNull(sectionOutputs);
+
+        var claims = new List<MechanicClaim>();
+
+        foreach (var (section, rawJson) in sectionOutputs)
+        {
+            if (string.IsNullOrWhiteSpace(rawJson))
+            {
+                continue;
+            }
+
+            JsonDocument doc;
+            try
+            {
+                doc = JsonDocument.Parse(rawJson);
+            }
+            catch (JsonException)
+            {
+                // Upstream validator should have caught this; defense in depth — skip section.
+                continue;
+            }
+
+            using (doc)
+            {
+                var root = doc.RootElement;
+                if (root.ValueKind != JsonValueKind.Object)
+                {
+                    continue;
+                }
+
+                var sectionClaims = section switch
+                {
+                    MechanicSection.Summary => ParseSummary(analysisId, root),
+                    MechanicSection.Mechanics => ParseMechanics(analysisId, root),
+                    MechanicSection.Victory => ParseVictory(analysisId, root),
+                    MechanicSection.Resources => ParseResources(analysisId, root),
+                    MechanicSection.Phases => ParsePhases(analysisId, root),
+                    MechanicSection.Faq => ParseFaq(analysisId, root),
+                    _ => Array.Empty<MechanicClaim>()
+                };
+
+                claims.AddRange(sectionClaims);
+            }
+        }
+
+        return claims;
+    }
+
+    // ============================================================
+    // Section: Summary
+    // Schema: { "summary": { "text": "...", "citations": [...] } }
+    // ============================================================
+    private static IEnumerable<MechanicClaim> ParseSummary(Guid analysisId, JsonElement root)
+    {
+        if (!root.TryGetProperty("summary", out var summary) || summary.ValueKind != JsonValueKind.Object)
+        {
+            yield break;
+        }
+
+        var text = ReadString(summary, "text");
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            yield break;
+        }
+
+        var claimId = Guid.NewGuid();
+        var citations = ExtractCitations(summary, claimId).ToList();
+        if (citations.Count == 0)
+        {
+            yield break;
+        }
+
+        yield return BuildClaim(
+            claimId: claimId,
+            analysisId: analysisId,
+            section: MechanicSection.Summary,
+            text: text!,
+            displayOrder: 0,
+            citations: citations);
+    }
+
+    // ============================================================
+    // Section: Mechanics
+    // Schema: { "mechanics": [{ "name": "...", "description": "...", "citations": [...] }] }
+    // ============================================================
+    private static IEnumerable<MechanicClaim> ParseMechanics(Guid analysisId, JsonElement root)
+    {
+        if (!root.TryGetProperty("mechanics", out var items) || items.ValueKind != JsonValueKind.Array)
+        {
+            yield break;
+        }
+
+        var displayOrder = 0;
+        foreach (var item in items.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            var description = ReadString(item, "description");
+            if (string.IsNullOrWhiteSpace(description))
+            {
+                continue;
+            }
+
+            var claimId = Guid.NewGuid();
+            var citations = ExtractCitations(item, claimId).ToList();
+            if (citations.Count == 0)
+            {
+                continue;
+            }
+
+            var name = ReadString(item, "name");
+            var text = string.IsNullOrWhiteSpace(name)
+                ? description!
+                : $"{name!.Trim()}: {description!.Trim()}";
+
+            yield return BuildClaim(
+                claimId: claimId,
+                analysisId: analysisId,
+                section: MechanicSection.Mechanics,
+                text: text,
+                displayOrder: displayOrder++,
+                citations: citations);
+        }
+    }
+
+    // ============================================================
+    // Section: Victory
+    // Schema: { "victory": { "primary": "...", "alternatives": ["..."], "citations": [...] } }
+    // The envelope holds one citation array shared between primary and alternatives.
+    // ============================================================
+    private static IEnumerable<MechanicClaim> ParseVictory(Guid analysisId, JsonElement root)
+    {
+        if (!root.TryGetProperty("victory", out var victory) || victory.ValueKind != JsonValueKind.Object)
+        {
+            yield break;
+        }
+
+        var primary = ReadString(victory, "primary");
+        if (string.IsNullOrWhiteSpace(primary))
+        {
+            yield break;
+        }
+
+        var displayOrder = 0;
+
+        // Primary claim with a fresh Id and its own citation copies.
+        var primaryClaimId = Guid.NewGuid();
+        var primaryCitations = ExtractCitations(victory, primaryClaimId).ToList();
+        if (primaryCitations.Count == 0)
+        {
+            yield break;
+        }
+
+        yield return BuildClaim(
+            claimId: primaryClaimId,
+            analysisId: analysisId,
+            section: MechanicSection.Victory,
+            text: primary!,
+            displayOrder: displayOrder++,
+            citations: primaryCitations);
+
+        // Alternatives reuse the same citation source — re-extract per claim so ClaimId wires up.
+        if (!victory.TryGetProperty("alternatives", out var alternatives)
+            || alternatives.ValueKind != JsonValueKind.Array)
+        {
+            yield break;
+        }
+
+        foreach (var alt in alternatives.EnumerateArray())
+        {
+            if (alt.ValueKind != JsonValueKind.String)
+            {
+                continue;
+            }
+
+            var text = alt.GetString();
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                continue;
+            }
+
+            var altClaimId = Guid.NewGuid();
+            var altCitations = ExtractCitations(victory, altClaimId).ToList();
+            if (altCitations.Count == 0)
+            {
+                continue;
+            }
+
+            yield return BuildClaim(
+                claimId: altClaimId,
+                analysisId: analysisId,
+                section: MechanicSection.Victory,
+                text: text!,
+                displayOrder: displayOrder++,
+                citations: altCitations);
+        }
+    }
+
+    // ============================================================
+    // Section: Resources
+    // Schema: { "resources": [{ "name": "...", "usage": "...", "citations": [...] }] }
+    // ============================================================
+    private static IEnumerable<MechanicClaim> ParseResources(Guid analysisId, JsonElement root)
+    {
+        if (!root.TryGetProperty("resources", out var items) || items.ValueKind != JsonValueKind.Array)
+        {
+            yield break;
+        }
+
+        var displayOrder = 0;
+        foreach (var item in items.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            var usage = ReadString(item, "usage");
+            if (string.IsNullOrWhiteSpace(usage))
+            {
+                continue;
+            }
+
+            var claimId = Guid.NewGuid();
+            var citations = ExtractCitations(item, claimId).ToList();
+            if (citations.Count == 0)
+            {
+                continue;
+            }
+
+            var name = ReadString(item, "name");
+            var text = string.IsNullOrWhiteSpace(name)
+                ? usage!
+                : $"{name!.Trim()}: {usage!.Trim()}";
+
+            yield return BuildClaim(
+                claimId: claimId,
+                analysisId: analysisId,
+                section: MechanicSection.Resources,
+                text: text,
+                displayOrder: displayOrder++,
+                citations: citations);
+        }
+    }
+
+    // ============================================================
+    // Section: Phases
+    // Schema: { "phases": [{ "name": "...", "description": "...", "order": 1, "citations": [...] }] }
+    // Entries are emitted in their declared `order`; when missing or duplicate we fall back to
+    // the source array order.
+    // ============================================================
+    private static IEnumerable<MechanicClaim> ParsePhases(Guid analysisId, JsonElement root)
+    {
+        if (!root.TryGetProperty("phases", out var items) || items.ValueKind != JsonValueKind.Array)
+        {
+            yield break;
+        }
+
+        var buffered = new List<(int? Order, int SourceIndex, JsonElement Element)>();
+        var sourceIndex = 0;
+        foreach (var item in items.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object)
+            {
+                sourceIndex++;
+                continue;
+            }
+
+            int? order = null;
+            if (item.TryGetProperty("order", out var orderEl)
+                && orderEl.ValueKind == JsonValueKind.Number
+                && orderEl.TryGetInt32(out var parsedOrder))
+            {
+                order = parsedOrder;
+            }
+
+            buffered.Add((order, sourceIndex, item));
+            sourceIndex++;
+        }
+
+        var ordered = buffered
+            .OrderBy(x => x.Order ?? int.MaxValue)
+            .ThenBy(x => x.SourceIndex);
+
+        var displayOrder = 0;
+        foreach (var (_, _, item) in ordered)
+        {
+            var description = ReadString(item, "description");
+            if (string.IsNullOrWhiteSpace(description))
+            {
+                continue;
+            }
+
+            var claimId = Guid.NewGuid();
+            var citations = ExtractCitations(item, claimId).ToList();
+            if (citations.Count == 0)
+            {
+                continue;
+            }
+
+            var name = ReadString(item, "name");
+            var text = string.IsNullOrWhiteSpace(name)
+                ? description!
+                : $"{name!.Trim()}: {description!.Trim()}";
+
+            yield return BuildClaim(
+                claimId: claimId,
+                analysisId: analysisId,
+                section: MechanicSection.Phases,
+                text: text,
+                displayOrder: displayOrder++,
+                citations: citations);
+        }
+    }
+
+    // ============================================================
+    // Section: FAQ
+    // Schema: { "faq": [{ "question": "...", "answer": "...", "citations": [...] }] }
+    // Stored as a single claim per entry with the question prefixed when present.
+    // ============================================================
+    private static IEnumerable<MechanicClaim> ParseFaq(Guid analysisId, JsonElement root)
+    {
+        if (!root.TryGetProperty("faq", out var items) || items.ValueKind != JsonValueKind.Array)
+        {
+            yield break;
+        }
+
+        var displayOrder = 0;
+        foreach (var item in items.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            var answer = ReadString(item, "answer");
+            if (string.IsNullOrWhiteSpace(answer))
+            {
+                continue;
+            }
+
+            var claimId = Guid.NewGuid();
+            var citations = ExtractCitations(item, claimId).ToList();
+            if (citations.Count == 0)
+            {
+                continue;
+            }
+
+            var question = ReadString(item, "question");
+            var text = string.IsNullOrWhiteSpace(question)
+                ? answer!
+                : $"Q: {question!.Trim()}\nA: {answer!.Trim()}";
+
+            yield return BuildClaim(
+                claimId: claimId,
+                analysisId: analysisId,
+                section: MechanicSection.Faq,
+                text: text,
+                displayOrder: displayOrder++,
+                citations: citations);
+        }
+    }
+
+    // ============================================================
+    // Helpers
+    // ============================================================
+
+    /// <summary>
+    /// Extracts <c>citations[]</c> under <paramref name="parent"/> and converts each entry to a
+    /// <see cref="MechanicCitation"/> with the supplied <paramref name="claimId"/>. Drops entries
+    /// that violate the citation factory's invariants so one bad quote doesn't take down an
+    /// otherwise-valid claim.
+    /// </summary>
+    private static IEnumerable<MechanicCitation> ExtractCitations(JsonElement parent, Guid claimId)
+    {
+        if (!parent.TryGetProperty("citations", out var citations)
+            || citations.ValueKind != JsonValueKind.Array)
+        {
+            yield break;
+        }
+
+        var displayOrder = 0;
+        foreach (var entry in citations.EnumerateArray())
+        {
+            if (entry.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            if (!entry.TryGetProperty("pdf_page", out var pageEl)
+                || pageEl.ValueKind != JsonValueKind.Number
+                || !pageEl.TryGetInt32(out var pdfPage)
+                || pdfPage <= 0)
+            {
+                continue;
+            }
+
+            var quote = ReadString(entry, "quote");
+            if (string.IsNullOrWhiteSpace(quote))
+            {
+                continue;
+            }
+
+            var trimmed = quote!.Trim();
+            if (trimmed.Length > MechanicCitation.MaxQuoteChars)
+            {
+                continue;
+            }
+
+            if (MechanicCitation.CountWords(trimmed) > MechanicCitation.MaxQuoteWords)
+            {
+                continue;
+            }
+
+            Guid? chunkId = null;
+            if (entry.TryGetProperty("chunk_id", out var chunkEl)
+                && chunkEl.ValueKind == JsonValueKind.String
+                && Guid.TryParse(chunkEl.GetString(), out var parsedChunkId))
+            {
+                chunkId = parsedChunkId;
+            }
+
+            MechanicCitation citation;
+            try
+            {
+                citation = MechanicCitation.Create(
+                    claimId: claimId,
+                    pdfPage: pdfPage,
+                    quote: trimmed,
+                    chunkId: chunkId,
+                    displayOrder: displayOrder);
+            }
+            catch (ArgumentException)
+            {
+                // Factory rejected — skip this citation, keep trying the rest.
+                continue;
+            }
+
+            displayOrder++;
+            yield return citation;
+        }
+    }
+
+    /// <summary>
+    /// Assembles a <see cref="MechanicClaim"/> via <see cref="MechanicClaim.Reconstitute"/> with
+    /// the pre-allocated <paramref name="claimId"/>. Reconstitute is used (not <c>Create</c>) so
+    /// citation FKs resolve at persistence time; text/displayOrder invariants are enforced by the
+    /// caller's trimming + the non-empty text guard above.
+    /// </summary>
+    private static MechanicClaim BuildClaim(
+        Guid claimId,
+        Guid analysisId,
+        MechanicSection section,
+        string text,
+        int displayOrder,
+        IReadOnlyList<MechanicCitation> citations)
+    {
+        return MechanicClaim.Reconstitute(
+            id: claimId,
+            analysisId: analysisId,
+            section: section,
+            text: text.Trim(),
+            displayOrder: displayOrder,
+            status: MechanicClaimStatus.Pending,
+            reviewedBy: null,
+            reviewedAt: null,
+            rejectionNote: null,
+            citations: citations);
+    }
+
+    private static string? ReadString(JsonElement obj, string propertyName)
+    {
+        if (!obj.TryGetProperty(propertyName, out var element))
+        {
+            return null;
+        }
+
+        return element.ValueKind == JsonValueKind.String ? element.GetString() : null;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicOutputValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicOutputValidator.cs
@@ -1,0 +1,149 @@
+using System.Text.Json;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
+
+/// <summary>
+/// M1.2 stub implementation of <see cref="IMechanicOutputValidator"/>. Enforces the
+/// cheap-to-check guardrails from ADR-051:
+/// <list type="bullet">
+/// <item><description><b>T1 (quote cap)</b>: every <c>citation.quote</c> must be ≤ 25 words.</description></item>
+/// <item><description><b>T4 (citation required)</b>: any object carrying a <c>claim</c>/<c>description</c>/<c>text</c>/<c>answer</c> field must have a non-empty <c>citations</c> array alongside it at the same level, unless it is the top-level section envelope.</description></item>
+/// <item><description><b>JSON well-formedness</b>: output must parse as JSON.</description></item>
+/// </list>
+/// The deeper checks (T2 long-verbatim detection, T3 semantic grounding) require access
+/// to the retrieved chunks and ship in M1.3 as a follow-up.
+/// </summary>
+internal sealed class MechanicOutputValidator : IMechanicOutputValidator
+{
+    private const int MaxQuoteWords = 25;
+
+    public MechanicValidationResult Validate(MechanicSection section, string rawJson)
+    {
+        if (string.IsNullOrWhiteSpace(rawJson))
+        {
+            return MechanicValidationResult.Invalid(new[]
+            {
+                new MechanicValidationViolation("well_formed", "Output is empty or whitespace.")
+            });
+        }
+
+        JsonDocument doc;
+        try
+        {
+            doc = JsonDocument.Parse(rawJson);
+        }
+        catch (JsonException ex)
+        {
+            return MechanicValidationResult.Invalid(new[]
+            {
+                new MechanicValidationViolation("well_formed", $"Output is not valid JSON: {ex.Message}")
+            });
+        }
+
+        var violations = new List<MechanicValidationViolation>();
+        try
+        {
+            WalkAndValidate(doc.RootElement, path: "$", violations);
+        }
+        finally
+        {
+            doc.Dispose();
+        }
+
+        return violations.Count == 0
+            ? MechanicValidationResult.Valid()
+            : MechanicValidationResult.Invalid(violations);
+    }
+
+    private static void WalkAndValidate(JsonElement element, string path, List<MechanicValidationViolation> violations)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                ValidateObject(element, path, violations);
+                foreach (var property in element.EnumerateObject())
+                {
+                    WalkAndValidate(property.Value, $"{path}.{property.Name}", violations);
+                }
+                break;
+
+            case JsonValueKind.Array:
+                var index = 0;
+                foreach (var item in element.EnumerateArray())
+                {
+                    WalkAndValidate(item, $"{path}[{index}]", violations);
+                    index++;
+                }
+                break;
+        }
+    }
+
+    private static void ValidateObject(JsonElement obj, string path, List<MechanicValidationViolation> violations)
+    {
+        // T1: quote word cap
+        if (obj.TryGetProperty("quote", out var quoteElement) && quoteElement.ValueKind == JsonValueKind.String)
+        {
+            var quote = quoteElement.GetString();
+            if (!string.IsNullOrWhiteSpace(quote))
+            {
+                var wordCount = CountWords(quote);
+                if (wordCount > MaxQuoteWords)
+                {
+                    violations.Add(new MechanicValidationViolation(
+                        Rule: "T1_quote_cap",
+                        Message: $"Citation quote has {wordCount} words, exceeds cap of {MaxQuoteWords}.",
+                        Path: $"{path}.quote"));
+                }
+            }
+        }
+
+        // T4: citation required for claim-bearing fields
+        var claimFields = new[] { "claim", "description", "text", "answer", "primary" };
+        foreach (var field in claimFields)
+        {
+            if (obj.TryGetProperty(field, out var claimElement)
+                && claimElement.ValueKind == JsonValueKind.String
+                && !string.IsNullOrWhiteSpace(claimElement.GetString()))
+            {
+                if (!HasNonEmptyCitations(obj))
+                {
+                    violations.Add(new MechanicValidationViolation(
+                        Rule: "T4_citation_required",
+                        Message: $"Field '{field}' is a claim but no non-empty 'citations' array is present at the same level.",
+                        Path: $"{path}.{field}"));
+                }
+                break; // one violation per object is enough
+            }
+        }
+    }
+
+    private static bool HasNonEmptyCitations(JsonElement obj)
+    {
+        if (!obj.TryGetProperty("citations", out var citations))
+        {
+            return false;
+        }
+        return citations.ValueKind == JsonValueKind.Array && citations.GetArrayLength() > 0;
+    }
+
+    private static int CountWords(string text)
+    {
+        var count = 0;
+        var inWord = false;
+        foreach (var c in text)
+        {
+            if (char.IsWhiteSpace(c))
+            {
+                if (inWord) count++;
+                inWord = false;
+            }
+            else
+            {
+                inWord = true;
+            }
+        }
+        if (inWord) count++;
+        return count;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicAnalysis.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicAnalysis.cs
@@ -35,6 +35,18 @@ public sealed class MechanicAnalysis : AggregateRoot<Guid>
         [MechanicAnalysisStatus.Published] = Array.Empty<MechanicAnalysisStatus>()
     };
 
+    /// <summary>
+    /// System-initiated rejection reasons, used by <see cref="AutoRejectFromDraft"/>.
+    /// Distinguishes automated failures (cost cap, LLM catastrophic) from human-initiated
+    /// rejections during review.
+    /// </summary>
+    public static class AutoRejectionReasons
+    {
+        public const string CostCapExceeded = "cost_cap_exceeded";
+        public const string LlmGenerationFailed = "llm_generation_failed";
+        public const string ValidationFailedBeyondRetry = "validation_failed_beyond_retry";
+    }
+
     // === Core identity / lineage ===
 
     public Guid SharedGameId { get; private set; }
@@ -424,6 +436,50 @@ public sealed class MechanicAnalysis : AggregateRoot<Guid>
         RejectionReason = reason.Trim();
 
         AddDomainEvent(new MechanicAnalysisStatusChangedEvent(Id, previous, Status, reviewerId, RejectionReason));
+    }
+
+    /// <summary>
+    /// System-initiated rejection from <see cref="MechanicAnalysisStatus.Draft"/>, bypassing the
+    /// normal <c>Draft → InReview → Rejected</c> flow. Used by the generation pipeline (M1.2) when
+    /// the run aborts mid-generation (cost cap exceeded, catastrophic LLM failure, validation beyond
+    /// retry budget). Preserves any partial claims generated so far as evidence.
+    /// </summary>
+    /// <param name="reason">One of <see cref="AutoRejectionReasons"/> constants; free-form strings
+    /// are accepted for forward-compatibility but discouraged.</param>
+    /// <param name="actorId">The admin who initiated the generation run; recorded as reviewer for
+    /// audit consistency (T6).</param>
+    /// <param name="utcNow">Timestamp for the rejection event.</param>
+    /// <exception cref="InvalidMechanicAnalysisStateException">
+    /// Thrown if the aggregate is not currently in <see cref="MechanicAnalysisStatus.Draft"/>.
+    /// </exception>
+    public void AutoRejectFromDraft(string reason, Guid actorId, DateTime utcNow)
+    {
+        if (string.IsNullOrWhiteSpace(reason))
+        {
+            throw new ArgumentException("Auto-rejection reason is required.", nameof(reason));
+        }
+
+        if (actorId == Guid.Empty)
+        {
+            throw new ArgumentException("ActorId cannot be empty.", nameof(actorId));
+        }
+
+        if (Status != MechanicAnalysisStatus.Draft)
+        {
+            throw new InvalidMechanicAnalysisStateException(
+                Id,
+                Status,
+                "auto-reject from draft",
+                MechanicAnalysisStatus.Draft);
+        }
+
+        var previous = Status;
+        Status = MechanicAnalysisStatus.Rejected;
+        ReviewedBy = actorId;
+        ReviewedAt = utcNow;
+        RejectionReason = reason.Trim();
+
+        AddDomainEvent(new MechanicAnalysisStatusChangedEvent(Id, previous, Status, actorId, RejectionReason));
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IMechanicAnalysisRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IMechanicAnalysisRepository.cs
@@ -51,6 +51,22 @@ public interface IMechanicAnalysisRepository
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Finds the existing non-rejected analysis for the (SharedGame, PdfDocument, PromptVersion)
+    /// tuple, or <c>null</c> if none exists. Supports T7 idempotency (ADR-051 §3.5): the generation
+    /// pipeline uses this lookup to short-circuit duplicate runs with the same prompt version.
+    /// </summary>
+    /// <remarks>
+    /// Rejected analyses (<see cref="Enums.MechanicAnalysisStatus.Rejected"/>) are excluded from
+    /// this lookup so operators can retry the same prompt version after a failure. Suppressed rows
+    /// are included to prevent silently creating a duplicate while a takedown is in effect.
+    /// </remarks>
+    Task<MechanicAnalysis?> FindByPromptVersionAsync(
+        Guid sharedGameId,
+        Guid pdfDocumentId,
+        string promptVersion,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Marks a previously loaded <see cref="MechanicAnalysis"/> as modified.
     /// Intended for entities loaded as <c>AsNoTracking</c> or detached.
     /// Tracked entities do not require an explicit call.

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/ISharedGameDocumentRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/ISharedGameDocumentRepository.cs
@@ -84,4 +84,14 @@ public interface ISharedGameDocumentRepository
     /// Counts the number of documents created by a specific user.
     /// </summary>
     Task<int> CountByUserAsync(Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks whether a specific PDF is linked to a shared game (any document type / any version).
+    /// Used by ISSUE-524 / M1.2 mechanic extractor handler to validate the (game, pdf) pair
+    /// without leaking <c>SharedGameDocument</c> entity projections into the command handler.
+    /// </summary>
+    Task<bool> IsPdfLinkedToGameAsync(
+        Guid sharedGameId,
+        Guid pdfDocumentId,
+        CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Configuration;
 using Api.BoundedContexts.SharedGameCatalog.Application.Jobs;
 using Api.BoundedContexts.SharedGameCatalog.Application.Services;
 using Api.BoundedContexts.SharedGameCatalog.Application.Services.BackgroundAnalysis;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Services;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
@@ -65,6 +66,18 @@ internal static class SharedGameCatalogServiceExtensions
         services.AddScoped<IRulebookChunkAnalyzer, LlmRulebookChunkAnalyzer>();
         services.AddScoped<IRulebookMerger, LlmRulebookMerger>();
         services.AddScoped<IBackgroundRulebookAnalysisOrchestrator, BackgroundRulebookAnalysisOrchestrator>();
+
+        // ISSUE-524 / M1.2: Mechanic Extractor services (ADR-051).
+        // Pipeline flow: handler → create Draft aggregate → enqueue IMechanicAnalysisExecutor
+        // on a fresh DI scope → executor loads aggregate, runs IMechanicAnalysisPipeline,
+        // parses with MechanicOutputParser, persists, publishes domain events.
+        // Singleton: prompts are embedded assembly resources + internal ConcurrentDictionary cache.
+        // Scoped would silently defeat the cache (new instance per request).
+        services.AddSingleton<IMechanicPromptProvider, EmbeddedMechanicPromptProvider>();
+        services.AddScoped<IMechanicOutputValidator, MechanicOutputValidator>();
+        services.AddScoped<IAnalysisCostEstimator, AnalysisCostEstimator>();
+        services.AddScoped<IMechanicAnalysisPipeline, MechanicAnalysisPipeline>();
+        services.AddScoped<IMechanicAnalysisExecutor, MechanicAnalysisExecutor>();
 
         // Issue #2729: Review lock configuration service with caching (Singleton for cache sharing)
         services.AddSingleton<IReviewLockConfigService, ReviewLockConfigService>();

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Prompts/MechanicExtractor/v1/faq.md
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Prompts/MechanicExtractor/v1/faq.md
@@ -1,0 +1,48 @@
+# FAQ Section (v1.0.0)
+
+Produce **5-10 frequently asked questions** about the rules, answered strictly from the retrieved chunks.
+
+## Output schema
+
+```json
+{
+  "faq": [
+    {
+      "question": "string (Italiano, ≤200 chars)",
+      "answer": "string (Italiano, reformulated, ≤500 chars)",
+      "citations": [
+        {
+          "pdf_page": 4,
+          "quote": "string ≤25 words",
+          "chunk_id": "string (optional)"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Field rules
+
+- `question`: A natural Italiano question a new player would ask. Phrase as a real question, not a section heading.
+- `answer`: Italiano reformulated answer. Every factual claim must map to a citation.
+- `citations`: **At least one citation per FAQ entry.** If the answer combines facts from multiple chunks, cite each one.
+
+## Extraction guidance
+
+- Generate **between 5 and 10 entries**. If the retrieved chunks cannot support 5, omit the `faq` field entirely rather than inventing questions.
+- Prefer questions about **rule edge cases, setup, tiebreakers, end-of-game conditions, and common misunderstandings** — not trivia that is obvious from the Summary section.
+- Do not ask questions you cannot answer from the chunks. Grounding is mandatory.
+- Answer in complete Italiano sentences. Do not copy the question into the answer.
+
+## Example (format only, content illustrative)
+
+```json
+{
+  "question": "Cosa succede se si esaurisce la riserva di un bene durante la produzione?",
+  "answer": "La produzione di quel bene si interrompe finché la riserva non viene ripristinata; gli altri beni continuano a essere prodotti normalmente.",
+  "citations": [
+    { "pdf_page": 6, "quote": "production halts until the supply is replenished", "chunk_id": "chunk-42" }
+  ]
+}
+```

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Prompts/MechanicExtractor/v1/mechanics.md
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Prompts/MechanicExtractor/v1/mechanics.md
@@ -1,0 +1,36 @@
+# Mechanics Section (v1.0.0)
+
+Extract the **core design mechanics** the rulebook describes, using short canonical names (not paragraphs).
+
+## Output schema
+
+```json
+{
+  "mechanics": [
+    {
+      "name": "string (short canonical name, e.g. 'Worker Placement')",
+      "description": "string (1-2 sentences, Italiano, reformulated, ≤280 chars)",
+      "citations": [
+        {
+          "pdf_page": 5,
+          "quote": "string ≤25 words",
+          "chunk_id": "string (optional)"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Field rules
+
+- `name`: Use **short canonical mechanic names** from the board-game design vocabulary (Worker Placement, Deck Building, Area Control, Set Collection, Tile Laying, Hand Management, Drafting, Auction, etc.). Keep names in English — they are canonical domain terms.
+- `description`: A short Italiano sentence explaining how the mechanic is used in **this specific game**. Reformulate, do not transcribe.
+- `citations`: Each mechanic must have at least one citation from the chunks where the mechanic is described.
+
+## Extraction guidance
+
+- List between **2 and 10 mechanics**. Do not invent mechanics not supported by the chunks.
+- Prefer fewer well-cited mechanics over many weakly-supported ones.
+- If two chunks describe the same mechanic with different framings, merge into one entry with both citations.
+- Do not include meta/structural elements (e.g. "turn order", "end game") as mechanics — those belong in the Phases or Victory sections.

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Prompts/MechanicExtractor/v1/phases.md
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Prompts/MechanicExtractor/v1/phases.md
@@ -1,0 +1,40 @@
+# Phases Section (v1.0.0)
+
+Extract the **turn-level or round-level phases** in the order they occur in a typical turn.
+
+## Output schema
+
+```json
+{
+  "phases": [
+    {
+      "name": "string (canonical phase name, Italiano or original if proper noun)",
+      "description": "string (Italiano, reformulated, ≤240 chars)",
+      "order": 1,
+      "isOptional": false,
+      "citations": [
+        {
+          "pdf_page": 8,
+          "quote": "string ≤25 words",
+          "chunk_id": "string (optional)"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Field rules
+
+- `name`: Short phase name. Use **Italiano for generic phases** ("Fase Azioni", "Fase Produzione", "Fase Pulizia"). Keep **proper nouns in original language** when the game uses a specific branded name (e.g. "Upkeep", "Mythos Phase").
+- `description`: Italiano reformulated description of what happens in this phase.
+- `order`: Integer, 1-based position in the sequence.
+- `isOptional`: `true` if the phase is skipped in certain conditions; `false` if always executed.
+- `citations`: At least one citation per phase.
+
+## Extraction guidance
+
+- Include between **0 and 10 phases**. Omit the field entirely if the game does not have a structured phase sequence (e.g. pure real-time games).
+- Phases must be in execution order. Use `order` starting at 1.
+- Do not include micro-steps within a phase as separate phases (e.g. "draw a card" is not a phase — it is part of an Upkeep phase).
+- Round-level phases (that bracket all player turns) and turn-level phases (within a single player's turn) can both be listed — describe the scope in `description`.

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Prompts/MechanicExtractor/v1/resources.md
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Prompts/MechanicExtractor/v1/resources.md
@@ -1,0 +1,40 @@
+# Resources Section (v1.0.0)
+
+Extract the **resources, currencies, materials, action tokens and cards** the game uses mechanically.
+
+## Output schema
+
+```json
+{
+  "resources": [
+    {
+      "name": "string (canonical resource name, keep original if proper noun)",
+      "type": "string (one of: currency | material | token | card | unit | other)",
+      "usage": "string (Italiano, reformulated, ≤240 chars)",
+      "isLimited": true,
+      "citations": [
+        {
+          "pdf_page": 7,
+          "quote": "string ≤25 words",
+          "chunk_id": "string (optional)"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Field rules
+
+- `name`: The resource name. **Keep proper nouns and game-specific terms in their original language** (e.g. "Victory Points", "Gold", "Wood", "Meeple", "Florino"). Do not translate proper nouns.
+- `type`: One of `currency`, `material`, `token`, `card`, `unit`, `other`.
+- `usage`: A short Italiano reformulated description of what the resource does in the game's economy.
+- `isLimited`: `true` if the resource has a finite supply from a common pool; `false` if unlimited / generated on demand.
+- `citations`: At least one citation per resource.
+
+## Extraction guidance
+
+- Include between **0 and 15 resources**. Omit the field entirely if none are described.
+- Do not include story-flavor objects that have no mechanical role.
+- Merge near-identical resources (e.g. "gold coins" and "coins") into one entry.
+- Action tokens (e.g. worker meeples, action cubes) belong here with `type: token` or `unit`.

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Prompts/MechanicExtractor/v1/summary.md
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Prompts/MechanicExtractor/v1/summary.md
@@ -1,0 +1,38 @@
+# Summary Section (v1.0.0)
+
+Extract a **neutral, reformulated descriptive summary** of the game's core identity from the retrieved rulebook chunks.
+
+## Output schema
+
+```json
+{
+  "summary": {
+    "text": "string (100-500 chars, Italiano, reformulated)",
+    "playerCountMin": 1,
+    "playerCountMax": 4,
+    "playTimeMinutes": 60,
+    "minAge": 10,
+    "citations": [
+      {
+        "pdf_page": 1,
+        "quote": "string ≤25 words",
+        "chunk_id": "string (optional)"
+      }
+    ]
+  }
+}
+```
+
+## Field rules
+
+- `text`: One or two sentences describing what the game is about and what players do. **Reformulate in your own words in Italiano**. Do not transcribe the rulebook's marketing copy.
+- `playerCountMin` / `playerCountMax`: Integers from the rulebook's player count range. Omit the field if not stated.
+- `playTimeMinutes`: Integer representing typical game duration. If a range is given (e.g. "45-60 minutes"), use the **upper bound**. Omit if not stated.
+- `minAge`: Integer minimum age from the box/rulebook. Omit if not stated.
+- `citations`: **Required**. At least one citation supporting the summary text. Add a citation for each numeric field whose source page differs.
+
+## Examples of acceptable reformulation
+
+- Source: *"Players take on the role of merchants trading goods between islands."*
+- ✅ Good: *"I giocatori interpretano mercanti che scambiano risorse tra isole."*
+- ❌ Bad (verbatim translation): *"I giocatori prendono il ruolo di mercanti che commerciano beni tra isole."*

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Prompts/MechanicExtractor/v1/system.md
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Prompts/MechanicExtractor/v1/system.md
@@ -1,0 +1,43 @@
+# Mechanic Extractor System Prompt (v1.0.0)
+
+You are a **board-game rules analyst** producing structured, citation-grounded descriptions of a game's mechanics for the MeepleAI platform.
+
+## Role and responsibilities
+
+You read **excerpts from the game's official rulebook PDF** provided as retrieved chunks and produce a JSON output matching the schema supplied for the current section.
+
+## Hard IP policy (ADR-051)
+
+You MUST comply with all of the following rules. Violations cause your output to be rejected by downstream validators.
+
+1. **Reformulation obbligatoria**: Every claim you produce must be **non-literal**. Never transcribe, translate verbatim, or lightly paraphrase the rulebook text. State rules in your own words.
+2. **Quote cap ≤ 25 words**: Every `citation.quote` field must contain **at most 25 words** lifted verbatim from the source chunk. Shorter is better. Do not concatenate sentences to stay under the cap — cite the shortest supporting fragment.
+3. **No long verbatim sequences**: Your non-`quote` text (claim bodies, summaries, descriptions) must not reproduce runs of **more than 10 consecutive words** from the source. Rephrase aggressively.
+4. **Citation obbligatoria**: Every factual claim must be supported by at least one `citation` with:
+   - `pdf_page`: integer page number referenced in the rulebook (the value present in the retrieved chunk).
+   - `quote`: short verbatim fragment ≤ 25 words that justifies the claim.
+   - `chunk_id` (when the chunk id is provided in the retrieved context): the id of the chunk the quote comes from.
+5. **Grounding**: Do not invent rules, components, phases, player counts, or victory conditions. If the retrieved chunks do not cover something, **omit it**; do not guess.
+6. **Language**: Write all claim bodies in **Italiano**, regardless of the rulebook language. Keep proper nouns, game-specific terms and numeric values untouched.
+
+## Output contract
+
+- Respond with **valid JSON only**, matching the schema for the requested section.
+- No preamble, no commentary, no Markdown fences.
+- Numeric fields must be numbers, not strings.
+- Omit optional fields when unknown rather than emitting empty strings.
+
+## Domain conventions
+
+- **Mechanics** are design patterns (e.g. Worker Placement, Deck Building) — short canonical names, not paragraphs.
+- **Resources** include currencies, materials, action tokens and cards.
+- **Phases** are turn-level or round-level steps in the order they occur in a typical turn.
+- **Victory** must describe the primary condition and any alternates explicitly stated in the rulebook.
+
+## Failure modes to avoid
+
+- ❌ Emitting a quote that contains more than 25 words.
+- ❌ Producing a claim without any citation.
+- ❌ Copying two or more consecutive sentences verbatim into a claim body.
+- ❌ Inferring rules from common board-game knowledge rather than from the provided chunks.
+- ❌ Wrapping JSON in Markdown fences or adding explanatory text.

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Prompts/MechanicExtractor/v1/victory.md
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Prompts/MechanicExtractor/v1/victory.md
@@ -1,0 +1,39 @@
+# Victory Section (v1.0.0)
+
+Extract the **victory conditions** exactly as described by the rulebook. Do not invent alternatives.
+
+## Output schema
+
+```json
+{
+  "victory": {
+    "primary": "string (Italiano, reformulated, ≤280 chars)",
+    "alternatives": [
+      "string (Italiano, reformulated, ≤280 chars)"
+    ],
+    "isPointBased": true,
+    "targetPoints": 15,
+    "citations": [
+      {
+        "pdf_page": 12,
+        "quote": "string ≤25 words",
+        "chunk_id": "string (optional)"
+      }
+    ]
+  }
+}
+```
+
+## Field rules
+
+- `primary`: The main victory condition in Italiano, reformulated. Example: *"Vince il giocatore con il maggior numero di punti vittoria al termine dell'ultimo round."*
+- `alternatives`: Array of 0+ additional winning conditions **explicitly stated** in the rulebook (e.g. instant-win conditions, tiebreakers that decide the game). Omit if none are described.
+- `isPointBased`: `true` if victory is decided by accumulated points; `false` for objective/last-player-standing/elimination games.
+- `targetPoints`: Integer threshold if the game ends when a player reaches a specific point total. Omit otherwise.
+- `citations`: At least one citation covering `primary`. Add more when alternatives or `targetPoints` come from different pages.
+
+## Failure modes
+
+- ❌ Do not infer tiebreakers from generic board-game convention — cite them from the rulebook.
+- ❌ Do not translate "most points" into a specific point target unless the rulebook states a number.
+- ❌ Do not add alternatives from your own imagination.

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicAnalysisRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicAnalysisRepository.cs
@@ -98,6 +98,37 @@ internal sealed class MechanicAnalysisRepository : RepositoryBase, IMechanicAnal
         return entities.Select(e => MapToDomain(e, e.Claims)).ToList();
     }
 
+    public async Task<MechanicAnalysis?> FindByPromptVersionAsync(
+        Guid sharedGameId,
+        Guid pdfDocumentId,
+        string promptVersion,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(promptVersion))
+        {
+            throw new ArgumentException("PromptVersion is required.", nameof(promptVersion));
+        }
+
+        // IgnoreQueryFilters so suppressed rows still block T7 idempotency collisions
+        // (a takedown on one row shouldn't silently spawn a duplicate).
+        // Exclude Rejected (status = 3) so operators can retry the same prompt version
+        // after an auto-rejection (cost cap, LLM failure).
+        var entity = await DbContext.MechanicAnalyses
+            .AsNoTracking()
+            .IgnoreQueryFilters()
+            .AsSplitQuery()
+            .Include(a => a.Claims)
+                .ThenInclude(c => c.Citations)
+            .Where(a => a.SharedGameId == sharedGameId
+                        && a.PdfDocumentId == pdfDocumentId
+                        && a.PromptVersion == promptVersion
+                        && a.Status != (int)MechanicAnalysisStatus.Rejected)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return entity is null ? null : MapToDomain(entity, entity.Claims);
+    }
+
     public void Update(MechanicAnalysis analysis)
     {
         ArgumentNullException.ThrowIfNull(analysis);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameDocumentRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameDocumentRepository.cs
@@ -209,6 +209,19 @@ internal sealed class SharedGameDocumentRepository : RepositoryBase, ISharedGame
             .ConfigureAwait(false);
     }
 
+    public async Task<bool> IsPdfLinkedToGameAsync(
+        Guid sharedGameId,
+        Guid pdfDocumentId,
+        CancellationToken cancellationToken = default)
+    {
+        return await DbContext.SharedGameDocuments
+            .AsNoTracking()
+            .AnyAsync(
+                d => d.SharedGameId == sharedGameId && d.PdfDocumentId == pdfDocumentId,
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     // Mapping methods
 
     private static SharedGameDocument MapToDomain(SharedGameDocumentEntity entity)

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/MechanicAnalysisStatusChangedNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/MechanicAnalysisStatusChangedNotificationHandler.cs
@@ -1,0 +1,130 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.UserNotifications.Application.Services;
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.EventHandlers;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.UserNotifications.Application.EventHandlers;
+
+/// <summary>
+/// Handles <see cref="MechanicAnalysisStatusChangedEvent"/> for the M1.2 pipeline
+/// (ISSUE-524 / ADR-051) and dispatches user-facing notifications on terminal transitions:
+/// <list type="bullet">
+///   <item><c>Draft → InReview</c>: pipeline succeeded, fires <see cref="NotificationType.MechanicAnalysisReady"/>.</item>
+///   <item><c>* → Rejected</c>: pipeline auto-rejected (e.g. cost cap), fires <see cref="NotificationType.MechanicAnalysisRejected"/>.</item>
+/// </list>
+/// Other transitions (Rejected→InReview moderator reopen, Draft→Rejected→...) are intentionally silent.
+/// Delivery is multi-channel via <see cref="INotificationDispatcher"/> (in-app + email + Slack
+/// when enabled), and the real-time push to admin dashboards is handled downstream by the
+/// <c>IUserNotificationBroadcaster</c> publish performed inside <c>INotificationRepository.AddAsync</c>.
+/// </summary>
+internal sealed class MechanicAnalysisStatusChangedNotificationHandler
+    : DomainEventHandlerBase<MechanicAnalysisStatusChangedEvent>
+{
+    private readonly INotificationDispatcher _dispatcher;
+    private readonly IMechanicAnalysisRepository _analysisRepository;
+
+    public MechanicAnalysisStatusChangedNotificationHandler(
+        MeepleAiDbContext dbContext,
+        INotificationDispatcher dispatcher,
+        IMechanicAnalysisRepository analysisRepository,
+        ILogger<MechanicAnalysisStatusChangedNotificationHandler> logger)
+        : base(dbContext, logger)
+    {
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        _analysisRepository = analysisRepository ?? throw new ArgumentNullException(nameof(analysisRepository));
+    }
+
+    protected override async Task HandleEventAsync(
+        MechanicAnalysisStatusChangedEvent domainEvent,
+        CancellationToken cancellationToken)
+    {
+        // Only terminal user-facing transitions produce a notification.
+        if (domainEvent.ToStatus is not MechanicAnalysisStatus.InReview
+            and not MechanicAnalysisStatus.Rejected)
+        {
+            return;
+        }
+
+        // Draft → InReview is the pipeline success path. Rejected → InReview is a reopen
+        // performed by a moderator, which is not a user-facing lifecycle event.
+        if (domainEvent.ToStatus == MechanicAnalysisStatus.InReview
+            && domainEvent.FromStatus != MechanicAnalysisStatus.Draft)
+        {
+            return;
+        }
+
+        var analysis = await _analysisRepository
+            .GetByIdAsync(domainEvent.AnalysisId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (analysis is null)
+        {
+            Logger.LogWarning(
+                "MechanicAnalysis {AnalysisId} not found when dispatching status-changed notification ({FromStatus} → {ToStatus})",
+                domainEvent.AnalysisId,
+                domainEvent.FromStatus,
+                domainEvent.ToStatus);
+            return;
+        }
+
+        var isReady = domainEvent.ToStatus == MechanicAnalysisStatus.InReview;
+        var notificationType = isReady
+            ? NotificationType.MechanicAnalysisReady
+            : NotificationType.MechanicAnalysisRejected;
+
+        var title = isReady
+            ? "Analisi meccaniche pronta"
+            : "Analisi meccaniche rifiutata";
+
+        var body = isReady
+            ? "Il pipeline di estrazione meccaniche è stato completato e l'analisi è pronta per la revisione admin."
+            : BuildRejectionBody(analysis.RejectionReason, domainEvent.Note);
+
+        await _dispatcher.DispatchAsync(new NotificationMessage
+        {
+            Type = notificationType,
+            RecipientUserId = analysis.CreatedBy,
+            Payload = new GenericPayload(title, body),
+            DeepLinkPath = $"/admin/mechanic-analyses/{domainEvent.AnalysisId}/review"
+        }, cancellationToken).ConfigureAwait(false);
+
+        Logger.LogInformation(
+            "Dispatched {NotificationType} for MechanicAnalysis {AnalysisId} (recipient={UserId}, {FromStatus} → {ToStatus})",
+            notificationType,
+            domainEvent.AnalysisId,
+            analysis.CreatedBy,
+            domainEvent.FromStatus,
+            domainEvent.ToStatus);
+    }
+
+    protected override Guid? GetUserId(MechanicAnalysisStatusChangedEvent domainEvent)
+        => domainEvent.ActorId;
+
+    protected override Dictionary<string, object?>? GetAuditMetadata(
+        MechanicAnalysisStatusChangedEvent domainEvent)
+    {
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["AnalysisId"] = domainEvent.AnalysisId,
+            ["FromStatus"] = domainEvent.FromStatus.ToString(),
+            ["ToStatus"] = domainEvent.ToStatus.ToString(),
+            ["ActorId"] = domainEvent.ActorId,
+            ["Action"] = "MechanicAnalysisStatusChangedNotification"
+        };
+    }
+
+    private static string BuildRejectionBody(string? rejectionReason, string? note)
+    {
+        var reason = !string.IsNullOrWhiteSpace(rejectionReason)
+            ? rejectionReason
+            : note;
+
+        return string.IsNullOrWhiteSpace(reason)
+            ? "Il pipeline di estrazione meccaniche è stato interrotto e l'analisi è stata rifiutata automaticamente."
+            : $"L'analisi meccaniche è stata rifiutata automaticamente. Motivo: {reason}";
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/ValueObjects/NotificationType.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/ValueObjects/NotificationType.cs
@@ -91,6 +91,12 @@ internal sealed class NotificationType : ValueObject
     // Slack connection forcibly revoked by workspace admin
     public static readonly NotificationType SlackConnectionRevoked = new("slack_connection_revoked");
 
+    // ISSUE-524 / M1.2: Mechanic analysis pipeline lifecycle (async pipeline completion alerts).
+    // MechanicAnalysisReady fires when the aggregate transitions to InReview (pipeline succeeded).
+    // MechanicAnalysisRejected fires when the aggregate is auto-rejected mid-pipeline (e.g. cost cap).
+    public static readonly NotificationType MechanicAnalysisReady = new("mechanic_analysis_ready");
+    public static readonly NotificationType MechanicAnalysisRejected = new("mechanic_analysis_rejected");
+
     private NotificationType(string value)
     {
         Value = value;
@@ -158,6 +164,8 @@ internal sealed class NotificationType : ValueObject
             "admin_manual_notification" => AdminManualNotification,
             "admin_pdf_processing_started" => AdminPdfProcessingStarted,
             "slack_connection_revoked" => SlackConnectionRevoked,
+            "mechanic_analysis_ready" => MechanicAnalysisReady,
+            "mechanic_analysis_rejected" => MechanicAnalysisRejected,
             // Legacy aliases — old type strings from DB or older clients map to new types
             "pdf_upload_completed" => DocumentReady,
             "processing_job_completed" => DocumentReady,

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs
@@ -195,14 +195,16 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
             || type == NotificationType.AdminReviewLockExpiring
             || type == NotificationType.AdminStaleShareRequests
             || type == NotificationType.RateLimitReached
-            || type == NotificationType.SlackConnectionRevoked)
+            || type == NotificationType.SlackConnectionRevoked
+            || type == NotificationType.MechanicAnalysisRejected)
             return NotificationSeverity.Warning;
 
         if (type == NotificationType.DocumentReady
             || type == NotificationType.RuleSpecGenerated
             || type == NotificationType.BadgeEarned
             || type == NotificationType.AgentReady
-            || type == NotificationType.GdprDataExportReady)
+            || type == NotificationType.GdprDataExportReady
+            || type == NotificationType.MechanicAnalysisReady)
             return NotificationSeverity.Success;
 
         return NotificationSeverity.Info;
@@ -234,6 +236,8 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
         if (type == NotificationType.GdprAccountDeleted) return "Account eliminato";
         if (type == NotificationType.GdprAiConsentUpdated) return "Consenso AI aggiornato";
         if (type == NotificationType.SlackConnectionRevoked) return "Slack disconnesso";
+        if (type == NotificationType.MechanicAnalysisReady) return "Analisi meccaniche pronta";
+        if (type == NotificationType.MechanicAnalysisRejected) return "Analisi meccaniche rifiutata";
 
         // Admin types
         if (type == NotificationType.AdminNewShareRequest) return "[Admin] Nuova Share Request";

--- a/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicAnalysisSectionRunEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicAnalysisSectionRunEntityConfiguration.cs
@@ -1,0 +1,90 @@
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.Configurations.SharedGameCatalog;
+
+/// <summary>
+/// EF configuration for <see cref="MechanicAnalysisSectionRunEntity"/> (ADR-051 / M1.2, B6=C).
+/// Per-section provider/token tracking rows. Write-once: no updates after completion.
+/// </summary>
+internal sealed class MechanicAnalysisSectionRunEntityConfiguration : IEntityTypeConfiguration<MechanicAnalysisSectionRunEntity>
+{
+    public void Configure(EntityTypeBuilder<MechanicAnalysisSectionRunEntity> builder)
+    {
+        builder.ToTable("mechanic_analysis_section_runs", t =>
+        {
+            t.HasCheckConstraint(
+                "ck_mechanic_section_runs_section_range",
+                "section BETWEEN 0 AND 5");
+
+            t.HasCheckConstraint(
+                "ck_mechanic_section_runs_status_range",
+                "status BETWEEN 0 AND 2");
+
+            t.HasCheckConstraint(
+                "ck_mechanic_section_runs_tokens_non_negative",
+                "prompt_tokens >= 0 AND completion_tokens >= 0 AND total_tokens >= 0");
+
+            t.HasCheckConstraint(
+                "ck_mechanic_section_runs_cost_non_negative",
+                "estimated_cost_usd >= 0");
+
+            t.HasCheckConstraint(
+                "ck_mechanic_section_runs_latency_non_negative",
+                "latency_ms >= 0");
+
+            t.HasCheckConstraint(
+                "ck_mechanic_section_runs_error_when_failed",
+                "status <> 1 OR error_message IS NOT NULL");
+        });
+
+        builder.HasKey(r => r.Id);
+
+        builder.Property(r => r.Id).HasColumnName("id").IsRequired();
+        builder.Property(r => r.AnalysisId).HasColumnName("analysis_id").IsRequired();
+        builder.Property(r => r.Section).HasColumnName("section").IsRequired();
+        builder.Property(r => r.RunOrder).HasColumnName("run_order").IsRequired();
+
+        builder.Property(r => r.Provider)
+            .HasColumnName("provider")
+            .HasMaxLength(64)
+            .IsRequired();
+
+        builder.Property(r => r.ModelUsed)
+            .HasColumnName("model_used")
+            .HasMaxLength(128)
+            .IsRequired();
+
+        builder.Property(r => r.PromptTokens).HasColumnName("prompt_tokens").HasDefaultValue(0).IsRequired();
+        builder.Property(r => r.CompletionTokens).HasColumnName("completion_tokens").HasDefaultValue(0).IsRequired();
+        builder.Property(r => r.TotalTokens).HasColumnName("total_tokens").HasDefaultValue(0).IsRequired();
+
+        builder.Property(r => r.EstimatedCostUsd)
+            .HasColumnName("estimated_cost_usd")
+            .HasColumnType("numeric(12,6)")
+            .HasDefaultValue(0m)
+            .IsRequired();
+
+        builder.Property(r => r.LatencyMs).HasColumnName("latency_ms").IsRequired();
+        builder.Property(r => r.Status).HasColumnName("status").IsRequired();
+
+        builder.Property(r => r.ErrorMessage)
+            .HasColumnName("error_message")
+            .HasMaxLength(4000);
+
+        builder.Property(r => r.StartedAt).HasColumnName("started_at").IsRequired();
+        builder.Property(r => r.CompletedAt).HasColumnName("completed_at").IsRequired();
+
+        builder.HasIndex(r => r.AnalysisId).HasDatabaseName("ix_mechanic_section_runs_analysis_id");
+        builder.HasIndex(r => new { r.AnalysisId, r.RunOrder })
+            .HasDatabaseName("ux_mechanic_section_runs_analysis_run_order")
+            .IsUnique();
+        builder.HasIndex(r => r.Provider).HasDatabaseName("ix_mechanic_section_runs_provider");
+
+        builder.HasOne(r => r.Analysis)
+            .WithMany(a => a.SectionRuns)
+            .HasForeignKey(r => r.AnalysisId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicAnalysisEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicAnalysisEntity.cs
@@ -54,4 +54,5 @@ public class MechanicAnalysisEntity
     // === Navigation ===
     public SharedGameEntity SharedGame { get; set; } = default!;
     public ICollection<MechanicClaimEntity> Claims { get; set; } = new List<MechanicClaimEntity>();
+    public ICollection<MechanicAnalysisSectionRunEntity> SectionRuns { get; set; } = new List<MechanicAnalysisSectionRunEntity>();
 }

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicAnalysisSectionRunEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicAnalysisSectionRunEntity.cs
@@ -1,0 +1,57 @@
+namespace Api.Infrastructure.Entities.SharedGameCatalog;
+
+/// <summary>
+/// Persistence record for a single section generation run within a
+/// <see cref="MechanicAnalysisEntity"/> (ADR-051 / M1.2, decision B6=C). Captures the provider,
+/// model, token usage, cost, latency and final status of each per-section LLM call so operators
+/// can audit token spend and diagnose provider failures without trawling logs.
+/// </summary>
+/// <remarks>
+/// One row per section attempt — rerunning the pipeline creates a new analysis with its own
+/// set of section runs. Rows are write-once: once a section completes, its row is immutable.
+/// </remarks>
+public class MechanicAnalysisSectionRunEntity
+{
+    public Guid Id { get; set; }
+
+    public Guid AnalysisId { get; set; }
+
+    /// <summary>
+    /// 0=Summary, 1=Mechanics, 2=Victory, 3=Resources, 4=Phases, 5=Faq.
+    /// Mirrors <c>Api.BoundedContexts.SharedGameCatalog.Domain.Enums.MechanicSection</c>.
+    /// </summary>
+    public int Section { get; set; }
+
+    /// <summary>Order within the pipeline run (0-based).</summary>
+    public int RunOrder { get; set; }
+
+    /// <summary>Provider that actually produced the completion (after fallback): deepseek, openrouter.</summary>
+    public string Provider { get; set; } = string.Empty;
+
+    /// <summary>Canonical model identifier returned by the provider.</summary>
+    public string ModelUsed { get; set; } = string.Empty;
+
+    public int PromptTokens { get; set; }
+    public int CompletionTokens { get; set; }
+    public int TotalTokens { get; set; }
+
+    public decimal EstimatedCostUsd { get; set; }
+
+    /// <summary>Wall-clock duration of the LLM call in milliseconds.</summary>
+    public int LatencyMs { get; set; }
+
+    /// <summary>0=Succeeded, 1=Failed, 2=SkippedDueToCostCap.</summary>
+    public int Status { get; set; }
+
+    /// <summary>Free-text error message when <see cref="Status"/> is Failed; null otherwise.</summary>
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>UTC timestamp when the run started.</summary>
+    public DateTime StartedAt { get; set; }
+
+    /// <summary>UTC timestamp when the run ended (success or failure).</summary>
+    public DateTime CompletedAt { get; set; }
+
+    // === Navigation ===
+    public MechanicAnalysisEntity Analysis { get; set; } = default!;
+}

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -140,6 +140,7 @@ public class MeepleAiDbContext : DbContext
     public DbSet<MechanicCitationEntity> MechanicCitations => Set<MechanicCitationEntity>(); // ISSUE-523: Child of MechanicClaim (ADR-051 T1 quote cap)
     public DbSet<MechanicStatusAuditEntity> MechanicStatusAudits => Set<MechanicStatusAuditEntity>(); // ISSUE-523: T6 audit trail for lifecycle transitions
     public DbSet<MechanicSuppressionAuditEntity> MechanicSuppressionAudits => Set<MechanicSuppressionAuditEntity>(); // ISSUE-523: T5 audit trail for suppressions
+    public DbSet<MechanicAnalysisSectionRunEntity> MechanicAnalysisSectionRuns => Set<MechanicAnalysisSectionRunEntity>(); // ISSUE-524: M1.2 per-section provider/token tracking (B6=C)
     public DbSet<QuickQuestionEntity> QuickQuestions => Set<QuickQuestionEntity>(); // ISSUE-2401: Sprint 3 - Quick questions AI generation
     public DbSet<UserLibraryEntryEntity> UserLibraryEntries => Set<UserLibraryEntryEntity>(); // User Library feature
     public DbSet<WishlistItemEntity> WishlistItems => Set<WishlistItemEntity>(); // ISSUE-3917: Wishlist management

--- a/apps/api/src/Api/Infrastructure/Migrations/20260423120440_M1_2_MechanicAnalysisSectionRuns.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260423120440_M1_2_MechanicAnalysisSectionRuns.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260423120440_M1_2_MechanicAnalysisSectionRuns")]
+    partial class M1_2_MechanicAnalysisSectionRuns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260423120440_M1_2_MechanicAnalysisSectionRuns.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260423120440_M1_2_MechanicAnalysisSectionRuns.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class M1_2_MechanicAnalysisSectionRuns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "mechanic_analysis_section_runs",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    analysis_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    section = table.Column<int>(type: "integer", nullable: false),
+                    run_order = table.Column<int>(type: "integer", nullable: false),
+                    provider = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    model_used = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    prompt_tokens = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    completion_tokens = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    total_tokens = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    estimated_cost_usd = table.Column<decimal>(type: "numeric(12,6)", nullable: false, defaultValue: 0m),
+                    latency_ms = table.Column<int>(type: "integer", nullable: false),
+                    status = table.Column<int>(type: "integer", nullable: false),
+                    error_message = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: true),
+                    started_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    completed_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_mechanic_analysis_section_runs", x => x.id);
+                    table.CheckConstraint("ck_mechanic_section_runs_cost_non_negative", "estimated_cost_usd >= 0");
+                    table.CheckConstraint("ck_mechanic_section_runs_error_when_failed", "status <> 1 OR error_message IS NOT NULL");
+                    table.CheckConstraint("ck_mechanic_section_runs_latency_non_negative", "latency_ms >= 0");
+                    table.CheckConstraint("ck_mechanic_section_runs_section_range", "section BETWEEN 0 AND 5");
+                    table.CheckConstraint("ck_mechanic_section_runs_status_range", "status BETWEEN 0 AND 2");
+                    table.CheckConstraint("ck_mechanic_section_runs_tokens_non_negative", "prompt_tokens >= 0 AND completion_tokens >= 0 AND total_tokens >= 0");
+                    table.ForeignKey(
+                        name: "FK_mechanic_analysis_section_runs_mechanic_analyses_analysis_id",
+                        column: x => x.analysis_id,
+                        principalTable: "mechanic_analyses",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_mechanic_section_runs_analysis_id",
+                table: "mechanic_analysis_section_runs",
+                column: "analysis_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_mechanic_section_runs_provider",
+                table: "mechanic_analysis_section_runs",
+                column: "provider");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_mechanic_section_runs_analysis_run_order",
+                table: "mechanic_analysis_section_runs",
+                columns: new[] { "analysis_id", "run_order" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "mechanic_analysis_section_runs");
+        }
+    }
+}

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -873,6 +873,7 @@ if (!isAlphaMode)
     v1Api.MapRagPipelineAdminEndpoints();  // RAG Pipeline builder (Issue #3463)
     v1Api.MapRagExecutionAdminEndpoints(); // RAG Execution replay & compare (Issue #4459)
     v1Api.MapAdminMechanicExtractorEndpoints(); // Mechanic Extractor: Variant C copyright-compliant analysis
+    v1Api.MapAdminMechanicAnalysesEndpoints();  // ISSUE-524 / M1.2: AI-generated mechanic analyses (async pipeline)
     v1Api.MapReportingEndpoints();         // ISSUE-916: Report generation & scheduling
     v1Api.MapTestingMetricsEndpoints();    // Issue #2139: Testing metrics API
     v1Api.MapBggImportQueueEndpoints(); // Issue #3541: BGG import queue management (admin-only)

--- a/apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs
@@ -1,0 +1,103 @@
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicExtractor;
+using Api.Filters;
+using MediatR;
+
+namespace Api.Routing;
+
+/// <summary>
+/// Admin endpoints for the AI-generated Mechanic Analysis workflow (ISSUE-524 / M1.2, ADR-051).
+/// Complements the older Variant C draft workflow by exposing an asynchronous pipeline:
+/// <list type="bullet">
+///   <item><c>POST /admin/mechanic-analyses</c> — kicks off the LLM pipeline (202 Accepted).</item>
+///   <item><c>GET  /admin/mechanic-analyses/{id}/status</c> — polls pipeline progress.</item>
+/// </list>
+/// The admin's user id is always read from the validated session (never trusted from the body).
+/// </summary>
+internal static class AdminMechanicAnalysesEndpoints
+{
+    public static void MapAdminMechanicAnalysesEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/admin/mechanic-analyses")
+            .WithTags("Admin - Mechanic Analyses (M1.2)")
+            .AddEndpointFilter<RequireAdminSessionFilter>();
+
+        // POST /api/v1/admin/mechanic-analyses
+        // Enqueues the async AI pipeline (B5=B). Returns 202 Accepted with polling URL.
+        group.MapPost("/", async (
+            GenerateMechanicAnalysisRequest request,
+            HttpContext httpContext,
+            IMediator mediator,
+            ILogger<Program> logger,
+            CancellationToken ct) =>
+        {
+            var session = (SessionStatusDto)httpContext.Items[nameof(SessionStatusDto)]!;
+            var adminId = session!.User!.Id;
+
+            logger.LogInformation(
+                "Admin {AdminId} kicking off mechanic analysis for game {SharedGameId}, PDF {PdfDocumentId}",
+                adminId,
+                request.SharedGameId,
+                request.PdfDocumentId);
+
+            CostCapOverrideInput? overrideInput = request.CostCapOverride is null
+                ? null
+                : new CostCapOverrideInput(request.CostCapOverride.NewCapUsd, request.CostCapOverride.Reason);
+
+            var command = new GenerateMechanicAnalysisCommand(
+                SharedGameId: request.SharedGameId,
+                PdfDocumentId: request.PdfDocumentId,
+                RequestedBy: adminId,
+                CostCapUsd: request.CostCapUsd,
+                CostCapOverride: overrideInput);
+
+            var response = await mediator.Send(command, ct).ConfigureAwait(false);
+
+            // 202 Accepted — pipeline runs asynchronously; client polls StatusUrl.
+            return Results.Accepted(response.StatusUrl, response);
+        })
+        .WithName("AdminGenerateMechanicAnalysis")
+        .WithSummary("Enqueue AI mechanic analysis pipeline (async)")
+        .WithDescription(
+            "Creates a Draft MechanicAnalysis aggregate and schedules the six-section LLM pipeline " +
+            "to run in the background. Returns 202 Accepted with a StatusUrl for polling.");
+
+        // GET /api/v1/admin/mechanic-analyses/{id}/status
+        // Returns lifecycle + per-section run telemetry for admin observability.
+        group.MapGet("/{id:guid}/status", async (
+            Guid id,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var query = new GetMechanicAnalysisStatusQuery(id);
+            var status = await mediator.Send(query, ct).ConfigureAwait(false);
+
+            return status is not null
+                ? Results.Ok(status)
+                : Results.NotFound();
+        })
+        .WithName("AdminGetMechanicAnalysisStatus")
+        .WithSummary("Poll mechanic analysis lifecycle + per-section telemetry")
+        .WithDescription(
+            "Returns the current status of a mechanic analysis including per-section " +
+            "LLM execution metrics (provider, model, tokens, latency, cost).");
+    }
+}
+
+/// <summary>
+/// Request body for <c>POST /admin/mechanic-analyses</c>. The admin user id is sourced from
+/// the validated session, never from the body.
+/// </summary>
+internal sealed record GenerateMechanicAnalysisRequest(
+    Guid SharedGameId,
+    Guid PdfDocumentId,
+    decimal CostCapUsd,
+    CostCapOverrideRequest? CostCapOverride = null);
+
+/// <summary>
+/// Optional planning-time cost cap override (B3=A). Mirrors
+/// <see cref="CostCapOverrideInput"/> but lives in the Routing layer so the request contract
+/// is not coupled to the internal command record.
+/// </summary>
+internal sealed record CostCapOverrideRequest(decimal NewCapUsd, string Reason);


### PR DESCRIPTION
## Summary
- Implementa **ISSUE-524 / M1.2** (ADR-051) come vertical slice monolitica
- `POST /api/v1/admin/mechanic-analyses` ritorna **202 Accepted** e delega al `IMechanicAnalysisExecutor` su scope DI fresco
- `GET /api/v1/admin/mechanic-analyses/{id}/status` abilita polling dello stato (Draft → InReview | Rejected)
- Pipeline: prompt embedded v1.0.0 → LLM → `MechanicOutputParser` → `MechanicOutputValidator` (hard-cap x1.0 + auto-reject) → persistenza `MechanicAnalysisSectionRunEntity` → notifica `MechanicAnalysisReady`

## Decisioni architetturali
- **B1=A** POST `/api/v1/admin/mechanic-analyses`
- **B2=A** hard-cap × 1.0 + auto-reject + admin cost-cap override
- **B3=A** planning-time override
- **B4=A** embedded `.md` prompts v1.0.0 (7 files: system/mechanics/phases/resources/victory/faq/summary)
- **B5=B** async 202 Accepted + UserNotifications integration
- **B6=C** child table `mechanic_analysis_section_runs`

## Review fixes applicate pre-PR
| | Fix | Motivazione |
|---|-----|-------------|
| R3 | Class summary comment corretto (`Draft→InReview` only) | Consistenza con guard a L54-58 |
| R4 | `ChangeTracker.Clear()` in cancellation + unexpected failure handlers | Evita leak di staged section-runs nel commit terminale |
| B2 | Handler usa `ISharedGameDocumentRepository.IsPdfLinkedToGameAsync` | Decoupling handler da entity projections |
| NTH7 | `EmbeddedMechanicPromptProvider` registrato come `Singleton` | Scoped defeatava silenziosamente la `ConcurrentDictionary` cache |

## Test plan
- [ ] Build verde locale (`dotnet build` → 0 err / 0 warn) ✅
- [ ] Code review via `/code-review:code-review` (gating requirement)
- [ ] Unit test esistenti M1.1 aggregate ancora verdi (`MechanicAnalysisTests`)
- [ ] **Integration tests end-to-end (20 AC Gherkin)** → **follow-up PR dedicata** (Task #22 resta aperto)
- [ ] Smoke test manuale su env staging post-merge

## Follow-up
- **Task #22**: integration tests end-to-end (Testcontainers + pipeline async + polling) — PR separata per isolamento scope
- Tech-debt non bloccante: R5 (SystemActorId semantics), R6 (DB round-trip consolidation), NTH8 (duplicated constant)

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)