### PR TITLE
feat(mockups): SP4 wave 1 — entity detail desktop (5 mockups)

### DIFF
--- a/admin-mockups/design_files/sp4-agent-detail.html
+++ b/admin-mockups/design_files/sp4-agent-detail.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 wave 1 · #4/5 · Agent detail — /agents/[id]</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-agent-detail.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-agent-detail.jsx
+++ b/admin-mockups/design_files/sp4-agent-detail.jsx
@@ -1,0 +1,1394 @@
+/* MeepleAI SP4 wave 1 — Schermata #4 / 5
+   Route: /agents/[id]
+   File: admin-mockups/design_files/sp4-agent-detail.{html,jsx}
+   Pattern desktop: Hero character sheet + body con tabs
+
+   Hero 200-220px (180 mobile): radial gradient entity-agent + avatar 96 + nome + persona + meta + action bar.
+   ConnectionBar sticky 1:1 prod (6 pip, toolkit empty dashed).
+   5 tabs: Identity / Knowledge / Performance / History / Settings.
+   Varianti: draft (setup banner) · active · archived (banner + read-only).
+
+   v2 nuovi:
+   - AgentHero            → apps/web/src/components/ui/v2/agent-hero/
+   - AgentTabs (riuso GameTabs animated underline)
+   - PersonaCard          → apps/web/src/components/ui/v2/persona-card/
+   - SystemPromptViewer   → apps/web/src/components/ui/v2/system-prompt-viewer/
+   - KbDocList            → apps/web/src/components/ui/v2/kb-doc-list/
+   - PerformanceKpi       → riuso GameStatsKpi
+   - ChatHistoryTimeline  → apps/web/src/components/ui/v2/chat-history-timeline/
+   - AgentSettingsForm    → apps/web/src/components/ui/v2/agent-settings-form/
+   - AgentDangerZone      → apps/web/src/components/ui/v2/agent-danger-zone/
+
+   Riusi prod: ConnectionBar (PR #549/#552), MeepleCard.list (kb, chat).
+*/
+
+const { useState, useEffect, useRef } = React;
+const DS = window.DS;
+
+const entityHsl = (type, alpha) => {
+  const c = DS.EC[type] || DS.EC.agent;
+  return alpha !== undefined
+    ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${alpha})`
+    : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
+};
+
+const AGENT_BASE = {
+  id:'a-wingspan-mage',
+  type:'agent',
+  title:'Mago di Wingspan',
+  avatar:'🧙‍♂️',
+  persona:'Esperto di strategia',
+  gameId:'g-wingspan',
+  desc:'Risponde a domande su poteri uccelli, combo motore e strategia ottimale per ogni habitat. Tono didattico ma diretto, non spoilera scelte.',
+  tone:'Didattico · diretto',
+  language:'Italiano',
+  responseStyle:'coaching',
+  model:'Claude Sonnet 4',
+  modelId:'claude-sonnet-4',
+  temperature: 0.4,
+  maxTokens: 1024,
+  customInstructions:'Cita sempre il regolamento ufficiale quando possibile.\nPer domande di scoring usa esempi numerici.\nNon rivelare carte avanzate dell\'espansione Asia.',
+  systemPrompt:`Sei "Mago di Wingspan", un agente esperto del gioco da tavolo Wingspan.\n\nTuo ruolo: aiutare i giocatori a capire poteri delle carte uccello, sinergie tra habitat e ottimizzare il loro motore di punti.\n\nLinee guida:\n- Cita SEMPRE il regolamento ufficiale (pagina e versione)\n- Per scoring usa esempi numerici concreti\n- Tono didattico ma diretto\n- Non spoilerare strategie avanzate dell'espansione Asia\n- Se non sei certo, rispondi "non sono sicuro" e suggerisci dove cercare`,
+  createdAt:'12 Gen 2026',
+  lastUsed:'5 minuti fa',
+  invocations: 230,
+};
+
+const KB_DOCS = [
+  { id:'k1', title:'Wingspan · Regolamento base v1.2.pdf', size:'4.2 MB', pages: 24, chunks: 142, status:'indexed', indexedAt:'8 Gen 2026' },
+  { id:'k2', title:'Wingspan · FAQ ufficiale.pdf', size:'1.1 MB', pages: 8, chunks: 38, status:'indexed', indexedAt:'8 Gen 2026' },
+  { id:'k3', title:'Wingspan · Espansione Europa.pdf', size:'3.8 MB', pages: 18, chunks: 96, status:'indexed', indexedAt:'15 Gen 2026' },
+  { id:'k4', title:'Wingspan · Carte uccello reference.csv', size:'180 KB', pages: 1, chunks: 178, status:'indexed', indexedAt:'18 Gen 2026' },
+  { id:'k5', title:'Wingspan · Espansione Oceania.pdf', size:'4.5 MB', pages: 22, chunks: 0, status:'processing', indexedAt:null },
+  { id:'k6', title:'Strategy guide community.pdf', size:'2.3 MB', pages: 14, chunks: 0, status:'failed', indexedAt:null, error:'Formato non riconosciuto' },
+];
+
+const TOP_QUESTIONS = [
+  { q:'Posso usare il potere di un uccello già attivato in un turno precedente?', count: 18 },
+  { q:'Come funziona il bonus di fine partita "ornitologo"?', count: 14 },
+  { q:'Devo scartare carte se non ho cibo per mangiarle?', count: 11 },
+  { q:'Quanti uccelli posso giocare al massimo per habitat?', count: 9 },
+  { q:'Cosa succede se finisco i token uovo durante l\'azione?', count: 7 },
+];
+
+const CHAT_HISTORY = [
+  { id:'c1', firstMsg:'Posso giocare un uccello che richiede 2 cibi se ne ho solo 1 e un jolly?', when:'5m fa', msgCount: 6, resolved: true },
+  { id:'c2', firstMsg:'Come si calcolano i punti delle uova bonus a fine partita?', when:'2h fa', msgCount: 4, resolved: true },
+  { id:'c3', firstMsg:'Spiega il potere "guadagna cibo da chiunque attivi questo habitat"', when:'ieri', msgCount: 8, resolved: true },
+  { id:'c4', firstMsg:'È legale rigiocare un uccello scartato dal mazzo?', when:'2g fa', msgCount: 3, resolved: false },
+  { id:'c5', firstMsg:'Combo migliore per habitat foresta in 4 giocatori?', when:'4g fa', msgCount: 12, resolved: true },
+  { id:'c6', firstMsg:'Differenza tra azione "guadagna cibo" e "predatore"', when:'1 sett fa', msgCount: 5, resolved: true },
+];
+
+// ─── ConnectionBar (1:1 prod) ────────────────────────
+const ConnectionBar = ({ connections, loading }) => {
+  if (loading) {
+    return (
+      <div style={{ display:'flex', gap: 8, padding:'8px 0', overflowX:'auto', scrollbarWidth:'none' }}>
+        {[0,1,2,3,4,5].map(i => (
+          <div key={i} className="mai-shimmer" style={{
+            height: 28, width: 92 + i*6, borderRadius: 999,
+            background:'var(--bg-muted)', flexShrink: 0,
+          }}/>
+        ))}
+      </div>
+    );
+  }
+  return (
+    <div className="mai-cb-scroll" style={{
+      display:'flex', alignItems:'center', gap: 8,
+      overflowX:'auto', padding:'8px 0', scrollbarWidth:'none',
+    }}>
+      {connections.map(c => {
+        const isEmpty = c.isEmpty || c.count === 0;
+        const ec = DS.EC[c.entityType];
+        return (
+          <button key={c.entityType} type="button"
+            aria-label={isEmpty ? c.label : `${c.label}: ${c.count}`}
+            style={{
+              display:'inline-flex', alignItems:'center', gap: 6,
+              padding:'6px 12px', borderRadius: 999,
+              fontSize: 12, fontWeight: 700, fontFamily:'var(--f-display)',
+              background: isEmpty ? 'transparent' : entityHsl(c.entityType, 0.1),
+              color: entityHsl(c.entityType),
+              border: isEmpty
+                ? `1.5px dashed ${entityHsl(c.entityType, 0.5)}`
+                : `1px solid ${entityHsl(c.entityType, 0.2)}`,
+              opacity: isEmpty ? 0.6 : 1,
+              cursor:'pointer', flexShrink: 0, whiteSpace:'nowrap',
+              transition:'transform var(--dur-sm) var(--ease-out), box-shadow var(--dur-sm)',
+            }}
+            onMouseEnter={e => { e.currentTarget.style.transform='scale(1.03)'; e.currentTarget.style.boxShadow='var(--shadow-md)'; }}
+            onMouseLeave={e => { e.currentTarget.style.transform=''; e.currentTarget.style.boxShadow=''; }}
+          >
+            <span aria-hidden="true" style={{ fontSize: 13 }}>{ec.em}</span>
+            {isEmpty ? (
+              <svg width="13" height="13" viewBox="0 0 24 24"
+                fill="none" stroke="currentColor" strokeWidth="2.5"
+                strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <line x1="12" y1="5" x2="12" y2="19"/>
+                <line x1="5" y1="12" x2="19" y2="12"/>
+              </svg>
+            ) : (
+              <span style={{ fontFamily:'var(--f-mono)', fontVariantNumeric:'tabular-nums', fontWeight: 700 }}>{c.count}</span>
+            )}
+            <span>{c.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+// ─── EntityChip game ─────────────────────────────────
+const EntityChipGame = ({ gameId, compact, dark }) => {
+  const g = DS.byId[gameId];
+  if (!g) return null;
+  const onDark = dark === true;
+  return (
+    <a href="#" onClick={e => e.preventDefault()} style={{
+      display:'inline-flex', alignItems:'center', gap: 5,
+      padding: compact ? '2px 8px' : '3px 10px',
+      borderRadius:'var(--r-pill)',
+      background: onDark ? 'rgba(255,255,255,.18)' : entityHsl('game', 0.1),
+      color: onDark ? '#fff' : entityHsl('game'),
+      fontFamily:'var(--f-display)',
+      fontSize: compact ? 11 : 12, fontWeight: 700,
+      textDecoration:'none',
+      border: onDark ? '1px solid rgba(255,255,255,.3)' : `1px solid ${entityHsl('game', 0.2)}`,
+      whiteSpace:'nowrap',
+      backdropFilter: onDark ? 'blur(8px)' : 'none',
+    }}>
+      <span aria-hidden="true">🎲</span>{g.title}
+    </a>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── AGENT HERO ─────────────────────────────────────
+// /* v2: AgentHero → apps/web/src/components/ui/v2/agent-hero/ */
+// ═══════════════════════════════════════════════════════
+const AgentHero = ({ agent, variant, compact, loading }) => {
+  if (loading) {
+    return (
+      <div style={{ position:'relative', height: compact ? 180 : 220, padding: compact ? '14px 16px' : '24px 32px' }}>
+        <div style={{ display:'flex', gap: compact ? 14 : 22, alignItems:'center', height:'100%' }}>
+          <div className="mai-shimmer" style={{
+            width: compact ? 72 : 96, height: compact ? 72 : 96,
+            borderRadius:'var(--r-lg)', background:'var(--bg-muted)', flexShrink: 0,
+          }}/>
+          <div style={{ flex: 1, display:'flex', flexDirection:'column', gap: 8 }}>
+            <div className="mai-shimmer" style={{ height: 14, width:'30%', background:'var(--bg-muted)', borderRadius: 4 }}/>
+            <div className="mai-shimmer" style={{ height: 30, width:'60%', background:'var(--bg-muted)', borderRadius: 6 }}/>
+            <div className="mai-shimmer" style={{ height: 12, width:'70%', background:'var(--bg-muted)', borderRadius: 4 }}/>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ position:'relative' }}>
+      {/* Variant banners */}
+      {variant === 'draft' && (
+        <div style={{
+          padding: compact ? '8px 16px' : '10px 32px',
+          background:'hsl(38, 92%, 50% / .14)',
+          borderBottom:'1px solid hsl(38, 92%, 50% / .3)',
+          display:'flex', alignItems:'center', gap: 10, flexWrap:'wrap',
+        }}>
+          <span aria-hidden="true" style={{ fontSize: 16 }}>⚙</span>
+          <span style={{
+            flex: 1, fontSize: 12.5, color:'hsl(38, 80%, 28%)', fontWeight: 700,
+          }}>Agente in setup — completa la configurazione per attivarlo.</span>
+          <button type="button" style={{
+            padding:'6px 12px', borderRadius:'var(--r-md)',
+            background:'hsl(38, 92%, 50%)', color:'#fff', border:'none',
+            fontFamily:'var(--f-display)', fontSize: 11.5, fontWeight: 800, cursor:'pointer',
+          }}>Completa setup →</button>
+        </div>
+      )}
+      {variant === 'archived' && (
+        <div style={{
+          padding: compact ? '8px 16px' : '10px 32px',
+          background:'var(--bg-muted)',
+          borderBottom:'1px solid var(--border)',
+          display:'flex', alignItems:'center', gap: 10, flexWrap:'wrap',
+        }}>
+          <span aria-hidden="true" style={{ fontSize: 16, color:'var(--text-muted)' }}>⊘</span>
+          <span style={{
+            flex: 1, fontSize: 12.5, color:'var(--text-sec)', fontWeight: 600,
+          }}>Agente archiviato il <strong>22 Mar 2026</strong>. Le chat e i KB sono in sola lettura.</span>
+          <button type="button" style={{
+            padding:'6px 12px', borderRadius:'var(--r-md)',
+            background: entityHsl('agent'), color:'#fff', border:'none',
+            fontFamily:'var(--f-display)', fontSize: 11.5, fontWeight: 800, cursor:'pointer',
+          }}>↻ Riattiva</button>
+        </div>
+      )}
+
+      {/* Hero body */}
+      <div style={{
+        position:'relative',
+        padding: compact ? '18px 16px' : '28px 32px',
+        background:`radial-gradient(circle at 20% 30%, ${entityHsl('agent', 0.18)} 0%, transparent 60%)`,
+        borderBottom:'1px solid var(--border-light)',
+      }}>
+        {/* radial gradient bg fallback */}
+        <div aria-hidden="true" style={{
+          position:'absolute', inset: 0,
+          background:`radial-gradient(circle at 80% 70%, ${entityHsl('agent', 0.08)} 0%, transparent 50%)`,
+          pointerEvents:'none',
+        }}/>
+
+        <div style={{
+          position:'relative', zIndex: 1,
+          display:'flex', gap: compact ? 14 : 22,
+          flexDirection: compact ? 'column' : 'row',
+          alignItems: compact ? 'flex-start' : 'center',
+        }}>
+          {/* Avatar */}
+          <div style={{
+            width: compact ? 72 : 96, height: compact ? 72 : 96,
+            borderRadius:'var(--r-lg)',
+            background: entityHsl('agent', 0.16),
+            color: entityHsl('agent'),
+            display:'flex', alignItems:'center', justifyContent:'center',
+            fontSize: compact ? 38 : 56,
+            flexShrink: 0,
+            border:`2px solid ${entityHsl('agent', 0.3)}`,
+            boxShadow:`0 8px 24px ${entityHsl('agent', 0.25)}`,
+          }} aria-hidden="true">{agent.avatar}</div>
+
+          {/* Name + persona + meta */}
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{
+              display:'flex', alignItems:'center', gap: 6, marginBottom: 6, flexWrap:'wrap',
+            }}>
+              <span style={{
+                display:'inline-flex', alignItems:'center', gap: 5,
+                padding:'3px 9px', borderRadius:'var(--r-pill)',
+                background: entityHsl('agent', 0.14),
+                color: entityHsl('agent'),
+                fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+                textTransform:'uppercase', letterSpacing:'.08em',
+              }}><span aria-hidden="true">🤖</span>Agent</span>
+              {variant === 'active' && (
+                <span style={{
+                  padding:'3px 9px', borderRadius:'var(--r-pill)',
+                  background:'hsl(140, 60%, 45% / .14)', color:'hsl(140, 50%, 35%)',
+                  fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+                  textTransform:'uppercase', letterSpacing:'.08em',
+                }}>● Attivo</span>
+              )}
+            </div>
+            <h1 style={{
+              fontFamily:'var(--f-display)', fontWeight: 800,
+              fontSize: compact ? 24 : 34, letterSpacing:'-.02em', lineHeight: 1.05,
+              color:'var(--text)', margin:'0 0 4px',
+            }}>{agent.title}</h1>
+            <div style={{
+              fontFamily:'var(--f-display)', fontSize: compact ? 13 : 14,
+              color: entityHsl('agent'), fontWeight: 700,
+              marginBottom: 10,
+            }}>{agent.persona} · Wingspan</div>
+            <div style={{
+              display:'flex', flexWrap:'wrap', gap:'5px 10px',
+              fontFamily:'var(--f-mono)', fontSize: compact ? 11 : 12,
+              color:'var(--text-muted)', fontWeight: 600,
+              alignItems:'center',
+            }}>
+              <EntityChipGame gameId={agent.gameId} compact={compact}/>
+              <span aria-hidden="true">·</span>
+              <span>creato {agent.createdAt}</span>
+              <span aria-hidden="true">·</span>
+              <span>ultimo uso <strong style={{ color:'var(--text-sec)' }}>{agent.lastUsed}</strong></span>
+              <span aria-hidden="true">·</span>
+              <span>{agent.model}</span>
+            </div>
+          </div>
+
+          {/* Action bar */}
+          <div style={{
+            display:'flex', gap: 8, flexShrink: 0,
+            alignSelf: compact ? 'stretch' : 'auto',
+            flexWrap: compact ? 'wrap' : 'nowrap',
+          }}>
+            {variant !== 'archived' && (
+              <button type="button" style={{
+                padding: compact ? '9px 14px' : '10px 18px', borderRadius:'var(--r-md)',
+                background: entityHsl('agent'), color:'#fff', border:'none',
+                fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+                cursor: variant === 'draft' ? 'not-allowed' : 'pointer',
+                opacity: variant === 'draft' ? 0.55 : 1,
+                boxShadow:`0 4px 14px ${entityHsl('agent', 0.4)}`,
+                display:'inline-flex', alignItems:'center', gap: 6,
+                flex: compact ? 1 : 'none',
+                justifyContent:'center',
+              }}><span aria-hidden="true">💬</span>Avvia chat</button>
+            )}
+            <button type="button" style={{
+              padding: compact ? '9px 12px' : '10px 14px', borderRadius:'var(--r-md)',
+              background:'transparent', color:'var(--text)',
+              border:'1px solid var(--border-strong)',
+              fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700,
+              cursor:'pointer',
+              display:'inline-flex', alignItems:'center', gap: 5,
+            }}><span aria-hidden="true">✎</span>{compact ? '' : 'Modifica'}</button>
+            <button type="button" aria-label="Altre azioni" style={{
+              padding: compact ? '9px 12px' : '10px 12px', borderRadius:'var(--r-md)',
+              background:'transparent', color:'var(--text)',
+              border:'1px solid var(--border-strong)',
+              fontSize: 14, cursor:'pointer', minWidth: 38,
+            }}>⋯</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ─── Tabs (riuso pattern animated underline) ────────
+const AgentTabs = ({ tabs, active, onChange, compact }) => {
+  const refs = useRef({});
+  const [ind, setInd] = useState({ left: 0, width: 0 });
+  useEffect(() => {
+    const el = refs.current[active];
+    if (el) setInd({ left: el.offsetLeft, width: el.offsetWidth });
+  }, [active, tabs.length, compact]);
+
+  return (
+    <div className="mai-cb-scroll" style={{
+      position:'relative',
+      display:'flex', alignItems:'center', gap: 2,
+      borderBottom:'1px solid var(--border)',
+      overflowX:'auto', scrollbarWidth:'none',
+      padding: compact ? '0 16px' : '0 32px',
+      background:'var(--bg)',
+    }} role="tablist">
+      {tabs.map(t => {
+        const isActive = t.id === active;
+        return (
+          <button key={t.id} type="button"
+            ref={el => { refs.current[t.id] = el; }}
+            onClick={() => onChange(t.id)}
+            role="tab" aria-selected={isActive}
+            style={{
+              display:'inline-flex', alignItems:'center', gap: 7,
+              padding:'12px 14px', background:'transparent', border:'none',
+              color: isActive ? entityHsl('agent') : 'var(--text-sec)',
+              fontFamily:'var(--f-display)', fontSize: 13,
+              fontWeight: isActive ? 800 : 700,
+              cursor:'pointer', whiteSpace:'nowrap', flexShrink: 0,
+            }}>
+            <span aria-hidden="true">{t.icon}</span>{t.label}
+            {t.count !== undefined && (
+              <span style={{
+                padding:'1px 7px', borderRadius:'var(--r-pill)',
+                background: isActive ? entityHsl('agent') : 'var(--bg-muted)',
+                color: isActive ? '#fff' : 'var(--text-muted)',
+                fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+              }}>{t.count}</span>
+            )}
+          </button>
+        );
+      })}
+      <span aria-hidden="true" style={{
+        position:'absolute', bottom: -1, left: ind.left, width: ind.width,
+        height: 2, background: entityHsl('agent'),
+        transition:'left .3s cubic-bezier(.4,0,.2,1), width .3s cubic-bezier(.4,0,.2,1)',
+        borderRadius:'2px 2px 0 0',
+      }}/>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── TAB: IDENTITY ──────────────────────────────────
+// ═══════════════════════════════════════════════════════
+// /* v2: PersonaCard */
+const PersonaCard = ({ agent, readonly }) => {
+  const [style, setStyle] = useState(agent.responseStyle);
+  return (
+    <div style={{
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)', padding: 18,
+    }}>
+      <h3 style={{
+        fontFamily:'var(--f-display)', fontSize: 15, fontWeight: 800,
+        color:'var(--text)', margin:'0 0 14px',
+      }}>Persona</h3>
+      <div style={{
+        display:'grid', gridTemplateColumns:'repeat(auto-fit, minmax(180px, 1fr))', gap: 14,
+        marginBottom: 14,
+      }}>
+        {[
+          { label:'Tono', value: agent.tone },
+          { label:'Lingua', value: agent.language },
+          { label:'Modello', value: agent.model },
+        ].map(s => (
+          <div key={s.label}>
+            <div style={{
+              fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+              textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 800, marginBottom: 4,
+            }}>{s.label}</div>
+            <div style={{
+              fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 700, color:'var(--text)',
+            }}>{s.value}</div>
+          </div>
+        ))}
+      </div>
+      <div>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 800, marginBottom: 6,
+        }}>Stile risposta</div>
+        <div role="radiogroup" style={{ display:'flex', gap: 6, flexWrap:'wrap' }}>
+          {['concisa','dettagliata','coaching'].map(s => {
+            const active = style === s;
+            return (
+              <button key={s} type="button" disabled={readonly}
+                onClick={() => !readonly && setStyle(s)}
+                aria-pressed={active}
+                style={{
+                  padding:'7px 14px',
+                  borderRadius:'var(--r-pill)',
+                  border: active ? `1px solid ${entityHsl('agent', 0.4)}` : '1px solid var(--border)',
+                  background: active ? entityHsl('agent', 0.12) : 'var(--bg-card)',
+                  color: active ? entityHsl('agent') : 'var(--text-sec)',
+                  fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 700,
+                  cursor: readonly ? 'not-allowed' : 'pointer',
+                  textTransform:'capitalize',
+                  opacity: readonly ? 0.7 : 1,
+                }}>{s}</button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// /* v2: SystemPromptViewer */
+const SystemPromptViewer = ({ prompt, readonly }) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div style={{
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)', padding: 18,
+    }}>
+      <button type="button" onClick={() => setOpen(o => !o)}
+        style={{
+          width:'100%', display:'flex', alignItems:'center', justifyContent:'space-between',
+          padding: 0, background:'transparent', border:'none', cursor:'pointer',
+          color:'var(--text)',
+        }}>
+        <span style={{
+          display:'flex', alignItems:'center', gap: 8,
+          fontFamily:'var(--f-display)', fontSize: 15, fontWeight: 800,
+        }}>
+          <span aria-hidden="true">📜</span>System prompt
+          <span style={{
+            padding:'1px 7px', borderRadius:'var(--r-pill)',
+            background:'var(--bg-muted)', color:'var(--text-muted)',
+            fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+            textTransform:'uppercase', letterSpacing:'.06em',
+          }}>read-only</span>
+        </span>
+        <span aria-hidden="true" style={{
+          transform: open ? 'rotate(90deg)' : 'rotate(0deg)',
+          transition:'transform var(--dur-sm)', color:'var(--text-muted)',
+        }}>›</span>
+      </button>
+      {open && (
+        <pre style={{
+          marginTop: 14, padding: 14,
+          background:'var(--bg-muted)', borderRadius:'var(--r-md)',
+          fontFamily:'var(--f-mono)', fontSize: 11.5, lineHeight: 1.6,
+          color:'var(--text-sec)',
+          whiteSpace:'pre-wrap', wordBreak:'break-word',
+          maxHeight: 280, overflowY:'auto',
+        }}>{prompt}</pre>
+      )}
+    </div>
+  );
+};
+
+const AVATAR_OPTS = ['🧙‍♂️','🤖','🧠','🎯','🎨','🦉','🦊','🐦','🌳','🚀','🧬','⚙','📚','🎲'];
+const AvatarSelector = ({ current, readonly }) => {
+  const [picked, setPicked] = useState(current);
+  return (
+    <div style={{
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)', padding: 18,
+    }}>
+      <h3 style={{
+        fontFamily:'var(--f-display)', fontSize: 15, fontWeight: 800,
+        color:'var(--text)', margin:'0 0 12px',
+      }}>Avatar</h3>
+      <div style={{
+        display:'grid', gridTemplateColumns:'repeat(auto-fill, minmax(48px, 1fr))', gap: 6,
+      }}>
+        {AVATAR_OPTS.map(a => {
+          const active = picked === a;
+          return (
+            <button key={a} type="button" disabled={readonly}
+              onClick={() => !readonly && setPicked(a)}
+              aria-label={`Avatar ${a}`} aria-pressed={active}
+              style={{
+                aspectRatio:'1 / 1', borderRadius:'var(--r-md)',
+                border: active ? `2px solid ${entityHsl('agent')}` : '1px solid var(--border)',
+                background: active ? entityHsl('agent', 0.12) : 'var(--bg)',
+                fontSize: 22,
+                cursor: readonly ? 'not-allowed' : 'pointer',
+                display:'flex', alignItems:'center', justifyContent:'center',
+                opacity: readonly ? 0.6 : 1,
+              }}>{a}</button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+const IdentityTab = ({ agent, readonly }) => (
+  <div style={{ display:'flex', flexDirection:'column', gap: 14 }}>
+    <PersonaCard agent={agent} readonly={readonly}/>
+    <SystemPromptViewer prompt={agent.systemPrompt} readonly={readonly}/>
+    <AvatarSelector current={agent.avatar} readonly={readonly}/>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── TAB: KNOWLEDGE ─────────────────────────────────
+// ═══════════════════════════════════════════════════════
+// /* v2: KbDocList */
+const KbStatusBadge = ({ status }) => {
+  const map = {
+    indexed:    { label:'✓ Indexed',    color:'success', bg:'hsl(140, 60%, 45% / .14)', fg:'hsl(140, 50%, 35%)' },
+    processing: { label:'⏳ Processing', color:'warn',    bg:'hsl(38, 92%, 50% / .14)',  fg:'hsl(38, 80%, 35%)' },
+    failed:     { label:'⚠ Failed',     color:'danger',  bg:'hsl(var(--c-danger) / .14)', fg:'hsl(var(--c-danger))' },
+  };
+  const m = map[status];
+  return (
+    <span style={{
+      padding:'2px 7px', borderRadius:'var(--r-pill)',
+      background: m.bg, color: m.fg,
+      fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+      textTransform:'uppercase', letterSpacing:'.06em',
+    }}>{m.label}</span>
+  );
+};
+
+const KbDocItem = ({ doc, readonly }) => (
+  <article tabIndex={0} className="mai-card-row" style={{
+    display:'flex', alignItems:'center', gap: 14, padding: 12,
+    background:'var(--bg-card)', border:'1px solid var(--border)',
+    borderRadius:'var(--r-lg)', cursor: readonly ? 'default' : 'pointer',
+  }}>
+    <div style={{
+      width: 42, height: 42, borderRadius:'var(--r-md)',
+      background: entityHsl('kb', 0.14), color: entityHsl('kb'),
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 20, flexShrink: 0,
+    }} aria-hidden="true">📄</div>
+    <div style={{ flex: 1, minWidth: 0 }}>
+      <div style={{
+        display:'flex', alignItems:'baseline', gap: 8, marginBottom: 4, flexWrap:'wrap',
+      }}>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 13, fontWeight: 700, color:'var(--text)',
+          whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis',
+          maxWidth: '100%',
+        }}>{doc.title}</div>
+        <KbStatusBadge status={doc.status}/>
+      </div>
+      <div style={{
+        fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+        fontWeight: 600,
+      }}>
+        {doc.size} · {doc.pages} pag · {doc.chunks} chunks
+        {doc.indexedAt && <> · indicizzato il <strong>{doc.indexedAt}</strong></>}
+        {doc.error && <> · <span style={{ color:'hsl(var(--c-danger))' }}>{doc.error}</span></>}
+      </div>
+    </div>
+    {!readonly && (
+      <button type="button" aria-label="Azioni" style={{
+        padding:'6px 10px', borderRadius:'var(--r-md)',
+        background:'transparent', border:'1px solid var(--border)',
+        color:'var(--text-sec)', fontSize: 13, cursor:'pointer',
+      }}>⋯</button>
+    )}
+  </article>
+);
+
+const KnowledgeTab = ({ readonly, hideUploadCta }) => (
+  <div style={{ display:'flex', flexDirection:'column', gap: 10 }}>
+    <div style={{
+      display:'flex', alignItems:'center', justifyContent:'space-between', gap: 8,
+    }}>
+      <div style={{
+        fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+        fontWeight: 700, letterSpacing:'.04em',
+      }}>{KB_DOCS.length} documenti · {KB_DOCS.filter(d => d.status === 'indexed').length} indicizzati</div>
+      {!hideUploadCta && (
+        <button type="button" style={{
+          padding:'8px 14px', borderRadius:'var(--r-md)',
+          background: entityHsl('kb'), color:'#fff', border:'none',
+          fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800,
+          cursor:'pointer',
+          boxShadow:`0 3px 10px ${entityHsl('kb', 0.35)}`,
+        }}>↑ Aggiungi documento</button>
+      )}
+    </div>
+    {KB_DOCS.map(d => <KbDocItem key={d.id} doc={d} readonly={readonly}/>)}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── TAB: PERFORMANCE ───────────────────────────────
+// ═══════════════════════════════════════════════════════
+const KpiCard = ({ label, value, unit, accent='agent', icon, trend }) => (
+  <div style={{
+    padding: 14,
+    background:'var(--bg-card)', border:'1px solid var(--border)',
+    borderRadius:'var(--r-lg)',
+    display:'flex', flexDirection:'column', gap: 6,
+  }}>
+    <div style={{ display:'flex', alignItems:'center', gap: 6 }}>
+      <span aria-hidden="true" style={{
+        width: 24, height: 24, borderRadius:'var(--r-sm)',
+        background: entityHsl(accent, 0.14), color: entityHsl(accent),
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 12,
+      }}>{icon}</span>
+      <span style={{
+        fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+        textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 800,
+      }}>{label}</span>
+    </div>
+    <div style={{
+      fontFamily:'var(--f-display)', fontSize: 28, fontWeight: 800,
+      color:'var(--text)', fontVariantNumeric:'tabular-nums', lineHeight: 1,
+    }}>{value}<span style={{ fontSize: 13, color:'var(--text-muted)', fontWeight: 600, marginLeft: 4 }}>{unit}</span></div>
+    {trend && (
+      <div style={{
+        fontFamily:'var(--f-mono)', fontSize: 10,
+        color: trend.startsWith('+') ? 'hsl(140, 50%, 35%)' : 'hsl(var(--c-danger))',
+        fontWeight: 700,
+      }}>{trend}</div>
+    )}
+  </div>
+);
+
+// Bar chart placeholder
+const ChatChart = () => {
+  const weeks = [12, 19, 24, 18, 31, 28, 42, 38];
+  const max = Math.max(...weeks);
+  const labels = ['8s','7s','6s','5s','4s','3s','2s','1s'];
+  return (
+    <div style={{
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)', padding: 18,
+    }}>
+      <div style={{
+        display:'flex', alignItems:'baseline', justifyContent:'space-between', marginBottom: 14,
+      }}>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 15, fontWeight: 800, color:'var(--text)', margin: 0,
+        }}>Chat per settimana</h3>
+        <span style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)', fontWeight: 700,
+        }}>ultime 8 settimane</span>
+      </div>
+      <div style={{ display:'flex', alignItems:'flex-end', gap: 8, height: 140, paddingBottom: 18, position:'relative' }}>
+        {weeks.map((w, i) => (
+          <div key={i} style={{ flex: 1, display:'flex', flexDirection:'column', alignItems:'center', gap: 4 }}>
+            <div style={{
+              fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)', fontWeight: 700,
+              fontVariantNumeric:'tabular-nums',
+            }}>{w}</div>
+            <div style={{
+              width:'80%', height: `${(w/max)*100}%`,
+              background:`linear-gradient(180deg, ${entityHsl('agent')} 0%, ${entityHsl('agent', 0.5)} 100%)`,
+              borderRadius:'4px 4px 0 0',
+              minHeight: 4,
+            }}/>
+            <div style={{
+              fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)', fontWeight: 600,
+              position:'absolute', bottom: 0,
+            }}>{labels[i]}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const TopQuestions = () => (
+  <div style={{
+    background:'var(--bg-card)', border:'1px solid var(--border)',
+    borderRadius:'var(--r-lg)', padding: 18,
+  }}>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: 15, fontWeight: 800, color:'var(--text)', margin:'0 0 12px',
+    }}>Domande ricorrenti</h3>
+    <div style={{ display:'flex', flexDirection:'column', gap: 0 }}>
+      {TOP_QUESTIONS.map((q, i) => (
+        <div key={i} style={{
+          display:'flex', alignItems:'flex-start', gap: 10, padding:'8px 0',
+          borderBottom: i < TOP_QUESTIONS.length - 1 ? '1px solid var(--border-light)' : 'none',
+        }}>
+          <span style={{
+            fontFamily:'var(--f-mono)', fontSize: 11, fontWeight: 800,
+            color:'var(--text-muted)', width: 22, flexShrink: 0,
+          }}>#{i+1}</span>
+          <span style={{ flex: 1, fontSize: 12.5, color:'var(--text-sec)', lineHeight: 1.5 }}>{q.q}</span>
+          <span style={{
+            padding:'1px 7px', borderRadius:'var(--r-pill)',
+            background: entityHsl('chat', 0.12), color: entityHsl('chat'),
+            fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800,
+            flexShrink: 0,
+          }}>{q.count}</span>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+const PerformanceTab = () => (
+  <div style={{ display:'flex', flexDirection:'column', gap: 14 }}>
+    <div style={{
+      display:'grid', gridTemplateColumns:'repeat(auto-fit, minmax(160px, 1fr))', gap: 10,
+    }}>
+      <KpiCard label="Chat totali" value="124" unit="" accent="chat" icon="💬" trend="+12% 30g"/>
+      <KpiCard label="Tempo risposta" value="2.3" unit="s" accent="event" icon="⏱" trend="-0.4s"/>
+      <KpiCard label="Soddisfazione" value="94" unit="%" accent="player" icon="👍" trend="+2%"/>
+      <KpiCard label="Citazioni KB" value="78" unit="%" accent="kb" icon="📚" trend="+5%"/>
+    </div>
+    <ChatChart/>
+    <TopQuestions/>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── TAB: HISTORY ───────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const ChatTimelineItem = ({ chat, isLast }) => (
+  <div style={{ display:'flex', gap: 12, position:'relative' }}>
+    {/* Timeline rail */}
+    <div style={{
+      width: 28, display:'flex', flexDirection:'column', alignItems:'center', flexShrink: 0,
+    }}>
+      <div style={{
+        width: 28, height: 28, borderRadius:'50%',
+        background: entityHsl('chat', 0.14), color: entityHsl('chat'),
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 12, border:`2px solid ${entityHsl('chat', 0.3)}`,
+      }} aria-hidden="true">💬</div>
+      {!isLast && (
+        <div style={{
+          width: 2, flex: 1, background:'var(--border)', marginTop: 2, minHeight: 24,
+        }}/>
+      )}
+    </div>
+    {/* Item */}
+    <article tabIndex={0} className="mai-card-row" style={{
+      flex: 1, padding: 12, marginBottom: isLast ? 0 : 12,
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)', cursor:'pointer',
+      display:'flex', flexDirection:'column', gap: 6,
+    }}>
+      <div style={{
+        display:'flex', alignItems:'baseline', gap: 8, justifyContent:'space-between', flexWrap:'wrap',
+      }}>
+        <span style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color: entityHsl('chat'),
+          fontWeight: 700,
+        }}>{chat.when}</span>
+        <span style={{
+          fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+          fontWeight: 700,
+        }}>{chat.msgCount} msg · {chat.resolved ? '✓ risolta' : '○ aperta'}</span>
+      </div>
+      <p style={{
+        fontSize: 13, color:'var(--text)', margin: 0, lineHeight: 1.5,
+        display:'-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient:'vertical', overflow:'hidden',
+      }}>
+        <span aria-hidden="true" style={{ color:'var(--text-muted)', marginRight: 6 }}>›</span>
+        {chat.firstMsg}
+      </p>
+    </article>
+  </div>
+);
+
+const HistoryTab = () => (
+  <div style={{ display:'flex', flexDirection:'column' }}>
+    {CHAT_HISTORY.map((c, i) => (
+      <ChatTimelineItem key={c.id} chat={c} isLast={i === CHAT_HISTORY.length - 1}/>
+    ))}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── TAB: SETTINGS ──────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const SettingsRow = ({ label, hint, children }) => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 16,
+    padding:'14px 0',
+    borderBottom:'1px solid var(--border-light)',
+  }}>
+    <div style={{ flex: 1 }}>
+      <div style={{
+        fontFamily:'var(--f-display)', fontSize: 13.5, fontWeight: 700, color:'var(--text)',
+      }}>{label}</div>
+      {hint && (
+        <div style={{
+          fontSize: 11.5, color:'var(--text-muted)', marginTop: 2, lineHeight: 1.4,
+        }}>{hint}</div>
+      )}
+    </div>
+    <div style={{ flexShrink: 0 }}>{children}</div>
+  </div>
+);
+
+const Toggle = ({ checked, onChange, disabled }) => (
+  <button type="button" disabled={disabled}
+    onClick={() => !disabled && onChange(!checked)}
+    aria-pressed={checked}
+    style={{
+      width: 40, height: 22, borderRadius: 999,
+      background: checked ? entityHsl('agent') : 'var(--bg-muted)',
+      border:'none', position:'relative',
+      cursor: disabled ? 'not-allowed' : 'pointer',
+      transition:'background var(--dur-sm)',
+      opacity: disabled ? 0.5 : 1,
+    }}>
+    <span aria-hidden="true" style={{
+      position:'absolute', top: 2, left: checked ? 20 : 2,
+      width: 18, height: 18, borderRadius:'50%',
+      background:'#fff', boxShadow:'0 1px 3px rgba(0,0,0,.2)',
+      transition:'left var(--dur-sm) var(--ease-spring)',
+    }}/>
+  </button>
+);
+
+// /* v2: AgentSettingsForm */
+const SettingsTab = ({ agent, readonly }) => {
+  const [active, setActive] = useState(true);
+  const [model, setModel] = useState(agent.modelId);
+  const [temp, setTemp] = useState(agent.temperature);
+  const [maxT, setMaxT] = useState(agent.maxTokens);
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap: 14 }}>
+      <div style={{
+        background:'var(--bg-card)', border:'1px solid var(--border)',
+        borderRadius:'var(--r-lg)', padding:'4px 18px 14px',
+      }}>
+        <SettingsRow label="Attivo" hint="L'agente è disponibile per nuove chat e suggerimenti.">
+          <Toggle checked={active} onChange={setActive} disabled={readonly}/>
+        </SettingsRow>
+        <SettingsRow label="Modello LLM" hint="Cambiare modello può influire su costo e qualità delle risposte.">
+          <select value={model} onChange={e=>setModel(e.target.value)} disabled={readonly}
+            style={{
+              padding:'7px 10px', borderRadius:'var(--r-md)',
+              border:'1px solid var(--border)', background:'var(--bg-card)',
+              color:'var(--text)', fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 700,
+              cursor: readonly ? 'not-allowed' : 'pointer',
+              opacity: readonly ? 0.7 : 1,
+            }}>
+            <option value="claude-sonnet-4">Claude Sonnet 4</option>
+            <option value="claude-opus-4">Claude Opus 4</option>
+            <option value="claude-haiku-4">Claude Haiku 4</option>
+            <option value="gpt-4o">GPT-4o</option>
+            <option value="gpt-4o-mini">GPT-4o mini</option>
+          </select>
+        </SettingsRow>
+        <SettingsRow label="Creatività (temperature)" hint="0 = risposte deterministiche · 1 = molto creative.">
+          <div style={{ display:'flex', alignItems:'center', gap: 10, minWidth: 200 }}>
+            <input type="range" min="0" max="1" step="0.05" value={temp} disabled={readonly}
+              onChange={e => setTemp(parseFloat(e.target.value))}
+              style={{
+                flex: 1, accentColor: entityHsl('agent'),
+                opacity: readonly ? 0.6 : 1,
+              }}/>
+            <span style={{
+              minWidth: 36, textAlign:'right',
+              fontFamily:'var(--f-mono)', fontSize: 12, fontWeight: 800,
+              color: entityHsl('agent'), fontVariantNumeric:'tabular-nums',
+            }}>{temp.toFixed(2)}</span>
+          </div>
+        </SettingsRow>
+        <SettingsRow label="Max tokens risposta" hint="Lunghezza massima di una risposta. Default 1024.">
+          <input type="number" value={maxT} disabled={readonly}
+            onChange={e=>setMaxT(parseInt(e.target.value)||0)}
+            min="128" max="4096" step="128"
+            style={{
+              width: 100, padding:'7px 10px', borderRadius:'var(--r-md)',
+              border:'1px solid var(--border)', background:'var(--bg-card)',
+              color:'var(--text)', fontFamily:'var(--f-mono)', fontSize: 12, fontWeight: 700,
+              textAlign:'right',
+            }}/>
+        </SettingsRow>
+      </div>
+
+      <div style={{
+        background:'var(--bg-card)', border:'1px solid var(--border)',
+        borderRadius:'var(--r-lg)', padding: 18,
+      }}>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 15, fontWeight: 800, color:'var(--text)', margin:'0 0 4px',
+        }}>Istruzioni custom</h3>
+        <p style={{ fontSize: 11.5, color:'var(--text-muted)', margin:'0 0 10px' }}>
+          Aggiunte al system prompt (1 per riga).
+        </p>
+        <textarea defaultValue={agent.customInstructions} disabled={readonly}
+          style={{
+            width:'100%', minHeight: 100,
+            padding: 12, borderRadius:'var(--r-md)',
+            border:'1px solid var(--border)', background:'var(--bg)',
+            color:'var(--text)', fontFamily:'var(--f-mono)', fontSize: 12, lineHeight: 1.6,
+            resize:'vertical',
+            opacity: readonly ? 0.7 : 1,
+          }}/>
+      </div>
+
+      {/* v2: AgentDangerZone */}
+      <div style={{
+        background:'hsl(var(--c-danger) / .04)',
+        border:'1px solid hsl(var(--c-danger) / .25)',
+        borderRadius:'var(--r-lg)', padding: 18,
+      }}>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800,
+          color:'hsl(var(--c-danger))', margin:'0 0 4px',
+          display:'flex', alignItems:'center', gap: 6,
+        }}><span aria-hidden="true">⚠</span>Danger zone</h3>
+        <p style={{ fontSize: 11.5, color:'var(--text-muted)', margin:'0 0 12px' }}>
+          Azioni irreversibili. Le chat e i KB associati non vengono cancellati.
+        </p>
+        <div style={{ display:'flex', gap: 8, flexWrap:'wrap' }}>
+          <button type="button" disabled={readonly} style={{
+            padding:'7px 14px', borderRadius:'var(--r-md)',
+            background:'transparent', border:'1px solid hsl(var(--c-danger) / .4)',
+            color:'hsl(var(--c-danger))', fontFamily:'var(--f-display)',
+            fontSize: 12, fontWeight: 800,
+            cursor: readonly ? 'not-allowed' : 'pointer',
+            opacity: readonly ? 0.5 : 1,
+          }}>⊘ Archivia</button>
+          <button type="button" disabled={readonly} style={{
+            padding:'7px 14px', borderRadius:'var(--r-md)',
+            background:'hsl(var(--c-danger))',
+            border:'1px solid hsl(var(--c-danger))',
+            color:'#fff', fontFamily:'var(--f-display)',
+            fontSize: 12, fontWeight: 800,
+            cursor: readonly ? 'not-allowed' : 'pointer',
+            opacity: readonly ? 0.5 : 1,
+          }}>🗑 Elimina (richiede conferma)</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── EMPTY/ERROR/LOADING per tab ────────────────────
+// ═══════════════════════════════════════════════════════
+const TabSkeleton = () => (
+  <div style={{ display:'flex', flexDirection:'column', gap: 10 }}>
+    {[0,1,2,3].map(i => (
+      <div key={i} className="mai-shimmer" style={{
+        height: 80 + (i%2)*16, borderRadius:'var(--r-lg)', background:'var(--bg-muted)',
+      }}/>
+    ))}
+  </div>
+);
+
+const TabError = ({ onRetry }) => (
+  <div style={{
+    padding:'32px 24px', textAlign:'center',
+    background:'hsl(var(--c-danger) / .08)',
+    border:'1px solid hsl(var(--c-danger) / .3)',
+    borderRadius:'var(--r-xl)',
+    display:'flex', flexDirection:'column', alignItems:'center',
+  }}>
+    <div style={{
+      width: 48, height: 48, borderRadius:'50%',
+      background:'hsl(var(--c-danger) / .15)', color:'hsl(var(--c-danger))',
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 22, marginBottom: 10,
+    }} aria-hidden="true">⚠</div>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800,
+      color:'var(--text)', margin:'0 0 4px',
+    }}>Errore caricamento</h3>
+    <p style={{ fontSize: 12, color:'var(--text-muted)', margin:'0 0 12px', maxWidth: 320 }}>
+      Impossibile recuperare i dati. Verifica la connessione.
+    </p>
+    <button type="button" onClick={onRetry}
+      style={{
+        padding:'7px 14px', borderRadius:'var(--r-md)',
+        background:'hsl(var(--c-danger))', color:'#fff', border:'none',
+        fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer',
+      }}>↻ Riprova</button>
+  </div>
+);
+
+const TabEmpty = ({ icon, title, sub, ctaLabel, ctaColor='agent' }) => (
+  <div style={{
+    padding:'40px 24px', textAlign:'center',
+    background:'var(--bg-card)',
+    border:'1px dashed var(--border-strong)',
+    borderRadius:'var(--r-xl)',
+    display:'flex', flexDirection:'column', alignItems:'center',
+  }}>
+    <div style={{
+      width: 60, height: 60, borderRadius:'50%',
+      background: entityHsl(ctaColor, 0.12), color: entityHsl(ctaColor),
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 28, marginBottom: 12,
+    }} aria-hidden="true">{icon}</div>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: 15, fontWeight: 800,
+      color:'var(--text)', margin:'0 0 4px',
+    }}>{title}</h3>
+    <p style={{ fontSize: 12.5, color:'var(--text-muted)', margin:'0 0 14px', maxWidth: 340 }}>
+      {sub}
+    </p>
+    {ctaLabel && (
+      <button type="button" style={{
+        padding:'8px 16px', borderRadius:'var(--r-md)',
+        background: entityHsl(ctaColor), color:'#fff', border:'none',
+        fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer',
+        boxShadow: `0 3px 10px ${entityHsl(ctaColor, 0.35)}`,
+      }}>{ctaLabel}</button>
+    )}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── BODY ───────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const AgentDetailBody = ({ stateOverride, variant='active', compact, initialTab='identity' }) => {
+  const [tab, setTab] = useState(initialTab);
+  useEffect(() => { setTab(initialTab); }, [initialTab]);
+
+  const isLoading = stateOverride === 'loading';
+  const isError = stateOverride === 'error';
+  const readonly = variant === 'archived';
+
+  const agent = AGENT_BASE;
+
+  const tabs = [
+    { id:'identity', icon:'🎭', label:'Identity' },
+    { id:'knowledge', icon:'📚', label:'Knowledge', count: KB_DOCS.length },
+    { id:'performance', icon:'📊', label:'Performance' },
+    { id:'history', icon:'💬', label:'History', count: variant === 'draft' ? 0 : CHAT_HISTORY.length },
+    { id:'settings', icon:'⚙', label:'Settings' },
+  ];
+
+  const connections = [
+    { entityType:'game', count: 1, label:'Gioco', isEmpty: false },
+    { entityType:'kb', count: 8, label:'KB', isEmpty: false },
+    { entityType:'chat', count: variant === 'draft' ? 0 : 124, label:'Chat', isEmpty: variant === 'draft' },
+    { entityType:'session', count: variant === 'draft' ? 0 : 12, label:'Partite', isEmpty: variant === 'draft' },
+    { entityType:'toolkit', count: 0, label:'Toolkit', isEmpty: true },
+    { entityType:'player', count: variant === 'draft' ? 0 : 4, label:'Giocatori', isEmpty: variant === 'draft' },
+  ];
+
+  const renderTab = () => {
+    if (isLoading) return <TabSkeleton/>;
+    if (isError) return <TabError/>;
+
+    if (variant === 'draft' && (tab === 'performance' || tab === 'history')) {
+      return <TabEmpty icon="📊" title="Disponibile dopo l'attivazione"
+        sub="Le metriche e la cronologia chat sono visibili solo per agenti attivi. Completa il setup per iniziare."
+        ctaLabel="Completa setup →"/>;
+    }
+
+    if (tab === 'identity') return <IdentityTab agent={agent} readonly={readonly}/>;
+    if (tab === 'knowledge') return <KnowledgeTab readonly={readonly} hideUploadCta={readonly}/>;
+    if (tab === 'performance') return <PerformanceTab/>;
+    if (tab === 'history') {
+      if (CHAT_HISTORY.length === 0) {
+        return <TabEmpty icon="💬" title="Nessuna chat ancora"
+          sub="Avvia la prima conversazione per iniziare a tracciare la cronologia."
+          ctaLabel="💬 Avvia prima chat" ctaColor="chat"/>;
+      }
+      return <HistoryTab/>;
+    }
+    if (tab === 'settings') return <SettingsTab agent={agent} readonly={readonly}/>;
+    return null;
+  };
+
+  return (
+    <>
+      <AgentHero agent={agent} variant={variant} compact={compact} loading={isLoading}/>
+      {/* ConnectionBar sticky */}
+      <div style={{
+        padding: compact ? '0 16px' : '0 32px',
+        background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+        borderBottom:'1px solid var(--border-light)',
+        position:'sticky', top: 0, zIndex: 8,
+      }}>
+        <ConnectionBar connections={connections} loading={isLoading}/>
+      </div>
+      <div style={{ position:'sticky', top: 45, zIndex: 7,
+        background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+      }}>
+        <AgentTabs tabs={tabs} active={tab} onChange={setTab} compact={compact}/>
+      </div>
+      <div style={{
+        padding: compact ? '14px 16px 32px' : '20px 32px 64px',
+      }}>
+        {renderTab()}
+      </div>
+    </>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── DESKTOP / MOBILE SHELLS ─────────────────────────
+// ═══════════════════════════════════════════════════════
+const DesktopNav = () => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 14,
+    padding:'10px 32px',
+    background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+    borderBottom:'1px solid var(--border)',
+  }}>
+    <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
+      <div style={{
+        width: 26, height: 26, borderRadius: 7,
+        background:'linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event)))',
+        color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+        fontWeight: 800, fontSize: 13, fontFamily:'var(--f-display)',
+      }}>M</div>
+      <span style={{ fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 14 }}>MeepleAI</span>
+    </div>
+    <div style={{
+      flex: 1, fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      marginLeft: 22,
+    }}>
+      <a href="#" style={{ color:'inherit' }}>Agenti</a>
+      <span aria-hidden="true"> / </span>
+      <strong style={{ color:'var(--text-sec)' }}>{AGENT_BASE.title}</strong>
+    </div>
+  </div>
+);
+
+const DesktopScreen = ({ stateOverride, variant, initialTab }) => (
+  <div style={{ minHeight: 720, background:'var(--bg)' }}>
+    <DesktopNav/>
+    <AgentDetailBody stateOverride={stateOverride} variant={variant} initialTab={initialTab}/>
+  </div>
+);
+
+const PhoneSbar = () => (
+  <div className="phone-sbar" style={{ color:'var(--text)' }}>
+    <span style={{ fontFamily:'var(--f-mono)' }}>14:32</span>
+    <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+  </div>
+);
+const PhoneTopNav = () => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 9,
+    padding:'10px 14px', background:'var(--glass-bg)',
+    backdropFilter:'blur(12px)',
+    borderBottom:'1px solid var(--border-light)',
+    position:'sticky', top: 0, zIndex: 9,
+  }}>
+    <button aria-label="Indietro" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      color:'var(--text)', fontSize: 14, cursor:'pointer',
+    }}>←</button>
+    <div style={{
+      flex: 1, fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+      textAlign:'center', fontWeight: 700,
+    }}>agents / mago-wingspan</div>
+    <button aria-label="Più" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      color:'var(--text)', fontSize: 14, cursor:'pointer',
+    }}>⋯</button>
+  </div>
+);
+const MobileScreen = ({ stateOverride, variant, initialTab }) => (
+  <>
+    <PhoneSbar/>
+    <div style={{ flex: 1, overflowY:'auto', position:'relative', background:'var(--bg)' }}>
+      <PhoneTopNav/>
+      <AgentDetailBody stateOverride={stateOverride} variant={variant} compact initialTab={initialTab}/>
+    </div>
+  </>
+);
+
+const PhoneShell = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 10 }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div className="phone">{children}</div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 340,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+const DesktopFrame = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 12, width:'100%' }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div style={{
+      width:'100%', maxWidth: 1280,
+      borderRadius:'var(--r-xl)', border:'1px solid var(--border)',
+      background:'var(--bg)', overflow:'hidden',
+      boxShadow:'var(--shadow-lg)',
+    }}>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 8,
+        padding:'9px 14px', background:'var(--bg-muted)',
+        borderBottom:'1px solid var(--border)',
+        fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      }}>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-event))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-warning))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-toolkit))' }}/>
+        <span style={{ flex: 1, textAlign:'center', letterSpacing:'.04em' }}>meepleai.app/agents/mago-wingspan</span>
+      </div>
+      {children}
+    </div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 720,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── ROOT ────────────────────────────────────────────
+const MOBILE_STATES = [
+  { id:'m1', stateOverride:null, variant:'active', tab:'identity', label:'01 · Active · Identity', desc:'Hero radial gradient + avatar 72 + persona + meta. Tab Identity: persona card + system prompt collapsible + avatar selector.' },
+  { id:'m2', stateOverride:null, variant:'active', tab:'knowledge', label:'02 · Active · Knowledge', desc:'6 KB doc list con badge status (indexed / processing / failed). Footer: count indicizzati + CTA upload.' },
+  { id:'m3', stateOverride:null, variant:'active', tab:'performance', label:'03 · Active · Performance', desc:'4 KPI cards con trend (chat/tempo/sat/citazioni KB) + bar chart 8 settimane + top 5 domande ricorrenti.' },
+  { id:'m4', stateOverride:null, variant:'active', tab:'history', label:'04 · Active · History', desc:'Timeline 6 chat con rail entity-chat + preview prima domanda + status risolta/aperta.' },
+  { id:'m5', stateOverride:null, variant:'active', tab:'settings', label:'05 · Active · Settings', desc:'Toggle attivo + dropdown modello + slider temperature + max tokens + textarea custom + Danger zone.' },
+  { id:'m6', stateOverride:null, variant:'draft', tab:'performance', label:'06 · Draft · locked tab', desc:'Banner giallo "Agente in setup" + chat/session/player pip empty dashed. Tab Performance/History mostrano empty con CTA setup.' },
+  { id:'m7', stateOverride:null, variant:'archived', tab:'identity', label:'07 · Archived · read-only', desc:'Banner grey persistente + CTA Riattiva. Avvia chat nascosto. Tutti i campi disabilitati con opacity .7.' },
+  { id:'m8', stateOverride:'loading', variant:'active', tab:'identity', label:'08 · Loading', desc:'Hero skeleton + ConnectionBar shimmer + tabs nav visible + body 4 row shimmer altezze variabili.' },
+];
+
+function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+  }, [dark]);
+  return (
+    <button onClick={() => setDark(d => !d)} className="theme-toggle"
+      aria-label={dark ? 'Tema chiaro' : 'Tema scuro'}>
+      <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span>
+      <span>{dark ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+}
+
+function App() {
+  return (
+    <div className="stage">
+      <ThemeToggle/>
+      <div className="stage-wrap">
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.08em', marginBottom: 8,
+        }}>SP4 wave 1 · #4/5 · Hero character sheet + tabs</div>
+        <h1>Agent detail — /agents/[id]</h1>
+        <p className="lead">
+          Hero radial gradient entity-agent + avatar 96 + persona + action bar variant-aware.
+          <strong> ConnectionBar</strong> sticky 1:1 prod (toolkit empty dashed).
+          5 tabs <strong>animated underline</strong>: Identity / Knowledge / Performance / History / Settings.
+          Varianti: <strong>active</strong> · <strong>draft</strong> (banner setup, perf/history locked) · <strong>archived</strong> (banner + read-only).
+        </p>
+
+        <div className="section-label">Mobile · 375 — 8 stati / tabs</div>
+        <div className="phones-grid">
+          {MOBILE_STATES.map(s => (
+            <PhoneShell key={s.id} label={s.label} desc={s.desc}>
+              <MobileScreen stateOverride={s.stateOverride} variant={s.variant} initialTab={s.tab}/>
+            </PhoneShell>
+          ))}
+        </div>
+
+        <div className="section-label">Desktop · 1440 — 5 stati chiave</div>
+        <div style={{ display:'flex', flexDirection:'column', gap: 36 }}>
+          <DesktopFrame label="09 · Desktop · Active · Performance"
+            desc="Tab Performance: 4 KPI grid (chat/tempo/sat/KB%), bar chart 8 settimane gradient agent, top 5 domande ricorrenti con count chip entity-chat.">
+            <DesktopScreen stateOverride={null} variant="active" initialTab="performance"/>
+          </DesktopFrame>
+          <DesktopFrame label="10 · Desktop · Active · Knowledge"
+            desc="6 KB doc con badge status (indexed verde / processing giallo / failed danger). Hover row con bordo entity-game accent. CTA upload entity-kb top-right.">
+            <DesktopScreen stateOverride={null} variant="active" initialTab="knowledge"/>
+          </DesktopFrame>
+          <DesktopFrame label="11 · Desktop · Active · Settings"
+            desc="Form completo (toggle / select modello / slider temperature accent agent / max tokens / textarea custom) + Danger zone con elimina destructive.">
+            <DesktopScreen stateOverride={null} variant="active" initialTab="settings"/>
+          </DesktopFrame>
+          <DesktopFrame label="12 · Desktop · Draft · setup"
+            desc="Banner giallo 'in setup' top hero + Avvia chat disabilitata (opacity .55). ConnectionBar: chat/session/player pip empty dashed. Tabs Performance/History mostrano empty con CTA Completa setup.">
+            <DesktopScreen stateOverride={null} variant="draft" initialTab="performance"/>
+          </DesktopFrame>
+          <DesktopFrame label="13 · Desktop · Archived · read-only"
+            desc="Banner grey persistente con CTA Riattiva. Avvia chat nascosto. Identity/Knowledge/Settings in read-only (toggle/slider/textarea con opacity .7 + cursor not-allowed).">
+            <DesktopScreen stateOverride={null} variant="archived" initialTab="identity"/>
+          </DesktopFrame>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes mai-shimmer-anim {
+          0%   { background-position: -200% 0; }
+          100% { background-position:  200% 0; }
+        }
+        .mai-shimmer {
+          background: linear-gradient(90deg, var(--bg-muted) 0%, var(--bg-hover) 50%, var(--bg-muted) 100%) !important;
+          background-size: 200% 100% !important;
+          animation: mai-shimmer-anim 1.4s linear infinite;
+        }
+        .phones-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+          gap: var(--s-7);
+          align-items: start;
+        }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage .lead { line-height: var(--lh-relax); }
+        .phone > div::-webkit-scrollbar { display: none; }
+        .mai-cb-scroll::-webkit-scrollbar { display: none; }
+        .mai-card-row {
+          outline: none;
+          transition: transform var(--dur-sm) var(--ease-out), border-color var(--dur-sm), box-shadow var(--dur-sm);
+        }
+        .mai-card-row:hover {
+          transform: translateY(-1px);
+          border-color: hsl(var(--c-agent) / .35);
+          box-shadow: var(--shadow-xs);
+        }
+        .mai-card-row:focus-visible {
+          outline: 2px solid hsl(var(--c-agent));
+          outline-offset: 2px;
+        }
+        button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible {
+          outline: 2px solid hsl(var(--c-agent));
+          outline-offset: 2px;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);

--- a/admin-mockups/design_files/sp4-agents-index.html
+++ b/admin-mockups/design_files/sp4-agents-index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 wave 1 · #3/5 · Agents index — /agents</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-agents-index.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-agents-index.jsx
+++ b/admin-mockups/design_files/sp4-agents-index.jsx
@@ -1,0 +1,907 @@
+/* MeepleAI SP4 wave 1 — Schermata #3 / 5
+   Route: /agents
+   File: admin-mockups/design_files/sp4-agents-index.{html,jsx}
+   Pattern desktop: Hero leggero + grid agenti (3-col 1280 max)
+
+   Hero 120-140px (100 mobile): titolo + subtitle + action bar destra
+   ([+ Crea agente] primary entity-agent + filter chips status).
+   Sotto-hero sticky: filter chips + search + sort.
+   Body grid agenti MeepleCard variante grid entity=agent.
+
+   Stati: default · empty · loading · error · filter-no-results.
+   Mobile 375 → 1 col. Tablet 768 → 2 col. Desktop 1440 → 3 col / 1280 max.
+
+   v2 nuovi:
+   - AgentsHero          → apps/web/src/components/ui/v2/agents-hero/
+   - AgentFilters        → apps/web/src/components/ui/v2/agent-filters/
+   - AgentCardGrid       → variante MeepleCard.grid per entity=agent
+   - EmptyAgents         → apps/web/src/components/ui/v2/empty-agents/
+
+   Riusi pixel-perfect:
+   - ConnectionChipStrip (PR #549/#552) come footer card
+   - EntityChip game cliccabile (per link gioco assegnato)
+*/
+
+const { useState, useEffect, useMemo } = React;
+const DS = window.DS;
+
+const entityHsl = (type, alpha) => {
+  const c = DS.EC[type] || DS.EC.agent;
+  return alpha !== undefined
+    ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${alpha})`
+    : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
+};
+
+// Estendo i 5 agenti DS a 9 per popolare grid 3-col
+const AGENTS_INDEX = [
+  ...DS.agents,
+  { id:'a-cascadia', type:'agent', title:'Naturalista di Cascadia', avatar:'🍃',
+    gameId:'g-cascadia', tags:['rules-master', 'tile-laying'], desc:'Spiega tessere e habitat scoring.',
+    chatCount: 38, kbCount: 1, sessionCount: 7, lastActive:'1h fa', status:'attivo',
+    model:'Claude Sonnet 4', invocations: 87 },
+  { id:'a-marvel', type:'agent', title:'Coach Marvel Champions', avatar:'🦸',
+    gameId:'g-marvel', tags:['lcg', 'helper'], desc:'Combo deck e strategia per ogni eroe.',
+    chatCount: 152, kbCount: 4, sessionCount: 14, lastActive:'30m fa', status:'attivo',
+    model:'Claude Opus 4', invocations: 412 },
+  { id:'a-dune', type:'agent', title:'Mentat di Arrakis', avatar:'🪐',
+    gameId:'g-dune', tags:['expert', 'strategist'], desc:'Workers, intrighi e svolte di battaglia.',
+    chatCount: 67, kbCount: 2, sessionCount: 9, lastActive:'5m fa', status:'attivo',
+    model:'Claude Sonnet 4', invocations: 198 },
+  { id:'a-terraforming', type:'agent', title:'Architetto di Marte', avatar:'🚀',
+    gameId:'g-terraforming', tags:['heavy', 'expert'], desc:'Progetti e milestone, ottimizza ossigeno e calore.',
+    chatCount: 0, kbCount: 3, sessionCount: 0, lastActive:'mai', status:'in-setup',
+    model:'Claude Sonnet 4', invocations: 0 },
+  { id:'a-pandemic', type:'agent', title:'Medico CDC', avatar:'🧬',
+    gameId:'g-pandemic', tags:['legacy', 'helper'], desc:'Coordinazione team, code rules legacy.',
+    chatCount: 12, kbCount: 1, sessionCount: 4, lastActive:'2g fa', status:'archiviato',
+    model:'Claude Haiku 4', invocations: 24 },
+];
+// Aggiungo campi mancanti a quelli base DS
+const baseAgents = DS.agents.map(a => ({
+  ...a,
+  status: a.id === 'a-azul' ? 'attivo' : (a.invocations > 0 ? 'attivo' : 'in-setup'),
+  chatCount: DS.chats.filter(c => c.gameId === a.gameId).reduce((s, c) => s + (c.messageCount || 0), 0) || a.invocations || 0,
+  kbCount: DS.kbs.filter(k => k.gameId === a.gameId).length,
+  sessionCount: DS.sessions.filter(s => s.gameId === a.gameId).length,
+}));
+const ALL_AGENTS = [...baseAgents, ...AGENTS_INDEX.slice(DS.agents.length)];
+
+// ─── Helpers ────────────────────────────────────────
+const STATUS_META = {
+  'attivo':     { label:'● Attivo',     color:'success', dotColor:'hsl(140, 60%, 45%)' },
+  'in-setup':   { label:'⚙ In setup',   color:'warning', dotColor:'hsl(38, 92%, 50%)' },
+  'archiviato': { label:'⊘ Archiviato', color:'muted',   dotColor:'hsl(220, 10%, 60%)' },
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── CONNECTIONCHIPSTRIP (footer, prod) ─────────────
+// /* v2: ConnectionChipStrip — ✅ in produzione (PR #549/#552) */
+// ═══════════════════════════════════════════════════════
+const ConnectionChipStrip = ({ connections, compact }) => {
+  const visible = connections.filter(c => !c.isEmpty).slice(0, 3);
+  if (visible.length === 0) {
+    return (
+      <div style={{
+        fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+        fontWeight: 600, letterSpacing:'.04em',
+      }}>Nessuna connessione</div>
+    );
+  }
+  return (
+    <div style={{ display:'flex', gap: 4, flexWrap:'wrap' }}>
+      {visible.map(c => {
+        const ec = DS.EC[c.entityType];
+        return (
+          <span key={c.entityType} style={{
+            display:'inline-flex', alignItems:'center', gap: 3,
+            padding: compact ? '2px 6px' : '3px 7px',
+            borderRadius: 999,
+            background: entityHsl(c.entityType, 0.1),
+            color: entityHsl(c.entityType),
+            fontFamily:'var(--f-display)', fontSize: compact ? 10 : 11, fontWeight: 700,
+            lineHeight: 1.2,
+          }}>
+            <span aria-hidden="true" style={{ fontSize: compact ? 10 : 11 }}>{ec.em}</span>
+            <span style={{ fontFamily:'var(--f-mono)', fontVariantNumeric:'tabular-nums' }}>{c.count}</span>
+          </span>
+        );
+      })}
+    </div>
+  );
+};
+
+// ─── EntityChip game cliccabile ─────────────────────
+const EntityChipGame = ({ gameId, compact }) => {
+  const g = DS.byId[gameId];
+  if (!g) return null;
+  return (
+    <a href="#" onClick={e => e.preventDefault()} style={{
+      display:'inline-flex', alignItems:'center', gap: 5,
+      padding: compact ? '2px 7px' : '3px 9px',
+      borderRadius:'var(--r-pill)',
+      background: entityHsl('game', 0.1),
+      color: entityHsl('game'),
+      fontFamily:'var(--f-display)',
+      fontSize: compact ? 10 : 11, fontWeight: 700,
+      textDecoration:'none',
+      border:`1px solid ${entityHsl('game', 0.2)}`,
+      whiteSpace:'nowrap',
+      maxWidth:'100%', overflow:'hidden', textOverflow:'ellipsis',
+    }}>
+      <span aria-hidden="true">🎲</span>
+      <span style={{ overflow:'hidden', textOverflow:'ellipsis' }}>{g.title}</span>
+    </a>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── AGENT CARD GRID (variante MeepleCard) ──────────
+// /* v2: AgentCardGrid — variante MeepleCard.grid entity=agent */
+// ═══════════════════════════════════════════════════════
+const AgentCardGrid = ({ agent, compact }) => {
+  const game = DS.byId[agent.gameId];
+  const status = STATUS_META[agent.status] || STATUS_META['attivo'];
+  const connections = [
+    { entityType:'game', count: 1, isEmpty: false },
+    { entityType:'kb', count: agent.kbCount, isEmpty: agent.kbCount === 0 },
+    { entityType:'chat', count: agent.chatCount, isEmpty: agent.chatCount === 0 },
+  ];
+  return (
+    <article tabIndex={0} className="mai-card-agent" style={{
+      background:'var(--bg-card)',
+      border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)',
+      overflow:'hidden',
+      cursor:'pointer',
+      display:'flex', flexDirection:'column',
+      position:'relative',
+      transition:'transform var(--dur-sm) var(--ease-out), border-color var(--dur-sm), box-shadow var(--dur-sm)',
+    }}>
+      {/* Top accent bar entity-agent */}
+      <div style={{
+        height: 4, background:`linear-gradient(90deg, ${entityHsl('agent')} 0%, ${entityHsl('agent', 0.5)} 100%)`,
+      }}/>
+
+      {/* Header: avatar + status badge */}
+      <div style={{
+        display:'flex', alignItems:'flex-start', gap: 12,
+        padding: compact ? '14px 14px 10px' : '16px 18px 12px',
+      }}>
+        <div style={{
+          width: compact ? 52 : 58, height: compact ? 52 : 58,
+          borderRadius:'var(--r-md)',
+          background: entityHsl('agent', 0.12),
+          color: entityHsl('agent'),
+          display:'flex', alignItems:'center', justifyContent:'center',
+          fontSize: compact ? 28 : 32,
+          flexShrink: 0,
+          border:`1px solid ${entityHsl('agent', 0.2)}`,
+        }} aria-hidden="true">{agent.avatar}</div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display:'flex', alignItems:'center', gap: 6, marginBottom: 4 }}>
+            <span style={{
+              padding:'2px 7px', borderRadius:'var(--r-pill)',
+              background: entityHsl('agent', 0.14), color: entityHsl('agent'),
+              fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+              textTransform:'uppercase', letterSpacing:'.06em',
+              display:'inline-flex', alignItems:'center', gap: 3,
+            }}><span aria-hidden="true">🤖</span>Agent</span>
+            <span style={{
+              padding:'2px 7px', borderRadius:'var(--r-pill)',
+              background: status.color === 'success' ? 'hsl(140, 60%, 45% / .14)'
+                       : status.color === 'warning' ? entityHsl('agent', 0.14)
+                       : 'var(--bg-muted)',
+              color: status.color === 'success' ? 'hsl(140, 50%, 35%)'
+                   : status.color === 'warning' ? entityHsl('agent')
+                   : 'var(--text-muted)',
+              fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+              textTransform:'uppercase', letterSpacing:'.06em',
+            }}>{status.label}</span>
+          </div>
+          <h3 style={{
+            fontFamily:'var(--f-display)', fontWeight: 800,
+            fontSize: compact ? 15 : 16, lineHeight: 1.15,
+            color:'var(--text)', margin:'0 0 5px',
+            display:'-webkit-box', WebkitLineClamp: 1, WebkitBoxOrient:'vertical', overflow:'hidden',
+          }}>{agent.title}</h3>
+          {game && <EntityChipGame gameId={agent.gameId} compact={compact}/>}
+        </div>
+      </div>
+
+      {/* Body: description + KPI inline */}
+      <div style={{
+        padding: compact ? '0 14px 12px' : '0 18px 14px',
+        flex: 1,
+        display:'flex', flexDirection:'column', gap: 10,
+      }}>
+        <p style={{
+          fontSize: compact ? 12.5 : 13, color:'var(--text-sec)',
+          lineHeight: 1.5, margin: 0,
+          display:'-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient:'vertical', overflow:'hidden',
+        }}>{agent.desc || 'Agente esperto del gioco, pronto a rispondere alle tue domande sulle regole.'}</p>
+
+        <div style={{
+          display:'flex', flexWrap:'wrap', gap: 10,
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          fontWeight: 700,
+        }}>
+          <span style={{ display:'inline-flex', alignItems:'center', gap: 4 }}>
+            <span aria-hidden="true">💬</span>
+            <span style={{ fontVariantNumeric:'tabular-nums', color:'var(--text-sec)' }}>{agent.chatCount}</span>
+          </span>
+          <span style={{ display:'inline-flex', alignItems:'center', gap: 4 }}>
+            <span aria-hidden="true">📚</span>
+            <span style={{ fontVariantNumeric:'tabular-nums', color:'var(--text-sec)' }}>{agent.kbCount} KB</span>
+          </span>
+          <span style={{ display:'inline-flex', alignItems:'center', gap: 4 }}>
+            <span aria-hidden="true">⏱</span>
+            <span style={{ color:'var(--text-sec)' }}>{agent.lastActive}</span>
+          </span>
+        </div>
+      </div>
+
+      {/* Footer: ConnectionChipStrip (max 3) */}
+      <div style={{
+        padding: compact ? '10px 14px' : '12px 18px',
+        borderTop:'1px solid var(--border-light)',
+        background:'var(--bg-muted)',
+      }}>
+        <ConnectionChipStrip connections={connections} compact={compact}/>
+      </div>
+    </article>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── AGENTS HERO ────────────────────────────────────
+// /* v2: AgentsHero → apps/web/src/components/ui/v2/agents-hero/ */
+// ═══════════════════════════════════════════════════════
+const AgentsHero = ({ compact, count }) => (
+  <header style={{
+    padding: compact ? '14px 16px 12px' : '24px 32px 16px',
+    background:`linear-gradient(180deg, ${entityHsl('agent', 0.08)} 0%, transparent 100%)`,
+    borderBottom:'1px solid var(--border-light)',
+    display:'flex', alignItems: compact ? 'flex-start' : 'center',
+    gap: 16, flexDirection: compact ? 'column' : 'row',
+  }}>
+    <div style={{ flex: 1, minWidth: 0 }}>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 6, marginBottom: 8,
+      }}>
+        <span style={{
+          display:'inline-flex', alignItems:'center', gap: 5,
+          padding:'3px 9px', borderRadius:'var(--r-pill)',
+          background: entityHsl('agent', 0.14),
+          color: entityHsl('agent'),
+          fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+          textTransform:'uppercase', letterSpacing:'.08em',
+        }}><span aria-hidden="true">🤖</span>Agents · /agents</span>
+      </div>
+      <h1 style={{
+        fontFamily:'var(--f-display)', fontWeight: 800,
+        fontSize: compact ? 22 : 32, letterSpacing:'-.02em', lineHeight: 1.05,
+        color:'var(--text)', margin:'0 0 4px',
+      }}>I tuoi agenti AI</h1>
+      <p style={{
+        color:'var(--text-sec)', fontSize: compact ? 12.5 : 14, lineHeight: 1.55,
+        margin: 0,
+      }}>Esperti dei tuoi giochi, sempre disponibili — {count} agenti totali.</p>
+    </div>
+    <button type="button" style={{
+      padding: compact ? '9px 14px' : '10px 18px',
+      borderRadius:'var(--r-md)',
+      background: entityHsl('agent'), color:'#fff', border:'none',
+      fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+      cursor:'pointer',
+      boxShadow:`0 4px 14px ${entityHsl('agent', 0.4)}`,
+      flexShrink: 0,
+      display:'inline-flex', alignItems:'center', gap: 6,
+      alignSelf: compact ? 'stretch' : 'auto',
+      justifyContent:'center',
+    }}>
+      <span aria-hidden="true">+</span>Crea agente
+    </button>
+  </header>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── AGENT FILTERS (sticky) ─────────────────────────
+// /* v2: AgentFilters → apps/web/src/components/ui/v2/agent-filters/ */
+// ═══════════════════════════════════════════════════════
+const STATUS_FILTERS = [
+  { id:'all', label:'Tutti' },
+  { id:'attivo', label:'Attivi' },
+  { id:'in-setup', label:'In setup' },
+  { id:'archiviato', label:'Archiviati' },
+];
+const SORT_OPTS = [
+  { id:'recent', label:'Più recenti' },
+  { id:'alpha', label:'Alfabetico' },
+  { id:'used', label:'Più usati' },
+];
+
+const AgentFilters = ({
+  q, setQ, status, setStatus, sort, setSort, compact, count,
+}) => (
+  <div className="mai-cb-scroll" style={{
+    padding: compact ? '10px 16px' : '12px 32px',
+    display:'flex', alignItems:'center',
+    gap: compact ? 8 : 12,
+    borderBottom:'1px solid var(--border-light)',
+    background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+    position:'sticky', top: 0, zIndex: 10,
+    overflowX: compact ? 'auto' : 'visible',
+    scrollbarWidth:'none',
+  }}>
+    {/* Status chips */}
+    <div role="tablist" style={{
+      display:'inline-flex', gap: 4, flexShrink: 0,
+    }}>
+      {STATUS_FILTERS.map(o => {
+        const active = status === o.id;
+        return (
+          <button key={o.id} role="tab" aria-selected={active}
+            onClick={()=>setStatus(o.id)}
+            style={{
+              padding:'6px 12px',
+              border: active ? `1px solid ${entityHsl('agent', 0.3)}` : '1px solid var(--border)',
+              background: active ? entityHsl('agent', 0.12) : 'var(--bg-card)',
+              color: active ? entityHsl('agent') : 'var(--text-sec)',
+              fontFamily:'var(--f-display)',
+              fontSize: 12, fontWeight: 700,
+              borderRadius:'var(--r-pill)',
+              cursor:'pointer', whiteSpace:'nowrap',
+              transition:'all var(--dur-sm) var(--ease-out)',
+            }}>{o.label}</button>
+        );
+      })}
+    </div>
+
+    <div style={{ flex: 1 }}/>
+
+    {/* Search */}
+    {!compact && (
+      <label style={{
+        display:'flex', alignItems:'center', gap: 8,
+        flex:'0 1 280px',
+        padding:'7px 12px',
+        background:'var(--bg-card)',
+        border:'1px solid var(--border)',
+        borderRadius:'var(--r-md)',
+      }}>
+        <span aria-hidden="true" style={{ color:'var(--text-muted)' }}>🔍</span>
+        <input
+          type="text" value={q} onChange={e=>setQ(e.target.value)}
+          placeholder="Cerca agente o gioco…"
+          style={{
+            flex: 1, border:'none', outline:'none', background:'transparent',
+            color:'var(--text)', fontFamily:'var(--f-body)', fontSize: 13,
+            minWidth: 0,
+          }}
+        />
+        {q && (
+          <button type="button" onClick={()=>setQ('')} aria-label="Pulisci"
+            style={{ border:'none', background:'transparent', color:'var(--text-muted)',
+              cursor:'pointer', fontSize: 13, padding: 0 }}>✕</button>
+        )}
+      </label>
+    )}
+
+    {/* Sort */}
+    <select value={sort} onChange={e=>setSort(e.target.value)}
+      aria-label="Ordina"
+      style={{
+        padding:'7px 10px', borderRadius:'var(--r-md)',
+        border:'1px solid var(--border)', background:'var(--bg-card)',
+        color:'var(--text)', fontFamily:'var(--f-display)',
+        fontSize: 12, fontWeight: 700, cursor:'pointer', flexShrink: 0,
+      }}>
+      {SORT_OPTS.map(o => <option key={o.id} value={o.id}>{o.label}</option>)}
+    </select>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── EMPTY / ERROR / LOADING ────────────────────────
+// ═══════════════════════════════════════════════════════
+// /* v2: EmptyAgents → apps/web/src/components/ui/v2/empty-agents/ */
+const EmptyAgents = ({ kind, onAction, compact }) => {
+  const cfg = {
+    'no-agents': {
+      icon:'🤖',
+      t:'Non hai ancora creato agenti',
+      sub:'Gli agenti AI rispondono alle domande sui tuoi giochi usando i regolamenti che carichi. Crea il primo per iniziare.',
+      cta:'Crea il tuo primo agente',
+    },
+    'no-results': {
+      icon:'🔎',
+      t:'Nessun agente corrisponde',
+      sub:'Prova a cambiare filtro status o azzera la ricerca per vedere tutti gli agenti.',
+      cta:'Azzera filtri',
+    },
+  }[kind];
+  return (
+    <div style={{
+      gridColumn:'1 / -1',
+      display:'flex', flexDirection:'column', alignItems:'center', textAlign:'center',
+      padding: compact ? '40px 20px' : '64px 32px',
+      background:'var(--bg-card)',
+      border:'1px dashed var(--border-strong)',
+      borderRadius:'var(--r-xl)',
+    }}>
+      <div style={{
+        width: compact ? 64 : 80, height: compact ? 64 : 80,
+        borderRadius:'50%',
+        background: entityHsl('agent', 0.12), color: entityHsl('agent'),
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: compact ? 32 : 40, marginBottom: 16,
+      }} aria-hidden="true">{cfg.icon}</div>
+      <h3 style={{
+        fontFamily:'var(--f-display)', fontSize: compact ? 16 : 19, fontWeight: 800,
+        color:'var(--text)', margin:'0 0 6px',
+      }}>{cfg.t}</h3>
+      <p style={{
+        fontSize: 13, color:'var(--text-muted)', maxWidth: 380,
+        margin:'0 0 18px', lineHeight: 1.55,
+      }}>{cfg.sub}</p>
+      <button type="button" onClick={onAction}
+        style={{
+          padding:'10px 18px', borderRadius:'var(--r-md)',
+          background: entityHsl('agent'), color:'#fff', border:'none',
+          fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800, cursor:'pointer',
+          boxShadow:`0 4px 14px ${entityHsl('agent', 0.35)}`,
+        }}>+ {cfg.cta}</button>
+    </div>
+  );
+};
+
+const ErrorState = ({ onRetry, compact }) => (
+  <div style={{
+    gridColumn:'1 / -1',
+    padding: compact ? '32px 20px' : '48px 32px',
+    background:'hsl(var(--c-danger) / .08)',
+    border:'1px solid hsl(var(--c-danger) / .3)',
+    borderRadius:'var(--r-xl)',
+    display:'flex', flexDirection:'column', alignItems:'center', textAlign:'center',
+  }}>
+    <div style={{
+      width: 56, height: 56, borderRadius:'50%',
+      background:'hsl(var(--c-danger) / .15)', color:'hsl(var(--c-danger))',
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 26, marginBottom: 12,
+    }} aria-hidden="true">⚠</div>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800,
+      color:'var(--text)', margin:'0 0 4px',
+    }}>Impossibile caricare gli agenti</h3>
+    <p style={{
+      fontSize: 12.5, color:'var(--text-muted)', maxWidth: 360,
+      margin:'0 0 16px',
+    }}>Si è verificato un errore di rete. Verifica la connessione e riprova.</p>
+    <button type="button" onClick={onRetry}
+      style={{
+        padding:'8px 16px', borderRadius:'var(--r-md)',
+        background:'hsl(var(--c-danger))', color:'#fff', border:'none',
+        fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer',
+      }}>↻ Riprova</button>
+  </div>
+);
+
+const SkeletonCard = ({ compact }) => (
+  <div style={{
+    background:'var(--bg-card)',
+    border:'1px solid var(--border)',
+    borderRadius:'var(--r-lg)',
+    overflow:'hidden',
+  }}>
+    <div className="mai-shimmer" style={{ height: 4, background:'var(--bg-muted)' }}/>
+    <div style={{ padding: compact ? 14 : 18, display:'flex', gap: 12 }}>
+      <div className="mai-shimmer" style={{
+        width: compact ? 52 : 58, height: compact ? 52 : 58,
+        borderRadius:'var(--r-md)', background:'var(--bg-muted)', flexShrink: 0,
+      }}/>
+      <div style={{ flex: 1, display:'flex', flexDirection:'column', gap: 6 }}>
+        <div className="mai-shimmer" style={{ height: 10, width:'40%', borderRadius: 4, background:'var(--bg-muted)' }}/>
+        <div className="mai-shimmer" style={{ height: 16, width:'70%', borderRadius: 4, background:'var(--bg-muted)' }}/>
+        <div className="mai-shimmer" style={{ height: 10, width:'50%', borderRadius: 4, background:'var(--bg-muted)' }}/>
+      </div>
+    </div>
+    <div style={{ padding:'0 18px 14px' }}>
+      <div className="mai-shimmer" style={{ height: 10, width:'90%', borderRadius: 4, background:'var(--bg-muted)', marginBottom: 6 }}/>
+      <div className="mai-shimmer" style={{ height: 10, width:'72%', borderRadius: 4, background:'var(--bg-muted)' }}/>
+    </div>
+    <div style={{
+      padding:'10px 18px', borderTop:'1px solid var(--border-light)',
+      background:'var(--bg-muted)', display:'flex', gap: 4,
+    }}>
+      {[0,1,2].map(i => (
+        <div key={i} className="mai-shimmer" style={{
+          height: 16, width: 28 + i*4, borderRadius: 999, background:'var(--bg-card)',
+        }}/>
+      ))}
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── BODY ───────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const filterAgents = (list, q, status) => {
+  let out = list;
+  if (q) {
+    const needle = q.toLowerCase();
+    out = out.filter(a => {
+      const game = DS.byId[a.gameId];
+      return a.title.toLowerCase().includes(needle) ||
+        (game && game.title.toLowerCase().includes(needle)) ||
+        (a.tags || []).some(t => t.toLowerCase().includes(needle));
+    });
+  }
+  if (status !== 'all') out = out.filter(a => a.status === status);
+  return out;
+};
+
+const sortAgents = (list, sort) => {
+  const out = [...list];
+  if (sort === 'alpha') return out.sort((a, b) => a.title.localeCompare(b.title));
+  if (sort === 'used') return out.sort((a, b) => (b.chatCount || 0) - (a.chatCount || 0));
+  return out; // recent default order
+};
+
+const AgentsIndexBody = ({ stateOverride, compact }) => {
+  const [q, setQ] = useState('');
+  const [status, setStatus] = useState('all');
+  const [sort, setSort] = useState('recent');
+
+  useEffect(() => {
+    if (stateOverride === 'no-results') {
+      setStatus('archiviato');
+      setQ('zzznotfound');
+    } else {
+      setStatus('all');
+      setQ('');
+    }
+  }, [stateOverride]);
+
+  const isLoading = stateOverride === 'loading';
+  const isEmpty = stateOverride === 'empty';
+  const isError = stateOverride === 'error';
+
+  const sourceList = isEmpty ? [] : ALL_AGENTS;
+  const filtered = useMemo(() => sortAgents(filterAgents(sourceList, q, status), sort),
+    [sourceList, q, status, sort]);
+
+  return (
+    <>
+      <AgentsHero compact={compact} count={ALL_AGENTS.length}/>
+      {!isError && !isEmpty && (
+        <AgentFilters
+          q={q} setQ={setQ}
+          status={status} setStatus={setStatus}
+          sort={sort} setSort={setSort}
+          compact={compact}
+          count={filtered.length}
+        />
+      )}
+      <div style={{
+        padding: compact ? '14px 16px 24px' : '24px 32px 64px',
+        maxWidth: 1280, margin:'0 auto',
+      }}>
+        {isError && <ErrorState compact={compact}/>}
+        {isEmpty && <EmptyAgents kind="no-agents" compact={compact}/>}
+        {!isError && !isEmpty && isLoading && (
+          <div style={{
+            display:'grid',
+            gridTemplateColumns: compact ? '1fr' : 'repeat(auto-fit, minmax(320px, 1fr))',
+            gap: compact ? 12 : 16,
+          }}>
+            {Array.from({ length: compact ? 4 : 6 }).map((_, i) => (
+              <SkeletonCard key={i} compact={compact}/>
+            ))}
+          </div>
+        )}
+        {!isError && !isEmpty && !isLoading && (
+          filtered.length === 0 ? (
+            <EmptyAgents kind="no-results" compact={compact}
+              onAction={() => { setStatus('all'); setQ(''); }}/>
+          ) : (
+            <div style={{
+              display:'grid',
+              gridTemplateColumns: compact ? '1fr' : 'repeat(auto-fit, minmax(320px, 1fr))',
+              gap: compact ? 12 : 16,
+            }}>
+              {filtered.map(a => <AgentCardGrid key={a.id} agent={a} compact={compact}/>)}
+            </div>
+          )
+        )}
+      </div>
+    </>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── DESKTOP / MOBILE SHELLS ─────────────────────────
+// ═══════════════════════════════════════════════════════
+const DesktopNav = ({ active = 'agents' }) => {
+  const items = [
+    { id:'home', label:'Home' },
+    { id:'library', label:'Libreria' },
+    { id:'games', label:'Giochi' },
+    { id:'agents', label:'Agenti' },
+    { id:'sessions', label:'Sessioni' },
+    { id:'toolkit', label:'Toolkit' },
+  ];
+  return (
+    <div style={{
+      display:'flex', alignItems:'center', gap: 14,
+      padding:'10px 32px',
+      background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+      borderBottom:'1px solid var(--border)',
+    }}>
+      <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
+        <div style={{
+          width: 26, height: 26, borderRadius: 7,
+          background:'linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event)))',
+          color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+          fontWeight: 800, fontSize: 13, fontFamily:'var(--f-display)',
+        }}>M</div>
+        <span style={{ fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 14 }}>MeepleAI</span>
+      </div>
+      <div style={{ display:'flex', alignItems:'center', gap: 2, marginLeft: 18 }}>
+        {items.map(it => (
+          <a key={it.id} href="#" onClick={e=>e.preventDefault()}
+            aria-current={it.id === active ? 'page' : undefined}
+            style={{
+              padding:'6px 12px', borderRadius:'var(--r-md)',
+              fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700,
+              color: it.id === active ? entityHsl('agent') : 'var(--text-sec)',
+              background: it.id === active ? entityHsl('agent', 0.12) : 'transparent',
+              textDecoration:'none',
+            }}>{it.label}</a>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const DesktopScreen = ({ stateOverride }) => (
+  <div style={{ minHeight: 720, background:'var(--bg)' }}>
+    <DesktopNav/>
+    <AgentsIndexBody stateOverride={stateOverride}/>
+  </div>
+);
+
+const PhoneSbar = () => (
+  <div className="phone-sbar" style={{ color:'var(--text)' }}>
+    <span style={{ fontFamily:'var(--f-mono)' }}>14:32</span>
+    <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+  </div>
+);
+const PhoneTopNav = () => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 9,
+    padding:'10px 14px', borderBottom:'1px solid var(--border)',
+    background:'var(--bg)',
+  }}>
+    <button aria-label="Indietro" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'transparent', border:'1px solid var(--border)',
+      color:'var(--text)', fontSize: 14, cursor:'pointer',
+    }}>←</button>
+    <div style={{ flex: 1, fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 700, textAlign:'center' }}>
+      Agenti
+    </div>
+    <button aria-label="Cerca" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'transparent', border:'1px solid var(--border)',
+      color:'var(--text)', fontSize: 14, cursor:'pointer',
+    }}>🔍</button>
+  </div>
+);
+const MobileBottomBar = () => {
+  const tabs = [
+    { id:'home', icon:'⌂', label:'Home' },
+    { id:'search', icon:'🔍', label:'Cerca' },
+    { id:'library', icon:'📚', label:'Libreria' },
+    { id:'agents', icon:'🤖', label:'Agenti', active: true },
+    { id:'profile', icon:'👤', label:'Profilo' },
+  ];
+  return (
+    <div style={{
+      position:'absolute', bottom: 0, left: 0, right: 0,
+      display:'flex',
+      padding:'8px 10px 12px',
+      background:'var(--glass-bg)', backdropFilter:'blur(14px)',
+      borderTop:'1px solid var(--border)',
+      zIndex: 5,
+    }}>
+      {tabs.map(t => (
+        <button key={t.id} style={{
+          flex: 1,
+          display:'flex', flexDirection:'column', alignItems:'center', gap: 2,
+          padding:'4px 0',
+          background:'transparent', border:'none',
+          color: t.active ? entityHsl('agent') : 'var(--text-muted)',
+          fontFamily:'var(--f-display)', fontSize: 9, fontWeight: 700,
+          cursor:'pointer',
+        }}>
+          <span aria-hidden="true" style={{ fontSize: 16 }}>{t.icon}</span>
+          <span>{t.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+};
+const MobileScreen = ({ stateOverride }) => (
+  <>
+    <PhoneSbar/>
+    <div style={{ flex: 1, overflowY:'auto', position:'relative', background:'var(--bg)' }}>
+      <PhoneTopNav/>
+      <div style={{ paddingBottom: 70 }}>
+        <AgentsIndexBody stateOverride={stateOverride} compact/>
+      </div>
+      <MobileBottomBar/>
+    </div>
+  </>
+);
+
+const PhoneShell = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 10 }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div className="phone">{children}</div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 340,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+const DesktopFrame = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 12, width:'100%' }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div style={{
+      width:'100%', maxWidth: 1280,
+      borderRadius:'var(--r-xl)', border:'1px solid var(--border)',
+      background:'var(--bg)', overflow:'hidden',
+      boxShadow:'var(--shadow-lg)',
+    }}>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 8,
+        padding:'9px 14px',
+        background:'var(--bg-muted)',
+        borderBottom:'1px solid var(--border)',
+        fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      }}>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-event))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-warning))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-toolkit))' }}/>
+        <span style={{ flex: 1, textAlign:'center', letterSpacing:'.04em' }}>meepleai.app/agents</span>
+      </div>
+      {children}
+    </div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 720,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── ROOT ────────────────────────────────────────────
+const MOBILE_STATES = [
+  { id:'default', label:'01 · Default', desc:'9 agenti totali, grid 1-col mobile, footer ConnectionChipStrip max 3 chip (game/kb/chat).' },
+  { id:'empty', label:'02 · Empty', desc:'Stato first-run: 🤖 + CTA "Crea il tuo primo agente" entity-agent.' },
+  { id:'loading', label:'03 · Loading', desc:'4 skeleton cards con accent bar shimmer + avatar placeholder + 2 line + 3 chip footer.' },
+  { id:'no-results', label:'04 · No results', desc:'Filter "Archiviati" + query "zzznotfound" → empty filtrato + CTA "Azzera filtri".' },
+  { id:'error', label:'05 · Error', desc:'Banner danger + retry CTA full-width. Hero/filtri nascosti durante errore.' },
+];
+
+function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+  }, [dark]);
+  return (
+    <button onClick={() => setDark(d => !d)} className="theme-toggle"
+      aria-label={dark ? 'Tema chiaro' : 'Tema scuro'}>
+      <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span>
+      <span>{dark ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+}
+
+function App() {
+  return (
+    <div className="stage">
+      <ThemeToggle/>
+      <div className="stage-wrap">
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.08em', marginBottom: 8,
+        }}>SP4 wave 1 · #3/5 · Hero leggero + grid agenti</div>
+        <h1>Agents index — /agents</h1>
+        <p className="lead">
+          Hero compatto entity-agent + filtri sticky (chips status + search + sort) +
+          grid auto-fit 320min (3-col @1280, 2-col tablet, 1-col mobile).
+          Card MeepleCard variante <strong>grid</strong> entity=agent con avatar emoji,
+          status badge, KPI inline, footer <strong>ConnectionChipStrip</strong> max 3 (game/kb/chat).
+        </p>
+
+        <div className="section-label">Mobile · 375 — 5 stati</div>
+        <div className="phones-grid">
+          {MOBILE_STATES.map(s => (
+            <PhoneShell key={s.id} label={s.label} desc={s.desc}>
+              <MobileScreen stateOverride={s.id === 'default' ? null : s.id}/>
+            </PhoneShell>
+          ))}
+        </div>
+
+        <div className="section-label">Desktop · 1440 — 4 stati</div>
+        <div style={{ display:'flex', flexDirection:'column', gap: 36 }}>
+          <DesktopFrame label="06 · Desktop · Default"
+            desc="Hero entity-agent + filtri sticky completi (chips + search 280 + sort) + grid 3-col auto-fit 320min, max-width 1280 centrato. 9 agent cards.">
+            <DesktopScreen stateOverride={null}/>
+          </DesktopFrame>
+          <DesktopFrame label="07 · Desktop · Empty"
+            desc="First-run: hero visibile (motiva alla creazione), filtri nascosti, empty state full-width entity-agent dashed con CTA primaria.">
+            <DesktopScreen stateOverride="empty"/>
+          </DesktopFrame>
+          <DesktopFrame label="08 · Desktop · Loading"
+            desc="6 skeleton cards (3-col × 2 row) con accent bar + avatar shimmer + KPI placeholder + footer chip placeholder. Hero e filtri visibili e interattivi.">
+            <DesktopScreen stateOverride="loading"/>
+          </DesktopFrame>
+          <DesktopFrame label="09 · Desktop · No results"
+            desc="Filter 'Archiviati' + query 'zzznotfound' → empty filtrato. Filtri restano sticky con stato corrente, CTA 'Azzera filtri' resetta entrambi.">
+            <DesktopScreen stateOverride="no-results"/>
+          </DesktopFrame>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes mai-shimmer-anim {
+          0%   { background-position: -200% 0; }
+          100% { background-position:  200% 0; }
+        }
+        .mai-shimmer {
+          background: linear-gradient(90deg, var(--bg-muted) 0%, var(--bg-hover) 50%, var(--bg-muted) 100%) !important;
+          background-size: 200% 100% !important;
+          animation: mai-shimmer-anim 1.4s linear infinite;
+        }
+        .phones-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+          gap: var(--s-7);
+          align-items: start;
+        }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage .lead { line-height: var(--lh-relax); }
+        .phone > div::-webkit-scrollbar { display: none; }
+        .mai-cb-scroll::-webkit-scrollbar { display: none; }
+        .mai-card-agent {
+          outline: none;
+        }
+        .mai-card-agent:hover {
+          transform: translateY(-2px);
+          border-color: hsl(var(--c-agent) / .4) !important;
+          box-shadow: 0 8px 24px hsl(var(--c-agent) / .18), var(--shadow-md);
+        }
+        .mai-card-agent:focus-visible {
+          outline: 2px solid hsl(var(--c-agent));
+          outline-offset: 2px;
+        }
+        select:focus-visible, input:focus-visible, button:focus-visible, a:focus-visible {
+          outline: 2px solid hsl(var(--c-agent));
+          outline-offset: 2px;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);

--- a/admin-mockups/design_files/sp4-game-detail.html
+++ b/admin-mockups/design_files/sp4-game-detail.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 wave 1 · #2/5 · Game detail — /games/[id]</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-game-detail.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-game-detail.jsx
+++ b/admin-mockups/design_files/sp4-game-detail.jsx
@@ -1,0 +1,1275 @@
+/* MeepleAI SP4 wave 1 — Schermata #2 / 5
+   Route: /games/[id]
+   File: admin-mockups/design_files/sp4-game-detail.{html,jsx}
+   Pattern desktop: Hero + body con tabs (5: Info / Sessions / Chat / Stats / Documents)
+
+   Hero 240px (180 mobile) cover gradient + overlay 0→60%, titolo Quicksand 4xl,
+   meta riga, azioni a destra variant-aware.
+   ConnectionBar 1:1 prod (PR #549/#552) sticky sotto hero.
+   Tabs animated underline (riuso v2 da SP3).
+   Varianti: own (CTA Gioca ora) · community (CTA Aggiungi a libreria, tabs locked).
+
+   v2 nuovi:
+   - GameHero            → apps/web/src/components/ui/v2/game-hero/
+   - GameTabs            → apps/web/src/components/ui/v2/game-tabs/  (animated underline)
+   - GameSpecsCard       → apps/web/src/components/ui/v2/game-specs-card/
+   - GameStatsKpi        → apps/web/src/components/ui/v2/game-stats-kpi/
+   - GameLeaderboard     → apps/web/src/components/ui/v2/game-leaderboard/
+   - HouseRulesList      → apps/web/src/components/ui/v2/house-rules-list/
+
+   Riusi pixel-perfect:
+   - ConnectionBar (PR #549/#552)
+   - MeepleCard variants list (session, kb)
+   - SettingsRow pattern (custom rules)
+*/
+
+const { useState, useEffect, useMemo, useRef } = React;
+const DS = window.DS;
+
+const entityHsl = (type, alpha) => {
+  const c = DS.EC[type] || DS.EC.game;
+  return alpha !== undefined
+    ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${alpha})`
+    : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
+};
+
+const GAME = DS.games.find(g => g.id === 'g-wingspan');
+const RELATED_AGENTS = DS.agents.filter(a => a.gameId === GAME.id);
+const RELATED_KBS = DS.kbs.filter(k => k.gameId === GAME.id);
+const RELATED_SESSIONS = DS.sessions.filter(s => s.gameId === GAME.id);
+const RELATED_CHATS = DS.chats.filter(c => c.gameId === GAME.id);
+
+// Mock add'l sessions for richer tab
+const MORE_SESSIONS = [
+  { id:'s-w-101', title:'Wingspan · Sabato', subtitle:'Conclusa · 4 giocatori', date:'12 Mar 2026',
+    duration:'1h 28m', winner:'Marco R.', score: 92, playerIds:['p-marco','p-sara','p-luca','p-giulia'] },
+  { id:'s-w-102', title:'Wingspan · Asia mode', subtitle:'Conclusa · 3 giocatori', date:'5 Mar 2026',
+    duration:'1h 12m', winner:'Sara T.', score: 89, playerIds:['p-sara','p-marco','p-andrea'] },
+  { id:'s-w-103', title:'Wingspan · Solo', subtitle:'Conclusa · solitario', date:'2 Mar 2026',
+    duration:'42m', winner:'Marco R.', score: 78, playerIds:['p-marco'] },
+  { id:'s-w-042', title:'Wingspan · Domenica', subtitle:'Conclusa · 5 giocatori', date:'24 Feb 2026',
+    duration:'1h 42m', winner:'Sara T.', score: 95, playerIds:['p-sara','p-marco','p-giulia','p-luca','p-andrea'] },
+];
+
+const HOUSE_RULES = [
+  { id:'hr1', label:'Bonus carte solo a fine partita', enabled: true },
+  { id:'hr2', label:'Penalità -3 punti se cibo avanza', enabled: false },
+  { id:'hr3', label:'Mani di 8 invece di 5', enabled: true },
+];
+
+const LEADERBOARD = [
+  { ...DS.players.find(p => p.id === 'p-sara'), wins: 8, plays: 14, avgScore: 87 },
+  { ...DS.players.find(p => p.id === 'p-marco'), wins: 5, plays: 12, avgScore: 81 },
+  { ...DS.players.find(p => p.id === 'p-luca'), wins: 2, plays: 9, avgScore: 72 },
+  { ...DS.players.find(p => p.id === 'p-giulia'), wins: 1, plays: 6, avgScore: 65 },
+];
+
+const MOCK_CHAT = [
+  { role:'user', text:'Posso usare l\'azione "guadagna cibo" sull\'habitat foresta anche quando il bosco è pieno?' },
+  { role:'agent', text:'Sì. L\'azione "guadagna cibo" si attiva sempre quando un uccello con quel potere viene attivato. Se il bosco è pieno, il bonus si applica solo per gli uccelli già piazzati.', cite:'wingspan-rules.pdf · pag 14' },
+  { role:'user', text:'E se il dado pesca un cibo non disponibile?' },
+];
+
+// ─── STARS ──────────────────────────────────────────
+const Stars = ({ value = 0, size = 11 }) => {
+  const full = Math.floor(value);
+  const half = value - full >= 0.5;
+  return (
+    <span style={{ display:'inline-flex', gap: 1, color:'hsl(var(--c-agent))', fontSize: size }}>
+      {[0,1,2,3,4].map(i => (
+        <span key={i} aria-hidden="true">{i < full ? '★' : (i === full && half ? '⯨' : '☆')}</span>
+      ))}
+    </span>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── CONNECTIONBAR (1:1 prod) ────────────────────────
+// /* v2: ConnectionBar — ✅ in produzione (PR #549/#552) */
+// ═══════════════════════════════════════════════════════
+const ConnectionBar = ({ connections, loading, onPipClick }) => {
+  if (loading) {
+    return (
+      <div style={{ display:'flex', gap: 8, padding:'8px 0', overflowX:'auto', scrollbarWidth:'none' }}>
+        {[0,1,2,3,4,5].map(i => (
+          <div key={i} className="mai-shimmer" style={{
+            height: 28, width: 92 + i*6, borderRadius: 999,
+            background:'var(--bg-muted)', flexShrink: 0,
+          }}/>
+        ))}
+      </div>
+    );
+  }
+  if (!connections || connections.length === 0) return null;
+  return (
+    <div className="mai-cb-scroll" style={{
+      display:'flex', alignItems:'center', gap: 8,
+      overflowX:'auto', padding:'8px 0', scrollbarWidth:'none',
+    }}>
+      {connections.map(c => {
+        const isEmpty = c.isEmpty || c.count === 0;
+        const ariaLabel = isEmpty ? c.label : `${c.label}: ${c.count}`;
+        const ec = DS.EC[c.entityType];
+        return (
+          <button
+            key={c.entityType}
+            type="button"
+            aria-label={ariaLabel}
+            onClick={() => onPipClick && onPipClick(c)}
+            style={{
+              display:'inline-flex', alignItems:'center', gap: 6,
+              padding:'6px 12px', borderRadius: 999,
+              fontSize: 12, fontWeight: 700, fontFamily:'var(--f-display)',
+              background: isEmpty ? 'transparent' : entityHsl(c.entityType, 0.1),
+              color: entityHsl(c.entityType),
+              border: isEmpty
+                ? `1.5px dashed ${entityHsl(c.entityType, 0.5)}`
+                : `1px solid ${entityHsl(c.entityType, 0.2)}`,
+              opacity: isEmpty ? 0.6 : 1,
+              cursor:'pointer', flexShrink: 0, whiteSpace:'nowrap',
+              transition:'transform var(--dur-sm) var(--ease-out), box-shadow var(--dur-sm)',
+            }}
+            onMouseEnter={e => {
+              e.currentTarget.style.transform = 'scale(1.03)';
+              e.currentTarget.style.boxShadow = 'var(--shadow-md)';
+            }}
+            onMouseLeave={e => {
+              e.currentTarget.style.transform = '';
+              e.currentTarget.style.boxShadow = '';
+            }}
+          >
+            <span aria-hidden="true" style={{ fontSize: 13, lineHeight: 1 }}>{ec.em}</span>
+            {isEmpty ? (
+              <svg width="13" height="13" viewBox="0 0 24 24"
+                fill="none" stroke="currentColor" strokeWidth="2.5"
+                strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <line x1="12" y1="5" x2="12" y2="19"/>
+                <line x1="5" y1="12" x2="19" y2="12"/>
+              </svg>
+            ) : (
+              <span style={{
+                fontFamily:'var(--f-mono)', fontVariantNumeric:'tabular-nums', fontWeight: 700,
+              }}>{c.count}</span>
+            )}
+            <span>{c.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── GAME HERO ──────────────────────────────────────
+// /* v2: GameHero → apps/web/src/components/ui/v2/game-hero/ */
+// ═══════════════════════════════════════════════════════
+const GameHero = ({ game, variant, compact, loading }) => {
+  if (loading) {
+    return (
+      <div style={{ position:'relative' }}>
+        <div className="mai-shimmer" style={{ height: compact ? 180 : 240, background:'var(--bg-muted)' }}/>
+        <div style={{ padding: compact ? '14px 16px' : '20px 32px', display:'flex', flexDirection:'column', gap: 8 }}>
+          <div className="mai-shimmer" style={{ height: 28, width:'52%', background:'var(--bg-muted)', borderRadius: 6 }}/>
+          <div className="mai-shimmer" style={{ height: 14, width:'72%', background:'var(--bg-muted)', borderRadius: 4 }}/>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div style={{ position:'relative', background:'var(--bg)' }}>
+      {/* Cover */}
+      <div style={{
+        height: compact ? 180 : 240,
+        background: game.cover,
+        position:'relative', overflow:'hidden',
+        display:'flex', alignItems:'center', justifyContent:'center',
+      }}>
+        <span aria-hidden="true" style={{
+          fontSize: compact ? 90 : 130,
+          filter:'drop-shadow(0 6px 18px rgba(0,0,0,.4))', opacity: .92,
+        }}>{game.coverEmoji}</span>
+        {/* gradient overlay 0→60% */}
+        <div style={{
+          position:'absolute', inset: 0,
+          background:'linear-gradient(180deg, transparent 0%, rgba(0,0,0,.6) 100%)',
+        }}/>
+        {/* Title overlay */}
+        <div style={{
+          position:'absolute', left: 0, right: 0, bottom: 0,
+          padding: compact ? '14px 16px' : '20px 32px',
+          color:'#fff',
+        }}>
+          <div style={{
+            display:'flex', alignItems:'center', gap: 6, marginBottom: 8,
+          }}>
+            <span style={{
+              display:'inline-flex', alignItems:'center', gap: 5,
+              padding:'3px 9px', borderRadius:'var(--r-pill)',
+              background:'rgba(255,255,255,.18)', backdropFilter:'blur(8px)',
+              color:'#fff',
+              fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+              textTransform:'uppercase', letterSpacing:'.08em',
+            }}><span aria-hidden="true">🎲</span>Game</span>
+            <span style={{
+              padding:'3px 9px', borderRadius:'var(--r-pill)',
+              background:'rgba(255,255,255,.18)', backdropFilter:'blur(8px)',
+              fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+              textTransform:'uppercase', letterSpacing:'.08em',
+            }}>{variant === 'own' ? '✓ In libreria' : '🌐 Community'}</span>
+          </div>
+          <h1 style={{
+            fontFamily:'var(--f-display)', fontWeight: 800,
+            fontSize: compact ? 28 : 40, letterSpacing:'-.02em', lineHeight: 1.05,
+            color:'#fff', margin:'0 0 6px',
+            textShadow:'0 2px 12px rgba(0,0,0,.3)',
+          }}>{game.title}</h1>
+          <div style={{
+            fontFamily:'var(--f-mono)', fontSize: compact ? 11 : 12,
+            color:'rgba(255,255,255,.92)', fontWeight: 600,
+            display:'flex', flexWrap:'wrap', gap:'4px 10px',
+          }}>
+            <span>{game.author}</span><span aria-hidden="true">·</span>
+            <span>{game.year}</span><span aria-hidden="true">·</span>
+            <span>{game.players} pl</span><span aria-hidden="true">·</span>
+            <span>{game.duration}</span><span aria-hidden="true">·</span>
+            <span>complexity {game.weight?.toFixed(1)}/5</span>
+            <span aria-hidden="true">·</span>
+            <span style={{ display:'inline-flex', gap: 4, alignItems:'center' }}>
+              <Stars value={game.stars} size={11}/> {game.rating}
+            </span>
+          </div>
+        </div>
+      </div>
+      {/* Action bar */}
+      <div style={{
+        display:'flex', alignItems:'center', gap: 8,
+        padding: compact ? '12px 16px' : '14px 32px',
+        background:'var(--bg)',
+        borderBottom:'1px solid var(--border-light)',
+        flexWrap: compact ? 'wrap' : 'nowrap',
+      }}>
+        {variant === 'own' ? (
+          <>
+            <button type="button" style={{
+              padding: compact ? '9px 14px' : '10px 18px', borderRadius:'var(--r-md)',
+              background: entityHsl('session'), color:'#fff', border:'none',
+              fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+              cursor:'pointer',
+              boxShadow:`0 4px 14px ${entityHsl('session', 0.4)}`,
+              display:'inline-flex', alignItems:'center', gap: 6,
+            }}><span aria-hidden="true">🎯</span>Gioca ora</button>
+            <button type="button" style={{
+              padding: compact ? '9px 12px' : '10px 14px', borderRadius:'var(--r-md)',
+              background:'transparent', color:'var(--text)',
+              border:'1px solid var(--border-strong)',
+              fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700,
+              cursor:'pointer',
+            }}>✎ Modifica</button>
+            <button type="button" aria-label="Condividi" style={{
+              padding: compact ? '9px 12px' : '10px 14px', borderRadius:'var(--r-md)',
+              background:'transparent', color:'var(--text)',
+              border:'1px solid var(--border-strong)',
+              fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700,
+              cursor:'pointer',
+            }}>↗</button>
+          </>
+        ) : (
+          <>
+            <button type="button" style={{
+              padding: compact ? '9px 14px' : '10px 18px', borderRadius:'var(--r-md)',
+              background: entityHsl('game'), color:'#fff', border:'none',
+              fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+              cursor:'pointer',
+              boxShadow:`0 4px 14px ${entityHsl('game', 0.4)}`,
+              display:'inline-flex', alignItems:'center', gap: 6,
+            }}>+ Aggiungi a libreria</button>
+            <button type="button" style={{
+              padding: compact ? '9px 12px' : '10px 14px', borderRadius:'var(--r-md)',
+              background:'transparent', color:'var(--text)',
+              border:'1px solid var(--border-strong)',
+              fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700,
+              cursor:'pointer',
+            }}>👀 Vedi simili</button>
+            <button type="button" aria-label="Condividi" style={{
+              padding: compact ? '9px 12px' : '10px 14px', borderRadius:'var(--r-md)',
+              background:'transparent', color:'var(--text)',
+              border:'1px solid var(--border-strong)',
+              fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700,
+              cursor:'pointer',
+            }}>↗</button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── GAME TABS (animated underline v2) ──────────────
+// /* v2: GameTabs → apps/web/src/components/ui/v2/game-tabs/ */
+// ═══════════════════════════════════════════════════════
+const GameTabs = ({ tabs, active, onChange, compact, locked }) => {
+  const refs = useRef({});
+  const [ind, setInd] = useState({ left: 0, width: 0 });
+  useEffect(() => {
+    const el = refs.current[active];
+    if (el) setInd({ left: el.offsetLeft, width: el.offsetWidth });
+  }, [active, tabs.length, compact]);
+
+  return (
+    <div className="mai-cb-scroll" style={{
+      position:'relative',
+      display:'flex', alignItems:'center', gap: 2,
+      borderBottom:'1px solid var(--border)',
+      overflowX:'auto', scrollbarWidth:'none',
+      padding: compact ? '0 16px' : '0 32px',
+      background:'var(--bg)',
+    }} role="tablist">
+      {tabs.map(t => {
+        const isActive = t.id === active;
+        const isLocked = locked && t.locked;
+        return (
+          <button
+            key={t.id}
+            type="button"
+            ref={el => { refs.current[t.id] = el; }}
+            onClick={() => !isLocked && onChange(t.id)}
+            role="tab"
+            aria-selected={isActive}
+            disabled={isLocked}
+            style={{
+              display:'inline-flex', alignItems:'center', gap: 7,
+              padding:'12px 14px', background:'transparent', border:'none',
+              color: isLocked ? 'var(--text-muted)' : (isActive ? entityHsl('game') : 'var(--text-sec)'),
+              fontFamily:'var(--f-display)', fontSize: 13,
+              fontWeight: isActive ? 800 : 700,
+              cursor: isLocked ? 'not-allowed' : 'pointer',
+              whiteSpace:'nowrap', flexShrink: 0,
+              transition:'color var(--dur-sm) var(--ease-out)',
+              opacity: isLocked ? 0.55 : 1,
+            }}
+          >
+            <span aria-hidden="true">{t.icon}</span>
+            <span>{t.label}</span>
+            {t.count !== undefined && (
+              <span style={{
+                padding:'1px 7px', borderRadius:'var(--r-pill)',
+                background: isActive ? entityHsl('game') : 'var(--bg-muted)',
+                color: isActive ? '#fff' : 'var(--text-muted)',
+                fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+                fontVariantNumeric:'tabular-nums',
+              }}>{t.count}</span>
+            )}
+            {isLocked && <span aria-hidden="true" style={{ fontSize: 10 }}>🔒</span>}
+          </button>
+        );
+      })}
+      <span aria-hidden="true" style={{
+        position:'absolute', bottom: -1, left: ind.left, width: ind.width,
+        height: 2, background: entityHsl('game'),
+        transition:'left .3s cubic-bezier(.4,0,.2,1), width .3s cubic-bezier(.4,0,.2,1)',
+        borderRadius:'2px 2px 0 0',
+      }}/>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── TAB: INFO ──────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+// /* v2: GameSpecsCard */
+const SpecsCard = ({ game }) => {
+  const specs = [
+    { label:'Giocatori', value: game.players },
+    { label:'Durata', value: game.duration },
+    { label:'Età', value: '14+' },
+    { label:'Complessità', value: `${game.weight.toFixed(1)} / 5` },
+    { label:'Anno', value: game.year },
+    { label:'Designer', value: game.author },
+    { label:'Editore', value: game.publisher },
+    { label:'Rating BGG', value: game.rating },
+  ];
+  return (
+    <div style={{
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)', padding: 18,
+    }}>
+      <h3 style={{
+        fontFamily:'var(--f-display)', fontSize: 15, fontWeight: 800,
+        color:'var(--text)', margin:'0 0 14px',
+      }}>Specifiche</h3>
+      <div style={{
+        display:'grid', gridTemplateColumns:'repeat(auto-fill, minmax(140px, 1fr))', gap: 12,
+      }}>
+        {specs.map(s => (
+          <div key={s.label}>
+            <div style={{
+              fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+              textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+              marginBottom: 3,
+            }}>{s.label}</div>
+            <div style={{
+              fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800,
+              color:'var(--text)',
+            }}>{s.value}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+// /* v2: HouseRulesList → apps/web/src/components/ui/v2/house-rules-list/ */
+const HouseRulesCard = () => {
+  const [rules, setRules] = useState(HOUSE_RULES);
+  return (
+    <div style={{
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)', padding: 18,
+    }}>
+      <div style={{
+        display:'flex', alignItems:'baseline', justifyContent:'space-between', marginBottom: 12,
+      }}>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 15, fontWeight: 800, color:'var(--text)', margin: 0,
+        }}>House rules</h3>
+        <button type="button" style={{
+          padding:'4px 10px', borderRadius:'var(--r-sm)',
+          background:'transparent', border:'1px solid var(--border)',
+          color:'var(--text-sec)', fontSize: 11, fontWeight: 700,
+          fontFamily:'var(--f-display)', cursor:'pointer',
+        }}>+ Aggiungi</button>
+      </div>
+      <div style={{ display:'flex', flexDirection:'column', gap: 0 }}>
+        {rules.map((r, i) => (
+          <label key={r.id} style={{
+            display:'flex', alignItems:'center', gap: 12,
+            padding:'10px 0',
+            borderBottom: i < rules.length - 1 ? '1px solid var(--border-light)' : 'none',
+            cursor:'pointer',
+          }}>
+            <span style={{
+              width: 36, height: 20, borderRadius: 999,
+              background: r.enabled ? entityHsl('game') : 'var(--bg-muted)',
+              position:'relative', transition:'background var(--dur-sm)',
+              flexShrink: 0,
+            }}>
+              <span style={{
+                position:'absolute', top: 2, left: r.enabled ? 18 : 2,
+                width: 16, height: 16, borderRadius: '50%',
+                background:'#fff', boxShadow:'0 1px 3px rgba(0,0,0,.2)',
+                transition:'left var(--dur-sm) var(--ease-spring)',
+              }}/>
+            </span>
+            <span style={{
+              flex: 1, fontSize: 13, color: r.enabled ? 'var(--text)' : 'var(--text-sec)',
+              fontWeight: 600,
+            }}>{r.label}</span>
+            <input type="checkbox" checked={r.enabled} style={{ display:'none' }}
+              onChange={() => setRules(rs => rs.map(x => x.id === r.id ? { ...x, enabled: !x.enabled } : x))}/>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const InfoTab = ({ game }) => (
+  <div style={{ display:'flex', flexDirection:'column', gap: 14 }}>
+    <div style={{
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)', padding: 18,
+    }}>
+      <h3 style={{
+        fontFamily:'var(--f-display)', fontSize: 15, fontWeight: 800,
+        color:'var(--text)', margin:'0 0 10px',
+      }}>Descrizione</h3>
+      <p style={{
+        fontSize: 13.5, color:'var(--text-sec)', lineHeight: 1.65, margin: 0,
+      }}>
+        In <strong>{game.title}</strong> sei un appassionato ornitologo che cerca di scoprire
+        e attirare i migliori uccelli nella tua riserva. Ogni uccello attiva una catena di
+        poteri progressivi nei tre habitat (foresta, prateria, zone umide). Combo, motori e
+        decisioni di tempistica caratterizzano una partita di {game.duration}.
+        Vince chi accumula più punti tra uccelli, uova, cibo e bonus di carta finale.
+      </p>
+    </div>
+    <SpecsCard game={game}/>
+    <HouseRulesCard/>
+  </div>
+);
+
+const InfoTabLocked = () => (
+  <CommunityGate
+    icon="📘"
+    title="Aggiungi alla libreria per personalizzare"
+    sub="Le house rules e gli specs personalizzati sono disponibili solo per i giochi nella tua libreria."
+  />
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── TAB: SESSIONS ──────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const SessionListItem = ({ s }) => (
+  <article tabIndex={0} className="mai-card-row" style={{
+    display:'flex', alignItems:'center', gap: 14, padding: 14,
+    background:'var(--bg-card)', border:'1px solid var(--border)',
+    borderRadius:'var(--r-lg)', cursor:'pointer',
+  }}>
+    <div style={{
+      width: 44, height: 44, borderRadius:'var(--r-md)',
+      background: entityHsl('session', 0.12), color: entityHsl('session'),
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 22, flexShrink: 0,
+    }} aria-hidden="true">🎯</div>
+    <div style={{ flex: 1, minWidth: 0 }}>
+      <div style={{
+        display:'flex', alignItems:'baseline', gap: 8, flexWrap:'wrap',
+        marginBottom: 3,
+      }}>
+        <h4 style={{
+          fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800,
+          color:'var(--text)', margin: 0,
+        }}>{s.title}</h4>
+        <span style={{
+          padding:'1px 7px', borderRadius:'var(--r-pill)',
+          background: entityHsl('session', 0.14), color: entityHsl('session'),
+          fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+          textTransform:'uppercase', letterSpacing:'.06em',
+        }}>{s.subtitle?.split('·')[0] || 'Conclusa'}</span>
+      </div>
+      <div style={{
+        fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+        fontWeight: 600,
+      }}>
+        {s.date || s.subtitle} · {s.duration} · {s.playerIds?.length || 0} giocatori
+        {s.winner && <> · 🏆 <strong style={{ color: entityHsl('player') }}>{s.winner}</strong></>}
+        {s.score && <> · {s.score} pt</>}
+      </div>
+    </div>
+    {/* avatar stack */}
+    <div style={{ display:'flex', alignItems:'center' }}>
+      {(s.playerIds || []).slice(0, 4).map((pid, i) => {
+        const p = DS.byId[pid];
+        return (
+          <div key={pid} style={{
+            width: 28, height: 28, borderRadius:'50%',
+            background: `hsl(${p?.color || 200}, 60%, 55%)`,
+            color:'#fff',
+            display:'inline-flex', alignItems:'center', justifyContent:'center',
+            fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 10,
+            border:'2px solid var(--bg-card)', marginLeft: i === 0 ? 0 : -8,
+            zIndex: 4 - i, flexShrink: 0,
+          }}>{p?.initials || '?'}</div>
+        );
+      })}
+    </div>
+  </article>
+);
+
+const SessionsTab = ({ compact }) => {
+  const all = [...RELATED_SESSIONS, ...MORE_SESSIONS];
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap: 10 }}>
+      {!compact && (
+        <div style={{
+          display:'flex', alignItems:'center', justifyContent:'space-between', gap: 8,
+        }}>
+          <div style={{
+            fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+            fontWeight: 700, letterSpacing:'.04em',
+          }}>{all.length} partite registrate</div>
+          <button type="button" style={{
+            padding:'8px 14px', borderRadius:'var(--r-md)',
+            background: entityHsl('session'), color:'#fff', border:'none',
+            fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800,
+            cursor:'pointer',
+            boxShadow:`0 3px 10px ${entityHsl('session', 0.35)}`,
+          }}>+ Nuova partita</button>
+        </div>
+      )}
+      {all.map(s => <SessionListItem key={s.id} s={s}/>)}
+    </div>
+  );
+};
+
+const CommunityGate = ({ icon, title, sub }) => (
+  <div style={{
+    padding:'40px 24px', textAlign:'center',
+    background:'var(--bg-card)',
+    border:'1px dashed var(--border-strong)',
+    borderRadius:'var(--r-xl)',
+    display:'flex', flexDirection:'column', alignItems:'center',
+  }}>
+    <div style={{
+      width: 64, height: 64, borderRadius:'50%',
+      background: entityHsl('game', 0.12), color: entityHsl('game'),
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 28, marginBottom: 14,
+    }} aria-hidden="true">{icon}</div>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800,
+      color:'var(--text)', margin:'0 0 6px',
+    }}>{title}</h3>
+    <p style={{
+      fontSize: 12.5, color:'var(--text-muted)', maxWidth: 360,
+      margin:'0 0 16px', lineHeight: 1.55,
+    }}>{sub}</p>
+    <button type="button" style={{
+      padding:'10px 18px', borderRadius:'var(--r-md)',
+      background: entityHsl('game'), color:'#fff', border:'none',
+      fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+      cursor:'pointer',
+      boxShadow:`0 4px 14px ${entityHsl('game', 0.35)}`,
+    }}>+ Aggiungi a libreria</button>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── TAB: CHAT ──────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const ChatTab = ({ compact }) => (
+  <div style={{ display:'flex', flexDirection:'column', gap: 12 }}>
+    {/* Agent header */}
+    <div style={{
+      display:'flex', alignItems:'center', gap: 12,
+      padding: 14,
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)',
+    }}>
+      <div style={{
+        width: 40, height: 40, borderRadius:'var(--r-md)',
+        background: entityHsl('agent', 0.14), color: entityHsl('agent'),
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 22, flexShrink: 0,
+      }} aria-hidden="true">🤖</div>
+      <div style={{ flex: 1 }}>
+        <div style={{
+          fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800, color:'var(--text)',
+        }}>Wingspan Rules</div>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          fontWeight: 600,
+        }}>Claude Sonnet · 2 KB · 230 invocazioni</div>
+      </div>
+      <span style={{
+        padding:'3px 9px', borderRadius:'var(--r-pill)',
+        background: entityHsl('agent', 0.14), color: entityHsl('agent'),
+        fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+        textTransform:'uppercase', letterSpacing:'.06em',
+      }}>● Attivo</span>
+    </div>
+
+    {/* Messages */}
+    <div style={{ display:'flex', flexDirection:'column', gap: 10, padding:'4px 0' }}>
+      {MOCK_CHAT.map((m, i) => m.role === 'user' ? (
+        <div key={i} style={{ display:'flex', justifyContent:'flex-end' }}>
+          <div style={{
+            maxWidth:'78%', padding:'10px 14px',
+            background: entityHsl('chat'), color:'#fff',
+            borderRadius:'var(--r-lg) var(--r-lg) 4px var(--r-lg)',
+            fontSize: 13, lineHeight: 1.5,
+            boxShadow: `0 2px 8px ${entityHsl('chat', 0.25)}`,
+          }}>{m.text}</div>
+        </div>
+      ) : (
+        <div key={i} style={{ display:'flex', justifyContent:'flex-start', gap: 8 }}>
+          <div style={{
+            width: 28, height: 28, borderRadius:'var(--r-md)',
+            background: entityHsl('agent', 0.14), color: entityHsl('agent'),
+            display:'flex', alignItems:'center', justifyContent:'center',
+            fontSize: 14, flexShrink: 0,
+          }} aria-hidden="true">🤖</div>
+          <div style={{ maxWidth:'78%' }}>
+            <div style={{
+              padding:'10px 14px',
+              background:'var(--bg-card)', border:'1px solid var(--border)',
+              borderRadius:'4px var(--r-lg) var(--r-lg) var(--r-lg)',
+              fontSize: 13, lineHeight: 1.55, color:'var(--text)',
+            }}>{m.text}</div>
+            {m.cite && (
+              <div style={{
+                marginTop: 4, padding:'4px 8px',
+                display:'inline-flex', alignItems:'center', gap: 5,
+                background: entityHsl('kb', 0.12), color: entityHsl('kb'),
+                borderRadius:'var(--r-sm)',
+                fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 700,
+              }}><span aria-hidden="true">📄</span>{m.cite}</div>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+
+    {/* Input */}
+    <div style={{
+      display:'flex', gap: 8, alignItems:'center',
+      padding:'10px 12px',
+      background:'var(--bg-card)', border:'1px solid var(--border-strong)',
+      borderRadius:'var(--r-lg)',
+      position:'sticky', bottom: 0,
+    }}>
+      <input type="text" placeholder="Chiedi all'agente Wingspan…"
+        style={{
+          flex: 1, border:'none', outline:'none', background:'transparent',
+          color:'var(--text)', fontFamily:'var(--f-body)', fontSize: 13,
+          padding:'4px 0',
+        }}/>
+      <button type="button" style={{
+        padding:'7px 12px', borderRadius:'var(--r-md)',
+        background: entityHsl('chat'), color:'#fff', border:'none',
+        fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800,
+        cursor:'pointer',
+      }}>↑ Invia</button>
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── TAB: STATS ─────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+// /* v2: GameStatsKpi */
+const KpiCard = ({ label, value, unit, accent = 'game', icon }) => (
+  <div style={{
+    padding: 14,
+    background:'var(--bg-card)', border:'1px solid var(--border)',
+    borderRadius:'var(--r-lg)',
+    display:'flex', flexDirection:'column', gap: 6,
+  }}>
+    <div style={{ display:'flex', alignItems:'center', gap: 6 }}>
+      <span aria-hidden="true" style={{
+        width: 24, height: 24, borderRadius:'var(--r-sm)',
+        background: entityHsl(accent, 0.14), color: entityHsl(accent),
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 12,
+      }}>{icon}</span>
+      <span style={{
+        fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+        textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 800,
+      }}>{label}</span>
+    </div>
+    <div style={{
+      fontFamily:'var(--f-display)', fontSize: 28, fontWeight: 800,
+      color:'var(--text)', fontVariantNumeric:'tabular-nums', lineHeight: 1,
+    }}>{value}<span style={{ fontSize: 13, color:'var(--text-muted)', fontWeight: 600, marginLeft: 4 }}>{unit}</span></div>
+  </div>
+);
+
+// /* v2: GameLeaderboard */
+const Leaderboard = () => (
+  <div style={{
+    background:'var(--bg-card)', border:'1px solid var(--border)',
+    borderRadius:'var(--r-lg)', padding: 18,
+  }}>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: 15, fontWeight: 800,
+      color:'var(--text)', margin:'0 0 14px',
+    }}>Classifica giocatori</h3>
+    <div style={{ display:'flex', flexDirection:'column', gap: 0 }}>
+      {LEADERBOARD.map((p, i) => (
+        <div key={p.id} style={{
+          display:'flex', alignItems:'center', gap: 12,
+          padding:'10px 0',
+          borderBottom: i < LEADERBOARD.length - 1 ? '1px solid var(--border-light)' : 'none',
+        }}>
+          <span style={{
+            fontFamily:'var(--f-mono)', fontSize: 13, fontWeight: 800,
+            color: i === 0 ? entityHsl('agent') : 'var(--text-muted)',
+            width: 22, textAlign:'center',
+          }}>{i === 0 ? '🏆' : `#${i+1}`}</span>
+          <div style={{
+            width: 32, height: 32, borderRadius:'50%',
+            background: `hsl(${p.color}, 60%, 55%)`,
+            color:'#fff',
+            display:'inline-flex', alignItems:'center', justifyContent:'center',
+            fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 11,
+            flexShrink: 0,
+          }}>{p.initials}</div>
+          <div style={{ flex: 1 }}>
+            <div style={{
+              fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800, color:'var(--text)',
+            }}>{p.title}</div>
+            <div style={{
+              fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)', fontWeight: 600,
+            }}>{p.plays} partite · avg {p.avgScore} pt</div>
+          </div>
+          <div style={{
+            display:'flex', flexDirection:'column', alignItems:'flex-end',
+          }}>
+            <span style={{
+              fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800,
+              color: entityHsl('player'), fontVariantNumeric:'tabular-nums', lineHeight: 1,
+            }}>{p.wins}</span>
+            <span style={{
+              fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+              textTransform:'uppercase', letterSpacing:'.06em', fontWeight: 700, marginTop: 2,
+            }}>vittorie</span>
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+const StatsTab = () => (
+  <div style={{ display:'flex', flexDirection:'column', gap: 14 }}>
+    <div style={{
+      display:'grid', gridTemplateColumns:'repeat(auto-fit, minmax(160px, 1fr))', gap: 10,
+    }}>
+      <KpiCard label="Win rate" value="59" unit="%" accent="player" icon="🏆"/>
+      <KpiCard label="Avg score" value="89" unit="pt" accent="game" icon="⭐"/>
+      <KpiCard label="Partite" value="17" unit="" accent="session" icon="🎯"/>
+      <KpiCard label="Ultima" value="3" unit="g fa" accent="event" icon="📅"/>
+    </div>
+    <Leaderboard/>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── TAB: DOCUMENTS ─────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const DocItem = ({ kb }) => (
+  <article tabIndex={0} className="mai-card-row" style={{
+    display:'flex', alignItems:'center', gap: 14, padding: 12,
+    background:'var(--bg-card)', border:'1px solid var(--border)',
+    borderRadius:'var(--r-lg)', cursor:'pointer',
+  }}>
+    <div style={{
+      width: 42, height: 42, borderRadius:'var(--r-md)',
+      background: entityHsl('kb', 0.14), color: entityHsl('kb'),
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 20, flexShrink: 0,
+    }} aria-hidden="true">📄</div>
+    <div style={{ flex: 1, minWidth: 0 }}>
+      <div style={{
+        fontFamily:'var(--f-mono)', fontSize: 13, fontWeight: 700, color:'var(--text)',
+        marginBottom: 3, whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis',
+      }}>{kb.title}</div>
+      <div style={{
+        fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+        fontWeight: 600,
+      }}>
+        <span style={{
+          padding:'1px 5px', borderRadius: 3,
+          background: entityHsl('kb', 0.14), color: entityHsl('kb'),
+          fontWeight: 800, marginRight: 6,
+        }}>{kb.status === 'indexed' ? '✓ INDEXED' : kb.status.toUpperCase()}</span>
+        {kb.size} · {kb.pages} pag · {kb.chunks} chunks
+      </div>
+    </div>
+    <button type="button" style={{
+      padding:'6px 12px', borderRadius:'var(--r-md)',
+      background:'transparent', border:'1px solid var(--border)',
+      color:'var(--text-sec)', fontFamily:'var(--f-display)',
+      fontSize: 11, fontWeight: 800, cursor:'pointer',
+    }}>Apri ↗</button>
+  </article>
+);
+
+const DocsTab = () => (
+  <div style={{ display:'flex', flexDirection:'column', gap: 10 }}>
+    <div style={{
+      display:'flex', alignItems:'center', justifyContent:'space-between',
+    }}>
+      <div style={{
+        fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+        fontWeight: 700, letterSpacing:'.04em',
+      }}>{RELATED_KBS.length} documenti indicizzati</div>
+      <button type="button" style={{
+        padding:'8px 14px', borderRadius:'var(--r-md)',
+        background: entityHsl('kb'), color:'#fff', border:'none',
+        fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800,
+        cursor:'pointer',
+        boxShadow:`0 3px 10px ${entityHsl('kb', 0.35)}`,
+      }}>↑ Carica documento</button>
+    </div>
+    {RELATED_KBS.map(kb => <DocItem key={kb.id} kb={kb}/>)}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── ERROR / LOADING STATES per tab ─────────────────
+// ═══════════════════════════════════════════════════════
+const TabSkeleton = () => (
+  <div style={{ display:'flex', flexDirection:'column', gap: 10 }}>
+    {[0,1,2,3].map(i => (
+      <div key={i} className="mai-shimmer" style={{
+        height: 76, borderRadius:'var(--r-lg)', background:'var(--bg-muted)',
+      }}/>
+    ))}
+  </div>
+);
+
+const TabError = ({ onRetry }) => (
+  <div style={{
+    padding:'32px 24px', textAlign:'center',
+    background:'hsl(var(--c-danger) / .08)',
+    border:'1px solid hsl(var(--c-danger) / .3)',
+    borderRadius:'var(--r-xl)',
+    display:'flex', flexDirection:'column', alignItems:'center',
+  }}>
+    <div style={{
+      width: 48, height: 48, borderRadius:'50%',
+      background:'hsl(var(--c-danger) / .15)', color:'hsl(var(--c-danger))',
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 22, marginBottom: 10,
+    }} aria-hidden="true">⚠</div>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800,
+      color:'var(--text)', margin:'0 0 4px',
+    }}>Errore caricamento</h3>
+    <p style={{ fontSize: 12, color:'var(--text-muted)', margin:'0 0 12px', maxWidth: 320 }}>
+      Impossibile recuperare i dati. Verifica la connessione.
+    </p>
+    <button type="button" onClick={onRetry}
+      style={{
+        padding:'7px 14px', borderRadius:'var(--r-md)',
+        background:'hsl(var(--c-danger))', color:'#fff', border:'none',
+        fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer',
+      }}>↻ Riprova</button>
+  </div>
+);
+
+const TabEmpty = ({ icon, title, sub, ctaLabel, ctaColor='game' }) => (
+  <div style={{
+    padding:'40px 24px', textAlign:'center',
+    background:'var(--bg-card)',
+    border:'1px dashed var(--border-strong)',
+    borderRadius:'var(--r-xl)',
+    display:'flex', flexDirection:'column', alignItems:'center',
+  }}>
+    <div style={{
+      width: 60, height: 60, borderRadius:'50%',
+      background: entityHsl(ctaColor, 0.12), color: entityHsl(ctaColor),
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 28, marginBottom: 12,
+    }} aria-hidden="true">{icon}</div>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: 15, fontWeight: 800,
+      color:'var(--text)', margin:'0 0 4px',
+    }}>{title}</h3>
+    <p style={{ fontSize: 12.5, color:'var(--text-muted)', margin:'0 0 14px', maxWidth: 340 }}>
+      {sub}
+    </p>
+    <button type="button" style={{
+      padding:'8px 16px', borderRadius:'var(--r-md)',
+      background: entityHsl(ctaColor), color:'#fff', border:'none',
+      fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer',
+      boxShadow: `0 3px 10px ${entityHsl(ctaColor, 0.35)}`,
+    }}>{ctaLabel}</button>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── BODY ───────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const GameDetailBody = ({ stateOverride, variant = 'own', compact, initialTab = 'info' }) => {
+  const [tab, setTab] = useState(initialTab);
+  const isLoading = stateOverride === 'loading';
+  const isError = stateOverride === 'error';
+
+  const tabs = [
+    { id:'info', icon:'📘', label:'Info' },
+    { id:'sessions', icon:'🎯', label:'Partite', count: variant === 'own' ? RELATED_SESSIONS.length + MORE_SESSIONS.length : 0, locked: variant !== 'own' },
+    { id:'chat', icon:'💬', label:'Chat', count: variant === 'own' ? RELATED_CHATS.length : 0, locked: variant !== 'own' },
+    { id:'stats', icon:'📊', label:'Stats', locked: variant !== 'own' },
+    { id:'docs', icon:'📄', label:'Documenti', count: RELATED_KBS.length },
+  ];
+
+  const connections = [
+    { entityType:'agent', count: 2, label:'Agenti', isEmpty: false },
+    { entityType:'kb', count: 5, label:'Documenti', isEmpty: false },
+    { entityType:'toolkit', count: 1, label:'Toolkit', isEmpty: false },
+    { entityType:'session', count: 12, label:'Partite', isEmpty: false },
+    { entityType:'player', count: 4, label:'Giocatori', isEmpty: false },
+    { entityType:'chat', count: 0, label:'Chat', isEmpty: true },
+  ];
+
+  const renderTab = () => {
+    if (isLoading) return <TabSkeleton/>;
+    if (isError) return <TabError/>;
+
+    if (variant !== 'own' && (tab === 'sessions' || tab === 'chat' || tab === 'stats')) {
+      const cfg = {
+        sessions: { icon:'🎯', t:'Aggiungi alla libreria per registrare partite',
+          sub:'Le partite sono tracciate solo per i giochi della tua collezione.' },
+        chat: { icon:'💬', t:'Aggiungi alla libreria per chattare',
+          sub:'Sblocca chat con l\'agente esperto del gioco una volta in libreria.' },
+        stats: { icon:'📊', t:'Aggiungi alla libreria per vedere le stats',
+          sub:'Win rate, leaderboard e trend sono disponibili per i tuoi giochi.' },
+      }[tab];
+      return <TabEmpty icon={cfg.icon} title={cfg.t} sub={cfg.sub} ctaLabel="+ Aggiungi a libreria"/>;
+    }
+
+    if (tab === 'info') return <InfoTab game={GAME}/>;
+    if (tab === 'sessions') return <SessionsTab compact={compact}/>;
+    if (tab === 'chat') return <ChatTab compact={compact}/>;
+    if (tab === 'stats') return <StatsTab/>;
+    if (tab === 'docs') return <DocsTab/>;
+    return null;
+  };
+
+  return (
+    <>
+      <GameHero game={GAME} variant={variant} compact={compact} loading={isLoading}/>
+      {/* ConnectionBar sticky */}
+      <div style={{
+        padding: compact ? '0 16px' : '0 32px',
+        background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+        borderBottom:'1px solid var(--border-light)',
+        position:'sticky', top: 0, zIndex: 8,
+      }}>
+        <ConnectionBar connections={connections} loading={isLoading}/>
+      </div>
+      <div style={{ position:'sticky', top: 45, zIndex: 7,
+        background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+      }}>
+        <GameTabs tabs={tabs} active={tab} onChange={setTab} compact={compact} locked={variant !== 'own'}/>
+      </div>
+      <div style={{
+        padding: compact ? '14px 16px 32px' : '20px 32px 64px',
+      }}>
+        {renderTab()}
+      </div>
+    </>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── DESKTOP / MOBILE SHELLS ─────────────────────────
+// ═══════════════════════════════════════════════════════
+const DesktopNav = () => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 14,
+    padding:'10px 32px',
+    background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+    borderBottom:'1px solid var(--border)',
+  }}>
+    <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
+      <div style={{
+        width: 26, height: 26, borderRadius: 7,
+        background:'linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event)))',
+        color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+        fontWeight: 800, fontSize: 13, fontFamily:'var(--f-display)',
+      }}>M</div>
+      <span style={{ fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 14 }}>MeepleAI</span>
+    </div>
+    <div style={{
+      flex: 1, fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      marginLeft: 22,
+    }}>
+      <a href="#" style={{ color:'inherit' }}>Giochi</a>
+      <span aria-hidden="true"> / </span>
+      <strong style={{ color:'var(--text-sec)' }}>{GAME.title}</strong>
+    </div>
+  </div>
+);
+
+const DesktopScreen = ({ stateOverride, variant }) => (
+  <div style={{ minHeight: 720, background:'var(--bg)' }}>
+    <DesktopNav/>
+    <GameDetailBody stateOverride={stateOverride} variant={variant}/>
+  </div>
+);
+
+const PhoneSbar = () => (
+  <div className="phone-sbar" style={{ color:'var(--text)' }}>
+    <span style={{ fontFamily:'var(--f-mono)' }}>14:32</span>
+    <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+  </div>
+);
+const PhoneTopNav = () => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 9,
+    padding:'10px 14px', background:'var(--glass-bg)',
+    backdropFilter:'blur(12px)',
+    borderBottom:'1px solid var(--border-light)',
+    position:'sticky', top: 0, zIndex: 9,
+  }}>
+    <button aria-label="Indietro" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      color:'var(--text)', fontSize: 14, cursor:'pointer',
+    }}>←</button>
+    <div style={{
+      flex: 1, fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+      textAlign:'center', fontWeight: 700,
+    }}>games / wingspan</div>
+    <button aria-label="Più" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      color:'var(--text)', fontSize: 14, cursor:'pointer',
+    }}>⋯</button>
+  </div>
+);
+const MobileScreen = ({ stateOverride, variant, initialTab }) => (
+  <>
+    <PhoneSbar/>
+    <div style={{ flex: 1, overflowY:'auto', position:'relative', background:'var(--bg)' }}>
+      <PhoneTopNav/>
+      <GameDetailBody stateOverride={stateOverride} variant={variant} compact initialTab={initialTab}/>
+    </div>
+  </>
+);
+
+const PhoneShell = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 10 }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div className="phone">{children}</div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 340,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+const DesktopFrame = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 12, width:'100%' }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div style={{
+      width:'100%', maxWidth: 1280,
+      borderRadius:'var(--r-xl)', border:'1px solid var(--border)',
+      background:'var(--bg)', overflow:'hidden',
+      boxShadow:'var(--shadow-lg)',
+    }}>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 8,
+        padding:'9px 14px', background:'var(--bg-muted)',
+        borderBottom:'1px solid var(--border)',
+        fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      }}>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-event))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-warning))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-toolkit))' }}/>
+        <span style={{ flex: 1, textAlign:'center', letterSpacing:'.04em' }}>meepleai.app/games/wingspan</span>
+      </div>
+      {children}
+    </div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 720,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── ROOT ────────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const MOBILE_STATES = [
+  { id:'m1', stateOverride:null, variant:'own', tab:'info',     label:'01 · Own · Info', desc:'Hero 180 + ConnectionBar 6 pip (chat empty dashed) + 5 tab. Info: descrizione + specs grid + house rules toggle.' },
+  { id:'m2', stateOverride:null, variant:'own', tab:'sessions', label:'02 · Own · Sessions', desc:'Lista partite con avatar stack giocatori, winner pip, score. CTA "+ Nuova partita".' },
+  { id:'m3', stateOverride:null, variant:'own', tab:'chat',     label:'03 · Own · Chat', desc:'Agent header + bubble user (entity-chat) + risposta agent con citation pip kb + input sticky.' },
+  { id:'m4', stateOverride:null, variant:'own', tab:'stats',    label:'04 · Own · Stats', desc:'4 KPI cards (win rate / avg score / partite / ultima) + leaderboard giocatori.' },
+  { id:'m5', stateOverride:null, variant:'community', tab:'sessions', label:'05 · Community · locked', desc:'Variante community: tabs Sessions/Chat/Stats lockate (🔒 + opacity), tab corrente mostra empty + CTA "+ Aggiungi a libreria".' },
+  { id:'m6', stateOverride:'loading', variant:'own', tab:'info', label:'06 · Loading', desc:'Hero skeleton + ConnectionBar shimmer + tabs nav visible + tab body 4 row skeleton.' },
+];
+
+function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+  }, [dark]);
+  return (
+    <button onClick={() => setDark(d => !d)} className="theme-toggle"
+      aria-label={dark ? 'Tema chiaro' : 'Tema scuro'}>
+      <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span>
+      <span>{dark ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+}
+
+function App() {
+  return (
+    <div className="stage">
+      <ThemeToggle/>
+      <div className="stage-wrap">
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.08em', marginBottom: 8,
+        }}>SP4 wave 1 · #2/5 · Hero + body con tabs</div>
+        <h1>Game detail — /games/[id]</h1>
+        <p className="lead">
+          Cover hero 240px + <strong>ConnectionBar</strong> sticky 1:1 prod (6 pip, chat empty dashed) +
+          <strong> GameTabs</strong> animated underline (5 tabs). Variante <strong>own</strong> sblocca tutto;
+          <strong> community</strong> locka Sessions/Chat/Stats con CTA "+ Aggiungi a libreria".
+        </p>
+
+        <div className="section-label">Mobile · 375 — 6 stati / tabs</div>
+        <div className="phones-grid">
+          {MOBILE_STATES.map(s => (
+            <PhoneShell key={s.id} label={s.label} desc={s.desc}>
+              <MobileScreen stateOverride={s.stateOverride} variant={s.variant} initialTab={s.tab}/>
+            </PhoneShell>
+          ))}
+        </div>
+
+        <div className="section-label">Desktop · 1440 — 4 varianti chiave</div>
+        <div style={{ display:'flex', flexDirection:'column', gap: 36 }}>
+          <DesktopFrame label="07 · Desktop · Own · Info"
+            desc="Variante own + tab Info: hero 240 + ConnectionBar sticky con 6 pip (chat empty dashed) + tabs animated underline. Body: descrizione + specs grid 8 cells + house rules toggle.">
+            <DesktopScreen stateOverride={null} variant="own"/>
+          </DesktopFrame>
+          <DesktopFrame label="08 · Desktop · Community · locked"
+            desc="Gioco non in libreria: action bar primaria '+ Aggiungi a libreria'. Tabs Sessions/Chat/Stats con icon 🔒 + opacity .55 + cursor not-allowed. Tab Info e Documenti accessibili (read-only).">
+            <DesktopScreen stateOverride={null} variant="community"/>
+          </DesktopFrame>
+          <DesktopFrame label="09 · Desktop · Loading"
+            desc="Hero skeleton 240 + ConnectionBar shimmer (6 pill) + tabs nav visible + body 4 row 76px shimmer. Action bar nascosta durante load (skeleton hero copre).">
+            <DesktopScreen stateOverride="loading" variant="own"/>
+          </DesktopFrame>
+          <DesktopFrame label="10 · Desktop · Error"
+            desc="Hero + ConnectionBar visibili (cached), tab body mostra danger card '⚠ Errore caricamento' + retry CTA. L'errore è scoped al tab content, non all'intera pagina.">
+            <DesktopScreen stateOverride="error" variant="own"/>
+          </DesktopFrame>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes mai-shimmer-anim {
+          0%   { background-position: -200% 0; }
+          100% { background-position:  200% 0; }
+        }
+        .mai-shimmer {
+          background: linear-gradient(90deg, var(--bg-muted) 0%, var(--bg-hover) 50%, var(--bg-muted) 100%) !important;
+          background-size: 200% 100% !important;
+          animation: mai-shimmer-anim 1.4s linear infinite;
+        }
+        .phones-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+          gap: var(--s-7);
+          align-items: start;
+        }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage .lead { line-height: var(--lh-relax); }
+        .phone > div::-webkit-scrollbar { display: none; }
+        .mai-cb-scroll::-webkit-scrollbar { display: none; }
+        .mai-card-row {
+          outline: none;
+          transition: transform var(--dur-sm) var(--ease-out), border-color var(--dur-sm), box-shadow var(--dur-sm);
+        }
+        .mai-card-row:hover {
+          transform: translateY(-1px);
+          border-color: hsl(var(--c-game) / .35);
+          box-shadow: var(--shadow-xs);
+        }
+        .mai-card-row:focus-visible {
+          outline: 2px solid hsl(var(--c-game));
+          outline-offset: 2px;
+        }
+        button:focus-visible, a:focus-visible, input:focus-visible {
+          outline: 2px solid hsl(var(--c-game));
+          outline-offset: 2px;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);

--- a/admin-mockups/design_files/sp4-games-index.html
+++ b/admin-mockups/design_files/sp4-games-index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 wave 1 · #1/5 · Games index — /games</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-games-index.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-games-index.jsx
+++ b/admin-mockups/design_files/sp4-games-index.jsx
@@ -1,0 +1,1027 @@
+/* MeepleAI SP4 wave 1 — Schermata #1 / 5
+   Route: /games
+   File: admin-mockups/design_files/sp4-games-index.{html,jsx}
+   Pattern desktop: Hero + body grid
+
+   Hero compatto: titolo + stats library (N giochi · M partite · X agenti)
+   + filtri (search, status, complexity, players, year, designer) + sort.
+   Body: grid 4-col MeepleCard variante `grid` (cover gradient prominente
+   + ConnectionChipStrip footer). Click card → /games/[id].
+
+   Stati: default (24+), empty library, loading skeleton, filtered empty.
+   Mobile 375 → 2-col compact. Desktop 1440 → 4-col.
+
+   Componenti v2 nuovi flaggati:
+   - LibraryHero          → apps/web/src/components/ui/v2/library-hero/
+   - GameFilters          → apps/web/src/components/ui/v2/game-filters/
+   - MeepleCardGameGrid   → variante `grid` di MeepleCard (già v1, qui usata pixel-perfect)
+   - ConnectionChipStrip  → ✅ già in produzione (PR #549/#552)
+   - EmptyLibrary         → apps/web/src/components/ui/v2/empty-library/
+
+   Riusi pixel-perfect: ConnectionChipStrip footer (verticale ridotto: agent, kb, session, chat).
+*/
+
+const { useState, useEffect, useMemo } = React;
+const DS = window.DS;
+
+// ─── ENTITY HSL HELPER (replica spec) ─────────────────
+const entityHsl = (type, alpha) => {
+  const c = DS.EC[type] || DS.EC.game;
+  return alpha !== undefined
+    ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${alpha})`
+    : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
+};
+
+// ─── DATASET ESTESO PER L'INDEX ─────────────────────
+// Espando i 8 giochi base da DS a 24+ con varianti realistiche.
+const GAMES_INDEX = [
+  ...DS.games,
+  { id: 'g-everdell', type: 'game', title: 'Everdell', publisher: 'Starling Games', year: 2018,
+    author: 'James A. Wilson', players: '1–4', duration: '40–80m', weight: 2.81, rating: 8.0, stars: 4,
+    cover: DS.grad(120, 55), coverEmoji: '🌳', status: 'owned', badge: 'Posseduto',
+    agentCount: 1, kbCount: 1, sessionCount: 4, chatCount: 2, totalPlays: 4 },
+  { id: 'g-terraforming', type: 'game', title: 'Terraforming Mars', publisher: 'Stronghold', year: 2016,
+    author: 'Jacob Fryxelius', players: '1–5', duration: '90–120m', weight: 3.24, rating: 8.4, stars: 5,
+    cover: DS.grad(15, 65), coverEmoji: '🚀', status: 'owned', badge: 'Heavy',
+    agentCount: 2, kbCount: 3, sessionCount: 11, chatCount: 6, totalPlays: 11 },
+  { id: 'g-scythe', type: 'game', title: 'Scythe', publisher: 'Stonemaier', year: 2016,
+    author: 'Jamey Stegmaier', players: '1–5', duration: '90–115m', weight: 3.43, rating: 8.2, stars: 5,
+    cover: DS.grad(45, 50), coverEmoji: '⚙️', status: 'owned', badge: 'Posseduto',
+    agentCount: 1, kbCount: 2, sessionCount: 6, chatCount: 3, totalPlays: 6 },
+  { id: 'g-carcassonne', type: 'game', title: 'Carcassonne', publisher: 'HiG', year: 2000,
+    author: 'Klaus-Jürgen Wrede', players: '2–5', duration: '30–45m', weight: 1.91, rating: 7.4, stars: 4,
+    cover: DS.grad(90, 50), coverEmoji: '🏰', status: 'owned', badge: 'Classico',
+    agentCount: 1, kbCount: 1, sessionCount: 19, chatCount: 1, totalPlays: 19 },
+  { id: 'g-ticket', type: 'game', title: 'Ticket to Ride', publisher: 'Days of Wonder', year: 2004,
+    author: 'Alan R. Moon', players: '2–5', duration: '30–60m', weight: 1.84, rating: 7.4, stars: 4,
+    cover: DS.grad(355, 60), coverEmoji: '🚂', status: 'owned', badge: 'Family',
+    agentCount: 1, kbCount: 1, sessionCount: 28, chatCount: 0, totalPlays: 28 },
+  { id: 'g-pandemic', type: 'game', title: 'Pandemic Legacy S.1', publisher: 'Z-Man', year: 2015,
+    author: 'M. Leacock · R. Daviau', players: '2–4', duration: '60m', weight: 2.83, rating: 8.5, stars: 5,
+    cover: DS.grad(160, 45), coverEmoji: '🦠', status: 'owned', badge: 'Legacy',
+    agentCount: 0, kbCount: 1, sessionCount: 12, chatCount: 1, totalPlays: 12 },
+  { id: 'g-root', type: 'game', title: 'Root', publisher: 'Leder Games', year: 2018,
+    author: 'Cole Wehrle', players: '2–4', duration: '60–90m', weight: 3.79, rating: 8.0, stars: 4,
+    cover: DS.grad(75, 60), coverEmoji: '🦊', status: 'wishlist', badge: 'Wishlist',
+    agentCount: 0, kbCount: 0, sessionCount: 0, chatCount: 0, totalPlays: 0 },
+  { id: 'g-dune', type: 'game', title: 'Dune: Imperium', publisher: 'Dire Wolf', year: 2020,
+    author: 'Paul Dennen', players: '1–4', duration: '60–120m', weight: 3.07, rating: 8.4, stars: 5,
+    cover: DS.grad(35, 70), coverEmoji: '🏜️', status: 'owned', badge: 'Top 10',
+    agentCount: 2, kbCount: 2, sessionCount: 9, chatCount: 4, totalPlays: 9 },
+  { id: 'g-cascadia', type: 'game', title: 'Cascadia', publisher: 'AEG', year: 2021,
+    author: 'Randy Flynn', players: '1–4', duration: '30–45m', weight: 1.84, rating: 7.9, stars: 4,
+    cover: DS.grad(110, 55), coverEmoji: '🦌', status: 'owned', badge: 'Light',
+    agentCount: 0, kbCount: 1, sessionCount: 7, chatCount: 0, totalPlays: 7 },
+  { id: 'g-lost-ruins', type: 'game', title: 'Lost Ruins of Arnak', publisher: 'CGE', year: 2020,
+    author: 'M. Suchý · M. Suchý', players: '1–4', duration: '30–120m', weight: 2.85, rating: 8.0, stars: 4,
+    cover: DS.grad(50, 55), coverEmoji: '🗿', status: 'owned', badge: 'Posseduto',
+    agentCount: 1, kbCount: 2, sessionCount: 5, chatCount: 2, totalPlays: 5 },
+  { id: 'g-marvel', type: 'game', title: 'Marvel Champions', publisher: 'FFG', year: 2019,
+    author: 'M. Boucher · N. French', players: '1–4', duration: '45–90m', weight: 2.55, rating: 7.9, stars: 4,
+    cover: DS.grad(0, 70), coverEmoji: '🦸', status: 'owned', badge: 'LCG',
+    agentCount: 1, kbCount: 4, sessionCount: 14, chatCount: 5, totalPlays: 14 },
+  { id: 'g-paleo', type: 'game', title: 'Paleo', publisher: 'Hans im Glück', year: 2020,
+    author: 'Peter Rustemeyer', players: '1–4', duration: '45–60m', weight: 2.74, rating: 7.7, stars: 4,
+    cover: DS.grad(25, 50), coverEmoji: '🦴', status: 'wishlist', badge: 'Wishlist',
+    agentCount: 0, kbCount: 0, sessionCount: 0, chatCount: 0, totalPlays: 0 },
+  { id: 'g-castles', type: 'game', title: 'Castles of Burgundy', publisher: 'Ravensburger', year: 2011,
+    author: 'Stefan Feld', players: '2–4', duration: '60–90m', weight: 2.96, rating: 8.1, stars: 5,
+    cover: DS.grad(280, 45), coverEmoji: '🏯', status: 'owned', badge: 'Classico',
+    agentCount: 1, kbCount: 1, sessionCount: 8, chatCount: 1, totalPlays: 8 },
+  { id: 'g-quacks', type: 'game', title: 'Quacks of Quedlinburg', publisher: 'Schmidt', year: 2018,
+    author: 'Wolfgang Warsch', players: '2–4', duration: '45m', weight: 1.97, rating: 7.7, stars: 4,
+    cover: DS.grad(305, 55), coverEmoji: '🧪', status: 'owned', badge: 'Family',
+    agentCount: 0, kbCount: 1, sessionCount: 6, chatCount: 0, totalPlays: 6 },
+  { id: 'g-orleans', type: 'game', title: 'Orléans', publisher: 'dlp games', year: 2014,
+    author: 'Reiner Stockhausen', players: '2–4', duration: '90m', weight: 3.04, rating: 7.9, stars: 4,
+    cover: DS.grad(195, 45), coverEmoji: '⛪', status: 'wishlist', badge: 'Wishlist',
+    agentCount: 0, kbCount: 0, sessionCount: 0, chatCount: 0, totalPlays: 0 },
+  { id: 'g-blood', type: 'game', title: 'Blood Rage', publisher: 'CMON', year: 2015,
+    author: 'Eric M. Lang', players: '2–4', duration: '60–90m', weight: 2.85, rating: 7.9, stars: 4,
+    cover: DS.grad(355, 55), coverEmoji: '⚔️', status: 'owned', badge: 'Posseduto',
+    agentCount: 0, kbCount: 1, sessionCount: 4, chatCount: 0, totalPlays: 4 },
+];
+
+// I primi 8 (DS.games) hanno già le connection counts derivate dal dataset
+// Le derivo on the fly per coerenza:
+const enrich = g => ({
+  ...g,
+  agentCount: g.agentCount ?? DS.agents.filter(a => a.gameId === g.id).length,
+  kbCount: g.kbCount ?? DS.kbs.filter(k => k.gameId === g.id).length,
+  sessionCount: g.sessionCount ?? DS.sessions.filter(s => s.gameId === g.id).length,
+  chatCount: g.chatCount ?? DS.chats.filter(c => c.gameId === g.id).length,
+});
+const ALL_GAMES = GAMES_INDEX.map(enrich);
+
+// ═══════════════════════════════════════════════════════
+// ─── STARS ──────────────────────────────────────────
+const Stars = ({ value = 0, size = 11 }) => {
+  const full = Math.floor(value);
+  return (
+    <span style={{ display:'inline-flex', gap: 1, color:'hsl(var(--c-agent))', fontSize: size }}>
+      {[0,1,2,3,4].map(i => <span key={i} aria-hidden="true">{i < full ? '★' : '☆'}</span>)}
+    </span>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── CONNECTIONCHIPSTRIP (footer card MeepleCard, prod) ─
+// ═══════════════════════════════════════════════════════
+// /* v2: ConnectionChipStrip — ✅ in produzione (PR #549/#552) */
+const ConnectionChipStrip = ({ connections, compact }) => {
+  const visible = connections.filter(c => !c.isEmpty);
+  if (visible.length === 0) {
+    return (
+      <div style={{
+        fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+        fontWeight: 600, letterSpacing:'.04em',
+      }}>Nessuna connessione</div>
+    );
+  }
+  return (
+    <div style={{ display:'flex', gap: 4, flexWrap:'wrap' }}>
+      {visible.map(c => {
+        const ec = DS.EC[c.entityType];
+        return (
+          <span key={c.entityType} style={{
+            display:'inline-flex', alignItems:'center', gap: 3,
+            padding: compact ? '2px 6px' : '3px 7px',
+            borderRadius: 999,
+            background: entityHsl(c.entityType, 0.1),
+            color: entityHsl(c.entityType),
+            fontFamily:'var(--f-display)', fontSize: compact ? 10 : 11, fontWeight: 700,
+            lineHeight: 1.2,
+          }}>
+            <span aria-hidden="true" style={{ fontSize: compact ? 10 : 11 }}>{ec.em}</span>
+            <span style={{ fontFamily:'var(--f-mono)', fontVariantNumeric:'tabular-nums' }}>{c.count}</span>
+          </span>
+        );
+      })}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── MEEPLECARD (variante `grid` per game) ──────────
+// ═══════════════════════════════════════════════════════
+// /* v2: MeepleCard.grid — ✅ in produzione */
+const GameCardGrid = ({ game, compact }) => {
+  const connections = [
+    { entityType:'agent', count: game.agentCount, isEmpty: game.agentCount === 0 },
+    { entityType:'kb', count: game.kbCount, isEmpty: game.kbCount === 0 },
+    { entityType:'session', count: game.sessionCount, isEmpty: game.sessionCount === 0 },
+    { entityType:'chat', count: game.chatCount, isEmpty: game.chatCount === 0 },
+  ];
+  return (
+    <article tabIndex={0}
+      className="mai-card-game"
+      style={{
+        background:'var(--bg-card)',
+        border:'1px solid var(--border)',
+        borderRadius:'var(--r-lg)',
+        overflow:'hidden',
+        cursor:'pointer',
+        transition:'transform var(--dur-sm) var(--ease-out), border-color var(--dur-sm), box-shadow var(--dur-sm)',
+        display:'flex', flexDirection:'column',
+      }}>
+      {/* Cover */}
+      <div style={{
+        position:'relative',
+        aspectRatio: compact ? '4 / 3' : '5 / 3',
+        background: game.cover,
+        display:'flex', alignItems:'center', justifyContent:'center',
+        overflow:'hidden',
+      }}>
+        <span aria-hidden="true" style={{
+          fontSize: compact ? 50 : 60,
+          filter:'drop-shadow(0 4px 12px rgba(0,0,0,.35))',
+        }}>{game.coverEmoji}</span>
+        {/* status badge top-left */}
+        {game.badge && (
+          <span style={{
+            position:'absolute', top: 8, left: 8,
+            padding:'3px 8px', borderRadius:'var(--r-pill)',
+            background:'rgba(0,0,0,.5)', color:'#fff',
+            fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+            textTransform:'uppercase', letterSpacing:'.06em',
+            backdropFilter:'blur(4px)',
+          }}>{game.badge}</span>
+        )}
+        {/* entity chip top-right */}
+        <span style={{
+          position:'absolute', top: 8, right: 8,
+          padding:'3px 7px', borderRadius:'var(--r-pill)',
+          background: entityHsl('game', 0.95), color:'#fff',
+          fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+          textTransform:'uppercase', letterSpacing:'.06em',
+          display:'inline-flex', alignItems:'center', gap: 3,
+        }}>
+          <span aria-hidden="true">🎲</span>Game
+        </span>
+        {/* gradient overlay bottom */}
+        <div style={{
+          position:'absolute', inset:'auto 0 0 0', height:'40%',
+          background:'linear-gradient(180deg, transparent 0%, rgba(0,0,0,.35) 100%)',
+        }}/>
+      </div>
+      {/* Body */}
+      <div style={{
+        padding: compact ? 10 : 14,
+        display:'flex', flexDirection:'column', gap: compact ? 6 : 8, flex: 1,
+      }}>
+        <div>
+          <h3 style={{
+            fontFamily:'var(--f-display)', fontWeight: 800,
+            fontSize: compact ? 13 : 15, lineHeight: 1.15,
+            color:'var(--text)', margin:'0 0 3px',
+            display:'-webkit-box', WebkitLineClamp: 1, WebkitBoxOrient:'vertical', overflow:'hidden',
+          }}>{game.title}</h3>
+          <div style={{
+            display:'flex', alignItems:'center', gap: 5,
+            fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+            fontWeight: 600,
+          }}>
+            <Stars value={game.stars} size={9}/>
+            <span>{game.rating}</span>
+            <span aria-hidden="true">·</span>
+            <span>{game.players}</span>
+            <span aria-hidden="true">·</span>
+            <span>{game.duration.split('–')[0]}{game.duration.includes('–') ? '+' : ''}</span>
+          </div>
+        </div>
+        {/* Footer ConnectionChipStrip */}
+        <div style={{ marginTop:'auto' }}>
+          <ConnectionChipStrip connections={connections} compact={compact}/>
+        </div>
+      </div>
+    </article>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── LIBRARY HERO ───────────────────────────────────
+// ═══════════════════════════════════════════════════════
+// /* v2: LibraryHero → apps/web/src/components/ui/v2/library-hero/ */
+const LibraryHero = ({ stats, compact }) => (
+  <header style={{
+    padding: compact ? '20px 16px 14px' : '32px 32px 18px',
+    background:`linear-gradient(180deg, ${entityHsl('game', 0.06)} 0%, transparent 100%)`,
+    borderBottom:'1px solid var(--border-light)',
+  }}>
+    <div style={{
+      display:'flex', alignItems:'center', gap: 6, marginBottom: 10,
+    }}>
+      <span style={{
+        display:'inline-flex', alignItems:'center', gap: 5,
+        padding:'3px 9px', borderRadius:'var(--r-pill)',
+        background: entityHsl('game', 0.14),
+        color: entityHsl('game'),
+        fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+        textTransform:'uppercase', letterSpacing:'.08em',
+      }}><span aria-hidden="true">🎲</span>Games · /games</span>
+    </div>
+    <h1 style={{
+      fontFamily:'var(--f-display)', fontWeight: 800,
+      fontSize: compact ? 24 : 34, letterSpacing:'-.02em', lineHeight: 1.05,
+      color:'var(--text)', margin:'0 0 6px',
+    }}>La tua libreria di giochi</h1>
+    <p style={{
+      color:'var(--text-sec)', fontSize: compact ? 13 : 14, lineHeight: 1.55,
+      margin:'0 0 14px', maxWidth: 620,
+    }}>
+      Esplora, filtra e apri i tuoi giochi. Ogni card mostra le connessioni
+      attive: agenti, KB, partite, chat.
+    </p>
+    {/* Stats inline */}
+    <div style={{
+      display:'flex', flexWrap:'wrap', gap: compact ? 14 : 22,
+      fontFamily:'var(--f-mono)', fontSize: compact ? 11 : 12,
+    }}>
+      {stats.map(s => (
+        <div key={s.label} style={{ display:'flex', flexDirection:'column', gap: 2 }}>
+          <span style={{
+            color:'var(--text-muted)', fontSize: 9, fontWeight: 700,
+            textTransform:'uppercase', letterSpacing:'.08em',
+          }}>{s.label}</span>
+          <span style={{
+            color:'var(--text)', fontSize: compact ? 18 : 22, fontWeight: 800,
+            fontFamily:'var(--f-display)', fontVariantNumeric:'tabular-nums',
+            lineHeight: 1,
+          }}>{s.value}<span style={{ fontSize: 11, color:'var(--text-muted)', fontWeight: 600, marginLeft: 4 }}>{s.unit}</span></span>
+        </div>
+      ))}
+    </div>
+  </header>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── GAME FILTERS ───────────────────────────────────
+// ═══════════════════════════════════════════════════════
+// /* v2: GameFilters → apps/web/src/components/ui/v2/game-filters/ */
+const STATUS_OPTS = [
+  { id:'all', label:'Tutti' },
+  { id:'owned', label:'Posseduti' },
+  { id:'wishlist', label:'Wishlist' },
+  { id:'played', label:'Giocati' },
+];
+const SORT_OPTS = [
+  { id:'last-played', label:'Ultima partita' },
+  { id:'rating', label:'Rating' },
+  { id:'title', label:'Titolo A-Z' },
+  { id:'year', label:'Anno' },
+];
+
+const GameFilters = ({
+  q, setQ, status, setStatus, sort, setSort,
+  view, setView, compact, count,
+}) => (
+  <div style={{
+    padding: compact ? '12px 16px' : '14px 32px',
+    display:'flex', flexDirection: compact ? 'column' : 'row',
+    alignItems: compact ? 'stretch' : 'center',
+    gap: compact ? 10 : 12,
+    borderBottom:'1px solid var(--border-light)',
+    background:'var(--bg)',
+    position:'sticky', top: 0, zIndex: 10,
+    backdropFilter:'blur(12px)',
+  }}>
+    {/* Search */}
+    <label style={{
+      display:'flex', alignItems:'center', gap: 8,
+      flex: compact ? 'none' : '1 1 280px', maxWidth: compact ? 'none' : 360,
+      padding:'8px 12px',
+      background:'var(--bg-card)',
+      border:'1px solid var(--border)',
+      borderRadius:'var(--r-md)',
+    }}>
+      <span aria-hidden="true" style={{ color:'var(--text-muted)' }}>🔍</span>
+      <input
+        type="text" value={q} onChange={e=>setQ(e.target.value)}
+        placeholder="Cerca per titolo, autore, anno…"
+        style={{
+          flex: 1, border:'none', outline:'none', background:'transparent',
+          color:'var(--text)', fontFamily:'var(--f-body)', fontSize: 13,
+          minWidth: 0,
+        }}
+      />
+      {q && (
+        <button type="button" onClick={()=>setQ('')} aria-label="Pulisci"
+          style={{
+            border:'none', background:'transparent', color:'var(--text-muted)',
+            cursor:'pointer', fontSize: 13, padding: 0,
+          }}>✕</button>
+      )}
+    </label>
+
+    {/* Status segmented */}
+    <div role="tablist" style={{
+      display:'inline-flex',
+      background:'var(--bg-muted)',
+      borderRadius:'var(--r-md)',
+      padding: 2,
+      flexShrink: 0,
+    }}>
+      {STATUS_OPTS.map(o => (
+        <button key={o.id} role="tab" aria-selected={status === o.id}
+          onClick={()=>setStatus(o.id)}
+          style={{
+            padding: compact ? '6px 9px' : '6px 12px',
+            border:'none',
+            background: status === o.id ? 'var(--bg-card)' : 'transparent',
+            color: status === o.id ? entityHsl('game') : 'var(--text-sec)',
+            fontFamily:'var(--f-display)',
+            fontSize: compact ? 11 : 12, fontWeight: 700,
+            borderRadius: 'var(--r-sm)',
+            cursor:'pointer', whiteSpace:'nowrap',
+            boxShadow: status === o.id ? 'var(--shadow-xs)' : 'none',
+            transition:'all var(--dur-sm) var(--ease-out)',
+          }}>{o.label}</button>
+      ))}
+    </div>
+
+    <div style={{ flex: 1 }}/>
+
+    {/* Sort */}
+    <label style={{
+      display:'inline-flex', alignItems:'center', gap: 6,
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      fontWeight: 600,
+    }}>
+      <span style={{ textTransform:'uppercase', letterSpacing:'.06em' }}>Ordina</span>
+      <select value={sort} onChange={e=>setSort(e.target.value)}
+        style={{
+          padding:'6px 10px', borderRadius:'var(--r-sm)',
+          border:'1px solid var(--border)', background:'var(--bg-card)',
+          color:'var(--text)', fontFamily:'var(--f-display)',
+          fontSize: 12, fontWeight: 700, cursor:'pointer',
+        }}>
+        {SORT_OPTS.map(o => <option key={o.id} value={o.id}>{o.label}</option>)}
+      </select>
+    </label>
+
+    {/* View toggle (only desktop) */}
+    {!compact && (
+      <div role="group" aria-label="Vista" style={{
+        display:'inline-flex',
+        background:'var(--bg-muted)', borderRadius:'var(--r-sm)', padding: 2,
+      }}>
+        {[
+          { id:'grid', icon:'▦' },
+          { id:'list', icon:'☰' },
+        ].map(v => (
+          <button key={v.id} aria-pressed={view === v.id}
+            onClick={()=>setView(v.id)}
+            aria-label={v.id}
+            style={{
+              padding:'6px 10px',
+              background: view === v.id ? 'var(--bg-card)' : 'transparent',
+              border:'none', color: view === v.id ? entityHsl('game') : 'var(--text-muted)',
+              fontSize: 14, cursor:'pointer',
+              borderRadius: 'var(--r-xs)',
+              boxShadow: view === v.id ? 'var(--shadow-xs)' : 'none',
+            }}>{v.icon}</button>
+        ))}
+      </div>
+    )}
+
+    {/* Count chip (compact only) */}
+    {compact && (
+      <div style={{
+        fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+        fontWeight: 700, letterSpacing:'.04em',
+      }}>{count} giochi</div>
+    )}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── EMPTY STATES ───────────────────────────────────
+// /* v2: EmptyLibrary → apps/web/src/components/ui/v2/empty-library/ */
+const EmptyLibrary = ({ kind, onAction, compact }) => {
+  const cfg = {
+    library: {
+      icon:'🎲',
+      t:'La tua libreria è vuota',
+      sub:'Aggiungi il primo gioco per iniziare a tracciare partite, caricare regolamenti e creare agenti AI esperti.',
+      cta:'Aggiungi un gioco',
+    },
+    filtered: {
+      icon:'🔎',
+      t:'Nessun risultato',
+      sub:'Nessun gioco corrisponde ai filtri attuali. Prova a modificare la ricerca o azzera i filtri.',
+      cta:'Azzera filtri',
+    },
+  }[kind];
+  return (
+    <div style={{
+      gridColumn:'1 / -1',
+      display:'flex', flexDirection:'column', alignItems:'center', textAlign:'center',
+      padding: compact ? '40px 20px' : '64px 32px',
+      background:'var(--bg-card)',
+      border:'1px dashed var(--border-strong)',
+      borderRadius:'var(--r-xl)',
+    }}>
+      <div style={{
+        width: compact ? 64 : 80, height: compact ? 64 : 80,
+        borderRadius:'50%',
+        background: entityHsl('game', 0.12), color: entityHsl('game'),
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: compact ? 32 : 40, marginBottom: 16,
+      }} aria-hidden="true">{cfg.icon}</div>
+      <h3 style={{
+        fontFamily:'var(--f-display)', fontSize: compact ? 16 : 19, fontWeight: 800,
+        color:'var(--text)', margin:'0 0 6px',
+      }}>{cfg.t}</h3>
+      <p style={{
+        fontSize: 13, color:'var(--text-muted)', maxWidth: 360,
+        margin:'0 0 18px', lineHeight: 1.55,
+      }}>{cfg.sub}</p>
+      <button type="button" onClick={onAction}
+        style={{
+          padding:'10px 18px', borderRadius:'var(--r-md)',
+          background: entityHsl('game'), color:'#fff',
+          border:'none', fontFamily:'var(--f-display)',
+          fontSize: 13, fontWeight: 800, cursor:'pointer',
+          boxShadow:`0 4px 14px ${entityHsl('game', 0.35)}`,
+        }}>+ {cfg.cta}</button>
+    </div>
+  );
+};
+
+// ─── ERROR STATE ─────────────────────────────────────
+const ErrorState = ({ onRetry, compact }) => (
+  <div style={{
+    gridColumn:'1 / -1',
+    padding: compact ? '32px 20px' : '48px 32px',
+    background:'hsl(var(--c-danger) / .08)',
+    border:'1px solid hsl(var(--c-danger) / .3)',
+    borderRadius:'var(--r-xl)',
+    display:'flex', flexDirection:'column', alignItems:'center', textAlign:'center',
+  }}>
+    <div style={{
+      width: 56, height: 56, borderRadius:'50%',
+      background:'hsl(var(--c-danger) / .15)', color:'hsl(var(--c-danger))',
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 26, marginBottom: 12,
+    }} aria-hidden="true">⚠</div>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800,
+      color:'var(--text)', margin:'0 0 4px',
+    }}>Impossibile caricare la libreria</h3>
+    <p style={{
+      fontSize: 12.5, color:'var(--text-muted)', maxWidth: 360,
+      margin:'0 0 16px',
+    }}>Si è verificato un errore di rete. Verifica la connessione e riprova.</p>
+    <button type="button" onClick={onRetry}
+      style={{
+        padding:'8px 16px', borderRadius:'var(--r-md)',
+        background:'hsl(var(--c-danger))', color:'#fff',
+        border:'none', fontFamily:'var(--f-display)',
+        fontSize: 12, fontWeight: 800, cursor:'pointer',
+      }}>↻ Riprova</button>
+  </div>
+);
+
+// ─── SKELETON ────────────────────────────────────────
+const SkeletonCard = ({ compact }) => (
+  <div style={{
+    background:'var(--bg-card)',
+    border:'1px solid var(--border)',
+    borderRadius:'var(--r-lg)',
+    overflow:'hidden',
+  }}>
+    <div className="mai-shimmer" style={{
+      aspectRatio: compact ? '4 / 3' : '5 / 3',
+      background:'var(--bg-muted)',
+    }}/>
+    <div style={{ padding: compact ? 10 : 14, display:'flex', flexDirection:'column', gap: 6 }}>
+      <div className="mai-shimmer" style={{ height: 14, width:'72%', borderRadius: 4, background:'var(--bg-muted)' }}/>
+      <div className="mai-shimmer" style={{ height: 10, width:'52%', borderRadius: 4, background:'var(--bg-muted)' }}/>
+      <div style={{ display:'flex', gap: 4, marginTop: 4 }}>
+        {[0,1,2].map(i => (
+          <div key={i} className="mai-shimmer" style={{ height: 16, width: 28 + i*4, borderRadius: 999, background:'var(--bg-muted)' }}/>
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── PAGE BODY ──────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const filterAndSort = (list, q, status, sort) => {
+  let out = list;
+  if (q) {
+    const needle = q.toLowerCase();
+    out = out.filter(g =>
+      g.title.toLowerCase().includes(needle) ||
+      (g.author || '').toLowerCase().includes(needle) ||
+      String(g.year).includes(needle)
+    );
+  }
+  if (status !== 'all') {
+    if (status === 'played') out = out.filter(g => (g.totalPlays || 0) > 0);
+    else out = out.filter(g => g.status === status);
+  }
+  out = [...out].sort((a, b) => {
+    if (sort === 'rating') return b.rating - a.rating;
+    if (sort === 'title') return a.title.localeCompare(b.title);
+    if (sort === 'year') return b.year - a.year;
+    return (b.totalPlays || 0) - (a.totalPlays || 0); // last-played proxy
+  });
+  return out;
+};
+
+const GamesIndexBody = ({ stateOverride, compact }) => {
+  const [q, setQ] = useState('');
+  const [status, setStatus] = useState('all');
+  const [sort, setSort] = useState('last-played');
+  const [view, setView] = useState('grid');
+
+  // Force filter scenarios
+  useEffect(() => {
+    if (stateOverride === 'filtered-empty') {
+      setQ('xyznotfound');
+    } else {
+      setQ('');
+      setStatus('all');
+    }
+  }, [stateOverride]);
+
+  const isLoading = stateOverride === 'loading';
+  const isEmpty = stateOverride === 'empty';
+  const isError = stateOverride === 'error';
+  const isFilteredEmpty = stateOverride === 'filtered-empty';
+
+  const sourceList = isEmpty ? [] : ALL_GAMES;
+  const filtered = useMemo(() => filterAndSort(sourceList, q, status, sort),
+    [sourceList, q, status, sort]);
+
+  const stats = [
+    { label:'Giochi', value: ALL_GAMES.length, unit:'' },
+    { label:'Partite', value: ALL_GAMES.reduce((s,g) => s + (g.totalPlays || 0), 0), unit:'' },
+    { label:'Agenti', value: ALL_GAMES.reduce((s,g) => s + g.agentCount, 0), unit:'' },
+    { label:'KB Docs', value: ALL_GAMES.reduce((s,g) => s + g.kbCount, 0), unit:'' },
+  ];
+
+  return (
+    <>
+      <LibraryHero stats={stats} compact={compact}/>
+      {!isError && !isEmpty && (
+        <GameFilters
+          q={q} setQ={setQ}
+          status={status} setStatus={setStatus}
+          sort={sort} setSort={setSort}
+          view={view} setView={setView}
+          compact={compact}
+          count={filtered.length}
+        />
+      )}
+
+      <div style={{
+        padding: compact ? '14px 16px 24px' : '24px 32px 64px',
+      }}>
+        {isError && <ErrorState compact={compact}/>}
+
+        {isEmpty && <EmptyLibrary kind="library" compact={compact}/>}
+
+        {!isError && !isEmpty && isLoading && (
+          <div style={{
+            display:'grid',
+            gridTemplateColumns: compact ? 'repeat(2, 1fr)' : 'repeat(4, 1fr)',
+            gap: compact ? 10 : 16,
+          }}>
+            {Array.from({ length: compact ? 6 : 12 }).map((_, i) => (
+              <SkeletonCard key={i} compact={compact}/>
+            ))}
+          </div>
+        )}
+
+        {!isError && !isEmpty && !isLoading && (
+          filtered.length === 0 ? (
+            <EmptyLibrary kind="filtered" compact={compact}
+              onAction={() => { setQ(''); setStatus('all'); }}/>
+          ) : view === 'grid' || compact ? (
+            <div style={{
+              display:'grid',
+              gridTemplateColumns: compact ? 'repeat(2, 1fr)' : 'repeat(4, 1fr)',
+              gap: compact ? 10 : 16,
+            }}>
+              {filtered.map(g => <GameCardGrid key={g.id} game={g} compact={compact}/>)}
+            </div>
+          ) : (
+            // Desktop list view
+            <div style={{ display:'flex', flexDirection:'column', gap: 8 }}>
+              {filtered.map(g => <GameRow key={g.id} game={g}/>)}
+            </div>
+          )
+        )}
+      </div>
+    </>
+  );
+};
+
+// ─── GAME ROW (list view, desktop) ──────────────────
+const GameRow = ({ game }) => {
+  const connections = [
+    { entityType:'agent', count: game.agentCount, isEmpty: game.agentCount === 0 },
+    { entityType:'kb', count: game.kbCount, isEmpty: game.kbCount === 0 },
+    { entityType:'session', count: game.sessionCount, isEmpty: game.sessionCount === 0 },
+    { entityType:'chat', count: game.chatCount, isEmpty: game.chatCount === 0 },
+  ];
+  return (
+    <article tabIndex={0} className="mai-card-game" style={{
+      display:'grid', gridTemplateColumns:'80px 2fr 1fr 1.2fr',
+      gap: 14, alignItems:'center',
+      padding: 12,
+      background:'var(--bg-card)',
+      border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)',
+      cursor:'pointer',
+    }}>
+      <div style={{
+        width: 80, height: 60,
+        background: game.cover, borderRadius:'var(--r-md)',
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 30,
+      }}>{game.coverEmoji}</div>
+      <div>
+        <div style={{
+          fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 15,
+          color:'var(--text)', marginBottom: 3,
+        }}>{game.title}</div>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          fontWeight: 600,
+        }}>
+          {game.author} · {game.year} · {game.players} pl · {game.duration}
+        </div>
+      </div>
+      <div style={{ display:'flex', alignItems:'center', gap: 8 }}>
+        <Stars value={game.stars}/>
+        <span style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, fontWeight: 700, color:'var(--text-sec)',
+        }}>{game.rating}</span>
+        <span style={{
+          padding:'2px 8px', borderRadius:'var(--r-pill)',
+          background: 'var(--bg-muted)',
+          color:'var(--text-muted)',
+          fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 700,
+        }}>{game.totalPlays || 0} partite</span>
+      </div>
+      <ConnectionChipStrip connections={connections}/>
+    </article>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── DESKTOP / MOBILE SHELLS ─────────────────────────
+// ═══════════════════════════════════════════════════════
+const DesktopNav = ({ active = 'games' }) => {
+  const items = [
+    { id:'home', label:'Home' },
+    { id:'library', label:'Libreria' },
+    { id:'games', label:'Giochi' },
+    { id:'agents', label:'Agenti' },
+    { id:'sessions', label:'Sessioni' },
+    { id:'toolkit', label:'Toolkit' },
+  ];
+  return (
+    <div style={{
+      display:'flex', alignItems:'center', gap: 14,
+      padding:'10px 32px',
+      background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+      borderBottom:'1px solid var(--border)',
+    }}>
+      <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
+        <div style={{
+          width: 26, height: 26, borderRadius: 7,
+          background:'linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event)))',
+          color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+          fontWeight: 800, fontSize: 13, fontFamily:'var(--f-display)',
+        }}>M</div>
+        <span style={{ fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 14 }}>MeepleAI</span>
+      </div>
+      <div style={{ display:'flex', alignItems:'center', gap: 2, marginLeft: 18 }}>
+        {items.map(it => (
+          <a key={it.id} href="#" onClick={e=>e.preventDefault()}
+            aria-current={it.id === active ? 'page' : undefined}
+            style={{
+              padding:'6px 12px', borderRadius:'var(--r-md)',
+              fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700,
+              color: it.id === active ? entityHsl('game') : 'var(--text-sec)',
+              background: it.id === active ? entityHsl('game', 0.1) : 'transparent',
+              textDecoration:'none',
+            }}>{it.label}</a>
+        ))}
+      </div>
+      <div style={{ flex: 1 }}/>
+      <button type="button" style={{
+        padding:'7px 14px', borderRadius:'var(--r-md)',
+        background: entityHsl('game'), color:'#fff',
+        border:'none', fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+        cursor:'pointer', boxShadow:`0 3px 10px ${entityHsl('game', 0.35)}`,
+      }}>+ Nuovo gioco</button>
+    </div>
+  );
+};
+
+const DesktopScreen = ({ stateOverride }) => (
+  <div style={{ minHeight: 720, background:'var(--bg)' }}>
+    <DesktopNav/>
+    <GamesIndexBody stateOverride={stateOverride}/>
+  </div>
+);
+
+const PhoneSbar = () => (
+  <div className="phone-sbar" style={{ color:'var(--text)' }}>
+    <span style={{ fontFamily:'var(--f-mono)' }}>14:32</span>
+    <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+  </div>
+);
+const PhoneTopNav = () => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 9,
+    padding:'10px 14px', borderBottom:'1px solid var(--border)',
+    background:'var(--bg)',
+  }}>
+    <button aria-label="Indietro" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'transparent', border:'1px solid var(--border)',
+      color:'var(--text)', fontSize: 14, cursor:'pointer',
+    }}>←</button>
+    <div style={{ flex: 1, fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 700, textAlign:'center' }}>
+      Giochi
+    </div>
+    <button aria-label="Aggiungi" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background: entityHsl('game'), border:'none',
+      color:'#fff', fontSize: 16, cursor:'pointer', fontWeight: 800,
+    }}>＋</button>
+  </div>
+);
+const MobileBottomBar = () => {
+  const tabs = [
+    { id:'home', icon:'⌂', label:'Home' },
+    { id:'search', icon:'🔍', label:'Cerca' },
+    { id:'library', icon:'📚', label:'Libreria', active: true },
+    { id:'chat', icon:'💬', label:'Chat' },
+    { id:'profile', icon:'👤', label:'Profilo' },
+  ];
+  return (
+    <div style={{
+      position:'absolute', bottom: 0, left: 0, right: 0,
+      display:'flex',
+      padding:'8px 10px 12px',
+      background:'var(--glass-bg)', backdropFilter:'blur(14px)',
+      borderTop:'1px solid var(--border)',
+      zIndex: 5,
+    }}>
+      {tabs.map(t => (
+        <button key={t.id} style={{
+          flex: 1,
+          display:'flex', flexDirection:'column', alignItems:'center', gap: 2,
+          padding:'4px 0',
+          background:'transparent', border:'none',
+          color: t.active ? entityHsl('game') : 'var(--text-muted)',
+          fontFamily:'var(--f-display)', fontSize: 9, fontWeight: 700,
+          cursor:'pointer',
+        }}>
+          <span aria-hidden="true" style={{ fontSize: 16 }}>{t.icon}</span>
+          <span>{t.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+};
+const MobileScreen = ({ stateOverride }) => (
+  <>
+    <PhoneSbar/>
+    <div style={{ flex: 1, overflowY:'auto', position:'relative', background:'var(--bg)' }}>
+      <PhoneTopNav/>
+      <div style={{ paddingBottom: 70 }}>
+        <GamesIndexBody stateOverride={stateOverride} compact/>
+      </div>
+      <MobileBottomBar/>
+    </div>
+  </>
+);
+
+const PhoneShell = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 10 }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div className="phone">{children}</div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 340,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+const DesktopFrame = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 12, width:'100%' }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div style={{
+      width:'100%', maxWidth: 1280,
+      borderRadius:'var(--r-xl)', border:'1px solid var(--border)',
+      background:'var(--bg)', overflow:'hidden',
+      boxShadow:'var(--shadow-lg)',
+    }}>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 8,
+        padding:'9px 14px',
+        background:'var(--bg-muted)',
+        borderBottom:'1px solid var(--border)',
+        fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      }}>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-event))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-warning))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-toolkit))' }}/>
+        <span style={{ flex: 1, textAlign:'center', letterSpacing:'.04em' }}>meepleai.app/games</span>
+      </div>
+      {children}
+    </div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 720,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── ROOT ────────────────────────────────────────────
+const MOBILE_STATES = [
+  { id:'default', label:'01 · Default', desc:'24+ giochi, grid 2-col compact, ConnectionChipStrip nei footer card.' },
+  { id:'empty', label:'02 · Empty library', desc:'Illustrazione 🎲 + CTA "Aggiungi un gioco" entity-color.' },
+  { id:'loading', label:'03 · Loading', desc:'6 skeleton cards shimmer (cover gray + 2 line + 3 chip pills).' },
+  { id:'filtered-empty', label:'04 · Filtered empty', desc:'Query "xyznotfound" → empty state filtrato + "Azzera filtri".' },
+  { id:'error', label:'05 · Error', desc:'Banner danger inline + retry CTA. Hero/filtri restano visibili.' },
+];
+
+function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+  }, [dark]);
+  return (
+    <button onClick={() => setDark(d => !d)} className="theme-toggle"
+      aria-label={dark ? 'Tema chiaro' : 'Tema scuro'}>
+      <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span>
+      <span>{dark ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+}
+
+function App() {
+  return (
+    <div className="stage">
+      <ThemeToggle/>
+      <div className="stage-wrap">
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.08em', marginBottom: 8,
+        }}>SP4 wave 1 · #1/5 · Hero + body grid</div>
+        <h1>Games index — /games</h1>
+        <p className="lead">
+          Hero compatto + filtri sticky + grid 4-col MeepleCard variante <strong>grid</strong>.
+          Footer card: <strong>ConnectionChipStrip</strong> (PR #549/#552, riuso pixel-perfect).
+          5 stati mobile (default / empty / loading / filtered-empty / error) e 4 desktop.
+        </p>
+
+        <div className="section-label">Mobile · 375 — 5 stati</div>
+        <div className="phones-grid">
+          {MOBILE_STATES.map(s => (
+            <PhoneShell key={s.id} label={s.label} desc={s.desc}>
+              <MobileScreen stateOverride={s.id}/>
+            </PhoneShell>
+          ))}
+        </div>
+
+        <div className="section-label">Desktop · 1440 — 4 stati</div>
+        <div style={{ display:'flex', flexDirection:'column', gap: 36 }}>
+          <DesktopFrame label="06 · Desktop · Default"
+            desc="Hero stats inline, filtri sticky, grid 4-col. 24 giochi reali (Catan, Wingspan, Brass…) con ConnectionChipStrip per agent/kb/session/chat in ogni footer.">
+            <DesktopScreen stateOverride="default"/>
+          </DesktopFrame>
+          <DesktopFrame label="07 · Desktop · Empty library"
+            desc="Stato 'first-run': nessun gioco. Filtri nascosti. Empty state full-width entity-color con CTA primario.">
+            <DesktopScreen stateOverride="empty"/>
+          </DesktopFrame>
+          <DesktopFrame label="08 · Desktop · Loading"
+            desc="12 skeleton cards (4-col × 3 row) con shimmer. Hero e filtri visibili e interattivi (skeleton-aware).">
+            <DesktopScreen stateOverride="loading"/>
+          </DesktopFrame>
+          <DesktopFrame label="09 · Desktop · Filtered empty"
+            desc="Query 'xyznotfound' → empty filtrato (icona 🔎) con CTA 'Azzera filtri'. Hero e filtri restano. Sort/view ancora interagibili.">
+            <DesktopScreen stateOverride="filtered-empty"/>
+          </DesktopFrame>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes mai-shimmer-anim {
+          0%   { background-position: -200% 0; }
+          100% { background-position:  200% 0; }
+        }
+        .mai-shimmer {
+          background: linear-gradient(90deg, var(--bg-muted) 0%, var(--bg-hover) 50%, var(--bg-muted) 100%) !important;
+          background-size: 200% 100% !important;
+          animation: mai-shimmer-anim 1.4s linear infinite;
+        }
+        .phones-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+          gap: var(--s-7);
+          align-items: start;
+        }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage .lead { line-height: var(--lh-relax); }
+        .phone > div::-webkit-scrollbar { display: none; }
+        .mai-card-game {
+          outline: none;
+        }
+        .mai-card-game:hover {
+          transform: translateY(-2px);
+          border-color: hsl(var(--c-game) / .4) !important;
+          box-shadow: var(--shadow-md);
+        }
+        .mai-card-game:focus-visible {
+          outline: 2px solid hsl(var(--c-game));
+          outline-offset: 2px;
+        }
+        select:focus-visible, input:focus-visible, button:focus-visible, a:focus-visible {
+          outline: 2px solid hsl(var(--c-game));
+          outline-offset: 2px;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);

--- a/admin-mockups/design_files/sp4-library-desktop.html
+++ b/admin-mockups/design_files/sp4-library-desktop.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 wave 1 · #5/5 · Library desktop — /library</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-library-desktop.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-library-desktop.jsx
+++ b/admin-mockups/design_files/sp4-library-desktop.jsx
@@ -1,0 +1,1574 @@
+/* MeepleAI SP4 wave 1 — Schermata #5 / 5 (FINALE)
+   Route: /library
+   Pattern: Hub power-user multi-entity desktop
+
+   v2 nuovi (FINALE):
+   - LibraryHero            → apps/web/src/components/ui/v2/library-hero/
+   - EntityTabBar           → riusato da AgentTabs (entity-aware variant)
+   - CrossEntityFilters     → apps/web/src/components/ui/v2/cross-entity-filters/
+   - AdvancedFiltersDrawer  → apps/web/src/components/ui/v2/advanced-filters-drawer/  ⭐ standalone reusable
+   - LibraryGrid            → apps/web/src/components/ui/v2/library-grid/ (3 view modes)
+   - BulkSelectionBar       → apps/web/src/components/ui/v2/bulk-selection-bar/
+   - RecentActivityRail     → apps/web/src/components/ui/v2/recent-activity-rail/
+
+   Riusi prod: MeepleCard.grid/list (PR #523), ConnectionChipStrip footer (PR #549/#552), EntityChip.
+
+   Nota: AdvancedFiltersDrawer è progettato come componente STANDALONE reusable.
+   Riceve: open, onClose, sections[], activeFilters, onApply, entityScope.
+   Riusabile in: sp4-games-index, sp4-agents-index, sp4-library-desktop, future surface.
+*/
+
+const { useState, useEffect, useRef, useMemo } = React;
+const DS = window.DS;
+
+const entityHsl = (type, alpha) => {
+  const c = DS.EC[type] || DS.EC.game;
+  return alpha !== undefined
+    ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${alpha})`
+    : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── LIBRARY HERO (compact 140) ───────────────────────
+// /* v2: LibraryHero */
+// ═══════════════════════════════════════════════════════
+const LibraryHero = ({ stats, compact }) => (
+  <div style={{
+    padding: compact ? '16px 16px' : '24px 32px',
+    background:`linear-gradient(135deg, ${entityHsl('game', 0.10)} 0%, ${entityHsl('agent', 0.06)} 50%, ${entityHsl('kb', 0.08)} 100%)`,
+    borderBottom:'1px solid var(--border-light)',
+    position:'relative', overflow:'hidden',
+  }}>
+    <div aria-hidden="true" style={{
+      position:'absolute', top:-40, right:-40,
+      width: 240, height: 240, borderRadius:'50%',
+      background:`radial-gradient(circle, ${entityHsl('game', 0.1)} 0%, transparent 70%)`,
+      pointerEvents:'none',
+    }}/>
+    <div style={{
+      position:'relative', zIndex: 1,
+      display:'flex', alignItems: compact ? 'flex-start' : 'flex-end',
+      flexDirection: compact ? 'column' : 'row',
+      gap: compact ? 14 : 24,
+      flexWrap:'wrap',
+    }}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{
+          display:'inline-flex', alignItems:'center', gap: 5,
+          padding:'2px 8px', borderRadius:'var(--r-pill)',
+          background:'var(--bg-card)', border:'1px solid var(--border)',
+          fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+          fontWeight: 800, textTransform:'uppercase', letterSpacing:'.08em',
+          marginBottom: 8,
+        }}>
+          <span aria-hidden="true">📚</span>Library · power-user view
+        </div>
+        <h1 style={{
+          fontFamily:'var(--f-display)', fontWeight: 800,
+          fontSize: compact ? 26 : 38,
+          letterSpacing:'-.02em', lineHeight: 1.05,
+          margin:'0 0 4px', color:'var(--text)',
+        }}>La tua libreria</h1>
+        <p style={{
+          fontFamily:'var(--f-body)', fontSize: compact ? 13 : 14.5,
+          color:'var(--text-sec)', margin: 0, fontWeight: 500,
+        }}>Tutti i tuoi giochi, agenti e documenti in un posto.</p>
+      </div>
+
+      {/* Stats inline */}
+      <div style={{
+        display:'flex', gap: compact ? 8 : 14, flexWrap:'wrap',
+      }}>
+        {stats.map(s => (
+          <div key={s.label} style={{
+            display:'flex', alignItems:'center', gap: 6,
+            padding:'7px 11px', borderRadius:'var(--r-md)',
+            background:'var(--bg-card)',
+            border:`1px solid ${entityHsl(s.entity, 0.2)}`,
+          }}>
+            <span aria-hidden="true" style={{ fontSize: 14 }}>{DS.EC[s.entity].em}</span>
+            <span style={{
+              fontFamily:'var(--f-mono)', fontSize: 14, fontWeight: 800,
+              color: entityHsl(s.entity), fontVariantNumeric:'tabular-nums',
+            }}>{s.count}</span>
+            <span style={{
+              fontFamily:'var(--f-display)', fontSize: 11.5, fontWeight: 700,
+              color:'var(--text-sec)',
+            }}>{s.label}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* Action bar */}
+      {!compact && (
+        <div style={{ display:'flex', gap: 8, flexShrink: 0, width:'100%', justifyContent:'flex-end' }}>
+          <button type="button" style={{
+            padding:'9px 16px', borderRadius:'var(--r-md)',
+            background: entityHsl('game'), color:'#fff', border:'none',
+            fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+            cursor:'pointer', display:'inline-flex', alignItems:'center', gap: 6,
+            boxShadow:`0 4px 14px ${entityHsl('game', 0.4)}`,
+          }}><span aria-hidden="true">+</span>Aggiungi gioco</button>
+          <button type="button" style={{
+            padding:'9px 14px', borderRadius:'var(--r-md)',
+            background:'var(--bg-card)', color:'var(--text)',
+            border:'1px solid var(--border-strong)',
+            fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700,
+            cursor:'pointer',
+          }}>↓ Importa BGG</button>
+          <button type="button" aria-label="Esporta" style={{
+            padding:'9px 12px', borderRadius:'var(--r-md)',
+            background:'var(--bg-card)', color:'var(--text)',
+            border:'1px solid var(--border-strong)',
+            fontSize: 14, cursor:'pointer', minWidth: 38,
+          }}>↗</button>
+        </div>
+      )}
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── ENTITY TAB BAR ───────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const EntityTabBar = ({ tabs, active, onChange, compact }) => {
+  const refs = useRef({});
+  const [ind, setInd] = useState({ left: 0, width: 0 });
+  useEffect(() => {
+    const el = refs.current[active];
+    if (el) setInd({ left: el.offsetLeft, width: el.offsetWidth });
+  }, [active, tabs.length, compact]);
+
+  const accent = active === 'all' ? 'game' : active;
+
+  return (
+    <div className="mai-cb-scroll" style={{
+      position:'relative',
+      display:'flex', alignItems:'center', gap: 2,
+      borderBottom:'1px solid var(--border)',
+      overflowX:'auto', scrollbarWidth:'none',
+      padding: compact ? '0 16px' : '0 32px',
+      background:'var(--bg)',
+    }} role="tablist">
+      {tabs.map(t => {
+        const isActive = t.id === active;
+        const ent = t.id === 'all' ? 'game' : t.id;
+        return (
+          <button key={t.id} type="button"
+            ref={el => { refs.current[t.id] = el; }}
+            onClick={() => onChange(t.id)}
+            role="tab" aria-selected={isActive}
+            style={{
+              display:'inline-flex', alignItems:'center', gap: 7,
+              padding:'12px 14px',
+              background: isActive ? entityHsl(ent, 0.08) : 'transparent',
+              border:'none',
+              color: isActive ? entityHsl(ent) : 'var(--text-sec)',
+              fontFamily:'var(--f-display)', fontSize: 13,
+              fontWeight: isActive ? 800 : 700,
+              cursor:'pointer', whiteSpace:'nowrap', flexShrink: 0,
+              borderRadius:'var(--r-sm) var(--r-sm) 0 0',
+            }}>
+            <span aria-hidden="true">{t.icon}</span>{t.label}
+            <span style={{
+              padding:'1px 7px', borderRadius:'var(--r-pill)',
+              background: isActive ? entityHsl(ent) : 'var(--bg-muted)',
+              color: isActive ? '#fff' : 'var(--text-muted)',
+              fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+              fontVariantNumeric:'tabular-nums',
+            }}>{t.count}</span>
+          </button>
+        );
+      })}
+      <span aria-hidden="true" style={{
+        position:'absolute', bottom: -1, left: ind.left, width: ind.width,
+        height: 2, background: entityHsl(accent),
+        transition:'left .3s cubic-bezier(.4,0,.2,1), width .3s cubic-bezier(.4,0,.2,1), background .3s',
+        borderRadius:'2px 2px 0 0',
+      }}/>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── CROSS-ENTITY FILTERS ROW ────────────────────────
+// /* v2: CrossEntityFilters */
+// ═══════════════════════════════════════════════════════
+const FilterChip = ({ label, value, onClick, hasValue }) => (
+  <button type="button" onClick={onClick} style={{
+    display:'inline-flex', alignItems:'center', gap: 5,
+    padding:'7px 11px', borderRadius:'var(--r-md)',
+    background: hasValue ? entityHsl('game', 0.1) : 'var(--bg-card)',
+    border: hasValue ? `1px solid ${entityHsl('game', 0.3)}` : '1px solid var(--border)',
+    color: hasValue ? entityHsl('game') : 'var(--text-sec)',
+    fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 700,
+    cursor:'pointer', whiteSpace:'nowrap', flexShrink: 0,
+  }}>
+    <span style={{
+      fontFamily:'var(--f-mono)', fontSize: 9,
+      textTransform:'uppercase', letterSpacing:'.06em',
+      color: hasValue ? entityHsl('game') : 'var(--text-muted)',
+      fontWeight: 800,
+    }}>{label}</span>
+    <span>{value}</span>
+    <span aria-hidden="true" style={{ fontSize: 10, opacity: .6 }}>▾</span>
+  </button>
+);
+
+const CrossEntityFilters = ({ activeFilterCount, onOpenDrawer, view, onViewChange, compact, search, onSearchChange }) => (
+  <div style={{
+    padding: compact ? '10px 16px' : '12px 32px',
+    background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+    borderBottom:'1px solid var(--border-light)',
+    display:'flex', flexDirection:'column', gap: 8,
+  }}>
+    {/* Search */}
+    <div style={{ position:'relative' }}>
+      <span aria-hidden="true" style={{
+        position:'absolute', left: 12, top:'50%', transform:'translateY(-50%)',
+        color:'var(--text-muted)', fontSize: 14, pointerEvents:'none',
+      }}>⌕</span>
+      <input
+        type="search" placeholder="Cerca in libreria... (premi /)"
+        value={search} onChange={e => onSearchChange(e.target.value)}
+        style={{
+          width:'100%', padding:'9px 12px 9px 34px',
+          borderRadius:'var(--r-md)', border:'1px solid var(--border)',
+          background:'var(--bg-card)', color:'var(--text)',
+          fontFamily:'var(--f-body)', fontSize: 13,
+        }}/>
+      <kbd aria-hidden="true" style={{
+        position:'absolute', right: 12, top:'50%', transform:'translateY(-50%)',
+        padding:'1px 6px', borderRadius: 4,
+        background:'var(--bg-muted)', border:'1px solid var(--border)',
+        fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+        fontWeight: 700,
+      }}>/</kbd>
+    </div>
+
+    {/* Filters row */}
+    <div className="mai-cb-scroll" style={{
+      display:'flex', alignItems:'center', gap: 6,
+      overflowX:'auto', scrollbarWidth:'none',
+    }}>
+      <FilterChip label="STATO" value="Tutti"/>
+      <FilterChip label="GIOCO" value="Tutti"/>
+      <FilterChip label="DATA" value="Sempre"/>
+      <FilterChip label="SORT" value="Recenti" hasValue/>
+      <span style={{
+        width: 1, height: 22, background:'var(--border)', flexShrink: 0, margin:'0 4px',
+      }}/>
+      <button type="button" onClick={onOpenDrawer} style={{
+        display:'inline-flex', alignItems:'center', gap: 6,
+        padding:'7px 11px', borderRadius:'var(--r-md)',
+        background: activeFilterCount > 0 ? entityHsl('agent', 0.1) : 'var(--bg-card)',
+        border: activeFilterCount > 0 ? `1px solid ${entityHsl('agent', 0.4)}` : '1px solid var(--border-strong)',
+        color: activeFilterCount > 0 ? entityHsl('agent') : 'var(--text)',
+        fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800,
+        cursor:'pointer', whiteSpace:'nowrap', flexShrink: 0,
+      }}>
+        <span aria-hidden="true">⚙</span>Filtri avanzati
+        {activeFilterCount > 0 && (
+          <span style={{
+            padding:'1px 6px', borderRadius:'var(--r-pill)',
+            background: entityHsl('agent'), color:'#fff',
+            fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+          }}>{activeFilterCount}</span>
+        )}
+      </button>
+
+      <div style={{ flex: 1 }}/>
+
+      {/* View toggle */}
+      <div role="radiogroup" aria-label="Vista" style={{
+        display:'inline-flex', borderRadius:'var(--r-md)',
+        border:'1px solid var(--border)', background:'var(--bg-card)',
+        overflow:'hidden', flexShrink: 0,
+      }}>
+        {[
+          { id:'grid', icon:'▦', label:'Grid' },
+          { id:'list', icon:'☰', label:'List' },
+          { id:'compact', icon:'≡', label:'Compact' },
+        ].map(v => {
+          const active = view === v.id;
+          return (
+            <button key={v.id} type="button" role="radio" aria-checked={active}
+              onClick={() => onViewChange(v.id)}
+              aria-label={v.label}
+              style={{
+                padding:'7px 10px',
+                background: active ? entityHsl('game', 0.12) : 'transparent',
+                color: active ? entityHsl('game') : 'var(--text-muted)',
+                border:'none', cursor:'pointer',
+                fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700,
+              }}>{v.icon}</button>
+          );
+        })}
+      </div>
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── ⭐ ADVANCED FILTERS DRAWER (standalone v2) ───────
+// /* v2: AdvancedFiltersDrawer
+//    apps/web/src/components/ui/v2/advanced-filters-drawer/
+//    Reusable: receives { open, onClose, sections, activeFilters, onApply, entityScope }
+//    Same component used in games-index, agents-index, library-desktop. */
+// ═══════════════════════════════════════════════════════
+const DRAWER_SECTIONS = [
+  {
+    id:'status', title:'Stato', icon:'●',
+    kind:'chips-multi',
+    options:[
+      { id:'owned', label:'Posseduto', icon:'✓', color:'game' },
+      { id:'wishlist', label:'Wishlist', icon:'★', color:'event' },
+      { id:'setup', label:'In setup', icon:'⚙', color:'agent' },
+      { id:'archived', label:'Archiviato', icon:'⊘', color:'kb' },
+    ],
+  },
+  {
+    id:'entity', title:'Tipo entità', icon:'⌗',
+    kind:'chips-multi',
+    options:[
+      { id:'game', label:'Giochi', icon:'🎲', color:'game' },
+      { id:'agent', label:'Agenti', icon:'🤖', color:'agent' },
+      { id:'kb', label:'Documenti KB', icon:'📚', color:'kb' },
+      { id:'session', label:'Sessioni', icon:'🎯', color:'session' },
+      { id:'chat', label:'Chat', icon:'💬', color:'chat' },
+    ],
+  },
+  {
+    id:'game', title:'Gioco', icon:'🎲',
+    kind:'select-multi',
+    placeholder:'Filtra per gioco specifico...',
+    options: DS.games.map(g => ({ id: g.id, label: g.title })),
+  },
+  {
+    id:'period', title:'Periodo', icon:'📅',
+    kind:'period-quick',
+    options:[
+      { id:'7d', label:'Ultimi 7 giorni' },
+      { id:'30d', label:'Ultimi 30 giorni' },
+      { id:'1y', label:'Ultimo anno' },
+      { id:'all', label:'Sempre' },
+      { id:'range', label:'Range personalizzato...' },
+    ],
+  },
+  {
+    id:'tags', title:'Tag', icon:'🏷',
+    kind:'chips-multi',
+    options:[
+      { id:'family', label:'Family', color:'event' },
+      { id:'strategy', label:'Strategy', color:'session' },
+      { id:'coop', label:'Coop', color:'kb' },
+      { id:'engine', label:'Engine builder', color:'agent' },
+      { id:'auction', label:'Auction', color:'toolkit' },
+      { id:'roll-and-write', label:'Roll & Write', color:'player' },
+      { id:'card-driven', label:'Card driven', color:'chat' },
+      { id:'tableau', label:'Tableau', color:'game' },
+    ],
+  },
+  {
+    id:'rating', title:'Rating', icon:'★',
+    kind:'range',
+    min: 1, max: 10, step: 0.5,
+    valueDefault: [6, 10],
+  },
+  {
+    id:'weight', title:'Complessità', icon:'⚖',
+    kind:'chips-multi',
+    options:[
+      { id:'light', label:'Light · 1.0–2.0', color:'kb' },
+      { id:'medium', label:'Medium · 2.0–3.0', color:'agent' },
+      { id:'heavy', label:'Heavy · 3.0–4.0', color:'game' },
+      { id:'extra', label:'Extra heavy · 4.0+', color:'event' },
+    ],
+  },
+];
+
+const DrawerSection = ({ section, value, onChange, defaultOpen }) => {
+  const [open, setOpen] = useState(defaultOpen ?? true);
+  return (
+    <div style={{
+      borderBottom:'1px solid var(--border-light)',
+    }}>
+      <button type="button" onClick={() => setOpen(o => !o)}
+        style={{
+          width:'100%', padding:'14px 18px',
+          background:'transparent', border:'none', cursor:'pointer',
+          display:'flex', alignItems:'center', gap: 10,
+          color:'var(--text)',
+        }}>
+        <span aria-hidden="true" style={{
+          fontSize: 13, color:'var(--text-muted)',
+        }}>{section.icon}</span>
+        <span style={{
+          flex: 1, textAlign:'left',
+          fontFamily:'var(--f-display)', fontSize: 13.5, fontWeight: 800,
+        }}>{section.title}</span>
+        {Array.isArray(value) && value.length > 0 && (
+          <span style={{
+            padding:'1px 7px', borderRadius:'var(--r-pill)',
+            background: entityHsl('agent'), color:'#fff',
+            fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+          }}>{value.length}</span>
+        )}
+        <span aria-hidden="true" style={{
+          transform: open ? 'rotate(90deg)' : 'rotate(0)',
+          transition:'transform var(--dur-sm)',
+          color:'var(--text-muted)', fontSize: 14,
+        }}>›</span>
+      </button>
+      {open && (
+        <div style={{ padding:'0 18px 16px' }}>
+          {section.kind === 'chips-multi' && (
+            <div style={{ display:'flex', flexWrap:'wrap', gap: 6 }}>
+              {section.options.map(o => {
+                const active = (value || []).includes(o.id);
+                const c = o.color || 'game';
+                return (
+                  <button key={o.id} type="button"
+                    onClick={() => onChange(active
+                      ? (value || []).filter(v => v !== o.id)
+                      : [...(value || []), o.id])}
+                    aria-pressed={active}
+                    style={{
+                      display:'inline-flex', alignItems:'center', gap: 5,
+                      padding:'6px 10px', borderRadius:'var(--r-pill)',
+                      background: active ? entityHsl(c, 0.14) : 'var(--bg-card)',
+                      border: active ? `1px solid ${entityHsl(c, 0.4)}` : '1px solid var(--border)',
+                      color: active ? entityHsl(c) : 'var(--text-sec)',
+                      fontFamily:'var(--f-display)', fontSize: 11.5, fontWeight: 700,
+                      cursor:'pointer',
+                    }}>
+                    {o.icon && <span aria-hidden="true">{o.icon}</span>}
+                    {o.label}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+          {section.kind === 'select-multi' && (
+            <div>
+              <div style={{
+                padding:'8px 10px', borderRadius:'var(--r-md)',
+                border:'1px solid var(--border)', background:'var(--bg-card)',
+                fontSize: 12, color:'var(--text-muted)', marginBottom: 8,
+                cursor:'pointer',
+              }}>{section.placeholder}</div>
+              <div style={{ display:'flex', flexWrap:'wrap', gap: 5 }}>
+                {section.options.slice(0, 5).map(o => {
+                  const active = (value || []).includes(o.id);
+                  return (
+                    <button key={o.id} type="button"
+                      onClick={() => onChange(active
+                        ? (value || []).filter(v => v !== o.id)
+                        : [...(value || []), o.id])}
+                      style={{
+                        padding:'4px 9px', borderRadius:'var(--r-pill)',
+                        background: active ? entityHsl('game', 0.12) : 'var(--bg-muted)',
+                        border: active ? `1px solid ${entityHsl('game', 0.4)}` : '1px solid transparent',
+                        color: active ? entityHsl('game') : 'var(--text-sec)',
+                        fontFamily:'var(--f-mono)', fontSize: 10.5, fontWeight: 700,
+                        cursor:'pointer',
+                      }}>{active && '✓ '}{o.label}</button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+          {section.kind === 'period-quick' && (
+            <div style={{ display:'flex', flexDirection:'column', gap: 4 }}>
+              {section.options.map(o => {
+                const active = value === o.id;
+                return (
+                  <button key={o.id} type="button"
+                    onClick={() => onChange(o.id)}
+                    aria-pressed={active}
+                    style={{
+                      display:'flex', alignItems:'center', gap: 8,
+                      padding:'7px 10px', borderRadius:'var(--r-md)',
+                      background: active ? entityHsl('event', 0.12) : 'transparent',
+                      border:'none',
+                      color: active ? entityHsl('event') : 'var(--text-sec)',
+                      fontFamily:'var(--f-display)', fontSize: 12.5, fontWeight: active ? 800 : 600,
+                      cursor:'pointer', textAlign:'left',
+                    }}>
+                    <span aria-hidden="true" style={{
+                      width: 10, height: 10, borderRadius:'50%',
+                      border: active ? `3px solid ${entityHsl('event')}` : '1.5px solid var(--border-strong)',
+                      flexShrink: 0,
+                    }}/>
+                    {o.label}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+          {section.kind === 'range' && (() => {
+            const [lo, hi] = value || section.valueDefault;
+            return (
+              <div>
+                <div style={{
+                  display:'flex', justifyContent:'space-between', marginBottom: 8,
+                  fontFamily:'var(--f-mono)', fontSize: 11, fontWeight: 700,
+                }}>
+                  <span style={{ color: entityHsl('event') }}>{lo}</span>
+                  <span style={{ color:'var(--text-muted)' }}>—</span>
+                  <span style={{ color: entityHsl('event') }}>{hi}</span>
+                </div>
+                <div style={{ position:'relative', height: 24 }}>
+                  <div style={{
+                    position:'absolute', top: 11, left: 0, right: 0, height: 4,
+                    borderRadius: 2, background:'var(--bg-muted)',
+                  }}/>
+                  <div style={{
+                    position:'absolute', top: 11,
+                    left: `${((lo - section.min) / (section.max - section.min)) * 100}%`,
+                    right: `${100 - ((hi - section.min) / (section.max - section.min)) * 100}%`,
+                    height: 4, borderRadius: 2,
+                    background: entityHsl('event'),
+                  }}/>
+                  {[lo, hi].map((v, i) => (
+                    <div key={i} aria-hidden="true" style={{
+                      position:'absolute', top: 6,
+                      left: `calc(${((v - section.min) / (section.max - section.min)) * 100}% - 7px)`,
+                      width: 14, height: 14, borderRadius:'50%',
+                      background: entityHsl('event'), border:'2px solid var(--bg)',
+                      boxShadow:'0 1px 4px rgba(0,0,0,.2)',
+                    }}/>
+                  ))}
+                </div>
+              </div>
+            );
+          })()}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const AdvancedFiltersDrawer = ({ open, onClose, activeFilters, onApply, compact }) => {
+  const [draft, setDraft] = useState(activeFilters || {});
+  useEffect(() => { setDraft(activeFilters || {}); }, [activeFilters, open]);
+  const count = Object.values(draft).reduce((acc, v) => {
+    if (Array.isArray(v)) return acc + v.length;
+    if (v) return acc + 1;
+    return acc;
+  }, 0);
+
+  if (!open) return null;
+  return (
+    <>
+      <div onClick={onClose} aria-hidden="true" style={{
+        position:'absolute', inset: 0, background:'rgba(0,0,0,.4)',
+        zIndex: 50, animation:'mai-fade-in .2s var(--ease-out)',
+      }}/>
+      <aside role="dialog" aria-label="Filtri avanzati" style={{
+        position:'absolute', top: 0, right: 0, bottom: 0,
+        width: compact ? '100%' : 400,
+        background:'var(--bg)', borderLeft:'1px solid var(--border)',
+        boxShadow:'-12px 0 40px rgba(0,0,0,.18)',
+        zIndex: 51, display:'flex', flexDirection:'column',
+        animation: compact ? 'mai-slide-up .25s var(--ease-out)' : 'mai-slide-left .25s var(--ease-out)',
+      }}>
+        {/* Header */}
+        <div style={{
+          padding:'14px 18px', borderBottom:'1px solid var(--border)',
+          display:'flex', alignItems:'center', gap: 10,
+        }}>
+          <span aria-hidden="true" style={{
+            width: 32, height: 32, borderRadius:'var(--r-md)',
+            background: entityHsl('agent', 0.12), color: entityHsl('agent'),
+            display:'flex', alignItems:'center', justifyContent:'center',
+            fontSize: 14,
+          }}>⚙</span>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800 }}>Filtri avanzati</div>
+            <div style={{
+              fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+              fontWeight: 700, textTransform:'uppercase', letterSpacing:'.06em',
+            }}>{count} attivi · scope: library</div>
+          </div>
+          <button onClick={onClose} aria-label="Chiudi" style={{
+            width: 30, height: 30, borderRadius:'var(--r-md)',
+            background:'var(--bg-muted)', border:'none', color:'var(--text)',
+            fontSize: 14, cursor:'pointer',
+          }}>✕</button>
+        </div>
+
+        {/* Body */}
+        <div style={{ flex: 1, overflowY:'auto' }}>
+          {DRAWER_SECTIONS.map((s, i) => (
+            <DrawerSection key={s.id} section={s}
+              value={draft[s.id]}
+              onChange={v => setDraft(d => ({ ...d, [s.id]: v }))}
+              defaultOpen={i < 3}/>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div style={{
+          padding:'12px 18px', borderTop:'1px solid var(--border)',
+          background:'var(--bg-card)',
+          display:'flex', gap: 8,
+        }}>
+          <button type="button" onClick={() => setDraft({})} style={{
+            padding:'9px 14px', borderRadius:'var(--r-md)',
+            background:'transparent', color:'var(--text-sec)',
+            border:'1px solid var(--border-strong)',
+            fontFamily:'var(--f-display)', fontSize: 12.5, fontWeight: 700,
+            cursor:'pointer',
+          }}>Reset</button>
+          <button type="button"
+            onClick={() => { onApply(draft); onClose(); }}
+            style={{
+              flex: 1, padding:'9px 14px', borderRadius:'var(--r-md)',
+              background: entityHsl('agent'), color:'#fff', border:'none',
+              fontFamily:'var(--f-display)', fontSize: 12.5, fontWeight: 800,
+              cursor:'pointer',
+              boxShadow: `0 3px 10px ${entityHsl('agent', 0.35)}`,
+            }}>Applica{count > 0 && ` (${count})`}</button>
+        </div>
+      </aside>
+    </>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── MeepleCard variants ─────────────────────────────
+// ═══════════════════════════════════════════════════════
+const StatusDot = ({ status }) => {
+  const map = {
+    owned: 'hsl(140, 50%, 45%)', active: 'hsl(140, 50%, 45%)', indexed:'hsl(140, 50%, 45%)',
+    wishlist: 'hsl(38, 90%, 55%)', setup: 'hsl(38, 90%, 55%)', processing:'hsl(38, 90%, 55%)',
+    archived:'var(--text-muted)', failed:'hsl(var(--c-danger))',
+    inprogress: entityHsl('session'), paused:'var(--text-muted)', completed:'hsl(140, 50%, 45%)',
+    idle:'var(--text-muted)',
+  };
+  return <span aria-hidden="true" style={{
+    width: 6, height: 6, borderRadius:'50%',
+    background: map[status] || 'var(--text-muted)',
+    flexShrink: 0,
+  }}/>;
+};
+
+const MeepleCardGrid = ({ entity, selectable, selected, onSelect }) => {
+  const ent = entity.type;
+  return (
+    <article tabIndex={0} className="mai-card-grid" style={{
+      position:'relative',
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)', overflow:'hidden',
+      display:'flex', flexDirection:'column',
+      cursor:'pointer',
+      borderColor: selected ? entityHsl(ent, 0.5) : 'var(--border)',
+      boxShadow: selected ? `0 0 0 2px ${entityHsl(ent, 0.3)}` : 'none',
+    }}>
+      {/* Top accent bar */}
+      <div aria-hidden="true" style={{
+        position:'absolute', top: 0, left: 0, right: 0, height: 3,
+        background: entityHsl(ent),
+        zIndex: 2,
+      }}/>
+      {/* Cover */}
+      <div style={{
+        height: 100, background: entity.cover, position:'relative',
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 38,
+      }} aria-hidden="true">
+        <span style={{ filter:'drop-shadow(0 2px 6px rgba(0,0,0,.3))' }}>{entity.coverEmoji || DS.EC[ent].em}</span>
+        {/* Entity badge */}
+        <div style={{
+          position:'absolute', top: 8, left: 8,
+          display:'inline-flex', alignItems:'center', gap: 4,
+          padding:'2px 7px', borderRadius:'var(--r-pill)',
+          background:'rgba(255,255,255,.85)', backdropFilter:'blur(6px)',
+          fontFamily:'var(--f-mono)', fontSize: 8.5, fontWeight: 800,
+          color: entityHsl(ent),
+          textTransform:'uppercase', letterSpacing:'.06em',
+        }}>
+          <span aria-hidden="true">{DS.EC[ent].em}</span>{DS.EC[ent].lb}
+        </div>
+        {/* Selection checkbox */}
+        {selectable && (
+          <button type="button" onClick={(e) => { e.stopPropagation(); onSelect(); }}
+            aria-label={selected ? 'Deseleziona' : 'Seleziona'}
+            style={{
+              position:'absolute', top: 8, right: 8,
+              width: 24, height: 24, borderRadius:'var(--r-sm)',
+              background: selected ? entityHsl(ent) : 'rgba(255,255,255,.85)',
+              border: selected ? 'none' : '1.5px solid rgba(255,255,255,.95)',
+              backdropFilter:'blur(6px)',
+              color: selected ? '#fff' : entityHsl(ent),
+              cursor:'pointer', fontSize: 13, fontWeight: 800,
+              display:'flex', alignItems:'center', justifyContent:'center',
+            }}>{selected ? '✓' : ''}</button>
+        )}
+        {/* 3-dot menu (hover) */}
+        {!selectable && (
+          <button type="button" onClick={(e) => e.stopPropagation()}
+            aria-label="Azioni" className="mai-card-menu"
+            style={{
+              position:'absolute', top: 8, right: 8,
+              width: 24, height: 24, borderRadius:'var(--r-sm)',
+              background:'rgba(255,255,255,.85)', backdropFilter:'blur(6px)',
+              border:'none', color:'var(--text)',
+              cursor:'pointer', fontSize: 14, fontWeight: 800,
+              display:'flex', alignItems:'center', justifyContent:'center',
+            }}>⋯</button>
+        )}
+      </div>
+      {/* Body */}
+      <div style={{ padding: 12, display:'flex', flexDirection:'column', gap: 4, flex: 1 }}>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 13.5, fontWeight: 800,
+          color:'var(--text)', margin: 0, lineHeight: 1.2,
+          display:'-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient:'vertical', overflow:'hidden',
+        }}>{entity.title}</h3>
+        <div style={{
+          fontSize: 11, color:'var(--text-muted)', margin:0,
+          display:'-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient:'vertical', overflow:'hidden',
+          lineHeight: 1.4,
+        }}>{entity.subtitle || `${entity.publisher || ''}${entity.year ? ' · ' + entity.year : ''}`}</div>
+        <div style={{ flex: 1 }}/>
+        <div style={{
+          display:'flex', alignItems:'center', gap: 5,
+          padding:'5px 0 0', borderTop:'1px solid var(--border-light)', marginTop: 4,
+        }}>
+          <StatusDot status={entity.status}/>
+          <span style={{
+            fontFamily:'var(--f-mono)', fontSize: 9.5, color:'var(--text-muted)',
+            textTransform:'uppercase', letterSpacing:'.06em', fontWeight: 700,
+          }}>{entity.badge || entity.status}</span>
+        </div>
+      </div>
+    </article>
+  );
+};
+
+const MeepleCardList = ({ entity, selectable, selected, onSelect }) => {
+  const ent = entity.type;
+  return (
+    <article tabIndex={0} className="mai-card-list" style={{
+      display:'flex', alignItems:'center', gap: 12, padding: 10,
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      borderColor: selected ? entityHsl(ent, 0.5) : 'var(--border)',
+      borderRadius:'var(--r-lg)', cursor:'pointer',
+      borderLeft: `3px solid ${entityHsl(ent)}`,
+    }}>
+      {selectable && (
+        <button type="button" onClick={(e) => { e.stopPropagation(); onSelect(); }}
+          aria-label={selected ? 'Deseleziona' : 'Seleziona'}
+          style={{
+            width: 22, height: 22, borderRadius:'var(--r-sm)',
+            background: selected ? entityHsl(ent) : 'transparent',
+            border: selected ? 'none' : `1.5px solid var(--border-strong)`,
+            color: selected ? '#fff' : 'transparent',
+            cursor:'pointer', fontSize: 12, fontWeight: 800,
+            display:'flex', alignItems:'center', justifyContent:'center',
+            flexShrink: 0,
+          }}>{selected ? '✓' : ''}</button>
+      )}
+      <div style={{
+        width: 42, height: 42, borderRadius:'var(--r-md)',
+        background: entity.cover,
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 20, flexShrink: 0,
+      }} aria-hidden="true">{entity.coverEmoji || DS.EC[ent].em}</div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{
+          display:'flex', alignItems:'center', gap: 6, marginBottom: 2, flexWrap:'wrap',
+        }}>
+          <span style={{
+            display:'inline-flex', alignItems:'center', gap: 3,
+            padding:'1px 6px', borderRadius:'var(--r-pill)',
+            background: entityHsl(ent, 0.12), color: entityHsl(ent),
+            fontFamily:'var(--f-mono)', fontSize: 8.5, fontWeight: 800,
+            textTransform:'uppercase', letterSpacing:'.06em',
+          }}>{DS.EC[ent].em}{DS.EC[ent].lb}</span>
+          <h3 style={{
+            fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+            color:'var(--text)', margin: 0,
+            whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis',
+            maxWidth: 280,
+          }}>{entity.title}</h3>
+        </div>
+        <div style={{
+          fontSize: 11, color:'var(--text-muted)', fontWeight: 500,
+          whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis',
+        }}>{entity.subtitle || `${entity.publisher || ''}${entity.year ? ' · ' + entity.year : ''}`}</div>
+      </div>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 5, flexShrink: 0,
+      }}>
+        <StatusDot status={entity.status}/>
+        <span style={{
+          fontFamily:'var(--f-mono)', fontSize: 9.5, color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.06em', fontWeight: 700,
+        }}>{entity.badge}</span>
+      </div>
+    </article>
+  );
+};
+
+const MeepleCardCompact = ({ entity, selectable, selected, onSelect }) => {
+  const ent = entity.type;
+  return (
+    <article tabIndex={0} style={{
+      display:'flex', alignItems:'center', gap: 10, padding:'7px 10px',
+      background: selected ? entityHsl(ent, 0.06) : 'transparent',
+      borderBottom:'1px solid var(--border-light)', cursor:'pointer',
+    }}>
+      {selectable && (
+        <input type="checkbox" checked={selected} onChange={onSelect} onClick={(e) => e.stopPropagation()}
+          style={{ accentColor: entityHsl(ent), flexShrink: 0 }}/>
+      )}
+      <span aria-hidden="true" style={{ fontSize: 14, width: 18, textAlign:'center', flexShrink: 0 }}>{DS.EC[ent].em}</span>
+      <span style={{
+        fontFamily:'var(--f-display)', fontSize: 12.5, fontWeight: 700,
+        color:'var(--text)', flex: 1,
+        whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis',
+      }}>{entity.title}</span>
+      <span style={{
+        fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)', fontWeight: 600,
+        whiteSpace:'nowrap', flexShrink: 0,
+      }}>{entity.subtitle || ''}</span>
+      <StatusDot status={entity.status}/>
+    </article>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── LIBRARY GRID ─────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const LibraryGrid = ({ items, view, selectable, selectedIds, onToggleSelect, compact, columns }) => {
+  if (view === 'list') {
+    return (
+      <div style={{ display:'flex', flexDirection:'column', gap: 6 }}>
+        {items.map(it => (
+          <MeepleCardList key={it.id} entity={it}
+            selectable={selectable}
+            selected={selectedIds.has(it.id)}
+            onSelect={() => onToggleSelect(it.id)}/>
+        ))}
+      </div>
+    );
+  }
+  if (view === 'compact') {
+    return (
+      <div style={{
+        background:'var(--bg-card)', border:'1px solid var(--border)',
+        borderRadius:'var(--r-lg)', overflow:'hidden',
+      }}>
+        {items.map(it => (
+          <MeepleCardCompact key={it.id} entity={it}
+            selectable={selectable}
+            selected={selectedIds.has(it.id)}
+            onSelect={() => onToggleSelect(it.id)}/>
+        ))}
+      </div>
+    );
+  }
+  return (
+    <div style={{
+      display:'grid',
+      gridTemplateColumns: compact
+        ? 'repeat(auto-fill, minmax(150px, 1fr))'
+        : `repeat(${columns}, minmax(0, 1fr))`,
+      gap: compact ? 8 : 12,
+    }}>
+      {items.map(it => (
+        <MeepleCardGrid key={it.id} entity={it}
+          selectable={selectable}
+          selected={selectedIds.has(it.id)}
+          onSelect={() => onToggleSelect(it.id)}/>
+      ))}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── BULK SELECTION BAR ───────────────────────────────
+// /* v2: BulkSelectionBar */
+// ═══════════════════════════════════════════════════════
+const BulkSelectionBar = ({ count, onClear, compact }) => {
+  if (count === 0) return null;
+  return (
+    <div role="region" aria-label="Selezione multipla" style={{
+      position:'absolute', bottom: 16, left: '50%', transform:'translateX(-50%)',
+      padding:'10px 14px', borderRadius:'var(--r-xl)',
+      background:'var(--text)',
+      color:'var(--bg)',
+      boxShadow:'0 12px 32px rgba(0,0,0,.3)',
+      display:'flex', alignItems:'center', gap: 10,
+      zIndex: 30, maxWidth: compact ? 'calc(100% - 32px)' : 720,
+      animation:'mai-slide-up .25s var(--ease-spring)',
+    }}>
+      <span style={{
+        padding:'2px 8px', borderRadius:'var(--r-pill)',
+        background: entityHsl('game'), color:'#fff',
+        fontFamily:'var(--f-mono)', fontSize: 11, fontWeight: 800,
+        fontVariantNumeric:'tabular-nums', flexShrink: 0,
+      }}>{count}</span>
+      <span style={{
+        fontFamily:'var(--f-display)', fontSize: 12.5, fontWeight: 700,
+        flex: 1, whiteSpace:'nowrap',
+      }}>{compact ? 'sel.' : 'selezionati'}</span>
+      {[
+        { icon:'⊘', label:'Archivia' },
+        { icon:'🏷', label:'Tag' },
+        { icon:'↗', label:'Esporta' },
+      ].map(a => (
+        <button key={a.label} type="button" style={{
+          padding: compact ? '6px 8px' : '6px 10px',
+          borderRadius:'var(--r-md)',
+          background:'rgba(255,255,255,.12)', color:'inherit', border:'none',
+          fontFamily:'var(--f-display)', fontSize: 11.5, fontWeight: 700,
+          cursor:'pointer', display:'inline-flex', alignItems:'center', gap: 5,
+          flexShrink: 0,
+        }}>
+          <span aria-hidden="true">{a.icon}</span>{!compact && a.label}
+        </button>
+      ))}
+      <button onClick={onClear} aria-label="Annulla selezione" style={{
+        padding:'6px 10px', borderRadius:'var(--r-md)',
+        background:'transparent', color:'inherit',
+        border:'1px solid rgba(255,255,255,.2)',
+        fontSize: 12, cursor:'pointer', flexShrink: 0,
+      }}>✕</button>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── RECENT ACTIVITY RAIL (right sidebar collapsible) ─
+// /* v2: RecentActivityRail */
+// ═══════════════════════════════════════════════════════
+const RecentActivityRail = () => (
+  <aside style={{
+    width: 280, flexShrink: 0,
+    background:'var(--bg-card)', borderLeft:'1px solid var(--border)',
+    padding: '18px 16px', overflowY:'auto',
+  }}>
+    <div style={{
+      display:'flex', alignItems:'center', justifyContent:'space-between',
+      marginBottom: 14,
+    }}>
+      <h3 style={{
+        fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+        color:'var(--text)', margin: 0,
+        display:'flex', alignItems:'center', gap: 6,
+      }}><span aria-hidden="true">🕐</span>Ultime modifiche</h3>
+      <button aria-label="Comprimi pannello" style={{
+        width: 24, height: 24, borderRadius:'var(--r-sm)',
+        background:'transparent', border:'1px solid var(--border)',
+        color:'var(--text-muted)', cursor:'pointer', fontSize: 11,
+      }}>›</button>
+    </div>
+    <div style={{ position:'relative' }}>
+      {DS.activity.slice(0, 6).map((a, i) => {
+        const ec = DS.EC[a.kind] || DS.EC.game;
+        return (
+          <div key={a.id} style={{ display:'flex', gap: 9, marginBottom: 10 }}>
+            <div style={{
+              display:'flex', flexDirection:'column', alignItems:'center', flexShrink: 0,
+            }}>
+              <div style={{
+                width: 22, height: 22, borderRadius:'50%',
+                background: entityHsl(a.kind, 0.14), color: entityHsl(a.kind),
+                display:'flex', alignItems:'center', justifyContent:'center',
+                fontSize: 10, border:`1.5px solid ${entityHsl(a.kind, 0.3)}`,
+              }} aria-hidden="true">{ec.em}</div>
+              {i < 5 && (
+                <div style={{ width: 1.5, flex: 1, background:'var(--border)', minHeight: 14, marginTop: 2 }}/>
+              )}
+            </div>
+            <div style={{ flex: 1, minWidth: 0, paddingBottom: 2 }}>
+              <div style={{
+                fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+                fontWeight: 700, textTransform:'uppercase', letterSpacing:'.06em',
+              }}>{a.at}</div>
+              <div style={{ fontSize: 11.5, color:'var(--text)', lineHeight: 1.4 }}>
+                <strong>{a.who}</strong> {a.what}{' '}
+                <a href="#" onClick={e=>e.preventDefault()} style={{
+                  color: entityHsl(a.kind), fontWeight: 700, textDecoration:'none',
+                }}>{DS.byId[a.ref]?.title || a.ref}</a>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+    <div style={{
+      marginTop: 12, padding:'10px 12px', borderRadius:'var(--r-md)',
+      background:'var(--bg-muted)',
+      fontSize: 11, color:'var(--text-muted)', lineHeight: 1.5,
+    }}>
+      <strong style={{ color:'var(--text-sec)', display:'block', marginBottom: 3 }}>⌨ Shortcuts</strong>
+      <div style={{ display:'flex', flexDirection:'column', gap: 2, fontFamily:'var(--f-mono)', fontSize: 10 }}>
+        <span><kbd style={kbdSt}>/</kbd> focus search</span>
+        <span><kbd style={kbdSt}>f</kbd> filtri avanzati</span>
+        <span><kbd style={kbdSt}>?</kbd> tutte le scorciatoie</span>
+      </div>
+    </div>
+  </aside>
+);
+
+const kbdSt = {
+  padding:'1px 5px', borderRadius: 3,
+  background:'var(--bg-card)', border:'1px solid var(--border)',
+  fontFamily:'var(--f-mono)', fontWeight: 800, color:'var(--text-sec)',
+  marginRight: 4,
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── EMPTY / LOADING / ERROR ──────────────────────────
+// ═══════════════════════════════════════════════════════
+const EmptyLibrary = ({ kind, compact }) => {
+  if (kind === 'first-run') {
+    return (
+      <div style={{
+        padding:'48px 24px', textAlign:'center',
+        background:'var(--bg-card)',
+        border:'1px dashed var(--border-strong)',
+        borderRadius:'var(--r-xl)',
+        display:'flex', flexDirection:'column', alignItems:'center',
+      }}>
+        <div style={{
+          width: 96, height: 96, borderRadius:'50%',
+          background:`radial-gradient(circle, ${entityHsl('game', 0.18)} 0%, transparent 70%)`,
+          display:'flex', alignItems:'center', justifyContent:'center',
+          fontSize: 44, marginBottom: 14,
+        }} aria-hidden="true">📚</div>
+        <h2 style={{
+          fontFamily:'var(--f-display)', fontSize: 20, fontWeight: 800,
+          color:'var(--text)', margin:'0 0 6px',
+        }}>La tua libreria è vuota</h2>
+        <p style={{
+          fontSize: 13.5, color:'var(--text-sec)', margin:'0 0 18px', maxWidth: 380, lineHeight: 1.55,
+        }}>Inizia aggiungendo il tuo primo gioco. Importa la collezione da BoardGameGeek o cerca per titolo.</p>
+        <div style={{ display:'flex', gap: 8, marginBottom: 22, flexWrap:'wrap', justifyContent:'center' }}>
+          <button type="button" style={{
+            padding:'9px 16px', borderRadius:'var(--r-md)',
+            background: entityHsl('game'), color:'#fff', border:'none',
+            fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+            cursor:'pointer', boxShadow:`0 4px 14px ${entityHsl('game', 0.4)}`,
+          }}>+ Aggiungi il tuo primo gioco</button>
+          <button type="button" style={{
+            padding:'9px 14px', borderRadius:'var(--r-md)',
+            background:'var(--bg)', color:'var(--text)',
+            border:'1px solid var(--border-strong)',
+            fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700, cursor:'pointer',
+          }}>↓ Importa da BGG</button>
+        </div>
+        {/* Suggested */}
+        <div style={{ width:'100%', maxWidth: 480 }}>
+          <div style={{
+            fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+            fontWeight: 800, textTransform:'uppercase', letterSpacing:'.08em',
+            marginBottom: 8, textAlign:'left',
+          }}>Suggerimenti dalla community</div>
+          <div style={{
+            display:'grid',
+            gridTemplateColumns: compact ? 'repeat(2, 1fr)' : 'repeat(3, 1fr)',
+            gap: 8,
+          }}>
+            {DS.games.slice(0, compact ? 4 : 3).map(g => (
+              <div key={g.id} style={{
+                padding: 10, borderRadius:'var(--r-md)',
+                background:'var(--bg)', border:'1px solid var(--border)',
+                cursor:'pointer', display:'flex', alignItems:'center', gap: 8,
+              }}>
+                <div style={{
+                  width: 32, height: 32, borderRadius:'var(--r-sm)',
+                  background: g.cover, display:'flex', alignItems:'center', justifyContent:'center',
+                  fontSize: 16, flexShrink: 0,
+                }} aria-hidden="true">{g.coverEmoji}</div>
+                <div style={{ flex: 1, minWidth: 0, textAlign:'left' }}>
+                  <div style={{
+                    fontFamily:'var(--f-display)', fontSize: 11.5, fontWeight: 800,
+                    color:'var(--text)', whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis',
+                  }}>{g.title}</div>
+                  <div style={{
+                    fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)', fontWeight: 700,
+                  }}>★ {g.rating}</div>
+                </div>
+                <span aria-hidden="true" style={{ color: entityHsl('game'), fontSize: 12, fontWeight: 800 }}>+</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+  if (kind === 'no-results') {
+    return (
+      <div style={{
+        padding:'40px 24px', textAlign:'center',
+        background:'var(--bg-card)',
+        border:'1px dashed var(--border-strong)',
+        borderRadius:'var(--r-xl)',
+        display:'flex', flexDirection:'column', alignItems:'center',
+      }}>
+        <div style={{
+          width: 60, height: 60, borderRadius:'50%',
+          background: entityHsl('agent', 0.12), color: entityHsl('agent'),
+          display:'flex', alignItems:'center', justifyContent:'center',
+          fontSize: 26, marginBottom: 12,
+        }} aria-hidden="true">⌕</div>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800,
+          color:'var(--text)', margin:'0 0 4px',
+        }}>Nessun risultato</h3>
+        <p style={{ fontSize: 12.5, color:'var(--text-muted)', margin:'0 0 14px', maxWidth: 320 }}>
+          Nessun elemento corrisponde ai filtri selezionati. Prova a rimuovere alcuni vincoli.
+        </p>
+        <button type="button" style={{
+          padding:'8px 14px', borderRadius:'var(--r-md)',
+          background:'transparent', color: entityHsl('agent'), border:`1px solid ${entityHsl('agent', 0.4)}`,
+          fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer',
+        }}>↻ Reset filtri</button>
+      </div>
+    );
+  }
+  if (kind === 'tab-empty-agents') {
+    return (
+      <div style={{
+        padding:'40px 24px', textAlign:'center',
+        background:'var(--bg-card)',
+        border:'1px dashed var(--border-strong)',
+        borderRadius:'var(--r-xl)',
+        display:'flex', flexDirection:'column', alignItems:'center',
+      }}>
+        <div style={{
+          width: 60, height: 60, borderRadius:'50%',
+          background: entityHsl('agent', 0.14), color: entityHsl('agent'),
+          display:'flex', alignItems:'center', justifyContent:'center',
+          fontSize: 28, marginBottom: 12,
+        }} aria-hidden="true">🤖</div>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800,
+          color:'var(--text)', margin:'0 0 4px',
+        }}>Nessun agente ancora</h3>
+        <p style={{ fontSize: 12.5, color:'var(--text-muted)', margin:'0 0 14px', maxWidth: 320 }}>
+          Crea un agente per ogni gioco — risponderà a domande sulle regole usando i tuoi documenti.
+        </p>
+        <button type="button" style={{
+          padding:'8px 16px', borderRadius:'var(--r-md)',
+          background: entityHsl('agent'), color:'#fff', border:'none',
+          fontFamily:'var(--f-display)', fontSize: 12.5, fontWeight: 800, cursor:'pointer',
+          boxShadow:`0 3px 10px ${entityHsl('agent', 0.35)}`,
+        }}>+ Crea il tuo primo agente</button>
+      </div>
+    );
+  }
+  return null;
+};
+
+const LoadingGrid = ({ columns, compact }) => (
+  <div style={{
+    display:'grid',
+    gridTemplateColumns: compact
+      ? 'repeat(auto-fill, minmax(150px, 1fr))'
+      : `repeat(${columns}, minmax(0, 1fr))`,
+    gap: compact ? 8 : 12,
+  }}>
+    {Array.from({ length: columns * 2 }).map((_, i) => (
+      <div key={i} className="mai-shimmer" style={{
+        height: 180, borderRadius:'var(--r-lg)', background:'var(--bg-muted)',
+      }}/>
+    ))}
+  </div>
+);
+
+const ErrorState = () => (
+  <div style={{
+    padding:'40px 24px', textAlign:'center',
+    background:'hsl(var(--c-danger) / .06)',
+    border:'1px solid hsl(var(--c-danger) / .25)',
+    borderRadius:'var(--r-xl)',
+    display:'flex', flexDirection:'column', alignItems:'center',
+  }}>
+    <div style={{
+      width: 56, height: 56, borderRadius:'50%',
+      background:'hsl(var(--c-danger) / .15)', color:'hsl(var(--c-danger))',
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 26, marginBottom: 12,
+    }} aria-hidden="true">⚠</div>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: 15, fontWeight: 800,
+      color:'var(--text)', margin:'0 0 4px',
+    }}>Errore caricamento libreria</h3>
+    <p style={{ fontSize: 12.5, color:'var(--text-muted)', margin:'0 0 12px', maxWidth: 320 }}>
+      Impossibile recuperare i dati. Verifica la connessione.
+    </p>
+    <button type="button" style={{
+      padding:'7px 14px', borderRadius:'var(--r-md)',
+      background:'hsl(var(--c-danger))', color:'#fff', border:'none',
+      fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer',
+    }}>↻ Riprova</button>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── BODY ─────────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const LibraryBody = ({ stateOverride, initialTab='all', initialView='grid', drawerOpen=false, withRail, compact, columns=4, withBulk=false }) => {
+  const [tab, setTab] = useState(initialTab);
+  const [view, setView] = useState(initialView);
+  const [drawer, setDrawer] = useState(drawerOpen);
+  const [search, setSearch] = useState('');
+  const [filters, setFilters] = useState({
+    status: ['owned'],
+    entity: ['game', 'agent', 'kb'],
+  });
+  const [selected, setSelected] = useState(new Set(withBulk ? ['g-azul', 'g-wingspan', 'a-azul-rules'] : []));
+
+  useEffect(() => { setTab(initialTab); }, [initialTab]);
+  useEffect(() => { setView(initialView); }, [initialView]);
+  useEffect(() => { setDrawer(drawerOpen); }, [drawerOpen]);
+
+  const items = useMemo(() => {
+    if (tab === 'game') return DS.games;
+    if (tab === 'agent') return DS.agents;
+    if (tab === 'kb') return DS.kbs;
+    if (tab === 'session') return DS.sessions;
+    if (tab === 'chat') return DS.chats;
+    // all → mix
+    return [
+      ...DS.games.slice(0, 4),
+      ...DS.agents.slice(0, 3),
+      ...DS.kbs.slice(0, 3),
+      ...DS.sessions.slice(0, 2),
+      ...DS.chats.slice(0, 2),
+    ];
+  }, [tab]);
+
+  const tabs = [
+    { id:'all',     icon:'⌗',  label:'Tutti',    count: 88 },
+    { id:'game',    icon:'🎲', label:'Giochi',   count: DS.games.length },
+    { id:'agent',   icon:'🤖', label:'Agenti',   count: DS.agents.length },
+    { id:'kb',      icon:'📚', label:'KB',       count: DS.kbs.length },
+    { id:'session', icon:'🎯', label:'Sessioni', count: DS.sessions.length },
+    { id:'chat',    icon:'💬', label:'Chat',     count: DS.chats.length },
+  ];
+
+  const stats = [
+    { entity:'game', count: DS.games.length, label:'giochi' },
+    { entity:'agent', count: DS.agents.length, label:'agenti' },
+    { entity:'kb', count: DS.kbs.length, label:'documenti' },
+    { entity:'chat', count: 312, label:'chat' },
+  ];
+
+  const activeFilterCount = Object.values(filters).reduce((acc, v) => {
+    if (Array.isArray(v)) return acc + v.length;
+    if (v) return acc + 1;
+    return acc;
+  }, 0);
+
+  const toggleSelect = (id) => {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  };
+
+  const renderBody = () => {
+    if (stateOverride === 'loading') return <LoadingGrid columns={columns} compact={compact}/>;
+    if (stateOverride === 'error') return <ErrorState/>;
+    if (stateOverride === 'empty-first-run') return <EmptyLibrary kind="first-run" compact={compact}/>;
+    if (stateOverride === 'empty-filtered') return <EmptyLibrary kind="no-results"/>;
+    if (stateOverride === 'empty-tab-agents') return <EmptyLibrary kind="tab-empty-agents"/>;
+    return <LibraryGrid items={items} view={view}
+      selectable={withBulk} selectedIds={selected} onToggleSelect={toggleSelect}
+      compact={compact} columns={columns}/>;
+  };
+
+  return (
+    <div style={{
+      flex: 1, display:'flex', flexDirection:'column', position:'relative',
+      background:'var(--bg)', minHeight: 0,
+    }}>
+      <LibraryHero stats={stats} compact={compact}/>
+      <div style={{ position:'sticky', top: 0, zIndex: 9, background:'var(--bg)' }}>
+        <EntityTabBar tabs={tabs} active={tab} onChange={setTab} compact={compact}/>
+      </div>
+      <div style={{ position:'sticky', top: 45, zIndex: 8 }}>
+        <CrossEntityFilters
+          activeFilterCount={activeFilterCount}
+          onOpenDrawer={() => setDrawer(true)}
+          view={view} onViewChange={setView}
+          compact={compact}
+          search={search} onSearchChange={setSearch}/>
+      </div>
+      <div style={{
+        display:'flex', flex: 1, minHeight: 0,
+      }}>
+        <div style={{
+          flex: 1, padding: compact ? '14px 16px 80px' : '20px 32px 80px',
+          overflowY:'auto',
+        }}>
+          {renderBody()}
+        </div>
+        {withRail && !compact && <RecentActivityRail/>}
+      </div>
+
+      <BulkSelectionBar count={selected.size} onClear={() => setSelected(new Set())} compact={compact}/>
+      <AdvancedFiltersDrawer
+        open={drawer} onClose={() => setDrawer(false)}
+        activeFilters={filters} onApply={setFilters}
+        compact={compact}/>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── FRAMES ───────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const TopNav = ({ compact }) => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 14,
+    padding: compact ? '9px 14px' : '10px 32px',
+    background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+    borderBottom:'1px solid var(--border)',
+  }}>
+    <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
+      <div style={{
+        width: 26, height: 26, borderRadius: 7,
+        background:'linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event)))',
+        color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+        fontWeight: 800, fontSize: 13, fontFamily:'var(--f-display)',
+      }}>M</div>
+      {!compact && <span style={{ fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 14 }}>MeepleAI</span>}
+    </div>
+    <div style={{
+      flex: 1, fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      marginLeft: compact ? 0 : 14, fontWeight: 700,
+      whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis',
+    }}>
+      <strong style={{ color:'var(--text-sec)' }}>Library</strong>
+    </div>
+    {!compact && (
+      <span aria-label="Notifiche" style={{
+        padding:'4px 8px', borderRadius:'var(--r-pill)',
+        background:'var(--bg-muted)', color:'var(--text-sec)',
+        fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 700,
+      }}>⌨ ? scorciatoie</span>
+    )}
+  </div>
+);
+
+const PhoneSbar = () => (
+  <div className="phone-sbar" style={{ color:'var(--text)' }}>
+    <span style={{ fontFamily:'var(--f-mono)' }}>14:32</span>
+    <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+  </div>
+);
+
+const PhoneScreen = (props) => (
+  <>
+    <PhoneSbar/>
+    <div style={{ flex: 1, overflow:'hidden', display:'flex', flexDirection:'column', position:'relative', background:'var(--bg)' }}>
+      <TopNav compact/>
+      <LibraryBody {...props} compact columns={2}/>
+    </div>
+  </>
+);
+
+const DesktopFrameInner = (props) => (
+  <div style={{ display:'flex', flexDirection:'column', minHeight: 740, position:'relative', background:'var(--bg)' }}>
+    <TopNav/>
+    <LibraryBody {...props}/>
+  </div>
+);
+
+const PhoneShell = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 10 }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div className="phone">{children}</div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 340,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+const DesktopFrame = ({ label, desc, children, fullWidth }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 12, width:'100%' }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div style={{
+      width:'100%', maxWidth: fullWidth ? 1600 : 1280,
+      borderRadius:'var(--r-xl)', border:'1px solid var(--border)',
+      background:'var(--bg)', overflow:'hidden',
+      boxShadow:'var(--shadow-lg)',
+    }}>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 8,
+        padding:'9px 14px', background:'var(--bg-muted)',
+        borderBottom:'1px solid var(--border)',
+        fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      }}>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-event))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-warning))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-toolkit))' }}/>
+        <span style={{ flex: 1, textAlign:'center', letterSpacing:'.04em' }}>meepleai.app/library</span>
+      </div>
+      {children}
+    </div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 720,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── ROOT ──────────────────────────────────────────────
+const MOBILE_STATES = [
+  { id:'m1', tab:'all', view:'grid', label:'01 · All · Grid 2-col', desc:'Hero compatto + tabs entity-aware + filter chips orizzontali + 2-col grid mix entity (giochi+agenti+KB+sessioni+chat).' },
+  { id:'m2', tab:'game', view:'grid', label:'02 · Giochi · Grid', desc:'Tab Giochi attiva (underline + bg subtle entity-game). Filtri sticky + 2-col cards entity-game con accent bar.' },
+  { id:'m3', tab:'agent', view:'list', label:'03 · Agenti · List', desc:'Tab Agenti attiva, vista list più densa con border-left entity-agent + status dot + badge mono.' },
+  { id:'m4', tab:'all', view:'compact', label:'04 · Compact view', desc:'Vista compact: una row per item, dot status + emoji entity. Massima densità per power-user.' },
+  { id:'m5', tab:'all', view:'grid', drawerOpen:true, label:'05 · Drawer aperto', desc:'AdvancedFiltersDrawer come bottom-sheet 100% width: 7 sezioni accordion (Stato/Entity/Gioco/Periodo/Tag/Rating/Complessità). Footer fisso Reset + Applica(N).' },
+  { id:'m6', tab:'all', view:'grid', state:'empty-first-run', label:'06 · Empty first-run', desc:'Hero + tabs visibili. Body: illustrazione + CTA Aggiungi/Importa + 4 suggerimenti BGG con add inline.' },
+  { id:'m7', tab:'all', view:'grid', state:'empty-filtered', label:'07 · Nessun risultato', desc:'Filtri attivi visibili nel chip "SORT". Body empty centered con CTA Reset filtri colore agent.' },
+  { id:'m8', tab:'all', view:'grid', state:'loading', label:'08 · Loading', desc:'Hero pieno + tabs + filtri reali, body 4 skeleton card altezza 180.' },
+];
+
+function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+  }, [dark]);
+  return (
+    <button onClick={() => setDark(d => !d)} className="theme-toggle"
+      aria-label={dark ? 'Tema chiaro' : 'Tema scuro'}>
+      <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span>
+      <span>{dark ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+}
+
+function App() {
+  return (
+    <div className="stage">
+      <ThemeToggle/>
+      <div className="stage-wrap">
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.08em', marginBottom: 8,
+        }}>SP4 wave 1 · #5/5 (FINALE) · Hub power-user multi-entity</div>
+        <h1>Library desktop — /library</h1>
+        <p className="lead">
+          Hub power-user: hero compatto stats inline · tabs entity-aware (Tutti/Giochi/Agenti/KB/Sessioni/Chat) · filtri sticky cross-entity · search ⌘/.
+          ⭐ <strong>AdvancedFiltersDrawer</strong> standalone reusable (7 sezioni accordion: status/entity/game/period/tags/rating/weight) — usabile anche in games-index e agents-index.
+          3 view modes (Grid/List/Compact) · bulk select con sticky bar · activity rail collapsible · keyboard shortcuts.
+        </p>
+
+        <div className="section-label">Mobile · 375 — 8 stati / variazioni</div>
+        <div className="phones-grid">
+          {MOBILE_STATES.map(s => (
+            <PhoneShell key={s.id} label={s.label} desc={s.desc}>
+              <PhoneScreen
+                stateOverride={s.state || null}
+                initialTab={s.tab}
+                initialView={s.view}
+                drawerOpen={s.drawerOpen || false}/>
+            </PhoneShell>
+          ))}
+        </div>
+
+        <div className="section-label">Desktop · 1440 — 5 stati chiave</div>
+        <div style={{ display:'flex', flexDirection:'column', gap: 36 }}>
+          <DesktopFrame label="09 · Desktop · All · Grid 4-col + Activity rail"
+            desc="Vista power-user completa: hero pieno (stats + 3 CTA), 6 tabs, filtri cross-entity sticky, grid 4-col mix entity. Sidebar destra 'Ultime modifiche' timeline + scorciatoie.">
+            <DesktopFrameInner stateOverride={null} initialTab="all" initialView="grid" withRail/>
+          </DesktopFrame>
+
+          <DesktopFrame label="10 · Desktop · Giochi · Grid + Bulk select"
+            desc="Tab Giochi · 3 card pre-selezionate (border + glow + checkbox visibile). Bulk selection bar floating bottom: count chip game, [Archivia] [Tag] [Esporta] + [✕].">
+            <DesktopFrameInner stateOverride={null} initialTab="game" initialView="grid" withBulk/>
+          </DesktopFrame>
+
+          <DesktopFrame label="11 · Desktop · AdvancedFiltersDrawer aperto"
+            desc="⭐ Componente standalone v2: side panel 400px right, 7 sezioni accordion. Stato (chips multi) · Entity (chips multi · 5 tipi) · Gioco (search+chips) · Periodo (radio quick) · Tag (chips) · Rating (range slider 1-10) · Complessità (chips). Footer Reset + Applica(N).">
+            <DesktopFrameInner stateOverride={null} initialTab="all" initialView="grid" drawerOpen/>
+          </DesktopFrame>
+
+          <DesktopFrame label="12 · Desktop · List view + Search active"
+            desc="Vista list: rows dense con avatar 42 + entity chip + title + subtitle + status. Hover lift entity-coloured. Adatta a power-user con tanti item.">
+            <DesktopFrameInner stateOverride={null} initialTab="all" initialView="list" withRail/>
+          </DesktopFrame>
+
+          <DesktopFrame label="13 · Desktop · Empty first-run"
+            desc="Nuovo utente: hero (stats a zero) + tabs visibili (count 0) + body con illustrazione 96 + CTA Aggiungi/Importa + 3 suggerimenti BGG con +.">
+            <DesktopFrameInner stateOverride="empty-first-run" initialTab="all" initialView="grid"/>
+          </DesktopFrame>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes mai-shimmer-anim {
+          0%   { background-position: -200% 0; }
+          100% { background-position:  200% 0; }
+        }
+        @keyframes mai-fade-in { from { opacity: 0; } to { opacity: 1; } }
+        @keyframes mai-slide-left { from { transform: translateX(100%); } to { transform: translateX(0); } }
+        @keyframes mai-slide-up { from { transform: translateY(100%); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+        .mai-shimmer {
+          background: linear-gradient(90deg, var(--bg-muted) 0%, var(--bg-hover) 50%, var(--bg-muted) 100%) !important;
+          background-size: 200% 100% !important;
+          animation: mai-shimmer-anim 1.4s linear infinite;
+        }
+        .phones-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+          gap: var(--s-7);
+          align-items: start;
+        }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage .lead { line-height: var(--lh-relax); }
+        .phone > div::-webkit-scrollbar { display: none; }
+        .mai-cb-scroll::-webkit-scrollbar { display: none; }
+        .mai-card-grid {
+          outline: none;
+          transition: transform var(--dur-sm) var(--ease-out), border-color var(--dur-sm), box-shadow var(--dur-sm);
+        }
+        .mai-card-grid:hover {
+          transform: translateY(-2px);
+          border-color: hsl(var(--c-game) / .35);
+          box-shadow: 0 8px 22px hsl(var(--c-game) / .14);
+        }
+        .mai-card-list {
+          outline: none;
+          transition: transform var(--dur-sm) var(--ease-out), border-color var(--dur-sm), box-shadow var(--dur-sm);
+        }
+        .mai-card-list:hover {
+          transform: translateX(2px);
+          box-shadow: var(--shadow-xs);
+        }
+        .mai-card-grid:focus-visible, .mai-card-list:focus-visible {
+          outline: 2px solid hsl(var(--c-game));
+          outline-offset: 2px;
+        }
+        .mai-card-menu { opacity: 0; transition: opacity var(--dur-sm); }
+        .mai-card-grid:hover .mai-card-menu { opacity: 1; }
+        button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible {
+          outline: 2px solid hsl(var(--c-agent));
+          outline-offset: 2px;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);


### PR DESCRIPTION
## Summary

SP4 wave 1 mockup batch — Entity Detail Desktop. Brief: `admin-mockups/briefs/SP4-entity-desktop.md`.

5 mockup HTML+JSX prodotti via Claude Design seguendo il pattern review per-mockup (matching SP3 workflow). Solo file in `admin-mockups/design_files/` — **nessun codice prod toccato**.

## Mockups (10 file, 6,282 LOC)

| # | File | Route | Pattern |
|---|------|-------|---------|
| 1 | `sp4-games-index` | `/games` | Hero + grid + AdvancedFiltersDrawer mention |
| 2 | `sp4-game-detail` | `/games/[id]` | Hero + 5 tabs (Info/Sessions/Chat/Stats/Documents), ConnectionBar 1:1, own/community |
| 3 | `sp4-agents-index` | `/agents` | Hero + grid agenti, ConnectionChipStrip footer, status filters |
| 4 | `sp4-agent-detail` | `/agents/[id]` | Character sheet, ConnectionBar 1:1, draft/active/archived |
| 5 | `sp4-library-desktop` | `/library` | Hub multi-entity, **AdvancedFiltersDrawer standalone** ⭐ |

## ConnectionBar reproduction 1:1 (PR #549/#552)

- `borderRadius: 999`, bg `entityHsl(type, 0.1)`
- `isEmpty` → dashed + opacity 0.6 + Plus icon
- aria-label include count, tabular-nums

## Componenti v2 emersi (handoff backlog)

⭐ **AdvancedFiltersDrawer** — standalone reusable, API `{ open, onClose, sections[], activeFilters, onApply, entityScope }`, side panel 400px desktop / bottom-sheet mobile, 7 sezioni accordion.

Altri: LibraryHero, AgentHero, AgentsHero, GameHero, GameTabs, GameSpecsCard, HouseRulesList, GameStatsKpi, GameLeaderboard, PersonaCard, SystemPromptViewer, KbDocList, ChatHistoryTimeline, AgentSettingsForm, AgentDangerZone, AgentFilters, CrossEntityFilters, EntityTabBar, AgentCardGrid, LibraryGrid, BulkSelectionBar, RecentActivityRail, EmptyAgents.

## Decisioni / micro-deviazioni (tutte approvate in review)

- **#1**: 4-core sticky filters + AdvancedFiltersDrawer (vs 6 inline) — mobile UX
- **#2**: locked tabs visible+disabled per community variant — feature discovery > segregazione
- **#3**: status badge inline (vs top-right floating) — leggibilità
- **#4**: timeline rail entity-chat (vs flat list) — pattern character sheet
- **#5**: drawer mobile bottom-sheet (vs slide-left) — thumb-zone ergonomics

## DoD

- [x] Tokens 100% da `tokens.css`
- [x] Light + dark funzionanti
- [x] Mobile 375px + desktop 1440px presenti
- [x] Stati default/empty/loading/error per surface
- [x] ConnectionBar 1:1 con prod
- [x] Naming convention `sp4-<scope>` rispettato

## Test plan

- [ ] Visual review HTML in browser (light + dark, mobile + desktop)
- [ ] Verifica ConnectionBar styling matches prod ConnectionBar component
- [ ] Verifica nessun secret/token reale nei file (already grep-checked: clean)

## Out of scope (wave 2)

- Session triade (C1 index, C2 live, C3 summary) — confermato come wave 2 scope
- Player (D), Toolkit (E), KB (F), Game Nights (G), Discover (I) — wave 3+

🤖 Generated with [Claude Code](https://claude.com/claude-code)