### PR TITLE
feat(game-night): public token-based RSVP backend (Wave A.5a) (#607)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/CreateGameNightInvitationByEmailCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/CreateGameNightInvitationByEmailCommand.cs
@@ -1,0 +1,18 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Organizer-issued command to create a token-based invitation for a single
+/// email address. Sends the invitation email synchronously after persistence
+/// (D1 a — see executive spec §5).
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// </summary>
+/// <param name="GameNightId">Target game night (must be owned by <paramref name="OrganizerUserId"/>).</param>
+/// <param name="Email">Recipient email — case-insensitive, normalized in the aggregate factory.</param>
+/// <param name="OrganizerUserId">Authenticated caller, validated against the parent event's organizer.</param>
+internal sealed record CreateGameNightInvitationByEmailCommand(
+    Guid GameNightId,
+    string Email,
+    Guid OrganizerUserId) : ICommand<GameNightInvitationDto>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/CreateGameNightInvitationByEmailCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/CreateGameNightInvitationByEmailCommandHandler.cs
@@ -1,0 +1,156 @@
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Configuration;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Handles organizer-issued creation of a token-based game-night invitation.
+/// Persists the aggregate and synchronously dispatches the invitation email
+/// (D1 a — see spec §5).
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// </summary>
+internal sealed class CreateGameNightInvitationByEmailCommandHandler
+    : ICommandHandler<CreateGameNightInvitationByEmailCommand, GameNightInvitationDto>
+{
+    private const string BaseUrlConfigKey = "App:BaseUrl";
+    private const string ExpiryDaysConfigKey = "GameNight:InvitationExpiryDays";
+    private const int DefaultExpiryDays = 14;
+
+    private readonly IGameNightInvitationRepository _invitationRepository;
+    private readonly IGameNightEventRepository _gameNightRepository;
+    private readonly IUserRepository _userRepository;
+    private readonly IGameRepository _gameRepository;
+    private readonly IGameNightEmailService _emailService;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IConfiguration _configuration;
+    private readonly TimeProvider _timeProvider;
+
+    public CreateGameNightInvitationByEmailCommandHandler(
+        IGameNightInvitationRepository invitationRepository,
+        IGameNightEventRepository gameNightRepository,
+        IUserRepository userRepository,
+        IGameRepository gameRepository,
+        IGameNightEmailService emailService,
+        IUnitOfWork unitOfWork,
+        IConfiguration configuration,
+        TimeProvider timeProvider)
+    {
+        _invitationRepository = invitationRepository ?? throw new ArgumentNullException(nameof(invitationRepository));
+        _gameNightRepository = gameNightRepository ?? throw new ArgumentNullException(nameof(gameNightRepository));
+        _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
+        _gameRepository = gameRepository ?? throw new ArgumentNullException(nameof(gameRepository));
+        _emailService = emailService ?? throw new ArgumentNullException(nameof(emailService));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+    }
+
+    public async Task<GameNightInvitationDto> Handle(
+        CreateGameNightInvitationByEmailCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var gameNight = await _gameNightRepository
+            .GetByIdAsync(command.GameNightId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException("GameNightEvent", command.GameNightId.ToString());
+
+        if (gameNight.OrganizerId != command.OrganizerUserId)
+        {
+            throw new UnauthorizedAccessException(
+                "Only the organizer can issue invitations for this game night");
+        }
+
+        var normalizedEmail = command.Email.Trim().ToLowerInvariant();
+
+        var alreadyInvited = await _invitationRepository
+            .ExistsPendingByEmailAsync(command.GameNightId, normalizedEmail, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (alreadyInvited)
+        {
+            throw new ConflictException(
+                $"A pending invitation already exists for {normalizedEmail} on this game night.");
+        }
+
+        var utcNow = _timeProvider.GetUtcNow();
+        var expiryDays = _configuration.GetValue<int?>(ExpiryDaysConfigKey) ?? DefaultExpiryDays;
+        var expiresAt = utcNow.AddDays(expiryDays);
+
+        var invitation = GameNightInvitation.Create(
+            gameNightId: command.GameNightId,
+            email: normalizedEmail,
+            expiresAt: expiresAt,
+            createdBy: command.OrganizerUserId,
+            utcNow: utcNow);
+
+        await _invitationRepository.AddAsync(invitation, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // D1 a: emit invitation email synchronously after persistence so guests
+        // receive the token-bearing accept/decline links.
+        await SendInvitationEmailAsync(gameNight, invitation, cancellationToken).ConfigureAwait(false);
+
+        return new GameNightInvitationDto(
+            Id: invitation.Id,
+            Token: invitation.Token,
+            GameNightId: invitation.GameNightId,
+            Email: invitation.Email,
+            Status: invitation.Status.ToString(),
+            ExpiresAt: invitation.ExpiresAt,
+            RespondedAt: invitation.RespondedAt,
+            RespondedByUserId: invitation.RespondedByUserId,
+            CreatedAt: invitation.CreatedAt,
+            CreatedBy: invitation.CreatedBy);
+    }
+
+    private async Task SendInvitationEmailAsync(
+        GameNightEvent gameNight,
+        GameNightInvitation invitation,
+        CancellationToken cancellationToken)
+    {
+        var baseUrl = _configuration[BaseUrlConfigKey]
+            ?? throw new InvalidOperationException(
+                $"Missing required configuration '{BaseUrlConfigKey}' for invitation URLs.");
+
+        var organizer = await _userRepository
+            .GetByIdAsync(gameNight.OrganizerId, cancellationToken)
+            .ConfigureAwait(false);
+
+        var organizerName = organizer?.DisplayName ?? "A friend";
+
+        var gameNames = new List<string>(capacity: gameNight.GameIds.Count);
+        foreach (var gameId in gameNight.GameIds)
+        {
+            var game = await _gameRepository.GetByIdAsync(gameId, cancellationToken).ConfigureAwait(false);
+            if (game is not null)
+            {
+                gameNames.Add(game.Title.Value);
+            }
+        }
+
+        var rsvpAcceptUrl = $"{baseUrl.TrimEnd('/')}/invites/{invitation.Token}?action=accept";
+        var rsvpDeclineUrl = $"{baseUrl.TrimEnd('/')}/invites/{invitation.Token}?action=decline";
+        var unsubscribeUrl = $"{baseUrl.TrimEnd('/')}/invites/{invitation.Token}/unsubscribe";
+
+        await _emailService.SendGameNightInvitationEmailAsync(
+            toEmail: invitation.Email,
+            organizerName: organizerName,
+            title: gameNight.Title,
+            scheduledAt: gameNight.ScheduledAt,
+            location: gameNight.Location,
+            gameNames: gameNames,
+            rsvpAcceptUrl: rsvpAcceptUrl,
+            rsvpDeclineUrl: rsvpDeclineUrl,
+            unsubscribeUrl: unsubscribeUrl,
+            ct: cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/RespondToGameNightInvitationByTokenCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/RespondToGameNightInvitationByTokenCommand.cs
@@ -1,0 +1,19 @@
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Public command to record a guest RSVP against a token-addressable
+/// invitation. Anonymous-friendly: <paramref name="ResponderUserId"/> is
+/// optional and only populated when the responding HTTP request happened to
+/// carry a valid auth cookie.
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// </summary>
+/// <param name="Token">The 22-character invitation token.</param>
+/// <param name="Response">Either <see cref="GameNightInvitationStatus.Accepted"/> or <see cref="GameNightInvitationStatus.Declined"/>.</param>
+/// <param name="ResponderUserId">Optional responder identity (cookie-authenticated guests only).</param>
+internal sealed record RespondToGameNightInvitationByTokenCommand(
+    string Token,
+    GameNightInvitationStatus Response,
+    Guid? ResponderUserId) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/RespondToGameNightInvitationByTokenCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/RespondToGameNightInvitationByTokenCommandHandler.cs
@@ -1,0 +1,91 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Handles public RSVP responses against a token-addressable invitation.
+/// Implements the idempotency contract from spec §2.2 / D2 (b):
+/// <list type="bullet">
+///   <item>Same-status response → no-op (200 OK).</item>
+///   <item>Switching Accepted ⇄ Declined → <see cref="ConflictException"/> (409).</item>
+///   <item>Expired or Cancelled invitations → <see cref="GoneException"/> (410).</item>
+/// </list>
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// </summary>
+internal sealed class RespondToGameNightInvitationByTokenCommandHandler
+    : ICommandHandler<RespondToGameNightInvitationByTokenCommand>
+{
+    private readonly IGameNightInvitationRepository _invitationRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly TimeProvider _timeProvider;
+
+    public RespondToGameNightInvitationByTokenCommandHandler(
+        IGameNightInvitationRepository invitationRepository,
+        IUnitOfWork unitOfWork,
+        TimeProvider timeProvider)
+    {
+        _invitationRepository = invitationRepository ?? throw new ArgumentNullException(nameof(invitationRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+    }
+
+    public async Task Handle(
+        RespondToGameNightInvitationByTokenCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var invitation = await _invitationRepository
+            .GetByTokenAsync(command.Token, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException("GameNightInvitation", command.Token);
+
+        var utcNow = _timeProvider.GetUtcNow();
+
+        // 410 Gone: terminal lifecycle states (cancelled by organizer or already expired).
+        if (invitation.Status == GameNightInvitationStatus.Cancelled
+            || invitation.Status == GameNightInvitationStatus.Expired)
+        {
+            throw new GoneException(
+                $"This invitation is no longer available (status: {invitation.Status}).");
+        }
+
+        // 410 Gone: pending invitation past the cutoff.
+        if (invitation.IsExpired(utcNow))
+        {
+            throw new GoneException("This invitation has expired.");
+        }
+
+        bool transitioned;
+        try
+        {
+            transitioned = command.Response switch
+            {
+                GameNightInvitationStatus.Accepted => invitation.Accept(command.ResponderUserId, utcNow),
+                GameNightInvitationStatus.Declined => invitation.Decline(command.ResponderUserId, utcNow),
+                _ => throw new ArgumentOutOfRangeException(
+                    nameof(command),
+                    $"Unsupported response status: {command.Response}"),
+            };
+        }
+        catch (InvalidOperationException ex)
+        {
+            // After the expiry/terminal guards above, the only remaining failure
+            // path is switching between Accepted ⇄ Declined → 409 Conflict.
+            throw new ConflictException(ex.Message, ex);
+        }
+
+        // Idempotent same-state response: nothing changed, no need to persist.
+        if (!transitioned)
+        {
+            return;
+        }
+
+        await _invitationRepository.UpdateAsync(invitation, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightInvitationDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightInvitationDto.cs
@@ -1,0 +1,25 @@
+namespace Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+
+/// <summary>
+/// Admin/organizer view of a game-night invitation, surfaces persistence-level
+/// fields (Token, ExpiresAt, RespondedAt, audit) needed to manage outstanding
+/// invitations.
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// </summary>
+/// <remarks>
+/// Returned by <c>POST /api/v1/game-nights/{gameNightId}/invitations</c>
+/// (status 201 Created) and by the organizer-facing list endpoint. Distinct from
+/// <see cref="PublicGameNightInvitationDto"/> which is the unauthenticated,
+/// token-addressable surface and intentionally hides organizer-only fields.
+/// </remarks>
+public sealed record GameNightInvitationDto(
+    Guid Id,
+    string Token,
+    Guid GameNightId,
+    string Email,
+    string Status,
+    DateTimeOffset ExpiresAt,
+    DateTimeOffset? RespondedAt,
+    Guid? RespondedByUserId,
+    DateTimeOffset CreatedAt,
+    Guid CreatedBy);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/PublicGameNightInvitationDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/PublicGameNightInvitationDto.cs
@@ -1,0 +1,40 @@
+namespace Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+
+/// <summary>
+/// Public, token-addressable view of a game-night invitation.
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Surface area aligned 1:1 with the mockup <c>InviteBody</c> component
+/// (`admin-mockups/design_files/sp3-accept-invite.jsx`). The endpoint
+/// <c>GET /api/v1/game-nights/invitations/{token}</c> returns this shape
+/// with no authentication required.
+/// </para>
+/// <para>
+/// <see cref="AlreadyRespondedAs"/> is populated to <c>"Accepted"</c> or
+/// <c>"Declined"</c> when the invitation has already been responded to,
+/// allowing the frontend to skip the action affordance and show a
+/// confirmation surface instead. <c>null</c> for pending invitations.
+/// </para>
+/// </remarks>
+public sealed record PublicGameNightInvitationDto(
+    string Token,
+    string Status,
+    DateTimeOffset ExpiresAt,
+    DateTimeOffset? RespondedAt,
+    Guid HostUserId,
+    string HostDisplayName,
+    string? HostAvatarUrl,
+    string? HostWelcomeMessage,
+    Guid GameNightId,
+    string Title,
+    DateTimeOffset ScheduledAt,
+    string? Location,
+    int? DurationMinutes,
+    int ExpectedPlayers,
+    int AcceptedSoFar,
+    Guid? PrimaryGameId,
+    string? PrimaryGameName,
+    string? PrimaryGameImageUrl,
+    string? AlreadyRespondedAs);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/GameNightInvitationRespondedHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/GameNightInvitationRespondedHandler.cs
@@ -1,0 +1,115 @@
+using Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using MediatR;
+using Microsoft.Extensions.Caching.Hybrid;
+
+namespace Api.BoundedContexts.GameManagement.Application.EventHandlers;
+
+/// <summary>
+/// Subscribes to <see cref="GameNightInvitationRespondedEvent"/> and performs
+/// the post-RSVP fan-out:
+/// <list type="number">
+///   <item>Invalidate the <c>game-night-invitation:{token}</c> cache tag so
+///         the next read of the public surface returns the fresh
+///         <c>AlreadyRespondedAs</c>/<c>RespondedAt</c> projection.</item>
+///   <item>Send the RSVP confirmation email to the responding guest
+///         (D1 a — see spec §5).</item>
+/// </list>
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Pitfall #2620 — injects raw <see cref="HybridCache"/> (NOT the
+/// <c>IHybridCacheService</c> wrapper) so we share the native tag index used
+/// by <see cref="GetGameNightInvitationByTokenQueryHandler"/> as producer.
+/// </para>
+/// <para>
+/// Multi-instance deployment caveat: <c>RemoveByTagAsync</c> evicts the L2
+/// distributed entry but only the L1 of this process — same caveat documented
+/// in legacy <c>VectorDocumentIndexedForKbFlagHandler</c>.
+/// </para>
+/// </remarks>
+internal sealed class GameNightInvitationRespondedHandler
+    : INotificationHandler<GameNightInvitationRespondedEvent>
+{
+    private readonly IGameNightInvitationRepository _invitationRepository;
+    private readonly IGameNightEventRepository _gameNightRepository;
+    private readonly IGameNightEmailService _emailService;
+    private readonly HybridCache _cache;
+    private readonly ILogger<GameNightInvitationRespondedHandler> _logger;
+
+    public GameNightInvitationRespondedHandler(
+        IGameNightInvitationRepository invitationRepository,
+        IGameNightEventRepository gameNightRepository,
+        IGameNightEmailService emailService,
+        HybridCache cache,
+        ILogger<GameNightInvitationRespondedHandler> logger)
+    {
+        _invitationRepository = invitationRepository ?? throw new ArgumentNullException(nameof(invitationRepository));
+        _gameNightRepository = gameNightRepository ?? throw new ArgumentNullException(nameof(gameNightRepository));
+        _emailService = emailService ?? throw new ArgumentNullException(nameof(emailService));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(
+        GameNightInvitationRespondedEvent notification,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        // Step 1 — cache invalidation (idempotent / cheap).
+        var cacheTag = GetGameNightInvitationByTokenQueryHandler.CacheTagPrefix + notification.Token;
+        await _cache.RemoveByTagAsync(cacheTag, cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Invalidated cache tag {CacheTag} after invitation {InvitationId} responded as {Status}",
+            cacheTag,
+            notification.GameNightInvitationId,
+            notification.Status);
+
+        // Step 2 — confirmation email (only when the responder said yes; declined
+        // guests don't need a confirmation, matching existing user-RSVP behavior).
+        if (notification.Status != Domain.Enums.GameNightInvitationStatus.Accepted)
+        {
+            return;
+        }
+
+        var invitation = await _invitationRepository
+            .GetByIdAsync(notification.GameNightInvitationId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (invitation is null)
+        {
+            _logger.LogWarning(
+                "Invitation {InvitationId} disappeared between event raise and handler — skipping confirmation email",
+                notification.GameNightInvitationId);
+            return;
+        }
+
+        var gameNight = await _gameNightRepository
+            .GetByIdAsync(invitation.GameNightId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (gameNight is null)
+        {
+            _logger.LogWarning(
+                "GameNight {GameNightId} not found for confirmation email of invitation {InvitationId}",
+                invitation.GameNightId,
+                invitation.Id);
+            return;
+        }
+
+        var unsubscribeUrl = $"/invites/{invitation.Token}/unsubscribe";
+
+        await _emailService.SendGameNightRsvpConfirmationEmailAsync(
+            toEmail: invitation.Email,
+            title: gameNight.Title,
+            scheduledAt: gameNight.ScheduledAt,
+            location: gameNight.Location,
+            unsubscribeUrl: unsubscribeUrl,
+            ct: cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightInvitationByTokenQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightInvitationByTokenQuery.cs
@@ -1,0 +1,13 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Public query to fetch the token-addressable view of a game-night
+/// invitation. No authentication required — token possession is the
+/// authorization mechanism.
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// </summary>
+internal sealed record GetGameNightInvitationByTokenQuery(
+    string Token) : IQuery<PublicGameNightInvitationDto?>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightInvitationByTokenQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightInvitationByTokenQueryHandler.cs
@@ -1,0 +1,148 @@
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.Extensions.Caching.Hybrid;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Handles the public, token-addressable invitation lookup. Cached at the
+/// L1 process / L2 distributed level via <see cref="HybridCache"/> with the
+/// per-token tag so the responded-event handler can invalidate after a
+/// guest RSVPs (perf gates: cold p95 &lt; 100ms / warm &lt; 30ms — spec §6).
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// </summary>
+internal sealed class GetGameNightInvitationByTokenQueryHandler
+    : IQueryHandler<GetGameNightInvitationByTokenQuery, PublicGameNightInvitationDto?>
+{
+    /// <summary>
+    /// Cache tag template: callers (event handlers) build the same string
+    /// to invalidate a single invitation without touching the rest of the
+    /// namespace. <c>game-night-invitation:{token}</c>.
+    /// </summary>
+    public const string CacheTagPrefix = "game-night-invitation:";
+
+    private static readonly HybridCacheEntryOptions CacheOptions = new()
+    {
+        LocalCacheExpiration = TimeSpan.FromSeconds(60),
+        Expiration = TimeSpan.FromSeconds(60),
+    };
+
+    private readonly IGameNightInvitationRepository _invitationRepository;
+    private readonly IGameNightEventRepository _gameNightRepository;
+    private readonly IUserRepository _userRepository;
+    private readonly IGameRepository _gameRepository;
+    private readonly HybridCache _cache;
+
+    public GetGameNightInvitationByTokenQueryHandler(
+        IGameNightInvitationRepository invitationRepository,
+        IGameNightEventRepository gameNightRepository,
+        IUserRepository userRepository,
+        IGameRepository gameRepository,
+        HybridCache cache)
+    {
+        _invitationRepository = invitationRepository ?? throw new ArgumentNullException(nameof(invitationRepository));
+        _gameNightRepository = gameNightRepository ?? throw new ArgumentNullException(nameof(gameNightRepository));
+        _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
+        _gameRepository = gameRepository ?? throw new ArgumentNullException(nameof(gameRepository));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+    }
+
+    public async Task<PublicGameNightInvitationDto?> Handle(
+        GetGameNightInvitationByTokenQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var cacheKey = CacheTagPrefix + query.Token;
+
+        return await _cache.GetOrCreateAsync<PublicGameNightInvitationDto?>(
+            cacheKey,
+            async ct => await BuildDtoAsync(query.Token, ct).ConfigureAwait(false),
+            CacheOptions,
+            tags: new[] { cacheKey },
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<PublicGameNightInvitationDto?> BuildDtoAsync(
+        string token,
+        CancellationToken cancellationToken)
+    {
+        var invitation = await _invitationRepository
+            .GetByTokenAsync(token, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (invitation is null)
+        {
+            return null;
+        }
+
+        var gameNight = await _gameNightRepository
+            .GetByIdAsync(invitation.GameNightId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (gameNight is null)
+        {
+            return null;
+        }
+
+        var organizer = await _userRepository
+            .GetByIdAsync(gameNight.OrganizerId, cancellationToken)
+            .ConfigureAwait(false);
+
+        Guid? primaryGameId = gameNight.GameIds.Count > 0 ? gameNight.GameIds[0] : null;
+        string? primaryGameName = null;
+        string? primaryGameImageUrl = null;
+
+        if (primaryGameId.HasValue)
+        {
+            var primaryGame = await _gameRepository
+                .GetByIdAsync(primaryGameId.Value, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (primaryGame is not null)
+            {
+                primaryGameName = primaryGame.Title.Value;
+                primaryGameImageUrl = primaryGame.ImageUrl;
+            }
+        }
+
+        var acceptedInvitations = await _invitationRepository
+            .CountAcceptedByGameNightIdAsync(invitation.GameNightId, cancellationToken)
+            .ConfigureAwait(false);
+
+        // AcceptedSoFar = organizer (always counted as attending) + accepted invitations.
+        var acceptedSoFar = 1 + acceptedInvitations;
+
+        return new PublicGameNightInvitationDto(
+            Token: invitation.Token,
+            Status: invitation.Status.ToString(),
+            ExpiresAt: invitation.ExpiresAt,
+            RespondedAt: invitation.RespondedAt,
+            HostUserId: gameNight.OrganizerId,
+            HostDisplayName: organizer?.DisplayName ?? "A friend",
+            HostAvatarUrl: organizer?.AvatarUrl,
+            HostWelcomeMessage: null,
+            GameNightId: gameNight.Id,
+            Title: gameNight.Title,
+            ScheduledAt: gameNight.ScheduledAt,
+            Location: gameNight.Location,
+            DurationMinutes: null,
+            ExpectedPlayers: gameNight.MaxPlayers ?? 0,
+            AcceptedSoFar: acceptedSoFar,
+            PrimaryGameId: primaryGameId,
+            PrimaryGameName: primaryGameName,
+            PrimaryGameImageUrl: primaryGameImageUrl,
+            AlreadyRespondedAs: MapAlreadyRespondedAs(invitation.Status));
+    }
+
+    private static string? MapAlreadyRespondedAs(GameNightInvitationStatus status) => status switch
+    {
+        GameNightInvitationStatus.Accepted => "Accepted",
+        GameNightInvitationStatus.Declined => "Declined",
+        _ => null,
+    };
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/CreateGameNightInvitationByEmailCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/CreateGameNightInvitationByEmailCommandValidator.cs
@@ -1,0 +1,26 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameManagement.Application.Validators.GameNights;
+
+/// <summary>
+/// Validator for <see cref="CreateGameNightInvitationByEmailCommand"/>.
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// </summary>
+internal sealed class CreateGameNightInvitationByEmailCommandValidator
+    : AbstractValidator<CreateGameNightInvitationByEmailCommand>
+{
+    public CreateGameNightInvitationByEmailCommandValidator()
+    {
+        RuleFor(x => x.GameNightId)
+            .NotEmpty().WithMessage("Game night ID is required");
+
+        RuleFor(x => x.OrganizerUserId)
+            .NotEmpty().WithMessage("Organizer user ID is required");
+
+        RuleFor(x => x.Email)
+            .NotEmpty().WithMessage("Email is required")
+            .EmailAddress().WithMessage("Email must be a valid address")
+            .MaximumLength(254).WithMessage("Email exceeds the 254-character RFC limit");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/RespondToGameNightInvitationByTokenCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/RespondToGameNightInvitationByTokenCommandValidator.cs
@@ -1,0 +1,29 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameManagement.Application.Validators.GameNights;
+
+/// <summary>
+/// Validator for <see cref="RespondToGameNightInvitationByTokenCommand"/>.
+/// Restricts <c>Response</c> to terminal user-actionable values; lifecycle
+/// transitions like Expired/Cancelled are managed inside the aggregate.
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// </summary>
+internal sealed class RespondToGameNightInvitationByTokenCommandValidator
+    : AbstractValidator<RespondToGameNightInvitationByTokenCommand>
+{
+    public RespondToGameNightInvitationByTokenCommandValidator()
+    {
+        RuleFor(x => x.Token)
+            .NotEmpty().WithMessage("Token is required")
+            .Length(22).WithMessage("Token must be exactly 22 characters")
+            .Matches("^[0-9A-Za-z]{22}$")
+                .WithMessage("Token must be base62 (digits and ASCII letters only)");
+
+        RuleFor(x => x.Response)
+            .Must(r => r == GameNightInvitationStatus.Accepted
+                       || r == GameNightInvitationStatus.Declined)
+            .WithMessage("Response must be either Accepted or Declined");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightInvitation.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightInvitation.cs
@@ -1,0 +1,248 @@
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.SharedKernel.Domain.Entities;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+
+/// <summary>
+/// Aggregate root representing a token-based game-night invitation.
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Distinct from the existing <see cref="GameNightRsvp"/> entity owned by
+/// <see cref="GameNightEvent"/>: that flow tracks RSVPs by <c>UserId</c> for users already
+/// known to the system. This aggregate persists the public, token-addressable invitation
+/// (sent by email to addresses that may not yet be registered) and its lifecycle.
+/// </para>
+/// <para>
+/// Idempotency contract (D2 b — see spec §2.2): repeating the current response is a
+/// no-op (returns <c>false</c>); attempting to switch between Accepted ⇄ Declined is
+/// rejected and surfaces as 409 Conflict at the endpoint layer; responses on terminal
+/// Expired/Cancelled invitations are rejected and surface as 410 Gone.
+/// </para>
+/// </remarks>
+internal sealed class GameNightInvitation : AggregateRoot<Guid>
+{
+    public string Token { get; private set; }
+    public Guid GameNightId { get; private set; }
+    public string Email { get; private set; }
+    public GameNightInvitationStatus Status { get; private set; }
+    public DateTimeOffset ExpiresAt { get; private set; }
+    public DateTimeOffset? RespondedAt { get; private set; }
+    public Guid? RespondedByUserId { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+    public Guid CreatedBy { get; private set; }
+
+#pragma warning disable CS8618
+    private GameNightInvitation() : base() { } // EF Core
+#pragma warning restore CS8618
+
+    private GameNightInvitation(
+        Guid id,
+        string token,
+        Guid gameNightId,
+        string email,
+        GameNightInvitationStatus status,
+        DateTimeOffset expiresAt,
+        DateTimeOffset? respondedAt,
+        Guid? respondedByUserId,
+        DateTimeOffset createdAt,
+        Guid createdBy) : base(id)
+    {
+        Token = token;
+        GameNightId = gameNightId;
+        Email = email;
+        Status = status;
+        ExpiresAt = expiresAt;
+        RespondedAt = respondedAt;
+        RespondedByUserId = respondedByUserId;
+        CreatedAt = createdAt;
+        CreatedBy = createdBy;
+    }
+
+    /// <summary>
+    /// Creates a new pending invitation with a freshly-generated token.
+    /// Raises <see cref="GameNightInvitationCreatedEvent"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// When <paramref name="gameNightId"/> or <paramref name="createdBy"/> is empty,
+    /// when <paramref name="email"/> is null/whitespace, or when
+    /// <paramref name="expiresAt"/> is not strictly in the future relative to
+    /// <paramref name="utcNow"/>.
+    /// </exception>
+    public static GameNightInvitation Create(
+        Guid gameNightId,
+        string email,
+        DateTimeOffset expiresAt,
+        Guid createdBy,
+        DateTimeOffset utcNow)
+    {
+        if (gameNightId == Guid.Empty)
+            throw new ArgumentException("GameNightId is required", nameof(gameNightId));
+        if (createdBy == Guid.Empty)
+            throw new ArgumentException("CreatedBy is required", nameof(createdBy));
+        if (string.IsNullOrWhiteSpace(email))
+            throw new ArgumentException("Email is required", nameof(email));
+        if (expiresAt <= utcNow)
+            throw new ArgumentException("ExpiresAt must be in the future", nameof(expiresAt));
+
+        var token = InvitationToken.Generate().Value;
+        var normalizedEmail = email.Trim().ToLowerInvariant();
+        var id = Guid.NewGuid();
+
+        var invitation = new GameNightInvitation(
+            id: id,
+            token: token,
+            gameNightId: gameNightId,
+            email: normalizedEmail,
+            status: GameNightInvitationStatus.Pending,
+            expiresAt: expiresAt,
+            respondedAt: null,
+            respondedByUserId: null,
+            createdAt: utcNow,
+            createdBy: createdBy);
+
+        invitation.AddDomainEvent(new GameNightInvitationCreatedEvent(
+            gameNightInvitationId: id,
+            gameNightId: gameNightId,
+            email: normalizedEmail,
+            token: token,
+            expiresAt: expiresAt));
+
+        return invitation;
+    }
+
+    /// <summary>
+    /// Reconstitutes an invitation from persistence data. Skips invariant checks.
+    /// </summary>
+    internal static GameNightInvitation Reconstitute(
+        Guid id,
+        string token,
+        Guid gameNightId,
+        string email,
+        GameNightInvitationStatus status,
+        DateTimeOffset expiresAt,
+        DateTimeOffset? respondedAt,
+        Guid? respondedByUserId,
+        DateTimeOffset createdAt,
+        Guid createdBy)
+    {
+        return new GameNightInvitation(
+            id: id,
+            token: token,
+            gameNightId: gameNightId,
+            email: email,
+            status: status,
+            expiresAt: expiresAt,
+            respondedAt: respondedAt,
+            respondedByUserId: respondedByUserId,
+            createdAt: createdAt,
+            createdBy: createdBy);
+    }
+
+    /// <summary>
+    /// Accepts the invitation. Idempotent (D2 b):
+    /// Pending→Accepted returns <c>true</c>; Accepted→Accepted no-ops returns <c>false</c>;
+    /// Declined throws (caller maps to 409); Expired/Cancelled throws (caller maps to 410).
+    /// </summary>
+    public bool Accept(Guid? userId, DateTimeOffset utcNow)
+    {
+        return Respond(GameNightInvitationStatus.Accepted, userId, utcNow);
+    }
+
+    /// <summary>
+    /// Declines the invitation. Idempotent (D2 b) — symmetric to <see cref="Accept"/>.
+    /// </summary>
+    public bool Decline(Guid? userId, DateTimeOffset utcNow)
+    {
+        return Respond(GameNightInvitationStatus.Declined, userId, utcNow);
+    }
+
+    /// <summary>
+    /// Cancels a pending or accepted invitation (organizer revokes, or parent GameNight
+    /// is cancelled). Idempotent: cancelling an already-cancelled invitation is a no-op.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// When the invitation is in <see cref="GameNightInvitationStatus.Declined"/> or
+    /// <see cref="GameNightInvitationStatus.Expired"/> (no transition path defined).
+    /// </exception>
+    public void Cancel(DateTimeOffset utcNow)
+    {
+        switch (Status)
+        {
+            case GameNightInvitationStatus.Cancelled:
+                return; // idempotent
+            case GameNightInvitationStatus.Pending:
+            case GameNightInvitationStatus.Accepted:
+                Status = GameNightInvitationStatus.Cancelled;
+                RespondedAt = utcNow;
+                return;
+            case GameNightInvitationStatus.Declined:
+            case GameNightInvitationStatus.Expired:
+                throw new InvalidOperationException(
+                    $"Cannot cancel invitation in status {Status}.");
+            default:
+                throw new InvalidOperationException(
+                    $"Unknown invitation status: {Status}.");
+        }
+    }
+
+    /// <summary>
+    /// True iff the invitation is still <see cref="GameNightInvitationStatus.Pending"/>
+    /// and the cutoff has passed. Terminal states (Accepted/Declined/Cancelled) are not
+    /// considered expired — expiry only matters for un-responded invitations.
+    /// </summary>
+    public bool IsExpired(DateTimeOffset utcNow)
+    {
+        return Status == GameNightInvitationStatus.Pending && utcNow >= ExpiresAt;
+    }
+
+    private bool Respond(
+        GameNightInvitationStatus desired,
+        Guid? userId,
+        DateTimeOffset utcNow)
+    {
+        // Terminal lifecycle states block all responses (caller maps to 410).
+        if (Status == GameNightInvitationStatus.Cancelled ||
+            Status == GameNightInvitationStatus.Expired)
+        {
+            throw new InvalidOperationException(
+                $"Cannot respond to invitation in status {Status}.");
+        }
+
+        // Implicit expiry on read: pending invitation past cutoff is treated as expired.
+        if (Status == GameNightInvitationStatus.Pending && utcNow >= ExpiresAt)
+        {
+            throw new InvalidOperationException(
+                "Cannot respond to invitation: it has expired.");
+        }
+
+        // Idempotent same-response (D2 b): no transition, no event.
+        if (Status == desired)
+        {
+            return false;
+        }
+
+        // Switching between Accepted ⇄ Declined is rejected (caller maps to 409).
+        if (Status != GameNightInvitationStatus.Pending)
+        {
+            throw new InvalidOperationException(
+                $"Cannot change response: invitation is already {Status}.");
+        }
+
+        Status = desired;
+        RespondedAt = utcNow;
+        RespondedByUserId = userId;
+
+        AddDomainEvent(new GameNightInvitationRespondedEvent(
+            gameNightInvitationId: Id,
+            gameNightId: GameNightId,
+            token: Token,
+            status: desired,
+            respondedByUserId: userId));
+
+        return true;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/IGameNightInvitationRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/IGameNightInvitationRepository.cs
@@ -1,0 +1,48 @@
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+
+/// <summary>
+/// Repository interface for the <see cref="GameNightInvitation"/> aggregate.
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// </summary>
+/// <remarks>
+/// Distinct from <see cref="IGameNightEventRepository"/>: that repo persists
+/// the parent event with its by-UserId RSVP collection; this one persists the
+/// public, token-addressable invitation aggregate (sent to email addresses
+/// possibly not registered yet).
+/// </remarks>
+internal interface IGameNightInvitationRepository : IRepository<GameNightInvitation, Guid>
+{
+    /// <summary>
+    /// Looks up an invitation by its public token. Returns <c>null</c> when
+    /// the token does not match any persisted invitation.
+    /// </summary>
+    Task<GameNightInvitation?> GetByTokenAsync(string token, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns all invitations belonging to a single game night, regardless of
+    /// status. Used by the organizer-facing list and by the
+    /// <c>AcceptedSoFar</c> aggregate when reading by token.
+    /// </summary>
+    Task<IReadOnlyList<GameNightInvitation>> GetByGameNightIdAsync(
+        Guid gameNightId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Counts the invitations on a game night that are currently in
+    /// <see cref="Domain.Enums.GameNightInvitationStatus.Accepted"/>.
+    /// Used to compute <c>AcceptedSoFar</c> efficiently without materializing
+    /// the full list.
+    /// </summary>
+    Task<int> CountAcceptedByGameNightIdAsync(
+        Guid gameNightId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// True iff a <see cref="Domain.Enums.GameNightInvitationStatus.Pending"/>
+    /// invitation already exists for the given <paramref name="gameNightId"/>
+    /// and normalized <paramref name="email"/>. Used by the create command to
+    /// reject duplicate invites without round-tripping the aggregate.
+    /// </summary>
+    Task<bool> ExistsPendingByEmailAsync(
+        Guid gameNightId, string email, CancellationToken cancellationToken = default);
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Enums/GameNightInvitationStatus.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Enums/GameNightInvitationStatus.cs
@@ -1,0 +1,23 @@
+namespace Api.BoundedContexts.GameManagement.Domain.Enums;
+
+/// <summary>
+/// Lifecycle status of a token-based game-night invitation.
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// </summary>
+public enum GameNightInvitationStatus
+{
+    /// <summary>Invitation created, awaiting guest response.</summary>
+    Pending = 0,
+
+    /// <summary>Guest accepted the invitation.</summary>
+    Accepted = 1,
+
+    /// <summary>Guest declined the invitation.</summary>
+    Declined = 2,
+
+    /// <summary>Expiration cutoff passed without a response.</summary>
+    Expired = 3,
+
+    /// <summary>Cancelled by organizer (or because the parent game night was cancelled).</summary>
+    Cancelled = 4,
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/GameNightInvitationCreatedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/GameNightInvitationCreatedEvent.cs
@@ -1,0 +1,35 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Events;
+
+/// <summary>
+/// Domain event raised when a token-based game-night invitation is created.
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// </summary>
+/// <remarks>
+/// Triggers downstream side effects: email dispatch via
+/// <see cref="Api.BoundedContexts.UserNotifications"/> integration handlers,
+/// and any analytics / activity log entries.
+/// </remarks>
+internal sealed class GameNightInvitationCreatedEvent : DomainEventBase
+{
+    public Guid GameNightInvitationId { get; }
+    public Guid GameNightId { get; }
+    public string Email { get; }
+    public string Token { get; }
+    public DateTimeOffset ExpiresAt { get; }
+
+    public GameNightInvitationCreatedEvent(
+        Guid gameNightInvitationId,
+        Guid gameNightId,
+        string email,
+        string token,
+        DateTimeOffset expiresAt)
+    {
+        GameNightInvitationId = gameNightInvitationId;
+        GameNightId = gameNightId;
+        Email = email;
+        Token = token;
+        ExpiresAt = expiresAt;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/GameNightInvitationRespondedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/GameNightInvitationRespondedEvent.cs
@@ -1,0 +1,37 @@
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Events;
+
+/// <summary>
+/// Domain event raised when a guest responds (Accept/Decline) to a token-based
+/// game-night invitation.
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// </summary>
+/// <remarks>
+/// Carries <see cref="RespondedByUserId"/> only when the responder happened to be
+/// authenticated at response time (optional cookie auth on the public endpoint).
+/// Anonymous guests yield <c>null</c>.
+/// </remarks>
+internal sealed class GameNightInvitationRespondedEvent : DomainEventBase
+{
+    public Guid GameNightInvitationId { get; }
+    public Guid GameNightId { get; }
+    public string Token { get; }
+    public GameNightInvitationStatus Status { get; }
+    public Guid? RespondedByUserId { get; }
+
+    public GameNightInvitationRespondedEvent(
+        Guid gameNightInvitationId,
+        Guid gameNightId,
+        string token,
+        GameNightInvitationStatus status,
+        Guid? respondedByUserId)
+    {
+        GameNightInvitationId = gameNightInvitationId;
+        GameNightId = gameNightId;
+        Token = token;
+        Status = status;
+        RespondedByUserId = respondedByUserId;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/ValueObjects/InvitationToken.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/ValueObjects/InvitationToken.cs
@@ -1,0 +1,92 @@
+using System.Security.Cryptography;
+using Api.SharedKernel.Utilities;
+
+namespace Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+
+/// <summary>
+/// Immutable value object representing a public invitation token used for game-night RSVP.
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Token shape: 22 base62 characters (alphabet 0-9, A-Z, a-z) encoding 16 bytes
+/// of cryptographic randomness (~131 bits of entropy). Suitable for URL path segments
+/// without percent-encoding and resistant to brute-force enumeration.
+/// </para>
+/// <para>
+/// Generated tokens MUST come from <see cref="Generate"/> (uses
+/// <see cref="RandomNumberGenerator"/>). The <see cref="Create"/> factory exists for
+/// reconstitution from persisted state and validates length + alphabet.
+/// </para>
+/// </remarks>
+public sealed record InvitationToken
+{
+    /// <summary>
+    /// Fixed length of every generated invitation token (22 base62 characters).
+    /// </summary>
+    public const int Length = 22;
+
+    /// <summary>
+    /// The token string. Always 22 characters, base62 alphabet.
+    /// </summary>
+    public string Value { get; }
+
+    private InvitationToken(string value) => Value = value;
+
+    /// <summary>
+    /// Reconstitutes a token from a persisted string. Validates length and alphabet.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when the input is null/empty/wrong length, or contains non-base62 characters.
+    /// </exception>
+    public static InvitationToken Create(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("Token cannot be empty", nameof(value));
+        }
+        if (value.Length != Length)
+        {
+            throw new ArgumentException($"Token must be {Length} characters", nameof(value));
+        }
+        if (!IsValidBase62(value))
+        {
+            throw new ArgumentException("Token must contain only base62 characters", nameof(value));
+        }
+
+        return new InvitationToken(value);
+    }
+
+    /// <summary>
+    /// Generates a fresh, cryptographically random invitation token.
+    /// </summary>
+    public static InvitationToken Generate()
+    {
+        Span<byte> bytes = stackalloc byte[16];
+        RandomNumberGenerator.Fill(bytes);
+        return new InvitationToken(Base62.Encode(bytes));
+    }
+
+    /// <summary>
+    /// Implicit conversion to string for ergonomic use as cache keys / URL segments.
+    /// </summary>
+    public static implicit operator string(InvitationToken token) => token.Value;
+
+    public override string ToString() => Value;
+
+    private static bool IsValidBase62(string s)
+    {
+        for (int i = 0; i < s.Length; i++)
+        {
+            char c = s[i];
+            bool isValid = (c >= '0' && c <= '9')
+                           || (c >= 'A' && c <= 'Z')
+                           || (c >= 'a' && c <= 'z');
+            if (!isValid)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/DependencyInjection/GameManagementServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/DependencyInjection/GameManagementServiceExtensions.cs
@@ -44,6 +44,7 @@ internal static class GameManagementServiceExtensions
         services.AddScoped<ISessionAttachmentRepository, SessionAttachmentRepository>(); // Issue #5360: Session photo attachments
         services.AddScoped<IGameNightPlaylistRepository, GameNightPlaylistRepository>(); // Issue #5582: Game Night Playlist
         services.AddScoped<IGameNightEventRepository, GameNightEventRepository>(); // Issue #42: Game Night Event
+        services.AddScoped<IGameNightInvitationRepository, GameNightInvitationRepository>(); // Issue #607: Token-based public RSVP invitations
         services.AddScoped<IRuleDisputeRepository, RuleDisputeRepository>(); // Structured rule dispute persistence
         services.AddScoped<IGamePhaseTemplateRepository, GamePhaseTemplateRepository>(); // Game phase templates for session setup
         services.AddScoped<IPhaseRulesSearchService, PhaseRulesSearchService>(); // Phase rules keyword search via TextChunks

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightInvitationRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightInvitationRepository.cs
@@ -1,0 +1,214 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
+
+/// <summary>
+/// EF Core implementation of <see cref="IGameNightInvitationRepository"/>.
+/// Maps between the domain <see cref="GameNightInvitation"/> aggregate and the
+/// <see cref="GameNightInvitationEntity"/> persistence model.
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// </summary>
+internal class GameNightInvitationRepository : RepositoryBase, IGameNightInvitationRepository
+{
+    private readonly ILogger<GameNightInvitationRepository> _logger;
+
+    public GameNightInvitationRepository(
+        MeepleAiDbContext dbContext,
+        IDomainEventCollector eventCollector,
+        ILogger<GameNightInvitationRepository> logger)
+        : base(dbContext, eventCollector)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Defensive enum parser: returns the parsed value when valid, otherwise logs an error
+    /// and returns the corruption fallback. Matches the pattern in
+    /// <see cref="GameNightEventRepository"/> to prevent 500 errors from legacy/typo'd
+    /// status values in the persistence layer.
+    /// </summary>
+    private TEnum ParseEnumSafe<TEnum>(
+        string rawValue,
+        TEnum corruptedFallback,
+        string entityId,
+        string fieldName) where TEnum : struct, Enum
+    {
+        if (Enum.TryParse<TEnum>(rawValue, ignoreCase: false, out var parsed)
+            && Enum.IsDefined(parsed))
+        {
+            return parsed;
+        }
+
+        _logger.LogError(
+            "Corrupted {EnumType} value '{RawValue}' for entity {EntityId}.{FieldName}. Mapped to {Fallback}.",
+            typeof(TEnum).Name, rawValue, entityId, fieldName, corruptedFallback);
+
+        return corruptedFallback;
+    }
+
+    public async Task<GameNightInvitation?> GetByIdAsync(
+        Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.GameNightInvitations
+            .AsNoTracking()
+            .FirstOrDefaultAsync(i => i.Id == id, cancellationToken).ConfigureAwait(false);
+
+        return entity is null ? null : MapToDomain(entity);
+    }
+
+    public async Task<GameNightInvitation?> GetByTokenAsync(
+        string token, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(token);
+
+        var entity = await DbContext.GameNightInvitations
+            .AsNoTracking()
+            .FirstOrDefaultAsync(i => i.Token == token, cancellationToken).ConfigureAwait(false);
+
+        return entity is null ? null : MapToDomain(entity);
+    }
+
+    public async Task<IReadOnlyList<GameNightInvitation>> GetAllAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var entities = await DbContext.GameNightInvitations
+            .AsNoTracking()
+            .OrderByDescending(i => i.CreatedAt)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return entities.Select(MapToDomain).ToList();
+    }
+
+    public async Task<IReadOnlyList<GameNightInvitation>> GetByGameNightIdAsync(
+        Guid gameNightId, CancellationToken cancellationToken = default)
+    {
+        var entities = await DbContext.GameNightInvitations
+            .AsNoTracking()
+            .Where(i => i.GameNightId == gameNightId)
+            .OrderByDescending(i => i.CreatedAt)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return entities.Select(MapToDomain).ToList();
+    }
+
+    public async Task<int> CountAcceptedByGameNightIdAsync(
+        Guid gameNightId, CancellationToken cancellationToken = default)
+    {
+        var acceptedLiteral = nameof(GameNightInvitationStatus.Accepted);
+
+        return await DbContext.GameNightInvitations
+            .AsNoTracking()
+            .Where(i => i.GameNightId == gameNightId && i.Status == acceptedLiteral)
+            .CountAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<bool> ExistsPendingByEmailAsync(
+        Guid gameNightId, string email, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(email);
+
+        var pendingLiteral = nameof(GameNightInvitationStatus.Pending);
+        var normalizedEmail = email.Trim().ToLowerInvariant();
+
+        return await DbContext.GameNightInvitations
+            .AsNoTracking()
+            .AnyAsync(
+                i => i.GameNightId == gameNightId
+                    && i.Email == normalizedEmail
+                    && i.Status == pendingLiteral,
+                cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task AddAsync(
+        GameNightInvitation invitation, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(invitation);
+        CollectDomainEvents(invitation);
+
+        var entity = MapToPersistence(invitation);
+        await DbContext.GameNightInvitations
+            .AddAsync(entity, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public Task UpdateAsync(
+        GameNightInvitation invitation, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(invitation);
+        CollectDomainEvents(invitation);
+
+        var entity = MapToPersistence(invitation);
+        DbContext.GameNightInvitations.Update(entity);
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(
+        GameNightInvitation invitation, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(invitation);
+        var entity = MapToPersistence(invitation);
+        DbContext.GameNightInvitations.Remove(entity);
+        return Task.CompletedTask;
+    }
+
+    public async Task<bool> ExistsAsync(
+        Guid id, CancellationToken cancellationToken = default)
+    {
+        return await DbContext.GameNightInvitations
+            .AsNoTracking()
+            .AnyAsync(i => i.Id == id, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static GameNightInvitationEntity MapToPersistence(GameNightInvitation domain)
+    {
+        ArgumentNullException.ThrowIfNull(domain);
+
+        return new GameNightInvitationEntity
+        {
+            Id = domain.Id,
+            Token = domain.Token,
+            GameNightId = domain.GameNightId,
+            Email = domain.Email,
+            Status = domain.Status.ToString(),
+            ExpiresAt = domain.ExpiresAt,
+            RespondedAt = domain.RespondedAt,
+            RespondedByUserId = domain.RespondedByUserId,
+            CreatedAt = domain.CreatedAt,
+            CreatedBy = domain.CreatedBy
+        };
+    }
+
+    private GameNightInvitation MapToDomain(GameNightInvitationEntity entity)
+    {
+        var status = ParseEnumSafe(
+            entity.Status,
+            GameNightInvitationStatus.Cancelled, // safest terminal fallback for corrupted rows
+            entity.Id.ToString(),
+            nameof(entity.Status));
+
+        var invitation = GameNightInvitation.Reconstitute(
+            id: entity.Id,
+            token: entity.Token,
+            gameNightId: entity.GameNightId,
+            email: entity.Email,
+            status: status,
+            expiresAt: entity.ExpiresAt,
+            respondedAt: entity.RespondedAt,
+            respondedByUserId: entity.RespondedByUserId,
+            createdAt: entity.CreatedAt,
+            createdBy: entity.CreatedBy);
+
+        // Reconstitute is a pure factory and does not raise events — defensive clear in case
+        // base AggregateRoot ctor introduces any (matches GameNightEventRepository pattern).
+        invitation.ClearDomainEvents();
+
+        return invitation;
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Entities/GameManagement/GameNightInvitationEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameManagement/GameNightInvitationEntity.cs
@@ -1,0 +1,59 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Api.Infrastructure.Entities.GameManagement;
+
+/// <summary>
+/// EF Core persistence entity for token-based game-night invitations.
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// </summary>
+/// <remarks>
+/// Distinct from <see cref="GameNightRsvpEntity"/>: that table tracks RSVPs by
+/// <c>UserId</c> for users already known to the system; this table persists the
+/// public, token-addressable invitation lifecycle (sent by email to addresses
+/// that may not yet be registered).
+/// </remarks>
+[Table("game_night_invitations")]
+public class GameNightInvitationEntity
+{
+    [Key]
+    [Column("id")]
+    public Guid Id { get; set; }
+
+    [Required]
+    [Column("token")]
+    [MaxLength(32)]
+    public string Token { get; set; } = string.Empty;
+
+    [Required]
+    [Column("game_night_id")]
+    public Guid GameNightId { get; set; }
+
+    [Required]
+    [Column("email")]
+    [MaxLength(320)]
+    public string Email { get; set; } = string.Empty;
+
+    [Required]
+    [Column("status")]
+    [MaxLength(20)]
+    public string Status { get; set; } = "Pending";
+
+    [Required]
+    [Column("expires_at")]
+    public DateTimeOffset ExpiresAt { get; set; }
+
+    [Column("responded_at")]
+    public DateTimeOffset? RespondedAt { get; set; }
+
+    [Column("responded_by_user_id")]
+    public Guid? RespondedByUserId { get; set; }
+
+    [Required]
+    [Column("created_at")]
+    public DateTimeOffset CreatedAt { get; set; }
+
+    [Required]
+    [Column("created_by")]
+    public Guid CreatedBy { get; set; }
+}

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/GameNightInvitationEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/GameNightInvitationEntityConfiguration.cs
@@ -1,0 +1,63 @@
+using Api.Infrastructure.Entities.GameManagement;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations.GameManagement;
+
+/// <summary>
+/// EF Core configuration for <see cref="GameNightInvitationEntity"/>.
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Indexes:
+/// <list type="bullet">
+///   <item><c>IX_game_night_invitations_token</c> — UNIQUE on Token, supports the
+///         primary public lookup path (<c>GET /api/v1/invites/{token}</c>).</item>
+///   <item><c>IX_game_night_invitations_event_email_status</c> — composite on
+///         (GameNightId, Email, Status), supports the duplicate-pending guard
+///         in <c>CreateGameNightInvitationByEmailCommand</c>.</item>
+///   <item><c>IX_game_night_invitations_event_status</c> — composite on
+///         (GameNightId, Status), supports the AcceptedSoFar count.</item>
+/// </list>
+/// </para>
+/// <para>
+/// FK: <c>GameNightId → game_night_events.id</c> with cascade delete, so
+/// cancelling a parent event purges its invitations atomically.
+/// </para>
+/// </remarks>
+internal class GameNightInvitationEntityConfiguration
+    : IEntityTypeConfiguration<GameNightInvitationEntity>
+{
+    public void Configure(EntityTypeBuilder<GameNightInvitationEntity> builder)
+    {
+        builder.ToTable("game_night_invitations");
+        builder.HasKey(i => i.Id);
+
+        builder.Property(i => i.Id).HasColumnName("id").ValueGeneratedNever();
+        builder.Property(i => i.Token).HasColumnName("token").HasMaxLength(32).IsRequired();
+        builder.Property(i => i.GameNightId).HasColumnName("game_night_id").IsRequired();
+        builder.Property(i => i.Email).HasColumnName("email").HasMaxLength(320).IsRequired();
+        builder.Property(i => i.Status).HasColumnName("status").HasMaxLength(20).IsRequired();
+        builder.Property(i => i.ExpiresAt).HasColumnName("expires_at").IsRequired();
+        builder.Property(i => i.RespondedAt).HasColumnName("responded_at");
+        builder.Property(i => i.RespondedByUserId).HasColumnName("responded_by_user_id");
+        builder.Property(i => i.CreatedAt).HasColumnName("created_at").IsRequired();
+        builder.Property(i => i.CreatedBy).HasColumnName("created_by").IsRequired();
+
+        builder.HasIndex(i => i.Token)
+            .HasDatabaseName("IX_game_night_invitations_token")
+            .IsUnique();
+
+        builder.HasIndex(i => new { i.GameNightId, i.Email, i.Status })
+            .HasDatabaseName("IX_game_night_invitations_event_email_status");
+
+        builder.HasIndex(i => new { i.GameNightId, i.Status })
+            .HasDatabaseName("IX_game_night_invitations_event_status");
+
+        builder.HasOne<GameNightEventEntity>()
+            .WithMany()
+            .HasForeignKey(i => i.GameNightId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -218,6 +218,7 @@ public class MeepleAiDbContext : DbContext
     public DbSet<GameNightEventEntity> GameNightEvents => Set<GameNightEventEntity>(); // ISSUE-42: Game Night Event
     public DbSet<GameNightRsvpEntity> GameNightRsvps => Set<GameNightRsvpEntity>(); // ISSUE-42: Game Night RSVP
     public DbSet<GameNightSessionEntity> GameNightSessions => Set<GameNightSessionEntity>(); // Game Night Sessions
+    public DbSet<GameNightInvitationEntity> GameNightInvitations => Set<GameNightInvitationEntity>(); // ISSUE-607: Token-based public RSVP invitations
     public DbSet<RuleDisputeEntity> RuleDisputes => Set<RuleDisputeEntity>(); // Structured rule dispute persistence
     public DbSet<BoundedContexts.AgentMemory.Infrastructure.Entities.GameMemoryEntity> GameMemories => Set<BoundedContexts.AgentMemory.Infrastructure.Entities.GameMemoryEntity>(); // AgentMemory: per-game memory
     public DbSet<BoundedContexts.AgentMemory.Infrastructure.Entities.GroupMemoryEntity> GroupMemories => Set<BoundedContexts.AgentMemory.Infrastructure.Entities.GroupMemoryEntity>(); // AgentMemory: play group memory

--- a/apps/api/src/Api/Infrastructure/Migrations/20260428191543_AddGameNightInvitations.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260428191543_AddGameNightInvitations.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428191543_AddGameNightInvitations")]
+    partial class AddGameNightInvitations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260428191543_AddGameNightInvitations.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260428191543_AddGameNightInvitations.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGameNightInvitations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "game_night_invitations",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    token = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    game_night_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    email = table.Column<string>(type: "character varying(320)", maxLength: 320, nullable: false),
+                    status = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    expires_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    responded_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    responded_by_user_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    created_by = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_game_night_invitations", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_game_night_invitations_game_night_events_game_night_id",
+                        column: x => x.game_night_id,
+                        principalTable: "game_night_events",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_game_night_invitations_event_email_status",
+                table: "game_night_invitations",
+                columns: new[] { "game_night_id", "email", "status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_game_night_invitations_event_status",
+                table: "game_night_invitations",
+                columns: new[] { "game_night_id", "status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_game_night_invitations_token",
+                table: "game_night_invitations",
+                column: "token",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "game_night_invitations");
+        }
+    }
+}

--- a/apps/api/src/Api/Middleware/Exceptions/GoneException.cs
+++ b/apps/api/src/Api/Middleware/Exceptions/GoneException.cs
@@ -1,0 +1,32 @@
+namespace Api.Middleware.Exceptions;
+
+using System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Exception thrown when a resource has reached a terminal lifecycle state and
+/// is no longer addressable (e.g. an expired or cancelled invitation token).
+/// Maps to HTTP 410 Gone.
+/// </summary>
+/// <remarks>
+/// Issue #607 (Wave A.5a): introduced for token-based invitation lifecycle —
+/// pending-past-expiry, cancelled, and expired states surface as 410 Gone so
+/// the frontend can render a terminal banner instead of retrying.
+/// </remarks>
+public class GoneException : HttpException
+{
+    [SetsRequiredMembers]
+    public GoneException(string message)
+        : base(StatusCodes.Status410Gone, "gone", message)
+    {
+    }
+
+    [SetsRequiredMembers]
+    public GoneException(string message, Exception innerException)
+        : base(StatusCodes.Status410Gone, "gone", message, innerException)
+    {
+    }
+
+    public GoneException()
+    {
+    }
+}

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -686,6 +686,7 @@ v1Api.MapBggEndpoints(); // ISSUE-3120: BoardGameGeek integration
 v1Api.MapGameManagementEndpoints(); // Issue #4273: Game search autocomplete
 v1Api.MapPrivateGameEndpoints();       // Private games (Issue #3663)
 v1Api.MapRuleSpecEndpoints();
+v1Api.MapGameNightEndpoints(); // Issue #46/#607: Game Night Event + public token-based RSVP (Wave A.5)
 
 // Document Processing
 v1Api.MapPdfEndpoints();
@@ -745,7 +746,6 @@ if (!isAlphaMode)
     v1Api.MapWhiteboardEndpoints(); // Issue #4971: Whiteboard base toolkit endpoints
     v1Api.MapSessionSnapshotEndpoints(); // Issue #4755: Session snapshot endpoints
     v1Api.MapPlaylistEndpoints(); // Issue #5582: Game Night Playlist endpoints
-    v1Api.MapGameNightEndpoints(); // Issue #46: Game Night Event endpoints
     v1Api.MapGameNightImprovvisataEndpoints(); // Game Night Improvvisata: E1-2 BGG import
     v1Api.MapRuleConflictFaqEndpoints(); // ISSUE-3966: Rule conflict FAQ management
     v1Api.MapVisionSnapshotEndpoints(); // Session Vision AI: board photo snapshots + game state extraction

--- a/apps/api/src/Api/Routing/GameNightEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameNightEndpoints.cs
@@ -113,6 +113,41 @@ internal static class GameNightEndpoints
             .WithSummary("Respond to a game night invitation")
             .WithDescription("Submits an RSVP response (Accepted, Declined, Maybe) to a game night invitation.");
 
+        // ── Public Token-Based RSVP Endpoints (Issue #607) ──────────────────
+
+        gameNights.MapGet("/invitations/{token}", HandleGetGameNightInvitationByToken)
+            .AllowAnonymous()
+            .Produces<PublicGameNightInvitationDto>(200)
+            .Produces(404)
+            .Produces(410)
+            .WithName("GetGameNightInvitationByToken")
+            .WithSummary("Get a game night invitation by token")
+            .WithDescription("Public endpoint to retrieve a game night invitation by its opaque token. Returns 410 Gone for terminal states (Expired, Cancelled).");
+
+        gameNights.MapPost("/invitations/{token}/respond", HandleRespondToGameNightInvitationByToken)
+            .AllowAnonymous()
+            .Produces<PublicGameNightInvitationDto>(200)
+            .Produces(400)
+            .Produces(404)
+            .Produces(409)
+            .Produces(410)
+            .WithName("RespondToGameNightInvitationByToken")
+            .WithSummary("Respond to a game night invitation by token")
+            .WithDescription("Public endpoint to submit an Accepted or Declined response. Optional auth: authenticated callers have their UserId attached. Idempotent on same-state; conflicts on switching across statuses.");
+
+        gameNights.MapPost("/{gameNightId:guid}/invitations", HandleCreateGameNightInvitationByEmail)
+            .RequireAuthenticatedUser()
+            .Produces<GameNightInvitationDto>(201)
+            .Produces(400)
+            .Produces(401)
+            .Produces(403)
+            .Produces(404)
+            .Produces(409)
+            .Produces(422)
+            .WithName("CreateGameNightInvitationByEmail")
+            .WithSummary("Create a token-addressable invitation by email")
+            .WithDescription("Organizer-only endpoint to issue an opaque-token invitation to a non-platform email. Returns 409 if a pending invitation for the same email already exists.");
+
         // ── Game Night Experience v2 Endpoints ──────────────────────────────
 
         gameNights.MapPost("/{id:guid}/sessions", HandleStartGameNightSession)
@@ -262,6 +297,53 @@ internal static class GameNightEndpoints
         return Results.NoContent();
     }
 
+    private static async Task<IResult> HandleCreateGameNightInvitationByEmail(
+        Guid gameNightId,
+        [FromBody] CreateInvitationByEmailRequest request,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+
+        var command = new CreateGameNightInvitationByEmailCommand(
+            GameNightId: gameNightId,
+            Email: request.Email,
+            OrganizerUserId: userId);
+
+        var dto = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.Created($"/api/v1/game-nights/{gameNightId}/invitations/{dto.Id}", dto);
+    }
+
+    private static async Task<IResult> HandleRespondToGameNightInvitationByToken(
+        string token,
+        [FromBody] RespondToInvitationByTokenRequest request,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        if (!Enum.TryParse<GameNightInvitationStatus>(request.Response, ignoreCase: true, out var status)
+            || (status != GameNightInvitationStatus.Accepted && status != GameNightInvitationStatus.Declined))
+        {
+            return Results.BadRequest(new { error = "Invalid response. Must be Accepted or Declined." });
+        }
+
+        var rawUserId = httpContext.User.GetUserId();
+        var responderUserId = rawUserId == Guid.Empty ? (Guid?)null : rawUserId;
+
+        var command = new RespondToGameNightInvitationByTokenCommand(
+            Token: token,
+            Response: status,
+            ResponderUserId: responderUserId);
+
+        await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+
+        var updated = await mediator.Send(
+            new GetGameNightInvitationByTokenQuery(token), cancellationToken).ConfigureAwait(false);
+
+        return updated is null ? Results.NotFound() : Results.Ok(updated);
+    }
+
     private static async Task<IResult> HandleStartGameNightSession(
         Guid id,
         [FromBody] StartGameNightSessionRequest request,
@@ -360,6 +442,17 @@ internal static class GameNightEndpoints
         return Results.Ok(result);
     }
 
+    private static async Task<IResult> HandleGetGameNightInvitationByToken(
+        string token,
+        [FromServices] IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(
+            new GetGameNightInvitationByTokenQuery(token), cancellationToken).ConfigureAwait(false);
+
+        return result is null ? Results.NotFound() : Results.Ok(result);
+    }
+
     #endregion
 
     #region Request Records
@@ -384,6 +477,10 @@ internal static class GameNightEndpoints
     private sealed record InviteToGameNightRequest(List<Guid> UserIds);
 
     private sealed record RespondToGameNightRequest(string Response);
+
+    // Public token-based RSVP request records (Issue #607)
+    private sealed record CreateInvitationByEmailRequest(string Email);
+    private sealed record RespondToInvitationByTokenRequest(string Response);
 
     // Game Night Experience v2 request records
     private sealed record StartGameNightSessionRequest(Guid GameId, string GameTitle);

--- a/apps/api/src/Api/SharedKernel/Utilities/Base62.cs
+++ b/apps/api/src/Api/SharedKernel/Utilities/Base62.cs
@@ -1,0 +1,75 @@
+namespace Api.SharedKernel.Utilities;
+
+/// <summary>
+/// Minimal Base62 encoder for compact, URL-safe identifiers.
+/// Used by domain value objects that need short tokens (e.g. <c>InvitationToken</c>).
+/// </summary>
+/// <remarks>
+/// Encodes raw bytes as base62 (alphabet 0-9, A-Z, a-z). 16 bytes (~131 bits of entropy)
+/// encode to 22 characters, providing collision-resistant invitation tokens that are
+/// safe to embed in URL path segments without percent-encoding.
+/// </remarks>
+internal static class Base62
+{
+    private const string Alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    private const int Base = 62;
+
+    /// <summary>
+    /// Encodes the given bytes as a base62 string.
+    /// </summary>
+    /// <remarks>
+    /// Uses big-integer style positional division. Output length is deterministic for
+    /// fixed-size inputs (16 bytes always produce 22 characters via left-padding).
+    /// </remarks>
+    public static string Encode(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.IsEmpty)
+        {
+            return string.Empty;
+        }
+
+        // Convert big-endian byte sequence to a non-negative big integer represented as
+        // an array of digits in base 62. We use a mutable byte array to support division.
+        var workingBuffer = new byte[bytes.Length];
+        bytes.CopyTo(workingBuffer);
+
+        var digits = new List<char>(capacity: 22);
+
+        // Repeatedly divide the big integer by 62, collecting remainders.
+        while (!IsZero(workingBuffer))
+        {
+            int remainder = 0;
+            for (int i = 0; i < workingBuffer.Length; i++)
+            {
+                int accumulator = (remainder << 8) | workingBuffer[i];
+                workingBuffer[i] = (byte)(accumulator / Base);
+                remainder = accumulator % Base;
+            }
+            digits.Add(Alphabet[remainder]);
+        }
+
+        // 16 bytes → up to 22 base62 chars. Pad with leading '0' so the encoding is
+        // length-deterministic (matches InvitationToken contract: always 22 chars).
+        // 22 = ceil(16 * log(256) / log(62)) = ceil(21.49) = 22
+        const int FixedLength = 22;
+        while (bytes.Length == 16 && digits.Count < FixedLength)
+        {
+            digits.Add(Alphabet[0]);
+        }
+
+        digits.Reverse();
+        return new string(digits.ToArray());
+    }
+
+    private static bool IsZero(ReadOnlySpan<byte> bytes)
+    {
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            if (bytes[i] != 0)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/apps/api/src/Api/appsettings.json
+++ b/apps/api/src/Api/appsettings.json
@@ -72,6 +72,10 @@
     "Comment": "Issue #593 Wave A.3a — runtime tunables for v2 /shared-games chip filters. Threshold lowered 4.5→4.0 in Wave A.3b (Issue #596) to match mockup sp3-shared-games.jsx:126.",
     "TopRatedThreshold": 4.0
   },
+  "GameNight": {
+    "Comment": "Issue #607 Wave A.5a — token-based public RSVP. InvitationExpiryDays controls TTL applied at invitation creation; expired pending invitations transition to Expired (410 Gone) on read.",
+    "InvitationExpiryDays": 14
+  },
   "Indexing": {
     "Comment": "ISSUE-3197: Vector indexing configuration for memory optimization",
     "EmbeddingBatchSize": 100

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Commands/GameNights/CreateGameNightInvitationByEmailCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Commands/GameNights/CreateGameNightInvitationByEmailCommandHandlerTests.cs
@@ -1,0 +1,242 @@
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Unit tests for <see cref="CreateGameNightInvitationByEmailCommandHandler"/>.
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// Verifies organizer authorization, duplicate-pending guard, and the email
+/// dispatch side-effect (D1 a — see executive spec §5).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class CreateGameNightInvitationByEmailCommandHandlerTests
+{
+    private static readonly DateTimeOffset UtcNow = new(2026, 5, 1, 12, 0, 0, TimeSpan.Zero);
+    private const string BaseUrl = "https://meepleai.test";
+
+    private readonly Mock<IGameNightInvitationRepository> _invitationRepoMock = new();
+    private readonly Mock<IGameNightEventRepository> _gameNightRepoMock = new();
+    private readonly Mock<IUserRepository> _userRepoMock = new();
+    private readonly Mock<IGameRepository> _gameRepoMock = new();
+    private readonly Mock<IGameNightEmailService> _emailServiceMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly FakeTimeProvider _timeProvider = new(UtcNow);
+    private readonly CreateGameNightInvitationByEmailCommandHandler _sut;
+
+    public CreateGameNightInvitationByEmailCommandHandlerTests()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["App:BaseUrl"] = BaseUrl,
+            })
+            .Build();
+
+        _sut = new CreateGameNightInvitationByEmailCommandHandler(
+            _invitationRepoMock.Object,
+            _gameNightRepoMock.Object,
+            _userRepoMock.Object,
+            _gameRepoMock.Object,
+            _emailServiceMock.Object,
+            _unitOfWorkMock.Object,
+            configuration,
+            _timeProvider);
+    }
+
+    private static GameNightEvent CreateGameNight(Guid organizerId)
+    {
+        return GameNightEvent.Create(
+            organizerId: organizerId,
+            title: "Friday Night Catan",
+            scheduledAt: UtcNow.AddDays(7),
+            description: null,
+            location: "My place",
+            maxPlayers: 5,
+            gameIds: null);
+    }
+
+    [Fact]
+    public async Task Handle_GameNightNotFound_ThrowsNotFoundException()
+    {
+        var gameNightId = Guid.NewGuid();
+        _gameNightRepoMock
+            .Setup(r => r.GetByIdAsync(gameNightId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GameNightEvent?)null);
+
+        var command = new CreateGameNightInvitationByEmailCommand(
+            gameNightId, "guest@example.com", Guid.NewGuid());
+
+        var act = async () => await _sut.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+        _unitOfWorkMock.Verify(
+            u => u.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_CallerIsNotOrganizer_ThrowsUnauthorizedAccessException()
+    {
+        var organizerId = Guid.NewGuid();
+        var attackerId = Guid.NewGuid();
+        var gameNight = CreateGameNight(organizerId);
+        _gameNightRepoMock
+            .Setup(r => r.GetByIdAsync(gameNight.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameNight);
+
+        var command = new CreateGameNightInvitationByEmailCommand(
+            gameNight.Id, "guest@example.com", attackerId);
+
+        var act = async () => await _sut.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+        _invitationRepoMock.Verify(
+            r => r.AddAsync(It.IsAny<GameNightInvitation>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_DuplicatePendingInvitation_ThrowsConflictException()
+    {
+        var organizerId = Guid.NewGuid();
+        var gameNight = CreateGameNight(organizerId);
+        _gameNightRepoMock
+            .Setup(r => r.GetByIdAsync(gameNight.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameNight);
+        _invitationRepoMock
+            .Setup(r => r.ExistsPendingByEmailAsync(
+                gameNight.Id, "guest@example.com", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var command = new CreateGameNightInvitationByEmailCommand(
+            gameNight.Id, "  GUEST@example.com  ", organizerId);
+
+        var act = async () => await _sut.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictException>();
+        // Duplicate guard normalizes email (trim + lowercase) before lookup.
+        _invitationRepoMock.Verify(
+            r => r.ExistsPendingByEmailAsync(
+                gameNight.Id, "guest@example.com", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _invitationRepoMock.Verify(
+            r => r.AddAsync(It.IsAny<GameNightInvitation>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_PersistsAggregateAndDispatchesEmail()
+    {
+        var organizerId = Guid.NewGuid();
+        var gameNight = CreateGameNight(organizerId);
+        _gameNightRepoMock
+            .Setup(r => r.GetByIdAsync(gameNight.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameNight);
+        _invitationRepoMock
+            .Setup(r => r.ExistsPendingByEmailAsync(
+                gameNight.Id, "guest@example.com", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _userRepoMock
+            .Setup(r => r.GetByIdAsync(organizerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Api.BoundedContexts.Authentication.Domain.Entities.User?)null);
+
+        GameNightInvitation? captured = null;
+        _invitationRepoMock
+            .Setup(r => r.AddAsync(It.IsAny<GameNightInvitation>(), It.IsAny<CancellationToken>()))
+            .Callback<GameNightInvitation, CancellationToken>((inv, _) => captured = inv);
+
+        var command = new CreateGameNightInvitationByEmailCommand(
+            gameNight.Id, "Guest@example.com", organizerId);
+
+        var dto = await _sut.Handle(command, CancellationToken.None);
+
+        captured.Should().NotBeNull();
+        captured!.Status.Should().Be(GameNightInvitationStatus.Pending);
+        captured.Email.Should().Be("guest@example.com");
+        captured.ExpiresAt.Should().Be(UtcNow.AddDays(14)); // DefaultExpiryDays.
+
+        _invitationRepoMock.Verify(
+            r => r.AddAsync(It.IsAny<GameNightInvitation>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _unitOfWorkMock.Verify(
+            u => u.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Email dispatched after persistence with token-bearing accept/decline URLs.
+        _emailServiceMock.Verify(
+            e => e.SendGameNightInvitationEmailAsync(
+                "guest@example.com",
+                "A friend", // Falls back to "A friend" when organizer is null.
+                gameNight.Title,
+                gameNight.ScheduledAt,
+                gameNight.Location,
+                It.IsAny<IReadOnlyList<string>>(),
+                $"{BaseUrl}/invites/{captured.Token}?action=accept",
+                $"{BaseUrl}/invites/{captured.Token}?action=decline",
+                $"{BaseUrl}/invites/{captured.Token}/unsubscribe",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        dto.Token.Should().Be(captured.Token);
+        dto.Status.Should().Be(nameof(GameNightInvitationStatus.Pending));
+        dto.GameNightId.Should().Be(gameNight.Id);
+    }
+
+    [Fact]
+    public async Task Handle_OverridesDefaultExpiryFromConfiguration()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["App:BaseUrl"] = BaseUrl,
+                ["GameNight:InvitationExpiryDays"] = "30",
+            })
+            .Build();
+
+        var sut = new CreateGameNightInvitationByEmailCommandHandler(
+            _invitationRepoMock.Object,
+            _gameNightRepoMock.Object,
+            _userRepoMock.Object,
+            _gameRepoMock.Object,
+            _emailServiceMock.Object,
+            _unitOfWorkMock.Object,
+            configuration,
+            _timeProvider);
+
+        var organizerId = Guid.NewGuid();
+        var gameNight = CreateGameNight(organizerId);
+        _gameNightRepoMock
+            .Setup(r => r.GetByIdAsync(gameNight.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameNight);
+        _invitationRepoMock
+            .Setup(r => r.ExistsPendingByEmailAsync(
+                gameNight.Id, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        GameNightInvitation? captured = null;
+        _invitationRepoMock
+            .Setup(r => r.AddAsync(It.IsAny<GameNightInvitation>(), It.IsAny<CancellationToken>()))
+            .Callback<GameNightInvitation, CancellationToken>((inv, _) => captured = inv);
+
+        var command = new CreateGameNightInvitationByEmailCommand(
+            gameNight.Id, "guest@example.com", organizerId);
+
+        await sut.Handle(command, CancellationToken.None);
+
+        captured!.ExpiresAt.Should().Be(UtcNow.AddDays(30));
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Commands/GameNights/RespondToGameNightInvitationByTokenCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Commands/GameNights/RespondToGameNightInvitationByTokenCommandHandlerTests.cs
@@ -1,0 +1,211 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Unit tests for <see cref="RespondToGameNightInvitationByTokenCommandHandler"/>.
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// Verifies the idempotency contract D2(b) and the HTTP status mapping
+/// (404/410/409) configured by the handler before the aggregate is invoked.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class RespondToGameNightInvitationByTokenCommandHandlerTests
+{
+    private const string Token = "abcdefghijklmnopqrstuv";
+    private static readonly DateTimeOffset UtcNow = new(2026, 5, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly Mock<IGameNightInvitationRepository> _invitationRepoMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly FakeTimeProvider _timeProvider = new(UtcNow);
+    private readonly RespondToGameNightInvitationByTokenCommandHandler _sut;
+
+    public RespondToGameNightInvitationByTokenCommandHandlerTests()
+    {
+        _sut = new RespondToGameNightInvitationByTokenCommandHandler(
+            _invitationRepoMock.Object,
+            _unitOfWorkMock.Object,
+            _timeProvider);
+    }
+
+    private static GameNightInvitation Reconstitute(
+        GameNightInvitationStatus status,
+        DateTimeOffset? expiresAt = null,
+        DateTimeOffset? respondedAt = null)
+    {
+        return GameNightInvitation.Reconstitute(
+            id: Guid.NewGuid(),
+            token: Token,
+            gameNightId: Guid.NewGuid(),
+            email: "guest@example.com",
+            status: status,
+            expiresAt: expiresAt ?? UtcNow.AddDays(7),
+            respondedAt: respondedAt,
+            respondedByUserId: null,
+            createdAt: UtcNow.AddDays(-1),
+            createdBy: Guid.NewGuid());
+    }
+
+    [Fact]
+    public async Task Handle_TokenNotFound_ThrowsNotFoundException()
+    {
+        _invitationRepoMock
+            .Setup(r => r.GetByTokenAsync(Token, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GameNightInvitation?)null);
+
+        var command = new RespondToGameNightInvitationByTokenCommand(
+            Token, GameNightInvitationStatus.Accepted, ResponderUserId: null);
+
+        var act = async () => await _sut.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_CancelledInvitation_ThrowsGoneException()
+    {
+        var invitation = Reconstitute(GameNightInvitationStatus.Cancelled);
+        _invitationRepoMock
+            .Setup(r => r.GetByTokenAsync(Token, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invitation);
+
+        var command = new RespondToGameNightInvitationByTokenCommand(
+            Token, GameNightInvitationStatus.Accepted, ResponderUserId: null);
+
+        var act = async () => await _sut.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<GoneException>();
+    }
+
+    [Fact]
+    public async Task Handle_ExpiredStatusInvitation_ThrowsGoneException()
+    {
+        var invitation = Reconstitute(GameNightInvitationStatus.Expired);
+        _invitationRepoMock
+            .Setup(r => r.GetByTokenAsync(Token, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invitation);
+
+        var command = new RespondToGameNightInvitationByTokenCommand(
+            Token, GameNightInvitationStatus.Accepted, ResponderUserId: null);
+
+        var act = async () => await _sut.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<GoneException>();
+    }
+
+    [Fact]
+    public async Task Handle_PendingButCutoffPassed_ThrowsGoneException()
+    {
+        // Pending past expiry → 410 Gone (implicit expiry on read, spec §2.2).
+        var invitation = Reconstitute(
+            GameNightInvitationStatus.Pending,
+            expiresAt: UtcNow.AddSeconds(-1));
+        _invitationRepoMock
+            .Setup(r => r.GetByTokenAsync(Token, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invitation);
+
+        var command = new RespondToGameNightInvitationByTokenCommand(
+            Token, GameNightInvitationStatus.Accepted, ResponderUserId: null);
+
+        var act = async () => await _sut.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<GoneException>();
+    }
+
+    [Fact]
+    public async Task Handle_SwitchAcceptedToDeclined_ThrowsConflictException()
+    {
+        // Already-accepted invitation cannot be flipped to Declined → 409 Conflict.
+        var invitation = Reconstitute(GameNightInvitationStatus.Accepted);
+        _invitationRepoMock
+            .Setup(r => r.GetByTokenAsync(Token, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invitation);
+
+        var command = new RespondToGameNightInvitationByTokenCommand(
+            Token, GameNightInvitationStatus.Declined, ResponderUserId: null);
+
+        var act = async () => await _sut.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictException>();
+        _unitOfWorkMock.Verify(
+            u => u.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_SameStateAccepted_IsIdempotentNoOp()
+    {
+        // Re-issuing Accept on Accepted invitation: 200 OK without persistence.
+        var invitation = Reconstitute(GameNightInvitationStatus.Accepted);
+        _invitationRepoMock
+            .Setup(r => r.GetByTokenAsync(Token, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invitation);
+
+        var command = new RespondToGameNightInvitationByTokenCommand(
+            Token, GameNightInvitationStatus.Accepted, ResponderUserId: null);
+
+        await _sut.Handle(command, CancellationToken.None);
+
+        _invitationRepoMock.Verify(
+            r => r.UpdateAsync(It.IsAny<GameNightInvitation>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _unitOfWorkMock.Verify(
+            u => u.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_PendingToAccepted_PersistsTransition()
+    {
+        var invitation = Reconstitute(GameNightInvitationStatus.Pending);
+        _invitationRepoMock
+            .Setup(r => r.GetByTokenAsync(Token, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invitation);
+
+        var responder = Guid.NewGuid();
+        var command = new RespondToGameNightInvitationByTokenCommand(
+            Token, GameNightInvitationStatus.Accepted, responder);
+
+        await _sut.Handle(command, CancellationToken.None);
+
+        invitation.Status.Should().Be(GameNightInvitationStatus.Accepted);
+        invitation.RespondedByUserId.Should().Be(responder);
+        _invitationRepoMock.Verify(
+            r => r.UpdateAsync(invitation, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _unitOfWorkMock.Verify(
+            u => u.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_PendingToDeclined_PersistsTransition()
+    {
+        var invitation = Reconstitute(GameNightInvitationStatus.Pending);
+        _invitationRepoMock
+            .Setup(r => r.GetByTokenAsync(Token, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invitation);
+
+        var command = new RespondToGameNightInvitationByTokenCommand(
+            Token, GameNightInvitationStatus.Declined, ResponderUserId: null);
+
+        await _sut.Handle(command, CancellationToken.None);
+
+        invitation.Status.Should().Be(GameNightInvitationStatus.Declined);
+        _invitationRepoMock.Verify(
+            r => r.UpdateAsync(invitation, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _unitOfWorkMock.Verify(
+            u => u.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/EventHandlers/GameNightInvitationRespondedHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/EventHandlers/GameNightInvitationRespondedHandlerTests.cs
@@ -1,0 +1,235 @@
+using Api.BoundedContexts.GameManagement.Application.EventHandlers;
+using Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.EventHandlers;
+
+/// <summary>
+/// Unit tests for <see cref="GameNightInvitationRespondedHandler"/>.
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// Verifies the post-RSVP fan-out:
+/// (a) cache tag invalidation for <c>game-night-invitation:{token}</c>;
+/// (b) Accepted-only confirmation email dispatch (declined guests skipped).
+///
+/// Uses raw <see cref="HybridCache"/> (NOT <c>IHybridCacheService</c>) to share
+/// the native tag index populated by
+/// <see cref="GetGameNightInvitationByTokenQueryHandler"/> (pitfall #2620).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class GameNightInvitationRespondedHandlerTests
+{
+    private const string Token = "abcdefghijklmnopqrstuv";
+    private static readonly DateTimeOffset UtcNow = new(2026, 5, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly Mock<IGameNightInvitationRepository> _invitationRepoMock = new();
+    private readonly Mock<IGameNightEventRepository> _gameNightRepoMock = new();
+    private readonly Mock<IGameNightEmailService> _emailServiceMock = new();
+    private readonly Mock<ILogger<GameNightInvitationRespondedHandler>> _loggerMock = new();
+
+    private static HybridCache CreateHybridCache()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IMemoryCache, MemoryCache>();
+        services.AddSingleton<IDistributedCache>(new MemoryDistributedCache(
+            Microsoft.Extensions.Options.Options.Create(new MemoryDistributedCacheOptions())));
+        services.AddHybridCache();
+        return services.BuildServiceProvider().GetRequiredService<HybridCache>();
+    }
+
+    private GameNightInvitationRespondedHandler CreateHandler(HybridCache cache) => new(
+        _invitationRepoMock.Object,
+        _gameNightRepoMock.Object,
+        _emailServiceMock.Object,
+        cache,
+        _loggerMock.Object);
+
+    private static GameNightInvitation Reconstitute(GameNightInvitationStatus status)
+    {
+        return GameNightInvitation.Reconstitute(
+            id: Guid.NewGuid(),
+            token: Token,
+            gameNightId: Guid.NewGuid(),
+            email: "guest@example.com",
+            status: status,
+            expiresAt: UtcNow.AddDays(7),
+            respondedAt: UtcNow,
+            respondedByUserId: null,
+            createdAt: UtcNow.AddDays(-1),
+            createdBy: Guid.NewGuid());
+    }
+
+    private static GameNightEvent CreateGameNight()
+    {
+        return GameNightEvent.Create(
+            organizerId: Guid.NewGuid(),
+            title: "Friday Night Catan",
+            scheduledAt: UtcNow.AddDays(7),
+            description: null,
+            location: "My place",
+            maxPlayers: 5,
+            gameIds: null);
+    }
+
+    private static GameNightInvitationRespondedEvent CreateEvent(
+        Guid invitationId, Guid gameNightId, GameNightInvitationStatus status)
+    {
+        return new GameNightInvitationRespondedEvent(
+            gameNightInvitationId: invitationId,
+            gameNightId: gameNightId,
+            token: Token,
+            status: status,
+            respondedByUserId: null);
+    }
+
+    [Fact]
+    public async Task Handle_AcceptedResponse_InvalidatesCacheAndSendsConfirmationEmail()
+    {
+        var cache = CreateHybridCache();
+        var cacheTag = GetGameNightInvitationByTokenQueryHandler.CacheTagPrefix + Token;
+
+        // Pre-seed cache entry tagged with the per-token tag → verify eviction.
+        await cache.GetOrCreateAsync<string>(
+            key: cacheTag,
+            factory: _ => ValueTask.FromResult("seed"),
+            options: null,
+            tags: new[] { cacheTag },
+            cancellationToken: CancellationToken.None);
+
+        var invitation = Reconstitute(GameNightInvitationStatus.Accepted);
+        var gameNight = CreateGameNight();
+        _invitationRepoMock
+            .Setup(r => r.GetByIdAsync(invitation.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invitation);
+        _gameNightRepoMock
+            .Setup(r => r.GetByIdAsync(invitation.GameNightId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameNight);
+
+        var notification = CreateEvent(
+            invitation.Id, invitation.GameNightId, GameNightInvitationStatus.Accepted);
+
+        await CreateHandler(cache).Handle(notification, CancellationToken.None);
+
+        // Verify cache eviction: factory must run again on subsequent access.
+        var factoryRan = false;
+        await cache.GetOrCreateAsync<string>(
+            key: cacheTag,
+            factory: _ =>
+            {
+                factoryRan = true;
+                return ValueTask.FromResult("repop");
+            },
+            options: null,
+            tags: new[] { cacheTag },
+            cancellationToken: CancellationToken.None);
+        factoryRan.Should().BeTrue();
+
+        // Verify confirmation email dispatched with token-bearing unsubscribe URL.
+        _emailServiceMock.Verify(
+            e => e.SendGameNightRsvpConfirmationEmailAsync(
+                "guest@example.com",
+                gameNight.Title,
+                gameNight.ScheduledAt,
+                gameNight.Location,
+                $"/invites/{Token}/unsubscribe",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DeclinedResponse_InvalidatesCacheButSkipsEmail()
+    {
+        var cache = CreateHybridCache();
+
+        var notification = CreateEvent(
+            Guid.NewGuid(), Guid.NewGuid(), GameNightInvitationStatus.Declined);
+
+        await CreateHandler(cache).Handle(notification, CancellationToken.None);
+
+        // Declined responses must NOT trigger confirmation email and must NOT
+        // round-trip the invitation/game-night repositories.
+        _emailServiceMock.Verify(
+            e => e.SendGameNightRsvpConfirmationEmailAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _invitationRepoMock.Verify(
+            r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _gameNightRepoMock.Verify(
+            r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_AcceptedButInvitationDisappeared_SkipsEmailGracefully()
+    {
+        // Race condition: aggregate purged between event raise and handler.
+        var cache = CreateHybridCache();
+        var invitationId = Guid.NewGuid();
+        _invitationRepoMock
+            .Setup(r => r.GetByIdAsync(invitationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GameNightInvitation?)null);
+
+        var notification = CreateEvent(
+            invitationId, Guid.NewGuid(), GameNightInvitationStatus.Accepted);
+
+        var act = async () => await CreateHandler(cache).Handle(notification, CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        _emailServiceMock.Verify(
+            e => e.SendGameNightRsvpConfirmationEmailAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_AcceptedButGameNightDisappeared_SkipsEmailGracefully()
+    {
+        var cache = CreateHybridCache();
+        var invitation = Reconstitute(GameNightInvitationStatus.Accepted);
+        _invitationRepoMock
+            .Setup(r => r.GetByIdAsync(invitation.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invitation);
+        _gameNightRepoMock
+            .Setup(r => r.GetByIdAsync(invitation.GameNightId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GameNightEvent?)null);
+
+        var notification = CreateEvent(
+            invitation.Id, invitation.GameNightId, GameNightInvitationStatus.Accepted);
+
+        var act = async () => await CreateHandler(cache).Handle(notification, CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        _emailServiceMock.Verify(
+            e => e.SendGameNightRsvpConfirmationEmailAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightInvitationByTokenQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightInvitationByTokenQueryHandlerTests.cs
@@ -1,0 +1,227 @@
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Unit tests for <see cref="GetGameNightInvitationByTokenQueryHandler"/>.
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// Verifies the public token-addressable projection, the
+/// <c>AcceptedSoFar = 1 + accepted-invitations</c> formula, the
+/// <c>AlreadyRespondedAs</c> mapping, and that responses are cached
+/// per-token via <see cref="HybridCache"/> (perf gates §6).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class GetGameNightInvitationByTokenQueryHandlerTests
+{
+    private const string Token = "abcdefghijklmnopqrstuv";
+    private static readonly DateTimeOffset UtcNow = new(2026, 5, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly Mock<IGameNightInvitationRepository> _invitationRepoMock = new();
+    private readonly Mock<IGameNightEventRepository> _gameNightRepoMock = new();
+    private readonly Mock<IUserRepository> _userRepoMock = new();
+    private readonly Mock<IGameRepository> _gameRepoMock = new();
+    private readonly HybridCache _cache = CreateHybridCache();
+    private readonly GetGameNightInvitationByTokenQueryHandler _sut;
+
+    public GetGameNightInvitationByTokenQueryHandlerTests()
+    {
+        _sut = new GetGameNightInvitationByTokenQueryHandler(
+            _invitationRepoMock.Object,
+            _gameNightRepoMock.Object,
+            _userRepoMock.Object,
+            _gameRepoMock.Object,
+            _cache);
+    }
+
+    private static HybridCache CreateHybridCache()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IMemoryCache, MemoryCache>();
+        services.AddSingleton<IDistributedCache>(new MemoryDistributedCache(
+            Microsoft.Extensions.Options.Options.Create(new MemoryDistributedCacheOptions())));
+        services.AddHybridCache();
+        return services.BuildServiceProvider().GetRequiredService<HybridCache>();
+    }
+
+    private static GameNightInvitation Reconstitute(GameNightInvitationStatus status)
+    {
+        return GameNightInvitation.Reconstitute(
+            id: Guid.NewGuid(),
+            token: Token,
+            gameNightId: Guid.NewGuid(),
+            email: "guest@example.com",
+            status: status,
+            expiresAt: UtcNow.AddDays(7),
+            respondedAt: status == GameNightInvitationStatus.Pending ? null : UtcNow,
+            respondedByUserId: null,
+            createdAt: UtcNow.AddDays(-1),
+            createdBy: Guid.NewGuid());
+    }
+
+    private static GameNightEvent CreateGameNight(Guid organizerId, List<Guid>? gameIds = null)
+    {
+        return GameNightEvent.Create(
+            organizerId: organizerId,
+            title: "Friday Night Catan",
+            scheduledAt: UtcNow.AddDays(7),
+            description: null,
+            location: "My place",
+            maxPlayers: 5,
+            gameIds: gameIds);
+    }
+
+    [Fact]
+    public async Task Handle_TokenNotFound_ReturnsNull()
+    {
+        _invitationRepoMock
+            .Setup(r => r.GetByTokenAsync(Token, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GameNightInvitation?)null);
+
+        var result = await _sut.Handle(
+            new GetGameNightInvitationByTokenQuery(Token), CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_GameNightMissing_ReturnsNull()
+    {
+        var invitation = Reconstitute(GameNightInvitationStatus.Pending);
+        _invitationRepoMock
+            .Setup(r => r.GetByTokenAsync(Token, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invitation);
+        _gameNightRepoMock
+            .Setup(r => r.GetByIdAsync(invitation.GameNightId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GameNightEvent?)null);
+
+        var result = await _sut.Handle(
+            new GetGameNightInvitationByTokenQuery(Token), CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_PendingInvitation_ProjectsAcceptedSoFarAsOrganizerPlusCount()
+    {
+        var invitation = Reconstitute(GameNightInvitationStatus.Pending);
+        var organizerId = Guid.NewGuid();
+        var gameNight = CreateGameNight(organizerId);
+
+        _invitationRepoMock
+            .Setup(r => r.GetByTokenAsync(Token, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invitation);
+        _gameNightRepoMock
+            .Setup(r => r.GetByIdAsync(invitation.GameNightId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameNight);
+        _userRepoMock
+            .Setup(r => r.GetByIdAsync(organizerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+        _invitationRepoMock
+            .Setup(r => r.CountAcceptedByGameNightIdAsync(
+                invitation.GameNightId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(3);
+
+        var result = await _sut.Handle(
+            new GetGameNightInvitationByTokenQuery(Token), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Token.Should().Be(Token);
+        result.Status.Should().Be(nameof(GameNightInvitationStatus.Pending));
+        // Organizer always counted as attending → +1 to accepted invitations.
+        result.AcceptedSoFar.Should().Be(4);
+        result.AlreadyRespondedAs.Should().BeNull();
+        result.HostDisplayName.Should().Be("A friend"); // Fallback when user is null.
+        result.PrimaryGameId.Should().BeNull(); // No GameIds.
+    }
+
+    [Fact]
+    public async Task Handle_AcceptedInvitation_MapsAlreadyRespondedAsAccepted()
+    {
+        var invitation = Reconstitute(GameNightInvitationStatus.Accepted);
+        var gameNight = CreateGameNight(Guid.NewGuid());
+
+        _invitationRepoMock
+            .Setup(r => r.GetByTokenAsync(Token, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invitation);
+        _gameNightRepoMock
+            .Setup(r => r.GetByIdAsync(invitation.GameNightId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameNight);
+
+        var result = await _sut.Handle(
+            new GetGameNightInvitationByTokenQuery(Token), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.AlreadyRespondedAs.Should().Be("Accepted");
+    }
+
+    [Fact]
+    public async Task Handle_PrimaryGameLookup_PopulatesNameAndImageUrl()
+    {
+        var primaryGameId = Guid.NewGuid();
+        var invitation = Reconstitute(GameNightInvitationStatus.Pending);
+        var gameNight = CreateGameNight(Guid.NewGuid(), gameIds: new List<Guid> { primaryGameId });
+        var game = new Api.BoundedContexts.GameManagement.Domain.Entities.Game(
+            id: primaryGameId,
+            title: new GameTitle("Catan"));
+        game.SetImages(iconUrl: null, imageUrl: "https://cdn.example/catan.jpg");
+
+        _invitationRepoMock
+            .Setup(r => r.GetByTokenAsync(Token, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invitation);
+        _gameNightRepoMock
+            .Setup(r => r.GetByIdAsync(invitation.GameNightId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameNight);
+        _gameRepoMock
+            .Setup(r => r.GetByIdAsync(primaryGameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        var result = await _sut.Handle(
+            new GetGameNightInvitationByTokenQuery(Token), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.PrimaryGameId.Should().Be(primaryGameId);
+        result.PrimaryGameName.Should().Be("Catan");
+        result.PrimaryGameImageUrl.Should().Be("https://cdn.example/catan.jpg");
+    }
+
+    [Fact]
+    public async Task Handle_RepeatedCalls_ServeFromCacheWithoutReinvokingRepository()
+    {
+        var invitation = Reconstitute(GameNightInvitationStatus.Pending);
+        var gameNight = CreateGameNight(Guid.NewGuid());
+
+        _invitationRepoMock
+            .Setup(r => r.GetByTokenAsync(Token, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invitation);
+        _gameNightRepoMock
+            .Setup(r => r.GetByIdAsync(invitation.GameNightId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameNight);
+
+        var first = await _sut.Handle(
+            new GetGameNightInvitationByTokenQuery(Token), CancellationToken.None);
+        var second = await _sut.Handle(
+            new GetGameNightInvitationByTokenQuery(Token), CancellationToken.None);
+
+        first.Should().NotBeNull();
+        second.Should().NotBeNull();
+        // Second call MUST hit cache (L1) — repo factory invoked exactly once.
+        _invitationRepoMock.Verify(
+            r => r.GetByTokenAsync(Token, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightInvitationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightInvitationTests.cs
@@ -1,0 +1,423 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain.Entities;
+
+/// <summary>
+/// Tests for the GameNightInvitation aggregate root.
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class GameNightInvitationTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 4, 28, 12, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset OneWeekFromNow = Now.AddDays(7);
+
+    private static GameNightInvitation NewPending(
+        DateTimeOffset? utcNow = null,
+        DateTimeOffset? expiresAt = null)
+    {
+        return GameNightInvitation.Create(
+            gameNightId: Guid.NewGuid(),
+            email: "guest@example.com",
+            expiresAt: expiresAt ?? OneWeekFromNow,
+            createdBy: Guid.NewGuid(),
+            utcNow: utcNow ?? Now);
+    }
+
+    #region Factory — Create
+
+    [Fact]
+    public void Create_WithValidArguments_ReturnsPendingInvitation()
+    {
+        var gameNightId = Guid.NewGuid();
+        var organizerId = Guid.NewGuid();
+
+        var invitation = GameNightInvitation.Create(
+            gameNightId: gameNightId,
+            email: "Guest@Example.com",
+            expiresAt: OneWeekFromNow,
+            createdBy: organizerId,
+            utcNow: Now);
+
+        invitation.Id.Should().NotBe(Guid.Empty);
+        invitation.GameNightId.Should().Be(gameNightId);
+        invitation.Email.Should().Be("guest@example.com", "email is normalized to lowercase + trimmed");
+        invitation.Status.Should().Be(GameNightInvitationStatus.Pending);
+        invitation.ExpiresAt.Should().Be(OneWeekFromNow);
+        invitation.RespondedAt.Should().BeNull();
+        invitation.RespondedByUserId.Should().BeNull();
+        invitation.CreatedAt.Should().Be(Now);
+        invitation.CreatedBy.Should().Be(organizerId);
+        invitation.Token.Should().HaveLength(22);
+        invitation.Token.Should().MatchRegex("^[0-9A-Za-z]{22}$");
+    }
+
+    [Fact]
+    public void Create_RaisesGameNightInvitationCreatedEvent()
+    {
+        var invitation = NewPending();
+
+        invitation.DomainEvents.Should().ContainSingle(e => e is GameNightInvitationCreatedEvent);
+        var evt = invitation.DomainEvents.OfType<GameNightInvitationCreatedEvent>().Single();
+        evt.GameNightInvitationId.Should().Be(invitation.Id);
+        evt.GameNightId.Should().Be(invitation.GameNightId);
+        evt.Email.Should().Be(invitation.Email);
+        evt.Token.Should().Be(invitation.Token);
+        evt.ExpiresAt.Should().Be(invitation.ExpiresAt);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void Create_WithNullOrWhitespaceEmail_Throws(string? email)
+    {
+        var action = () => GameNightInvitation.Create(
+            gameNightId: Guid.NewGuid(),
+            email: email!,
+            expiresAt: OneWeekFromNow,
+            createdBy: Guid.NewGuid(),
+            utcNow: Now);
+
+        action.Should().Throw<ArgumentException>().WithMessage("*Email*");
+    }
+
+    [Fact]
+    public void Create_WithEmptyGameNightId_Throws()
+    {
+        var action = () => GameNightInvitation.Create(
+            gameNightId: Guid.Empty,
+            email: "guest@example.com",
+            expiresAt: OneWeekFromNow,
+            createdBy: Guid.NewGuid(),
+            utcNow: Now);
+
+        action.Should().Throw<ArgumentException>().WithMessage("*GameNightId*");
+    }
+
+    [Fact]
+    public void Create_WithEmptyCreatedBy_Throws()
+    {
+        var action = () => GameNightInvitation.Create(
+            gameNightId: Guid.NewGuid(),
+            email: "guest@example.com",
+            expiresAt: OneWeekFromNow,
+            createdBy: Guid.Empty,
+            utcNow: Now);
+
+        action.Should().Throw<ArgumentException>().WithMessage("*CreatedBy*");
+    }
+
+    [Fact]
+    public void Create_WithExpiresAtInThePast_Throws()
+    {
+        var action = () => GameNightInvitation.Create(
+            gameNightId: Guid.NewGuid(),
+            email: "guest@example.com",
+            expiresAt: Now.AddMinutes(-1),
+            createdBy: Guid.NewGuid(),
+            utcNow: Now);
+
+        action.Should().Throw<ArgumentException>().WithMessage("*future*");
+    }
+
+    [Fact]
+    public void Create_WithExpiresAtEqualToNow_Throws()
+    {
+        var action = () => GameNightInvitation.Create(
+            gameNightId: Guid.NewGuid(),
+            email: "guest@example.com",
+            expiresAt: Now,
+            createdBy: Guid.NewGuid(),
+            utcNow: Now);
+
+        action.Should().Throw<ArgumentException>().WithMessage("*future*");
+    }
+
+    #endregion
+
+    #region Accept
+
+    [Fact]
+    public void Accept_OnPending_TransitionsToAccepted_ReturnsTrue()
+    {
+        var invitation = NewPending();
+        var userId = Guid.NewGuid();
+        var respondedAt = Now.AddHours(1);
+
+        var changed = invitation.Accept(userId, respondedAt);
+
+        changed.Should().BeTrue();
+        invitation.Status.Should().Be(GameNightInvitationStatus.Accepted);
+        invitation.RespondedAt.Should().Be(respondedAt);
+        invitation.RespondedByUserId.Should().Be(userId);
+    }
+
+    [Fact]
+    public void Accept_OnPending_RaisesGameNightInvitationRespondedEvent()
+    {
+        var invitation = NewPending();
+        var userId = Guid.NewGuid();
+
+        invitation.Accept(userId, Now.AddHours(1));
+
+        var evt = invitation.DomainEvents.OfType<GameNightInvitationRespondedEvent>().SingleOrDefault();
+        evt.Should().NotBeNull();
+        evt!.GameNightInvitationId.Should().Be(invitation.Id);
+        evt.GameNightId.Should().Be(invitation.GameNightId);
+        evt.Token.Should().Be(invitation.Token);
+        evt.Status.Should().Be(GameNightInvitationStatus.Accepted);
+        evt.RespondedByUserId.Should().Be(userId);
+    }
+
+    [Fact]
+    public void Accept_OnPending_WithoutUserId_AllowsAnonymousResponse()
+    {
+        var invitation = NewPending();
+
+        var changed = invitation.Accept(userId: null, utcNow: Now.AddHours(1));
+
+        changed.Should().BeTrue();
+        invitation.Status.Should().Be(GameNightInvitationStatus.Accepted);
+        invitation.RespondedByUserId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Accept_OnAccepted_NoOp_ReturnsFalse()
+    {
+        var invitation = NewPending();
+        invitation.Accept(Guid.NewGuid(), Now.AddHours(1));
+        invitation.ClearDomainEvents();
+
+        var changed = invitation.Accept(Guid.NewGuid(), Now.AddHours(2));
+
+        changed.Should().BeFalse("D2 b idempotency: same response is a no-op");
+        invitation.Status.Should().Be(GameNightInvitationStatus.Accepted);
+        invitation.DomainEvents.Should().BeEmpty("no event raised on idempotent no-op");
+    }
+
+    [Fact]
+    public void Accept_OnDeclined_Throws()
+    {
+        var invitation = NewPending();
+        invitation.Decline(Guid.NewGuid(), Now.AddHours(1));
+
+        var action = () => invitation.Accept(Guid.NewGuid(), Now.AddHours(2));
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("*already*Declined*");
+    }
+
+    [Fact]
+    public void Accept_OnExpired_Throws()
+    {
+        var invitation = NewPending(expiresAt: Now.AddMinutes(5));
+
+        var action = () => invitation.Accept(Guid.NewGuid(), Now.AddHours(1));
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("*expired*");
+    }
+
+    [Fact]
+    public void Accept_OnCancelled_Throws()
+    {
+        var invitation = NewPending();
+        invitation.Cancel(Now.AddHours(1));
+
+        var action = () => invitation.Accept(Guid.NewGuid(), Now.AddHours(2));
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Cancelled*");
+    }
+
+    #endregion
+
+    #region Decline
+
+    [Fact]
+    public void Decline_OnPending_TransitionsToDeclined_ReturnsTrue()
+    {
+        var invitation = NewPending();
+        var respondedAt = Now.AddHours(1);
+
+        var changed = invitation.Decline(Guid.NewGuid(), respondedAt);
+
+        changed.Should().BeTrue();
+        invitation.Status.Should().Be(GameNightInvitationStatus.Declined);
+        invitation.RespondedAt.Should().Be(respondedAt);
+    }
+
+    [Fact]
+    public void Decline_OnDeclined_NoOp_ReturnsFalse()
+    {
+        var invitation = NewPending();
+        invitation.Decline(Guid.NewGuid(), Now.AddHours(1));
+        invitation.ClearDomainEvents();
+
+        var changed = invitation.Decline(Guid.NewGuid(), Now.AddHours(2));
+
+        changed.Should().BeFalse();
+        invitation.DomainEvents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Decline_OnAccepted_Throws()
+    {
+        var invitation = NewPending();
+        invitation.Accept(Guid.NewGuid(), Now.AddHours(1));
+
+        var action = () => invitation.Decline(Guid.NewGuid(), Now.AddHours(2));
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("*already*Accepted*");
+    }
+
+    #endregion
+
+    #region Cancel
+
+    [Fact]
+    public void Cancel_FromPending_TransitionsToCancelled()
+    {
+        var invitation = NewPending();
+        var cancelledAt = Now.AddHours(1);
+
+        invitation.Cancel(cancelledAt);
+
+        invitation.Status.Should().Be(GameNightInvitationStatus.Cancelled);
+        invitation.RespondedAt.Should().Be(cancelledAt);
+    }
+
+    [Fact]
+    public void Cancel_FromAccepted_TransitionsToCancelled()
+    {
+        // Organizer revokes an accepted invite (or game night is cancelled).
+        var invitation = NewPending();
+        invitation.Accept(Guid.NewGuid(), Now.AddHours(1));
+
+        invitation.Cancel(Now.AddHours(2));
+
+        invitation.Status.Should().Be(GameNightInvitationStatus.Cancelled);
+    }
+
+    [Fact]
+    public void Cancel_FromCancelled_IsIdempotent()
+    {
+        var invitation = NewPending();
+        invitation.Cancel(Now.AddHours(1));
+
+        var action = () => invitation.Cancel(Now.AddHours(2));
+
+        action.Should().NotThrow();
+        invitation.Status.Should().Be(GameNightInvitationStatus.Cancelled);
+    }
+
+    [Fact]
+    public void Cancel_FromDeclined_Throws()
+    {
+        var invitation = NewPending();
+        invitation.Decline(Guid.NewGuid(), Now.AddHours(1));
+
+        var action = () => invitation.Cancel(Now.AddHours(2));
+
+        action.Should().Throw<InvalidOperationException>();
+    }
+
+    #endregion
+
+    #region IsExpired
+
+    [Fact]
+    public void IsExpired_WhenPendingAndPastExpiresAt_ReturnsTrue()
+    {
+        var invitation = NewPending(expiresAt: Now.AddMinutes(5));
+
+        invitation.IsExpired(Now.AddMinutes(10)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsExpired_WhenPendingAndAtExpiresAt_ReturnsTrue()
+    {
+        // Boundary: utcNow == ExpiresAt is treated as expired (>=).
+        var expiresAt = Now.AddMinutes(5);
+        var invitation = NewPending(expiresAt: expiresAt);
+
+        invitation.IsExpired(expiresAt).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsExpired_WhenPendingAndBeforeExpiresAt_ReturnsFalse()
+    {
+        var invitation = NewPending(expiresAt: Now.AddDays(7));
+
+        invitation.IsExpired(Now.AddHours(1)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsExpired_WhenAccepted_ReturnsFalse_RegardlessOfTime()
+    {
+        // Terminal state: expiry is irrelevant.
+        var invitation = NewPending(expiresAt: Now.AddMinutes(5));
+        invitation.Accept(Guid.NewGuid(), Now.AddMinutes(1));
+
+        invitation.IsExpired(Now.AddDays(30)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsExpired_WhenDeclined_ReturnsFalse()
+    {
+        var invitation = NewPending(expiresAt: Now.AddMinutes(5));
+        invitation.Decline(Guid.NewGuid(), Now.AddMinutes(1));
+
+        invitation.IsExpired(Now.AddDays(30)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsExpired_WhenCancelled_ReturnsFalse()
+    {
+        var invitation = NewPending(expiresAt: Now.AddMinutes(5));
+        invitation.Cancel(Now.AddMinutes(1));
+
+        invitation.IsExpired(Now.AddDays(30)).Should().BeFalse();
+    }
+
+    #endregion
+
+    #region Reconstitute
+
+    [Fact]
+    public void Reconstitute_RestoresState_WithoutRaisingEvents()
+    {
+        var id = Guid.NewGuid();
+        var token = "ABCDEFGHIJKLMNOPQRSTUV";
+        var gameNightId = Guid.NewGuid();
+        var createdBy = Guid.NewGuid();
+        var respondedBy = Guid.NewGuid();
+
+        var invitation = GameNightInvitation.Reconstitute(
+            id: id,
+            token: token,
+            gameNightId: gameNightId,
+            email: "guest@example.com",
+            status: GameNightInvitationStatus.Accepted,
+            expiresAt: OneWeekFromNow,
+            respondedAt: Now.AddHours(1),
+            respondedByUserId: respondedBy,
+            createdAt: Now,
+            createdBy: createdBy);
+
+        invitation.Id.Should().Be(id);
+        invitation.Token.Should().Be(token);
+        invitation.Status.Should().Be(GameNightInvitationStatus.Accepted);
+        invitation.RespondedByUserId.Should().Be(respondedBy);
+        invitation.DomainEvents.Should().BeEmpty("reconstitution must not raise events");
+    }
+
+    #endregion
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/ValueObjects/InvitationTokenTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/ValueObjects/InvitationTokenTests.cs
@@ -1,0 +1,127 @@
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain.ValueObjects;
+
+/// <summary>
+/// Tests for the InvitationToken value object.
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class InvitationTokenTests
+{
+    #region Generate
+
+    [Fact]
+    public void Generate_Returns22CharacterToken()
+    {
+        var token = InvitationToken.Generate();
+
+        token.Value.Should().HaveLength(InvitationToken.Length);
+        token.Value.Should().HaveLength(22);
+    }
+
+    [Fact]
+    public void Generate_ReturnsBase62Characters()
+    {
+        var token = InvitationToken.Generate();
+
+        token.Value.Should().MatchRegex("^[0-9A-Za-z]{22}$");
+    }
+
+    [Fact]
+    public void Generate_ProducesUniqueTokensAcrossManyCalls()
+    {
+        // 1000 tokens at ~131 bits entropy → collision probability vanishingly small.
+        var tokens = new HashSet<string>();
+        for (int i = 0; i < 1000; i++)
+        {
+            tokens.Add(InvitationToken.Generate().Value);
+        }
+
+        tokens.Should().HaveCount(1000, "all generated tokens should be unique");
+    }
+
+    #endregion
+
+    #region Create (reconstitution)
+
+    [Fact]
+    public void Create_WithValidToken_Succeeds()
+    {
+        var raw = InvitationToken.Generate().Value;
+
+        var token = InvitationToken.Create(raw);
+
+        token.Value.Should().Be(raw);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void Create_WithNullOrWhitespace_Throws(string? value)
+    {
+        var action = () => InvitationToken.Create(value!);
+
+        action.Should().Throw<ArgumentException>()
+            .WithMessage("*empty*");
+    }
+
+    [Theory]
+    [InlineData("short")]
+    [InlineData("0123456789012345678901234")] // 25 chars
+    [InlineData("0123456789012345678901")]    // 22 chars but valid → handled by next test
+    public void Create_WithWrongLength_Throws(string value)
+    {
+        if (value.Length == 22)
+        {
+            // Skip the boundary case here — covered by Create_WithValidToken_Succeeds.
+            return;
+        }
+
+        var action = () => InvitationToken.Create(value);
+
+        action.Should().Throw<ArgumentException>()
+            .WithMessage("*22 characters*");
+    }
+
+    [Theory]
+    [InlineData("0123456789012345678901-")]   // 23 chars, has dash → length wins
+    [InlineData("0123456789-12345678901")]    // 22 chars, has dash
+    [InlineData("0123456789+12345678901")]    // 22 chars, has plus
+    [InlineData("0123456789/12345678901")]    // 22 chars, has slash (invalid base62)
+    [InlineData("01234567890123456789 1")]    // 22 chars, has space
+    public void Create_WithNonBase62Characters_Throws(string value)
+    {
+        var action = () => InvitationToken.Create(value);
+
+        action.Should().Throw<ArgumentException>();
+    }
+
+    #endregion
+
+    #region Implicit conversion
+
+    [Fact]
+    public void ImplicitConversion_ToString_ReturnsValue()
+    {
+        var token = InvitationToken.Generate();
+
+        string asString = token;
+
+        asString.Should().Be(token.Value);
+    }
+
+    [Fact]
+    public void ToString_ReturnsValue()
+    {
+        var token = InvitationToken.Generate();
+
+        token.ToString().Should().Be(token.Value);
+    }
+
+    #endregion
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/GameNightInvitationRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/GameNightInvitationRepositoryIntegrationTests.cs
@@ -1,0 +1,362 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Infrastructure;
+
+/// <summary>
+/// Integration tests for <see cref="GameNightInvitationRepository"/> against a real PostgreSQL
+/// database via Testcontainers. Validates schema-level constraints (unique token index, FK
+/// cascade delete) and aggregate-level repository semantics (duplicate-pending guard,
+/// AcceptedSoFar count formula) that cannot be exercised by EF Core InMemory.
+/// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class GameNightInvitationRepositoryIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private MeepleAiDbContext _dbContext = null!;
+    private GameNightInvitationRepository _repository = null!;
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private Guid _organizerId;
+
+    private static readonly DateTimeOffset Now =
+        new(2026, 4, 28, 12, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset OneWeekFromNow = Now.AddDays(7);
+
+    public GameNightInvitationRepositoryIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_invitation_repo_{Guid.NewGuid():N}";
+        _connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        _dbContext = _fixture.CreateDbContext(_connectionString);
+        await _dbContext.Database.MigrateAsync();
+
+        _organizerId = Guid.NewGuid();
+
+        var mockCollector = new Mock<IDomainEventCollector>();
+        mockCollector
+            .Setup(e => e.GetAndClearEvents())
+            .Returns(new List<Api.SharedKernel.Domain.Interfaces.IDomainEvent>().AsReadOnly());
+
+        _repository = new GameNightInvitationRepository(
+            _dbContext,
+            mockCollector.Object,
+            NullLogger<GameNightInvitationRepository>.Instance);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    private async Task<Guid> SeedGameNightEventAsync()
+    {
+        var eventId = Guid.NewGuid();
+        _dbContext.GameNightEvents.Add(new GameNightEventEntity
+        {
+            Id = eventId,
+            OrganizerId = _organizerId,
+            Title = "Test Night",
+            ScheduledAt = Now.AddHours(48),
+            Location = "Home",
+            MaxPlayers = 6,
+            GameIdsJson = "[]",
+            Status = "Published",
+            CreatedAt = Now,
+            UpdatedAt = Now
+        });
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+        return eventId;
+    }
+
+    private GameNightInvitation NewInvitation(Guid gameNightId, string email)
+    {
+        return GameNightInvitation.Create(
+            gameNightId: gameNightId,
+            email: email,
+            expiresAt: OneWeekFromNow,
+            createdBy: _organizerId,
+            utcNow: Now);
+    }
+
+    // ============================================================
+    // Round-trip: AddAsync → GetByTokenAsync / GetByIdAsync
+    // ============================================================
+
+    [Fact]
+    public async Task AddAsync_ThenGetByToken_RoundTripsAggregate()
+    {
+        var gameNightId = await SeedGameNightEventAsync();
+        var invitation = NewInvitation(gameNightId, "guest@example.com");
+
+        await _repository.AddAsync(invitation);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var loaded = await _repository.GetByTokenAsync(invitation.Token);
+
+        loaded.Should().NotBeNull();
+        loaded!.Id.Should().Be(invitation.Id);
+        loaded.Token.Should().Be(invitation.Token);
+        loaded.GameNightId.Should().Be(gameNightId);
+        loaded.Email.Should().Be("guest@example.com");
+        loaded.Status.Should().Be(GameNightInvitationStatus.Pending);
+        loaded.ExpiresAt.Should().BeCloseTo(OneWeekFromNow, TimeSpan.FromMilliseconds(1));
+        loaded.CreatedBy.Should().Be(_organizerId);
+    }
+
+    // ============================================================
+    // Schema constraint: UNIQUE index on token
+    // ============================================================
+
+    [Fact]
+    public async Task AddAsync_WithDuplicateToken_ThrowsOnSave()
+    {
+        var gameNightId = await SeedGameNightEventAsync();
+
+        // Persist first row directly via raw entity to control the token.
+        const string sharedToken = "abcdefghijklmnopqrstuv";
+        _dbContext.GameNightInvitations.Add(new GameNightInvitationEntity
+        {
+            Id = Guid.NewGuid(),
+            Token = sharedToken,
+            GameNightId = gameNightId,
+            Email = "first@example.com",
+            Status = "Pending",
+            ExpiresAt = OneWeekFromNow,
+            CreatedAt = Now,
+            CreatedBy = _organizerId
+        });
+        await _dbContext.SaveChangesAsync();
+
+        // Attempt to add a second row with the same token.
+        _dbContext.GameNightInvitations.Add(new GameNightInvitationEntity
+        {
+            Id = Guid.NewGuid(),
+            Token = sharedToken,
+            GameNightId = gameNightId,
+            Email = "second@example.com",
+            Status = "Pending",
+            ExpiresAt = OneWeekFromNow,
+            CreatedAt = Now,
+            CreatedBy = _organizerId
+        });
+
+        var act = async () => await _dbContext.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<DbUpdateException>(
+            "the IX_game_night_invitations_token unique index must reject duplicate tokens");
+    }
+
+    // ============================================================
+    // Schema constraint: FK cascade delete from game_night_events
+    // ============================================================
+
+    [Fact]
+    public async Task DeleteParentEvent_CascadesToInvitations()
+    {
+        var gameNightId = await SeedGameNightEventAsync();
+        var invitation = NewInvitation(gameNightId, "guest@example.com");
+
+        await _repository.AddAsync(invitation);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Sanity: invitation exists.
+        (await _dbContext.GameNightInvitations.AnyAsync(i => i.Id == invitation.Id))
+            .Should().BeTrue();
+
+        // Delete the parent event.
+        var parent = await _dbContext.GameNightEvents.SingleAsync(e => e.Id == gameNightId);
+        _dbContext.GameNightEvents.Remove(parent);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        (await _dbContext.GameNightInvitations.AnyAsync(i => i.Id == invitation.Id))
+            .Should().BeFalse("cascade delete must purge invitations when the parent event is removed");
+    }
+
+    // ============================================================
+    // Repository semantics: duplicate-pending guard
+    // ============================================================
+
+    [Fact]
+    public async Task ExistsPendingByEmailAsync_FindsCaseInsensitiveMatch()
+    {
+        var gameNightId = await SeedGameNightEventAsync();
+        var invitation = NewInvitation(gameNightId, "Guest@Example.com");
+
+        await _repository.AddAsync(invitation);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Lookup with mixed-case email — repository must normalize internally.
+        var existsExact = await _repository.ExistsPendingByEmailAsync(gameNightId, "Guest@Example.com");
+        var existsLower = await _repository.ExistsPendingByEmailAsync(gameNightId, "guest@example.com");
+        var existsUpper = await _repository.ExistsPendingByEmailAsync(gameNightId, "GUEST@EXAMPLE.COM");
+        var existsPadded = await _repository.ExistsPendingByEmailAsync(gameNightId, "  guest@example.com  ");
+
+        existsExact.Should().BeTrue();
+        existsLower.Should().BeTrue();
+        existsUpper.Should().BeTrue();
+        existsPadded.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExistsPendingByEmailAsync_DoesNotMatch_NonPendingInvitation()
+    {
+        var gameNightId = await SeedGameNightEventAsync();
+        var invitation = NewInvitation(gameNightId, "guest@example.com");
+        invitation.Accept(userId: Guid.NewGuid(), utcNow: Now.AddHours(1));
+
+        await _repository.AddAsync(invitation);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var exists = await _repository.ExistsPendingByEmailAsync(gameNightId, "guest@example.com");
+
+        exists.Should().BeFalse("only Pending invitations should block re-issuance");
+    }
+
+    [Fact]
+    public async Task ExistsPendingByEmailAsync_ScopesByGameNightId()
+    {
+        var firstEventId = await SeedGameNightEventAsync();
+        var secondEventId = await SeedGameNightEventAsync();
+        var invitation = NewInvitation(firstEventId, "guest@example.com");
+
+        await _repository.AddAsync(invitation);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var existsInFirst = await _repository.ExistsPendingByEmailAsync(firstEventId, "guest@example.com");
+        var existsInSecond = await _repository.ExistsPendingByEmailAsync(secondEventId, "guest@example.com");
+
+        existsInFirst.Should().BeTrue();
+        existsInSecond.Should().BeFalse(
+            "duplicate-pending guard must scope by event so the same email can be invited to different events");
+    }
+
+    // ============================================================
+    // Repository semantics: AcceptedSoFar count formula
+    // ============================================================
+
+    [Fact]
+    public async Task CountAcceptedByGameNightIdAsync_CountsOnlyAcceptedRows()
+    {
+        var gameNightId = await SeedGameNightEventAsync();
+        var otherGameNightId = await SeedGameNightEventAsync();
+        var responder = Guid.NewGuid();
+
+        // Two Accepted in target event.
+        var accepted1 = NewInvitation(gameNightId, "a1@example.com");
+        accepted1.Accept(responder, Now.AddHours(1));
+        var accepted2 = NewInvitation(gameNightId, "a2@example.com");
+        accepted2.Accept(responder, Now.AddHours(1));
+
+        // One Pending and one Declined in target event.
+        var pending = NewInvitation(gameNightId, "p1@example.com");
+        var declined = NewInvitation(gameNightId, "d1@example.com");
+        declined.Decline(responder, Now.AddHours(1));
+
+        // One Accepted in *other* event (must not bleed in).
+        var crossEvent = NewInvitation(otherGameNightId, "x1@example.com");
+        crossEvent.Accept(responder, Now.AddHours(1));
+
+        foreach (var i in new[] { accepted1, accepted2, pending, declined, crossEvent })
+        {
+            await _repository.AddAsync(i);
+        }
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var count = await _repository.CountAcceptedByGameNightIdAsync(gameNightId);
+
+        count.Should().Be(2,
+            "only Accepted rows scoped to the target event should be counted");
+    }
+
+    // ============================================================
+    // UpdateAsync round-trip preserves status transitions
+    // ============================================================
+
+    [Fact]
+    public async Task UpdateAsync_PersistsStatusTransition()
+    {
+        var gameNightId = await SeedGameNightEventAsync();
+        var invitation = NewInvitation(gameNightId, "guest@example.com");
+
+        await _repository.AddAsync(invitation);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var loaded = await _repository.GetByTokenAsync(invitation.Token);
+        loaded!.Accept(userId: Guid.NewGuid(), utcNow: Now.AddHours(2));
+
+        await _repository.UpdateAsync(loaded);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var refreshed = await _repository.GetByTokenAsync(invitation.Token);
+        refreshed.Should().NotBeNull();
+        refreshed!.Status.Should().Be(GameNightInvitationStatus.Accepted);
+        refreshed.RespondedAt.Should().NotBeNull();
+        refreshed.RespondedByUserId.Should().NotBeNull();
+    }
+
+    // ============================================================
+    // GetByGameNightIdAsync returns ordered list
+    // ============================================================
+
+    [Fact]
+    public async Task GetByGameNightIdAsync_ReturnsInvitationsOrderedByCreatedAtDesc()
+    {
+        var gameNightId = await SeedGameNightEventAsync();
+
+        var first = GameNightInvitation.Create(
+            gameNightId: gameNightId,
+            email: "first@example.com",
+            expiresAt: OneWeekFromNow,
+            createdBy: _organizerId,
+            utcNow: Now);
+
+        var second = GameNightInvitation.Create(
+            gameNightId: gameNightId,
+            email: "second@example.com",
+            expiresAt: OneWeekFromNow,
+            createdBy: _organizerId,
+            utcNow: Now.AddMinutes(5));
+
+        await _repository.AddAsync(first);
+        await _repository.AddAsync(second);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var result = await _repository.GetByGameNightIdAsync(gameNightId);
+
+        result.Should().HaveCount(2);
+        result[0].Email.Should().Be("second@example.com", "newest invitation comes first");
+        result[1].Email.Should().Be("first@example.com");
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightInvitationEndpointsTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightInvitationEndpointsTests.cs
@@ -1,0 +1,574 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// E2E integration tests for the public token-based RSVP endpoints introduced in
+/// Issue #607 (Wave A.5a). Validates the full HTTP surface (status codes, request/response
+/// shape, idempotency D2 b, anonymous access) end-to-end against a real PostgreSQL database
+/// via Testcontainers. Mocks <see cref="IGameNightEmailService"/> to avoid SMTP I/O.
+/// </summary>
+/// <remarks>
+/// Endpoints covered:
+/// <list type="bullet">
+///   <item><c>GET  /api/v1/game-nights/invitations/{token}</c></item>
+///   <item><c>POST /api/v1/game-nights/invitations/{token}/respond</c></item>
+///   <item><c>POST /api/v1/game-nights/{gameNightId}/invitations</c></item>
+/// </list>
+/// Idempotency contract D2 b: same-state response → 200 no-op; switch Accepted ⇄ Declined →
+/// 409 Conflict; pending past-expiry / terminal Expired or Cancelled → 410 Gone.
+/// </remarks>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class GameNightInvitationEndpointsTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private readonly Mock<IGameNightEmailService> _emailServiceMock = new();
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    public GameNightInvitationEndpointsTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"game_night_invite_e2e_{Guid.NewGuid():N}";
+
+        _emailServiceMock
+            .Setup(s => s.SendGameNightInvitationEmailAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<DateTimeOffset>(), It.IsAny<string?>(), It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+
+        _factory = IntegrationWebApplicationFactory.Create(
+            connectionString,
+            extraConfig: new Dictionary<string, string?>
+            {
+                ["App:BaseUrl"] = "https://meepleai.test",
+                ["GameNight:InvitationExpiryDays"] = "14"
+            });
+
+        // Override email service to a no-op mock (avoid SMTP)
+        _factory = _factory.WithWebHostBuilder(b => b.ConfigureTestServices(s =>
+        {
+            s.RemoveAll(typeof(IGameNightEmailService));
+            s.AddSingleton(_emailServiceMock.Object);
+        }));
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+        }
+
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        await _factory.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ────────────────────────────────────────────────────────────────────
+
+    private async Task<Guid> SeedGameNightAsync(Guid organizerId, string title = "Test Night")
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var eventId = Guid.NewGuid();
+        dbContext.GameNightEvents.Add(new GameNightEventEntity
+        {
+            Id = eventId,
+            OrganizerId = organizerId,
+            Title = title,
+            ScheduledAt = DateTimeOffset.UtcNow.AddDays(7),
+            Location = "Home",
+            MaxPlayers = 6,
+            GameIdsJson = "[]",
+            Status = "Published",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        });
+        await dbContext.SaveChangesAsync();
+        return eventId;
+    }
+
+    private async Task<GameNightInvitationEntity> SeedInvitationAsync(
+        Guid gameNightId,
+        Guid createdBy,
+        string email = "guest@example.com",
+        string status = "Pending",
+        DateTimeOffset? expiresAt = null,
+        DateTimeOffset? respondedAt = null,
+        Guid? respondedByUserId = null)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var entity = new GameNightInvitationEntity
+        {
+            Id = Guid.NewGuid(),
+            Token = GenerateToken(),
+            GameNightId = gameNightId,
+            Email = email.Trim().ToLowerInvariant(),
+            Status = status,
+            ExpiresAt = expiresAt ?? DateTimeOffset.UtcNow.AddDays(14),
+            RespondedAt = respondedAt,
+            RespondedByUserId = respondedByUserId,
+            CreatedAt = DateTimeOffset.UtcNow,
+            CreatedBy = createdBy
+        };
+        dbContext.GameNightInvitations.Add(entity);
+        await dbContext.SaveChangesAsync();
+        return entity;
+    }
+
+    private static string GenerateToken()
+    {
+        // 22-char base62 — matches InvitationToken.Generate() shape. Crypto RNG (CA5394).
+        const string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        var chars = new char[22];
+        for (var i = 0; i < chars.Length; i++)
+            chars[i] = alphabet[RandomNumberGenerator.GetInt32(alphabet.Length)];
+        return new string(chars);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // GET /game-nights/invitations/{token} — public lookup
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetInvitationByToken_UnknownToken_Returns404()
+    {
+        var response = await _client.GetAsync("/api/v1/game-nights/invitations/nonexistent-token-1234567");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetInvitationByToken_PendingInvitation_Returns200WithPublicDto()
+    {
+        var organizerId = Guid.NewGuid();
+        var gameNightId = await SeedGameNightAsync(organizerId);
+        var invitation = await SeedInvitationAsync(gameNightId, organizerId);
+
+        var response = await _client.GetAsync($"/api/v1/game-nights/invitations/{invitation.Token}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<PublicGameNightInvitationDto>();
+        dto.Should().NotBeNull();
+        dto!.Token.Should().Be(invitation.Token);
+        dto.Status.Should().Be("Pending");
+        dto.GameNightId.Should().Be(gameNightId);
+        dto.AlreadyRespondedAs.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetInvitationByToken_AnonymousRequest_AllowedNoAuthRequired()
+    {
+        // Sanity check: no cookie header — no auth — should still resolve.
+        var organizerId = Guid.NewGuid();
+        var gameNightId = await SeedGameNightAsync(organizerId);
+        var invitation = await SeedInvitationAsync(gameNightId, organizerId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get,
+            $"/api/v1/game-nights/invitations/{invitation.Token}");
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task GetInvitationByToken_AcceptedInvitation_DtoReportsAlreadyRespondedAs()
+    {
+        var organizerId = Guid.NewGuid();
+        var gameNightId = await SeedGameNightAsync(organizerId);
+        var invitation = await SeedInvitationAsync(
+            gameNightId, organizerId,
+            status: "Accepted",
+            respondedAt: DateTimeOffset.UtcNow);
+
+        var response = await _client.GetAsync($"/api/v1/game-nights/invitations/{invitation.Token}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<PublicGameNightInvitationDto>();
+        dto!.Status.Should().Be("Accepted");
+        dto.AlreadyRespondedAs.Should().Be("Accepted");
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // POST /game-nights/invitations/{token}/respond — public RSVP
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RespondByToken_AcceptAnonymous_Returns200WithUpdatedDto()
+    {
+        var organizerId = Guid.NewGuid();
+        var gameNightId = await SeedGameNightAsync(organizerId);
+        var invitation = await SeedInvitationAsync(gameNightId, organizerId);
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/v1/game-nights/invitations/{invitation.Token}/respond",
+            new { Response = "Accepted" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<PublicGameNightInvitationDto>();
+        dto!.Status.Should().Be("Accepted");
+        dto.RespondedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task RespondByToken_DeclineAnonymous_Returns200()
+    {
+        var organizerId = Guid.NewGuid();
+        var gameNightId = await SeedGameNightAsync(organizerId);
+        var invitation = await SeedInvitationAsync(gameNightId, organizerId);
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/v1/game-nights/invitations/{invitation.Token}/respond",
+            new { Response = "Declined" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<PublicGameNightInvitationDto>();
+        dto!.Status.Should().Be("Declined");
+    }
+
+    [Fact]
+    public async Task RespondByToken_AuthenticatedUser_PopulatesRespondedByUserId()
+    {
+        var organizerId = Guid.NewGuid();
+        var gameNightId = await SeedGameNightAsync(organizerId);
+        var invitation = await SeedInvitationAsync(gameNightId, organizerId);
+
+        Guid responderId;
+        string sessionToken;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            (responderId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        }
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/game-nights/invitations/{invitation.Token}/respond",
+            sessionToken,
+            new { Response = "Accepted" });
+
+        var response = await _client.SendAsync(request);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Verify persistence layer captured the responder
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var persisted = await dbContext.GameNightInvitations
+                .AsNoTracking()
+                .FirstAsync(i => i.Id == invitation.Id);
+            persisted.Status.Should().Be("Accepted");
+            persisted.RespondedByUserId.Should().Be(responderId);
+        }
+    }
+
+    [Fact]
+    public async Task RespondByToken_UnknownToken_Returns404()
+    {
+        var response = await _client.PostAsJsonAsync(
+            "/api/v1/game-nights/invitations/UnknownTokenAbcdef1234/respond",
+            new { Response = "Accepted" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task RespondByToken_InvalidResponseValue_Returns400()
+    {
+        var organizerId = Guid.NewGuid();
+        var gameNightId = await SeedGameNightAsync(organizerId);
+        var invitation = await SeedInvitationAsync(gameNightId, organizerId);
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/v1/game-nights/invitations/{invitation.Token}/respond",
+            new { Response = "Maybe" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Theory]
+    [InlineData("Pending")]
+    [InlineData("Expired")]
+    [InlineData("Cancelled")]
+    public async Task RespondByToken_RejectsSystemSetStatusValue_Returns400(string systemStatus)
+    {
+        var organizerId = Guid.NewGuid();
+        var gameNightId = await SeedGameNightAsync(organizerId);
+        var invitation = await SeedInvitationAsync(gameNightId, organizerId);
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/v1/game-nights/invitations/{invitation.Token}/respond",
+            new { Response = systemStatus });
+
+        // Endpoint enum guard rejects non-Accept/Decline values with 400.
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task RespondByToken_SameStateRepeat_Returns200NoOp()
+    {
+        // Idempotency D2 b: repeating the current response is a no-op (200, not 409).
+        var organizerId = Guid.NewGuid();
+        var gameNightId = await SeedGameNightAsync(organizerId);
+        var invitation = await SeedInvitationAsync(
+            gameNightId, organizerId,
+            status: "Accepted",
+            respondedAt: DateTimeOffset.UtcNow);
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/v1/game-nights/invitations/{invitation.Token}/respond",
+            new { Response = "Accepted" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task RespondByToken_SwitchAcceptedToDeclined_Returns409Conflict()
+    {
+        // Idempotency D2 b: switching Accepted ⇄ Declined surfaces as 409 Conflict.
+        var organizerId = Guid.NewGuid();
+        var gameNightId = await SeedGameNightAsync(organizerId);
+        var invitation = await SeedInvitationAsync(
+            gameNightId, organizerId,
+            status: "Accepted",
+            respondedAt: DateTimeOffset.UtcNow);
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/v1/game-nights/invitations/{invitation.Token}/respond",
+            new { Response = "Declined" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task RespondByToken_OnExpiredInvitation_Returns410Gone()
+    {
+        // D2 b: terminal Expired surfaces as 410 Gone.
+        var organizerId = Guid.NewGuid();
+        var gameNightId = await SeedGameNightAsync(organizerId);
+        var invitation = await SeedInvitationAsync(
+            gameNightId, organizerId,
+            status: "Expired",
+            expiresAt: DateTimeOffset.UtcNow.AddDays(-1));
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/v1/game-nights/invitations/{invitation.Token}/respond",
+            new { Response = "Accepted" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Gone);
+    }
+
+    [Fact]
+    public async Task RespondByToken_OnCancelledInvitation_Returns410Gone()
+    {
+        var organizerId = Guid.NewGuid();
+        var gameNightId = await SeedGameNightAsync(organizerId);
+        var invitation = await SeedInvitationAsync(
+            gameNightId, organizerId,
+            status: "Cancelled");
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/v1/game-nights/invitations/{invitation.Token}/respond",
+            new { Response = "Accepted" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Gone);
+    }
+
+    [Fact]
+    public async Task RespondByToken_PendingPastExpiry_Returns410Gone()
+    {
+        // D2 b: pending invitation past ExpiresAt cutoff is treated as terminal-Expired
+        // by the handler (transitions on read) → 410 Gone on respond attempt.
+        var organizerId = Guid.NewGuid();
+        var gameNightId = await SeedGameNightAsync(organizerId);
+        var invitation = await SeedInvitationAsync(
+            gameNightId, organizerId,
+            status: "Pending",
+            expiresAt: DateTimeOffset.UtcNow.AddDays(-1));
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/v1/game-nights/invitations/{invitation.Token}/respond",
+            new { Response = "Accepted" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Gone);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // POST /game-nights/{gameNightId}/invitations — organizer create
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateInvitationByEmail_Anonymous_Returns401()
+    {
+        var organizerId = Guid.NewGuid();
+        var gameNightId = await SeedGameNightAsync(organizerId);
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/v1/game-nights/{gameNightId}/invitations",
+            new { Email = "guest@example.com" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task CreateInvitationByEmail_AsOrganizer_Returns201WithDto()
+    {
+        // Authenticate as a user whose ID is the organizer of the seeded game night.
+        Guid organizerId;
+        string sessionToken;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            (organizerId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        }
+        var gameNightId = await SeedGameNightAsync(organizerId);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/game-nights/{gameNightId}/invitations",
+            sessionToken,
+            new { Email = "guest@example.com" });
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var dto = await response.Content.ReadFromJsonAsync<GameNightInvitationDto>();
+        dto.Should().NotBeNull();
+        dto!.GameNightId.Should().Be(gameNightId);
+        dto.Email.Should().Be("guest@example.com");
+        dto.Status.Should().Be("Pending");
+        dto.Token.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task CreateInvitationByEmail_AsNonOrganizer_Returns403()
+    {
+        var organizerId = Guid.NewGuid(); // fake organizer (no session)
+        var gameNightId = await SeedGameNightAsync(organizerId);
+
+        // Authenticate as a different user (not the organizer)
+        Guid otherUserId;
+        string sessionToken;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            (otherUserId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        }
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/game-nights/{gameNightId}/invitations",
+            sessionToken,
+            new { Email = "guest@example.com" });
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task CreateInvitationByEmail_UnknownGameNight_Returns404()
+    {
+        Guid userId;
+        string sessionToken;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        }
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/game-nights/{Guid.NewGuid()}/invitations",
+            sessionToken,
+            new { Email = "guest@example.com" });
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task CreateInvitationByEmail_DuplicatePending_Returns409()
+    {
+        Guid organizerId;
+        string sessionToken;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            (organizerId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        }
+        var gameNightId = await SeedGameNightAsync(organizerId);
+        await SeedInvitationAsync(gameNightId, organizerId, email: "guest@example.com");
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/game-nights/{gameNightId}/invitations",
+            sessionToken,
+            new { Email = "GUEST@EXAMPLE.COM" }); // case-insensitive de-dup
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task CreateInvitationByEmail_InvalidEmailFormat_ReturnsValidationError()
+    {
+        Guid organizerId;
+        string sessionToken;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            (organizerId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        }
+        var gameNightId = await SeedGameNightAsync(organizerId);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/game-nights/{gameNightId}/invitations",
+            sessionToken,
+            new { Email = "not-an-email" });
+
+        var response = await _client.SendAsync(request);
+
+        // FluentValidation pipeline surfaces invalid email as 400 BadRequest or 422 UnprocessableEntity
+        // depending on configuration; both indicate validation failure.
+        ((int)response.StatusCode).Should().BeOneOf(400, 422);
+    }
+}

--- a/docs/superpowers/specs/2026-04-28-v2-migration-wave-a-5a-game-night-public-rsvp.md
+++ b/docs/superpowers/specs/2026-04-28-v2-migration-wave-a-5a-game-night-public-rsvp.md
@@ -1,0 +1,509 @@
+# Wave A.5a — GameNight Public Token-based RSVP (Backend Extension)
+
+**Issue**: #607 (sub-issue di umbrella #579)
+**Branch**: `feature/issue-607-game-night-public-rsvp-be`
+**Parent**: `main-dev`
+**Date**: 2026-04-28
+**Status**: Spec → TDD red phase
+
+---
+
+## 1. Context
+
+### 1.1 Driver
+
+Mockup `admin-mockups/design_files/sp3-accept-invite.jsx` (committed da PR #568 SP3 batch) modella un **invito a serata di gioco (game night RSVP)** con 7 stati pubblici (default/logged-in/accepted-success/declined/token-expired/token-invalid/already-accepted). Il flusso è **token-based**, **public** (no login required), con confetti animation su accept.
+
+### 1.2 Domain mismatch identificato
+
+Discovery pre-spec ha rivelato che il design panel iniziale aveva confuso due flussi distinti:
+
+| Aspetto | Mockup `sp3-accept-invite.jsx` | Route `/accept-invite?token=X` esistente |
+|---|---|---|
+| BC | GameManagement (game night RSVP) | Authentication (account creation) |
+| Trigger | Host invita guest a serata futura | Admin invita user a creare account |
+| Form | Accept/Decline boolean | Password + 4 strength rules |
+| Stati | 7 pubblici | 4 (loading/valid/submitting/success) |
+| Endpoint backend | **NON ESISTE** | `/api/v1/auth/{validate,accept}-invitation` |
+| Token shape | Path param `/invites/[token]` (umbrella #579) | Query string `?token=X` |
+
+L'umbrella #579 elenca esplicitamente la route target Wave A.5 come `/invites/[token]` (greenfield), confermando che si tratta di una nuova route, NON una migrazione brownfield di `/accept-invite`.
+
+### 1.3 Backend GameManagement BC — stato attuale
+
+**Già presente**:
+- `IGameNightEmailService.SendGameNightInvitationEmailAsync(toEmail, organizerName, title, scheduledAt, location, gameNames, rsvpAcceptUrl, rsvpDeclineUrl, unsubscribeUrl, ct)` (Issue #44/#47) — email pronta con parametri RSVP URL nella signature
+- `RespondToGameNightCommand(GameNightId, UserId, Response)` — auth-required, by GameNightId
+- `InviteToGameNightCommand` — invita per UserIds list, NO email NO token
+- `GameNightEvent` aggregate root con `Invitees` collection, lifecycle Published/Cancelled/Completed
+- `IGameNightEventRepository` con CRUD + queries
+
+**Mancante**:
+- Aggregate `GameNightInvitation` con token persistente (separata da Invitees by-UserId)
+- `IGameNightInvitationRepository`
+- Token generation + email orchestration nel flusso invite-by-email
+- Endpoint pubblici (no auth) per RSVP via token
+- HybridCache + invalidation per public lookup hot path
+
+### 1.4 Decisioni risolte
+
+- **D1 (a)** — Email integration reale: A.5a chiama `SendGameNightInvitationEmailAsync` con URL costruite dinamicamente. Richiede `IUrlBuilder` (riuso esistente o nuovo helper).
+- **D2 (b)** — Idempotency same-response: 200 OK quando response richiesta == stato corrente (refresh-safe), 409 Conflict solo quando l'utente cerca di cambiare risposta.
+
+---
+
+## 2. Architecture
+
+### 2.1 Layer breakdown
+
+```
+GameManagement BC
+├── Domain
+│   ├── Entities/GameNightEvent/
+│   │   ├── GameNightInvitation.cs         (NEW — aggregate root)
+│   │   └── GameNightInvitationStatus.cs   (NEW — enum)
+│   ├── ValueObjects/
+│   │   └── InvitationToken.cs             (NEW — VO immutable record)
+│   └── Events/
+│       ├── GameNightInvitationCreated.cs  (NEW)
+│       └── GameNightInvitationResponded.cs (NEW)
+├── Application
+│   ├── Commands/GameNights/
+│   │   ├── CreateGameNightInvitationByEmailCommand.cs (NEW)
+│   │   ├── CreateGameNightInvitationByEmailCommandHandler.cs
+│   │   ├── CreateGameNightInvitationByEmailValidator.cs
+│   │   ├── RespondToGameNightInvitationByTokenCommand.cs (NEW)
+│   │   ├── RespondToGameNightInvitationByTokenCommandHandler.cs
+│   │   └── RespondToGameNightInvitationByTokenValidator.cs
+│   ├── Queries/GameNights/
+│   │   ├── GetGameNightInvitationByTokenQuery.cs (NEW)
+│   │   └── GetGameNightInvitationByTokenQueryHandler.cs
+│   ├── DTOs/GameNights/
+│   │   ├── GameNightInvitationDto.cs (NEW — admin/organizer view)
+│   │   └── PublicGameNightInvitationDto.cs (NEW — public token view)
+│   └── EventHandlers/
+│       └── GameNightInvitationRespondedHandler.cs (NEW — cache invalidation)
+├── Infrastructure
+│   ├── Persistence/Configurations/
+│   │   └── GameNightInvitationConfiguration.cs (NEW — EF Core)
+│   ├── Persistence/Repositories/
+│   │   └── GameNightInvitationRepository.cs (NEW)
+│   └── Migrations/
+│       └── 2026XXXX_AddGameNightInvitations.cs (NEW)
+└── Domain/Repositories/
+    └── IGameNightInvitationRepository.cs (NEW)
+
+Routing/
+└── GameNightEndpoints.cs (EXTEND — 3 new endpoints)
+
+SharedKernel/
+└── Application/Services/
+    └── IUrlBuilder.cs (EXISTING or NEW — verify in commit 1)
+```
+
+### 2.2 Aggregate design — `GameNightInvitation`
+
+**Properties**:
+```csharp
+public Guid Id { get; private set; }
+public string Token { get; private set; }              // 22-char base62
+public Guid GameNightId { get; private set; }          // FK → GameNightEvent
+public string Email { get; private set; }              // lowercase, validated
+public GameNightInvitationStatus Status { get; private set; }
+public DateTimeOffset ExpiresAt { get; private set; }
+public DateTimeOffset? RespondedAt { get; private set; }
+public Guid? RespondedByUserId { get; private set; }   // optional auth association
+public DateTimeOffset CreatedAt { get; private set; }
+public Guid CreatedBy { get; private set; }            // organizer userId
+```
+
+**Status enum**:
+```csharp
+public enum GameNightInvitationStatus
+{
+    Pending = 0,
+    Accepted = 1,
+    Declined = 2,
+    Expired = 3,
+    Cancelled = 4,  // organizer cancels invite OR game night cancelled
+}
+```
+
+**Factory**:
+```csharp
+public static GameNightInvitation Create(
+    Guid gameNightId,
+    string email,
+    DateTimeOffset expiresAt,
+    Guid createdBy,
+    DateTimeOffset utcNow)
+{
+    if (string.IsNullOrWhiteSpace(email))
+        throw new ArgumentException("Email is required", nameof(email));
+    if (expiresAt <= utcNow)
+        throw new ArgumentException("ExpiresAt must be in the future", nameof(expiresAt));
+
+    return new GameNightInvitation
+    {
+        Id = Guid.NewGuid(),
+        Token = InvitationToken.Generate().Value,
+        GameNightId = gameNightId,
+        Email = email.Trim().ToLowerInvariant(),
+        Status = GameNightInvitationStatus.Pending,
+        ExpiresAt = expiresAt,
+        RespondedAt = null,
+        RespondedByUserId = null,
+        CreatedAt = utcNow,
+        CreatedBy = createdBy,
+    };
+}
+```
+
+**Domain methods**:
+```csharp
+// Idempotent: returns true if state changed, false if already in this state
+public bool Accept(Guid? userId, DateTimeOffset utcNow);
+public bool Decline(Guid? userId, DateTimeOffset utcNow);
+public void Cancel(DateTimeOffset utcNow);
+public bool IsExpired(DateTimeOffset utcNow) =>
+    Status == GameNightInvitationStatus.Pending && utcNow >= ExpiresAt;
+```
+
+**Idempotency rule** (D2 b):
+- `Accept` su Pending → transition Pending→Accepted, returns `true`
+- `Accept` su Accepted → no-op, returns `false` (caller mappa a 200 OK)
+- `Accept` su Declined → throws `InvalidOperationException` (caller mappa a 409 Conflict)
+- `Accept` su Expired/Cancelled → throws `InvalidOperationException` (caller mappa a 410 Gone)
+
+### 2.3 Value object — `InvitationToken`
+
+```csharp
+public sealed record InvitationToken
+{
+    public string Value { get; }
+
+    private InvitationToken(string value) => Value = value;
+
+    public static InvitationToken Create(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("Token cannot be empty", nameof(value));
+        if (value.Length != 22)
+            throw new ArgumentException("Token must be 22 characters", nameof(value));
+        if (!IsValidBase62(value))
+            throw new ArgumentException("Token must be base62", nameof(value));
+        return new InvitationToken(value);
+    }
+
+    public static InvitationToken Generate()
+    {
+        // 16 bytes (~131 bits entropy) → base62 → 22 chars
+        Span<byte> bytes = stackalloc byte[16];
+        RandomNumberGenerator.Fill(bytes);
+        return new InvitationToken(Base62.Encode(bytes));
+    }
+
+    private static bool IsValidBase62(string s) =>
+        s.All(c => (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'));
+}
+```
+
+### 2.4 Public DTO — `PublicGameNightInvitationDto`
+
+Surface area allineata 1:1 al mockup `InviteBody` component:
+
+```csharp
+public sealed record PublicGameNightInvitationDto(
+    string Token,
+    string Status,                    // "Pending" | "Accepted" | "Declined" | "Expired" | "Cancelled"
+    DateTimeOffset ExpiresAt,
+    DateTimeOffset? RespondedAt,
+
+    // Host (organizer) info
+    Guid HostUserId,
+    string HostDisplayName,
+    string? HostAvatarUrl,
+    string? HostWelcomeMessage,       // optional custom welcome from organizer
+
+    // Game info
+    Guid GameNightId,
+    string Title,                     // game night title
+    DateTimeOffset ScheduledAt,
+    string? Location,
+    int? DurationMinutes,
+    int ExpectedPlayers,
+    int AcceptedSoFar,                // count of Accepted invitations + organizer
+
+    // Primary game (first in playlist if multi-game game night)
+    Guid? PrimaryGameId,
+    string? PrimaryGameName,
+    string? PrimaryGameImageUrl,
+
+    // Idempotency hint for frontend
+    string? AlreadyRespondedAs        // "Accepted" | "Declined" | null
+);
+```
+
+---
+
+## 3. Endpoints
+
+All in `Routing/GameNightEndpoints.cs` (file esistente, esteso):
+
+### 3.1 Public — Get invitation by token
+
+```
+GET /api/v1/game-nights/invitations/{token}
+Auth: NONE (public)
+
+Responses:
+  200 OK   → PublicGameNightInvitationDto (anche se Accepted/Declined → AlreadyRespondedAs popolato)
+  404      → Token sconosciuto
+  410 Gone → Status == Expired || Cancelled
+```
+
+**Performance gate**: p95 cold <100ms, warm <30ms (HybridCache TTL 60s, tag `game-night-invitation:{token}`).
+
+### 3.2 Public — Respond to invitation by token
+
+```
+POST /api/v1/game-nights/invitations/{token}/respond
+Auth: OPTIONAL (cookie auth se presente, popolata in RespondedByUserId)
+Body: { "response": "accepted" | "declined" }
+
+Responses:
+  200 OK     → PublicGameNightInvitationDto aggiornato (idempotent same-response OK)
+  400        → response invalida (non in {accepted, declined})
+  404        → Token sconosciuto
+  409 Conflict → Tentativo di cambiare risposta (Accepted→Declined o viceversa)
+  410 Gone   → Expired || Cancelled
+```
+
+Side-effects su Accept (transition Pending→Accepted):
+- Fires `GameNightInvitationResponded` domain event
+- Event handler invalida cache `game-night-invitation:{token}`
+- Calls `IGameNightEmailService.SendGameNightRsvpConfirmationEmailAsync` (existing method)
+
+### 3.3 Auth-required — Create invitation by email (organizer)
+
+```
+POST /api/v1/game-nights/{gameNightId}/invitations
+Auth: REQUIRED (organizer-only)
+Body: { "email": "guest@example.com" }
+
+Responses:
+  201 Created → GameNightInvitationDto (admin view, include Token + ExpiresAt)
+  400         → Email format invalida
+  401         → Non autenticato
+  403         → Non organizer del GameNight
+  404         → GameNight sconosciuto
+  409 Conflict → Pending invitation già esistente per (gameNightId, email)
+  422         → GameNight non pubblicato o scaduto
+```
+
+Side-effects:
+- Persiste `GameNightInvitation`
+- Fires `GameNightInvitationCreated` domain event
+- Builds `rsvpAcceptUrl = $"{baseUrl}/invites/{token}?action=accept"` e `rsvpDeclineUrl = $"{baseUrl}/invites/{token}?action=decline"`
+- Calls `IGameNightEmailService.SendGameNightInvitationEmailAsync(...)` con URLs costruiti
+
+---
+
+## 4. Test plan
+
+### 4.1 Domain unit tests (`tests/Api.Tests/UnitTests/Domain/GameManagement/`)
+
+`GameNightInvitationTests.cs`:
+- `Create_WithValidParams_ReturnsAggregate`
+- `Create_WithEmptyEmail_Throws`
+- `Create_WithPastExpiresAt_Throws`
+- `Create_NormalizesEmailToLowercase`
+- `Accept_OnPending_TransitionsToAccepted_ReturnsTrue`
+- `Accept_OnAccepted_NoOp_ReturnsFalse` (D2 b idempotency)
+- `Accept_OnDeclined_Throws` (response change)
+- `Accept_OnExpired_Throws`
+- `Accept_OnCancelled_Throws`
+- `Decline_OnPending_TransitionsToDeclined_ReturnsTrue`
+- `Decline_OnDeclined_NoOp_ReturnsFalse`
+- `Decline_OnAccepted_Throws`
+- `Cancel_FromPending_TransitionsToCancelled`
+- `Cancel_FromAccepted_TransitionsToCancelled` (organizer revokes)
+- `IsExpired_WhenPastExpiresAtAndPending_ReturnsTrue`
+- `IsExpired_WhenAccepted_ReturnsFalse` (terminal state, expiry irrelevant)
+- `Accept_RecordsRespondedAt_AndOptionalUserId`
+
+`InvitationTokenTests.cs`:
+- `Generate_Returns22CharBase62`
+- `Generate_ProducesUniqueTokens` (10000 iterations, no collisions)
+- `Create_WithValidToken_Succeeds`
+- `Create_WithEmpty_Throws`
+- `Create_WithWrongLength_Throws`
+- `Create_WithInvalidChars_Throws`
+
+### 4.2 Application unit tests (`tests/Api.Tests/UnitTests/Application/GameManagement/`)
+
+`CreateGameNightInvitationByEmailCommandHandlerTests.cs`:
+- `Handle_WhenOrganizer_PersistsAggregate_AndSendsEmail`
+- `Handle_WhenNotOrganizer_ThrowsUnauthorized`
+- `Handle_WhenGameNightNotFound_ThrowsNotFound`
+- `Handle_WhenGameNightNotPublished_ThrowsConflict`
+- `Handle_WhenDuplicatePending_ThrowsConflict`
+- `Handle_BuildsRsvpUrls_WithCorrectFormat`
+- `Handle_FiresInvitationCreatedEvent`
+
+`GetGameNightInvitationByTokenQueryHandlerTests.cs`:
+- `Handle_ValidToken_ReturnsPublicDto`
+- `Handle_UnknownToken_ThrowsNotFound`
+- `Handle_ExpiredToken_ThrowsGoneException` (or maps to 410)
+- `Handle_CachesResultByToken_60sTTL`
+- `Handle_PopulatesAlreadyRespondedAs_WhenStatusNotPending`
+- `Handle_AcceptedSoFar_CountsOrganizer_PlusAcceptedInvitations`
+
+`RespondToGameNightInvitationByTokenCommandHandlerTests.cs`:
+- `Handle_AcceptOnPending_Transitions_AndSendsConfirmationEmail`
+- `Handle_AcceptOnAccepted_Idempotent_NoEmailResent` (D2 b)
+- `Handle_AcceptOnDeclined_ThrowsConflict` (response change)
+- `Handle_DeclineOnPending_Transitions_NoEmail`
+- `Handle_OnExpired_ThrowsGone`
+- `Handle_OnCancelled_ThrowsGone`
+- `Handle_WithUserId_RecordsRespondedByUserId`
+- `Handle_WithoutUserId_LeavesRespondedByNull` (anonymous guest)
+- `Handle_FiresInvitationRespondedEvent`
+
+`GameNightInvitationRespondedHandlerTests.cs`:
+- Pattern mirror Wave A.3a `*ForCatalogAggregatesHandlerTests` (real `HybridCache` from DI, NOT mock):
+  - Pre-seed cache entry tagged `game-night-invitation:{token}` → fire event → re-call `GetOrCreateAsync` con stessa key/tag → verify factory re-invokes (= eviction worked)
+- **CRITICAL**: inject raw `HybridCache` (NOT wrapper `IHybridCacheService`) per consistency con producer query handler — pitfall #2620 lesson da Wave A.3a
+
+### 4.3 Integration tests (Testcontainers Postgres)
+
+`tests/Api.Tests/IntegrationTests/GameManagement/GameNightInvitationEndpointsTests.cs`:
+
+Public GET `/api/v1/game-nights/invitations/{token}`:
+- `GetByToken_ValidPending_Returns200_PublicDto`
+- `GetByToken_UnknownToken_Returns404`
+- `GetByToken_ExpiredInvitation_Returns410`
+- `GetByToken_AlreadyAccepted_Returns200_WithAlreadyRespondedAs`
+- `GetByToken_NoAuthRequired_Anonymous_Returns200`
+- `GetByToken_Performance_Warm_p95Below30ms` (Stopwatch, 100 iterations)
+- `GetByToken_Performance_Cold_p95Below100ms`
+
+Public POST `/api/v1/game-nights/invitations/{token}/respond`:
+- `Respond_AcceptPending_Returns200_StatusAccepted`
+- `Respond_AcceptAccepted_Idempotent_Returns200`
+- `Respond_AcceptDeclined_Returns409_ResponseChange`
+- `Respond_DeclinePending_Returns200_StatusDeclined`
+- `Respond_DeclineDeclined_Idempotent_Returns200`
+- `Respond_OnExpired_Returns410`
+- `Respond_OnCancelled_Returns410`
+- `Respond_UnknownToken_Returns404`
+- `Respond_InvalidResponseValue_Returns400` (e.g. "maybe")
+- `Respond_WithCookieAuth_PopulatesRespondedByUserId`
+- `Respond_AnonymousGuest_LeavesRespondedByUserIdNull`
+
+Auth POST `/api/v1/game-nights/{gameNightId}/invitations`:
+- `CreateInvite_AsOrganizer_Returns201_AndEmailSent` (verify via `IEmailService` mock SendCount)
+- `CreateInvite_AsNonOrganizer_Returns403`
+- `CreateInvite_GameNightNotFound_Returns404`
+- `CreateInvite_DuplicatePending_Returns409`
+- `CreateInvite_GameNightNotPublished_Returns422`
+- `CreateInvite_InvalidEmail_Returns400`
+- `CreateInvite_AnonymousUser_Returns401`
+
+### 4.4 Coverage targets
+
+- Domain: 100% line + branch (small surface, all paths testable)
+- Application handlers: 100% line + branch
+- Repository: 90%+ via integration tests (some EF-internal paths excluded)
+- Endpoints: 100% via integration tests
+- **PR target**: codecov/patch ≥85%
+
+---
+
+## 5. Commit boundary (TDD red→green)
+
+Single PR, 4 commit boundary mirror Wave A.3a:
+
+### Commit 1 — Domain layer (RED then GREEN)
+- `GameNightInvitation` aggregate + `GameNightInvitationStatus` enum + `InvitationToken` VO
+- `GameNightInvitationCreated`/`GameNightInvitationResponded` domain events
+- `Base62` helper (verify if exists in SharedKernel, else create minimal impl)
+- 100% domain unit tests
+- **No EF, no DI registration yet** — pure domain commit
+
+### Commit 2 — Application layer (RED then GREEN)
+- 2 commands + 1 query + handlers + validators
+- 2 DTOs (`GameNightInvitationDto`, `PublicGameNightInvitationDto`)
+- `IGameNightInvitationRepository` interface in Domain
+- `GameNightInvitationRespondedHandler` event handler (cache invalidation)
+- 100% application unit tests con repository mocks + real HybridCache for handler
+
+### Commit 3 — Infrastructure (RED then GREEN)
+- EF Core configuration `GameNightInvitationConfiguration` (table + indexes + FK)
+- EF migration `AddGameNightInvitations`
+- `GameNightInvitationRepository` impl
+- DI registration in `GameManagementServiceExtensions`
+- `IUrlBuilder` riuso o nuovo helper minimal
+- Repository integration tests con Testcontainers
+
+### Commit 4 — Endpoints + email integration (RED then GREEN)
+- 3 endpoint in `GameNightEndpoints.cs`
+- `appsettings.json` + `appsettings.Development.json` con `GameNight:InvitationExpiryDays = 14`
+- Integration tests E2E con Testcontainers (auth + public)
+- OpenAPI/Scalar surface verification
+
+---
+
+## 6. Risks & Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Token enumeration attack | High | 131-bit entropy + rate limit per IP su public GET (riusa middleware esistente se presente, altrimenti TODO follow-up issue) |
+| Email enumeration via 404 vs 410 | Medium | Response shape uniforme (no leak su esistenza email destinatario) — usiamo solo token come selettore |
+| Cache poisoning su public lookup | Low | Token immutable, cache key = token diretto, no user input nel payload |
+| Race condition double-RSVP | Low | EF concurrency token su `GameNightInvitation.RowVersion` (`[Timestamp]` byte[]) — catch `DbUpdateConcurrencyException` → retry once |
+| Email service downtime blocking organizer flow | Medium | Email send NON in transazione DB. Se email fail → log error, return 201 con DTO (organizer può re-trigger via UI in follow-up). Trade-off: documentato nel handler. |
+| HybridCache tag-store mismatch (pitfall #2620) | High | Inject raw `HybridCache` nell'event handler, **NON** wrapper `IHybridCacheService` — mirror lesson Wave A.3a |
+| Performance degrade su lookup hot path | Medium | HybridCache TTL 60s + integration test gate p95 <30ms warm/<100ms cold |
+| Migration deployment lock contention | Low | Tabella nuova, no ALTER su esistenti — zero contention |
+
+---
+
+## 7. Out of scope
+
+- `.ics` calendar download endpoint (deferred per umbrella #579 out-of-scope)
+- Frontend route `/invites/[token]` (Wave A.5b separate child issue, post-merge)
+- Email reminder 24h pre-event (esiste già `SendGameNightReminder24hEmailAsync`, non toccato)
+- RSVP via authenticated user dashboard (esiste già `RespondToGameNightCommand`, non toccato)
+- Email templates redesign per match v2 brand (mockup è frontend route, email template separata)
+- Rate limiting su public endpoints (follow-up se security issue emerge in pen test)
+- Webhook outbound notifications (organizer wants to be notified when guest accepts) — esiste già `SendGameNightInvitationEmailAsync` per organizer? Verificare in commit 4, NON estendere qui.
+
+---
+
+## 8. Definition of Done
+
+- [ ] 4 commit committed e pushed su `feature/issue-607-game-night-public-rsvp-be`
+- [ ] Tutti i test pass localmente (`dotnet test --filter "BoundedContext=GameManagement"`)
+- [ ] PR opened con `Closes #607` body keyword, base = `main-dev`
+- [ ] CI all green: Backend Unit ✅, Detect Changes ✅, validate-source-branch ✅, GitGuardian ✅, CI Success ✅
+- [ ] codecov/patch ≥85%
+- [ ] PR squash merged con `--delete-branch` flag (use `--admin` se codecov/patch flake non-blocking, mirror Wave A pattern)
+- [ ] Branch eliminato local (`git branch -D feature/issue-607-game-night-public-rsvp-be`) + remote (auto via `--delete-branch`)
+- [ ] `git remote prune origin` per cleanup ref
+- [ ] `main-dev` fast-forwarded localmente
+- [ ] Issue #607 chiusa (auto via `Closes #607`)
+- [ ] Wave A.5b child issue creata sotto #579 (frontend route greenfield)
+- [ ] MEMORY.md aggiornato con session entry "PR #XXX MERGED — Wave A.5a backend complete"
+
+---
+
+## 9. References
+
+- Umbrella: #579 (V2 Phase 1 Wave A — SP3 public routes)
+- Pattern precedent: #594 (Wave A.3a backend) → #600 (Wave A.3b frontend)
+- Existing email infra: Issue #44 / #47 (game night notifications)
+- Existing RSVP (auth-required): Issue #46 (GameNight API endpoints)
+- Existing invite token flow (different BC): Issue #3354 (live-session invite, SessionTracking BC)
+- HybridCache tag-store pitfall: #2620
+- Mockup driver: `admin-mockups/design_files/sp3-accept-invite.jsx` (committed PR #568)


### PR DESCRIPTION
## Summary

Wave A.5a backend slice for **Issue #607** (token-based public RSVP for Game Nights). Delivers the full DDD vertical slice (Domain → Application → Infrastructure → Endpoints) so Wave A.5b frontend can implement the greenfield `/invites/[token]` route per mockup `sp3-accept-invite.jsx`.

### What this PR adds
- **Domain layer** — `GameNightInvitation` aggregate (token-addressable, distinct from existing `GameNightRsvp` UserId-addressable), `InvitationToken` value object (~131-bit base62), idempotency state machine: same-state → no-op, switch Accepted⇄Declined → `ConflictException`, terminal/expired → `GoneException`.
- **Application layer** — 3 commands/queries via MediatR:
  - `CreateGameNightInvitationByEmailCommand` (organizer-only, sends email)
  - `RespondToGameNightInvitationByTokenCommand` (optional-auth)
  - `GetGameNightInvitationByTokenQuery`
  - `GameNightInvitationRespondedHandler` (HybridCache invalidation w/ raw `HybridCache` injection per pitfall #2620)
- **Infrastructure layer** — EF Core entity + migration `AddGameNightInvitations`, `GameNightInvitationRepository` w/ token-based + email-based queries.
- **HTTP surface** (CQRS, IMediator-only):
  - `GET  /api/v1/game-nights/invitations/{token}` (public)
  - `POST /api/v1/game-nights/invitations/{token}/respond` (optional auth)
  - `POST /api/v1/game-nights/{gameNightId}/invitations` (organizer-only)
- **Config** — `GameNight:InvitationExpiryDays = 14` in `appsettings.json`.
- **Alpha-mode gating** — `MapGameNightEndpoints()` moved out of `!isAlphaMode` block to expose RSVP in Alpha mode.

### Status code matrix
| Scenario | HTTP |
|----------|------|
| Token not found | 404 |
| Anonymous lookup of pending invitation | 200 |
| Already responded (DTO reports `AlreadyRespondedAs`) | 200 |
| Same-state response (idempotent no-op) | 200 |
| Switch Accepted ⇄ Declined | 409 |
| Terminal Expired/Cancelled or pending past expiry | 410 |
| Invalid response value (not Accepted/Declined) | 400 |
| Anonymous create | 401 |
| Non-organizer create | 403 |
| Duplicate pending email (case-insensitive) | 409 |
| Invalid email format | 400 / 422 |

## Test plan
- [x] **Domain unit tests** — aggregate state transitions, token generation
- [x] **Application unit tests** — handlers, validators, idempotency contract
- [x] **Infrastructure integration tests** — repository against Testcontainers Postgres
- [x] **E2E integration tests** — 23 tests covering all 3 endpoints, HTTP surface, idempotency, anonymous access, mocked `IGameNightEmailService` (no SMTP I/O)
- [x] `dotnet build` — 0 errors, 0 new warnings
- [ ] CI green (Backend Unit + GitGuardian + validate-source-branch + Detect Changes)
- [ ] codecov/patch ≥85%

Closes #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)