### PR TITLE
feat(meeple-card): unify ConnectionChip, OwnershipBadge, LifecycleStateBadge

### DIFF
--- a/apps/web/src/components/ui/data-display/meeple-card/__tests__/tokens-entityTokens.test.ts
+++ b/apps/web/src/components/ui/data-display/meeple-card/__tests__/tokens-entityTokens.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { entityTokens } from '../tokens';
+
+describe('entityTokens()', () => {
+  it('returns solid color using existing entityHsl', () => {
+    const t = entityTokens('game');
+    expect(t.solid).toBe('hsl(25, 95%, 45%)');
+  });
+
+  it('returns fill with 0.12 alpha', () => {
+    const t = entityTokens('game');
+    expect(t.fill).toBe('hsla(25, 95%, 45%, 0.12)');
+  });
+
+  it('returns border with 0.35 alpha', () => {
+    const t = entityTokens('game');
+    expect(t.border).toBe('hsla(25, 95%, 45%, 0.35)');
+  });
+
+  it('returns named tokens for hover, glow, shadow, muted, dashed', () => {
+    const t = entityTokens('kb');
+    expect(t.hover).toBe('hsla(210, 40%, 55%, 0.22)');
+    expect(t.glow).toBe('hsla(210, 40%, 55%, 0.18)');
+    expect(t.shadow).toBe('hsla(210, 40%, 55%, 0.25)');
+    expect(t.muted).toBe('hsla(210, 40%, 55%, 0.06)');
+    expect(t.dashed).toBe('hsla(210, 40%, 55%, 0.25)');
+  });
+
+  it('returns textOn = #ffffff', () => {
+    expect(entityTokens('agent').textOn).toBe('#ffffff');
+  });
+});

--- a/apps/web/src/components/ui/data-display/meeple-card/index.ts
+++ b/apps/web/src/components/ui/data-display/meeple-card/index.ts
@@ -10,6 +10,10 @@ export type {
   CardStatus,
   CoverLabel,
   Carousel3DProps,
+  ConnectionItem,
+  ConnectionChipProps,
+  OwnershipBadge as OwnershipBadgeValue,
+  LifecycleState,
 } from './types';
 export { FlipCard } from './features/FlipCard';
 export { HoverPreview } from './features/HoverPreview';
@@ -23,4 +27,11 @@ export type {
 export { FlipBack } from './features/FlipBack';
 export type { FlipBackProps, FlipBackSection } from './features/FlipBack';
 export { MeepleCardSkeleton } from './skeleton';
-export { entityColors, entityHsl, entityLabel, entityIcon } from './tokens';
+export { entityColors, entityHsl, entityLabel, entityIcon, entityTokens } from './tokens';
+export { ConnectionChip } from './parts/ConnectionChip';
+export { ConnectionChipStrip } from './parts/ConnectionChipStrip';
+export { ConnectionChipPopover } from './parts/ConnectionChipPopover';
+export { OwnershipBadge } from './parts/OwnershipBadge';
+export { LifecycleStateBadge } from './parts/LifecycleStateBadge';
+export { entityIcons, ENTITY_ICON_SIZE, ENTITY_ICON_STROKE } from './parts/entity-icons';
+export { mapLegacyStatus, resolveStatus } from './parts/status-adapter';

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChip.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChip.tsx
@@ -3,6 +3,7 @@
 import { useState, type CSSProperties } from 'react';
 
 import { Plus } from 'lucide-react';
+import Link from 'next/link';
 
 import { entityLabel } from '../tokens';
 import { entityTokens } from '../tokens';
@@ -141,6 +142,7 @@ export function ConnectionChip({
     } else if (hasCreate) {
       onCreate?.();
     }
+    // href without items/create is rendered as <Link>, no click handler needed here.
   };
 
   const ariaLabel = hasCount
@@ -149,21 +151,35 @@ export function ConnectionChip({
       ? (createLabel ?? `Aggiungi ${labelEffective}`)
       : labelEffective;
 
+  const rootClassName = `group/chip relative inline-flex flex-col items-center outline-none focus-visible:ring-2 focus-visible:ring-offset-1 ${
+    disabled ? 'cursor-not-allowed opacity-40' : isInteractive ? 'cursor-pointer' : 'cursor-default'
+  }`;
+  const rootStyle = { ['--tw-ring-color' as string]: tokens.solid } as CSSProperties;
+
+  // Render as <Link> when href is provided and there's no popover to open.
+  if (href && !hasItems && !disabled) {
+    return (
+      <Link
+        href={href}
+        aria-label={ariaLabel}
+        onClick={hasCreate ? () => onCreate?.() : undefined}
+        className={rootClassName}
+        style={rootStyle}
+      >
+        {chipInner}
+        {labelEl}
+      </Link>
+    );
+  }
+
   const buttonEl = (
     <button
       type="button"
       aria-label={ariaLabel}
-      aria-disabled={disabled || undefined}
       disabled={disabled}
       onClick={handleActivate}
-      className={`group/chip relative inline-flex flex-col items-center outline-none focus-visible:ring-2 focus-visible:ring-offset-1 ${
-        disabled
-          ? 'cursor-not-allowed opacity-40'
-          : isInteractive
-            ? 'cursor-pointer'
-            : 'cursor-default'
-      }`}
-      style={{ ['--tw-ring-color' as string]: tokens.solid } as CSSProperties}
+      className={rootClassName}
+      style={rootStyle}
     >
       {chipInner}
       {labelEl}

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChip.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChip.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { useState, type CSSProperties } from 'react';
+
+import { Plus } from 'lucide-react';
+
+import { entityLabel } from '../tokens';
+import { entityTokens } from '../tokens';
+import { ConnectionChipPopover } from './ConnectionChipPopover';
+import { ENTITY_ICON_SIZE, ENTITY_ICON_STROKE, entityIcons } from './entity-icons';
+
+import type { ConnectionChipProps } from '../types';
+
+const CHIP_PX = { sm: 22, md: 28 } as const;
+const BADGE_PX = { sm: 14, md: 16 } as const;
+const PLUS_PX = { sm: 12, md: 14 } as const;
+
+function formatCount(count: number): string {
+  return count > 99 ? '99+' : String(count);
+}
+
+export function ConnectionChip({
+  entityType,
+  count = 0,
+  items,
+  size = 'md',
+  showLabel,
+  label,
+  onCreate,
+  createLabel,
+  href,
+  colorOverride,
+  disabled = false,
+  loading = false,
+}: ConnectionChipProps) {
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const tokens = entityTokens(entityType);
+  const color = colorOverride ?? tokens.solid;
+  const Icon = entityIcons[entityType];
+  const chipPx = CHIP_PX[size];
+  const iconPx = ENTITY_ICON_SIZE[size];
+  const badgePx = BADGE_PX[size];
+  const plusPx = PLUS_PX[size];
+  const labelEffective = label ?? entityLabel[entityType];
+  const showLabelEffective = showLabel ?? size === 'md';
+
+  const hasCount = count > 0;
+  const isEmpty = count === 0;
+  const hasCreate = onCreate !== undefined;
+  const hasItems = (items?.length ?? 0) > 0;
+  const isInteractive = !disabled && !loading && (hasItems || hasCreate || !!href);
+
+  if (loading) {
+    return (
+      <span
+        data-testid="connection-chip-loading"
+        className="inline-flex animate-pulse rounded-full"
+        style={{
+          width: chipPx,
+          height: chipPx,
+          background: tokens.muted,
+        }}
+      />
+    );
+  }
+
+  const chipFaceStyle: CSSProperties = {
+    width: chipPx,
+    height: chipPx,
+    background: isEmpty ? tokens.muted : tokens.fill,
+    border: `1px ${isEmpty ? 'dashed' : 'solid'} ${isEmpty ? tokens.dashed : tokens.border}`,
+    color,
+    opacity: isEmpty ? (hasCreate ? 0.85 : 0.6) : 1,
+    ['--mc-chip-color' as string]: color,
+    ['--mc-chip-glow' as string]: tokens.glow,
+    ['--mc-chip-shadow' as string]: tokens.shadow,
+    ['--mc-chip-hover-bg' as string]: tokens.hover,
+  };
+
+  const chipInner = (
+    <span
+      className="relative inline-flex items-center justify-center rounded-full transition-all duration-200 group-hover/chip:scale-[1.08] group-hover/chip:bg-[var(--mc-chip-hover-bg)] group-hover/chip:shadow-[0_0_0_4px_var(--mc-chip-glow),0_4px_12px_var(--mc-chip-shadow)] motion-reduce:group-hover/chip:scale-100"
+      style={chipFaceStyle}
+    >
+      <Icon
+        size={iconPx}
+        strokeWidth={ENTITY_ICON_STROKE}
+        aria-hidden="true"
+        style={{ opacity: isEmpty ? (hasCreate ? 0.7 : 0.45) : 1 }}
+      />
+
+      {hasCount && (
+        <span
+          data-testid="connection-chip-badge"
+          className="absolute flex items-center justify-center rounded-full font-semibold text-white shadow-sm [font-feature-settings:'tnum']"
+          style={{
+            top: -4,
+            right: -4,
+            height: badgePx,
+            minWidth: badgePx,
+            padding: '0 3px',
+            fontSize: size === 'sm' ? 9 : 10,
+            lineHeight: 1,
+            background: color,
+            boxShadow: '0 0 0 2px var(--mc-bg-card, #fff)',
+          }}
+        >
+          {formatCount(count)}
+        </span>
+      )}
+
+      {isEmpty && hasCreate && (
+        <span
+          data-testid="connection-chip-plus"
+          aria-hidden="true"
+          className="absolute flex items-center justify-center rounded-full text-white shadow-sm"
+          style={{
+            bottom: -3,
+            right: -3,
+            height: plusPx,
+            width: plusPx,
+            background: color,
+          }}
+        >
+          <Plus size={plusPx - 4} strokeWidth={3} />
+        </span>
+      )}
+    </span>
+  );
+
+  const labelEl = showLabelEffective ? (
+    <span className="mt-0.5 text-[9px] font-semibold uppercase tracking-wide text-[var(--mc-text-muted)] group-hover/chip:text-[var(--mc-text-secondary)]">
+      {labelEffective}
+    </span>
+  ) : null;
+
+  const handleActivate = () => {
+    if (!isInteractive) return;
+    if (hasItems) {
+      setPopoverOpen(true);
+    } else if (hasCreate) {
+      onCreate?.();
+    }
+  };
+
+  const ariaLabel = hasCount
+    ? `${count} ${labelEffective}`
+    : hasCreate
+      ? (createLabel ?? `Aggiungi ${labelEffective}`)
+      : labelEffective;
+
+  const buttonEl = (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      aria-disabled={disabled || undefined}
+      disabled={disabled}
+      onClick={handleActivate}
+      className={`group/chip relative inline-flex flex-col items-center outline-none focus-visible:ring-2 focus-visible:ring-offset-1 ${
+        disabled
+          ? 'cursor-not-allowed opacity-40'
+          : isInteractive
+            ? 'cursor-pointer'
+            : 'cursor-default'
+      }`}
+      style={{ ['--tw-ring-color' as string]: tokens.solid } as CSSProperties}
+    >
+      {chipInner}
+      {labelEl}
+    </button>
+  );
+
+  if (hasItems && !disabled) {
+    return (
+      <ConnectionChipPopover
+        open={popoverOpen}
+        onOpenChange={setPopoverOpen}
+        items={items ?? []}
+        onCreate={onCreate}
+        createLabel={createLabel}
+        entityType={entityType}
+      >
+        {buttonEl}
+      </ConnectionChipPopover>
+    );
+  }
+
+  return buttonEl;
+}

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChipPopover.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChipPopover.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { type ReactNode } from 'react';
+
+import { Plus } from 'lucide-react';
+import Link from 'next/link';
+
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/overlays/popover';
+
+import { entityLabel } from '../tokens';
+import { entityTokens } from '../tokens';
+import { ENTITY_ICON_STROKE, entityIcons } from './entity-icons';
+
+import type { ConnectionItem, MeepleEntityType } from '../types';
+
+export interface ConnectionChipPopoverProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  items: ConnectionItem[];
+  onCreate?: () => void;
+  createLabel?: string;
+  entityType: MeepleEntityType;
+  children: ReactNode;
+}
+
+export function ConnectionChipPopover({
+  open,
+  onOpenChange,
+  items,
+  onCreate,
+  createLabel = 'Create',
+  entityType,
+  children,
+}: ConnectionChipPopoverProps) {
+  const tokens = entityTokens(entityType);
+  const Icon = entityIcons[entityType];
+  const label = entityLabel[entityType];
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+
+      <PopoverContent
+        align="start"
+        sideOffset={6}
+        className="w-56 p-0 overflow-hidden"
+        style={{
+          border: `1px solid ${tokens.border}`,
+          background: 'var(--mc-bg-card, hsl(222 47% 11%))',
+        }}
+      >
+        <div
+          className="flex items-center gap-2 border-b px-3 py-2 text-xs font-semibold uppercase tracking-wide"
+          style={{ borderColor: tokens.border, color: tokens.solid }}
+        >
+          <Icon size={14} strokeWidth={ENTITY_ICON_STROKE} aria-hidden="true" />
+          <span>
+            {label} ({items.length})
+          </span>
+        </div>
+
+        {items.length > 0 && (
+          <ul className="max-h-60 overflow-y-auto py-1" role="list">
+            {items.map(item => (
+              <li key={item.id}>
+                <Link
+                  href={item.href}
+                  onClick={() => onOpenChange(false)}
+                  className="flex items-center gap-2 px-3 py-1.5 text-sm transition-colors hover:bg-white/5"
+                  style={{ color: 'var(--mc-text, inherit)' }}
+                >
+                  <span className="shrink-0" style={{ color: tokens.solid }}>
+                    <Icon size={14} strokeWidth={ENTITY_ICON_STROKE} aria-hidden="true" />
+                  </span>
+                  <span className="truncate">{item.label}</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {onCreate && (
+          <div className="border-t px-3 py-2" style={{ borderColor: tokens.border }}>
+            <button
+              type="button"
+              onClick={() => {
+                onCreate();
+                onOpenChange(false);
+              }}
+              className="flex w-full items-center gap-2 rounded-sm px-1 py-1 text-sm font-medium transition-colors hover:opacity-80"
+              style={{ color: tokens.solid }}
+            >
+              <Plus size={14} aria-hidden="true" />
+              <span>{createLabel}</span>
+            </button>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChipStrip.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChipStrip.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { ConnectionChip } from './ConnectionChip';
+
+import type { ConnectionChipProps } from '../types';
+
+export type ConnectionChipStripVariant = 'footer' | 'inline';
+
+interface ConnectionChipStripProps {
+  variant: ConnectionChipStripVariant;
+  connections: ConnectionChipProps[];
+  className?: string;
+}
+
+/**
+ * Layout container for multiple ConnectionChip.
+ *
+ * - `footer`: md chips, border-top, labels visible, used in grid/featured/hero card footer.
+ * - `inline`: sm chips, no border, no labels, used in list/compact/focus meta-row.
+ */
+export function ConnectionChipStrip({ variant, connections, className }: ConnectionChipStripProps) {
+  if (connections.length === 0) return null;
+
+  const defaultSize: 'sm' | 'md' = variant === 'footer' ? 'md' : 'sm';
+
+  const containerClass =
+    variant === 'footer'
+      ? 'flex items-center justify-center gap-3 border-t border-[var(--mc-border-light)] bg-[var(--mc-nav-footer-bg)] px-2.5 py-2 backdrop-blur-lg'
+      : 'flex items-center gap-1.5';
+
+  return (
+    <div className={`${containerClass} ${className ?? ''}`.trim()} data-strip-variant={variant}>
+      {connections.map((chipProps, i) => (
+        <ConnectionChip
+          key={`${chipProps.entityType}-${i}`}
+          size={chipProps.size ?? defaultSize}
+          showLabel={chipProps.showLabel ?? variant === 'footer'}
+          {...chipProps}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/LifecycleStateBadge.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/LifecycleStateBadge.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { AlertTriangle, CheckCheck, Loader2, Settings2, type LucideIcon } from 'lucide-react';
+
+import { entityHsl } from '../tokens';
+
+import type { LifecycleState, MeepleEntityType } from '../types';
+
+interface LifecycleStateBadgeProps {
+  value: LifecycleState;
+  entityType: MeepleEntityType;
+  className?: string;
+}
+
+interface StaticConfig {
+  kind: 'icon';
+  icon: LucideIcon;
+  color: string;
+  label: string;
+  spin?: boolean;
+}
+
+interface DotConfig {
+  kind: 'dot';
+  fillEntity: boolean;
+  outline?: boolean;
+  label: string;
+  pulse?: boolean;
+}
+
+const CONFIG: Record<LifecycleState, StaticConfig | DotConfig> = {
+  active: { kind: 'dot', fillEntity: true, label: 'Active', pulse: true },
+  idle: { kind: 'dot', fillEntity: false, outline: true, label: 'Idle' },
+  completed: {
+    kind: 'icon',
+    icon: CheckCheck,
+    color: 'hsl(152 76% 40%)',
+    label: 'Completed',
+  },
+  setup: {
+    kind: 'icon',
+    icon: Settings2,
+    color: 'hsl(38 92% 50%)',
+    label: 'Setup',
+  },
+  processing: {
+    kind: 'icon',
+    icon: Loader2,
+    color: 'hsl(200 89% 55%)',
+    label: 'Processing',
+    spin: true,
+  },
+  failed: {
+    kind: 'icon',
+    icon: AlertTriangle,
+    color: 'hsl(0 84% 60%)',
+    label: 'Failed',
+  },
+};
+
+export function LifecycleStateBadge({ value, entityType, className }: LifecycleStateBadgeProps) {
+  const cfg = CONFIG[value];
+
+  if (cfg.kind === 'dot') {
+    const color = cfg.fillEntity ? entityHsl(entityType) : 'hsl(215 20% 60%)';
+    return (
+      <span
+        data-testid={`lifecycle-badge-${value}`}
+        aria-label={cfg.label}
+        title={cfg.label}
+        className={`inline-block rounded-full ${cfg.pulse ? 'animate-pulse' : ''} ${className ?? ''}`.trim()}
+        style={{
+          width: 8,
+          height: 8,
+          background: cfg.outline ? 'transparent' : color,
+          border: cfg.outline ? `1.5px solid ${color}` : 'none',
+        }}
+      />
+    );
+  }
+
+  const Icon = cfg.icon;
+  return (
+    <span
+      data-testid={`lifecycle-badge-${value}`}
+      aria-label={cfg.label}
+      title={cfg.label}
+      className={`inline-flex items-center ${className ?? ''}`.trim()}
+      style={{ color: cfg.color }}
+    >
+      <Icon
+        size={14}
+        strokeWidth={1.75}
+        aria-hidden="true"
+        className={cfg.spin ? 'animate-spin' : undefined}
+      />
+    </span>
+  );
+}

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/OwnershipBadge.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/OwnershipBadge.tsx
@@ -49,6 +49,7 @@ export function OwnershipBadge({ value, size = 20, className }: OwnershipBadgePr
 
   return (
     <span
+      role="img"
       data-testid={`ownership-badge-${value}`}
       aria-label={LABEL[value]}
       title={LABEL[value]}

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/OwnershipBadge.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/OwnershipBadge.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { Archive, CheckCircle2, Heart, type LucideIcon } from 'lucide-react';
+
+import type { OwnershipBadge as OwnershipValue } from '../types';
+
+interface OwnershipConfig {
+  icon: LucideIcon;
+  fg: string;
+  bg: string;
+  fill?: boolean;
+}
+
+const CONFIG: Record<OwnershipValue, OwnershipConfig> = {
+  owned: {
+    icon: CheckCircle2,
+    fg: 'hsl(152 76% 40%)',
+    bg: 'hsl(152 76% 40% / 0.12)',
+    fill: true,
+  },
+  wishlist: {
+    icon: Heart,
+    fg: 'hsl(350 89% 60%)',
+    bg: 'hsl(350 89% 60% / 0.12)',
+    fill: true,
+  },
+  archived: {
+    icon: Archive,
+    fg: 'hsl(215 20% 50%)',
+    bg: 'hsl(215 20% 50% / 0.08)',
+  },
+};
+
+const LABEL: Record<OwnershipValue, string> = {
+  owned: 'Owned',
+  wishlist: 'Wishlist',
+  archived: 'Archived',
+};
+
+interface OwnershipBadgeProps {
+  value: OwnershipValue;
+  size?: number;
+  className?: string;
+}
+
+export function OwnershipBadge({ value, size = 20, className }: OwnershipBadgeProps) {
+  const cfg = CONFIG[value];
+  const Icon = cfg.icon;
+
+  return (
+    <span
+      data-testid={`ownership-badge-${value}`}
+      aria-label={LABEL[value]}
+      title={LABEL[value]}
+      className={`inline-flex items-center justify-center rounded-full ${className ?? ''}`.trim()}
+      style={{
+        width: size,
+        height: size,
+        background: cfg.bg,
+        color: cfg.fg,
+      }}
+    >
+      <Icon
+        size={Math.round(size * 0.65)}
+        strokeWidth={1.75}
+        fill={cfg.fill ? 'currentColor' : 'none'}
+        aria-hidden="true"
+      />
+    </span>
+  );
+}

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx
@@ -41,7 +41,7 @@ describe('ConnectionChip', () => {
     const onCreate = vi.fn();
     render(<ConnectionChip entityType="player" count={0} onCreate={onCreate} disabled />);
     const btn = screen.getByRole('button');
-    expect(btn).toHaveAttribute('aria-disabled', 'true');
+    expect(btn).toBeDisabled();
     await userEvent.click(btn);
     expect(onCreate).not.toHaveBeenCalled();
   });
@@ -83,5 +83,12 @@ describe('ConnectionChip', () => {
     const btn = screen.getByRole('button');
     expect(btn.getAttribute('aria-label')).toMatch(/5/);
     expect(btn.getAttribute('aria-label')?.toLowerCase()).toMatch(/session/);
+  });
+
+  it('renders as a link when href is provided and no items/popover', () => {
+    render(<ConnectionChip entityType="kb" count={3} href="/kb/123" />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/kb/123');
+    expect(link.getAttribute('aria-label')).toMatch(/3/);
   });
 });

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ConnectionChip } from '../ConnectionChip';
+
+describe('ConnectionChip', () => {
+  it('renders count badge when count > 0', () => {
+    render(<ConnectionChip entityType="session" count={5} />);
+    expect(screen.getByTestId('connection-chip-badge')).toHaveTextContent('5');
+  });
+
+  it('renders "99+" when count > 99', () => {
+    render(<ConnectionChip entityType="kb" count={150} />);
+    expect(screen.getByTestId('connection-chip-badge')).toHaveTextContent('99+');
+  });
+
+  it('omits badge when count is 0', () => {
+    render(<ConnectionChip entityType="chat" count={0} />);
+    expect(screen.queryByTestId('connection-chip-badge')).not.toBeInTheDocument();
+  });
+
+  it('shows plus overlay when count=0 and onCreate provided', () => {
+    render(<ConnectionChip entityType="player" count={0} onCreate={() => {}} />);
+    expect(screen.getByTestId('connection-chip-plus')).toBeInTheDocument();
+  });
+
+  it('omits plus overlay when count=0 and no onCreate', () => {
+    render(<ConnectionChip entityType="player" count={0} />);
+    expect(screen.queryByTestId('connection-chip-plus')).not.toBeInTheDocument();
+  });
+
+  it('calls onCreate when empty chip is clicked', async () => {
+    const onCreate = vi.fn();
+    render(<ConnectionChip entityType="player" count={0} onCreate={onCreate} />);
+    await userEvent.click(screen.getByRole('button'));
+    expect(onCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('is not clickable when disabled', async () => {
+    const onCreate = vi.fn();
+    render(<ConnectionChip entityType="player" count={0} onCreate={onCreate} disabled />);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveAttribute('aria-disabled', 'true');
+    await userEvent.click(btn);
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+
+  it('renders skeleton when loading=true', () => {
+    render(<ConnectionChip entityType="kb" loading />);
+    expect(screen.getByTestId('connection-chip-loading')).toBeInTheDocument();
+    expect(screen.queryByTestId('connection-chip-badge')).not.toBeInTheDocument();
+  });
+
+  it('renders a Lucide SVG icon (not emoji) for the entity', () => {
+    const { container } = render(<ConnectionChip entityType="game" count={3} />);
+    expect(container.querySelector('svg')).toBeTruthy();
+  });
+
+  it('shows label under chip when showLabel=true', () => {
+    render(<ConnectionChip entityType="kb" count={3} showLabel label="Docs" />);
+    expect(screen.getByText('Docs')).toBeInTheDocument();
+  });
+
+  it('opens popover when clicked and items are present', async () => {
+    render(
+      <ConnectionChip
+        entityType="session"
+        count={2}
+        items={[
+          { id: '1', label: 'First', href: '/sessions/1' },
+          { id: '2', label: 'Second', href: '/sessions/2' },
+        ]}
+      />
+    );
+    await userEvent.click(screen.getByRole('button'));
+    expect(await screen.findByText('First')).toBeInTheDocument();
+    expect(screen.getByText('Second')).toBeInTheDocument();
+  });
+
+  it('has aria-label including count and entity label', () => {
+    render(<ConnectionChip entityType="session" count={5} />);
+    const btn = screen.getByRole('button');
+    expect(btn.getAttribute('aria-label')).toMatch(/5/);
+    expect(btn.getAttribute('aria-label')?.toLowerCase()).toMatch(/session/);
+  });
+});

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChipPopover.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChipPopover.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ConnectionChipPopover } from '../ConnectionChipPopover';
+
+const items = [
+  { id: '1', label: 'Wingspan Night #12', href: '/sessions/1' },
+  { id: '2', label: 'Wingspan Night #13', href: '/sessions/2' },
+];
+
+describe('ConnectionChipPopover', () => {
+  it('renders children as trigger', () => {
+    render(
+      <ConnectionChipPopover
+        open={false}
+        onOpenChange={() => {}}
+        items={items}
+        entityType="session"
+      >
+        <button>trigger</button>
+      </ConnectionChipPopover>
+    );
+    expect(screen.getByRole('button', { name: /trigger/i })).toBeInTheDocument();
+  });
+
+  it('shows items when open', () => {
+    render(
+      <ConnectionChipPopover open onOpenChange={() => {}} items={items} entityType="session">
+        <button>trigger</button>
+      </ConnectionChipPopover>
+    );
+    expect(screen.getByText('Wingspan Night #12')).toBeInTheDocument();
+    expect(screen.getByText('Wingspan Night #13')).toBeInTheDocument();
+  });
+
+  it('renders create button when onCreate provided', () => {
+    const onCreate = vi.fn();
+    render(
+      <ConnectionChipPopover
+        open
+        onOpenChange={() => {}}
+        items={items}
+        onCreate={onCreate}
+        createLabel="Nuova sessione"
+        entityType="session"
+      >
+        <button>trigger</button>
+      </ConnectionChipPopover>
+    );
+    expect(screen.getByRole('button', { name: /nuova sessione/i })).toBeInTheDocument();
+  });
+
+  it('calls onCreate and closes popover on create click', async () => {
+    const onCreate = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <ConnectionChipPopover
+        open
+        onOpenChange={onOpenChange}
+        items={[]}
+        onCreate={onCreate}
+        createLabel="Nuova sessione"
+        entityType="session"
+      >
+        <button>trigger</button>
+      </ConnectionChipPopover>
+    );
+    await userEvent.click(screen.getByRole('button', { name: /nuova sessione/i }));
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('renders Lucide icon matching entity type (not emoji)', () => {
+    render(
+      <ConnectionChipPopover open onOpenChange={() => {}} items={items} entityType="session">
+        <button>trigger</button>
+      </ConnectionChipPopover>
+    );
+    // Radix Popover renders content in a Portal; query the full document.
+    expect(document.querySelector('svg')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChipStrip.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChipStrip.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { ConnectionChipStrip } from '../ConnectionChipStrip';
+
+describe('ConnectionChipStrip', () => {
+  it('returns null when connections array is empty', () => {
+    const { container } = render(<ConnectionChipStrip variant="footer" connections={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders a chip per connection (footer variant)', () => {
+    render(
+      <ConnectionChipStrip
+        variant="footer"
+        connections={[
+          { entityType: 'kb', count: 3 },
+          { entityType: 'session', count: 5 },
+        ]}
+      />
+    );
+    expect(screen.getAllByRole('button')).toHaveLength(2);
+  });
+
+  it('renders smaller chips in inline variant by default', () => {
+    const { container } = render(
+      <ConnectionChipStrip variant="inline" connections={[{ entityType: 'kb', count: 3 }]} />
+    );
+    const chipFace = container.querySelector('span[style*="width: 22px"]');
+    expect(chipFace).toBeTruthy();
+  });
+
+  it('renders larger chips in footer variant by default', () => {
+    const { container } = render(
+      <ConnectionChipStrip variant="footer" connections={[{ entityType: 'kb', count: 3 }]} />
+    );
+    const chipFace = container.querySelector('span[style*="width: 28px"]');
+    expect(chipFace).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/LifecycleStateBadge.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/LifecycleStateBadge.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { LifecycleStateBadge } from '../LifecycleStateBadge';
+
+describe('LifecycleStateBadge', () => {
+  it.each(['active', 'idle', 'completed', 'setup', 'processing', 'failed'] as const)(
+    'renders for value=%s',
+    value => {
+      render(<LifecycleStateBadge value={value} entityType="game" />);
+      expect(screen.getByTestId(`lifecycle-badge-${value}`)).toBeInTheDocument();
+    }
+  );
+
+  it('renders processing with spinning Loader2 icon', () => {
+    const { container } = render(<LifecycleStateBadge value="processing" entityType="kb" />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('class')).toMatch(/animate-spin/);
+  });
+
+  it('renders active with entity-colored dot', () => {
+    render(<LifecycleStateBadge value="active" entityType="session" />);
+    const badge = screen.getByTestId('lifecycle-badge-active');
+    // Session color hsl(240, 60%, 55%) gets normalized by JSDOM to rgb(71, 71, 209).
+    // Verify the dot carries an entity-derived background (non-empty rgb).
+    expect(badge.getAttribute('style') ?? '').toMatch(/background:\s*rgb\(/);
+  });
+});

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/OwnershipBadge.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/OwnershipBadge.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { OwnershipBadge } from '../OwnershipBadge';
+
+describe('OwnershipBadge', () => {
+  it('renders owned with CheckCircle2', () => {
+    const { container } = render(<OwnershipBadge value="owned" />);
+    expect(screen.getByTestId('ownership-badge-owned')).toBeInTheDocument();
+    expect(container.querySelector('svg')).toBeTruthy();
+  });
+
+  it('renders wishlist with Heart', () => {
+    render(<OwnershipBadge value="wishlist" />);
+    expect(screen.getByTestId('ownership-badge-wishlist')).toBeInTheDocument();
+  });
+
+  it('renders archived with Archive', () => {
+    render(<OwnershipBadge value="archived" />);
+    expect(screen.getByTestId('ownership-badge-archived')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/entity-icons.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/entity-icons.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+
+import { entityIcons, ENTITY_ICON_STROKE, ENTITY_ICON_SIZE } from '../entity-icons';
+
+import type { MeepleEntityType } from '../../types';
+
+const allEntities: MeepleEntityType[] = [
+  'game',
+  'player',
+  'session',
+  'agent',
+  'kb',
+  'chat',
+  'event',
+  'toolkit',
+  'tool',
+];
+
+describe('entityIcons registry', () => {
+  it('has a Lucide component for every MeepleEntityType', () => {
+    for (const entity of allEntities) {
+      expect(entityIcons[entity]).toBeDefined();
+      expect(typeof entityIcons[entity]).toBe('object');
+    }
+  });
+
+  it('exports canonical stroke and size constants', () => {
+    expect(ENTITY_ICON_STROKE).toBe(1.75);
+    expect(ENTITY_ICON_SIZE.sm).toBe(14);
+    expect(ENTITY_ICON_SIZE.md).toBe(16);
+  });
+
+  it('each icon renders as an SVG element', () => {
+    for (const entity of allEntities) {
+      const Icon = entityIcons[entity];
+      const { container } = render(<Icon size={14} strokeWidth={1.75} />);
+      const svg = container.querySelector('svg');
+      expect(svg).toBeTruthy();
+      expect(svg?.getAttribute('stroke-width')).toBe('1.75');
+    }
+  });
+});

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/status-adapter.test.ts
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/status-adapter.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { mapLegacyStatus, resolveStatus } from '../status-adapter';
+
+describe('mapLegacyStatus()', () => {
+  it('maps ownership values', () => {
+    expect(mapLegacyStatus('owned')).toEqual({ ownership: 'owned' });
+    expect(mapLegacyStatus('wishlist')).toEqual({ ownership: 'wishlist' });
+    expect(mapLegacyStatus('archived')).toEqual({ ownership: 'archived' });
+  });
+
+  it('maps direct lifecycle values', () => {
+    expect(mapLegacyStatus('active')).toEqual({ lifecycle: 'active' });
+    expect(mapLegacyStatus('idle')).toEqual({ lifecycle: 'idle' });
+    expect(mapLegacyStatus('completed')).toEqual({ lifecycle: 'completed' });
+    expect(mapLegacyStatus('setup')).toEqual({ lifecycle: 'setup' });
+    expect(mapLegacyStatus('processing')).toEqual({ lifecycle: 'processing' });
+    expect(mapLegacyStatus('failed')).toEqual({ lifecycle: 'failed' });
+  });
+
+  it('merges inprogress → active', () => {
+    expect(mapLegacyStatus('inprogress')).toEqual({ lifecycle: 'active' });
+  });
+
+  it('merges paused → idle', () => {
+    expect(mapLegacyStatus('paused')).toEqual({ lifecycle: 'idle' });
+  });
+
+  it('drops internal indexed state from UI', () => {
+    expect(mapLegacyStatus('indexed')).toEqual({});
+  });
+
+  it('returns empty for undefined input', () => {
+    expect(mapLegacyStatus(undefined)).toEqual({});
+  });
+});
+
+describe('resolveStatus()', () => {
+  it('prefers explicit ownership over legacy status', () => {
+    expect(resolveStatus({ ownership: 'wishlist', legacyStatus: 'owned' })).toEqual({
+      ownership: 'wishlist',
+      lifecycle: undefined,
+    });
+  });
+
+  it('prefers explicit lifecycle over legacy status', () => {
+    expect(resolveStatus({ lifecycle: 'failed', legacyStatus: 'active' })).toEqual({
+      ownership: undefined,
+      lifecycle: 'failed',
+    });
+  });
+
+  it('falls back to legacy when explicit props are absent', () => {
+    expect(resolveStatus({ legacyStatus: 'owned' })).toEqual({
+      ownership: 'owned',
+      lifecycle: undefined,
+    });
+  });
+
+  it('returns empty dimensions when nothing is provided', () => {
+    expect(resolveStatus({})).toEqual({
+      ownership: undefined,
+      lifecycle: undefined,
+    });
+  });
+});

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/entity-icons.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/entity-icons.tsx
@@ -1,0 +1,39 @@
+import {
+  BookOpen,
+  Bot,
+  Briefcase,
+  Calendar,
+  Dices,
+  MessageCircle,
+  Swords,
+  UserCircle2,
+  Wrench,
+  type LucideIcon,
+} from 'lucide-react';
+
+import type { MeepleEntityType } from '../types';
+
+/**
+ * Unified Lucide icon registry for all MeepleEntityType values.
+ *
+ * Use this instead of `tokens.entityIcon` (emoji, deprecated) or `nav-items/icons.tsx`
+ * (semantic keys, legacy). Every entity has a single canonical Lucide component.
+ */
+export const entityIcons: Record<MeepleEntityType, LucideIcon> = {
+  game: Dices,
+  player: UserCircle2,
+  session: Swords,
+  agent: Bot,
+  kb: BookOpen,
+  chat: MessageCircle,
+  event: Calendar,
+  toolkit: Briefcase,
+  tool: Wrench,
+};
+
+export const ENTITY_ICON_STROKE = 1.75;
+
+export const ENTITY_ICON_SIZE = {
+  sm: 14,
+  md: 16,
+} as const;

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/status-adapter.ts
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/status-adapter.ts
@@ -1,0 +1,60 @@
+import type { CardStatus, LifecycleState, OwnershipBadge } from '../types';
+
+export interface MappedStatus {
+  ownership?: OwnershipBadge;
+  lifecycle?: LifecycleState;
+}
+
+/**
+ * Maps the legacy `CardStatus` enum (12 values, 3 mixed axes) onto the
+ * two-axis model (ownership, lifecycle).
+ *
+ * Merges:
+ *  - `inprogress` → `active` (synonym)
+ *  - `paused` → `idle` (semantically equivalent)
+ *  - `indexed` → {} (internal KB pipeline state, never user-facing)
+ */
+export function mapLegacyStatus(status: CardStatus | undefined): MappedStatus {
+  switch (status) {
+    case 'owned':
+      return { ownership: 'owned' };
+    case 'wishlist':
+      return { ownership: 'wishlist' };
+    case 'archived':
+      return { ownership: 'archived' };
+    case 'active':
+    case 'inprogress':
+      return { lifecycle: 'active' };
+    case 'idle':
+    case 'paused':
+      return { lifecycle: 'idle' };
+    case 'completed':
+      return { lifecycle: 'completed' };
+    case 'setup':
+      return { lifecycle: 'setup' };
+    case 'processing':
+      return { lifecycle: 'processing' };
+    case 'failed':
+      return { lifecycle: 'failed' };
+    case 'indexed':
+    case undefined:
+    default:
+      return {};
+  }
+}
+
+/**
+ * Resolves final `{ownership, lifecycle}` from new props or legacy status.
+ * New props win; legacy status fills gaps only.
+ */
+export function resolveStatus(input: {
+  ownership?: OwnershipBadge;
+  lifecycle?: LifecycleState;
+  legacyStatus?: CardStatus;
+}): MappedStatus {
+  const fromLegacy = mapLegacyStatus(input.legacyStatus);
+  return {
+    ownership: input.ownership ?? fromLegacy.ownership,
+    lifecycle: input.lifecycle ?? fromLegacy.lifecycle,
+  };
+}

--- a/apps/web/src/components/ui/data-display/meeple-card/tokens.ts
+++ b/apps/web/src/components/ui/data-display/meeple-card/tokens.ts
@@ -44,6 +44,38 @@ export const entityIcon: Record<MeepleEntityType, string> = {
   tool: '🔧',
 };
 
+/**
+ * Named derived colors for an entity.
+ *
+ * Replaces inline `entityHsl(entity, 0.12)` calls with semantic names.
+ * Use these when styling ConnectionChip, badges, popovers, etc.
+ */
+export interface EntityTokens {
+  solid: string; // full color — icons, badge bg
+  fill: string; // 0.12 — chip bg default
+  border: string; // 0.35 — chip border default
+  hover: string; // 0.22 — chip bg on hover
+  glow: string; // 0.18 — box-shadow spread
+  shadow: string; // 0.25 — box-shadow drop
+  muted: string; // 0.06 — empty/disabled bg
+  dashed: string; // 0.25 — dashed border empty state
+  textOn: string; // text color on solid bg
+}
+
+export function entityTokens(entity: MeepleEntityType): EntityTokens {
+  return {
+    solid: entityHsl(entity),
+    fill: entityHsl(entity, 0.12),
+    border: entityHsl(entity, 0.35),
+    hover: entityHsl(entity, 0.22),
+    glow: entityHsl(entity, 0.18),
+    shadow: entityHsl(entity, 0.25),
+    muted: entityHsl(entity, 0.06),
+    dashed: entityHsl(entity, 0.25),
+    textOn: '#ffffff',
+  };
+}
+
 export const statusColors: Record<string, { bg: string; text: string }> = {
   owned: { bg: '#dcfce7', text: '#166534' },
   wishlist: { bg: '#fef3c7', text: '#92400e' },

--- a/apps/web/src/components/ui/data-display/meeple-card/types.ts
+++ b/apps/web/src/components/ui/data-display/meeple-card/types.ts
@@ -57,6 +57,31 @@ export type CardStatus =
   | 'completed'
   | 'paused';
 
+export interface ConnectionItem {
+  id: string;
+  label: string;
+  href: string;
+}
+
+export interface ConnectionChipProps {
+  entityType: MeepleEntityType;
+  count?: number;
+  items?: ConnectionItem[];
+  size?: 'sm' | 'md';
+  showLabel?: boolean;
+  label?: string;
+  onCreate?: () => void;
+  createLabel?: string;
+  href?: string;
+  colorOverride?: string;
+  disabled?: boolean;
+  loading?: boolean;
+}
+
+export type OwnershipBadge = 'owned' | 'wishlist' | 'archived';
+
+export type LifecycleState = 'active' | 'idle' | 'completed' | 'setup' | 'processing' | 'failed';
+
 export interface CoverLabel {
   text: string;
   color?: string;
@@ -79,6 +104,10 @@ export interface MeepleCardProps {
   actions?: MeepleCardAction[];
   navItems?: NavFooterItem[];
   manaPips?: ManaPip[];
+  connections?: ConnectionChipProps[];
+  connectionsVariant?: 'footer' | 'inline' | 'auto';
+  ownership?: OwnershipBadge;
+  lifecycle?: LifecycleState;
   onClick?: () => void;
   flippable?: boolean;
   flipBackContent?: ReactNode;

--- a/docs/superpowers/plans/2026-04-23-meeplecard-connectionchip-plan.md
+++ b/docs/superpowers/plans/2026-04-23-meeplecard-connectionchip-plan.md
@@ -1,0 +1,1643 @@
+# MeepleCard ConnectionChip — Implementation Plan (Step 1: Additive)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `ManaPips` + `NavFooterItem` duplication with a unified `ConnectionChip` component wearing Lucide icons, and consolidate `CardStatus` into orthogonal `ownership`/`lifecycle` axes — all additive and backward-compatible.
+
+**Architecture:** New tokens + new components coexist with legacy props. `MeepleCard` accepts both APIs; internal adapter maps legacy `CardStatus` to the new two-axis model. Deletion of legacy files is deferred to Step 3 (out of scope here).
+
+**Tech Stack:** Next.js 16, React 19, TypeScript, Tailwind 4, Radix Popover, Lucide icons, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-04-23-meeplecard-connectionchip-design.md`
+
+**Out of scope (follow-up plans):**
+- Typography scale refactor (§9 of spec)
+- Card surface warm tokens (§8.4)
+- Dark mode entity color parity with `useEntityColor` hook (§8.3)
+- Contrast validation CI script (§11.1)
+- Migration of consumer call-sites (Step 2)
+- Legacy cleanup (Step 3)
+
+---
+
+## File Structure
+
+**New files (parts/):**
+- `entity-icons.tsx` — Lucide icon registry keyed by `MeepleEntityType`
+- `ConnectionChip.tsx` — unified chip replacing ManaPip + NavFooterItem visual
+- `ConnectionChipStrip.tsx` — layout container (variant: footer | inline)
+- `ConnectionChipPopover.tsx` — popover drill-down with items + create
+- `OwnershipBadge.tsx` — corner badge for owned/wishlist/archived
+- `LifecycleStateBadge.tsx` — inline badge for active/idle/completed/setup/processing/failed
+- `status-adapter.ts` — pure function mapping legacy `CardStatus` → `{ownership, lifecycle}`
+
+**Modified files:**
+- `tokens.ts` — add `entityTokens()` helper returning named derived colors
+- `types.ts` — add `OwnershipBadge`, `LifecycleState`, `ConnectionItem`, `ConnectionChipProps`, extend `MeepleCardProps`
+- `index.ts` — re-export new components
+- `MeepleCard.tsx` — internal legacy→new status adapter (no prop removal)
+
+**New tests (parts/__tests__/):**
+- `entity-icons.test.tsx`
+- `ConnectionChip.test.tsx`
+- `ConnectionChipStrip.test.tsx`
+- `ConnectionChipPopover.test.tsx`
+- `OwnershipBadge.test.tsx`
+- `LifecycleStateBadge.test.tsx`
+- `status-adapter.test.ts`
+
+**Untouched (legacy, retained for backward compat until Step 3):**
+- `ManaPips.tsx`, `ManaPipPopover.tsx`, `NavFooter.tsx`, `nav-items/*`, existing `entityIcon` emoji in `tokens.ts`
+
+---
+
+## Task 1: Create entity icons registry
+
+**Files:**
+- Create: `apps/web/src/components/ui/data-display/meeple-card/parts/entity-icons.tsx`
+- Test: `apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/entity-icons.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+```tsx
+// apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/entity-icons.test.tsx
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+
+import { entityIcons, ENTITY_ICON_STROKE, ENTITY_ICON_SIZE } from '../entity-icons';
+
+import type { MeepleEntityType } from '../../types';
+
+const allEntities: MeepleEntityType[] = [
+  'game', 'player', 'session', 'agent',
+  'kb', 'chat', 'event', 'toolkit', 'tool',
+];
+
+describe('entityIcons registry', () => {
+  it('has a Lucide component for every MeepleEntityType', () => {
+    for (const entity of allEntities) {
+      expect(entityIcons[entity]).toBeDefined();
+      expect(typeof entityIcons[entity]).toBe('object');
+    }
+  });
+
+  it('exports canonical stroke and size constants', () => {
+    expect(ENTITY_ICON_STROKE).toBe(1.75);
+    expect(ENTITY_ICON_SIZE.sm).toBe(14);
+    expect(ENTITY_ICON_SIZE.md).toBe(16);
+  });
+
+  it('each icon renders as an SVG element', () => {
+    for (const entity of allEntities) {
+      const Icon = entityIcons[entity];
+      const { container } = render(<Icon size={14} strokeWidth={1.75} />);
+      const svg = container.querySelector('svg');
+      expect(svg).toBeTruthy();
+      expect(svg?.getAttribute('stroke-width')).toBe('1.75');
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cd apps/web && pnpm test src/components/ui/data-display/meeple-card/parts/__tests__/entity-icons.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create entity-icons.tsx**
+
+```tsx
+// apps/web/src/components/ui/data-display/meeple-card/parts/entity-icons.tsx
+import {
+  BookOpen,
+  Bot,
+  Briefcase,
+  Calendar,
+  Dices,
+  MessageCircle,
+  Swords,
+  UserCircle2,
+  Wrench,
+  type LucideIcon,
+} from 'lucide-react';
+
+import type { MeepleEntityType } from '../types';
+
+/**
+ * Unified Lucide icon registry for all MeepleEntityType values.
+ *
+ * Use this instead of `tokens.entityIcon` (emoji, deprecated) or `nav-items/icons.tsx`
+ * (semantic keys, legacy). Every entity has a single canonical Lucide component.
+ */
+export const entityIcons: Record<MeepleEntityType, LucideIcon> = {
+  game: Dices,
+  player: UserCircle2,
+  session: Swords,
+  agent: Bot,
+  kb: BookOpen,
+  chat: MessageCircle,
+  event: Calendar,
+  toolkit: Briefcase,
+  tool: Wrench,
+};
+
+export const ENTITY_ICON_STROKE = 1.75;
+
+export const ENTITY_ICON_SIZE = {
+  sm: 14,
+  md: 16,
+} as const;
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `cd apps/web && pnpm test src/components/ui/data-display/meeple-card/parts/__tests__/entity-icons.test.tsx`
+Expected: PASS 3/3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/meeple-card/parts/entity-icons.tsx \
+        apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/entity-icons.test.tsx
+git commit -m "feat(meeple-card): add unified entity-icons Lucide registry"
+```
+
+---
+
+## Task 2: Add `entityTokens()` derived-color helper
+
+**Files:**
+- Modify: `apps/web/src/components/ui/data-display/meeple-card/tokens.ts`
+- Test: `apps/web/src/components/ui/data-display/meeple-card/__tests__/tokens-entityTokens.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// apps/web/src/components/ui/data-display/meeple-card/__tests__/tokens-entityTokens.test.ts
+import { describe, expect, it } from 'vitest';
+
+import { entityTokens } from '../tokens';
+
+describe('entityTokens()', () => {
+  it('returns solid color using existing entityHsl', () => {
+    const t = entityTokens('game');
+    expect(t.solid).toBe('hsl(25, 95%, 45%)');
+  });
+
+  it('returns fill with 0.12 alpha', () => {
+    const t = entityTokens('game');
+    expect(t.fill).toBe('hsla(25, 95%, 45%, 0.12)');
+  });
+
+  it('returns border with 0.35 alpha', () => {
+    const t = entityTokens('game');
+    expect(t.border).toBe('hsla(25, 95%, 45%, 0.35)');
+  });
+
+  it('returns named tokens for hover, glow, shadow, muted, dashed', () => {
+    const t = entityTokens('kb');
+    expect(t.hover).toBe('hsla(210, 40%, 55%, 0.22)');
+    expect(t.glow).toBe('hsla(210, 40%, 55%, 0.18)');
+    expect(t.shadow).toBe('hsla(210, 40%, 55%, 0.25)');
+    expect(t.muted).toBe('hsla(210, 40%, 55%, 0.06)');
+    expect(t.dashed).toBe('hsla(210, 40%, 55%, 0.25)');
+  });
+
+  it('returns textOn = #ffffff', () => {
+    expect(entityTokens('agent').textOn).toBe('#ffffff');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/web && pnpm test src/components/ui/data-display/meeple-card/__tests__/tokens-entityTokens.test.ts`
+Expected: FAIL — `entityTokens` not exported.
+
+- [ ] **Step 3: Implement helper**
+
+Append to `apps/web/src/components/ui/data-display/meeple-card/tokens.ts`:
+
+```ts
+/**
+ * Named derived colors for an entity.
+ *
+ * Replaces inline `entityHsl(entity, 0.12)` calls with semantic names.
+ * Use these when styling ConnectionChip, badges, popovers, etc.
+ */
+export interface EntityTokens {
+  solid: string;   // full color — icons, badge bg
+  fill: string;    // 0.12 — chip bg default
+  border: string;  // 0.35 — chip border default
+  hover: string;   // 0.22 — chip bg on hover
+  glow: string;    // 0.18 — box-shadow spread
+  shadow: string;  // 0.25 — box-shadow drop
+  muted: string;   // 0.06 — empty/disabled bg
+  dashed: string;  // 0.25 — dashed border empty state
+  textOn: string;  // text color on solid bg
+}
+
+export function entityTokens(entity: MeepleEntityType): EntityTokens {
+  return {
+    solid: entityHsl(entity),
+    fill: entityHsl(entity, 0.12),
+    border: entityHsl(entity, 0.35),
+    hover: entityHsl(entity, 0.22),
+    glow: entityHsl(entity, 0.18),
+    shadow: entityHsl(entity, 0.25),
+    muted: entityHsl(entity, 0.06),
+    dashed: entityHsl(entity, 0.25),
+    textOn: '#ffffff',
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `cd apps/web && pnpm test src/components/ui/data-display/meeple-card/__tests__/tokens-entityTokens.test.ts`
+Expected: PASS 5/5.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/meeple-card/tokens.ts \
+        apps/web/src/components/ui/data-display/meeple-card/__tests__/tokens-entityTokens.test.ts
+git commit -m "feat(meeple-card): add entityTokens() named derived-color helper"
+```
+
+---
+
+## Task 3: Add new status and connection types
+
+**Files:**
+- Modify: `apps/web/src/components/ui/data-display/meeple-card/types.ts`
+
+No test needed (pure type declarations). Compilation is the verification.
+
+- [ ] **Step 1: Extend types.ts**
+
+Append to `apps/web/src/components/ui/data-display/meeple-card/types.ts` (BEFORE the final `}` of the file, after existing `MeepleCardProps` interface):
+
+```ts
+// ============================================================================
+// ConnectionChip & two-axis status (Step 1 additive; legacy coexists)
+// ============================================================================
+
+export interface ConnectionItem {
+  id: string;
+  label: string;
+  href: string;
+}
+
+export interface ConnectionChipProps {
+  entityType: MeepleEntityType;
+  count?: number;
+  items?: ConnectionItem[];
+  size?: 'sm' | 'md';
+  showLabel?: boolean;
+  label?: string;
+  onCreate?: () => void;
+  createLabel?: string;
+  href?: string;
+  colorOverride?: string;
+  disabled?: boolean;
+  loading?: boolean;
+}
+
+export type OwnershipBadge = 'owned' | 'wishlist' | 'archived';
+
+export type LifecycleState =
+  | 'active'
+  | 'idle'
+  | 'completed'
+  | 'setup'
+  | 'processing'
+  | 'failed';
+```
+
+And extend `MeepleCardProps` by adding (inside the interface, alongside existing `status?`, `navItems?`, `manaPips?`):
+
+```ts
+  /** New unified connections API. When present, preferred over manaPips/navItems. */
+  connections?: ConnectionChipProps[];
+  /** Where ConnectionChipStrip renders: 'footer' below image, 'inline' in meta-row, 'auto' per-variant default. */
+  connectionsVariant?: 'footer' | 'inline' | 'auto';
+  /** New ownership badge (owned/wishlist/archived). When present, preferred over status. */
+  ownership?: OwnershipBadge;
+  /** New lifecycle state. When present, preferred over status. */
+  lifecycle?: LifecycleState;
+```
+
+- [ ] **Step 2: Verify types compile**
+
+Run: `cd apps/web && pnpm typecheck`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/meeple-card/types.ts
+git commit -m "feat(meeple-card): add ConnectionChip/Ownership/Lifecycle types"
+```
+
+---
+
+## Task 4: Create status adapter
+
+**Files:**
+- Create: `apps/web/src/components/ui/data-display/meeple-card/parts/status-adapter.ts`
+- Test: `apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/status-adapter.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/status-adapter.test.ts
+import { describe, expect, it } from 'vitest';
+
+import { mapLegacyStatus } from '../status-adapter';
+
+import type { CardStatus } from '../../types';
+
+describe('mapLegacyStatus()', () => {
+  it('maps ownership values', () => {
+    expect(mapLegacyStatus('owned')).toEqual({ ownership: 'owned' });
+    expect(mapLegacyStatus('wishlist')).toEqual({ ownership: 'wishlist' });
+    expect(mapLegacyStatus('archived')).toEqual({ ownership: 'archived' });
+  });
+
+  it('maps direct lifecycle values', () => {
+    expect(mapLegacyStatus('active')).toEqual({ lifecycle: 'active' });
+    expect(mapLegacyStatus('idle')).toEqual({ lifecycle: 'idle' });
+    expect(mapLegacyStatus('completed')).toEqual({ lifecycle: 'completed' });
+    expect(mapLegacyStatus('setup')).toEqual({ lifecycle: 'setup' });
+    expect(mapLegacyStatus('processing')).toEqual({ lifecycle: 'processing' });
+    expect(mapLegacyStatus('failed')).toEqual({ lifecycle: 'failed' });
+  });
+
+  it('merges inprogress → active', () => {
+    expect(mapLegacyStatus('inprogress')).toEqual({ lifecycle: 'active' });
+  });
+
+  it('merges paused → idle', () => {
+    expect(mapLegacyStatus('paused')).toEqual({ lifecycle: 'idle' });
+  });
+
+  it('drops internal indexed state from UI', () => {
+    expect(mapLegacyStatus('indexed')).toEqual({});
+  });
+
+  it('returns empty for undefined input', () => {
+    expect(mapLegacyStatus(undefined)).toEqual({});
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/web && pnpm test src/components/ui/data-display/meeple-card/parts/__tests__/status-adapter.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create status-adapter.ts**
+
+```ts
+// apps/web/src/components/ui/data-display/meeple-card/parts/status-adapter.ts
+import type { CardStatus, LifecycleState, OwnershipBadge } from '../types';
+
+export interface MappedStatus {
+  ownership?: OwnershipBadge;
+  lifecycle?: LifecycleState;
+}
+
+/**
+ * Maps the legacy `CardStatus` enum (12 values, 3 mixed axes) onto the
+ * two-axis model (ownership, lifecycle).
+ *
+ * Merges:
+ *  - `inprogress` → `active` (synonym)
+ *  - `paused` → `idle` (semantically equivalent)
+ *  - `indexed` → {} (internal KB pipeline state, never user-facing)
+ */
+export function mapLegacyStatus(status: CardStatus | undefined): MappedStatus {
+  switch (status) {
+    case 'owned':
+      return { ownership: 'owned' };
+    case 'wishlist':
+      return { ownership: 'wishlist' };
+    case 'archived':
+      return { ownership: 'archived' };
+    case 'active':
+    case 'inprogress':
+      return { lifecycle: 'active' };
+    case 'idle':
+    case 'paused':
+      return { lifecycle: 'idle' };
+    case 'completed':
+      return { lifecycle: 'completed' };
+    case 'setup':
+      return { lifecycle: 'setup' };
+    case 'processing':
+      return { lifecycle: 'processing' };
+    case 'failed':
+      return { lifecycle: 'failed' };
+    case 'indexed':
+    case undefined:
+    default:
+      return {};
+  }
+}
+
+/**
+ * Resolves final `{ownership, lifecycle}` from new props or legacy status.
+ * New props win; legacy status fills gaps only.
+ */
+export function resolveStatus(input: {
+  ownership?: OwnershipBadge;
+  lifecycle?: LifecycleState;
+  legacyStatus?: CardStatus;
+}): MappedStatus {
+  const fromLegacy = mapLegacyStatus(input.legacyStatus);
+  return {
+    ownership: input.ownership ?? fromLegacy.ownership,
+    lifecycle: input.lifecycle ?? fromLegacy.lifecycle,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `cd apps/web && pnpm test src/components/ui/data-display/meeple-card/parts/__tests__/status-adapter.test.ts`
+Expected: PASS 6/6.
+
+- [ ] **Step 5: Add test for `resolveStatus` precedence**
+
+Append to the test file:
+
+```ts
+import { resolveStatus } from '../status-adapter';
+
+describe('resolveStatus()', () => {
+  it('prefers explicit ownership over legacy status', () => {
+    expect(
+      resolveStatus({ ownership: 'wishlist', legacyStatus: 'owned' }),
+    ).toEqual({ ownership: 'wishlist', lifecycle: undefined });
+  });
+
+  it('prefers explicit lifecycle over legacy status', () => {
+    expect(
+      resolveStatus({ lifecycle: 'failed', legacyStatus: 'active' }),
+    ).toEqual({ ownership: undefined, lifecycle: 'failed' });
+  });
+
+  it('falls back to legacy when explicit props are absent', () => {
+    expect(resolveStatus({ legacyStatus: 'owned' })).toEqual({
+      ownership: 'owned',
+      lifecycle: undefined,
+    });
+  });
+
+  it('returns empty dimensions when nothing is provided', () => {
+    expect(resolveStatus({})).toEqual({
+      ownership: undefined,
+      lifecycle: undefined,
+    });
+  });
+});
+```
+
+- [ ] **Step 6: Run expanded tests**
+
+Run: `cd apps/web && pnpm test src/components/ui/data-display/meeple-card/parts/__tests__/status-adapter.test.ts`
+Expected: PASS 10/10.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/meeple-card/parts/status-adapter.ts \
+        apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/status-adapter.test.ts
+git commit -m "feat(meeple-card): add legacy CardStatus → two-axis adapter"
+```
+
+---
+
+## Task 5: Create `ConnectionChipPopover`
+
+**Files:**
+- Create: `apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChipPopover.tsx`
+- Test: `apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChipPopover.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+```tsx
+// apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChipPopover.test.tsx
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ConnectionChipPopover } from '../ConnectionChipPopover';
+
+const items = [
+  { id: '1', label: 'Wingspan Night #12', href: '/sessions/1' },
+  { id: '2', label: 'Wingspan Night #13', href: '/sessions/2' },
+];
+
+describe('ConnectionChipPopover', () => {
+  it('renders children as trigger', () => {
+    render(
+      <ConnectionChipPopover
+        open={false}
+        onOpenChange={() => {}}
+        items={items}
+        entityType="session"
+      >
+        <button>trigger</button>
+      </ConnectionChipPopover>,
+    );
+    expect(screen.getByRole('button', { name: /trigger/i })).toBeInTheDocument();
+  });
+
+  it('shows items when open', () => {
+    render(
+      <ConnectionChipPopover
+        open
+        onOpenChange={() => {}}
+        items={items}
+        entityType="session"
+      >
+        <button>trigger</button>
+      </ConnectionChipPopover>,
+    );
+    expect(screen.getByText('Wingspan Night #12')).toBeInTheDocument();
+    expect(screen.getByText('Wingspan Night #13')).toBeInTheDocument();
+  });
+
+  it('renders create button when onCreate provided', () => {
+    const onCreate = vi.fn();
+    render(
+      <ConnectionChipPopover
+        open
+        onOpenChange={() => {}}
+        items={items}
+        onCreate={onCreate}
+        createLabel="Nuova sessione"
+        entityType="session"
+      >
+        <button>trigger</button>
+      </ConnectionChipPopover>,
+    );
+    expect(screen.getByRole('button', { name: /nuova sessione/i })).toBeInTheDocument();
+  });
+
+  it('calls onCreate and closes popover on create click', async () => {
+    const onCreate = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <ConnectionChipPopover
+        open
+        onOpenChange={onOpenChange}
+        items={[]}
+        onCreate={onCreate}
+        createLabel="Nuova sessione"
+        entityType="session"
+      >
+        <button>trigger</button>
+      </ConnectionChipPopover>,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /nuova sessione/i }));
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('renders Lucide icon matching entity type (not emoji)', () => {
+    const { container } = render(
+      <ConnectionChipPopover
+        open
+        onOpenChange={() => {}}
+        items={items}
+        entityType="session"
+      >
+        <button>trigger</button>
+      </ConnectionChipPopover>,
+    );
+    // Presence of any svg inside popover rules out emoji-only rendering
+    expect(container.querySelector('svg')).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cd apps/web && pnpm test src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChipPopover.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create ConnectionChipPopover.tsx**
+
+```tsx
+// apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChipPopover.tsx
+'use client';
+
+import { type ReactNode } from 'react';
+
+import { Plus } from 'lucide-react';
+import Link from 'next/link';
+
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/overlays/popover';
+
+import { entityLabel, entityTokens } from '../tokens';
+import { ENTITY_ICON_STROKE, entityIcons } from './entity-icons';
+
+import type { ConnectionItem } from '../types';
+import type { MeepleEntityType } from '../types';
+
+export interface ConnectionChipPopoverProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  items: ConnectionItem[];
+  onCreate?: () => void;
+  createLabel?: string;
+  entityType: MeepleEntityType;
+  children: ReactNode;
+}
+
+export function ConnectionChipPopover({
+  open,
+  onOpenChange,
+  items,
+  onCreate,
+  createLabel = 'Create',
+  entityType,
+  children,
+}: ConnectionChipPopoverProps) {
+  const tokens = entityTokens(entityType);
+  const Icon = entityIcons[entityType];
+  const label = entityLabel[entityType];
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+
+      <PopoverContent
+        align="start"
+        sideOffset={6}
+        className="w-56 p-0 overflow-hidden"
+        style={{
+          border: `1px solid ${tokens.border}`,
+          background: 'var(--mc-bg-card, hsl(222 47% 11%))',
+        }}
+      >
+        <div
+          className="flex items-center gap-2 border-b px-3 py-2 text-xs font-semibold uppercase tracking-wide"
+          style={{ borderColor: tokens.border, color: tokens.solid }}
+        >
+          <Icon size={14} strokeWidth={ENTITY_ICON_STROKE} aria-hidden="true" />
+          <span>
+            {label} ({items.length})
+          </span>
+        </div>
+
+        {items.length > 0 && (
+          <ul className="max-h-60 overflow-y-auto py-1" role="list">
+            {items.map(item => (
+              <li key={item.id}>
+                <Link
+                  href={item.href}
+                  onClick={() => onOpenChange(false)}
+                  className="flex items-center gap-2 px-3 py-1.5 text-sm transition-colors hover:bg-white/5"
+                  style={{ color: 'var(--mc-text, inherit)' }}
+                >
+                  <span className="shrink-0" style={{ color: tokens.solid }}>
+                    <Icon size={14} strokeWidth={ENTITY_ICON_STROKE} aria-hidden="true" />
+                  </span>
+                  <span className="truncate">{item.label}</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {onCreate && (
+          <div className="border-t px-3 py-2" style={{ borderColor: tokens.border }}>
+            <button
+              type="button"
+              onClick={() => {
+                onCreate();
+                onOpenChange(false);
+              }}
+              className="flex w-full items-center gap-2 rounded-sm px-1 py-1 text-sm font-medium transition-colors hover:opacity-80"
+              style={{ color: tokens.solid }}
+            >
+              <Plus size={14} aria-hidden="true" />
+              <span>{createLabel}</span>
+            </button>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `cd apps/web && pnpm test src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChipPopover.test.tsx`
+Expected: PASS 5/5.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChipPopover.tsx \
+        apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChipPopover.test.tsx
+git commit -m "feat(meeple-card): add ConnectionChipPopover with Lucide header"
+```
+
+---
+
+## Task 6: Create `ConnectionChip` (core component)
+
+**Files:**
+- Create: `apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChip.tsx`
+- Test: `apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+```tsx
+// apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ConnectionChip } from '../ConnectionChip';
+
+describe('ConnectionChip', () => {
+  it('renders count badge when count > 0', () => {
+    render(<ConnectionChip entityType="session" count={5} />);
+    expect(screen.getByTestId('connection-chip-badge')).toHaveTextContent('5');
+  });
+
+  it('renders "99+" when count > 99', () => {
+    render(<ConnectionChip entityType="kb" count={150} />);
+    expect(screen.getByTestId('connection-chip-badge')).toHaveTextContent('99+');
+  });
+
+  it('omits badge when count is 0', () => {
+    render(<ConnectionChip entityType="chat" count={0} />);
+    expect(screen.queryByTestId('connection-chip-badge')).not.toBeInTheDocument();
+  });
+
+  it('shows plus overlay when count=0 and onCreate provided', () => {
+    render(<ConnectionChip entityType="player" count={0} onCreate={() => {}} />);
+    expect(screen.getByTestId('connection-chip-plus')).toBeInTheDocument();
+  });
+
+  it('omits plus overlay when count=0 and no onCreate', () => {
+    render(<ConnectionChip entityType="player" count={0} />);
+    expect(screen.queryByTestId('connection-chip-plus')).not.toBeInTheDocument();
+  });
+
+  it('calls onCreate when empty chip is clicked', async () => {
+    const onCreate = vi.fn();
+    render(<ConnectionChip entityType="player" count={0} onCreate={onCreate} />);
+    await userEvent.click(screen.getByRole('button'));
+    expect(onCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('is not clickable when disabled', async () => {
+    const onCreate = vi.fn();
+    render(
+      <ConnectionChip entityType="player" count={0} onCreate={onCreate} disabled />,
+    );
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveAttribute('aria-disabled', 'true');
+    await userEvent.click(btn);
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+
+  it('renders skeleton when loading=true', () => {
+    render(<ConnectionChip entityType="kb" loading />);
+    expect(screen.getByTestId('connection-chip-loading')).toBeInTheDocument();
+    expect(screen.queryByTestId('connection-chip-badge')).not.toBeInTheDocument();
+  });
+
+  it('renders a Lucide SVG icon (not emoji) for the entity', () => {
+    const { container } = render(<ConnectionChip entityType="game" count={3} />);
+    expect(container.querySelector('svg')).toBeTruthy();
+  });
+
+  it('shows label under chip when showLabel=true', () => {
+    render(<ConnectionChip entityType="kb" count={3} showLabel label="Docs" />);
+    expect(screen.getByText('Docs')).toBeInTheDocument();
+  });
+
+  it('opens popover when clicked and items are present', async () => {
+    render(
+      <ConnectionChip
+        entityType="session"
+        count={2}
+        items={[
+          { id: '1', label: 'First', href: '/sessions/1' },
+          { id: '2', label: 'Second', href: '/sessions/2' },
+        ]}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button'));
+    expect(await screen.findByText('First')).toBeInTheDocument();
+    expect(screen.getByText('Second')).toBeInTheDocument();
+  });
+
+  it('has aria-label including count and entity label', () => {
+    render(<ConnectionChip entityType="session" count={5} />);
+    const btn = screen.getByRole('button');
+    expect(btn.getAttribute('aria-label')).toMatch(/5/);
+    expect(btn.getAttribute('aria-label')?.toLowerCase()).toMatch(/session/);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/web && pnpm test src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement ConnectionChip.tsx**
+
+```tsx
+// apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChip.tsx
+'use client';
+
+import { useState } from 'react';
+
+import { Plus } from 'lucide-react';
+
+import { entityLabel, entityTokens } from '../tokens';
+import { ConnectionChipPopover } from './ConnectionChipPopover';
+import { ENTITY_ICON_SIZE, ENTITY_ICON_STROKE, entityIcons } from './entity-icons';
+
+import type { ConnectionChipProps } from '../types';
+
+const CHIP_PX = { sm: 22, md: 28 } as const;
+const BADGE_PX = { sm: 14, md: 16 } as const;
+const PLUS_PX = { sm: 12, md: 14 } as const;
+
+function formatCount(count: number): string {
+  return count > 99 ? '99+' : String(count);
+}
+
+export function ConnectionChip({
+  entityType,
+  count = 0,
+  items,
+  size = 'md',
+  showLabel,
+  label,
+  onCreate,
+  createLabel,
+  href,
+  colorOverride,
+  disabled = false,
+  loading = false,
+}: ConnectionChipProps) {
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const tokens = entityTokens(entityType);
+  const color = colorOverride ?? tokens.solid;
+  const Icon = entityIcons[entityType];
+  const chipPx = CHIP_PX[size];
+  const iconPx = ENTITY_ICON_SIZE[size];
+  const badgePx = BADGE_PX[size];
+  const plusPx = PLUS_PX[size];
+  const labelEffective = label ?? entityLabel[entityType];
+  const showLabelEffective = showLabel ?? size === 'md';
+
+  const hasCount = count > 0;
+  const isEmpty = count === 0;
+  const hasCreate = onCreate !== undefined;
+  const hasItems = (items?.length ?? 0) > 0;
+  const isInteractive = !disabled && !loading && (hasItems || hasCreate || href);
+
+  // Loading skeleton
+  if (loading) {
+    return (
+      <span
+        data-testid="connection-chip-loading"
+        className="inline-flex animate-pulse rounded-full"
+        style={{
+          width: chipPx,
+          height: chipPx,
+          background: tokens.muted,
+        }}
+      />
+    );
+  }
+
+  const chipFaceStyle: React.CSSProperties = {
+    width: chipPx,
+    height: chipPx,
+    background: isEmpty ? tokens.muted : tokens.fill,
+    border: `1px ${isEmpty ? 'dashed' : 'solid'} ${isEmpty ? tokens.dashed : tokens.border}`,
+    color,
+    opacity: isEmpty ? (hasCreate ? 0.85 : 0.6) : 1,
+    '--mc-chip-color': color,
+    '--mc-chip-glow': tokens.glow,
+    '--mc-chip-shadow': tokens.shadow,
+    '--mc-chip-hover-bg': tokens.hover,
+  } as React.CSSProperties;
+
+  const chipInner = (
+    <span
+      className="relative inline-flex items-center justify-center rounded-full transition-all duration-200 group-hover/chip:scale-[1.08] group-hover/chip:bg-[var(--mc-chip-hover-bg)] group-hover/chip:shadow-[0_0_0_4px_var(--mc-chip-glow),0_4px_12px_var(--mc-chip-shadow)] motion-reduce:group-hover/chip:scale-100"
+      style={chipFaceStyle}
+    >
+      <Icon
+        size={iconPx}
+        strokeWidth={ENTITY_ICON_STROKE}
+        aria-hidden="true"
+        style={{ opacity: isEmpty ? (hasCreate ? 0.7 : 0.45) : 1 }}
+      />
+
+      {hasCount && (
+        <span
+          data-testid="connection-chip-badge"
+          className="absolute flex items-center justify-center rounded-full font-semibold text-white shadow-sm [font-feature-settings:'tnum']"
+          style={{
+            top: -4,
+            right: -4,
+            height: badgePx,
+            minWidth: badgePx,
+            padding: '0 3px',
+            fontSize: size === 'sm' ? 9 : 10,
+            lineHeight: 1,
+            background: color,
+            boxShadow: '0 0 0 2px var(--mc-bg-card, #fff)',
+          }}
+        >
+          {formatCount(count)}
+        </span>
+      )}
+
+      {isEmpty && hasCreate && (
+        <span
+          data-testid="connection-chip-plus"
+          aria-hidden="true"
+          className="absolute flex items-center justify-center rounded-full text-white shadow-sm"
+          style={{
+            bottom: -3,
+            right: -3,
+            height: plusPx,
+            width: plusPx,
+            background: color,
+          }}
+        >
+          <Plus size={plusPx - 4} strokeWidth={3} />
+        </span>
+      )}
+    </span>
+  );
+
+  const labelEl = showLabelEffective ? (
+    <span className="mt-0.5 text-[9px] font-semibold uppercase tracking-wide text-[var(--mc-text-muted)] group-hover/chip:text-[var(--mc-text-secondary)]">
+      {labelEffective}
+    </span>
+  ) : null;
+
+  const handleActivate = () => {
+    if (!isInteractive) return;
+    if (hasItems) {
+      setPopoverOpen(true);
+    } else if (hasCreate) {
+      onCreate?.();
+    }
+  };
+
+  const ariaLabel = hasCount
+    ? `${count} ${labelEffective}`
+    : hasCreate
+      ? (createLabel ?? `Aggiungi ${labelEffective}`)
+      : labelEffective;
+
+  const buttonEl = (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      aria-disabled={disabled || undefined}
+      disabled={disabled}
+      onClick={handleActivate}
+      className={`group/chip relative inline-flex flex-col items-center outline-none focus-visible:ring-2 focus-visible:ring-offset-1 ${
+        disabled ? 'cursor-not-allowed opacity-40' : isInteractive ? 'cursor-pointer' : 'cursor-default'
+      }`}
+      style={{ '--tw-ring-color': tokens.solid } as React.CSSProperties}
+    >
+      {chipInner}
+      {labelEl}
+    </button>
+  );
+
+  // Wrap in popover when items present
+  if (hasItems && !disabled) {
+    return (
+      <ConnectionChipPopover
+        open={popoverOpen}
+        onOpenChange={setPopoverOpen}
+        items={items ?? []}
+        onCreate={onCreate}
+        createLabel={createLabel}
+        entityType={entityType}
+      >
+        {buttonEl}
+      </ConnectionChipPopover>
+    );
+  }
+
+  return buttonEl;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd apps/web && pnpm test src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx`
+Expected: PASS 12/12.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChip.tsx \
+        apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx
+git commit -m "feat(meeple-card): add unified ConnectionChip component"
+```
+
+---
+
+## Task 7: Create `ConnectionChipStrip`
+
+**Files:**
+- Create: `apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChipStrip.tsx`
+- Test: `apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChipStrip.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+```tsx
+// apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChipStrip.test.tsx
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { ConnectionChipStrip } from '../ConnectionChipStrip';
+
+describe('ConnectionChipStrip', () => {
+  it('returns null when connections array is empty', () => {
+    const { container } = render(<ConnectionChipStrip variant="footer" connections={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders a chip per connection (footer variant)', () => {
+    render(
+      <ConnectionChipStrip
+        variant="footer"
+        connections={[
+          { entityType: 'kb', count: 3 },
+          { entityType: 'session', count: 5 },
+        ]}
+      />,
+    );
+    expect(screen.getAllByRole('button')).toHaveLength(2);
+  });
+
+  it('renders smaller chips in inline variant by default', () => {
+    const { container } = render(
+      <ConnectionChipStrip
+        variant="inline"
+        connections={[{ entityType: 'kb', count: 3 }]}
+      />,
+    );
+    // inline variant forces size="sm" — chip dimension 22px
+    const chipFace = container.querySelector('span[style*="width: 22px"]');
+    expect(chipFace).toBeTruthy();
+  });
+
+  it('renders larger chips in footer variant by default', () => {
+    const { container } = render(
+      <ConnectionChipStrip
+        variant="footer"
+        connections={[{ entityType: 'kb', count: 3 }]}
+      />,
+    );
+    const chipFace = container.querySelector('span[style*="width: 28px"]');
+    expect(chipFace).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/web && pnpm test src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChipStrip.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement ConnectionChipStrip.tsx**
+
+```tsx
+// apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChipStrip.tsx
+'use client';
+
+import { ConnectionChip } from './ConnectionChip';
+
+import type { ConnectionChipProps } from '../types';
+
+export type ConnectionChipStripVariant = 'footer' | 'inline';
+
+interface ConnectionChipStripProps {
+  variant: ConnectionChipStripVariant;
+  connections: ConnectionChipProps[];
+  className?: string;
+}
+
+/**
+ * Layout container for multiple ConnectionChip.
+ *
+ * - `footer`: md chips, border-top, labels visible, used in grid/featured/hero card footer.
+ * - `inline`: sm chips, no border, no labels, used in list/compact/focus meta-row.
+ */
+export function ConnectionChipStrip({
+  variant,
+  connections,
+  className,
+}: ConnectionChipStripProps) {
+  if (connections.length === 0) return null;
+
+  const defaultSize: 'sm' | 'md' = variant === 'footer' ? 'md' : 'sm';
+
+  const containerClass =
+    variant === 'footer'
+      ? 'flex items-center justify-center gap-3 border-t border-[var(--mc-border-light)] bg-[var(--mc-nav-footer-bg)] px-2.5 py-2 backdrop-blur-lg'
+      : 'flex items-center gap-1.5';
+
+  return (
+    <div className={`${containerClass} ${className ?? ''}`.trim()} data-strip-variant={variant}>
+      {connections.map((chipProps, i) => (
+        <ConnectionChip
+          key={`${chipProps.entityType}-${i}`}
+          size={chipProps.size ?? defaultSize}
+          showLabel={chipProps.showLabel ?? variant === 'footer'}
+          {...chipProps}
+        />
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `cd apps/web && pnpm test src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChipStrip.test.tsx`
+Expected: PASS 4/4.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChipStrip.tsx \
+        apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChipStrip.test.tsx
+git commit -m "feat(meeple-card): add ConnectionChipStrip layout container"
+```
+
+---
+
+## Task 8: Create `OwnershipBadge`
+
+**Files:**
+- Create: `apps/web/src/components/ui/data-display/meeple-card/parts/OwnershipBadge.tsx`
+- Test: `apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/OwnershipBadge.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+```tsx
+// apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/OwnershipBadge.test.tsx
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { OwnershipBadge } from '../OwnershipBadge';
+
+describe('OwnershipBadge', () => {
+  it('renders owned with CheckCircle2', () => {
+    const { container } = render(<OwnershipBadge value="owned" />);
+    expect(screen.getByTestId('ownership-badge-owned')).toBeInTheDocument();
+    expect(container.querySelector('svg')).toBeTruthy();
+  });
+
+  it('renders wishlist with Heart', () => {
+    render(<OwnershipBadge value="wishlist" />);
+    expect(screen.getByTestId('ownership-badge-wishlist')).toBeInTheDocument();
+  });
+
+  it('renders archived with Archive', () => {
+    render(<OwnershipBadge value="archived" />);
+    expect(screen.getByTestId('ownership-badge-archived')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/web && pnpm test src/components/ui/data-display/meeple-card/parts/__tests__/OwnershipBadge.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement OwnershipBadge.tsx**
+
+```tsx
+// apps/web/src/components/ui/data-display/meeple-card/parts/OwnershipBadge.tsx
+'use client';
+
+import { Archive, CheckCircle2, Heart, type LucideIcon } from 'lucide-react';
+
+import type { OwnershipBadge as OwnershipValue } from '../types';
+
+interface OwnershipConfig {
+  icon: LucideIcon;
+  fg: string;
+  bg: string;
+  fill?: boolean;
+}
+
+const CONFIG: Record<OwnershipValue, OwnershipConfig> = {
+  owned: {
+    icon: CheckCircle2,
+    fg: 'hsl(152 76% 40%)',
+    bg: 'hsl(152 76% 40% / 0.12)',
+    fill: true,
+  },
+  wishlist: {
+    icon: Heart,
+    fg: 'hsl(350 89% 60%)',
+    bg: 'hsl(350 89% 60% / 0.12)',
+    fill: true,
+  },
+  archived: {
+    icon: Archive,
+    fg: 'hsl(215 20% 50%)',
+    bg: 'hsl(215 20% 50% / 0.08)',
+  },
+};
+
+const LABEL: Record<OwnershipValue, string> = {
+  owned: 'Owned',
+  wishlist: 'Wishlist',
+  archived: 'Archived',
+};
+
+interface OwnershipBadgeProps {
+  value: OwnershipValue;
+  size?: number;
+  className?: string;
+}
+
+export function OwnershipBadge({ value, size = 20, className }: OwnershipBadgeProps) {
+  const cfg = CONFIG[value];
+  const Icon = cfg.icon;
+
+  return (
+    <span
+      data-testid={`ownership-badge-${value}`}
+      aria-label={LABEL[value]}
+      title={LABEL[value]}
+      className={`inline-flex items-center justify-center rounded-full ${className ?? ''}`.trim()}
+      style={{
+        width: size,
+        height: size,
+        background: cfg.bg,
+        color: cfg.fg,
+      }}
+    >
+      <Icon
+        size={Math.round(size * 0.65)}
+        strokeWidth={1.75}
+        fill={cfg.fill ? 'currentColor' : 'none'}
+        aria-hidden="true"
+      />
+    </span>
+  );
+}
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `cd apps/web && pnpm test src/components/ui/data-display/meeple-card/parts/__tests__/OwnershipBadge.test.tsx`
+Expected: PASS 3/3.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/meeple-card/parts/OwnershipBadge.tsx \
+        apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/OwnershipBadge.test.tsx
+git commit -m "feat(meeple-card): add OwnershipBadge component"
+```
+
+---
+
+## Task 9: Create `LifecycleStateBadge`
+
+**Files:**
+- Create: `apps/web/src/components/ui/data-display/meeple-card/parts/LifecycleStateBadge.tsx`
+- Test: `apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/LifecycleStateBadge.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+```tsx
+// apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/LifecycleStateBadge.test.tsx
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { LifecycleStateBadge } from '../LifecycleStateBadge';
+
+describe('LifecycleStateBadge', () => {
+  it.each(['active', 'idle', 'completed', 'setup', 'processing', 'failed'] as const)(
+    'renders for value=%s',
+    value => {
+      render(<LifecycleStateBadge value={value} entityType="game" />);
+      expect(screen.getByTestId(`lifecycle-badge-${value}`)).toBeInTheDocument();
+    },
+  );
+
+  it('renders processing with spinning Loader2 icon', () => {
+    const { container } = render(<LifecycleStateBadge value="processing" entityType="kb" />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('class')).toMatch(/animate-spin/);
+  });
+
+  it('renders active with entity-colored dot', () => {
+    render(<LifecycleStateBadge value="active" entityType="session" />);
+    const badge = screen.getByTestId('lifecycle-badge-active');
+    // Session color is hsl(240, 60%, 55%)
+    expect(badge.getAttribute('style') ?? '').toMatch(/240/);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/web && pnpm test src/components/ui/data-display/meeple-card/parts/__tests__/LifecycleStateBadge.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement LifecycleStateBadge.tsx**
+
+```tsx
+// apps/web/src/components/ui/data-display/meeple-card/parts/LifecycleStateBadge.tsx
+'use client';
+
+import {
+  AlertTriangle,
+  CheckCheck,
+  Loader2,
+  Settings2,
+  type LucideIcon,
+} from 'lucide-react';
+
+import { entityHsl } from '../tokens';
+
+import type { LifecycleState, MeepleEntityType } from '../types';
+
+interface LifecycleStateBadgeProps {
+  value: LifecycleState;
+  entityType: MeepleEntityType;
+  className?: string;
+}
+
+interface StaticConfig {
+  kind: 'icon';
+  icon: LucideIcon;
+  color: string;
+  label: string;
+  spin?: boolean;
+}
+
+interface DotConfig {
+  kind: 'dot';
+  fillEntity: boolean; // true = entity color, false = neutral
+  outline?: boolean;
+  label: string;
+  pulse?: boolean;
+}
+
+const CONFIG: Record<LifecycleState, StaticConfig | DotConfig> = {
+  active: { kind: 'dot', fillEntity: true, label: 'Active', pulse: true },
+  idle: { kind: 'dot', fillEntity: false, outline: true, label: 'Idle' },
+  completed: {
+    kind: 'icon',
+    icon: CheckCheck,
+    color: 'hsl(152 76% 40%)',
+    label: 'Completed',
+  },
+  setup: {
+    kind: 'icon',
+    icon: Settings2,
+    color: 'hsl(38 92% 50%)',
+    label: 'Setup',
+  },
+  processing: {
+    kind: 'icon',
+    icon: Loader2,
+    color: 'hsl(200 89% 55%)',
+    label: 'Processing',
+    spin: true,
+  },
+  failed: {
+    kind: 'icon',
+    icon: AlertTriangle,
+    color: 'hsl(0 84% 60%)',
+    label: 'Failed',
+  },
+};
+
+export function LifecycleStateBadge({
+  value,
+  entityType,
+  className,
+}: LifecycleStateBadgeProps) {
+  const cfg = CONFIG[value];
+
+  if (cfg.kind === 'dot') {
+    const color = cfg.fillEntity ? entityHsl(entityType) : 'hsl(215 20% 60%)';
+    return (
+      <span
+        data-testid={`lifecycle-badge-${value}`}
+        aria-label={cfg.label}
+        title={cfg.label}
+        className={`inline-block rounded-full ${cfg.pulse ? 'animate-pulse' : ''} ${className ?? ''}`.trim()}
+        style={{
+          width: 8,
+          height: 8,
+          background: cfg.outline ? 'transparent' : color,
+          border: cfg.outline ? `1.5px solid ${color}` : 'none',
+        }}
+      />
+    );
+  }
+
+  const Icon = cfg.icon;
+  return (
+    <span
+      data-testid={`lifecycle-badge-${value}`}
+      aria-label={cfg.label}
+      title={cfg.label}
+      className={`inline-flex items-center ${className ?? ''}`.trim()}
+      style={{ color: cfg.color }}
+    >
+      <Icon
+        size={14}
+        strokeWidth={1.75}
+        aria-hidden="true"
+        className={cfg.spin ? 'animate-spin' : undefined}
+      />
+    </span>
+  );
+}
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `cd apps/web && pnpm test src/components/ui/data-display/meeple-card/parts/__tests__/LifecycleStateBadge.test.tsx`
+Expected: PASS 8/8 (6 from it.each + 2 specific).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/meeple-card/parts/LifecycleStateBadge.tsx \
+        apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/LifecycleStateBadge.test.tsx
+git commit -m "feat(meeple-card): add LifecycleStateBadge component"
+```
+
+---
+
+## Task 10: Extend `index.ts` public exports
+
+**Files:**
+- Modify: `apps/web/src/components/ui/data-display/meeple-card/index.ts`
+
+- [ ] **Step 1: Read current exports**
+
+Run: `cat apps/web/src/components/ui/data-display/meeple-card/index.ts`
+
+- [ ] **Step 2: Append new exports**
+
+Add to the file:
+
+```ts
+export { ConnectionChip } from './parts/ConnectionChip';
+export { ConnectionChipStrip } from './parts/ConnectionChipStrip';
+export { ConnectionChipPopover } from './parts/ConnectionChipPopover';
+export { OwnershipBadge } from './parts/OwnershipBadge';
+export { LifecycleStateBadge } from './parts/LifecycleStateBadge';
+export { entityIcons, ENTITY_ICON_SIZE, ENTITY_ICON_STROKE } from './parts/entity-icons';
+export { mapLegacyStatus, resolveStatus } from './parts/status-adapter';
+export { entityTokens } from './tokens';
+export type {
+  ConnectionChipProps,
+  ConnectionItem,
+  OwnershipBadge as OwnershipBadgeValue,
+  LifecycleState,
+} from './types';
+```
+
+- [ ] **Step 3: Verify typecheck**
+
+Run: `cd apps/web && pnpm typecheck`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/meeple-card/index.ts
+git commit -m "feat(meeple-card): export ConnectionChip primitives from package"
+```
+
+---
+
+## Task 11: Full test run + lint
+
+- [ ] **Step 1: Run the whole meeple-card suite**
+
+Run: `cd apps/web && pnpm test src/components/ui/data-display/meeple-card`
+Expected: all existing tests still pass; new tests (entity-icons, tokens-entityTokens, status-adapter, ConnectionChip, ConnectionChipStrip, ConnectionChipPopover, OwnershipBadge, LifecycleStateBadge) pass.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `cd apps/web && pnpm typecheck`
+Expected: no errors.
+
+- [ ] **Step 3: Run lint**
+
+Run: `cd apps/web && pnpm lint`
+Expected: no errors in modified files. If lint auto-fixes, re-run tests.
+
+- [ ] **Step 4: Final commit (any lint fixups)**
+
+If lint produced changes:
+```bash
+git add -u
+git commit -m "chore(meeple-card): lint fixups for ConnectionChip additions"
+```
+
+Otherwise skip.
+
+---
+
+## Task 12: Push branch and open PR
+
+- [ ] **Step 1: Detect current branch and parent**
+
+Run:
+```bash
+git branch --show-current
+```
+Expected: current feature branch (e.g. `feature/meeplecard-connectionchip`). If on `main-dev` or `main`, create a feature branch first:
+```bash
+git checkout -b feature/meeplecard-connectionchip-step1
+git config branch.feature/meeplecard-connectionchip-step1.parent main-dev
+```
+
+- [ ] **Step 2: Push**
+
+Run: `git push -u origin HEAD`
+
+- [ ] **Step 3: Open PR to parent**
+
+Run:
+```bash
+gh pr create --base main-dev --title "feat(meeple-card): Step 1 — ConnectionChip additive rollout" --body "$(cat <<'EOF'
+## Summary
+- Adds unified `ConnectionChip` / `ConnectionChipStrip` / `ConnectionChipPopover` replacing the ManaPips+NavFooterItem duplication visually and functionally.
+- Restores the functional role users expected: count badge + drill-down popover + create affordance.
+- Adds Lucide `entityIcons` registry — emoji `entityIcon` in `tokens.ts` remains deprecated and will be removed in Step 3.
+- Adds `entityTokens()` named derived-color helper (`fill/border/hover/glow/…`).
+- Introduces two-axis status model (`OwnershipBadge`, `LifecycleStateBadge`) with a pure `mapLegacyStatus` adapter that preserves existing `CardStatus` behaviour.
+- Fully **additive** — no legacy API removed, all existing tests must still pass.
+
+## Spec
+`docs/superpowers/specs/2026-04-23-meeplecard-connectionchip-design.md`
+
+## Plan
+`docs/superpowers/plans/2026-04-23-meeplecard-connectionchip-plan.md`
+
+## Test plan
+- [ ] New unit tests (entity-icons, tokens-entityTokens, status-adapter, ConnectionChip, ConnectionChipStrip, ConnectionChipPopover, OwnershipBadge, LifecycleStateBadge) pass
+- [ ] `pnpm typecheck` clean
+- [ ] `pnpm lint` clean
+- [ ] Existing meeple-card tests (ManaPips, NavFooter, MeepleCard) still pass
+- [ ] Manual smoke: no consumer of MeepleCard breaks
+
+## Follow-ups (separate PRs, see spec §10)
+- Step 2 — call-site migration sweep per bounded area
+- Step 3 — legacy cleanup + bundle size rebaseline
+- Typography scale, dark-mode color parity, contrast CI (follow-up plans)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Record PR URL for memory**
+
+Note the PR URL returned by `gh pr create`.
+
+---
+
+## Done Criteria
+
+- All 8 new unit test files pass (entity-icons, tokens-entityTokens, status-adapter, ConnectionChip, ConnectionChipStrip, ConnectionChipPopover, OwnershipBadge, LifecycleStateBadge)
+- Typecheck + lint clean
+- Existing meeple-card test suite unchanged (no regressions)
+- PR opened against parent branch (not `main`)
+- No legacy prop (`status`, `navItems`, `manaPips`) removed — backward compat guaranteed

--- a/docs/superpowers/specs/2026-04-23-meeplecard-connectionchip-design.md
+++ b/docs/superpowers/specs/2026-04-23-meeplecard-connectionchip-design.md
@@ -1,0 +1,648 @@
+# MeepleCard ConnectionChip Redesign — Design Spec
+
+**Date**: 2026-04-23
+**Scope**: MeepleCard UI component — iconography, visual states, entity colors, typography
+**Focus areas**: A (Visual identity & tone), C (Iconography & illustration), E (Stati visuali & feedback)
+**Status**: Draft, pending user review
+
+---
+
+## 1. Problem Statement
+
+The `MeepleCard` component currently has two parallel sub-systems that express related concepts with inconsistent visual treatment:
+
+- **`ManaPips`** — small colored dots (6/8/12px) shown in meta-row. Originally conceived to represent connected entities (KB docs, sessions, agent, chat) linked to the parent card. After a recent update, pips lost their functional role (no popover drill-down, no create-affordance) and their visual quality (icons replaced by flat colored dots). Users perceive this as a regression.
+- **`NavFooterItem`** — richer buttons (28px circle + Lucide icon + count badge + plus overlay + label + hover glow) used in card footer. This is the visual language users expect.
+
+Related issues:
+- Icon dualism: `tokens.entityIcon` uses emoji (🎲👤🎯🤖📚💬📅🧰🔧) in popover headers; `nav-items/icons.tsx` uses Lucide icons in NavFooter. Same entity renders differently in different contexts.
+- `CardStatus` enum (12 values) mixes three orthogonal semantic axes (ownership/lifecycle/processing) forcing users to choose one when multiple could apply.
+- `entityColor` covers only 7/9 entities; missing `toolkit` and `tool`. Derived values (`/0.12`, `/0.35`) are inlined everywhere with no named tokens.
+- Typography scale is ad-hoc: title/subtitle/meta sizes drift slightly between variants.
+
+## 2. Goals
+
+1. **Unify** `ManaPips` and `NavFooterItem` into a single `ConnectionChip` component with size variants.
+2. **Restore functional role** of connection visualization: count, drill-down popover, create-affordance.
+3. **Unify iconography** around Lucide icons for all 9 entity types; remove emoji dualism.
+4. **Consolidate CardStatus** from 12 values into two orthogonal dimensions (ownership + lifecycle).
+5. **Complete entity color system** for all 9 entities with named derived tokens and WCAG AA validation.
+6. **Codify typography scale** for MeepleCard with tokens applied consistently across variants.
+
+## 3. Non-Goals
+
+- Redesigning MeepleCard variants (grid/list/compact/featured/hero/focus layouts stay).
+- Motion/micro-interactions overhaul (focus B was explicitly deferred).
+- Replacing Quicksand/Nunito fonts.
+- Changing backend DTOs (connections is a presentation-layer concept).
+
+---
+
+## 4. Design: `ConnectionChip` component
+
+### 4.1 API
+
+```ts
+// src/components/ui/data-display/meeple-card/parts/ConnectionChip.tsx
+
+export interface ConnectionItem {
+  id: string;
+  label: string;
+  href: string;
+}
+
+export interface ConnectionChipProps {
+  entityType: MeepleEntityType;
+  count?: number;
+  items?: ConnectionItem[];
+  size?: 'sm' | 'md';       // sm=22px inline, md=28px footer
+  showLabel?: boolean;       // default: size==='md'
+  label?: string;            // override auto-label
+  onCreate?: () => void;
+  createLabel?: string;
+  href?: string;             // direct link (no popover)
+  colorOverride?: string;    // rare, for custom contexts
+  disabled?: boolean;
+  loading?: boolean;
+}
+```
+
+```ts
+// src/components/ui/data-display/meeple-card/parts/ConnectionChipStrip.tsx
+
+export interface ConnectionChipStripProps {
+  variant: 'footer' | 'inline';
+  children: React.ReactNode;
+  className?: string;
+}
+```
+
+### 4.2 Integration with MeepleCard
+
+```diff
+// types.ts — MeepleCardProps
+- navItems?: NavItemProps[];
+- manaPips?: ManaPipProps[];
++ connections?: ConnectionChipProps[];
++ connectionsVariant?: 'footer' | 'inline' | 'auto';   // default: 'auto'
+```
+
+**Per-variant auto-defaults** when `connectionsVariant='auto'`:
+
+| Card variant | Strip variant |
+|--------------|---------------|
+| grid         | footer        |
+| list         | inline        |
+| compact      | inline        |
+| featured     | footer        |
+| hero         | footer        |
+| focus        | inline        |
+
+### 4.3 File layout
+
+```
+apps/web/src/components/ui/data-display/meeple-card/
+  parts/
+    ConnectionChip.tsx                  NEW
+    ConnectionChipStrip.tsx             NEW
+    ConnectionChipPopover.tsx           NEW (was ManaPipPopover)
+    entity-icons.tsx                    NEW (unified icon registry)
+    typography.ts                       NEW (cardTypeClass)
+    ManaPips.tsx                        DELETE
+    nav-items/NavFooter.tsx             DELETE
+    nav-items/NavFooterItem.tsx         DELETE
+    nav-items/icons.tsx                 DELETE (merged into entity-icons)
+  MeepleCard.tsx                        MODIFIED (props diff)
+  types.ts                              MODIFIED
+  tokens.ts                             MODIFIED (see §6, §7)
+  hooks/useEntityColor.ts               NEW (light/dark resolver)
+  index.ts                              MODIFIED (re-exports)
+```
+
+---
+
+## 5. Iconography
+
+### 5.1 Unified entity icon registry
+
+```tsx
+// src/components/ui/data-display/meeple-card/parts/entity-icons.tsx
+import {
+  Dices, UserCircle2, Swords, Bot,
+  BookOpen, MessageCircle, Calendar,
+  Briefcase, Wrench, type LucideIcon,
+} from 'lucide-react';
+import type { MeepleEntityType } from '../types';
+
+export const entityIcons: Record<MeepleEntityType, LucideIcon> = {
+  game:    Dices,
+  player:  UserCircle2,
+  session: Swords,
+  agent:   Bot,
+  kb:      BookOpen,
+  chat:    MessageCircle,
+  event:   Calendar,
+  toolkit: Briefcase,
+  tool:    Wrench,
+};
+
+export const ENTITY_ICON_STROKE = 1.75;
+export const ENTITY_ICON_SIZE = { sm: 14, md: 16 } as const;
+```
+
+### 5.2 Emoji removal
+
+```diff
+// tokens.ts
+- export const entityIcon: Record<MeepleEntityType, string> = {
+-   game: '🎲', player: '👤', session: '🎯', agent: '🤖',
+-   kb: '📚', chat: '💬', event: '📅', toolkit: '🧰', tool: '🔧',
+- };
+```
+
+Emoji usage survives only where **textual/narrative** (empty-state copy, avatar fallbacks). All **iconographic** usage migrates to Lucide.
+
+### 5.3 Stroke and size policy
+
+| Context                                 | Icon size | Container | Stroke |
+|-----------------------------------------|-----------|-----------|--------|
+| `ConnectionChip size="sm"` (inline)     | 14px      | 22×22     | 1.75   |
+| `ConnectionChip size="md"` (footer)     | 16px      | 28×28     | 1.75   |
+| `ConnectionChipPopover` header          | 16px      | inline    | 1.75   |
+
+---
+
+## 6. Visual states
+
+### 6.1 State matrix
+
+| State            | count  | onCreate | Badge  | Plus overlay | Border  | Icon opacity |
+|------------------|--------|----------|--------|--------------|---------|--------------|
+| Default          | >0     | any      | ✓      | ✗            | solid   | 1.0          |
+| Empty + create   | 0      | ✓        | ✗      | ✓            | dashed  | 0.55         |
+| Empty muted      | 0      | ✗        | ✗      | ✗            | dashed  | 0.35         |
+| Hover            | >0     | any      | ✓      | ✗            | solid   | 1.0          |
+| Popover open     | >0     | any      | ✓      | ✗            | solid   | 1.0          |
+| Disabled         | any    | any      | dimmed | dimmed       | solid   | 0.4          |
+| Loading          | —      | —        | ✗      | ✗            | none    | — (skeleton) |
+
+### 6.2 Count formatting
+
+- `count <= 99` → numeric badge
+- `count > 99` → `"99+"`
+- `count === 0 && onCreate` → plus overlay, no badge
+- `count === 0 && !onCreate` → no badge, no plus
+
+### 6.3 Tokens
+
+```ts
+// tokens.ts additions
+export const connectionChipSizes = {
+  sm: { chip: 22, icon: 14, badge: 14, plus: 12, gap: 4 },
+  md: { chip: 28, icon: 16, badge: 16, plus: 14, gap: 6 },
+} as const;
+
+export const connectionChipTransitions = {
+  hover: 'transform 180ms cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 180ms ease-out',
+  glow:  (entityColor: string) =>
+    `0 0 0 4px hsl(${entityColor} / 0.18), 0 4px 12px hsl(${entityColor} / 0.25)`,
+};
+```
+
+### 6.4 Hover behaviour
+
+- Transform: `scale(1.08)` on md, `scale(1.12)` on sm
+- Box-shadow: glow using entity-colored drop + spread
+- `prefers-reduced-motion`: disables transform, keeps glow
+
+### 6.5 Popover
+
+Uses Radix `Popover`, `side="bottom"`, `align="start"`. Structure:
+
+- Header: `<Icon /> Label (count)` + close button
+- Body: list of items with `<a href>`, hover bg `entity.fill`, max-height 320px scroll internal
+- Footer (optional): "+ Create new ..." if `onCreate` defined
+
+### 6.6 Accessibility
+
+- Chip: `role="button"` when clickable; `aria-label` includes count + entity label (or `createLabel` for empty+create)
+- Plus overlay: `aria-hidden="true"` (decorative)
+- Popover inherits Radix a11y (focus trap, ESC, ARIA)
+- `prefers-reduced-motion` respected
+
+---
+
+## 7. CardStatus consolidation
+
+### 7.1 Two-axis model
+
+Replace single `CardStatus` enum with two orthogonal dimensions:
+
+```ts
+// types.ts
+export type OwnershipBadge =
+  | 'owned'
+  | 'wishlist'
+  | 'archived';
+
+export type LifecycleState =
+  | 'active'
+  | 'idle'
+  | 'completed'
+  | 'setup'
+  | 'processing'
+  | 'failed';
+
+// MeepleCardProps diff
++ ownership?: OwnershipBadge;
++ lifecycle?: LifecycleState;
+  status?: CardStatus;  // retained during Step 1–2 (deprecated), removed in Step 3
+```
+
+During Steps 1–2 the legacy `status` prop coexists with the new `ownership`/`lifecycle` props and is mapped via the adapter in §7.4. In Step 3 `status` and `CardStatus` enum are removed.
+
+### 7.2 Consolidation decisions
+
+| Legacy value | New mapping                  | Rationale                                         |
+|--------------|------------------------------|---------------------------------------------------|
+| `owned`      | `ownership: 'owned'`         | Direct                                            |
+| `wishlist`   | `ownership: 'wishlist'`      | Direct                                            |
+| `archived`   | `ownership: 'archived'`      | Direct                                            |
+| `active`     | `lifecycle: 'active'`        | Direct                                            |
+| `inprogress` | `lifecycle: 'active'`        | **Merged** — synonym of `active`                  |
+| `idle`       | `lifecycle: 'idle'`          | Direct                                            |
+| `paused`     | `lifecycle: 'idle'`          | **Merged** — semantically equivalent              |
+| `completed`  | `lifecycle: 'completed'`     | Direct                                            |
+| `setup`      | `lifecycle: 'setup'`         | Direct                                            |
+| `processing` | `lifecycle: 'processing'`    | Direct                                            |
+| `indexed`    | `{}` (removed from UI)       | Internal KB pipeline state, not user-facing       |
+| `failed`     | `lifecycle: 'failed'`        | Direct                                            |
+
+Net: **12 → 9 values** across 2 orthogonal axes. A card can now express BOTH ownership and lifecycle (e.g. `owned` + `active`).
+
+### 7.3 Visual treatment
+
+**Ownership badge** (top-right corner):
+
+| Value      | Icon (Lucide) | Foreground           | Background             |
+|------------|---------------|----------------------|------------------------|
+| `owned`    | `CheckCircle2`| `hsl(152 76% 40%)`   | `hsl(152 76% 40% / .12)` |
+| `wishlist` | `Heart` filled| `hsl(350 89% 60%)`   | `hsl(350 89% 60% / .12)` |
+| `archived` | `Archive`     | `hsl(215 20% 50%)`   | `hsl(215 20% 50% / .08)` |
+
+**Lifecycle state** (inline, in meta-row):
+
+| Value        | Icon          | Color                | Animation           |
+|--------------|---------------|----------------------|---------------------|
+| `active`     | filled dot    | entity color         | pulse opacity 0.8→1, 2s infinite |
+| `idle`       | outline dot   | `hsl(215 20% 60%)`   | none                |
+| `completed`  | `CheckCheck`  | `hsl(152 76% 40%)`   | none                |
+| `setup`      | `Settings2`   | `hsl(38 92% 50%)`    | none                |
+| `processing` | `Loader2`     | `hsl(200 89% 55%)`   | rotate 360°, 1.2s infinite |
+| `failed`     | `AlertTriangle` | `hsl(0 84% 60%)`   | none                |
+
+**Rule**: max 1 ownership + 1 lifecycle visible per card. On `compact` variant: ownership only (no lifecycle to preserve density).
+
+### 7.4 Legacy adapter
+
+Step 1 (additive, non-breaking): `MeepleCard` accepts both `status` (legacy) and `ownership`/`lifecycle` (new). Internally, legacy maps via:
+
+```ts
+function mapLegacyStatus(status: CardStatus): {
+  ownership?: OwnershipBadge;
+  lifecycle?: LifecycleState;
+} {
+  switch (status) {
+    case 'owned':      return { ownership: 'owned' };
+    case 'wishlist':   return { ownership: 'wishlist' };
+    case 'archived':   return { ownership: 'archived' };
+    case 'active':
+    case 'inprogress': return { lifecycle: 'active' };
+    case 'idle':
+    case 'paused':     return { lifecycle: 'idle' };
+    case 'completed':  return { lifecycle: 'completed' };
+    case 'setup':      return { lifecycle: 'setup' };
+    case 'processing': return { lifecycle: 'processing' };
+    case 'indexed':    return {};
+    case 'failed':     return { lifecycle: 'failed' };
+  }
+}
+```
+
+Deprecation console warning in dev mode.
+
+---
+
+## 8. Entity colors and design tokens
+
+### 8.1 Complete entity color registry
+
+```ts
+// tokens.ts
+export const entityColor: Record<MeepleEntityType, string> = {
+  game:    '25 95% 45%',
+  player:  '262 83% 58%',
+  session: '240 60% 55%',
+  agent:   '38 92% 50%',
+  kb:      '210 40% 55%',
+  chat:    '220 80% 55%',
+  event:   '350 89% 60%',
+  toolkit: '165 70% 42%',   // NEW — teal
+  tool:    '280 55% 55%',   // NEW — violet (desaturated vs player purple)
+};
+```
+
+Hue separation check: minimum ΔH ≥ 15° between any two entities. Current minimum: `chat` (220) vs `session` (240) = 20°. Passes.
+
+### 8.2 Named derived tokens
+
+```ts
+export const entityTokens = (entity: MeepleEntityType) => {
+  const h = entityColor[entity];
+  return {
+    solid:  `hsl(${h})`,
+    fill:   `hsl(${h} / 0.12)`,
+    border: `hsl(${h} / 0.35)`,
+    hover:  `hsl(${h} / 0.22)`,
+    glow:   `hsl(${h} / 0.18)`,
+    shadow: `hsl(${h} / 0.25)`,
+    muted:  `hsl(${h} / 0.06)`,
+    dashed: `hsl(${h} / 0.25)`,
+    textOn: '#ffffff',
+  };
+};
+```
+
+Replaces all inline `hsl(... / 0.12)` etc. across ConnectionChip, popover, badges.
+
+### 8.3 Dark mode parity
+
+```ts
+export const entityColorDark: Record<MeepleEntityType, string> = {
+  game:    '25 95% 60%',
+  player:  '262 83% 70%',
+  session: '240 70% 70%',
+  agent:   '38 92% 62%',
+  kb:      '210 55% 68%',
+  chat:    '220 80% 70%',
+  event:   '350 89% 72%',
+  toolkit: '165 65% 55%',
+  tool:    '280 60% 68%',
+};
+```
+
+Values above are initial estimates; final lightness per entity will be tuned to pass the contrast thresholds in §11.1 before merging Step 1. Any entity that fails validation gets its lightness adjusted (hue stays fixed for brand consistency).
+
+`useEntityColor(entity)` hook resolves light/dark based on theme. Exposed as CSS variables at root (`--entity-color-game`, etc.) so any component can read without prop-drilling.
+
+### 8.4 Card surface tokens
+
+```ts
+export const cardSurface = {
+  light: {
+    bg:          '#fdf8f3',
+    bgElevated:  '#ffffff',
+    shadow:      '0 2px 8px hsl(25 40% 30% / 0.08), 0 1px 2px hsl(25 40% 30% / 0.04)',
+    shadowHover: '0 8px 24px hsl(25 40% 30% / 0.14), 0 2px 6px hsl(25 40% 30% / 0.06)',
+    border:      'hsl(25 20% 88%)',
+  },
+  dark: {
+    bg:          '#1c1917',
+    bgElevated:  '#292524',
+    shadow:      '0 2px 8px hsl(0 0% 0% / 0.3), 0 1px 2px hsl(0 0% 0% / 0.15)',
+    shadowHover: '0 8px 24px hsl(0 0% 0% / 0.5), 0 2px 6px hsl(0 0% 0% / 0.25)',
+    border:      'hsl(25 10% 20%)',
+  },
+};
+```
+
+Shadow hue is warm (25°) instead of neutral gray, reinforcing the "board game warmth" identity.
+
+---
+
+## 9. Typography scale
+
+### 9.1 Token definition
+
+```ts
+// tokens.ts
+export const cardTypography = {
+  display:      { family: 'Quicksand', weight: 700, size: '1.875rem', leading: '1.15', tracking: '-0.02em' },
+  title:        { family: 'Quicksand', weight: 600, size: '1.125rem', leading: '1.3',  tracking: '-0.005em' },
+  titleCompact: { family: 'Quicksand', weight: 600, size: '0.9375rem', leading: '1.35', tracking: '0' },
+  subtitle:     { family: 'Nunito',    weight: 500, size: '0.875rem', leading: '1.4',  tracking: '0', opacity: 0.75 },
+  body:         { family: 'Nunito',    weight: 400, size: '0.875rem', leading: '1.5',  tracking: '0' },
+  meta:         { family: 'Nunito',    weight: 500, size: '0.75rem',  leading: '1.3',  tracking: '0.01em', opacity: 0.7 },
+  caption:      { family: 'Nunito',    weight: 600, size: '0.6875rem', leading: '1.2', tracking: '0.02em' },
+  numeric:      { family: 'Quicksand', weight: 600, size: '0.625rem', leading: '1',    tracking: '0', features: '"tnum"' },
+};
+```
+
+### 9.2 Tailwind class derivatives
+
+```ts
+// src/components/ui/data-display/meeple-card/parts/typography.ts
+export const cardTypeClass = {
+  display:      'font-[Quicksand] font-bold text-[1.875rem] leading-[1.15] -tracking-[0.02em]',
+  title:        'font-[Quicksand] font-semibold text-lg leading-[1.3] -tracking-[0.005em]',
+  titleCompact: 'font-[Quicksand] font-semibold text-[0.9375rem] leading-[1.35]',
+  subtitle:     'font-[Nunito] font-medium text-sm leading-[1.4] opacity-75',
+  body:         'font-[Nunito] font-normal text-sm leading-[1.5]',
+  meta:         'font-[Nunito] font-medium text-xs leading-[1.3] tracking-[0.01em] opacity-70',
+  caption:      'font-[Nunito] font-semibold text-[0.6875rem] leading-[1.2] tracking-[0.02em]',
+  numeric:      'font-[Quicksand] font-semibold text-[0.625rem] leading-none [font-feature-settings:"tnum"]',
+} as const;
+```
+
+No wrapper components — classes only.
+
+### 9.3 Variant mapping
+
+| Variant  | Title          | Subtitle  | Body                | Meta   |
+|----------|----------------|-----------|---------------------|--------|
+| grid     | `title`        | `subtitle`| —                   | `meta` |
+| list     | `titleCompact` | `subtitle`| `body` (1-line)     | `meta` |
+| compact  | `titleCompact` | `meta`    | —                   | `meta` |
+| featured | `title`        | `subtitle`| `body` (2-line)     | `meta` |
+| hero     | `display`      | `subtitle`| `body`              | `meta` |
+| focus    | `title`        | `subtitle`| `body`              | `meta` |
+
+### 9.4 Truncation rules
+
+| Token          | Line clamp |
+|----------------|------------|
+| `display`      | 2          |
+| `title`        | 2          |
+| `titleCompact` | 2          |
+| `subtitle`     | 1          |
+| `body` (list)  | 1          |
+| `body` (featured/hero) | 2  |
+
+### 9.5 Responsive
+
+Typography is non-responsive within a card (variant switching handles layout changes). Single exception:
+
+- `display` below 640px viewport scales to 1.5rem (24px) to avoid layout break in mobile hero.
+
+### 9.6 Accessibility
+
+- Minimum size 11px (caption only, not on continuous text)
+- Minimum line-height 1.3 (`body` uses 1.5 per WCAG 1.4.12 suggestion)
+- Opacity 0.7/0.75 on meta/subtitle validated via contrast script (§11.1)
+
+---
+
+## 10. Migration strategy
+
+### 10.1 File changes summary
+
+**DELETE**: `ManaPips.tsx`, `ManaPipPopover.tsx` (renamed), `nav-items/NavFooter.tsx`, `nav-items/NavFooterItem.tsx`, `nav-items/icons.tsx`
+**NEW**: `ConnectionChip.tsx`, `ConnectionChipStrip.tsx`, `ConnectionChipPopover.tsx`, `entity-icons.tsx`, `typography.ts`, `hooks/useEntityColor.ts`
+**MODIFIED**: `MeepleCard.tsx`, `tokens.ts`, `types.ts`, `variants/*.tsx`, `index.ts`
+
+### 10.2 Consumer call-sites
+
+| File                                                              | Change                                                        |
+|-------------------------------------------------------------------|---------------------------------------------------------------|
+| `ui/navigation/connection-bar/ConnectionBar.tsx`                  | Internals refactor to use `ConnectionChipStrip variant="inline"` |
+| `ui/navigation/connection-bar/build-connections.ts`               | Return type becomes `ConnectionChipProps[]`                   |
+| `app/(authenticated)/games/[id]/GameDetailDesktop.tsx`            | No signature change (uses `ConnectionBar`)                    |
+| `app/(authenticated)/agents/[id]/AgentCharacterSheet.tsx`         | No signature change                                           |
+| `app/(authenticated)/sessions/[id]/page.tsx`                      | No signature change                                           |
+| Storybook stories / snapshot tests touching MeepleCard            | Update fixtures from `navItems`/`manaPips` to `connections`   |
+
+Scope discovery commands:
+```bash
+grep -rn "navItems=\|manaPips=" apps/web/src
+grep -rn "entityIcon\[" apps/web/src
+grep -rn "NavFooterItem\|ManaPips" apps/web/src
+```
+
+### 10.3 Three-step rollout
+
+**Step 1 — Additive (non-breaking PR #1)**
+- Introduce all new components, tokens, icons.
+- `MeepleCard` accepts both legacy (`navItems`, `manaPips`, `status`) and new (`connections`, `ownership`, `lifecycle`) props.
+- Legacy props internally mapped via adapters.
+- Dev-only `console.warn` on legacy props usage.
+- Contrast validation CI enabled.
+
+**Step 2 — Migration sweep (one PR per bounded area)**
+- Convert call-sites per area: games, agents, sessions, library, admin.
+- Update `ConnectionBar` internals to use `ConnectionChipStrip`.
+- Update snapshot baselines.
+
+**Step 3 — Cleanup (PR N)**
+- Remove legacy props from `MeepleCardProps`.
+- Delete deprecated files.
+- Remove `entityIcon` emoji export from `tokens.ts`.
+- Update `bundle-size-baseline.json`.
+
+### 10.4 Out of scope
+
+- Variants of MeepleCard (layouts stay).
+- Motion/hover animations beyond chip-level glow.
+- Backend or DTO changes.
+
+---
+
+## 11. Test & validation strategy
+
+### 11.1 Token validation (CI gate)
+
+New script: `apps/web/scripts/validate-contrast.ts`
+
+Validates for each `MeepleEntityType` × `{light, dark}`:
+- `contrast(solid, cardBg) ≥ 3.0` (icon on card surface)
+- `contrast(white, solid) ≥ 4.5` (count badge text)
+- `contrast(solid, fill) ≥ 3.0` (icon on own fill)
+
+Additional:
+- Ownership/lifecycle colors vs card bg ≥ 3.0
+- Opacity-reduced text (`meta` at 0.7, `subtitle` at 0.75) vs card bg ≥ 4.5
+
+Outputs `apps/web/reports/contrast-validation.md`. CI workflow `.github/workflows/design-tokens.yml` fails if any threshold unmet.
+
+### 11.2 Unit tests (Vitest)
+
+**`ConnectionChip.test.tsx`** (target ≥95% coverage):
+- Renders count badge when count > 0
+- Renders "99+" when count > 99
+- No badge when count === 0
+- Plus overlay when count === 0 && onCreate
+- No plus when count === 0 && !onCreate
+- Click opens popover when items present
+- Click calls onCreate when empty + create, no items
+- Disabled blocks interactions
+- Enter/Space triggers same as click
+- Escape closes popover
+- aria-label includes count + entity label
+- Every `MeepleEntityType` resolves a Lucide component in `entityIcons`
+
+**`status-adapter.test.ts`**: All 12 legacy `CardStatus` values map correctly, including merges (`inprogress → active`, `paused → idle`, `indexed → {}`).
+
+### 11.3 Integration tests
+
+**`MeepleCard.integration.test.tsx`**: "Wingspan ALL entities" scenario asserting 4 count badges, 1 plus overlay, ownership badge rendered.
+
+Visual regression via existing snapshot tooling (if present): 6 variants × 2 modes = 12 snapshots baseline.
+
+### 11.4 E2E tests (Playwright)
+
+**`tests/e2e/meeple-card-connections.spec.ts`** (new):
+- Connection chip opens popover and navigates via item link
+- Empty chip with create affordance triggers create flow
+
+Existing E2E on games/agents/sessions pages must continue passing unchanged (no snapshot updates without justification).
+
+### 11.5 Accessibility audit
+
+- `axe-core` run in Vitest: zero violations of severity `serious` or `critical`.
+- Manual keyboard checklist documented:
+  - Tab order through every chip
+  - Enter/Space activates chip
+  - Escape closes popover, focus returns to chip
+  - Arrow keys navigate popover items
+  - Screen reader announces count + entity + action
+  - `prefers-reduced-motion` disables transform, keeps glow
+
+### 11.6 Bundle size check
+
+Update `bundle-size-baseline.json` at end of Step 3. Expected net delta: **−3 KB to +2 KB gzipped** (fewer components, more Lucide icon imports, all tree-shakeable). CI fails if delta > +5 KB without justification.
+
+### 11.7 Definition of done
+
+- [ ] Unit + integration + contrast CI green
+- [ ] E2E on ≥3 migrated call-sites
+- [ ] Axe zero serious/critical
+- [ ] Contrast validation covers 9 entities × 2 modes
+- [ ] Bundle delta documented
+- [ ] Snapshot baselines updated
+- [ ] Keyboard nav manually verified
+- [ ] Session memory updated with `ConnectionChip` pattern
+
+---
+
+## 12. Risks and mitigations
+
+| Risk                                                              | Mitigation                                                       |
+|-------------------------------------------------------------------|------------------------------------------------------------------|
+| Consumer outside `MeepleCard` imports `tokens.entityIcon` emoji   | Step 1 grep sweep; keep emoji export deprecated until Step 3     |
+| Dark mode color shifts fail contrast                              | `validate-contrast.ts` is CI-gated; adjust lightness per entity  |
+| `AgentCharacterSheet` loading regression                          | `ConnectionChip.loading` prop is drop-in on existing `docsLoading \|\| threadsLoading` gate |
+| Bundle size grows beyond baseline                                 | CI enforces +5 KB limit; tree-shakeable Lucide imports           |
+| Snapshot churn delays migration PRs                               | Snapshots regenerated in Step 2 PRs per bounded area, not bulk   |
+| Users still have legacy muscle memory for `status` enum           | Step 1 keeps `status` working with adapter + console.warn        |
+
+---
+
+## 13. Open questions
+
+None after user review of sections 1–5 + extended sections 4.1–4.3 (all approved).
+
+---
+
+## 14. Next steps
+
+1. User reviews this spec.
+2. On approval, invoke `writing-plans` skill to produce an implementation plan matching the three-step rollout in §10.3.


### PR DESCRIPTION
## Summary

Refactor del componente **MeepleCard** per unificare `ManaPips` (pallini colorati) + `NavFooterItem` (icone Lucide) in un singolo `ConnectionChip`, e consolidare il tipo a 12 valori `CardStatus` su due assi ortogonali (`OwnershipBadge` + `LifecycleState`).

- **`ConnectionChip`** — chip unificato count+icon con varianti `sm|md`, stato vuoto (dashed + `onCreate`), badge count con `99+` overflow, popover Radix con item list.
- **`ConnectionChipStrip`** — container layout con varianti `footer` (md + labels, border-top) e `inline` (sm, no labels).
- **`ConnectionChipPopover`** — popover Radix con header entity-colored, item list `next/link`, pulsante create con auto-close.
- **`OwnershipBadge`** — CheckCircle2 / Heart / Archive, colori dedicati.
- **`LifecycleStateBadge`** — dot con `animate-pulse` (active/idle) + icon (completed/setup/processing/failed).
- **`entityTokens()`** — helper derivato HSL: `{solid, fill, border, hover, glow, shadow, muted, dashed, textOn}`.
- **`entity-icons` registry** — Lucide unificata per tutti i 9 `MeepleEntityType`.
- **`status-adapter`** — `mapLegacyStatus(CardStatus)` + `resolveStatus({ownership, lifecycle, legacyStatus})` per migrazione graduale.

Spec: `docs/superpowers/specs/2026-04-23-meeplecard-connectionchip-spec.md`
Plan: `docs/superpowers/plans/2026-04-23-meeplecard-connectionchip-plan.md`

## Test plan

- [x] Test `ConnectionChipPopover` (5 tests)
- [x] Test `ConnectionChip` (12 tests)
- [x] Test `ConnectionChipStrip` (4 tests)
- [x] Test `OwnershipBadge` (3 tests)
- [x] Test `LifecycleStateBadge` (8 tests)
- [x] Test `status-adapter` (10 tests)
- [x] Test `entityTokens` (5 tests)
- [x] Full meeple-card suite: **137/137 pass**
- [x] TypeScript typecheck: clean
- [x] Lint: 0 errors, no new warnings
- [ ] Integrazione in `MeepleCard` (pianificata in PR successiva — questa PR aggiunge solo i primitives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)