### PR TITLE
feat(a11y): extract useTablistKeyboardNav hook (Wave A.6 Tier 1)

### DIFF
--- a/apps/web/src/components/ui/v2/faq/category-tabs.tsx
+++ b/apps/web/src/components/ui/v2/faq/category-tabs.tsx
@@ -22,11 +22,12 @@
 
 'use client';
 
-import type { JSX, KeyboardEvent } from 'react';
-import { useCallback, useRef } from 'react';
+import type { JSX } from 'react';
+import { useMemo } from 'react';
 
 import clsx from 'clsx';
 
+import { useTablistKeyboardNav } from '@/hooks/useTablistKeyboardNav';
 import type { CategoryId, FAQCategory } from '@/lib/faq/data';
 
 export interface CategoryTabsProps {
@@ -50,41 +51,11 @@ export function CategoryTabs({
   ariaLabel = 'FAQ categories',
   className,
 }: CategoryTabsProps): JSX.Element {
-  const tabRefs = useRef<Map<CategoryId, HTMLButtonElement>>(new Map());
-
-  const focusTab = useCallback((id: CategoryId) => {
-    tabRefs.current.get(id)?.focus();
-  }, []);
-
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLButtonElement>, currentId: CategoryId) => {
-      const orderedIds = categories.map(c => c.id);
-      const idx = orderedIds.indexOf(currentId);
-      if (idx === -1) return;
-      let nextIdx: number | null = null;
-      switch (e.key) {
-        case 'ArrowLeft':
-          nextIdx = (idx - 1 + orderedIds.length) % orderedIds.length;
-          break;
-        case 'ArrowRight':
-          nextIdx = (idx + 1) % orderedIds.length;
-          break;
-        case 'Home':
-          nextIdx = 0;
-          break;
-        case 'End':
-          nextIdx = orderedIds.length - 1;
-          break;
-        default:
-          return;
-      }
-      e.preventDefault();
-      const nextId = orderedIds[nextIdx];
-      onChange(nextId);
-      focusTab(nextId);
-    },
-    [categories, onChange, focusTab]
-  );
+  const orderedIds = useMemo(() => categories.map(c => c.id), [categories]);
+  const { tabRefs, handleKeyDown } = useTablistKeyboardNav<CategoryId>({
+    orderedKeys: orderedIds,
+    onChange,
+  });
 
   return (
     <div

--- a/apps/web/src/components/ui/v2/shared-game-detail/tabs.tsx
+++ b/apps/web/src/components/ui/v2/shared-game-detail/tabs.tsx
@@ -26,12 +26,13 @@
 
 'use client';
 
-import type { JSX, KeyboardEvent } from 'react';
-import { useCallback, useRef } from 'react';
+import type { JSX } from 'react';
+import { useMemo } from 'react';
 
 import clsx from 'clsx';
 
 import { entityHsl } from '@/components/ui/data-display/meeple-card/tokens';
+import { useTablistKeyboardNav } from '@/hooks/useTablistKeyboardNav';
 
 export const TAB_KEYS = ['overview', 'toolkits', 'agents', 'knowledge', 'community'] as const;
 
@@ -79,43 +80,11 @@ export function Tabs({
   className,
   idBase = DEFAULT_ID_BASE,
 }: TabsProps): JSX.Element {
-  const tabRefs = useRef<Map<TabKey, HTMLButtonElement>>(new Map());
-
-  const focusTab = useCallback((key: TabKey) => {
-    tabRefs.current.get(key)?.focus();
-  }, []);
-
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLButtonElement>, currentKey: TabKey) => {
-      const orderedKeys = tabs.map(t => t.key);
-      const idx = orderedKeys.indexOf(currentKey);
-      if (idx === -1) return;
-
-      let nextIdx: number | null = null;
-      switch (e.key) {
-        case 'ArrowLeft':
-          nextIdx = (idx - 1 + orderedKeys.length) % orderedKeys.length;
-          break;
-        case 'ArrowRight':
-          nextIdx = (idx + 1) % orderedKeys.length;
-          break;
-        case 'Home':
-          nextIdx = 0;
-          break;
-        case 'End':
-          nextIdx = orderedKeys.length - 1;
-          break;
-        default:
-          return;
-      }
-
-      e.preventDefault();
-      const nextKey = orderedKeys[nextIdx];
-      onChange(nextKey);
-      focusTab(nextKey);
-    },
-    [tabs, onChange, focusTab]
-  );
+  const orderedKeys = useMemo(() => tabs.map(t => t.key), [tabs]);
+  const { tabRefs, handleKeyDown } = useTablistKeyboardNav<TabKey>({
+    orderedKeys,
+    onChange,
+  });
 
   return (
     <div

--- a/apps/web/src/hooks/__tests__/useTablistKeyboardNav.test.ts
+++ b/apps/web/src/hooks/__tests__/useTablistKeyboardNav.test.ts
@@ -1,0 +1,272 @@
+/**
+ * useTablistKeyboardNav — pure hook unit tests (Wave A.6 Tier 1, Issue #622).
+ *
+ * Validates the WAI-ARIA APG tablist keyboard contract extracted from
+ * Wave A.4 (`shared-game-detail/tabs.tsx`) and Wave A.4-followup PR #620
+ * (`category-tabs.tsx`). Both call sites had near-identical inline logic;
+ * this hook is the consolidated, generically-typed implementation.
+ *
+ * Contract (mirrors WAI-ARIA APG horizontal tablist):
+ *   - ArrowRight → next key (wraps last → first)
+ *   - ArrowLeft  → previous key (wraps first → last)
+ *   - Home       → first key
+ *   - End        → last key
+ *   - Other keys (ArrowUp, ArrowDown, char keys) → no-op
+ *   - Activation is automatic: focus = onChange same tick
+ *   - preventDefault is called for Arrow/Home/End to suppress page scroll
+ *
+ * Test strategy: pure handler invocation with synthetic KeyboardEvents +
+ * manually-populated `tabRefs` Map. No React tree needed — that's exactly
+ * the value of extracting this hook.
+ */
+
+import { renderHook } from '@testing-library/react';
+import type { KeyboardEvent } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useTablistKeyboardNav } from '../useTablistKeyboardNav';
+
+type Key = 'a' | 'b' | 'c' | 'd';
+
+interface SyntheticEventOpts {
+  readonly key: string;
+}
+
+function makeEvent({ key }: SyntheticEventOpts): KeyboardEvent<HTMLButtonElement> & {
+  readonly preventDefault: ReturnType<typeof vi.fn>;
+} {
+  const preventDefault = vi.fn();
+  return {
+    key,
+    preventDefault,
+  } as unknown as KeyboardEvent<HTMLButtonElement> & {
+    readonly preventDefault: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeButtonStub(): HTMLButtonElement & { readonly focus: ReturnType<typeof vi.fn> } {
+  const focus = vi.fn();
+  return { focus } as unknown as HTMLButtonElement & { readonly focus: ReturnType<typeof vi.fn> };
+}
+
+interface SetupOpts<T extends string> {
+  readonly orderedKeys: ReadonlyArray<T>;
+}
+
+function setup<T extends string>({ orderedKeys }: SetupOpts<T>) {
+  const onChange = vi.fn();
+  const { result } = renderHook(() => useTablistKeyboardNav<T>({ orderedKeys, onChange }));
+  // Populate refs with stubbed buttons so focus() can be asserted.
+  const buttons = new Map<T, HTMLButtonElement & { readonly focus: ReturnType<typeof vi.fn> }>();
+  for (const key of orderedKeys) {
+    const btn = makeButtonStub();
+    buttons.set(key, btn);
+    result.current.tabRefs.current.set(key, btn);
+  }
+  return { result, onChange, buttons };
+}
+
+describe('useTablistKeyboardNav (Wave A.6 Tier 1)', () => {
+  describe('return shape', () => {
+    it('returns tabRefs as a Map ref and handleKeyDown as a function', () => {
+      const { result } = renderHook(() =>
+        useTablistKeyboardNav<Key>({ orderedKeys: ['a', 'b'], onChange: vi.fn() })
+      );
+      expect(result.current.tabRefs.current).toBeInstanceOf(Map);
+      expect(typeof result.current.handleKeyDown).toBe('function');
+    });
+
+    it('tabRefs persists across re-renders (stable ref identity)', () => {
+      const { result, rerender } = renderHook(
+        ({ keys }: { keys: ReadonlyArray<Key> }) =>
+          useTablistKeyboardNav<Key>({ orderedKeys: keys, onChange: vi.fn() }),
+        { initialProps: { keys: ['a', 'b'] as ReadonlyArray<Key> } }
+      );
+      const firstRef = result.current.tabRefs;
+      rerender({ keys: ['a', 'b', 'c'] as ReadonlyArray<Key> });
+      expect(result.current.tabRefs).toBe(firstRef);
+    });
+  });
+
+  describe('ArrowRight', () => {
+    it('advances to the next key', () => {
+      const { result, onChange, buttons } = setup<Key>({ orderedKeys: ['a', 'b', 'c'] });
+      result.current.handleKeyDown(makeEvent({ key: 'ArrowRight' }), 'a');
+      expect(onChange).toHaveBeenCalledWith('b');
+      expect(buttons.get('b')!.focus).toHaveBeenCalledOnce();
+    });
+
+    it('wraps from last key to first', () => {
+      const { result, onChange, buttons } = setup<Key>({ orderedKeys: ['a', 'b', 'c'] });
+      result.current.handleKeyDown(makeEvent({ key: 'ArrowRight' }), 'c');
+      expect(onChange).toHaveBeenCalledWith('a');
+      expect(buttons.get('a')!.focus).toHaveBeenCalledOnce();
+    });
+
+    it('calls preventDefault to suppress page scroll', () => {
+      const { result } = setup<Key>({ orderedKeys: ['a', 'b'] });
+      const e = makeEvent({ key: 'ArrowRight' });
+      result.current.handleKeyDown(e, 'a');
+      expect(e.preventDefault).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('ArrowLeft', () => {
+    it('retreats to the previous key', () => {
+      const { result, onChange, buttons } = setup<Key>({ orderedKeys: ['a', 'b', 'c'] });
+      result.current.handleKeyDown(makeEvent({ key: 'ArrowLeft' }), 'b');
+      expect(onChange).toHaveBeenCalledWith('a');
+      expect(buttons.get('a')!.focus).toHaveBeenCalledOnce();
+    });
+
+    it('wraps from first key to last', () => {
+      const { result, onChange, buttons } = setup<Key>({ orderedKeys: ['a', 'b', 'c'] });
+      result.current.handleKeyDown(makeEvent({ key: 'ArrowLeft' }), 'a');
+      expect(onChange).toHaveBeenCalledWith('c');
+      expect(buttons.get('c')!.focus).toHaveBeenCalledOnce();
+    });
+
+    it('calls preventDefault', () => {
+      const { result } = setup<Key>({ orderedKeys: ['a', 'b'] });
+      const e = makeEvent({ key: 'ArrowLeft' });
+      result.current.handleKeyDown(e, 'b');
+      expect(e.preventDefault).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('Home', () => {
+    it('jumps to the first key', () => {
+      const { result, onChange, buttons } = setup<Key>({ orderedKeys: ['a', 'b', 'c', 'd'] });
+      result.current.handleKeyDown(makeEvent({ key: 'Home' }), 'c');
+      expect(onChange).toHaveBeenCalledWith('a');
+      expect(buttons.get('a')!.focus).toHaveBeenCalledOnce();
+    });
+
+    it('is a no-op when already on first key (still calls onChange + focuses for idempotency)', () => {
+      // Note: WAI-ARIA APG doesn't require short-circuit. Calling onChange with
+      // the current key is acceptable and simpler. Same-key case is tolerated.
+      const { result, onChange, buttons } = setup<Key>({ orderedKeys: ['a', 'b', 'c'] });
+      result.current.handleKeyDown(makeEvent({ key: 'Home' }), 'a');
+      expect(onChange).toHaveBeenCalledWith('a');
+      expect(buttons.get('a')!.focus).toHaveBeenCalledOnce();
+    });
+
+    it('calls preventDefault', () => {
+      const { result } = setup<Key>({ orderedKeys: ['a', 'b'] });
+      const e = makeEvent({ key: 'Home' });
+      result.current.handleKeyDown(e, 'b');
+      expect(e.preventDefault).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('End', () => {
+    it('jumps to the last key', () => {
+      const { result, onChange, buttons } = setup<Key>({ orderedKeys: ['a', 'b', 'c', 'd'] });
+      result.current.handleKeyDown(makeEvent({ key: 'End' }), 'b');
+      expect(onChange).toHaveBeenCalledWith('d');
+      expect(buttons.get('d')!.focus).toHaveBeenCalledOnce();
+    });
+
+    it('calls preventDefault', () => {
+      const { result } = setup<Key>({ orderedKeys: ['a', 'b'] });
+      const e = makeEvent({ key: 'End' });
+      result.current.handleKeyDown(e, 'a');
+      expect(e.preventDefault).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('ignored keys (no-op)', () => {
+    it.each(['ArrowUp', 'ArrowDown', 'a', 'Enter', ' ', 'Escape', 'Tab'])(
+      'does not call onChange or preventDefault for %s',
+      keyName => {
+        const { result, onChange } = setup<Key>({ orderedKeys: ['a', 'b', 'c'] });
+        const e = makeEvent({ key: keyName });
+        result.current.handleKeyDown(e, 'a');
+        expect(onChange).not.toHaveBeenCalled();
+        expect(e.preventDefault).not.toHaveBeenCalled();
+      }
+    );
+  });
+
+  describe('defensive: unknown currentKey', () => {
+    it('is a no-op when currentKey is not in orderedKeys', () => {
+      const { result, onChange } = setup<Key>({ orderedKeys: ['a', 'b'] });
+      const e = makeEvent({ key: 'ArrowRight' });
+      // 'd' is not in orderedKeys
+      result.current.handleKeyDown(e, 'd');
+      expect(onChange).not.toHaveBeenCalled();
+      expect(e.preventDefault).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('defensive: missing ref for next key', () => {
+    it('still calls onChange even if focus target is unmounted', () => {
+      // Edge case: tab key exists in orderedKeys but its button ref was never
+      // registered (e.g., conditionally rendered). onChange still fires; focus
+      // is silently skipped (`?.focus()` optional chain).
+      const { result, onChange } = setup<Key>({ orderedKeys: ['a', 'b', 'c'] });
+      result.current.tabRefs.current.delete('b');
+      const e = makeEvent({ key: 'ArrowRight' });
+      expect(() => result.current.handleKeyDown(e, 'a')).not.toThrow();
+      expect(onChange).toHaveBeenCalledWith('b');
+    });
+  });
+
+  describe('single-key array (degenerate case)', () => {
+    it('ArrowRight wraps onto self', () => {
+      const { result, onChange, buttons } = setup<Key>({ orderedKeys: ['a'] });
+      result.current.handleKeyDown(makeEvent({ key: 'ArrowRight' }), 'a');
+      expect(onChange).toHaveBeenCalledWith('a');
+      expect(buttons.get('a')!.focus).toHaveBeenCalledOnce();
+    });
+
+    it('ArrowLeft wraps onto self', () => {
+      const { result, onChange } = setup<Key>({ orderedKeys: ['a'] });
+      result.current.handleKeyDown(makeEvent({ key: 'ArrowLeft' }), 'a');
+      expect(onChange).toHaveBeenCalledWith('a');
+    });
+
+    it('Home/End → self', () => {
+      const { result, onChange } = setup<Key>({ orderedKeys: ['a'] });
+      result.current.handleKeyDown(makeEvent({ key: 'Home' }), 'a');
+      result.current.handleKeyDown(makeEvent({ key: 'End' }), 'a');
+      expect(onChange).toHaveBeenNthCalledWith(1, 'a');
+      expect(onChange).toHaveBeenNthCalledWith(2, 'a');
+    });
+  });
+
+  describe('orderedKeys reactivity', () => {
+    it('uses the latest orderedKeys after re-render', () => {
+      const onChange = vi.fn();
+      const { result, rerender } = renderHook(
+        ({ keys }: { keys: ReadonlyArray<Key> }) =>
+          useTablistKeyboardNav<Key>({ orderedKeys: keys, onChange }),
+        { initialProps: { keys: ['a', 'b'] as ReadonlyArray<Key> } }
+      );
+
+      // Initially 2 keys: ArrowRight from 'b' wraps to 'a'.
+      result.current.handleKeyDown(makeEvent({ key: 'ArrowRight' }), 'b');
+      expect(onChange).toHaveBeenLastCalledWith('a');
+
+      // Add a third key. ArrowRight from 'b' should now go to 'c', not wrap.
+      rerender({ keys: ['a', 'b', 'c'] as ReadonlyArray<Key> });
+      result.current.handleKeyDown(makeEvent({ key: 'ArrowRight' }), 'b');
+      expect(onChange).toHaveBeenLastCalledWith('c');
+    });
+  });
+
+  describe('generic key type', () => {
+    it('works with arbitrary string union', () => {
+      type CustomKey = 'overview' | 'details' | 'history';
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useTablistKeyboardNav<CustomKey>({
+          orderedKeys: ['overview', 'details', 'history'],
+          onChange,
+        })
+      );
+      result.current.handleKeyDown(makeEvent({ key: 'End' }), 'overview');
+      expect(onChange).toHaveBeenCalledWith('history');
+    });
+  });
+});

--- a/apps/web/src/hooks/useTablistKeyboardNav.ts
+++ b/apps/web/src/hooks/useTablistKeyboardNav.ts
@@ -1,0 +1,131 @@
+/**
+ * useTablistKeyboardNav — WAI-ARIA APG horizontal tablist keyboard contract.
+ *
+ * Wave A.6 Tier 1 (Issue #622). Extracted from inline implementations in:
+ *   - components/ui/v2/faq/category-tabs.tsx (Issue #588 hotfix, PR #620)
+ *   - components/ui/v2/shared-game-detail/tabs.tsx (Wave A.4)
+ *
+ * Provides a reusable hook so future tablist surfaces don't reinvent the
+ * keyboard contract. Closes the governance gap where 5 sites maintain near-
+ * identical inline switch handlers.
+ *
+ * Keyboard contract (WAI-ARIA APG horizontal tablist):
+ *   - ArrowLeft  → previous key (wraps first → last)
+ *   - ArrowRight → next key (wraps last → first)
+ *   - Home       → first key
+ *   - End        → last key
+ *   - Activation is automatic: focus = onChange same tick. Consumers that
+ *     need lazy-mount panel guards must manage that themselves; this hook
+ *     assumes statically-rendered panels (FAQ-style) or amortized cost.
+ *   - Other keys (ArrowUp/Down, character keys, Enter/Space/Escape/Tab) are
+ *     intentional no-ops — preventDefault is NOT called so default browser
+ *     behavior (e.g. Tab moves focus out of the tablist) is preserved.
+ *
+ * Defensive behavior:
+ *   - Unknown `currentKey` (not in `orderedKeys`) → no-op, no preventDefault
+ *   - Missing ref (key in orderedKeys but no button registered) → onChange
+ *     still fires; focus call is a silent no-op (matches existing behavior
+ *     in extracted sites where focusTab gracefully handles undefined).
+ *
+ * @example
+ * ```tsx
+ * type TabKey = 'all' | 'games' | 'ai';
+ * const ORDER: ReadonlyArray<TabKey> = ['all', 'games', 'ai'];
+ *
+ * const { tabRefs, handleKeyDown } = useTablistKeyboardNav<TabKey>({
+ *   orderedKeys: ORDER,
+ *   onChange: setActive,
+ * });
+ *
+ * return (
+ *   <div role="tablist">
+ *     {ORDER.map(key => (
+ *       <button
+ *         key={key}
+ *         ref={node => {
+ *           if (node) tabRefs.current.set(key, node);
+ *           else tabRefs.current.delete(key);
+ *         }}
+ *         role="tab"
+ *         tabIndex={key === active ? 0 : -1}
+ *         onKeyDown={e => handleKeyDown(e, key)}
+ *       >
+ *         {labels[key]}
+ *       </button>
+ *     ))}
+ *   </div>
+ * );
+ * ```
+ */
+
+'use client';
+
+import { useCallback, useRef, type KeyboardEvent, type MutableRefObject } from 'react';
+
+export interface UseTablistKeyboardNavArgs<T extends string> {
+  /**
+   * Ordered list of tab keys defining navigation order. ArrowLeft/Right wrap
+   * around the bounds of this array; Home/End jump to first/last.
+   */
+  readonly orderedKeys: ReadonlyArray<T>;
+  /**
+   * Activation callback fired synchronously with focus movement. Consumers
+   * should set state here; the hook assumes automatic activation per
+   * WAI-ARIA APG (focus = activation same tick).
+   */
+  readonly onChange: (key: T) => void;
+}
+
+export interface UseTablistKeyboardNavReturn<T extends string> {
+  /**
+   * Mutable Map ref keyed by tab key. Consumer must populate via React ref
+   * callback on each tab button. Hook reads this map to call .focus() on
+   * the new active tab after onChange.
+   */
+  readonly tabRefs: MutableRefObject<Map<T, HTMLButtonElement>>;
+  /**
+   * Stable keydown handler. Bind to each tab button as
+   * `onKeyDown={e => handleKeyDown(e, thisTabKey)}`.
+   */
+  readonly handleKeyDown: (e: KeyboardEvent<HTMLButtonElement>, currentKey: T) => void;
+}
+
+export function useTablistKeyboardNav<T extends string>({
+  orderedKeys,
+  onChange,
+}: UseTablistKeyboardNavArgs<T>): UseTablistKeyboardNavReturn<T> {
+  const tabRefs = useRef<Map<T, HTMLButtonElement>>(new Map());
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLButtonElement>, currentKey: T) => {
+      const idx = orderedKeys.indexOf(currentKey);
+      if (idx === -1) return;
+
+      let nextIdx: number | null = null;
+      switch (e.key) {
+        case 'ArrowLeft':
+          nextIdx = (idx - 1 + orderedKeys.length) % orderedKeys.length;
+          break;
+        case 'ArrowRight':
+          nextIdx = (idx + 1) % orderedKeys.length;
+          break;
+        case 'Home':
+          nextIdx = 0;
+          break;
+        case 'End':
+          nextIdx = orderedKeys.length - 1;
+          break;
+        default:
+          return;
+      }
+
+      e.preventDefault();
+      const nextKey = orderedKeys[nextIdx];
+      onChange(nextKey);
+      tabRefs.current.get(nextKey)?.focus();
+    },
+    [orderedKeys, onChange]
+  );
+
+  return { tabRefs, handleKeyDown };
+}


### PR DESCRIPTION
## Summary

Wave A.6 Tier 1 — extract WAI-ARIA APG horizontal tablist keyboard contract into reusable hook. Closes governance gap where Wave A.4 absorbed Issue #588 only in `shared-game-detail/tabs.tsx` (PR #620 added inline mirror in FAQ `category-tabs.tsx`); both call sites now share `useTablistKeyboardNav<T extends string>`.

- Hook: `apps/web/src/hooks/useTablistKeyboardNav.ts` — generic over key type, returns `{ tabRefs, handleKeyDown }`. Defensive on unknown currentKey + missing ref. preventDefault only on handled keys.
- Tests: 27/27 pure handler tests (synthetic events + manually-populated refs Map, no React tree).
- Migrated: `category-tabs.tsx` (16/16 pre-existing tests still pass), `shared-game-detail/tabs.tsx` (10/10 still pass).

Total: **53/53 pass** + typecheck clean + lint clean.

## Closes

Closes #622

## Refs

Refs #588 — original WAI-ARIA tablist Arrow-key contract.
Refs #579 — Wave A umbrella.

## Tier 1.5 deferred (semantic divergence — separate follow-up)

3 sites with inline keyboard handlers but divergent semantics:
- `chat-unified/RuleSourceCard.tsx` — 4-direction (ArrowUp==Left, ArrowDown==Right). Needs `orientation: 'both'` hook extension.
- `session/ToolRail.tsx` — same 4-direction pattern.
- `ui/data-display/card-deck/CardDeck.tsx` — ARIA carousel (region+roledescription, index-based, no-wrap, transform side-effects), not a canonical tablist.

These were originally counted as Tier 1 in Issue #622 scoping, but auditing the implementations revealed they don't share the horizontal-only WAI-ARIA APG contract this hook implements. Filing as Tier 1.5 / Tier 2 follow-up.

## Test plan

- [x] `pnpm test useTablistKeyboardNav --run` → 27/27 pass
- [x] `pnpm test category-tabs --run` → 16/16 pass (pre-existing tests, post-migration)
- [x] `pnpm test "v2/shared-game-detail/tabs" --run` → 10/10 pass (pre-existing, post-migration)
- [x] `pnpm typecheck` → clean
- [x] `pnpm lint` → clean
- [ ] CI: Migrated Routes Baseline (FAQ + shared-game-detail visual regressions unaffected — keyboard handler refactor preserves DOM/rendering)
- [ ] CI: Frontend Build & Test
- [ ] CI: E2E Critical Paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)