### PR TITLE
fix(connectionchip): resolve a11y + semantic findings (#543)

### DIFF
--- a/apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChip.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChip.tsx
@@ -161,16 +161,11 @@ export function ConnectionChip({
   }`;
   const rootStyle = { ['--tw-ring-color' as string]: tokens.solid } as CSSProperties;
 
-  // Render as <Link> when href is provided and there's no popover to open.
-  if (href && !hasItems && !disabled) {
+  // Render as <Link> when href is provided, no popover, no create handler, and not disabled.
+  // onCreate has precedence over href: when count=0 with onCreate, we render a button to invoke create.
+  if (href && !hasItems && !hasCreate && !disabled) {
     return (
-      <Link
-        href={href}
-        aria-label={ariaLabel}
-        onClick={hasCreate ? () => onCreate?.() : undefined}
-        className={rootClassName}
-        style={rootStyle}
-      >
+      <Link href={href} aria-label={ariaLabel} className={rootClassName} style={rootStyle}>
         {chipInner}
         {labelEl}
       </Link>

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChip.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChip.tsx
@@ -20,6 +20,11 @@ function formatCount(count: number): string {
   return count > 99 ? '99+' : String(count);
 }
 
+function formatCountForLabel(count: number, label: string): string {
+  if (count > 99) return `99 or more ${label}`;
+  return `${count} ${label}`;
+}
+
 export function ConnectionChip({
   entityType,
   count = 0,
@@ -146,7 +151,7 @@ export function ConnectionChip({
   };
 
   const ariaLabel = hasCount
-    ? `${count} ${labelEffective}`
+    ? formatCountForLabel(count, labelEffective)
     : hasCreate
       ? (createLabel ?? `Aggiungi ${labelEffective}`)
       : labelEffective;

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChipPopover.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChipPopover.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type ReactNode } from 'react';
+import { useId, type ReactNode } from 'react';
 
 import { Plus } from 'lucide-react';
 import Link from 'next/link';
@@ -35,6 +35,7 @@ export function ConnectionChipPopover({
   const tokens = entityTokens(entityType);
   const Icon = entityIcons[entityType];
   const label = entityLabel[entityType];
+  const headerId = useId();
 
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
@@ -43,6 +44,7 @@ export function ConnectionChipPopover({
       <PopoverContent
         align="start"
         sideOffset={6}
+        aria-labelledby={headerId}
         className="w-56 p-0 overflow-hidden"
         style={{
           border: `1px solid ${tokens.border}`,
@@ -50,6 +52,7 @@ export function ConnectionChipPopover({
         }}
       >
         <div
+          id={headerId}
           className="flex items-center gap-2 border-b px-3 py-2 text-xs font-semibold uppercase tracking-wide"
           style={{ borderColor: tokens.border, color: tokens.solid }}
         >

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx
@@ -98,4 +98,25 @@ describe('ConnectionChip', () => {
     expect(btn.getAttribute('aria-label')).toMatch(/99 or more/i);
     expect(btn.getAttribute('aria-label')).not.toMatch(/150/);
   });
+
+  it('does NOT render as Link when hasCreate is true and href is provided (even with count 0)', () => {
+    const onCreate = vi.fn();
+    render(<ConnectionChip entityType="player" count={0} href="/players" onCreate={onCreate} />);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('invokes onCreate when clicked with href + count 0 + onCreate', async () => {
+    const onCreate = vi.fn();
+    render(<ConnectionChip entityType="player" count={0} href="/players" onCreate={onCreate} />);
+    await userEvent.click(screen.getByRole('button'));
+    expect(onCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders as disabled button when href is provided and disabled is true', () => {
+    render(<ConnectionChip entityType="kb" count={0} href="/kb/123" disabled />);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    const btn = screen.getByRole('button');
+    expect(btn).toBeDisabled();
+  });
 });

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx
@@ -92,6 +92,13 @@ describe('ConnectionChip', () => {
     expect(link.getAttribute('aria-label')).toMatch(/3/);
   });
 
+  it('renders as Link when count > 0 and href provided but no items preloaded', () => {
+    render(<ConnectionChip entityType="session" count={3} href="/sessions" />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/sessions');
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
   it('uses "99 or more" in aria-label when count exceeds 99', () => {
     render(<ConnectionChip entityType="session" count={150} />);
     const btn = screen.getByRole('button');

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx
@@ -91,4 +91,11 @@ describe('ConnectionChip', () => {
     expect(link).toHaveAttribute('href', '/kb/123');
     expect(link.getAttribute('aria-label')).toMatch(/3/);
   });
+
+  it('uses "99 or more" in aria-label when count exceeds 99', () => {
+    render(<ConnectionChip entityType="session" count={150} />);
+    const btn = screen.getByRole('button');
+    expect(btn.getAttribute('aria-label')).toMatch(/99 or more/i);
+    expect(btn.getAttribute('aria-label')).not.toMatch(/150/);
+  });
 });

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChipPopover.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChipPopover.test.tsx
@@ -80,4 +80,38 @@ describe('ConnectionChipPopover', () => {
     // Radix Popover renders content in a Portal; query the full document.
     expect(document.querySelector('svg')).toBeTruthy();
   });
+
+  it('PopoverContent has aria-labelledby pointing to the header title', () => {
+    render(
+      <ConnectionChipPopover open onOpenChange={() => {}} items={items} entityType="session">
+        <button>trigger</button>
+      </ConnectionChipPopover>
+    );
+    // Radix Popover renders content in a Portal. The Content element exposes role="dialog";
+    // fallback strategy: cerca per role, se null fallback sul wrapper Radix data attribute.
+    const content =
+      document.querySelector('[role="dialog"]') ??
+      document.querySelector('[data-radix-popper-content-wrapper] > *');
+    expect(content).toBeTruthy();
+
+    const labelledBy = content?.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+
+    const header = document.getElementById(labelledBy!);
+    expect(header).toBeTruthy();
+    // Header mostra "Session (N)" — il testo include l'entity label
+    expect(header?.textContent?.toLowerCase()).toMatch(/session/);
+  });
+
+  it('pressing Escape closes the popover', async () => {
+    const onOpenChange = vi.fn();
+    render(
+      <ConnectionChipPopover open onOpenChange={onOpenChange} items={items} entityType="session">
+        <button>trigger</button>
+      </ConnectionChipPopover>
+    );
+    // Radix ascolta Escape a livello document; il focus non deve essere forzato dentro il popover.
+    await userEvent.keyboard('{Escape}');
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
 });

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChipPopover.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChipPopover.test.tsx
@@ -87,11 +87,8 @@ describe('ConnectionChipPopover', () => {
         <button>trigger</button>
       </ConnectionChipPopover>
     );
-    // Radix Popover renders content in a Portal. The Content element exposes role="dialog";
-    // fallback strategy: cerca per role, se null fallback sul wrapper Radix data attribute.
-    const content =
-      document.querySelector('[role="dialog"]') ??
-      document.querySelector('[data-radix-popper-content-wrapper] > *');
+    // Radix Popover renders content in a Portal. PopoverContent exposes role="dialog" by default.
+    const content = document.querySelector('[role="dialog"]');
     expect(content).toBeTruthy();
 
     const labelledBy = content?.getAttribute('aria-labelledby');

--- a/docs/superpowers/plans/2026-04-23-connectionchip-a11y-fixes-plan.md
+++ b/docs/superpowers/plans/2026-04-23-connectionchip-a11y-fixes-plan.md
@@ -1,0 +1,443 @@
+# ConnectionChip a11y + semantic fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Risolvere 5 findings dal code review di PR #542 (issue #543): Critical `href+onCreate` double-trigger, WCAG 1.3.3 `aria-label` vs `99+`, PopoverContent senza nome accessibile, test gaps per `href+disabled` e keyboard nav.
+
+**Architecture:** 3 task TDD stretti in sequenza: (1) helper `formatCountForLabel` + aria-label match visuale, (2) branching `onCreate` precede `href`, (3) `useId()` + `aria-labelledby` su `PopoverContent`. Ogni task: test rosso → impl minima → verde → commit.
+
+**Tech Stack:** Next.js 16 + React 19 (useId), Radix Popover, Vitest + Testing Library, TypeScript.
+
+**Spec**: `docs/superpowers/specs/2026-04-23-connectionchip-a11y-fixes-design.md`
+**Branch**: `feature/issue-543-connectionchip-a11y-fixes` (da `main-dev`)
+**Target PR**: `main-dev`
+
+---
+
+## File structure
+
+| File | Azione | Responsabilità |
+|------|--------|----------------|
+| `apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChip.tsx` | Modify | Helper `formatCountForLabel` + branching `hasCreate` precede href |
+| `apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChipPopover.tsx` | Modify | `useId()` per headerId + `aria-labelledby` su `PopoverContent` |
+| `apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx` | Modify | +3 test: aria-label 99+, button-not-Link quando hasCreate+href+count=0, disabled+href |
+| `apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChipPopover.test.tsx` | Modify | +2 test: aria-labelledby wiring, Escape chiude + focus return |
+
+**Regressione**: 137 test esistenti di `meeple-card/` devono restare verdi.
+
+---
+
+## Working directory & test commands
+
+**CRITICAL**: tutti i comandi `pnpm` vanno eseguiti da `apps/web`. `cd` non persiste tra chiamate Bash — usa percorsi assoluti.
+
+```bash
+# Test singolo file
+cd D:/Repositories/meepleai-monorepo-frontend/apps/web && pnpm vitest run src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx
+
+# Test intera suite meeple-card (regression guard)
+cd D:/Repositories/meepleai-monorepo-frontend/apps/web && pnpm vitest run src/components/ui/data-display/meeple-card/
+```
+
+**Lint-staged pattern**: prettier riformatterà i file al commit (double quotes, rimuove blank line tra import group). Pass.
+
+---
+
+## Task 1: Helper `formatCountForLabel` + aria-label match visuale
+
+**Findings risolti**: Important #2 (WCAG 1.3.3)
+
+**Files:**
+- Modify: `apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChip.tsx:19-21, 148-152`
+- Test: `apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx`
+
+### - [ ] Step 1: Scrivere il test rosso per `count > 99`
+
+Aggiungere in `ConnectionChip.test.tsx` dentro `describe('ConnectionChip', () => { ... })`, dopo il test `has aria-label including count and entity label` (riga ~87):
+
+```tsx
+it('uses "99 or more" in aria-label when count exceeds 99', () => {
+  render(<ConnectionChip entityType="session" count={150} />);
+  const btn = screen.getByRole('button');
+  expect(btn.getAttribute('aria-label')).toMatch(/99 or more/i);
+  expect(btn.getAttribute('aria-label')).not.toMatch(/150/);
+});
+```
+
+### - [ ] Step 2: Far fallire il test
+
+Run:
+```bash
+cd D:/Repositories/meepleai-monorepo-frontend/apps/web && pnpm vitest run src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx -t "99 or more"
+```
+
+Expected: FAIL — aria-label contiene `"150 sessions"`, non `"99 or more sessions"`.
+
+### - [ ] Step 3: Aggiungere helper `formatCountForLabel`
+
+In `ConnectionChip.tsx`, subito dopo `formatCount` (riga 19-21), aggiungere:
+
+```ts
+function formatCountForLabel(count: number, label: string): string {
+  if (count > 99) return `99 or more ${label}`;
+  return `${count} ${label}`;
+}
+```
+
+### - [ ] Step 4: Usare helper nell'aria-label
+
+In `ConnectionChip.tsx`, sostituire le righe 148-152:
+
+```tsx
+const ariaLabel = hasCount
+  ? `${count} ${labelEffective}`
+  : hasCreate
+    ? (createLabel ?? `Aggiungi ${labelEffective}`)
+    : labelEffective;
+```
+
+con:
+
+```tsx
+const ariaLabel = hasCount
+  ? formatCountForLabel(count, labelEffective)
+  : hasCreate
+    ? (createLabel ?? `Aggiungi ${labelEffective}`)
+    : labelEffective;
+```
+
+### - [ ] Step 5: Far passare il test e verificare nessuna regressione
+
+Run:
+```bash
+cd D:/Repositories/meepleai-monorepo-frontend/apps/web && pnpm vitest run src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx
+```
+
+Expected: tutti i test ConnectionChip pass (esistenti 14 + 1 nuovo = 15 pass).
+
+### - [ ] Step 6: Commit
+
+```bash
+git add apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChip.tsx apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx
+git commit -m "fix(connectionchip): match aria-label to visual for count > 99 (#543)
+
+WCAG 2.1 SC 1.3.3 — screen reader now announces '99 or more {label}'
+when the badge displays '99+', matching sensory characteristics.
+
+Co-Authored-By: Claude Opus 4 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Branching — `onCreate` precede `href` + test `href + disabled`
+
+**Findings risolti**: Critical #1, Test gap #4
+
+**Files:**
+- Modify: `apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChip.tsx:159-173`
+- Test: `apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx`
+
+### - [ ] Step 1: Scrivere i test rossi per branching
+
+Aggiungere in `ConnectionChip.test.tsx` dopo il test `renders as a link when href is provided and no items/popover` (riga ~93):
+
+```tsx
+it('renders as button (not Link) when hasCreate is true and count is 0 even if href is provided', async () => {
+  const onCreate = vi.fn();
+  render(<ConnectionChip entityType="player" count={0} href="/players" onCreate={onCreate} />);
+  expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  const btn = screen.getByRole('button');
+  await userEvent.click(btn);
+  expect(onCreate).toHaveBeenCalledTimes(1);
+});
+
+it('renders as disabled button when href is provided and disabled is true', () => {
+  render(<ConnectionChip entityType="kb" count={0} href="/kb/123" disabled />);
+  expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  const btn = screen.getByRole('button');
+  expect(btn).toBeDisabled();
+});
+```
+
+### - [ ] Step 2: Far fallire i test
+
+Run:
+```bash
+cd D:/Repositories/meepleai-monorepo-frontend/apps/web && pnpm vitest run src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx -t "renders as button|renders as disabled button"
+```
+
+Expected: FAIL — primo test: Link renderizzato invece di button (e onCreate non chiamato). Secondo test: PASS già (disabled guard esiste), ma deve continuare a passare.
+
+### - [ ] Step 3: Aggiornare branching per far vincere `onCreate`
+
+In `ConnectionChip.tsx`, riga 160, sostituire:
+
+```tsx
+// Render as <Link> when href is provided and there's no popover to open.
+if (href && !hasItems && !disabled) {
+  return (
+    <Link
+      href={href}
+      aria-label={ariaLabel}
+      onClick={hasCreate ? () => onCreate?.() : undefined}
+      className={rootClassName}
+      style={rootStyle}
+    >
+      {chipInner}
+      {labelEl}
+    </Link>
+  );
+}
+```
+
+con:
+
+```tsx
+// Render as <Link> when href is provided, no popover, no create handler, and not disabled.
+// onCreate has precedence over href: when count=0 with onCreate, we render a button to invoke create.
+if (href && !hasItems && !hasCreate && !disabled) {
+  return (
+    <Link
+      href={href}
+      aria-label={ariaLabel}
+      className={rootClassName}
+      style={rootStyle}
+    >
+      {chipInner}
+      {labelEl}
+    </Link>
+  );
+}
+```
+
+Nota: rimosso `onClick={hasCreate ? () => onCreate?.() : undefined}` perché il branch ora esclude `hasCreate` — il workaround è dead code.
+
+### - [ ] Step 4: Far passare i test e verificare nessuna regressione
+
+Run:
+```bash
+cd D:/Repositories/meepleai-monorepo-frontend/apps/web && pnpm vitest run src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx
+```
+
+Expected: 17 pass (15 precedenti + 2 nuovi). Particolare attenzione al test esistente `renders as a link when href is provided and no items/popover` (riga 88): deve continuare a passare perché non passa `onCreate`.
+
+### - [ ] Step 5: Commit
+
+```bash
+git add apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChip.tsx apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx
+git commit -m "fix(connectionchip): onCreate takes precedence over href (#543)
+
+Before: href + onCreate + count=0 rendered <Link> with onClick
+fallback that did not prevent navigation (double-trigger).
+After: branch to <Link> only when hasCreate is false.
+
+Adds regression test for href + disabled combination.
+
+Co-Authored-By: Claude Opus 4 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `PopoverContent` accessibile + Escape test
+
+**Findings risolti**: Important #3, Test gap #5 (Escape + focus return)
+
+**Files:**
+- Modify: `apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChipPopover.tsx`
+- Test: `apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChipPopover.test.tsx`
+
+### - [ ] Step 1: Scrivere i test rossi per aria-labelledby e Escape
+
+Aggiungere in `ConnectionChipPopover.test.tsx` dopo l'ultimo test (`renders Lucide icon matching entity type`, riga ~83):
+
+```tsx
+it('PopoverContent has aria-labelledby pointing to the header title', () => {
+  render(
+    <ConnectionChipPopover open onOpenChange={() => {}} items={items} entityType="session">
+      <button>trigger</button>
+    </ConnectionChipPopover>
+  );
+  // Radix Popover renders content in a Portal; use document queries.
+  const content = document.querySelector('[role="dialog"]');
+  expect(content).toBeTruthy();
+  const labelledBy = content?.getAttribute('aria-labelledby');
+  expect(labelledBy).toBeTruthy();
+  const header = document.getElementById(labelledBy!);
+  expect(header).toBeTruthy();
+  expect(header?.textContent).toMatch(/session/i);
+});
+
+it('pressing Escape closes the popover', async () => {
+  const onOpenChange = vi.fn();
+  render(
+    <ConnectionChipPopover open onOpenChange={onOpenChange} items={items} entityType="session">
+      <button>trigger</button>
+    </ConnectionChipPopover>
+  );
+  await userEvent.keyboard('{Escape}');
+  expect(onOpenChange).toHaveBeenCalledWith(false);
+});
+```
+
+### - [ ] Step 2: Far fallire il test aria-labelledby
+
+Run:
+```bash
+cd D:/Repositories/meepleai-monorepo-frontend/apps/web && pnpm vitest run src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChipPopover.test.tsx -t "aria-labelledby"
+```
+
+Expected: FAIL — `PopoverContent` non ha `aria-labelledby`.
+
+Il test Escape dovrebbe già passare (Radix lo gestisce nativamente), ma fa parte del gap da colmare.
+
+### - [ ] Step 3: Importare `useId` e applicare `aria-labelledby`
+
+In `ConnectionChipPopover.tsx`, modificare l'import React a riga 3:
+
+```tsx
+import { useId, type ReactNode } from 'react';
+```
+
+Nella funzione `ConnectionChipPopover`, dopo `const label = entityLabel[entityType];` (riga 37), aggiungere:
+
+```tsx
+const headerId = useId();
+```
+
+Aggiornare `PopoverContent` (riga 43) aggiungendo `aria-labelledby={headerId}`:
+
+```tsx
+<PopoverContent
+  align="start"
+  sideOffset={6}
+  aria-labelledby={headerId}
+  className="w-56 p-0 overflow-hidden"
+  style={{
+    border: `1px solid ${tokens.border}`,
+    background: 'var(--mc-bg-card, hsl(222 47% 11%))',
+  }}
+>
+```
+
+Aggiornare il `div` header (riga 52) aggiungendo `id={headerId}`:
+
+```tsx
+<div
+  id={headerId}
+  className="flex items-center gap-2 border-b px-3 py-2 text-xs font-semibold uppercase tracking-wide"
+  style={{ borderColor: tokens.border, color: tokens.solid }}
+>
+```
+
+### - [ ] Step 4: Far passare i test e verificare nessuna regressione
+
+Run:
+```bash
+cd D:/Repositories/meepleai-monorepo-frontend/apps/web && pnpm vitest run src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChipPopover.test.tsx
+```
+
+Expected: 7 pass (5 esistenti + 2 nuovi).
+
+### - [ ] Step 5: Regression guard — suite completa meeple-card
+
+Run:
+```bash
+cd D:/Repositories/meepleai-monorepo-frontend/apps/web && pnpm vitest run src/components/ui/data-display/meeple-card/
+```
+
+Expected: tutti i test pass. Baseline post-Task 2: 137+4 = 141 test pass attesi dopo questa PR (4 nuovi in ConnectionChip.test + 2 in ConnectionChipPopover.test — `2+2+2=6` aggiunti, però ne abbiamo aggiunti 3 in Task 1+2 e 2 in Task 3 = 5. Baseline atteso: 142).
+
+Se fallimenti di test pre-esistenti NON introdotti in questa PR compaiono, annotarli ma non bloccare — eventuale issue separata.
+
+### - [ ] Step 6: Commit
+
+```bash
+git add apps/web/src/components/ui/data-display/meeple-card/parts/ConnectionChipPopover.tsx apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChipPopover.test.tsx
+git commit -m "fix(connectionchip-popover): add accessible name via aria-labelledby (#543)
+
+useId() generates stable id for the header title; PopoverContent
+references it via aria-labelledby so screen readers announce
+the entity label when the dialog opens.
+
+Adds regression test for Escape key behavior.
+
+Co-Authored-By: Claude Opus 4 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Typecheck + push + PR
+
+### - [ ] Step 1: Typecheck complessivo
+
+Run:
+```bash
+cd D:/Repositories/meepleai-monorepo-frontend/apps/web && pnpm typecheck
+```
+
+Expected: no errors.
+
+### - [ ] Step 2: Push branch
+
+Run:
+```bash
+git push -u origin feature/issue-543-connectionchip-a11y-fixes
+```
+
+### - [ ] Step 3: Creare PR verso `main-dev`
+
+Run (da bash, HEREDOC):
+```bash
+gh pr create --base main-dev --title "fix(connectionchip): resolve a11y + semantic findings (#543)" --body "$(cat <<'EOF'
+## Summary
+
+Risolve i 5 findings del code review post-merge di PR #542 (issue #543):
+
+- **Critical**: `onCreate` ora ha precedenza su `href` quando `count=0` — niente più double-trigger
+- **Important (WCAG 1.3.3)**: `aria-label` dice "99 or more {label}" quando il badge mostra `99+`
+- **Important**: `PopoverContent` ora ha nome accessibile via `aria-labelledby` → `id` dell'header
+- **Test gap**: coperti `href + disabled` (button disabilitato, non Link) e `Escape` key (chiude popover)
+
+Blocca Step 1.6 (renderer integration in MeepleCard.tsx).
+
+## Test plan
+
+- [x] 3 nuovi test in `ConnectionChip.test.tsx` (aria-label 99+, button-not-Link con hasCreate+href, disabled+href)
+- [x] 2 nuovi test in `ConnectionChipPopover.test.tsx` (aria-labelledby wiring, Escape closes)
+- [x] Regression guard: suite meeple-card/ completa pass
+- [x] `pnpm typecheck` pass
+
+## Spec & Plan
+
+- Spec: \`docs/superpowers/specs/2026-04-23-connectionchip-a11y-fixes-design.md\`
+- Plan: \`docs/superpowers/plans/2026-04-23-connectionchip-a11y-fixes-plan.md\`
+
+Closes #543
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+**Spec coverage**:
+- §3.1 (branching `onCreate` precede `href`) → Task 2 ✓
+- §3.2 (helper `formatCountForLabel`) → Task 1 ✓
+- §3.3 (`useId` + `aria-labelledby`) → Task 3 ✓
+- §4.1 test 1 (button-not-Link hasCreate+count=0+href) → Task 2 Step 1 ✓
+- §4.1 test 2 (disabled button con href+disabled) → Task 2 Step 1 ✓
+- §4.1 test 3 (99 or more in aria-label) → Task 1 Step 1 ✓
+- §4.2 test 4 (aria-labelledby wiring) → Task 3 Step 1 ✓
+- §4.2 test 5 (Escape closes + focus return) → Task 3 Step 1 (solo Escape closes; focus return gestito da Radix, non verifichiamo esplicitamente perché in JSDOM il focus management può essere flakey) ✓
+- §4.3 Regression guard → Task 3 Step 5 ✓
+
+**Placeholder scan**: nessun TBD/TODO. Ogni step ha codice completo o comando esatto.
+
+**Type consistency**: `formatCountForLabel(count: number, label: string): string` usato coerentemente. `headerId` generato con `useId()` usato su `PopoverContent` e `div` header. Signature stabile tra task.
+
+**Scope**: ristretto a 4 file (2 src + 2 test) + 1 PR. Out of scope correttamente deferiti (renderer integration, i18n, Tab cycling).
+
+**Note su §4.2 test 5**: il design dello spec parlava di "Escape + focus return". Nel piano ho ridotto a "Escape closes" perché testare il focus return in JSDOM è instabile (Radix usa `document.activeElement` con FocusScope che in JSDOM si comporta diversamente da browser reale). Il comportamento è garantito da Radix e coperto da Playwright E2E a livello app. Documentato qui come deviazione consapevole.

--- a/docs/superpowers/plans/2026-04-23-connectionchip-a11y-fixes-plan.md
+++ b/docs/superpowers/plans/2026-04-23-connectionchip-a11y-fixes-plan.md
@@ -139,15 +139,22 @@ Co-Authored-By: Claude Opus 4 <noreply@anthropic.com>"
 
 ### - [ ] Step 1: Scrivere i test rossi per branching
 
-Aggiungere in `ConnectionChip.test.tsx` dopo il test `renders as a link when href is provided and no items/popover` (riga ~93):
+Aggiungere in `ConnectionChip.test.tsx` dopo il test `renders as a link when href is provided and no items/popover` (riga ~93).
+
+**Nota**: il primo caso è splittato in due `it()` separati per isolare la diagnostica del FAIL. Il primo verifica solo "non è un Link" (sicuramente FAIL con codice attuale perché `href+count=0+onCreate` entra nel ramo Link). Il secondo verifica il click handler (dipende dal rendering come button).
 
 ```tsx
-it('renders as button (not Link) when hasCreate is true and count is 0 even if href is provided', async () => {
+it('does NOT render as Link when hasCreate is true and href is provided (even with count 0)', () => {
   const onCreate = vi.fn();
   render(<ConnectionChip entityType="player" count={0} href="/players" onCreate={onCreate} />);
   expect(screen.queryByRole('link')).not.toBeInTheDocument();
-  const btn = screen.getByRole('button');
-  await userEvent.click(btn);
+  expect(screen.getByRole('button')).toBeInTheDocument();
+});
+
+it('invokes onCreate when clicked with href + count 0 + onCreate', async () => {
+  const onCreate = vi.fn();
+  render(<ConnectionChip entityType="player" count={0} href="/players" onCreate={onCreate} />);
+  await userEvent.click(screen.getByRole('button'));
   expect(onCreate).toHaveBeenCalledTimes(1);
 });
 
@@ -163,10 +170,13 @@ it('renders as disabled button when href is provided and disabled is true', () =
 
 Run:
 ```bash
-cd D:/Repositories/meepleai-monorepo-frontend/apps/web && pnpm vitest run src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx -t "renders as button|renders as disabled button"
+cd D:/Repositories/meepleai-monorepo-frontend/apps/web && pnpm vitest run src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx -t "does NOT render as Link|invokes onCreate when clicked|renders as disabled button"
 ```
 
-Expected: FAIL — primo test: Link renderizzato invece di button (e onCreate non chiamato). Secondo test: PASS già (disabled guard esiste), ma deve continuare a passare.
+Expected:
+- Test 1 ("does NOT render as Link"): **FAIL** — codice attuale renderizza `<Link>` perché guardia è `href && !hasItems && !disabled` senza `!hasCreate`
+- Test 2 ("invokes onCreate when clicked"): **FAIL** — l'handler `onClick` sul `<Link>` potrebbe non venir chiamato in JSDOM, o essere chiamato ma la navigation non impedita; diagnostica isolata
+- Test 3 ("renders as disabled button"): **PASS già** — `!disabled` guard esiste; continuerà a passare dopo l'impl
 
 ### - [ ] Step 3: Aggiornare branching per far vincere `onCreate`
 
@@ -219,7 +229,7 @@ Run:
 cd D:/Repositories/meepleai-monorepo-frontend/apps/web && pnpm vitest run src/components/ui/data-display/meeple-card/parts/__tests__/ConnectionChip.test.tsx
 ```
 
-Expected: 17 pass (15 precedenti + 2 nuovi). Particolare attenzione al test esistente `renders as a link when href is provided and no items/popover` (riga 88): deve continuare a passare perché non passa `onCreate`.
+Expected: 18 pass (15 precedenti + 3 nuovi). Particolare attenzione al test esistente `renders as a link when href is provided and no items/popover` (riga 88): deve continuare a passare perché non passa `onCreate`.
 
 ### - [ ] Step 5: Commit
 
@@ -257,14 +267,20 @@ it('PopoverContent has aria-labelledby pointing to the header title', () => {
       <button>trigger</button>
     </ConnectionChipPopover>
   );
-  // Radix Popover renders content in a Portal; use document queries.
-  const content = document.querySelector('[role="dialog"]');
+  // Radix Popover renders content in a Portal. The Content element exposes role="dialog";
+  // fallback strategy: cerca per role, se null fallback sul wrapper Radix data attribute.
+  const content =
+    document.querySelector('[role="dialog"]') ??
+    document.querySelector('[data-radix-popper-content-wrapper] > *');
   expect(content).toBeTruthy();
+
   const labelledBy = content?.getAttribute('aria-labelledby');
   expect(labelledBy).toBeTruthy();
+
   const header = document.getElementById(labelledBy!);
   expect(header).toBeTruthy();
-  expect(header?.textContent).toMatch(/session/i);
+  // Header mostra "Session (N)" — il testo include l'entity label
+  expect(header?.textContent?.toLowerCase()).toMatch(/session/);
 });
 
 it('pressing Escape closes the popover', async () => {
@@ -274,10 +290,13 @@ it('pressing Escape closes the popover', async () => {
       <button>trigger</button>
     </ConnectionChipPopover>
   );
+  // Radix ascolta Escape a livello document; il focus non deve essere forzato dentro il popover.
   await userEvent.keyboard('{Escape}');
   expect(onOpenChange).toHaveBeenCalledWith(false);
 });
 ```
+
+**Nota diagnostica**: se il test aria-labelledby fallisce sulla prima asserzione (`content` null), il `PopoverContent` non sta renderizzando `role="dialog"` — verificare la versione di `@radix-ui/react-popover`. Con versioni recenti (≥1.0) il role è impostato di default sul `Content`.
 
 ### - [ ] Step 2: Far fallire il test aria-labelledby
 
@@ -345,7 +364,7 @@ Run:
 cd D:/Repositories/meepleai-monorepo-frontend/apps/web && pnpm vitest run src/components/ui/data-display/meeple-card/
 ```
 
-Expected: tutti i test pass. Baseline post-Task 2: 137+4 = 141 test pass attesi dopo questa PR (4 nuovi in ConnectionChip.test + 2 in ConnectionChipPopover.test — `2+2+2=6` aggiunti, però ne abbiamo aggiunti 3 in Task 1+2 e 2 in Task 3 = 5. Baseline atteso: 142).
+Expected: tutti i test pass. Baseline: 137 precedenti + 1 (Task 1) + 3 (Task 2) + 2 (Task 3) = **143 test pass attesi**.
 
 Se fallimenti di test pre-esistenti NON introdotti in questa PR compaiono, annotarli ma non bloccare — eventuale issue separata.
 

--- a/docs/superpowers/specs/2026-04-23-connectionchip-a11y-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-23-connectionchip-a11y-fixes-design.md
@@ -1,0 +1,159 @@
+# ConnectionChip a11y + semantic fixes (Step 1.5)
+
+**Data**: 2026-04-23
+**Issue**: [#543](https://github.com/meepleAi-app/meepleai-monorepo/issues/543)
+**Parent PR**: #542 (merged in `bf372d5bc`)
+**Predecessore logico**: Step 1 (primitives creati) → **Step 1.5 = questo spec** → Step 1.6 (renderer integration)
+
+## 1. Contesto
+
+Il code review post-merge di PR #542 (MeepleCard ConnectionChip primitives) ha identificato 5 issue da risolvere prima di integrare le primitive nel renderer `MeepleCard.tsx` (Step 1.6). Queste sono **bloccanti** per l'integrazione perché riguardano semantica del componente e accessibilità.
+
+### Findings da code review (`feature-dev:code-reviewer`)
+
+**Critical**:
+1. `ConnectionChip.tsx:165` — il ramo `<Link>` renderizza `next/link` anche quando `onCreate` è set con `count=0`, creando un "double-trigger" (sia navigazione via href che callback create). Il commento in `handleActivate:138-146` dice che `onCreate` deve avere precedenza quando count=0, ma il branching non lo rispetta.
+
+**Important**:
+2. `ConnectionChip.tsx:148-152` — `aria-label` usa `count` grezzo ("150 things") ma il badge visivo mostra "99+". Viola WCAG 2.1 SC 1.3.3 (Info and Relationships) perché screen reader legge un numero diverso da quello mostrato.
+3. `ConnectionChipPopover.tsx:43-98` — `PopoverContent` di Radix non ha `aria-labelledby` né nome accessibile. Lo screen reader annuncia solo il ruolo "dialog" senza titolo.
+
+**Test gaps**:
+4. Combinazione `href + disabled` non testata. La guard `!disabled` a riga 160 evita il rendering come Link quando disabilitato, ma non c'è regression test.
+5. Popover keyboard navigation non testata: Escape chiude + focus return al trigger, Tab cycling tra items.
+
+## 2. Obiettivi
+
+- **Risolvere il Critical** allineando branching alla semantica documentata in `handleActivate`
+- **Matchare visuale e a11y label** per conformità WCAG 1.3.3
+- **Dare nome accessibile al PopoverContent** tramite `aria-labelledby`
+- **Colmare test gap** su `href + disabled` e keyboard nav del popover
+- **Zero regressioni** sui 137 test esistenti della suite `meeple-card`
+
+## 3. Design
+
+### 3.1 Semantica `ConnectionChip` — onCreate ha precedenza su href
+
+**Regola**: quando un chip ha `onCreate` set (empty state), la creazione vince sulla navigazione. Ha senso UX: se `count=0` e c'è un `onCreate`, l'utente dovrebbe creare la prima entità, non navigare a una pagina lista vuota.
+
+**Branching attuale** (problema):
+```tsx
+if (href && !hasItems && !disabled) {
+  return <Link href={href} onClick={hasCreate ? () => onCreate?.() : undefined}>...
+}
+```
+Il `onClick` sul Link è un workaround che non previene la navigazione (click default Link non viene cancellato).
+
+**Nuovo branching**:
+```tsx
+if (href && !hasItems && !hasCreate && !disabled) {
+  return <Link href={href}>...</Link>
+}
+// altrimenti fallback a <button>
+```
+
+**Conseguenze**:
+- `href + count=0 + onCreate` → `<button>` (invoca `onCreate` via `handleActivate`)
+- `href + count=0 + no onCreate` → `<Link>` (naviga, nessun create handler)
+- `href + count>0` → `<button>` con `hasItems=true` (apre popover; invariato)
+- `href + disabled` → `<button disabled>` (invariato)
+
+### 3.2 `aria-label` matcha il visuale — helper `formatCountForLabel`
+
+**Regola**: il testo annunciato dallo screen reader deve riflettere ciò che l'utente vede. Badge mostra `99+` per `count > 99`, quindi label deve dire "99 or more".
+
+**Helper puro** (in `ConnectionChip.tsx`, top-level):
+```ts
+function formatCountForLabel(count: number, label: string): string {
+  if (count > 99) return `99 or more ${label}`;
+  return `${count} ${label}`;
+}
+```
+
+Usato al posto del template string inline a riga 148-152. Nessuna i18n: stringa hard-coded inglese coerente con il resto del componente.
+
+### 3.3 `PopoverContent` accessibile — `aria-labelledby`
+
+**In `ConnectionChipPopover.tsx`**:
+
+1. Generare id stabile con `useId()`:
+   ```tsx
+   const headerId = useId();
+   ```
+2. Applicare al div header (riga ~52):
+   ```tsx
+   <div id={headerId} className="...">
+     <h3>{title}</h3>
+   </div>
+   ```
+3. Passare a `PopoverContent`:
+   ```tsx
+   <PopoverContent aria-labelledby={headerId}>
+   ```
+
+**Risultato**: screen reader annuncia "dialog, {title}" quando il popover apre.
+
+## 4. Test plan (TDD)
+
+**Approccio**: scrivere i test **prima** delle modifiche, verificare che falliscano, poi implementare.
+
+### 4.1 Nuovi test in `ConnectionChip.test.tsx`
+
+1. **`renders as button (not Link) when hasCreate is true and count is 0`**
+   Props: `href="/x" count={0} onCreate={fn}`
+   Asserzione: `queryByRole('link')` è null, `getByRole('button')` esiste
+   Verifica anche che click invochi `onCreate` (non navighi).
+
+2. **`renders as disabled button when href is provided and disabled is true`**
+   Props: `href="/x" disabled count={0}`
+   Asserzione: `queryByRole('link')` null, `getByRole('button').disabled === true`
+
+3. **`uses "99 or more" in aria-label when count exceeds 99`**
+   Props: `count={150} label="items"`
+   Asserzione: `getByRole('button')` ha `aria-label` matching `/99 or more items/`
+   Snapshot comportamento esistente per `count <= 99` in un secondo test.
+
+### 4.2 Nuovi test in `ConnectionChipPopover.test.tsx`
+
+4. **`PopoverContent has aria-labelledby pointing to header title`**
+   Apri popover (trigger click).
+   Query popover content via `document.querySelector` (Radix Portal).
+   Asserzione: `content.getAttribute('aria-labelledby')` === id del div header.
+
+5. **`pressing Escape closes popover and returns focus to trigger`**
+   Apri popover, `fireEvent.keyDown(document.activeElement, { key: 'Escape' })`.
+   Asserzione: popover unmounted, `document.activeElement === trigger`.
+
+### 4.3 Regression guard
+
+- Eseguire `pnpm vitest run apps/web/src/components/ui/data-display/meeple-card/` prima del merge
+- **Baseline**: 137/137 pass (da PR #542)
+- Eventuali fallimenti di test esistenti segnalano regressione → block merge
+
+## 5. Scope & Out of scope
+
+**In scope**:
+- 3 modifiche a `ConnectionChip.tsx` (branching + helper + uso helper)
+- 2 modifiche a `ConnectionChipPopover.tsx` (useId + labelledby)
+- 3 nuovi test in `ConnectionChip.test.tsx`
+- 2 nuovi test in `ConnectionChipPopover.test.tsx`
+
+**Out of scope** (deferiti):
+- Integrazione primitives in `MeepleCard.tsx` → Step 1.6
+- Tab cycling test (gestito nativamente da Radix, non serve test custom)
+- i18n delle stringhe "99 or more" → quando si introduce i18n globale
+- Migrazione consumer legacy → Step 2
+
+## 6. Rollout
+
+**Branch**: `feature/issue-543-connectionchip-a11y-fixes` (da `main-dev`)
+**Target PR**: `main-dev`
+**Effort stimato**: ~1 giorno (TDD stretto, scope ristretto)
+**Blocca**: Step 1.6 (non procedere a integrazione renderer finché #543 chiuso)
+
+## 7. Riferimenti
+
+- Code review: PR #542 comments (via `feature-dev:code-reviewer`)
+- WCAG 2.1 SC 1.3.3: https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships
+- Radix Popover docs: https://www.radix-ui.com/primitives/docs/components/popover
+- Spec parent: `docs/superpowers/specs/2026-04-23-meeplecard-connectionchip-design.md`


### PR DESCRIPTION
## Summary

Follow-up to PR #542 — risolve i 5 finding di code review tracciati in issue #543:

- **Critical**: `href + onCreate` ora dà precedenza a `onCreate` → render come `<button>` invece di `<Link>` (doppio-trigger rimosso).
- **Important (a11y)**: `aria-label` ora usa "99 or more {label}" quando `count > 99`, coerente con il badge visivo `99+` (WCAG 1.3.3).
- **Important (a11y)**: `PopoverContent` ha `aria-labelledby` che punta al titolo di intestazione — screen reader annunciano l'entità quando il dialog si apre.
- **Test gap**: aggiunti test per `href + onCreate`, `href + disabled`, e navigazione keyboard (Escape chiude il popover).

Riferimenti:
- Spec: \`docs/superpowers/specs/2026-04-23-connectionchip-a11y-fixes-spec.md\`
- Plan: \`docs/superpowers/plans/2026-04-23-connectionchip-a11y-fixes-plan.md\`

## Changes

| File | Change |
|------|--------|
| \`ConnectionChip.tsx\` | \`formatCountForLabel\` helper; branching \`href && !hasItems && !hasCreate && !disabled\` |
| \`ConnectionChipPopover.tsx\` | \`useId()\` + \`aria-labelledby\` su PopoverContent + \`id\` su header |
| \`__tests__/ConnectionChip.test.tsx\` | +4 test (99+, href+onCreate x2, href+disabled) |
| \`__tests__/ConnectionChipPopover.test.tsx\` | +2 test (aria-labelledby, Escape) |

## Test plan

- [x] \`pnpm vitest run src/components/ui/data-display/meeple-card/\` → **144/144 pass**
- [x] \`pnpm typecheck\` → OK (via pre-commit hook)
- [x] Lint-staged auto-format applicato
- [ ] Review manuale screen-reader (opzionale, coperto da test unit)

Closes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)