### PR TITLE
chore(web): remove deprecated agentId prop from GameTableZoneKnowledge

### DIFF
--- a/apps/web/src/components/library/game-table/GameTableZoneKnowledge.tsx
+++ b/apps/web/src/components/library/game-table/GameTableZoneKnowledge.tsx
@@ -60,8 +60,6 @@ import { HouseRulesSection } from './HouseRulesSection';
 
 export interface GameTableZoneKnowledgeProps {
   gameId: string;
-  /** @deprecated Use gameId — the agent is now resolved automatically via useGameAgents */
-  agentId?: string;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
Removes the deprecated `agentId?: string` prop from `GameTableZoneKnowledgeProps`. The agent is resolved automatically via `useGameAgents({ gameId })` inside the component, so the prop has been dead code since the rewrite.

## Verification
- Grep `<GameTableZoneKnowledge` across `apps/web/src` → zero JSX call-sites (component is exported but currently unconsumed; broader dead-code cleanup tracked separately)
- `pnpm typecheck` clean
- lint-staged + prettier passed via pre-commit

## Test plan
- [x] Typecheck clean (`pnpm typecheck`)
- [ ] CI green (Frontend Build & Test, lint, e2e)
- [ ] Code review

Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)