### PR TITLE
feat(web): tablist hook orientation extension + ToolRail migration (Tier 1.5)

### DIFF
--- a/apps/web/src/components/session/ToolRail.tsx
+++ b/apps/web/src/components/session/ToolRail.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import {
   Camera,
@@ -12,6 +12,7 @@ import {
   RotateCcw,
 } from 'lucide-react';
 
+import { useTablistKeyboardNav } from '@/hooks/useTablistKeyboardNav';
 import { cn } from '@/lib/utils';
 
 export interface ToolItem {
@@ -155,19 +156,18 @@ export function ToolRail({
   const baseTools = tools.filter(t => t.type === 'base');
   const customTools = tools.filter(t => t.type === 'custom');
 
-  // Keyboard navigation: cycle through all tools using activeTool as anchor
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
-    const currentIndex = tools.findIndex(t => t.id === activeTool);
-    if (currentIndex === -1) return;
-
-    if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
-      e.preventDefault();
-      onToolChange(tools[(currentIndex + 1) % tools.length].id);
-    } else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
-      e.preventDefault();
-      onToolChange(tools[(currentIndex - 1 + tools.length) % tools.length].id);
-    }
-  };
+  // Wave A.6 Tier 1.5 (Issue #625): unified keyboard navigation across all
+  // tools using the shared tablist hook. `orientation: 'both'` mirrors the
+  // legacy contract where ArrowUp≡ArrowLeft and ArrowDown≡ArrowRight, so
+  // either axis advances regardless of which sub-tablist (vertical desktop
+  // rail / horizontal mobile bar / custom-tools section) currently has focus.
+  // Bonus a11y: Home/End now jump to first/last (not in original handler).
+  const orderedToolIds = useMemo(() => tools.map(t => t.id), [tools]);
+  const { handleKeyDown } = useTablistKeyboardNav<string>({
+    orderedKeys: orderedToolIds,
+    onChange: onToolChange,
+    orientation: 'both',
+  });
 
   return (
     <>
@@ -209,7 +209,7 @@ export function ToolRail({
           aria-label="Strumenti base"
           aria-orientation="vertical"
           className="flex flex-col gap-1 px-1"
-          onKeyDown={handleKeyDown}
+          onKeyDown={e => handleKeyDown(e, activeTool)}
         >
           {baseTools.map(tool => (
             <ToolButton
@@ -240,7 +240,7 @@ export function ToolRail({
               aria-label="Strumenti custom"
               aria-orientation="vertical"
               className="flex flex-col gap-1 px-1"
-              onKeyDown={handleKeyDown}
+              onKeyDown={e => handleKeyDown(e, activeTool)}
             >
               {customTools.map(tool => (
                 <ToolButton
@@ -270,7 +270,7 @@ export function ToolRail({
           aria-label="Strumenti sessione"
           aria-orientation="horizontal"
           className="flex items-center justify-around px-2 py-1.5 overflow-x-auto"
-          onKeyDown={handleKeyDown}
+          onKeyDown={e => handleKeyDown(e, activeTool)}
         >
           {tools.slice(0, 5).map(tool => (
             <button

--- a/apps/web/src/hooks/__tests__/useTablistKeyboardNav.test.ts
+++ b/apps/web/src/hooks/__tests__/useTablistKeyboardNav.test.ts
@@ -269,4 +269,195 @@ describe('useTablistKeyboardNav (Wave A.6 Tier 1)', () => {
       expect(onChange).toHaveBeenCalledWith('history');
     });
   });
+
+  // ═════════════════════════════════════════════════════════════════════════
+  // Wave A.6 Tier 1.5 (Issue #625) — orientation extension
+  // ═════════════════════════════════════════════════════════════════════════
+
+  describe('orientation: default (backward-compat)', () => {
+    it('treats omitted orientation as horizontal — ArrowUp ignored', () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useTablistKeyboardNav<Key>({ orderedKeys: ['a', 'b', 'c'], onChange })
+      );
+      const e = makeEvent({ key: 'ArrowUp' });
+      result.current.handleKeyDown(e, 'b');
+      expect(onChange).not.toHaveBeenCalled();
+      expect(e.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('treats omitted orientation as horizontal — ArrowDown ignored', () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useTablistKeyboardNav<Key>({ orderedKeys: ['a', 'b', 'c'], onChange })
+      );
+      const e = makeEvent({ key: 'ArrowDown' });
+      result.current.handleKeyDown(e, 'b');
+      expect(onChange).not.toHaveBeenCalled();
+      expect(e.preventDefault).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("orientation: 'vertical'", () => {
+    function setupVertical<T extends string>({
+      orderedKeys,
+    }: {
+      readonly orderedKeys: ReadonlyArray<T>;
+    }) {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useTablistKeyboardNav<T>({ orderedKeys, onChange, orientation: 'vertical' })
+      );
+      const buttons = new Map<
+        T,
+        HTMLButtonElement & { readonly focus: ReturnType<typeof vi.fn> }
+      >();
+      for (const key of orderedKeys) {
+        const btn = makeButtonStub();
+        buttons.set(key, btn);
+        result.current.tabRefs.current.set(key, btn);
+      }
+      return { result, onChange, buttons };
+    }
+
+    it('ArrowDown advances to next key', () => {
+      const { result, onChange, buttons } = setupVertical<Key>({ orderedKeys: ['a', 'b', 'c'] });
+      result.current.handleKeyDown(makeEvent({ key: 'ArrowDown' }), 'a');
+      expect(onChange).toHaveBeenCalledWith('b');
+      expect(buttons.get('b')!.focus).toHaveBeenCalledOnce();
+    });
+
+    it('ArrowDown wraps last → first', () => {
+      const { result, onChange, buttons } = setupVertical<Key>({ orderedKeys: ['a', 'b', 'c'] });
+      result.current.handleKeyDown(makeEvent({ key: 'ArrowDown' }), 'c');
+      expect(onChange).toHaveBeenCalledWith('a');
+      expect(buttons.get('a')!.focus).toHaveBeenCalledOnce();
+    });
+
+    it('ArrowUp retreats to previous key', () => {
+      const { result, onChange, buttons } = setupVertical<Key>({ orderedKeys: ['a', 'b', 'c'] });
+      result.current.handleKeyDown(makeEvent({ key: 'ArrowUp' }), 'b');
+      expect(onChange).toHaveBeenCalledWith('a');
+      expect(buttons.get('a')!.focus).toHaveBeenCalledOnce();
+    });
+
+    it('ArrowUp wraps first → last', () => {
+      const { result, onChange, buttons } = setupVertical<Key>({ orderedKeys: ['a', 'b', 'c'] });
+      result.current.handleKeyDown(makeEvent({ key: 'ArrowUp' }), 'a');
+      expect(onChange).toHaveBeenCalledWith('c');
+      expect(buttons.get('c')!.focus).toHaveBeenCalledOnce();
+    });
+
+    it('calls preventDefault on ArrowDown/ArrowUp to suppress page scroll', () => {
+      const { result } = setupVertical<Key>({ orderedKeys: ['a', 'b'] });
+      const eDown = makeEvent({ key: 'ArrowDown' });
+      const eUp = makeEvent({ key: 'ArrowUp' });
+      result.current.handleKeyDown(eDown, 'a');
+      result.current.handleKeyDown(eUp, 'b');
+      expect(eDown.preventDefault).toHaveBeenCalledOnce();
+      expect(eUp.preventDefault).toHaveBeenCalledOnce();
+    });
+
+    it('ignores ArrowLeft/ArrowRight (horizontal-only keys)', () => {
+      const { result, onChange } = setupVertical<Key>({ orderedKeys: ['a', 'b', 'c'] });
+      const eLeft = makeEvent({ key: 'ArrowLeft' });
+      const eRight = makeEvent({ key: 'ArrowRight' });
+      result.current.handleKeyDown(eLeft, 'b');
+      result.current.handleKeyDown(eRight, 'b');
+      expect(onChange).not.toHaveBeenCalled();
+      expect(eLeft.preventDefault).not.toHaveBeenCalled();
+      expect(eRight.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('Home/End still work in vertical orientation', () => {
+      const { result, onChange } = setupVertical<Key>({ orderedKeys: ['a', 'b', 'c', 'd'] });
+      result.current.handleKeyDown(makeEvent({ key: 'Home' }), 'c');
+      expect(onChange).toHaveBeenLastCalledWith('a');
+      result.current.handleKeyDown(makeEvent({ key: 'End' }), 'a');
+      expect(onChange).toHaveBeenLastCalledWith('d');
+    });
+  });
+
+  describe("orientation: 'both'", () => {
+    function setupBoth<T extends string>({
+      orderedKeys,
+    }: {
+      readonly orderedKeys: ReadonlyArray<T>;
+    }) {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useTablistKeyboardNav<T>({ orderedKeys, onChange, orientation: 'both' })
+      );
+      const buttons = new Map<
+        T,
+        HTMLButtonElement & { readonly focus: ReturnType<typeof vi.fn> }
+      >();
+      for (const key of orderedKeys) {
+        const btn = makeButtonStub();
+        buttons.set(key, btn);
+        result.current.tabRefs.current.set(key, btn);
+      }
+      return { result, onChange, buttons };
+    }
+
+    it.each([
+      ['ArrowRight', 'a', 'b'],
+      ['ArrowDown', 'a', 'b'],
+      ['ArrowLeft', 'b', 'a'],
+      ['ArrowUp', 'b', 'a'],
+    ] as const)('%s from %s navigates to %s', (key, from, expected) => {
+      const { result, onChange, buttons } = setupBoth<Key>({ orderedKeys: ['a', 'b', 'c'] });
+      result.current.handleKeyDown(makeEvent({ key }), from);
+      expect(onChange).toHaveBeenCalledWith(expected);
+      expect(buttons.get(expected as Key)!.focus).toHaveBeenCalledOnce();
+    });
+
+    it('ArrowDown wraps last → first (same axis as ArrowRight)', () => {
+      const { result, onChange } = setupBoth<Key>({ orderedKeys: ['a', 'b', 'c'] });
+      result.current.handleKeyDown(makeEvent({ key: 'ArrowDown' }), 'c');
+      expect(onChange).toHaveBeenCalledWith('a');
+    });
+
+    it('ArrowUp wraps first → last (same axis as ArrowLeft)', () => {
+      const { result, onChange } = setupBoth<Key>({ orderedKeys: ['a', 'b', 'c'] });
+      result.current.handleKeyDown(makeEvent({ key: 'ArrowUp' }), 'a');
+      expect(onChange).toHaveBeenCalledWith('c');
+    });
+
+    it('Home/End still work in both orientation', () => {
+      const { result, onChange } = setupBoth<Key>({ orderedKeys: ['a', 'b', 'c', 'd'] });
+      result.current.handleKeyDown(makeEvent({ key: 'Home' }), 'c');
+      expect(onChange).toHaveBeenLastCalledWith('a');
+      result.current.handleKeyDown(makeEvent({ key: 'End' }), 'a');
+      expect(onChange).toHaveBeenLastCalledWith('d');
+    });
+
+    it('still ignores non-arrow/Home/End keys', () => {
+      const { result, onChange } = setupBoth<Key>({ orderedKeys: ['a', 'b', 'c'] });
+      const e = makeEvent({ key: 'Enter' });
+      result.current.handleKeyDown(e, 'a');
+      expect(onChange).not.toHaveBeenCalled();
+      expect(e.preventDefault).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("orientation: 'horizontal' explicit (parity with default)", () => {
+    it('explicit horizontal behaves identically to omitted orientation', () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useTablistKeyboardNav<Key>({
+          orderedKeys: ['a', 'b', 'c'],
+          onChange,
+          orientation: 'horizontal',
+        })
+      );
+      // ArrowUp ignored
+      const eUp = makeEvent({ key: 'ArrowUp' });
+      result.current.handleKeyDown(eUp, 'b');
+      expect(onChange).not.toHaveBeenCalled();
+      // ArrowRight works
+      result.current.handleKeyDown(makeEvent({ key: 'ArrowRight' }), 'a');
+      expect(onChange).toHaveBeenCalledWith('b');
+    });
+  });
 });

--- a/apps/web/src/hooks/useTablistKeyboardNav.ts
+++ b/apps/web/src/hooks/useTablistKeyboardNav.ts
@@ -1,25 +1,31 @@
 /**
- * useTablistKeyboardNav — WAI-ARIA APG horizontal tablist keyboard contract.
+ * useTablistKeyboardNav — WAI-ARIA APG tablist keyboard contract.
  *
- * Wave A.6 Tier 1 (Issue #622). Extracted from inline implementations in:
+ * Wave A.6 Tier 1 (Issue #622) — initial horizontal-only extraction.
+ * Wave A.6 Tier 1.5 (Issue #625) — orientation extension (vertical / both).
+ *
+ * Extracted from inline implementations in:
  *   - components/ui/v2/faq/category-tabs.tsx (Issue #588 hotfix, PR #620)
  *   - components/ui/v2/shared-game-detail/tabs.tsx (Wave A.4)
+ *   - components/session/ToolRail.tsx (Tier 1.5, orientation: 'both')
  *
  * Provides a reusable hook so future tablist surfaces don't reinvent the
- * keyboard contract. Closes the governance gap where 5 sites maintain near-
- * identical inline switch handlers.
+ * keyboard contract. Closes the governance gap where multiple sites maintain
+ * near-identical inline switch handlers.
  *
- * Keyboard contract (WAI-ARIA APG horizontal tablist):
- *   - ArrowLeft  → previous key (wraps first → last)
- *   - ArrowRight → next key (wraps last → first)
- *   - Home       → first key
- *   - End        → last key
+ * Keyboard contract (WAI-ARIA APG tablist):
+ *   - ArrowLeft  → previous key (wraps first → last) — horizontal | both
+ *   - ArrowRight → next key (wraps last → first)     — horizontal | both
+ *   - ArrowUp    → previous key (wraps first → last) — vertical   | both
+ *   - ArrowDown  → next key (wraps last → first)     — vertical   | both
+ *   - Home       → first key (all orientations)
+ *   - End        → last key  (all orientations)
  *   - Activation is automatic: focus = onChange same tick. Consumers that
  *     need lazy-mount panel guards must manage that themselves; this hook
  *     assumes statically-rendered panels (FAQ-style) or amortized cost.
- *   - Other keys (ArrowUp/Down, character keys, Enter/Space/Escape/Tab) are
- *     intentional no-ops — preventDefault is NOT called so default browser
- *     behavior (e.g. Tab moves focus out of the tablist) is preserved.
+ *   - Off-axis arrow keys (e.g. ArrowUp in horizontal mode) and other keys
+ *     (character keys, Enter/Space/Escape/Tab) are intentional no-ops —
+ *     preventDefault is NOT called so default browser behavior is preserved.
  *
  * Defensive behavior:
  *   - Unknown `currentKey` (not in `orderedKeys`) → no-op, no preventDefault
@@ -62,9 +68,22 @@
 
 import { useCallback, useRef, type KeyboardEvent, type MutableRefObject } from 'react';
 
+/**
+ * Tablist orientation following the WAI-ARIA APG model.
+ *
+ * - `'horizontal'` (default): ArrowLeft/Right navigate; ArrowUp/Down ignored.
+ *   Mirrors `aria-orientation="horizontal"` (the ARIA default for tablists).
+ * - `'vertical'`: ArrowUp/Down navigate; ArrowLeft/Right ignored. Pair with
+ *   `aria-orientation="vertical"` on the tablist container.
+ * - `'both'`: all four arrow keys map to the same linear order (Up≡Left,
+ *   Down≡Right). Useful when a tablist visually wraps to two axes (e.g.
+ *   rail/list components) and consumers want either axis to advance.
+ */
+export type TablistOrientation = 'horizontal' | 'vertical' | 'both';
+
 export interface UseTablistKeyboardNavArgs<T extends string> {
   /**
-   * Ordered list of tab keys defining navigation order. ArrowLeft/Right wrap
+   * Ordered list of tab keys defining navigation order. Arrow keys wrap
    * around the bounds of this array; Home/End jump to first/last.
    */
   readonly orderedKeys: ReadonlyArray<T>;
@@ -74,6 +93,11 @@ export interface UseTablistKeyboardNavArgs<T extends string> {
    * WAI-ARIA APG (focus = activation same tick).
    */
   readonly onChange: (key: T) => void;
+  /**
+   * Which arrow keys participate in navigation. Defaults to `'horizontal'`
+   * to preserve the original Wave A.6 Tier 1 contract for existing consumers.
+   */
+  readonly orientation?: TablistOrientation;
 }
 
 export interface UseTablistKeyboardNavReturn<T extends string> {
@@ -93,6 +117,7 @@ export interface UseTablistKeyboardNavReturn<T extends string> {
 export function useTablistKeyboardNav<T extends string>({
   orderedKeys,
   onChange,
+  orientation = 'horizontal',
 }: UseTablistKeyboardNavArgs<T>): UseTablistKeyboardNavReturn<T> {
   const tabRefs = useRef<Map<T, HTMLButtonElement>>(new Map());
 
@@ -101,12 +126,25 @@ export function useTablistKeyboardNav<T extends string>({
       const idx = orderedKeys.indexOf(currentKey);
       if (idx === -1) return;
 
+      const horizontalActive = orientation === 'horizontal' || orientation === 'both';
+      const verticalActive = orientation === 'vertical' || orientation === 'both';
+
       let nextIdx: number | null = null;
       switch (e.key) {
         case 'ArrowLeft':
+          if (!horizontalActive) return;
           nextIdx = (idx - 1 + orderedKeys.length) % orderedKeys.length;
           break;
         case 'ArrowRight':
+          if (!horizontalActive) return;
+          nextIdx = (idx + 1) % orderedKeys.length;
+          break;
+        case 'ArrowUp':
+          if (!verticalActive) return;
+          nextIdx = (idx - 1 + orderedKeys.length) % orderedKeys.length;
+          break;
+        case 'ArrowDown':
+          if (!verticalActive) return;
           nextIdx = (idx + 1) % orderedKeys.length;
           break;
         case 'Home':
@@ -124,7 +162,7 @@ export function useTablistKeyboardNav<T extends string>({
       onChange(nextKey);
       tabRefs.current.get(nextKey)?.focus();
     },
-    [orderedKeys, onChange]
+    [orderedKeys, onChange, orientation]
   );
 
   return { tabRefs, handleKeyDown };

--- a/apps/web/src/hooks/useTablistKeyboardNav.ts
+++ b/apps/web/src/hooks/useTablistKeyboardNav.ts
@@ -108,10 +108,13 @@ export interface UseTablistKeyboardNavReturn<T extends string> {
    */
   readonly tabRefs: MutableRefObject<Map<T, HTMLButtonElement>>;
   /**
-   * Stable keydown handler. Bind to each tab button as
-   * `onKeyDown={e => handleKeyDown(e, thisTabKey)}`.
+   * Stable keydown handler. Bind per-button as
+   * `onKeyDown={e => handleKeyDown(e, thisTabKey)}` (preferred), or on the
+   * tablist container as `onKeyDown={e => handleKeyDown(e, activeKey)}` for
+   * surfaces that prefer container-level event delegation. The event type is
+   * widened to `HTMLElement` so both patterns satisfy TypeScript.
    */
-  readonly handleKeyDown: (e: KeyboardEvent<HTMLButtonElement>, currentKey: T) => void;
+  readonly handleKeyDown: (e: KeyboardEvent<HTMLElement>, currentKey: T) => void;
 }
 
 export function useTablistKeyboardNav<T extends string>({
@@ -122,7 +125,7 @@ export function useTablistKeyboardNav<T extends string>({
   const tabRefs = useRef<Map<T, HTMLButtonElement>>(new Map());
 
   const handleKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLButtonElement>, currentKey: T) => {
+    (e: KeyboardEvent<HTMLElement>, currentKey: T) => {
       const idx = orderedKeys.indexOf(currentKey);
       if (idx === -1) return;
 


### PR DESCRIPTION
## Summary

Wave A.6 Tier 1.5 — extends `useTablistKeyboardNav` (Tier 1, PR #623) with an `orientation` parameter to support `'horizontal' | 'vertical' | 'both'`, and migrates `ToolRail` as the second consumer.

Closes #625

## What's in

- **Hook extension**: optional `orientation?: 'horizontal' | 'vertical' | 'both'` (default `'horizontal'`, fully backward-compatible). Vertical mode activates ArrowUp/Down and gates off ArrowLeft/Right; `both` activates all four arrow keys (Up≡Left, Down≡Right). Home/End remain unconditional.
- **Hook event type widened** to `KeyboardEvent<HTMLElement>` so consumers can pick per-button binding (category-tabs / shared-game-detail tabs) or container-level binding (ToolRail) without TS friction.
- **ToolRail migration**: replaces inline 12-line `handleKeyDown` (shared across 3 sub-tablists: vertical desktop rail, custom-tools section, horizontal mobile bar) with `useTablistKeyboardNav<string>({ orientation: 'both' })`. Bonus a11y: Home/End now jump to first/last (the original handler omitted these).

## Tests

- 18 new hook tests across 4 describe blocks (default backward-compat, vertical, both, explicit-horizontal parity) — 45/45 hook tests green
- 24/24 ToolRail tests green (15 ToolRail + 9 ToolRailCamera) post-migration
- 16/16 category-tabs (Tier 1 consumer) still green
- 10/10 shared-game-detail/tabs (Tier 1 consumer) still green
- TypeScript clean (`pnpm typecheck`)

## Tier 2 deferred (out of scope)

Audit of remaining tablist sites revealed two patterns that don't cleanly fit the current hook contract:

- **`RuleSourceCard.tsx`** — index-based state (no stable per-item key), focus via `querySelectorAll('[role="tab"]')`. Would need either a key-stable refactor of the citation chip list or an `useTablistKeyboardNavByIndex` variant. Defer until pattern recurs.
- **`CardDeck.tsx`** — `role="region" aria-roledescription="carousel"`, no wrap, transform-driven side-effects. Semantically a carousel, not a tablist. If multiple carousels accumulate later, factor `useCarouselKeyboardNav` instead.

## Test plan

- [x] Hook unit tests (45/45)
- [x] ToolRail behavior unchanged for ArrowUp/Down/Left/Right; Home/End now navigate (a11y improvement)
- [x] Existing Tier 1 consumers (category-tabs, shared-game-detail tabs) unaffected by default
- [x] TypeScript check clean

Refs #579, Refs #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)