### PR TITLE
docs(frontend): v2 migration matrix + 46 SP4 component stubs (#573)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,12 @@ Entity types: `game` (orange) · `player` (purple) · `collection` (teal) · `ev
 Variants: `grid` (default) · `list` · `compact` · `featured` · `hero`
 Docs: [docs/frontend/meeple-card-design-tokens.md](./docs/frontend/meeple-card-design-tokens.md)
 
+### V2 Migration Components
+
+Phase 0 of the v2 design migration — see [docs/superpowers/specs/2026-04-26-v2-design-migration.md](./docs/superpowers/specs/2026-04-26-v2-design-migration.md) — pre-stubs the 46 feature components introduced by SP4 wave 1+2 mockups under `apps/web/src/components/v2/<feature>/`. The single source of truth for the mapping `<Mockup, Component, Path, Route, AcceptanceCriteria, Status, PR>` is [docs/frontend/v2-migration-matrix.md](./docs/frontend/v2-migration-matrix.md). Pick `pending` rows from there before implementing v2 features; update `Status` and `PR` in the same PR that lands the implementation.
+
+Path discipline: existing v2 *primitives* live under `apps/web/src/components/ui/v2/` (auth-card, btn, drawer, …); new SP4 *feature compositions* live under `apps/web/src/components/v2/`. Do not collapse the two trees.
+
 ## Testing
 
 ### Backend (Target: 90%+) — 930+ classes | 13,134+ tests

--- a/apps/web/src/components/v2/agent-detail/AgentCharacterSheet.tsx
+++ b/apps/web/src/components/v2/agent-detail/AgentCharacterSheet.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-agent-detail.jsx
+// Mapped from mockup component: AgentHero
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface AgentCharacterSheetProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function AgentCharacterSheet(_props: AgentCharacterSheetProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/agent-detail/AgentDangerZone.tsx
+++ b/apps/web/src/components/v2/agent-detail/AgentDangerZone.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-agent-detail.jsx
+// Mapped from mockup component: SettingsTab
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface AgentDangerZoneProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function AgentDangerZone(_props: AgentDangerZoneProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/agent-detail/AgentSettingsForm.tsx
+++ b/apps/web/src/components/v2/agent-detail/AgentSettingsForm.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-agent-detail.jsx
+// Mapped from mockup component: SettingsTab
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface AgentSettingsFormProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function AgentSettingsForm(_props: AgentSettingsFormProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/agent-detail/ChatHistoryTimeline.tsx
+++ b/apps/web/src/components/v2/agent-detail/ChatHistoryTimeline.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-agent-detail.jsx
+// Mapped from mockup component: ChatTimelineItem
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface ChatHistoryTimelineProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function ChatHistoryTimeline(_props: ChatHistoryTimelineProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/agent-detail/KbDocList.tsx
+++ b/apps/web/src/components/v2/agent-detail/KbDocList.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-agent-detail.jsx
+// Mapped from mockup component: KbDocItem
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface KbDocListProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function KbDocList(_props: KbDocListProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/agent-detail/PersonaCard.tsx
+++ b/apps/web/src/components/v2/agent-detail/PersonaCard.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-agent-detail.jsx
+// Mapped from mockup component: PersonaCard
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface PersonaCardProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function PersonaCard(_props: PersonaCardProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/agent-detail/SystemPromptViewer.tsx
+++ b/apps/web/src/components/v2/agent-detail/SystemPromptViewer.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-agent-detail.jsx
+// Mapped from mockup component: SystemPromptViewer
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface SystemPromptViewerProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function SystemPromptViewer(_props: SystemPromptViewerProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/agents/AgentDetailPanel.tsx
+++ b/apps/web/src/components/v2/agents/AgentDetailPanel.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-agents-index.jsx
+// Mapped from mockup component: AgentsIndexBody
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface AgentDetailPanelProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function AgentDetailPanel(_props: AgentDetailPanelProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/agents/AgentsFiltersStrip.tsx
+++ b/apps/web/src/components/v2/agents/AgentsFiltersStrip.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-agents-index.jsx
+// Mapped from mockup component: AgentFilters
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface AgentsFiltersStripProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function AgentsFiltersStrip(_props: AgentsFiltersStripProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/agents/AgentsHero.tsx
+++ b/apps/web/src/components/v2/agents/AgentsHero.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-agents-index.jsx
+// Mapped from mockup component: AgentsHero
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface AgentsHeroProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function AgentsHero(_props: AgentsHeroProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/agents/AgentsSidebarList.tsx
+++ b/apps/web/src/components/v2/agents/AgentsSidebarList.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-agents-index.jsx
+// Mapped from mockup component: AgentCardGrid
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface AgentsSidebarListProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function AgentsSidebarList(_props: AgentsSidebarListProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/agents/EmptyAgents.tsx
+++ b/apps/web/src/components/v2/agents/EmptyAgents.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-agents-index.jsx
+// Mapped from mockup component: EmptyAgents
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface EmptyAgentsProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function EmptyAgents(_props: EmptyAgentsProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/game-detail/GameDetailAgentsList.tsx
+++ b/apps/web/src/components/v2/game-detail/GameDetailAgentsList.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-game-detail.jsx
+// Mapped from mockup component: ChatTab
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface GameDetailAgentsListProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function GameDetailAgentsList(_props: GameDetailAgentsListProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/game-detail/GameDetailFaqList.tsx
+++ b/apps/web/src/components/v2/game-detail/GameDetailFaqList.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-game-detail.jsx
+// Mapped from mockup component: InfoTab
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface GameDetailFaqListProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function GameDetailFaqList(_props: GameDetailFaqListProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/game-detail/GameDetailHero.tsx
+++ b/apps/web/src/components/v2/game-detail/GameDetailHero.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-game-detail.jsx
+// Mapped from mockup component: GameHero
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface GameDetailHeroProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function GameDetailHero(_props: GameDetailHeroProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/game-detail/GameDetailKbDocList.tsx
+++ b/apps/web/src/components/v2/game-detail/GameDetailKbDocList.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-game-detail.jsx
+// Mapped from mockup component: DocsTab
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface GameDetailKbDocListProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function GameDetailKbDocList(_props: GameDetailKbDocListProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/game-detail/GameDetailKpiCards.tsx
+++ b/apps/web/src/components/v2/game-detail/GameDetailKpiCards.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-game-detail.jsx
+// Mapped from mockup component: KpiCard
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface GameDetailKpiCardsProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function GameDetailKpiCards(_props: GameDetailKpiCardsProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/game-detail/GameDetailRulesAccordion.tsx
+++ b/apps/web/src/components/v2/game-detail/GameDetailRulesAccordion.tsx
@@ -1,0 +1,16 @@
+// TODO: implement per admin-mockups/design_files/sp4-game-detail.jsx
+// Mapped from mockup component: HouseRulesCard
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface GameDetailRulesAccordionProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function GameDetailRulesAccordion(
+  _props: GameDetailRulesAccordionProps
+): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/game-detail/GameDetailSessionsRail.tsx
+++ b/apps/web/src/components/v2/game-detail/GameDetailSessionsRail.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-game-detail.jsx
+// Mapped from mockup component: SessionsTab
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface GameDetailSessionsRailProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function GameDetailSessionsRail(_props: GameDetailSessionsRailProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/game-detail/GameDetailTabsAnimated.tsx
+++ b/apps/web/src/components/v2/game-detail/GameDetailTabsAnimated.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-game-detail.jsx
+// Mapped from mockup component: GameTabs
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface GameDetailTabsAnimatedProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function GameDetailTabsAnimated(_props: GameDetailTabsAnimatedProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/games/AdvancedFiltersDrawer.tsx
+++ b/apps/web/src/components/v2/games/AdvancedFiltersDrawer.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-games-index.jsx
+// Mapped from mockup component: GameFilters
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface AdvancedFiltersDrawerProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function AdvancedFiltersDrawer(_props: AdvancedFiltersDrawerProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/games/GamesEmptyState.tsx
+++ b/apps/web/src/components/v2/games/GamesEmptyState.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-games-index.jsx
+// Mapped from mockup component: EmptyLibrary
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface GamesEmptyStateProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function GamesEmptyState(_props: GamesEmptyStateProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/games/GamesFiltersInline.tsx
+++ b/apps/web/src/components/v2/games/GamesFiltersInline.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-games-index.jsx
+// Mapped from mockup component: GameFilters
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface GamesFiltersInlineProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function GamesFiltersInline(_props: GamesFiltersInlineProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/games/GamesHero.tsx
+++ b/apps/web/src/components/v2/games/GamesHero.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-games-index.jsx
+// Mapped from mockup component: LibraryHero
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface GamesHeroProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function GamesHero(_props: GamesHeroProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/games/GamesResultsGrid.tsx
+++ b/apps/web/src/components/v2/games/GamesResultsGrid.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-games-index.jsx
+// Mapped from mockup component: GameCardGrid
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface GamesResultsGridProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function GamesResultsGrid(_props: GamesResultsGridProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/library/BulkSelectionBar.tsx
+++ b/apps/web/src/components/v2/library/BulkSelectionBar.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-library-desktop.jsx
+// Mapped from mockup component: BulkSelectionBar
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface BulkSelectionBarProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function BulkSelectionBar(_props: BulkSelectionBarProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/library/LibraryHeroDesktop.tsx
+++ b/apps/web/src/components/v2/library/LibraryHeroDesktop.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-library-desktop.jsx
+// Mapped from mockup component: LibraryHero
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface LibraryHeroDesktopProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function LibraryHeroDesktop(_props: LibraryHeroDesktopProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/library/LibraryHybridGrid.tsx
+++ b/apps/web/src/components/v2/library/LibraryHybridGrid.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-library-desktop.jsx
+// Mapped from mockup component: LibraryGrid
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface LibraryHybridGridProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function LibraryHybridGrid(_props: LibraryHybridGridProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/library/LibraryTabs.tsx
+++ b/apps/web/src/components/v2/library/LibraryTabs.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-library-desktop.jsx
+// Mapped from mockup component: EntityTabBar
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface LibraryTabsProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function LibraryTabs(_props: LibraryTabsProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/library/RecentActivityRail.tsx
+++ b/apps/web/src/components/v2/library/RecentActivityRail.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-library-desktop.jsx
+// Mapped from mockup component: RecentActivityRail
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface RecentActivityRailProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function RecentActivityRail(_props: RecentActivityRailProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/session-live/ActionLogTimeline.tsx
+++ b/apps/web/src/components/v2/session-live/ActionLogTimeline.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-session-live-parts.jsx
+// Mapped from mockup component: ActionLogTimeline
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface ActionLogTimelineProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function ActionLogTimeline(_props: ActionLogTimelineProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/session-live/LiveAgentChat.tsx
+++ b/apps/web/src/components/v2/session-live/LiveAgentChat.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-session-live.jsx
+// Mapped from mockup component: LiveAgentChat
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface LiveAgentChatProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function LiveAgentChat(_props: LiveAgentChatProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/session-live/LiveScoringPanel.tsx
+++ b/apps/web/src/components/v2/session-live/LiveScoringPanel.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-session-live-parts.jsx
+// Mapped from mockup component: LiveScoringPanel
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface LiveScoringPanelProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function LiveScoringPanel(_props: LiveScoringPanelProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/session-live/LiveTopBar.tsx
+++ b/apps/web/src/components/v2/session-live/LiveTopBar.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-session-live-parts.jsx
+// Mapped from mockup component: LiveTopBar
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface LiveTopBarProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function LiveTopBar(_props: LiveTopBarProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/session-live/PlayerRosterLive.tsx
+++ b/apps/web/src/components/v2/session-live/PlayerRosterLive.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-session-live-parts.jsx
+// Mapped from mockup component: PlayerRosterLive
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface PlayerRosterLiveProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function PlayerRosterLive(_props: PlayerRosterLiveProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/session-live/SessionToolsRail.tsx
+++ b/apps/web/src/components/v2/session-live/SessionToolsRail.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-session-live.jsx
+// Mapped from mockup component: SessionToolsRail
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface SessionToolsRailProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function SessionToolsRail(_props: SessionToolsRailProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/session-live/TurnIndicator.tsx
+++ b/apps/web/src/components/v2/session-live/TurnIndicator.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-session-live-parts.jsx
+// Mapped from mockup component: TurnIndicator
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface TurnIndicatorProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function TurnIndicator(_props: TurnIndicatorProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/session-summary/PhotosGallery.tsx
+++ b/apps/web/src/components/v2/session-summary/PhotosGallery.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-session-summary.jsx
+// Mapped from mockup component: PhotoGallery
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface PhotosGalleryProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function PhotosGallery(_props: PhotosGalleryProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/session-summary/ScoringBreakdownTable.tsx
+++ b/apps/web/src/components/v2/session-summary/ScoringBreakdownTable.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-session-summary-parts.jsx
+// Mapped from mockup component: ScoringBreakdownTable
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface ScoringBreakdownTableProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function ScoringBreakdownTable(_props: ScoringBreakdownTableProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/session-summary/SessionDiaryTimeline.tsx
+++ b/apps/web/src/components/v2/session-summary/SessionDiaryTimeline.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-session-summary.jsx
+// Mapped from mockup component: Diary
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface SessionDiaryTimelineProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function SessionDiaryTimeline(_props: SessionDiaryTimelineProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/session-summary/SessionKpiGrid.tsx
+++ b/apps/web/src/components/v2/session-summary/SessionKpiGrid.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-session-summary-parts.jsx
+// Mapped from mockup component: KpiGrid
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface SessionKpiGridProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function SessionKpiGrid(_props: SessionKpiGridProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/session-summary/SessionShareCard.tsx
+++ b/apps/web/src/components/v2/session-summary/SessionShareCard.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-session-summary.jsx
+// Mapped from mockup component: ShareCard
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface SessionShareCardProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function SessionShareCard(_props: SessionShareCardProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/session-summary/SessionSummaryHero.tsx
+++ b/apps/web/src/components/v2/session-summary/SessionSummaryHero.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-session-summary-parts.jsx
+// Mapped from mockup component: SummaryHeroPodium
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface SessionSummaryHeroProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function SessionSummaryHero(_props: SessionSummaryHeroProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/sessions/ConnectionChipStripFooter.tsx
+++ b/apps/web/src/components/v2/sessions/ConnectionChipStripFooter.tsx
@@ -1,0 +1,16 @@
+// TODO: implement per admin-mockups/design_files/sp4-sessions-index.jsx
+// Mapped from mockup component: ChipStrip
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface ConnectionChipStripFooterProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function ConnectionChipStripFooter(
+  _props: ConnectionChipStripFooterProps
+): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/sessions/SessionsFilters.tsx
+++ b/apps/web/src/components/v2/sessions/SessionsFilters.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-sessions-index.jsx
+// Mapped from mockup component: SessionFilters
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface SessionsFiltersProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function SessionsFilters(_props: SessionsFiltersProps): ReactElement | null {
+  return null;
+}

--- a/apps/web/src/components/v2/sessions/SessionsHero.tsx
+++ b/apps/web/src/components/v2/sessions/SessionsHero.tsx
@@ -1,0 +1,14 @@
+// TODO: implement per admin-mockups/design_files/sp4-sessions-index.jsx
+// Mapped from mockup component: SessionsHero
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+
+import type { ReactElement } from 'react';
+
+export interface SessionsHeroProps {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function SessionsHero(_props: SessionsHeroProps): ReactElement | null {
+  return null;
+}

--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -329,8 +329,10 @@ try {
 - [Testing Guide](../testing/README.md)
 - [User Flows](../11-user-flows/README.md)
 - [Development Guide](../development/README.md)
+- [V2 Migration Component Matrix](./v2-migration-matrix.md) — 46 SP4 wave 1+2 component stubs, paths, routes, acceptance criteria
+- [Bundle-size Budget Enforcement](./bundle-size-budget.md) — per-route First Load JS gate
 
 ---
 
-**Last Updated**: 2026-01-31
+**Last Updated**: 2026-04-29
 **Maintainer**: Frontend Team

--- a/docs/frontend/v2-migration-matrix.md
+++ b/docs/frontend/v2-migration-matrix.md
@@ -1,0 +1,200 @@
+# V2 Migration Component Matrix
+
+> Wave A closeout — Step 5 (Issue #573).
+> Pre-requisite for Phase 1+2 of the v2 design migration ([spec](../superpowers/specs/2026-04-26-v2-design-migration.md), section 3.3).
+
+This matrix is the **single source of truth** for the ~46 v2 feature components that the
+SP4 wave 1 + 2 mockups introduced and that do not yet exist in the codebase. Each row
+binds a mockup definition to a target component path, route, and acceptance criteria so
+that downstream PRs can pick up an entry and turn it from `pending` → `done` without
+ambiguity.
+
+## Scope and ground rules
+
+- **In scope**: 46 feature components extracted from `admin-mockups/design_files/sp4-*.jsx`
+  wave 1 + 2 (10 mockups). Stubs live under `apps/web/src/components/v2/<feature>/`.
+- **Out of scope**: existing v2 primitives at `apps/web/src/components/ui/v2/` (auth-card,
+  btn, divider, drawer, entity-card, entity-chip, entity-pip, faq, hero-gradient,
+  input-field, invites, join, notification-card, oauth-buttons, pricing-card, pwd-input,
+  settings-list, settings-row, shared-game-detail, shared-games, step-progress,
+  strength-meter, success-card). These are reused, not re-stubbed.
+- **Path divergence is intentional** (per spec §3.3): primitives stay under
+  `components/ui/v2/`; *feature* compositions for SP4 routes live under
+  `components/v2/<feature>/`. Do not collapse the two trees.
+- **Component count**: refined from the spec Appendix A (52 entries) to **46** by
+  deferring six entries that are better served by v2 *primitives* once those exist
+  (`PauseOverlay`, `EndgameDialog`, `ConnectionLostBanner` → v2 dialog/banner primitives;
+  `ChatHighlights`, `SessionShareCard`, `PlayAgainCta` → composed inline from primitives).
+  These are tracked in the [Deferred entries](#deferred-entries) section below.
+
+## How to use
+
+1. Pick a row with `Status = pending`.
+2. Read the acceptance criteria column for what counts as "done" for that component.
+3. Implement the stub at the listed path; keep the path stable.
+4. Open a PR; on merge, update `Status = done` and `PR ref = #N` in this file via the same PR.
+5. The matrix moves with the codebase: never edit it from a side branch unless you are
+   landing the implementation in the same PR.
+
+## Status legend
+
+| Symbol | Meaning |
+|--------|---------|
+| `pending` | Stub exists, no implementation yet |
+| `in-progress` | A PR is open against the component |
+| `done` | Implementation merged; PR linked |
+
+## Acceptance criteria abbreviations
+
+Used in the **AC** column to keep the table compact.
+
+| Abbrev | Meaning |
+|--------|---------|
+| `T` | **Token compliance** — uses design tokens from `tailwind.config` / CSS vars; no hard-coded colors / spacing. |
+| `A` | **a11y role/aria** — correct `role`, `aria-*`, focus order; passes axe. WCAG 2.1 AA target. |
+| `M` | **prefers-reduced-motion** — animations gated; provides static fallback. |
+| `V` | **Viewport coverage** — renders correctly across `375px` (mobile), `768px` (tablet), `1280px` (desktop). |
+
+A "done" component must satisfy all four (`T`, `A`, `M`, `V`) unless explicitly waived in
+the PR review.
+
+## Wave 1 — 30 components
+
+### Games index — `/games` — 5 components
+
+| Mockup | Component | Path | Route | Status | PR | AC |
+|--------|-----------|------|-------|--------|----|----|
+| `sp4-games-index.jsx` | `GamesHero` | `apps/web/src/components/v2/games/GamesHero.tsx` | `/games` | pending | — | T A M V |
+| `sp4-games-index.jsx` | `GamesFiltersInline` | `apps/web/src/components/v2/games/GamesFiltersInline.tsx` | `/games` | pending | — | T A V |
+| `sp4-games-index.jsx` | `AdvancedFiltersDrawer` | `apps/web/src/components/v2/games/AdvancedFiltersDrawer.tsx` | `/games` | pending | — | T A M V |
+| `sp4-games-index.jsx` | `GamesResultsGrid` | `apps/web/src/components/v2/games/GamesResultsGrid.tsx` | `/games` | pending | — | T A V |
+| `sp4-games-index.jsx` | `GamesEmptyState` | `apps/web/src/components/v2/games/GamesEmptyState.tsx` | `/games` | pending | — | T A V |
+
+### Game detail — `/games/[id]` — 8 components
+
+| Mockup | Component | Path | Route | Status | PR | AC |
+|--------|-----------|------|-------|--------|----|----|
+| `sp4-game-detail.jsx` | `GameDetailHero` | `apps/web/src/components/v2/game-detail/GameDetailHero.tsx` | `/games/[id]` | pending | — | T A M V |
+| `sp4-game-detail.jsx` | `GameDetailTabsAnimated` | `apps/web/src/components/v2/game-detail/GameDetailTabsAnimated.tsx` | `/games/[id]` | pending | — | T A M V |
+| `sp4-game-detail.jsx` | `GameDetailKpiCards` | `apps/web/src/components/v2/game-detail/GameDetailKpiCards.tsx` | `/games/[id]` | pending | — | T A V |
+| `sp4-game-detail.jsx` | `GameDetailFaqList` | `apps/web/src/components/v2/game-detail/GameDetailFaqList.tsx` | `/games/[id]` | pending | — | T A V |
+| `sp4-game-detail.jsx` | `GameDetailRulesAccordion` | `apps/web/src/components/v2/game-detail/GameDetailRulesAccordion.tsx` | `/games/[id]` | pending | — | T A M V |
+| `sp4-game-detail.jsx` | `GameDetailSessionsRail` | `apps/web/src/components/v2/game-detail/GameDetailSessionsRail.tsx` | `/games/[id]` | pending | — | T A V |
+| `sp4-game-detail.jsx` | `GameDetailAgentsList` | `apps/web/src/components/v2/game-detail/GameDetailAgentsList.tsx` | `/games/[id]` | pending | — | T A V |
+| `sp4-game-detail.jsx` | `GameDetailKbDocList` | `apps/web/src/components/v2/game-detail/GameDetailKbDocList.tsx` | `/games/[id]` | pending | — | T A V |
+
+### Agents index — `/agents` — 5 components
+
+| Mockup | Component | Path | Route | Status | PR | AC |
+|--------|-----------|------|-------|--------|----|----|
+| `sp4-agents-index.jsx` | `AgentsHero` | `apps/web/src/components/v2/agents/AgentsHero.tsx` | `/agents` | pending | — | T A M V |
+| `sp4-agents-index.jsx` | `AgentsSidebarList` | `apps/web/src/components/v2/agents/AgentsSidebarList.tsx` | `/agents` | pending | — | T A V |
+| `sp4-agents-index.jsx` | `AgentDetailPanel` | `apps/web/src/components/v2/agents/AgentDetailPanel.tsx` | `/agents` | pending | — | T A V |
+| `sp4-agents-index.jsx` | `AgentsFiltersStrip` | `apps/web/src/components/v2/agents/AgentsFiltersStrip.tsx` | `/agents` | pending | — | T A V |
+| `sp4-agents-index.jsx` | `EmptyAgents` | `apps/web/src/components/v2/agents/EmptyAgents.tsx` | `/agents` | pending | — | T A V |
+
+### Agent detail — `/agents/[id]` — 7 components
+
+| Mockup | Component | Path | Route | Status | PR | AC |
+|--------|-----------|------|-------|--------|----|----|
+| `sp4-agent-detail.jsx` | `AgentCharacterSheet` | `apps/web/src/components/v2/agent-detail/AgentCharacterSheet.tsx` | `/agents/[id]` | pending | — | T A V |
+| `sp4-agent-detail.jsx` | `PersonaCard` | `apps/web/src/components/v2/agent-detail/PersonaCard.tsx` | `/agents/[id]` | pending | — | T A V |
+| `sp4-agent-detail.jsx` | `SystemPromptViewer` | `apps/web/src/components/v2/agent-detail/SystemPromptViewer.tsx` | `/agents/[id]` | pending | — | T A V |
+| `sp4-agent-detail.jsx` | `KbDocList` | `apps/web/src/components/v2/agent-detail/KbDocList.tsx` | `/agents/[id]` | pending | — | T A V |
+| `sp4-agent-detail.jsx` | `ChatHistoryTimeline` | `apps/web/src/components/v2/agent-detail/ChatHistoryTimeline.tsx` | `/agents/[id]` | pending | — | T A M V |
+| `sp4-agent-detail.jsx` | `AgentSettingsForm` | `apps/web/src/components/v2/agent-detail/AgentSettingsForm.tsx` | `/agents/[id]` | pending | — | T A V |
+| `sp4-agent-detail.jsx` | `AgentDangerZone` | `apps/web/src/components/v2/agent-detail/AgentDangerZone.tsx` | `/agents/[id]` | pending | — | T A V |
+
+### Library — `/library` — 5 components
+
+| Mockup | Component | Path | Route | Status | PR | AC |
+|--------|-----------|------|-------|--------|----|----|
+| `sp4-library-desktop.jsx` | `LibraryHeroDesktop` | `apps/web/src/components/v2/library/LibraryHeroDesktop.tsx` | `/library` | pending | — | T A M V |
+| `sp4-library-desktop.jsx` | `LibraryTabs` | `apps/web/src/components/v2/library/LibraryTabs.tsx` | `/library` | pending | — | T A M V |
+| `sp4-library-desktop.jsx` | `LibraryHybridGrid` | `apps/web/src/components/v2/library/LibraryHybridGrid.tsx` | `/library` | pending | — | T A V |
+| `sp4-library-desktop.jsx` | `BulkSelectionBar` | `apps/web/src/components/v2/library/BulkSelectionBar.tsx` | `/library` | pending | — | T A M V |
+| `sp4-library-desktop.jsx` | `RecentActivityRail` | `apps/web/src/components/v2/library/RecentActivityRail.tsx` | `/library` | pending | — | T A V |
+
+## Wave 2 — 16 components
+
+### Sessions index — `/sessions` — 3 components
+
+| Mockup | Component | Path | Route | Status | PR | AC |
+|--------|-----------|------|-------|--------|----|----|
+| `sp4-sessions-index.jsx` | `SessionsHero` | `apps/web/src/components/v2/sessions/SessionsHero.tsx` | `/sessions` | pending | — | T A M V |
+| `sp4-sessions-index.jsx` | `SessionsFilters` | `apps/web/src/components/v2/sessions/SessionsFilters.tsx` | `/sessions` | pending | — | T A V |
+| `sp4-sessions-index.jsx` | `ConnectionChipStripFooter` | `apps/web/src/components/v2/sessions/ConnectionChipStripFooter.tsx` | `/sessions` | pending | — | T A V |
+
+### Session live — `/sessions/[id]` — 7 components
+
+| Mockup | Component | Path | Route | Status | PR | AC |
+|--------|-----------|------|-------|--------|----|----|
+| `sp4-session-live-parts.jsx` | `LiveTopBar` | `apps/web/src/components/v2/session-live/LiveTopBar.tsx` | `/sessions/[id]` | pending | — | T A V |
+| `sp4-session-live-parts.jsx` | `TurnIndicator` | `apps/web/src/components/v2/session-live/TurnIndicator.tsx` | `/sessions/[id]` | pending | — | T A M V |
+| `sp4-session-live-parts.jsx` | `PlayerRosterLive` | `apps/web/src/components/v2/session-live/PlayerRosterLive.tsx` | `/sessions/[id]` | pending | — | T A V |
+| `sp4-session-live-parts.jsx` | `LiveScoringPanel` | `apps/web/src/components/v2/session-live/LiveScoringPanel.tsx` | `/sessions/[id]` | pending | — | T A V |
+| `sp4-session-live-parts.jsx` | `ActionLogTimeline` | `apps/web/src/components/v2/session-live/ActionLogTimeline.tsx` | `/sessions/[id]` | pending | — | T A V |
+| `sp4-session-live.jsx` | `SessionToolsRail` | `apps/web/src/components/v2/session-live/SessionToolsRail.tsx` | `/sessions/[id]` | pending | — | T A V |
+| `sp4-session-live.jsx` | `LiveAgentChat` | `apps/web/src/components/v2/session-live/LiveAgentChat.tsx` | `/sessions/[id]` | pending | — | T A V |
+
+### Session summary — `/sessions/[id]/summary` — 6 components
+
+| Mockup | Component | Path | Route | Status | PR | AC |
+|--------|-----------|------|-------|--------|----|----|
+| `sp4-session-summary-parts.jsx` | `SessionSummaryHero` | `apps/web/src/components/v2/session-summary/SessionSummaryHero.tsx` | `/sessions/[id]/summary` | pending | — | T A M V |
+| `sp4-session-summary-parts.jsx` | `SessionKpiGrid` | `apps/web/src/components/v2/session-summary/SessionKpiGrid.tsx` | `/sessions/[id]/summary` | pending | — | T A V |
+| `sp4-session-summary-parts.jsx` | `ScoringBreakdownTable` | `apps/web/src/components/v2/session-summary/ScoringBreakdownTable.tsx` | `/sessions/[id]/summary` | pending | — | T A V |
+| `sp4-session-summary.jsx` | `SessionDiaryTimeline` | `apps/web/src/components/v2/session-summary/SessionDiaryTimeline.tsx` | `/sessions/[id]/summary` | pending | — | T A V |
+| `sp4-session-summary.jsx` | `PhotosGallery` | `apps/web/src/components/v2/session-summary/PhotosGallery.tsx` | `/sessions/[id]/summary` | pending | — | T A V |
+| `sp4-session-summary.jsx` | `SessionShareCard` | `apps/web/src/components/v2/session-summary/SessionShareCard.tsx` | `/sessions/[id]/summary` | pending | — | T A V |
+
+## Stub format (informational)
+
+Each stub follows this minimal contract so `pnpm typecheck` stays green and downstream
+PRs can replace bodies without touching imports:
+
+```tsx
+// TODO: implement per admin-mockups/design_files/sp4-<mockup>.jsx
+// Mapped from mockup component: <MockupName>
+// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+
+import type { ReactElement } from 'react';
+
+export interface <Component>Props {
+  // TODO: extract props contract from mockup analysis
+}
+
+export function <Component>(_props: <Component>Props): ReactElement | null {
+  return null;
+}
+```
+
+## Deferred entries
+
+These six components from the spec Appendix A are intentionally **not stubbed** under
+`components/v2/`; they will be implemented as compositions of primitives once the
+relevant primitive lands under `components/ui/v2/`:
+
+| Spec name | Reason | Replacement strategy |
+|-----------|--------|----------------------|
+| `PauseOverlay` | Modal-shaped, no feature-specific state | v2 dialog primitive + content slot |
+| `EndgameDialog` | Modal-shaped, deterministic content | v2 dialog primitive + content slot |
+| `ConnectionLostBanner` | Pure status banner | v2 banner / toast primitive |
+| `ChatHighlights` | Inline section under summary | inline composition with v2 list primitive |
+| `SessionShareCard` (was deferred → restored) | The card *is* feature-specific (game state, score, image export); kept as feature stub | — |
+| `PlayAgainCta` | Single CTA button | v2 button primitive |
+| `GamesSortBar` | Small UI sliver, often inlined with filters | inline composition with v2 button + dropdown primitives |
+
+Note: `SessionShareCard` was originally on the deferred list during refinement but moved
+back to the matrix because the card composes feature-specific data (final score, photo,
+session title) into a single artifact suitable for image export — that is feature-level
+work, not a primitive composition. The total stays at 46 by dropping `GamesSortBar`
+instead.
+
+## References
+
+- Issue #573 — *[V2 Phase 0] Migration contract matrix + 46 component stub*.
+- Wave A umbrella #579.
+- v2 design migration spec: [`docs/superpowers/specs/2026-04-26-v2-design-migration.md`](../superpowers/specs/2026-04-26-v2-design-migration.md).
+- Existing v2 primitives index: [`apps/web/src/components/ui/v2/`](../../apps/web/src/components/ui/v2/).
+- Mockups: [`admin-mockups/design_files/`](../../admin-mockups/design_files/) (sp4-* wave 1+2).


### PR DESCRIPTION
## Summary

Phase 0c of the v2 design migration ([spec](../docs/superpowers/specs/2026-04-26-v2-design-migration.md)) — pre-stubs the **46 SP4 wave 1+2 feature components** with a single-source-of-truth migration matrix so that downstream Phase 1+2 PRs can replace the bodies in place without touching imports or planning.

- **46 stubs** under \`apps/web/src/components/v2/<feature>/\` (8 feature dirs: agent-detail, agents, game-detail, games, library, session-live, session-summary, sessions). Each stub: TODO comment with mockup pointer + spec link + tracking link, typed Props interface (empty for now), \`ReactElement | null\` return = \`null\` body.
- **\`docs/frontend/v2-migration-matrix.md\`** (~200 lines) — the contract: \`<Mockup, Component, Path, Route, Status, PR, AC>\` per row. AC abbreviations: T (token compliance), A (a11y role/aria, WCAG 2.1 AA), M (prefers-reduced-motion), V (viewport coverage 375/768/1280px). \"Deferred entries\" section documents the 52→46 reconciliation between spec Appendix A and Issue #573 title.
- **CLAUDE.md** new \"### V2 Migration Components\" subsection (between Card Components and Testing) — links the matrix and locks the path-discipline rule: existing v2 *primitives* under \`components/ui/v2/\` vs new SP4 *feature compositions* under \`components/v2/\`. Two trees, do not collapse.
- **\`docs/frontend/README.md\`** Related Documentation now points at the matrix and the bundle-size budget doc landed in #631.

## Path discipline (intentional)

\`apps/web/src/components/ui/v2/\` (23 existing dirs) holds **primitives**: auth-card, btn, drawer, hero-frame, ribbon, tag, etc. \`apps/web/src/components/v2/\` (NEW) holds **feature compositions**: \`GamesHero\`, \`AgentDetailPanel\`, \`SessionToolsRail\`, …. Composition files import primitives. Keeping the two trees separate makes the primitive catalog stable and the feature surface scopable per route.

## Inventory reconciliation (52 → 46)

Spec Appendix A inventoried 52 components; Issue #573 title says 46. Six are deferred to v2 primitives once those land (covered by separate primitive PRs, not by SP4 wave 1+2 stubs):

PauseOverlay, EndgameDialog, ConnectionLostBanner, ChatHighlights, PlayAgainCta, GamesSortBar.

Documented in matrix's \"Deferred entries\" section with rationale.

## Verification

- \`pnpm typecheck\` ✅ clean (apps/web)
- \`pnpm lint --max-warnings=510\` ✅ 0 errors / 31 pre-existing warnings (well under cap)
- Pre-commit hooks ✅ prettier --write + eslint --fix --max-warnings=0 (staged) + tsc --noEmit
- Bundle-size budget gate from #631 should be unaffected (no chunks ship — bodies are \`null\`)

## Test plan

- [x] Typecheck green
- [x] Lint green  
- [x] Pre-commit green
- [ ] CI: Frontend Build & Test
- [ ] CI: Migrated Routes Baseline
- [ ] CI: E2E Critical Paths
- [ ] CI: Backend Unit (skip — frontend-only)
- [ ] CI: Python Orchestration (skip — frontend-only)
- [ ] CI: GitGuardian
- [ ] CI: validate-source-branch
- [ ] CI: \`frontend-bundle-size\` (#631 gate — should pass; null bodies do not affect First Load JS)
- [ ] CI: ci-success aggregate

## How downstream PRs use this

1. Pick a row with \`Status = pending\` from the matrix.
2. Implement the component body in the existing stub file (do not move it).
3. Update the row's \`Status\` to \`in-progress\` then \`done\` and fill in the \`PR\` column in the same PR.
4. Imports already point at the stable path → no churn.

Closes #573
Refs #579 (Wave A umbrella) #495 #496 #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)