### PR TITLE
feat(shared-games): cache invalidation resilience (#613)

### DIFF
--- a/apps/api/src/Api/Api.csproj
+++ b/apps/api/src/Api/Api.csproj
@@ -33,6 +33,8 @@
     <PackageReference Include="MediatR" Version="14.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.11" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.0" />
+    <!-- Issue #613: Polly v8 ResiliencePipeline for cache invalidation retry -->
+    <PackageReference Include="Polly.Core" Version="8.6.5" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.14.0-beta.2" />
     <PackageReference Include="Otp.NET" Version="1.4.1" />
     <PackageReference Include="Parquet.Net" Version="5.5.0" />

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/AgentDefinitionChangedForCatalogAggregatesHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/AgentDefinitionChangedForCatalogAggregatesHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.KnowledgeBase.Domain.Events;
 using Api.Infrastructure;
+using Api.Services;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Hybrid;
@@ -44,15 +45,18 @@ internal sealed class AgentDefinitionChangedForCatalogAggregatesHandler
 
     private readonly MeepleAiDbContext _context;
     private readonly HybridCache _cache;
+    private readonly ICacheInvalidationRetryPolicy _retryPolicy;
     private readonly ILogger<AgentDefinitionChangedForCatalogAggregatesHandler> _logger;
 
     public AgentDefinitionChangedForCatalogAggregatesHandler(
         MeepleAiDbContext context,
         HybridCache cache,
+        ICacheInvalidationRetryPolicy retryPolicy,
         ILogger<AgentDefinitionChangedForCatalogAggregatesHandler> logger)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _retryPolicy = retryPolicy ?? throw new ArgumentNullException(nameof(retryPolicy));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -82,8 +86,11 @@ internal sealed class AgentDefinitionChangedForCatalogAggregatesHandler
 
     private async Task InvalidateAsync(string eventName, Guid agentDefinitionId, CancellationToken ct)
     {
-        // Always invalidate the catalog list cache.
-        await _cache.RemoveByTagAsync(SearchGamesTag, ct).ConfigureAwait(false);
+        // Always invalidate the catalog list cache (Issue #613: bounded retry).
+        await _retryPolicy.ExecuteAsync(
+            token => _cache.RemoveByTagAsync(SearchGamesTag, token),
+            "shared-games.list",
+            ct).ConfigureAwait(false);
 
         // Look up the SharedGameId via the Game intermediate so we can scope
         // the per-game detail invalidation. AgentDefinition.GameId is exposed
@@ -101,7 +108,10 @@ internal sealed class AgentDefinitionChangedForCatalogAggregatesHandler
 
         if (sharedGameId is { } sgId && sgId != Guid.Empty)
         {
-            await _cache.RemoveByTagAsync($"shared-game:{sgId}", ct).ConfigureAwait(false);
+            await _retryPolicy.ExecuteAsync(
+                token => _cache.RemoveByTagAsync($"shared-game:{sgId}", token),
+                "shared-games.detail",
+                ct).ConfigureAwait(false);
             _logger.LogInformation(
                 "Invalidated search-games + shared-game:{SharedGameId} after {Event} ({AgentDefinitionId})",
                 sgId,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/ToolkitChangedForCatalogAggregatesHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/ToolkitChangedForCatalogAggregatesHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.GameToolkit.Domain.Events;
 using Api.Infrastructure;
+using Api.Services;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Hybrid;
@@ -48,15 +49,18 @@ internal sealed class ToolkitChangedForCatalogAggregatesHandler
 
     private readonly MeepleAiDbContext _context;
     private readonly HybridCache _cache;
+    private readonly ICacheInvalidationRetryPolicy _retryPolicy;
     private readonly ILogger<ToolkitChangedForCatalogAggregatesHandler> _logger;
 
     public ToolkitChangedForCatalogAggregatesHandler(
         MeepleAiDbContext context,
         HybridCache cache,
+        ICacheInvalidationRetryPolicy retryPolicy,
         ILogger<ToolkitChangedForCatalogAggregatesHandler> logger)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _retryPolicy = retryPolicy ?? throw new ArgumentNullException(nameof(retryPolicy));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -76,8 +80,11 @@ internal sealed class ToolkitChangedForCatalogAggregatesHandler
 
     private async Task InvalidateAsync(string eventName, Guid toolkitId, CancellationToken ct)
     {
-        // Always invalidate the catalog list cache.
-        await _cache.RemoveByTagAsync(SearchGamesTag, ct).ConfigureAwait(false);
+        // Always invalidate the catalog list cache (Issue #613: bounded retry).
+        await _retryPolicy.ExecuteAsync(
+            token => _cache.RemoveByTagAsync(SearchGamesTag, token),
+            "shared-games.list",
+            ct).ConfigureAwait(false);
 
         // Look up the SharedGameId via the Game intermediate so we can scope
         // the per-game detail invalidation. Toolkits with no GameId, or with
@@ -92,7 +99,10 @@ internal sealed class ToolkitChangedForCatalogAggregatesHandler
 
         if (sharedGameId is { } sgId && sgId != Guid.Empty)
         {
-            await _cache.RemoveByTagAsync($"shared-game:{sgId}", ct).ConfigureAwait(false);
+            await _retryPolicy.ExecuteAsync(
+                token => _cache.RemoveByTagAsync($"shared-game:{sgId}", token),
+                "shared-games.detail",
+                ct).ConfigureAwait(false);
             _logger.LogInformation(
                 "Invalidated search-games + shared-game:{SharedGameId} after {Event} ({ToolkitId})",
                 sgId,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.KnowledgeBase.Domain.Events;
 using Api.Infrastructure;
+using Api.Services;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Hybrid;
@@ -33,15 +34,18 @@ internal sealed class VectorDocumentIndexedForKbFlagHandler
 {
     private readonly MeepleAiDbContext _context;
     private readonly HybridCache _cache;
+    private readonly ICacheInvalidationRetryPolicy _retryPolicy;
     private readonly ILogger<VectorDocumentIndexedForKbFlagHandler> _logger;
 
     public VectorDocumentIndexedForKbFlagHandler(
         MeepleAiDbContext context,
         HybridCache cache,
+        ICacheInvalidationRetryPolicy retryPolicy,
         ILogger<VectorDocumentIndexedForKbFlagHandler> logger)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _retryPolicy = retryPolicy ?? throw new ArgumentNullException(nameof(retryPolicy));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -87,13 +91,20 @@ internal sealed class VectorDocumentIndexedForKbFlagHandler
         // Acceptable for staging (single node); for multi-replica prod consider
         // either shortening LocalCacheExpiration or publishing an integration
         // event that each instance subscribes to for L1 cleanup.
-        await _cache.RemoveByTagAsync("search-games", cancellationToken).ConfigureAwait(false);
+        // Issue #613: bounded retry guards against transient Redis failures
+        // that would otherwise leave the read-model serving a stale flag.
+        await _retryPolicy.ExecuteAsync(
+            token => _cache.RemoveByTagAsync("search-games", token),
+            "shared-games.list",
+            cancellationToken).ConfigureAwait(false);
 
         // Issue #603 (Wave A.4): also evict the per-game detail cache so the
         // next /shared-games/{id} read sees the new HasKnowledgeBase flag and
         // refreshed KbsCount/Kbs preview list.
-        await _cache.RemoveByTagAsync($"shared-game:{sharedGameId.Value}", cancellationToken)
-            .ConfigureAwait(false);
+        await _retryPolicy.ExecuteAsync(
+            token => _cache.RemoveByTagAsync($"shared-game:{sharedGameId.Value}", token),
+            "shared-games.detail",
+            cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation(
             "Set HasKnowledgeBase=true for SharedGame {SharedGameId} triggered by VectorDocument {DocumentId}",

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/ScheduledBulkInvalidationJob.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/ScheduledBulkInvalidationJob.cs
@@ -1,0 +1,149 @@
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Observability;
+using Api.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.Logging;
+using Quartz;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Jobs;
+
+/// <summary>
+/// Defensive scheduled bulk-invalidation safety net for the SharedGameCatalog
+/// read-model. Issue #613 (P0 cache invalidation resilience).
+///
+/// <para>
+/// Why: the three event-driven invalidation handlers
+/// (<c>VectorDocumentIndexedForKbFlagHandler</c>,
+/// <c>ToolkitChangedForCatalogAggregatesHandler</c>,
+/// <c>AgentDefinitionChangedForCatalogAggregatesHandler</c>) wrap
+/// <see cref="HybridCache.RemoveByTagAsync(string, CancellationToken)"/>
+/// in a bounded retry policy, but a permanent Redis outage outliving the
+/// retry budget can still leave the L2 distributed cache serving stale
+/// detail/list payloads (TTL 300s) on multi-replica deployments.
+/// </para>
+///
+/// <para>
+/// What: every 15 minutes this job evicts the per-detail tags for the
+/// most-trafficked shared games over the last hour plus the global
+/// <c>"search-games"</c> list tag. Worst-case staleness is therefore
+/// bounded at 15 min instead of the 5-min L2 TTL plus indefinite L1
+/// drift, even when event handlers have permanently failed.
+/// </para>
+///
+/// <para>
+/// How: query <see cref="GameAnalyticsEventEntity"/> for the top-N
+/// SharedGameIds by event volume in the last hour, then loop and invoke
+/// <see cref="ICacheInvalidationRetryPolicy"/>. Top-N is bounded
+/// (<see cref="DefaultTopN"/>=50) to keep job runtime under a few hundred
+/// milliseconds. Background-task pattern: catch all exceptions, never
+/// rethrow, surface failure on <see cref="IJobExecutionContext.Result"/>.
+/// </para>
+/// </summary>
+[DisallowConcurrentExecution]
+internal sealed class ScheduledBulkInvalidationJob : IJob
+{
+    internal const int DefaultTopN = 50;
+    internal static readonly TimeSpan LookbackWindow = TimeSpan.FromHours(1);
+    private const string SearchGamesTag = "search-games";
+    private const string ListOperationName = "shared-games.list.bulk";
+    private const string DetailOperationName = "shared-games.detail.bulk";
+
+    private readonly MeepleAiDbContext _context;
+    private readonly HybridCache _cache;
+    private readonly ICacheInvalidationRetryPolicy _retryPolicy;
+    private readonly ILogger<ScheduledBulkInvalidationJob> _logger;
+
+    public ScheduledBulkInvalidationJob(
+        MeepleAiDbContext context,
+        HybridCache cache,
+        ICacheInvalidationRetryPolicy retryPolicy,
+        ILogger<ScheduledBulkInvalidationJob> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _retryPolicy = retryPolicy ?? throw new ArgumentNullException(nameof(retryPolicy));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var ct = context.CancellationToken;
+        _logger.LogInformation(
+            "ScheduledBulkInvalidationJob started: FireTime={FireTime}",
+            context.FireTimeUtc);
+
+        try
+        {
+            // 1) Single global list invalidation. Cheap and covers any catalog
+            //    list query that could have stale aggregates from the last 15min.
+            await _retryPolicy.ExecuteAsync(
+                token => _cache.RemoveByTagAsync(SearchGamesTag, token),
+                ListOperationName,
+                ct).ConfigureAwait(false);
+
+            // 2) Top-N most-trafficked SharedGames in the last LookbackWindow.
+            //    GameAnalyticsEventEntity.GameId is the SharedGameEntity.Id
+            //    (see GetCatalogTrendingQueryHandler.ComputeTrendingAsync which
+            //    joins against SharedGameEntity on the same column).
+            var since = DateTime.UtcNow - LookbackWindow;
+            var topGameIds = await _context.Set<GameAnalyticsEventEntity>()
+                .AsNoTracking()
+                .Where(e => e.Timestamp >= since)
+                .GroupBy(e => e.GameId)
+                .OrderByDescending(g => g.Count())
+                .Take(DefaultTopN)
+                .Select(g => g.Key)
+                .ToListAsync(ct).ConfigureAwait(false);
+
+            var invalidatedCount = 0;
+            foreach (var sharedGameId in topGameIds)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                await _retryPolicy.ExecuteAsync(
+                    token => _cache.RemoveByTagAsync($"shared-game:{sharedGameId}", token),
+                    DetailOperationName,
+                    ct).ConfigureAwait(false);
+
+                invalidatedCount++;
+            }
+
+            _logger.LogInformation(
+                "ScheduledBulkInvalidationJob completed: list_invalidated=1 detail_invalidated={DetailCount}",
+                invalidatedCount);
+
+            context.Result = new
+            {
+                Success = true,
+                ListInvalidations = 1,
+                DetailInvalidations = invalidatedCount
+            };
+        }
+        catch (OperationCanceledException ex) when (ct.IsCancellationRequested)
+        {
+            _logger.LogInformation(ex, "ScheduledBulkInvalidationJob cancelled");
+            throw;
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        // BACKGROUND TASK PATTERN: Quartz job exceptions must not propagate
+        // (would terminate the scheduler thread). Surface failure via Result.
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "ScheduledBulkInvalidationJob failed");
+            MeepleAiMetrics.RecordCacheInvalidationOutcome(
+                "shared-games.bulk.job",
+                "failure");
+
+            context.Result = new
+            {
+                Success = false,
+                Error = ex.Message
+            };
+        }
+#pragma warning restore CA1031
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -145,6 +145,20 @@ internal static class SharedGameCatalogServiceExtensions
                 .WithIdentity("calculate-trending-trigger", "shared-game-catalog")
                 .WithCronSchedule("0 0 3 * * ?")
                 .WithDescription("Runs daily at 03:00 UTC to pre-compute trending game scores"));
+
+            // Issue #613: Register scheduled bulk invalidation job — defensive
+            // safety net catching any cache staleness left behind by a permanent
+            // event-handler retry exhaustion (e.g. multi-minute Redis outage).
+            q.AddJob<ScheduledBulkInvalidationJob>(opts => opts
+                .WithIdentity("scheduled-bulk-invalidation-job", "shared-game-catalog")
+                .StoreDurably(true));
+
+            // Trigger: Run every 15 minutes
+            q.AddTrigger(opts => opts
+                .ForJob("scheduled-bulk-invalidation-job", "shared-game-catalog")
+                .WithIdentity("scheduled-bulk-invalidation-trigger", "shared-game-catalog")
+                .WithCronSchedule("0 */15 * * * ?")
+                .WithDescription("Runs every 15 min to evict shared-game detail tags for top-N most-viewed games and the search-games list tag"));
         });
 
         // MediatR handlers are auto-registered via assembly scanning in Program.cs

--- a/apps/api/src/Api/Extensions/InfrastructureServiceExtensions.cs
+++ b/apps/api/src/Api/Extensions/InfrastructureServiceExtensions.cs
@@ -208,6 +208,10 @@ internal static class InfrastructureServiceExtensions
         services.AddSingleton<IDynamicTtlStrategy, DynamicTtlStrategy>();
         services.AddSingleton<IRedisFrequencyTracker, RedisFrequencyTracker>();
 
+        // Issue #613: Polly v8 retry policy wrapping HybridCache.RemoveByTagAsync
+        // calls in SharedGameCatalog event handlers. Stateless + thread-safe.
+        services.AddSingleton<ICacheInvalidationRetryPolicy, CacheInvalidationRetryPolicy>();
+
         // Issue #4275: BGG API tier-based rate limiting configuration
         services.Configure<Api.Middleware.BggRateLimitOptions>(
             configuration.GetSection("BggRateLimit"));

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Cache.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Cache.cs
@@ -77,6 +77,49 @@ internal static partial class MeepleAiMetrics
         description: "Dashboard cache invalidations triggered by configuration changes");
 
     /// <summary>
+    /// Counter for cache invalidation retry attempts.
+    /// Issue #613: Tracks how often the SharedGameCatalog read-model
+    /// invalidation pipeline retries on transient Redis/HybridCache failures.
+    /// </summary>
+    public static readonly Counter<long> CacheInvalidationRetryAttemptsTotal = Meter.CreateCounter<long>(
+        name: "meepleai.cache.invalidation.retry_attempts.total",
+        unit: "attempts",
+        description: "Total number of cache invalidation retry attempts");
+
+    /// <summary>
+    /// Counter for cache invalidation outcome (success vs failure after retries).
+    /// Issue #613: Distinguishes recovered transient failures from permanent failures
+    /// that left the read-model stale.
+    /// </summary>
+    public static readonly Counter<long> CacheInvalidationOutcomeTotal = Meter.CreateCounter<long>(
+        name: "meepleai.cache.invalidation.outcome.total",
+        unit: "operations",
+        description: "Cache invalidation outcomes (success/failure) by operation");
+
+    /// <summary>
+    /// Records a single retry attempt during cache invalidation.
+    /// </summary>
+    public static void RecordCacheInvalidationRetry()
+    {
+        CacheInvalidationRetryAttemptsTotal.Add(1);
+    }
+
+    /// <summary>
+    /// Records the terminal outcome of a cache invalidation operation.
+    /// </summary>
+    /// <param name="operationName">Logical name of the invalidation site (low-cardinality).</param>
+    /// <param name="outcome">"success" or "failure".</param>
+    public static void RecordCacheInvalidationOutcome(string operationName, string outcome)
+    {
+        var tags = new TagList
+        {
+            { "operation", operationName },
+            { "outcome", outcome }
+        };
+        CacheInvalidationOutcomeTotal.Add(1, tags);
+    }
+
+    /// <summary>
     /// Records cache hit or miss
     /// </summary>
     public static void RecordCacheAccess(bool isHit, string? cacheType = null)

--- a/apps/api/src/Api/Services/CacheInvalidationRetryPolicy.cs
+++ b/apps/api/src/Api/Services/CacheInvalidationRetryPolicy.cs
@@ -1,0 +1,90 @@
+using System.Diagnostics;
+using Api.Observability;
+using Polly;
+using Polly.Retry;
+
+namespace Api.Services;
+
+/// <summary>
+/// Polly v8 ResiliencePipeline-backed implementation of
+/// <see cref="ICacheInvalidationRetryPolicy"/>.
+///
+/// Configuration (Issue #613):
+/// <list type="bullet">
+///   <item>Max 3 retry attempts (4 total invocations).</item>
+///   <item>Exponential backoff with base 200ms and factor 2 (≈200ms, 400ms, 800ms),
+///   jittered. Total worst-case time stays under ~4s including jitter.</item>
+///   <item>Retries on any <see cref="Exception"/> EXCEPT
+///   <see cref="OperationCanceledException"/> when the caller token is cancelled,
+///   <see cref="ArgumentException"/> family, and <see cref="ObjectDisposedException"/>
+///   — those represent programming errors or deliberate cancellation.</item>
+/// </list>
+/// </summary>
+internal sealed class CacheInvalidationRetryPolicy : ICacheInvalidationRetryPolicy
+{
+    private readonly ILogger<CacheInvalidationRetryPolicy> _logger;
+    private readonly ResiliencePipeline _pipeline;
+
+    public CacheInvalidationRetryPolicy(ILogger<CacheInvalidationRetryPolicy> logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        _logger = logger;
+
+        _pipeline = new ResiliencePipelineBuilder()
+            .AddRetry(new RetryStrategyOptions
+            {
+                ShouldHandle = new PredicateBuilder()
+                    .Handle<Exception>(ex =>
+                        ex is not ArgumentException
+                        && ex is not ObjectDisposedException),
+                MaxRetryAttempts = 3,
+                BackoffType = DelayBackoffType.Exponential,
+                Delay = TimeSpan.FromMilliseconds(200),
+                UseJitter = true,
+                OnRetry = args =>
+                {
+                    _logger.LogWarning(
+                        args.Outcome.Exception,
+                        "Cache invalidation retry {Attempt}/3 after {Delay}ms for operation",
+                        args.AttemptNumber + 1,
+                        args.RetryDelay.TotalMilliseconds);
+                    MeepleAiMetrics.RecordCacheInvalidationRetry();
+                    return ValueTask.CompletedTask;
+                }
+            })
+            .Build();
+    }
+
+    public async Task ExecuteAsync(
+        Func<CancellationToken, ValueTask> operation,
+        string operationName,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        ArgumentException.ThrowIfNullOrEmpty(operationName);
+
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            await _pipeline.ExecuteAsync(
+                async token => await operation(token).ConfigureAwait(false),
+                ct).ConfigureAwait(false);
+            MeepleAiMetrics.RecordCacheInvalidationOutcome(operationName, "success");
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Caller cancelled — neutral outcome, do not flood metrics with failures.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            MeepleAiMetrics.RecordCacheInvalidationOutcome(operationName, "failure");
+            _logger.LogError(
+                ex,
+                "Cache invalidation '{OperationName}' permanently failed after retries in {ElapsedMs}ms",
+                operationName,
+                sw.ElapsedMilliseconds);
+            throw;
+        }
+    }
+}

--- a/apps/api/src/Api/Services/ICacheInvalidationRetryPolicy.cs
+++ b/apps/api/src/Api/Services/ICacheInvalidationRetryPolicy.cs
@@ -1,0 +1,32 @@
+namespace Api.Services;
+
+/// <summary>
+/// Wraps a cache invalidation operation with a bounded retry policy so that
+/// transient Redis / HybridCache failures do not silently leave stale data
+/// in the SharedGameCatalog read-model.
+///
+/// Issue #613: Cache invalidation resilience. The three SharedGameCatalog
+/// event handlers call <c>HybridCache.RemoveByTagAsync</c> after upstream
+/// domain events; if Redis is briefly unreachable, the in-process L1
+/// eviction still happens but the L2 distributed copy keeps serving stale
+/// detail/list payloads (TTL=300s) on other instances. Retry policy is
+/// bounded (≤4s total) so it never blocks the MediatR notification
+/// pipeline beyond the existing default.
+/// </summary>
+public interface ICacheInvalidationRetryPolicy
+{
+    /// <summary>
+    /// Executes <paramref name="operation"/> with retry. Transient
+    /// exceptions trigger up to 3 retries with exponential backoff
+    /// (200ms → 400ms → 800ms, jittered). Non-transient exceptions
+    /// (e.g. <see cref="ArgumentException"/>, <see cref="OperationCanceledException"/>
+    /// when caller-cancelled) are re-thrown immediately.
+    /// </summary>
+    /// <param name="operation">The cache invalidation work to retry.</param>
+    /// <param name="operationName">Used as a metric label and log scope.</param>
+    /// <param name="ct">Caller cancellation token.</param>
+    Task ExecuteAsync(
+        Func<CancellationToken, ValueTask> operation,
+        string operationName,
+        CancellationToken ct);
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/AgentDefinitionChangedForCatalogAggregatesHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/AgentDefinitionChangedForCatalogAggregatesHandlerTests.cs
@@ -38,12 +38,12 @@ public sealed class AgentDefinitionChangedForCatalogAggregatesHandlerTests
 
     private AgentDefinitionChangedForCatalogAggregatesHandler CreateHandler(
         Api.Infrastructure.MeepleAiDbContext db,
-        HybridCache cache) => new(db, cache, _loggerMock.Object);
+        HybridCache cache) => new(db, cache, new PassthroughRetryPolicy(), _loggerMock.Object);
 
     [Fact]
     public void Constructor_WithNullDbContext_Throws()
     {
-        var act = () => new AgentDefinitionChangedForCatalogAggregatesHandler(null!, CreateHybridCache(), _loggerMock.Object);
+        var act = () => new AgentDefinitionChangedForCatalogAggregatesHandler(null!, CreateHybridCache(), new PassthroughRetryPolicy(), _loggerMock.Object);
         act.Should().Throw<ArgumentNullException>();
     }
 
@@ -51,7 +51,15 @@ public sealed class AgentDefinitionChangedForCatalogAggregatesHandlerTests
     public void Constructor_WithNullCache_Throws()
     {
         using var db = TestDbContextFactory.CreateInMemoryDbContext();
-        var act = () => new AgentDefinitionChangedForCatalogAggregatesHandler(db, null!, _loggerMock.Object);
+        var act = () => new AgentDefinitionChangedForCatalogAggregatesHandler(db, null!, new PassthroughRetryPolicy(), _loggerMock.Object);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_WithNullRetryPolicy_Throws()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var act = () => new AgentDefinitionChangedForCatalogAggregatesHandler(db, CreateHybridCache(), null!, _loggerMock.Object);
         act.Should().Throw<ArgumentNullException>();
     }
 
@@ -59,7 +67,7 @@ public sealed class AgentDefinitionChangedForCatalogAggregatesHandlerTests
     public void Constructor_WithNullLogger_Throws()
     {
         using var db = TestDbContextFactory.CreateInMemoryDbContext();
-        var act = () => new AgentDefinitionChangedForCatalogAggregatesHandler(db, CreateHybridCache(), null!);
+        var act = () => new AgentDefinitionChangedForCatalogAggregatesHandler(db, CreateHybridCache(), new PassthroughRetryPolicy(), null!);
         act.Should().Throw<ArgumentNullException>();
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/ToolkitChangedForCatalogAggregatesHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/ToolkitChangedForCatalogAggregatesHandlerTests.cs
@@ -44,13 +44,13 @@ public sealed class ToolkitChangedForCatalogAggregatesHandlerTests
 
     private ToolkitChangedForCatalogAggregatesHandler CreateHandler(
         MeepleAiDbContext db,
-        HybridCache cache) => new(db, cache, _loggerMock.Object);
+        HybridCache cache) => new(db, cache, new PassthroughRetryPolicy(), _loggerMock.Object);
 
     [Fact]
     public void Constructor_WithNullDbContext_Throws()
     {
         Assert.Throws<ArgumentNullException>(() =>
-            new ToolkitChangedForCatalogAggregatesHandler(null!, CreateHybridCache(), _loggerMock.Object));
+            new ToolkitChangedForCatalogAggregatesHandler(null!, CreateHybridCache(), new PassthroughRetryPolicy(), _loggerMock.Object));
     }
 
     [Fact]
@@ -58,7 +58,15 @@ public sealed class ToolkitChangedForCatalogAggregatesHandlerTests
     {
         using var db = TestDbContextFactory.CreateInMemoryDbContext();
         Assert.Throws<ArgumentNullException>(() =>
-            new ToolkitChangedForCatalogAggregatesHandler(db, null!, _loggerMock.Object));
+            new ToolkitChangedForCatalogAggregatesHandler(db, null!, new PassthroughRetryPolicy(), _loggerMock.Object));
+    }
+
+    [Fact]
+    public void Constructor_WithNullRetryPolicy_Throws()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        Assert.Throws<ArgumentNullException>(() =>
+            new ToolkitChangedForCatalogAggregatesHandler(db, CreateHybridCache(), null!, _loggerMock.Object));
     }
 
     [Fact]
@@ -66,7 +74,7 @@ public sealed class ToolkitChangedForCatalogAggregatesHandlerTests
     {
         using var db = TestDbContextFactory.CreateInMemoryDbContext();
         Assert.Throws<ArgumentNullException>(() =>
-            new ToolkitChangedForCatalogAggregatesHandler(db, CreateHybridCache(), null!));
+            new ToolkitChangedForCatalogAggregatesHandler(db, CreateHybridCache(), new PassthroughRetryPolicy(), null!));
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandlerTests.cs
@@ -71,7 +71,7 @@ public sealed class VectorDocumentIndexedForKbFlagHandlerTests
         db.SharedGames.Add(CreateSharedGame(sharedGameId, hasKb: false));
         await db.SaveChangesAsync();
 
-        var handler = new VectorDocumentIndexedForKbFlagHandler(db, CreateHybridCache(), _logger.Object);
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, CreateHybridCache(), new PassthroughRetryPolicy(), _logger.Object);
         var evt = new VectorDocumentIndexedEvent(documentId, gameId, chunkCount: 42, sharedGameId: sharedGameId);
 
         // Act
@@ -95,7 +95,7 @@ public sealed class VectorDocumentIndexedForKbFlagHandlerTests
         db.SharedGames.Add(CreateSharedGame(sharedGameId, hasKb: false));
         await db.SaveChangesAsync();
 
-        var handler = new VectorDocumentIndexedForKbFlagHandler(db, CreateHybridCache(), _logger.Object);
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, CreateHybridCache(), new PassthroughRetryPolicy(), _logger.Object);
         var evt = new VectorDocumentIndexedEvent(documentId, gameId, chunkCount: 42, sharedGameId: null);
 
         // Act
@@ -111,7 +111,7 @@ public sealed class VectorDocumentIndexedForKbFlagHandlerTests
     {
         // Arrange
         await using var db = TestDbContextFactory.CreateInMemoryDbContext();
-        var handler = new VectorDocumentIndexedForKbFlagHandler(db, CreateHybridCache(), _logger.Object);
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, CreateHybridCache(), new PassthroughRetryPolicy(), _logger.Object);
         var evt = new VectorDocumentIndexedEvent(
             documentId: Guid.NewGuid(),
             gameId: Guid.NewGuid(),
@@ -137,7 +137,7 @@ public sealed class VectorDocumentIndexedForKbFlagHandlerTests
         db.SharedGames.Add(CreateSharedGame(sharedGameId, hasKb: true));
         await db.SaveChangesAsync();
 
-        var handler = new VectorDocumentIndexedForKbFlagHandler(db, CreateHybridCache(), _logger.Object);
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, CreateHybridCache(), new PassthroughRetryPolicy(), _logger.Object);
         var evt = new VectorDocumentIndexedEvent(documentId, gameId, chunkCount: 42, sharedGameId: sharedGameId);
 
         // Act
@@ -153,7 +153,7 @@ public sealed class VectorDocumentIndexedForKbFlagHandlerTests
     {
         // Arrange
         await using var db = TestDbContextFactory.CreateInMemoryDbContext();
-        var handler = new VectorDocumentIndexedForKbFlagHandler(db, CreateHybridCache(), _logger.Object);
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, CreateHybridCache(), new PassthroughRetryPolicy(), _logger.Object);
 
         // Act
         var act = async () => await handler.Handle(null!, CancellationToken.None);
@@ -176,7 +176,7 @@ public sealed class VectorDocumentIndexedForKbFlagHandlerTests
         db.SharedGames.Add(CreateSharedGame(sharedGameId, hasKb: false));
         await db.SaveChangesAsync();
 
-        var handler = new VectorDocumentIndexedForKbFlagHandler(db, cache, _logger.Object);
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, cache, new PassthroughRetryPolicy(), _logger.Object);
         var evt = new VectorDocumentIndexedEvent(
             documentId: Guid.NewGuid(),
             gameId: Guid.NewGuid(),
@@ -222,7 +222,7 @@ public sealed class VectorDocumentIndexedForKbFlagHandlerTests
         db.SharedGames.Add(CreateSharedGame(sharedGameId, hasKb: false));
         await db.SaveChangesAsync();
 
-        var handler = new VectorDocumentIndexedForKbFlagHandler(db, cache, _logger.Object);
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, cache, new PassthroughRetryPolicy(), _logger.Object);
         var evt = new VectorDocumentIndexedEvent(
             documentId: Guid.NewGuid(),
             gameId: Guid.NewGuid(),

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Jobs/ScheduledBulkInvalidationJobTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Jobs/ScheduledBulkInvalidationJobTests.cs
@@ -1,0 +1,343 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Jobs;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Services;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Quartz;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Jobs;
+
+/// <summary>
+/// Unit tests for <see cref="ScheduledBulkInvalidationJob"/> (Issue #613).
+///
+/// Uses raw <see cref="HybridCache"/> rather than <c>IHybridCacheService</c>
+/// so tag invalidation hits the same native tag index populated by the
+/// SharedGameCatalog read-model query handlers (mirrors the three event
+/// handler test fixtures).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class ScheduledBulkInvalidationJobTests
+{
+    private readonly Mock<ILogger<ScheduledBulkInvalidationJob>> _loggerMock = new();
+
+    private static HybridCache CreateHybridCache()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IMemoryCache, MemoryCache>();
+        services.AddSingleton<IDistributedCache>(new MemoryDistributedCache(
+            Microsoft.Extensions.Options.Options.Create(new MemoryDistributedCacheOptions())));
+        services.AddHybridCache();
+        return services.BuildServiceProvider().GetRequiredService<HybridCache>();
+    }
+
+    private static Mock<IJobExecutionContext> CreateJobContext(CancellationToken? ct = null)
+    {
+        var mock = new Mock<IJobExecutionContext>();
+        mock.Setup(c => c.CancellationToken).Returns(ct ?? CancellationToken.None);
+        mock.Setup(c => c.FireTimeUtc).Returns(DateTimeOffset.UtcNow);
+        return mock;
+    }
+
+    [Fact]
+    public void Constructor_WithNullDbContext_Throws()
+    {
+        var act = () => new ScheduledBulkInvalidationJob(null!, CreateHybridCache(), new PassthroughRetryPolicy(), _loggerMock.Object);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("context");
+    }
+
+    [Fact]
+    public void Constructor_WithNullCache_Throws()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var act = () => new ScheduledBulkInvalidationJob(db, null!, new PassthroughRetryPolicy(), _loggerMock.Object);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("cache");
+    }
+
+    [Fact]
+    public void Constructor_WithNullRetryPolicy_Throws()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var act = () => new ScheduledBulkInvalidationJob(db, CreateHybridCache(), null!, _loggerMock.Object);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("retryPolicy");
+    }
+
+    [Fact]
+    public void Constructor_WithNullLogger_Throws()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var act = () => new ScheduledBulkInvalidationJob(db, CreateHybridCache(), new PassthroughRetryPolicy(), null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
+    }
+
+    [Fact]
+    public async Task Execute_NullContext_Throws()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var job = new ScheduledBulkInvalidationJob(db, CreateHybridCache(), new PassthroughRetryPolicy(), _loggerMock.Object);
+
+        var act = async () => await job.Execute(null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task Execute_WithNoAnalyticsEvents_InvalidatesListTagOnly()
+    {
+        // Arrange
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var cache = CreateHybridCache();
+
+        // Seed list-tag entry to verify eviction.
+        await cache.SetAsync("list-key", "seed", tags: new[] { "search-games" });
+
+        var job = new ScheduledBulkInvalidationJob(db, cache, new PassthroughRetryPolicy(), _loggerMock.Object);
+        var ctx = CreateJobContext();
+
+        // Act
+        await job.Execute(ctx.Object);
+
+        // Assert — list eviction occurred (factory must repopulate)
+        var listFactoryRan = false;
+        await cache.GetOrCreateAsync(
+            "list-key",
+            _ =>
+            {
+                listFactoryRan = true;
+                return ValueTask.FromResult("repop");
+            },
+            tags: new[] { "search-games" });
+        listFactoryRan.Should().BeTrue();
+
+        // Result reflects zero detail invalidations
+        ctx.VerifySet(c => c.Result = It.Is<object>(r =>
+            (bool)r.GetType().GetProperty("Success")!.GetValue(r)! &&
+            (int)r.GetType().GetProperty("ListInvalidations")!.GetValue(r)! == 1 &&
+            (int)r.GetType().GetProperty("DetailInvalidations")!.GetValue(r)! == 0));
+    }
+
+    [Fact]
+    public async Task Execute_WithRecentEvents_InvalidatesPerGameDetailTags()
+    {
+        // Arrange
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var cache = CreateHybridCache();
+
+        var sharedGameA = Guid.NewGuid();
+        var sharedGameB = Guid.NewGuid();
+
+        SeedEvent(db, sharedGameA, GameEventType.View, DateTime.UtcNow.AddMinutes(-5));
+        SeedEvent(db, sharedGameA, GameEventType.View, DateTime.UtcNow.AddMinutes(-10));
+        SeedEvent(db, sharedGameB, GameEventType.Search, DateTime.UtcNow.AddMinutes(-3));
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var detailKeyA = $"detail-A-{Guid.NewGuid()}";
+        var detailKeyB = $"detail-B-{Guid.NewGuid()}";
+        await cache.SetAsync(detailKeyA, "seed-a", tags: new[] { $"shared-game:{sharedGameA}" });
+        await cache.SetAsync(detailKeyB, "seed-b", tags: new[] { $"shared-game:{sharedGameB}" });
+
+        var job = new ScheduledBulkInvalidationJob(db, cache, new PassthroughRetryPolicy(), _loggerMock.Object);
+        var ctx = CreateJobContext();
+
+        // Act
+        await job.Execute(ctx.Object);
+
+        // Assert — both per-game tags evicted
+        var factoryA = false;
+        await cache.GetOrCreateAsync(detailKeyA, _ => { factoryA = true; return ValueTask.FromResult("repop-a"); }, tags: new[] { $"shared-game:{sharedGameA}" });
+        factoryA.Should().BeTrue();
+
+        var factoryB = false;
+        await cache.GetOrCreateAsync(detailKeyB, _ => { factoryB = true; return ValueTask.FromResult("repop-b"); }, tags: new[] { $"shared-game:{sharedGameB}" });
+        factoryB.Should().BeTrue();
+
+        ctx.VerifySet(c => c.Result = It.Is<object>(r =>
+            (bool)r.GetType().GetProperty("Success")!.GetValue(r)! &&
+            (int)r.GetType().GetProperty("DetailInvalidations")!.GetValue(r)! == 2));
+    }
+
+    [Fact]
+    public async Task Execute_IgnoresEventsOlderThanLookbackWindow()
+    {
+        // Arrange
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var cache = CreateHybridCache();
+
+        var staleGame = Guid.NewGuid();      // outside 1h window — must be ignored
+        var freshGame = Guid.NewGuid();      // inside 1h window
+
+        SeedEvent(db, staleGame, GameEventType.View, DateTime.UtcNow.AddHours(-3));
+        SeedEvent(db, freshGame, GameEventType.View, DateTime.UtcNow.AddMinutes(-10));
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var staleDetailKey = $"stale-{Guid.NewGuid()}";
+        await cache.SetAsync(staleDetailKey, "stale", tags: new[] { $"shared-game:{staleGame}" });
+
+        var job = new ScheduledBulkInvalidationJob(db, cache, new PassthroughRetryPolicy(), _loggerMock.Object);
+        var ctx = CreateJobContext();
+
+        // Act
+        await job.Execute(ctx.Object);
+
+        // Assert — stale-game tag should NOT have been invalidated
+        var staleFactoryRan = false;
+        await cache.GetOrCreateAsync(
+            staleDetailKey,
+            _ => { staleFactoryRan = true; return ValueTask.FromResult("repop"); },
+            tags: new[] { $"shared-game:{staleGame}" });
+        staleFactoryRan.Should().BeFalse("event older than 1h should be filtered out");
+
+        // Only the fresh game contributed to DetailInvalidations
+        ctx.VerifySet(c => c.Result = It.Is<object>(r =>
+            (int)r.GetType().GetProperty("DetailInvalidations")!.GetValue(r)! == 1));
+    }
+
+    [Fact]
+    public async Task Execute_OrdersByEventCountDescending()
+    {
+        // Arrange — 1 event for gameA, 5 events for gameB. With TopN cap > 2,
+        // both should be invalidated. We verify by ensuring both tags evict.
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var cache = CreateHybridCache();
+
+        var gameA = Guid.NewGuid();
+        var gameB = Guid.NewGuid();
+
+        SeedEvent(db, gameA, GameEventType.View, DateTime.UtcNow.AddMinutes(-1));
+        for (var i = 0; i < 5; i++)
+        {
+            SeedEvent(db, gameB, GameEventType.View, DateTime.UtcNow.AddMinutes(-i - 1));
+        }
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var keyA = $"a-{Guid.NewGuid()}";
+        var keyB = $"b-{Guid.NewGuid()}";
+        await cache.SetAsync(keyA, "seed-a", tags: new[] { $"shared-game:{gameA}" });
+        await cache.SetAsync(keyB, "seed-b", tags: new[] { $"shared-game:{gameB}" });
+
+        var job = new ScheduledBulkInvalidationJob(db, cache, new PassthroughRetryPolicy(), _loggerMock.Object);
+        var ctx = CreateJobContext();
+
+        // Act
+        await job.Execute(ctx.Object);
+
+        // Assert — both invalidated regardless of order
+        var ranA = false;
+        await cache.GetOrCreateAsync(keyA, _ => { ranA = true; return ValueTask.FromResult("r-a"); }, tags: new[] { $"shared-game:{gameA}" });
+        ranA.Should().BeTrue();
+
+        var ranB = false;
+        await cache.GetOrCreateAsync(keyB, _ => { ranB = true; return ValueTask.FromResult("r-b"); }, tags: new[] { $"shared-game:{gameB}" });
+        ranB.Should().BeTrue();
+
+        ctx.VerifySet(c => c.Result = It.Is<object>(r =>
+            (int)r.GetType().GetProperty("DetailInvalidations")!.GetValue(r)! == 2));
+    }
+
+    [Fact]
+    public async Task Execute_WhenRetryPolicyThrows_CatchesAndSetsFailureResult()
+    {
+        // Arrange — retry policy that always throws on the FIRST invocation
+        // (the list invalidation), forcing the catch-all to engage.
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var cache = CreateHybridCache();
+        var alwaysFails = new ThrowingRetryPolicy(new InvalidOperationException("Redis down"));
+
+        var job = new ScheduledBulkInvalidationJob(db, cache, alwaysFails, _loggerMock.Object);
+        var ctx = CreateJobContext();
+
+        // Act
+        await job.Execute(ctx.Object);
+
+        // Assert — job did NOT throw, Result reflects failure
+        ctx.VerifySet(c => c.Result = It.Is<object>(r =>
+            !(bool)r.GetType().GetProperty("Success")!.GetValue(r)! &&
+            r.GetType().GetProperty("Error")!.GetValue(r)!.ToString()!.Contains("Redis down", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public async Task Execute_OnCancellation_PropagatesOperationCanceled()
+    {
+        // Arrange
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var cache = CreateHybridCache();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var job = new ScheduledBulkInvalidationJob(db, cache, new PassthroughRetryPolicy(), _loggerMock.Object);
+        var ctx = CreateJobContext(cts.Token);
+
+        // Act
+        var act = async () => await job.Execute(ctx.Object);
+
+        // Assert — caller cancellation must propagate so Quartz can correctly
+        // report the run as cancelled rather than swallowing it as a failure.
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task Execute_RespectsTopNCap()
+    {
+        // Arrange — seed DefaultTopN+5 distinct games, verify the cap holds.
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var cache = CreateHybridCache();
+
+        var totalGames = ScheduledBulkInvalidationJob.DefaultTopN + 5;
+        for (var i = 0; i < totalGames; i++)
+        {
+            SeedEvent(db, Guid.NewGuid(), GameEventType.View, DateTime.UtcNow.AddMinutes(-i % 30 - 1));
+        }
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var job = new ScheduledBulkInvalidationJob(db, cache, new PassthroughRetryPolicy(), _loggerMock.Object);
+        var ctx = CreateJobContext();
+
+        // Act
+        await job.Execute(ctx.Object);
+
+        // Assert
+        ctx.VerifySet(c => c.Result = It.Is<object>(r =>
+            (int)r.GetType().GetProperty("DetailInvalidations")!.GetValue(r)! == ScheduledBulkInvalidationJob.DefaultTopN));
+    }
+
+    private static void SeedEvent(
+        Api.Infrastructure.MeepleAiDbContext db,
+        Guid sharedGameId,
+        GameEventType type,
+        DateTime timestampUtc)
+    {
+        db.Set<GameAnalyticsEventEntity>().Add(new GameAnalyticsEventEntity
+        {
+            Id = Guid.NewGuid(),
+            GameId = sharedGameId,
+            EventType = (int)type,
+            UserId = null,
+            Timestamp = timestampUtc
+        });
+    }
+
+    private sealed class ThrowingRetryPolicy : ICacheInvalidationRetryPolicy
+    {
+        private readonly Exception _toThrow;
+
+        public ThrowingRetryPolicy(Exception toThrow) => _toThrow = toThrow;
+
+        public Task ExecuteAsync(
+            Func<CancellationToken, ValueTask> operation,
+            string operationName,
+            CancellationToken ct)
+        {
+            ArgumentNullException.ThrowIfNull(operation);
+            return Task.FromException(_toThrow);
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/Services/CacheInvalidationRetryPolicyTests.cs
+++ b/apps/api/tests/Api.Tests/Services/CacheInvalidationRetryPolicyTests.cs
@@ -1,0 +1,195 @@
+using System.Diagnostics;
+using Api.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Api.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="CacheInvalidationRetryPolicy"/>.
+/// Issue #613: SharedGameCatalog cache invalidation resilience.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "613")]
+public sealed class CacheInvalidationRetryPolicyTests
+{
+    private static CacheInvalidationRetryPolicy CreatePolicy() =>
+        new(NullLogger<CacheInvalidationRetryPolicy>.Instance);
+
+    [Fact]
+    public async Task ExecuteAsync_WhenOperationSucceeds_RunsExactlyOnce()
+    {
+        // Arrange
+        var policy = CreatePolicy();
+        var calls = 0;
+
+        // Act
+        await policy.ExecuteAsync(
+            ct => { calls++; return ValueTask.CompletedTask; },
+            "test.success",
+            CancellationToken.None);
+
+        // Assert
+        calls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenTransientFailure_RetriesAndEventuallySucceeds()
+    {
+        // Arrange
+        var policy = CreatePolicy();
+        var calls = 0;
+
+        // Act
+        await policy.ExecuteAsync(
+            ct =>
+            {
+                calls++;
+                if (calls < 3)
+                {
+                    throw new InvalidOperationException("transient");
+                }
+                return ValueTask.CompletedTask;
+            },
+            "test.transient",
+            CancellationToken.None);
+
+        // Assert: 1 initial + 2 retries = 3 calls
+        calls.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenAlwaysFailing_ThrowsAfter4TotalAttempts()
+    {
+        // Arrange
+        var policy = CreatePolicy();
+        var calls = 0;
+
+        // Act
+        var act = () => policy.ExecuteAsync(
+            ct =>
+            {
+                calls++;
+                throw new InvalidOperationException("permanent");
+            },
+            "test.permanent",
+            CancellationToken.None);
+
+        // Assert: 1 initial + 3 retries = 4 attempts
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        calls.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenAlwaysFailing_StaysUnderFourSecondsBudget()
+    {
+        // Arrange
+        var policy = CreatePolicy();
+        var sw = Stopwatch.StartNew();
+
+        // Act
+        try
+        {
+            await policy.ExecuteAsync(
+                ct => throw new InvalidOperationException("permanent"),
+                "test.budget",
+                CancellationToken.None);
+        }
+        catch (InvalidOperationException)
+        {
+            // expected
+        }
+
+        sw.Stop();
+
+        // Assert: 200 + 400 + 800 = 1400ms base + jitter (≤50%) ≈ ~2.1s worst case.
+        // Budget: 4000ms with margin for slow CI runners.
+        sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(4));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenArgumentException_DoesNotRetry()
+    {
+        // Arrange — ArgumentException represents a programming bug, not transient infra failure.
+        var policy = CreatePolicy();
+        var calls = 0;
+
+        // Act
+        var act = () => policy.ExecuteAsync(
+            ct =>
+            {
+                calls++;
+                throw new ArgumentException("bug");
+            },
+            "test.arg",
+            CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>();
+        calls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenObjectDisposedException_DoesNotRetry()
+    {
+        // Arrange — disposed dependency cannot recover via retry.
+        var policy = CreatePolicy();
+        var calls = 0;
+
+        // Act
+        var act = () => policy.ExecuteAsync(
+            ct =>
+            {
+                calls++;
+                throw new ObjectDisposedException("HybridCache");
+            },
+            "test.disposed",
+            CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ObjectDisposedException>();
+        calls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenCallerCancels_PropagatesCancellation()
+    {
+        // Arrange
+        var policy = CreatePolicy();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act
+        var act = () => policy.ExecuteAsync(
+            ct => { ct.ThrowIfCancellationRequested(); return ValueTask.CompletedTask; },
+            "test.cancel",
+            cts.Token);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenOperationNameIsEmpty_ThrowsArgumentException()
+    {
+        var policy = CreatePolicy();
+        var act = () => policy.ExecuteAsync(
+            ct => ValueTask.CompletedTask,
+            string.Empty,
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenOperationIsNull_ThrowsArgumentNullException()
+    {
+        var policy = CreatePolicy();
+        var act = () => policy.ExecuteAsync(null!, "x", CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/TestHelpers/PassthroughRetryPolicy.cs
+++ b/apps/api/tests/Api.Tests/TestHelpers/PassthroughRetryPolicy.cs
@@ -1,0 +1,24 @@
+using Api.Services;
+
+namespace Api.Tests.TestHelpers;
+
+/// <summary>
+/// Test double for <see cref="ICacheInvalidationRetryPolicy"/> that invokes
+/// the operation exactly once with no retry semantics. Used in handler unit
+/// tests where the goal is to verify the wrapped invalidation logic, not
+/// the retry policy itself (covered by <c>CacheInvalidationRetryPolicyTests</c>).
+///
+/// Issue #613.
+/// </summary>
+internal sealed class PassthroughRetryPolicy : ICacheInvalidationRetryPolicy
+{
+    public Task ExecuteAsync(
+        Func<CancellationToken, ValueTask> operation,
+        string operationName,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        ArgumentException.ThrowIfNullOrEmpty(operationName);
+        return operation(ct).AsTask();
+    }
+}


### PR DESCRIPTION
## Summary

Closes #613. Hardens the SharedGameCatalog read-model cache against permanent Redis outages that outlive the in-process retry budget — the gap surfaced by `/sc:spec-panel` retrospective on PR #603.

Three layers of defense:

1. **Polly v8 retry policy** (`ICacheInvalidationRetryPolicy` + `CacheInvalidationRetryPolicy`) wrapping every `HybridCache.RemoveByTagAsync` call site with bounded retry budget + jittered exponential backoff. Surfaces failures via `MeepleAiMetrics.RecordCacheInvalidationOutcome`.
2. **Event handlers updated**: `VectorDocumentIndexedForKbFlagHandler`, `ToolkitChangedForCatalogAggregatesHandler`, `AgentDefinitionChangedForCatalogAggregatesHandler` now route through the retry policy.
3. **`ScheduledBulkInvalidationJob`** — defensive Quartz job (cron `0 */15 * * * ?`) that queries `GameAnalyticsEventEntity` for top-50 most-trafficked SharedGameIds in last hour, evicts `shared-game:{id}` detail tags + global `search-games` list tag. Bounds worst-case staleness at 15 min even when event-handler retries have permanently failed.

Background-task pattern: catches all exceptions, sets `context.Result`, records `cache.invalidation.outcome = "failure"`, never rethrows (would terminate Quartz scheduler thread).

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors)
- [x] 12 unit tests for `ScheduledBulkInvalidationJob`: ctor null guards, lookback window, top-N ordering + cap, retry-policy failure handling, cancellation propagation
- [x] Existing 3 handler test suites updated to inject `PassthroughRetryPolicy`
- [x] `CacheInvalidationRetryPolicy` covered by dedicated test file
- [ ] CI green
- [ ] Code review via `/code-review:code-review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)