### PR TITLE
chore(web): stop tracking auto-generated next-env.d.ts

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts';
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- `apps/web/next-env.d.ts` è listato in `.gitignore` (L213) ma era ancora tracked: causa diff spurio in ogni PR ogni volta che Next.js lo rigenera durante un build
- `git rm --cached` lo rimuove dall'index lasciandolo on-disk (Next.js lo ricrea automaticamente)

## Test plan
- [x] `pnpm typecheck` ✅ (verde dopo cleanup `.next/` cache pre-commit)
- [x] Pre-commit hook passa
- [ ] CI verde su PR
- [ ] Verificare che dopo `pnpm dev` il file venga rigenerato e NON appaia in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)