### PR TITLE
refactor(rag): pass precomputed queryVector to SearchQueryHandler (#563)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandler.cs
@@ -112,12 +112,9 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
             "[AskQuestionHandler] ENTRY - Processing AskQuestionQuery: GameId={GameId}, Question={Question}",
             query.GameId, query.Question);
 
-        // P1-5: Semantic cache lookup — generate query vector and check for a cached response
-        // NOTE: The query embedding is computed here for semantic cache lookup.
-        // SearchQueryHandler also computes an embedding independently for vector search (architectural boundary).
-#pragma warning disable S1135, MA0026 // Deferred: requires SearchQueryHandler signature change to accept pre-computed vector
-        // TODO: Pass queryVector to SearchQueryHandler to eliminate the duplicate embedding call.
-#pragma warning restore S1135, MA0026
+        // P1-5: Semantic cache lookup — generate query vector and check for a cached response.
+        // Issue #563: The vector produced here is now also forwarded to SearchQueryHandler via
+        // SearchQuery.QueryVector to eliminate the duplicate embedding call (~50-200ms saved per cache miss).
         float[]? queryVector = null;
         if (!query.BypassCache)
         {
@@ -196,10 +193,11 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
         }
 
         // Step 1: Perform vector search and calculate confidence
+        // Issue #563: Forward the cache-lookup vector (if computed above) so SearchQueryHandler skips its own embedding call.
         _logger.LogDebug("[AskQuestionHandler] Step 1: Starting vector search...");
         var sw1 = System.Diagnostics.Stopwatch.StartNew();
         var (searchResults, domainSearchResults, searchConfidence) = await PerformSearchAndCalculateConfidenceAsync(
-            query, cancellationToken).ConfigureAwait(false);
+            query, queryVector, cancellationToken).ConfigureAwait(false);
         sw1.Stop();
         _logger.LogInformation("[AskQuestionHandler] Step 1 DONE: Vector search completed in {ElapsedMs}ms - {ResultCount} results, confidence: {Confidence}",
             sw1.ElapsedMilliseconds, searchResults.Count, searchConfidence.Value);
@@ -319,6 +317,7 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
     /// </summary>
     private async Task<(List<SearchResultDto> searchResults, List<Domain.Entities.SearchResult> domainResults, Confidence confidence)> PerformSearchAndCalculateConfidenceAsync(
         AskQuestionQuery query,
+        float[]? precomputedQueryVector,
         CancellationToken cancellationToken)
     {
         var searchQuery = new SearchQuery(
@@ -327,7 +326,8 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
             TopK: 5,
             MinScore: 0.55,
             SearchMode: query.SearchMode ?? "hybrid",
-            Language: query.Language
+            Language: query.Language,
+            QueryVector: precomputedQueryVector // Issue #563: reuse cache-lookup vector when available
         );
 
         var searchResults = await _searchQueryHandler.Handle(searchQuery, cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQuery.cs
@@ -5,7 +5,10 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
 
 /// <summary>
 /// Query to perform vector/hybrid search.
-/// Issue #2051: Supports document filtering via DocumentIds
+/// Issue #2051: Supports document filtering via DocumentIds.
+/// Issue #563: Optional <see cref="QueryVector"/> lets callers pass a pre-computed
+/// embedding to skip the duplicate embedding call inside <c>SearchQueryHandler</c>.
+/// When null, the handler computes the embedding itself (legacy/default path).
 /// </summary>
 internal record SearchQuery(
     Guid GameId,
@@ -16,5 +19,9 @@ internal record SearchQuery(
     string Language = "en",
     IReadOnlyList<Guid>? DocumentIds = null, // Issue #2051: Filter by document IDs (null = all)
     Guid? UserId = null,
-    string? UserRole = null
+    string? UserRole = null,
+    // Issue #563: Pre-computed query embedding to avoid duplicate generation.
+    // Caller is responsible for ensuring the vector matches Query + Language and was produced
+    // by the same embedding model the search handler would use. Null = handler computes its own.
+    IReadOnlyList<float>? QueryVector = null
 ) : IQuery<List<SearchResultDto>>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs
@@ -66,18 +66,33 @@ internal class SearchQueryHandler : IQueryHandler<SearchQuery, List<SearchResult
         // Validate search parameters
         _vectorSearchService.ValidateSearchParameters(query.TopK, query.MinScore);
 
-        // Generate query embedding
-        _logger.LogDebug("[SearchQueryHandler] Step 1: Generating embedding via IEmbeddingService...");
-        var sw1 = System.Diagnostics.Stopwatch.StartNew();
-        var queryEmbedding = await _embeddingService.GenerateEmbeddingAsync(
-            query.Query,
-            query.Language,
-            cancellationToken).ConfigureAwait(false);
-        sw1.Stop();
-        _logger.LogInformation("[SearchQueryHandler] Step 1 DONE: Embedding generated in {ElapsedMs}ms - Success: {Success}",
-            sw1.ElapsedMilliseconds, queryEmbedding.Success);
+        // Step 1: Resolve query embedding.
+        // Issue #563: When the caller supplies a pre-computed QueryVector (e.g., AskQuestionQueryHandler
+        // already produced one for semantic cache lookup), reuse it to avoid a duplicate embedding call
+        // (~50–200ms savings per cache miss). Otherwise fall back to generating one here.
+        Vector queryVector;
+        if (query.QueryVector is { Count: > 0 } precomputed)
+        {
+            _logger.LogDebug(
+                "[SearchQueryHandler] Step 1: Reusing caller-supplied query vector (Dim={Dim}) — skipping embedding call",
+                precomputed.Count);
+            // Materialize to float[] (Vector ctor requires array). ToArray() is a no-op when caller passes float[].
+            queryVector = new Vector(precomputed as float[] ?? precomputed.ToArray());
+        }
+        else
+        {
+            _logger.LogDebug("[SearchQueryHandler] Step 1: Generating embedding via IEmbeddingService...");
+            var sw1 = System.Diagnostics.Stopwatch.StartNew();
+            var queryEmbedding = await _embeddingService.GenerateEmbeddingAsync(
+                query.Query,
+                query.Language,
+                cancellationToken).ConfigureAwait(false);
+            sw1.Stop();
+            _logger.LogInformation("[SearchQueryHandler] Step 1 DONE: Embedding generated in {ElapsedMs}ms - Success: {Success}",
+                sw1.ElapsedMilliseconds, queryEmbedding.Success);
 
-        var queryVector = new Vector(queryEmbedding.ToFloatArray());
+            queryVector = new Vector(queryEmbedding.ToFloatArray());
+        }
 
         // Execute search based on mode
         _logger.LogDebug("[SearchQueryHandler] Step 2: Executing {SearchMode} search...", query.SearchMode);

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandlerTests.cs
@@ -1,0 +1,229 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Unit tests for <see cref="SearchQueryHandler"/>.
+///
+/// Issue #563: Verifies that callers can supply a pre-computed query vector via
+/// <see cref="SearchQuery.QueryVector"/> to avoid a duplicate embedding call,
+/// and that the legacy fallback path (no caller vector → handler embeds) still works.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public sealed class SearchQueryHandlerTests
+{
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    private static readonly Guid TestGameId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private const string TestQuery = "how do I win the game?";
+    private const string TestLanguage = "en";
+
+    /// <summary>
+    /// Issue #563 — happy path: caller supplies a pre-computed query vector,
+    /// so the handler MUST NOT invoke <see cref="IEmbeddingService.GenerateEmbeddingAsync(string, string, CancellationToken)"/>,
+    /// and the supplied vector MUST flow through to <see cref="IEmbeddingRepository.SearchByVectorAsync"/>.
+    /// </summary>
+    [Fact]
+    public async Task Handle_WithPrecomputedQueryVector_SkipsEmbeddingService()
+    {
+        // Arrange
+        var precomputed = new float[] { 0.1f, 0.2f, 0.3f, 0.4f };
+
+        var embeddingServiceMock = new Mock<IEmbeddingService>(MockBehavior.Strict);
+        // No setup: a strict mock will throw if GenerateEmbeddingAsync is invoked.
+
+        var capturedVectors = new List<Vector>();
+        var embeddingRepositoryMock = new Mock<IEmbeddingRepository>();
+        embeddingRepositoryMock
+            .Setup(r => r.SearchByVectorAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<Vector>(),
+                It.IsAny<int>(),
+                It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Guid, Vector, int, double, IReadOnlyList<Guid>?, CancellationToken>(
+                (_, vector, _, _, _, _) => capturedVectors.Add(vector))
+            .ReturnsAsync(new List<Embedding>());
+
+        var ragAccessMock = new Mock<IRagAccessService>();
+        // No UserId on query → access check is skipped, no setup needed.
+
+        var handler = CreateHandler(
+            embeddingRepositoryMock.Object,
+            embeddingServiceMock.Object,
+            ragAccessMock.Object);
+
+        var query = new SearchQuery(
+            GameId: TestGameId,
+            Query: TestQuery,
+            TopK: 5,
+            MinScore: 0.55,
+            SearchMode: "vector",
+            Language: TestLanguage,
+            QueryVector: precomputed);
+
+        // Act
+        var result = await handler.Handle(query, TestCancellationToken);
+
+        // Assert
+        result.Should().NotBeNull();
+
+        // The strict mock guarantees GenerateEmbeddingAsync was never called,
+        // but verify explicitly for documentation / regression safety.
+        embeddingServiceMock.Verify(
+            s => s.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        embeddingServiceMock.Verify(
+            s => s.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        // The pre-computed vector must reach the repository unchanged.
+        capturedVectors.Should().HaveCount(1);
+        capturedVectors[0].Values.Should().Equal(precomputed);
+    }
+
+    /// <summary>
+    /// Issue #563 — fallback path: when the caller does not supply a vector
+    /// (legacy/default behavior), the handler MUST generate one via
+    /// <see cref="IEmbeddingService"/> exactly once and forward it to the repository.
+    /// </summary>
+    [Fact]
+    public async Task Handle_WithoutQueryVector_GeneratesEmbedding()
+    {
+        // Arrange
+        var generated = new float[] { 0.9f, 0.8f, 0.7f, 0.6f };
+
+        var embeddingServiceMock = new Mock<IEmbeddingService>();
+        embeddingServiceMock
+            .Setup(s => s.GenerateEmbeddingAsync(TestQuery, TestLanguage, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EmbeddingResult.CreateSuccess(new List<float[]> { generated }));
+
+        var capturedVectors = new List<Vector>();
+        var embeddingRepositoryMock = new Mock<IEmbeddingRepository>();
+        embeddingRepositoryMock
+            .Setup(r => r.SearchByVectorAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<Vector>(),
+                It.IsAny<int>(),
+                It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Guid, Vector, int, double, IReadOnlyList<Guid>?, CancellationToken>(
+                (_, vector, _, _, _, _) => capturedVectors.Add(vector))
+            .ReturnsAsync(new List<Embedding>());
+
+        var ragAccessMock = new Mock<IRagAccessService>();
+
+        var handler = CreateHandler(
+            embeddingRepositoryMock.Object,
+            embeddingServiceMock.Object,
+            ragAccessMock.Object);
+
+        var query = new SearchQuery(
+            GameId: TestGameId,
+            Query: TestQuery,
+            TopK: 5,
+            MinScore: 0.55,
+            SearchMode: "vector",
+            Language: TestLanguage,
+            QueryVector: null);
+
+        // Act
+        var result = await handler.Handle(query, TestCancellationToken);
+
+        // Assert
+        result.Should().NotBeNull();
+
+        embeddingServiceMock.Verify(
+            s => s.GenerateEmbeddingAsync(TestQuery, TestLanguage, It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        capturedVectors.Should().HaveCount(1);
+        capturedVectors[0].Values.Should().Equal(generated);
+    }
+
+    /// <summary>
+    /// Issue #563 — defensive: an empty (Count == 0) caller vector is treated as "no vector"
+    /// (pattern is <c>{ Count: &gt; 0 }</c>), and the handler falls back to embedding generation.
+    /// Guards against silently passing a zero-dim vector to vector search.
+    /// </summary>
+    [Fact]
+    public async Task Handle_WithEmptyQueryVector_FallsBackToEmbedding()
+    {
+        // Arrange
+        var generated = new float[] { 0.5f, 0.5f };
+
+        var embeddingServiceMock = new Mock<IEmbeddingService>();
+        embeddingServiceMock
+            .Setup(s => s.GenerateEmbeddingAsync(TestQuery, TestLanguage, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EmbeddingResult.CreateSuccess(new List<float[]> { generated }));
+
+        var embeddingRepositoryMock = new Mock<IEmbeddingRepository>();
+        embeddingRepositoryMock
+            .Setup(r => r.SearchByVectorAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<Vector>(),
+                It.IsAny<int>(),
+                It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Embedding>());
+
+        var ragAccessMock = new Mock<IRagAccessService>();
+
+        var handler = CreateHandler(
+            embeddingRepositoryMock.Object,
+            embeddingServiceMock.Object,
+            ragAccessMock.Object);
+
+        var query = new SearchQuery(
+            GameId: TestGameId,
+            Query: TestQuery,
+            TopK: 5,
+            MinScore: 0.55,
+            SearchMode: "vector",
+            Language: TestLanguage,
+            QueryVector: Array.Empty<float>());
+
+        // Act
+        await handler.Handle(query, TestCancellationToken);
+
+        // Assert: empty list ≠ supplied → embedding service is called.
+        embeddingServiceMock.Verify(
+            s => s.GenerateEmbeddingAsync(TestQuery, TestLanguage, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    private static SearchQueryHandler CreateHandler(
+        IEmbeddingRepository embeddingRepository,
+        IEmbeddingService embeddingService,
+        IRagAccessService ragAccessService)
+    {
+        var vectorSearchService = new VectorSearchDomainService();
+        var rrfFusionService = new RrfFusionDomainService();
+        var hybridSearchService = new Mock<IHybridSearchService>().Object;
+        var logger = new Mock<ILogger<SearchQueryHandler>>().Object;
+
+        return new SearchQueryHandler(
+            embeddingRepository,
+            vectorSearchService,
+            rrfFusionService,
+            embeddingService,
+            hybridSearchService,
+            ragAccessService,
+            logger);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #563.

`AskQuestionQueryHandler` already produced a query embedding vector for the P1-5 semantic cache lookup, then `SearchQueryHandler` called the embedding service **again** to produce the same vector for vector search — burning ~50–200ms per cache miss on a redundant network round trip. This PR threads the precomputed vector through `SearchQuery` so the second embedding call is skipped.

## Changes

- **`SearchQuery.cs`**: add optional `QueryVector` (`IReadOnlyList<float>?`, default `null`)
- **`SearchQueryHandler.cs`**: when `QueryVector` is non-empty, reuse it and skip `IEmbeddingService.GenerateEmbeddingAsync`. Legacy path (`null`) preserved unchanged.
- **`AskQuestionQueryHandler.cs`**: forward the cache-lookup vector via `SearchQuery.QueryVector`. Remove the deferred TODO and `#pragma warning disable S1135, MA0026`.

The four other `SearchQuery` callers (`KnowledgeBaseEndpoints`, `StreamQaQueryHandler`, `ExplainQueryHandler`, `SuggestPlayerMoveCommandHandler`) have no precomputed vector available and are unaffected — `QueryVector` defaults to `null`, so the embedding generation path remains the default.

## DoD (#563)

- [x] Update `SearchQuery` shape to accept an optional `QueryVector`.
- [x] Update `AskQuestionQueryHandler` to wire its cache-lookup vector through.
- [x] Remove the `#pragma warning` and TODO at the top of `AskQuestionQueryHandler`.
- [x] Unit tests covering vector passthrough + fallback behavior.
- [ ] Benchmarks before/after — deferred to a follow-up issue (out of scope for atomic refactor).

## Test plan

- [x] `dotnet build` — clean (0 errors).
- [x] `SearchQueryHandlerTests` — 3/3 passing (passthrough, embedding fallback, empty-vector defensive fallback).
- [x] `AskQuestionQueryHandlerTests` — 5/5 passing (no regression).
- [ ] Manual smoke on staging post-merge (cache-miss latency drop visible in logs / `meepleai.rag.first_token_latency` histogram).

🤖 Generated with [Claude Code](https://claude.com/claude-code)