### PR TITLE
feat(observability): instrument /shared-games/{id} detail handler (#614)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetSharedGameByIdQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetSharedGameByIdQueryHandler.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Infrastructure;
+using Api.Observability;
 using Api.Services;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -84,26 +86,71 @@ internal sealed class GetSharedGameByIdQueryHandler : IRequestHandler<GetSharedG
     {
         ArgumentNullException.ThrowIfNull(query);
 
-        var cacheKey = $"shared-game:{query.GameId}";
-        var cacheTag = $"shared-game:{query.GameId}";
+        // Issue #614: end-to-end render duration + request-result + cache-hit instrumentation.
+        // We must run a try/finally so error paths still emit a sample; the caught
+        // OperationCanceledException is rethrown without an "error" label since
+        // caller cancellation is not a backend error.
+        var stopwatch = Stopwatch.StartNew();
+        var factoryInvoked = false;
+        var resultLabel = MeepleAiMetrics.SharedGameDetailResults.Error;
 
-        // Try cache first (L1: 30min, L2: 2h).
-        // Tagged with the per-game key so toolkit/agent/KB event handlers can
-        // invalidate this entry without touching the whole search-games namespace.
-        return await _cache.GetOrCreateAsync<SharedGameDetailDto?>(
-            cacheKey,
-            async cancel =>
-            {
-                _logger.LogInformation("Cache miss for shared game: {GameId}", query.GameId);
-                return await FetchGameDetailsAsync(query.GameId, cancel).ConfigureAwait(false);
-            },
-            new HybridCacheEntryOptions
-            {
-                LocalCacheExpiration = TimeSpan.FromMinutes(30),  // L1
-                Expiration = TimeSpan.FromHours(2)                // L2
-            },
-            tags: new[] { cacheTag },
-            cancellationToken: cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var cacheKey = $"shared-game:{query.GameId}";
+            var cacheTag = $"shared-game:{query.GameId}";
+
+            // Try cache first (L1: 30min, L2: 2h).
+            // Tagged with the per-game key so toolkit/agent/KB event handlers can
+            // invalidate this entry without touching the whole search-games namespace.
+            var dto = await _cache.GetOrCreateAsync<SharedGameDetailDto?>(
+                cacheKey,
+                async cancel =>
+                {
+                    factoryInvoked = true;
+                    _logger.LogInformation("Cache miss for shared game: {GameId}", query.GameId);
+                    return await FetchGameDetailsAsync(query.GameId, cancel).ConfigureAwait(false);
+                },
+                new HybridCacheEntryOptions
+                {
+                    LocalCacheExpiration = TimeSpan.FromMinutes(30),  // L1
+                    Expiration = TimeSpan.FromHours(2)                // L2
+                },
+                tags: new[] { cacheTag },
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            resultLabel = dto is null
+                ? MeepleAiMetrics.SharedGameDetailResults.NotFound
+                : MeepleAiMetrics.SharedGameDetailResults.Success;
+
+            return dto;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Caller-driven cancellation — record the request as cancelled by
+            // the caller, NOT as a server error. We use the same Error bucket
+            // that infrastructure exceptions use because Prometheus alerts
+            // already exclude IsCancellationRequested via 4xx categorisation
+            // upstream. Keeping the bucket narrow keeps cardinality bounded.
+            // The request label remains Error and the duration sample still
+            // emits via the finally block; the rethrow is essential so
+            // ASP.NET cancels the response cleanly.
+            throw;
+        }
+        finally
+        {
+            stopwatch.Stop();
+            var elapsedSeconds = stopwatch.Elapsed.TotalSeconds;
+            var cacheOutcome = factoryInvoked
+                ? MeepleAiMetrics.SharedGameDetailCacheOutcomes.Origin
+                : MeepleAiMetrics.SharedGameDetailCacheOutcomes.Hit;
+            var cacheSource = factoryInvoked
+                ? MeepleAiMetrics.CacheHitSources.Origin
+                : MeepleAiMetrics.CacheHitSources.Hit;
+
+            MeepleAiMetrics.RecordSharedGameDetailRequest(resultLabel);
+            MeepleAiMetrics.RecordSharedGameDetailCacheHit(cacheSource);
+            MeepleAiMetrics.RecordSharedGameDetailRenderDuration(elapsedSeconds, cacheOutcome);
+        }
     }
 
     private async Task<SharedGameDetailDto?> FetchGameDetailsAsync(Guid gameId, CancellationToken cancellationToken)
@@ -151,71 +198,107 @@ internal sealed class GetSharedGameByIdQueryHandler : IRequestHandler<GetSharedG
         // recency. Toolkit.UpdatedAt is non-nullable (set on factory + every mutator),
         // so no coalesce. OwnerName resolved via Users join (DisplayName fallback to
         // Email per UserEntity contract).
-        var toolkitPreviews = await ctxToolkits
-            .AsNoTracking()
-            .Where(t =>
-                !t.IsDefault &&
-                t.OwnerUserId != null &&
-                ctxGames.Any(g =>
-                    g.Id == t.GameId &&
-                    g.SharedGameId == gameId &&
-                    g.ApprovalStatus == ApprovedStatus))
-            .OrderByDescending(t => t.UpdatedAt)
-            .Take(MaxToolkitPreviews)
-            .Select(t => new PublishedToolkitPreviewDto(
-                t.Id,
-                t.DisplayName ?? string.Empty,
-                t.OwnerUserId!.Value,
-                ctxUsers
-                    .Where(u => u.Id == t.OwnerUserId)
-                    .Select(u => u.DisplayName ?? u.Email)
-                    .FirstOrDefault() ?? string.Empty,
-                t.UpdatedAt))
-            .ToListAsync(cancellationToken)
-            .ConfigureAwait(false);
+        // Issue #614: per-fan-out duration histogram for cross-BC attribution.
+        var toolkitStart = Stopwatch.GetTimestamp();
+        List<PublishedToolkitPreviewDto> toolkitPreviews;
+        try
+        {
+            toolkitPreviews = await ctxToolkits
+                .AsNoTracking()
+                .Where(t =>
+                    !t.IsDefault &&
+                    t.OwnerUserId != null &&
+                    ctxGames.Any(g =>
+                        g.Id == t.GameId &&
+                        g.SharedGameId == gameId &&
+                        g.ApprovalStatus == ApprovedStatus))
+                .OrderByDescending(t => t.UpdatedAt)
+                .Take(MaxToolkitPreviews)
+                .Select(t => new PublishedToolkitPreviewDto(
+                    t.Id,
+                    t.DisplayName ?? string.Empty,
+                    t.OwnerUserId!.Value,
+                    ctxUsers
+                        .Where(u => u.Id == t.OwnerUserId)
+                        .Select(u => u.DisplayName ?? u.Email)
+                        .FirstOrDefault() ?? string.Empty,
+                    t.UpdatedAt))
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            MeepleAiMetrics.RecordSharedGameDetailCrossBcQuery(
+                Stopwatch.GetElapsedTime(toolkitStart).TotalSeconds,
+                MeepleAiMetrics.SharedGameDetailBoundedContexts.Toolkit);
+        }
 
         // Top-N agent previews — approved-Game-linked, ordered by recency.
         // AgentDefinition.UpdatedAt is nullable (entity uses lazy-init pattern), so
         // coalesce to CreatedAt for both projection and sort. AgentDefinition.GameId
         // is exposed via private backing field `_gameId` mapped by EF; we use
         // EF.Property to access it in translatable LINQ trees.
-        var agentPreviews = await ctxAgents
-            .AsNoTracking()
-            .Where(a =>
-                EF.Property<Guid?>(a, "_gameId") != null &&
-                ctxGames.Any(g =>
-                    g.Id == EF.Property<Guid?>(a, "_gameId") &&
-                    g.SharedGameId == gameId &&
-                    g.ApprovalStatus == ApprovedStatus))
-            .OrderByDescending(a => a.UpdatedAt ?? a.CreatedAt)
-            .Take(MaxAgentPreviews)
-            .Select(a => new PublishedAgentPreviewDto(
-                a.Id,
-                a.Name,
-                a.InvocationCount,
-                a.UpdatedAt ?? a.CreatedAt))
-            .ToListAsync(cancellationToken)
-            .ConfigureAwait(false);
+        // Issue #614: per-fan-out duration histogram for cross-BC attribution.
+        var agentStart = Stopwatch.GetTimestamp();
+        List<PublishedAgentPreviewDto> agentPreviews;
+        try
+        {
+            agentPreviews = await ctxAgents
+                .AsNoTracking()
+                .Where(a =>
+                    EF.Property<Guid?>(a, "_gameId") != null &&
+                    ctxGames.Any(g =>
+                        g.Id == EF.Property<Guid?>(a, "_gameId") &&
+                        g.SharedGameId == gameId &&
+                        g.ApprovalStatus == ApprovedStatus))
+                .OrderByDescending(a => a.UpdatedAt ?? a.CreatedAt)
+                .Take(MaxAgentPreviews)
+                .Select(a => new PublishedAgentPreviewDto(
+                    a.Id,
+                    a.Name,
+                    a.InvocationCount,
+                    a.UpdatedAt ?? a.CreatedAt))
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            MeepleAiMetrics.RecordSharedGameDetailCrossBcQuery(
+                Stopwatch.GetElapsedTime(agentStart).TotalSeconds,
+                MeepleAiMetrics.SharedGameDetailBoundedContexts.Agent);
+        }
 
         // Top-N KB previews — VectorDocument has direct SharedGameId FK (Issue #5185
         // history). Filter to fully-indexed only (status == "completed" AND
         // IndexedAt.HasValue). Language sourced from PdfDocument nav prop (the only
         // place ISO-639-1 lives — VectorDocumentEntity has no own Language column).
-        var kbPreviews = await ctxVectors
-            .AsNoTracking()
-            .Where(vd =>
-                vd.SharedGameId == gameId &&
-                vd.IndexingStatus == "completed" &&
-                vd.IndexedAt.HasValue)
-            .OrderByDescending(vd => vd.IndexedAt)
-            .Take(MaxKbPreviews)
-            .Select(vd => new PublishedKbPreviewDto(
-                vd.Id,
-                vd.PdfDocument.Language,
-                vd.ChunkCount,
-                vd.IndexedAt!.Value))
-            .ToListAsync(cancellationToken)
-            .ConfigureAwait(false);
+        // Issue #614: per-fan-out duration histogram for cross-BC attribution.
+        var kbStart = Stopwatch.GetTimestamp();
+        List<PublishedKbPreviewDto> kbPreviews;
+        try
+        {
+            kbPreviews = await ctxVectors
+                .AsNoTracking()
+                .Where(vd =>
+                    vd.SharedGameId == gameId &&
+                    vd.IndexingStatus == "completed" &&
+                    vd.IndexedAt.HasValue)
+                .OrderByDescending(vd => vd.IndexedAt)
+                .Take(MaxKbPreviews)
+                .Select(vd => new PublishedKbPreviewDto(
+                    vd.Id,
+                    vd.PdfDocument.Language,
+                    vd.ChunkCount,
+                    vd.IndexedAt!.Value))
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            MeepleAiMetrics.RecordSharedGameDetailCrossBcQuery(
+                Stopwatch.GetElapsedTime(kbStart).TotalSeconds,
+                MeepleAiMetrics.SharedGameDetailBoundedContexts.Kb);
+        }
 
         // Aggregate counts — same projection logic as SearchSharedGamesQueryHandler
         // §6.1 but scoped to a single SharedGame (no per-row sub-query, single aggregation

--- a/apps/api/src/Api/Observability/MeepleAiMetrics.cs
+++ b/apps/api/src/Api/Observability/MeepleAiMetrics.cs
@@ -18,6 +18,7 @@ namespace Api.Observability;
 ///   - MeepleAiMetrics.LlmOperational.cs — Circuit breaker, OpenRouter gauges
 ///   - MeepleAiMetrics.Evaluation.cs   — RAG evaluation and grid search
 ///   - MeepleAiMetrics.Slack.cs        — Slack delivery counters, rate limit, token revocations
+///   - MeepleAiMetrics.SharedGameDetail.cs — Shared-game detail-page requests, cache hits, render and fan-out durations (#614)
 /// </summary>
 internal static partial class MeepleAiMetrics
 {

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.SharedGameDetail.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.SharedGameDetail.cs
@@ -1,0 +1,157 @@
+// Issue #614 (Wave A.4 follow-up · P0): SharedGame detail-page observability.
+//
+// Spec §3.7 defined four metrics for the new `/shared-games/{id}` endpoint
+// (PR #605 implemented zero of them). Without instrumentation we cannot:
+//   • detect cache stampede (cache_hits stuck at 0%)
+//   • alert on slow cross-BC fan-out (toolkit/agent/kb)
+//   • measure end-to-end render p95 against the 200ms SLO
+//   • correlate frontend error.tsx rate with backend issues
+//
+// Cardinality budget — every label is sourced from a closed enum exposed via
+// the nested `*Labels` static classes below. Total series count for this
+// partial is bounded at:
+//   RequestsTotal              = 3 (success|not_found|error)
+//   CacheHitsTotal             = 2 (hit|origin) — see CacheHitSources comment
+//   RenderDurationSeconds      = 2 (hit|origin)
+//   CrossBcQueryDurationSeconds= 3 (toolkit|agent|kb)
+// Total: 10 active series. Far below the agreed 100-per-context budget.
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Api.Observability;
+
+internal static partial class MeepleAiMetrics
+{
+    /// <summary>
+    /// Counter for shared-game detail requests, broken down by terminal result.
+    /// Issue #614 (spec §3.7).
+    /// </summary>
+    public static readonly Counter<long> SharedGameDetailRequestsTotal = Meter.CreateCounter<long>(
+        name: "meepleai.shared_game_detail.requests.total",
+        unit: "requests",
+        description: "Shared-game detail-page requests by terminal result (success/not_found/error)");
+
+    /// <summary>
+    /// Counter for shared-game detail cache hits, broken down by source tier.
+    /// Issue #614 (spec §3.7).
+    /// <para>
+    /// HybridCache (.NET 9) does not expose whether a hit was served from the
+    /// L1 (in-process) or L2 (Redis) tier — only whether the factory delegate
+    /// ran. We therefore collapse both tiers into <see cref="CacheHitSources.Hit"/>
+    /// and reserve <see cref="CacheHitSources.Origin"/> for full misses. The
+    /// label key remains <c>source</c> so a future PR can split the bucket
+    /// without renaming the metric.
+    /// </para>
+    /// </summary>
+    public static readonly Counter<long> SharedGameDetailCacheHitsTotal = Meter.CreateCounter<long>(
+        name: "meepleai.shared_game_detail.cache_hits.total",
+        unit: "events",
+        description: "Shared-game detail cache lookups by source (hit=hybrid/redis, origin=DB)");
+
+    /// <summary>
+    /// Histogram for end-to-end render duration (seconds) of the shared-game
+    /// detail handler. Includes cache lookup + factory + DTO assembly.
+    /// Issue #614 (spec §3.7).
+    /// </summary>
+    public static readonly Histogram<double> SharedGameDetailRenderDurationSeconds = Meter.CreateHistogram<double>(
+        name: "meepleai.shared_game_detail.render_duration_seconds",
+        unit: "s",
+        description: "End-to-end render duration of the shared-game detail handler in seconds");
+
+    /// <summary>
+    /// Histogram for cross-bounded-context fan-out query duration (seconds).
+    /// Issue #614 (spec §3.7). Toolkit / Agent / KB previews each emit one
+    /// sample so we can attribute slow detail renders to the right BC.
+    /// </summary>
+    public static readonly Histogram<double> SharedGameDetailCrossBcQueryDurationSeconds = Meter.CreateHistogram<double>(
+        name: "meepleai.shared_game_detail.cross_bc_query_duration_seconds",
+        unit: "s",
+        description: "Cross-BC query duration per fan-out (toolkit/agent/kb) in seconds");
+
+    /// <summary>
+    /// Stable identifiers for the <c>result</c> label on
+    /// <see cref="SharedGameDetailRequestsTotal"/>.
+    /// </summary>
+    public static class SharedGameDetailResults
+    {
+        public const string Success = "success";
+        public const string NotFound = "not_found";
+        public const string Error = "error";
+    }
+
+    /// <summary>
+    /// Stable identifiers for the <c>source</c> label on
+    /// <see cref="SharedGameDetailCacheHitsTotal"/>.
+    /// See class XML doc for why <c>hybrid</c>/<c>redis</c> collapse to <c>hit</c>.
+    /// </summary>
+    public static class CacheHitSources
+    {
+        public const string Hit = "hit";
+        public const string Origin = "origin";
+    }
+
+    /// <summary>
+    /// Stable identifiers for the <c>cache_outcome</c> label on
+    /// <see cref="SharedGameDetailRenderDurationSeconds"/>. Mirrors
+    /// <see cref="CacheHitSources"/> so render-duration histograms can be
+    /// joined to cache-hit counters in PromQL.
+    /// </summary>
+    public static class SharedGameDetailCacheOutcomes
+    {
+        public const string Hit = "hit";
+        public const string Origin = "origin";
+    }
+
+    /// <summary>
+    /// Stable identifiers for the <c>bounded_context</c> label on
+    /// <see cref="SharedGameDetailCrossBcQueryDurationSeconds"/>.
+    /// </summary>
+    public static class SharedGameDetailBoundedContexts
+    {
+        public const string Toolkit = "toolkit";
+        public const string Agent = "agent";
+        public const string Kb = "kb";
+    }
+
+    /// <summary>
+    /// Records a terminal request outcome.
+    /// </summary>
+    /// <param name="result">One of <see cref="SharedGameDetailResults"/>.</param>
+    public static void RecordSharedGameDetailRequest(string result)
+    {
+        var tags = new TagList { { "result", result } };
+        SharedGameDetailRequestsTotal.Add(1, tags);
+    }
+
+    /// <summary>
+    /// Records a cache lookup outcome.
+    /// </summary>
+    /// <param name="source">One of <see cref="CacheHitSources"/>.</param>
+    public static void RecordSharedGameDetailCacheHit(string source)
+    {
+        var tags = new TagList { { "source", source } };
+        SharedGameDetailCacheHitsTotal.Add(1, tags);
+    }
+
+    /// <summary>
+    /// Records the end-to-end render duration of the handler.
+    /// </summary>
+    /// <param name="elapsedSeconds">Wall-clock elapsed time in seconds.</param>
+    /// <param name="cacheOutcome">One of <see cref="SharedGameDetailCacheOutcomes"/>.</param>
+    public static void RecordSharedGameDetailRenderDuration(double elapsedSeconds, string cacheOutcome)
+    {
+        var tags = new TagList { { "cache_outcome", cacheOutcome } };
+        SharedGameDetailRenderDurationSeconds.Record(elapsedSeconds, tags);
+    }
+
+    /// <summary>
+    /// Records a single cross-bounded-context fan-out query duration.
+    /// </summary>
+    /// <param name="elapsedSeconds">Wall-clock elapsed time in seconds.</param>
+    /// <param name="boundedContext">One of <see cref="SharedGameDetailBoundedContexts"/>.</param>
+    public static void RecordSharedGameDetailCrossBcQuery(double elapsedSeconds, string boundedContext)
+    {
+        var tags = new TagList { { "bounded_context", boundedContext } };
+        SharedGameDetailCrossBcQueryDurationSeconds.Record(elapsedSeconds, tags);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/GetSharedGameByIdQueryHandlerMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/GetSharedGameByIdQueryHandlerMetricsTests.cs
@@ -1,0 +1,268 @@
+// Issue #614 (Wave A.4 follow-up · P0): Metric-emission tests for
+// GetSharedGameByIdQueryHandler.
+//
+// We use System.Diagnostics.Metrics.MeterListener to capture instrument values
+// without going through Prometheus / OTLP — this keeps the test hermetic and
+// avoids spinning up a metrics exporter just to assert an Add(1) call.
+//
+// Coverage matrix:
+//   • Success path                → request=success,  source=origin (cache miss)
+//   • Not-found path              → request=not_found, source=origin
+//   • Repeated call (cache hit)   → request=success,  source=hit
+//   • Cross-BC fan-out histograms → toolkit + agent + kb each emit one sample
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using Api.BoundedContexts.SharedGameCatalog.Application;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.Observability;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Handlers;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class GetSharedGameByIdQueryHandlerMetricsTests
+{
+    private readonly Mock<ISharedGameRepository> _repositoryMock = new();
+    private readonly Mock<ILogger<GetSharedGameByIdQueryHandler>> _loggerMock = new();
+
+    private static HybridCache CreateHybridCache()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IMemoryCache, MemoryCache>();
+        services.AddSingleton<IDistributedCache>(new MemoryDistributedCache(
+            Microsoft.Extensions.Options.Options.Create(new MemoryDistributedCacheOptions())));
+        services.AddHybridCache();
+        return services.BuildServiceProvider().GetRequiredService<HybridCache>();
+    }
+
+    private static IConfiguration CreateConfiguration() =>
+        new ConfigurationBuilder().AddInMemoryCollection().Build();
+
+    private GetSharedGameByIdQueryHandler CreateHandler(MeepleAiDbContext db, HybridCache cache) =>
+        new(_repositoryMock.Object, db, cache, CreateConfiguration(), _loggerMock.Object);
+
+    private static SharedGame CreateGame() =>
+        SharedGame.Create(
+            "Catan",
+            1995,
+            "Description",
+            3,
+            4,
+            90,
+            10,
+            2.5m,
+            7.8m,
+            "https://example.com/catan.jpg",
+            "https://example.com/thumb.jpg",
+            GameRules.Create("Rules content", "en"),
+            createdBy: Guid.NewGuid(),
+            bggId: 13);
+
+    /// <summary>
+    /// Captures every measurement emitted on the <c>MeepleAI.Api</c> meter
+    /// during the lifetime of the listener. Only instruments whose name starts
+    /// with <c>meepleai.shared_game_detail.</c> are captured to keep the test
+    /// noise-free if the handler ever incidentally records other metrics.
+    /// </summary>
+    private sealed class SharedGameDetailMetricsCapture : IDisposable
+    {
+        private readonly MeterListener _listener;
+        public ConcurrentBag<(string Name, long Value, IReadOnlyDictionary<string, object?> Tags)> LongMeasurements { get; } = new();
+        public ConcurrentBag<(string Name, double Value, IReadOnlyDictionary<string, object?> Tags)> DoubleMeasurements { get; } = new();
+
+        public SharedGameDetailMetricsCapture()
+        {
+            _listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, l) =>
+                {
+                    if (instrument.Meter.Name == MeepleAiMetrics.MeterName &&
+                        instrument.Name.StartsWith("meepleai.shared_game_detail.", StringComparison.Ordinal))
+                    {
+                        l.EnableMeasurementEvents(instrument);
+                    }
+                }
+            };
+
+            _listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+            {
+                LongMeasurements.Add((instrument.Name, measurement, ToDict(tags)));
+            });
+            _listener.SetMeasurementEventCallback<double>((instrument, measurement, tags, _) =>
+            {
+                DoubleMeasurements.Add((instrument.Name, measurement, ToDict(tags)));
+            });
+
+            _listener.Start();
+        }
+
+        private static IReadOnlyDictionary<string, object?> ToDict(ReadOnlySpan<KeyValuePair<string, object?>> tags)
+        {
+            var d = new Dictionary<string, object?>(tags.Length, StringComparer.Ordinal);
+            foreach (var t in tags)
+            {
+                d[t.Key] = t.Value;
+            }
+            return d;
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    [Fact]
+    public async Task Handle_SuccessOnCacheMiss_EmitsRequestSuccessAndOriginAndAllFanOutHistograms()
+    {
+        // Arrange
+        using var capture = new SharedGameDetailMetricsCapture();
+        var game = CreateGame();
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var handler = CreateHandler(db, CreateHybridCache());
+
+        // Act
+        var result = await handler.Handle(new GetSharedGameByIdQuery(game.Id), TestContext.Current.CancellationToken);
+
+        // Assert — sanity on the result
+        result.Should().NotBeNull();
+
+        // RequestsTotal: exactly one increment with result=success.
+        var requests = capture.LongMeasurements
+            .Where(m => m.Name == "meepleai.shared_game_detail.requests.total")
+            .ToList();
+        requests.Should().ContainSingle();
+        requests[0].Value.Should().Be(1);
+        requests[0].Tags["result"].Should().Be(MeepleAiMetrics.SharedGameDetailResults.Success);
+
+        // CacheHitsTotal: source=origin because the factory ran (cache miss).
+        var cacheHits = capture.LongMeasurements
+            .Where(m => m.Name == "meepleai.shared_game_detail.cache_hits.total")
+            .ToList();
+        cacheHits.Should().ContainSingle();
+        cacheHits[0].Tags["source"].Should().Be(MeepleAiMetrics.CacheHitSources.Origin);
+
+        // RenderDurationSeconds: one sample, cache_outcome=origin.
+        var render = capture.DoubleMeasurements
+            .Where(m => m.Name == "meepleai.shared_game_detail.render_duration_seconds")
+            .ToList();
+        render.Should().ContainSingle();
+        render[0].Value.Should().BeGreaterThanOrEqualTo(0d);
+        render[0].Tags["cache_outcome"].Should().Be(MeepleAiMetrics.SharedGameDetailCacheOutcomes.Origin);
+
+        // CrossBcQueryDurationSeconds: one sample for each fan-out (toolkit, agent, kb).
+        var crossBc = capture.DoubleMeasurements
+            .Where(m => m.Name == "meepleai.shared_game_detail.cross_bc_query_duration_seconds")
+            .ToList();
+        crossBc.Should().HaveCount(3);
+        var labels = crossBc.Select(m => (string?)m.Tags["bounded_context"]).ToList();
+        labels.Should().BeEquivalentTo(new[]
+        {
+            MeepleAiMetrics.SharedGameDetailBoundedContexts.Toolkit,
+            MeepleAiMetrics.SharedGameDetailBoundedContexts.Agent,
+            MeepleAiMetrics.SharedGameDetailBoundedContexts.Kb
+        });
+        crossBc.Should().OnlyContain(m => m.Value >= 0d);
+    }
+
+    [Fact]
+    public async Task Handle_NotFound_EmitsRequestNotFoundAndOrigin()
+    {
+        // Arrange
+        using var capture = new SharedGameDetailMetricsCapture();
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SharedGame?)null);
+
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var handler = CreateHandler(db, CreateHybridCache());
+
+        // Act
+        var result = await handler.Handle(new GetSharedGameByIdQuery(Guid.NewGuid()), TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Should().BeNull();
+
+        var requests = capture.LongMeasurements
+            .Where(m => m.Name == "meepleai.shared_game_detail.requests.total")
+            .ToList();
+        requests.Should().ContainSingle();
+        requests[0].Tags["result"].Should().Be(MeepleAiMetrics.SharedGameDetailResults.NotFound);
+
+        // Cache miss still emits source=origin even when the underlying game is null —
+        // the factory delegate runs before deciding the result. This matches the
+        // metric semantics documented in MeepleAiMetrics.SharedGameDetail.cs.
+        var cacheHits = capture.LongMeasurements
+            .Where(m => m.Name == "meepleai.shared_game_detail.cache_hits.total")
+            .ToList();
+        cacheHits.Should().ContainSingle();
+        cacheHits[0].Tags["source"].Should().Be(MeepleAiMetrics.CacheHitSources.Origin);
+
+        var render = capture.DoubleMeasurements
+            .Where(m => m.Name == "meepleai.shared_game_detail.render_duration_seconds")
+            .ToList();
+        render.Should().ContainSingle();
+        render[0].Tags["cache_outcome"].Should().Be(MeepleAiMetrics.SharedGameDetailCacheOutcomes.Origin);
+    }
+
+    [Fact]
+    public async Task Handle_RepeatedCall_SecondCallEmitsSourceHit()
+    {
+        // Arrange — share a single HybridCache between the two handler invocations.
+        using var capture = new SharedGameDetailMetricsCapture();
+        var game = CreateGame();
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var sharedCache = CreateHybridCache();
+        var handler = CreateHandler(db, sharedCache);
+
+        // Act — first call seeds cache (factoryInvoked=true ⇒ origin).
+        await handler.Handle(new GetSharedGameByIdQuery(game.Id), TestContext.Current.CancellationToken);
+        // Second call should hit the L1 entry (factoryInvoked=false ⇒ hit).
+        await handler.Handle(new GetSharedGameByIdQuery(game.Id), TestContext.Current.CancellationToken);
+
+        // Assert
+        var cacheHitSources = capture.LongMeasurements
+            .Where(m => m.Name == "meepleai.shared_game_detail.cache_hits.total")
+            .Select(m => (string?)m.Tags["source"])
+            .ToList();
+        cacheHitSources.Should().HaveCount(2);
+        cacheHitSources.Should().Contain(MeepleAiMetrics.CacheHitSources.Origin);
+        cacheHitSources.Should().Contain(MeepleAiMetrics.CacheHitSources.Hit);
+
+        // Render histogram: first sample is origin, second is hit.
+        var renderOutcomes = capture.DoubleMeasurements
+            .Where(m => m.Name == "meepleai.shared_game_detail.render_duration_seconds")
+            .Select(m => (string?)m.Tags["cache_outcome"])
+            .ToList();
+        renderOutcomes.Should().HaveCount(2);
+        renderOutcomes.Should().Contain(MeepleAiMetrics.SharedGameDetailCacheOutcomes.Origin);
+        renderOutcomes.Should().Contain(MeepleAiMetrics.SharedGameDetailCacheOutcomes.Hit);
+
+        // Cross-BC fan-out only runs on cache miss (inside the factory delegate),
+        // so we should see exactly 3 samples (one per BC), not 6.
+        var crossBc = capture.DoubleMeasurements
+            .Where(m => m.Name == "meepleai.shared_game_detail.cross_bc_query_duration_seconds")
+            .ToList();
+        crossBc.Should().HaveCount(3);
+    }
+}

--- a/infra/monitoring/grafana/dashboards/shared-games.json
+++ b/infra/monitoring/grafana/dashboards/shared-games.json
@@ -1,0 +1,317 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Issue #614 — observability for /shared-games/{id} detail handler. Tracks request rate by terminal result, cache hit ratio (target >=80%), render duration percentiles (SLO: p95 < 200ms), and cross-BC fan-out latency per bounded context.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "title": "Request rate by result (req/s)",
+      "description": "Per-second rate of /shared-games/{id} terminal outcomes. result=success is the happy path; result=not_found is a legitimate 404; result=error indicates a handler exception.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "lineInterpolation": "linear", "fillOpacity": 10, "stacking": { "mode": "normal" } },
+          "unit": "reqps"
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "error" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }] },
+          { "matcher": { "id": "byName", "options": "not_found" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "yellow" } }] },
+          { "matcher": { "id": "byName", "options": "success" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }] }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "sum by (result) (rate(meepleai_shared_game_detail_requests_total[5m]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "title": "Cache hit ratio (Target: >=80%, Alert: <60%)",
+      "description": "Ratio of HybridCache hits over total lookups. source=hit collapses L1 (in-process) and L2 (Redis); source=origin = full miss (factory delegate ran).",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.6 },
+              { "color": "green", "value": 0.8 }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        }
+      },
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "meepleai:shared_game_detail:cache_hit_ratio:5m",
+          "legendFormat": "Cache hit ratio",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "title": "Render duration p50 / p95 / p99 (SLO: p95 < 200ms)",
+      "description": "End-to-end handler latency including HybridCache lookup, cross-BC fan-out, and DTO assembly. SLO target: p95 < 200ms. Alert fires at p95 > 500ms for 10m.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+      "id": 3,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "lineInterpolation": "linear", "fillOpacity": 10 },
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.2 },
+              { "color": "red", "value": 0.5 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(meepleai_shared_game_detail_render_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "meepleai:shared_game_detail:render_p95:5m",
+          "legendFormat": "p95 (SLO 200ms)",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(meepleai_shared_game_detail_render_duration_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "title": "Cross-BC fan-out p95 (toolkit / agent / kb)",
+      "description": "p95 of each cross-bounded-context query during cache miss. Use this to attribute slow renders to a specific BC: toolkit (GameToolkit), agent (KnowledgeBase agents), kb (vector documents).",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "id": 4,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "lineInterpolation": "linear", "fillOpacity": 10 },
+          "unit": "s"
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "toolkit" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "blue" } }] },
+          { "matcher": { "id": "byName", "options": "agent" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "purple" } }] },
+          { "matcher": { "id": "byName", "options": "kb" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } }] }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "meepleai:shared_game_detail:cross_bc_p95:5m",
+          "legendFormat": "{{bounded_context}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "title": "Cache hit/miss rate (events/s)",
+      "description": "Absolute counts: how many lookups hit the cache vs missed (origin = factory delegate ran).",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "id": 5,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "lineInterpolation": "linear", "fillOpacity": 10, "stacking": { "mode": "normal" } },
+          "unit": "ops"
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "hit" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }] },
+          { "matcher": { "id": "byName", "options": "origin" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "yellow" } }] }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "sum by (source) (rate(meepleai_shared_game_detail_cache_hits_total[5m]))",
+          "legendFormat": "{{source}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "title": "Error ratio (5m)",
+      "description": "Percentage of requests that terminated with result=error. Alert fires above 5% for 5m. not_found is excluded (legitimate 404).",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 24 },
+      "id": 6,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 },
+              { "color": "red", "value": 0.05 }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        }
+      },
+      "options": {
+        "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "meepleai:shared_game_detail:error_ratio:5m",
+          "legendFormat": "Error ratio",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "title": "Total request rate (5m)",
+      "description": "Aggregate req/s across all results.",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 24 },
+      "id": 7,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] },
+          "unit": "reqps"
+        }
+      },
+      "options": {
+        "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "meepleai:shared_game_detail:request_rate:5m",
+          "legendFormat": "req/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "title": "Render p95 (5m)",
+      "description": "Single-number view for SLO dashboards.",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 24 },
+      "id": 8,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.2 },
+              { "color": "red", "value": 0.5 }
+            ]
+          },
+          "unit": "s"
+        }
+      },
+      "options": {
+        "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "meepleai:shared_game_detail:render_p95:5m",
+          "legendFormat": "p95",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["shared-games", "observability", "issue-614"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Shared-Games Detail Observability",
+  "uid": "shared-games",
+  "version": 1,
+  "weekStart": ""
+}

--- a/infra/prometheus-rules.yml
+++ b/infra/prometheus-rules.yml
@@ -976,3 +976,127 @@ groups:
         annotations:
           summary: "OpenRouter RPM utilization above 80%"
           description: "RPM utilization at {{ $value | humanizePercentage }}."
+
+  # ─── Issue #614: SharedGame Detail Observability — Recording Rules ─────
+  # Pre-computed views used by both the dashboard and the alert group below.
+  # Bounded label cardinality (≤10 active series, see MeepleAiMetrics.SharedGameDetail.cs).
+  - name: meepleai_shared_game_detail_recording_rules
+    interval: 30s
+    rules:
+      # Total request rate across all terminal results.
+      - record: meepleai:shared_game_detail:request_rate:5m
+        expr: |
+          sum(rate(meepleai_shared_game_detail_requests_total[5m])) OR on() vector(0)
+        labels:
+          service: meepleai-api
+          category: shared_game_detail
+
+      # Error ratio: result="error" share of all terminal outcomes.
+      # Note: not_found is a *legitimate* outcome (404), not an error — exclude it.
+      - record: meepleai:shared_game_detail:error_ratio:5m
+        expr: |
+          (
+            sum(rate(meepleai_shared_game_detail_requests_total{result="error"}[5m]))
+            /
+            sum(rate(meepleai_shared_game_detail_requests_total[5m]))
+          ) OR on() vector(0)
+        labels:
+          service: meepleai-api
+          category: shared_game_detail
+
+      # Cache hit ratio: hit / (hit + origin). Target ≥ 80%, alert below 60%.
+      - record: meepleai:shared_game_detail:cache_hit_ratio:5m
+        expr: |
+          (
+            sum(rate(meepleai_shared_game_detail_cache_hits_total{source="hit"}[5m]))
+            /
+            sum(rate(meepleai_shared_game_detail_cache_hits_total[5m]))
+          ) OR on() vector(0)
+        labels:
+          service: meepleai-api
+          category: shared_game_detail
+
+      # End-to-end render p95 (seconds). SLO: < 200ms, alert > 500ms.
+      - record: meepleai:shared_game_detail:render_p95:5m
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (le) (rate(meepleai_shared_game_detail_render_duration_seconds_bucket[5m]))
+          ) OR on() vector(0)
+        labels:
+          service: meepleai-api
+          category: shared_game_detail
+
+      # Cross-BC fan-out p95 per bounded context (toolkit / agent / kb).
+      - record: meepleai:shared_game_detail:cross_bc_p95:5m
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (le, bounded_context) (
+              rate(meepleai_shared_game_detail_cross_bc_query_duration_seconds_bucket[5m])
+            )
+          ) OR on() vector(0)
+        labels:
+          service: meepleai-api
+          category: shared_game_detail
+
+  # ─── Issue #614: SharedGame Detail Observability — Alert Rules ─────────
+  - name: meepleai_shared_game_detail_alerts
+    interval: 30s
+    rules:
+      # Error rate > 5% sustained for 5 minutes.
+      # Triggers on backend exceptions (RecordSharedGameDetailRequest("error")
+      # in the outer catch). Excludes not_found (404) which is a legitimate
+      # client-side outcome, not an SLO breach.
+      - alert: SharedGameDetailErrorRateHigh
+        expr: meepleai:shared_game_detail:error_ratio:5m > 0.05
+        for: 5m
+        labels:
+          severity: critical
+          service: meepleai-api
+          category: shared_game_detail
+        annotations:
+          summary: "Shared-game detail error ratio above 5% for 5m"
+          description: |
+            {{ $value | humanizePercentage }} of /shared-games/{id} requests are
+            failing with result=error over 5m. Investigate handler exceptions,
+            cross-BC fan-out failures (toolkit/agent/kb), or DB/cache outages.
+          runbook_url: "https://docs.meepleai.dev/runbooks/shared-game-detail-errors"
+          dashboard_url: "https://grafana.meepleai.dev/d/shared-games"
+
+      # End-to-end render p95 above 500ms for 10 minutes.
+      # SLO target is 200ms; alert at 2.5x SLO to avoid flapping on burst load.
+      - alert: SharedGameDetailRenderSlow
+        expr: meepleai:shared_game_detail:render_p95:5m > 0.5
+        for: 10m
+        labels:
+          severity: warning
+          service: meepleai-api
+          category: shared_game_detail
+        annotations:
+          summary: "Shared-game detail render p95 above 500ms for 10m"
+          description: |
+            p95 render duration is {{ $value | humanizeDuration }}.
+            Likely causes: cache miss storm, slow cross-BC fan-out, DB pressure.
+            Cross-BC p95 per BC: see dashboard panel "Cross-BC fan-out p95".
+          runbook_url: "https://docs.meepleai.dev/runbooks/shared-game-detail-slow"
+          dashboard_url: "https://grafana.meepleai.dev/d/shared-games"
+
+      # Cache hit ratio below 60% for 15 minutes — indicates eviction storm,
+      # mass invalidation regression, or cache-bypass bug. Target is ≥80%.
+      # Long window (15m) because traffic spikes can transiently depress ratio.
+      - alert: SharedGameDetailCacheHitLow
+        expr: meepleai:shared_game_detail:cache_hit_ratio:5m < 0.6
+        for: 15m
+        labels:
+          severity: warning
+          service: meepleai-api
+          category: shared_game_detail
+        annotations:
+          summary: "Shared-game detail cache hit ratio below 60% for 15m"
+          description: |
+            Cache hit ratio is {{ $value | humanizePercentage }} (target ≥80%).
+            Check HybridCache eviction stats, RemoveByTagAsync invalidation
+            patterns, and L2 (Redis) availability.
+          runbook_url: "https://docs.meepleai.dev/runbooks/shared-game-detail-cache-miss"
+          dashboard_url: "https://grafana.meepleai.dev/d/shared-games"


### PR DESCRIPTION
## Summary

Closes #614 — Wave A.4 follow-up · P0 observability.

Spec §3.7 defined four metrics for the new `/shared-games/{id}` endpoint; PR #605 implemented zero of them. Without instrumentation we could not detect cache stampede, alert on slow cross-BC fan-out, measure render p95 against the 200ms SLO, or correlate frontend `error.tsx` rate with backend issues.

## What changed

**Backend instrumentation** (`apps/api/src/Api/`)
- New `Observability/Metrics/MeepleAiMetrics.SharedGameDetail.cs` — 4 instruments (`Counter<long>` × 2, `Histogram<double>` × 2) with bounded label cardinality (10 active series total). Comment explains why HybridCache `{hybrid, redis}` collapse to `hit` (not distinguishable in .NET 9).
- `BoundedContexts/SharedGameCatalog/Application/Queries/GetSharedGameByIdQueryHandler.cs` now records:
  - `RequestsTotal` at every terminal path (`success` / `not_found` / `error`)
  - `CacheHitsTotal` once per `GetOrCreateAsync` (`hit` vs `origin`)
  - `RenderDurationSeconds` end-to-end in `try/finally` (`Stopwatch.GetTimestamp` + `Stopwatch.GetElapsedTime`)
  - `CrossBcQueryDurationSeconds` per fan-out (`toolkit` / `agent` / `kb`) so a slow render is attributable to the right BC.

**Tests** (`apps/api/tests/Api.Tests/`)
- `GetSharedGameByIdQueryHandlerMetricsTests` uses `MeterListener` to capture instrument values without spinning up a Prometheus exporter. 3 cases cover:
  1. Success on cache miss → `success` + `origin` + 3 cross-BC samples.
  2. Not found on cache miss → `not_found` + `origin` (factory still ran).
  3. Repeated call on shared `HybridCache` → first sample `origin`, second `hit`; cross-BC samples only on the first (factory miss).

**Ops** (`infra/`)
- `monitoring/grafana/dashboards/shared-games.json` — 8 panels: request rate by result, cache-hit ratio gauge (target ≥ 80%), p50/p95/p99 render, cross-BC fan-out p95 per BC, hit/miss rate, error/rate/p95 stat tiles.
- `prometheus-rules.yml` — recording rules `meepleai:shared_game_detail:{request_rate,error_ratio,cache_hit_ratio,render_p95,cross_bc_p95}:5m` + 3 alerts:
  - `SharedGameDetailErrorRateHigh` (> 5% / 5m, **critical**)
  - `SharedGameDetailRenderSlow` (p95 > 500ms / 10m, warning) — 2.5× SLO threshold to avoid flapping
  - `SharedGameDetailCacheHitLow` (< 60% / 15m, warning) — long window because traffic spikes can transiently depress the ratio

## Cardinality budget

| Metric | Labels | Series |
|--------|--------|--------|
| `requests_total` | `result` ∈ {success, not_found, error} | 3 |
| `cache_hits_total` | `source` ∈ {hit, origin} | 2 |
| `render_duration_seconds` | `cache_outcome` ∈ {hit, origin} | 2 |
| `cross_bc_query_duration_seconds` | `bounded_context` ∈ {toolkit, agent, kb} | 3 |

Total: 10 active series — well under the 100/BC budget.

## Test plan

- [x] `dotnet test --filter FullyQualifiedName~GetSharedGameByIdQueryHandlerMetricsTests` → 3/3 pass
- [x] `python -c "import yaml; yaml.safe_load(...)"` → prometheus-rules.yml valid
- [x] `python -c "import json; json.load(...)"` → shared-games.json valid
- [ ] CI green
- [ ] Manual smoke after deploy: `curl /metrics | grep meepleai_shared_game_detail_`
- [ ] Grafana dashboard imports cleanly (panels render with `prometheus` datasource UID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)