### PR TITLE
fix(mechanic-extractor): classify pipeline crashes as PipelineCrashed (#597)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicAnalysisExecutor.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicAnalysisExecutor.cs
@@ -349,6 +349,8 @@ internal sealed class MechanicAnalysisExecutor : IMechanicAnalysisExecutor
 
     private async Task HandleUnexpectedFailureAsync(Guid analysisId, Exception originalException)
     {
+        var rejectionReason = ClassifyUnexpectedFailureReason(originalException);
+
         try
         {
             // Same rationale as HandleCancellationAsync: a pipeline crash may leave half-staged
@@ -366,7 +368,7 @@ internal sealed class MechanicAnalysisExecutor : IMechanicAnalysisExecutor
             }
 
             analysis.AutoRejectFromDraft(
-                MechanicAnalysis.AutoRejectionReasons.LlmGenerationFailed,
+                rejectionReason,
                 analysis.CreatedBy,
                 _timeProvider.GetUtcNow().UtcDateTime);
             _analysisRepository.Update(analysis);
@@ -377,9 +379,33 @@ internal sealed class MechanicAnalysisExecutor : IMechanicAnalysisExecutor
             _logger.LogError(
                 cleanupEx,
                 "Mechanic analysis {AnalysisId} failed to transition to Rejected after pipeline crash. " +
-                "Original exception: {OriginalMessage}",
-                analysisId, originalException.Message);
+                "Intended rejection reason: {RejectionReason}. Original exception: {OriginalExceptionType} - {OriginalMessage}",
+                analysisId,
+                rejectionReason,
+                originalException.GetType().FullName,
+                originalException.Message);
         }
+    }
+
+    /// <summary>
+    /// Classifies an unexpected exception escaping the pipeline into the appropriate
+    /// <see cref="MechanicAnalysis.AutoRejectionReasons"/> value. Issue #597.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="MechanicAnalysisPipeline"/> never throws on LLM errors — those are
+    /// surfaced as <c>MechanicPipelineOutcome.AbortedLlmFailed</c> via the result envelope. So
+    /// any exception caught at the executor's outer boundary is, by definition, a non-LLM
+    /// failure (DB transient, OOM, network bug, validation crash, etc.) and maps to
+    /// <see cref="MechanicAnalysis.AutoRejectionReasons.PipelineCrashed"/>.
+    /// <para>
+    /// Static + internal so unit tests can pin the mapping without needing the full executor
+    /// dependency graph (DbContext, repositories, pipeline).
+    /// </para>
+    /// </remarks>
+    internal static string ClassifyUnexpectedFailureReason(Exception originalException)
+    {
+        ArgumentNullException.ThrowIfNull(originalException);
+        return MechanicAnalysis.AutoRejectionReasons.PipelineCrashed;
     }
 
     private async Task<string> LoadRetrievalContextAsync(Guid pdfDocumentId, CancellationToken cancellationToken)

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicAnalysis.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicAnalysis.cs
@@ -42,11 +42,19 @@ public sealed class MechanicAnalysis : AggregateRoot<Guid>
     /// Distinguishes automated failures (cost cap, LLM catastrophic) from human-initiated
     /// rejections during review.
     /// </summary>
+    /// <remarks>
+    /// <see cref="PipelineCrashed"/> is reserved for unexpected exceptions that escape the
+    /// pipeline's own error handling (DB error, OOM, network timeout, validation crash, etc.).
+    /// LLM-specific failures are surfaced by the pipeline as
+    /// <c>MechanicPipelineOutcome.AbortedLlmFailed</c> and mapped to <see cref="LlmGenerationFailed"/>
+    /// — they never reach the unexpected-failure path. Issue #597.
+    /// </remarks>
     public static class AutoRejectionReasons
     {
         public const string CostCapExceeded = "cost_cap_exceeded";
         public const string LlmGenerationFailed = "llm_generation_failed";
         public const string ValidationFailedBeyondRetry = "validation_failed_beyond_retry";
+        public const string PipelineCrashed = "pipeline_crashed";
     }
 
     // === Core identity / lineage ===

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicAnalysisExecutorClassifyUnexpectedFailureReasonTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicAnalysisExecutorClassifyUnexpectedFailureReasonTests.cs
@@ -1,0 +1,84 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
+
+/// <summary>
+/// Unit tests for <see cref="MechanicAnalysisExecutor.ClassifyUnexpectedFailureReason"/> — the
+/// rejection-reason classifier introduced by issue #597. Pins the contract that any exception
+/// escaping the pipeline's own error handling maps to
+/// <see cref="MechanicAnalysis.AutoRejectionReasons.PipelineCrashed"/> rather than the previous
+/// hardcoded <see cref="MechanicAnalysis.AutoRejectionReasons.LlmGenerationFailed"/> — which
+/// produced misleading audit trails and false-positive LLM alerts on infra failures.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class MechanicAnalysisExecutorClassifyUnexpectedFailureReasonTests
+{
+    [Fact]
+    public void Classify_DbUpdateException_ReturnsPipelineCrashed_NotLlmGenerationFailed()
+    {
+        // Simulates a DB transient failure (FK violation, deadlock retry exhausted, …) crashing
+        // mid-pipeline. Pre-fix this was misclassified as `LlmGenerationFailed`.
+        var ex = new Microsoft.EntityFrameworkCore.DbUpdateException("FK violation");
+
+        var reason = MechanicAnalysisExecutor.ClassifyUnexpectedFailureReason(ex);
+
+        reason.Should().Be(MechanicAnalysis.AutoRejectionReasons.PipelineCrashed);
+        reason.Should().NotBe(MechanicAnalysis.AutoRejectionReasons.LlmGenerationFailed);
+    }
+
+    [Fact]
+    public void Classify_OutOfMemoryException_ReturnsPipelineCrashed()
+    {
+        var ex = new OutOfMemoryException("section run buffer exceeded");
+
+        var reason = MechanicAnalysisExecutor.ClassifyUnexpectedFailureReason(ex);
+
+        reason.Should().Be(MechanicAnalysis.AutoRejectionReasons.PipelineCrashed);
+    }
+
+    [Fact]
+    public void Classify_NullReferenceException_ReturnsPipelineCrashed()
+    {
+        // Code defect crashing the pipeline — must not pollute LLM telemetry.
+        var ex = new NullReferenceException("repository returned null unexpectedly");
+
+        var reason = MechanicAnalysisExecutor.ClassifyUnexpectedFailureReason(ex);
+
+        reason.Should().Be(MechanicAnalysis.AutoRejectionReasons.PipelineCrashed);
+    }
+
+    [Fact]
+    public void Classify_HttpRequestException_ReturnsPipelineCrashed()
+    {
+        // Network-layer failure (e.g. DNS, TLS handshake) that escaped retry policy in a
+        // dependency. Distinct from LLM API errors (which the pipeline reports via
+        // AbortedLlmFailed without throwing).
+        var ex = new HttpRequestException("Name or service not known");
+
+        var reason = MechanicAnalysisExecutor.ClassifyUnexpectedFailureReason(ex);
+
+        reason.Should().Be(MechanicAnalysis.AutoRejectionReasons.PipelineCrashed);
+    }
+
+    [Fact]
+    public void Classify_GenericException_ReturnsPipelineCrashed()
+    {
+        var ex = new InvalidOperationException("unexpected pipeline state");
+
+        var reason = MechanicAnalysisExecutor.ClassifyUnexpectedFailureReason(ex);
+
+        reason.Should().Be(MechanicAnalysis.AutoRejectionReasons.PipelineCrashed);
+    }
+
+    [Fact]
+    public void Classify_NullException_Throws()
+    {
+        Action act = () => MechanicAnalysisExecutor.ClassifyUnexpectedFailureReason(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## Summary

Bug fix for #597: `HandleUnexpectedFailureAsync` was hardcoding `LlmGenerationFailed` as the rejection reason for **any** unexpected exception escaping the pipeline, polluting LLM telemetry with infra failures (DB errors, OOM, network timeouts, code defects).

**Root cause**: pipeline-level LLM failures never reach this catch — they're surfaced via `MechanicPipelineOutcome.AbortedLlmFailed` envelope and mapped correctly by `ApplyAbort`. Anything escaping to the outer catch is by definition NOT an LLM failure.

## Changes

- **Domain**: new constant `MechanicAnalysis.AutoRejectionReasons.PipelineCrashed = "pipeline_crashed"` with XML doc clarifying when to use it vs `LlmGenerationFailed`
- **Application**: extracted `MechanicAnalysisExecutor.ClassifyUnexpectedFailureReason(ex)` static method; replaced hardcoded reason; enhanced cleanup-failure logging to record original exception type + intended rejection reason
- **Tests**: 6 new unit tests pinning the classifier contract for DbUpdateException, OutOfMemoryException, NullReferenceException, HttpRequestException, generic Exception, and null guard

## Frontend impact

None. `apps/web` renders `RejectionReason` as raw string — new value displays correctly without UI changes.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~MechanicAnalysisExecutor"` → 12/12 pass
- [x] Full SharedGameCatalog unit suite → 973/973 pass
- [x] Build clean
- [ ] Verify in staging: induce a non-LLM crash (e.g., DB down mid-pipeline) → analysis transitions to Rejected with `pipeline_crashed`, NOT `llm_generation_failed`

Closes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)