### PR TITLE
feat(shared-games): error contract + dedicated NotFound/Error states (#615)

### DIFF
--- a/apps/web/src/app/(public)/shared-games/[id]/error.tsx
+++ b/apps/web/src/app/(public)/shared-games/[id]/error.tsx
@@ -1,0 +1,62 @@
+/**
+ * /shared-games/[id] — route-level error boundary (Wave A.4 follow-up · Issue #615).
+ *
+ * Fires when `page.tsx`'s SSR fetch re-throws a non-404 failure (5xx, network,
+ * timeout, schema mismatch). The `loadInitialData` helper deliberately
+ * differentiates 404 (→ `notFound()` → `not-found.tsx`) from everything else
+ * (→ this boundary), so this surface is reserved for unexpected backend
+ * trouble — retry is the right primary action.
+ *
+ * Distinct from `page-client.tsx`'s post-mount error branch: that one covers
+ * background refetch failures after a successful first paint; this one covers
+ * the cold-start SSR case. The user-facing copy is the same on purpose.
+ *
+ * Client Component (mandatory for Next.js error boundaries — `reset` is a
+ * client-only callback).
+ */
+
+'use client';
+
+import { useEffect, type JSX } from 'react';
+
+import { ErrorState } from '@/components/ui/v2/shared-game-detail';
+import { logger } from '@/lib/logger';
+
+interface SharedGameDetailErrorProps {
+  readonly error: Error & { digest?: string };
+  readonly reset: () => void;
+}
+
+export default function SharedGameDetailError({
+  error,
+  reset,
+}: SharedGameDetailErrorProps): JSX.Element {
+  useEffect(() => {
+    logger.error('SharedGameDetail SSR error:', error);
+  }, [error]);
+
+  return (
+    <main
+      data-testid="shared-game-detail-page"
+      data-state="error"
+      className="min-h-screen bg-background"
+    >
+      <div className="mx-auto max-w-[1024px] px-4 py-8 sm:px-6 lg:px-8">
+        <ErrorState
+          labels={{
+            title: 'Errore di caricamento',
+            description:
+              'Non siamo riusciti a caricare il dettaglio del gioco. Riprova fra un momento.',
+            retryLabel: 'Riprova',
+          }}
+          onRetry={reset}
+        />
+        {process.env.NODE_ENV === 'development' && error.digest && (
+          <p className="mt-3 text-center font-mono text-xs text-[hsl(var(--text-muted))]">
+            Digest: {error.digest}
+          </p>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/(public)/shared-games/[id]/not-found.tsx
+++ b/apps/web/src/app/(public)/shared-games/[id]/not-found.tsx
@@ -1,0 +1,37 @@
+/**
+ * /shared-games/[id] — server-side 404 boundary (Wave A.4 follow-up · Issue #615).
+ *
+ * Fires when `page.tsx` calls `notFound()` after detecting a backend HTTP 404
+ * during SSR data fetch. Distinct from `page-client.tsx`'s post-mount
+ * `NotFoundState` branch (which fires when the user navigates to a stale id
+ * after the game was unpublished). Same component, same labels — Next.js
+ * routes the SSR case here automatically.
+ *
+ * Server Component: labels hardcoded in Italian (project is single-locale —
+ * mirror `apps/web/src/app/admin/(dashboard)/shared-games/not-found.tsx`).
+ */
+
+import type { JSX } from 'react';
+
+import { NotFoundState } from '@/components/ui/v2/shared-game-detail';
+
+export default function SharedGameDetailNotFound(): JSX.Element {
+  return (
+    <main
+      data-testid="shared-game-detail-page"
+      data-state="not-found"
+      className="min-h-screen bg-background"
+    >
+      <div className="mx-auto max-w-[1024px] px-4 py-8 sm:px-6 lg:px-8">
+        <NotFoundState
+          labels={{
+            title: 'Gioco non trovato',
+            description:
+              'Il gioco richiesto non esiste o non è più disponibile nel catalogo community.',
+            backLabel: 'Torna al catalogo',
+          }}
+        />
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/(public)/shared-games/[id]/page-client.tsx
+++ b/apps/web/src/app/(public)/shared-games/[id]/page-client.tsx
@@ -26,8 +26,10 @@ import {
   AgentListItem,
   ContributorsStrip,
   EmptyState,
+  ErrorState,
   Hero,
   KbDocItem,
+  NotFoundState,
   StickyCta,
   TAB_KEYS,
   Tabs,
@@ -52,14 +54,18 @@ function tabSerialize(value: TabKey): string | null {
 }
 
 /**
- * 5-state surface for visual-test escape hatch. Mirror Wave A.3b pattern.
+ * 6-state surface for visual-test escape hatch. Mirror Wave A.3b pattern.
  *  - default     → real data renders
  *  - loading     → mounted skeleton, suppress data
  *  - error       → ErrorState card, suppress data
- *  - not-found   → handled server-side via notFound(); kept for symmetry
+ *  - not-found   → NotFoundState card; visual-regression coverage of post-mount 404
  *  - empty-tab   → forces `toolkits=[], agents=[], kbs=[]` to exercise EmptyState
+ *
+ * Issue #615: `not-found` was previously handled exclusively server-side via
+ * `notFound()`. Wave A.4 follow-up adds the post-mount client surface so
+ * visual tests can exercise it without forcing an actual 404 round-trip.
  */
-type DetailStateOverride = 'default' | 'loading' | 'error' | 'empty-tab';
+type DetailStateOverride = 'default' | 'loading' | 'error' | 'not-found' | 'empty-tab';
 
 const IS_NON_PROD = process.env.NODE_ENV !== 'production';
 // Visual-regression CI sets this to '1' before `pnpm build` so the bootstrap
@@ -72,6 +78,7 @@ const VALID_STATE_OVERRIDES: ReadonlySet<DetailStateOverride> = new Set([
   'default',
   'loading',
   'error',
+  'not-found',
   'empty-tab',
 ]);
 
@@ -103,7 +110,10 @@ export function SharedGameDetailPageClient({
     deserialize: tabDeserialize,
   });
 
-  const { data, isError, isLoading } = useSharedGameDetail({ id, initialData: detail });
+  const { data, status, isFetching, refetch } = useSharedGameDetail({
+    id,
+    initialData: detail,
+  });
 
   // SSR seed guarantees `data` is defined on first paint, but TanStack Query
   // can briefly undefine it during refetch. Fall back to the SSR `detail` prop.
@@ -114,8 +124,13 @@ export function SharedGameDetailPageClient({
   const agents = stateOverride === 'empty-tab' ? [] : (game.agents ?? []);
   const kbs = stateOverride === 'empty-tab' ? [] : (game.kbs ?? []);
 
-  const showError = stateOverride === 'error' || isError;
-  const showLoading = stateOverride === 'loading' || (isLoading && !data);
+  // FSM status from the hook (Issue #615). `stateOverride` short-circuits for
+  // visual-regression coverage; otherwise the hook's derived `status` drives
+  // the surface choice.
+  const effectiveStatus = stateOverride ?? status;
+  const showLoading = effectiveStatus === 'loading';
+  const showError = effectiveStatus === 'error';
+  const showNotFound = effectiveStatus === 'not-found';
 
   // --- Resolve labels (single useMemo per surface to keep child components pure) ---
 
@@ -260,18 +275,37 @@ export function SharedGameDetailPageClient({
     );
   }
 
+  if (showNotFound) {
+    return (
+      <main data-testid="shared-game-detail-page" className="min-h-screen bg-background">
+        <div className="mx-auto max-w-[1024px] px-4 py-8 sm:px-6 lg:px-8">
+          <NotFoundState
+            labels={{
+              title: t('pages.sharedGameDetail.states.notFound.title'),
+              description: t('pages.sharedGameDetail.states.notFound.description'),
+              backLabel: t('pages.sharedGameDetail.states.notFound.backLabel'),
+            }}
+          />
+        </div>
+      </main>
+    );
+  }
+
   if (showError) {
     return (
       <main data-testid="shared-game-detail-page" className="min-h-screen bg-background">
         <div className="mx-auto max-w-[1024px] px-4 py-8 sm:px-6 lg:px-8">
-          <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-6 text-center">
-            <h1 className="font-display text-xl font-semibold text-foreground">
-              {t('pages.sharedGameDetail.states.error.title')}
-            </h1>
-            <p className="mt-2 text-sm text-[hsl(var(--text-muted))]">
-              {t('pages.sharedGameDetail.states.error.description')}
-            </p>
-          </div>
+          <ErrorState
+            labels={{
+              title: t('pages.sharedGameDetail.states.error.title'),
+              description: t('pages.sharedGameDetail.states.error.description'),
+              retryLabel: t('pages.sharedGameDetail.states.error.retryLabel'),
+            }}
+            onRetry={() => {
+              void refetch();
+            }}
+            isRetrying={isFetching}
+          />
         </div>
       </main>
     );

--- a/apps/web/src/app/(public)/shared-games/[id]/page.tsx
+++ b/apps/web/src/app/(public)/shared-games/[id]/page.tsx
@@ -20,6 +20,7 @@ import { notFound } from 'next/navigation';
 import {
   getSharedGameDetail,
   getTopContributors,
+  SharedGamesApiError,
   type SharedGameDetailV2,
   type TopContributor,
 } from '@/lib/api/shared-games';
@@ -59,21 +60,37 @@ async function loadInitialData(id: string): Promise<SsrInitialData> {
   let detail: SharedGameDetailV2 | null = null;
   let contributors: readonly TopContributor[] = [];
 
-  try {
-    const [detailResult, contributorsResult] = await Promise.allSettled([
-      getSharedGameDetail(id, { next: { revalidate: 60 } }),
-      getTopContributors(8, { next: { revalidate: 60 } }),
-    ]);
+  // SSR timeout cap: the public page must not hang the Next.js render
+  // when the backend is degraded. 2000ms aligns with the SLO p95 target
+  // (200ms) plus a 10x safety margin — beyond that we fail open with
+  // the visual fallback states. Issue #615.
+  const [detailResult, contributorsResult] = await Promise.allSettled([
+    getSharedGameDetail(id, { next: { revalidate: 60 }, timeoutMs: 2000 }),
+    getTopContributors(8, { next: { revalidate: 60 }, timeoutMs: 2000 }),
+  ]);
 
-    if (detailResult.status === 'fulfilled') {
-      detail = detailResult.value;
+  if (detailResult.status === 'fulfilled') {
+    detail = detailResult.value;
+  } else {
+    // Distinguish 404 (legitimate "no such game" → notFound()) from
+    // 5xx / network / timeout / parse failures (→ error.tsx). Re-throwing
+    // here lets Next.js bubble the error up to the nearest error boundary.
+    // Issue #615.
+    const reason = detailResult.reason;
+    const isHttp404 =
+      reason instanceof SharedGamesApiError && reason.kind === 'http' && reason.httpStatus === 404;
+    if (!isHttp404) {
+      throw reason instanceof Error
+        ? reason
+        : new Error('Unknown SSR failure loading shared game detail');
     }
-    if (contributorsResult.status === 'fulfilled') {
-      contributors = contributorsResult.value;
-    }
-  } catch {
-    // Defense in depth — Promise.allSettled doesn't reject. Fall through with defaults.
+    // 404: fall through with detail = null; page() calls notFound().
   }
+
+  if (contributorsResult.status === 'fulfilled') {
+    contributors = contributorsResult.value;
+  }
+  // Contributors failure is non-fatal — the carousel just renders empty.
 
   return { detail, contributors };
 }
@@ -87,7 +104,10 @@ export async function generateMetadata({ params }: SharedGameDetailPageProps): P
   let detail: SharedGameDetailV2 | null = fixture?.detail ?? null;
   if (!detail) {
     try {
-      detail = await getSharedGameDetail(id, { next: { revalidate: 60 } });
+      detail = await getSharedGameDetail(id, {
+        next: { revalidate: 60 },
+        timeoutMs: 2000,
+      });
     } catch {
       // Fall through: page will render notFound() if detail is null.
     }

--- a/apps/web/src/components/ui/v2/shared-game-detail/error-state.test.tsx
+++ b/apps/web/src/components/ui/v2/shared-game-detail/error-state.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Wave A.4 follow-up (Issue #615) — ErrorState rendering tests.
+ *
+ * Verifies the dedicated error surface contract:
+ *  - role="alert" + aria-live="assertive" for assertive announcement
+ *  - h2 title + description + retry button (NOT anchor — retry is action)
+ *  - onRetry invocation on click
+ *  - disabled + aria-busy when isRetrying=true; click is no-op
+ *  - data-slot for query stability
+ *  - Optional className passthrough
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ErrorState } from './error-state';
+
+const baseLabels = {
+  title: 'Errore di caricamento',
+  description: 'Si è verificato un problema. Riprova fra un momento.',
+  retryLabel: 'Riprova',
+};
+
+describe('ErrorState (Wave A.4 follow-up)', () => {
+  it('renders title and description text', () => {
+    render(<ErrorState labels={baseLabels} onRetry={vi.fn()} />);
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Errore di caricamento' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Si è verificato un problema. Riprova fra un momento.')
+    ).toBeInTheDocument();
+  });
+
+  it('exposes role="alert" with aria-live="assertive"', () => {
+    render(<ErrorState labels={baseLabels} onRetry={vi.fn()} />);
+    const root = screen.getByRole('alert');
+    expect(root).toBeInTheDocument();
+    expect(root).toHaveAttribute('aria-live', 'assertive');
+  });
+
+  it('renders retry CTA as button (not anchor — retry is an action)', () => {
+    render(<ErrorState labels={baseLabels} onRetry={vi.fn()} />);
+    const button = screen.getByRole('button', { name: 'Riprova' });
+    expect(button).toBeInTheDocument();
+    expect(button.tagName).toBe('BUTTON');
+  });
+
+  it('invokes onRetry when retry button is clicked', () => {
+    const onRetry = vi.fn();
+    render(<ErrorState labels={baseLabels} onRetry={onRetry} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Riprova' }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables retry button and sets aria-busy when isRetrying=true', () => {
+    render(<ErrorState labels={baseLabels} onRetry={vi.fn()} isRetrying={true} />);
+    const button = screen.getByRole('button', { name: 'Riprova' });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('does not invoke onRetry when click fires on disabled button', () => {
+    const onRetry = vi.fn();
+    render(<ErrorState labels={baseLabels} onRetry={onRetry} isRetrying={true} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Riprova' }));
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it('omits aria-busy when not retrying (defaults to undefined, not "false")', () => {
+    render(<ErrorState labels={baseLabels} onRetry={vi.fn()} />);
+    const button = screen.getByRole('button', { name: 'Riprova' });
+    expect(button).not.toHaveAttribute('aria-busy');
+    expect(button).not.toBeDisabled();
+  });
+
+  it('exposes data-slot attribute', () => {
+    const { container } = render(<ErrorState labels={baseLabels} onRetry={vi.fn()} />);
+    const root = container.querySelector('[data-slot="shared-game-detail-error-state"]');
+    expect(root).not.toBeNull();
+  });
+
+  it('passes through optional className', () => {
+    const { container } = render(
+      <ErrorState labels={baseLabels} onRetry={vi.fn()} className="my-custom-class" />
+    );
+    const root = container.querySelector('[data-slot="shared-game-detail-error-state"]');
+    expect(root?.className).toContain('my-custom-class');
+  });
+});

--- a/apps/web/src/components/ui/v2/shared-game-detail/error-state.tsx
+++ b/apps/web/src/components/ui/v2/shared-game-detail/error-state.tsx
@@ -1,0 +1,82 @@
+/**
+ * ErrorState — dedicated error surface for /shared-games/[id] V2.
+ *
+ * Issue #615 (Wave A.4 follow-up · P1). Rendered when the FSM hook
+ * (`useSharedGameDetail`) reports `status === 'error'`, which maps to
+ * any non-404 failure: 5xx, network, timeout, or schema mismatch.
+ * Intentionally generic — we do NOT leak the underlying `error.message`
+ * (it can contain the raw URL or backend stack frames). Diagnostic
+ * digest still flows to the route-level `error.tsx`, which the user
+ * can check there.
+ *
+ * Visual language matches `EmptyState` and `NotFoundState` so the whole
+ * detail page family shares one placeholder vocabulary. Renders a
+ * `Riprova` button instead of a static link — error state is most
+ * commonly transient, so retry is the primary action.
+ */
+
+import type { JSX } from 'react';
+
+import clsx from 'clsx';
+
+export interface ErrorStateLabels {
+  /** Heading; e.g. "Errore di caricamento". */
+  readonly title: string;
+  /** Body copy with general guidance ("Riprova fra un momento"). */
+  readonly description: string;
+  /** Retry CTA label; e.g. "Riprova". */
+  readonly retryLabel: string;
+}
+
+export interface ErrorStateProps {
+  readonly labels: ErrorStateLabels;
+  /**
+   * Invoked when the user clicks the retry button. Typically wired to
+   * `useSharedGameDetail().refetch` (post-mount errors) or to Next.js's
+   * `reset()` callback (route-level `error.tsx`).
+   */
+  readonly onRetry: () => void;
+  /**
+   * Disables the retry button — useful while a refetch is already in
+   * flight to prevent duplicate requests.
+   */
+  readonly isRetrying?: boolean;
+  readonly className?: string;
+}
+
+export function ErrorState({
+  labels,
+  onRetry,
+  isRetrying = false,
+  className,
+}: ErrorStateProps): JSX.Element {
+  return (
+    <div
+      data-slot="shared-game-detail-error-state"
+      role="alert"
+      aria-live="assertive"
+      className={clsx(
+        'flex flex-col items-center justify-center gap-3 rounded-lg border border-destructive/40 bg-destructive/5 px-6 py-10 text-center',
+        className
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className="flex h-16 w-16 items-center justify-center rounded-full bg-destructive/10 text-[28px]"
+      >
+        ⚠️
+      </span>
+      <h2 className="m-0 font-display text-base font-semibold text-foreground">{labels.title}</h2>
+      <p className="m-0 max-w-md text-sm text-[hsl(var(--text-muted))]">{labels.description}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        disabled={isRetrying}
+        aria-busy={isRetrying || undefined}
+        className="mt-2 inline-flex items-center justify-center rounded-md border border-border bg-background px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {labels.retryLabel}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/v2/shared-game-detail/index.ts
+++ b/apps/web/src/components/ui/v2/shared-game-detail/index.ts
@@ -18,11 +18,17 @@ export type {
 export { EmptyState } from './empty-state';
 export type { EmptyStateKind, EmptyStateLabels, EmptyStateProps } from './empty-state';
 
+export { ErrorState } from './error-state';
+export type { ErrorStateLabels, ErrorStateProps } from './error-state';
+
 export { Hero } from './hero';
 export type { HeroLabels, HeroProps } from './hero';
 
 export { KbDocItem } from './kb-doc-item';
 export type { KbDocItemLabels, KbDocItemProps, KbDocKind } from './kb-doc-item';
+
+export { NotFoundState } from './not-found-state';
+export type { NotFoundStateLabels, NotFoundStateProps } from './not-found-state';
 
 export { StickyCta } from './sticky-cta';
 export type { StickyCtaLabels, StickyCtaProps } from './sticky-cta';

--- a/apps/web/src/components/ui/v2/shared-game-detail/not-found-state.test.tsx
+++ b/apps/web/src/components/ui/v2/shared-game-detail/not-found-state.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * Wave A.4 follow-up (Issue #615) — NotFoundState rendering tests.
+ *
+ * Verifies the dedicated 404 surface contract:
+ *  - role="status" for assistive tech (non-error, informational)
+ *  - h2 title + description + anchor CTA
+ *  - data-slot for query stability
+ *  - Default backHref='/shared-games' + override
+ *  - Optional className passthrough
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { NotFoundState } from './not-found-state';
+
+const baseLabels = {
+  title: 'Gioco non trovato',
+  description: 'Il gioco potrebbe essere stato rimosso o non è più disponibile.',
+  backLabel: 'Torna al catalogo',
+};
+
+describe('NotFoundState (Wave A.4 follow-up)', () => {
+  it('renders title and description text', () => {
+    render(<NotFoundState labels={baseLabels} />);
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Gioco non trovato' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Il gioco potrebbe essere stato rimosso o non è più disponibile.')
+    ).toBeInTheDocument();
+  });
+
+  it('exposes role="status" for non-disruptive assistive announcement', () => {
+    render(<NotFoundState labels={baseLabels} />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('renders back CTA as anchor with default href=/shared-games', () => {
+    render(<NotFoundState labels={baseLabels} />);
+    const link = screen.getByRole('link', { name: 'Torna al catalogo' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/shared-games');
+  });
+
+  it('honors backHref override', () => {
+    render(<NotFoundState labels={baseLabels} backHref="/custom/path" />);
+    const link = screen.getByRole('link', { name: 'Torna al catalogo' });
+    expect(link).toHaveAttribute('href', '/custom/path');
+  });
+
+  it('exposes data-slot attribute', () => {
+    const { container } = render(<NotFoundState labels={baseLabels} />);
+    const root = container.querySelector('[data-slot="shared-game-detail-not-found-state"]');
+    expect(root).not.toBeNull();
+  });
+
+  it('passes through optional className', () => {
+    const { container } = render(<NotFoundState labels={baseLabels} className="my-custom-class" />);
+    const root = container.querySelector('[data-slot="shared-game-detail-not-found-state"]');
+    expect(root?.className).toContain('my-custom-class');
+  });
+});

--- a/apps/web/src/components/ui/v2/shared-game-detail/not-found-state.tsx
+++ b/apps/web/src/components/ui/v2/shared-game-detail/not-found-state.tsx
@@ -1,0 +1,68 @@
+/**
+ * NotFoundState — dedicated 404 surface for /shared-games/[id] V2.
+ *
+ * Issue #615 (Wave A.4 follow-up · P1). Rendered when the FSM hook
+ * (`useSharedGameDetail`) reports `status === 'not-found'`, which maps
+ * 1:1 to a backend HTTP 404. Distinct from the generic `not-found.tsx`
+ * route file: that one fires when SSR detects 404 before the client
+ * mounts; this component covers the post-mount case (e.g. user navigated
+ * to a stale id after the game was unpublished).
+ *
+ * Mirrors the visual language of `EmptyState` (dashed-border card, 64px
+ * icon circle, centered text) so the whole detail page family has one
+ * coherent placeholder vocabulary.
+ */
+
+import type { JSX } from 'react';
+
+import clsx from 'clsx';
+
+export interface NotFoundStateLabels {
+  /** Heading; e.g. "Gioco non trovato". */
+  readonly title: string;
+  /** Body copy explaining the cause and any next step. */
+  readonly description: string;
+  /** CTA label; e.g. "Torna al catalogo". */
+  readonly backLabel: string;
+}
+
+export interface NotFoundStateProps {
+  readonly labels: NotFoundStateLabels;
+  /**
+   * Where the back-CTA links to. Defaults to the public catalog index.
+   */
+  readonly backHref?: string;
+  readonly className?: string;
+}
+
+export function NotFoundState({
+  labels,
+  backHref = '/shared-games',
+  className,
+}: NotFoundStateProps): JSX.Element {
+  return (
+    <div
+      data-slot="shared-game-detail-not-found-state"
+      role="status"
+      className={clsx(
+        'flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-border bg-muted/30 px-6 py-10 text-center',
+        className
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className="flex h-16 w-16 items-center justify-center rounded-full bg-muted text-[28px]"
+      >
+        🔍
+      </span>
+      <h2 className="m-0 font-display text-base font-semibold text-foreground">{labels.title}</h2>
+      <p className="m-0 max-w-md text-sm text-[hsl(var(--text-muted))]">{labels.description}</p>
+      <a
+        href={backHref}
+        className="mt-2 inline-flex items-center justify-center rounded-md border border-border bg-background px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {labels.backLabel}
+      </a>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/useSharedGameDetail.test.tsx
+++ b/apps/web/src/hooks/useSharedGameDetail.test.tsx
@@ -27,7 +27,7 @@ vi.mock('@/lib/api/shared-games', async orig => {
   };
 });
 
-import { getSharedGameDetail } from '@/lib/api/shared-games';
+import { getSharedGameDetail, SharedGamesApiError } from '@/lib/api/shared-games';
 import { useSharedGameDetail } from './useSharedGameDetail';
 
 const mockGet = getSharedGameDetail as ReturnType<typeof vi.fn>;
@@ -130,5 +130,105 @@ describe('useSharedGameDetail (Wave A.4)', () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(result.current.error).toBe(err);
     expect(result.current.data).toBeUndefined();
+  });
+
+  // --- Issue #615 — FSM status derivation ---
+
+  describe('FSM status (Issue #615)', () => {
+    it('derives status="default" when data has nested entities', () => {
+      const populated: SharedGameDetailV2 = {
+        ...SAMPLE_DETAIL,
+        toolkitsCount: 2,
+        agentsCount: 0,
+        kbsCount: 1,
+      };
+      const { result } = renderHook(
+        () => useSharedGameDetail({ id: SAMPLE_ID, initialData: populated }),
+        { wrapper: createWrapper() }
+      );
+      expect(result.current.status).toBe('default');
+    });
+
+    it('derives status="empty" when all nested counts are zero', () => {
+      // SAMPLE_DETAIL has toolkitsCount=0, agentsCount=0, kbsCount=0
+      const { result } = renderHook(
+        () => useSharedGameDetail({ id: SAMPLE_ID, initialData: SAMPLE_DETAIL }),
+        { wrapper: createWrapper() }
+      );
+      expect(result.current.status).toBe('empty');
+    });
+
+    it('derives status="not-found" on SharedGamesApiError with httpStatus=404', async () => {
+      const err = new SharedGamesApiError('Not found', 'http', { httpStatus: 404 });
+      mockGet.mockRejectedValue(err);
+      const { result } = renderHook(() => useSharedGameDetail({ id: SAMPLE_ID }), {
+        wrapper: createWrapper(),
+      });
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.status).toBe('not-found');
+    });
+
+    it('derives status="error" on non-404 SharedGamesApiError (e.g. 5xx)', async () => {
+      const err = new SharedGamesApiError('Server error', 'http', { httpStatus: 500 });
+      mockGet.mockRejectedValue(err);
+      const { result } = renderHook(() => useSharedGameDetail({ id: SAMPLE_ID }), {
+        wrapper: createWrapper(),
+      });
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.status).toBe('error');
+    });
+
+    it('derives status="error" on timeout / network failure', async () => {
+      const err = new SharedGamesApiError('Timeout', 'timeout');
+      mockGet.mockRejectedValue(err);
+      const { result } = renderHook(() => useSharedGameDetail({ id: SAMPLE_ID }), {
+        wrapper: createWrapper(),
+      });
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.status).toBe('error');
+    });
+
+    it('derives status="error" on non-typed Error (defensive default)', async () => {
+      mockGet.mockRejectedValue(new Error('boom'));
+      const { result } = renderHook(() => useSharedGameDetail({ id: SAMPLE_ID }), {
+        wrapper: createWrapper(),
+      });
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.status).toBe('error');
+    });
+
+    it('derives status="loading" when no data + no error + first fetch in flight', async () => {
+      // Slow promise so loading state is observable
+      let resolveFn: (v: SharedGameDetailV2) => void = () => {};
+      mockGet.mockReturnValue(
+        new Promise<SharedGameDetailV2>(resolve => {
+          resolveFn = resolve;
+        })
+      );
+      const { result } = renderHook(() => useSharedGameDetail({ id: SAMPLE_ID }), {
+        wrapper: createWrapper(),
+      });
+      expect(result.current.status).toBe('loading');
+      // Cleanup so the promise doesn't leak
+      resolveFn(SAMPLE_DETAIL);
+      await waitFor(() => expect(result.current.data).toBeDefined());
+    });
+
+    it('keeps status="error" priority over stale data during refetch failure', async () => {
+      // First call resolves; second call rejects with 5xx — the FSM contract says
+      // an error during refetch over stale data must surface "error", not "default".
+      mockGet
+        .mockResolvedValueOnce(SAMPLE_DETAIL)
+        .mockRejectedValueOnce(new SharedGamesApiError('Boom', 'http', { httpStatus: 500 }));
+      const { result } = renderHook(() => useSharedGameDetail({ id: SAMPLE_ID }), {
+        wrapper: createWrapper(),
+      });
+      await waitFor(() => expect(result.current.data).toBeDefined());
+      expect(result.current.status).toBe('empty'); // SAMPLE_DETAIL has zero counts
+
+      await result.current.refetch();
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.status).toBe('error');
+    });
   });
 });

--- a/apps/web/src/hooks/useSharedGameDetail.ts
+++ b/apps/web/src/hooks/useSharedGameDetail.ts
@@ -12,15 +12,37 @@
  *    refetch on mount when SSR succeeded.
  *  - `enabled: id.length > 0` defends against router transitions where `id`
  *    is briefly empty.
+ *
+ * Issue #615 — FSM status: the hook collapses TanStack Query's flag soup
+ * (`isLoading | isFetching | isError | data`) plus the typed error contract
+ * from `SharedGamesApiError` into a single `status` value the UI can switch
+ * on. The five terminal states model what the page can actually render —
+ * `'empty'` is derived from data shape, `'not-found'` requires an HTTP 404.
  */
 
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
 
-import { getSharedGameDetail, type SharedGameDetailV2 } from '@/lib/api/shared-games';
+import {
+  SharedGamesApiError,
+  getSharedGameDetail,
+  type SharedGameDetailV2,
+} from '@/lib/api/shared-games';
 
 const STALE_MS = 60_000;
+
+/**
+ * Finite-state machine for the detail page surface. Mutually exclusive —
+ * exactly one applies at any time.
+ *
+ *  - `loading`   — first fetch in flight, no SSR seed.
+ *  - `default`   — data present and at least one of toolkits/agents/kbs is non-empty.
+ *  - `empty`     — data present but `toolkitsCount === 0 && agentsCount === 0 && kbsCount === 0`.
+ *  - `not-found` — backend returned HTTP 404 (game does not exist or is unpublished).
+ *  - `error`     — any other failure: 5xx, network, timeout, schema mismatch.
+ */
+export type SharedGameDetailFsmStatus = 'loading' | 'default' | 'empty' | 'not-found' | 'error';
 
 export interface UseSharedGameDetailArgs {
   readonly id: string;
@@ -30,11 +52,50 @@ export interface UseSharedGameDetailArgs {
 
 export interface UseSharedGameDetailResult {
   readonly data: SharedGameDetailV2 | undefined;
+  readonly status: SharedGameDetailFsmStatus;
   readonly isLoading: boolean;
   readonly isFetching: boolean;
   readonly isError: boolean;
   readonly error: Error | null;
   readonly refetch: () => Promise<void>;
+}
+
+/**
+ * Decide whether a successful detail payload is "empty" — no toolkits,
+ * no agents, no KBs. Matches the spec's `'empty'` UI state, distinct from
+ * `'not-found'`: the game exists, but nobody has shared anything yet.
+ */
+function isDetailEmpty(detail: SharedGameDetailV2): boolean {
+  return detail.toolkitsCount === 0 && detail.agentsCount === 0 && detail.kbsCount === 0;
+}
+
+/**
+ * Map TanStack Query's status surface + our typed error contract to the
+ * five-state FSM. Order matters: error first (so an error during a refetch
+ * over stale data still surfaces), then data-present branches, then
+ * loading.
+ */
+function deriveFsmStatus(
+  data: SharedGameDetailV2 | undefined,
+  error: Error | null,
+  isLoading: boolean
+): SharedGameDetailFsmStatus {
+  if (error) {
+    if (error instanceof SharedGamesApiError && error.kind === 'http' && error.httpStatus === 404) {
+      return 'not-found';
+    }
+    return 'error';
+  }
+  if (data) {
+    return isDetailEmpty(data) ? 'empty' : 'default';
+  }
+  if (isLoading) {
+    return 'loading';
+  }
+  // Disabled query (id === '') or unfetched — treat as loading from the
+  // UI's perspective; pages that legitimately render with no id won't
+  // mount this hook.
+  return 'loading';
 }
 
 export function useSharedGameDetail(args: UseSharedGameDetailArgs): UseSharedGameDetailResult {
@@ -48,12 +109,15 @@ export function useSharedGameDetail(args: UseSharedGameDetailArgs): UseSharedGam
     enabled: args.id.length > 0,
   });
 
+  const status = deriveFsmStatus(result.data, result.error, result.isLoading);
+
   const refetch = async (): Promise<void> => {
     await result.refetch();
   };
 
   return {
     data: result.data,
+    status,
     isLoading: result.isLoading,
     isFetching: result.isFetching,
     isError: result.isError,

--- a/apps/web/src/lib/api/shared-games.ts
+++ b/apps/web/src/lib/api/shared-games.ts
@@ -197,7 +197,46 @@ export interface SearchSharedGamesArgs {
   readonly pageSize?: number;
 }
 
+// ========== Errors ==========
+
+/**
+ * Typed error for SharedGames v2 API failures. Carries enough context for the
+ * `useSharedGameDetail` FSM to map an exception to a UI status:
+ *   - `kind='http'` + `httpStatus===404` → `'not-found'`
+ *   - `kind='http'` + 5xx                → `'error'`
+ *   - `kind='network' | 'timeout'`       → `'error'`
+ *   - `kind='parse'`                     → `'error'` (server returned malformed payload)
+ *
+ * Issue #615.
+ */
+export class SharedGamesApiError extends Error {
+  readonly kind: 'http' | 'network' | 'timeout' | 'parse';
+  readonly httpStatus?: number;
+
+  constructor(
+    message: string,
+    kind: SharedGamesApiError['kind'],
+    options?: ErrorOptions & { httpStatus?: number }
+  ) {
+    super(message, options);
+    this.name = 'SharedGamesApiError';
+    this.kind = kind;
+    this.httpStatus = options?.httpStatus;
+  }
+}
+
 // ========== Fetch helpers ==========
+
+/**
+ * Extended init type for SharedGames v2 fetches. `timeoutMs` triggers an
+ * AbortController abort after the specified delay — used by the SSR path
+ * (page.tsx sets `timeoutMs: 2000`) to keep the public detail page from
+ * hanging the Next.js render. Client-side callers omit it; abort is owned
+ * by TanStack Query via `useSharedGameDetail`.
+ *
+ * Issue #615.
+ */
+export type SharedGamesRequestInit = RequestInit & { timeoutMs?: number };
 
 function buildSearchUrl(args: SearchSharedGamesArgs): string {
   const params = new URLSearchParams();
@@ -217,7 +256,25 @@ function buildSearchUrl(args: SearchSharedGamesArgs): string {
   return `${getApiBase()}/api/v1/shared-games?${params.toString()}`;
 }
 
-async function getJson<T>(url: string, schema: z.ZodType<T>, init?: RequestInit): Promise<T> {
+async function getJson<T>(
+  url: string,
+  schema: z.ZodType<T>,
+  init?: SharedGamesRequestInit
+): Promise<T> {
+  // Timeout wiring: SSR callers pass `timeoutMs` so a slow backend can't
+  // block the public detail page render. Client callers omit it; the
+  // hook owns cancellation via TanStack Query's per-query AbortController.
+  // If the caller already passed an `init.signal`, we honour it as-is and
+  // skip our own controller — composing two signals would require
+  // AbortSignal.any (Node 20+/widely-shipped browsers) and isn't needed
+  // for current call sites.
+  const useOurController = init?.timeoutMs !== undefined && !init?.signal;
+  const controller = useOurController ? new AbortController() : null;
+  const timeoutId =
+    controller && init?.timeoutMs !== undefined
+      ? setTimeout(() => controller.abort(), init.timeoutMs)
+      : null;
+
   let response: Response;
   try {
     response = await fetch(url, {
@@ -225,22 +282,58 @@ async function getJson<T>(url: string, schema: z.ZodType<T>, init?: RequestInit)
       credentials: 'include',
       headers: { Accept: 'application/json' },
       ...init,
+      signal: controller?.signal ?? init?.signal,
     });
   } catch (cause) {
-    throw new Error(`Request to ${url} failed before reaching the server`, { cause });
+    // AbortError: distinguish caller-cancelled vs our-timeout-fired.
+    const isAbort =
+      cause instanceof Error && (cause.name === 'AbortError' || cause.name === 'TimeoutError');
+    if (isAbort && controller?.signal.aborted) {
+      throw new SharedGamesApiError(
+        `Request to ${url} timed out after ${init?.timeoutMs}ms`,
+        'timeout',
+        { cause }
+      );
+    }
+    if (isAbort) {
+      // Caller-owned abort — re-throw the original so consumers can detect
+      // cancellation via `cause.name === 'AbortError'` if they care.
+      throw cause;
+    }
+    throw new SharedGamesApiError(
+      `Request to ${url} failed before reaching the server`,
+      'network',
+      { cause }
+    );
+  } finally {
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+    }
   }
+
   if (!response.ok) {
-    throw new Error(`Request to ${url} failed with status ${response.status}`);
+    throw new SharedGamesApiError(
+      `Request to ${url} failed with status ${response.status}`,
+      'http',
+      { httpStatus: response.status }
+    );
   }
+
   const body = (await response.json()) as unknown;
-  return schema.parse(body);
+  try {
+    return schema.parse(body);
+  } catch (cause) {
+    throw new SharedGamesApiError(`Response from ${url} did not match expected schema`, 'parse', {
+      cause,
+    });
+  }
 }
 
 // ========== Public functions ==========
 
 export async function searchSharedGames(
   args: SearchSharedGamesArgs,
-  init?: RequestInit
+  init?: SharedGamesRequestInit
 ): Promise<PagedSharedGamesV2> {
   const url = buildSearchUrl(args);
   return getJson(url, PagedSharedGamesV2Schema, init);
@@ -248,14 +341,16 @@ export async function searchSharedGames(
 
 export async function getTopContributors(
   limit = 5,
-  init?: RequestInit
+  init?: SharedGamesRequestInit
 ): Promise<readonly TopContributor[]> {
   const bounded = Math.min(20, Math.max(1, Math.trunc(limit)));
   const url = `${getApiBase()}/api/v1/shared-games/top-contributors?limit=${bounded}`;
   return getJson(url, z.array(TopContributorSchema), init);
 }
 
-export async function getCategories(init?: RequestInit): Promise<readonly GameCategoryV2[]> {
+export async function getCategories(
+  init?: SharedGamesRequestInit
+): Promise<readonly GameCategoryV2[]> {
   const url = `${getApiBase()}/api/v1/shared-games/categories`;
   return getJson(url, z.array(GameCategoryV2Schema), init);
 }
@@ -272,7 +367,7 @@ export async function getCategories(init?: RequestInit): Promise<readonly GameCa
  */
 export async function getSharedGameDetail(
   id: string,
-  init?: RequestInit
+  init?: SharedGamesRequestInit
 ): Promise<SharedGameDetailV2> {
   const url = `${getApiBase()}/api/v1/shared-games/${encodeURIComponent(id)}`;
   return getJson(url, SharedGameDetailV2Schema, init);


### PR DESCRIPTION
## Summary

Wave A.4 follow-up · **Issue #615** (P1) — frontend error contract hardening for `/shared-games/[id]`.

- **AbortController + timeoutMs**: `getJson` now wires `AbortSignal` with optional `timeoutMs`. SSR call sites set `timeoutMs=2000` to avoid hanging Next.js renders. Client-side default = no timeout (TanStack Query owns abort).
- **Typed errors**: `SharedGamesApiError` discriminated by `kind` (`timeout` \| `network` \| `http` \| `schema`) with optional `httpStatus`. Rejects identify cause without string-matching.
- **FSM status**: `useSharedGameDetail` derives a 5-state status union (`loading` \| `default` \| `empty` \| `not-found` \| `error`). 404 detected via `SharedGamesApiError({kind:'http', httpStatus:404})`. Error wins over stale data on refetch failure.
- **Dedicated states**: `NotFoundState` (role=status, anchor CTA) and `ErrorState` (role=alert, aria-live=assertive, button CTA + aria-busy). Inline error block in `page-client.tsx` replaced + connected to FSM.
- **Route boundaries**: `not-found.tsx` (Server Component) and `error.tsx` (Client Component for `reset` callback) wired to Next.js 16 App Router conventions; SSR 404 → `notFound()` → `not-found.tsx`, SSR 5xx → `error.tsx`.

## Test plan

- [x] `apps/web` `pnpm typecheck` clean
- [x] `error-state.test.tsx` — 9 cases (role/aria/button/onRetry/disabled/aria-busy/data-slot/className)
- [x] `not-found-state.test.tsx` — 6 cases (role/anchor/backHref override/data-slot/className)
- [x] `useSharedGameDetail.test.tsx` FSM block — 8 cases (loading observability, error priority over stale data, all 5 states + 404 vs 5xx vs timeout vs plain Error)
- [x] All 116+ targeted tests pass
- [x] No regressions in existing 88 v2 component tests

## Closes

Closes #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)