### PR TITLE
feat(ci): per-route bundle-size budget gate (#629)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,20 +642,63 @@ jobs:
           path: apps/web/playwright-report/
           retention-days: 7
 
+  # Frontend bundle-size budget enforcement (Issue #629).
+  # Builds the app and verifies First Load JS for budgeted public routes
+  # against `apps/web/.bundle-budgets.json`. Fails when any route exceeds
+  # `budget × (1 + tolerance)` (default 5%). Documented in
+  # `docs/frontend/bundle-size-budget.md`.
+  frontend-bundle-size:
+    name: Frontend - Bundle Size
+    runs-on: ${{ needs.changes.outputs.runner }}
+    timeout-minutes: 15
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
+    defaults:
+      run:
+        working-directory: apps/web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Frontend
+        uses: ./.github/actions/setup-frontend
+        with:
+          node-version: '20'
+          pnpm-version: '10'
+          working-directory: apps/web
+          frozen-lockfile: 'true'
+
+      - name: Build App
+        run: pnpm build
+        env:
+          NEXT_PUBLIC_API_BASE: http://localhost:8080
+
+      - name: Check Bundle Budgets
+        run: pnpm bundle:check
+
+      - name: Upload Bundle Budget Report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bundle-budget-report-${{ github.run_number }}
+          path: apps/web/.next/diagnostics/bundle-budget-report.json
+          retention-days: 30
+
   # Final status check
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [frontend, frontend-a11y, backend-unit, backend-integration, python-tests, e2e]
+    needs: [frontend, frontend-a11y, frontend-bundle-size, backend-unit, backend-integration, python-tests, e2e]
     if: always()
     steps:
       - name: Check Status
         run: |
           # Required jobs (block CI)
-          for job in frontend frontend-a11y backend-unit python-tests e2e; do
+          for job in frontend frontend-a11y frontend-bundle-size backend-unit python-tests e2e; do
             result="${{ needs.frontend.result }}"
             case "$job" in
               frontend-a11y) result="${{ needs.frontend-a11y.result }}" ;;
+              frontend-bundle-size) result="${{ needs.frontend-bundle-size.result }}" ;;
               backend-unit) result="${{ needs.backend-unit.result }}" ;;
               python-tests) result="${{ needs.python-tests.result }}" ;;
               e2e) result="${{ needs.e2e.result }}" ;;
@@ -761,7 +804,7 @@ jobs:
         || github.base_ref == 'main-staging'
         || github.base_ref == 'main'
       )
-    needs: [changes, frontend, frontend-a11y, backend-unit, backend-integration, python-tests, e2e, ci-success, deploy-preview]
+    needs: [changes, frontend, frontend-a11y, frontend-bundle-size, backend-unit, backend-integration, python-tests, e2e, ci-success, deploy-preview]
     uses: ./.github/workflows/notify-slack.yml
     with:
       event: failed

--- a/apps/web/.bundle-budgets.json
+++ b/apps/web/.bundle-budgets.json
@@ -1,0 +1,27 @@
+{
+  "description": "Per-route First Load JS budgets (gzipped bytes). Fails CI if measured size exceeds budget × (1 + tolerance). See docs/frontend/bundle-size-budget.md.",
+  "updatedAt": "2026-04-29",
+  "tolerance": 0.05,
+  "routes": {
+    "/shared-games": {
+      "gzippedBytes": 570217,
+      "note": "Wave A.3b catalog. Baseline 2026-04-29 measured."
+    },
+    "/shared-games/[id]": {
+      "gzippedBytes": 606268,
+      "note": "Wave A.4 detail. Baseline 2026-04-29 measured. Aspirational target 45KB documented in docs/frontend/bundle-size-budget.md (out of scope #629; deferred to optimization pass)."
+    },
+    "/discover": {
+      "gzippedBytes": 619000,
+      "note": "Baseline 2026-04-29 measured."
+    },
+    "/library": {
+      "gzippedBytes": 660649,
+      "note": "Baseline 2026-04-29 measured."
+    },
+    "/chat/[threadId]": {
+      "gzippedBytes": 631411,
+      "note": "Baseline 2026-04-29 measured."
+    }
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
     "dev:visual-docs": "cross-env NODE_OPTIONS=\"--max-old-space-size=16384\" node ./node_modules/next/dist/bin/next dev -p 3000",
     "build": "cross-env NODE_OPTIONS=\"--require ./scripts/dommatrix-polyfill.js --max-old-space-size=4096\" node ./node_modules/next/dist/bin/next build",
     "build:analyze": "cross-env NODE_OPTIONS=\"--require ./scripts/dommatrix-polyfill.js --max-old-space-size=4096\" ANALYZE=true node ./node_modules/next/dist/bin/next build",
+    "bundle:check": "node scripts/check-bundle-budgets.mjs",
     "start": "node ./node_modules/next/dist/bin/next start -p 3000",
     "generate:api": "tsx scripts/generate-api-client.ts",
     "cleanup:testhost": "node -e \"try { require('child_process').execSync('powershell.exe -ExecutionPolicy Bypass -File ../../tools/cleanup/cleanup-test-processes.ps1 -TestHostOnly', { stdio: 'inherit' }); } catch (e) { console.log('Cleanup skipped (Windows-only)'); }\"",

--- a/apps/web/scripts/check-bundle-budgets.mjs
+++ b/apps/web/scripts/check-bundle-budgets.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * check-bundle-budgets.mjs — Per-route First Load JS budget enforcement.
+ *
+ * Issue #629 (Wave A closeout Step 4). Reads Next.js 16 Turbopack diagnostic
+ * output `.next/diagnostics/route-bundle-stats.json` (canonical per-route
+ * `firstLoadChunkPaths` manifest), computes gzipped sum, validates against
+ * `apps/web/.bundle-budgets.json`. Exits non-zero when any budgeted route
+ * exceeds `budget * (1 + tolerance)`.
+ *
+ * Inputs:
+ *   - `.next/diagnostics/route-bundle-stats.json` (Next.js build artifact)
+ *   - `apps/web/.bundle-budgets.json` (committed budgets)
+ *
+ * Outputs:
+ *   - stdout: human-readable per-route table (✅ / ⚠️ / ❌)
+ *   - file: `.next/diagnostics/bundle-budget-report.json` (machine-readable
+ *     summary; CI uploads as artifact)
+ *   - exit code: 0 = all routes within budget; 1 = at least one exceeds
+ *     `budget × (1 + tolerance)`; 2 = configuration error (missing file,
+ *     unknown route, etc.)
+ *
+ * Usage:
+ *   pnpm build && node scripts/check-bundle-budgets.mjs
+ *   # or via package.json: pnpm bundle:check
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { gzipSync } from 'node:zlib';
+
+const STATS_PATH = '.next/diagnostics/route-bundle-stats.json';
+const BUDGETS_PATH = '.bundle-budgets.json';
+const REPORT_PATH = '.next/diagnostics/bundle-budget-report.json';
+
+function fail(msg, code = 2) {
+  console.error(`❌ ${msg}`);
+  process.exit(code);
+}
+
+function fmtKb(bytes) {
+  return `${(bytes / 1024).toFixed(1)} KB`;
+}
+
+function fmtPct(ratio) {
+  const sign = ratio >= 0 ? '+' : '';
+  return `${sign}${(ratio * 100).toFixed(2)}%`;
+}
+
+if (!existsSync(STATS_PATH)) {
+  fail(`Missing ${STATS_PATH}. Run \`pnpm build\` before \`bundle:check\`.`);
+}
+if (!existsSync(BUDGETS_PATH)) {
+  fail(`Missing ${BUDGETS_PATH} (committed budgets file).`);
+}
+
+const stats = JSON.parse(readFileSync(STATS_PATH, 'utf8'));
+const config = JSON.parse(readFileSync(BUDGETS_PATH, 'utf8'));
+
+const tolerance = typeof config.tolerance === 'number' ? config.tolerance : 0.05;
+const budgets = config.routes ?? {};
+
+if (Object.keys(budgets).length === 0) {
+  fail(`No routes in ${BUDGETS_PATH}.`);
+}
+
+const results = [];
+let hasFailure = false;
+let hasConfigError = false;
+
+for (const [route, entry] of Object.entries(budgets)) {
+  const budget = entry.gzippedBytes;
+  if (typeof budget !== 'number' || budget <= 0) {
+    console.error(`⚠️  ${route}: invalid budget value (${budget}).`);
+    hasConfigError = true;
+    continue;
+  }
+
+  const match = stats.find(s => s.route === route);
+  if (!match) {
+    console.error(
+      `⚠️  ${route}: not found in ${STATS_PATH}. Was the route renamed or removed?`,
+    );
+    hasConfigError = true;
+    results.push({ route, budget, status: 'missing' });
+    continue;
+  }
+
+  let measuredGzipped = 0;
+  for (const chunkPath of match.firstLoadChunkPaths) {
+    const normalized = chunkPath.replace(/\\/g, '/');
+    if (!existsSync(normalized)) {
+      console.error(`⚠️  ${route}: chunk missing on disk: ${normalized}`);
+      hasConfigError = true;
+      continue;
+    }
+    const buf = readFileSync(normalized);
+    measuredGzipped += gzipSync(buf, { level: 9 }).length;
+  }
+
+  const maxAllowed = Math.floor(budget * (1 + tolerance));
+  const overage = measuredGzipped - budget;
+  const ratio = overage / budget;
+  const exceeds = measuredGzipped > maxAllowed;
+
+  let icon;
+  if (exceeds) {
+    icon = '❌';
+    hasFailure = true;
+  } else if (overage > 0) {
+    icon = '⚠️';
+  } else {
+    icon = '✅';
+  }
+
+  results.push({
+    route,
+    budget,
+    measured: measuredGzipped,
+    maxAllowed,
+    overageBytes: overage,
+    overageRatio: ratio,
+    exceeds,
+    chunkCount: match.firstLoadChunkPaths.length,
+  });
+
+  console.log(
+    `${icon} ${route.padEnd(28)} ${fmtKb(measuredGzipped).padStart(11)} (budget ${fmtKb(budget)}, Δ ${fmtPct(ratio)}, max ${fmtKb(maxAllowed)})`,
+  );
+}
+
+const summary = {
+  generatedAt: new Date().toISOString(),
+  tolerance,
+  totalRoutes: results.length,
+  failingRoutes: results.filter(r => r.exceeds).length,
+  warningRoutes: results.filter(r => !r.exceeds && (r.overageBytes ?? 0) > 0).length,
+  results,
+};
+
+mkdirSync(dirname(REPORT_PATH), { recursive: true });
+writeFileSync(REPORT_PATH, JSON.stringify(summary, null, 2));
+console.log(`\nReport written to ${REPORT_PATH}.`);
+
+if (hasFailure) {
+  console.error(
+    `\n❌ Bundle budget violation: ${summary.failingRoutes} route(s) exceed budget × (1 + ${tolerance}). Update budgets in ${BUDGETS_PATH} or reduce bundle size.`,
+  );
+  process.exit(1);
+}
+
+if (hasConfigError) {
+  console.error(`\n⚠️  Configuration error in ${BUDGETS_PATH} or build output.`);
+  process.exit(2);
+}
+
+console.log(`\n✅ All ${results.length} routes within budget (tolerance ${tolerance * 100}%).`);

--- a/docs/frontend/bundle-size-budget.md
+++ b/docs/frontend/bundle-size-budget.md
@@ -1,0 +1,186 @@
+# Bundle-size budget enforcement
+
+> Wave A closeout — Step 4 (Issue #629).
+> CI gate: `frontend-bundle-size` job in `.github/workflows/ci.yml`.
+
+The frontend has a per-route **First Load JS** budget gate that fails any PR
+exceeding the budget by more than the configured tolerance (default **5%**).
+This document explains what is measured, how to operate the gate, and how to
+adjust budgets when a justified bundle increase needs to land.
+
+## What is measured
+
+Next.js 16 (Turbopack) emits `.next/diagnostics/route-bundle-stats.json` during
+`pnpm build`. For each app-router route the file lists:
+
+- `route` — route path (e.g. `/shared-games/[id]`).
+- `firstLoadUncompressedJsBytes` — uncompressed total JS the browser must
+  download on first visit (vendor + framework + page-specific).
+- `firstLoadChunkPaths` — concrete `.next/static/chunks/*.js` files that make
+  up that First Load.
+
+The check script gzips each chunk (level 9) and sums the compressed bytes —
+this is the canonical user-perceived load size and matches what most CDNs
+serve. The gate compares the measured gzipped sum to the budget in
+`apps/web/.bundle-budgets.json`.
+
+## Source of truth
+
+`apps/web/.bundle-budgets.json` is the **only** place where budgets live.
+Schema:
+
+```json
+{
+  "description": "...",
+  "updatedAt": "YYYY-MM-DD",
+  "tolerance": 0.05,
+  "routes": {
+    "/route/path": {
+      "gzippedBytes": 123456,
+      "note": "free-form context for reviewers"
+    }
+  }
+}
+```
+
+- `tolerance`: fraction over budget that is still allowed (e.g. `0.05` = 5%).
+- `gzippedBytes`: hard target. The gate fails when measured size exceeds
+  `floor(gzippedBytes * (1 + tolerance))`.
+- `note`: short context (baseline date, aspirational target, optimization
+  notes). Reviewers read this first when a budget update lands.
+
+## Budgeted routes (initial seed, 2026-04-29)
+
+The seed reflects the **measured baseline** at the time #629 landed, not an
+aspirational ideal — the issue explicitly excludes "editing route code to fit
+budgets" from this work. Budgets give us a regression floor; future
+optimization passes will tighten them.
+
+| Route | Baseline (gzipped) | Notes |
+|-------|--------------------|-------|
+| `/shared-games` | ~557 KB | Wave A.3b catalog (PR #600). |
+| `/shared-games/[id]` | ~592 KB | Wave A.4 detail (PR #605). Aspirational target **45 KB** documented in #629; deferred to a future optimization pass. |
+| `/discover` | ~605 KB | — |
+| `/library` | ~645 KB | — |
+| `/chat/[threadId]` | ~617 KB | — |
+
+> **Note on the 45 KB target.** Issue #629 references "45 KB gzipped JS per
+> Wave A.4 spec §SLO" for `/shared-games/[id]`. The Wave A.4 spec
+> ([2026-04-28-v2-migration-wave-a-4-shared-game-detail.md](../superpowers/specs/2026-04-28-v2-migration-wave-a-4-shared-game-detail.md))
+> actually defines a **+30 KB delta** ceiling vs the prior baseline, not a
+> 45 KB absolute. The 45 KB number is an aspirational target — keep the floor
+> at the measured baseline so the gate enforces "no regression", and reduce
+> the budget in dedicated optimization PRs.
+
+## Local workflow
+
+```bash
+cd apps/web
+pnpm build           # produces .next/diagnostics/route-bundle-stats.json
+pnpm bundle:check    # validates against .bundle-budgets.json
+```
+
+Sample output:
+
+```
+✅ /shared-games                   556.9 KB (budget 556.9 KB, Δ +0.00%, max 584.7 KB)
+✅ /shared-games/[id]              592.1 KB (budget 592.1 KB, Δ +0.00%, max 621.7 KB)
+...
+✅ All 5 routes within budget (tolerance 5%).
+```
+
+Glyphs:
+
+- ✅ — measured ≤ budget.
+- ⚠️ — measured > budget but ≤ `budget × (1 + tolerance)` (passes; consider
+  trimming).
+- ❌ — measured > `budget × (1 + tolerance)` → CI fails.
+
+The script also writes `apps/web/.next/diagnostics/bundle-budget-report.json`
+with machine-readable per-route results — CI uploads this as the
+`bundle-budget-report-<run>` artifact (30-day retention).
+
+## CI behaviour
+
+`frontend-bundle-size` is a **blocking** job:
+
+- Triggered when `dorny/paths-filter` detects changes under `apps/web/**`,
+  `apps/web/package.json`, or `pnpm-lock.yaml` (same scope as the other
+  frontend jobs).
+- Builds the app, runs `pnpm bundle:check`.
+- Aggregated into `ci-success` so a budget violation blocks the PR.
+- Always uploads the JSON report so reviewers can inspect deltas even on
+  failure.
+
+## When the gate fails
+
+A failure means: a route now ships more First Load JS than its budget × 1.05
+allows. The default response is **investigate, do not bump the budget**.
+
+1. **Read the per-route line** — the offender is the route with `❌`.
+2. **Check the diff** for new dependencies, new client components, or new
+   barrel-file re-exports landing on a server route.
+3. **Use `pnpm build:analyze`** (`@next/bundle-analyzer`) to inspect what
+   landed in the chunk: opens an interactive treemap.
+4. **Fix the regression** by code-splitting (`next/dynamic`, lazy imports),
+   removing unused dependencies, or moving client logic behind a server
+   boundary.
+
+A budget bump is only acceptable when:
+
+- The growth is **intentional** (a feature explicitly authorized to enlarge
+  the bundle, e.g. a new mandatory editor on a route).
+- The diff is reviewed by someone other than the author.
+- The `note` field is updated with a one-line rationale + linking PR/issue.
+- Ideally, the bump goes in its own PR titled `chore(bundle): bump <route>
+  budget …`, kept small for git-blame visibility.
+
+## Bumping a budget
+
+```bash
+cd apps/web
+pnpm build
+pnpm bundle:check    # confirms the new measurement
+# edit .bundle-budgets.json:
+#   - update "gzippedBytes" to the new measured value (or measured + small
+#     headroom)
+#   - update "updatedAt" to today
+#   - update "note" with rationale + PR/issue link
+git add .bundle-budgets.json
+git commit -m "chore(bundle): bump <route> budget — <rationale>"
+```
+
+## Adding a new budgeted route
+
+When a new public route ships, add it to the seed:
+
+1. Build the app: `pnpm build`.
+2. Look up the measured gzipped size in
+   `.next/diagnostics/bundle-budget-report.json` (the script reports the
+   measured value alongside the budget when the route is already listed; for
+   a new route, run the parser inline or just inspect the chunk paths in
+   `route-bundle-stats.json`).
+3. Add an entry to `.bundle-budgets.json` with `gzippedBytes` =
+   measured-current and a `note` documenting the baseline date.
+4. Commit alongside the route landing PR.
+
+The script fails with a configuration error (exit 2) when a route in the
+budgets file is missing from the build output — this catches renames and
+removals.
+
+## Related infra
+
+- `apps/web/__tests__/bundle-size.test.ts` — global `.next/static/chunks/*.js`
+  total budget (Vitest, `apps/web/bundle-size-baseline.json`). Complements the
+  per-route gate: the global test catches background bloat across all chunks
+  even when no individual route changes; the per-route gate catches bloat
+  isolated to a budgeted route.
+- `pnpm build:analyze` — manual treemap via `@next/bundle-analyzer`.
+
+## References
+
+- Issue #629 — *FE: bundle-size tracker (size-limit) for public routes*.
+- Issue #617 / Task #73 — Wave A.4 polish (the original 45 KB ask, deferred
+  here).
+- Wave A umbrella #579.
+- ADR-053 — Wave A.4 spec.


### PR DESCRIPTION
## Summary

- Adds **blocking CI gate** that fails PRs when First Load JS for budgeted public routes exceeds budget × (1 + 5%)
- Source: `.next/diagnostics/route-bundle-stats.json` (Next.js 16 Turbopack canonical per-route diagnostic) — script gzips `firstLoadChunkPaths` (level 9) and compares to `apps/web/.bundle-budgets.json`
- Seeds budgets for 5 routes from measured 2026-04-29 baseline (regression floor; not optimization target)

## Why

Per umbrella #579 / Wave A closeout Step 4 (#629). Wave A landed several public routes (`/shared-games`, `/shared-games/[id]`, `/discover`, `/library`, `/chat/[threadId]`) and we want a CI floor that catches accidental bloat regressions before merge — without forcing route refactors right now.

The gate is **complementary** to the existing global Vitest test (`apps/web/__tests__/bundle-size.test.ts`, total `.next/static/chunks/*.js` cap): the global test catches background bloat across all chunks, the per-route gate catches bloat isolated to a budgeted route.

## What's new

| File | Change |
|---|---|
| `apps/web/.bundle-budgets.json` | **NEW** — single source of truth (5 routes, 5% tolerance) |
| `apps/web/scripts/check-bundle-budgets.mjs` | **NEW** — parser + enforcement (exit 0/1/2) |
| `apps/web/package.json` | `+1` line — `bundle:check` script |
| `.github/workflows/ci.yml` | new `frontend-bundle-size` blocking job + `ci-success` aggregator updates |
| `docs/frontend/bundle-size-budget.md` | **NEW** — operator workflow + bumping procedure |

## Seed budgets (gzipped, measured 2026-04-29)

| Route | Baseline | Notes |
|---|---|---|
| `/shared-games` | 557 KB | Wave A.3b catalog (PR #600) |
| `/shared-games/[id]` | 592 KB | Wave A.4 detail (PR #605). Aspirational target **45 KB** documented; deferred to optimization pass |
| `/discover` | 605 KB | — |
| `/library` | 645 KB | — |
| `/chat/[threadId]` | 617 KB | — |

> **45 KB note**: Issue #629 cites \"45 KB per Wave A.4 spec §SLO\" for `/shared-games/[id]`. The Wave A.4 spec actually defines a +30 KB *delta* ceiling vs prior baseline, not a 45 KB absolute. The 45 KB number is aspirational — keeping the floor at measured-current makes the gate enforce \"no regression now\" while a future optimization PR can tighten it. Documented in `docs/frontend/bundle-size-budget.md` and the route's `note` field.

## CI behaviour

- Triggered by `dorny/paths-filter` on `apps/web/**`, `apps/web/package.json`, `pnpm-lock.yaml` (same scope as other frontend jobs)
- `pnpm build` → `pnpm bundle:check` → exit 1 on violation → blocks PR via `ci-success` aggregator
- Always uploads `bundle-budget-report.json` artifact (30-day retention) so reviewers see deltas even on failure

## Test plan

- [x] Local success: `pnpm build && pnpm bundle:check` → all 5 routes ✅, 0% delta from budget
- [x] Local fail simulation: temporarily reduced `/library` budget −15% → `❌ /library 645.2 KB (budget 548.4 KB, Δ +17.65%, max 575.8 KB)` exit 1, restored after
- [x] Report file written to `.next/diagnostics/bundle-budget-report.json`
- [x] Pre-commit: `pnpm typecheck` clean
- [x] Pre-push: full `pnpm build` + backend build verified
- [ ] CI: `frontend-bundle-size` job passes (will verify on merge)
- [ ] CI: `ci-success` aggregator includes the new job (will verify on merge)

## Out of scope

Per #629: **not** editing route code to fit budgets. Initial seed reflects measured baseline as a regression floor; future optimization passes will tighten budgets in dedicated `chore(bundle): bump <route>` PRs.

Closes #629
Refs #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)