### PR TITLE
fix(mechanic-extractor): guard NaN override cap + reset suppress reason on cancel

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx
@@ -265,11 +265,13 @@ export default function MechanicAnalysesPage() {
 
   const canSuppress = !!status && !status.isSuppressed;
 
+  const parsedOverrideCap = Number.parseFloat(overrideCapUsd);
+  const isOverrideCapValid = Number.isFinite(parsedOverrideCap) && parsedOverrideCap > 0;
   const canGenerate =
     !!selectedGameId &&
     !!selectedPdfId &&
     costCapUsd !== '' &&
-    (!overrideEnabled || (!!overrideReason && overrideReason.length >= 20)) &&
+    (!overrideEnabled || (isOverrideCapValid && !!overrideReason && overrideReason.length >= 20)) &&
     !generateMutation.isPending;
 
   return (
@@ -655,7 +657,15 @@ export default function MechanicAnalysesPage() {
       )}
 
       {/* Suppress dialog */}
-      <AlertDialog open={suppressOpen} onOpenChange={setSuppressOpen}>
+      <AlertDialog
+        open={suppressOpen}
+        onOpenChange={open => {
+          setSuppressOpen(open);
+          if (!open) {
+            setSuppressReason('');
+          }
+        }}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Suppress this analysis?</AlertDialogTitle>


### PR DESCRIPTION
## Summary
Follow-up fixes to PR #547 (ISSUE-524 / M1.2 async pipeline admin UI).

Addresses two review findings scored 75 (below the `/code-review:code-review` auto-comment cutoff of 80) but independently verified as real:

- **`canGenerate` NaN guard** — when `overrideEnabled=true` with an empty/non-positive `overrideCapUsd`, the form could POST `Number.parseFloat('') = NaN` to `POST /api/v1/admin/mechanic-analyses`. Now guarded with `Number.isFinite(parsedOverrideCap) && parsedOverrideCap > 0`.
- **Suppress dialog reason reset** — closing the AlertDialog via Cancel / overlay / Escape left `suppressReason` populated, showing stale text on reopen. Now reset inside `onOpenChange(open => …)` when `open` becomes `false`.

## Test plan
- [x] `pnpm typecheck` clean
- [x] All 16 existing Vitest cases still pass (`page.test.tsx`)
- [ ] Manual smoke: open the analyses page, toggle override with empty cap → Generate button stays disabled; open suppress dialog → type reason → Cancel → reopen → reason empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)