### PR TITLE
fix(web): set IT page metadata + Suspense fallback for v2 pages

### DIFF
--- a/apps/web/src/app/(auth)/reset-password/page.tsx
+++ b/apps/web/src/app/(auth)/reset-password/page.tsx
@@ -7,7 +7,15 @@
 
 import { Suspense } from 'react';
 
+import { Metadata } from 'next';
+
 import { ResetPasswordFallback, ResetPasswordPageContent } from './_content';
+
+export const metadata: Metadata = {
+  title: 'Reimposta password | MeepleAI',
+  description: 'Reimposta la password del tuo account MeepleAI in modo sicuro.',
+  robots: { index: false, follow: false },
+};
 
 export default function ResetPasswordPage() {
   return (

--- a/apps/web/src/app/(auth)/verify-email/page.tsx
+++ b/apps/web/src/app/(auth)/verify-email/page.tsx
@@ -7,18 +7,26 @@
 
 import { Suspense } from 'react';
 
+import { Metadata } from 'next';
+
 import { AuthCard } from '@/components/ui/v2/auth-card';
 
 import { VerifyEmailContent } from './_content';
+
+export const metadata: Metadata = {
+  title: 'Verifica email | MeepleAI',
+  description: 'Verifica il tuo indirizzo email per attivare il tuo account MeepleAI.',
+  robots: { index: false, follow: false },
+};
 
 export default function VerifyEmailPage() {
   return (
     <Suspense
       fallback={
-        <AuthCard title="Email verification">
+        <AuthCard title="Verifica email">
           <div className="text-center py-8">
             <div className="animate-pulse text-muted-foreground text-sm">
-              Verifying your email...
+              Verifica email in corso...
             </div>
           </div>
         </AuthCard>

--- a/apps/web/src/app/(public)/cookie-settings/layout.tsx
+++ b/apps/web/src/app/(public)/cookie-settings/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Preferenze cookie | MeepleAI',
+  description:
+    'Gestisci il tuo consenso ai cookie su MeepleAI. Modifica le preferenze in qualsiasi momento.',
+  robots: { index: false, follow: true },
+};
+
+export default function CookieSettingsLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/web/src/app/(public)/faq/layout.tsx
+++ b/apps/web/src/app/(public)/faq/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Domande Frequenti | MeepleAI',
+  description:
+    'Trova risposte alle domande più comuni su MeepleAI: come funziona, formati supportati, account e sicurezza.',
+  robots: { index: true, follow: true },
+};
+
+export default function FaqLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/web/src/app/(public)/how-it-works/layout.tsx
+++ b/apps/web/src/app/(public)/how-it-works/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Come Funziona | MeepleAI',
+  description:
+    'Scopri come MeepleAI ti aiuta a comprendere le regole dei giochi da tavolo in tre semplici passaggi.',
+  robots: { index: true, follow: true },
+};
+
+export default function HowItWorksLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/web/src/app/_not-found-content.tsx
+++ b/apps/web/src/app/_not-found-content.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { HeroGradient } from '@/components/ui/v2/hero-gradient';
+import { useTranslation } from '@/hooks/useTranslation';
+
+export function NotFoundContent() {
+  const { t } = useTranslation();
+
+  return (
+    <main>
+      <HeroGradient
+        title={
+          <>
+            <span aria-hidden="true" className="block text-xl font-mono text-muted-foreground mb-2">
+              404
+            </span>
+            {t('pages.errors.notFound.title')}
+          </>
+        }
+        subtitle={t('pages.errors.notFound.subtitle')}
+        primaryCta={{ label: t('pages.errors.notFound.homeCta'), href: '/' }}
+        secondaryCta={{ label: t('pages.errors.notFound.exploreCta'), href: '/games' }}
+      />
+    </main>
+  );
+}

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,31 +1,18 @@
-'use client';
+import { Metadata } from 'next';
 
-import { HeroGradient } from '@/components/ui/v2/hero-gradient';
-import { useTranslation } from '@/hooks/useTranslation';
+import { NotFoundContent } from './_not-found-content';
 
 // NOTE: `export const dynamic = 'force-dynamic'` is retained per spec risk #1
 // (known Next.js 16 DOMMatrix bug with client imports in not-found.tsx). If
 // `pnpm build` succeeds without it, remove in a follow-up — not in this task.
 export const dynamic = 'force-dynamic';
 
-export default function NotFound() {
-  const { t } = useTranslation();
+export const metadata: Metadata = {
+  title: 'Pagina non trovata | MeepleAI',
+  description: 'La pagina che stai cercando non esiste o è stata spostata.',
+  robots: { index: false, follow: false },
+};
 
-  return (
-    <main>
-      <HeroGradient
-        title={
-          <>
-            <span aria-hidden="true" className="block text-xl font-mono text-muted-foreground mb-2">
-              404
-            </span>
-            {t('pages.errors.notFound.title')}
-          </>
-        }
-        subtitle={t('pages.errors.notFound.subtitle')}
-        primaryCta={{ label: t('pages.errors.notFound.homeCta'), href: '/' }}
-        secondaryCta={{ label: t('pages.errors.notFound.exploreCta'), href: '/games' }}
-      />
-    </main>
-  );
+export default function NotFound() {
+  return <NotFoundContent />;
 }

--- a/apps/web/src/app/offline/layout.tsx
+++ b/apps/web/src/app/offline/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Sei offline | MeepleAI',
+  description: 'Non sei connesso a internet. Puoi ancora accedere ai contenuti salvati in cache.',
+  robots: { index: false, follow: false },
+};
+
+export default function OfflineLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}


### PR DESCRIPTION
## Summary
- Adds per-route Italian `<title>` metadata to 6 v2 pages that were falling back to the global English root title `MeepleAI - AI-Powered Board Game Rules Assistant`
- Translates `/verify-email` Suspense SSR fallback from English to Italian
- Refactors `not-found.tsx` into server (metadata) + client (NotFoundContent) split

## Bugs fixed (from prior autonomous browser tour)
The following pages were rendering the English root fallback `<title>` because they either lacked per-route metadata or were `'use client'` pages without a sibling server `layout.tsx`:
- `/reset-password`
- `/verify-email` (also: English Suspense fallback flash)
- `/faq`
- `/how-it-works`
- `/cookie-settings`
- `/offline`
- `not-found.tsx`

## Pattern
- **Server pages with Suspense** (`reset-password`, `verify-email`): added `export const metadata` directly
- **`'use client'` pages** (`faq`, `how-it-works`, `cookie-settings`, `offline`): added sibling server `layout.tsx` returning `children` and exporting `metadata` (mirrors `(auth)/register/layout.tsx`)
- **`not-found.tsx`** (needs `useTranslation`): split into server `not-found.tsx` (metadata + `force-dynamic`) wrapping client `_not-found-content.tsx`
- **Suspense fallback IT**: hardcoded Italian strings in `verify-email` SSR fallback (no `useTranslation` available server-side)

## Files changed (8)
- `apps/web/src/app/(auth)/reset-password/page.tsx` — added metadata
- `apps/web/src/app/(auth)/verify-email/page.tsx` — added metadata + IT fallback
- `apps/web/src/app/(public)/faq/layout.tsx` (new)
- `apps/web/src/app/(public)/how-it-works/layout.tsx` (new)
- `apps/web/src/app/(public)/cookie-settings/layout.tsx` (new)
- `apps/web/src/app/_not-found-content.tsx` (new)
- `apps/web/src/app/not-found.tsx` (refactor server/client split)
- `apps/web/src/app/offline/layout.tsx` (new)

## Test plan
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` clean on all 8 modified/new files (32 pre-existing warnings unchanged)
- [x] \`pnpm test src/app/__tests__/not-found.test.tsx\` — 2/2 passing
- [ ] Browser smoke: \`/reset-password\`, \`/verify-email\`, \`/faq\`, \`/how-it-works\`, \`/cookie-settings\`, \`/offline\`, any 404 — verify IT title in browser tab