### PR TITLE
refactor(chat): extract useThreadMessages hook (Phase 1)

### DIFF
--- a/apps/web/src/components/chat-unified/ChatMessageList.tsx
+++ b/apps/web/src/components/chat-unified/ChatMessageList.tsx
@@ -40,7 +40,7 @@ import { toChatMessageProps } from './utils/toChatMessageProps';
 export type { ChatMessageItem, StreamStateForMessages };
 
 export interface ChatMessageListProps {
-  messages: ChatMessageItem[];
+  messages: ReadonlyArray<ChatMessageItem>;
   streamState: StreamStateForMessages;
   isEditor: boolean;
   isAdmin: boolean;

--- a/apps/web/src/components/chat-unified/ChatThreadView.tsx
+++ b/apps/web/src/components/chat-unified/ChatThreadView.tsx
@@ -165,7 +165,12 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
         timestamp: new Date().toISOString(),
         followUpQuestions: metadata.followUpQuestions,
       };
-      setMessages(prev => [...prev, assistantMessage]);
+      setMessages(prev => {
+        const next = [...prev, assistantMessage];
+        // Phase 1 Task 4 — dual-write: mirror SSE-complete append into useThreadMessages.
+        replaceMessagesInHook(next);
+        return next;
+      });
       // TTS: auto-speak response when last message was voice-initiated
       if (voicePrefs.ttsEnabled && lastMessageWasVoiceRef.current) {
         speak(answer);
@@ -340,7 +345,12 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
         content: messageContent,
         timestamp: new Date().toISOString(),
       };
-      setMessages(prev => [...prev, userMessage]);
+      setMessages(prev => {
+        const next = [...prev, userMessage];
+        // Phase 1 Task 4 — dual-write: mirror optimistic user append into useThreadMessages.
+        replaceMessagesInHook(next);
+        return next;
+      });
 
       // QA stream path: game context available → use RAG QA streaming (#415)
       // Priority: gameId check FIRST because POST /agents/{id}/chat does not exist
@@ -522,21 +532,27 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
         });
 
         if (response?.messages) {
-          setMessages(
-            response.messages.map(
-              (m): ChatMessageItem => ({
-                id: m.backendMessageId ?? `msg-${Date.now()}-${Math.random()}`,
-                role: m.role as 'user' | 'assistant',
-                content: m.content,
-                timestamp: m.timestamp,
-              })
-            )
+          const mapped: ChatMessageItem[] = response.messages.map(
+            (m): ChatMessageItem => ({
+              id: m.backendMessageId ?? `msg-${Date.now()}-${Math.random()}`,
+              role: m.role as 'user' | 'assistant',
+              content: m.content,
+              timestamp: m.timestamp,
+            })
           );
+          setMessages(mapped);
+          // Phase 1 Task 4 — dual-write: mirror REST-fallback list replace into useThreadMessages.
+          replaceMessagesInHook(mapped);
         }
       } catch {
         setError("Errore nell'invio del messaggio");
         // Remove optimistic message on error
-        setMessages(prev => prev.filter(m => m.id !== userMessage.id));
+        setMessages(prev => {
+          const next = prev.filter(m => m.id !== userMessage.id);
+          // Phase 1 Task 4 — dual-write: mirror optimistic rollback into useThreadMessages.
+          replaceMessagesInHook(next);
+          return next;
+        });
       } finally {
         setIsSending(false);
       }
@@ -552,6 +568,7 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
       sendViaSSE,
       voicePrefs.ttsEnabled,
       speak,
+      replaceMessagesInHook,
     ]
   );
 

--- a/apps/web/src/components/chat-unified/ChatThreadView.tsx
+++ b/apps/web/src/components/chat-unified/ChatThreadView.tsx
@@ -22,7 +22,12 @@ import { useRouter } from 'next/navigation';
 import { AgentSelector, type AgentType, AGENT_NAMES } from '@/components/agent/AgentSelector';
 import { AgentSettingsDrawer } from '@/components/agent/settings';
 import { useAuth } from '@/components/auth/AuthProvider';
-import { collectCitations, getSuggestedQuestions, useChatScroll } from '@/components/chat/shared';
+import {
+  collectCitations,
+  getSuggestedQuestions,
+  useChatScroll,
+  useThreadMessages,
+} from '@/components/chat/shared';
 import { PageViewerPanel } from '@/components/chat/viewer/PageViewerPanel';
 import { buildWelcomeMessage, getWelcomeFollowUpQuestions } from '@/config/agent-welcome';
 import { useAgentChatStream, type ProxyGameContext } from '@/hooks/useAgentChatStream';
@@ -80,6 +85,11 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
   // State
   const [thread, setThread] = useState<ThreadData | null>(null);
   const [messages, setMessages] = useState<ChatMessageItem[]>([]);
+
+  // Phase 1 Strangler Fig — hook mirrors local state during migration.
+  // Tasks 3-6 dual-write to both sources; Task 7 removes the local useState.
+  // Plan: docs/superpowers/plans/2026-04-24-chat-thread-state-hook.md
+  const { replaceMessages: replaceMessagesInHook } = useThreadMessages();
   const [inputValue, setInputValue] = useState('');
   const [isLoading, setIsLoading] = useState(true);
   const [isSending, setIsSending] = useState(false);
@@ -253,8 +263,12 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
             followUpQuestions: followUps,
           };
           setMessages([welcomeMessage]);
+          // Phase 1 Task 3 — dual-write: mirror hydration into useThreadMessages.
+          replaceMessagesInHook([welcomeMessage]);
         } else {
           setMessages(mappedMessages);
+          // Phase 1 Task 3 — dual-write: mirror hydration into useThreadMessages.
+          replaceMessagesInHook(mappedMessages);
         }
       } catch {
         setError('Errore nel caricamento della conversazione');
@@ -264,7 +278,7 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
     }
 
     void loadThread();
-  }, [threadId]);
+  }, [threadId, replaceMessagesInHook]);
 
   // Handle continuation — append more content to the last assistant message
   const handleContinue = useCallback(

--- a/apps/web/src/components/chat-unified/ChatThreadView.tsx
+++ b/apps/web/src/components/chat-unified/ChatThreadView.tsx
@@ -84,12 +84,19 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
 
   // State
   const [thread, setThread] = useState<ThreadData | null>(null);
-  const [messages, setMessages] = useState<ChatMessageItem[]>([]);
 
-  // Phase 1 Strangler Fig — hook mirrors local state during migration.
-  // Tasks 3-6 dual-write to both sources; Task 7 removes the local useState.
+  // Phase 1 Strangler Fig (Task 7 flip) — useThreadMessages is now the sole
+  // source of truth for the message list + AbortController lifecycle.
   // Plan: docs/superpowers/plans/2026-04-24-chat-thread-state-hook.md
-  const { replaceMessages: replaceMessagesInHook } = useThreadMessages();
+  const {
+    messages,
+    replaceMessages: replaceMessagesInHook,
+    appendMessage,
+    patchMessageById,
+    removeMessageById,
+    abortCurrent,
+    beginAbort,
+  } = useThreadMessages();
   const [inputValue, setInputValue] = useState('');
   const [isLoading, setIsLoading] = useState(true);
   const [isSending, setIsSending] = useState(false);
@@ -112,7 +119,6 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
   const voicePrefs = useVoicePreferencesStore();
   const lastMessageWasVoiceRef = useRef(false);
   const handleSendRef = useRef<((content?: string) => void) | undefined>(undefined);
-  const qaAbortRef = useRef<AbortController | null>(null);
 
   const {
     state: voiceState,
@@ -165,12 +171,7 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
         timestamp: new Date().toISOString(),
         followUpQuestions: metadata.followUpQuestions,
       };
-      setMessages(prev => {
-        const next = [...prev, assistantMessage];
-        // Phase 1 Task 4 — dual-write: mirror SSE-complete append into useThreadMessages.
-        replaceMessagesInHook(next);
-        return next;
-      });
+      appendMessage(assistantMessage);
       // TTS: auto-speak response when last message was voice-initiated
       if (voicePrefs.ttsEnabled && lastMessageWasVoiceRef.current) {
         speak(answer);
@@ -196,16 +197,13 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
     streamState.currentAnswer,
   ]);
 
-  // Abort QA stream on unmount
-  useEffect(
-    () => () => {
-      qaAbortRef.current?.abort();
-    },
-    []
-  );
-
   // Load thread data
+  // NOTE: useThreadMessages owns the unmount cleanup for the in-flight stream.
+  // When threadId changes we ALSO abort synchronously at the top of the effect
+  // so switching threads never leaks a partial stream onto the new thread
+  // (invariant: tests/ChatThreadView.invariants.test.tsx).
   useEffect(() => {
+    abortCurrent();
     async function loadThread() {
       setIsLoading(true);
       setError(null);
@@ -267,12 +265,8 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
             timestamp: new Date().toISOString(),
             followUpQuestions: followUps,
           };
-          setMessages([welcomeMessage]);
-          // Phase 1 Task 3 — dual-write: mirror hydration into useThreadMessages.
           replaceMessagesInHook([welcomeMessage]);
         } else {
-          setMessages(mappedMessages);
-          // Phase 1 Task 3 — dual-write: mirror hydration into useThreadMessages.
           replaceMessagesInHook(mappedMessages);
         }
       } catch {
@@ -283,15 +277,14 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
     }
 
     void loadThread();
-  }, [threadId, replaceMessagesInHook]);
+  }, [threadId, replaceMessagesInHook, abortCurrent]);
 
   // Handle continuation — append more content to the last assistant message
   const handleContinue = useCallback(
     (continuationToken: string) => {
       void (async () => {
         setIsSending(true);
-        const abortController = new AbortController();
-        qaAbortRef.current = abortController;
+        const abortController = beginAbort();
         try {
           const lastAssistant = [...messages].reverse().find(m => m.role === 'assistant');
           if (!lastAssistant || !thread?.gameId) return;
@@ -308,14 +301,9 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
                   : ((event.data as { token?: string })?.token ?? '');
               if (token) {
                 appendedContent += token;
-                const content = appendedContent;
-                setMessages(prev => {
-                  const next = prev.map(m =>
-                    m.id === lastAssistant.id ? { ...m, content, continuationToken: undefined } : m
-                  );
-                  // Phase 1 Task 5 — dual-write: mirror continuation token patch into useThreadMessages.
-                  replaceMessagesInHook(next);
-                  return next;
+                patchMessageById(lastAssistant.id, {
+                  content: appendedContent,
+                  continuationToken: undefined,
                 });
               }
             }
@@ -324,11 +312,10 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
           /* handled */
         } finally {
           setIsSending(false);
-          qaAbortRef.current = null;
         }
       })();
     },
-    [messages, thread?.gameId, replaceMessagesInHook]
+    [messages, thread?.gameId, beginAbort, patchMessageById]
   );
 
   // Send message - SSE streaming when agentId available, REST fallback otherwise
@@ -348,12 +335,7 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
         content: messageContent,
         timestamp: new Date().toISOString(),
       };
-      setMessages(prev => {
-        const next = [...prev, userMessage];
-        // Phase 1 Task 4 — dual-write: mirror optimistic user append into useThreadMessages.
-        replaceMessagesInHook(next);
-        return next;
-      });
+      appendMessage(userMessage);
 
       // QA stream path: game context available → use RAG QA streaming (#415)
       // Priority: gameId check FIRST because POST /agents/{id}/chat does not exist
@@ -367,15 +349,9 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
           content: '',
           timestamp: new Date().toISOString(),
         };
-        setMessages(prev => {
-          const next = [...prev, assistantMessage];
-          // Phase 1 Task 6 — dual-write: mirror QA assistant placeholder into useThreadMessages.
-          replaceMessagesInHook(next);
-          return next;
-        });
+        appendMessage(assistantMessage);
 
-        const abortController = new AbortController();
-        qaAbortRef.current = abortController;
+        const abortController = beginAbort();
         let finalAnswer = '';
         let citations: unknown[] = [];
         let followUpQuestions: string[] = [];
@@ -401,29 +377,15 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
               case QA_EVENT_TYPES.INLINE_CITATION: {
                 const data = event.data as { citations: InlineCitationMatch[] };
                 if (data.citations) {
-                  setMessages(prev => {
-                    const next = prev.map(m =>
-                      m.id === assistantMsgId ? { ...m, inlineCitations: data.citations } : m
-                    );
-                    // Phase 1 Task 6 — dual-write: mirror inline-citation patch.
-                    replaceMessagesInHook(next);
-                    return next;
-                  });
+                  patchMessageById(assistantMsgId, { inlineCitations: data.citations });
                 }
                 break;
               }
               case QA_EVENT_TYPES.CONTINUATION_AVAILABLE: {
                 const data = event.data as ContinuationData;
                 if (data.continuationToken) {
-                  setMessages(prev => {
-                    const next = prev.map(m =>
-                      m.id === assistantMsgId
-                        ? { ...m, continuationToken: data.continuationToken }
-                        : m
-                    );
-                    // Phase 1 Task 6 — dual-write: mirror continuation-available patch.
-                    replaceMessagesInHook(next);
-                    return next;
+                  patchMessageById(assistantMsgId, {
+                    continuationToken: data.continuationToken,
                   });
                 }
                 break;
@@ -439,14 +401,7 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
                   }>;
                 };
                 if (data.citations) {
-                  setMessages(prev => {
-                    const next = prev.map(m =>
-                      m.id === assistantMsgId ? { ...m, snippets: data.citations } : m
-                    );
-                    // Phase 1 Task 6 — dual-write: mirror citations-snippets patch.
-                    replaceMessagesInHook(next);
-                    return next;
-                  });
+                  patchMessageById(assistantMsgId, { snippets: data.citations });
                 }
                 break;
               }
@@ -458,15 +413,7 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
                     : ((event.data as { token?: string })?.token ?? '');
                 if (token) {
                   finalAnswer += token;
-                  const currentContent = finalAnswer;
-                  setMessages(prev => {
-                    const next = prev.map(m =>
-                      m.id === assistantMsgId ? { ...m, content: currentContent } : m
-                    );
-                    // Phase 1 Task 6 — dual-write: mirror token-accumulator patch.
-                    replaceMessagesInHook(next);
-                    return next;
-                  });
+                  patchMessageById(assistantMsgId, { content: finalAnswer });
                 }
                 break;
               }
@@ -497,20 +444,10 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
           }
 
           // Update assistant message with final data (citations + followUpQuestions)
-          setMessages(prev => {
-            const next = prev.map(m =>
-              m.id === assistantMsgId
-                ? {
-                    ...m,
-                    content: finalAnswer,
-                    citations: citations as import('@/types').Citation[],
-                    followUpQuestions,
-                  }
-                : m
-            );
-            // Phase 1 Task 6 — dual-write: mirror final QA complete patch.
-            replaceMessagesInHook(next);
-            return next;
+          patchMessageById(assistantMsgId, {
+            content: finalAnswer,
+            citations: citations as import('@/types').Citation[],
+            followUpQuestions,
           });
 
           // Persist assistant message to backend
@@ -530,12 +467,7 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
           if ((err as Error).name !== 'AbortError') {
             setError("Errore nell'invio del messaggio");
             // Remove optimistic assistant message on error
-            setMessages(prev => {
-              const next = prev.filter(m => m.id !== assistantMsgId);
-              // Phase 1 Task 6 — dual-write: mirror QA assistant rollback.
-              replaceMessagesInHook(next);
-              return next;
-            });
+            removeMessageById(assistantMsgId);
           }
         } finally {
           setIsSending(false);
@@ -570,19 +502,12 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
               timestamp: m.timestamp,
             })
           );
-          setMessages(mapped);
-          // Phase 1 Task 4 — dual-write: mirror REST-fallback list replace into useThreadMessages.
           replaceMessagesInHook(mapped);
         }
       } catch {
         setError("Errore nell'invio del messaggio");
         // Remove optimistic message on error
-        setMessages(prev => {
-          const next = prev.filter(m => m.id !== userMessage.id);
-          // Phase 1 Task 4 — dual-write: mirror optimistic rollback into useThreadMessages.
-          replaceMessagesInHook(next);
-          return next;
-        });
+        removeMessageById(userMessage.id);
       } finally {
         setIsSending(false);
       }
@@ -599,6 +524,10 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
       voicePrefs.ttsEnabled,
       speak,
       replaceMessagesInHook,
+      appendMessage,
+      patchMessageById,
+      removeMessageById,
+      beginAbort,
     ]
   );
 

--- a/apps/web/src/components/chat-unified/ChatThreadView.tsx
+++ b/apps/web/src/components/chat-unified/ChatThreadView.tsx
@@ -367,7 +367,12 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
           content: '',
           timestamp: new Date().toISOString(),
         };
-        setMessages(prev => [...prev, assistantMessage]);
+        setMessages(prev => {
+          const next = [...prev, assistantMessage];
+          // Phase 1 Task 6 — dual-write: mirror QA assistant placeholder into useThreadMessages.
+          replaceMessagesInHook(next);
+          return next;
+        });
 
         const abortController = new AbortController();
         qaAbortRef.current = abortController;
@@ -396,24 +401,30 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
               case QA_EVENT_TYPES.INLINE_CITATION: {
                 const data = event.data as { citations: InlineCitationMatch[] };
                 if (data.citations) {
-                  setMessages(prev =>
-                    prev.map(m =>
+                  setMessages(prev => {
+                    const next = prev.map(m =>
                       m.id === assistantMsgId ? { ...m, inlineCitations: data.citations } : m
-                    )
-                  );
+                    );
+                    // Phase 1 Task 6 — dual-write: mirror inline-citation patch.
+                    replaceMessagesInHook(next);
+                    return next;
+                  });
                 }
                 break;
               }
               case QA_EVENT_TYPES.CONTINUATION_AVAILABLE: {
                 const data = event.data as ContinuationData;
                 if (data.continuationToken) {
-                  setMessages(prev =>
-                    prev.map(m =>
+                  setMessages(prev => {
+                    const next = prev.map(m =>
                       m.id === assistantMsgId
                         ? { ...m, continuationToken: data.continuationToken }
                         : m
-                    )
-                  );
+                    );
+                    // Phase 1 Task 6 — dual-write: mirror continuation-available patch.
+                    replaceMessagesInHook(next);
+                    return next;
+                  });
                 }
                 break;
               }
@@ -428,11 +439,14 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
                   }>;
                 };
                 if (data.citations) {
-                  setMessages(prev =>
-                    prev.map(m =>
+                  setMessages(prev => {
+                    const next = prev.map(m =>
                       m.id === assistantMsgId ? { ...m, snippets: data.citations } : m
-                    )
-                  );
+                    );
+                    // Phase 1 Task 6 — dual-write: mirror citations-snippets patch.
+                    replaceMessagesInHook(next);
+                    return next;
+                  });
                 }
                 break;
               }
@@ -445,9 +459,14 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
                 if (token) {
                   finalAnswer += token;
                   const currentContent = finalAnswer;
-                  setMessages(prev =>
-                    prev.map(m => (m.id === assistantMsgId ? { ...m, content: currentContent } : m))
-                  );
+                  setMessages(prev => {
+                    const next = prev.map(m =>
+                      m.id === assistantMsgId ? { ...m, content: currentContent } : m
+                    );
+                    // Phase 1 Task 6 — dual-write: mirror token-accumulator patch.
+                    replaceMessagesInHook(next);
+                    return next;
+                  });
                 }
                 break;
               }
@@ -478,8 +497,8 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
           }
 
           // Update assistant message with final data (citations + followUpQuestions)
-          setMessages(prev =>
-            prev.map(m =>
+          setMessages(prev => {
+            const next = prev.map(m =>
               m.id === assistantMsgId
                 ? {
                     ...m,
@@ -488,8 +507,11 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
                     followUpQuestions,
                   }
                 : m
-            )
-          );
+            );
+            // Phase 1 Task 6 — dual-write: mirror final QA complete patch.
+            replaceMessagesInHook(next);
+            return next;
+          });
 
           // Persist assistant message to backend
           if (finalAnswer) {
@@ -508,7 +530,12 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
           if ((err as Error).name !== 'AbortError') {
             setError("Errore nell'invio del messaggio");
             // Remove optimistic assistant message on error
-            setMessages(prev => prev.filter(m => m.id !== assistantMsgId));
+            setMessages(prev => {
+              const next = prev.filter(m => m.id !== assistantMsgId);
+              // Phase 1 Task 6 — dual-write: mirror QA assistant rollback.
+              replaceMessagesInHook(next);
+              return next;
+            });
           }
         } finally {
           setIsSending(false);

--- a/apps/web/src/components/chat-unified/ChatThreadView.tsx
+++ b/apps/web/src/components/chat-unified/ChatThreadView.tsx
@@ -309,11 +309,14 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
               if (token) {
                 appendedContent += token;
                 const content = appendedContent;
-                setMessages(prev =>
-                  prev.map(m =>
+                setMessages(prev => {
+                  const next = prev.map(m =>
                     m.id === lastAssistant.id ? { ...m, content, continuationToken: undefined } : m
-                  )
-                );
+                  );
+                  // Phase 1 Task 5 — dual-write: mirror continuation token patch into useThreadMessages.
+                  replaceMessagesInHook(next);
+                  return next;
+                });
               }
             }
           }
@@ -325,7 +328,7 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
         }
       })();
     },
-    [messages, thread?.gameId]
+    [messages, thread?.gameId, replaceMessagesInHook]
   );
 
   // Send message - SSE streaming when agentId available, REST fallback otherwise

--- a/apps/web/src/components/chat-unified/__tests__/ChatThreadView.invariants.test.tsx
+++ b/apps/web/src/components/chat-unified/__tests__/ChatThreadView.invariants.test.tsx
@@ -424,18 +424,13 @@ describe('ChatThreadView — thread-message invariants (characterization)', () =
   // -------------------------------------------------------------------------
   // Invariant 5 — Hydration aborts stream
   //
-  // CURRENT BEHAVIOR (pre-extraction): the cleanup useEffect at
-  // ChatThreadView.tsx:184-190 has empty deps `[]`, so it ONLY fires on unmount,
-  // NOT on threadId change. Switching threads mid-stream leaks the in-flight
-  // controller.
-  //
-  // This test pins the current (buggy) behavior so the extraction PR
-  // (`docs/superpowers/plans/2026-04-24-chat-thread-state-hook.md`, Task 6)
-  // is forced to flip the assertion — that PR will change `.toBe(false)` to
-  // `.toBe(true)` in the same commit that wires the hook's hydration abort.
+  // After `useThreadMessages` extraction (Task 7): the hydration effect in
+  // ChatThreadView now calls `abortCurrent()` at the top before re-loading
+  // thread data. Switching threadId synchronously aborts any in-flight
+  // stream, closing the controller leak that existed pre-extraction.
   // -------------------------------------------------------------------------
 
-  it('invariant 5 (current/leaky): switching threadId does NOT abort the in-flight stream — FIXME flip after hook extraction', async () => {
+  it('invariant 5: switching threadId aborts the in-flight stream', async () => {
     setQaStreamScript(
       [
         { type: QA_EVENT_TYPES_REAL.TOKEN, data: 'slow' },
@@ -457,9 +452,7 @@ describe('ChatThreadView — thread-message invariants (characterization)', () =
       view.rerender(<ChatThreadView threadId="thread-2" />);
     });
 
-    // FIXME(useThreadMessages-extraction): this assertion must flip to .toBe(true)
-    // once the hook owns the hydration-abort lifecycle. See plan Task 6.4.
-    expect(streamInvocations[0]?.aborted).toBe(false);
+    expect(streamInvocations[0]?.aborted).toBe(true);
   });
 
   // -------------------------------------------------------------------------

--- a/apps/web/src/components/chat-unified/utils/isLastAssistantMessage.ts
+++ b/apps/web/src/components/chat-unified/utils/isLastAssistantMessage.ts
@@ -19,7 +19,10 @@ import type { ChatMessageItem } from '../ChatMessageList';
  * isLastAssistantMessage(messages, 2); // false (user message)
  * ```
  */
-export function isLastAssistantMessage(messages: ChatMessageItem[], index: number): boolean {
+export function isLastAssistantMessage(
+  messages: ReadonlyArray<ChatMessageItem>,
+  index: number
+): boolean {
   const msg = messages[index];
   if (!msg || msg.role !== 'assistant') return false;
   // Find the last message with role='assistant' and compare its index

--- a/apps/web/src/components/chat/shared/__tests__/useThreadMessages.test.ts
+++ b/apps/web/src/components/chat/shared/__tests__/useThreadMessages.test.ts
@@ -30,7 +30,11 @@ function userMsg(id: string, content: string): ChatMessageItem {
   return { id, role: 'user', content };
 }
 
-function assistantMsg(id: string, content: string, extras: Partial<ChatMessageItem> = {}): ChatMessageItem {
+function assistantMsg(
+  id: string,
+  content: string,
+  extras: Partial<ChatMessageItem> = {}
+): ChatMessageItem {
   return { id, role: 'assistant', content, ...extras };
 }
 
@@ -217,7 +221,10 @@ describe('threadMessagesReducer', () => {
 
   it('does not mutate the input state for any action', () => {
     const snapshot: ThreadMessagesState = seed([userMsg('u1', 'hello')]);
-    const frozen = Object.freeze({ ...snapshot, messages: Object.freeze(snapshot.messages.slice()) });
+    const frozen = Object.freeze({
+      ...snapshot,
+      messages: Object.freeze(snapshot.messages.slice()),
+    });
     const actions: ThreadMessagesAction[] = [
       { type: 'APPEND', message: assistantMsg('a1', 'hi') },
       { type: 'PATCH_BY_ID', id: 'u1', patch: { content: 'edited' } },
@@ -251,12 +258,57 @@ describe('useThreadMessages (scaffold)', () => {
     const firstSend = result.current.sendMessage;
     const firstContinue = result.current.continueStream;
     const firstAbort = result.current.abortCurrent;
+    const firstBeginAbort = result.current.beginAbort;
     const firstReplace = result.current.replaceMessages;
+    const firstAppend = result.current.appendMessage;
+    const firstPatch = result.current.patchMessageById;
+    const firstRemove = result.current.removeMessageById;
     rerender();
     expect(result.current.sendMessage).toBe(firstSend);
     expect(result.current.continueStream).toBe(firstContinue);
     expect(result.current.abortCurrent).toBe(firstAbort);
+    expect(result.current.beginAbort).toBe(firstBeginAbort);
     expect(result.current.replaceMessages).toBe(firstReplace);
+    expect(result.current.appendMessage).toBe(firstAppend);
+    expect(result.current.patchMessageById).toBe(firstPatch);
+    expect(result.current.removeMessageById).toBe(firstRemove);
+  });
+
+  it('appendMessage dispatches APPEND (freshly-read state, not closure)', () => {
+    const { result } = renderHook(() => useThreadMessages());
+    act(() => {
+      result.current.appendMessage(userMsg('u1', 'hello'));
+    });
+    act(() => {
+      result.current.appendMessage(assistantMsg('a1', 'hi'));
+    });
+    expect(result.current.messages.map(m => m.id)).toEqual(['u1', 'a1']);
+  });
+
+  it('patchMessageById merges partial updates into the matching message', () => {
+    const { result } = renderHook(() => useThreadMessages());
+    act(() => {
+      result.current.appendMessage(assistantMsg('a1', 'partial'));
+    });
+    act(() => {
+      result.current.patchMessageById('a1', { content: 'final' });
+    });
+    expect(result.current.messages[0]).toEqual({
+      id: 'a1',
+      role: 'assistant',
+      content: 'final',
+    });
+  });
+
+  it('removeMessageById drops the matching message', () => {
+    const { result } = renderHook(() => useThreadMessages());
+    act(() => {
+      result.current.replaceMessages([userMsg('u1', 'a'), assistantMsg('a1', 'b')]);
+    });
+    act(() => {
+      result.current.removeMessageById('a1');
+    });
+    expect(result.current.messages.map(m => m.id)).toEqual(['u1']);
   });
 
   it('replaceMessages swaps the list synchronously', () => {
@@ -289,6 +341,39 @@ describe('useThreadMessages (scaffold)', () => {
     }).not.toThrow();
   });
 
+  it('beginAbort returns a fresh AbortController and aborts the previous one', () => {
+    const { result } = renderHook(() => useThreadMessages());
+
+    let first!: AbortController;
+    act(() => {
+      first = result.current.beginAbort();
+    });
+    expect(first.signal.aborted).toBe(false);
+
+    let second!: AbortController;
+    act(() => {
+      second = result.current.beginAbort();
+    });
+    // Starting a new abort cycle MUST cancel the previous in-flight controller
+    // so the single-stream invariant holds even if callers forget to abort.
+    expect(first.signal.aborted).toBe(true);
+    expect(second.signal.aborted).toBe(false);
+    expect(second).not.toBe(first);
+  });
+
+  it('abortCurrent aborts the controller returned by beginAbort', () => {
+    const { result } = renderHook(() => useThreadMessages());
+    let controller!: AbortController;
+    act(() => {
+      controller = result.current.beginAbort();
+    });
+    expect(controller.signal.aborted).toBe(false);
+    act(() => {
+      result.current.abortCurrent();
+    });
+    expect(controller.signal.aborted).toBe(true);
+  });
+
   it('sendMessage and continueStream are no-op stubs that resolve', async () => {
     // Scaffold contract: wiring lands in Tasks 4-6. The stubs must still
     // satisfy the TS signature and not reject so call-sites can be migrated
@@ -297,9 +382,7 @@ describe('useThreadMessages (scaffold)', () => {
     await expect(
       result.current.sendMessage('anything', { threadId: 't1' })
     ).resolves.toBeUndefined();
-    await expect(
-      result.current.continueStream('tok', { gameId: 'g1' })
-    ).resolves.toBeUndefined();
+    await expect(result.current.continueStream('tok', { gameId: 'g1' })).resolves.toBeUndefined();
     // State remains untouched because the stubs don't dispatch.
     expect(result.current.messages).toEqual([]);
     expect(result.current.streamStatus).toBe('idle');

--- a/apps/web/src/components/chat/shared/__tests__/useThreadMessages.test.ts
+++ b/apps/web/src/components/chat/shared/__tests__/useThreadMessages.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Unit tests for the `useThreadMessages` reducer + hook scaffold.
+ *
+ * Phase 1, Task 2: verifies the pure reducer and the initial hook surface.
+ * Streaming/SSE behavior is intentionally NOT exercised here — those land
+ * in Tasks 4-6 once `sendMessage`/`continueStream` are wired.
+ *
+ * The reducer is the load-bearing piece: covering every action variant
+ * plus bail-out fast paths (no-op REMOVE_BY_ID, identity SET_STREAM_STATUS,
+ * etc.) gives us a stable foundation before ChatThreadView migrates.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { ChatMessageItem } from '../types';
+import {
+  initialThreadMessagesState,
+  threadMessagesReducer,
+  useThreadMessages,
+  type ThreadMessagesAction,
+  type ThreadMessagesState,
+} from '../useThreadMessages';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function userMsg(id: string, content: string): ChatMessageItem {
+  return { id, role: 'user', content };
+}
+
+function assistantMsg(id: string, content: string, extras: Partial<ChatMessageItem> = {}): ChatMessageItem {
+  return { id, role: 'assistant', content, ...extras };
+}
+
+function seed(messages: ChatMessageItem[] = []): ThreadMessagesState {
+  return { ...initialThreadMessagesState, messages };
+}
+
+// ---------------------------------------------------------------------------
+// Reducer — pure function tests
+// ---------------------------------------------------------------------------
+
+describe('threadMessagesReducer', () => {
+  it('starts from the documented initial state', () => {
+    expect(initialThreadMessagesState).toEqual({
+      messages: [],
+      streamStatus: 'idle',
+      currentAnswer: '',
+      lastMessageWasVoice: false,
+    });
+  });
+
+  describe('APPEND', () => {
+    it('appends a message to an empty list', () => {
+      const msg = userMsg('u1', 'hello');
+      const next = threadMessagesReducer(seed(), { type: 'APPEND', message: msg });
+      expect(next.messages).toEqual([msg]);
+    });
+
+    it('preserves order when appending multiple messages', () => {
+      const m1 = userMsg('u1', 'hello');
+      const m2 = assistantMsg('a1', 'hi');
+      const m3 = userMsg('u2', 'how are you?');
+      let state = seed();
+      state = threadMessagesReducer(state, { type: 'APPEND', message: m1 });
+      state = threadMessagesReducer(state, { type: 'APPEND', message: m2 });
+      state = threadMessagesReducer(state, { type: 'APPEND', message: m3 });
+      expect(state.messages.map(m => m.id)).toEqual(['u1', 'a1', 'u2']);
+    });
+
+    it('returns a new messages array (no in-place mutation)', () => {
+      const before = seed([userMsg('u1', 'hello')]);
+      const after = threadMessagesReducer(before, {
+        type: 'APPEND',
+        message: assistantMsg('a1', 'hi'),
+      });
+      expect(after.messages).not.toBe(before.messages);
+      expect(before.messages).toEqual([userMsg('u1', 'hello')]); // untouched
+    });
+  });
+
+  describe('PATCH_BY_ID', () => {
+    it('merges the patch into the matching message', () => {
+      const state = seed([assistantMsg('a1', 'partial')]);
+      const next = threadMessagesReducer(state, {
+        type: 'PATCH_BY_ID',
+        id: 'a1',
+        patch: { content: 'partial token' },
+      });
+      expect(next.messages[0]).toEqual({
+        id: 'a1',
+        role: 'assistant',
+        content: 'partial token',
+      });
+    });
+
+    it('leaves unrelated messages untouched (by reference)', () => {
+      const u1 = userMsg('u1', 'hello');
+      const a1 = assistantMsg('a1', 'partial');
+      const state = seed([u1, a1]);
+      const next = threadMessagesReducer(state, {
+        type: 'PATCH_BY_ID',
+        id: 'a1',
+        patch: { content: 'partial token' },
+      });
+      expect(next.messages[0]).toBe(u1);
+      expect(next.messages[1]).not.toBe(a1);
+    });
+
+    it('is a no-op when the id is not found', () => {
+      const state = seed([userMsg('u1', 'hello')]);
+      const next = threadMessagesReducer(state, {
+        type: 'PATCH_BY_ID',
+        id: 'does-not-exist',
+        patch: { content: 'ignored' },
+      });
+      expect(next).toBe(state);
+    });
+
+    it('can patch follow-up questions without touching content', () => {
+      const state = seed([assistantMsg('a1', 'done')]);
+      const next = threadMessagesReducer(state, {
+        type: 'PATCH_BY_ID',
+        id: 'a1',
+        patch: { followUpQuestions: ['what next?'] },
+      });
+      expect(next.messages[0]).toEqual({
+        id: 'a1',
+        role: 'assistant',
+        content: 'done',
+        followUpQuestions: ['what next?'],
+      });
+    });
+  });
+
+  describe('REMOVE_BY_ID', () => {
+    it('removes the matching message', () => {
+      const state = seed([userMsg('u1', 'a'), assistantMsg('a1', 'b'), userMsg('u2', 'c')]);
+      const next = threadMessagesReducer(state, { type: 'REMOVE_BY_ID', id: 'a1' });
+      expect(next.messages.map(m => m.id)).toEqual(['u1', 'u2']);
+    });
+
+    it('is a no-op when the id is not present (state identity preserved)', () => {
+      const state = seed([userMsg('u1', 'a')]);
+      const next = threadMessagesReducer(state, { type: 'REMOVE_BY_ID', id: 'missing' });
+      expect(next).toBe(state);
+    });
+  });
+
+  describe('REPLACE_ALL', () => {
+    it('replaces the entire list', () => {
+      const state = seed([userMsg('u1', 'old')]);
+      const replacement = [assistantMsg('welcome', 'hi there')];
+      const next = threadMessagesReducer(state, {
+        type: 'REPLACE_ALL',
+        messages: replacement,
+      });
+      expect(next.messages).toBe(replacement);
+    });
+
+    it('accepts an empty replacement (thread clear)', () => {
+      const state = seed([userMsg('u1', 'a')]);
+      const next = threadMessagesReducer(state, { type: 'REPLACE_ALL', messages: [] });
+      expect(next.messages).toEqual([]);
+    });
+  });
+
+  describe('SET_STREAM_STATUS', () => {
+    it('transitions idle → streaming → idle', () => {
+      let state = initialThreadMessagesState;
+      state = threadMessagesReducer(state, { type: 'SET_STREAM_STATUS', status: 'streaming' });
+      expect(state.streamStatus).toBe('streaming');
+      state = threadMessagesReducer(state, { type: 'SET_STREAM_STATUS', status: 'idle' });
+      expect(state.streamStatus).toBe('idle');
+    });
+
+    it('is a no-op when the status is unchanged', () => {
+      const state = { ...initialThreadMessagesState, streamStatus: 'streaming' as const };
+      const next = threadMessagesReducer(state, { type: 'SET_STREAM_STATUS', status: 'streaming' });
+      expect(next).toBe(state);
+    });
+  });
+
+  describe('SET_CURRENT_ANSWER', () => {
+    it('updates the buffered answer', () => {
+      const next = threadMessagesReducer(initialThreadMessagesState, {
+        type: 'SET_CURRENT_ANSWER',
+        answer: 'hello wo',
+      });
+      expect(next.currentAnswer).toBe('hello wo');
+    });
+
+    it('is a no-op when the answer is unchanged', () => {
+      const state = { ...initialThreadMessagesState, currentAnswer: 'same' };
+      const next = threadMessagesReducer(state, { type: 'SET_CURRENT_ANSWER', answer: 'same' });
+      expect(next).toBe(state);
+    });
+  });
+
+  describe('SET_VOICE_FLAG', () => {
+    it('flips the voice flag on and off', () => {
+      let state = initialThreadMessagesState;
+      state = threadMessagesReducer(state, { type: 'SET_VOICE_FLAG', flag: true });
+      expect(state.lastMessageWasVoice).toBe(true);
+      state = threadMessagesReducer(state, { type: 'SET_VOICE_FLAG', flag: false });
+      expect(state.lastMessageWasVoice).toBe(false);
+    });
+
+    it('is a no-op when the flag is unchanged', () => {
+      const state = { ...initialThreadMessagesState, lastMessageWasVoice: true };
+      const next = threadMessagesReducer(state, { type: 'SET_VOICE_FLAG', flag: true });
+      expect(next).toBe(state);
+    });
+  });
+
+  it('does not mutate the input state for any action', () => {
+    const snapshot: ThreadMessagesState = seed([userMsg('u1', 'hello')]);
+    const frozen = Object.freeze({ ...snapshot, messages: Object.freeze(snapshot.messages.slice()) });
+    const actions: ThreadMessagesAction[] = [
+      { type: 'APPEND', message: assistantMsg('a1', 'hi') },
+      { type: 'PATCH_BY_ID', id: 'u1', patch: { content: 'edited' } },
+      { type: 'REMOVE_BY_ID', id: 'u1' },
+      { type: 'REPLACE_ALL', messages: [userMsg('u2', 'new')] },
+      { type: 'SET_STREAM_STATUS', status: 'streaming' },
+      { type: 'SET_CURRENT_ANSWER', answer: 'buf' },
+      { type: 'SET_VOICE_FLAG', flag: true },
+    ];
+    for (const action of actions) {
+      expect(() => threadMessagesReducer(frozen, action)).not.toThrow();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hook — scaffold surface tests (streaming behavior deferred to Tasks 4-6)
+// ---------------------------------------------------------------------------
+
+describe('useThreadMessages (scaffold)', () => {
+  it('exposes the documented initial surface', () => {
+    const { result } = renderHook(() => useThreadMessages());
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.streamStatus).toBe('idle');
+    expect(result.current.currentAnswer).toBe('');
+    expect(result.current.lastMessageWasVoice).toBe(false);
+  });
+
+  it('returns stable callback identities across re-renders', () => {
+    const { result, rerender } = renderHook(() => useThreadMessages());
+    const firstSend = result.current.sendMessage;
+    const firstContinue = result.current.continueStream;
+    const firstAbort = result.current.abortCurrent;
+    const firstReplace = result.current.replaceMessages;
+    rerender();
+    expect(result.current.sendMessage).toBe(firstSend);
+    expect(result.current.continueStream).toBe(firstContinue);
+    expect(result.current.abortCurrent).toBe(firstAbort);
+    expect(result.current.replaceMessages).toBe(firstReplace);
+  });
+
+  it('replaceMessages swaps the list synchronously', () => {
+    const { result } = renderHook(() => useThreadMessages());
+    const next = [assistantMsg('welcome', 'hi there')];
+    act(() => {
+      result.current.replaceMessages(next);
+    });
+    expect(result.current.messages).toEqual(next);
+  });
+
+  it('replaceMessages([]) clears the thread', () => {
+    const { result } = renderHook(() => useThreadMessages());
+    act(() => {
+      result.current.replaceMessages([userMsg('u1', 'hello')]);
+    });
+    expect(result.current.messages).toHaveLength(1);
+    act(() => {
+      result.current.replaceMessages([]);
+    });
+    expect(result.current.messages).toEqual([]);
+  });
+
+  it('abortCurrent is safe to call when no stream is in flight', () => {
+    const { result } = renderHook(() => useThreadMessages());
+    expect(() => {
+      act(() => {
+        result.current.abortCurrent();
+      });
+    }).not.toThrow();
+  });
+
+  it('sendMessage and continueStream are no-op stubs that resolve', async () => {
+    // Scaffold contract: wiring lands in Tasks 4-6. The stubs must still
+    // satisfy the TS signature and not reject so call-sites can be migrated
+    // incrementally without crashing.
+    const { result } = renderHook(() => useThreadMessages());
+    await expect(
+      result.current.sendMessage('anything', { threadId: 't1' })
+    ).resolves.toBeUndefined();
+    await expect(
+      result.current.continueStream('tok', { gameId: 'g1' })
+    ).resolves.toBeUndefined();
+    // State remains untouched because the stubs don't dispatch.
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.streamStatus).toBe('idle');
+  });
+});

--- a/apps/web/src/components/chat/shared/index.ts
+++ b/apps/web/src/components/chat/shared/index.ts
@@ -12,3 +12,16 @@ export type {
 
 export { collectCitations, getSuggestedQuestions } from './messages';
 export { useChatScroll, type UseChatScrollResult } from './useChatScroll';
+export {
+  useThreadMessages,
+  threadMessagesReducer,
+  initialThreadMessagesState,
+  type UseThreadMessagesResult,
+  type UseThreadMessagesOptions,
+  type ThreadSendContext,
+  type SendOptions,
+  type StreamStatus,
+  type ThreadStreamError,
+  type ThreadMessagesState,
+  type ThreadMessagesAction,
+} from './useThreadMessages';

--- a/apps/web/src/components/chat/shared/useThreadMessages.ts
+++ b/apps/web/src/components/chat/shared/useThreadMessages.ts
@@ -1,0 +1,215 @@
+/**
+ * `useThreadMessages` — Phase 1 Strangler Fig extraction (SCAFFOLD).
+ *
+ * Facade hook that owns the message list + streaming lifecycle for a single
+ * chat thread. Replaces the scattered `useState<ChatMessageItem[]>` +
+ * `qaAbortRef` + `lastMessageWasVoiceRef` machinery inside
+ * `chat-unified/ChatThreadView.tsx` with a single `useReducer` + action API.
+ *
+ * STATUS: Task 2 — reducer + stubs only. `sendMessage`/`continueStream`
+ * dispatch no-ops until Tasks 4-6 wire them to `qaStream`/`api.chat.*`.
+ * `replaceMessages` and `abortCurrent` are functional from day one so they
+ * can be dropped into ChatThreadView without further changes.
+ *
+ * Plan: docs/superpowers/plans/2026-04-24-chat-thread-state-hook.md
+ * Invariants: apps/web/src/components/chat-unified/__tests__/ChatThreadView.invariants.test.tsx
+ *
+ * Module boundary: lives under `chat/shared/**` — MUST NOT import from
+ * `chat-unified/**` or `chat/panel/**` (enforced by ESLint).
+ */
+
+import { useCallback, useEffect, useReducer, useRef } from 'react';
+
+import type { ChatMessageItem } from './types';
+
+// ---------------------------------------------------------------------------
+// Public API types
+// ---------------------------------------------------------------------------
+
+export type StreamStatus = 'idle' | 'streaming' | 'error';
+
+export interface SendOptions {
+  fromVoice?: boolean;
+}
+
+export interface ThreadSendContext {
+  gameId?: string;
+  threadId: string;
+  agentId?: string;
+  responseStyle?: 'concise' | 'detailed';
+}
+
+export interface ThreadStreamError {
+  kind: 'stream' | 'persist' | 'qa';
+  message: string;
+}
+
+export interface UseThreadMessagesOptions {
+  onError?: (err: ThreadStreamError) => void;
+  onPersist?: (msg: ChatMessageItem) => Promise<void>;
+  onStreamComplete?: (answer: string) => void;
+}
+
+export interface UseThreadMessagesResult {
+  messages: ReadonlyArray<ChatMessageItem>;
+  streamStatus: StreamStatus;
+  currentAnswer: string;
+  lastMessageWasVoice: boolean;
+  sendMessage: (
+    content: string,
+    ctx: ThreadSendContext,
+    options?: SendOptions
+  ) => Promise<void>;
+  continueStream: (token: string, ctx: Pick<ThreadSendContext, 'gameId'>) => Promise<void>;
+  abortCurrent: () => void;
+  replaceMessages: (next: ReadonlyArray<ChatMessageItem>) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Reducer — pure, unit-testable
+// ---------------------------------------------------------------------------
+
+export interface ThreadMessagesState {
+  readonly messages: ReadonlyArray<ChatMessageItem>;
+  readonly streamStatus: StreamStatus;
+  readonly currentAnswer: string;
+  readonly lastMessageWasVoice: boolean;
+}
+
+export type ThreadMessagesAction =
+  | { type: 'APPEND'; message: ChatMessageItem }
+  | { type: 'PATCH_BY_ID'; id: string; patch: Partial<ChatMessageItem> }
+  | { type: 'REMOVE_BY_ID'; id: string }
+  | { type: 'REPLACE_ALL'; messages: ReadonlyArray<ChatMessageItem> }
+  | { type: 'SET_STREAM_STATUS'; status: StreamStatus }
+  | { type: 'SET_CURRENT_ANSWER'; answer: string }
+  | { type: 'SET_VOICE_FLAG'; flag: boolean };
+
+export const initialThreadMessagesState: ThreadMessagesState = {
+  messages: [],
+  streamStatus: 'idle',
+  currentAnswer: '',
+  lastMessageWasVoice: false,
+};
+
+export function threadMessagesReducer(
+  state: ThreadMessagesState,
+  action: ThreadMessagesAction
+): ThreadMessagesState {
+  switch (action.type) {
+    case 'APPEND':
+      return { ...state, messages: [...state.messages, action.message] };
+
+    case 'PATCH_BY_ID': {
+      // No-op fast path: bail out if the id isn't present so React's
+      // referential equality check can skip downstream re-renders.
+      const idx = state.messages.findIndex(m => m.id === action.id);
+      if (idx < 0) return state;
+      const next = state.messages.slice();
+      next[idx] = { ...next[idx], ...action.patch };
+      return { ...state, messages: next };
+    }
+
+    case 'REMOVE_BY_ID': {
+      const next = state.messages.filter(m => m.id !== action.id);
+      if (next.length === state.messages.length) return state;
+      return { ...state, messages: next };
+    }
+
+    case 'REPLACE_ALL':
+      return { ...state, messages: action.messages };
+
+    case 'SET_STREAM_STATUS':
+      if (state.streamStatus === action.status) return state;
+      return { ...state, streamStatus: action.status };
+
+    case 'SET_CURRENT_ANSWER':
+      if (state.currentAnswer === action.answer) return state;
+      return { ...state, currentAnswer: action.answer };
+
+    case 'SET_VOICE_FLAG':
+      if (state.lastMessageWasVoice === action.flag) return state;
+      return { ...state, lastMessageWasVoice: action.flag };
+
+    default: {
+      // Exhaustiveness guard — TS will flag a missing case if a new action
+      // variant is added without a branch.
+      const _exhaustive: never = action;
+      void _exhaustive;
+      return state;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook — owns the reducer and the AbortController lifecycle
+// ---------------------------------------------------------------------------
+
+export function useThreadMessages(
+  options: UseThreadMessagesOptions = {}
+): UseThreadMessagesResult {
+  const [state, dispatch] = useReducer(threadMessagesReducer, initialThreadMessagesState);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Stable callback refs so consumers that pass inline lambdas (e.g. the
+  // transient renders during hydration) don't force `sendMessage` / `continueStream`
+  // identity churn. Wired in Tasks 4-6.
+  const optionsRef = useRef(options);
+  useEffect(() => {
+    optionsRef.current = options;
+  }, [options]);
+
+  const abortCurrent = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+  }, []);
+
+  const replaceMessages = useCallback((next: ReadonlyArray<ChatMessageItem>) => {
+    dispatch({ type: 'REPLACE_ALL', messages: next });
+  }, []);
+
+  // Auto-abort in-flight stream on unmount. This is the single source of
+  // truth for stream lifecycle; ChatThreadView's existing empty-deps cleanup
+  // effect will be removed in Task 7.
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+      abortRef.current = null;
+    };
+  }, []);
+
+  // TASK 4-6 WIRING TARGETS -------------------------------------------------
+  // These stubs intentionally only flip streamStatus so consumers can type
+  // against the final shape without the reducer being in a half-wired state.
+
+  const sendMessage = useCallback<UseThreadMessagesResult['sendMessage']>(
+    async (_content, _ctx, _opts) => {
+      // TODO(task-4/6): append user bubble, abort prior stream, open
+      // qaStream, patch assistant placeholder, dispatch COMPLETE/ERROR.
+      // Intentionally unimplemented in Task 2 so consumers cannot depend
+      // on it prematurely.
+      return Promise.resolve();
+    },
+    []
+  );
+
+  const continueStream = useCallback<UseThreadMessagesResult['continueStream']>(
+    async (_token, _ctx) => {
+      // TODO(task-5): resume qaStream with continuation token and patch
+      // the last assistant message captured at call time.
+      return Promise.resolve();
+    },
+    []
+  );
+
+  return {
+    messages: state.messages,
+    streamStatus: state.streamStatus,
+    currentAnswer: state.currentAnswer,
+    lastMessageWasVoice: state.lastMessageWasVoice,
+    sendMessage,
+    continueStream,
+    abortCurrent,
+    replaceMessages,
+  };
+}

--- a/apps/web/src/components/chat/shared/useThreadMessages.ts
+++ b/apps/web/src/components/chat/shared/useThreadMessages.ts
@@ -55,14 +55,27 @@ export interface UseThreadMessagesResult {
   streamStatus: StreamStatus;
   currentAnswer: string;
   lastMessageWasVoice: boolean;
-  sendMessage: (
-    content: string,
-    ctx: ThreadSendContext,
-    options?: SendOptions
-  ) => Promise<void>;
+  sendMessage: (content: string, ctx: ThreadSendContext, options?: SendOptions) => Promise<void>;
   continueStream: (token: string, ctx: Pick<ThreadSendContext, 'gameId'>) => Promise<void>;
   abortCurrent: () => void;
+  /**
+   * Creates a new `AbortController`, stores it as the hook's current controller
+   * (so `abortCurrent` can abort it later), and returns it. Aborts any
+   * previous in-flight controller automatically to guarantee single-stream
+   * invariants. Used by consumers that still own the streaming loop locally
+   * while the hook's own `sendMessage` is still a stub.
+   */
+  beginAbort: () => AbortController;
   replaceMessages: (next: ReadonlyArray<ChatMessageItem>) => void;
+  /**
+   * Granular action dispatchers. These reach the reducer via the latest state
+   * snapshot (not a closure), so they are safe to call from long-lived
+   * callbacks (e.g. streaming `for await` loops) where the surrounding
+   * `messages` closure would otherwise be stale.
+   */
+  appendMessage: (msg: ChatMessageItem) => void;
+  patchMessageById: (id: string, patch: Partial<ChatMessageItem>) => void;
+  removeMessageById: (id: string) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -145,9 +158,7 @@ export function threadMessagesReducer(
 // Hook — owns the reducer and the AbortController lifecycle
 // ---------------------------------------------------------------------------
 
-export function useThreadMessages(
-  options: UseThreadMessagesOptions = {}
-): UseThreadMessagesResult {
+export function useThreadMessages(options: UseThreadMessagesOptions = {}): UseThreadMessagesResult {
   const [state, dispatch] = useReducer(threadMessagesReducer, initialThreadMessagesState);
   const abortRef = useRef<AbortController | null>(null);
 
@@ -164,8 +175,27 @@ export function useThreadMessages(
     abortRef.current = null;
   }, []);
 
+  const beginAbort = useCallback(() => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    return controller;
+  }, []);
+
   const replaceMessages = useCallback((next: ReadonlyArray<ChatMessageItem>) => {
     dispatch({ type: 'REPLACE_ALL', messages: next });
+  }, []);
+
+  const appendMessage = useCallback((message: ChatMessageItem) => {
+    dispatch({ type: 'APPEND', message });
+  }, []);
+
+  const patchMessageById = useCallback((id: string, patch: Partial<ChatMessageItem>) => {
+    dispatch({ type: 'PATCH_BY_ID', id, patch });
+  }, []);
+
+  const removeMessageById = useCallback((id: string) => {
+    dispatch({ type: 'REMOVE_BY_ID', id });
   }, []);
 
   // Auto-abort in-flight stream on unmount. This is the single source of
@@ -210,6 +240,10 @@ export function useThreadMessages(
     sendMessage,
     continueStream,
     abortCurrent,
+    beginAbort,
     replaceMessages,
+    appendMessage,
+    patchMessageById,
+    removeMessageById,
   };
 }

--- a/docs/frontend/chat-shared-primitives.md
+++ b/docs/frontend/chat-shared-primitives.md
@@ -1,6 +1,8 @@
 # Chat Shared Primitives (`components/chat/shared/`)
 
-> **Phase 0 Strangler Fig** — foundational extraction for the eventual `chat-unified → chat/panel` unification. Zero behavioral change. Both view layers (monolithic `chat-unified/ChatThreadView` and slide-over `chat/panel/*`) consume from this module.
+> **Phase 0 Strangler Fig** — foundational extraction for the eventual `chat-unified → chat/panel` unification. Zero behavioral change.
+> **Phase 1** ✅ — `useThreadMessages` owns the message list + `AbortController` lifecycle for a single thread (plan: [`docs/superpowers/plans/2026-04-24-chat-thread-state-hook.md`](../superpowers/plans/2026-04-24-chat-thread-state-hook.md)).
+> Both view layers (monolithic `chat-unified/ChatThreadView` and slide-over `chat/panel/*`) consume from this module.
 
 ## 1. Purpose
 
@@ -29,8 +31,34 @@
 | `getSuggestedQuestions` | Pure fn (`ChatMessageItem[] → string[]`) | `messages.ts` | `chat-unified/ChatThreadView` | 01f0cd383 |
 | `useChatScroll` | Hook (auto-scroll on message change) | `useChatScroll.ts` | `chat-unified/ChatThreadView` | cb52416be |
 | `UseChatScrollResult` | Type | `useChatScroll.ts` | internal | cb52416be |
+| `useThreadMessages` | Hook (message list + `AbortController` lifecycle via `useReducer`) | `useThreadMessages.ts` | `chat-unified/ChatThreadView` | 3fe57f694 … e4b28a333 |
+| `ThreadMessagesState`, `ThreadMessagesAction` | Reducer types (`APPEND`, `PATCH_BY_ID`, `REMOVE_BY_ID`, `REPLACE_ALL`, `SET_STREAM_STATUS`, `SET_CURRENT_ANSWER`, `SET_VOICE_FLAG`) | `useThreadMessages.ts` | internal / tests | 3fe57f694 |
+| `threadMessagesReducer`, `initialThreadMessagesState` | Pure reducer + initial state | `useThreadMessages.ts` | tests | 3fe57f694 |
+| `UseThreadMessagesOptions`, `UseThreadMessagesResult`, `ThreadSendContext`, `SendOptions`, `StreamStatus`, `ThreadStreamError` | Public hook types | `useThreadMessages.ts` | `chat-unified/ChatThreadView` | 3fe57f694 |
 
-Pinned invariants for future `useThreadMessages` extraction (deferred to Phase 1): see `__tests__/useThreadMessages-invariants.test.ts` (6 characterization tests, commit `7cbe36829`).
+Pinned invariants that drove the `useThreadMessages` extraction live at [`apps/web/src/components/chat-unified/__tests__/ChatThreadView.invariants.test.tsx`](../../apps/web/src/components/chat-unified/__tests__/ChatThreadView.invariants.test.tsx) (6 characterization tests, commit `7cbe36829`). Invariant 5 (hydration-abort) was flipped from `.toBe(false)` to `.toBe(true)` in Task 7 (commit `e4b28a333`), closing the cross-`threadId` controller leak.
+
+### 2.1 `useThreadMessages` API
+
+The hook owns **all** in-flight state for a single thread: the message array, the active `AbortController`, and the `SSE`-streaming bookkeeping. It is the only sanctioned way to mutate chat messages from the view layer — direct `useState<ChatMessageItem[]>` is forbidden in `chat-unified/**`.
+
+| Method | Signature | Purpose |
+|--------|-----------|---------|
+| `messages` | `ReadonlyArray<ChatMessageItem>` | Snapshot of the current thread. Never mutate directly. |
+| `replaceMessages(next)` | `(ReadonlyArray<ChatMessageItem>) => void` | Hydration or full reset (REST fallback). Dispatches `REPLACE_ALL`. |
+| `appendMessage(msg)` | `(ChatMessageItem) => void` | Add optimistic user bubble or assistant placeholder. Dispatches `APPEND`. |
+| `patchMessageById(id, patch)` | `(string, Partial<ChatMessageItem>) => void` | Stream tokens, citations, continuation tokens. Dispatches `PATCH_BY_ID` (no-op if id not found). |
+| `removeMessageById(id)` | `(string) => void` | Rollback on stream/persist error. Dispatches `REMOVE_BY_ID`. |
+| `abortCurrent()` | `() => void` | Abort the current in-flight controller (if any) and clear the ref. Idempotent. |
+| `beginAbort()` | `() => AbortController` | Abort any previous controller, create a fresh one, store it as the hook's current ref, and return it. Canonical single-stream gate. |
+
+**Why granular dispatch methods and not a `setMessages` escape hatch?**
+
+`patchMessageById` / `appendMessage` / `removeMessageById` reach the reducer via `useReducer`'s stable `dispatch` — they always operate on the latest state snapshot. This is essential for the streaming `for await` loops that live in `ChatThreadView.handleSendMessage`: those callbacks run for the full duration of an SSE stream, and a closure-captured `messages` array would grow stale after the first token. Dispatch-based APIs eliminate this trap by design.
+
+**Why does `beginAbort()` return the controller?**
+
+`ChatThreadView` still owns the streaming call sites (the hook's `sendMessage` is a stub — Tasks 4–6 of the deferred full-hook extraction). Callers need the `AbortSignal` to pass to `qaStream` / `fetch`. `beginAbort()` gives them the signal while guaranteeing the hook's `abortRef` is authoritative, so that `abortCurrent()` (invoked by the hydration effect on `threadId` change, or by the unmount cleanup) always cancels the right stream.
 
 ## 3. Citation type hierarchy
 
@@ -65,12 +93,16 @@ Enforced by ESLint `no-restricted-imports` rule in [`apps/web/eslint.config.mjs`
 
 - **Phase 0** ✅ (this module) — foundational extraction, zero behavioral change, dual-consumer via `chat/panel` migration.
 - **Phase 0.5** — unify `Citation` across `ui/meeple/chat-message.tsx`, `ui/data-display/citation-link.tsx`, `chat-unified/CitationBadge.tsx` (10 scattered definitions). Extend ESLint boundary to enforce.
-- **Phase 1** — extract `useThreadMessages` from `chat-unified/ChatThreadView` into `chat/shared/` using the 6 pinned invariants (`__tests__/useThreadMessages-invariants.test.ts`).
+- **Phase 1** ✅ — `useThreadMessages` extracted and wired into `ChatThreadView`. Message list + `AbortController` lifecycle now live in `chat/shared/`. All 6 pinned invariants green (invariant 5 flipped from leaky to correct). See plan: [`2026-04-24-chat-thread-state-hook.md`](../superpowers/plans/2026-04-24-chat-thread-state-hook.md).
+  - **Deferred (Phase 1.5)**: `sendMessage` / `continueStream` inside the hook are still stubs. `ChatThreadView` owns the QA-stream / REST-fallback call sites and uses `beginAbort()` + the granular dispatchers. Full in-hook streaming is deferred until the slide-over panel (`chat/panel/*`) is ready to reuse the same hook — doing it now would fossilize `chat-unified`-specific quirks into the shared layer.
 - **Phases 2–6** — [chat-unified-full-page-refactor](../superpowers/plans/) — rewrite `/chat/[threadId]`, `AgentCharacterSheet`, `AgentExtraMeepleCard` to consume `chat/panel/*` components, then delete the `chat-unified/` module (~35 files). Requires first porting citations/feedback/TTS/debug-panel parity from `ChatThreadView` to `chat/panel`.
 
 ## References
 
-- Plan: [`docs/superpowers/plans/2026-04-24-chat-shared-primitives-phase-0.md`](../superpowers/plans/2026-04-24-chat-shared-primitives-phase-0.md)
+- Plan (Phase 0): [`docs/superpowers/plans/2026-04-24-chat-shared-primitives-phase-0.md`](../superpowers/plans/2026-04-24-chat-shared-primitives-phase-0.md)
+- Plan (Phase 1): [`docs/superpowers/plans/2026-04-24-chat-thread-state-hook.md`](../superpowers/plans/2026-04-24-chat-thread-state-hook.md)
 - Source: [`apps/web/src/components/chat/shared/`](../../apps/web/src/components/chat/shared/)
+- Hook unit tests: [`apps/web/src/components/chat/shared/__tests__/useThreadMessages.test.ts`](../../apps/web/src/components/chat/shared/__tests__/useThreadMessages.test.ts) (30 tests)
+- Invariant tests: [`apps/web/src/components/chat-unified/__tests__/ChatThreadView.invariants.test.tsx`](../../apps/web/src/components/chat-unified/__tests__/ChatThreadView.invariants.test.tsx) (6 characterization tests)
 - ESLint boundary rule: [`apps/web/eslint.config.mjs`](../../apps/web/eslint.config.mjs) (search `chat/shared`)
 - E2E smoke: [`apps/web/e2e/chat/thread-view-smoke.spec.ts`](../../apps/web/e2e/chat/thread-view-smoke.spec.ts)


### PR DESCRIPTION
## Summary

Phase 1 Strangler Fig extraction of `useThreadMessages` from `ChatThreadView`. Replaces the scattered `useState<ChatMessageItem[]>` + `qaAbortRef` machinery with a reducer-backed facade hook under `chat/shared/`.

- Plan: [`docs/superpowers/plans/2026-04-24-chat-thread-state-hook.md`](docs/superpowers/plans/2026-04-24-chat-thread-state-hook.md)
- Parent branch: `main-dev` (per CLAUDE.md PR target rule)

## What changed

| Task | Commit | What |
|------|--------|------|
| 2 | `3fe57f694` | Scaffold `useThreadMessages` reducer + stubbed API |
| 3 | `560e04baf` | Migrate thread hydration to `replaceMessages` |
| 4 | `ee534389b` | Migrate REST-fallback send to hook |
| 5 | `bc887fc35` | Migrate continuation flow to hook |
| 6 | `735d826e0` | Migrate QA-stream send to hook |
| 7 | `e4b28a333` | Remove direct `setMessages`/`qaAbortRef` escape hatches; add `beginAbort()`; flip invariant 5 to `.toBe(true)` |
| 8 | `e39eac7f5` | Document hook API + Phase 1 completion in `chat-shared-primitives.md` |

## Architecture

- **Hook** (`apps/web/src/components/chat/shared/useThreadMessages.ts`) — `useReducer`-backed facade over `messages`, `streamStatus`, `currentAnswer`, `lastMessageWasVoice`. Exposes granular dispatchers (`appendMessage` / `patchMessageById` / `removeMessageById` / `replaceMessages`) that use dispatch (not closure) so they stay fresh inside long-lived SSE `for await` loops.
- **AbortController lifecycle** — `beginAbort()` aborts any previous controller, allocates a fresh one, stores it in the hook's `abortRef`, and returns it to the caller. `abortCurrent()` is called at the top of the hydration effect and on unmount. This closes the cross-`threadId` controller leak (pre-extraction: invariant 5 was `.toBe(false)` / leaky, now `.toBe(true)` / correct).
- **Deferred Phase 1.5** — the hook's own `sendMessage`/`continueStream` remain intentional stubs. `ChatThreadView` owns the streaming call sites and uses `beginAbort()` + granular dispatchers. We'll wire the in-hook streaming only when `chat/panel/*` needs the same behavior — doing it now would fossilize `chat-unified`-specific quirks.
- **Module boundary** — `chat/shared/**` cannot import from `chat-unified/**` or `chat/panel/**` (ESLint-enforced). Keeps the shared layer a leaf in the dependency graph.

## AC-1 gate

```
$ grep -n "setMessages\|qaAbortRef" apps/web/src/components/chat-unified/ChatThreadView.tsx
# (no matches)
```

## Test plan

- [x] `pnpm vitest run src/components/chat/shared/__tests__/useThreadMessages.test.ts` — 30/30 passed
- [x] `pnpm vitest run src/components/chat-unified/__tests__/ChatThreadView.invariants.test.tsx` — 6/6 passed (inv 5 flipped)
- [x] `pnpm vitest run src/components/chat-unified/__tests__` — 194/194 passed (ChatThreadView.test, ChatMessageList characterization)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors, no new warnings
- [x] Pre-push hook: Next.js production build — passed

## Risk / rollback

Each task commit is independently reversible. Rollback of any single commit is safe — the hook was wired incrementally through the granular dispatch API, and the final flip (Task 7) is the only behavior-changing commit (inv 5 leaky → correct).

🤖 Generated with [Claude Code](https://claude.ai/code)