### PR TITLE
feat(mockups): SP3 public secondary — 5 reduced-scope mockups

### DIFF
--- a/admin-mockups/briefs/SP3-public-secondary.md
+++ b/admin-mockups/briefs/SP3-public-secondary.md
@@ -169,7 +169,18 @@ Questo sub-project sblocca: (1) completamento pubblico per SEO + compliance lega
 - **no-content**: gioco senza toolkit — CTA "Sii il primo a pubblicare"
 - **loading**: skeleton hero + tab
 
-**Componenti v2 da progettare**: `GamePublicHero`, `ToolkitPublicListItem`, riusa connection-bar pattern di SP4.
+**Componenti v2 da progettare**: `GamePublicHero`, `ToolkitPublicListItem`.
+
+**Componente già stabile (NON ridisegnare)**: `ConnectionBar` è già in produzione (PR #549 Step 1.6 + PR #552 Step 2). Path componente: `apps/web/src/components/ui/data-display/connection-bar/ConnectionBar.tsx`; tipi in `types.ts` (`ConnectionPip`, `ConnectionBarProps`). Il mockup deve mostrare la stessa primitive con pip-button entity-colored (`entityHsl(entityType, 0.1)` background, `entityHsl(entityType)` foreground), forma `rounded-full px-3 py-1.5 text-xs font-bold`, scroll orizzontale `overflow-x-auto`. Per il dettaglio shared-game pubblico, popolare con:
+```tsx
+const connections: ConnectionPip[] = [
+  { entityType: 'toolkit', count: 4, label: 'Toolkit',  icon: ToolboxIcon, isEmpty: false },
+  { entityType: 'agent',   count: 2, label: 'Agenti',   icon: Bot,         isEmpty: false },
+  { entityType: 'kb',      count: 7, label: 'Documenti',icon: FileText,    isEmpty: false },
+  { entityType: 'player',  count: 12,label: 'Top contributors', icon: User, isEmpty: false },
+];
+```
+Per il caricamento Claude Design: includere `ConnectionBar.tsx` + `types.ts` come reference visiva (Tier 2 pattern code).
 
 ---
 

--- a/admin-mockups/briefs/SP4-entity-desktop.md
+++ b/admin-mockups/briefs/SP4-entity-desktop.md
@@ -29,6 +29,39 @@ Per ogni detail page decidi esplicitamente:
 
 Connection bar (pip delle entità collegate) **sempre presente** sotto l'hero/header, entro 80px dal top.
 
+### Componenti già stabili — NON ridisegnare
+
+Questi componenti v2 sono **già implementati e mergiati su `main-dev`**. Riusali pixel-perfect, non reinventare:
+
+| Componente | Path codice | Stato | Mockup riferimento |
+|------------|-------------|-------|---------------------|
+| `ConnectionBar` | `apps/web/src/components/ui/data-display/connection-bar/ConnectionBar.tsx` | ✅ in produzione (PR #549, #552) — applicata su `GameDetailDesktop`, `AgentCharacterSheet` | layout pip rounded-full, icona + count + label, entity color, isEmpty → "+" |
+| `ConnectionChip` / `ConnectionChipPopover` / `ConnectionChipStrip` | `apps/web/src/components/ui/data-display/meeple-card/parts/` | ✅ in produzione (PR #542, #545, #549, #552) — usata in MeepleCard footer | strip orizzontale per card |
+| `MeepleCard` | `apps/web/src/components/ui/data-display/meeple-card/` | ✅ in produzione | tutte le varianti (grid/list/compact/featured/hero) e i 9 entity types |
+| `RecentsBar` | `apps/web/src/components/ui/navigation/recents-bar/` | ✅ in produzione (M5) | pill recent entities |
+| `MobileBottomBar` + `MiniNavSlot` | `apps/web/src/components/layout/` | ✅ in produzione (M5) | 5-tab nav mobile |
+| Drawer stack (`useCascadeNavigationStore`) | `apps/web/src/stores/cascadeNavigationStore.ts` | ✅ in produzione (M5) | side-panel desktop / bottom-sheet mobile, max 3 stack |
+
+**Per SP4 il tuo lavoro è**: estendere l'uso di questi componenti alle entity che ancora non li hanno (KB, Toolkit, Player, Game Nights), NON ridefinire il pattern. Se senti il bisogno di deviare dal pattern stabile, **flagga esplicitamente con motivazione** — il default è riuso.
+
+### Connection bar — input concreto per ogni entity
+
+Per ogni detail produrre, definisci esplicitamente la lista pip da mostrare nella connection-bar (entityType + count + icon + label). Esempio già in produzione:
+
+```tsx
+// Game detail desktop (riferimento implementazione attuale)
+const connections: ConnectionPip[] = [
+  { entityType: 'agent',   count: 2, label: 'Agenti',    icon: Bot,        isEmpty: false },
+  { entityType: 'kb',      count: 5, label: 'Documenti', icon: FileText,   isEmpty: false },
+  { entityType: 'toolkit', count: 1, label: 'Toolkit',   icon: ToolboxIcon,isEmpty: false },
+  { entityType: 'session', count: 12,label: 'Partite',   icon: Target,     isEmpty: false },
+  { entityType: 'player',  count: 4, label: 'Giocatori', icon: User,       isEmpty: false },
+  { entityType: 'chat',    count: 0, label: 'Chat',      icon: MessageCircle, isEmpty: true },
+];
+```
+
+Riusa identica struttura per tutte le entity SP4. Vedi `apps/web/src/components/ui/data-display/connection-bar/build-connections.ts` per i builder esistenti (`buildGameConnections`, `buildAgentConnections`, `buildSessionConnections`).
+
 ## Schermate da produrre (16, raggruppate per entity)
 
 ### A. Game (`--c-game`, 🎲)

--- a/admin-mockups/design_files/sp3-accept-invite.html
+++ b/admin-mockups/design_files/sp3-accept-invite.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>SP3 · Accept Invite — MeepleAI</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@500;600;700;800&family=Nunito:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet"/>
+  <link rel="stylesheet" href="tokens.css"/>
+  <link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+  <script src="data.js"></script>
+  <script type="text/babel" src="sp3-accept-invite.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp3-accept-invite.jsx
+++ b/admin-mockups/design_files/sp3-accept-invite.jsx
@@ -1,0 +1,954 @@
+/* MeepleAI SP3 — Accept Invite (game night)
+   Route target: /accept-invite/[token]
+   Pagina che riceve un invite token via email per unirsi a una serata di
+   gioco come guest player. 7 stati richiesti.
+
+   Componenti v2 nuovi:
+   - InviteHostCard (avatar+nome+welcome message, riusabile in #5 detail)
+   - SessionMetaGrid (game · date · time · duration · players)
+   - DeclinedShell (variante neutrale del SuccessShell)
+
+   Riusi:
+   - AuthCard, InputField, PrimaryBtn (SP1)
+   - SuccessCard pattern (SP1, riusato in #1) — esteso a "accepted-success"
+   - Banner (#1)
+   - MeepleCardGame compact (#2)
+
+   Decisioni di design:
+   - Avatar host: ROUND, 56px sulla card, 40px nelle versioni compatte.
+     Round è coerente con il sistema (player-pip, contributors sidebar in #2).
+   - Token-expired CTA: link a "Contatta host" (mailto-style) — più diretto
+     di /join che è alpha generica. /join rimane fallback in fondo.
+   - Animazione success: confetti leggero (CSS-only, 12 particelle) — è una
+     interazione celebrativa one-shot e l'utente è già al picco emotivo.
+*/
+
+const { useState, useEffect, useMemo, useRef } = React;
+const DS = window.DS;
+
+// ─── DATI MOCK INVITE ────────────────────────────────
+// Host preso da DS.players[0] (Marco R., Membro Gen 2025)
+const HOST = DS.players[0];
+// Game preso da DS.games — scegliamo Wingspan (gradient verde, leggibile su entrambe le card)
+const GAME = DS.games.find(g => g.id === 'g-wingspan') || DS.games[2];
+
+const INVITE = {
+  id: 'inv-7f3a9c',
+  token: 'MOCKUP-FAKE-TOKEN-DO-NOT-USE',
+  hostName: HOST.title,         // "Marco R."
+  hostInitials: HOST.initials,
+  hostColor: HOST.color,
+  hostFav: HOST.fav,
+  game: GAME,
+  date: 'Sabato 9 Maggio 2026',
+  dateShort: 'Sab 9 Mag',
+  time: '20:30',
+  duration: '90–120m',
+  location: 'Casa di Marco · Milano (NoLo)',
+  expectedPlayers: 4,
+  acceptedSoFar: 2,
+  welcomeMessage: 'Ehi! Domenica vorrei provare Wingspan con il toolkit \'Wingspan: Friendly\'. Ti aspetto :)',
+  expiresAt: 'Venerdì 8 Maggio · 18:00',
+};
+
+// Already-confirmed roster (per stato "already-accepted")
+const ROSTER = [
+  { id: HOST.id, name: HOST.title, initials: HOST.initials, color: HOST.color, isHost: true },
+  { id: 'p-sara', name: 'Sara T.', initials: 'ST', color: 320 },
+  { id: 'p-andrea', name: 'Andrea P.', initials: 'AP', color: 100 },
+];
+
+// ─── BRAND MARK ──────────────────────────────────────
+const BrandMark = ({ size = 44 }) => (
+  <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
+    <div style={{
+      width: size, height: size, borderRadius: 12,
+      background: 'linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event)) 60%, hsl(var(--c-player)))',
+      display:'flex', alignItems:'center', justifyContent:'center',
+      color:'#fff', fontWeight: 800, fontSize: size > 40 ? 18 : 14,
+      fontFamily:'var(--f-display)',
+      boxShadow:'0 4px 14px hsl(var(--c-game) / .3)',
+    }}>M</div>
+    <span style={{
+      fontFamily:'var(--f-display)', fontWeight: 700, fontSize: 14,
+      letterSpacing:'-.02em', color:'var(--text)',
+    }}>MeepleAI</span>
+  </div>
+);
+
+// ─── BANNER (riuso #1) ───────────────────────────────
+const Banner = ({ tone='info', children, action }) => {
+  const colors = { success:'c-toolkit', error:'c-danger', warning:'c-warning', info:'c-info' };
+  const c = colors[tone];
+  const icon = tone === 'success' ? '✓' : tone === 'error' ? '✕' : tone === 'warning' ? '!' : 'ℹ';
+  return (
+    <div role={tone === 'error' ? 'alert' : 'status'} style={{
+      display:'flex', alignItems:'flex-start', gap: 10,
+      padding:'10px 12px', borderRadius:'var(--r-md)',
+      background:`hsl(var(--${c}) / .1)`,
+      border:`1px solid hsl(var(--${c}) / .25)`,
+      color:`hsl(var(--${c}))`,
+      fontSize: 12, fontWeight: 600, marginBottom: 14,
+    }}>
+      <span aria-hidden="true" style={{
+        fontSize: 11, lineHeight: 1, flexShrink: 0,
+        width: 18, height: 18, borderRadius:'50%',
+        background:`hsl(var(--${c}) / .18)`,
+        display:'inline-flex', alignItems:'center', justifyContent:'center',
+        marginTop: 1,
+      }}>{icon}</span>
+      <span style={{ flex: 1, lineHeight: 1.5 }}>{children}</span>
+      {action}
+    </div>
+  );
+};
+
+// ─── HOST AVATAR ────────────────────────────────────
+const HostAvatar = ({ size = 56, host = INVITE, ring = true }) => (
+  <div style={{
+    width: size, height: size, borderRadius: '50%',
+    background: `hsl(${host.hostColor} 60% 55%)`,
+    color: '#fff',
+    display:'inline-flex', alignItems:'center', justifyContent:'center',
+    fontFamily: 'var(--f-display)', fontWeight: 800, fontSize: size * 0.36,
+    boxShadow: ring
+      ? `0 0 0 3px var(--bg-card), 0 0 0 5px hsl(${host.hostColor} 60% 55% / .3), 0 6px 20px hsl(${host.hostColor} 60% 55% / .35)`
+      : 'inset 0 1px 0 rgba(255,255,255,.15)',
+    flexShrink: 0,
+  }} aria-hidden="true">{host.hostInitials}</div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── INVITEHOSTCARD (NUOVO COMPONENTE V2) ────────────
+// ═══════════════════════════════════════════════════════
+const InviteHostCard = ({ host = INVITE, compact }) => (
+  <div style={{
+    display:'flex', alignItems:'flex-start', gap: 12,
+    padding: compact ? '11px 12px' : '14px 14px',
+    background:`hsl(${host.hostColor} 60% 55% / .07)`,
+    border:`1px solid hsl(${host.hostColor} 60% 55% / .25)`,
+    borderRadius:'var(--r-lg)',
+  }}>
+    <HostAvatar size={compact ? 38 : 44} host={host} ring={false}/>
+    <div style={{ flex: 1, minWidth: 0 }}>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 6, marginBottom: 4,
+      }}>
+        <span style={{
+          fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 700,
+          color:'var(--text-muted)', textTransform:'uppercase', letterSpacing:'.08em',
+        }}>Host</span>
+        <span style={{
+          fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700,
+          color:'var(--text)',
+        }}>{host.hostName}</span>
+        <span aria-hidden="true" style={{
+          width: 5, height: 5, borderRadius:'50%',
+          background:'hsl(var(--c-toolkit))', flexShrink: 0,
+        }} title="Online"/>
+      </div>
+      <div style={{
+        fontSize: 12, color:'var(--text-sec)', lineHeight: 1.5,
+        fontStyle: host.welcomeMessage ? 'italic' : 'normal',
+      }}>
+        {host.welcomeMessage
+          ? <>«{host.welcomeMessage}»</>
+          : <span style={{ color:'var(--text-muted)' }}>Nessun messaggio dall'host.</span>
+        }
+      </div>
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── SESSIONMETAGRID (NUOVO COMPONENTE V2) ───────────
+// ═══════════════════════════════════════════════════════
+const SessionMetaGrid = ({ inv = INVITE, compact }) => {
+  const meta = [
+    { icon:'📅', label:'Data',     value: inv.date,     mono: false },
+    { icon:'🕗', label:'Ora',      value: inv.time,     mono: true  },
+    { icon:'⏱',  label:'Durata',   value: inv.duration, mono: true  },
+    { icon:'📍', label:'Luogo',    value: inv.location, mono: false },
+    { icon:'👥', label:'Giocatori',value: `${inv.acceptedSoFar} confermati / ${inv.expectedPlayers} attesi`, mono: false },
+  ];
+  return (
+    <ul style={{
+      listStyle:'none', padding: 0, margin: 0,
+      display:'flex', flexDirection:'column',
+      borderRadius:'var(--r-lg)',
+      border:'1px solid var(--border)',
+      background:'var(--bg-muted)',
+      overflow:'hidden',
+    }}>
+      {meta.map((m, i) => (
+        <li key={m.label} style={{
+          display:'flex', alignItems:'center', gap: 10,
+          padding: compact ? '8px 12px' : '9px 14px',
+          borderTop: i === 0 ? 'none' : '1px solid var(--border-light)',
+        }}>
+          <span aria-hidden="true" style={{
+            width: 22, height: 22, borderRadius: 6,
+            background:'var(--bg-card)',
+            display:'inline-flex', alignItems:'center', justifyContent:'center',
+            fontSize: 12, flexShrink: 0,
+          }}>{m.icon}</span>
+          <span style={{
+            fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+            textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+            width: 60, flexShrink: 0,
+          }}>{m.label}</span>
+          <span style={{
+            flex: 1, fontSize: 12, color:'var(--text)', fontWeight: 600,
+            fontFamily: m.mono ? 'var(--f-mono)' : 'var(--f-body)',
+            textAlign:'right',
+          }}>{m.value}</span>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+// ─── GAME COMPACT CARD (riuso pattern MeepleCard #2) ─
+const MeepleCardGameCompact = ({ game }) => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 12,
+    padding: 10,
+    border:'1px solid var(--border)',
+    borderRadius:'var(--r-lg)',
+    background:'var(--bg-card)',
+  }}>
+    <div style={{
+      width: 56, height: 56, borderRadius:'var(--r-md)',
+      background: game.cover,
+      display:'flex', alignItems:'center', justifyContent:'center',
+      flexShrink: 0,
+    }}>
+      <span aria-hidden="true" style={{
+        fontSize: 26, filter:'drop-shadow(0 2px 5px rgba(0,0,0,.25))',
+      }}>{game.coverEmoji}</span>
+    </div>
+    <div style={{ flex: 1, minWidth: 0 }}>
+      <div style={{
+        fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 700,
+        color:'var(--text)', marginBottom: 2,
+        whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis',
+      }}>{game.title}</div>
+      <div style={{
+        fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+        letterSpacing:'.03em',
+      }}>
+        {game.year} · {game.players || '1–5'} pl · {game.duration || '40–80m'}
+      </div>
+    </div>
+  </div>
+);
+
+// ─── INPUT FIELD (riuso da #1) ──────────────────────
+const InputField = ({ label, type='text', placeholder, value, onChange, error, hint, optional, disabled }) => (
+  <div style={{ marginBottom: 13 }}>
+    <label style={{
+      display:'flex', alignItems:'baseline', justifyContent:'space-between',
+      fontSize: 10, fontWeight: 700, fontFamily:'var(--f-display)',
+      color:'var(--text-sec)', marginBottom: 5,
+      textTransform:'uppercase', letterSpacing:'.06em',
+    }}>
+      <span>{label}</span>
+      {optional && <span style={{
+        fontWeight: 600, color:'var(--text-muted)',
+        fontFamily:'var(--f-mono)', textTransform:'none', letterSpacing: 0,
+        fontSize: 10,
+      }}>opzionale</span>}
+    </label>
+    <input
+      type={type} placeholder={placeholder} value={value}
+      onChange={onChange} disabled={disabled}
+      style={{
+        display:'block', width:'100%',
+        padding:'10px 12px',
+        borderRadius:'var(--r-md)',
+        border: error ? '1.5px solid hsl(var(--c-danger))' : '1.5px solid var(--border)',
+        background: error ? 'hsl(var(--c-danger) / .07)' : 'var(--bg)',
+        color:'var(--text)', fontSize: 13, outline:'none',
+        fontFamily:'var(--f-body)',
+        transition:'border-color var(--dur-sm) var(--ease-out)',
+        boxSizing:'border-box',
+        opacity: disabled ? .65 : 1,
+      }}
+    />
+    {error && <div style={{ fontSize: 11, color:'hsl(var(--c-danger))', marginTop: 4, fontWeight: 600 }}>{error}</div>}
+    {hint && !error && <div style={{ fontSize: 11, color:'var(--text-muted)', marginTop: 4 }}>{hint}</div>}
+  </div>
+);
+
+// ─── PRIMARY BTN (riuso da #1) ──────────────────────
+const PrimaryBtn = ({ children, onClick, disabled, loading }) => (
+  <button type="button" onClick={onClick} disabled={disabled || loading}
+    style={{
+      display:'inline-flex', alignItems:'center', justifyContent:'center', gap: 8,
+      width:'100%', padding:'11px 14px', fontSize: 14,
+      borderRadius:'var(--r-md)',
+      fontFamily:'var(--f-display)', fontWeight: 700, border:'none',
+      background:'hsl(var(--c-game))', color:'#fff',
+      boxShadow:'0 3px 12px hsl(var(--c-game) / .35)',
+      cursor: (disabled || loading) ? 'not-allowed' : 'pointer',
+      opacity: (disabled || loading) ? .7 : 1,
+      transition:'transform var(--dur-sm) var(--ease-out), box-shadow var(--dur-sm)',
+    }}
+    onMouseDown={e => !(disabled || loading) && (e.currentTarget.style.transform='scale(.98)')}
+    onMouseUp={e => (e.currentTarget.style.transform='')}
+    onMouseLeave={e => (e.currentTarget.style.transform='')}
+  >
+    {loading && (
+      <span aria-hidden="true" style={{
+        width: 14, height: 14, border:'2px solid rgba(255,255,255,.4)',
+        borderTopColor:'#fff', borderRadius:'50%',
+        animation:'mai-spin .7s linear infinite', display:'inline-block',
+      }}/>
+    )}
+    {children}
+  </button>
+);
+
+// ─── GHOST BTN ──────────────────────────────────────
+const GhostBtn = ({ children, onClick, disabled, danger }) => (
+  <button type="button" onClick={onClick} disabled={disabled}
+    style={{
+      display:'inline-flex', alignItems:'center', justifyContent:'center', gap: 6,
+      width:'100%', padding:'9px 14px', fontSize: 13,
+      borderRadius:'var(--r-md)',
+      fontFamily:'var(--f-display)', fontWeight: 600,
+      background:'transparent',
+      border:`1px solid var(--border)`,
+      color: danger ? 'hsl(var(--c-danger))' : 'var(--text-sec)',
+      cursor: disabled ? 'not-allowed' : 'pointer',
+      opacity: disabled ? .55 : 1,
+      transition:'all var(--dur-sm) var(--ease-out)',
+    }}
+    onMouseEnter={e => !disabled && (e.currentTarget.style.background = 'var(--bg-hover)')}
+    onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
+  >{children}</button>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── AUTH CARD SHELL ─────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const AuthCard = ({ children, width = 380 }) => (
+  <div style={{
+    width: '100%', maxWidth: width,
+    background:'var(--bg-card)',
+    border:'1px solid var(--border)',
+    borderRadius:'var(--r-2xl)',
+    padding: '22px 22px 20px',
+    boxShadow:'var(--shadow-lg)',
+    boxSizing:'border-box',
+  }}>{children}</div>
+);
+
+// ─── HERO LEGGERO ────────────────────────────────────
+const Hero = ({ inv = INVITE, compact }) => (
+  <div style={{
+    textAlign:'center',
+    padding: compact ? '14px 16px 6px' : '18px 24px 8px',
+  }}>
+    <div style={{
+      display:'inline-flex', alignItems:'center', gap: 6,
+      padding:'4px 10px', borderRadius:'var(--r-pill)',
+      background:'hsl(var(--c-event) / .14)',
+      color:'hsl(var(--c-event))',
+      fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 700,
+      textTransform:'uppercase', letterSpacing:'.08em',
+      marginBottom: 10,
+    }}>
+      <span aria-hidden="true">🎯</span>
+      Game night
+    </div>
+    <h1 style={{
+      fontFamily:'var(--f-display)', fontWeight: 800,
+      fontSize: compact ? 17 : 20,
+      letterSpacing:'-.01em', lineHeight: 1.2,
+      color:'var(--text)', margin: '0 0 4px',
+    }}>
+      <strong style={{ color:'hsl(var(--c-game))' }}>{inv.hostName}</strong>{' '}ti invita a giocare a{' '}
+      <strong style={{ color:'hsl(var(--c-toolkit))' }}>{inv.game.title}</strong>
+    </h1>
+    <p style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      letterSpacing:'.04em', margin: 0,
+    }}>{inv.dateShort} · {inv.time}</p>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── ROSTER MINI (per already-accepted) ──────────────
+// ═══════════════════════════════════════════════════════
+const RosterMini = ({ roster = ROSTER }) => (
+  <div style={{
+    display:'flex', flexDirection:'column', gap: 7,
+    padding:'12px',
+    background:'var(--bg-muted)',
+    border:'1px solid var(--border)',
+    borderRadius:'var(--r-lg)',
+  }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+      marginBottom: 2,
+    }}>// Confermati</div>
+    {roster.map(p => (
+      <div key={p.id} style={{ display:'flex', alignItems:'center', gap: 9 }}>
+        <span style={{
+          width: 26, height: 26, borderRadius:'50%',
+          background:`hsl(${p.color} 60% 55%)`, color:'#fff',
+          display:'inline-flex', alignItems:'center', justifyContent:'center',
+          fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 10, flexShrink: 0,
+        }} aria-hidden="true">{p.initials}</span>
+        <span style={{
+          flex: 1, fontSize: 12, fontWeight: 600, color:'var(--text)',
+        }}>{p.name}</span>
+        {p.isHost && <span style={{
+          padding:'1px 7px', borderRadius:'var(--r-pill)',
+          background:'hsl(var(--c-game) / .14)', color:'hsl(var(--c-game))',
+          fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 700,
+          textTransform:'uppercase', letterSpacing:'.06em',
+        }}>Host</span>}
+      </div>
+    ))}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── CONFETTI (CSS-only, 12 particles) ──────────────
+// ═══════════════════════════════════════════════════════
+const Confetti = () => {
+  const particles = useMemo(() => Array.from({ length: 14 }, (_, i) => ({
+    id: i,
+    left: 5 + Math.random() * 90,
+    delay: Math.random() * 0.4,
+    duration: 1.4 + Math.random() * 1.0,
+    color: ['c-game','c-event','c-toolkit','c-player','c-agent'][i % 5],
+    size: 6 + Math.random() * 6,
+    rotate: Math.random() * 360,
+  })), []);
+  return (
+    <div aria-hidden="true" style={{
+      position:'absolute', inset: 0, overflow:'hidden', pointerEvents:'none',
+    }}>
+      {particles.map(p => (
+        <span key={p.id} style={{
+          position:'absolute', top: '-12px', left: `${p.left}%`,
+          width: p.size, height: p.size,
+          background: `hsl(var(--${p.color}))`,
+          borderRadius: p.id % 2 ? '50%' : '2px',
+          transform: `rotate(${p.rotate}deg)`,
+          animation: `mai-confetti ${p.duration}s cubic-bezier(.4,.7,.6,1) ${p.delay}s forwards`,
+        }}/>
+      ))}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── ACCEPTEDSUCCESS SHELL ───────────────────────────
+// ═══════════════════════════════════════════════════════
+const AcceptedSuccessShell = ({ inv = INVITE, onDismiss }) => (
+  <div style={{ position:'relative', overflow:'hidden' }}>
+    <Confetti/>
+    <div style={{
+      display:'flex', flexDirection:'column', alignItems:'center', textAlign:'center',
+      padding:'4px 4px 4px',
+    }}>
+      <div style={{
+        width: 64, height: 64, borderRadius:'50%',
+        background:'hsl(var(--c-toolkit) / .14)',
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 30, marginBottom: 14,
+        boxShadow:'inset 0 0 0 3px hsl(var(--c-toolkit) / .25)',
+      }} aria-hidden="true">🎲</div>
+      <h2 style={{
+        fontFamily:'var(--f-display)', fontSize: 19, fontWeight: 800,
+        color:'var(--text)', margin:'0 0 6px', letterSpacing:'-.01em',
+      }}>Ci sei!</h2>
+      <p style={{
+        fontSize: 12, color:'var(--text-muted)', lineHeight: 1.6, margin:'0 0 16px',
+      }}>
+        {inv.hostName} riceverà la tua conferma.<br/>
+        Ti ricordiamo l'evento il giorno prima.
+      </p>
+      <div style={{
+        width:'100%', padding:'12px 14px',
+        background:'var(--bg-muted)', borderRadius:'var(--r-md)',
+        marginBottom: 14, textAlign:'left',
+        border:'1px solid var(--border-light)',
+      }}>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 700,
+          color:'var(--text-muted)', textTransform:'uppercase', letterSpacing:'.08em',
+          marginBottom: 6,
+        }}>Riepilogo</div>
+        <div style={{ display:'flex', alignItems:'center', gap: 8, marginBottom: 4 }}>
+          <span aria-hidden="true">🎲</span>
+          <strong style={{ fontFamily:'var(--f-display)', fontSize: 14, color:'var(--text)' }}>{inv.game.title}</strong>
+        </div>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+          letterSpacing:'.04em',
+        }}>{inv.dateShort} · {inv.time} · {inv.location.split(' · ')[0]}</div>
+      </div>
+      <PrimaryBtn onClick={onDismiss}>Vai alla sessione →</PrimaryBtn>
+      <button type="button" onClick={onDismiss} style={{
+        marginTop: 10, padding: 8, fontSize: 11,
+        background:'transparent', border:'none',
+        color:'var(--text-muted)', textDecoration:'underline',
+        cursor:'pointer', fontFamily:'var(--f-body)',
+      }}>Aggiungi al calendario (.ics)</button>
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── DECLINED SHELL ──────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const DeclinedShell = ({ inv = INVITE, onUndo }) => (
+  <div style={{
+    display:'flex', flexDirection:'column', alignItems:'center', textAlign:'center',
+    padding:'4px 4px 4px',
+  }}>
+    <div style={{
+      width: 60, height: 60, borderRadius:'50%',
+      background:'var(--bg-muted)',
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 26, marginBottom: 14,
+      border:'1px solid var(--border)',
+    }} aria-hidden="true">🌙</div>
+    <h2 style={{
+      fontFamily:'var(--f-display)', fontSize: 18, fontWeight: 700,
+      color:'var(--text)', margin:'0 0 6px',
+    }}>Ok, sarà per la prossima!</h2>
+    <p style={{
+      fontSize: 12, color:'var(--text-muted)', lineHeight: 1.6, margin:'0 0 16px',
+    }}>
+      {inv.hostName} riceverà la tua risposta.<br/>
+      Nessun problema — ti aspettiamo per la prossima serata.
+    </p>
+    <div style={{ display:'flex', flexDirection:'column', gap: 8, width:'100%' }}>
+      <a href="#" onClick={e => e.preventDefault()} style={{
+        display:'inline-flex', alignItems:'center', justifyContent:'center',
+        padding:'10px 14px', borderRadius:'var(--r-md)',
+        background:'var(--bg-muted)', color:'var(--text)',
+        fontFamily:'var(--f-display)', fontWeight: 700, fontSize: 13,
+        textDecoration:'none',
+        border:'1px solid var(--border)',
+      }}>Torna alla home →</a>
+      <button onClick={onUndo} style={{
+        padding: 8, fontSize: 11,
+        background:'transparent', border:'none',
+        color:'var(--text-muted)', textDecoration:'underline',
+        cursor:'pointer', fontFamily:'var(--f-body)',
+      }}>Ho cambiato idea, accetta l'invito</button>
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── INVITE BODY (default | logged-in | error stati) ─
+// ═══════════════════════════════════════════════════════
+const InviteBody = ({ stateOverride }) => {
+  const [inner, setInner] = useState(stateOverride);
+  useEffect(() => setInner(stateOverride), [stateOverride]);
+
+  // ── Stato accepted-success
+  if (inner === 'accepted-success') {
+    return <AcceptedSuccessShell onDismiss={() => setInner(stateOverride)}/>;
+  }
+
+  // ── Stato declined
+  if (inner === 'declined') {
+    return <DeclinedShell onUndo={() => setInner('logged-in')}/>;
+  }
+
+  // ── Errori (token-expired | token-invalid | already-accepted)
+  if (inner === 'token-expired') {
+    return (
+      <div>
+        <Banner tone="error">
+          Questo invito è <strong>scaduto</strong> il {INVITE.expiresAt}.
+        </Banner>
+        <p style={{
+          fontSize: 12, color:'var(--text-sec)', lineHeight: 1.6,
+          margin:'0 0 14px', textAlign:'center',
+        }}>
+          Per partecipare alla serata, contatta direttamente l'host
+          per ricevere un nuovo invito.
+        </p>
+        <div style={{ display:'flex', flexDirection:'column', gap: 8 }}>
+          <PrimaryBtn onClick={() => {}}>✉ Contatta {INVITE.hostName}</PrimaryBtn>
+          <a href="#" onClick={e=>e.preventDefault()} style={{
+            display:'inline-flex', alignItems:'center', justifyContent:'center',
+            padding:'9px 14px', borderRadius:'var(--r-md)',
+            color:'var(--text-muted)', fontSize: 12,
+            textDecoration:'underline', fontFamily:'var(--f-body)',
+          }}>Torna alla home</a>
+        </div>
+      </div>
+    );
+  }
+
+  if (inner === 'token-invalid') {
+    return (
+      <div>
+        <Banner tone="error">
+          Questo invito non è valido o è già stato utilizzato.
+        </Banner>
+        <p style={{
+          fontSize: 12, color:'var(--text-sec)', lineHeight: 1.6,
+          margin:'0 0 14px', textAlign:'center',
+        }}>
+          Possibili cause:
+        </p>
+        <ul style={{
+          fontSize: 12, color:'var(--text-muted)', lineHeight: 1.7,
+          paddingLeft: 18, margin:'0 0 16px',
+        }}>
+          <li>Il link è stato copiato in modo incompleto</li>
+          <li>L'invito è già stato accettato da un altro device</li>
+          <li>L'host ha revocato l'invito</li>
+        </ul>
+        <PrimaryBtn onClick={() => {}}>Torna alla home →</PrimaryBtn>
+      </div>
+    );
+  }
+
+  if (inner === 'already-accepted') {
+    return (
+      <div>
+        <Banner tone="info">
+          Hai <strong>già confermato</strong> la partecipazione a questa serata.
+        </Banner>
+        <RosterMini/>
+        <div style={{ marginTop: 14, display:'flex', flexDirection:'column', gap: 8 }}>
+          <PrimaryBtn onClick={() => {}}>Vai alla sessione →</PrimaryBtn>
+          <GhostBtn onClick={() => setInner('declined')} danger>
+            Disdici la partecipazione
+          </GhostBtn>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Stato default (non loggato) | logged-in
+  const isLogged = inner === 'logged-in';
+  return (
+    <div>
+      <MeepleCardGameCompact game={INVITE.game}/>
+      <div style={{ height: 12 }}/>
+      <SessionMetaGrid/>
+      <div style={{ height: 12 }}/>
+      <InviteHostCard/>
+      <div style={{ height: 16 }}/>
+
+      {!isLogged && (
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 700,
+          color:'var(--text-muted)', textTransform:'uppercase', letterSpacing:'.08em',
+          marginBottom: 8, paddingTop: 4,
+          borderTop:'1px dashed var(--border)',
+        }}>// Per accettare, accedi o registrati</div>
+      )}
+
+      <div style={{ display:'flex', flexDirection:'column', gap: 9 }}>
+        <PrimaryBtn onClick={() => setInner('accepted-success')}>
+          {isLogged ? '✓ Accetta invito' : 'Accetta e accedi →'}
+        </PrimaryBtn>
+        <GhostBtn onClick={() => setInner('declined')}>Non posso partecipare</GhostBtn>
+      </div>
+
+      {!isLogged && (
+        <p style={{
+          fontSize: 11, color:'var(--text-muted)', lineHeight: 1.55,
+          margin:'12px 0 0', textAlign:'center',
+        }}>
+          Hai già un account? <a href="#" onClick={e=>e.preventDefault()} style={{
+            color:'hsl(var(--c-game))', fontWeight: 600, textDecoration:'none',
+          }}>Accedi</a> per accettare in 1 click.
+        </p>
+      )}
+    </div>
+  );
+};
+
+// ─── PAGE WRAPPER ────────────────────────────────────
+const InvitePage = ({ stateOverride, compact }) => (
+  <div style={{
+    minHeight:'100%',
+    background:'radial-gradient(80% 60% at 50% 0%, hsl(var(--c-game) / .06), transparent 70%)',
+    display:'flex', flexDirection:'column',
+    padding: compact ? '12px 0 18px' : '20px 0 32px',
+  }}>
+    <div style={{ padding: compact ? '0 16px 8px' : '0 24px 12px' }}>
+      <BrandMark/>
+    </div>
+    <Hero compact={compact}/>
+    <div style={{
+      display:'flex', justifyContent:'center',
+      padding: compact ? '8px 14px 0' : '12px 24px 0',
+    }}>
+      <AuthCard width={compact ? '100%' : 380}>
+        <InviteBody stateOverride={stateOverride}/>
+      </AuthCard>
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── MOBILE 375 SCREEN ───────────────────────────────
+// ═══════════════════════════════════════════════════════
+const PhoneSbar = () => (
+  <div className="phone-sbar">
+    <span style={{ fontFamily:'var(--f-mono)' }}>14:32</span>
+    <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+  </div>
+);
+
+const InviteMobileScreen = ({ stateOverride }) => (
+  <>
+    <PhoneSbar/>
+    <div style={{
+      flex: 1, overflowY:'auto', scrollbarWidth:'none',
+      background:'var(--bg)',
+    }}>
+      <InvitePage stateOverride={stateOverride} compact/>
+    </div>
+  </>
+);
+
+const PhoneShell = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 10 }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div className="phone">{children}</div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 340,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── DESKTOP 1440 SCREEN ─────────────────────────────
+// ═══════════════════════════════════════════════════════
+const DesktopFrame = ({ children, label, desc }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 12, width:'100%' }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div style={{
+      width:'100%', maxWidth: 1180,
+      borderRadius:'var(--r-xl)',
+      border:'1px solid var(--border)',
+      background:'var(--bg)',
+      overflow:'hidden',
+      boxShadow:'var(--shadow-lg)',
+    }}>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 8,
+        padding:'9px 14px',
+        background:'var(--bg-muted)',
+        borderBottom:'1px solid var(--border)',
+        fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      }}>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-event))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-warning))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-toolkit))' }}/>
+        <span style={{ flex: 1, textAlign:'center', letterSpacing:'.04em' }}>meepleai.app/accept-invite/{INVITE.token.slice(0, 8)}…</span>
+      </div>
+      {children}
+    </div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 720,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+// Desktop layout: split — left big game card + roster context, right form
+const InviteDesktopScreen = ({ stateOverride }) => (
+  <div style={{
+    minHeight: 640,
+    background:'radial-gradient(75% 55% at 50% -10%, hsl(var(--c-game) / .08), transparent 70%)',
+    padding:'20px 32px 32px',
+  }}>
+    <div style={{ marginBottom: 16 }}><BrandMark/></div>
+    <div style={{
+      display:'grid', gridTemplateColumns:'1.1fr 1fr', gap: 32,
+      maxWidth: 980, margin:'0 auto',
+      alignItems:'start',
+    }}>
+      {/* LEFT — game hero + meta */}
+      <div>
+        <div style={{
+          display:'inline-flex', alignItems:'center', gap: 6,
+          padding:'4px 10px', borderRadius:'var(--r-pill)',
+          background:'hsl(var(--c-event) / .14)',
+          color:'hsl(var(--c-event))',
+          fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 700,
+          textTransform:'uppercase', letterSpacing:'.08em',
+          marginBottom: 12,
+        }}>
+          <span aria-hidden="true">🎯</span>Game night
+        </div>
+        <h1 style={{
+          fontFamily:'var(--f-display)', fontWeight: 800,
+          fontSize: 28, letterSpacing:'-.02em', lineHeight: 1.15,
+          color:'var(--text)', margin: '0 0 6px',
+        }}>
+          <strong style={{ color:'hsl(var(--c-game))' }}>{INVITE.hostName}</strong>{' '}ti invita a giocare a{' '}
+          <strong style={{ color:'hsl(var(--c-toolkit))' }}>{INVITE.game.title}</strong>
+        </h1>
+        <p style={{
+          fontFamily:'var(--f-body)', fontSize: 14, color:'var(--text-sec)',
+          lineHeight: 1.55, margin:'0 0 18px',
+        }}>
+          {INVITE.date} · {INVITE.time} · {INVITE.location}
+        </p>
+
+        {/* Big game card */}
+        <div style={{
+          borderRadius:'var(--r-xl)', overflow:'hidden',
+          border:'1px solid var(--border)',
+          background:'var(--bg-card)',
+          marginBottom: 14,
+          boxShadow:'var(--shadow-xs)',
+        }}>
+          <div style={{
+            height: 120,
+            background: INVITE.game.cover,
+            display:'flex', alignItems:'center', justifyContent:'center',
+          }}>
+            <span aria-hidden="true" style={{
+              fontSize: 48, filter:'drop-shadow(0 3px 8px rgba(0,0,0,.25))',
+            }}>{INVITE.game.coverEmoji}</span>
+          </div>
+          <div style={{ padding:'12px 14px' }}>
+            <div style={{
+              fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 700,
+              color:'var(--text)', marginBottom: 3,
+            }}>{INVITE.game.title}</div>
+            <div style={{
+              fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+              letterSpacing:'.04em',
+            }}>{INVITE.game.year} · {INVITE.game.players || '1–5'} pl · {INVITE.game.duration || '40–80m'}</div>
+          </div>
+        </div>
+
+        <SessionMetaGrid/>
+      </div>
+
+      {/* RIGHT — invite card */}
+      <div>
+        <AuthCard width="100%">
+          <InviteBody stateOverride={stateOverride}/>
+        </AuthCard>
+      </div>
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── ROOT ────────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const MOBILE_STATES = [
+  { id: 'default',           label: '01 · Default (non loggato)',   desc: 'Token valido. CTA "Accetta e accedi" → flow login dopo. Link "Hai già account? Accedi".' },
+  { id: 'logged-in',         label: '02 · Logged-in',               desc: 'Utente loggato. CTA secca "Accetta invito" — 1 click conferma.' },
+  { id: 'accepted-success',  label: '03 · Accepted (success)',      desc: 'Confetti CSS one-shot + riepilogo. CTA "Vai alla sessione". Link .ics calendar.' },
+  { id: 'declined',          label: '04 · Declined',                desc: 'Tono neutro non-shame. Link "ho cambiato idea" per undo.' },
+  { id: 'token-expired',     label: '05 · Token expired',           desc: 'Banner error + CTA "Contatta host" (mailto). Niente /join che è alpha generica.' },
+  { id: 'token-invalid',     label: '06 · Token invalid',           desc: 'Banner error + checklist diagnostica (link rotto, già usato, revocato).' },
+  { id: 'already-accepted',  label: '07 · Already accepted',        desc: 'Roster confermati visibili. CTA "vai alla sessione" + ghost "disdici".' },
+];
+
+function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+  }, [dark]);
+  return (
+    <button onClick={() => setDark(d => !d)} className="theme-toggle"
+      aria-label={dark ? 'Passa a tema chiaro' : 'Passa a tema scuro'}>
+      <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span>
+      <span>{dark ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+}
+
+function App() {
+  return (
+    <div className="stage">
+      <ThemeToggle/>
+      <div className="stage-wrap">
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.08em', marginBottom: 8,
+        }}>SP3 · Public Secondary · #3</div>
+        <h1>Accept Invite — Game night</h1>
+        <p className="lead">
+          <code style={{ background:'var(--bg-muted)', padding:'2px 7px', borderRadius:'var(--r-sm)', fontSize: 12 }}>/accept-invite/[token]</code>
+          {' · '}7 stati: 2 happy-path (non loggato + loggato) · 2 outcome (accepted+confetti, declined) · 3 errori token (expired, invalid, already-accepted).
+          Componenti v2 nuovi: <strong>InviteHostCard</strong>, <strong>SessionMetaGrid</strong>, <strong>RosterMini</strong>.
+          Riusa AuthCard, PrimaryBtn, Banner, MeepleCardGameCompact.
+        </p>
+
+        <div className="section-label">Mobile · 375 — 7 stati</div>
+        <div className="phones-grid">
+          {MOBILE_STATES.map(s => (
+            <PhoneShell key={s.id} label={s.label} desc={s.desc}>
+              <InviteMobileScreen stateOverride={s.id}/>
+            </PhoneShell>
+          ))}
+        </div>
+
+        <div className="section-label">Desktop · 1440 — split layout</div>
+        <div style={{ display:'flex', flexDirection:'column', gap: 36 }}>
+          <DesktopFrame label="08 · Desktop · Default (non loggato)"
+            desc="Layout split. LEFT: hero copy + game cover hero (120px) + SessionMetaGrid. RIGHT: AuthCard 380 con InviteHostCard + CTA. Sopra-fold complete: niente scroll richiesto.">
+            <InviteDesktopScreen stateOverride="default"/>
+          </DesktopFrame>
+          <DesktopFrame label="09 · Desktop · Accepted (success)"
+            desc="Stessa griglia, RIGHT diventa SuccessShell con confetti animation. LEFT context rimane visibile per dare permanenza al risultato.">
+            <InviteDesktopScreen stateOverride="accepted-success"/>
+          </DesktopFrame>
+          <DesktopFrame label="10 · Desktop · Token expired"
+            desc="LEFT hero rimane (l'utente capisce a cosa è stato invitato), RIGHT mostra error state + CTA contatta host.">
+            <InviteDesktopScreen stateOverride="token-expired"/>
+          </DesktopFrame>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes mai-spin { to { transform: rotate(360deg); } }
+        @keyframes mai-confetti {
+          0%   { transform: translate3d(0, 0, 0) rotate(0deg); opacity: 0; }
+          10%  { opacity: 1; }
+          100% { transform: translate3d(var(--mai-cx, 0), 280px, 0) rotate(540deg); opacity: 0; }
+        }
+        .phones-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+          gap: var(--s-7);
+          align-items: start;
+        }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage .lead { line-height: var(--lh-relax); }
+        .phone > div::-webkit-scrollbar { display: none; }
+        button:focus-visible, a:focus-visible, input:focus-visible {
+          outline: 2px solid hsl(var(--c-game));
+          outline-offset: 2px;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);

--- a/admin-mockups/design_files/sp3-faq-enhanced.html
+++ b/admin-mockups/design_files/sp3-faq-enhanced.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>SP3 · FAQ Enhanced — MeepleAI</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@500;600;700;800&family=Nunito:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet"/>
+  <link rel="stylesheet" href="tokens.css"/>
+  <link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+  <script src="data.js"></script>
+  <script type="text/babel" src="sp3-faq-enhanced.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp3-faq-enhanced.jsx
+++ b/admin-mockups/design_files/sp3-faq-enhanced.jsx
@@ -1,0 +1,991 @@
+/* MeepleAI SP3 — FAQ Enhanced
+   Route: /faq (replaces existing static FAQ from PR #553)
+   Pagina informativa pubblica con search + categorie + quick answers + accordion.
+
+   Decisioni di design:
+   - Categorie come tab pills sticky (pattern #4) — sidebar NO: troppo spazio sprecato
+     su una pagina informativa.
+   - Quick answers: 4 cards (2x2 desktop, 1x4 mobile). 4 > 5 perché grid pulita
+     e 4 fit naturalmente in 2 col su tablet/desktop.
+   - Highlight match di ricerca: <mark> con background hsl(c-warning, .25) +
+     color text + font-weight 700 — più scannable di bold-only, meno aggressivo
+     di bg pieno yellow.
+   - Accordion: clone visivo di Radix Accordion (pattern attuale) — single-open,
+     animated chevron rotate, smooth height transition.
+*/
+
+const { useState, useMemo, useEffect, useRef, useCallback } = React;
+
+// ─── FAQ DATASET ──────────────────────────────────────
+const FAQ_CATEGORIES = [
+  { id:'all',     label:'Tutte',           icon:'📚' },
+  { id:'account', label:'Account & Login', icon:'👤' },
+  { id:'games',   label:'Giochi & Library',icon:'🎲' },
+  { id:'ai',      label:'AI & Chat',       icon:'🤖' },
+  { id:'privacy', label:'Privacy & Dati',  icon:'🔒' },
+  { id:'billing', label:'Billing & Alpha', icon:'💳' },
+];
+
+const FAQS = [
+  // Account
+  { id:'q1', cat:'account', q:'Come creo un account su MeepleAI?',
+    short:'Durante l\'alpha privata, accedi tramite invito ricevuto via email o iscriviti alla waitlist su /join.',
+    long:'Durante l\'**alpha privata** (in corso fino a Q2 2026), MeepleAI è accessibile solo tramite invito.\n\nCi sono due modi:\n\n1. **Inviti diretti**: se conosci un membro alpha, puoi chiedergli un link `/accept-invite/{token}`. Ogni utente ha 5 inviti.\n2. **Waitlist**: registrati su `/join` indicando il tuo gioco preferito. Inviamo nuovi inviti settimanalmente in base alla posizione.\n\nDopo il go-live pubblico (post-alpha), la registrazione sarà aperta a tutti.',
+    popular: true, popularRank: 1 },
+  { id:'q2', cat:'account', q:'Ho dimenticato la password, come la recupero?',
+    short:'Vai su /login e clicca "Password dimenticata?". Riceverai un\'email con il link di reset entro 5 minuti.',
+    long:'Dalla pagina `/login` clicca **"Password dimenticata?"**. Inserisci la tua email registrata.\n\nRiceverai entro 5 minuti un\'email con un link di reset (valido 1 ora). Se non vedi l\'email, controlla **spam/promozioni**.\n\nSe il problema persiste, contattaci via `/contact`.',
+    popular: false },
+  { id:'q3', cat:'account', q:'Posso cambiare la mia email?',
+    short:'Sì, da Impostazioni → Account → Email. Riceverai una verifica al nuovo indirizzo prima del cambio.',
+    long:'Vai in **Impostazioni → Account → Email**. Inserisci la nuova email e la password attuale.\n\nTi invieremo un link di **verifica al nuovo indirizzo**: il cambio diventa effettivo solo dopo la conferma.',
+    popular: false },
+
+  // Games
+  { id:'q4', cat:'games', q:'Come installo un toolkit per un gioco?',
+    short:'Apri il gioco dal catalogo → tab Toolkit → clicca "Installa" sul toolkit desiderato. Si attiva entro 30 secondi.',
+    long:'Per **installare un toolkit**:\n\n1. Vai al **Catalogo Giochi** (`/games`)\n2. Apri il gioco desiderato (es. Wingspan)\n3. Tab **Toolkit** → scegli un toolkit (Official o Community)\n4. Clicca **"Installa"**\n\nIl toolkit si attiva entro 30 secondi. Lo trovi sotto **"I miei toolkit"** nel pannello laterale del gioco. Per disinstallare, click destro → Rimuovi.',
+    popular: true, popularRank: 2 },
+  { id:'q5', cat:'games', q:'Posso aggiungere un gioco non presente nel catalogo?',
+    short:'Durante l\'alpha solo gli admin possono aggiungere giochi. Suggerisci nuovi giochi via /contact.',
+    long:'Durante l\'**alpha privata**, l\'aggiunta di nuovi giochi al catalogo è ristretta agli admin per garantire qualità delle KB.\n\nPuoi **suggerire un gioco** via `/contact`: indicaci titolo, editore, anno e link BoardGameGeek. Valutiamo le richieste settimanalmente. Post-alpha, gli utenti potranno proporre giochi self-service con approvazione moderata.',
+    popular: false },
+  { id:'q6', cat:'games', q:'Come funziona la mia libreria personale?',
+    short:'La libreria contiene i giochi che possiedi o segui. Aggiungi giochi dal catalogo con il pulsante "Possiedo".',
+    long:'La **Libreria** (`/library`) traccia i giochi che possiedi o vuoi seguire.\n\nDal catalogo, clicca **"Possiedo"** per aggiungerlo, **"Wishlist"** per seguirlo. Dalla libreria puoi:\n\n- Vedere statistiche delle tue partite\n- Accedere rapidamente a toolkit e KB\n- Ricevere notifiche su nuovi contenuti community',
+    popular: false },
+
+  // AI
+  { id:'q7', cat:'ai', q:'Come funzionano gli agenti AI di MeepleAI?',
+    short:'Ogni agente è specializzato per un gioco. Risponde a domande di regole, strategia e setup citando la KB ufficiale.',
+    long:'Gli **agenti AI** sono specializzati per gioco. Ogni agente:\n\n- Usa una **KB indicizzata** (regolamenti, FAQ ufficiali, errata)\n- Cita sempre la fonte (pagina del manuale o URL)\n- Supporta **modelli diversi**: Claude Sonnet, GPT-4o, Gemini Pro\n\nApri un agente da una pagina gioco → tab **Agenti** → "Prova". La conversazione è privata di default; puoi condividerla post-fact con un link.',
+    popular: true, popularRank: 3 },
+  { id:'q8', cat:'ai', q:'Le mie conversazioni con l\'AI sono private?',
+    short:'Sì. Le chat sono private per default. Puoi condividerle con un link pubblico se decidi di aiutare la community.',
+    long:'**Sì, le tue conversazioni sono private** per default e non vengono usate per training.\n\nPuoi opzionalmente **rendere pubblica** una conversazione (toggle "Condividi") per aiutare altri giocatori. Solo le chat marcate come pubbliche sono visibili nel catalogo `/shared-chats`.',
+    popular: false },
+  { id:'q9', cat:'ai', q:'Posso scegliere quale modello AI usare?',
+    short:'Sì. Ogni agente espone i modelli supportati (Claude, GPT-4o, Gemini). Cambialo dal menu chat in alto.',
+    long:'Sì. Ogni agente dichiara i **modelli supportati**. Dal menu chat (in alto a destra durante una conversazione) puoi switchare tra:\n\n- **Claude Sonnet** (default, qualità top)\n- **GPT-4o** (veloce, economico)\n- **Gemini Pro** (long-context per regolamenti grossi)\n\nDurante l\'alpha tutti i modelli sono **gratis** con limite 100 msg/giorno.',
+    popular: false },
+
+  // Privacy
+  { id:'q10', cat:'privacy', q:'Quali dati raccoglie MeepleAI?',
+    short:'Email, nickname, attività di gioco e conversazioni AI. Nessun dato di pagamento durante alpha. Dettagli su /privacy.',
+    long:'Raccogliamo:\n\n- **Account**: email, nickname, password (hash bcrypt)\n- **Gameplay**: giochi posseduti, sessioni, statistiche\n- **AI**: conversazioni con gli agenti (private per default)\n\nNon raccogliamo **dati di pagamento** durante l\'alpha (gratis). I dati sono ospitati su server EU (Frankfurt).\n\nPolicy completa: `/privacy`.',
+    popular: true, popularRank: 4 },
+  { id:'q11', cat:'privacy', q:'Posso esportare i miei dati?',
+    short:'Sì. Da Impostazioni → Privacy → Esporta dati. Ricevi un .zip con JSON e markdown entro 24h.',
+    long:'Sì, conformemente al **GDPR Art. 20**.\n\nDa **Impostazioni → Privacy → Esporta i miei dati**, richiedi un export. Riceverai entro 24h un `.zip` contenente:\n\n- `account.json` — profilo e impostazioni\n- `library.json` — giochi posseguiti, statistiche\n- `conversations/*.md` — tutte le chat in markdown\n\nL\'export è disponibile per il download per 7 giorni.',
+    popular: false },
+  { id:'q12', cat:'privacy', q:'Come elimino il mio account?',
+    short:'Da Impostazioni → Account → Elimina account. La cancellazione è definitiva dopo 30 giorni di grace period.',
+    long:'Da **Impostazioni → Account → Elimina account**.\n\nDopo la richiesta hai **30 giorni di grace period** per ripensarci (basta fare login). Trascorso il periodo, **tutti i tuoi dati sono cancellati** in modo definitivo: account, conversazioni, contributi pubblici (toolkit/agenti) vengono anonymizzati.',
+    popular: false },
+
+  // Billing
+  { id:'q13', cat:'billing', q:'MeepleAI è gratuito?',
+    short:'Durante l\'alpha sì, completamente gratuito. Post-alpha avremo un free tier + piano Pro a pagamento.',
+    long:'Durante l\'**alpha privata** MeepleAI è **completamente gratuito** per i membri invitati.\n\nPost-alpha (Q2 2026 stimato) avremo:\n\n- **Free tier**: catalogo pubblico, 50 msg AI/giorno, 1 toolkit installato\n- **Pro** (~ €5/mese): AI illimitata, toolkit illimitati, agenti privati, priorità support\n\nI membri alpha riceveranno **3 mesi Pro gratis** come ringraziamento.',
+    popular: true, popularRank: 5 },
+  { id:'q14', cat:'billing', q:'Quanto durerà l\'alpha?',
+    short:'L\'alpha è iniziata Gen 2026. Stimiamo go-live pubblico in Q2 2026 (Apr-Giu).',
+    long:'L\'**alpha privata** è partita a **Gennaio 2026** con i primi 100 inviti.\n\nStimiamo il go-live pubblico per **Q2 2026** (Aprile-Giugno), in funzione di:\n\n- Stabilità infrastruttura\n- Catalogo giochi (target 100+ giochi indicizzati)\n- Feedback alpha members\n\nAggiornamenti regolari sul nostro changelog `/changelog`.',
+    popular: false },
+];
+
+const POPULAR_FAQS = FAQS.filter(f => f.popular).sort((a,b) => a.popularRank - b.popularRank).slice(0, 4);
+
+// ═══════════════════════════════════════════════════════
+// ─── HIGHLIGHT UTIL ──────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const highlight = (text, query) => {
+  if (!query || !query.trim()) return text;
+  const q = query.trim();
+  const escaped = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`(${escaped})`, 'gi');
+  const parts = text.split(re);
+  return parts.map((part, i) =>
+    re.test(part) ? <mark key={i} style={{
+      background:'hsl(var(--c-warning) / .28)',
+      color:'var(--text)',
+      padding:'1px 3px', borderRadius: 3,
+      fontWeight: 700,
+    }}>{part}</mark> : part
+  );
+};
+
+// Strip tokens **bold** from short for highlight
+const renderShort = (text, query) => highlight(text, query);
+
+// Render long: split by ** for bold + lists
+const renderLong = (text, query) => {
+  const lines = text.split('\n');
+  return lines.map((line, i) => {
+    if (line.trim() === '') return <div key={i} style={{ height: 6 }}/>;
+    if (/^\d+\.\s/.test(line)) {
+      const content = line.replace(/^\d+\.\s/, '');
+      const num = line.match(/^(\d+)\./)[1];
+      return (
+        <div key={i} style={{ display:'flex', gap: 8, marginBottom: 4 }}>
+          <span style={{
+            fontFamily:'var(--f-mono)', color:'var(--text-muted)',
+            fontWeight: 700, fontSize: 12, flexShrink: 0,
+          }}>{num}.</span>
+          <span>{renderInline(content, query)}</span>
+        </div>
+      );
+    }
+    if (line.startsWith('- ')) {
+      return (
+        <div key={i} style={{ display:'flex', gap: 8, marginBottom: 3 }}>
+          <span style={{ color:'var(--text-muted)', flexShrink: 0 }}>•</span>
+          <span>{renderInline(line.slice(2), query)}</span>
+        </div>
+      );
+    }
+    return <p key={i} style={{ margin:'0 0 6px', lineHeight: 1.6 }}>{renderInline(line, query)}</p>;
+  });
+};
+const renderInline = (text, query) => {
+  // Split by ** bold ** marks → render bold parts, then highlight inside
+  const parts = text.split(/(\*\*[^*]+\*\*|`[^`]+`)/g);
+  return parts.map((p, i) => {
+    if (p.startsWith('**') && p.endsWith('**')) {
+      return <strong key={i} style={{ color:'var(--text)' }}>{highlight(p.slice(2, -2), query)}</strong>;
+    }
+    if (p.startsWith('`') && p.endsWith('`')) {
+      return <code key={i} style={{
+        fontFamily:'var(--f-mono)', fontSize: 11.5,
+        padding:'1px 5px', borderRadius: 4,
+        background:'var(--bg-muted)', color:'hsl(var(--c-info))',
+      }}>{p.slice(1, -1)}</code>;
+    }
+    return <span key={i}>{highlight(p, query)}</span>;
+  });
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── BANNER (riuso) ──────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const Banner = ({ tone='info', children, action }) => {
+  const colors = { success:'c-toolkit', error:'c-danger', warning:'c-warning', info:'c-info' };
+  const c = colors[tone];
+  const icon = tone === 'success' ? '✓' : tone === 'error' ? '✕' : tone === 'warning' ? '!' : 'ℹ';
+  return (
+    <div role="status" style={{
+      display:'flex', alignItems:'flex-start', gap: 10,
+      padding:'12px 14px', borderRadius:'var(--r-md)',
+      background:`hsl(var(--${c}) / .1)`,
+      border:`1px solid hsl(var(--${c}) / .25)`,
+      color:`hsl(var(--${c}))`,
+      fontSize: 13, fontWeight: 600,
+    }}>
+      <span aria-hidden="true" style={{
+        fontSize: 11, lineHeight: 1, flexShrink: 0,
+        width: 20, height: 20, borderRadius:'50%',
+        background:`hsl(var(--${c}) / .18)`,
+        display:'inline-flex', alignItems:'center', justifyContent:'center',
+        marginTop: 1,
+      }}>{icon}</span>
+      <span style={{ flex: 1, lineHeight: 1.55, color:'var(--text)' }}>{children}</span>
+      {action}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── FAQ SEARCHBAR ───────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const FAQSearchBar = ({ value, onChange, placeholder='Cerca tra le FAQ...' }) => {
+  const inputRef = useRef(null);
+  return (
+    <div style={{
+      position:'relative',
+      display:'flex', alignItems:'center',
+      background:'var(--bg-card)',
+      border:'1.5px solid var(--border)',
+      borderRadius:'var(--r-pill)',
+      boxShadow:'var(--shadow-sm)',
+      transition:'border-color var(--dur-sm), box-shadow var(--dur-sm)',
+    }}
+    onFocus={e => {
+      e.currentTarget.style.borderColor = 'hsl(var(--c-game) / .55)';
+      e.currentTarget.style.boxShadow = '0 0 0 4px hsl(var(--c-game) / .12), var(--shadow-md)';
+    }}
+    onBlur={e => {
+      e.currentTarget.style.borderColor = 'var(--border)';
+      e.currentTarget.style.boxShadow = 'var(--shadow-sm)';
+    }}
+    >
+      <span aria-hidden="true" style={{
+        position:'absolute', left: 18,
+        fontSize: 16, color:'var(--text-muted)',
+        pointerEvents:'none',
+      }}>🔍</span>
+      <input
+        ref={inputRef}
+        type="search"
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        placeholder={placeholder}
+        aria-label="Cerca tra le FAQ"
+        style={{
+          flex: 1, minWidth: 0,
+          padding:'14px 18px 14px 46px',
+          border:'none', outline:'none', background:'transparent',
+          fontFamily:'var(--f-body)', fontSize: 15,
+          color:'var(--text)',
+          borderRadius:'var(--r-pill)',
+        }}
+      />
+      {value && (
+        <button
+          type="button"
+          onClick={() => { onChange(''); inputRef.current?.focus(); }}
+          aria-label="Cancella ricerca"
+          style={{
+            marginRight: 8,
+            width: 30, height: 30,
+            borderRadius:'50%',
+            background:'var(--bg-muted)',
+            border:'none', color:'var(--text-sec)',
+            fontSize: 13, cursor:'pointer',
+            display:'inline-flex', alignItems:'center', justifyContent:'center',
+            flexShrink: 0,
+          }}>✕</button>
+      )}
+      {value && (
+        <span style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          paddingRight: 16, fontWeight: 700, whiteSpace:'nowrap',
+        }}>↵ Enter</span>
+      )}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── QUICK ANSWER CARD ───────────────────────────────
+// ═══════════════════════════════════════════════════════
+const QuickAnswerCard = ({ faq, onClick }) => {
+  const cat = FAQ_CATEGORIES.find(c => c.id === faq.cat);
+  return (
+    <button type="button" onClick={onClick} style={{
+      display:'flex', flexDirection:'column', gap: 8,
+      padding: 16, textAlign:'left',
+      background:'var(--bg-card)',
+      border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)',
+      cursor:'pointer',
+      transition:'all var(--dur-sm) var(--ease-out)',
+      width:'100%', height:'100%',
+    }}
+    onMouseEnter={e => {
+      e.currentTarget.style.borderColor = 'hsl(var(--c-game) / .35)';
+      e.currentTarget.style.transform = 'translateY(-2px)';
+      e.currentTarget.style.boxShadow = 'var(--shadow-md)';
+    }}
+    onMouseLeave={e => {
+      e.currentTarget.style.borderColor = 'var(--border)';
+      e.currentTarget.style.transform = '';
+      e.currentTarget.style.boxShadow = '';
+    }}
+    >
+      <div style={{
+        display:'flex', alignItems:'center', gap: 8,
+        fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 700,
+        color:'var(--text-muted)', textTransform:'uppercase',
+        letterSpacing:'.08em',
+      }}>
+        <span aria-hidden="true">{cat.icon}</span>
+        <span>{cat.label}</span>
+        <span style={{ marginLeft:'auto', color:'hsl(var(--c-game))' }}>#{faq.popularRank}</span>
+      </div>
+      <h3 style={{
+        fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 700,
+        color:'var(--text)', margin: 0, lineHeight: 1.35,
+      }}>{faq.q}</h3>
+      <p style={{
+        fontSize: 12.5, color:'var(--text-sec)',
+        lineHeight: 1.55, margin: 0,
+        display:'-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient:'vertical',
+        overflow:'hidden',
+      }}>{faq.short}</p>
+      <div style={{
+        marginTop: 'auto',
+        fontFamily:'var(--f-mono)', fontSize: 11, fontWeight: 700,
+        color:'hsl(var(--c-game))',
+      }}>Leggi tutto →</div>
+    </button>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── CATEGORY TABS (sticky) ──────────────────────────
+// ═══════════════════════════════════════════════════════
+const CategoryTabs = ({ active, onChange, counts }) => {
+  const refs = useRef({});
+  const [ind, setInd] = useState({ left: 0, width: 0 });
+  useEffect(() => {
+    const el = refs.current[active];
+    if (el) setInd({ left: el.offsetLeft, width: el.offsetWidth });
+  }, [active]);
+
+  return (
+    <div style={{
+      position:'sticky', top: 0, zIndex: 3,
+      background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+      borderBottom:'1px solid var(--border)',
+      margin:'0 -16px', padding:'0 16px',
+    }}>
+      <div style={{
+        position:'relative',
+        display:'flex', alignItems:'center', gap: 4,
+        overflowX:'auto', scrollbarWidth:'none',
+        padding:'10px 0',
+      }} className="mai-cb-scroll" role="tablist" aria-label="Categorie FAQ">
+        {FAQ_CATEGORIES.map(c => {
+          const isActive = c.id === active;
+          const count = counts[c.id] ?? 0;
+          return (
+            <button
+              key={c.id}
+              type="button"
+              ref={el => { refs.current[c.id] = el; }}
+              onClick={() => onChange(c.id)}
+              role="tab" aria-selected={isActive}
+              style={{
+                display:'inline-flex', alignItems:'center', gap: 6,
+                padding:'8px 13px',
+                background: isActive ? 'hsl(var(--c-game) / .12)' : 'transparent',
+                border: isActive ? '1px solid hsl(var(--c-game) / .3)' : '1px solid var(--border)',
+                borderRadius:'var(--r-pill)',
+                color: isActive ? 'hsl(var(--c-game))' : 'var(--text-sec)',
+                fontFamily:'var(--f-display)', fontSize: 12.5,
+                fontWeight: isActive ? 700 : 600,
+                cursor:'pointer',
+                whiteSpace:'nowrap', flexShrink: 0,
+                transition:'all var(--dur-sm) var(--ease-out)',
+              }}
+            >
+              <span aria-hidden="true">{c.icon}</span>
+              <span>{c.label}</span>
+              <span style={{
+                padding:'1px 6px', borderRadius:'var(--r-pill)',
+                background: isActive ? 'hsl(var(--c-game) / .25)' : 'var(--bg-muted)',
+                color: isActive ? 'hsl(var(--c-game))' : 'var(--text-muted)',
+                fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+                fontVariantNumeric:'tabular-nums',
+                minWidth: 16, textAlign:'center',
+              }}>{count}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── ACCORDION ITEM ──────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const AccordionItem = ({ faq, isOpen, onToggle, query, idx, scrollTarget }) => {
+  const cat = FAQ_CATEGORIES.find(c => c.id === faq.cat);
+  const ref = useRef(null);
+  useEffect(() => {
+    if (scrollTarget && ref.current) {
+      // Mock — non scrolla in iframe ma evidenzia
+    }
+  }, [scrollTarget]);
+
+  return (
+    <div ref={ref} id={`faq-${faq.id}`} style={{
+      borderBottom:'1px solid var(--border)',
+      background: scrollTarget ? 'hsl(var(--c-warning) / .05)' : 'transparent',
+      transition:'background var(--dur-md)',
+    }}>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={isOpen}
+        aria-controls={`faq-${faq.id}-panel`}
+        style={{
+          width:'100%', textAlign:'left',
+          display:'flex', alignItems:'flex-start', gap: 12,
+          padding:'18px 4px',
+          background:'transparent', border:'none',
+          cursor:'pointer',
+        }}>
+        <span aria-hidden="true" style={{
+          fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 700,
+          color:'var(--text-muted)',
+          padding:'2px 7px', borderRadius:'var(--r-pill)',
+          background:'var(--bg-muted)',
+          letterSpacing:'.04em',
+          flexShrink: 0, marginTop: 2,
+        }}>{cat.icon} {cat.label}</span>
+        <span style={{
+          flex: 1,
+          fontFamily:'var(--f-display)',
+          fontSize: 15, fontWeight: 600,
+          color:'var(--text)',
+          lineHeight: 1.45,
+        }}>{renderShort(faq.q, query)}</span>
+        <span aria-hidden="true" style={{
+          flexShrink: 0,
+          width: 28, height: 28, borderRadius:'50%',
+          display:'inline-flex', alignItems:'center', justifyContent:'center',
+          background: isOpen ? 'hsl(var(--c-game))' : 'var(--bg-muted)',
+          color: isOpen ? '#fff' : 'var(--text-sec)',
+          fontSize: 11, fontWeight: 700,
+          transform: isOpen ? 'rotate(180deg)' : 'rotate(0)',
+          transition:'all var(--dur-md) var(--ease-out)',
+        }}>▾</span>
+      </button>
+      <div
+        id={`faq-${faq.id}-panel`}
+        role="region"
+        style={{
+          maxHeight: isOpen ? 800 : 0,
+          overflow:'hidden',
+          transition: isOpen
+            ? 'max-height .35s cubic-bezier(.4,0,.2,1)'
+            : 'max-height .25s cubic-bezier(.4,0,.2,1)',
+        }}>
+        <div style={{
+          padding:'0 4px 18px 4px',
+          fontSize: 13.5, color:'var(--text-sec)',
+          lineHeight: 1.65,
+          maxWidth: 720,
+        }}>
+          {renderLong(faq.long, query)}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── CONTACT FOOTER CARD ─────────────────────────────
+// ═══════════════════════════════════════════════════════
+const ContactFooterCard = () => (
+  <div style={{
+    display:'flex', flexDirection:'column', alignItems:'center',
+    gap: 10, padding:'28px 24px',
+    textAlign:'center',
+    background:'linear-gradient(135deg, hsl(var(--c-game) / .08), hsl(var(--c-event) / .06))',
+    border:'1px solid hsl(var(--c-game) / .2)',
+    borderRadius:'var(--r-xl)',
+  }}>
+    <div style={{
+      width: 56, height: 56, borderRadius:'50%',
+      background:'hsl(var(--c-game) / .15)',
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 26, marginBottom: 4,
+    }} aria-hidden="true">💬</div>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: 18, fontWeight: 700,
+      color:'var(--text)', margin: 0,
+    }}>Non hai trovato risposta?</h3>
+    <p style={{
+      fontSize: 13.5, color:'var(--text-sec)', maxWidth: 420,
+      margin:'0 0 6px', lineHeight: 1.6,
+    }}>Il nostro team risponde entro 24 ore. Scrivici per richieste, bug o feedback sulla piattaforma.</p>
+    <a href="#" onClick={e=>e.preventDefault()} style={{
+      padding:'10px 20px', borderRadius:'var(--r-pill)',
+      background:'hsl(var(--c-game))', color:'#fff',
+      fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 700,
+      textDecoration:'none',
+      boxShadow:'0 4px 14px hsl(var(--c-game) / .35)',
+      transition:'transform var(--dur-sm)',
+    }}
+    onMouseEnter={e => e.currentTarget.style.transform = 'translateY(-1px)'}
+    onMouseLeave={e => e.currentTarget.style.transform = ''}
+    >Contattaci →</a>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── HERO ────────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const Hero = ({ query, setQuery, compact }) => (
+  <div style={{
+    padding: compact ? '28px 16px 20px' : '56px 32px 32px',
+    textAlign:'center',
+    background:'linear-gradient(180deg, hsl(var(--c-game) / .04), transparent)',
+    borderBottom:'1px solid var(--border)',
+  }}>
+    <div style={{
+      display:'inline-flex', alignItems:'center', gap: 6,
+      padding:'4px 10px', borderRadius:'var(--r-pill)',
+      background:'hsl(var(--c-game) / .12)',
+      color:'hsl(var(--c-game))',
+      fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 700,
+      textTransform:'uppercase', letterSpacing:'.1em',
+      marginBottom: 12,
+    }}>
+      <span aria-hidden="true">📚</span>
+      <span>Centro assistenza</span>
+    </div>
+    <h1 style={{
+      fontFamily:'var(--f-display)', fontWeight: 800,
+      fontSize: compact ? 26 : 38,
+      letterSpacing:'-.02em', lineHeight: 1.1,
+      color:'var(--text)', margin:'0 0 8px',
+    }}>Domande frequenti</h1>
+    <p style={{
+      fontSize: compact ? 14 : 16, color:'var(--text-sec)',
+      maxWidth: 540, margin:'0 auto 22px', lineHeight: 1.55,
+    }}>Trova risposte rapide su MeepleAI — account, giochi, AI, privacy e altro.</p>
+    <div style={{ maxWidth: 580, margin:'0 auto' }}>
+      <FAQSearchBar value={query} onChange={setQuery}/>
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── PAGE BODY ───────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const FAQPageBody = ({ stateOverride, compact }) => {
+  const initialState = stateOverride === 'category-filter' ? { cat:'ai',  q:'' }
+                     : stateOverride === 'search-results'  ? { cat:'all', q:'come installo un toolkit' }
+                     : stateOverride === 'search-no'       ? { cat:'all', q:'xyz123' }
+                     : { cat:'all', q:'' };
+
+  const [activeCat, setActiveCat] = useState(initialState.cat);
+  const [query, setQuery] = useState(initialState.q);
+  const [openIds, setOpenIds] = useState(() => stateOverride === 'search-results' ? new Set(['q4']) : new Set());
+  const [scrollTo, setScrollTo] = useState(stateOverride === 'search-results' ? 'q4' : null);
+
+  const isLoading = stateOverride === 'loading';
+
+  // Filter
+  const filteredFAQs = useMemo(() => {
+    let list = FAQS;
+    if (activeCat !== 'all') list = list.filter(f => f.cat === activeCat);
+    if (query.trim()) {
+      const q = query.toLowerCase().trim();
+      list = list.filter(f =>
+        f.q.toLowerCase().includes(q) ||
+        f.short.toLowerCase().includes(q) ||
+        f.long.toLowerCase().includes(q)
+      );
+    }
+    return list;
+  }, [activeCat, query]);
+
+  // Counts per category (always against full set, ignoring active cat)
+  const counts = useMemo(() => {
+    const c = { all: FAQS.length };
+    FAQ_CATEGORIES.forEach(cat => {
+      if (cat.id === 'all') return;
+      const list = query.trim()
+        ? FAQS.filter(f => f.cat === cat.id && (
+            f.q.toLowerCase().includes(query.toLowerCase()) ||
+            f.short.toLowerCase().includes(query.toLowerCase()) ||
+            f.long.toLowerCase().includes(query.toLowerCase())
+          ))
+        : FAQS.filter(f => f.cat === cat.id);
+      c[cat.id] = list.length;
+    });
+    if (query.trim()) {
+      c.all = FAQS.filter(f =>
+        f.q.toLowerCase().includes(query.toLowerCase()) ||
+        f.short.toLowerCase().includes(query.toLowerCase()) ||
+        f.long.toLowerCase().includes(query.toLowerCase())
+      ).length;
+    }
+    return c;
+  }, [query]);
+
+  const toggleOpen = useCallback((id) => {
+    setOpenIds(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+    setScrollTo(null);
+  }, []);
+
+  const onQuickAnswerClick = (faq) => {
+    setQuery('');
+    setActiveCat(faq.cat);
+    setOpenIds(new Set([faq.id]));
+    setScrollTo(faq.id);
+  };
+
+  if (isLoading) {
+    return (
+      <>
+        <Hero query="" setQuery={()=>{}} compact={compact}/>
+        <div style={{ padding: compact ? '20px 16px' : '32px', maxWidth: 880, margin:'0 auto' }}>
+          <div style={{
+            display:'grid',
+            gridTemplateColumns: compact ? '1fr' : 'repeat(2, 1fr)',
+            gap: 12, marginBottom: 24,
+          }}>
+            {[0,1,2,3].map(i => (
+              <div key={i} className="mai-shimmer" style={{
+                height: 130, borderRadius:'var(--r-lg)',
+                background:'var(--bg-muted)',
+              }}/>
+            ))}
+          </div>
+          <div style={{ display:'flex', gap: 8, marginBottom: 16 }}>
+            {[0,1,2,3,4].map(i => (
+              <div key={i} className="mai-shimmer" style={{
+                height: 32, width: 100,
+                borderRadius:'var(--r-pill)',
+                background:'var(--bg-muted)',
+                flexShrink: 0,
+              }}/>
+            ))}
+          </div>
+          {[0,1,2,3,4].map(i => (
+            <div key={i} className="mai-shimmer" style={{
+              height: 60, marginBottom: 1,
+              background:'var(--bg-muted)',
+            }}/>
+          ))}
+        </div>
+      </>
+    );
+  }
+
+  const showNoResults = query.trim() && filteredFAQs.length === 0;
+  const showQuickAnswers = !query.trim() && activeCat === 'all';
+
+  return (
+    <>
+      <Hero query={query} setQuery={setQuery} compact={compact}/>
+
+      <div style={{
+        padding: compact ? '20px 16px 32px' : '28px 32px 56px',
+        maxWidth: 880, margin:'0 auto',
+      }}>
+        {/* Search status */}
+        {query.trim() && filteredFAQs.length > 0 && (
+          <Banner tone="success">
+            <strong>{filteredFAQs.length}</strong> risultat{filteredFAQs.length === 1 ? 'o' : 'i'} per
+            "<strong>{query}</strong>"
+          </Banner>
+        )}
+
+        {showNoResults && (
+          <Banner tone="info" action={
+            <a href="#" onClick={e=>e.preventDefault()} style={{
+              padding:'6px 12px', borderRadius:'var(--r-md)',
+              background:'hsl(var(--c-game))', color:'#fff',
+              fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 700,
+              textDecoration:'none', whiteSpace:'nowrap',
+            }}>Contattaci →</a>
+          }>
+            <strong>Nessun risultato</strong> per "<strong>{query}</strong>". Prova con altri termini o contattaci direttamente.
+          </Banner>
+        )}
+
+        {/* Quick Answers */}
+        {showQuickAnswers && (
+          <div style={{ marginBottom: 24, marginTop: query.trim() ? 16 : 0 }}>
+            <div style={{
+              display:'flex', alignItems:'baseline', gap: 8,
+              marginBottom: 12,
+            }}>
+              <h2 style={{
+                fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 700,
+                color:'var(--text)', margin: 0,
+                textTransform:'uppercase', letterSpacing:'.08em',
+              }}>⚡ Risposte rapide</h2>
+              <span style={{
+                fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+                fontWeight: 600,
+              }}>top 4 più cercate</span>
+            </div>
+            <div style={{
+              display:'grid',
+              gridTemplateColumns: compact ? '1fr' : 'repeat(2, 1fr)',
+              gap: 12,
+            }}>
+              {POPULAR_FAQS.map(f => (
+                <QuickAnswerCard key={f.id} faq={f} onClick={() => onQuickAnswerClick(f)}/>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Category tabs */}
+        {!showNoResults && (
+          <div style={{ marginTop: showQuickAnswers ? 8 : (query.trim() ? 16 : 0), marginBottom: 8 }}>
+            <CategoryTabs active={activeCat} onChange={setActiveCat} counts={counts}/>
+          </div>
+        )}
+
+        {/* Accordion */}
+        {!showNoResults && filteredFAQs.length > 0 && (
+          <div style={{
+            background:'var(--bg-card)',
+            border:'1px solid var(--border)',
+            borderRadius:'var(--r-lg)',
+            padding:'4px 18px',
+            marginTop: 4,
+          }}>
+            {filteredFAQs.map((f, idx) => (
+              <AccordionItem
+                key={f.id}
+                faq={f}
+                idx={idx}
+                isOpen={openIds.has(f.id)}
+                onToggle={() => toggleOpen(f.id)}
+                query={query}
+                scrollTarget={scrollTo === f.id}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Footer CTA */}
+        <div style={{ marginTop: 32 }}>
+          <ContactFooterCard/>
+        </div>
+      </div>
+    </>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── DESKTOP / MOBILE SHELLS ─────────────────────────
+// ═══════════════════════════════════════════════════════
+const PhoneSbar = () => (
+  <div className="phone-sbar">
+    <span style={{ fontFamily:'var(--f-mono)' }}>14:32</span>
+    <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+  </div>
+);
+const PhoneTopNav = () => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 9,
+    padding:'10px 14px', borderBottom:'1px solid var(--border)',
+    background:'var(--bg)',
+    position:'sticky', top: 0, zIndex: 5,
+  }}>
+    <button aria-label="Indietro" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'transparent', border:'1px solid var(--border)',
+      color:'var(--text)', fontSize: 14, cursor:'pointer',
+    }}>←</button>
+    <div style={{ flex: 1, fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)', textAlign:'center' }}>
+      meepleai.app / faq
+    </div>
+    <div style={{ width: 32 }}/>
+  </div>
+);
+
+const MobileScreen = ({ stateOverride }) => (
+  <>
+    <PhoneSbar/>
+    <div style={{
+      flex: 1, overflowY:'auto', scrollbarWidth:'none',
+      background:'var(--bg)', position:'relative',
+    }}>
+      <PhoneTopNav/>
+      <FAQPageBody stateOverride={stateOverride} compact/>
+    </div>
+  </>
+);
+
+const PhoneShell = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 10 }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div className="phone">{children}</div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 340,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+const DesktopNav = () => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 14,
+    padding:'12px 32px',
+    background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+    borderBottom:'1px solid var(--border)',
+    position:'sticky', top: 0, zIndex: 6,
+  }}>
+    <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
+      <div style={{
+        width: 26, height: 26, borderRadius: 7,
+        background:'linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event)))',
+        color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+        fontWeight: 800, fontSize: 13, fontFamily:'var(--f-display)',
+      }}>M</div>
+      <span style={{ fontFamily:'var(--f-display)', fontWeight: 700, fontSize: 14 }}>MeepleAI</span>
+    </div>
+    <nav style={{ flex: 1, display:'flex', gap: 18, marginLeft: 24,
+      fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 600,
+      color:'var(--text-sec)' }}>
+      <a href="#" style={{ color:'inherit' }}>Catalogo</a>
+      <a href="#" style={{ color:'inherit' }}>Shared games</a>
+      <a href="#" style={{ color:'hsl(var(--c-game))', fontWeight: 700 }}>FAQ</a>
+      <a href="#" style={{ color:'inherit' }}>Privacy</a>
+    </nav>
+    <a href="#" onClick={e=>e.preventDefault()} style={{
+      padding:'7px 14px', borderRadius:'var(--r-md)',
+      color:'#fff', fontSize: 13, fontWeight: 700, fontFamily:'var(--f-display)',
+      background:'hsl(var(--c-game))',
+      boxShadow:'0 3px 10px hsl(var(--c-game) / .3)',
+      textDecoration:'none',
+    }}>Accedi</a>
+  </div>
+);
+
+const DesktopScreen = ({ stateOverride }) => (
+  <div style={{ minHeight: 720, background:'var(--bg)' }}>
+    <DesktopNav/>
+    <FAQPageBody stateOverride={stateOverride}/>
+  </div>
+);
+
+const DesktopFrame = ({ children, label, desc }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 12, width:'100%' }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div style={{
+      width:'100%', maxWidth: 1280,
+      borderRadius:'var(--r-xl)',
+      border:'1px solid var(--border)',
+      background:'var(--bg)',
+      overflow:'hidden',
+      boxShadow:'var(--shadow-lg)',
+    }}>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 8,
+        padding:'9px 14px',
+        background:'var(--bg-muted)',
+        borderBottom:'1px solid var(--border)',
+        fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      }}>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-event))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-warning))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-toolkit))' }}/>
+        <span style={{ flex: 1, textAlign:'center', letterSpacing:'.04em' }}>meepleai.app/faq</span>
+      </div>
+      {children}
+    </div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 720,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── ROOT ────────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const MOBILE_STATES = [
+  { id:'default',           label:'01 · Default',          desc:'Hero + search vuota + 4 quick answer card stacked + tab "Tutte" attivo + accordion 14 FAQ.' },
+  { id:'category-filter',   label:'02 · Filtro categoria', desc:'Tab "AI & Chat" attivo. Quick answers nascoste (mostrate solo con cat=all + query vuota). Solo 3 FAQ AI.' },
+  { id:'search-results',    label:'03 · Search results',   desc:'Query "come installo un toolkit". Banner success "1 risultato". Match highlighted con <mark> bg yellow. FAQ q4 auto-expanded e bg warning subtle.' },
+  { id:'search-no',         label:'04 · No results',       desc:'Query "xyz123". Banner info + CTA inline contattaci. Nessuna lista, niente quick answers, niente accordion.' },
+  { id:'loading',           label:'05 · Loading',          desc:'Hero static + 4 card skeleton + 5 tab skeleton + 5 accordion row skeleton.' },
+];
+
+function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+  }, [dark]);
+  return (
+    <button onClick={() => setDark(d => !d)} className="theme-toggle"
+      aria-label={dark ? 'Passa a tema chiaro' : 'Passa a tema scuro'}>
+      <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span>
+      <span>{dark ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+}
+
+function App() {
+  return (
+    <div className="stage">
+      <ThemeToggle/>
+      <div className="stage-wrap">
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.08em', marginBottom: 8,
+        }}>SP3 · Public Secondary · #5 — FAQ Enhanced (delta su PR #553)</div>
+        <h1>FAQ Enhanced — /faq</h1>
+        <p className="lead">
+          Versione enhanced della pagina /faq esistente. Aggiunge: <strong>FAQSearchBar</strong> (large pill +
+          clear-button), <strong>QuickAnswerCard</strong> grid (top 4 popular), <strong>CategoryTabs</strong> sticky
+          (riuso pattern #4 con count badge), <strong>Accordion radix-style</strong> animato + <mark style={{
+            background:'hsl(var(--c-warning) / .28)', padding:'1px 4px', borderRadius: 3, fontWeight: 700,
+          }}>highlight match</mark> con &lt;mark&gt; bg warning. Footer CTA "Contattaci" gradient card.
+        </p>
+
+        <div className="section-label">Mobile · 375 — 5 stati</div>
+        <div className="phones-grid">
+          {MOBILE_STATES.map(s => (
+            <PhoneShell key={s.id} label={s.label} desc={s.desc}>
+              <MobileScreen stateOverride={s.id}/>
+            </PhoneShell>
+          ))}
+        </div>
+
+        <div className="section-label">Desktop · 1440 — 4 viste</div>
+        <div style={{ display:'flex', flexDirection:'column', gap: 36 }}>
+          <DesktopFrame label="06 · Desktop · Default"
+            desc="Quick answers in grid 2x2. Categorie tab orizzontali sticky con count badge. Accordion 14 FAQ. Footer card gradient.">
+            <DesktopScreen stateOverride="default"/>
+          </DesktopFrame>
+          <DesktopFrame label="07 · Desktop · Filtro AI & Chat"
+            desc="Tab AI selezionato (count 3). Quick answers nascoste perché cat ≠ all. Solo 3 FAQ AI in accordion.">
+            <DesktopScreen stateOverride="category-filter"/>
+          </DesktopFrame>
+          <DesktopFrame label="08 · Desktop · Search results"
+            desc={`Query "come installo un toolkit". Banner success "1 risultato". Match highlighted nell'accordion (auto-expanded). Quick answers nascoste durante search.`}>
+            <DesktopScreen stateOverride="search-results"/>
+          </DesktopFrame>
+          <DesktopFrame label="09 · Desktop · No results"
+            desc={`Query "xyz123". Banner info + CTA inline. Nessun accordion. Footer rimane.`}>
+            <DesktopScreen stateOverride="search-no"/>
+          </DesktopFrame>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes mai-shimmer-anim {
+          0%   { background-position: -200% 0; }
+          100% { background-position:  200% 0; }
+        }
+        .mai-shimmer {
+          background: linear-gradient(90deg, var(--bg-muted) 0%, var(--bg-hover) 50%, var(--bg-muted) 100%) !important;
+          background-size: 200% 100% !important;
+          animation: mai-shimmer-anim 1.4s linear infinite;
+        }
+        .phones-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+          gap: var(--s-7);
+          align-items: start;
+        }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage .lead { line-height: var(--lh-relax); }
+        .phone > div::-webkit-scrollbar { display: none; }
+        .mai-cb-scroll::-webkit-scrollbar { display: none; }
+        button:focus-visible, a:focus-visible, input:focus-visible {
+          outline: 2px solid currentColor;
+          outline-offset: 2px;
+        }
+        mark { color: var(--text); }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);

--- a/admin-mockups/design_files/sp3-join.html
+++ b/admin-mockups/design_files/sp3-join.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>SP3 · Join / Waitlist — MeepleAI</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@500;600;700;800&family=Nunito:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet"/>
+  <link rel="stylesheet" href="tokens.css"/>
+  <link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+  <script src="data.js"></script>
+  <script type="text/babel" src="sp3-join.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp3-join.jsx
+++ b/admin-mockups/design_files/sp3-join.jsx
@@ -1,0 +1,892 @@
+/* MeepleAI SP3 — Join / Waitlist Alpha
+   Route target: /join
+   Pagina pubblica per richiedere accesso all'alpha privata. Form waitlist
+   (email, nome, gioco preferito, newsletter) con 5 stati: default, submitting,
+   success, error, already-on-list. Riusa AuthCard/InputField/PwdInput/SuccessCard
+   pattern; introduce GamePreferenceSelect (top 10 + Altro).
+
+   Caricato da sp3-join.html via Babel standalone, stessa tecnica di auth-flow.jsx. */
+
+const { useState, useEffect, useRef, useMemo } = React;
+
+// ─── DATI ────────────────────────────────────────────
+// Top 10 giochi preferiti (riusa data.js + qualche extra realistico)
+const TOP_GAMES = [
+  { id: 'g-azul', label: 'Azul', emoji: '🔷' },
+  { id: 'g-catan', label: 'I Coloni di Catan', emoji: '🌾' },
+  { id: 'g-wingspan', label: 'Wingspan', emoji: '🦜' },
+  { id: 'g-brass', label: 'Brass: Birmingham', emoji: '🏭' },
+  { id: 'g-gloomhaven', label: 'Gloomhaven', emoji: '⚔️' },
+  { id: 'g-arknova', label: 'Ark Nova', emoji: '🦒' },
+  { id: 'g-spirit', label: 'Spirit Island', emoji: '🌋' },
+  { id: 'g-7wonders', label: '7 Wonders Duel', emoji: '🏛️' },
+  { id: 'g-carcassonne', label: 'Carcassonne', emoji: '🏰' },
+  { id: 'g-ticket', label: 'Ticket to Ride', emoji: '🚂' },
+  { id: 'g-other', label: 'Altro…', emoji: '✦' },
+];
+
+const ALPHA_FEATURES = [
+  { e: 'kb', emoji: '📚', title: 'Library smart',
+    desc: 'Aggiungi un gioco e l\'AI indicizza il manuale in 60 secondi.' },
+  { e: 'agent', emoji: '🤖', title: 'Agenti AI',
+    desc: 'Un esperto dedicato per ogni gioco. Cita la pagina del PDF.' },
+  { e: 'session', emoji: '🎯', title: 'Session live',
+    desc: 'Timer, punteggio, storico — tutto durante la partita.' },
+];
+
+// ─── BRAND MARK (clone da auth-flow) ─────────────────
+const BrandMark = ({ size = 52 }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 6 }}>
+    <div style={{
+      width: size, height: size, borderRadius: size > 40 ? 16 : 12,
+      background: 'linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event)) 60%, hsl(var(--c-player)))',
+      display:'flex', alignItems:'center', justifyContent:'center',
+      color:'#fff', fontWeight: 800, fontSize: size > 40 ? 24 : 18,
+      fontFamily:'var(--f-display)',
+      boxShadow:'0 6px 20px hsl(var(--c-game) / .35)',
+      flexShrink: 0,
+    }}>M</div>
+    <span style={{
+      fontFamily:'var(--f-display)', fontWeight: 700, fontSize: size > 40 ? 16 : 13,
+      letterSpacing:'-.02em', color:'var(--text)',
+    }}>MeepleAI</span>
+  </div>
+);
+
+// ─── ALPHA BADGE PILL ────────────────────────────────
+const AlphaPill = () => (
+  <div style={{
+    display:'inline-flex', alignItems:'center', gap: 6,
+    padding:'4px 10px', borderRadius:'var(--r-pill)',
+    background:'hsl(var(--c-event) / .14)',
+    color:'hsl(var(--c-event))',
+    fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 700,
+    textTransform:'uppercase', letterSpacing:'.08em',
+  }}>
+    <span style={{ width: 6, height: 6, borderRadius:'50%', background:'hsl(var(--c-event))' }}/>
+    Alpha privata
+  </div>
+);
+
+// ─── INPUT FIELD (cloned + minor tweaks) ─────────────
+const InputField = ({ label, type='text', placeholder, value, onChange, error, hint, optional, disabled }) => (
+  <div style={{ marginBottom: 13 }}>
+    <label style={{
+      display:'flex', alignItems:'baseline', justifyContent:'space-between',
+      fontSize: 10, fontWeight: 700, fontFamily:'var(--f-display)',
+      color:'var(--text-sec)', marginBottom: 5,
+      textTransform:'uppercase', letterSpacing:'.06em',
+    }}>
+      <span>{label}</span>
+      {optional && <span style={{
+        fontWeight: 600, color:'var(--text-muted)',
+        fontFamily:'var(--f-mono)', textTransform:'none', letterSpacing: 0,
+        fontSize: 10,
+      }}>opzionale</span>}
+    </label>
+    <input
+      type={type}
+      placeholder={placeholder}
+      value={value}
+      onChange={onChange}
+      disabled={disabled}
+      style={{
+        display:'block', width:'100%',
+        padding:'10px 12px',
+        borderRadius:'var(--r-md)',
+        border: error ? '1.5px solid hsl(var(--c-danger))' : '1.5px solid var(--border)',
+        background: error ? 'hsl(var(--c-danger) / .07)' : 'var(--bg)',
+        color:'var(--text)', fontSize: 13, outline:'none',
+        fontFamily:'var(--f-body)',
+        transition:'border-color var(--dur-sm) var(--ease-out)',
+        boxSizing:'border-box',
+        opacity: disabled ? .65 : 1,
+      }}
+    />
+    {error && <div style={{ fontSize: 11, color:'hsl(var(--c-danger))', marginTop: 4, fontWeight: 600 }}>{error}</div>}
+    {hint && !error && <div style={{ fontSize: 11, color:'var(--text-muted)', marginTop: 4 }}>{hint}</div>}
+  </div>
+);
+
+// ─── GAMEPREFERENCESELECT (NUOVO COMPONENTE V2) ──────
+// Combobox-like: pulsante che apre un popover-listbox con i top 10 + "Altro".
+// Quando si sceglie "Altro" si rivela un input testuale. Tastiera-friendly.
+const GamePreferenceSelect = ({ value, onChange, otherText, onOtherText, error }) => {
+  const [open, setOpen] = useState(false);
+  const [activeIdx, setActiveIdx] = useState(0);
+  const btnRef = useRef(null);
+  const popRef = useRef(null);
+
+  const selected = TOP_GAMES.find(g => g.id === value);
+  const isOther = value === 'g-other';
+
+  // Click outside
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e) => {
+      if (!btnRef.current?.contains(e.target) && !popRef.current?.contains(e.target)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDoc);
+    return () => document.removeEventListener('mousedown', onDoc);
+  }, [open]);
+
+  const onKey = (e) => {
+    if (!open && (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown')) {
+      e.preventDefault();
+      setOpen(true);
+      const i = TOP_GAMES.findIndex(g => g.id === value);
+      setActiveIdx(i >= 0 ? i : 0);
+      return;
+    }
+    if (!open) return;
+    if (e.key === 'Escape') { e.preventDefault(); setOpen(false); btnRef.current?.focus(); }
+    else if (e.key === 'ArrowDown') { e.preventDefault(); setActiveIdx(i => Math.min(i + 1, TOP_GAMES.length - 1)); }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); setActiveIdx(i => Math.max(i - 1, 0)); }
+    else if (e.key === 'Enter') {
+      e.preventDefault();
+      onChange(TOP_GAMES[activeIdx].id);
+      setOpen(false);
+      btnRef.current?.focus();
+    }
+  };
+
+  return (
+    <div style={{ marginBottom: 13 }}>
+      <label style={{
+        display:'block', fontSize: 10, fontWeight: 700, fontFamily:'var(--f-display)',
+        color:'var(--text-sec)', marginBottom: 5,
+        textTransform:'uppercase', letterSpacing:'.06em',
+      }}>Quale gioco vorresti un agente per?</label>
+
+      <div style={{ position:'relative' }}>
+        <button
+          ref={btnRef}
+          type="button"
+          onClick={() => setOpen(v => !v)}
+          onKeyDown={onKey}
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          aria-label="Seleziona gioco preferito"
+          style={{
+            display:'flex', alignItems:'center', justifyContent:'space-between',
+            width:'100%', padding:'10px 12px',
+            borderRadius:'var(--r-md)',
+            border: error ? '1.5px solid hsl(var(--c-danger))' : '1.5px solid var(--border)',
+            background: error ? 'hsl(var(--c-danger) / .07)' : 'var(--bg)',
+            color:'var(--text)', fontSize: 13, fontFamily:'var(--f-body)',
+            cursor:'pointer', textAlign:'left',
+            outline:'none',
+            transition:'border-color var(--dur-sm) var(--ease-out)',
+          }}>
+          <span style={{ display:'flex', alignItems:'center', gap: 8 }}>
+            {selected ? (
+              <>
+                <span aria-hidden="true" style={{ fontSize: 16, lineHeight: 1 }}>{selected.emoji}</span>
+                <span>{selected.label}</span>
+              </>
+            ) : (
+              <span style={{ color:'var(--text-muted)' }}>Scegli un gioco…</span>
+            )}
+          </span>
+          <span aria-hidden="true" style={{
+            fontFamily:'var(--f-mono)', color:'var(--text-muted)', fontSize: 11,
+            transform: open ? 'rotate(180deg)' : 'none',
+            transition:'transform var(--dur-sm)',
+          }}>▾</span>
+        </button>
+
+        {open && (
+          <div
+            ref={popRef}
+            role="listbox"
+            aria-label="Lista giochi"
+            style={{
+              position:'absolute', top:'calc(100% + 4px)', left: 0, right: 0,
+              maxHeight: 240, overflowY:'auto',
+              background:'var(--bg-card)',
+              border:'1px solid var(--border)',
+              borderRadius:'var(--r-md)',
+              boxShadow:'var(--shadow-lg)',
+              zIndex: 5,
+              padding: 4,
+            }}>
+            {TOP_GAMES.map((g, i) => {
+              const isSel = g.id === value;
+              const isAct = i === activeIdx;
+              const isOtherRow = g.id === 'g-other';
+              return (
+                <div
+                  key={g.id}
+                  role="option"
+                  aria-selected={isSel}
+                  onClick={() => { onChange(g.id); setOpen(false); btnRef.current?.focus(); }}
+                  onMouseEnter={() => setActiveIdx(i)}
+                  style={{
+                    display:'flex', alignItems:'center', gap: 9,
+                    padding:'7px 10px', borderRadius:'var(--r-sm)',
+                    cursor:'pointer', fontSize: 13, color:'var(--text)',
+                    background: isAct ? 'var(--bg-hover)' : 'transparent',
+                    fontWeight: isSel ? 700 : 500,
+                    fontFamily: isOtherRow ? 'var(--f-mono)' : 'var(--f-body)',
+                    borderTop: isOtherRow ? '1px solid var(--border-light)' : 'none',
+                    marginTop: isOtherRow ? 4 : 0,
+                    paddingTop: isOtherRow ? 11 : 7,
+                  }}>
+                  <span aria-hidden="true" style={{ fontSize: 15, lineHeight: 1 }}>{g.emoji}</span>
+                  <span style={{ flex: 1 }}>{g.label}</span>
+                  {isSel && <span aria-hidden="true" style={{ color:'hsl(var(--c-game))', fontWeight: 800 }}>✓</span>}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Other text input (rivelato solo se "Altro") */}
+      {isOther && (
+        <input
+          type="text"
+          autoFocus
+          value={otherText}
+          onChange={onOtherText}
+          placeholder="Es. Terraforming Mars"
+          style={{
+            display:'block', width:'100%', marginTop: 8,
+            padding:'9px 12px',
+            borderRadius:'var(--r-md)',
+            border:'1.5px solid var(--border)',
+            background:'var(--bg)',
+            color:'var(--text)', fontSize: 13, outline:'none',
+            fontFamily:'var(--f-body)',
+            boxSizing:'border-box',
+          }}
+        />
+      )}
+
+      {error && <div style={{ fontSize: 11, color:'hsl(var(--c-danger))', marginTop: 4, fontWeight: 600 }}>{error}</div>}
+    </div>
+  );
+};
+
+// ─── CHECKBOX RIGA ───────────────────────────────────
+const CheckRow = ({ checked, onChange, children }) => (
+  <label style={{ display:'flex', alignItems:'flex-start', gap: 8, cursor:'pointer', marginBottom: 14 }}>
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={onChange}
+      style={{
+        marginTop: 2, accentColor:'hsl(var(--c-game))',
+        width: 14, height: 14, flexShrink: 0, cursor:'pointer',
+      }}
+    />
+    <span style={{ fontSize: 11, color:'var(--text-sec)', lineHeight: 1.55 }}>{children}</span>
+  </label>
+);
+
+// ─── PRIMARY BTN (con stato loading) ─────────────────
+const PrimaryBtn = ({ children, onClick, disabled, loading }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    disabled={disabled || loading}
+    style={{
+      display:'inline-flex', alignItems:'center', justifyContent:'center', gap: 8,
+      width:'100%',
+      padding:'11px 14px', fontSize: 14, borderRadius:'var(--r-md)',
+      fontFamily:'var(--f-display)', fontWeight: 700,
+      border: 'none',
+      background: 'hsl(var(--c-game))',
+      color: '#fff',
+      opacity: (disabled || loading) ? .65 : 1,
+      cursor: (disabled || loading) ? 'not-allowed' : 'pointer',
+      transition:'all var(--dur-sm) var(--ease-out)',
+      boxShadow: loading ? 'none' : '0 4px 14px hsl(var(--c-game) / .3)',
+    }}>
+    {loading && <Spinner/>}
+    {children}
+  </button>
+);
+
+const Spinner = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true" style={{
+    animation:'mai-spin 0.9s linear infinite',
+  }}>
+    <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="2.5" fill="none" opacity=".25"/>
+    <path d="M21 12a9 9 0 0 0-9-9" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" fill="none"/>
+  </svg>
+);
+
+// ─── BANNER (success / error / info) ─────────────────
+const Banner = ({ tone='info', children }) => {
+  const colors = {
+    success: 'c-toolkit',
+    error:   'c-danger',
+    warning: 'c-warning',
+    info:    'c-info',
+  };
+  const c = colors[tone];
+  return (
+    <div role={tone === 'error' ? 'alert' : 'status'} style={{
+      display:'flex', alignItems:'flex-start', gap: 9,
+      padding:'10px 12px',
+      borderRadius:'var(--r-md)',
+      background:`hsl(var(--${c}) / .1)`,
+      border:`1px solid hsl(var(--${c}) / .25)`,
+      color:`hsl(var(--${c}))`,
+      fontSize: 12, fontWeight: 600,
+      marginBottom: 12,
+    }}>
+      <span aria-hidden="true" style={{ fontSize: 14, lineHeight: 1.2, flexShrink: 0 }}>
+        {tone === 'success' ? '✓' : tone === 'error' ? '✕' : tone === 'warning' ? '!' : 'ℹ'}
+      </span>
+      <span style={{ lineHeight: 1.45 }}>{children}</span>
+    </div>
+  );
+};
+
+// ─── FEATURE MINI-CARD ───────────────────────────────
+const FeatureCard = ({ feat }) => (
+  <div className={`e-${feat.e}`} style={{
+    background:'var(--bg-card)',
+    border:'1px solid var(--border)',
+    borderRadius:'var(--r-lg)',
+    padding:'14px 13px',
+    display:'flex', flexDirection:'column', gap: 7,
+    boxShadow:'var(--shadow-xs)',
+  }}>
+    <div style={{
+      width: 30, height: 30, borderRadius: 9,
+      background:'hsl(var(--e) / .14)',
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 16,
+    }} aria-hidden="true">{feat.emoji}</div>
+    <div style={{
+      fontFamily:'var(--f-display)', fontWeight: 700, fontSize: 13,
+      color:'var(--text)',
+    }}>{feat.title}</div>
+    <div style={{
+      fontSize: 11, color:'var(--text-sec)', lineHeight: 1.5,
+    }}>{feat.desc}</div>
+    <div style={{
+      marginTop: 'auto',
+      display:'inline-flex', alignSelf:'flex-start',
+      padding:'2px 7px', borderRadius:'var(--r-sm)',
+      background:'hsl(var(--e) / .12)', color:'hsl(var(--e))',
+      fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 700,
+      textTransform:'uppercase', letterSpacing:'.06em',
+    }}>{feat.e}</div>
+  </div>
+);
+
+// ─── HERO TEXT ───────────────────────────────────────
+const HeroText = ({ compact }) => (
+  <div style={{ textAlign: compact ? 'left' : 'center', marginBottom: compact ? 16 : 22 }}>
+    <div style={{ display:'flex', justifyContent: compact ? 'flex-start' : 'center', marginBottom: 14 }}>
+      <AlphaPill/>
+    </div>
+    <h1 style={{
+      fontFamily:'var(--f-display)', fontWeight: 800,
+      fontSize: compact ? 22 : 26,
+      letterSpacing:'-.02em', lineHeight: 1.15,
+      color:'var(--text)',
+      margin:'0 0 8px',
+    }}>
+      MeepleAI è in <span style={{
+        background:'linear-gradient(95deg, hsl(var(--c-game)), hsl(var(--c-event)))',
+        WebkitBackgroundClip:'text', WebkitTextFillColor:'transparent',
+        backgroundClip:'text', color:'transparent',
+      }}>alpha privata</span>
+    </h1>
+    <p style={{
+      fontFamily:'var(--f-body)', fontSize: 13,
+      color:'var(--text-sec)', lineHeight: 1.55,
+      margin: 0, maxWidth: compact ? 360 : 320,
+      marginLeft: compact ? 0 : 'auto', marginRight: compact ? 0 : 'auto',
+    }}>
+      Stiamo aprendo l'accesso a piccoli gruppi di boardgamer.
+      Lascia la tua email — ti contattiamo non appena c'è posto.
+    </p>
+  </div>
+);
+
+// ─── JOIN FORM (cuore della pagina, riusabile) ───────
+// Riceve `state` esterno per forzare la varianti del preview.
+const JoinForm = ({ stateOverride }) => {
+  // GDPR Art. 7 + EDPB: opt-in esplicito, MAI pre-flagged
+  const [form, setForm] = useState({ email:'', name:'', game:'', other:'', news: false });
+  const [errors, setErrors] = useState({});
+  const [innerState, setInnerState] = useState('default');
+  const state = stateOverride || innerState;
+
+  const set = (k) => (e) => setForm(f => ({ ...f, [k]: e.target.value }));
+  const setGame = (id) => setForm(f => ({ ...f, game: id, other: id === 'g-other' ? f.other : '' }));
+
+  const submit = () => {
+    const e = {};
+    if (!form.email.includes('@')) e.email = 'Email non valida';
+    if (!form.game) e.game = 'Seleziona un gioco';
+    if (form.game === 'g-other' && form.other.trim().length < 2) e.game = 'Specifica il gioco';
+    setErrors(e);
+    if (Object.keys(e).length === 0) {
+      setInnerState('submitting');
+      setTimeout(() => setInnerState('success'), 1100);
+    }
+  };
+
+  // ── Stato success
+  if (state === 'success') {
+    return (
+      <div style={{
+        display:'flex', flexDirection:'column', alignItems:'center', textAlign:'center',
+        padding:'8px 4px 4px',
+      }}>
+        <div style={{
+          width: 64, height: 64, borderRadius:'50%',
+          background:'hsl(var(--c-toolkit) / .14)',
+          display:'flex', alignItems:'center', justifyContent:'center',
+          fontSize: 30, marginBottom: 14,
+        }} aria-hidden="true">🎲</div>
+        <h2 style={{
+          fontFamily:'var(--f-display)', fontSize: 19, fontWeight: 700,
+          color:'var(--text)', margin:'0 0 6px',
+        }}>Sei in lista!</h2>
+        <p style={{
+          fontSize: 12, color:'var(--text-muted)', lineHeight: 1.6, margin:'0 0 16px',
+        }}>
+          Ti contattiamo entro <strong style={{ color:'var(--text)' }}>2–3 settimane</strong>.<br/>
+          Intanto controlla la mail per la conferma.
+        </p>
+        <div style={{
+          width:'100%', padding:'10px 12px',
+          background:'var(--bg-muted)', borderRadius:'var(--r-md)',
+          marginBottom: 14, textAlign:'left',
+        }}>
+          <div style={{
+            fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 700,
+            color:'var(--text-muted)', textTransform:'uppercase', letterSpacing:'.08em',
+            marginBottom: 4,
+          }}>La tua posizione</div>
+          <div style={{
+            fontFamily:'var(--f-display)', fontSize: 22, fontWeight: 800,
+            color:'hsl(var(--c-game))', lineHeight: 1.1,
+          }}>#247 <span style={{
+            fontSize: 11, color:'var(--text-muted)', fontWeight: 600,
+            fontFamily:'var(--f-mono)', letterSpacing:'.04em',
+          }}>· stima 2 settimane</span></div>
+        </div>
+        <button type="button" onClick={() => { setInnerState('default'); setForm({ email:'', name:'', game:'', other:'', news: true }); }}
+          style={{
+            display:'inline-flex', alignItems:'center', justifyContent:'center',
+            width:'100%', padding:'10px 14px', fontSize: 13,
+            borderRadius:'var(--r-md)',
+            fontFamily:'var(--f-display)', fontWeight: 700,
+            background:'transparent', border:'1px solid var(--border)',
+            color:'var(--text-sec)', cursor:'pointer',
+          }}>Iscrivi un'altra email</button>
+      </div>
+    );
+  }
+
+  // Variante "already-on-list"
+  const showAlreadyBanner = state === 'already-on-list';
+  const showErrorBanner   = state === 'error';
+  const isSubmitting      = state === 'submitting';
+
+  return (
+    <div>
+      {showAlreadyBanner && (
+        <Banner tone="warning">
+          Questa email è <strong>già in lista</strong> — sei alla posizione <strong>#247</strong>.
+          Stima ingresso: <strong>2 settimane</strong>.
+        </Banner>
+      )}
+      {showErrorBanner && (
+        <Banner tone="error">
+          Qualcosa è andato storto. Controlla la connessione e riprova fra qualche secondo.
+        </Banner>
+      )}
+
+      <InputField
+        label="Email"
+        type="email"
+        placeholder="tu@email.com"
+        value={form.email}
+        onChange={set('email')}
+        error={errors.email || (showErrorBanner && 'Errore di rete') || (showAlreadyBanner && 'Già registrata')}
+        disabled={isSubmitting}
+      />
+      <InputField
+        label="Nome"
+        placeholder="Come ti chiami?"
+        value={form.name}
+        onChange={set('name')}
+        optional
+        disabled={isSubmitting}
+        hint="Se ce lo dici, ti chiamiamo per nome nelle email"
+      />
+      <GamePreferenceSelect
+        value={form.game}
+        onChange={setGame}
+        otherText={form.other}
+        onOtherText={set('other')}
+        error={errors.game}
+      />
+      <CheckRow checked={form.news} onChange={e => setForm(f => ({ ...f, news: e.target.checked }))}>
+        Voglio ricevere <strong style={{ color:'var(--text)' }}>aggiornamenti via email</strong> (opzionale).
+        Update prodotto, devlog e inviti early-access — niente spam, una volta al mese.
+      </CheckRow>
+
+      <PrimaryBtn onClick={submit} loading={isSubmitting}>
+        {isSubmitting ? 'Invio in corso…' : 'Entra in waitlist →'}
+      </PrimaryBtn>
+
+      <div style={{
+        textAlign:'center', marginTop: 12,
+        fontSize: 11, color:'var(--text-muted)',
+        fontFamily:'var(--f-mono)', letterSpacing:'.02em',
+      }}>
+        Già hai un invito? <a href="#" onClick={e => e.preventDefault()}
+          style={{ color:'hsl(var(--c-game))', fontWeight: 700, fontFamily:'var(--f-display)' }}>
+          Accedi
+        </a>
+      </div>
+    </div>
+  );
+};
+
+// ─── PHONE FRAME ─────────────────────────────────────
+const PhoneSbar = () => (
+  <div className="phone-sbar">
+    <span style={{ fontFamily:'var(--f-mono)' }}>14:32</span>
+    <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+  </div>
+);
+
+// ─── JOIN MOBILE SCREEN (a phone-shaped instance) ────
+const JoinMobileScreen = ({ stateOverride }) => (
+  <>
+    <PhoneSbar/>
+    <div style={{
+      flex: 1, overflowY:'auto', scrollbarWidth:'none',
+      background:'var(--bg)',
+      padding:'18px 16px 22px',
+    }}>
+      <div style={{ display:'flex', justifyContent:'center', marginBottom: 14 }}>
+        <BrandMark size={42}/>
+      </div>
+
+      <HeroText/>
+
+      <div style={{
+        background:'var(--bg-card)',
+        borderRadius:'var(--r-2xl)',
+        border:'1px solid var(--border)',
+        boxShadow:'var(--shadow-lg)',
+        padding:'18px 16px 16px',
+      }}>
+        <JoinForm stateOverride={stateOverride}/>
+      </div>
+
+      {/* Cosa ti aspetta */}
+      <div style={{ marginTop: 22 }}>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 700,
+          color:'var(--text-muted)', textTransform:'uppercase', letterSpacing:'.08em',
+          marginBottom: 10, paddingLeft: 2,
+        }}>// Cosa ti aspetta</div>
+        <div style={{ display:'flex', flexDirection:'column', gap: 8 }}>
+          {ALPHA_FEATURES.map(f => <FeatureCard key={f.title} feat={f}/>)}
+        </div>
+      </div>
+
+      {/* Footer mini */}
+      <div style={{
+        marginTop: 22, paddingTop: 14, borderTop:'1px solid var(--border-light)',
+        textAlign:'center',
+        fontSize: 10, color:'var(--text-muted)', fontFamily:'var(--f-mono)',
+        letterSpacing:'.04em',
+      }}>
+        © 2026 MeepleAI · <a href="#" onClick={e=>e.preventDefault()} style={{ color:'inherit' }}>Privacy</a> · <a href="#" onClick={e=>e.preventDefault()} style={{ color:'inherit' }}>Termini</a>
+      </div>
+    </div>
+  </>
+);
+
+const PhoneShell = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 10 }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div className="phone">{children}</div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 340,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+// ─── DESKTOP LAYOUT (1440-style frame) ───────────────
+const DesktopFrame = ({ children, label, desc }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 12, width:'100%' }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div style={{
+      width: '100%', maxWidth: 1280,
+      borderRadius:'var(--r-xl)',
+      border:'1px solid var(--border)',
+      background:'var(--bg)',
+      overflow:'hidden',
+      boxShadow:'var(--shadow-lg)',
+    }}>
+      {/* fake browser chrome */}
+      <div style={{
+        display:'flex', alignItems:'center', gap: 8,
+        padding:'9px 14px',
+        background:'var(--bg-muted)',
+        borderBottom:'1px solid var(--border)',
+        fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      }}>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-event))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-warning))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-toolkit))' }}/>
+        <span style={{ flex: 1, textAlign:'center', letterSpacing:'.04em' }}>meepleai.app/join</span>
+      </div>
+      {children}
+    </div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 720,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+// Desktop nav clone (versione semplificata di public.jsx PublicNav)
+const DesktopNav = () => (
+  <div style={{
+    position:'sticky', top: 0, zIndex: 5,
+    display:'flex', alignItems:'center', gap: 14,
+    padding:'12px 32px',
+    background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+    borderBottom:'1px solid var(--border)',
+  }}>
+    <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
+      <div style={{
+        width: 26, height: 26, borderRadius: 7,
+        background:'linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event)))',
+        color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+        fontWeight: 800, fontSize: 13, fontFamily:'var(--f-display)',
+      }}>M</div>
+      <span style={{ fontFamily:'var(--f-display)', fontWeight: 700, fontSize: 14, color:'var(--text)' }}>MeepleAI</span>
+    </div>
+    <div style={{ flex: 1, display:'flex', gap: 6, marginLeft: 22 }}>
+      {['Prodotto','Prezzi','Chi siamo','Contatti'].map(l => (
+        <a key={l} href="#" onClick={e=>e.preventDefault()} style={{
+          padding:'6px 12px', borderRadius:'var(--r-md)',
+          color:'var(--text-sec)', fontSize: 13, fontWeight: 600,
+          fontFamily:'var(--f-display)',
+        }}>{l}</a>
+      ))}
+    </div>
+    <a href="#" onClick={e=>e.preventDefault()} style={{
+      padding:'6px 12px', borderRadius:'var(--r-md)',
+      color:'var(--text-sec)', fontSize: 13, fontWeight: 700, fontFamily:'var(--f-display)',
+      border:'1px solid var(--border)',
+    }}>Accedi</a>
+    <a href="#" onClick={e=>e.preventDefault()} style={{
+      padding:'7px 14px', borderRadius:'var(--r-md)',
+      color:'#fff', fontSize: 13, fontWeight: 700, fontFamily:'var(--f-display)',
+      background:'hsl(var(--c-game))',
+      boxShadow:'0 3px 10px hsl(var(--c-game) / .3)',
+    }}>Inizia gratis</a>
+  </div>
+);
+
+const JoinDesktopScreen = ({ stateOverride }) => (
+  <div>
+    <DesktopNav/>
+    <div style={{
+      display:'grid',
+      gridTemplateColumns:'1.1fr .9fr',
+      gap: 40,
+      padding:'48px 64px 56px',
+      minHeight: 720,
+      position:'relative',
+      background:'radial-gradient(120% 80% at 80% 0%, hsl(var(--c-event) / .07), transparent 60%), radial-gradient(80% 70% at 0% 100%, hsl(var(--c-game) / .06), transparent 70%)',
+    }}>
+      {/* Left: hero + features */}
+      <div style={{ paddingTop: 12 }}>
+        <HeroText compact/>
+
+        <div style={{
+          display:'grid', gridTemplateColumns:'1fr 1fr 1fr', gap: 12,
+          marginTop: 20,
+        }}>
+          {ALPHA_FEATURES.map(f => <FeatureCard key={f.title} feat={f}/>)}
+        </div>
+
+        {/* Stats riga */}
+        <div style={{
+          marginTop: 28,
+          display:'grid', gridTemplateColumns:'repeat(3, 1fr)', gap: 14,
+        }}>
+          {[
+            { v:'1.247', l:'già in lista' },
+            { v:'~2 set.', l:'tempo medio attesa' },
+            { v:'100%', l:'gratis durante alpha' },
+          ].map(s => (
+            <div key={s.l} style={{
+              padding:'12px 14px',
+              borderRadius:'var(--r-lg)',
+              background:'var(--bg-card)',
+              border:'1px solid var(--border)',
+              boxShadow:'var(--shadow-xs)',
+            }}>
+              <div style={{
+                fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 22,
+                color:'hsl(var(--c-game))', lineHeight: 1.1,
+              }}>{s.v}</div>
+              <div style={{
+                fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+                textTransform:'uppercase', letterSpacing:'.08em', marginTop: 4,
+              }}>{s.l}</div>
+            </div>
+          ))}
+        </div>
+
+        <div style={{
+          marginTop: 28,
+          display:'flex', alignItems:'center', gap: 10,
+          fontSize: 11, color:'var(--text-muted)',
+          fontFamily:'var(--f-mono)', letterSpacing:'.04em',
+        }}>
+          <span style={{
+            display:'inline-flex', width: 22, height: 22, borderRadius:'50%',
+            background:'linear-gradient(135deg, hsl(var(--c-player)), hsl(var(--c-game)))',
+          }}/>
+          <span style={{
+            display:'inline-flex', width: 22, height: 22, borderRadius:'50%',
+            background:'linear-gradient(135deg, hsl(var(--c-event)), hsl(var(--c-toolkit)))',
+            marginLeft: -10, border:'2px solid var(--bg)',
+          }}/>
+          <span style={{
+            display:'inline-flex', width: 22, height: 22, borderRadius:'50%',
+            background:'linear-gradient(135deg, hsl(var(--c-kb)), hsl(var(--c-chat)))',
+            marginLeft: -10, border:'2px solid var(--bg)',
+          }}/>
+          <span style={{ marginLeft: 4 }}>+ 1.244 boardgamer ti hanno preceduto</span>
+        </div>
+      </div>
+
+      {/* Right: form card */}
+      <div style={{ position:'sticky', top: 80, alignSelf:'start' }}>
+        <div style={{
+          background:'var(--bg-card)',
+          border:'1px solid var(--border)',
+          borderRadius:'var(--r-2xl)',
+          boxShadow:'var(--shadow-lg)',
+          padding:'24px 22px 22px',
+        }}>
+          <h2 style={{
+            fontFamily:'var(--f-display)', fontWeight: 700, fontSize: 18,
+            color:'var(--text)', margin:'0 0 4px', letterSpacing:'-.01em',
+          }}>Richiedi accesso</h2>
+          <p style={{
+            fontSize: 12, color:'var(--text-muted)', margin:'0 0 16px', lineHeight: 1.55,
+          }}>Lascia la tua email — ti contattiamo non appena c'è posto.</p>
+          <JoinForm stateOverride={stateOverride}/>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── ROOT — STAGE LAYOUT ─────────────────────────────
+// ═══════════════════════════════════════════════════════
+const MOBILE_STATES = [
+  { id: 'default',         label: '01 · Default',         desc: 'Form vuoto — primo accesso. GamePreferenceSelect chiuso.' },
+  { id: 'submitting',      label: '02 · Submitting',      desc: 'Bottone in loading, campi disabilitati durante invio.' },
+  { id: 'success',         label: '03 · Success',         desc: 'SuccessCard con posizione waitlist + countdown stimato.' },
+  { id: 'error',           label: '04 · Error',           desc: 'Banner rosso top, errore di rete — campo email evidenziato.' },
+  { id: 'already-on-list', label: '05 · Già in lista',    desc: 'Banner ambra: email già registrata, mostra posizione esistente.' },
+];
+
+function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+  }, [dark]);
+  return (
+    <button
+      onClick={() => setDark(d => !d)}
+      className="theme-toggle"
+      aria-label={dark ? 'Passa a tema chiaro' : 'Passa a tema scuro'}>
+      <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span>
+      <span>{dark ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+}
+
+function App() {
+  return (
+    <div className="stage">
+      <ThemeToggle/>
+      <div className="stage-wrap">
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.08em', marginBottom: 8,
+        }}>SP3 · Public Secondary · #1</div>
+        <h1>Join / Waitlist Alpha</h1>
+        <p className="lead">
+          <code style={{ background:'var(--bg-muted)', padding:'2px 7px', borderRadius:'var(--r-sm)', fontSize: 12 }}>/join</code>
+          {' · '}5 stati, mobile 375 + desktop 1440.
+          Riusa <strong>AuthCard / InputField / SuccessCard</strong> da SP1; introduce <strong>GamePreferenceSelect</strong> (combobox a11y, top 10 + Altro).
+          Toggle tema in alto a destra per verificare light/dark.
+        </p>
+
+        {/* MOBILE — 5 stati */}
+        <div className="section-label">Mobile · 375 — 5 stati</div>
+        <div className="phones-grid">
+          {MOBILE_STATES.map(s => (
+            <PhoneShell key={s.id} label={s.label} desc={s.desc}>
+              <JoinMobileScreen stateOverride={s.id}/>
+            </PhoneShell>
+          ))}
+        </div>
+
+        {/* DESKTOP — default + success */}
+        <div className="section-label">Desktop · 1440 — split hero + form sticky</div>
+        <div style={{ display:'flex', flexDirection:'column', gap: 36 }}>
+          <DesktopFrame label="06 · Desktop · Default"
+            desc="Hero a sinistra (kicker alpha + h1 + features mini-card + social proof avatar stack); form sticky a destra. Background con due radial-gradient a bassa opacità (event + game).">
+            <JoinDesktopScreen stateOverride="default"/>
+          </DesktopFrame>
+          <DesktopFrame label="07 · Desktop · Success"
+            desc="Stato success desktop — la card a destra mostra la posizione waitlist con countdown.">
+            <JoinDesktopScreen stateOverride="success"/>
+          </DesktopFrame>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes mai-spin { to { transform: rotate(360deg); } }
+        .phones-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+          gap: var(--s-7);
+          align-items: start;
+        }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage .lead { line-height: var(--lh-relax); }
+        /* keep phone scroll smooth */
+        .phone > div::-webkit-scrollbar { display: none; }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);

--- a/admin-mockups/design_files/sp3-shared-game-detail.html
+++ b/admin-mockups/design_files/sp3-shared-game-detail.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>SP3 · Shared Game Detail — MeepleAI</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@500;600;700;800&family=Nunito:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet"/>
+  <link rel="stylesheet" href="tokens.css"/>
+  <link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+  <script src="data.js"></script>
+  <script type="text/babel" src="sp3-shared-game-detail.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp3-shared-game-detail.jsx
+++ b/admin-mockups/design_files/sp3-shared-game-detail.jsx
@@ -1,0 +1,1116 @@
+/* MeepleAI SP3 — Shared Game Detail (public catalog item)
+   Route target: /shared-games/[slug]
+   Vetrina pubblica di un singolo gioco condiviso. Hero gioco + ConnectionBar
+   (riprodotta 1:1 dal componente prod PR #549/#552) + 3 tabs (toolkit /
+   agenti / docs) + contributors strip + sticky CTA "Accedi per installare".
+
+   Componenti v2 nuovi:
+   - ConnectionBar (riproduzione fedele del componente prod, vedi specs)
+   - ToolkitPublicListItem
+   - AgentPublicListItem
+   - KBPublicDocItem
+   - ContributorsStrip
+   - Tabs (rounded-full + animated underline indicator)
+
+   Riusi: Banner (#1, #2, #3), entity-color system da DS.
+
+   Decisioni di design:
+   - CTA "Accedi per installare": sticky-bottom su mobile (full-width),
+     anchored bottom-right floating su desktop (più CTA-test friendly).
+   - Tabs underline: ANIMATED slide (300ms cubic-bezier(.4,0,.2,1)),
+     scaleX scale-aware. Più premium, costa 6 LOC.
+   - Top contributors: 8 (sweet spot — abbastanza per dare social proof,
+     non così tanti da diventare noise; mobile mostra primi 5 + "+3").
+*/
+
+const { useState, useEffect, useMemo, useRef } = React;
+const DS = window.DS;
+
+// Game = Wingspan (cover gradient verde, 5 toolkit, 2 agenti, 7 docs nel default)
+const GAME = DS.games.find(g => g.id === 'g-wingspan') || DS.games[2];
+
+// ─── DATASET PUBBLICO (mockato) ──────────────────────
+const PUB_TOOLKITS = [
+  { id:'tk-wing-friendly', title:'Wingspan: Friendly', author:'Marco R.', authorId:'p-marco',
+    rating:4.8, ratingCount: 142, installs: 2840, official: false, badge:'Top 10',
+    desc:'Toolkit completo per partite rilassate: timer 5min/turno, score helper, mazzo uccelli.',
+    tools: 5, version:'2.1.0', updated:'3 giorni fa' },
+  { id:'tk-wing-tournament', title:'Tournament Pack', author:'Stonemaier (Official)', authorId:'p-official',
+    rating:4.9, ratingCount: 287, installs: 5120, official: true,
+    desc:'Pacchetto ufficiale per tornei: timer aggressivo, scorekeeper conforme regole 2024.',
+    tools: 8, version:'1.0.0', updated:'1 sett. fa' },
+  { id:'tk-wing-solo', title:'Solo Mode Tracker', author:'Sara T.', authorId:'p-sara',
+    rating:4.6, ratingCount: 89, installs: 1340, official: false,
+    desc:'Tracker dedicato modalità solitario con automa Automaton incluso.',
+    tools: 3, version:'1.4.2', updated:'2 sett. fa' },
+  { id:'tk-wing-asia', title:'Asia Expansion Helper', author:'Luca B.', authorId:'p-luca',
+    rating:4.4, ratingCount: 56, installs: 720, official: false,
+    desc:'Estensione per Asia expansion: tracker boschi, monsoni, nuovi tipi alimentari.',
+    tools: 4, version:'0.9.0-beta', updated:'5 giorni fa' },
+];
+
+const PUB_AGENTS = [
+  { id:'a-wing-rules', title:'Wingspan Rules Expert', model:'Claude Sonnet', author:'Marco R.',
+    convs: 1842, expertise:['Regole base','Bonus carte','Asia expansion'], rating: 4.7,
+    desc:'Risponde su regole base + Europe/Oceania/Asia expansion. Cita sempre la pagina del rulebook.' },
+  { id:'a-wing-strategy', title:'Wingspan Strategy Coach', model:'GPT-4o', author:'Sara T.',
+    convs: 624, expertise:['Apertura','Engine building','Endgame'], rating: 4.5,
+    desc:'Coach per migliorare punteggi: analizza la tua mano e suggerisce la mossa ottimale.' },
+];
+
+const PUB_KBS = [
+  { id:'kb-wing-en', title:'wingspan-rules-en.pdf', kind:'PDF', pages: 24, lang:'EN', size:'4.8 MB' },
+  { id:'kb-wing-it', title:'wingspan-regolamento-ita.pdf', kind:'PDF', pages: 22, lang:'IT', size:'4.2 MB' },
+  { id:'kb-wing-faq', title:'wingspan-faq-bgg.md', kind:'MD',  pages: 8,  lang:'EN', size:'180 KB' },
+  { id:'kb-wing-asia', title:'wingspan-asia-rules.pdf', kind:'PDF', pages: 12, lang:'EN', size:'2.1 MB' },
+  { id:'kb-wing-europe', title:'wingspan-europe.pdf', kind:'PDF', pages: 8, lang:'EN', size:'1.4 MB' },
+  { id:'kb-wing-bgg', title:'BoardGameGeek FAQ', kind:'URL', pages: null, lang:'EN', size:null,
+    url:'boardgamegeek.com/wingspan/faq' },
+  { id:'kb-wing-errata', title:'wingspan-errata-2024.pdf', kind:'PDF', pages: 4, lang:'EN', size:'320 KB' },
+];
+
+const PUB_CONTRIBUTORS = [
+  { id:'p-marco',  name:'Marco R.',  initials:'MR', color: 262, contribs: 12 },
+  { id:'p-sara',   name:'Sara T.',   initials:'ST', color: 320, contribs: 9 },
+  { id:'p-luca',   name:'Luca B.',   initials:'LB', color: 180, contribs: 6 },
+  { id:'p-andrea', name:'Andrea P.', initials:'AP', color: 100, contribs: 5 },
+  { id:'p-giulia', name:'Giulia M.', initials:'GM', color: 10,  contribs: 4 },
+  { id:'p-elena',  name:'Elena F.',  initials:'EF', color: 200, contribs: 3 },
+  { id:'p-nico',   name:'Nico V.',   initials:'NV', color: 35,  contribs: 2 },
+  { id:'p-paolo',  name:'Paolo R.',  initials:'PR', color: 290, contribs: 2 },
+];
+
+// Datasets per stati
+const DATASETS = {
+  default:  { toolkits: PUB_TOOLKITS,         agents: PUB_AGENTS,        kbs: PUB_KBS,           contributors: PUB_CONTRIBUTORS },
+  minimal:  { toolkits: PUB_TOOLKITS.slice(0,1), agents: [],             kbs: PUB_KBS.slice(0,1),contributors: PUB_CONTRIBUTORS.slice(0,1) },
+  'no-content': { toolkits: [], agents: [], kbs: [], contributors: [] },
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── CONNECTIONBAR (riproduzione 1:1 da PR #549/#552) ─
+// ═══════════════════════════════════════════════════════
+// Container: flex items-center gap-2 overflow-x-auto py-2
+// Pip = button rounded-full px-3 py-1.5 text-xs font-bold
+// bg: entityHsl(type, 0.1) — fg: entityHsl(type)
+// empty: border-dashed opacity-60 + Plus icon
+// hover: scale 1.03 + shadow-md
+// Layout pip: [Icon] [count tabular-nums] [label]
+// aria-label: "${label}: ${count}" o "${label}" se empty
+// returns null se connections.length === 0
+const ConnectionBar = ({ connections, loading }) => {
+  if (loading) {
+    return (
+      <div style={{
+        display:'flex', alignItems:'center', gap: 8,
+        overflowX:'auto', padding:'8px 0', scrollbarWidth:'none',
+      }}>
+        {[0,1,2,3].map(i => (
+          <div key={i} className="mai-shimmer" style={{
+            height: 28, width: 96 + i*8,
+            borderRadius: 999,
+            background:'var(--bg-muted)',
+            flexShrink: 0,
+          }}/>
+        ))}
+      </div>
+    );
+  }
+
+  if (!connections || connections.length === 0) return null;
+
+  return (
+    <div style={{
+      display:'flex', alignItems:'center', gap: 8,
+      overflowX:'auto', padding:'8px 0',
+      scrollbarWidth:'none',
+    }} className="mai-cb-scroll">
+      {connections.map(c => {
+        const ec = DS.EC[c.entityType] || DS.EC.game;
+        const isEmpty = c.isEmpty || c.count === 0;
+        const ariaLabel = isEmpty ? c.label : `${c.label}: ${c.count}`;
+        return (
+          <button
+            key={c.entityType}
+            type="button"
+            aria-label={ariaLabel}
+            style={{
+              display:'inline-flex', alignItems:'center', gap: 6,
+              padding:'6px 12px',  // py-1.5 px-3
+              borderRadius: 999,    // rounded-full
+              fontSize: 12, fontWeight: 700,  // text-xs font-bold
+              fontFamily:'var(--f-display)',
+              background: isEmpty ? 'transparent' : `hsl(${ec.h} ${ec.s}% ${ec.l}% / .1)`,
+              color: `hsl(${ec.h} ${ec.s}% ${ec.l}%)`,
+              border: isEmpty
+                ? `1.5px dashed hsl(${ec.h} ${ec.s}% ${ec.l}% / .55)`
+                : `1px solid hsl(${ec.h} ${ec.s}% ${ec.l}% / .2)`,
+              opacity: isEmpty ? 0.6 : 1,
+              cursor:'pointer',
+              flexShrink: 0, whiteSpace:'nowrap',
+              transition:'transform var(--dur-sm) var(--ease-out), box-shadow var(--dur-sm)',
+              outlineOffset: 2,
+            }}
+            onMouseEnter={e => {
+              e.currentTarget.style.transform = 'scale(1.03)';
+              e.currentTarget.style.boxShadow = 'var(--shadow-md)';
+            }}
+            onMouseLeave={e => {
+              e.currentTarget.style.transform = '';
+              e.currentTarget.style.boxShadow = '';
+            }}
+          >
+            {/* Icon — h-3.5 w-3.5 strokeWidth=2 */}
+            <svg width="14" height="14" viewBox="0 0 24 24"
+              fill="none" stroke="currentColor" strokeWidth="2"
+              strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              {ec.em ? null : <circle cx="12" cy="12" r="9"/>}
+            </svg>
+            {/* Emoji fallback for visual coherence with rest of system */}
+            <span aria-hidden="true" style={{ fontSize: 13, lineHeight: 1 }}>{ec.em}</span>
+
+            {/* Count (tabular-nums) or Plus icon */}
+            {isEmpty ? (
+              <svg width="14" height="14" viewBox="0 0 24 24"
+                fill="none" stroke="currentColor" strokeWidth="2"
+                strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <line x1="12" y1="5" x2="12" y2="19"/>
+                <line x1="5" y1="12" x2="19" y2="12"/>
+              </svg>
+            ) : (
+              <span style={{
+                fontFamily:'var(--f-mono)', fontVariantNumeric:'tabular-nums',
+                fontWeight: 700,
+              }}>{c.count}</span>
+            )}
+            <span>{c.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+// ─── BANNER (riuso) ──────────────────────────────────
+const Banner = ({ tone='info', children, action }) => {
+  const colors = { success:'c-toolkit', error:'c-danger', warning:'c-warning', info:'c-info' };
+  const c = colors[tone];
+  const icon = tone === 'success' ? '✓' : tone === 'error' ? '✕' : tone === 'warning' ? '!' : 'ℹ';
+  return (
+    <div role={tone === 'error' ? 'alert' : 'status'} style={{
+      display:'flex', alignItems:'flex-start', gap: 10,
+      padding:'12px 14px', borderRadius:'var(--r-md)',
+      background:`hsl(var(--${c}) / .1)`,
+      border:`1px solid hsl(var(--${c}) / .25)`,
+      color:`hsl(var(--${c}))`,
+      fontSize: 13, fontWeight: 600,
+    }}>
+      <span aria-hidden="true" style={{
+        fontSize: 11, lineHeight: 1, flexShrink: 0,
+        width: 20, height: 20, borderRadius:'50%',
+        background:`hsl(var(--${c}) / .18)`,
+        display:'inline-flex', alignItems:'center', justifyContent:'center',
+        marginTop: 1,
+      }}>{icon}</span>
+      <span style={{ flex: 1, lineHeight: 1.55 }}>{children}</span>
+      {action}
+    </div>
+  );
+};
+
+// ─── STAR RATING ─────────────────────────────────────
+const Stars = ({ value = 0, size = 11 }) => {
+  const full = Math.floor(value);
+  const half = value - full >= 0.5;
+  return (
+    <span style={{ display:'inline-flex', gap: 1, color:'hsl(var(--c-agent))', fontSize: size }}>
+      {[0,1,2,3,4].map(i => (
+        <span key={i} aria-hidden="true">
+          {i < full ? '★' : (i === full && half ? '⯨' : '☆')}
+        </span>
+      ))}
+    </span>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── HERO ────────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const GameHero = ({ game = GAME, compact, loading }) => {
+  if (loading) {
+    return (
+      <div style={{ position:'relative' }}>
+        <div className="mai-shimmer" style={{
+          height: compact ? 160 : 220,
+          background:'var(--bg-muted)',
+        }}/>
+        <div style={{
+          padding: compact ? '16px 16px 8px' : '20px 32px 8px',
+          display:'flex', flexDirection:'column', gap: 8,
+        }}>
+          <div className="mai-shimmer" style={{ height: 24, width:'50%', background:'var(--bg-muted)', borderRadius: 6 }}/>
+          <div className="mai-shimmer" style={{ height: 14, width:'70%', background:'var(--bg-muted)', borderRadius: 4 }}/>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div style={{ position:'relative' }}>
+      {/* Cover */}
+      <div style={{
+        height: compact ? 160 : 220,
+        background: game.cover,
+        position:'relative',
+        display:'flex', alignItems:'center', justifyContent:'center',
+        overflow:'hidden',
+      }}>
+        <span aria-hidden="true" style={{
+          fontSize: compact ? 80 : 110,
+          filter:'drop-shadow(0 6px 18px rgba(0,0,0,.3))',
+          opacity: .92,
+        }}>{game.coverEmoji}</span>
+        {/* gradient overlay bottom */}
+        <div style={{
+          position:'absolute', inset: 0,
+          background:'linear-gradient(180deg, transparent 50%, rgba(0,0,0,.25) 100%)',
+        }}/>
+      </div>
+      {/* Title row */}
+      <div style={{
+        padding: compact ? '14px 16px 6px' : '20px 32px 8px',
+      }}>
+        <div style={{
+          display:'flex', alignItems:'center', gap: 8, marginBottom: 6,
+        }}>
+          <span style={{
+            display:'inline-flex', alignItems:'center', gap: 5,
+            padding:'3px 9px', borderRadius:'var(--r-pill)',
+            background:'hsl(var(--c-game) / .14)',
+            color:'hsl(var(--c-game))',
+            fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 700,
+            textTransform:'uppercase', letterSpacing:'.08em',
+          }}>
+            <span aria-hidden="true">🎲</span>Gioco
+          </span>
+          <Stars value={game.stars}/>
+          <span style={{
+            fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+            fontWeight: 700,
+          }}>{game.rating}</span>
+        </div>
+        <h1 style={{
+          fontFamily:'var(--f-display)', fontWeight: 800,
+          fontSize: compact ? 22 : 30,
+          letterSpacing:'-.02em', lineHeight: 1.1,
+          color:'var(--text)', margin:'0 0 6px',
+        }}>{game.title}</h1>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          letterSpacing:'.04em',
+          display:'flex', flexWrap:'wrap', gap:'4px 10px',
+        }}>
+          <span>{game.author}</span>
+          <span aria-hidden="true">·</span>
+          <span>{game.year}</span>
+          <span aria-hidden="true">·</span>
+          <span>{game.players} pl</span>
+          <span aria-hidden="true">·</span>
+          <span>{game.duration}</span>
+          <span aria-hidden="true">·</span>
+          <span>complexity {game.weight?.toFixed(1)}/5</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── TABS V2 (rounded-full + animated underline) ─────
+// ═══════════════════════════════════════════════════════
+const Tabs = ({ tabs, active, onChange }) => {
+  const refs = useRef({});
+  const [ind, setInd] = useState({ left: 0, width: 0 });
+
+  useEffect(() => {
+    const el = refs.current[active];
+    if (el) {
+      setInd({ left: el.offsetLeft, width: el.offsetWidth });
+    }
+  }, [active, tabs.length]);
+
+  return (
+    <div style={{
+      position:'relative',
+      display:'flex', alignItems:'center', gap: 4,
+      borderBottom:'1px solid var(--border)',
+      overflowX:'auto', scrollbarWidth:'none',
+    }} className="mai-cb-scroll">
+      {tabs.map(t => {
+        const isActive = t.id === active;
+        return (
+          <button
+            key={t.id}
+            type="button"
+            ref={el => { refs.current[t.id] = el; }}
+            onClick={() => onChange(t.id)}
+            role="tab"
+            aria-selected={isActive}
+            style={{
+              display:'inline-flex', alignItems:'center', gap: 7,
+              padding:'10px 14px',
+              background: isActive ? 'hsl(var(--c-game) / .08)' : 'transparent',
+              border:'none',
+              borderRadius:'var(--r-pill) var(--r-pill) 0 0',
+              color: isActive ? 'hsl(var(--c-game))' : 'var(--text-sec)',
+              fontFamily:'var(--f-display)', fontSize: 13,
+              fontWeight: isActive ? 700 : 600,
+              cursor:'pointer',
+              whiteSpace:'nowrap', flexShrink: 0,
+              transition:'all var(--dur-sm) var(--ease-out)',
+            }}
+          >
+            <span aria-hidden="true">{t.icon}</span>
+            <span>{t.label}</span>
+            <span style={{
+              padding:'1px 7px', borderRadius:'var(--r-pill)',
+              background: isActive ? 'hsl(var(--c-game))' : 'var(--bg-muted)',
+              color: isActive ? '#fff' : 'var(--text-muted)',
+              fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+              fontVariantNumeric:'tabular-nums',
+            }}>{t.count}</span>
+          </button>
+        );
+      })}
+      {/* Animated underline */}
+      <span aria-hidden="true" style={{
+        position:'absolute', bottom: -1, left: ind.left, width: ind.width,
+        height: 2, background:'hsl(var(--c-game))',
+        transition:'left .3s cubic-bezier(.4,0,.2,1), width .3s cubic-bezier(.4,0,.2,1)',
+        borderRadius:'2px 2px 0 0',
+      }}/>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── TOOLKITPUBLICLISTITEM ───────────────────────────
+// ═══════════════════════════════════════════════════════
+const ToolkitPublicListItem = ({ tk }) => {
+  const ec = DS.EC.toolkit;
+  return (
+    <article style={{
+      display:'flex', gap: 12, padding: 14,
+      border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)',
+      background:'var(--bg-card)',
+      transition:'border-color var(--dur-sm), box-shadow var(--dur-sm)',
+    }}
+    onMouseEnter={e => { e.currentTarget.style.borderColor=`hsl(${ec.h} ${ec.s}% ${ec.l}% / .35)`; e.currentTarget.style.boxShadow='var(--shadow-xs)'; }}
+    onMouseLeave={e => { e.currentTarget.style.borderColor='var(--border)'; e.currentTarget.style.boxShadow=''; }}
+    >
+      <div style={{
+        width: 44, height: 44, borderRadius:'var(--r-md)',
+        background:`hsl(${ec.h} ${ec.s}% ${ec.l}% / .12)`,
+        color:`hsl(${ec.h} ${ec.s}% ${ec.l}%)`,
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 22, flexShrink: 0,
+      }} aria-hidden="true">🧰</div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{
+          display:'flex', alignItems:'baseline', gap: 7, marginBottom: 3,
+          flexWrap:'wrap',
+        }}>
+          <h3 style={{
+            fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 700,
+            color:'var(--text)', margin: 0,
+          }}>{tk.title}</h3>
+          {tk.official ? (
+            <span style={{
+              padding:'1px 7px', borderRadius:'var(--r-pill)',
+              background:'hsl(var(--c-info) / .14)', color:'hsl(var(--c-info))',
+              fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 700,
+              textTransform:'uppercase', letterSpacing:'.06em',
+            }}>✓ official</span>
+          ) : (
+            <span style={{
+              padding:'1px 7px', borderRadius:'var(--r-pill)',
+              background:'var(--bg-muted)', color:'var(--text-muted)',
+              fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 700,
+              textTransform:'uppercase', letterSpacing:'.06em',
+            }}>community</span>
+          )}
+          {tk.badge && (
+            <span style={{
+              padding:'1px 7px', borderRadius:'var(--r-pill)',
+              background:'hsl(var(--c-event) / .14)', color:'hsl(var(--c-event))',
+              fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 700,
+              textTransform:'uppercase', letterSpacing:'.06em',
+            }}>{tk.badge}</span>
+          )}
+        </div>
+        <div style={{
+          fontSize: 11, color:'var(--text-muted)',
+          fontFamily:'var(--f-mono)', letterSpacing:'.03em',
+          marginBottom: 6,
+        }}>
+          di <strong style={{ color:'var(--text-sec)' }}>{tk.author}</strong>
+          {' · v'}{tk.version}
+          {' · '}{tk.tools} strumenti
+          {' · '}aggiornato {tk.updated}
+        </div>
+        <p style={{
+          fontSize: 12.5, color:'var(--text-sec)', lineHeight: 1.5,
+          margin:'0 0 8px',
+        }}>{tk.desc}</p>
+        <div style={{
+          display:'flex', alignItems:'center', gap: 12, flexWrap:'wrap',
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          fontWeight: 700,
+        }}>
+          <span style={{ display:'inline-flex', alignItems:'center', gap: 4 }}>
+            <Stars value={tk.rating}/>
+            <span>{tk.rating}</span>
+            <span style={{ color:'var(--text-muted)', fontWeight: 500 }}>({tk.ratingCount})</span>
+          </span>
+          <span aria-hidden="true">·</span>
+          <span>↓ {tk.installs.toLocaleString('it-IT')} install</span>
+        </div>
+      </div>
+      <button type="button" style={{
+        alignSelf:'center',
+        padding:'8px 14px', borderRadius:'var(--r-md)',
+        background:'transparent',
+        border:`1.5px solid hsl(${ec.h} ${ec.s}% ${ec.l}%)`,
+        color:`hsl(${ec.h} ${ec.s}% ${ec.l}%)`,
+        fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 700,
+        cursor:'pointer', flexShrink: 0,
+        transition:'all var(--dur-sm) var(--ease-out)',
+      }}
+      onMouseEnter={e => { e.currentTarget.style.background=`hsl(${ec.h} ${ec.s}% ${ec.l}% / .12)`; }}
+      onMouseLeave={e => { e.currentTarget.style.background='transparent'; }}
+      >Anteprima</button>
+    </article>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── AGENTPUBLICLISTITEM ─────────────────────────────
+// ═══════════════════════════════════════════════════════
+const AgentPublicListItem = ({ ag }) => {
+  const ec = DS.EC.agent;
+  return (
+    <article style={{
+      display:'flex', gap: 12, padding: 14,
+      border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)',
+      background:'var(--bg-card)',
+      transition:'border-color var(--dur-sm), box-shadow var(--dur-sm)',
+    }}
+    onMouseEnter={e => { e.currentTarget.style.borderColor=`hsl(${ec.h} ${ec.s}% ${ec.l}% / .35)`; e.currentTarget.style.boxShadow='var(--shadow-xs)'; }}
+    onMouseLeave={e => { e.currentTarget.style.borderColor='var(--border)'; e.currentTarget.style.boxShadow=''; }}
+    >
+      <div style={{
+        width: 44, height: 44, borderRadius:'var(--r-md)',
+        background:`hsl(${ec.h} ${ec.s}% ${ec.l}% / .12)`,
+        color:`hsl(${ec.h} ${ec.s}% ${ec.l}%)`,
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 22, flexShrink: 0,
+      }} aria-hidden="true">🤖</div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display:'flex', alignItems:'baseline', gap: 7, marginBottom: 3, flexWrap:'wrap' }}>
+          <h3 style={{
+            fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 700,
+            color:'var(--text)', margin: 0,
+          }}>{ag.title}</h3>
+          <span style={{
+            padding:'1px 7px', borderRadius:'var(--r-pill)',
+            background:'hsl(var(--c-agent) / .14)', color:'hsl(var(--c-agent))',
+            fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 700,
+          }}>{ag.model}</span>
+        </div>
+        <div style={{
+          fontSize: 11, color:'var(--text-muted)',
+          fontFamily:'var(--f-mono)', letterSpacing:'.03em',
+          marginBottom: 6,
+        }}>di <strong style={{ color:'var(--text-sec)' }}>{ag.author}</strong></div>
+        <p style={{
+          fontSize: 12.5, color:'var(--text-sec)', lineHeight: 1.5,
+          margin:'0 0 8px',
+        }}>{ag.desc}</p>
+        <div style={{
+          display:'flex', flexWrap:'wrap', gap: 5, marginBottom: 8,
+        }}>
+          {ag.expertise.map(t => (
+            <span key={t} style={{
+              padding:'2px 8px', borderRadius:'var(--r-pill)',
+              background:'var(--bg-muted)',
+              color:'var(--text-sec)',
+              fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 600,
+            }}>{t}</span>
+          ))}
+        </div>
+        <div style={{
+          display:'flex', alignItems:'center', gap: 12,
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)', fontWeight: 700,
+        }}>
+          <span style={{ display:'inline-flex', alignItems:'center', gap: 4 }}>
+            <Stars value={ag.rating}/><span>{ag.rating}</span>
+          </span>
+          <span aria-hidden="true">·</span>
+          <span>💬 {ag.convs.toLocaleString('it-IT')} conversazioni</span>
+        </div>
+      </div>
+      <button type="button" style={{
+        alignSelf:'center',
+        padding:'8px 14px', borderRadius:'var(--r-md)',
+        background:`hsl(${ec.h} ${ec.s}% ${ec.l}%)`,
+        border:'none', color:'#fff',
+        fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 700,
+        cursor:'pointer', flexShrink: 0,
+        boxShadow:`0 3px 10px hsl(${ec.h} ${ec.s}% ${ec.l}% / .35)`,
+      }}>Prova →</button>
+    </article>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── KBPUBLICDOCITEM ─────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const KBPublicDocItem = ({ kb }) => {
+  const ec = DS.EC.kb;
+  const kindIcon = kb.kind === 'PDF' ? '📄' : kb.kind === 'MD' ? '📝' : '🔗';
+  return (
+    <article style={{
+      display:'flex', alignItems:'center', gap: 12, padding:'10px 14px',
+      border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)',
+      background:'var(--bg-card)',
+      transition:'border-color var(--dur-sm)',
+    }}
+    onMouseEnter={e => { e.currentTarget.style.borderColor=`hsl(${ec.h} ${ec.s}% ${ec.l}% / .35)`; }}
+    onMouseLeave={e => { e.currentTarget.style.borderColor='var(--border)'; }}
+    >
+      <div style={{
+        width: 36, height: 36, borderRadius:'var(--r-md)',
+        background:`hsl(${ec.h} ${ec.s}% ${ec.l}% / .12)`,
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 18, flexShrink: 0,
+      }} aria-hidden="true">{kindIcon}</div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 13, fontWeight: 700,
+          color:'var(--text)', marginBottom: 2,
+          whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis',
+        }}>{kb.title}</div>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+          letterSpacing:'.04em',
+        }}>
+          <span style={{
+            padding:'1px 5px', borderRadius: 3,
+            background:`hsl(${ec.h} ${ec.s}% ${ec.l}% / .14)`,
+            color:`hsl(${ec.h} ${ec.s}% ${ec.l}%)`,
+            fontWeight: 700, marginRight: 6,
+          }}>{kb.kind}</span>
+          <span>{kb.lang}</span>
+          {kb.pages && <><span aria-hidden="true"> · </span><span>{kb.pages} pag</span></>}
+          {kb.size && <><span aria-hidden="true"> · </span><span>{kb.size}</span></>}
+          {kb.url && <><span aria-hidden="true"> · </span><span>{kb.url}</span></>}
+        </div>
+      </div>
+      <button type="button" style={{
+        padding:'6px 12px', borderRadius:'var(--r-md)',
+        background:'transparent', border:'1px solid var(--border)',
+        color:'var(--text-sec)',
+        fontFamily:'var(--f-display)', fontSize: 11, fontWeight: 700,
+        cursor:'pointer', flexShrink: 0,
+      }}>Apri ↗</button>
+    </article>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── CONTRIBUTORSSTRIP ───────────────────────────────
+// ═══════════════════════════════════════════════════════
+const ContributorsStrip = ({ contributors, compact, max = 8 }) => {
+  if (!contributors || contributors.length === 0) return null;
+  const visible = contributors.slice(0, compact ? 5 : max);
+  const overflow = contributors.length - visible.length;
+
+  return (
+    <div style={{
+      display:'flex', alignItems:'center', gap: 12,
+      padding:'14px 16px',
+      background:'var(--bg-muted)',
+      border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)',
+    }}>
+      <div style={{ flexShrink: 0 }}>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+          marginBottom: 2,
+        }}>Top contributors</div>
+        <div style={{
+          fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700,
+          color:'var(--text)',
+        }}>{contributors.length} player{contributors.length === 1 ? '' : 's'}</div>
+      </div>
+      {/* Avatar overlap stack */}
+      <div style={{ display:'flex', alignItems:'center', flex: 1, minWidth: 0 }}>
+        {visible.map((p, i) => (
+          <div key={p.id} title={`${p.name} · ${p.contribs} contributi`} style={{
+            width: 34, height: 34, borderRadius:'50%',
+            background:`hsl(${p.color} 60% 55%)`,
+            color:'#fff',
+            display:'inline-flex', alignItems:'center', justifyContent:'center',
+            fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 11,
+            border:'2px solid var(--bg)',
+            marginLeft: i === 0 ? 0 : -8,
+            flexShrink: 0,
+            position:'relative', zIndex: visible.length - i,
+            cursor:'pointer',
+            transition:'transform var(--dur-sm)',
+          }}
+          onMouseEnter={e => { e.currentTarget.style.transform='translateY(-2px)'; e.currentTarget.style.zIndex = 999; }}
+          onMouseLeave={e => { e.currentTarget.style.transform=''; e.currentTarget.style.zIndex = visible.length - i; }}
+          aria-label={`${p.name}, ${p.contribs} contributi`}
+          >{p.initials}</div>
+        ))}
+        {overflow > 0 && (
+          <div style={{
+            width: 34, height: 34, borderRadius:'50%',
+            background:'var(--bg-card)', border:'2px solid var(--bg)',
+            color:'var(--text-muted)',
+            display:'inline-flex', alignItems:'center', justifyContent:'center',
+            fontFamily:'var(--f-mono)', fontWeight: 800, fontSize: 10,
+            marginLeft: -8, flexShrink: 0,
+          }}>+{overflow}</div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── EMPTY STATE PER TAB ─────────────────────────────
+// ═══════════════════════════════════════════════════════
+const TabEmpty = ({ kind }) => {
+  const cfg = {
+    toolkit:{ icon:'🧰', t:'Nessun toolkit ancora', sub:'Sii il primo a pubblicare un toolkit per questo gioco.' },
+    agent:  { icon:'🤖', t:'Nessun agente ancora',  sub:'Pubblica un agente AI esperto per aiutare gli altri giocatori.' },
+    kb:     { icon:'📄', t:'Nessun documento KB',   sub:'Carica regolamenti, FAQ o riferimenti per indicizzare la knowledge base.' },
+  }[kind];
+  return (
+    <div style={{
+      display:'flex', flexDirection:'column', alignItems:'center', textAlign:'center',
+      padding:'40px 20px',
+    }}>
+      <div style={{
+        width: 64, height: 64, borderRadius:'50%',
+        background:'var(--bg-muted)',
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 28, marginBottom: 14,
+      }} aria-hidden="true">{cfg.icon}</div>
+      <h3 style={{ fontFamily:'var(--f-display)', fontSize: 15, fontWeight: 700, color:'var(--text)', margin:'0 0 4px' }}>{cfg.t}</h3>
+      <p style={{ fontSize: 12.5, color:'var(--text-muted)', maxWidth: 320, margin: 0, lineHeight: 1.55 }}>{cfg.sub}</p>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── PAGE BODY ───────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const SharedGameDetailBody = ({ stateOverride, compact }) => {
+  const [tab, setTab] = useState('toolkits');
+
+  const isLoading = stateOverride === 'loading';
+  const isError = stateOverride === 'error';
+  const isNoContent = stateOverride === 'no-content';
+  const ds = DATASETS[stateOverride === 'minimal' ? 'minimal' : (isNoContent ? 'no-content' : 'default')];
+
+  const connections = useMemo(() => [
+    { entityType:'toolkit', count: ds.toolkits.length, label:'Toolkit',  isEmpty: ds.toolkits.length === 0 },
+    { entityType:'agent',   count: ds.agents.length,   label:'Agenti',   isEmpty: ds.agents.length === 0 },
+    { entityType:'kb',      count: ds.kbs.length,      label:'Documenti',isEmpty: ds.kbs.length === 0 },
+    { entityType:'player',  count: ds.contributors.length, label:'Contributors', isEmpty: ds.contributors.length === 0 },
+  ], [stateOverride]);
+
+  const tabs = [
+    { id:'toolkits', icon:'🧰', label:'Toolkit',   count: ds.toolkits.length },
+    { id:'agents',   icon:'🤖', label:'Agenti',    count: ds.agents.length },
+    { id:'kbs',      icon:'📄', label:'Documenti', count: ds.kbs.length },
+  ];
+
+  return (
+    <>
+      <GameHero compact={compact} loading={isLoading}/>
+      <div style={{
+        padding: compact ? '0 16px' : '0 32px',
+      }}>
+        <ConnectionBar connections={connections} loading={isLoading}/>
+      </div>
+
+      <div style={{
+        padding: compact ? '12px 16px 100px' : '16px 32px 80px',
+        display:'flex', flexDirection:'column', gap: 16,
+      }}>
+        {isError && (
+          <Banner tone="error">
+            Impossibile caricare i contenuti pubblici per questo gioco.
+            Riprova tra qualche istante o segnala il problema all'host.
+          </Banner>
+        )}
+
+        {isNoContent && (
+          <Banner tone="info" action={
+            <a href="#" onClick={e=>e.preventDefault()} style={{
+              padding:'5px 10px', borderRadius:'var(--r-md)',
+              background:'hsl(var(--c-info))', color:'#fff',
+              fontFamily:'var(--f-display)', fontSize: 11, fontWeight: 700,
+              textDecoration:'none', whiteSpace:'nowrap',
+            }}>Docs autore →</a>
+          }>
+            <strong>Nessun contenuto pubblicato</strong> per <strong>{GAME.title}</strong>.
+            Sii il primo a pubblicare un toolkit, agente o KB!
+          </Banner>
+        )}
+
+        {!isLoading && !isError && !isNoContent && (
+          <>
+            {/* Tabs */}
+            <Tabs tabs={tabs} active={tab} onChange={setTab}/>
+
+            {/* Tab content */}
+            <div style={{ display:'flex', flexDirection:'column', gap: 10 }}>
+              {tab === 'toolkits' && (ds.toolkits.length > 0
+                ? ds.toolkits.map(tk => <ToolkitPublicListItem key={tk.id} tk={tk}/>)
+                : <TabEmpty kind="toolkit"/>)}
+              {tab === 'agents' && (ds.agents.length > 0
+                ? ds.agents.map(ag => <AgentPublicListItem key={ag.id} ag={ag}/>)
+                : <TabEmpty kind="agent"/>)}
+              {tab === 'kbs' && (ds.kbs.length > 0
+                ? ds.kbs.map(kb => <KBPublicDocItem key={kb.id} kb={kb}/>)
+                : <TabEmpty kind="kb"/>)}
+            </div>
+
+            {/* Contributors */}
+            {ds.contributors.length > 0 && (
+              <ContributorsStrip contributors={ds.contributors} compact={compact}/>
+            )}
+          </>
+        )}
+
+        {isLoading && (
+          <>
+            {/* Tabs skeleton */}
+            <div style={{ display:'flex', gap: 8, padding:'8px 0', borderBottom:'1px solid var(--border)' }}>
+              {[0,1,2].map(i => (
+                <div key={i} className="mai-shimmer" style={{
+                  height: 32, width: 100, borderRadius: 'var(--r-pill)',
+                  background:'var(--bg-muted)',
+                }}/>
+              ))}
+            </div>
+            {/* Card skeleton */}
+            {[0,1,2].map(i => (
+              <div key={i} className="mai-shimmer" style={{
+                height: 92, borderRadius:'var(--r-lg)',
+                background:'var(--bg-muted)',
+              }}/>
+            ))}
+          </>
+        )}
+      </div>
+    </>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── STICKY CTA ──────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const StickyCTAMobile = () => (
+  <div style={{
+    position:'absolute', bottom: 0, left: 0, right: 0,
+    padding:'10px 14px',
+    background:'var(--glass-bg)', backdropFilter:'blur(14px)',
+    borderTop:'1px solid var(--border)',
+    zIndex: 5,
+  }}>
+    <button type="button" style={{
+      width:'100%', padding:'12px 14px', fontSize: 14,
+      borderRadius:'var(--r-md)',
+      fontFamily:'var(--f-display)', fontWeight: 700, border:'none',
+      background:'hsl(var(--c-game))', color:'#fff',
+      boxShadow:'0 6px 20px hsl(var(--c-game) / .4)',
+      cursor:'pointer',
+    }}>🔒 Accedi per installare</button>
+  </div>
+);
+
+const FloatingCTADesktop = () => (
+  <div style={{
+    position:'absolute', bottom: 24, right: 24,
+    display:'flex', alignItems:'center', gap: 10,
+    padding:'10px 14px',
+    background:'var(--bg-card)',
+    border:'1px solid var(--border)',
+    borderRadius:'var(--r-pill)',
+    boxShadow:'var(--shadow-lg)',
+    zIndex: 5,
+  }}>
+    <span aria-hidden="true" style={{ fontSize: 16 }}>🔒</span>
+    <span style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      fontWeight: 600,
+    }}>Accedi per installare</span>
+    <button type="button" style={{
+      padding:'7px 14px', borderRadius:'var(--r-pill)',
+      background:'hsl(var(--c-game))', color:'#fff',
+      border:'none', fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 700,
+      cursor:'pointer',
+      boxShadow:'0 3px 10px hsl(var(--c-game) / .35)',
+    }}>Accedi →</button>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── MOBILE / DESKTOP SHELLS ─────────────────────────
+// ═══════════════════════════════════════════════════════
+const PhoneSbar = () => (
+  <div className="phone-sbar">
+    <span style={{ fontFamily:'var(--f-mono)' }}>14:32</span>
+    <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+  </div>
+);
+const PhoneTopNav = () => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 9,
+    padding:'10px 14px', borderBottom:'1px solid var(--border)',
+    background:'var(--bg)',
+    position:'sticky', top: 0, zIndex: 4,
+  }}>
+    <button aria-label="Indietro" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'transparent', border:'1px solid var(--border)',
+      color:'var(--text)', fontSize: 14, cursor:'pointer',
+    }}>←</button>
+    <div style={{ flex: 1, fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)', textAlign:'center' }}>
+      shared-games / wingspan
+    </div>
+    <button aria-label="Condividi" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'transparent', border:'1px solid var(--border)',
+      color:'var(--text)', fontSize: 14, cursor:'pointer',
+    }}>↗</button>
+  </div>
+);
+
+const MobileScreen = ({ stateOverride }) => (
+  <>
+    <PhoneSbar/>
+    <div style={{
+      flex: 1, overflowY:'auto', scrollbarWidth:'none',
+      background:'var(--bg)', position:'relative',
+    }}>
+      <PhoneTopNav/>
+      <SharedGameDetailBody stateOverride={stateOverride} compact/>
+      <StickyCTAMobile/>
+    </div>
+  </>
+);
+
+const PhoneShell = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 10 }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div className="phone">{children}</div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 340,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+const DesktopNav = () => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 14,
+    padding:'12px 32px',
+    background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+    borderBottom:'1px solid var(--border)',
+  }}>
+    <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
+      <div style={{
+        width: 26, height: 26, borderRadius: 7,
+        background:'linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event)))',
+        color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+        fontWeight: 800, fontSize: 13, fontFamily:'var(--f-display)',
+      }}>M</div>
+      <span style={{ fontFamily:'var(--f-display)', fontWeight: 700, fontSize: 14 }}>MeepleAI</span>
+    </div>
+    <div style={{
+      flex: 1, fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      marginLeft: 22,
+    }}>
+      <a href="#" style={{ color:'inherit' }}>Catalogo</a>
+      <span aria-hidden="true"> / </span>
+      <strong style={{ color:'var(--text-sec)' }}>{GAME.title}</strong>
+    </div>
+    <a href="#" onClick={e=>e.preventDefault()} style={{
+      padding:'7px 14px', borderRadius:'var(--r-md)',
+      color:'#fff', fontSize: 13, fontWeight: 700, fontFamily:'var(--f-display)',
+      background:'hsl(var(--c-game))',
+      boxShadow:'0 3px 10px hsl(var(--c-game) / .3)',
+      textDecoration:'none',
+    }}>Accedi / Registrati</a>
+  </div>
+);
+
+const DesktopScreen = ({ stateOverride }) => (
+  <div style={{ position:'relative', minHeight: 720 }}>
+    <DesktopNav/>
+    <SharedGameDetailBody stateOverride={stateOverride}/>
+    <FloatingCTADesktop/>
+  </div>
+);
+
+const DesktopFrame = ({ children, label, desc }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 12, width:'100%' }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div style={{
+      width:'100%', maxWidth: 1280,
+      borderRadius:'var(--r-xl)',
+      border:'1px solid var(--border)',
+      background:'var(--bg)',
+      overflow:'hidden',
+      boxShadow:'var(--shadow-lg)',
+    }}>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 8,
+        padding:'9px 14px',
+        background:'var(--bg-muted)',
+        borderBottom:'1px solid var(--border)',
+        fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      }}>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-event))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-warning))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-toolkit))' }}/>
+        <span style={{ flex: 1, textAlign:'center', letterSpacing:'.04em' }}>meepleai.app/shared-games/wingspan</span>
+      </div>
+      {children}
+    </div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 720,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── ROOT ────────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const MOBILE_STATES = [
+  { id:'default',    label:'01 · Default (rich)',  desc:'4 toolkit, 2 agenti, 7 docs, 8 contributors. Tab default toolkits. ConnectionBar tutta piena.' },
+  { id:'minimal',    label:'02 · Minimal',         desc:'1 toolkit, 0 agenti (pip empty: dashed border + Plus icon, opacity .6), 1 doc, 1 contributor.' },
+  { id:'no-content', label:'03 · No content',      desc:'Banner info "Sii il primo" + CTA Docs autore. Niente tabs renderizzati. ConnectionBar mostra TUTTI pip empty.' },
+  { id:'loading',    label:'04 · Loading',         desc:'Skeleton hero (cover gray + 2 line) + ConnectionBar (4 pill grigi shimmer) + tabs skeleton + 3 card placeholders.' },
+  { id:'error',      label:'05 · Error',           desc:'Banner error full-width + CTA "ritenta" implicito (refresh). Hero rimane visibile.' },
+];
+
+function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+  }, [dark]);
+  return (
+    <button onClick={() => setDark(d => !d)} className="theme-toggle"
+      aria-label={dark ? 'Passa a tema chiaro' : 'Passa a tema scuro'}>
+      <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span>
+      <span>{dark ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+}
+
+function App() {
+  return (
+    <div className="stage">
+      <ThemeToggle/>
+      <div className="stage-wrap">
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.08em', marginBottom: 8,
+        }}>SP3 · Public Secondary · #4 — CRITICO (ConnectionBar prod)</div>
+        <h1>Shared Game Detail — /shared-games/[slug]</h1>
+        <p className="lead">
+          5 stati: default · minimal · no-content · loading · error.
+          <strong> ConnectionBar</strong> riprodotta 1:1 dalla spec PR #549/#552:
+          rounded-full px-3 py-1.5, bg entityHsl 10% / fg solid, hover scale 1.03,
+          empty pip = dashed border + Plus icon. Componenti v2 nuovi: <strong>Tabs</strong> (animated underline),
+          <strong> ToolkitPublicListItem</strong>, <strong>AgentPublicListItem</strong>, <strong>KBPublicDocItem</strong>, <strong>ContributorsStrip</strong>.
+        </p>
+
+        <div className="section-label">Mobile · 375 — 5 stati</div>
+        <div className="phones-grid">
+          {MOBILE_STATES.map(s => (
+            <PhoneShell key={s.id} label={s.label} desc={s.desc}>
+              <MobileScreen stateOverride={s.id}/>
+            </PhoneShell>
+          ))}
+        </div>
+
+        <div className="section-label">Desktop · 1440 — full width</div>
+        <div style={{ display:'flex', flexDirection:'column', gap: 36 }}>
+          <DesktopFrame label="06 · Desktop · Default"
+            desc="Floating CTA bottom-right: pill compatto con icona lucchetto + accedi. Hero 220px + ConnectionBar full + tabs animated + lista toolkit.">
+            <DesktopScreen stateOverride="default"/>
+          </DesktopFrame>
+          <DesktopFrame label="07 · Desktop · Minimal"
+            desc="ConnectionBar mostra agent pip dashed empty (Plus icon + opacity .6), kb pip pieno (1), player pip pieno (1). Tab agenti vuoto = TabEmpty illustrato.">
+            <DesktopScreen stateOverride="minimal"/>
+          </DesktopFrame>
+          <DesktopFrame label="08 · Desktop · No content"
+            desc="Banner info + CTA action inline. ConnectionBar tutta empty (4 pip dashed). Niente tabs, niente lista. Hero rimane.">
+            <DesktopScreen stateOverride="no-content"/>
+          </DesktopFrame>
+          <DesktopFrame label="09 · Desktop · Loading"
+            desc="Hero skeleton (cover 220px gray + 2 lines) + ConnectionBar 4 pill shimmer + 3 tab pills skeleton + 3 card 92px shimmer.">
+            <DesktopScreen stateOverride="loading"/>
+          </DesktopFrame>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes mai-shimmer-anim {
+          0%   { background-position: -200% 0; }
+          100% { background-position:  200% 0; }
+        }
+        .mai-shimmer {
+          background: linear-gradient(90deg, var(--bg-muted) 0%, var(--bg-hover) 50%, var(--bg-muted) 100%) !important;
+          background-size: 200% 100% !important;
+          animation: mai-shimmer-anim 1.4s linear infinite;
+        }
+        .phones-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+          gap: var(--s-7);
+          align-items: start;
+        }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage .lead { line-height: var(--lh-relax); }
+        .phone > div::-webkit-scrollbar { display: none; }
+        .mai-cb-scroll::-webkit-scrollbar { display: none; }
+        button:focus-visible, a:focus-visible {
+          outline: 2px solid currentColor;
+          outline-offset: 2px;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);

--- a/admin-mockups/design_files/sp3-shared-games.html
+++ b/admin-mockups/design_files/sp3-shared-games.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>SP3 · Shared Games — MeepleAI</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@500;600;700;800&family=Nunito:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet"/>
+  <link rel="stylesheet" href="tokens.css"/>
+  <link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+  <script src="data.js"></script>
+  <script type="text/babel" src="sp3-shared-games.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp3-shared-games.jsx
+++ b/admin-mockups/design_files/sp3-shared-games.jsx
@@ -1,0 +1,1108 @@
+/* MeepleAI SP3 — Shared Games (public catalog index)
+   Route target: /shared-games
+   Vetrina pubblica del SharedGameCatalog. Hero leggero + filter bar sticky +
+   grid MeepleCard entity=game variant=grid. Sidebar desktop "Top contributors".
+   4 stati: default (24+ giochi) · loading (skeleton 3×3) · empty-search ·
+   filtered-empty (con CTA reset filtri).
+
+   Componenti v2 nuovi:
+   - SharedGamesFilters (search + chip filters + sort)
+   - ContributorsSidebar (desktop only)
+   Riusa: Banner (#1), MeepleCard primitive (qui implementata in variante "grid"
+   coerente col pattern esistente: cover gradient, rating, badge "N tk · M ag").
+
+   Caricato da sp3-shared-games.html via Babel standalone. */
+
+const { useState, useEffect, useMemo, useRef } = React;
+const DS = window.DS;
+
+// ─── Estendiamo il dataset DS con metadata public-catalog ─────────
+// (toolkit/agent counts derivati o mockati per i giochi che non li hanno;
+//  i conteggi sono coerenti con DS.toolkits / DS.agents / DS.kbs)
+const buildPublicGames = () => {
+  const tkByGame = {};   DS.toolkits.forEach(t => { if (t.gameId) tkByGame[t.gameId] = (tkByGame[t.gameId]||0)+1; });
+  const agByGame = {};   DS.agents.forEach(a => { if (a.gameId) agByGame[a.gameId] = (agByGame[a.gameId]||0)+1; });
+  const kbByGame = {};   DS.kbs.forEach(k => { if (k.gameId) kbByGame[k.gameId] = (kbByGame[k.gameId]||0)+1; });
+
+  // Metadata extra per filtro (genere + complexity bucket)
+  const extra = {
+    'g-azul':       { genre:'Astratto',   complexity:'leggero',  newWeek: 4 },
+    'g-catan':      { genre:'Famiglia',   complexity:'medio',    newWeek: 0 },
+    'g-wingspan':   { genre:'Engine',     complexity:'medio',    newWeek: 2 },
+    'g-brass':      { genre:'Economico',  complexity:'pesante',  newWeek: 1 },
+    'g-gloomhaven': { genre:'Avventura',  complexity:'pesante',  newWeek: 0 },
+    'g-arknova':    { genre:'Engine',     complexity:'pesante',  newWeek: 5 },
+    'g-spirit':     { genre:'Coop',       complexity:'pesante',  newWeek: 0 },
+    'g-7wonders':   { genre:'Drafting',   complexity:'leggero',  newWeek: 3 },
+  };
+
+  return DS.games.map(g => ({
+    ...g,
+    tkCount: tkByGame[g.id] || 0,
+    agCount: agByGame[g.id] || 0,
+    kbCount: kbByGame[g.id] || 0,
+    contribCount: (tkByGame[g.id]||0) * 2 + (agByGame[g.id]||0),
+    ...(extra[g.id] || { genre:'Misto', complexity:'medio', newWeek: 0 }),
+  }));
+};
+
+// Aggiungiamo qualche gioco extra (italiani realistici) per arrivare a 24+
+const EXTRA_GAMES = [
+  { id:'g-carcassonne', title:'Carcassonne', publisher:'Hans im Glück', year:2000, author:'Klaus-Jürgen Wrede',
+    players:'2–5', duration:'30–45m', weight:1.92, rating:7.4, stars:4, coverEmoji:'🏰',
+    cover: DS.grad(45, 60), genre:'Famiglia', complexity:'leggero',
+    tkCount:3, agCount:2, kbCount:2, newWeek:1, contribCount:8 },
+  { id:'g-ticket', title:'Ticket to Ride Europe', publisher:'Days of Wonder', year:2005, author:'Alan R. Moon',
+    players:'2–5', duration:'30–60m', weight:1.92, rating:7.5, stars:4, coverEmoji:'🚂',
+    cover: DS.grad(0, 70), genre:'Famiglia', complexity:'leggero',
+    tkCount:2, agCount:1, kbCount:1, newWeek:0, contribCount:5 },
+  { id:'g-everdell', title:'Everdell', publisher:'Starling', year:2018, author:'James A. Wilson',
+    players:'1–4', duration:'40–80m', weight:2.81, rating:8.2, stars:5, coverEmoji:'🌲',
+    cover: DS.grad(110, 50), genre:'Engine', complexity:'medio',
+    tkCount:4, agCount:2, kbCount:3, newWeek:2, contribCount:10 },
+  { id:'g-terra', title:'Terraforming Mars', publisher:'FryxGames', year:2016, author:'Jacob Fryxelius',
+    players:'1–5', duration:'120m', weight:3.24, rating:8.4, stars:5, coverEmoji:'🪐',
+    cover: DS.grad(15, 65), genre:'Engine', complexity:'pesante',
+    tkCount:5, agCount:3, kbCount:4, newWeek:6, contribCount:13 },
+  { id:'g-scythe', title:'Scythe', publisher:'Stonemaier', year:2016, author:'Jamey Stegmaier',
+    players:'1–5', duration:'90–115m', weight:3.43, rating:8.2, stars:5, coverEmoji:'⚙️',
+    cover: DS.grad(180, 40), genre:'Strategico', complexity:'pesante',
+    tkCount:3, agCount:2, kbCount:2, newWeek:0, contribCount:8 },
+  { id:'g-root', title:'Root', publisher:'Leder Games', year:2018, author:'Cole Wehrle',
+    players:'2–4', duration:'60–90m', weight:3.79, rating:8.1, stars:5, coverEmoji:'🦊',
+    cover: DS.grad(140, 55), genre:'Asimmetrico', complexity:'pesante',
+    tkCount:2, agCount:2, kbCount:2, newWeek:1, contribCount:6 },
+  { id:'g-nemesis', title:'Nemesis', publisher:'Awaken Realms', year:2018, author:'Adam Kwapiński',
+    players:'1–5', duration:'90–180m', weight:3.69, rating:7.9, stars:4, coverEmoji:'👽',
+    cover: DS.grad(280, 45), genre:'Avventura', complexity:'pesante',
+    tkCount:1, agCount:1, kbCount:2, newWeek:0, contribCount:3 },
+  { id:'g-cascadia', title:'Cascadia', publisher:'Flatout', year:2021, author:'Randy Flynn',
+    players:'1–4', duration:'30–45m', weight:1.84, rating:7.8, stars:4, coverEmoji:'🦌',
+    cover: DS.grad(95, 50), genre:'Astratto', complexity:'leggero',
+    tkCount:3, agCount:1, kbCount:1, newWeek:4, contribCount:7 },
+  { id:'g-vinhos', title:'Viticulture EE', publisher:'Stonemaier', year:2015, author:'Jamey Stegmaier',
+    players:'1–6', duration:'45–90m', weight:2.94, rating:8.2, stars:5, coverEmoji:'🍇',
+    cover: DS.grad(330, 50), genre:'Worker', complexity:'medio',
+    tkCount:2, agCount:1, kbCount:2, newWeek:0, contribCount:5 },
+  { id:'g-cosmic', title:'Cosmic Encounter', publisher:'FFG', year:2008, author:'Eberle · Olotka',
+    players:'3–5', duration:'60–120m', weight:2.59, rating:7.5, stars:4, coverEmoji:'🛸',
+    cover: DS.grad(260, 60), genre:'Asimmetrico', complexity:'medio',
+    tkCount:1, agCount:1, kbCount:1, newWeek:0, contribCount:3 },
+  { id:'g-pandemic', title:'Pandemic Legacy S1', publisher:'Z-Man', year:2015, author:'Daviau · Leacock',
+    players:'2–4', duration:'60m', weight:2.83, rating:8.5, stars:5, coverEmoji:'🦠',
+    cover: DS.grad(160, 50), genre:'Coop', complexity:'medio',
+    tkCount:4, agCount:2, kbCount:3, newWeek:2, contribCount:11 },
+  { id:'g-orleans', title:'Orléans', publisher:'dlp Games', year:2014, author:'Reiner Stockhausen',
+    players:'2–4', duration:'90m', weight:3.07, rating:7.9, stars:4, coverEmoji:'🏰',
+    cover: DS.grad(50, 55), genre:'Bag-build', complexity:'medio',
+    tkCount:2, agCount:1, kbCount:1, newWeek:0, contribCount:4 },
+  { id:'g-pax', title:'Pax Pamir 2nd Ed.', publisher:'Wehrlegig', year:2019, author:'Cole Wehrle',
+    players:'1–5', duration:'45–120m', weight:3.49, rating:8.1, stars:5, coverEmoji:'🐪',
+    cover: DS.grad(35, 60), genre:'Politico', complexity:'pesante',
+    tkCount:1, agCount:1, kbCount:1, newWeek:1, contribCount:3 },
+  { id:'g-kingdomino', title:'Kingdomino', publisher:'Blue Orange', year:2016, author:'Bruno Cathala',
+    players:'2–4', duration:'15–25m', weight:1.21, rating:7.4, stars:4, coverEmoji:'👑',
+    cover: DS.grad(75, 65), genre:'Famiglia', complexity:'leggero',
+    tkCount:2, agCount:1, kbCount:1, newWeek:3, contribCount:5 },
+  { id:'g-sherlock', title:'Sherlock Holmes Consulting', publisher:'Space Cowboys', year:2017, author:'AA.VV.',
+    players:'1–8', duration:'60–120m', weight:3.05, rating:7.7, stars:4, coverEmoji:'🔍',
+    cover: DS.grad(20, 35), genre:'Investigativo', complexity:'medio',
+    tkCount:1, agCount:1, kbCount:2, newWeek:0, contribCount:3 },
+  { id:'g-blood', title:'Blood Rage', publisher:'CMON', year:2015, author:'Eric M. Lang',
+    players:'2–4', duration:'60–90m', weight:2.91, rating:7.9, stars:4, coverEmoji:'⚔️',
+    cover: DS.grad(355, 60), genre:'Strategico', complexity:'medio',
+    tkCount:2, agCount:1, kbCount:1, newWeek:0, contribCount:4 },
+];
+
+const ALL_GAMES = [
+  ...buildPublicGames(),
+  ...EXTRA_GAMES,
+].sort((a, b) => (b.rating || 0) - (a.rating || 0));
+
+// Filter chips definition
+const FILTER_CHIPS = [
+  { id:'with-toolkit', label:'Con toolkit',   icon:'🧰', e:'toolkit', test: g => g.tkCount > 0 },
+  { id:'with-agent',   label:'Con agente',    icon:'🤖', e:'agent',   test: g => g.agCount > 0 },
+  { id:'top-rated',    label:'Top rated',     icon:'⭐', e:'game',    test: g => (g.rating || 0) >= 8 },
+  { id:'new',          label:'Nuovi',         icon:'✨', e:'event',   test: g => g.newWeek >= 2 },
+];
+
+// ─── BANNER (riusato da #1) ───────────────────────────────
+const Banner = ({ tone='info', children, action }) => {
+  const colors = { success:'c-toolkit', error:'c-danger', warning:'c-warning', info:'c-info' };
+  const c = colors[tone];
+  const icon = tone === 'success' ? '✓' : tone === 'error' ? '✕' : tone === 'warning' ? '!' : 'ℹ';
+  return (
+    <div role={tone === 'error' ? 'alert' : 'status'} style={{
+      display:'flex', alignItems:'center', gap: 10,
+      padding:'10px 12px', borderRadius:'var(--r-md)',
+      background:`hsl(var(--${c}) / .1)`,
+      border:`1px solid hsl(var(--${c}) / .25)`,
+      color:`hsl(var(--${c}))`,
+      fontSize: 12, fontWeight: 600,
+    }}>
+      <span aria-hidden="true" style={{
+        fontSize: 13, lineHeight: 1, flexShrink: 0,
+        width: 18, height: 18, borderRadius:'50%',
+        background:`hsl(var(--${c}) / .18)`,
+        display:'inline-flex', alignItems:'center', justifyContent:'center',
+      }}>{icon}</span>
+      <span style={{ flex: 1, lineHeight: 1.45 }}>{children}</span>
+      {action}
+    </div>
+  );
+};
+
+// ─── ENTITY PIP (round, riusabile) ───────────────────────
+const EntityPip = ({ type='game', size = 22, label }) => {
+  const ec = DS.EC[type] || DS.EC.game;
+  return (
+    <span aria-label={label} title={label} style={{
+      display:'inline-flex', alignItems:'center', justifyContent:'center',
+      width: size, height: size, borderRadius:'50%',
+      background: `hsl(${ec.h} ${ec.s}% ${ec.l}% / .14)`,
+      color: `hsl(${ec.h} ${ec.s}% ${ec.l}%)`,
+      fontSize: size * 0.5,
+      flexShrink: 0,
+    }}>{ec.em}</span>
+  );
+};
+
+// ─── ENTITY CHIP (count + emoji) ─────────────────────────
+const EntityChip = ({ type='game', count, label }) => {
+  const ec = DS.EC[type] || DS.EC.game;
+  return (
+    <span style={{
+      display:'inline-flex', alignItems:'center', gap: 4,
+      padding:'2px 7px', borderRadius:'var(--r-sm)',
+      background:`hsl(${ec.h} ${ec.s}% ${ec.l}% / .12)`,
+      color:`hsl(${ec.h} ${ec.s}% ${ec.l}%)`,
+      fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 700,
+      whiteSpace:'nowrap',
+    }}>
+      <span aria-hidden="true">{ec.em}</span>
+      <span>{count}</span>
+      {label && <span style={{ opacity:.7, fontWeight:600 }}>{label}</span>}
+    </span>
+  );
+};
+
+// ─── STAR RATING ─────────────────────────────────────────
+const Stars = ({ value = 0 }) => {
+  const full = Math.floor(value);
+  const half = value - full >= 0.5;
+  return (
+    <span style={{ display:'inline-flex', gap: 1, color:'hsl(var(--c-agent))', fontSize: 11 }}>
+      {[0,1,2,3,4].map(i => (
+        <span key={i} aria-hidden="true">
+          {i < full ? '★' : (i === full && half ? '⯨' : '☆')}
+        </span>
+      ))}
+    </span>
+  );
+};
+
+// ─── MEEPLECARD entity=game variant=grid ─────────────────
+// Pattern coerente con l'esistente: cover gradient hero, body con
+// titolo/meta, footer con rating + entity chips.
+const MeepleCardGame = ({ game, compact }) => (
+  <article tabIndex={0} aria-label={`${game.title} — gioco condiviso`} style={{
+    background:'var(--bg-card)',
+    border:'1px solid var(--border)',
+    borderRadius:'var(--r-xl)',
+    overflow:'hidden',
+    display:'flex', flexDirection:'column',
+    boxShadow:'var(--shadow-xs)',
+    transition:'transform var(--dur-sm) var(--ease-out), box-shadow var(--dur-sm), border-color var(--dur-sm)',
+    cursor:'pointer',
+  }}
+  onMouseEnter={e => { e.currentTarget.style.transform='translateY(-2px)'; e.currentTarget.style.boxShadow='var(--shadow-md)'; e.currentTarget.style.borderColor='hsl(var(--c-game) / .35)'; }}
+  onMouseLeave={e => { e.currentTarget.style.transform=''; e.currentTarget.style.boxShadow='var(--shadow-xs)'; e.currentTarget.style.borderColor='var(--border)'; }}
+  >
+    {/* Cover */}
+    <div style={{
+      height: compact ? 96 : 116,
+      background: game.cover,
+      position:'relative',
+      display:'flex', alignItems:'center', justifyContent:'center',
+    }}>
+      <span aria-hidden="true" style={{
+        fontSize: compact ? 36 : 44,
+        filter:'drop-shadow(0 3px 8px rgba(0,0,0,.25))',
+      }}>{game.coverEmoji}</span>
+      {game.newWeek >= 2 && (
+        <span style={{
+          position:'absolute', top: 8, right: 8,
+          padding:'3px 7px', borderRadius:'var(--r-pill)',
+          background:'hsl(var(--c-event))', color:'#fff',
+          fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+          textTransform:'uppercase', letterSpacing:'.08em',
+          boxShadow:'0 2px 6px hsl(var(--c-event) / .35)',
+        }}>+{game.newWeek}</span>
+      )}
+    </div>
+    {/* Body */}
+    <div style={{
+      padding: compact ? '10px 12px 11px' : '12px 14px 13px',
+      display:'flex', flexDirection:'column', gap: 6, flex: 1,
+    }}>
+      <div style={{
+        display:'flex', alignItems:'flex-start', justifyContent:'space-between', gap: 8,
+      }}>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontWeight: 700,
+          fontSize: compact ? 13 : 14, color:'var(--text)',
+          letterSpacing:'-.01em', margin: 0, lineHeight: 1.2,
+        }}>{game.title}</h3>
+        <div style={{ display:'flex', alignItems:'center', gap: 4, flexShrink:0 }}>
+          <Stars value={game.rating / 2}/>
+        </div>
+      </div>
+      <div style={{
+        fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+        letterSpacing:'.03em',
+      }}>
+        {game.year} · {game.players} pl · {game.duration}
+      </div>
+      <div style={{ display:'flex', flexWrap:'wrap', gap: 4, marginTop: 'auto', paddingTop: 6 }}>
+        {game.tkCount > 0 && <EntityChip type="toolkit" count={game.tkCount} label={game.tkCount === 1 ? 'tk' : 'tk'}/>}
+        {game.agCount > 0 && <EntityChip type="agent" count={game.agCount} label={game.agCount === 1 ? 'ag' : 'ag'}/>}
+        {game.kbCount > 0 && <EntityChip type="kb" count={game.kbCount}/>}
+      </div>
+    </div>
+  </article>
+);
+
+// ─── SKELETON CARD ───────────────────────────────────────
+const SkeletonCard = ({ delay = 0 }) => (
+  <div style={{
+    background:'var(--bg-card)',
+    border:'1px solid var(--border)',
+    borderRadius:'var(--r-xl)',
+    overflow:'hidden',
+    display:'flex', flexDirection:'column',
+  }}>
+    <div className="mai-shimmer" style={{ height: 116, background:'var(--bg-muted)' }}/>
+    <div style={{ padding:'12px 14px 13px', display:'flex', flexDirection:'column', gap: 7 }}>
+      <div className="mai-shimmer" style={{ height: 13, width:'70%', background:'var(--bg-muted)', borderRadius: 4 }}/>
+      <div className="mai-shimmer" style={{ height: 10, width:'52%', background:'var(--bg-muted)', borderRadius: 4 }}/>
+      <div style={{ display:'flex', gap: 5, marginTop: 4 }}>
+        <div className="mai-shimmer" style={{ height: 16, width: 36, background:'var(--bg-muted)', borderRadius: 4 }}/>
+        <div className="mai-shimmer" style={{ height: 16, width: 36, background:'var(--bg-muted)', borderRadius: 4 }}/>
+      </div>
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── SHAREDGAMESFILTERS (NUOVO COMPONENTE V2) ─────────
+// ═══════════════════════════════════════════════════════
+const SharedGamesFilters = ({
+  query, onQuery, activeChips, onToggleChip,
+  genre, onGenre, sort, onSort,
+  resultCount, totalCount,
+  variant = 'desktop',
+}) => {
+  const isMobile = variant === 'mobile';
+
+  return (
+    <div style={{
+      position:'sticky', top: isMobile ? 0 : 56, zIndex: 4,
+      background:'var(--glass-bg)', backdropFilter:'blur(14px)',
+      borderBottom:'1px solid var(--border)',
+      padding: isMobile ? '12px 14px 10px' : '14px 24px 12px',
+      display:'flex', flexDirection:'column', gap: 10,
+    }}>
+      {/* Riga 1 — search + sort */}
+      <div style={{ display:'flex', alignItems:'center', gap: 8 }}>
+        <div style={{ position:'relative', flex: 1 }}>
+          <span aria-hidden="true" style={{
+            position:'absolute', left: 11, top:'50%', transform:'translateY(-50%)',
+            color:'var(--text-muted)', fontSize: 14, pointerEvents:'none',
+          }}>🔍</span>
+          <input
+            type="search"
+            value={query}
+            onChange={e => onQuery(e.target.value)}
+            placeholder="Cerca per titolo, autore, editore…"
+            aria-label="Cerca giochi"
+            style={{
+              width:'100%', padding:'9px 12px 9px 34px',
+              borderRadius:'var(--r-md)',
+              border:'1.5px solid var(--border)',
+              background:'var(--bg-card)',
+              color:'var(--text)', fontSize: 13, outline:'none',
+              fontFamily:'var(--f-body)', boxSizing:'border-box',
+              transition:'border-color var(--dur-sm)',
+            }}
+            onFocus={e => e.target.style.borderColor='hsl(var(--c-game))'}
+            onBlur={e => e.target.style.borderColor='var(--border)'}
+          />
+        </div>
+        {!isMobile && (
+          <select
+            value={genre} onChange={e => onGenre(e.target.value)}
+            aria-label="Filtra per genere"
+            style={{
+              padding:'9px 12px',
+              borderRadius:'var(--r-md)',
+              border:'1.5px solid var(--border)',
+              background:'var(--bg-card)', color:'var(--text)',
+              fontSize: 12, fontFamily:'var(--f-body)', fontWeight: 600,
+              cursor:'pointer', outline:'none',
+            }}>
+            <option value="">Tutti i generi</option>
+            {['Astratto','Famiglia','Engine','Economico','Strategico','Coop','Avventura','Drafting','Asimmetrico','Politico','Worker','Bag-build','Investigativo'].map(g => (
+              <option key={g} value={g}>{g}</option>
+            ))}
+          </select>
+        )}
+        <select
+          value={sort} onChange={e => onSort(e.target.value)}
+          aria-label="Ordina"
+          style={{
+            padding:'9px 12px',
+            borderRadius:'var(--r-md)',
+            border:'1.5px solid var(--border)',
+            background:'var(--bg-card)', color:'var(--text)',
+            fontSize: 12, fontFamily:'var(--f-body)', fontWeight: 600,
+            cursor:'pointer', outline:'none',
+          }}>
+          <option value="rating">⭐ Top rated</option>
+          <option value="contrib">🧰 Più toolkit</option>
+          <option value="new">✨ Più recenti</option>
+          <option value="title">A–Z</option>
+        </select>
+      </div>
+
+      {/* Riga 2 — chips */}
+      <div style={{ display:'flex', alignItems:'center', gap: 8, flexWrap:'wrap' }}>
+        <div style={{
+          display:'flex', gap: 6, flexWrap:'wrap', flex: 1,
+          overflowX: isMobile ? 'auto' : 'visible',
+          paddingBottom: isMobile ? 2 : 0,
+          scrollbarWidth:'none',
+        }}>
+          {FILTER_CHIPS.map(chip => {
+            const active = activeChips.includes(chip.id);
+            const ec = DS.EC[chip.e] || DS.EC.game;
+            return (
+              <button
+                key={chip.id}
+                type="button"
+                onClick={() => onToggleChip(chip.id)}
+                aria-pressed={active}
+                style={{
+                  display:'inline-flex', alignItems:'center', gap: 5,
+                  padding:'5px 10px', borderRadius:'var(--r-pill)',
+                  border: active
+                    ? `1.5px solid hsl(${ec.h} ${ec.s}% ${ec.l}%)`
+                    : '1px solid var(--border)',
+                  background: active
+                    ? `hsl(${ec.h} ${ec.s}% ${ec.l}% / .14)`
+                    : 'var(--bg-card)',
+                  color: active ? `hsl(${ec.h} ${ec.s}% ${ec.l}%)` : 'var(--text-sec)',
+                  fontFamily:'var(--f-display)', fontSize: 11, fontWeight: 700,
+                  whiteSpace:'nowrap', cursor:'pointer',
+                  transition:'all var(--dur-sm) var(--ease-out)',
+                }}>
+                <span aria-hidden="true">{chip.icon}</span>
+                <span>{chip.label}</span>
+                {active && <span aria-hidden="true" style={{ marginLeft: 2 }}>✕</span>}
+              </button>
+            );
+          })}
+        </div>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+          fontWeight: 700, letterSpacing:'.04em', textTransform:'uppercase',
+          whiteSpace:'nowrap', flexShrink: 0,
+        }}>
+          {resultCount === totalCount
+            ? `${totalCount} giochi`
+            : `${resultCount} di ${totalCount}`}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── CONTRIBUTORSSIDEBAR (NUOVO COMPONENTE V2) ────────
+// ═══════════════════════════════════════════════════════
+const ContributorsSidebar = () => {
+  // Top contributors — derivati da DS.players
+  const contribs = DS.players
+    .map(p => ({ ...p, contribs: p.totalSessions + (p.totalWins * 2) }))
+    .sort((a,b) => b.contribs - a.contribs)
+    .slice(0, 5);
+
+  return (
+    <aside aria-label="Top contributor" style={{
+      position:'sticky', top: 116, alignSelf:'start',
+      background:'var(--bg-card)',
+      border:'1px solid var(--border)',
+      borderRadius:'var(--r-xl)',
+      padding:'18px 16px',
+      boxShadow:'var(--shadow-xs)',
+    }}>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 7,
+        marginBottom: 14, paddingBottom: 10,
+        borderBottom:'1px solid var(--border-light)',
+      }}>
+        <EntityPip type="player" size={22}/>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontWeight: 700, fontSize: 13,
+          color:'var(--text)', margin: 0, letterSpacing:'-.01em',
+        }}>Top contributor</h3>
+      </div>
+
+      <ol style={{ listStyle:'none', padding: 0, margin: 0, display:'flex', flexDirection:'column', gap: 10 }}>
+        {contribs.map((p, i) => (
+          <li key={p.id} style={{
+            display:'flex', alignItems:'center', gap: 10,
+          }}>
+            <span style={{
+              width: 18, textAlign:'right',
+              fontFamily:'var(--f-mono)', fontSize: 11, fontWeight: 800,
+              color: i === 0 ? 'hsl(var(--c-game))' : 'var(--text-muted)',
+            }}>#{i+1}</span>
+            <span style={{
+              width: 32, height: 32, borderRadius:'50%',
+              background:`hsl(${p.color} 60% 55%)`,
+              color:'#fff',
+              display:'inline-flex', alignItems:'center', justifyContent:'center',
+              fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 11,
+              flexShrink: 0,
+              boxShadow:'inset 0 1px 0 rgba(255,255,255,.15)',
+            }} aria-hidden="true">{p.initials}</span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{
+                fontFamily:'var(--f-display)', fontWeight: 700, fontSize: 12,
+                color:'var(--text)', whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis',
+              }}>{p.title}</div>
+              <div style={{
+                fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+                letterSpacing:'.04em', textTransform:'uppercase',
+              }}>
+                {p.totalSessions} partite · fav: {p.fav}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ol>
+
+      <div style={{
+        marginTop: 14, paddingTop: 12,
+        borderTop:'1px solid var(--border-light)',
+        display:'flex', flexDirection:'column', gap: 8,
+      }}>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+          letterSpacing:'.08em', textTransform:'uppercase', fontWeight: 700,
+        }}>// Stats community</div>
+        <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap: 8 }}>
+          <div>
+            <div style={{ fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800, color:'hsl(var(--c-toolkit))' }}>
+              {DS.toolkits.length * 3 + 18}
+            </div>
+            <div style={{ fontSize: 10, color:'var(--text-muted)' }}>toolkit pubbl.</div>
+          </div>
+          <div>
+            <div style={{ fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800, color:'hsl(var(--c-agent))' }}>
+              {DS.agents.length * 2 + 12}
+            </div>
+            <div style={{ fontSize: 10, color:'var(--text-muted)' }}>agenti attivi</div>
+          </div>
+        </div>
+      </div>
+    </aside>
+  );
+};
+
+// ─── HERO PUBLIC (compact) ───────────────────────────────
+const SharedGamesHero = ({ compact }) => (
+  <section style={{
+    padding: compact ? '24px 16px 20px' : '40px 24px 28px',
+    textAlign: compact ? 'left' : 'center',
+    position:'relative',
+    background: compact ? 'transparent'
+      : 'radial-gradient(80% 60% at 50% 0%, hsl(var(--c-toolkit) / .07), transparent 70%)',
+  }}>
+    <div style={{
+      display:'inline-flex', alignItems:'center', gap: 6,
+      padding:'4px 10px', borderRadius:'var(--r-pill)',
+      background:'hsl(var(--c-toolkit) / .14)',
+      color:'hsl(var(--c-toolkit))',
+      fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 700,
+      textTransform:'uppercase', letterSpacing:'.08em',
+      marginBottom: 12,
+    }}>
+      <span style={{ width: 6, height: 6, borderRadius:'50%', background:'hsl(var(--c-toolkit))' }}/>
+      Catalogo community
+    </div>
+    <h1 style={{
+      fontFamily:'var(--f-display)', fontWeight: 800,
+      fontSize: compact ? 22 : 32,
+      letterSpacing:'-.02em', lineHeight: 1.1,
+      color:'var(--text)', margin:'0 0 8px',
+    }}>
+      Giochi <span style={{
+        background:'linear-gradient(95deg, hsl(var(--c-game)), hsl(var(--c-toolkit)))',
+        WebkitBackgroundClip:'text', WebkitTextFillColor:'transparent',
+        backgroundClip:'text', color:'transparent',
+      }}>condivisi</span> dalla community
+    </h1>
+    <p style={{
+      fontFamily:'var(--f-body)', fontSize: compact ? 12 : 14,
+      color:'var(--text-sec)', lineHeight: 1.55,
+      margin: 0, maxWidth: compact ? '100%' : 540,
+      marginLeft: compact ? 0 : 'auto', marginRight: compact ? 0 : 'auto',
+    }}>
+      Toolkit, agenti AI e knowledge base pubblicati da boardgamer come te.
+      Esplora liberamente — accedi quando vuoi installare.
+    </p>
+  </section>
+);
+
+// ─── FILTER + SEARCH HOOK ────────────────────────────────
+const useFilteredGames = (override) => {
+  const [query, setQuery] = useState('');
+  const [activeChips, setActiveChips] = useState([]);
+  const [genre, setGenre] = useState('');
+  const [sort, setSort] = useState('rating');
+
+  // Override forza dataset (per stati empty/empty-search)
+  useEffect(() => {
+    if (override === 'empty-search') { setQuery('terraform'); setGenre(''); setActiveChips([]); }
+    else if (override === 'filtered-empty') { setQuery(''); setActiveChips(['with-toolkit','with-agent','top-rated','new']); setGenre('Investigativo'); }
+    else { setQuery(''); setActiveChips([]); setGenre(''); }
+  }, [override]);
+
+  const toggleChip = (id) => setActiveChips(c => c.includes(id) ? c.filter(x=>x!==id) : [...c, id]);
+  const reset = () => { setQuery(''); setActiveChips([]); setGenre(''); };
+
+  const filtered = useMemo(() => {
+    let res = ALL_GAMES.slice();
+    if (query) {
+      const q = query.toLowerCase();
+      res = res.filter(g =>
+        g.title.toLowerCase().includes(q) ||
+        (g.author||'').toLowerCase().includes(q) ||
+        (g.publisher||'').toLowerCase().includes(q)
+      );
+    }
+    if (genre) res = res.filter(g => g.genre === genre);
+    activeChips.forEach(id => {
+      const chip = FILTER_CHIPS.find(c => c.id === id);
+      if (chip) res = res.filter(chip.test);
+    });
+    if (sort === 'rating')   res.sort((a,b) => (b.rating||0) - (a.rating||0));
+    if (sort === 'contrib')  res.sort((a,b) => b.contribCount - a.contribCount);
+    if (sort === 'new')      res.sort((a,b) => b.newWeek - a.newWeek);
+    if (sort === 'title')    res.sort((a,b) => a.title.localeCompare(b.title));
+
+    // Override forzato per "empty-search" — query "terraform" lascia 1 match,
+    // ma vogliamo 0 per stato empty: filtriamo come se non ci fosse match.
+    if (override === 'empty-search') return [];
+    if (override === 'filtered-empty') return [];
+    return res;
+  }, [query, genre, activeChips, sort, override]);
+
+  return { query, setQuery, activeChips, toggleChip, genre, setGenre, sort, setSort, filtered, reset };
+};
+
+// ─── EMPTY STATE ─────────────────────────────────────────
+const EmptyState = ({ kind, onReset, query }) => {
+  const isSearch = kind === 'empty-search';
+  return (
+    <div style={{
+      gridColumn:'1 / -1',
+      display:'flex', flexDirection:'column', alignItems:'center', textAlign:'center',
+      padding:'48px 24px',
+    }}>
+      <div style={{
+        width: 72, height: 72, borderRadius:'50%',
+        background: isSearch ? 'hsl(var(--c-info) / .12)' : 'hsl(var(--c-warning) / .12)',
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 32, marginBottom: 16,
+      }} aria-hidden="true">{isSearch ? '🔎' : '🎲'}</div>
+      <h3 style={{
+        fontFamily:'var(--f-display)', fontWeight: 700, fontSize: 17,
+        color:'var(--text)', margin:'0 0 6px',
+      }}>
+        {isSearch ? 'Nessun gioco trovato' : 'Nessun match con i filtri attuali'}
+      </h3>
+      <p style={{
+        fontSize: 13, color:'var(--text-muted)', lineHeight: 1.55,
+        maxWidth: 380, margin:'0 0 20px',
+      }}>
+        {isSearch
+          ? <>La ricerca per <strong style={{ color:'var(--text)' }}>"{query || 'terraform'}"</strong> non ha prodotto risultati. Prova con un titolo diverso o rimuovi i filtri.</>
+          : <>Hai applicato troppi filtri insieme. Rimuovili tutti per vedere il catalogo completo.</>}
+      </p>
+      <button
+        type="button"
+        onClick={onReset}
+        style={{
+          padding:'9px 16px',
+          borderRadius:'var(--r-md)',
+          border:'1.5px solid hsl(var(--c-game))',
+          background:'transparent',
+          color:'hsl(var(--c-game))',
+          fontFamily:'var(--f-display)', fontWeight: 700, fontSize: 13,
+          cursor:'pointer',
+          transition:'all var(--dur-sm) var(--ease-out)',
+        }}
+        onMouseEnter={e => { e.currentTarget.style.background='hsl(var(--c-game) / .1)'; }}
+        onMouseLeave={e => { e.currentTarget.style.background='transparent'; }}
+      >
+        ↺ Reset filtri
+      </button>
+    </div>
+  );
+};
+
+// ─── ERROR STATE ─────────────────────────────────────────
+const ErrorState = ({ onRetry }) => (
+  <div style={{
+    gridColumn:'1 / -1',
+    display:'flex', flexDirection:'column', alignItems:'center', textAlign:'center',
+    padding:'48px 24px',
+  }}>
+    <div style={{
+      width: 72, height: 72, borderRadius:'50%',
+      background:'hsl(var(--c-danger) / .12)',
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 32, marginBottom: 16,
+    }} aria-hidden="true">🛑</div>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontWeight: 700, fontSize: 17,
+      color:'var(--text)', margin:'0 0 6px',
+    }}>Impossibile caricare il catalogo</h3>
+    <p style={{
+      fontSize: 13, color:'var(--text-muted)', lineHeight: 1.55,
+      maxWidth: 380, margin:'0 0 18px',
+    }}>
+      Il servizio è temporaneamente non disponibile. Riprova tra qualche secondo.
+    </p>
+    <button
+      type="button"
+      onClick={onRetry}
+      style={{
+        padding:'9px 16px',
+        borderRadius:'var(--r-md)',
+        border:'none',
+        background:'hsl(var(--c-game))',
+        color:'#fff',
+        fontFamily:'var(--f-display)', fontWeight: 700, fontSize: 13,
+        cursor:'pointer',
+        boxShadow:'0 3px 10px hsl(var(--c-game) / .3)',
+      }}
+    >Riprova</button>
+  </div>
+);
+
+// ─── GRID (default | loading | empty | error) ────────────
+const SharedGamesGrid = ({ state, games, onReset, query, columns = 3, compact }) => {
+  const gridStyle = {
+    display:'grid',
+    gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+    gap: compact ? 10 : 14,
+  };
+
+  if (state === 'loading') {
+    return (
+      <div style={gridStyle}>
+        {Array.from({ length: columns * 3 }).map((_, i) => (
+          <SkeletonCard key={i}/>
+        ))}
+      </div>
+    );
+  }
+  if (state === 'error') {
+    return <div style={gridStyle}><ErrorState onRetry={onReset}/></div>;
+  }
+  if (games.length === 0) {
+    return <div style={gridStyle}><EmptyState kind={state} onReset={onReset} query={query}/></div>;
+  }
+
+  return (
+    <div style={gridStyle}>
+      {games.map(g => <MeepleCardGame key={g.id} game={g} compact={compact}/>)}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── MOBILE 375 SCREEN ───────────────────────────────
+// ═══════════════════════════════════════════════════════
+const PhoneSbar = () => (
+  <div className="phone-sbar">
+    <span style={{ fontFamily:'var(--f-mono)' }}>14:32</span>
+    <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+  </div>
+);
+
+const PhoneTopNav = () => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 9,
+    padding:'10px 14px',
+    borderBottom:'1px solid var(--border)',
+    background:'var(--bg)',
+  }}>
+    <div style={{
+      width: 24, height: 24, borderRadius: 7,
+      background:'linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event)))',
+      color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+      fontWeight: 800, fontSize: 12, fontFamily:'var(--f-display)',
+    }}>M</div>
+    <span style={{
+      fontFamily:'var(--f-display)', fontWeight: 700, fontSize: 13, color:'var(--text)',
+    }}>MeepleAI</span>
+    <div style={{ flex: 1 }}/>
+    <button aria-label="Accedi" style={{
+      padding:'5px 12px', borderRadius:'var(--r-md)',
+      background:'transparent', border:'1px solid var(--border)',
+      color:'var(--text)', fontFamily:'var(--f-display)', fontSize: 11, fontWeight: 700,
+      cursor:'pointer',
+    }}>Accedi</button>
+  </div>
+);
+
+const SharedGamesMobileScreen = ({ stateOverride }) => {
+  const f = useFilteredGames(stateOverride);
+  const isLoading = stateOverride === 'loading';
+  const isError   = stateOverride === 'error';
+
+  return (
+    <>
+      <PhoneSbar/>
+      <div style={{
+        flex: 1, overflowY:'auto', scrollbarWidth:'none',
+        background:'var(--bg)', display:'flex', flexDirection:'column',
+      }}>
+        <PhoneTopNav/>
+        <SharedGamesHero compact/>
+        <SharedGamesFilters
+          query={f.query} onQuery={f.setQuery}
+          activeChips={f.activeChips} onToggleChip={f.toggleChip}
+          genre={f.genre} onGenre={f.setGenre}
+          sort={f.sort} onSort={f.setSort}
+          resultCount={f.filtered.length}
+          totalCount={ALL_GAMES.length}
+          variant="mobile"
+        />
+        <div style={{ padding:'14px 14px 22px' }}>
+          <SharedGamesGrid
+            state={isLoading ? 'loading' : isError ? 'error' : stateOverride}
+            games={f.filtered}
+            onReset={f.reset}
+            query={f.query}
+            columns={2}
+            compact
+          />
+
+          {/* Paginator (default only) */}
+          {!isLoading && !isError && f.filtered.length > 0 && (
+            <div style={{
+              marginTop: 18, paddingTop: 16,
+              borderTop:'1px solid var(--border-light)',
+              textAlign:'center',
+            }}>
+              <button style={{
+                padding:'9px 18px', borderRadius:'var(--r-md)',
+                background:'var(--bg-muted)', border:'1px solid var(--border)',
+                color:'var(--text)', fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 700,
+                cursor:'pointer',
+              }}>Carica altri ({Math.max(0, ALL_GAMES.length - f.filtered.length + 8)})</button>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+const PhoneShell = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 10 }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div className="phone">{children}</div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 340,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── DESKTOP 1440 SCREEN ─────────────────────────────
+// ═══════════════════════════════════════════════════════
+const DesktopNav = () => (
+  <div style={{
+    position:'sticky', top: 0, zIndex: 5,
+    display:'flex', alignItems:'center', gap: 14,
+    padding:'12px 32px',
+    background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+    borderBottom:'1px solid var(--border)',
+  }}>
+    <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
+      <div style={{
+        width: 26, height: 26, borderRadius: 7,
+        background:'linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event)))',
+        color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+        fontWeight: 800, fontSize: 13, fontFamily:'var(--f-display)',
+      }}>M</div>
+      <span style={{ fontFamily:'var(--f-display)', fontWeight: 700, fontSize: 14, color:'var(--text)' }}>MeepleAI</span>
+    </div>
+    <div style={{ flex: 1, display:'flex', gap: 6, marginLeft: 22 }}>
+      {[
+        { l:'Prodotto' }, { l:'Prezzi' },
+        { l:'Catalogo', active:true }, { l:'Chi siamo' }, { l:'Contatti' },
+      ].map(it => (
+        <a key={it.l} href="#" onClick={e=>e.preventDefault()} style={{
+          padding:'6px 12px', borderRadius:'var(--r-md)',
+          color: it.active ? 'hsl(var(--c-game))' : 'var(--text-sec)',
+          background: it.active ? 'hsl(var(--c-game) / .12)' : 'transparent',
+          fontSize: 13, fontWeight: it.active ? 700 : 600, fontFamily:'var(--f-display)',
+        }}>{it.l}</a>
+      ))}
+    </div>
+    <a href="#" onClick={e=>e.preventDefault()} style={{
+      padding:'6px 12px', borderRadius:'var(--r-md)',
+      color:'var(--text-sec)', fontSize: 13, fontWeight: 700, fontFamily:'var(--f-display)',
+      border:'1px solid var(--border)',
+    }}>Accedi</a>
+    <a href="#" onClick={e=>e.preventDefault()} style={{
+      padding:'7px 14px', borderRadius:'var(--r-md)',
+      color:'#fff', fontSize: 13, fontWeight: 700, fontFamily:'var(--f-display)',
+      background:'hsl(var(--c-game))',
+      boxShadow:'0 3px 10px hsl(var(--c-game) / .3)',
+    }}>Inizia gratis</a>
+  </div>
+);
+
+const SharedGamesDesktopScreen = ({ stateOverride }) => {
+  const f = useFilteredGames(stateOverride);
+  const isLoading = stateOverride === 'loading';
+  const isError   = stateOverride === 'error';
+
+  return (
+    <div>
+      <DesktopNav/>
+      <SharedGamesHero/>
+      <SharedGamesFilters
+        query={f.query} onQuery={f.setQuery}
+        activeChips={f.activeChips} onToggleChip={f.toggleChip}
+        genre={f.genre} onGenre={f.setGenre}
+        sort={f.sort} onSort={f.setSort}
+        resultCount={f.filtered.length}
+        totalCount={ALL_GAMES.length}
+        variant="desktop"
+      />
+      <div style={{
+        display:'grid', gridTemplateColumns:'1fr 268px', gap: 28,
+        padding:'24px 32px 48px',
+      }}>
+        {/* Main grid */}
+        <div>
+          <SharedGamesGrid
+            state={isLoading ? 'loading' : isError ? 'error' : stateOverride}
+            games={f.filtered}
+            onReset={f.reset}
+            query={f.query}
+            columns={3}
+          />
+          {!isLoading && !isError && f.filtered.length > 0 && (
+            <div style={{
+              marginTop: 28, paddingTop: 18,
+              borderTop:'1px solid var(--border-light)',
+              display:'flex', alignItems:'center', justifyContent:'space-between',
+            }}>
+              <div style={{
+                fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+                letterSpacing:'.04em',
+              }}>Pag. 1 di 3</div>
+              <div style={{ display:'flex', gap: 6 }}>
+                <button disabled style={{
+                  width: 32, height: 32, borderRadius:'var(--r-md)',
+                  background:'var(--bg-muted)', border:'1px solid var(--border)',
+                  color:'var(--text-muted)', fontFamily:'var(--f-mono)', fontSize: 14,
+                  cursor:'not-allowed',
+                }} aria-label="Pagina precedente">←</button>
+                {[1,2,3].map(p => (
+                  <button key={p} style={{
+                    width: 32, height: 32, borderRadius:'var(--r-md)',
+                    background: p === 1 ? 'hsl(var(--c-game))' : 'var(--bg-card)',
+                    border:'1px solid var(--border)',
+                    color: p === 1 ? '#fff' : 'var(--text)',
+                    fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 700,
+                    cursor:'pointer',
+                  }} aria-label={`Pagina ${p}`} aria-current={p === 1 ? 'page' : undefined}>{p}</button>
+                ))}
+                <button style={{
+                  width: 32, height: 32, borderRadius:'var(--r-md)',
+                  background:'var(--bg-card)', border:'1px solid var(--border)',
+                  color:'var(--text)', fontFamily:'var(--f-mono)', fontSize: 14,
+                  cursor:'pointer',
+                }} aria-label="Pagina successiva">→</button>
+              </div>
+            </div>
+          )}
+        </div>
+        {/* Sidebar */}
+        <ContributorsSidebar/>
+      </div>
+    </div>
+  );
+};
+
+// ─── DESKTOP FRAME (browser chrome) ──────────────────────
+const DesktopFrame = ({ children, label, desc }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 12, width:'100%' }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div style={{
+      width: '100%', maxWidth: 1280,
+      borderRadius:'var(--r-xl)',
+      border:'1px solid var(--border)',
+      background:'var(--bg)',
+      overflow:'hidden',
+      boxShadow:'var(--shadow-lg)',
+    }}>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 8,
+        padding:'9px 14px',
+        background:'var(--bg-muted)',
+        borderBottom:'1px solid var(--border)',
+        fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      }}>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-event))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-warning))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-toolkit))' }}/>
+        <span style={{ flex: 1, textAlign:'center', letterSpacing:'.04em' }}>meepleai.app/shared-games</span>
+      </div>
+      {children}
+    </div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 720,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── ROOT — STAGE ────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const MOBILE_STATES = [
+  { id: 'default',         label: '01 · Default',         desc: '24 giochi caricati, ordinati per rating. Filtri tutti off.' },
+  { id: 'loading',         label: '02 · Loading',         desc: 'Skeleton 2×3 con shimmer animato; filtri rimangono interattivi.' },
+  { id: 'empty-search',    label: '03 · Empty search',    desc: 'Query "terraform" senza risultati — illustration + CTA reset.' },
+  { id: 'filtered-empty',  label: '04 · Filtered empty',  desc: 'Tutti i 4 chip + genere "Investigativo" combinati: zero match.' },
+];
+
+function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+  }, [dark]);
+  return (
+    <button
+      onClick={() => setDark(d => !d)}
+      className="theme-toggle"
+      aria-label={dark ? 'Passa a tema chiaro' : 'Passa a tema scuro'}>
+      <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span>
+      <span>{dark ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+}
+
+function App() {
+  return (
+    <div className="stage">
+      <ThemeToggle/>
+      <div className="stage-wrap">
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.08em', marginBottom: 8,
+        }}>SP3 · Public Secondary · #2</div>
+        <h1>Shared Games — Catalog Index</h1>
+        <p className="lead">
+          <code style={{ background:'var(--bg-muted)', padding:'2px 7px', borderRadius:'var(--r-sm)', fontSize: 12 }}>/shared-games</code>
+          {' · '}24 giochi catalogati con counts toolkit/agent/kb derivati da
+          {' '}<code style={{ background:'var(--bg-muted)', padding:'1px 6px', borderRadius:'var(--r-sm)', fontSize: 11 }}>data.js</code>.
+          Hero leggero + filter bar sticky + grid responsive (3-col desktop, 2-col mobile).
+          Componenti v2 nuovi: <strong>SharedGamesFilters</strong>, <strong>ContributorsSidebar</strong>.
+          Riusa <strong>MeepleCard</strong> primitive (entity=game variante grid) e <strong>Banner</strong> (#1).
+        </p>
+
+        <div className="section-label">Mobile · 375 — 4 stati</div>
+        <div className="phones-grid">
+          {MOBILE_STATES.map(s => (
+            <PhoneShell key={s.id} label={s.label} desc={s.desc}>
+              <SharedGamesMobileScreen stateOverride={s.id}/>
+            </PhoneShell>
+          ))}
+        </div>
+
+        <div className="section-label">Desktop · 1440 — main grid + contributors sidebar</div>
+        <div style={{ display:'flex', flexDirection:'column', gap: 36 }}>
+          <DesktopFrame label="05 · Desktop · Default"
+            desc="Grid 3-col, sidebar 268px sticky con top contributors da DS.players + stats community. Pagination minimal in fondo.">
+            <SharedGamesDesktopScreen stateOverride="default"/>
+          </DesktopFrame>
+          <DesktopFrame label="06 · Desktop · Loading"
+            desc="Skeleton 3×3 con shimmer; sidebar visibile (i contributors caricano in parallelo, qui semplificato).">
+            <SharedGamesDesktopScreen stateOverride="loading"/>
+          </DesktopFrame>
+          <DesktopFrame label="07 · Desktop · Filtered empty"
+            desc="Tutti e 4 i filtri attivi + genere niche: empty state con CTA reset. Nota i chip evidenziati nella filter bar.">
+            <SharedGamesDesktopScreen stateOverride="filtered-empty"/>
+          </DesktopFrame>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes mai-shimmer-anim {
+          0%   { background-position: -200% 0; }
+          100% { background-position:  200% 0; }
+        }
+        .mai-shimmer {
+          background: linear-gradient(
+            90deg,
+            var(--bg-muted) 0%,
+            var(--bg-hover) 50%,
+            var(--bg-muted) 100%
+          ) !important;
+          background-size: 200% 100% !important;
+          animation: mai-shimmer-anim 1.4s linear infinite;
+        }
+        .phones-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+          gap: var(--s-7);
+          align-items: start;
+        }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage .lead { line-height: var(--lh-relax); }
+        .phone > div::-webkit-scrollbar { display: none; }
+        article:focus-visible {
+          outline: 2px solid hsl(var(--c-game));
+          outline-offset: 2px;
+        }
+        button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible {
+          outline: 2px solid hsl(var(--c-game));
+          outline-offset: 2px;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);

--- a/docs/superpowers/specs/2026-04-21-redesign-v2-program.md
+++ b/docs/superpowers/specs/2026-04-21-redesign-v2-program.md
@@ -103,7 +103,13 @@ Il programma è spezzato in 5 sub-project con audience/scope distinti. Ogni SP h
 **Brief Claude Design**: `admin-mockups/briefs/SP4-entity-desktop.md` — **pronto, da eseguire**.
 **Mockup**: da produrre (~16 file `sp4-*.{html,jsx}`).
 **Spec implementativa**: da scrivere dopo mockup.
-**Dipendenze**: SP2 completo (drawer stack + EntityChip + connection-bar consolidati).
+**Dipendenze**: SP2 completo (drawer stack + EntityChip consolidati).
+**Componenti già stabili in produzione (NON ridisegnare)**:
+- `ConnectionBar` (`apps/web/src/components/ui/data-display/connection-bar/`) — PR #549 (Step 1.6) + PR #552 (Step 2 call-site migration). API contract: `ConnectionPip[]` con `{ entityType, count, label, icon, isEmpty }`.
+- `ConnectionChip` family (`apps/web/src/components/ui/data-display/meeple-card/parts/`) — PR #542, #545, #549, #552.
+- `MeepleCard` unificato — già in produzione su 17 call-site.
+- `RecentsBar`, `MobileBottomBar`, `MiniNavSlot`, drawer stack — M5.
+SP4 deve **istanziare** ConnectionBar passando `connections` builder-driven (vedi `build-connections.ts`), non riprogettarla.
 **Priorità implementativa**:
 1. Game detail + Agent character sheet — già top-traffic
 2. Session live desktop — core live play
@@ -181,7 +187,7 @@ Prima di chiudere un SP per passare al successivo:
 - **Tailwind config**: mappa HSL entity tokens. Cambi additivi safe, rename breaking.
 - **`MeepleCard`**: già unificato, NON creare varianti parallele. Estendere con nuovi entity types solo se servono (ma constraint è: 9 entity type, no nuovi).
 - **Drawer stack**: `useCascadeNavigationStore` è contract. Modifiche richiedono migration di tutti i consumer.
-- **Connection-bar**: pattern già montato su Game/Agent/Session desktop (M5). SP4 deve estendere agli altri entity, NON reinventare.
+- **Connection-bar**: ✅ stabile in produzione (PR #549 Step 1.6 + PR #552 Step 2). Componente: `apps/web/src/components/ui/data-display/connection-bar/ConnectionBar.tsx`. Tipi: `types.ts` (`ConnectionPip`, `ConnectionBarProps`). Builder puri: `build-connections.ts` (`buildGameConnections`, `buildAgentConnections`, `buildSessionConnections`). SP4 deve **istanziare** passando `connections` props, NON ridisegnare. SP3 mockup pubblici che mostrano relazioni tra entity (es. shared-game-detail) usano la stessa primitive.
 
 ### Rischi
 


### PR DESCRIPTION
## Summary

Batch SP3 ridotto Claude Design — 5 mockup per le pagine pubbliche secondarie del Redesign v2 program.

| # | Mockup | Route | Stati mobile | Viste desktop |
|---|---|---|---|---|
| 1 | `sp3-join` | `/join` | 5 (default·submitting·success·error·already-on-list) | 2 (default·success) |
| 2 | `sp3-shared-games` | `/shared-games` | 4 (default·loading·empty-search·filtered-empty·error) | 3 |
| 3 | `sp3-accept-invite` | `/accept-invite/[token]` | 7 (default·logged-in·accepted·declined·expired·invalid·already-accepted) | 3 split-layout |
| 4 | `sp3-shared-game-detail` | `/shared-games/[slug]` | 5 (default·minimal·no-content·loading·error) | 4 |
| 5 | `sp3-faq-enhanced` | `/faq` | 5 (default·category·search·search-no·loading) | 4 |

## Componenti v2 introdotti

Tutti riutilizzabili in SP3+ e in altre wave del program:
- **Banner** (4 toni: success/error/warning/info) — riusato in tutti 5
- **FeatureCard**, **AlphaPill**, **GamePreferenceSelect** [#1]
- **MeepleCardGame** variant grid, **SharedGamesFilters** [#2]
- **InviteHostCard**, **SessionMetaGrid**, **RosterMini**, **Confetti** CSS-only [#3]
- **ConnectionBar** (riproduzione 1:1 PR #549/#552), **Tabs** animated underline, **ToolkitPublicListItem**, **AgentPublicListItem**, **KBPublicDocItem**, **ContributorsStrip** [#4]
- **FAQSearchBar**, **QuickAnswerCard**, **CategoryTabs** sticky pills, **AccordionItem** v2 [#5]

## ConnectionBar — verifica 1:1 con produzione

Il mockup #4 riproduce fedelmente `apps/web/src/components/ui/data-display/connection-bar/ConnectionBar.tsx` (PR #549 Step 1.6 + PR #552 Step 2). Verifiche superate:
- `borderRadius: 999` (rounded-full) ✅
- `hsl(... / .1)` background = `entityHsl(type, 0.1)` ✅
- `isEmpty` logic + dashed border + opacity 0.6 + Plus icon ✅
- `aria-label`: pieno = `${label}: ${count}`, empty = solo `label` ✅
- `tabular-nums` font feature per il count ✅

⚠️ **Per il dev impl**: NON copiare il JSX del mockup, **istanziare il componente prod** passando `connections: ConnectionPip[]`.

## Plan update incluso

- `admin-mockups/briefs/SP4-entity-desktop.md` — aggiunta sezione "Componenti già stabili — NON ridisegnare" (tabella ConnectionBar, ConnectionChip family, MeepleCard, RecentsBar, MobileBottomBar+MiniNavSlot, drawer stack) + esempio TSX `ConnectionPip[]` per Game detail desktop.
- `admin-mockups/briefs/SP3-public-secondary.md` — schermata #7 (shared-game-detail) referenzia ConnectionBar componente prod con specifica visiva 1:1.
- `docs/superpowers/specs/2026-04-21-redesign-v2-program.md` — SP4 dipendenze elenca PR concrete (#549/#552); sezione "Dipendenze tecniche" puntuale su connection-bar = stabile in produzione.

## Decisioni architettoniche pre-impl

| Area | Decisione |
|---|---|
| Newsletter waitlist | opt-in **OFF** default (GDPR Art. 7 + EDPB) |
| Session creation invite | pre-existing `GameNightSession`, accept = relation transition |
| `.ics` endpoint | `GET /api/v1/invites/{token}.ics` (token = auth) |
| ConnectionBar pip click | pieno → scroll+switch tab; empty → `/login?returnTo=...` |
| FAQ dataset | static markdown frontmatter (CMS post-alpha) |
| i18n | `useTranslation()` + `messages/{it,en}.json` per stringhe nuove |
| popularRank FAQ | marketing-curated Alpha, analytics-driven post-alpha |
| Search query persistence | URL hash `#q=...` (link condivisibili) |

## Token hygiene

100% CSS vars da `tokens.css`. Zero hex hardcoded eccetto:
- phone-shell inset 22px (ereditato da `auth-flow.jsx`, coerenza con SP1 mockups)
- font-size mini-text 9-11px (sotto la scala `--fs-xs:11`, coerenti con kicker mono auth-flow)

## Test plan

- [ ] Aprire ogni `.html` nel browser per verifica visiva (stati mobile + desktop, light + dark via toggle)
- [ ] Verificare ConnectionBar match 1:1 confrontando `sp3-shared-game-detail.jsx` con `apps/web/src/components/ui/data-display/connection-bar/ConnectionBar.tsx`
- [ ] Confermare GDPR opt-in OFF in `sp3-join.jsx` (`news: false` default)
- [ ] Review brief updates per coerenza riferimenti PR

## Out of scope

Questa PR contiene **solo mockup** (no impl produzione). Le pagine reali verranno implementate in PR successive seguendo le decisioni elencate sopra.

## Next steps

Post-merge:
1. Aggiornamento `MEMORY.md` con chiusura batch SP3 mockup
2. Scelta forking: spec impl SP3 OR SP4 wave 1 mockup Claude Design (4 desktop entity: Game/Agent/Session/Library)

🤖 Generated with [Claude Code](https://claude.com/claude-code)