### PR TITLE
docs(mockups): SP3 missing + SP4 wave 3 + D1 players-index

### DIFF
--- a/admin-mockups/design_files/sp3-how-it-works.html
+++ b/admin-mockups/design_files/sp3-how-it-works.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<!-- MeepleAI SP3 missing — #2 · How it works (educational 4-step)
+     Route: /how-it-works
+     Riusa: HeroGradient (public.jsx pub-hero pattern) + EntityChip
+     Nuovo v2: HowItWorksStep -->
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>MeepleAI · /how-it-works — Come funziona</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp3-how-it-works.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp3-how-it-works.jsx
+++ b/admin-mockups/design_files/sp3-how-it-works.jsx
@@ -1,0 +1,754 @@
+/* MeepleAI SP3 missing — #2 · How it works
+   Route: /how-it-works
+   Riusa: HeroGradient pattern from public.jsx (pub-hero/pub-wrap inlined as styles)
+          + EntityChip (e-chip pattern)
+   Nuovo v2: HowItWorksStep
+   Pagina educativa statica — nessuna variante dinamica per stato.
+*/
+
+const { useState, useEffect, useRef, useMemo } = React;
+
+// ── ENTITY HELPERS ──────────────────────────────────────────────────────────
+const ENTITIES = {
+  game:    { c: 'var(--c-game)',    icon: '🎲', label: 'Game' },
+  kb:      { c: 'var(--c-kb)',      icon: '📄', label: 'KB' },
+  agent:   { c: 'var(--c-agent)',   icon: '🤖', label: 'Agent' },
+  session: { c: 'var(--c-session)', icon: '🎯', label: 'Session' },
+  toolkit: { c: 'var(--c-toolkit)', icon: '🧰', label: 'Toolkit' },
+  player:  { c: 'var(--c-player)',  icon: '👤', label: 'Player' },
+  chat:    { c: 'var(--c-chat)',    icon: '💬', label: 'Chat' },
+  event:   { c: 'var(--c-event)',   icon: '🎉', label: 'Event' },
+};
+const eHsl = (k, a = 1) => `hsl(var(--${ENTITIES[k]?.c.replace('var(--', '').replace(')', '') || 'c-game'}) / ${a})`;
+
+// EntityChip — riusa pattern e-chip da public.jsx
+const EntityChip = ({ entity, label, size = 'sm', icon = true }) => {
+  const e = ENTITIES[entity] || ENTITIES.game;
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: 5,
+      padding: size === 'lg' ? '5px 10px' : '3px 8px',
+      borderRadius: 999,
+      background: `hsl(${e.c.replace('var(--', '').replace(')', '')} / 0.12)`.replace('var(--', '').replace(')', ''),
+      backgroundColor: `hsl(var(${e.c.startsWith('var') ? e.c.slice(4, -1) : ''}) / 0.12)`,
+      color: `hsl(${e.c.startsWith('var') ? `var(${e.c.slice(4, -1)})` : e.c})`,
+      fontSize: size === 'lg' ? 12 : 11,
+      fontFamily: 'var(--f-display)',
+      fontWeight: 600,
+      letterSpacing: '0.01em',
+      whiteSpace: 'nowrap',
+      border: `1px solid hsl(var(${e.c.slice(4, -1)}) / 0.22)`,
+    }}>
+      {icon && <span style={{ fontSize: size === 'lg' ? 12 : 11 }}>{e.icon}</span>}
+      {label || e.label}
+    </span>
+  );
+};
+
+// ── HEROGRADIENT (riuso 1:1 da public.jsx) ─────────────────────────────────
+// Pattern: pub-hero section + pub-hero-bg + pub-wrap + hero-kicker + h1 con .mark + hero-lead + hero-ctas
+// Inline-styles equivalenti delle classi components.css di public.jsx
+const HeroGradient = ({ kicker, title, mark, subtitle, emojiStack, isMobile = false }) => {
+  return (
+    <section style={{
+      position: 'relative',
+      padding: isMobile ? '48px 0 40px' : '88px 0 72px',
+      overflow: 'hidden',
+      background: 'var(--bg)',
+      borderBottom: '1px solid var(--border)',
+    }}>
+      {/* pub-hero-bg: gradient radiale 3-color come public.jsx */}
+      <div aria-hidden="true" style={{
+        position: 'absolute', inset: 0,
+        backgroundImage: `
+          radial-gradient(800px circle at 18% 30%, hsl(var(--c-game) / 0.18), transparent 55%),
+          radial-gradient(700px circle at 82% 25%, hsl(var(--c-event) / 0.16), transparent 55%),
+          radial-gradient(900px circle at 50% 110%, hsl(var(--c-toolkit) / 0.14), transparent 60%)
+        `,
+        pointerEvents: 'none',
+      }} />
+      <div style={{
+        position: 'relative', maxWidth: 1100, margin: '0 auto',
+        padding: '0 24px', textAlign: 'center',
+      }}>
+        {emojiStack && (
+          <div aria-hidden="true" style={{
+            fontSize: isMobile ? 40 : 56, marginBottom: isMobile ? 14 : 18, letterSpacing: '-0.04em', lineHeight: 1,
+            filter: 'drop-shadow(0 6px 16px hsl(var(--c-game) / 0.25))',
+          }}>{emojiStack}</div>
+        )}
+        <p style={{
+          margin: '0 0 14px', fontFamily: 'var(--f-mono)',
+          fontSize: isMobile ? 10.5 : 12, fontWeight: 600,
+          color: 'var(--text-muted)', letterSpacing: '0.12em', textTransform: 'uppercase',
+        }}>{kicker}</p>
+        <h1 style={{
+          fontFamily: 'var(--f-display)',
+          fontSize: isMobile ? 30 : 'clamp(34px, 5vw, 56px)',
+          fontWeight: 700,
+          lineHeight: 1.05,
+          letterSpacing: '-0.02em',
+          margin: '0 0 18px',
+          color: 'var(--text)',
+          textWrap: 'balance',
+        }}>
+          {title}
+          {mark && (
+            <>
+              {' '}
+              <span style={{
+                background: `linear-gradient(120deg, hsl(var(--c-game)), hsl(var(--c-event)))`,
+                WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent',
+                backgroundClip: 'text',
+              }}>{mark}</span>
+            </>
+          )}
+        </h1>
+        <p style={{
+          margin: '0 auto', maxWidth: 640,
+          fontSize: isMobile ? 14.5 : 17, lineHeight: 1.55,
+          color: 'var(--text-sec)',
+        }}>{subtitle}</p>
+      </div>
+    </section>
+  );
+};
+
+// ── HOWITWORKSSTEP — nuovo v2 ──────────────────────────────────────────────
+const HowItWorksStep = ({ stepNum, totalSteps, entity, title, bullets, illustration, reverse = false, isMobile = false }) => {
+  const e = ENTITIES[entity];
+
+  return (
+    <article
+      aria-label={`Passo ${stepNum} di ${totalSteps}`}
+      style={{
+        display: 'grid',
+        gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr',
+        gap: isMobile ? 24 : 56,
+        alignItems: 'center',
+        padding: isMobile ? '36px 20px' : '56px 40px',
+        background: 'var(--bg-card)',
+        border: `1px solid var(--border)`,
+        borderLeft: `4px solid hsl(var(--${e.c.replace('var(--', '').replace(')', '')}))`,
+        borderRadius: 'var(--r-xl, 20px)',
+        boxShadow: 'var(--shadow-sm)',
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      {/* TEXT SIDE */}
+      <div style={{ order: reverse && !isMobile ? 2 : 1 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 14, marginBottom: 14 }}>
+          <span
+            aria-label={`Passo ${stepNum} di ${totalSteps}`}
+            style={{
+              fontFamily: 'var(--f-display)',
+              fontWeight: 700,
+              fontSize: isMobile ? 64 : 96,
+              lineHeight: 0.85,
+              letterSpacing: '-0.04em',
+              color: `hsl(var(--${e.c.replace('var(--', '').replace(')', '')}))`,
+              fontVariantNumeric: 'tabular-nums',
+              flexShrink: 0,
+            }}
+          >
+            0{stepNum}
+          </span>
+          <EntityChip entity={entity} size="lg" />
+        </div>
+        <h2 style={{
+          fontFamily: 'var(--f-display)',
+          fontWeight: 700,
+          fontSize: isMobile ? 24 : 32,
+          lineHeight: 1.15,
+          letterSpacing: '-0.015em',
+          margin: '0 0 18px',
+          color: 'var(--text)',
+          textWrap: 'balance',
+        }}>{title}</h2>
+        <ul style={{
+          listStyle: 'none', padding: 0, margin: 0,
+          display: 'flex', flexDirection: 'column', gap: 12,
+          fontFamily: 'var(--f-body)',
+        }}>
+          {bullets.map((b, i) => (
+            <li key={i} style={{
+              display: 'flex', gap: 12, alignItems: 'flex-start',
+              fontSize: 15.5, lineHeight: 1.55,
+              color: 'var(--text-sec)',
+            }}>
+              <span style={{
+                flexShrink: 0,
+                width: 22, height: 22, borderRadius: '50%',
+                display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                background: `hsl(var(--${e.c.replace('var(--', '').replace(')', '')}) / 0.14)`,
+                color: `hsl(var(--${e.c.replace('var(--', '').replace(')', '')}))`,
+                fontSize: 12, fontWeight: 700,
+                marginTop: 1,
+                fontFamily: 'var(--f-display)',
+              }}>✓</span>
+              <span>{b}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* ILLUSTRATION SIDE */}
+      <div style={{
+        order: reverse && !isMobile ? 1 : 2,
+        position: 'relative',
+        minHeight: isMobile ? 220 : 300,
+        borderRadius: 'var(--r-lg, 16px)',
+        overflow: 'hidden',
+        background: `linear-gradient(135deg,
+          hsl(var(--${e.c.replace('var(--', '').replace(')', '')}) / 0.15),
+          hsl(var(--${e.c.replace('var(--', '').replace(')', '')}) / 0.04))`,
+        border: `1px dashed hsl(var(--${e.c.replace('var(--', '').replace(')', '')}) / 0.3)`,
+        padding: 24,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}>
+        {illustration}
+      </div>
+    </article>
+  );
+};
+
+// ── ILLUSTRAZIONI per i 4 step ─────────────────────────────────────────────
+// Step 1: Library — search + add Game card
+const IllusStep1 = () => (
+  <div style={{ width: '100%', maxWidth: 360, display: 'flex', flexDirection: 'column', gap: 12 }}>
+    {/* search bar mockup */}
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 10,
+      padding: '10px 14px',
+      background: 'var(--bg-card)',
+      border: '1px solid var(--border-strong)',
+      borderRadius: 999,
+      fontSize: 13, color: 'var(--text-muted)',
+      fontFamily: 'var(--f-body)',
+    }}>
+      <span aria-hidden="true">🔍</span>
+      <span>cerca su BGG…</span>
+      <span style={{ marginLeft: 'auto', fontFamily: 'var(--f-mono)', fontSize: 10,
+        padding: '2px 6px', border: '1px solid var(--border)', borderRadius: 4,
+        color: 'var(--text-muted)', background: 'var(--bg-muted)' }}>⌘K</span>
+    </div>
+    {/* 2 game cards */}
+    {[
+      { e: '🐦', t: 'Wingspan', m: 'Stonemaier · 2019', state: 'owned', cv: '--c-toolkit' },
+      { e: '🔷', t: 'Azul', m: 'Plan B · 2017', state: 'wishlist', cv: '--c-event' },
+    ].map(g => (
+      <div key={g.t} style={{
+        display: 'flex', alignItems: 'center', gap: 12,
+        padding: '10px 12px',
+        background: 'var(--bg-card)',
+        border: '1px solid var(--border)',
+        borderRadius: 12,
+      }}>
+        <div style={{
+          width: 40, height: 40, borderRadius: 8,
+          background: `linear-gradient(135deg, hsl(var(--c-game) / 0.3), hsl(var(--c-game) / 0.1))`,
+          display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 20,
+        }}>{g.e}</div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 13.5, color: 'var(--text)' }}>{g.t}</div>
+          <div style={{ fontSize: 11, color: 'var(--text-muted)', fontFamily: 'var(--f-body)' }}>{g.m}</div>
+        </div>
+        <span style={{
+          fontSize: 10, fontFamily: 'var(--f-display)', fontWeight: 700,
+          padding: '3px 8px', borderRadius: 999,
+          background: `hsl(var(${g.cv}) / 0.14)`,
+          color: `hsl(var(${g.cv}))`,
+          textTransform: 'uppercase', letterSpacing: '0.04em',
+        }}>{g.state}</span>
+      </div>
+    ))}
+    {/* +Add button */}
+    <button style={{
+      padding: '8px 12px',
+      background: 'transparent',
+      border: '1px dashed var(--border-strong)',
+      borderRadius: 12,
+      color: 'var(--text-muted)',
+      fontFamily: 'var(--f-display)', fontWeight: 600, fontSize: 12.5,
+      cursor: 'pointer',
+    }}>+ Aggiungi gioco</button>
+  </div>
+);
+
+// Step 2: PDF → KB → Agent flow
+const IllusStep2 = () => (
+  <div style={{ width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, flexWrap: 'wrap' }}>
+    {[
+      { icon: '📕', label: 'PDF', sub: 'wingspan-rules.pdf', cv: '--c-game' },
+      { icon: '⚙️', label: 'Chunking', sub: 'OCR + 768d', cv: '--c-tool', dashed: true },
+      { icon: '📄', label: 'KB', sub: '24 pag · 89 chunks', cv: '--c-kb' },
+      { icon: '🤖', label: 'Agent', sub: 'Wingspan Rules', cv: '--c-agent' },
+    ].map((n, i, arr) => (
+      <React.Fragment key={n.label}>
+        <div style={{
+          display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6,
+          padding: '12px 10px',
+          minWidth: 78,
+          background: n.dashed ? 'transparent' : 'var(--bg-card)',
+          border: n.dashed
+            ? `1px dashed hsl(var(${n.cv}) / 0.4)`
+            : `1px solid hsl(var(${n.cv}) / 0.3)`,
+          borderRadius: 12,
+          opacity: n.dashed ? 0.85 : 1,
+        }}>
+          <div style={{
+            width: 36, height: 36, borderRadius: 8,
+            background: `hsl(var(${n.cv}) / 0.15)`,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontSize: 18,
+          }}>{n.icon}</div>
+          <div style={{
+            fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 11,
+            color: `hsl(var(${n.cv}))`,
+          }}>{n.label}</div>
+          <div style={{ fontSize: 9, color: 'var(--text-muted)', fontFamily: 'var(--f-mono)', textAlign: 'center' }}>{n.sub}</div>
+        </div>
+        {i < arr.length - 1 && (
+          <span aria-hidden="true" style={{
+            color: 'var(--text-muted)', fontSize: 14, fontFamily: 'var(--f-mono)',
+          }}>→</span>
+        )}
+      </React.Fragment>
+    ))}
+  </div>
+);
+
+// Step 3: Session live + chat + timer
+const IllusStep3 = () => (
+  <div style={{ width: '100%', maxWidth: 340, display: 'flex', flexDirection: 'column', gap: 10 }}>
+    {/* Session header */}
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 10,
+      padding: '10px 12px',
+      background: `hsl(var(--c-session) / 0.1)`,
+      border: '1px solid hsl(var(--c-session) / 0.3)',
+      borderRadius: 12,
+    }}>
+      <span style={{
+        width: 8, height: 8, borderRadius: '50%',
+        background: 'hsl(var(--c-session))',
+        boxShadow: '0 0 0 4px hsl(var(--c-session) / 0.2)',
+        flexShrink: 0,
+      }} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 12.5, color: 'var(--text)' }}>
+          Serata Azul · Turno 3/5
+        </div>
+        <div style={{ fontSize: 10, color: 'var(--text-muted)', fontFamily: 'var(--f-mono)' }}>
+          AZL-7X2K · 4 giocatori
+        </div>
+      </div>
+      <span style={{
+        fontFamily: 'var(--f-mono)', fontSize: 14, fontWeight: 700,
+        color: 'hsl(var(--c-session))',
+        fontVariantNumeric: 'tabular-nums',
+      }}>⏱ 45:21</span>
+    </div>
+    {/* Chat bubbles */}
+    <div style={{
+      padding: '10px 12px',
+      background: 'var(--bg-muted)',
+      borderRadius: 12, fontSize: 12,
+      display: 'flex', flexDirection: 'column', gap: 8,
+    }}>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start' }}>
+        <span style={{ fontSize: 14 }}>👤</span>
+        <div style={{
+          padding: '6px 10px',
+          background: 'var(--bg-card)',
+          borderRadius: '12px 12px 12px 2px',
+          fontFamily: 'var(--f-body)', fontSize: 12,
+          color: 'var(--text)',
+          maxWidth: '80%',
+        }}>Marco: posso prendere 2 tessere dal centro?</div>
+      </div>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', justifyContent: 'flex-end' }}>
+        <div style={{
+          padding: '6px 10px',
+          background: 'hsl(var(--c-agent) / 0.14)',
+          border: '1px solid hsl(var(--c-agent) / 0.3)',
+          borderRadius: '12px 12px 2px 12px',
+          fontFamily: 'var(--f-body)', fontSize: 12,
+          color: 'var(--text)',
+          maxWidth: '80%',
+        }}>
+          Sì, prendi tutte le tessere di un colore (pag. 4).{' '}
+          <span style={{ color: 'hsl(var(--c-kb))', fontFamily: 'var(--f-mono)', fontSize: 10 }}>📄 azul-regole-ita.pdf</span>
+        </div>
+        <span style={{ fontSize: 14 }}>🤖</span>
+      </div>
+    </div>
+    {/* Live event log */}
+    <div style={{
+      fontFamily: 'var(--f-mono)', fontSize: 10,
+      color: 'var(--text-muted)',
+      padding: '6px 10px',
+      background: 'var(--bg-sunken)',
+      borderRadius: 8,
+      borderLeft: '2px solid hsl(var(--c-session))',
+    }}>
+      [21:42] Davide → +5 punti riga · [21:43] Marco turno
+    </div>
+  </div>
+);
+
+// Step 4: Toolkit bundle
+const IllusStep4 = () => (
+  <div style={{ width: '100%', maxWidth: 340 }}>
+    <div style={{
+      padding: '16px 18px',
+      background: 'var(--bg-card)',
+      border: '1px solid hsl(var(--c-toolkit) / 0.4)',
+      borderRadius: 16,
+      boxShadow: 'var(--shadow-sm)',
+      position: 'relative',
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
+        <div style={{
+          width: 40, height: 40, borderRadius: 10,
+          background: `linear-gradient(135deg, hsl(var(--c-toolkit) / 0.3), hsl(var(--c-toolkit) / 0.08))`,
+          display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 20,
+        }}>🧰</div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 14, color: 'var(--text)' }}>
+            Azul Helper Bundle
+          </div>
+          <div style={{ fontSize: 10.5, color: 'var(--text-muted)', fontFamily: 'var(--f-mono)' }}>
+            v2.1.0 · Davide · 234 install
+          </div>
+        </div>
+      </div>
+      <div style={{
+        display: 'flex', flexWrap: 'wrap', gap: 6,
+        padding: '10px 0',
+        borderTop: '1px solid var(--border-light)',
+        borderBottom: '1px solid var(--border-light)',
+        marginBottom: 10,
+      }}>
+        <EntityChip entity="agent" label="1 Agent" />
+        <EntityChip entity="kb" label="3 KB" />
+        <EntityChip entity="toolkit" label="2 Tools" />
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 11.5, color: 'var(--text-sec)' }}>
+        <span style={{ color: 'hsl(var(--c-event))', fontSize: 13 }}>★★★★★</span>
+        <span style={{ fontFamily: 'var(--f-mono)' }}>4.9 · 47 review</span>
+        <span style={{
+          marginLeft: 'auto',
+          padding: '3px 8px', borderRadius: 999,
+          background: 'hsl(var(--c-toolkit) / 0.14)',
+          color: 'hsl(var(--c-toolkit))',
+          fontSize: 10, fontFamily: 'var(--f-display)', fontWeight: 700,
+          textTransform: 'uppercase', letterSpacing: '0.04em',
+        }}>v2.1.0</span>
+      </div>
+    </div>
+  </div>
+);
+
+// ── PAGE BODY ──────────────────────────────────────────────────────────────
+const HowItWorksBody = ({ isMobile = false }) => {
+  const steps = [
+    {
+      entity: 'game',
+      title: 'Costruisci la tua library',
+      bullets: [
+        'Cerca giochi direttamente da BoardGameGeek o aggiungili manualmente',
+        'Importa il regolamento PDF — l\'OCR parte automaticamente',
+        'Organizza per stato: posseduti, wishlist, già giocati',
+      ],
+      illustration: <IllusStep1 />,
+    },
+    {
+      entity: 'kb',
+      title: 'Gli agenti leggono le regole',
+      bullets: [
+        'Carica il regolamento — chunking + embedding e5-base 768d',
+        'L\'agent custom per gioco indicizza ogni regola con citazione pagina',
+        'Niente allucinazioni: ogni risposta linka al manuale ufficiale',
+      ],
+      illustration: <IllusStep2 />,
+    },
+    {
+      entity: 'session',
+      title: 'Gioca con l\'aiuto dell\'AI',
+      bullets: [
+        'Chiedi una regola in chat e ottieni la risposta in 1.2s',
+        'Scoring automatico, timer turno, log eventi cronologico',
+        'Tutto in tempo reale durante la partita — niente pause',
+      ],
+      illustration: <IllusStep3 />,
+    },
+    {
+      entity: 'toolkit',
+      title: 'Condividi toolkit con la community',
+      bullets: [
+        'Bundle Agent + KB + Tools in un toolkit installabile',
+        'Pubblica con versioning semver, ricevi rating e feedback',
+        'I migliori contributor (come Davide) entrano nei consigliati',
+      ],
+      illustration: <IllusStep4 />,
+    },
+  ];
+
+  return (
+    <>
+      <HeroGradient
+        kicker="Educazione · Onboarding · 4 step"
+        title="Come funziona"
+        mark="MeepleAI"
+        subtitle="Dal regolamento PDF alla partita assistita in 4 passi. Niente vendita, solo come funziona davvero."
+        emojiStack="🎲 🤖 🧰"
+        isMobile={isMobile}
+      />
+
+      {/* STEP CARDS */}
+      <section style={{
+        padding: isMobile ? '32px 14px 16px' : '64px 24px 32px',
+        maxWidth: 1180, margin: '0 auto',
+        display: 'flex', flexDirection: 'column', gap: isMobile ? 18 : 28,
+      }}>
+        {steps.map((s, i) => (
+          <HowItWorksStep
+            key={i}
+            stepNum={i + 1}
+            totalSteps={steps.length}
+            entity={s.entity}
+            title={s.title}
+            bullets={s.bullets}
+            illustration={s.illustration}
+            reverse={i % 2 === 1}
+            isMobile={isMobile}
+          />
+        ))}
+      </section>
+
+      {/* FOOTER CTA */}
+      <section style={{
+        padding: isMobile ? '32px 14px 56px' : '64px 24px 96px',
+        textAlign: 'center',
+      }}>
+        <div style={{
+          maxWidth: 640, margin: '0 auto',
+          padding: isMobile ? '32px 20px' : '48px 32px',
+          background: `linear-gradient(135deg,
+            hsl(var(--c-game) / 0.12),
+            hsl(var(--c-toolkit) / 0.12))`,
+          border: '1px solid hsl(var(--c-game) / 0.25)',
+          borderRadius: 24,
+          position: 'relative',
+          overflow: 'hidden',
+        }}>
+          <div aria-hidden="true" style={{
+            position: 'absolute', inset: 0,
+            backgroundImage: 'radial-gradient(400px circle at 80% 20%, hsl(var(--c-event) / 0.18), transparent 60%)',
+            pointerEvents: 'none',
+          }} />
+          <div style={{ position: 'relative' }}>
+            <h2 style={{
+              fontFamily: 'var(--f-display)',
+              fontSize: isMobile ? 22 : 'clamp(24px, 3.5vw, 36px)',
+              fontWeight: 700,
+              margin: '0 0 14px',
+              letterSpacing: '-0.015em',
+              lineHeight: 1.1,
+              color: 'var(--text)',
+            }}>Pronto a giocare meglio?</h2>
+            <p style={{
+              fontFamily: 'var(--f-body)', fontSize: 15.5,
+              color: 'var(--text-sec)', margin: '0 auto 24px',
+              maxWidth: 460, lineHeight: 1.55,
+            }}>Crea il tuo account gratis. Nessuna carta richiesta. Setup in 2 minuti.</p>
+            <a href="#/register" style={{
+              display: 'inline-flex', alignItems: 'center', gap: 8,
+              padding: '12px 26px',
+              background: `linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-toolkit)))`,
+              color: '#fff',
+              fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 15,
+              borderRadius: 999,
+              textDecoration: 'none',
+              boxShadow: '0 8px 24px hsl(var(--c-game) / 0.35)',
+            }}>Inizia gratis →</a>
+            <div style={{ marginTop: 18, fontSize: 13.5, color: 'var(--text-muted)' }}>
+              Hai già un account?{' '}
+              <a href="#/login" style={{
+                color: 'hsl(var(--c-game))', fontWeight: 600, textDecoration: 'underline',
+                textDecorationColor: 'hsl(var(--c-game) / 0.4)', textUnderlineOffset: 3,
+              }}>Accedi</a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+};
+
+// ── DESKTOP / MOBILE FRAMES ────────────────────────────────────────────────
+const DesktopScreen = ({ label, theme }) => (
+  <div data-screen-label={label} style={{
+    width: 1440,
+    background: 'var(--bg)',
+    borderRadius: 16,
+    border: '1px solid var(--border-strong)',
+    overflow: 'hidden',
+    boxShadow: '0 32px 64px -24px rgba(0,0,0,0.25), 0 12px 32px -12px rgba(0,0,0,0.12)',
+  }} data-theme={theme}>
+    <div style={{
+      padding: '8px 14px',
+      background: 'var(--bg-sunken)',
+      borderBottom: '1px solid var(--border)',
+      display: 'flex', alignItems: 'center', gap: 10,
+      fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)',
+    }}>
+      <span style={{ display: 'inline-flex', gap: 6 }}>
+        <span style={{ width: 10, height: 10, borderRadius: '50%', background: '#FF5F57' }} />
+        <span style={{ width: 10, height: 10, borderRadius: '50%', background: '#FEBC2E' }} />
+        <span style={{ width: 10, height: 10, borderRadius: '50%', background: '#28C840' }} />
+      </span>
+      <span style={{ marginLeft: 8 }}>meepleai.app/how-it-works · {label}</span>
+    </div>
+    <div style={{ background: 'var(--bg)' }}>
+      <HowItWorksBody isMobile={false} />
+    </div>
+  </div>
+);
+
+const MobileScreen = ({ label, theme }) => (
+  <div style={{
+    width: 375,
+    background: 'var(--bg)',
+    borderRadius: 36,
+    border: '8px solid #1a1410',
+    overflow: 'hidden',
+    boxShadow: '0 30px 60px rgba(0,0,0,0.6)',
+    position: 'relative',
+  }} data-theme={theme} data-screen-label={label}>
+    {/* status bar */}
+    <div style={{
+      height: 30, background: 'var(--bg-sunken)',
+      display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+      padding: '0 18px',
+      fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 11,
+      color: 'var(--text)',
+    }}>
+      <span>9:41</span>
+      <span style={{ display: 'inline-flex', gap: 6, alignItems: 'center' }}>
+        <span>●●●</span><span>📶</span><span>🔋</span>
+      </span>
+    </div>
+    <HowItWorksBody isMobile={true} />
+  </div>
+);
+
+// ── APP ────────────────────────────────────────────────────────────────────
+const App = () => {
+  const [theme, setTheme] = useState(() => {
+    try { return localStorage.getItem('mai-sp3-how-it-works-theme') || 'light'; } catch { return 'light'; }
+  });
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    try { localStorage.setItem('mai-sp3-how-it-works-theme', theme); } catch {}
+  }, [theme]);
+
+  return (
+    <div style={{
+      minHeight: '100vh',
+      background: theme === 'dark' ? '#0a0805' : '#e8dfcf',
+      padding: '40px 24px 80px',
+    }}>
+      {/* Toolbar */}
+      <div style={{
+        maxWidth: 1480, margin: '0 auto 32px',
+        display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap',
+      }}>
+        <div>
+          <div style={{
+            fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 22,
+            color: theme === 'dark' ? '#f0e4d2' : '#2b1f12',
+            letterSpacing: '-0.015em',
+          }}>SP3 · #2 — How it works</div>
+          <div style={{
+            fontFamily: 'var(--f-mono)', fontSize: 12,
+            color: theme === 'dark' ? '#8a7860' : '#9a8870',
+          }}>Route: /how-it-works · Pagina educativa statica · Riusa HeroGradient da public.jsx</div>
+        </div>
+        <div style={{ marginLeft: 'auto', display: 'inline-flex', gap: 8 }}>
+          <button onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+            style={{
+              padding: '8px 14px', borderRadius: 999,
+              border: '1px solid ' + (theme === 'dark' ? 'rgba(224,180,110,0.28)' : 'rgba(180,130,80,0.32)'),
+              background: theme === 'dark' ? '#1e1710' : '#fff',
+              color: theme === 'dark' ? '#f0e4d2' : '#2b1f12',
+              fontFamily: 'var(--f-display)', fontWeight: 600, fontSize: 13,
+              cursor: 'pointer',
+            }}>{theme === 'light' ? '🌙 Dark' : '☀️ Light'}</button>
+        </div>
+      </div>
+
+      {/* DESKTOP */}
+      <h2 style={{
+        maxWidth: 1480, margin: '0 auto 14px',
+        fontFamily: 'var(--f-display)', fontSize: 14, fontWeight: 700,
+        textTransform: 'uppercase', letterSpacing: '0.08em',
+        color: theme === 'dark' ? '#c8b896' : '#5a4a38',
+      }}>Desktop · 1440</h2>
+      <div style={{
+        maxWidth: 1480, margin: '0 auto 48px',
+        display: 'flex', justifyContent: 'center',
+      }}>
+        <DesktopScreen label="01 Default desktop · How it works" theme={theme} />
+      </div>
+
+      {/* MOBILE */}
+      <h2 style={{
+        maxWidth: 1480, margin: '0 auto 14px',
+        fontFamily: 'var(--f-display)', fontSize: 14, fontWeight: 700,
+        textTransform: 'uppercase', letterSpacing: '0.08em',
+        color: theme === 'dark' ? '#c8b896' : '#5a4a38',
+      }}>Mobile · 375</h2>
+      <div style={{
+        maxWidth: 1480, margin: '0 auto 48px',
+        display: 'flex', justifyContent: 'center',
+      }}>
+        <MobileScreen label="02 Default mobile · How it works" theme={theme} />
+      </div>
+
+      {/* DOD CHECKLIST */}
+      <div style={{
+        maxWidth: 900, margin: '40px auto 0',
+        padding: '24px 28px',
+        background: theme === 'dark' ? '#1e1710' : '#fff',
+        border: '1px solid ' + (theme === 'dark' ? 'rgba(224,180,110,0.14)' : 'rgba(180,130,80,0.18)'),
+        borderRadius: 16,
+        color: theme === 'dark' ? '#f0e4d2' : '#2b1f12',
+      }}>
+        <h3 style={{ fontFamily: 'var(--f-display)', margin: '0 0 12px', fontSize: 18 }}>DoD Checklist · sp3-how-it-works</h3>
+        <ul style={{ fontFamily: 'var(--f-body)', fontSize: 13.5, lineHeight: 1.7, color: theme === 'dark' ? '#c8b896' : '#5a4a38', paddingLeft: 20, margin: 0 }}>
+          <li>✓ Route target /how-it-works</li>
+          <li>✓ Hero: emoji stack 🎲🤖🧰 + h1 "Come funziona MeepleAI" + subtitle 1-riga</li>
+          <li>✓ HeroGradient riusato 1:1 da public.jsx (pub-hero pattern: kicker mono + h1 con .mark gradient + hero-lead)</li>
+          <li>✓ 4 step alternati left/right desktop (reverse su index pari), stacked mobile</li>
+          <li>✓ Step cards: numero ordinale 01/02/03/04 grande Quicksand + EntityChip palette + h2 + 3 bullet + illustrazione gradient placeholder</li>
+          <li>✓ Border-left palette entity progressione cromatica: Game → KB → Session → Toolkit</li>
+          <li>✓ Illustrazioni inline (NO immagini esterne): library mockup · PDF→KB→Agent flow · Session+chat+timer · Toolkit bundle card</li>
+          <li>✓ Dati realistici (Wingspan, Azul, Marco, Davide, AZL-7X2K, e5-base 768d)</li>
+          <li>✓ Footer: gradient game→toolkit pill CTA "Inizia gratis" → /register + sub-CTA testuale "Accedi" → /login</li>
+          <li>✓ ARIA: h1 unico hero · article+h2 step · aria-label "Passo N di 4" su numero</li>
+          <li>✓ Light + Dark mode toggle persistito</li>
+          <li>✓ Mobile 375 + Desktop 1440</li>
+          <li>✓ Componente v2 nuovo: HowItWorksStep · Riusi: HeroGradient (public.jsx), EntityChip (e-chip pattern)</li>
+          <li>✓ NON sovrascritto components.css né data.js</li>
+          <li>✓ Stato singolo (default) — pagina statica come da contratto</li>
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/admin-mockups/design_files/sp3-legal.html
+++ b/admin-mockups/design_files/sp3-legal.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<!-- MeepleAI SP3 missing — #3 · Legal pages template
+     Route: /terms (riusabile per /privacy /cookies)
+     Template UNICO — flag: privacy + cookies useranno stesso shell con contenuto diverso -->
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>MeepleAI · /terms — Termini di Servizio</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp3-legal.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp3-legal.jsx
+++ b/admin-mockups/design_files/sp3-legal.jsx
@@ -1,0 +1,646 @@
+/* MeepleAI SP3 missing — #3 · Legal pages template
+   Route: /terms (template riusabile per /privacy /cookies)
+   Componenti v2 nuovi: LegalPageShell, LegalTOC
+   isMobile: prop esplicita dalla frame + scroll-spy basato su elementi nel DOM
+*/
+
+const { useState, useEffect, useRef } = React;
+
+// ── PLACEHOLDER CONTENT ────────────────────────────────────────────────────
+const TERMS_DOC = {
+  type: 'terms',
+  docTitle: 'Termini di Servizio',
+  updated: '26 aprile 2026',
+  version: '2.4.0',
+  sections: [
+    {
+      id: 'accettazione',
+      h: 'Accettazione dei termini',
+      paragraphs: [
+        'Accedendo o utilizzando MeepleAI ("il Servizio") accetti integralmente i presenti Termini di Servizio e la nostra Privacy Policy. Se non concordi con uno qualsiasi dei termini qui descritti, non sei autorizzato a utilizzare il Servizio.',
+        'L\'accettazione avviene al primo accesso al Servizio o al momento della creazione del tuo account. Continuando a usare MeepleAI dopo eventuali modifiche, confermi l\'accettazione della versione aggiornata dei termini.',
+        'Se utilizzi MeepleAI per conto di un\'organizzazione, dichiari di avere l\'autorità necessaria per impegnare tale organizzazione al rispetto dei presenti termini.',
+      ],
+    },
+    {
+      id: 'descrizione-servizio',
+      h: 'Descrizione del servizio',
+      paragraphs: [
+        'MeepleAI è un servizio di companion app per giochi da tavolo che permette agli utenti di costruire una libreria personale, indicizzare regolamenti tramite agenti AI, gestire sessioni di gioco e condividere toolkit con la community.',
+        'Il Servizio include funzionalità di intelligenza artificiale generativa basate su modelli di linguaggio di terze parti. Le risposte degli agenti sono indicative e non sostituiscono la consultazione del regolamento ufficiale del gioco. MeepleAI non garantisce l\'accuratezza assoluta delle informazioni fornite dagli agenti.',
+        'Il Servizio è offerto in versione free, pro e team. Le caratteristiche di ciascun piano sono descritte sulla pagina /pricing e possono variare nel tempo con preavviso di almeno 30 giorni per gli utenti paganti.',
+      ],
+    },
+    {
+      id: 'account-utente',
+      h: 'Account utente e responsabilità',
+      paragraphs: [
+        'Per accedere alla maggior parte delle funzionalità di MeepleAI è necessario creare un account. Sei responsabile della riservatezza delle tue credenziali e di tutte le attività che avvengono sotto il tuo account.',
+        'Devi notificarci immediatamente qualsiasi uso non autorizzato del tuo account scrivendo a security@meepleai.app. MeepleAI non è responsabile per perdite causate dall\'uso non autorizzato del tuo account dovuto a tua negligenza nella custodia delle credenziali.',
+        'Devi avere almeno 16 anni per creare un account. I minori di 16 anni possono utilizzare il Servizio solo con il consenso di un genitore o tutore legale, fornendo prova del consenso al nostro Data Protection Officer.',
+      ],
+    },
+    {
+      id: 'contenuti-utente',
+      h: 'Contenuti utente e proprietà intellettuale',
+      paragraphs: [
+        'Mantieni la piena proprietà di tutti i contenuti che carichi su MeepleAI, inclusi PDF di regolamenti, house rules, toolkit personalizzati e dati delle sessioni di gioco. Concedi a MeepleAI una licenza limitata, non esclusiva e gratuita per elaborare, indicizzare e mostrare tali contenuti al solo scopo di fornirti il Servizio.',
+        'È tua responsabilità assicurarti di avere il diritto di caricare il materiale che condividi. Non caricare PDF di regolamenti coperti da copyright se non sei l\'editore o non hai esplicita autorizzazione. MeepleAI rispetta il DMCA e risponde tempestivamente alle richieste di rimozione legittime.',
+        'I toolkit pubblicati sulla community vengono distribuiti con licenza CC-BY-SA 4.0 di default, salvo diversa licenza specificata dall\'autore al momento della pubblicazione. Gli agenti e le KB rimangono di proprietà esclusiva del creatore.',
+      ],
+    },
+    {
+      id: 'comportamenti-vietati',
+      h: 'Comportamenti vietati',
+      paragraphs: [
+        'È vietato utilizzare MeepleAI per: caricare contenuti illegali, diffamatori, osceni o che violino diritti di terzi; tentare di aggirare le limitazioni del piano sottoscritto; eseguire scraping automatizzato del catalogo community; effettuare attacchi DoS o tentativi di intrusione nei nostri sistemi.',
+        'È inoltre vietato pubblicare toolkit o contenuti che incoraggino comportamenti tossici nella community boardgame, harassment di altri utenti o violazioni dei diritti di proprietà intellettuale di editori e autori.',
+        'MeepleAI si riserva il diritto di sospendere o terminare account in violazione di queste regole, senza preavviso nei casi più gravi e con notifica via email negli altri casi. La decisione di MeepleAI è insindacabile.',
+      ],
+    },
+    {
+      id: 'limitazione-responsabilita',
+      h: 'Limitazione di responsabilità',
+      paragraphs: [
+        'Il Servizio è fornito "così com\'è" senza garanzie di alcun tipo, espresse o implicite. MeepleAI non garantisce che il Servizio sarà ininterrotto, privo di errori o conforme a qualsiasi tua specifica esigenza.',
+        'In nessun caso MeepleAI sarà responsabile per danni indiretti, incidentali, speciali, consequenziali o punitivi derivanti dall\'uso o dall\'impossibilità di utilizzare il Servizio. La responsabilità totale di MeepleAI nei tuoi confronti è limitata all\'ammontare pagato negli ultimi 12 mesi, o a 50 euro se utilizzi il piano free.',
+        'Le risposte degli agenti AI hanno scopo informativo e non costituiscono consulenza legale, medica, finanziaria o di altro tipo. Le decisioni durante una partita rimangono responsabilità dei giocatori.',
+      ],
+    },
+    {
+      id: 'modifiche-termini',
+      h: 'Modifiche ai termini',
+      paragraphs: [
+        'MeepleAI può modificare questi termini in qualsiasi momento. Le modifiche sostanziali saranno notificate via email registrata almeno 30 giorni prima dell\'entrata in vigore. Le modifiche minori (refusi, chiarimenti) entrano in vigore immediatamente con notifica in-app.',
+        'La versione corrente dei termini è sempre disponibile su questa pagina con data di aggiornamento e numero di versione semver. Le versioni precedenti sono archiviate e accessibili tramite la nostra pagina /legal/archive.',
+        'Se non concordi con le modifiche, hai diritto a chiudere il tuo account entro 30 giorni dalla notifica e ricevere il rimborso pro-rata della parte non goduta dell\'abbonamento attivo.',
+      ],
+    },
+    {
+      id: 'legge-applicabile',
+      h: 'Legge applicabile e foro competente',
+      paragraphs: [
+        'I presenti termini sono regolati dalla legge italiana. Qualsiasi controversia derivante dall\'utilizzo del Servizio sarà sottoposta in via esclusiva alla giurisdizione del Tribunale di Milano, fatto salvo il diritto del consumatore di adire il foro della propria residenza ai sensi del Codice del Consumo.',
+        'Prima di intraprendere azioni legali, le parti si impegnano a tentare una risoluzione amichevole tramite il nostro DPO (privacy@meepleai.app) per un periodo minimo di 30 giorni dalla prima comunicazione formale.',
+        'Se una qualsiasi clausola di questi termini fosse dichiarata invalida o inapplicabile da un\'autorità competente, la restante parte dei termini rimarrà pienamente in vigore.',
+      ],
+    },
+  ],
+};
+
+// ── LEGAL TOC — desktop sticky + mobile collapsible ────────────────────────
+const LegalTOC = ({ sections, activeId, onClickAnchor, isMobile }) => {
+  if (isMobile) {
+    return (
+      <details
+        style={{
+          margin: '0 0 24px',
+          background: 'var(--bg-card)',
+          border: '1px solid var(--border)',
+          borderRadius: 12,
+          overflow: 'hidden',
+        }}
+      >
+        <summary
+          style={{
+            cursor: 'pointer',
+            padding: '14px 16px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            fontFamily: 'var(--f-display)',
+            fontWeight: 700,
+            fontSize: 14,
+            color: 'var(--text)',
+            listStyle: 'none',
+          }}
+        >
+          <span aria-hidden="true">📋</span>
+          <span>Indice</span>
+          <span style={{
+            marginLeft: 'auto',
+            fontFamily: 'var(--f-mono)', fontSize: 11,
+            color: 'var(--text-muted)', fontWeight: 500,
+          }}>{sections.length} sezioni</span>
+        </summary>
+        <nav role="navigation" aria-label="Indice della pagina"
+          style={{
+            display: 'flex', flexDirection: 'column',
+            borderTop: '1px solid var(--border-light)',
+            padding: '8px 0',
+          }}>
+          {sections.map((s, i) => (
+            <a
+              key={s.id}
+              href={`#${s.id}`}
+              onClick={e => onClickAnchor(e, s.id)}
+              style={{
+                padding: '8px 16px',
+                fontSize: 13.5, fontFamily: 'var(--f-body)',
+                color: 'var(--text-sec)', textDecoration: 'none',
+                display: 'flex', gap: 10, alignItems: 'center',
+              }}
+            >
+              <span style={{
+                fontFamily: 'var(--f-mono)', fontSize: 11,
+                color: 'var(--text-muted)', fontVariantNumeric: 'tabular-nums',
+                minWidth: 18,
+              }}>{String(i + 1).padStart(2, '0')}</span>
+              {s.h}
+            </a>
+          ))}
+        </nav>
+      </details>
+    );
+  }
+
+  return (
+    <aside style={{ position: 'sticky', top: 24, alignSelf: 'start', width: 240 }}>
+      <div style={{
+        fontFamily: 'var(--f-mono)',
+        fontSize: 11, fontWeight: 600,
+        color: 'var(--text-muted)',
+        textTransform: 'uppercase',
+        letterSpacing: '0.12em',
+        marginBottom: 14,
+        paddingLeft: 12,
+      }}>
+        In questa pagina
+      </div>
+      <nav role="navigation" aria-label="Indice della pagina"
+        style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        {sections.map((s, i) => {
+          const isActive = activeId === s.id;
+          return (
+            <a
+              key={s.id}
+              href={`#${s.id}`}
+              aria-current={isActive ? 'location' : undefined}
+              onClick={e => onClickAnchor(e, s.id)}
+              style={{
+                position: 'relative',
+                padding: '8px 12px 8px 14px',
+                borderLeft: `2px solid ${isActive ? 'hsl(var(--c-kb))' : 'transparent'}`,
+                background: isActive ? 'hsl(var(--c-kb) / 0.06)' : 'transparent',
+                color: isActive ? 'var(--text)' : 'var(--text-sec)',
+                fontFamily: 'var(--f-body)',
+                fontSize: 13.5,
+                fontWeight: isActive ? 700 : 500,
+                textDecoration: 'none',
+                lineHeight: 1.4,
+                borderRadius: '0 8px 8px 0',
+                transition: 'all 120ms ease',
+                display: 'flex', gap: 10, alignItems: 'flex-start',
+              }}
+            >
+              <span style={{
+                fontFamily: 'var(--f-mono)', fontSize: 10.5,
+                color: isActive ? 'hsl(var(--c-kb))' : 'var(--text-muted)',
+                fontVariantNumeric: 'tabular-nums',
+                fontWeight: 600,
+                marginTop: 2,
+                minWidth: 18,
+              }}>{String(i + 1).padStart(2, '0')}</span>
+              <span>{s.h}</span>
+            </a>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+};
+
+// ── LEGAL PAGE SHELL — Hero + Layout ───────────────────────────────────────
+const LegalPageShell = ({ doc, isMobile }) => {
+  const [activeId, setActiveId] = useState(doc.sections[0]?.id);
+  const bodyRef = useRef(null);
+
+  // scroll-spy — observes section H2 elements within the body
+  useEffect(() => {
+    if (isMobile) return;
+    const root = bodyRef.current;
+    if (!root) return;
+    const sections = doc.sections.map(s => root.querySelector(`#${s.id}`)).filter(Boolean);
+    const observer = new IntersectionObserver(
+      entries => {
+        const visible = entries
+          .filter(e => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible[0]?.target?.id) setActiveId(visible[0].target.id);
+      },
+      { rootMargin: '-20% 0px -60% 0px', threshold: [0, 0.5, 1] }
+    );
+    sections.forEach(s => observer.observe(s));
+    return () => observer.disconnect();
+  }, [doc.sections, isMobile]);
+
+  const handleAnchor = (e, id) => {
+    e.preventDefault();
+    const el = bodyRef.current?.querySelector(`#${id}`);
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      setActiveId(id);
+    }
+  };
+
+  return (
+    <main style={{ background: 'var(--bg)', minHeight: '100%' }}>
+      {/* HERO */}
+      <header style={{
+        padding: isMobile ? '40px 16px 28px' : '64px 24px 40px',
+        borderBottom: '1px solid var(--border)',
+        background: `linear-gradient(180deg, hsl(var(--c-kb) / 0.04), transparent 80%)`,
+      }}>
+        <div style={{ maxWidth: 1180, margin: '0 auto' }}>
+          <div style={{
+            display: 'inline-flex', alignItems: 'center', gap: 8,
+            padding: '4px 10px',
+            background: 'hsl(var(--c-kb) / 0.12)',
+            color: 'hsl(var(--c-kb))',
+            border: '1px solid hsl(var(--c-kb) / 0.25)',
+            borderRadius: 999,
+            fontFamily: 'var(--f-display)', fontWeight: 600, fontSize: 11,
+            letterSpacing: '0.06em', textTransform: 'uppercase',
+            marginBottom: 16,
+          }}>
+            <span aria-hidden="true">📄</span>
+            <span>{doc.type === 'terms' ? 'Termini' : doc.type === 'privacy' ? 'Privacy' : 'Cookie'}</span>
+          </div>
+          <h1 style={{
+            fontFamily: 'var(--f-display)',
+            fontSize: isMobile ? 30 : 44,
+            fontWeight: 700,
+            lineHeight: 1.1,
+            letterSpacing: '-0.02em',
+            margin: '0 0 12px',
+            color: 'var(--text)',
+            textWrap: 'balance',
+          }}>{doc.docTitle}</h1>
+          <div style={{
+            display: 'flex', flexWrap: 'wrap', gap: 16,
+            fontFamily: 'var(--f-mono)', fontSize: 12.5,
+            color: 'var(--text-muted)',
+          }}>
+            <span>Ultimo aggiornamento: <strong style={{ color: 'var(--text-sec)', fontWeight: 600 }}>{doc.updated}</strong></span>
+            <span style={{ color: 'var(--border-strong)' }}>·</span>
+            <span>Versione <strong style={{ color: 'var(--text-sec)', fontWeight: 600 }}>{doc.version}</strong></span>
+          </div>
+        </div>
+      </header>
+
+      {/* LAYOUT */}
+      <div style={{
+        maxWidth: 1180, margin: '0 auto',
+        padding: isMobile ? '24px 16px 60px' : '40px 24px 80px',
+        display: isMobile ? 'block' : 'grid',
+        gridTemplateColumns: isMobile ? '1fr' : '240px minmax(0, 1fr)',
+        gap: isMobile ? 0 : 56,
+        alignItems: 'start',
+      }}>
+        <LegalTOC
+          sections={doc.sections}
+          activeId={activeId}
+          onClickAnchor={handleAnchor}
+          isMobile={isMobile}
+        />
+
+        {/* BODY */}
+        <article ref={bodyRef} style={{
+          maxWidth: '68ch',
+          fontFamily: 'var(--f-body)',
+          color: 'var(--text)',
+          lineHeight: 1.75,
+          fontSize: isMobile ? 15 : 16,
+        }}>
+          {doc.sections.map((s, i) => (
+            <section
+              key={s.id}
+              id={s.id}
+              style={{
+                marginBottom: isMobile ? 36 : 48,
+                scrollMarginTop: 80,
+              }}
+            >
+              <div style={{
+                display: 'flex', alignItems: 'baseline', gap: 12,
+                marginBottom: 14,
+              }}>
+                <span style={{
+                  fontFamily: 'var(--f-mono)',
+                  fontSize: 12, fontWeight: 600,
+                  color: 'hsl(var(--c-kb))',
+                  fontVariantNumeric: 'tabular-nums',
+                  letterSpacing: '0.04em',
+                }}>{String(i + 1).padStart(2, '0')}</span>
+                <h2 style={{
+                  fontFamily: 'var(--f-display)',
+                  fontSize: isMobile ? 22 : 26,
+                  fontWeight: 700,
+                  lineHeight: 1.2,
+                  letterSpacing: '-0.015em',
+                  margin: 0,
+                  color: 'var(--text)',
+                  textWrap: 'balance',
+                }}>{s.h}</h2>
+              </div>
+              {s.paragraphs.map((p, pi) => (
+                <p key={pi} style={{
+                  margin: '0 0 14px',
+                  textWrap: 'pretty',
+                  color: 'var(--text-sec)',
+                }}>{renderInline(p)}</p>
+              ))}
+            </section>
+          ))}
+
+          {/* Footer card */}
+          <aside style={{
+            marginTop: 16,
+            padding: isMobile ? '24px 20px' : '28px 32px',
+            background: `linear-gradient(135deg,
+              hsl(var(--c-kb) / 0.08),
+              hsl(var(--c-toolkit) / 0.06))`,
+            border: '1px solid hsl(var(--c-kb) / 0.22)',
+            borderRadius: 16,
+          }}>
+            <div style={{
+              fontFamily: 'var(--f-display)',
+              fontWeight: 700,
+              fontSize: isMobile ? 17 : 20,
+              color: 'var(--text)',
+              marginBottom: 6,
+              letterSpacing: '-0.01em',
+            }}>Hai domande sui nostri termini?</div>
+            <p style={{
+              margin: '0 0 16px',
+              fontFamily: 'var(--f-body)', fontSize: 14.5, lineHeight: 1.6,
+              color: 'var(--text-sec)',
+            }}>
+              Per qualsiasi richiesta legale o sulla privacy, contatta direttamente il nostro Data Protection Officer.
+              Risponderemo entro 5 giorni lavorativi.
+            </p>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, alignItems: 'center' }}>
+              <a href="mailto:privacy@meepleai.app" style={{
+                display: 'inline-flex', alignItems: 'center', gap: 8,
+                padding: '8px 14px',
+                background: 'hsl(var(--c-kb))',
+                color: '#fff',
+                borderRadius: 999,
+                textDecoration: 'none',
+                fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 13.5,
+                boxShadow: '0 4px 12px hsl(var(--c-kb) / 0.3)',
+              }}>
+                <span aria-hidden="true">✉</span>
+                <code style={{
+                  fontFamily: 'var(--f-mono)', fontSize: 12.5, fontWeight: 600,
+                  color: '#fff', background: 'transparent',
+                }}>privacy@meepleai.app</code>
+              </a>
+              <a href="#/contact" style={{
+                fontFamily: 'var(--f-display)', fontWeight: 600,
+                fontSize: 13.5,
+                color: 'hsl(var(--c-kb))',
+                textDecoration: 'underline',
+                textDecorationColor: 'hsl(var(--c-kb) / 0.4)',
+                textUnderlineOffset: 3,
+              }}>Vai al modulo contatto →</a>
+            </div>
+          </aside>
+        </article>
+      </div>
+    </main>
+  );
+};
+
+// helper: render inline links + emails as styled spans
+function renderInline(text) {
+  // simple regex pass for emails to color them entity=kb mono inline
+  const parts = text.split(/(\b[\w.-]+@[\w.-]+\.\w+\b|\/\w[\w-]*)/g);
+  return parts.map((p, i) => {
+    if (/^[\w.-]+@[\w.-]+\.\w+$/.test(p)) {
+      return (
+        <code key={i} style={{
+          fontFamily: 'var(--f-mono)', fontSize: '0.92em',
+          background: 'var(--bg-muted)',
+          padding: '2px 6px', borderRadius: 4,
+          color: 'hsl(var(--c-kb))',
+        }}>{p}</code>
+      );
+    }
+    if (/^\/\w[\w-]*$/.test(p)) {
+      return (
+        <a key={i} href={`#${p}`} style={{
+          color: 'hsl(var(--c-kb))',
+          textDecoration: 'underline',
+          textDecorationColor: 'hsl(var(--c-kb) / 0.4)',
+          textUnderlineOffset: 2,
+          fontFamily: 'var(--f-mono)', fontSize: '0.92em',
+        }}>{p}</a>
+      );
+    }
+    return <React.Fragment key={i}>{p}</React.Fragment>;
+  });
+}
+
+// ── DESKTOP / MOBILE FRAMES ────────────────────────────────────────────────
+const DesktopScreen = ({ label, theme, doc }) => (
+  <div data-screen-label={label} data-theme={theme} style={{
+    width: 1440,
+    background: 'var(--bg)',
+    borderRadius: 16,
+    border: '1px solid var(--border-strong)',
+    overflow: 'hidden',
+    boxShadow: '0 32px 64px -24px rgba(0,0,0,0.25), 0 12px 32px -12px rgba(0,0,0,0.12)',
+  }}>
+    <div style={{
+      padding: '8px 14px',
+      background: 'var(--bg-sunken)',
+      borderBottom: '1px solid var(--border)',
+      display: 'flex', alignItems: 'center', gap: 10,
+      fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)',
+    }}>
+      <span style={{ display: 'inline-flex', gap: 6 }}>
+        <span style={{ width: 10, height: 10, borderRadius: '50%', background: '#FF5F57' }} />
+        <span style={{ width: 10, height: 10, borderRadius: '50%', background: '#FEBC2E' }} />
+        <span style={{ width: 10, height: 10, borderRadius: '50%', background: '#28C840' }} />
+      </span>
+      <span style={{ marginLeft: 8 }}>meepleai.app/{doc.type} · {label}</span>
+    </div>
+    <LegalPageShell doc={doc} isMobile={false} />
+  </div>
+);
+
+const MobileScreen = ({ label, theme, doc }) => (
+  <div data-screen-label={label} data-theme={theme} style={{
+    width: 375,
+    background: 'var(--bg)',
+    borderRadius: 36,
+    border: '8px solid #1a1410',
+    overflow: 'hidden',
+    boxShadow: '0 30px 60px rgba(0,0,0,0.6)',
+    position: 'relative',
+  }}>
+    <div style={{
+      height: 30, background: 'var(--bg-sunken)',
+      display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+      padding: '0 18px',
+      fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 11,
+      color: 'var(--text)',
+    }}>
+      <span>9:41</span>
+      <span style={{ display: 'inline-flex', gap: 6, alignItems: 'center' }}>
+        <span>●●●</span><span>📶</span><span>🔋</span>
+      </span>
+    </div>
+    <LegalPageShell doc={doc} isMobile={true} />
+  </div>
+);
+
+// ── APP ────────────────────────────────────────────────────────────────────
+const App = () => {
+  const [theme, setTheme] = useState(() => {
+    try { return localStorage.getItem('mai-sp3-legal-theme') || 'light'; } catch { return 'light'; }
+  });
+  const [docOpen, setDocOpen] = useState(false); // mobile TOC default closed
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    try { localStorage.setItem('mai-sp3-legal-theme', theme); } catch {}
+  }, [theme]);
+
+  return (
+    <div style={{
+      minHeight: '100vh',
+      background: theme === 'dark' ? '#0a0805' : '#e8dfcf',
+      padding: '40px 24px 80px',
+    }}>
+      {/* Toolbar */}
+      <div style={{
+        maxWidth: 1480, margin: '0 auto 32px',
+        display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap',
+      }}>
+        <div>
+          <div style={{
+            fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 22,
+            color: theme === 'dark' ? '#f0e4d2' : '#2b1f12',
+            letterSpacing: '-0.015em',
+          }}>SP3 · #3 — Legal pages template</div>
+          <div style={{
+            fontFamily: 'var(--f-mono)', fontSize: 12,
+            color: theme === 'dark' ? '#8a7860' : '#9a8870',
+          }}>Route: /terms · Template UNICO riusabile per /privacy + /cookies (stesso shell, contenuto diverso)</div>
+        </div>
+        <div style={{ marginLeft: 'auto' }}>
+          <button onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+            style={{
+              padding: '8px 14px', borderRadius: 999,
+              border: '1px solid ' + (theme === 'dark' ? 'rgba(224,180,110,0.28)' : 'rgba(180,130,80,0.32)'),
+              background: theme === 'dark' ? '#1e1710' : '#fff',
+              color: theme === 'dark' ? '#f0e4d2' : '#2b1f12',
+              fontFamily: 'var(--f-display)', fontWeight: 600, fontSize: 13,
+              cursor: 'pointer',
+            }}>{theme === 'light' ? '🌙 Dark' : '☀️ Light'}</button>
+        </div>
+      </div>
+
+      {/* DESKTOP */}
+      <h2 style={{
+        maxWidth: 1480, margin: '0 auto 14px',
+        fontFamily: 'var(--f-display)', fontSize: 14, fontWeight: 700,
+        textTransform: 'uppercase', letterSpacing: '0.08em',
+        color: theme === 'dark' ? '#c8b896' : '#5a4a38',
+      }}>Desktop · 1440 — Terms (template)</h2>
+      <div style={{
+        maxWidth: 1480, margin: '0 auto 48px',
+        display: 'flex', justifyContent: 'center',
+      }}>
+        <DesktopScreen label="01 Desktop · /terms · TOC sticky + body 68ch" theme={theme} doc={TERMS_DOC} />
+      </div>
+
+      {/* MOBILE */}
+      <h2 style={{
+        maxWidth: 1480, margin: '0 auto 14px',
+        fontFamily: 'var(--f-display)', fontSize: 14, fontWeight: 700,
+        textTransform: 'uppercase', letterSpacing: '0.08em',
+        color: theme === 'dark' ? '#c8b896' : '#5a4a38',
+      }}>Mobile · 375 — Terms (template)</h2>
+      <div style={{
+        maxWidth: 1480, margin: '0 auto 48px',
+        display: 'flex', justifyContent: 'center',
+      }}>
+        <MobileScreen label="02 Mobile · /terms · TOC <details> collassabile" theme={theme} doc={TERMS_DOC} />
+      </div>
+
+      {/* TEMPLATE FLAG */}
+      <div style={{
+        maxWidth: 900, margin: '40px auto 24px',
+        padding: '20px 24px',
+        background: theme === 'dark' ? '#1e1710' : '#fff',
+        border: '1px dashed hsl(174 60% 45% / 0.5)',
+        borderRadius: 16,
+        color: theme === 'dark' ? '#f0e4d2' : '#2b1f12',
+      }}>
+        <div style={{
+          fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 15,
+          marginBottom: 8, color: 'hsl(var(--c-kb))',
+          display: 'flex', alignItems: 'center', gap: 8,
+        }}>
+          <span aria-hidden="true">⚠</span>
+          Template note (per il reviewer)
+        </div>
+        <p style={{
+          margin: 0, fontFamily: 'var(--f-body)', fontSize: 13.5, lineHeight: 1.7,
+          color: theme === 'dark' ? '#c8b896' : '#5a4a38',
+        }}>
+          Questo è un mockup UNICO che funge da template per <strong>3 route</strong>:{' '}
+          <code style={{ fontFamily: 'var(--f-mono)', fontSize: 12, padding: '2px 6px',
+            background: theme === 'dark' ? '#241c13' : '#efe6d9', borderRadius: 4 }}>/terms</code>,{' '}
+          <code style={{ fontFamily: 'var(--f-mono)', fontSize: 12, padding: '2px 6px',
+            background: theme === 'dark' ? '#241c13' : '#efe6d9', borderRadius: 4 }}>/privacy</code>,{' '}
+          <code style={{ fontFamily: 'var(--f-mono)', fontSize: 12, padding: '2px 6px',
+            background: theme === 'dark' ? '#241c13' : '#efe6d9', borderRadius: 4 }}>/cookies</code>.
+          {' '}Lo shell <code style={{ fontFamily: 'var(--f-mono)', fontSize: 12 }}>LegalPageShell</code> accetta una prop{' '}
+          <code style={{ fontFamily: 'var(--f-mono)', fontSize: 12 }}>doc</code> con{' '}
+          <code style={{ fontFamily: 'var(--f-mono)', fontSize: 12 }}>{`{ type, docTitle, updated, version, sections[] }`}</code>.
+          Per privacy + cookies basterà definire un altro oggetto con la stessa shape e cambierà solo il chip in alto, il titolo e il body — TOC, scroll-spy, sticky desktop, details mobile, footer DPO sono identici.
+        </p>
+      </div>
+
+      {/* DOD CHECKLIST */}
+      <div style={{
+        maxWidth: 900, margin: '0 auto',
+        padding: '24px 28px',
+        background: theme === 'dark' ? '#1e1710' : '#fff',
+        border: '1px solid ' + (theme === 'dark' ? 'rgba(224,180,110,0.14)' : 'rgba(180,130,80,0.18)'),
+        borderRadius: 16,
+        color: theme === 'dark' ? '#f0e4d2' : '#2b1f12',
+      }}>
+        <h3 style={{ fontFamily: 'var(--f-display)', margin: '0 0 12px', fontSize: 18 }}>DoD Checklist · sp3-legal</h3>
+        <ul style={{ fontFamily: 'var(--f-body)', fontSize: 13.5, lineHeight: 1.7, color: theme === 'dark' ? '#c8b896' : '#5a4a38', paddingLeft: 20, margin: 0 }}>
+          <li>✓ Route target /terms (template UNICO riusabile per /privacy /cookies — flag visibile)</li>
+          <li>✓ Hero: chip entity-kb + h1 "Termini di Servizio" + meta "Ultimo aggiornamento: 26 aprile 2026 · Versione 2.4.0" mono</li>
+          <li>✓ Border-bottom soft hero + gradient sottile kb tint</li>
+          <li>✓ Desktop: grid 240px sidebar + body 68ch · TOC sticky top:24 con scroll-spy IntersectionObserver</li>
+          <li>✓ TOC item active: border-left 2px hsl(--c-kb) + bg --c-kb/0.06 + text bold + numero 01–08 mono color-coded</li>
+          <li>✓ Smooth scroll su click anchor + scrollMarginTop:80px sulle sezioni</li>
+          <li>✓ Mobile: single column, TOC in &lt;details&gt; collassabile con summary "📋 Indice · 8 sezioni"</li>
+          <li>✓ 8 sezioni H2 placeholder Terms italiano realistico (NO lorem ipsum), 2-3 paragrafi ciascuna</li>
+          <li>✓ Tipografia reading: --f-body Nunito, line-height 1.75, max-width 68ch, fontSize 16/15</li>
+          <li>✓ H2 Quicksand --fs-2xl (~26px desktop / 22px mobile), scroll-margin-top 80</li>
+          <li>✓ Email inline rese come &lt;code&gt; --f-mono + bg --bg-muted + radius 4 + color --c-kb (helper renderInline)</li>
+          <li>✓ Link inline /contact rendered come anchor mono color --c-kb underline soft</li>
+          <li>✓ Footer card: gradient kb→toolkit, "Hai domande sui nostri termini?" + CTA mailto privacy@meepleai.app + sub-CTA /contact</li>
+          <li>✓ ARIA: &lt;main&gt; wrapper, nav role="navigation" aria-label="Indice della pagina", aria-current="location" su sezione attiva</li>
+          <li>✓ &lt;details&gt; mobile con &lt;summary&gt; clickable nativo (toggle keyboard accessibile out-of-the-box)</li>
+          <li>✓ Light + Dark mode toggle persistito</li>
+          <li>✓ NO window.innerWidth in body components — isMobile è prop esplicita dalla frame (lezione sp3-how-it-works applicata)</li>
+          <li>✓ Componenti v2 nuovi: LegalPageShell · LegalTOC (varianti sticky+collapsible)</li>
+          <li>✓ NON sovrascritto components.css né data.js</li>
+          <li>✓ Stato singolo (default) — content statico come da contratto</li>
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/admin-mockups/design_files/sp3-library-public.html
+++ b/admin-mockups/design_files/sp3-library-public.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<!-- MeepleAI SP3 missing — #8 · /library (public variant, non-loggato)
+     ULTIMO OBBLIGATORIO SP3 -->
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>MeepleAI · /library — La library della community</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp3-library-public.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp3-library-public.jsx
+++ b/admin-mockups/design_files/sp3-library-public.jsx
@@ -1,0 +1,816 @@
+/* MeepleAI SP3 missing — #8 · /library (public variant)
+   ULTIMO OBBLIGATORIO SP3
+   Componenti v2 nuovi: CommunityStatsRow · FeaturedGamesCarousel
+   Riusi: HeroGradient (pattern pub-hero) · MeepleCard hero/grid · EntityChip
+*/
+
+const { useState, useEffect, useRef } = React;
+
+// ── DATA ───────────────────────────────────────────────────────────────────
+const FEATURED_GAMES = [
+  { id: 'g-wingspan', t: 'Wingspan', a: 'Stonemaier · 2019', sessions: 8421, hue: 142, sat: 30, emoji: '🐦' },
+  { id: 'g-azul', t: 'Azul', a: 'Plan B · 2017', sessions: 7280, hue: 200, sat: 55, emoji: '🔷' },
+  { id: 'g-brass-bham', t: 'Brass: Birmingham', a: 'Roxley · 2018', sessions: 6940, hue: 28, sat: 45, emoji: '⚙️' },
+  { id: 'g-7wonders', t: '7 Wonders', a: 'Repos · 2010', sessions: 6105, hue: 36, sat: 50, emoji: '🏛' },
+  { id: 'g-ticket-ride', t: 'Ticket to Ride', a: 'Days of Wonder · 2004', sessions: 5870, hue: 8, sat: 55, emoji: '🚂' },
+  { id: 'g-catan', t: 'Catan', a: 'Kosmos · 1995', sessions: 5240, hue: 18, sat: 45, emoji: '🏝' },
+  { id: 'g-carcassonne', t: 'Carcassonne', a: 'Hans im Glück · 2000', sessions: 4980, hue: 88, sat: 30, emoji: '🏰' },
+  { id: 'g-terraforming-mars', t: 'Terraforming Mars', a: 'Stronghold · 2016', sessions: 4720, hue: 12, sat: 60, emoji: '🪐' },
+  { id: 'g-spirit-island', t: 'Spirit Island', a: 'Greater Than · 2017', sessions: 4150, hue: 168, sat: 40, emoji: '🌿' },
+  { id: 'g-gloomhaven', t: 'Gloomhaven', a: 'Cephalofair · 2017', sessions: 3920, hue: 268, sat: 28, emoji: '⚔️' },
+];
+
+const TRENDING_GAMES = [
+  { id: 'g-wyrmspan', t: 'Wyrmspan', a: 'Stonemaier · 2024', growth: 47, hue: 348, sat: 35, emoji: '🐉' },
+  { id: 'g-arcs', t: 'Arcs', a: 'Leder Games · 2024', growth: 39, hue: 252, sat: 40, emoji: '🌌' },
+  { id: 'g-sea-salt-paper', t: 'Sea Salt & Paper', a: 'Bombyx · 2022', growth: 34, hue: 188, sat: 50, emoji: '🐚' },
+  { id: 'g-harmonies', t: 'Harmonies', a: 'Libellud · 2024', growth: 28, hue: 158, sat: 35, emoji: '🦊' },
+  { id: 'g-sky-team', t: 'Sky Team', a: 'Le Scorpion · 2023', growth: 25, hue: 218, sat: 50, emoji: '✈️' },
+  { id: 'g-lacrimosa', t: 'Lacrimosa', a: 'Devir · 2022', growth: 22, hue: 22, sat: 35, emoji: '🎼' },
+  { id: 'g-darwins', t: 'Darwin\'s Journey', a: 'ThunderGryph · 2023', growth: 19, hue: 78, sat: 35, emoji: '🦎' },
+  { id: 'g-revive', t: 'Revive', a: 'Aporta · 2022', growth: 17, hue: 308, sat: 35, emoji: '🌱' },
+];
+
+const CATEGORIES = [
+  { id: 'c-strategia', label: 'Strategia', count: 1284, emoji: '♟' },
+  { id: 'c-famiglia', label: 'Famiglia', count: 942, emoji: '👨‍👩‍👧' },
+  { id: 'c-party', label: 'Party', count: 487, emoji: '🎉' },
+  { id: 'c-cooperativo', label: 'Cooperativo', count: 312, emoji: '🤝' },
+  { id: 'c-astratto', label: 'Astratto', count: 268, emoji: '◆' },
+  { id: 'c-tematico', label: 'Tematico', count: 524, emoji: '🗡' },
+  { id: 'c-wargame', label: 'Wargame', count: 198, emoji: '⚔' },
+];
+
+// ── PRIMITIVES ─────────────────────────────────────────────────────────────
+const Skeleton = ({ w = '100%', h = 16, r = 6, style = {} }) => (
+  <div style={{
+    width: w, height: h, borderRadius: r,
+    background: 'linear-gradient(90deg, var(--bg-sunken) 0%, var(--bg-muted) 50%, var(--bg-sunken) 100%)',
+    backgroundSize: '200% 100%',
+    animation: 'meepleSkeleton 1.6s linear infinite',
+    ...style,
+  }} />
+);
+
+// Hero gradient (riuso pattern pub-hero da sp3-how-it-works)
+const HeroGradient = ({ kicker, title, subtitle, isMobile }) => (
+  <header style={{
+    position: 'relative',
+    padding: isMobile ? '52px 16px 40px' : '88px 24px 56px',
+    overflow: 'hidden',
+    isolation: 'isolate',
+  }}>
+    {/* Multi-radial gradient soft */}
+    <div aria-hidden="true" style={{
+      position: 'absolute', inset: 0, zIndex: -1,
+      background: `
+        radial-gradient(ellipse 60% 80% at 18% 30%, hsl(var(--c-game) / 0.18), transparent 60%),
+        radial-gradient(ellipse 50% 70% at 82% 20%, hsl(var(--c-player) / 0.16), transparent 60%),
+        radial-gradient(ellipse 55% 60% at 50% 90%, hsl(var(--c-session) / 0.14), transparent 60%),
+        var(--bg)
+      `,
+    }} />
+    <div style={{ maxWidth: 1180, margin: '0 auto', textAlign: 'center' }}>
+      <div style={{
+        fontFamily: 'var(--f-mono)', fontWeight: 600,
+        fontSize: 11, letterSpacing: '0.18em', textTransform: 'uppercase',
+        color: 'hsl(var(--c-player))', marginBottom: 14,
+        display: 'inline-flex', alignItems: 'center', gap: 8,
+      }}>
+        <span style={{
+          width: 6, height: 6, borderRadius: '50%',
+          background: 'hsl(var(--c-player))',
+          boxShadow: '0 0 8px hsl(var(--c-player) / 0.6)',
+          animation: 'meeplePulse 2s ease-in-out infinite',
+        }} />
+        {kicker}
+      </div>
+      <h1 style={{
+        fontFamily: 'var(--f-display)',
+        fontSize: isMobile ? 36 : 60,
+        fontWeight: 700,
+        lineHeight: 1.05,
+        letterSpacing: '-0.025em',
+        margin: '0 0 16px',
+        color: 'var(--text)',
+        textWrap: 'balance',
+      }}>{title.before}<span style={{
+        background: `linear-gradient(105deg, hsl(var(--c-game)) 0%, hsl(var(--c-player)) 60%, hsl(var(--c-session)) 100%)`,
+        WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent',
+        backgroundClip: 'text',
+      }}>{title.mark}</span>{title.after}</h1>
+      <p style={{
+        margin: '0 auto', maxWidth: 580,
+        fontFamily: 'var(--f-body)', fontSize: isMobile ? 16 : 19,
+        lineHeight: 1.55, color: 'var(--text-sec)',
+      }}>{subtitle}</p>
+    </div>
+  </header>
+);
+
+// ── COMMUNITY STATS ROW (componente v2 nuovo) ─────────────────────────────
+const useCountUp = (target, duration = 1400, run = true) => {
+  const [v, setV] = useState(run ? 0 : target);
+  useEffect(() => {
+    if (!run) { setV(target); return; }
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (reduced) { setV(target); return; }
+    let raf, start;
+    const tick = (t) => {
+      if (!start) start = t;
+      const p = Math.min((t - start) / duration, 1);
+      const eased = 1 - Math.pow(1 - p, 3);
+      setV(Math.floor(target * eased));
+      if (p < 1) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [target, duration, run]);
+  return v;
+};
+
+const StatNum = ({ target, format = 'int', run }) => {
+  const v = useCountUp(target, 1400, run);
+  const formatted = format === 'int'
+    ? v.toLocaleString('it-IT')
+    : `${(v / 1_000_000).toFixed(1)}M`;
+  return <span style={{ fontVariantNumeric: 'tabular-nums' }}>{formatted}</span>;
+};
+
+const CommunityStatsRow = ({ isMobile, run }) => {
+  const stats = [
+    { icon: '👤', label: 'giocatori attivi', target: 12847, format: 'int', cv: '--c-player' },
+    { icon: '🎯', label: 'partite giocate', target: 89234, format: 'int', cv: '--c-session' },
+    { icon: '💬', label: 'ore di chat con agenti', target: 4_200_000, format: 'M', cv: '--c-chat' },
+  ];
+  return (
+    <div style={{
+      maxWidth: 1180, margin: '0 auto',
+      padding: isMobile ? '0 16px' : '0 24px',
+      marginTop: isMobile ? -24 : -36,
+      position: 'relative', zIndex: 2,
+    }}>
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: isMobile ? '1fr' : 'repeat(3, 1fr)',
+        gap: isMobile ? 12 : 16,
+      }}>
+        {stats.map(s => (
+          <div key={s.label} style={{
+            background: 'var(--bg-card)',
+            border: '1px solid var(--border)',
+            borderRadius: 16,
+            padding: isMobile ? '18px 20px' : '24px 28px',
+            display: 'flex', alignItems: 'center', gap: 16,
+            boxShadow: '0 4px 16px -4px rgba(0,0,0,0.06)',
+          }}>
+            <div style={{
+              width: 48, height: 48, borderRadius: 12,
+              background: `hsl(var(${s.cv}) / 0.14)`,
+              display: 'grid', placeItems: 'center',
+              fontSize: 22,
+              flexShrink: 0,
+            }}>{s.icon}</div>
+            <div style={{ minWidth: 0, flex: 1 }}>
+              <div style={{
+                fontFamily: 'var(--f-display)',
+                fontSize: isMobile ? 26 : 30, fontWeight: 700,
+                color: `hsl(var(${s.cv}))`,
+                lineHeight: 1.1, letterSpacing: '-0.02em',
+              }}>
+                <StatNum target={s.target} format={s.format} run={run} />
+              </div>
+              <div style={{
+                fontFamily: 'var(--f-body)',
+                fontSize: 13.5, color: 'var(--text-sec)',
+                marginTop: 2,
+              }}>{s.label}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const StatsRowSkeleton = ({ isMobile }) => (
+  <div style={{
+    maxWidth: 1180, margin: '0 auto',
+    padding: isMobile ? '0 16px' : '0 24px',
+    marginTop: isMobile ? -24 : -36,
+    position: 'relative', zIndex: 2,
+  }}>
+    <div style={{
+      display: 'grid',
+      gridTemplateColumns: isMobile ? '1fr' : 'repeat(3, 1fr)',
+      gap: isMobile ? 12 : 16,
+    }}>
+      {[0, 1, 2].map(i => (
+        <div key={i} style={{
+          background: 'var(--bg-card)', border: '1px solid var(--border)',
+          borderRadius: 16, padding: isMobile ? '18px 20px' : '24px 28px',
+          display: 'flex', alignItems: 'center', gap: 16,
+        }}>
+          <Skeleton w={48} h={48} r={12} />
+          <div style={{ flex: 1 }}>
+            <Skeleton w="60%" h={26} r={6} style={{ marginBottom: 8 }} />
+            <Skeleton w="80%" h={12} r={6} />
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+// ── MEEPLE CARD HERO (riuso variant) ──────────────────────────────────────
+const MeepleCardHero = ({ g, rank }) => (
+  <article style={{
+    width: 320, minWidth: 320,
+    background: 'var(--bg-card)',
+    border: '1px solid var(--border)',
+    borderRadius: 18,
+    overflow: 'hidden',
+    scrollSnapAlign: 'start',
+    boxShadow: '0 4px 16px -4px rgba(0,0,0,0.08)',
+    display: 'flex', flexDirection: 'column',
+  }}>
+    {/* cover */}
+    <div style={{
+      position: 'relative',
+      height: 160,
+      background: `linear-gradient(135deg, hsl(${g.hue} ${g.sat}% 55%) 0%, hsl(${(g.hue + 30) % 360} ${g.sat}% 40%) 100%)`,
+      display: 'grid', placeItems: 'center',
+      fontSize: 64,
+    }}>
+      <span aria-hidden="true">{g.emoji}</span>
+      {rank != null && (
+        <div style={{
+          position: 'absolute', top: 10, left: 10,
+          padding: '4px 10px',
+          background: 'rgba(20,14,8,0.72)',
+          color: '#fff', backdropFilter: 'blur(8px)',
+          borderRadius: 999,
+          fontFamily: 'var(--f-mono)', fontSize: 11, fontWeight: 700,
+          letterSpacing: '0.05em',
+        }}>#{rank}</div>
+      )}
+    </div>
+    {/* body */}
+    <div style={{ padding: '14px 16px 16px', flex: 1, display: 'flex', flexDirection: 'column' }}>
+      <h3 style={{
+        margin: '0 0 4px',
+        fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 17,
+        color: 'var(--text)', letterSpacing: '-0.01em', lineHeight: 1.2,
+      }}>{g.t}</h3>
+      <div style={{
+        fontFamily: 'var(--f-body)', fontSize: 12.5, color: 'var(--text-muted)',
+        marginBottom: 12,
+      }}>{g.a}</div>
+      <div style={{
+        marginTop: 'auto',
+        display: 'inline-flex', alignItems: 'center', gap: 6,
+        padding: '5px 10px',
+        background: 'hsl(var(--c-session) / 0.12)',
+        border: '1px solid hsl(var(--c-session) / 0.25)',
+        borderRadius: 999,
+        fontFamily: 'var(--f-mono)', fontSize: 11.5, fontWeight: 600,
+        color: 'hsl(var(--c-session))',
+        alignSelf: 'flex-start',
+        fontVariantNumeric: 'tabular-nums',
+      }}>
+        <span aria-hidden="true">🎯</span>
+        {g.sessions.toLocaleString('it-IT')} partite
+      </div>
+    </div>
+  </article>
+);
+
+const MeepleCardHeroSkel = () => (
+  <div style={{
+    width: 320, minWidth: 320,
+    background: 'var(--bg-card)', border: '1px solid var(--border)',
+    borderRadius: 18, overflow: 'hidden',
+  }}>
+    <Skeleton w="100%" h={160} r={0} />
+    <div style={{ padding: '14px 16px 16px' }}>
+      <Skeleton w="65%" h={18} r={5} style={{ marginBottom: 8 }} />
+      <Skeleton w="45%" h={12} r={4} style={{ marginBottom: 14 }} />
+      <Skeleton w={110} h={26} r={999} />
+    </div>
+  </div>
+);
+
+// ── FEATURED GAMES CAROUSEL (componente v2 nuovo) ─────────────────────────
+const FeaturedGamesCarousel = ({ games, isMobile, loading }) => {
+  const scrollerRef = useRef(null);
+  const scrollBy = (dx) => {
+    scrollerRef.current?.scrollBy({ left: dx, behavior: 'smooth' });
+  };
+  return (
+    <section style={{ maxWidth: 1180, margin: '0 auto', padding: isMobile ? '40px 0 0' : '64px 0 0' }}>
+      <div style={{
+        display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between',
+        gap: 16, padding: isMobile ? '0 16px' : '0 24px',
+        marginBottom: 18,
+      }}>
+        <div>
+          <h2 style={{
+            margin: 0, fontFamily: 'var(--f-display)',
+            fontSize: isMobile ? 24 : 30, fontWeight: 700,
+            color: 'var(--text)', letterSpacing: '-0.02em',
+            display: 'flex', alignItems: 'center', gap: 10,
+          }}>
+            <span aria-hidden="true">🔥</span>
+            I più giocati
+          </h2>
+          <div style={{
+            marginTop: 4,
+            fontFamily: 'var(--f-body)', fontSize: 13.5,
+            color: 'var(--text-muted)',
+          }}>Top 10 ultimi 30 giorni</div>
+        </div>
+        {!isMobile && !loading && (
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button onClick={() => scrollBy(-360)} aria-label="Scorri indietro" style={carouselBtn} className="meeple-carousel-btn">‹</button>
+            <button onClick={() => scrollBy(360)} aria-label="Scorri avanti" style={carouselBtn} className="meeple-carousel-btn">›</button>
+          </div>
+        )}
+      </div>
+      <div
+        ref={scrollerRef}
+        role="region"
+        aria-label="Carousel giochi più giocati"
+        style={{
+          display: 'flex', gap: 16,
+          overflowX: 'auto', overflowY: 'hidden',
+          scrollSnapType: 'x mandatory',
+          padding: isMobile ? '4px 16px 24px' : '4px 24px 24px',
+          scrollPaddingInline: isMobile ? 16 : 24,
+          scrollbarWidth: 'thin',
+        }}
+      >
+        {loading
+          ? Array.from({ length: 5 }).map((_, i) => <MeepleCardHeroSkel key={i} />)
+          : games.map((g, i) => <MeepleCardHero key={g.id} g={g} rank={i + 1} />)}
+      </div>
+    </section>
+  );
+};
+
+const carouselBtn = {
+  width: 36, height: 36, borderRadius: '50%',
+  border: '1px solid var(--border-strong)',
+  background: 'var(--bg-card)',
+  color: 'var(--text)',
+  fontFamily: 'var(--f-display)', fontSize: 18, fontWeight: 700,
+  cursor: 'pointer',
+  display: 'grid', placeItems: 'center',
+  boxShadow: '0 2px 8px -2px rgba(0,0,0,0.08)',
+};
+
+// ── TRENDING ROW ──────────────────────────────────────────────────────────
+const MeepleCardGrid = ({ g }) => (
+  <article style={{
+    background: 'var(--bg-card)',
+    border: '1px solid var(--border)',
+    borderRadius: 14, overflow: 'hidden',
+    display: 'flex', flexDirection: 'column',
+    minWidth: 0,
+  }}>
+    <div style={{
+      position: 'relative',
+      aspectRatio: '1 / 1',
+      background: `linear-gradient(135deg, hsl(${g.hue} ${g.sat}% 58%), hsl(${(g.hue + 25) % 360} ${g.sat}% 42%))`,
+      display: 'grid', placeItems: 'center', fontSize: 52,
+    }}>
+      <span aria-hidden="true">{g.emoji}</span>
+      <div style={{
+        position: 'absolute', top: 8, right: 8,
+        padding: '3px 8px',
+        background: 'hsl(var(--c-toolkit) / 0.95)',
+        color: '#fff',
+        borderRadius: 999,
+        fontFamily: 'var(--f-mono)', fontSize: 10.5, fontWeight: 700,
+        letterSpacing: '0.03em',
+        fontVariantNumeric: 'tabular-nums',
+        boxShadow: '0 2px 6px rgba(0,0,0,0.18)',
+      }}>+{g.growth}% sessioni</div>
+    </div>
+    <div style={{ padding: '10px 12px 12px' }}>
+      <div style={{
+        fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 14,
+        color: 'var(--text)', lineHeight: 1.2, marginBottom: 2,
+        whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+      }}>{g.t}</div>
+      <div style={{
+        fontFamily: 'var(--f-body)', fontSize: 11.5, color: 'var(--text-muted)',
+        whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+      }}>{g.a}</div>
+    </div>
+  </article>
+);
+
+const MeepleCardGridSkel = () => (
+  <div style={{
+    background: 'var(--bg-card)', border: '1px solid var(--border)',
+    borderRadius: 14, overflow: 'hidden',
+  }}>
+    <Skeleton w="100%" h={0} r={0} style={{ aspectRatio: '1 / 1', height: 'auto' }} />
+    <div style={{ padding: '10px 12px 12px' }}>
+      <Skeleton w="70%" h={14} r={4} style={{ marginBottom: 6 }} />
+      <Skeleton w="50%" h={10} r={4} />
+    </div>
+  </div>
+);
+
+const TrendingRow = ({ games, isMobile, loading }) => (
+  <section style={{ maxWidth: 1180, margin: '0 auto', padding: isMobile ? '40px 16px 0' : '56px 24px 0' }}>
+    <div style={{ marginBottom: 18 }}>
+      <h2 style={{
+        margin: 0, fontFamily: 'var(--f-display)',
+        fontSize: isMobile ? 22 : 28, fontWeight: 700,
+        color: 'var(--text)', letterSpacing: '-0.02em',
+        display: 'flex', alignItems: 'center', gap: 10,
+      }}>
+        <span aria-hidden="true">📈</span>
+        In crescita questa settimana
+      </h2>
+      <div style={{
+        marginTop: 4, fontFamily: 'var(--f-body)', fontSize: 13.5,
+        color: 'var(--text-muted)',
+      }}>Giochi con la maggior crescita di sessioni vs settimana precedente</div>
+    </div>
+    <div style={{
+      display: 'grid',
+      gridTemplateColumns: isMobile ? 'repeat(2, 1fr)' : 'repeat(4, 1fr)',
+      gap: isMobile ? 12 : 16,
+    }}>
+      {loading
+        ? Array.from({ length: 8 }).map((_, i) => <MeepleCardGridSkel key={i} />)
+        : games.map(g => <MeepleCardGrid key={g.id} g={g} />)}
+    </div>
+  </section>
+);
+
+// ── CATEGORIES ROW ────────────────────────────────────────────────────────
+const CategoriesRow = ({ cats, isMobile, loading }) => (
+  <section style={{ maxWidth: 1180, margin: '0 auto', padding: isMobile ? '40px 16px 0' : '56px 24px 0' }}>
+    <div style={{ marginBottom: 18 }}>
+      <h2 style={{
+        margin: 0, fontFamily: 'var(--f-display)',
+        fontSize: isMobile ? 22 : 28, fontWeight: 700,
+        color: 'var(--text)', letterSpacing: '-0.02em',
+        display: 'flex', alignItems: 'center', gap: 10,
+      }}>
+        <span aria-hidden="true">🎲</span>
+        Esplora per genere
+      </h2>
+      <div style={{
+        marginTop: 4, fontFamily: 'var(--f-body)', fontSize: 13.5,
+        color: 'var(--text-muted)',
+      }}>Filtra il catalogo community per il tipo di esperienza che cerchi</div>
+    </div>
+    <div style={{
+      display: 'flex', flexWrap: 'wrap',
+      gap: isMobile ? 10 : 12,
+    }}>
+      {loading
+        ? Array.from({ length: 7 }).map((_, i) => (
+            <Skeleton key={i} w={isMobile ? 130 : 160} h={isMobile ? 64 : 76} r={14} />
+          ))
+        : cats.map(c => (
+          <button key={c.id} type="button" style={{
+            border: '1px solid hsl(var(--c-game) / 0.28)',
+            background: `linear-gradient(135deg, hsl(var(--c-game) / 0.05), hsl(var(--c-game) / 0.10))`,
+            borderRadius: 14,
+            padding: isMobile ? '12px 16px' : '14px 20px',
+            cursor: 'pointer',
+            display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 4,
+            fontFamily: 'var(--f-display)',
+            color: 'var(--text)',
+            transition: 'all 140ms ease',
+            minWidth: isMobile ? 130 : 160,
+          }}>
+            <span style={{
+              display: 'inline-flex', alignItems: 'center', gap: 8,
+              fontWeight: 700, fontSize: isMobile ? 14.5 : 16,
+            }}>
+              <span aria-hidden="true">{c.emoji}</span>
+              {c.label}
+            </span>
+            <span style={{
+              fontFamily: 'var(--f-mono)', fontSize: 11.5, fontWeight: 500,
+              color: 'var(--text-muted)',
+              fontVariantNumeric: 'tabular-nums',
+            }}>{c.count.toLocaleString('it-IT')} giochi</span>
+          </button>
+        ))}
+    </div>
+  </section>
+);
+
+// ── FOOTER CTA ────────────────────────────────────────────────────────────
+const FooterCTA = ({ isMobile }) => (
+  <section style={{ maxWidth: 1180, margin: '0 auto', padding: isMobile ? '56px 16px 40px' : '88px 24px 64px' }}>
+    <div style={{
+      position: 'relative',
+      borderRadius: 24, overflow: 'hidden',
+      padding: isMobile ? '40px 24px' : '64px 56px',
+      background: `linear-gradient(135deg,
+        hsl(var(--c-game) / 0.14) 0%,
+        hsl(var(--c-toolkit) / 0.16) 100%)`,
+      border: '1px solid hsl(var(--c-game) / 0.28)',
+      textAlign: isMobile ? 'left' : 'center',
+    }}>
+      <div aria-hidden="true" style={{
+        position: 'absolute', inset: 0, zIndex: 0,
+        background: `radial-gradient(ellipse 50% 60% at 80% 30%, hsl(var(--c-toolkit) / 0.18), transparent 60%)`,
+      }} />
+      <div style={{ position: 'relative', zIndex: 1 }}>
+        <h2 style={{
+          margin: '0 0 12px',
+          fontFamily: 'var(--f-display)', fontWeight: 700,
+          fontSize: isMobile ? 28 : 40,
+          letterSpacing: '-0.02em', lineHeight: 1.1,
+          color: 'var(--text)', textWrap: 'balance',
+        }}>Unisciti alla community</h2>
+        <p style={{
+          margin: '0 auto 24px',
+          maxWidth: 480,
+          fontFamily: 'var(--f-body)', fontSize: isMobile ? 15.5 : 17.5,
+          lineHeight: 1.55, color: 'var(--text-sec)',
+        }}>Crea il tuo account e inizia a tracciare le tue partite, costruire la tua libreria e chiedere agli agenti AI tutto sui regolamenti.</p>
+        <div style={{
+          display: 'flex', flexWrap: 'wrap', gap: 16,
+          alignItems: 'center',
+          justifyContent: isMobile ? 'flex-start' : 'center',
+        }}>
+          <a href="#/register" style={{
+            display: 'inline-flex', alignItems: 'center', gap: 8,
+            padding: '14px 28px',
+            background: 'hsl(var(--c-game))',
+            color: '#fff',
+            borderRadius: 999,
+            textDecoration: 'none',
+            fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 15.5,
+            letterSpacing: '-0.01em',
+            boxShadow: '0 8px 20px -6px hsl(var(--c-game) / 0.5)',
+          }}>
+            Crea account gratis
+            <span aria-hidden="true">→</span>
+          </a>
+          <a href="#/login" style={{
+            fontFamily: 'var(--f-body)', fontSize: 14.5,
+            color: 'var(--text-sec)',
+            textDecoration: 'none',
+          }}>
+            Hai già un account? <span style={{
+              color: 'hsl(var(--c-game))',
+              textDecoration: 'underline',
+              textDecorationColor: 'hsl(var(--c-game) / 0.4)',
+              textUnderlineOffset: 3,
+              fontWeight: 600,
+            }}>Accedi</span>
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+);
+
+// ── PAGE BODY ─────────────────────────────────────────────────────────────
+const LibraryPublicBody = ({ isMobile, loading }) => (
+  <main style={{ background: 'var(--bg)', minHeight: '100%' }}>
+    {loading ? (
+      <header style={{
+        padding: isMobile ? '52px 16px 40px' : '88px 24px 56px',
+        textAlign: 'center', background: 'var(--bg)',
+      }}>
+        <div style={{ maxWidth: 1180, margin: '0 auto' }}>
+          <Skeleton w={140} h={12} r={4} style={{ margin: '0 auto 18px' }} />
+          <Skeleton w={isMobile ? '90%' : 600} h={isMobile ? 38 : 60} r={10} style={{ margin: '0 auto 16px' }} />
+          <Skeleton w={isMobile ? '80%' : 460} h={isMobile ? 18 : 22} r={6} style={{ margin: '0 auto' }} />
+        </div>
+      </header>
+    ) : (
+      <HeroGradient
+        kicker="Community MeepleAI"
+        title={{ before: 'La library della ', mark: 'community', after: '' }}
+        subtitle="Cosa si gioca, cosa si scopre — in tempo reale"
+        isMobile={isMobile}
+      />
+    )}
+
+    {loading
+      ? <StatsRowSkeleton isMobile={isMobile} />
+      : <CommunityStatsRow isMobile={isMobile} run={!loading} />
+    }
+
+    <FeaturedGamesCarousel games={FEATURED_GAMES} isMobile={isMobile} loading={loading} />
+    <TrendingRow games={TRENDING_GAMES} isMobile={isMobile} loading={loading} />
+    <CategoriesRow cats={CATEGORIES} isMobile={isMobile} loading={loading} />
+
+    {!loading && <FooterCTA isMobile={isMobile} />}
+  </main>
+);
+
+// ── FRAMES ────────────────────────────────────────────────────────────────
+const DesktopScreen = ({ label, theme, loading }) => (
+  <div data-screen-label={label} data-theme={theme} style={{
+    width: 1440, background: 'var(--bg)',
+    borderRadius: 16, border: '1px solid var(--border-strong)',
+    overflow: 'hidden',
+    boxShadow: '0 32px 64px -24px rgba(0,0,0,0.25), 0 12px 32px -12px rgba(0,0,0,0.12)',
+  }}>
+    <div style={{
+      padding: '8px 14px',
+      background: 'var(--bg-sunken)', borderBottom: '1px solid var(--border)',
+      display: 'flex', alignItems: 'center', gap: 10,
+      fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)',
+    }}>
+      <span style={{ display: 'inline-flex', gap: 6 }}>
+        <span style={{ width: 10, height: 10, borderRadius: '50%', background: '#FF5F57' }} />
+        <span style={{ width: 10, height: 10, borderRadius: '50%', background: '#FEBC2E' }} />
+        <span style={{ width: 10, height: 10, borderRadius: '50%', background: '#28C840' }} />
+      </span>
+      <span style={{ marginLeft: 8 }}>meepleai.app/library · {label}</span>
+    </div>
+    <LibraryPublicBody isMobile={false} loading={loading} />
+  </div>
+);
+
+const MobileScreen = ({ label, theme, loading }) => (
+  <div data-screen-label={label} data-theme={theme} style={{
+    width: 375, background: 'var(--bg)',
+    borderRadius: 36, border: '8px solid #1a1410',
+    overflow: 'hidden',
+    boxShadow: '0 30px 60px rgba(0,0,0,0.6)',
+  }}>
+    <div style={{
+      height: 30, background: 'var(--bg-sunken)',
+      display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+      padding: '0 18px',
+      fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 11,
+      color: 'var(--text)',
+    }}>
+      <span>9:41</span>
+      <span style={{ display: 'inline-flex', gap: 6, alignItems: 'center' }}>
+        <span>●●●</span><span>📶</span><span>🔋</span>
+      </span>
+    </div>
+    <LibraryPublicBody isMobile={true} loading={loading} />
+  </div>
+);
+
+// ── APP ───────────────────────────────────────────────────────────────────
+const App = () => {
+  const [theme, setTheme] = useState(() => {
+    try { return localStorage.getItem('mai-sp3-libpub-theme') || 'light'; } catch { return 'light'; }
+  });
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    try { localStorage.setItem('mai-sp3-libpub-theme', theme); } catch {}
+  }, [theme]);
+
+  // inject keyframes once
+  useEffect(() => {
+    if (document.getElementById('meeple-libpub-keyframes')) return;
+    const s = document.createElement('style');
+    s.id = 'meeple-libpub-keyframes';
+    s.textContent = `
+      @keyframes meepleSkeleton { 0%{background-position:200% 0} 100%{background-position:-200% 0} }
+      @keyframes meeplePulse { 0%,100%{opacity:1; transform:scale(1)} 50%{opacity:0.6; transform:scale(1.4)} }
+      .meeple-carousel-btn:hover { background: var(--bg-muted); transform: translateY(-1px); }
+      @media (prefers-reduced-motion: reduce) {
+        @keyframes meepleSkeleton { 0%,100%{background-position:0 0} }
+        @keyframes meeplePulse { 0%,100%{opacity:1; transform:scale(1)} }
+      }
+    `;
+    document.head.appendChild(s);
+  }, []);
+
+  return (
+    <div style={{
+      minHeight: '100vh',
+      background: theme === 'dark' ? '#0a0805' : '#e8dfcf',
+      padding: '40px 24px 80px',
+    }}>
+      {/* Toolbar */}
+      <div style={{
+        maxWidth: 1480, margin: '0 auto 32px',
+        display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap',
+      }}>
+        <div>
+          <div style={{
+            fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 22,
+            color: theme === 'dark' ? '#f0e4d2' : '#2b1f12',
+            letterSpacing: '-0.015em',
+          }}>SP3 · #8 — /library (public, non-loggato) · ULTIMO OBBLIGATORIO</div>
+          <div style={{
+            fontFamily: 'var(--f-mono)', fontSize: 12,
+            color: theme === 'dark' ? '#8a7860' : '#9a8870',
+          }}>Default popolato + Loading skeleton · Desktop 1440 · Mobile 375 · Light/Dark</div>
+        </div>
+        <div style={{ marginLeft: 'auto' }}>
+          <button onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+            style={{
+              padding: '8px 14px', borderRadius: 999,
+              border: '1px solid ' + (theme === 'dark' ? 'rgba(224,180,110,0.28)' : 'rgba(180,130,80,0.32)'),
+              background: theme === 'dark' ? '#1e1710' : '#fff',
+              color: theme === 'dark' ? '#f0e4d2' : '#2b1f12',
+              fontFamily: 'var(--f-display)', fontWeight: 600, fontSize: 13,
+              cursor: 'pointer',
+            }}>{theme === 'light' ? '🌙 Dark' : '☀️ Light'}</button>
+        </div>
+      </div>
+
+      {/* DESKTOP DEFAULT */}
+      <SectionLabel theme={theme}>Desktop · 1440 — Default popolato</SectionLabel>
+      <Center>
+        <DesktopScreen label="01 Desktop · /library · Default" theme={theme} loading={false} />
+      </Center>
+
+      {/* DESKTOP LOADING */}
+      <SectionLabel theme={theme}>Desktop · 1440 — Loading skeleton</SectionLabel>
+      <Center>
+        <DesktopScreen label="02 Desktop · /library · Loading" theme={theme} loading={true} />
+      </Center>
+
+      {/* MOBILE DEFAULT */}
+      <SectionLabel theme={theme}>Mobile · 375 — Default popolato</SectionLabel>
+      <Center>
+        <MobileScreen label="03 Mobile · /library · Default" theme={theme} loading={false} />
+      </Center>
+
+      {/* MOBILE LOADING */}
+      <SectionLabel theme={theme}>Mobile · 375 — Loading skeleton</SectionLabel>
+      <Center>
+        <MobileScreen label="04 Mobile · /library · Loading" theme={theme} loading={true} />
+      </Center>
+
+      {/* DOD */}
+      <div style={{
+        maxWidth: 900, margin: '40px auto 0',
+        padding: '24px 28px',
+        background: theme === 'dark' ? '#1e1710' : '#fff',
+        border: '1px solid ' + (theme === 'dark' ? 'rgba(224,180,110,0.14)' : 'rgba(180,130,80,0.18)'),
+        borderRadius: 16,
+        color: theme === 'dark' ? '#f0e4d2' : '#2b1f12',
+      }}>
+        <div style={{
+          display: 'inline-flex', alignItems: 'center', gap: 8,
+          padding: '4px 12px',
+          background: 'hsl(var(--c-toolkit) / 0.14)',
+          color: 'hsl(var(--c-toolkit))',
+          border: '1px solid hsl(var(--c-toolkit) / 0.32)',
+          borderRadius: 999,
+          fontFamily: 'var(--f-mono)', fontSize: 11, fontWeight: 700,
+          letterSpacing: '0.06em', textTransform: 'uppercase',
+          marginBottom: 14,
+        }}>🏁 Ultimo obbligatorio SP3 · 8/8 mandatory complete</div>
+        <h3 style={{ fontFamily: 'var(--f-display)', margin: '0 0 12px', fontSize: 18 }}>DoD Checklist · sp3-library-public</h3>
+        <ul style={{ fontFamily: 'var(--f-body)', fontSize: 13.5, lineHeight: 1.7, color: theme === 'dark' ? '#c8b896' : '#5a4a38', paddingLeft: 20, margin: 0 }}>
+          <li>✓ Route target /library public variant (non-loggato) — diverso dalla /library authenticated</li>
+          <li>✓ Hero community: kicker "Community MeepleAI" + h1 "La library della community" con span gradient game→player→session + subtitle "Cosa si gioca, cosa si scopre — in tempo reale"</li>
+          <li>✓ Sfondo gradient radiale game+player+session soft, tre ellissi posizionate (18/30, 82/20, 50/90)</li>
+          <li>✓ CommunityStatsRow: 3 card desktop / stack vertical mobile · 12.847 player · 89.234 session · 4.2M chat · count-up animation rispetta prefers-reduced-motion · tabular-nums</li>
+          <li>✓ FeaturedGamesCarousel: top 10, MeepleCard hero 320×280, scroll-snap-type:x mandatory + scrollPaddingInline · frecce ‹ › desktop sopra md (mobile niente, swipe nativo)</li>
+          <li>✓ Cards hero: cover gradient hue/sat per gioco + rank badge #N + emoji 64px + titolo + autore + chip mono "🎯 N partite" palette session</li>
+          <li>✓ 10 giochi: Wingspan, Azul, Brass: Birmingham, 7 Wonders, Ticket to Ride, Catan, Carcassonne, Terraforming Mars, Spirit Island, Gloomhaven</li>
+          <li>✓ Trending row: 8 giochi growth, MeepleCard grid aspectRatio 1:1, 4-col desktop / 2-col mobile, badge "+N% sessioni" palette toolkit (success)</li>
+          <li>✓ Categories row: 7 pill grandi (Strategia, Famiglia, Party, Cooperativo, Astratto, Tematico, Wargame) con count "N giochi" e gradient game/0.05→0.10</li>
+          <li>✓ Footer CTA: card gradient game→toolkit + h2 "Unisciti alla community" + subtitle + pill "Crea account gratis →" /register + sub-CTA "Hai già un account? Accedi" /login</li>
+          <li>✓ Loading state: Hero shimmer + StatsRow 3 box + Carousel 5 card hero skel + Trending 8 card grid skel + Categories 7 pill skel — NO empty (community sempre popolata)</li>
+          <li>✓ ID short readable: g-wingspan, g-azul, c-strategia (no UUID-like)</li>
+          <li>✓ Testo italiano integrale, numeri locale-it (12.847, 89.234, 4,2M)</li>
+          <li>✓ Riusi: HeroGradient (pattern pub-hero) · MeepleCard hero/grid · scroll-snap-type (lezione sp4-discover)</li>
+          <li>✓ Componenti v2 nuovi: CommunityStatsRow · FeaturedGamesCarousel</li>
+          <li>✓ ARIA: &lt;main&gt;, &lt;article&gt;, role="region" aria-label sul carousel scroller, aria-label sui button frecce, aria-hidden sulle emoji decorative, &lt;h1&gt; unico, h2 per ogni section</li>
+          <li>✓ Light + Dark mode toggle persistito</li>
+          <li>✓ NO window.innerWidth in body — isMobile è prop esplicita dalla frame (lezione sp3-how-it-works applicata)</li>
+          <li>✓ NON sovrascritto components.css né data.js</li>
+          <li>✓ 4 frame generati: Desktop default · Desktop loading · Mobile default · Mobile loading</li>
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+const SectionLabel = ({ children, theme }) => (
+  <h2 style={{
+    maxWidth: 1480, margin: '0 auto 14px',
+    fontFamily: 'var(--f-display)', fontSize: 14, fontWeight: 700,
+    textTransform: 'uppercase', letterSpacing: '0.08em',
+    color: theme === 'dark' ? '#c8b896' : '#5a4a38',
+  }}>{children}</h2>
+);
+
+const Center = ({ children }) => (
+  <div style={{
+    maxWidth: 1480, margin: '0 auto 48px',
+    display: 'flex', justifyContent: 'center',
+  }}>{children}</div>
+);
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/admin-mockups/design_files/sp4-discover.html
+++ b/admin-mockups/design_files/sp4-discover.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<!-- MeepleAI SP4 wave 3 — I · Discover (Netflix-style cross-entity)
+     Route: /discover -->
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>MeepleAI · /discover — Scopri</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-discover.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-discover.jsx
+++ b/admin-mockups/design_files/sp4-discover.jsx
@@ -1,0 +1,1388 @@
+/* MeepleAI SP4 wave 3 — Schermata I / 5 (CONCLUSIVA wave 3)
+   Route: /discover
+   File: admin-mockups/design_files/sp4-discover.{html,jsx}
+   Pattern: Hero discover + horizontal rows Netflix-style. Cross-entity (mix di tutte le 9 entity).
+
+   v2 nuovi (per impl post-merge):
+   - DiscoverHero          → apps/web/src/components/ui/v2/discover-hero/
+   - DiscoverSearchBox     → apps/web/src/components/ui/v2/discover-search-box/
+   - EntityFilterPillBar   → apps/web/src/components/ui/v2/entity-filter-pill-bar/
+   - HorizontalRow         → apps/web/src/components/ui/v2/horizontal-row/
+   - RowScroller           → apps/web/src/components/ui/v2/row-scroller/
+
+   Riusi:
+   - MeepleCard variant="featured"|"grid"|"compact"|"list" (wave 1) → 4 card variants distinti
+   - AdvancedFiltersDrawer (wave 1) → CTA "Filtri avanzati" che apre drawer
+   - EntityChip (wave 1) per filter pills
+   - Tabs animated underline (wave 1) → entity filter pills indicator
+
+   Deviazioni: scroll-snap usa CSS native (no JS scroll lib). Frecce desktop solo su :hover via CSS.
+*/
+
+const { useState, useEffect, useRef, useMemo } = React;
+const DS = window.DS;
+
+const entityHsl = (type, alpha) => {
+  const c = DS.EC[type] || DS.EC.game;
+  return alpha !== undefined
+    ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${alpha})`
+    : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
+};
+
+// ─── ENTITY FILTER PILLS ─────────────────────────────────
+const FILTERS = [
+  { id:'all',     label:'Tutti',     em:null,  type:null },
+  { id:'game',    label:'Giochi',    em:'🎲',  type:'game' },
+  { id:'agent',   label:'Agenti',    em:'🤖',  type:'agent' },
+  { id:'toolkit', label:'Toolkit',   em:'🧰',  type:'toolkit' },
+  { id:'kb',      label:'KB',        em:'📄',  type:'kb' },
+  { id:'player',  label:'Persone',   em:'👤',  type:'player' },
+  { id:'event',   label:'Eventi',    em:'🎉',  type:'event' },
+];
+
+// ═══════════════════════════════════════════════════════
+// PRIMITIVES
+// ═══════════════════════════════════════════════════════
+const TypeChip = ({ type, sm }) => {
+  const meta = DS.EC[type];
+  if (!meta) return null;
+  return (
+    <span style={{
+      display:'inline-flex', alignItems:'center', gap: 4,
+      padding: sm ? '2px 7px' : '3px 9px', borderRadius:'var(--r-pill)',
+      background: entityHsl(type, 0.12), color: entityHsl(type),
+      border:`1px solid ${entityHsl(type, 0.22)}`,
+      fontFamily:'var(--f-mono)', fontSize: sm ? 9 : 10, fontWeight: 800,
+      textTransform:'uppercase', letterSpacing:'.06em',
+      whiteSpace:'nowrap',
+    }}>
+      <span aria-hidden="true">{meta.em}</span>
+      <span>{meta.lb}</span>
+    </span>
+  );
+};
+
+const Stars = ({ n }) => (
+  <span aria-label={`${n} stelle`} style={{ color:'hsl(var(--c-warning))', fontSize: 10, letterSpacing: 1 }}>
+    {'★'.repeat(n)}<span style={{ color:'var(--text-muted)', opacity: .35 }}>{'★'.repeat(5 - n)}</span>
+  </span>
+);
+
+// ═══════════════════════════════════════════════════════
+// CARDS — 4 VARIANTS
+// /* v2: lifts MeepleCard variants from wave 1 (PR #549) */
+// ═══════════════════════════════════════════════════════
+
+// ── FEATURED — large hero card, 320×220 cover ─────────
+const FeaturedCard = ({ entity, mobile }) => {
+  const e = entity;
+  const w = mobile ? 280 : 320;
+  return (
+    <article style={{
+      flex:`0 0 ${w}px`, scrollSnapAlign:'start',
+      borderRadius:'var(--r-xl)', overflow:'hidden',
+      background:'var(--bg-card)',
+      border:'1px solid var(--border)',
+      boxShadow:`0 4px 14px ${entityHsl(e.type, 0.18)}`,
+      transition:'transform var(--dur-md), box-shadow var(--dur-md)',
+      cursor:'pointer',
+    }} className="mai-card-hover">
+      <div style={{
+        height: 160, background: e.cover, position:'relative',
+        display:'flex', alignItems:'flex-end', padding: 12,
+      }}>
+        <div aria-hidden="true" style={{
+          position:'absolute', inset: 0,
+          background:'linear-gradient(180deg, transparent 50%, rgba(0,0,0,.55))',
+        }}/>
+        <div style={{
+          position:'absolute', top: 12, right: 12,
+        }}>
+          <TypeChip type={e.type} sm/>
+        </div>
+        <div style={{
+          position:'absolute', top: 12, left: 12, fontSize: 32,
+          filter:'drop-shadow(0 2px 6px rgba(0,0,0,.4))',
+        }} aria-hidden="true">{e.coverEmoji}</div>
+        {e.badge && (
+          <span style={{
+            position:'relative', zIndex: 1,
+            padding:'3px 9px', borderRadius:'var(--r-pill)',
+            background:'rgba(0,0,0,.55)', color:'#fff',
+            fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800,
+            textTransform:'uppercase', letterSpacing:'.06em',
+            backdropFilter:'blur(6px)',
+          }}>{e.badge}</span>
+        )}
+      </div>
+      <div style={{ padding: 14, display:'flex', flexDirection:'column', gap: 6 }}>
+        <h3 style={{
+          margin: 0, fontFamily:'var(--f-display)', fontSize: 15, fontWeight: 800,
+          color:'var(--text)', lineHeight: 1.25,
+          textWrap:'pretty',
+          overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap',
+        }}>{e.title}</h3>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          fontWeight: 600,
+          overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap',
+        }}>{e.subtitle || `${e.publisher || ''} · ${e.year || ''}`}</div>
+        <div style={{
+          display:'flex', alignItems:'center', gap: 8, marginTop: 4,
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+          fontWeight: 600,
+        }}>
+          {e.stars && <Stars n={e.stars}/>}
+          {e.rating && <span style={{ color: entityHsl(e.type), fontWeight: 800 }}>{e.rating.toFixed(1)}</span>}
+          {e.invocations && <span>{e.invocations} usi</span>}
+          {e.useCount !== undefined && <span>{e.useCount} install</span>}
+          {e.totalSessions && <span>{e.totalSessions} partite</span>}
+        </div>
+      </div>
+    </article>
+  );
+};
+
+// ── GRID — square card, 180px ─────────────────────────
+const GridCard = ({ entity, mobile }) => {
+  const e = entity;
+  const w = mobile ? 150 : 180;
+  return (
+    <article style={{
+      flex:`0 0 ${w}px`, scrollSnapAlign:'start',
+      borderRadius:'var(--r-lg)', overflow:'hidden',
+      background:'var(--bg-card)',
+      border:'1px solid var(--border)',
+      cursor:'pointer',
+      transition:'transform var(--dur-md), box-shadow var(--dur-md)',
+    }} className="mai-card-hover">
+      <div style={{
+        aspectRatio:'1 / 1', background: e.cover, position:'relative',
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 50,
+      }} aria-hidden="true">
+        <div style={{ filter:'drop-shadow(0 4px 8px rgba(0,0,0,.3))' }}>{e.coverEmoji}</div>
+        <div style={{ position:'absolute', top: 8, right: 8 }}>
+          <TypeChip type={e.type} sm/>
+        </div>
+      </div>
+      <div style={{ padding:'10px 12px', display:'flex', flexDirection:'column', gap: 3 }}>
+        <h3 style={{
+          margin: 0, fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+          color:'var(--text)', lineHeight: 1.25,
+          overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap',
+        }}>{e.title}</h3>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+          fontWeight: 600,
+          overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap',
+        }}>
+          {e.publisher && `${e.publisher} · ${e.year}`}
+          {!e.publisher && e.subtitle}
+        </div>
+        {e.stars && <Stars n={e.stars}/>}
+      </div>
+    </article>
+  );
+};
+
+// ── COMPACT — small horizontal card 240×72 ────────────
+const CompactCard = ({ entity, mobile, statLabel, statValue }) => {
+  const e = entity;
+  const w = mobile ? 240 : 260;
+  return (
+    <article style={{
+      flex:`0 0 ${w}px`, scrollSnapAlign:'start',
+      display:'flex', alignItems:'center', gap: 10,
+      padding: 10,
+      background:'var(--bg-card)',
+      border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)',
+      cursor:'pointer',
+      transition:'border-color var(--dur-sm), box-shadow var(--dur-sm)',
+    }} className="mai-card-hover">
+      <div style={{
+        width: 52, height: 52, borderRadius:'var(--r-md)',
+        background: e.cover,
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 22, flexShrink: 0,
+        border:`1px solid ${entityHsl(e.type, 0.22)}`,
+      }} aria-hidden="true">
+        {e.initials ? (
+          <span style={{
+            fontFamily:'var(--f-display)', color:'#fff', fontWeight: 800, fontSize: 16,
+          }}>{e.initials}</span>
+        ) : e.coverEmoji}
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{
+          display:'flex', alignItems:'center', gap: 6, marginBottom: 2,
+        }}>
+          <h3 style={{
+            margin: 0, fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+            color:'var(--text)', lineHeight: 1.2, flex: 1, minWidth: 0,
+            overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap',
+          }}>{e.title}</h3>
+        </div>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+          fontWeight: 600, marginBottom: 3,
+          overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap',
+        }}>{e.subtitle}</div>
+        <div style={{
+          display:'flex', alignItems:'center', gap: 6,
+        }}>
+          <TypeChip type={e.type} sm/>
+          {statLabel && (
+            <span style={{
+              fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 700,
+              color: entityHsl(e.type),
+            }}>{statValue} {statLabel}</span>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+};
+
+// ── LIST — wide row card 360×80 ───────────────────────
+const ListRowCard = ({ entity, mobile, eventDay, eventTime }) => {
+  const e = entity;
+  const w = mobile ? 290 : 380;
+  return (
+    <article style={{
+      flex:`0 0 ${w}px`, scrollSnapAlign:'start',
+      display:'flex', gap: 12,
+      padding: 12,
+      background:'var(--bg-card)',
+      border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)',
+      borderLeft:`3px solid ${entityHsl(e.type)}`,
+      cursor:'pointer',
+      transition:'border-color var(--dur-sm), box-shadow var(--dur-sm)',
+    }} className="mai-card-hover">
+      {eventDay !== undefined ? (
+        <div style={{
+          flexShrink: 0,
+          width: 56, padding: 6,
+          background: entityHsl(e.type, 0.08),
+          border:`1px solid ${entityHsl(e.type, 0.22)}`,
+          borderRadius:'var(--r-md)',
+          display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center',
+        }}>
+          <div style={{
+            fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+            color: entityHsl(e.type), textTransform:'uppercase', letterSpacing:'.08em',
+          }}>Mar</div>
+          <div style={{
+            fontFamily:'var(--f-display)', fontSize: 22, fontWeight: 800,
+            color: entityHsl(e.type), lineHeight: 1, fontVariantNumeric:'tabular-nums',
+          }}>{eventDay}</div>
+          <div style={{
+            fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 700,
+            color:'var(--text-sec)', marginTop: 2,
+          }}>{eventTime}</div>
+        </div>
+      ) : (
+        <div style={{
+          width: 56, height: 56, borderRadius:'var(--r-md)',
+          background: e.cover,
+          display:'flex', alignItems:'center', justifyContent:'center',
+          fontSize: 22, flexShrink: 0,
+          border:`1px solid ${entityHsl(e.type, 0.22)}`,
+        }} aria-hidden="true">{e.coverEmoji}</div>
+      )}
+      <div style={{ flex: 1, minWidth: 0, display:'flex', flexDirection:'column', gap: 4 }}>
+        <h3 style={{
+          margin: 0, fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+          color:'var(--text)', lineHeight: 1.25,
+          overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap',
+        }}>{e.title}</h3>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          fontWeight: 600,
+          overflow:'hidden', display:'-webkit-box',
+          WebkitLineClamp: 2, WebkitBoxOrient:'vertical',
+        }}>{e.subtitle}</div>
+        <div style={{
+          display:'flex', alignItems:'center', gap: 6, marginTop: 2,
+          flexWrap:'wrap',
+        }}>
+          <TypeChip type={e.type} sm/>
+          {e.pages && (
+            <span style={{
+              fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 700,
+              color:'var(--text-sec)',
+            }}>{e.pages} pag · {e.chunks} chunk</span>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// HORIZONTAL ROW
+// /* v2: HorizontalRow + RowScroller — apps/web/src/components/ui/v2/horizontal-row/ */
+// ═══════════════════════════════════════════════════════
+const HorizontalRow = ({ title, emoji, count, items, renderCard, mobile }) => {
+  const trackRef = useRef(null);
+  const [scrollState, setScrollState] = useState({ left: false, right: true });
+
+  const onScroll = () => {
+    const el = trackRef.current;
+    if (!el) return;
+    const left = el.scrollLeft > 4;
+    const right = el.scrollLeft + el.clientWidth < el.scrollWidth - 4;
+    setScrollState({ left, right });
+  };
+
+  useEffect(() => {
+    const el = trackRef.current;
+    if (!el) return;
+    onScroll();
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const scroll = (dir) => {
+    const el = trackRef.current;
+    if (!el) return;
+    el.scrollBy({ left: dir * (el.clientWidth * 0.85), behavior: 'smooth' });
+  };
+
+  return (
+    <section className="mai-row" style={{
+      display:'flex', flexDirection:'column', gap: 12,
+      position:'relative',
+    }}>
+      <header style={{
+        display:'flex', alignItems:'center', gap: 10,
+        padding: mobile ? '0 16px' : '0 32px',
+      }}>
+        <h2 style={{
+          margin: 0, fontFamily:'var(--f-display)',
+          fontSize: mobile ? 16 : 20, fontWeight: 800,
+          color:'var(--text)', display:'inline-flex', alignItems:'center', gap: 8,
+        }}>
+          <span aria-hidden="true">{emoji}</span>
+          <span>{title}</span>
+        </h2>
+        <span style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          fontWeight: 700,
+        }}>· {count}</span>
+        <button type="button" style={{
+          marginLeft:'auto', padding:'6px 10px', borderRadius:'var(--r-md)',
+          background:'transparent', color:'var(--text-sec)',
+          border:'none', cursor:'pointer',
+          fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 700,
+        }}>Vedi tutti →</button>
+      </header>
+
+      <div style={{ position:'relative' }}>
+        {/* Left arrow — desktop only on hover */}
+        {!mobile && scrollState.left && (
+          <button type="button" aria-label="Scorri a sinistra"
+            onClick={() => scroll(-1)}
+            className="mai-row-arrow mai-row-arrow-left"
+            style={{
+              position:'absolute', top:'50%', left: 12, transform:'translateY(-50%)',
+              width: 38, height: 38, borderRadius:'50%',
+              background:'var(--bg-card)', border:'1px solid var(--border-strong)',
+              color:'var(--text)', fontSize: 16, cursor:'pointer',
+              boxShadow:'var(--shadow-md)', zIndex: 2,
+            }}>‹</button>
+        )}
+        {!mobile && scrollState.right && (
+          <button type="button" aria-label="Scorri a destra"
+            onClick={() => scroll(1)}
+            className="mai-row-arrow mai-row-arrow-right"
+            style={{
+              position:'absolute', top:'50%', right: 12, transform:'translateY(-50%)',
+              width: 38, height: 38, borderRadius:'50%',
+              background:'var(--bg-card)', border:'1px solid var(--border-strong)',
+              color:'var(--text)', fontSize: 16, cursor:'pointer',
+              boxShadow:'var(--shadow-md)', zIndex: 2,
+            }}>›</button>
+        )}
+
+        <div ref={trackRef} style={{
+          display:'flex', gap: 12,
+          padding: mobile ? '4px 16px 12px' : '4px 32px 12px',
+          overflowX:'auto', overflowY:'hidden',
+          scrollSnapType:'x mandatory',
+          scrollbarWidth:'none',
+          WebkitOverflowScrolling:'touch',
+        }} className="mai-row-track">
+          {items.map((item, i) => (
+            <React.Fragment key={item.entity?.id || i}>
+              {renderCard(item, i)}
+            </React.Fragment>
+          ))}
+        </div>
+
+        {/* Right edge fade hint */}
+        {scrollState.right && (
+          <div aria-hidden="true" style={{
+            position:'absolute', top: 0, right: 0, bottom: 0, width: 60,
+            background:`linear-gradient(90deg, transparent, var(--bg))`,
+            pointerEvents:'none',
+          }}/>
+        )}
+        {scrollState.left && (
+          <div aria-hidden="true" style={{
+            position:'absolute', top: 0, left: 0, bottom: 0, width: 60,
+            background:`linear-gradient(-90deg, transparent, var(--bg))`,
+            pointerEvents:'none',
+          }}/>
+        )}
+      </div>
+    </section>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// HERO
+// /* v2: DiscoverHero + DiscoverSearchBox + EntityFilterPillBar */
+// ═══════════════════════════════════════════════════════
+const DiscoverHero = ({ filter, onFilter, mobile, onOpenAdvanced }) => {
+  const refs = useRef({});
+  const [ind, setInd] = useState({ left: 0, width: 0 });
+  useEffect(() => {
+    const el = refs.current[filter];
+    if (el) setInd({ left: el.offsetLeft, width: el.offsetWidth });
+  }, [filter]);
+
+  return (
+    <div style={{
+      padding: mobile ? '20px 16px 18px' : '36px 32px 28px',
+      background:`
+        radial-gradient(at 8% 20%, ${entityHsl('event', 0.18)}, transparent 45%),
+        radial-gradient(at 95% 0%, ${entityHsl('toolkit', 0.18)}, transparent 45%),
+        radial-gradient(at 50% 100%, ${entityHsl('agent', 0.10)}, transparent 50%),
+        var(--bg)
+      `,
+      borderBottom:'1px solid var(--border-light)',
+    }}>
+      <div style={{
+        maxWidth: 1280, margin:'0 auto',
+        display:'flex', flexDirection:'column', gap: mobile ? 14 : 20,
+      }}>
+        {/* Title + subtitle */}
+        <div>
+          <div style={{
+            display:'inline-flex', alignItems:'center', gap: 8,
+            padding:'4px 10px', borderRadius:'var(--r-pill)',
+            background:'var(--bg-card)', border:'1px solid var(--border)',
+            fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800,
+            textTransform:'uppercase', letterSpacing:'.08em', marginBottom: 10,
+            color:'var(--text-sec)',
+          }}>
+            <span aria-hidden="true">✨</span>
+            <span>Discover</span>
+          </div>
+          <h1 style={{
+            margin: 0, fontFamily:'var(--f-display)',
+            fontSize: mobile ? 28 : 38, fontWeight: 800,
+            color:'var(--text)', letterSpacing:'-.015em', lineHeight: 1.05,
+          }}>Scopri</h1>
+          <p style={{
+            margin:'6px 0 0', fontSize: mobile ? 13 : 15,
+            color:'var(--text-sec)', maxWidth: 520, lineHeight: 1.5,
+          }}>Esplora cosa c'è di nuovo nella community: giochi, agenti, toolkit, persone ed eventi.</p>
+        </div>
+
+        {/* Search + advanced */}
+        <div style={{
+          display:'flex', gap: 8, flexWrap:'wrap',
+        }}>
+          <label style={{
+            flex: 1, minWidth: mobile ? 0 : 320,
+            display:'flex', alignItems:'center', gap: 10,
+            padding: mobile ? '10px 14px' : '12px 18px',
+            background:'var(--bg-card)',
+            border:'1px solid var(--border)',
+            borderRadius:'var(--r-md)',
+            boxShadow:'var(--shadow-sm)',
+          }}>
+            <span aria-hidden="true" style={{ fontSize: 16 }}>🔍</span>
+            <input
+              type="search"
+              placeholder={mobile ? 'Cerca giochi, agenti…' : 'Cerca giochi, agenti, toolkit, persone…'}
+              style={{
+                flex: 1, border:'none', outline:'none', background:'transparent',
+                fontFamily:'var(--f-display)', fontSize: mobile ? 13 : 14, fontWeight: 600,
+                color:'var(--text)',
+              }}
+              aria-label="Cerca nella community"/>
+            <kbd style={{
+              padding:'2px 8px', borderRadius:'var(--r-sm)',
+              background:'var(--bg-muted)', border:'1px solid var(--border)',
+              fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 700,
+              color:'var(--text-muted)',
+            }}>⌘K</kbd>
+          </label>
+          <button type="button" onClick={onOpenAdvanced}
+            style={{
+              padding: mobile ? '10px 14px' : '12px 18px',
+              borderRadius:'var(--r-md)',
+              background:'var(--bg-card)', border:'1px solid var(--border)',
+              color:'var(--text-sec)', cursor:'pointer',
+              fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700,
+              display:'inline-flex', alignItems:'center', gap: 7,
+              whiteSpace:'nowrap',
+            }}>
+            <span aria-hidden="true">⚙</span>
+            <span>Filtri avanzati</span>
+          </button>
+        </div>
+
+        {/* Entity filter pills (animated underline) */}
+        <div style={{ position:'relative' }}>
+          <div style={{
+            display:'flex', gap: 4, borderBottom:'1px solid var(--border)',
+            overflowX:'auto', scrollbarWidth:'none',
+          }} role="tablist" aria-label="Filtra per tipo">
+            {FILTERS.map(f => {
+              const isActive = filter === f.id;
+              const c = f.type ? entityHsl(f.type) : 'var(--text)';
+              return (
+                <button key={f.id} type="button"
+                  ref={el => { refs.current[f.id] = el; }}
+                  onClick={() => onFilter(f.id)}
+                  role="tab" aria-selected={isActive}
+                  style={{
+                    padding: mobile ? '8px 12px' : '10px 14px',
+                    background:'transparent', border:'none',
+                    color: isActive ? c : 'var(--text-sec)',
+                    fontFamily:'var(--f-display)',
+                    fontSize: mobile ? 12 : 13,
+                    fontWeight: isActive ? 800 : 700, cursor:'pointer',
+                    display:'inline-flex', alignItems:'center', gap: 6,
+                    whiteSpace:'nowrap', flexShrink: 0,
+                  }}>
+                  {f.em && <span aria-hidden="true">{f.em}</span>}
+                  <span>{f.label}</span>
+                </button>
+              );
+            })}
+          </div>
+          <span aria-hidden="true" style={{
+            position:'absolute', bottom: -1, left: ind.left, width: ind.width,
+            height: 2,
+            background: filter === 'all' ? 'var(--text)' :
+                        FILTERS.find(f => f.id === filter)?.type
+                        ? entityHsl(FILTERS.find(f => f.id === filter).type)
+                        : 'var(--text)',
+            transition:'left .3s var(--ease-out), width .3s var(--ease-out), background .3s',
+          }}/>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ROWS — DATA BUILDERS
+// ═══════════════════════════════════════════════════════
+const buildRows = () => {
+  // Trending = mix tipi (1 per tipo, top 8 cross-entity)
+  const trending = [
+    DS.byId['g-wingspan'], DS.byId['tk-azul-v2'], DS.byId['a-azul-rules'],
+    DS.byId['g-brass'], DS.byId['p-marco'], DS.byId['kb-azul-ita'],
+    DS.byId['g-arknova'], DS.byId['tk-generic'],
+  ].filter(Boolean);
+
+  const newGames = DS.games.filter(g => g.kbState !== 'initial').slice(0, 6);
+  const popularAgents = [...DS.agents].sort((a,b) => b.invocations - a.invocations);
+  const recommendedToolkits = DS.toolkits.filter(t => t.status === 'active');
+  const recentKbs = DS.kbs.filter(k => k.status === 'indexed');
+  const topPlayers = [...DS.players].sort((a,b) => b.totalSessions - a.totalSessions).slice(0, 5);
+  const nearbyEvents = DS.events.filter(e => e.status !== 'completed');
+
+  return { trending, newGames, popularAgents, recommendedToolkits, recentKbs, topPlayers, nearbyEvents };
+};
+
+const ROW_DEFS = [
+  { id:'trending', emoji:'🔥', title:'Trending questa settimana', variant:'featured', dataKey:'trending', types:'all' },
+  { id:'games',    emoji:'🎲', title:'Giochi nuovi nella community', variant:'grid',    dataKey:'newGames', types:'game' },
+  { id:'agents',   emoji:'🤖', title:'Agenti più installati',         variant:'compact', dataKey:'popularAgents', types:'agent',
+    statLabel:'usi', statKey:'invocations' },
+  { id:'tk',       emoji:'🧰', title:'Toolkit consigliati per te',    variant:'featured', dataKey:'recommendedToolkits', types:'toolkit', personalized:true },
+  { id:'kb',       emoji:'📄', title:'KB recenti',                    variant:'list',    dataKey:'recentKbs', types:'kb' },
+  { id:'players',  emoji:'👥', title:'Top contributor questo mese',  variant:'compact', dataKey:'topPlayers', types:'player',
+    statLabel:'partite', statKey:'totalSessions' },
+  { id:'events',   emoji:'🎉', title:'Eventi vicini a te',            variant:'list',    dataKey:'nearbyEvents', types:'event' },
+];
+
+// ═══════════════════════════════════════════════════════
+// BODY
+// ═══════════════════════════════════════════════════════
+const DiscoverBody = ({ stateOverride, mobile, initialFilter = 'all', initialAdvOpen = false }) => {
+  const [filter, setFilter] = useState(initialFilter);
+  const [advOpen, setAdvOpen] = useState(initialAdvOpen);
+  const data = useMemo(buildRows, []);
+
+  // Filter rows by entity type
+  const visibleRows = ROW_DEFS.filter(r => {
+    if (filter === 'all') return true;
+    if (r.types === 'all') return true; // Trending always visible
+    return r.types === filter;
+  });
+
+  const renderCard = (entity, def) => {
+    if (!entity) return null;
+    if (def.variant === 'featured') return <FeaturedCard entity={entity} mobile={mobile}/>;
+    if (def.variant === 'grid')     return <GridCard entity={entity} mobile={mobile}/>;
+    if (def.variant === 'compact')  {
+      const v = def.statKey ? entity[def.statKey] : null;
+      return <CompactCard entity={entity} mobile={mobile} statLabel={def.statLabel} statValue={v}/>;
+    }
+    if (def.variant === 'list') {
+      // Events get date block
+      const props = entity.type === 'event' ? { eventDay: entity.date?.split(' ')[0], eventTime: entity.time?.split('–')[0] } : {};
+      return <ListRowCard entity={entity} mobile={mobile} {...props}/>;
+    }
+    return null;
+  };
+
+  return (
+    <div style={{ background:'var(--bg)', minHeight:'100%' }}>
+      <DiscoverHero filter={filter} onFilter={setFilter}
+        mobile={mobile} onOpenAdvanced={() => setAdvOpen(true)}/>
+
+      {stateOverride === 'empty' ? <EmptyAll mobile={mobile}/>
+       : stateOverride === 'error' ? <ErrorState mobile={mobile}/>
+       : stateOverride === 'loading' ? <LoadingRows mobile={mobile}/>
+       : (
+        <div style={{
+          padding: mobile ? '20px 0 24px' : '32px 0',
+          display:'flex', flexDirection:'column', gap: mobile ? 24 : 36,
+        }}>
+          {visibleRows.length === 0 ? (
+            <EmptyFilter filter={filter} mobile={mobile} onClear={() => setFilter('all')}/>
+          ) : (
+            visibleRows.map(def => {
+              const items = data[def.dataKey] || [];
+              return (
+                <HorizontalRow key={def.id}
+                  title={def.title} emoji={def.emoji} count={items.length}
+                  items={items.map(e => ({ entity: e }))}
+                  renderCard={({ entity }) => renderCard(entity, def)}
+                  mobile={mobile}/>
+              );
+            })
+          )}
+
+          {/* Footer CTA */}
+          {visibleRows.length > 0 && (
+            <FooterCTA mobile={mobile}/>
+          )}
+        </div>
+      )}
+
+      {/* Advanced Filters Drawer (riuso wave 1) */}
+      {advOpen && <AdvancedFiltersDrawer onClose={() => setAdvOpen(false)} mobile={mobile}/>}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ADVANCED FILTERS DRAWER (riuso wave 1)
+// ═══════════════════════════════════════════════════════
+const AdvancedFiltersDrawer = ({ onClose, mobile }) => (
+  <div role="dialog" aria-label="Filtri avanzati"
+    style={{
+      position:'absolute', inset: 0, zIndex: 50,
+      display:'flex', alignItems: mobile ? 'flex-end' : 'stretch',
+      justifyContent: mobile ? 'stretch' : 'flex-end',
+      background:'rgba(0,0,0,.5)',
+    }} onClick={onClose}>
+    <aside onClick={e => e.stopPropagation()} style={{
+      width: mobile ? '100%' : 420,
+      maxHeight: mobile ? '85vh' : '100%',
+      background:'var(--bg)',
+      borderRadius: mobile ? 'var(--r-xl) var(--r-xl) 0 0' : 0,
+      display:'flex', flexDirection:'column',
+      overflow:'hidden',
+      animation:`slideIn${mobile ? 'Up' : 'Right'} .25s var(--ease-out)`,
+    }}>
+      {mobile && (
+        <div aria-hidden="true" style={{
+          width: 36, height: 4, borderRadius:'var(--r-pill)',
+          background:'var(--border-strong)', margin:'10px auto 0',
+        }}/>
+      )}
+      <header style={{
+        padding:'16px 20px',
+        borderBottom:'1px solid var(--border)',
+        display:'flex', alignItems:'center', gap: 10,
+      }}>
+        <h2 style={{
+          margin: 0, fontFamily:'var(--f-display)', fontSize: 17, fontWeight: 800,
+          color:'var(--text)', flex: 1,
+        }}>Filtri avanzati</h2>
+        <button type="button" onClick={onClose} aria-label="Chiudi"
+          style={{
+            width: 32, height: 32, borderRadius:'var(--r-md)',
+            background:'var(--bg-card)', border:'1px solid var(--border)',
+            color:'var(--text)', fontSize: 16, cursor:'pointer',
+          }}>×</button>
+      </header>
+      <div style={{
+        flex: 1, overflow:'auto', padding:'18px 20px',
+        display:'flex', flexDirection:'column', gap: 18,
+      }}>
+        <FilterGroup title="Numero giocatori" options={['1', '2', '3-4', '5+']} sel={['2','3-4']}/>
+        <FilterGroup title="Durata partita" options={['<30m', '30-60m', '1-2h', '>2h']} sel={['30-60m']}/>
+        <FilterGroup title="Difficoltà" options={['Light', 'Medium', 'Heavy']} sel={[]}/>
+        <FilterGroup title="Stato KB" options={['Indicizzato', 'Parziale', 'Mancante']} sel={['Indicizzato']}/>
+        <FilterGroup title="Strategia agente" options={['RAG', 'Router', 'Hybrid']} sel={[]}/>
+        <FilterGroup title="Anno pubblicazione" options={['2020+', '2015-2019', '<2015']} sel={[]}/>
+      </div>
+      <footer style={{
+        padding:'14px 20px',
+        borderTop:'1px solid var(--border)',
+        background:'var(--bg-card)',
+        display:'flex', gap: 10,
+      }}>
+        <button type="button" style={{
+          flex: 1, padding:'10px', borderRadius:'var(--r-md)',
+          background:'transparent', color:'var(--text-sec)',
+          border:'1px solid var(--border-strong)',
+          fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700, cursor:'pointer',
+        }}>Reimposta</button>
+        <button type="button" style={{
+          flex: 2, padding:'10px', borderRadius:'var(--r-md)',
+          background:`linear-gradient(135deg, ${entityHsl('event')}, ${entityHsl('agent')})`,
+          color:'#fff', border:'none',
+          fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800, cursor:'pointer',
+        }}>Applica · 3 attivi</button>
+      </footer>
+    </aside>
+    <style>{`
+      @keyframes slideInUp { from { transform: translateY(100%); } to { transform: translateY(0); } }
+      @keyframes slideInRight { from { transform: translateX(100%); } to { transform: translateX(0); } }
+      @media (prefers-reduced-motion: reduce) {
+        @keyframes slideInUp { from, to { transform: none; } }
+        @keyframes slideInRight { from, to { transform: none; } }
+      }
+    `}</style>
+  </div>
+);
+
+const FilterGroup = ({ title, options, sel }) => (
+  <fieldset style={{ border:'none', padding: 0, margin: 0 }}>
+    <legend style={{
+      fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800,
+      color:'var(--text-muted)', textTransform:'uppercase', letterSpacing:'.08em',
+      marginBottom: 10,
+    }}>{title}</legend>
+    <div style={{ display:'flex', gap: 6, flexWrap:'wrap' }}>
+      {options.map(opt => {
+        const active = sel.includes(opt);
+        return (
+          <button key={opt} type="button" aria-pressed={active}
+            style={{
+              padding:'6px 12px', borderRadius:'var(--r-pill)',
+              background: active ? entityHsl('agent', 0.15) : 'var(--bg-card)',
+              color: active ? entityHsl('agent') : 'var(--text-sec)',
+              border: active ? `1px solid ${entityHsl('agent', 0.4)}` : '1px solid var(--border)',
+              fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800,
+              cursor:'pointer',
+            }}>{opt}</button>
+        );
+      })}
+    </div>
+  </fieldset>
+);
+
+// ═══════════════════════════════════════════════════════
+// FOOTER CTA
+// ═══════════════════════════════════════════════════════
+const FooterCTA = ({ mobile }) => (
+  <section style={{
+    margin: mobile ? '12px 16px 0' : '24px 32px 0',
+    padding: mobile ? 24 : 36,
+    borderRadius:'var(--r-xl)',
+    background:`
+      radial-gradient(at 0% 0%, ${entityHsl('toolkit', 0.18)}, transparent 50%),
+      radial-gradient(at 100% 100%, ${entityHsl('player', 0.18)}, transparent 50%),
+      var(--bg-card)
+    `,
+    border:`1px solid ${entityHsl('toolkit', 0.2)}`,
+    display:'flex', flexDirection: mobile ? 'column' : 'row',
+    alignItems: mobile ? 'flex-start' : 'center', gap: mobile ? 14 : 20,
+  }}>
+    <div style={{ flex: 1 }}>
+      <div style={{
+        display:'inline-flex', alignItems:'center', gap: 6,
+        padding:'3px 9px', borderRadius:'var(--r-pill)',
+        background: entityHsl('toolkit', 0.15), color: entityHsl('toolkit'),
+        fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800,
+        textTransform:'uppercase', letterSpacing:'.06em',
+        marginBottom: 8,
+      }}>
+        <span aria-hidden="true">🧰</span>
+        <span>Per autori</span>
+      </div>
+      <h2 style={{
+        margin: 0, fontFamily:'var(--f-display)',
+        fontSize: mobile ? 18 : 22, fontWeight: 800,
+        color:'var(--text)', lineHeight: 1.2,
+      }}>Hai contenuti da pubblicare?</h2>
+      <p style={{
+        margin:'4px 0 0', fontSize: mobile ? 12.5 : 14,
+        color:'var(--text-sec)', lineHeight: 1.55, maxWidth: 520,
+      }}>Crea un toolkit, condividi una KB o pubblica un agente. La community ti ringrazia.</p>
+    </div>
+    <button type="button" style={{
+      padding: mobile ? '12px 22px' : '14px 28px',
+      borderRadius:'var(--r-md)',
+      background:`linear-gradient(135deg, ${entityHsl('toolkit')}, ${entityHsl('player')})`,
+      color:'#fff', border:'none',
+      fontFamily:'var(--f-display)', fontSize: mobile ? 13 : 14, fontWeight: 800,
+      cursor:'pointer',
+      boxShadow:`0 4px 14px ${entityHsl('toolkit', 0.3)}`,
+      whiteSpace:'nowrap',
+    }}>+ Nuovo toolkit →</button>
+  </section>
+);
+
+// ═══════════════════════════════════════════════════════
+// STATES
+// ═══════════════════════════════════════════════════════
+const EmptyAll = ({ mobile }) => (
+  <div style={{
+    padding: mobile ? '32px 16px 24px' : '48px 32px 32px',
+    display:'flex', flexDirection:'column', gap: mobile ? 24 : 32,
+  }}>
+    {/* Solo Trending row */}
+    <HorizontalRow
+      title="Trending questa settimana" emoji="🔥"
+      count={8}
+      items={buildRows().trending.map(e => ({ entity: e }))}
+      renderCard={({ entity }) => <FeaturedCard entity={entity} mobile={mobile}/>}
+      mobile={mobile}/>
+
+    <div style={{
+      margin: mobile ? '0 16px' : '0 32px',
+      padding: mobile ? '32px 24px' : '48px 32px',
+      borderRadius:'var(--r-xl)',
+      background:'var(--bg-card)', border:'1px dashed var(--border-strong)',
+      display:'flex', flexDirection: mobile ? 'column' : 'row',
+      alignItems:'center', gap: 18,
+      textAlign: mobile ? 'center' : 'left',
+    }}>
+      <div style={{
+        width: 72, height: 72, borderRadius:'50%',
+        background: entityHsl('agent', 0.12), color: entityHsl('agent'),
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 32, flexShrink: 0,
+      }} aria-hidden="true">🌱</div>
+      <div style={{ flex: 1 }}>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 17, fontWeight: 800,
+          color:'var(--text)', margin:'0 0 6px',
+        }}>Stai iniziando ora!</h3>
+        <p style={{
+          fontSize: 13, color:'var(--text-muted)', margin: 0, lineHeight: 1.6,
+          maxWidth: 460,
+        }}>I consigli personalizzati appariranno qui dopo qualche partita o interazione con un agente. Nel frattempo, esplora la libreria pubblica.</p>
+      </div>
+      <button type="button" style={{
+        padding:'12px 22px', borderRadius:'var(--r-md)',
+        background: entityHsl('agent'), color:'#fff', border:'none',
+        fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+        cursor:'pointer', whiteSpace:'nowrap',
+        boxShadow:`0 4px 12px ${entityHsl('agent', 0.3)}`,
+      }}>Esplora la libreria</button>
+    </div>
+  </div>
+);
+
+const EmptyFilter = ({ filter, mobile, onClear }) => {
+  const f = FILTERS.find(x => x.id === filter);
+  return (
+    <div style={{
+      padding: mobile ? '40px 24px' : '60px 32px',
+      display:'flex', justifyContent:'center',
+    }}>
+      <div style={{
+        maxWidth: 420, textAlign:'center',
+        padding:'32px 24px',
+        background:'var(--bg-card)', border:'1px dashed var(--border-strong)',
+        borderRadius:'var(--r-xl)',
+      }}>
+        <div style={{ fontSize: 36, marginBottom: 10 }} aria-hidden="true">{f?.em || '🔍'}</div>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800,
+          color:'var(--text)', margin:'0 0 6px',
+        }}>Nessun {f?.label.toLowerCase()} trending al momento</h3>
+        <p style={{
+          fontSize: 12.5, color:'var(--text-muted)', margin:'0 0 14px', lineHeight: 1.6,
+        }}>Prova a rimuovere il filtro o cerca per parola chiave.</p>
+        <button type="button" onClick={onClear} style={{
+          padding:'8px 18px', borderRadius:'var(--r-md)',
+          background:'var(--bg)', color:'var(--text)',
+          border:'1px solid var(--border-strong)',
+          fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer',
+        }}>Mostra tutti</button>
+      </div>
+    </div>
+  );
+};
+
+const LoadingRows = ({ mobile }) => (
+  <div style={{
+    padding: mobile ? '20px 0 24px' : '32px 0',
+    display:'flex', flexDirection:'column', gap: mobile ? 24 : 36,
+  }}>
+    {[0, 1, 2].map(i => (
+      <div key={i} style={{
+        display:'flex', flexDirection:'column', gap: 12,
+      }}>
+        <div style={{ padding: mobile ? '0 16px' : '0 32px' }}>
+          <div className="mai-shimmer" style={{
+            width: 220, height: 22, borderRadius:'var(--r-sm)',
+            background:'var(--bg-muted)',
+          }}/>
+        </div>
+        <div style={{
+          display:'flex', gap: 12,
+          padding: mobile ? '4px 16px 12px' : '4px 32px 12px',
+          overflowX:'hidden',
+        }}>
+          {[0,1,2,3,4].map(j => (
+            <div key={j} className="mai-shimmer" style={{
+              flex:`0 0 ${i === 0 ? (mobile ? 280 : 320) : (i === 1 ? (mobile ? 150 : 180) : (mobile ? 240 : 260))}px`,
+              height: i === 0 ? 280 : (i === 1 ? (mobile ? 200 : 240) : 72),
+              borderRadius:'var(--r-lg)',
+              background:'var(--bg-muted)',
+            }}/>
+          ))}
+        </div>
+      </div>
+    ))}
+  </div>
+);
+
+const ErrorState = ({ mobile }) => (
+  <div style={{ padding:'60px 32px', display:'flex', justifyContent:'center' }}>
+    <div style={{
+      maxWidth: 440, textAlign:'center',
+      padding:'32px 24px',
+      background:'hsl(var(--c-danger) / .08)',
+      border:'1px solid hsl(var(--c-danger) / .3)',
+      borderRadius:'var(--r-xl)',
+      display:'flex', flexDirection:'column', alignItems:'center',
+    }}>
+      <div style={{
+        width: 56, height: 56, borderRadius:'50%',
+        background:'hsl(var(--c-danger) / .15)', color:'hsl(var(--c-danger))',
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 26, marginBottom: 12,
+      }} aria-hidden="true">⚠</div>
+      <h3 style={{
+        fontFamily:'var(--f-display)', fontSize: 17, fontWeight: 800,
+        color:'var(--text)', margin:'0 0 6px',
+      }}>Discover non disponibile</h3>
+      <p style={{
+        fontSize: 12.5, color:'var(--text-muted)', maxWidth: 380, margin:'0 0 16px',
+        lineHeight: 1.6,
+      }}>Il servizio di raccomandazione è temporaneamente offline. Riprova tra qualche istante o esplora direttamente la libreria.</p>
+      <div style={{ display:'flex', gap: 10 }}>
+        <button type="button" style={{
+          padding:'10px 18px', borderRadius:'var(--r-md)',
+          background:'hsl(var(--c-danger))', color:'#fff', border:'none',
+          fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer',
+        }}>↻ Riprova</button>
+        <button type="button" style={{
+          padding:'10px 18px', borderRadius:'var(--r-md)',
+          background:'transparent', color:'var(--text)',
+          border:'1px solid var(--border-strong)',
+          fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer',
+        }}>Vai alla libreria</button>
+      </div>
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// SHELLS
+// ═══════════════════════════════════════════════════════
+const DesktopNav = () => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 14,
+    padding:'10px 32px',
+    background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+    borderBottom:'1px solid var(--border)',
+    position:'sticky', top: 0, zIndex: 10,
+  }}>
+    <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
+      <div style={{
+        width: 26, height: 26, borderRadius: 7,
+        background:`linear-gradient(135deg, ${entityHsl('event')}, ${entityHsl('agent')})`,
+        color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+        fontWeight: 800, fontSize: 13, fontFamily:'var(--f-display)',
+      }}>M</div>
+      <span style={{ fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 14 }}>MeepleAI</span>
+    </div>
+    <div style={{
+      flex: 1, fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      marginLeft: 22,
+    }}>
+      <strong style={{ color:'var(--text-sec)' }}>Discover</strong>
+    </div>
+  </div>
+);
+
+const DesktopScreen = (props) => (
+  <div style={{ background:'var(--bg)', position:'relative' }}>
+    <DesktopNav/>
+    <DiscoverBody {...props}/>
+  </div>
+);
+
+const PhoneSbar = () => (
+  <div className="phone-sbar" style={{ color:'var(--text)' }}>
+    <span style={{ fontFamily:'var(--f-mono)' }}>14:32</span>
+    <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+  </div>
+);
+const PhoneTopNav = () => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 9,
+    padding:'10px 14px', background:'var(--glass-bg)',
+    backdropFilter:'blur(12px)',
+    borderBottom:'1px solid var(--border-light)',
+    position:'sticky', top: 0, zIndex: 10,
+  }}>
+    <button aria-label="Indietro" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      color:'var(--text)', fontSize: 14, cursor:'pointer',
+    }}>←</button>
+    <div style={{
+      flex: 1, fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+      textAlign:'center', fontWeight: 700,
+    }}>/discover</div>
+    <button aria-label="Profilo" style={{
+      width: 32, height: 32, borderRadius:'50%',
+      background:`linear-gradient(135deg, ${entityHsl('player')}, ${entityHsl('event')})`,
+      color:'#fff', border:'none',
+      fontFamily:'var(--f-display)', fontSize: 11, fontWeight: 800, cursor:'pointer',
+    }}>MR</button>
+  </div>
+);
+const MobileScreen = (props) => (
+  <>
+    <PhoneSbar/>
+    <div style={{ flex: 1, overflowY:'auto', position:'relative', background:'var(--bg)' }}>
+      <PhoneTopNav/>
+      <DiscoverBody {...props} mobile/>
+    </div>
+  </>
+);
+
+const PhoneShell = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 10 }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div className="phone">{children}</div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 340,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+const DesktopFrame = ({ label, desc, children, height = 1100 }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 12, width:'100%' }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div style={{
+      width:'100%', maxWidth: 1440,
+      borderRadius:'var(--r-xl)', border:'1px solid var(--border)',
+      background:'var(--bg)', overflow:'hidden',
+      boxShadow:'var(--shadow-lg)',
+      position:'relative',
+      maxHeight: height,
+    }}>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 8,
+        padding:'9px 14px', background:'var(--bg-muted)',
+        borderBottom:'1px solid var(--border)',
+        fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      }}>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-event))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-warning))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-toolkit))' }}/>
+        <span style={{ flex: 1, textAlign:'center', letterSpacing:'.04em' }}>meepleai.app/discover</span>
+      </div>
+      <div style={{ overflow:'auto', maxHeight: height - 40 }}>
+        {children}
+      </div>
+    </div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 720,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ROOT
+// ═══════════════════════════════════════════════════════
+const MOBILE_STATES = [
+  { id:'m1', filter:'all', label:'01 · Default · Tutti', desc:'Mobile default: hero compatto + 7 rows scrollable orizzontalmente con scroll-snap. Search box con placeholder corto.' },
+  { id:'m2', filter:'game', label:'02 · Filtro Giochi', desc:'Filtrato 🎲: solo Trending (mix) + "Giochi nuovi" rimangono visibili. Indicator underline cambia colore in arancio (game).' },
+  { id:'m3', filter:'agent', label:'03 · Filtro Agenti', desc:'Filtrato 🤖: solo Trending + "Agenti più installati". Indicator giallo (agent palette).' },
+  { id:'m4', stateOverride:'empty', label:'04 · Empty (utente nuovo)', desc:'Solo Trending row + cell consigli "🌱 Stai iniziando ora!" con CTA "Esplora la libreria". No personalization.' },
+  { id:'m5', stateOverride:'loading', label:'05 · Loading skeleton', desc:'2 rows skeleton: header bar + 5 cards shimmer con altezze realistiche per featured/grid/compact.' },
+  { id:'m6', stateOverride:'error', label:'06 · Error', desc:'Alert danger "Discover non disponibile" + 2 CTA (Riprova / Vai alla libreria).' },
+];
+
+const App = () => {
+  const [theme, setTheme] = useState(() => {
+    const saved = localStorage.getItem('mai-theme');
+    if (saved) return saved;
+    return document.documentElement.getAttribute('data-theme') || 'light';
+  });
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('mai-theme', theme);
+  }, [theme]);
+
+  return (
+    <div style={{
+      minHeight:'100vh', background:'var(--bg)', color:'var(--text)',
+      padding:'24px 24px 80px',
+    }}>
+      {/* Card hover styles */}
+      <style>{`
+        .mai-card-hover:hover {
+          transform: translateY(-2px);
+          box-shadow: var(--shadow-lg);
+          border-color: var(--border-strong);
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .mai-card-hover:hover { transform: none; }
+        }
+        .mai-row-track::-webkit-scrollbar { display: none; }
+        .mai-row-arrow { opacity: 0; transition: opacity .2s; }
+        .mai-row:hover .mai-row-arrow { opacity: 1; }
+        @media (hover: none) {
+          .mai-row-arrow { opacity: 1; }
+        }
+        @keyframes maiShimmer {
+          0% { background-position: -200% 0; }
+          100% { background-position: 200% 0; }
+        }
+        .mai-shimmer {
+          background: linear-gradient(
+            90deg,
+            var(--bg-muted) 0%,
+            var(--bg-card) 50%,
+            var(--bg-muted) 100%
+          );
+          background-size: 200% 100%;
+          animation: maiShimmer 1.6s linear infinite;
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .mai-shimmer { animation: none; }
+        }
+      `}</style>
+
+      <header style={{
+        maxWidth: 1440, margin:'0 auto 32px',
+        display:'flex', alignItems:'center', gap: 12, flexWrap:'wrap',
+      }}>
+        <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
+          <div style={{
+            width: 32, height: 32, borderRadius: 8,
+            background:`linear-gradient(135deg, ${entityHsl('event')}, ${entityHsl('agent')}, ${entityHsl('toolkit')})`,
+            color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+            fontWeight: 800, fontFamily:'var(--f-display)',
+          }}>I</div>
+          <div>
+            <div style={{ fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 16 }}>SP4 wave 3 · I</div>
+            <div style={{ fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)' }}>
+              /discover — Hero + horizontal rows (Netflix style)
+            </div>
+          </div>
+        </div>
+        <div style={{ flex: 1 }}/>
+        <span style={{
+          padding:'4px 10px', borderRadius:'var(--r-pill)',
+          background: entityHsl('toolkit', 0.15), color: entityHsl('toolkit'),
+          fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800,
+          textTransform:'uppercase', letterSpacing:'.08em',
+        }}>Wave 3 · 5/5 conclusivo</span>
+        <button type="button" onClick={() => setTheme(t => t === 'light' ? 'dark' : 'light')}
+          style={{
+            padding:'8px 14px', borderRadius:'var(--r-md)',
+            background:'var(--bg-card)', border:'1px solid var(--border)',
+            color:'var(--text)', fontFamily:'var(--f-display)',
+            fontSize: 12, fontWeight: 800, cursor:'pointer',
+          }}>🌗 {theme === 'light' ? 'Light' : 'Dark'}</button>
+      </header>
+
+      <section style={{ maxWidth: 1440, margin:'0 auto', display:'flex', flexDirection:'column', gap: 36 }}>
+        <DesktopFrame label="Desktop · 01 · Default · Tutti" height={1200}
+          desc="Hero full-width gradient radiale event/toolkit/agent + h1 'Scopri' grande + search ⌘K + Filtri avanzati + 7 entity pills (Tutti attivo). Sotto: 7 rows orizzontali con scroll-snap. Riga 1 'Trending' featured 320×280 (mix entity) · Riga 2 'Giochi nuovi' grid 180² · Riga 3 'Agenti' compact con stat 'usi' · Riga 4 'Toolkit consigliati' featured · Riga 5 'KB recenti' list · Riga 6 'Top contributor' compact con stat 'partite' · Riga 7 'Eventi' list con date block. Frecce ‹ › appaiono on hover row. Fade gradient su edges. Footer CTA gradient toolkit→player.">
+          <DesktopScreen initialFilter="all"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 02 · Filtro Giochi" height={900}
+          desc="Pill 🎲 Giochi attiva. Indicator underline arancio (entity color game). Visibili: Trending (sempre, mix) + Giochi nuovi grid. Le altre rows (agenti/toolkit/kb/players/events) collassano.">
+          <DesktopScreen initialFilter="game"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 03 · Filtro Toolkit" height={900}
+          desc="Pill 🧰 Toolkit attiva, indicator verde. Trending + Toolkit consigliati featured. Mostra il pattern 'personalizzato per te' implicito.">
+          <DesktopScreen initialFilter="toolkit"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 04 · Empty (utente nuovo)" height={900}
+          desc="Solo Trending row visibile + cell empty 'Stai iniziando ora! 🌱' con CTA 'Esplora la libreria'. No personalization → mostra solo content pubblico curato.">
+          <DesktopScreen initialFilter="all" stateOverride="empty"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 05 · Loading" height={900}
+          desc="Hero rendered, body con 3 rows skeleton: title bar shimmer + 5 cards shimmer per row. Altezze realistiche per featured/grid/compact.">
+          <DesktopScreen initialFilter="all" stateOverride="loading"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 06 · Error" height={760}
+          desc="Hero rendered, body alert danger 'Discover non disponibile' + due CTA (Riprova / Vai alla libreria). Il servizio raccomandazioni può essere offline indipendentemente dalle altre route.">
+          <DesktopScreen initialFilter="all" stateOverride="error"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 07 · AdvancedFiltersDrawer aperto" height={1100}
+          desc="Drawer da destra (420px) con 6 fieldset filtri: Numero giocatori, Durata, Difficoltà, Stato KB, Strategia agente, Anno. Footer Reimposta + 'Applica · 3 attivi' gradient. Riusa pattern wave 1.">
+          <DesktopScreen initialFilter="all" initialAdvOpen/>
+        </DesktopFrame>
+      </section>
+
+      <section style={{ maxWidth: 1440, margin:'48px auto 0' }}>
+        <h2 style={{
+          fontFamily:'var(--f-display)', fontSize: 22, fontWeight: 800,
+          marginBottom: 8,
+        }}>Mobile · 375px</h2>
+        <p style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-muted)', marginBottom: 24,
+        }}>6 stati: default tutti · filtro Giochi · filtro Agenti · empty (utente nuovo) · loading · error.</p>
+        <div style={{
+          display:'flex', flexWrap:'wrap', gap: 32, justifyContent:'center',
+        }}>
+          {MOBILE_STATES.map(m => (
+            <PhoneShell key={m.id} label={m.label} desc={m.desc}>
+              <MobileScreen initialFilter={m.filter} stateOverride={m.stateOverride}/>
+            </PhoneShell>
+          ))}
+        </div>
+      </section>
+
+      <section style={{
+        maxWidth: 900, margin:'64px auto 0',
+        padding: 24, borderRadius:'var(--r-xl)',
+        background:'var(--bg-card)', border:'1px solid var(--border)',
+      }}>
+        <h2 style={{
+          fontFamily:'var(--f-display)', fontSize: 18, fontWeight: 800, marginBottom: 12,
+        }}>Definition of Done · I discover (CONCLUSIVO wave 3)</h2>
+        <ul style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-sec)',
+          lineHeight: 1.9, listStyle:'none', padding: 0, margin: 0,
+        }}>
+          <li>✓ Solo CSS variables da tokens.css (zero hex hardcoded)</li>
+          <li>✓ Helper entityHsl(type, alpha) inline</li>
+          <li>✓ Light + dark mode (toggle header) — gradient hero ricalcolato via tokens</li>
+          <li>✓ Mobile 375px (6 phone) + Desktop 1440px (7 frame)</li>
+          <li>✓ Pattern: Hero discover header + 7 horizontal rows Netflix-style con scroll-snap</li>
+          <li>✓ Hero: badge "Discover" + h1 "Scopri" + subtitle + search box ⌘K + CTA "Filtri avanzati" + 7 entity filter pills (Tutti/Giochi/Agenti/Toolkit/KB/Persone/Eventi) con animated underline</li>
+          <li>✓ 7 rows: Trending (featured mix) · Giochi nuovi (grid) · Agenti popolari (compact +stat usi) · Toolkit consigliati (featured) · KB recenti (list) · Top contributor (compact +stat partite) · Eventi (list con date block)</li>
+          <li>✓ MeepleCard 4 varianti: featured 320×280 · grid 180² · compact 260×72 · list 380×80 — riuso wave 1 lifted</li>
+          <li>✓ Frecce ‹ › appaiono on hover (CSS .mai-row:hover .mai-row-arrow) · sempre visibili su touch (@media hover: none)</li>
+          <li>✓ Fade gradient su scroll edges (mostra solo se scrollabile)</li>
+          <li>✓ scroll-snap-type: x mandatory + scroll-snap-align: start su ogni card</li>
+          <li>✓ AdvancedFiltersDrawer riuso wave 1: 6 fieldset (giocatori/durata/difficoltà/stato KB/strategia/anno) + footer gradient "Applica · 3 attivi"</li>
+          <li>✓ Footer CTA gradient toolkit→player "Hai contenuti da pubblicare?" → /toolkits/new</li>
+          <li>✓ Stati: default / empty (solo Trending + cell "Stai iniziando ora!") / loading (skeleton 3 rows) / error (Discover non disponibile + Riprova)</li>
+          <li>✓ Empty filter sub-state: filtra ma 0 risultati → "Nessun [tipo] trending" + CTA Mostra tutti</li>
+          <li>✓ ARIA: role="tablist"/"tab" sui filter pills · aria-pressed sui filter group · aria-label "Cerca", "Scorri a sinistra/destra" · role="dialog" sul drawer</li>
+          <li>✓ prefers-reduced-motion gestito (hover transform + shimmer + slideIn keyframes)</li>
+          <li>✓ Testo italiano · dati realistici da data.js (Wingspan, Azul Toolkit v2, Azul Rules Expert, Marco R., gn-wingspan-mar15, kb-azul-ita)</li>
+          <li>✓ ID short readable: gn-wingspan-mar15, tk-azul-v2, a-azul-rules — NO UUID</li>
+          <li>✓ Commento di apertura con route /discover</li>
+        </ul>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800, marginTop: 18, marginBottom: 8,
+        }}>Nuovi componenti v2 emersi</h3>
+        <ul style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-sec)',
+          lineHeight: 1.8, listStyle:'none', padding: 0, margin: 0,
+        }}>
+          <li>· DiscoverHero (gradient radiale 3-color + title + subtitle + search + advanced + entity pills)</li>
+          <li>· DiscoverSearchBox (search input + ⌘K kbd + icona)</li>
+          <li>· EntityFilterPillBar (7 pills horizontal scroll + animated underline color-coded per entity)</li>
+          <li>· HorizontalRow (header titolo+emoji+count+'Vedi tutti' + scroller + frecce + fades)</li>
+          <li>· RowScroller (scroll-snap track + arrow buttons hover-reveal + edge fades)</li>
+          <li>· FooterCTA (gradient radiale 2-color + badge + h2 + descrizione + CTA gradient)</li>
+        </ul>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800, marginTop: 18, marginBottom: 8,
+        }}>Riusi pixel-perfect</h3>
+        <ul style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-sec)',
+          lineHeight: 1.8, listStyle:'none', padding: 0, margin: 0,
+        }}>
+          <li>· MeepleCard tutte 4 varianti (featured/grid/compact/list) — wave 1 PR #549</li>
+          <li>· AdvancedFiltersDrawer pattern (wave 1) → riusato 1:1 con drawer V3 right-side</li>
+          <li>· EntityChip (wave 1) → TypeChip per category mark sui card</li>
+          <li>· Tabs animated underline (wave 1) → entity filter pills indicator</li>
+          <li>· Drawer V3 right-side (03-drawer-variants) per AdvancedFiltersDrawer</li>
+          <li>· Drawer V1 bottom-sheet (03-drawer-variants) per advanced mobile</li>
+        </ul>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800, marginTop: 18, marginBottom: 8,
+          color:'hsl(var(--c-warning))',
+        }}>Deviazioni flaggate</h3>
+        <ul style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-sec)',
+          lineHeight: 1.8, listStyle:'none', padding: 0, margin: 0,
+        }}>
+          <li>· Frame 7 (drawer aperto) usa `initialAdvOpen` prop ma il body ha state proprio — è solo demo statica, in produzione il drawer è state-driven full</li>
+          <li>· Eventi list usa `entity.date.split(' ')[0]` per estrarre il day → fragile, in prod va parsato dato strutturato</li>
+          <li>· Personalizzazione "Toolkit consigliati per te" è fake — backend deve fornire endpoint /discover/recommendations?userId=</li>
+          <li>· Search input non collegato a backend — solo placeholder UI</li>
+          <li>· Hero gradient radiale a 3 colori entity può variare con palette dark — verificare contrasto AAA su small text</li>
+          <li>· @keyframes inline (slideIn + shimmer + maiShimmer) non in components.css come da contratto NON sovrascrivere</li>
+          <li>· Filter pills "Persone" / "Eventi" non distinguono Player vs Event detail (entrambi entità) — in prod chiarire scope</li>
+        </ul>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800, marginTop: 18, marginBottom: 8,
+          color: entityHsl('toolkit'),
+        }}>🎉 Wave 3 completa — 5/5 mockup consegnati</h3>
+        <ul style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-sec)',
+          lineHeight: 1.8, listStyle:'none', padding: 0, margin: 0,
+        }}>
+          <li>· D · sp4-player-detail (split-view sticky + 6 tabs + connections graph)</li>
+          <li>· E · sp4-toolkit-detail (split-view + 6 tabs Public/Own + tools list)</li>
+          <li>· F · sp4-kb-detail (split-view chunks + markdown preview + sub-tabs Rendered/Raw)</li>
+          <li>· G · sp4-game-nights-index (calendar/list toggle + day drawer)</li>
+          <li>· I · sp4-discover (hero + 7 horizontal rows Netflix + advanced drawer) ← QUESTO</li>
+        </ul>
+      </section>
+    </div>
+  );
+};
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);

--- a/admin-mockups/design_files/sp4-game-nights-index.html
+++ b/admin-mockups/design_files/sp4-game-nights-index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<!-- MeepleAI SP4 wave 3 — G · Game nights index (calendar / list toggle)
+     Route: /game-nights -->
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>MeepleAI · /game-nights — Serate di gioco</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-game-nights-index.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-game-nights-index.jsx
+++ b/admin-mockups/design_files/sp4-game-nights-index.jsx
@@ -1,0 +1,1274 @@
+/* MeepleAI SP4 wave 3 — Schermata G / 5
+   Route: /game-nights
+   File: admin-mockups/design_files/sp4-game-nights-index.{html,jsx}
+   Pattern: Toggle Calendar / List view (header switch). Palette --c-event con gradient event→session.
+
+   v2 nuovi (per impl post-merge):
+   - GameNightsHeader      → apps/web/src/components/ui/v2/game-nights-header/
+   - CalendarMonthGrid     → apps/web/src/components/ui/v2/calendar-month-grid/
+   - CalendarDayCell       → apps/web/src/components/ui/v2/calendar-day-cell/
+   - GameNightListCard     → apps/web/src/components/ui/v2/game-night-list-card/
+   - DayDetailDrawer       → apps/web/src/components/ui/v2/day-detail-drawer/
+   - FilterPillBar         → apps/web/src/components/ui/v2/filter-pill-bar/
+
+   Riusi:
+   - MeepleCard variant="list" (wave 1)
+   - Tabs animated underline (wave 1) per Calendar/List toggle
+   - EntityChip game/player (wave 1)
+   - ConnectionChipStrip per partecipanti (PR #549/#552)
+
+   Deviazioni: vista Calendar è grid statico mese corrente — paginazione mese ‹ › è solo visiva, no fetch reale.
+*/
+
+const { useState, useEffect, useRef, useMemo } = React;
+const DS = window.DS;
+
+const entityHsl = (type, alpha) => {
+  const c = DS.EC[type] || DS.EC.event;
+  return alpha !== undefined
+    ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${alpha})`
+    : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
+};
+
+// ─── EVENTS FIXTURE (March 2026) ─────────────────────────
+const TODAY = { y: 2026, m: 2, d: 12 }; // 12 Mar 2026 (Thu)
+const MONTH_LABEL = 'Marzo 2026';
+
+const NIGHTS = [
+  { id:'gn-wingspan-mar15', day: 15, time:'19:00', dur:'3h', org:'p-marco',
+    title:'Serata Wingspan da Marco', loc:'Casa Marco',
+    gameId:'g-wingspan', playerIds:['p-marco','p-sara','p-luca','p-giulia','p-andrea'],
+    status:'confirmed', role:'organizer', month: 2 },
+  { id:'gn-azul-mar18', day: 18, time:'20:30', dur:'2h', org:'p-sara',
+    title:'Azul rapido', loc:'Casa Sara',
+    gameId:'g-azul', playerIds:['p-sara','p-marco','p-luca'],
+    status:'confirmed', role:'invited', month: 2 },
+  { id:'gn-brass-mar20', day: 20, time:'19:30', dur:'3h 30m', org:'p-marco',
+    title:'Demo Brass Birmingham', loc:'Sala B&B Lentia',
+    gameId:'g-brass', playerIds:['p-marco','p-andrea','p-sara','p-luca'],
+    status:'planned', role:'organizer', month: 2 },
+  { id:'gn-catan-mar22', day: 22, time:'15:00', dur:'4h', org:'p-luca',
+    title:'Catan Maratona', loc:'Casa Luca',
+    gameId:'g-catan', playerIds:['p-luca','p-sara','p-andrea','p-giulia'],
+    status:'confirmed', role:'invited', month: 2 },
+  { id:'gn-7w-mar22', day: 22, time:'21:00', dur:'1h', org:'p-marco',
+    title:'7 Wonders Duel — partita doppia', loc:'Casa Marco',
+    gameId:'g-7wonders', playerIds:['p-marco','p-giulia'],
+    status:'planned', role:'organizer', month: 2 },
+  { id:'gn-arknova-mar24', day: 24, time:'19:00', dur:'2h 30m', org:'p-andrea',
+    title:'Ark Nova primo tavolo', loc:'Ludoteca Centrale',
+    gameId:'g-arknova', playerIds:['p-andrea','p-sara'],
+    status:'planned', role:'invited', month: 2 },
+  { id:'gn-spirit-mar26', day: 26, time:'20:00', dur:'3h', org:'p-sara',
+    title:'Spirit Island co-op', loc:'Casa Sara',
+    gameId:'g-spirit', playerIds:['p-sara','p-marco','p-luca'],
+    status:'cancelled', role:'invited', month: 2 },
+  { id:'gn-wingspan-mar28', day: 28, time:'14:30', dur:'2h', org:'p-marco',
+    title:'Wingspan family edition', loc:'Casa Marco',
+    gameId:'g-wingspan', playerIds:['p-marco','p-giulia','p-andrea','p-sara','p-luca','p-andrea'],
+    status:'confirmed', role:'organizer', month: 2 },
+  // Past
+  { id:'gn-azul-feb20', day: 20, time:'19:00', dur:'2h 15m', org:'p-marco',
+    title:'Azul torneo casalingo', loc:'Casa Marco',
+    gameId:'g-azul', playerIds:['p-marco','p-sara','p-luca','p-giulia'],
+    status:'completed', role:'organizer', month: 1 },
+  { id:'gn-brass-feb20', day: 25, time:'20:00', dur:'2h 50m', org:'p-andrea',
+    title:'Demo Brass Birmingham', loc:'Sala B&B',
+    gameId:'g-brass', playerIds:['p-andrea','p-marco','p-sara'],
+    status:'completed', role:'invited', month: 1 },
+  { id:'gn-catan-feb12', day: 12, time:'19:30', dur:'3h', org:'p-luca',
+    title:'Catan classico', loc:'Casa Luca',
+    gameId:'g-catan', playerIds:['p-luca','p-sara','p-marco','p-giulia'],
+    status:'completed', role:'invited', month: 1 },
+];
+
+const STATUS_META = {
+  confirmed: { label:'Confermata', dotColor: entityHsl('toolkit'), bg: entityHsl('toolkit', 0.12) },
+  planned:   { label:'In programma', dotColor: entityHsl('agent'), bg: entityHsl('agent', 0.12) },
+  cancelled: { label:'Annullata', dotColor: 'hsl(var(--c-danger))', bg: 'hsl(var(--c-danger) / .12)' },
+  completed: { label:'Conclusa', dotColor:'hsl(var(--c-muted))', bg: 'hsl(var(--c-muted) / .15)' },
+};
+
+const ROLE_OPTS = ['Tutte', 'Organizzo', 'Invitato', 'Concluse'];
+
+// ═══════════════════════════════════════════════════════
+// PRIMITIVES
+// ═══════════════════════════════════════════════════════
+const EntityChip = ({ type, label, sm }) => (
+  <span style={{
+    display:'inline-flex', alignItems:'center', gap: 5,
+    padding: sm ? '2px 7px' : '4px 10px', borderRadius:'var(--r-pill)',
+    background: entityHsl(type, 0.12), color: entityHsl(type),
+    border:`1px solid ${entityHsl(type, 0.22)}`,
+    fontFamily:'var(--f-display)', fontSize: sm ? 10 : 11, fontWeight: 700,
+    whiteSpace:'nowrap',
+  }}>
+    <span aria-hidden="true">{DS.EC[type]?.em}</span>
+    <span>{label}</span>
+  </span>
+);
+
+const StatusPill = ({ status }) => {
+  const m = STATUS_META[status];
+  return (
+    <span style={{
+      display:'inline-flex', alignItems:'center', gap: 5,
+      padding:'3px 9px', borderRadius:'var(--r-pill)',
+      background: m.bg, color: m.dotColor,
+      fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800,
+      textTransform:'uppercase', letterSpacing:'.06em',
+      border:`1px solid ${m.dotColor}33`,
+    }}>
+      <span aria-hidden="true" style={{
+        width: 6, height: 6, borderRadius:'50%', background: m.dotColor,
+      }}/>
+      <span>{m.label}</span>
+    </span>
+  );
+};
+
+const PlayerAvatars = ({ playerIds, max = 5 }) => {
+  const list = playerIds.slice(0, max);
+  const extra = playerIds.length - max;
+  return (
+    <div style={{ display:'inline-flex', alignItems:'center' }}>
+      {list.map((pid, i) => {
+        const p = DS.byId[pid];
+        if (!p) return null;
+        return (
+          <span key={`${pid}-${i}`} title={p.title}
+            style={{
+              width: 26, height: 26, borderRadius:'50%',
+              background:`hsl(${p.color}, 55%, 50%)`,
+              color:'#fff', fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 10,
+              display:'inline-flex', alignItems:'center', justifyContent:'center',
+              border:'2px solid var(--bg-card)',
+              marginLeft: i === 0 ? 0 : -8,
+              zIndex: max - i,
+            }}>{p.initials}</span>
+        );
+      })}
+      {extra > 0 && (
+        <span style={{
+          width: 26, height: 26, borderRadius:'50%',
+          background:'var(--bg-muted)', color:'var(--text-sec)',
+          fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800,
+          display:'inline-flex', alignItems:'center', justifyContent:'center',
+          border:'2px solid var(--bg-card)', marginLeft: -8, zIndex: 0,
+        }}>+{extra}</span>
+      )}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// HEADER + TOGGLE + FILTERS
+// ═══════════════════════════════════════════════════════
+const Header = ({ view, onView, role, onRole, mobile, total }) => {
+  const refs = useRef({});
+  const [ind, setInd] = useState({ left: 0, width: 0 });
+  useEffect(() => {
+    const el = refs.current[view];
+    if (el) setInd({ left: el.offsetLeft, width: el.offsetWidth });
+  }, [view]);
+
+  return (
+    <div style={{
+      padding: mobile ? '14px 16px 0' : '24px 32px 0',
+      background:'var(--bg)',
+      display:'flex', flexDirection:'column', gap: mobile ? 12 : 16,
+    }}>
+      {/* Title row + CTA */}
+      <div style={{
+        display:'flex', alignItems: mobile ? 'flex-start' : 'flex-end',
+        gap: 12, flexWrap:'wrap',
+        flexDirection: mobile ? 'column' : 'row',
+      }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{
+            display:'inline-flex', alignItems:'center', gap: 8,
+            padding:'4px 10px', borderRadius:'var(--r-pill)',
+            background: entityHsl('event', 0.12), color: entityHsl('event'),
+            fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800,
+            textTransform:'uppercase', letterSpacing:'.08em', marginBottom: 8,
+          }}>
+            <span aria-hidden="true">📅</span>
+            <span>Game nights</span>
+          </div>
+          <h1 style={{
+            margin: 0, fontFamily:'var(--f-display)',
+            fontSize: mobile ? 24 : 30, fontWeight: 800,
+            color:'var(--text)', letterSpacing:'-.01em', lineHeight: 1.1,
+          }}>Serate di gioco</h1>
+          <div style={{
+            marginTop: 4, fontFamily:'var(--f-mono)', fontSize: 12,
+            color:'var(--text-muted)', fontWeight: 600,
+          }}>
+            <strong style={{ color: entityHsl('event'), fontFamily:'var(--f-mono)' }}>{total}</strong>
+            {' '}serate questo mese · {NIGHTS.filter(n => n.status === 'confirmed' && n.month === 2).length} confermate
+          </div>
+        </div>
+        <button type="button" style={{
+          padding:'10px 16px', borderRadius:'var(--r-md)',
+          background:`linear-gradient(135deg, ${entityHsl('event')}, ${entityHsl('session')})`,
+          color:'#fff', border:'none',
+          fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800, cursor:'pointer',
+          display:'inline-flex', alignItems:'center', gap: 7,
+          boxShadow:`0 4px 12px ${entityHsl('event', 0.3)}`,
+          alignSelf: mobile ? 'stretch' : 'auto',
+          justifyContent:'center',
+        }}>
+          <span aria-hidden="true">+</span>
+          <span>Nuova serata</span>
+        </button>
+      </div>
+
+      {/* View toggle + filters row */}
+      <div style={{
+        display:'flex', alignItems:'center', gap: 12, flexWrap:'wrap',
+        justifyContent: mobile ? 'space-between' : 'flex-start',
+      }}>
+        {/* Calendar/List toggle */}
+        <div style={{ position:'relative' }}>
+          <div style={{
+            display:'flex', gap: 2, borderBottom:'1px solid var(--border)',
+          }} role="tablist" aria-label="Vista serate">
+            {[
+              { id:'calendar', icon:'🗓', label:'Calendario' },
+              { id:'list', icon:'☰', label:'Lista' },
+            ].map(t => {
+              const isActive = view === t.id;
+              return (
+                <button key={t.id} type="button"
+                  ref={el => { refs.current[t.id] = el; }}
+                  onClick={() => onView(t.id)}
+                  role="tab" aria-selected={isActive}
+                  style={{
+                    padding:'10px 16px', background:'transparent', border:'none',
+                    color: isActive ? entityHsl('event') : 'var(--text-sec)',
+                    fontFamily:'var(--f-display)', fontSize: 13,
+                    fontWeight: isActive ? 800 : 700, cursor:'pointer',
+                    display:'inline-flex', alignItems:'center', gap: 6,
+                  }}>
+                  <span aria-hidden="true">{t.icon}</span>
+                  <span>{t.label}</span>
+                </button>
+              );
+            })}
+          </div>
+          <span aria-hidden="true" style={{
+            position:'absolute', bottom: -1, left: ind.left, width: ind.width,
+            height: 2, background: entityHsl('event'),
+            transition:'left .3s var(--ease-out), width .3s var(--ease-out)',
+          }}/>
+        </div>
+
+        {/* Filter pills */}
+        <div style={{
+          display:'flex', gap: 6, flexWrap:'wrap',
+          marginLeft: mobile ? 0 : 'auto',
+          overflowX: mobile ? 'auto' : 'visible',
+          scrollbarWidth:'none',
+        }}>
+          {ROLE_OPTS.map(opt => {
+            const active = role === opt;
+            return (
+              <button key={opt} type="button" onClick={() => onRole(opt)}
+                aria-pressed={active}
+                style={{
+                  padding:'6px 12px', borderRadius:'var(--r-pill)',
+                  background: active ? entityHsl('event', 0.15) : 'var(--bg-card)',
+                  color: active ? entityHsl('event') : 'var(--text-sec)',
+                  border: active
+                    ? `1px solid ${entityHsl('event', 0.4)}`
+                    : '1px solid var(--border)',
+                  fontFamily:'var(--f-display)', fontSize: 11, fontWeight: 800,
+                  cursor:'pointer', whiteSpace:'nowrap',
+                }}>{opt}</button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// CALENDAR VIEW
+// /* v2: CalendarMonthGrid → apps/web/src/components/ui/v2/calendar-month-grid/ */
+// ═══════════════════════════════════════════════════════
+const buildMonthGrid = () => {
+  // Mar 2026 starts on Sunday Mar 1 → ISO week starts Mon, so first Mon-week is Feb 23
+  // Days: Lun=1 ... Dom=7. Mar 1 2026 = Sunday → grid starts Feb 23 (Mon)
+  const cells = [];
+  // Feb tail: 23..28 (6 days) — but we only need up to Sun before Mar 1
+  // Actually Mar 1 2026 is Sunday so prepend 6 days: Mon Feb 23 ... Sat Feb 28
+  for (let d = 23; d <= 28; d++) cells.push({ day: d, otherMonth: true, isFeb: true });
+  // March: 1..31
+  for (let d = 1; d <= 31; d++) cells.push({ day: d, otherMonth: false });
+  // April pad to fill last week (42 cells = 6 weeks)
+  let pad = 42 - cells.length;
+  for (let d = 1; d <= pad; d++) cells.push({ day: d, otherMonth: true, isApr: true });
+  return cells;
+};
+
+const eventsForDay = (cell, role) => {
+  if (cell.otherMonth) return [];
+  const monthIdx = 2; // March
+  return NIGHTS.filter(n => {
+    if (n.month !== monthIdx) return false;
+    if (n.day !== cell.day) return false;
+    if (role === 'Tutte') return true;
+    if (role === 'Organizzo') return n.role === 'organizer';
+    if (role === 'Invitato') return n.role === 'invited';
+    if (role === 'Concluse') return n.status === 'completed';
+    return true;
+  });
+};
+
+const DayCell = ({ cell, events, isToday, onClick, mobile }) => {
+  const hasEvents = events.length > 0;
+  const max = mobile ? 1 : 3;
+  const visible = events.slice(0, max);
+  const overflow = events.length - max;
+  return (
+    <button type="button" onClick={() => hasEvents && onClick(cell, events)}
+      aria-label={`Giorno ${cell.day}${hasEvents ? `, ${events.length} eventi` : ''}`}
+      disabled={cell.otherMonth}
+      style={{
+        textAlign:'left',
+        minHeight: mobile ? 64 : 110,
+        padding: mobile ? 4 : 8,
+        background: cell.otherMonth ? 'transparent'
+          : hasEvents ? entityHsl('event', 0.05) : 'var(--bg-card)',
+        border: isToday
+          ? `2px solid ${entityHsl('event')}`
+          : '1px solid var(--border-light)',
+        borderRadius: mobile ? 6 : 'var(--r-md)',
+        cursor: hasEvents ? 'pointer' : (cell.otherMonth ? 'default' : 'default'),
+        opacity: cell.otherMonth ? 0.35 : 1,
+        display:'flex', flexDirection:'column', gap: 4,
+        transition:'background var(--dur-sm)',
+        position:'relative',
+      }}>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 4,
+      }}>
+        <span style={{
+          fontFamily:'var(--f-mono)', fontSize: mobile ? 11 : 12,
+          fontWeight: isToday ? 800 : 700,
+          color: isToday ? entityHsl('event')
+                : cell.otherMonth ? 'var(--text-muted)' : 'var(--text)',
+        }}>{cell.day}</span>
+        {isToday && !mobile && (
+          <span style={{
+            fontFamily:'var(--f-mono)', fontSize: 8, fontWeight: 800,
+            color: entityHsl('event'), textTransform:'uppercase', letterSpacing:'.08em',
+            marginLeft:'auto',
+          }}>Oggi</span>
+        )}
+      </div>
+      <div style={{ display:'flex', flexDirection:'column', gap: 2, flex: 1 }}>
+        {visible.map(ev => {
+          const meta = STATUS_META[ev.status];
+          return (
+            <div key={ev.id} style={{
+              padding: mobile ? '2px 5px' : '3px 6px',
+              borderRadius: 4,
+              background: ev.status === 'cancelled'
+                ? 'hsl(var(--c-danger) / .12)'
+                : entityHsl('event', 0.18),
+              color: ev.status === 'cancelled'
+                ? 'hsl(var(--c-danger))'
+                : entityHsl('event'),
+              fontFamily:'var(--f-display)', fontSize: mobile ? 9 : 10,
+              fontWeight: 700,
+              borderLeft: `2px solid ${ev.status === 'cancelled' ? 'hsl(var(--c-danger))' : entityHsl('event')}`,
+              overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap',
+              textDecoration: ev.status === 'cancelled' ? 'line-through' : 'none',
+              opacity: ev.status === 'cancelled' ? 0.7 : 1,
+            }}>
+              <span style={{ fontFamily:'var(--f-mono)', fontWeight: 800 }}>{ev.time}</span>
+              {!mobile && <> · {DS.byId[ev.gameId]?.title || ev.title}</>}
+            </div>
+          );
+        })}
+        {overflow > 0 && (
+          <div style={{
+            fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 700,
+            color: entityHsl('event'), padding:'1px 4px',
+          }}>+{overflow} altri</div>
+        )}
+      </div>
+    </button>
+  );
+};
+
+const CalendarView = ({ role, onDayClick, mobile, stateOverride }) => {
+  const cells = buildMonthGrid();
+  const dayLabels = ['Lun','Mar','Mer','Gio','Ven','Sab','Dom'];
+
+  if (stateOverride === 'loading') {
+    return (
+      <div style={{ padding: mobile ? '0 16px 24px' : '24px 32px' }}>
+        <div className="mai-shimmer" style={{
+          height: 36, marginBottom: 12,
+          borderRadius:'var(--r-md)', background:'var(--bg-muted)',
+        }}/>
+        <div style={{
+          display:'grid', gridTemplateColumns:'repeat(7, 1fr)', gap: 4,
+        }}>
+          {Array.from({ length: 35 }).map((_, i) => (
+            <div key={i} className="mai-shimmer" style={{
+              height: mobile ? 64 : 110,
+              borderRadius:'var(--r-md)', background:'var(--bg-muted)',
+            }}/>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{
+      padding: mobile ? '12px 16px 24px' : '20px 32px 32px',
+      display:'flex', flexDirection:'column', gap: 12,
+    }}>
+      {/* Month nav */}
+      <div style={{
+        display:'flex', alignItems:'center', gap: 10, flexWrap:'wrap',
+      }}>
+        <button type="button" aria-label="Mese precedente" style={{
+          width: 32, height: 32, borderRadius:'var(--r-md)',
+          background:'var(--bg-card)', border:'1px solid var(--border)',
+          color:'var(--text)', fontSize: 14, cursor:'pointer',
+        }}>‹</button>
+        <h2 style={{
+          margin: 0, fontFamily:'var(--f-display)', fontSize: mobile ? 16 : 20,
+          fontWeight: 800, color:'var(--text)', minWidth: 140,
+        }}>{MONTH_LABEL}</h2>
+        <button type="button" aria-label="Mese successivo" style={{
+          width: 32, height: 32, borderRadius:'var(--r-md)',
+          background:'var(--bg-card)', border:'1px solid var(--border)',
+          color:'var(--text)', fontSize: 14, cursor:'pointer',
+        }}>›</button>
+        <button type="button" style={{
+          marginLeft: 6, padding:'6px 14px', borderRadius:'var(--r-md)',
+          background:'transparent', color: entityHsl('event'),
+          border:`1px solid ${entityHsl('event', 0.4)}`,
+          fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer',
+        }}>Oggi</button>
+        <div style={{
+          marginLeft:'auto', fontFamily:'var(--f-mono)', fontSize: 11,
+          color:'var(--text-muted)', fontWeight: 700,
+        }}>
+          {NIGHTS.filter(n => n.month === 2).length} serate · {NIGHTS.filter(n => n.month === 2 && n.status === 'cancelled').length} annullate
+        </div>
+      </div>
+
+      {/* Day labels */}
+      <div style={{
+        display:'grid', gridTemplateColumns:'repeat(7, 1fr)', gap: 4,
+      }}>
+        {dayLabels.map(d => (
+          <div key={d} style={{
+            padding:'6px 4px', textAlign: mobile ? 'center' : 'left',
+            fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800,
+            color:'var(--text-muted)', textTransform:'uppercase',
+            letterSpacing:'.08em',
+          }}>{d}</div>
+        ))}
+      </div>
+
+      {/* Cells grid */}
+      <div style={{
+        display:'grid', gridTemplateColumns:'repeat(7, 1fr)', gap: 4,
+      }}>
+        {cells.map((cell, i) => {
+          const events = eventsForDay(cell, role);
+          const isToday = !cell.otherMonth && cell.day === TODAY.d;
+          return (
+            <DayCell key={i} cell={cell} events={events} isToday={isToday}
+              onClick={onDayClick} mobile={mobile}/>
+          );
+        })}
+      </div>
+
+      {/* Legend */}
+      <div style={{
+        display:'flex', gap: 14, flexWrap:'wrap', paddingTop: 8,
+        fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+        fontWeight: 700,
+      }}>
+        <span style={{ display:'inline-flex', alignItems:'center', gap: 5 }}>
+          <span style={{ width: 10, height: 10, borderRadius: 2, background: entityHsl('event', 0.18) }}/>
+          Serata
+        </span>
+        <span style={{ display:'inline-flex', alignItems:'center', gap: 5 }}>
+          <span style={{ width: 10, height: 10, borderRadius: 2, background:'hsl(var(--c-danger) / .18)' }}/>
+          Annullata
+        </span>
+        <span style={{ display:'inline-flex', alignItems:'center', gap: 5 }}>
+          <span style={{ width: 10, height: 10, borderRadius: 4, border:`2px solid ${entityHsl('event')}` }}/>
+          Oggi
+        </span>
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// LIST VIEW
+// /* v2: GameNightListCard → apps/web/src/components/ui/v2/game-night-list-card/ */
+// ═══════════════════════════════════════════════════════
+const ListCard = ({ night, mobile }) => {
+  const game = DS.byId[night.gameId];
+  const gameTitle = game?.title || night.title;
+  const isOrg = night.role === 'organizer';
+  const isCompleted = night.status === 'completed';
+  const isCancelled = night.status === 'cancelled';
+
+  return (
+    <article style={{
+      display:'flex', flexDirection: mobile ? 'column' : 'row',
+      gap: mobile ? 10 : 14,
+      padding: mobile ? 14 : 16,
+      background:'var(--bg-card)',
+      border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)',
+      borderLeft: `3px solid ${
+        isCancelled ? 'hsl(var(--c-danger))' : entityHsl('event')
+      }`,
+      opacity: isCancelled ? 0.78 : 1,
+      transition:'border-color var(--dur-sm), box-shadow var(--dur-sm)',
+    }}>
+      {/* Date block */}
+      <div style={{
+        flexShrink: 0,
+        width: mobile ? 'auto' : 78,
+        padding: mobile ? '0' : '6px 10px',
+        background: mobile ? 'transparent' : entityHsl('event', 0.08),
+        border: mobile ? 'none' : `1px solid ${entityHsl('event', 0.22)}`,
+        borderRadius:'var(--r-md)',
+        display:'flex',
+        flexDirection: mobile ? 'row' : 'column',
+        alignItems: mobile ? 'center' : 'center',
+        justifyContent:'center',
+        gap: mobile ? 8 : 0,
+      }}>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: mobile ? 10 : 9, fontWeight: 800,
+          color: entityHsl('event'), textTransform:'uppercase', letterSpacing:'.08em',
+        }}>{night.month === 2 ? 'Mar' : 'Feb'}</div>
+        <div style={{
+          fontFamily:'var(--f-display)', fontSize: mobile ? 22 : 28, fontWeight: 800,
+          color: entityHsl('event'), lineHeight: 1, fontVariantNumeric:'tabular-nums',
+        }}>{night.day}</div>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: mobile ? 10 : 10, fontWeight: 700,
+          color:'var(--text-sec)', marginTop: mobile ? 0 : 2,
+        }}>{night.time}</div>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+          marginTop: mobile ? 0 : 1, marginLeft: mobile ? 'auto' : 0,
+        }}>· {night.dur}</div>
+      </div>
+
+      {/* Body */}
+      <div style={{ flex: 1, minWidth: 0, display:'flex', flexDirection:'column', gap: 8 }}>
+        <div style={{
+          display:'flex', alignItems:'flex-start', gap: 8, flexWrap:'wrap',
+        }}>
+          <h3 style={{
+            margin: 0, fontFamily:'var(--f-display)', fontSize: mobile ? 14 : 16,
+            fontWeight: 800, color:'var(--text)', lineHeight: 1.3,
+            flex: 1, minWidth: 0,
+            textDecoration: isCancelled ? 'line-through' : 'none',
+          }}>{night.title}</h3>
+          <StatusPill status={night.status}/>
+        </div>
+
+        <div style={{
+          display:'flex', alignItems:'center', gap: 6, flexWrap:'wrap',
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+        }}>
+          <span aria-hidden="true">📍</span>
+          <span style={{ fontWeight: 600 }}>{night.loc}</span>
+          {game && (
+            <>
+              <span aria-hidden="true" style={{ opacity: 0.4 }}>·</span>
+              <EntityChip type="game" label={gameTitle} sm/>
+            </>
+          )}
+          {isOrg && (
+            <span style={{
+              padding:'2px 7px', borderRadius:'var(--r-pill)',
+              background: entityHsl('player', 0.12), color: entityHsl('player'),
+              fontFamily:'var(--f-display)', fontSize: 10, fontWeight: 800,
+              border:`1px solid ${entityHsl('player', 0.22)}`,
+            }}>● Organizzo</span>
+          )}
+        </div>
+
+        <div style={{
+          display:'flex', alignItems:'center', gap: 10, flexWrap:'wrap',
+          paddingTop: 6, borderTop:'1px solid var(--border-light)',
+        }}>
+          <PlayerAvatars playerIds={night.playerIds} max={mobile ? 4 : 5}/>
+          <span style={{
+            fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+            fontWeight: 700,
+          }}>{night.playerIds.length} partecipanti</span>
+          <div style={{ flex: 1 }}/>
+          {/* CTA contestuali */}
+          {isCompleted ? (
+            <button type="button" style={{
+              padding:'6px 12px', borderRadius:'var(--r-md)',
+              background:'transparent', color:'var(--text)',
+              border:'1px solid var(--border-strong)',
+              fontFamily:'var(--f-display)', fontSize: 11, fontWeight: 800, cursor:'pointer',
+            }}>Vedi summary →</button>
+          ) : isCancelled ? (
+            <button type="button" style={{
+              padding:'6px 12px', borderRadius:'var(--r-md)',
+              background:'transparent', color:'var(--text-muted)',
+              border:'1px solid var(--border)',
+              fontFamily:'var(--f-display)', fontSize: 11, fontWeight: 700, cursor:'pointer',
+            }}>Riprogramma</button>
+          ) : isOrg ? (
+            <button type="button" style={{
+              padding:'6px 12px', borderRadius:'var(--r-md)',
+              background: entityHsl('event'), color:'#fff', border:'none',
+              fontFamily:'var(--f-display)', fontSize: 11, fontWeight: 800, cursor:'pointer',
+            }}>Modifica</button>
+          ) : (
+            <div style={{ display:'flex', gap: 6 }}>
+              <button type="button" style={{
+                padding:'6px 12px', borderRadius:'var(--r-md)',
+                background: entityHsl('toolkit'), color:'#fff', border:'none',
+                fontFamily:'var(--f-display)', fontSize: 11, fontWeight: 800, cursor:'pointer',
+                lineHeight: 1.4,
+              }}>✓ Partecipo</button>
+              <button type="button" style={{
+                padding:'6px 10px', borderRadius:'var(--r-md)',
+                background:'transparent', color:'var(--text-sec)',
+                border:'1px solid var(--border-strong)',
+                fontFamily:'var(--f-display)', fontSize: 11, fontWeight: 700, cursor:'pointer',
+              }}>Forse</button>
+            </div>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+};
+
+const ListView = ({ role, mobile, stateOverride }) => {
+  if (stateOverride === 'loading') {
+    return (
+      <div style={{
+        padding: mobile ? '12px 16px 24px' : '20px 32px 32px',
+        display:'flex', flexDirection:'column', gap: 12,
+      }}>
+        {[0,1,2,3].map(i => (
+          <div key={i} className="mai-shimmer" style={{
+            height: mobile ? 130 : 116, borderRadius:'var(--r-lg)', background:'var(--bg-muted)',
+          }}/>
+        ))}
+      </div>
+    );
+  }
+
+  const filtered = NIGHTS.filter(n => {
+    if (role === 'Tutte') return true;
+    if (role === 'Organizzo') return n.role === 'organizer';
+    if (role === 'Invitato') return n.role === 'invited';
+    if (role === 'Concluse') return n.status === 'completed';
+    return true;
+  });
+
+  // Group by month: 2 = Marzo 2026, 1 = Febbraio 2026
+  const groups = [
+    { key: 2, label:'Marzo 2026', sub:'Mese corrente', items: filtered.filter(n => n.month === 2)
+      .sort((a, b) => a.day - b.day) },
+    { key: 1, label:'Febbraio 2026', sub:'Storico', items: filtered.filter(n => n.month === 1)
+      .sort((a, b) => b.day - a.day) },
+  ].filter(g => g.items.length > 0);
+
+  if (groups.length === 0) {
+    return (
+      <div style={{
+        padding: mobile ? '40px 16px' : '60px 32px',
+        display:'flex', alignItems:'center', justifyContent:'center',
+      }}>
+        <div style={{
+          maxWidth: 380, textAlign:'center',
+          padding:'32px 24px',
+          background:'var(--bg-card)', border:'1px dashed var(--border-strong)',
+          borderRadius:'var(--r-xl)',
+        }}>
+          <div style={{ fontSize: 36, marginBottom: 10 }} aria-hidden="true">🔍</div>
+          <h3 style={{
+            fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800,
+            color:'var(--text)', margin:'0 0 6px',
+          }}>Nessuna serata in questo filtro</h3>
+          <p style={{
+            fontSize: 12.5, color:'var(--text-muted)', margin: 0, lineHeight: 1.6,
+          }}>Cambia filtro o crea una nuova serata.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{
+      padding: mobile ? '12px 16px 24px' : '20px 32px 32px',
+      display:'flex', flexDirection:'column', gap: 24,
+    }}>
+      {groups.map(g => (
+        <section key={g.key}>
+          <div style={{
+            position:'sticky', top: mobile ? 56 : 0, zIndex: 5,
+            padding:'8px 0', marginBottom: 10,
+            background:'var(--bg)',
+            display:'flex', alignItems:'baseline', gap: 10, flexWrap:'wrap',
+          }}>
+            <h2 style={{
+              margin: 0, fontFamily:'var(--f-display)', fontSize: mobile ? 16 : 18,
+              fontWeight: 800, color:'var(--text)',
+            }}>{g.label}</h2>
+            <span style={{
+              fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+              fontWeight: 700,
+            }}>{g.items.length} serate · {g.sub}</span>
+          </div>
+          <div style={{ display:'flex', flexDirection:'column', gap: 10 }}>
+            {g.items.map(n => <ListCard key={n.id} night={n} mobile={mobile}/>)}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// DAY DRAWER
+// /* v2: DayDetailDrawer → apps/web/src/components/ui/v2/day-detail-drawer/ */
+// ═══════════════════════════════════════════════════════
+const DayDrawer = ({ open, day, events, onClose, mobile }) => {
+  if (!open) return null;
+  return (
+    <div role="dialog" aria-label={`Serate del ${day} marzo`}
+      style={{
+        position:'absolute', inset: 0, zIndex: 50,
+        display:'flex', alignItems:'flex-end', justifyContent: mobile ? 'stretch' : 'flex-end',
+        background:'rgba(0,0,0,.5)',
+      }} onClick={onClose}>
+      <aside onClick={e => e.stopPropagation()} style={{
+        width: mobile ? '100%' : 480, maxWidth:'100%',
+        height: mobile ? 'auto' : '100%', maxHeight: mobile ? '88vh' : '100%',
+        background:'var(--bg)',
+        borderTopLeftRadius: mobile ? 'var(--r-xl)' : 'var(--r-xl)',
+        borderTopRightRadius: mobile ? 'var(--r-xl)' : 0,
+        borderBottomLeftRadius: mobile ? 0 : 0,
+        boxShadow:'var(--shadow-xl)',
+        overflow:'auto',
+        animation:`slideIn ${mobile ? 'Up' : 'Right'} .25s var(--ease-out)`,
+      }}>
+        {mobile && (
+          <div aria-hidden="true" style={{
+            width: 36, height: 4, borderRadius:'var(--r-pill)',
+            background:'var(--border-strong)', margin:'10px auto 0',
+          }}/>
+        )}
+        <header style={{
+          padding:'16px 20px',
+          display:'flex', alignItems:'flex-start', gap: 12,
+          borderBottom:'1px solid var(--border)',
+          position:'sticky', top: 0, zIndex: 1, background:'var(--bg)',
+        }}>
+          <div style={{
+            width: 50, height: 50, borderRadius:'var(--r-md)',
+            background: entityHsl('event', 0.12), color: entityHsl('event'),
+            display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center',
+            fontFamily:'var(--f-display)', fontWeight: 800,
+            border:`1px solid ${entityHsl('event', 0.22)}`,
+          }}>
+            <span style={{ fontSize: 9, fontFamily:'var(--f-mono)', textTransform:'uppercase' }}>Mar</span>
+            <span style={{ fontSize: 20 }}>{day}</span>
+          </div>
+          <div style={{ flex: 1 }}>
+            <h2 style={{
+              margin: 0, fontFamily:'var(--f-display)', fontSize: 18, fontWeight: 800,
+              color:'var(--text)',
+            }}>{day} marzo 2026</h2>
+            <div style={{
+              fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-muted)',
+              fontWeight: 700, marginTop: 2,
+            }}>{events.length} {events.length === 1 ? 'serata' : 'serate'} in programma</div>
+          </div>
+          <button type="button" onClick={onClose} aria-label="Chiudi"
+            style={{
+              width: 32, height: 32, borderRadius:'var(--r-md)',
+              background:'var(--bg-card)', border:'1px solid var(--border)',
+              color:'var(--text)', fontSize: 16, cursor:'pointer',
+            }}>×</button>
+        </header>
+        <div style={{ padding:'14px 20px 20px', display:'flex', flexDirection:'column', gap: 10 }}>
+          {events.map(n => <ListCard key={n.id} night={n} mobile={mobile}/>)}
+          <button type="button" style={{
+            padding:'10px 14px', borderRadius:'var(--r-md)',
+            background:'transparent', color: entityHsl('event'),
+            border:`1px dashed ${entityHsl('event', 0.4)}`,
+            fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer',
+            marginTop: 4,
+          }}>+ Aggiungi serata in questo giorno</button>
+        </div>
+      </aside>
+      <style>{`
+        @keyframes slideInUp { from { transform: translateY(100%); } to { transform: translateY(0); } }
+        @keyframes slideInRight { from { transform: translateX(100%); } to { transform: translateX(0); } }
+        @media (prefers-reduced-motion: reduce) {
+          @keyframes slideInUp { from, to { transform: none; } }
+          @keyframes slideInRight { from, to { transform: none; } }
+        }
+      `}</style>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// EMPTY / ERROR
+// ═══════════════════════════════════════════════════════
+const EmptyAll = ({ mobile }) => (
+  <div style={{
+    padding: mobile ? '40px 24px' : '80px 32px',
+    display:'flex', alignItems:'center', justifyContent:'center',
+  }}>
+    <div style={{
+      maxWidth: 460, textAlign:'center',
+      padding:'40px 28px',
+      background:'var(--bg-card)', border:'1px dashed var(--border-strong)',
+      borderRadius:'var(--r-xl)',
+      display:'flex', flexDirection:'column', alignItems:'center',
+    }}>
+      <div style={{
+        width: 80, height: 80, borderRadius:'50%',
+        background: entityHsl('event', 0.12), color: entityHsl('event'),
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 36, marginBottom: 16,
+      }} aria-hidden="true">📅</div>
+      <h3 style={{
+        fontFamily:'var(--f-display)', fontSize: 19, fontWeight: 800,
+        color:'var(--text)', margin:'0 0 8px',
+      }}>Nessuna serata in programma</h3>
+      <p style={{
+        fontSize: 13.5, color:'var(--text-muted)', maxWidth: 360, margin:'0 0 20px',
+        lineHeight: 1.6,
+      }}>Crea la prima serata per organizzare le tue partite, invitare il gruppo e tenere traccia di chi gioca a cosa.</p>
+      <button type="button" style={{
+        padding:'12px 22px', borderRadius:'var(--r-md)',
+        background:`linear-gradient(135deg, ${entityHsl('event')}, ${entityHsl('session')})`,
+        color:'#fff', border:'none',
+        fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800, cursor:'pointer',
+        boxShadow:`0 4px 12px ${entityHsl('event', 0.3)}`,
+      }}>+ Crea la prima serata</button>
+    </div>
+  </div>
+);
+
+const ErrorState = () => (
+  <div style={{ padding:'60px 32px', display:'flex', justifyContent:'center' }}>
+    <div style={{
+      maxWidth: 440, textAlign:'center',
+      padding:'32px 24px',
+      background:'hsl(var(--c-danger) / .08)',
+      border:'1px solid hsl(var(--c-danger) / .3)',
+      borderRadius:'var(--r-xl)',
+      display:'flex', flexDirection:'column', alignItems:'center',
+    }}>
+      <div style={{
+        width: 56, height: 56, borderRadius:'50%',
+        background:'hsl(var(--c-danger) / .15)', color:'hsl(var(--c-danger))',
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 26, marginBottom: 12,
+      }} aria-hidden="true">⚠</div>
+      <h3 style={{
+        fontFamily:'var(--f-display)', fontSize: 17, fontWeight: 800,
+        color:'var(--text)', margin:'0 0 6px',
+      }}>Impossibile caricare le serate</h3>
+      <p style={{
+        fontSize: 12.5, color:'var(--text-muted)', maxWidth: 380, margin:'0 0 16px',
+        lineHeight: 1.6,
+      }}>Errore di rete durante il fetch del calendario. Verifica la connessione e riprova.</p>
+      <button type="button" style={{
+        padding:'10px 20px', borderRadius:'var(--r-md)',
+        background:'hsl(var(--c-danger))', color:'#fff', border:'none',
+        fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer',
+      }}>↻ Riprova</button>
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// BODY
+// ═══════════════════════════════════════════════════════
+const GameNightsBody = ({ stateOverride, mobile, initialView = 'calendar', initialRole = 'Tutte', drawerDay = null }) => {
+  const [view, setView] = useState(initialView);
+  const [role, setRole] = useState(initialRole);
+  const [drawer, setDrawer] = useState(drawerDay ? { open: true, day: drawerDay, events: NIGHTS.filter(n => n.month === 2 && n.day === drawerDay) } : { open: false, day: null, events: [] });
+
+  const total = NIGHTS.filter(n => n.month === 2).length;
+
+  return (
+    <div style={{ background:'var(--bg)' }}>
+      <Header view={view} onView={setView} role={role} onRole={setRole}
+        mobile={mobile} total={total}/>
+
+      {stateOverride === 'empty' ? <EmptyAll mobile={mobile}/>
+       : stateOverride === 'error' ? <ErrorState/>
+       : view === 'calendar'
+        ? <CalendarView role={role} mobile={mobile}
+            stateOverride={stateOverride}
+            onDayClick={(cell, events) => setDrawer({ open: true, day: cell.day, events })}/>
+        : <ListView role={role} mobile={mobile} stateOverride={stateOverride}/>
+      }
+
+      <DayDrawer open={drawer.open} day={drawer.day} events={drawer.events}
+        onClose={() => setDrawer(d => ({ ...d, open: false }))} mobile={mobile}/>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// SHELLS
+// ═══════════════════════════════════════════════════════
+const DesktopNav = () => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 14,
+    padding:'10px 32px',
+    background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+    borderBottom:'1px solid var(--border)',
+  }}>
+    <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
+      <div style={{
+        width: 26, height: 26, borderRadius: 7,
+        background:`linear-gradient(135deg, ${entityHsl('event')}, ${entityHsl('session')})`,
+        color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+        fontWeight: 800, fontSize: 13, fontFamily:'var(--f-display)',
+      }}>M</div>
+      <span style={{ fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 14 }}>MeepleAI</span>
+    </div>
+    <div style={{
+      flex: 1, fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      marginLeft: 22,
+    }}>
+      <strong style={{ color:'var(--text-sec)' }}>Serate di gioco</strong>
+    </div>
+  </div>
+);
+
+const DesktopScreen = (props) => (
+  <div style={{ background:'var(--bg)' }}>
+    <DesktopNav/>
+    <GameNightsBody {...props}/>
+  </div>
+);
+
+const PhoneSbar = () => (
+  <div className="phone-sbar" style={{ color:'var(--text)' }}>
+    <span style={{ fontFamily:'var(--f-mono)' }}>14:32</span>
+    <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+  </div>
+);
+const PhoneTopNav = () => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 9,
+    padding:'10px 14px', background:'var(--glass-bg)',
+    backdropFilter:'blur(12px)',
+    borderBottom:'1px solid var(--border-light)',
+  }}>
+    <button aria-label="Indietro" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      color:'var(--text)', fontSize: 14, cursor:'pointer',
+    }}>←</button>
+    <div style={{
+      flex: 1, fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+      textAlign:'center', fontWeight: 700,
+    }}>/game-nights</div>
+    <button aria-label="Più opzioni" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      color:'var(--text)', fontSize: 14, cursor:'pointer',
+    }}>⋯</button>
+  </div>
+);
+const MobileScreen = (props) => (
+  <>
+    <PhoneSbar/>
+    <div style={{ flex: 1, overflowY:'auto', position:'relative', background:'var(--bg)' }}>
+      <PhoneTopNav/>
+      <GameNightsBody {...props} mobile/>
+    </div>
+  </>
+);
+
+const PhoneShell = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 10 }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div className="phone">{children}</div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 340,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+const DesktopFrame = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 12, width:'100%' }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div style={{
+      width:'100%', maxWidth: 1440,
+      borderRadius:'var(--r-xl)', border:'1px solid var(--border)',
+      background:'var(--bg)', overflow:'hidden',
+      boxShadow:'var(--shadow-lg)',
+      position:'relative',
+    }}>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 8,
+        padding:'9px 14px', background:'var(--bg-muted)',
+        borderBottom:'1px solid var(--border)',
+        fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      }}>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-event))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-warning))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-toolkit))' }}/>
+        <span style={{ flex: 1, textAlign:'center', letterSpacing:'.04em' }}>meepleai.app/game-nights</span>
+      </div>
+      {children}
+    </div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 720,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ROOT
+// ═══════════════════════════════════════════════════════
+const MOBILE_STATES = [
+  { id:'m1', view:'list', role:'Tutte',
+    label:'01 · Default · List view (mobile)',
+    desc:'Mobile default = LIST (più usabile su 375). Group sticky "Marzo 2026" + cards verticali con date block compatto + status pill + RSVP.' },
+  { id:'m2', view:'calendar', role:'Tutte',
+    label:'02 · Calendar · grid compresso',
+    desc:'Calendar mobile: grid 7-col con celle compatte (1 evento + count). Tap cella apre drawer giorno.' },
+  { id:'m3', view:'list', role:'Organizzo',
+    label:'03 · Filter Organizzo',
+    desc:'Lista filtrata "Organizzo": solo serate dove l\'utente è organizer. Pill "● Organizzo" visibile + CTA "Modifica".' },
+  { id:'m4', view:'list', role:'Tutte', drawerDay: 22,
+    label:'04 · Day drawer (22 mar)',
+    desc:'Bottom-sheet drawer giorno con 2 serate (Catan + 7 Wonders), CTA "+ Aggiungi serata".' },
+  { id:'m5', view:'list', stateOverride:'empty',
+    label:'05 · Empty',
+    desc:'Empty state full-screen: icona event 80px + CTA "+ Crea la prima serata".' },
+  { id:'m6', view:'list', stateOverride:'loading',
+    label:'06 · Loading',
+    desc:'Skeleton 4 cards list con altezza realistica (130px).' },
+];
+
+const App = () => {
+  const [theme, setTheme] = useState(() => {
+    const saved = localStorage.getItem('mai-theme');
+    if (saved) return saved;
+    return document.documentElement.getAttribute('data-theme') || 'light';
+  });
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('mai-theme', theme);
+  }, [theme]);
+
+  return (
+    <div style={{
+      minHeight:'100vh', background:'var(--bg)', color:'var(--text)',
+      padding:'24px 24px 80px',
+    }}>
+      <header style={{
+        maxWidth: 1440, margin:'0 auto 32px',
+        display:'flex', alignItems:'center', gap: 12, flexWrap:'wrap',
+      }}>
+        <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
+          <div style={{
+            width: 32, height: 32, borderRadius: 8,
+            background:`linear-gradient(135deg, ${entityHsl('event')}, ${entityHsl('session')})`,
+            color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+            fontWeight: 800, fontFamily:'var(--f-display)',
+          }}>G</div>
+          <div>
+            <div style={{ fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 16 }}>SP4 wave 3 · G</div>
+            <div style={{ fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)' }}>
+              /game-nights — Serate index (calendar / list)
+            </div>
+          </div>
+        </div>
+        <div style={{ flex: 1 }}/>
+        <button type="button" onClick={() => setTheme(t => t === 'light' ? 'dark' : 'light')}
+          style={{
+            padding:'8px 14px', borderRadius:'var(--r-md)',
+            background:'var(--bg-card)', border:'1px solid var(--border)',
+            color:'var(--text)', fontFamily:'var(--f-display)',
+            fontSize: 12, fontWeight: 800, cursor:'pointer',
+          }}>🌗 {theme === 'light' ? 'Light' : 'Dark'}</button>
+      </header>
+
+      <section style={{ maxWidth: 1440, margin:'0 auto', display:'flex', flexDirection:'column', gap: 36 }}>
+        <DesktopFrame label="Desktop · 01 · Calendar · Default · Tutte"
+          desc="Pattern: header con title + count (8 serate · 4 confermate) + CTA gradient event→session + toggle Calendario/Lista (animated underline) + filter pills. Calendar grid 7-col (Lun-Dom) Marzo 2026, oggi=12 highlight border event, celle con eventi event/.05 bg, max 3 chip per cella + '+N altri'. Cancellata=danger bg + line-through.">
+          <DesktopScreen initialView="calendar" initialRole="Tutte"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 02 · Calendar · Filter Organizzo"
+          desc="Stesso layout calendar ma filtrato: solo eventi role=organizer (Marco). Le altre celle si svuotano. Pill 'Organizzo' attiva.">
+          <DesktopScreen initialView="calendar" initialRole="Organizzo"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 03 · List · Default · Tutte"
+          desc="Vista lista: group header sticky 'Marzo 2026' + 'Febbraio 2026'. Cards orizzontali (date block 78px sx + body con titolo + status pill + meta location/game/role + avatars overlap + CTA contestuali). Pattern MeepleCard variant='list'.">
+          <DesktopScreen initialView="list" initialRole="Tutte"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 04 · List · Filter Concluse"
+          desc="Solo serate completed (Feb): cards con CTA 'Vedi summary →' invece di RSVP/Modifica.">
+          <DesktopScreen initialView="list" initialRole="Concluse"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 05 · Calendar + Day drawer aperto (22 mar)"
+          desc="Drawer da sx scivolato in da destra (480px) con 2 serate del 22 marzo (Catan Maratona + 7 Wonders Duel) + CTA dashed '+ Aggiungi serata in questo giorno'.">
+          <DesktopScreen initialView="calendar" initialRole="Tutte" drawerDay={22}/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 06 · Empty"
+          desc="Header normale ma body empty state: icona event 80px + h3 + CTA gradient grande '+ Crea la prima serata'.">
+          <DesktopScreen initialView="calendar" stateOverride="empty"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 07 · Calendar · Loading"
+          desc="Header normale, calendar skeleton: nav skeleton + grid 35 celle skeleton 110px. Hydration progressivo.">
+          <DesktopScreen initialView="calendar" stateOverride="loading"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 08 · Error"
+          desc="Header normale, body alert danger 'Impossibile caricare le serate' + CTA '↻ Riprova'.">
+          <DesktopScreen initialView="calendar" stateOverride="error"/>
+        </DesktopFrame>
+      </section>
+
+      <section style={{ maxWidth: 1440, margin:'48px auto 0' }}>
+        <h2 style={{
+          fontFamily:'var(--f-display)', fontSize: 22, fontWeight: 800,
+          marginBottom: 8,
+        }}>Mobile · 375px</h2>
+        <p style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-muted)', marginBottom: 24,
+        }}>6 stati: list default · calendar compresso · filtro Organizzo · day drawer (bottom-sheet) · empty · loading.</p>
+        <div style={{
+          display:'flex', flexWrap:'wrap', gap: 32, justifyContent:'center',
+        }}>
+          {MOBILE_STATES.map(m => (
+            <PhoneShell key={m.id} label={m.label} desc={m.desc}>
+              <MobileScreen initialView={m.view} initialRole={m.role}
+                stateOverride={m.stateOverride} drawerDay={m.drawerDay}/>
+            </PhoneShell>
+          ))}
+        </div>
+      </section>
+
+      <section style={{
+        maxWidth: 900, margin:'64px auto 0',
+        padding: 24, borderRadius:'var(--r-xl)',
+        background:'var(--bg-card)', border:'1px solid var(--border)',
+      }}>
+        <h2 style={{
+          fontFamily:'var(--f-display)', fontSize: 18, fontWeight: 800, marginBottom: 12,
+        }}>Definition of Done · G game-nights-index</h2>
+        <ul style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-sec)',
+          lineHeight: 1.9, listStyle:'none', padding: 0, margin: 0,
+        }}>
+          <li>✓ Solo CSS variables da tokens.css (zero hex hardcoded)</li>
+          <li>✓ Helper entityHsl(type, alpha) inline</li>
+          <li>✓ Light + dark mode (toggle header)</li>
+          <li>✓ Mobile 375px (6 phone) + Desktop 1440px (8 frame)</li>
+          <li>✓ Pattern: toggle Calendar/List (Tabs animated underline) nel header</li>
+          <li>✓ Mobile default = LIST · desktop default = CALENDAR</li>
+          <li>✓ Palette --c-event rosa/red · gradient event→session per CTA + brand mark</li>
+          <li>✓ Header: titolo + count totali "8 serate" + 4 filter pills (Tutte/Organizzo/Invitato/Concluse) + CTA gradient "+ Nuova serata"</li>
+          <li>✓ Calendar: nav ‹ › + Oggi · grid 7-col Lun-Dom · today highlight 2px border event · giorni con eventi bg event/.05 · max 3 chip per cella · "+N altri" overflow · cancelled=danger+line-through · legend</li>
+          <li>✓ List: gruppi sticky per mese + ListCard (date block 78px + body + status pill + location/game/role + avatars + CTA contestuali)</li>
+          <li>✓ Day drawer: aperto su click cella · slide da right (desktop) / bottom (mobile) · header con date block 50px + close · cards interne riusano ListCard · CTA dashed "+ Aggiungi serata"</li>
+          <li>✓ CTA contestuali: completed=Vedi summary · cancelled=Riprogramma · organizer=Modifica · invited=Partecipo + Forse</li>
+          <li>✓ PlayerAvatars overlap (max 5 + "+N") riuso pattern ConnectionChipStrip</li>
+          <li>✓ Stati: default / empty (CTA crea prima) / loading (skeleton grid o list) / error (Riprova)</li>
+          <li>✓ ARIA: role="tablist"/"tab" sui toggle · aria-pressed sui filter pills · aria-label su nav mese · role="dialog" sul drawer</li>
+          <li>✓ prefers-reduced-motion gestito (slideIn keyframes annullati)</li>
+          <li>✓ Testo italiano · dati realistici (Wingspan da Marco, Brass Birmingham, Casa Marco, Sala B&B Lentia, Ludoteca Centrale)</li>
+          <li>✓ ID short readable: gn-wingspan-mar15, gn-brass-feb20, p-marco — NO UUID</li>
+          <li>✓ Commento di apertura con route /game-nights</li>
+        </ul>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800, marginTop: 18, marginBottom: 8,
+        }}>Nuovi componenti v2 emersi</h3>
+        <ul style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-sec)',
+          lineHeight: 1.8, listStyle:'none', padding: 0, margin: 0,
+        }}>
+          <li>· GameNightsHeader (badge category + title + count + filter pills + view toggle + CTA gradient)</li>
+          <li>· CalendarMonthGrid (grid 7-col Lun-Dom + nav prev/next + Oggi CTA + legend)</li>
+          <li>· CalendarDayCell (numero + max 3 chip ev + "+N altri" + today border + bg conditional)</li>
+          <li>· GameNightListCard (date block sx + body + status pill + role pill + avatars + CTA contestuali)</li>
+          <li>· DayDetailDrawer (slide da right desktop / bottom-sheet mobile + header date block + lista ListCard)</li>
+          <li>· FilterPillBar (4 pills Tutte/Organizzo/Invitato/Concluse con aria-pressed)</li>
+          <li>· StatusPill (4 varianti confirmed/planned/cancelled/completed con dot + bg + border)</li>
+          <li>· PlayerAvatars (overlap negative margin -8px + "+N" extra circle)</li>
+        </ul>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800, marginTop: 18, marginBottom: 8,
+        }}>Riusi pixel-perfect</h3>
+        <ul style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-sec)',
+          lineHeight: 1.8, listStyle:'none', padding: 0, margin: 0,
+        }}>
+          <li>· MeepleCard variant="list" (wave 1) — lifted into ListCard</li>
+          <li>· Tabs animated underline (wave 1) per Calendar/List toggle</li>
+          <li>· EntityChip game/player (wave 1)</li>
+          <li>· ConnectionChipStrip pattern → PlayerAvatars overlap (PR #549/#552)</li>
+          <li>· Drawer V1 bottom-sheet (mobile) + V3 right-side (desktop) da 03-drawer-variants</li>
+        </ul>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800, marginTop: 18, marginBottom: 8,
+          color: entityHsl('warning'),
+        }}>Deviazioni flaggate</h3>
+        <ul style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-sec)',
+          lineHeight: 1.8, listStyle:'none', padding: 0, margin: 0,
+        }}>
+          <li>· Calendar è grid statico Marzo 2026 — paginazione mese ‹ › è solo visiva, no fetch reale (frontend logic da implementare)</li>
+          <li>· "Conclusa" group header non ha sticky offset top in mobile (nav top + group header sticky non perfettamente coordinati su 375px) — verificare in produzione</li>
+          <li>· 5° serata duplicata di Andrea negli avatars (mar 28 ha Andrea due volte nei playerIds) per testare overflow "+1" — fix dataset finale</li>
+          <li>· Drawer animation usa @keyframes inline, non components.css (come da contratto: NON sovrascrivere)</li>
+          <li>· Filter "Concluse" semantica include solo passate del mese visibile + Febbraio — pattern UX da chiarire (filtra storico?)</li>
+        </ul>
+      </section>
+    </div>
+  );
+};
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);

--- a/admin-mockups/design_files/sp4-kb-detail.html
+++ b/admin-mockups/design_files/sp4-kb-detail.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<!-- MeepleAI SP4 wave 3 — F · KB document detail (split-view chunks list + preview)
+     Route: /kb/[id]
+     Sticky sx (header doc + meta + search + chunks list) / preview dx (markdown + ConnectionBar + actions). -->
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>MeepleAI · /kb/[id] — KB document detail</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-kb-detail.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-kb-detail.jsx
+++ b/admin-mockups/design_files/sp4-kb-detail.jsx
@@ -1,0 +1,1332 @@
+/* MeepleAI SP4 wave 3 — Schermata F / 5
+   Route: /kb/[id]
+   File: admin-mockups/design_files/sp4-kb-detail.{html,jsx}
+   Pattern desktop: Split-view (sx meta+search+chunks list scrollable · dx preview chunk full).
+   Palette --c-kb (teal). Document detail singolo (no index).
+
+   v2 nuovi (per impl post-merge):
+   - KbHeader              → apps/web/src/components/ui/v2/kb-header/
+   - KbChunkListPanel      → apps/web/src/components/ui/v2/kb-chunk-list-panel/
+   - KbChunkPreview        → apps/web/src/components/ui/v2/kb-chunk-preview/
+   - ChunkSearchBox        → apps/web/src/components/ui/v2/chunk-search-box/
+   - MarkdownRenderBlock   → apps/web/src/components/ui/v2/markdown-render-block/
+
+   Riusi pixel-perfect:
+   - ConnectionBar (PR #549/#552)
+   - TabSkeleton/TabError/TabEmpty (wave 1)
+   - Tabs animated underline (wave 1) per sub-tabs preview Markdown/Raw
+
+   Deviazioni: chunks "usato in N chat" è metric stub — backend deve esporre embedding usage counter.
+*/
+
+const { useState, useEffect, useRef, useMemo } = React;
+const DS = window.DS;
+
+const entityHsl = (type, alpha) => {
+  const c = DS.EC[type] || DS.EC.kb;
+  return alpha !== undefined
+    ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${alpha})`
+    : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
+};
+
+// ─── KB FIXTURE ──────────────────────────────────────
+const KB = {
+  ...DS.byId['kb-azul-ita'],
+  kind: 'PDF · Manuale ufficiale',
+  version: '1.2',
+  updatedAt: '8 Mar 2026',
+  uploadedAt: '12 Gen 2026',
+  uploadedBy: 'p-marco',
+  agentIds: ['a-azul-rules'],
+  hash: 'sha256:7a3c…f9b1',
+};
+
+const CHUNKS = [
+  { id: 'c1', n: 1, page: 1, section: 'Introduzione',
+    heading: 'Benvenuto in Azul',
+    cat: 'Intro', usedIn: 8,
+    snippet: 'Azul è un gioco da tavolo per 2-4 giocatori in cui gli artigiani decorano le pareti del Palazzo Reale di Évora con tessere ispirate alle piastrelle azulejos portoghesi.',
+    body: `# Benvenuto in Azul
+
+Azul è un gioco da tavolo per **2-4 giocatori** in cui gli artigiani decorano le pareti del Palazzo Reale di Évora con tessere ispirate alle piastrelle *azulejos* portoghesi.
+
+## Obiettivo
+Accumulare il maggior numero di punti vittoria completando righe, colonne e set di colore sul proprio tabellone personale entro la fine della partita.
+
+## Durata
+Una partita standard dura **30-45 minuti**. La fine è innescata quando un giocatore completa una riga orizzontale del proprio muro.` },
+
+  { id: 'c2', n: 2, page: 2, section: 'Setup',
+    heading: 'Preparazione del tavolo',
+    cat: 'Setup', usedIn: 12,
+    snippet: 'Posiziona le 5 (2 giocatori), 7 (3 giocatori) o 9 (4 giocatori) factory display al centro del tavolo. Ogni giocatore prende un tabellone personale.',
+    body: `# Preparazione del tavolo
+
+## Numero di factory display
+
+| Giocatori | Factory |
+|-----------|---------|
+| 2         | 5       |
+| 3         | 7       |
+| 4         | 9       |
+
+## Setup giocatore
+1. Ogni giocatore prende un **tabellone personale**
+2. Posiziona il segnalino punti su 0
+3. Mescola tutte le 100 tessere nel sacchetto
+4. Riempi ogni factory con **4 tessere** estratte casualmente
+
+## Primo giocatore
+Il giocatore più giovane riceve il segnalino "primo giocatore" e inizia il primo round.` },
+
+  { id: 'c3', n: 3, page: 4, section: 'Turno di gioco',
+    heading: 'Fase 1 — Offering',
+    cat: 'Turno', usedIn: 15,
+    snippet: 'Nel proprio turno il giocatore deve scegliere: prendere tutte le tessere di un colore da una factory display, oppure tutte le tessere di un colore dal centro tavolo.',
+    body: `# Fase Offering
+
+Nel proprio turno il giocatore deve scegliere **una sola** delle due azioni:
+
+## A. Prendere da una factory
+- Scegli una factory display
+- Prendi **tutte le tessere di un solo colore** presenti su quella factory
+- Sposta le tessere rimanenti al centro del tavolo
+
+## B. Prendere dal centro
+- Prendi **tutte le tessere di un solo colore** dal centro tavolo
+- Se sei il primo a prendere dal centro in questo round, prendi anche il segnalino "primo giocatore" e mettilo nella penalità
+
+> ⚠️ **Importante**: devi sempre prendere _tutte_ le tessere di un colore, non puoi sceglierne solo alcune.` },
+
+  { id: 'c4', n: 4, page: 6, section: 'Turno di gioco',
+    heading: 'Fase 2 — Pattern strip',
+    cat: 'Turno', usedIn: 11,
+    snippet: 'Le tessere prese vanno posizionate in una sola pattern strip a tua scelta. Le strip hanno capacità crescente da 1 a 5.',
+    body: `# Fase Pattern strip
+
+Le tessere prese durante l'Offering vanno posizionate in **una sola pattern strip** a tua scelta sul lato sinistro del tabellone.
+
+## Regole di posizionamento
+- Le pattern strip hanno capacità crescente: **1, 2, 3, 4, 5** dalla riga in alto
+- Una strip può contenere solo tessere di un colore
+- Se una strip è già parzialmente piena con un colore, puoi aggiungere solo tessere dello stesso colore
+- Tessere in eccesso vanno nella **floor line** (penalità)
+
+\`\`\`
+Riga 1: [_]
+Riga 2: [_][_]
+Riga 3: [_][_][_]
+Riga 4: [_][_][_][_]
+Riga 5: [_][_][_][_][_]
+\`\`\`` },
+
+  { id: 'c5', n: 5, page: 8, section: 'Punteggio',
+    heading: 'Fase 3 — Wall tiling',
+    cat: 'Punteggio', usedIn: 18,
+    snippet: 'Quando una pattern strip è completa, sposta una tessera sul muro nella riga corrispondente. Calcola i punti in base alle tessere adiacenti.',
+    body: `# Fase Wall tiling
+
+Quando una **pattern strip è completa** (tutte le caselle riempite), sposta **una sola tessera** sul muro nella riga corrispondente, nella casella del colore giusto.
+
+## Calcolo punteggio
+
+Per ogni tessera spostata sul muro:
+1. Conta le tessere adiacenti orizzontalmente (inclusa la nuova)
+2. Conta le tessere adiacenti verticalmente (inclusa la nuova)
+3. Se la tessera è isolata su un asse, vale **1 punto**
+4. Altrimenti, vale la somma delle tessere su entrambi gli assi
+
+> **Esempio**: tessera con 2 vicini orizzontali e 3 verticali = 5 punti (2+3, non si conta due volte)` },
+
+  { id: 'c6', n: 6, page: 10, section: 'Punteggio',
+    heading: 'Bonus di fine partita',
+    cat: 'Endgame', usedIn: 22,
+    snippet: 'A fine partita: 2 punti per ogni riga orizzontale completa, 7 punti per ogni colonna completa, 10 punti per ogni set di 5 tessere dello stesso colore.',
+    body: `# Bonus di fine partita
+
+A fine partita si calcolano i bonus:
+
+| Bonus              | Punti  |
+|--------------------|--------|
+| Riga completa      | **2**  |
+| Colonna completa   | **7**  |
+| Set di 5 colori    | **10** |
+
+## Innesco fine partita
+La partita finisce alla **fine del round** in cui almeno un giocatore ha completato una riga orizzontale del muro.
+
+## Vincitore
+Il giocatore con il punteggio più alto vince. In caso di pareggio, vince chi ha più righe complete; se ancora pari, chi ha più colonne complete.` },
+
+  { id: 'c7', n: 7, page: 11, section: 'FAQ',
+    heading: 'Posso non prendere tessere?',
+    cat: 'FAQ', usedIn: 4,
+    snippet: 'No. Sei sempre obbligato a prendere tessere durante l\'Offering, anche se ti costringono a riempire la floor line.',
+    body: `# FAQ — Posso non prendere tessere?
+
+**No.** Sei sempre obbligato a prendere tessere durante l'Offering, anche se ti costringono a riempire la floor line e perdere punti.
+
+> Questa regola previene situazioni di stallo e mantiene il gioco dinamico.
+
+## Casi limite
+- Se tutte le factory sono vuote e il centro è vuoto, il round termina
+- Se prendere tessere ti costringe a >7 di penalità, prendi solo le prime 7 (le altre tornano nel sacchetto)` },
+
+  { id: 'c8', n: 8, page: 12, section: 'FAQ',
+    heading: 'Cosa succede se finisce il sacchetto?',
+    cat: 'FAQ', usedIn: 6,
+    snippet: 'Quando il sacchetto è vuoto durante il refill delle factory, riempi il sacchetto con tutte le tessere scartate e mescola.',
+    body: `# FAQ — Cosa succede se finisce il sacchetto?
+
+Quando il sacchetto si svuota durante il refill delle factory:
+
+1. Prendi **tutte le tessere scartate** (quelle eliminate dalla floor line nei round precedenti)
+2. Rimettile nel sacchetto
+3. Mescola
+4. Continua il refill
+
+> Se anche le tessere scartate non bastano, le factory restano parzialmente vuote per quel round.` },
+];
+
+const CAT_COLOR = {
+  Intro:     entityHsl('player'),
+  Setup:     entityHsl('event'),
+  Turno:     entityHsl('agent'),
+  Punteggio: entityHsl('toolkit'),
+  Endgame:   entityHsl('event'),
+  FAQ:       entityHsl('chat'),
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── PRIMITIVES ─────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const EntityChip = ({ type, label, icon, sm }) => (
+  <span style={{
+    display:'inline-flex', alignItems:'center', gap: 5,
+    padding: sm ? '2px 8px' : '4px 10px', borderRadius:'var(--r-pill)',
+    background: entityHsl(type, 0.12), color: entityHsl(type),
+    border:`1px solid ${entityHsl(type, 0.2)}`,
+    fontFamily:'var(--f-display)', fontSize: sm ? 10 : 11, fontWeight: 700,
+    whiteSpace:'nowrap',
+  }}>
+    <span aria-hidden="true">{icon || DS.EC[type]?.em}</span>
+    <span>{label}</span>
+  </span>
+);
+
+const ConnectionBar = ({ chips }) => (
+  <div className="mai-cb-scroll" style={{
+    display:'flex', alignItems:'center', gap: 8,
+    overflowX:'auto', padding:'8px 0', scrollbarWidth:'none',
+  }}>
+    {chips.map((c, i) => {
+      const empty = c.count === 0 || c.empty;
+      return (
+        <button key={i} type="button"
+          aria-label={`${c.label}: ${c.count}`}
+          style={{
+            display:'inline-flex', alignItems:'center', gap: 6,
+            padding:'5px 11px', borderRadius:'var(--r-pill)',
+            background: empty ? 'transparent' : entityHsl(c.entity, 0.1),
+            color: entityHsl(c.entity),
+            border: empty
+              ? `1.5px dashed ${entityHsl(c.entity, 0.5)}`
+              : `1px solid ${entityHsl(c.entity, 0.22)}`,
+            fontFamily:'var(--f-display)', fontSize: 11, fontWeight: 700,
+            cursor:'pointer', whiteSpace:'nowrap', flexShrink: 0,
+            opacity: empty ? 0.65 : 1,
+          }}>
+          <span aria-hidden="true">{DS.EC[c.entity].em}</span>
+          {!empty && <span style={{ fontFamily:'var(--f-mono)', fontWeight: 800 }}>{c.count}</span>}
+          <span>{c.label}</span>
+        </button>
+      );
+    })}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── KB HEADER (sticky top sx) ──────────────────────
+// /* v2: KbHeader → apps/web/src/components/ui/v2/kb-header/ */
+// ═══════════════════════════════════════════════════════
+const KbHeader = ({ kb, mobile }) => {
+  const game = DS.byId[kb.gameId];
+  const cover = `linear-gradient(135deg, ${entityHsl('kb')} 0%, hsl(${DS.EC.kb.h - 10}, 60%, 28%) 50%, hsl(${game ? 200 : DS.EC.kb.h}, 65%, 40%) 100%)`;
+  return (
+    <div style={{
+      borderRadius:'var(--r-xl)', overflow:'hidden',
+      border:`1px solid ${entityHsl('kb', 0.3)}`,
+      boxShadow:`0 4px 14px ${entityHsl('kb', 0.18)}`,
+      flexShrink: 0,
+    }}>
+      <div style={{
+        height: mobile ? 80 : 96, background: cover, position:'relative',
+      }}>
+        <div style={{
+          position:'absolute', inset: 0,
+          background:'radial-gradient(circle at 80% 30%, rgba(255,255,255,.18), transparent 60%)',
+        }}/>
+        <div style={{
+          position:'absolute', top: 10, left: 12, display:'flex', gap: 6,
+        }}>
+          <span style={{
+            padding:'3px 9px', borderRadius:'var(--r-pill)',
+            background:'rgba(0,0,0,.4)', color:'#fff',
+            fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+            textTransform:'uppercase', letterSpacing:'.08em',
+            backdropFilter:'blur(4px)',
+          }}>📄 KB</span>
+          <span style={{
+            padding:'3px 9px', borderRadius:'var(--r-pill)',
+            background:'rgba(34, 187, 80, 0.85)', color:'#fff',
+            fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+            textTransform:'uppercase', letterSpacing:'.08em',
+          }}>● Indicizzato</span>
+        </div>
+        <div style={{
+          position:'absolute', bottom: 10, right: 12,
+          fontFamily:'var(--f-mono)', fontSize: 10, color:'rgba(255,255,255,.85)',
+          fontWeight: 700,
+        }}>v{kb.version}</div>
+        <div style={{
+          position:'absolute', bottom: 8, left: 14, fontSize: 36, lineHeight: 1, opacity: 0.85,
+        }} aria-hidden="true">📄</div>
+      </div>
+      <div style={{ padding: 14, background:'var(--bg-card)' }}>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, fontWeight: 700,
+          color:'var(--text)', marginBottom: 4, wordBreak:'break-all',
+        }}>{kb.title}</div>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)', fontWeight: 600,
+          marginBottom: 8,
+        }}>{kb.kind}</div>
+        <div style={{ display:'flex', gap: 6, flexWrap:'wrap' }}>
+          {game && <EntityChip type="game" label={game.title} sm/>}
+          <EntityChip type="player" label="Marco R." sm/>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── META STATS ─────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const MetaStats = ({ kb }) => (
+  <dl style={{
+    margin: 0, padding: 12,
+    background:'var(--bg-card)', border:'1px solid var(--border)',
+    borderRadius:'var(--r-lg)',
+    display:'grid', gridTemplateColumns:'repeat(2, 1fr)', rowGap: 10, columnGap: 12,
+    flexShrink: 0,
+  }}>
+    {[
+      ['Pagine', kb.pages],
+      ['Chunks', kb.chunks],
+      ['Versione', `v${kb.version}`],
+      ['Aggiornato', kb.updatedAt],
+      ['Embedding', kb.embedding],
+      ['Dimensione', kb.size],
+    ].map(([k, v]) => (
+      <div key={k}>
+        <dt style={{
+          fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 800,
+          marginBottom: 2,
+        }}>{k}</dt>
+        <dd style={{
+          margin: 0, fontFamily:'var(--f-mono)', fontSize: 12,
+          color:'var(--text)', fontWeight: 700, fontVariantNumeric:'tabular-nums',
+        }}>{v}</dd>
+      </div>
+    ))}
+  </dl>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── SEARCH BOX ─────────────────────────────────────
+// /* v2: ChunkSearchBox → apps/web/src/components/ui/v2/chunk-search-box/ */
+// ═══════════════════════════════════════════════════════
+const SearchBox = ({ value, onChange, count, total }) => (
+  <div style={{ display:'flex', flexDirection:'column', gap: 6, flexShrink: 0 }}>
+    <div style={{ position:'relative' }}>
+      <span aria-hidden="true" style={{
+        position:'absolute', left: 12, top:'50%', transform:'translateY(-50%)',
+        fontSize: 13, color:'var(--text-muted)',
+      }}>🔍</span>
+      <input type="search" value={value} onChange={e => onChange(e.target.value)}
+        placeholder="Cerca nel documento..."
+        aria-label="Cerca chunks"
+        style={{
+          width:'100%', padding:'10px 36px 10px 34px',
+          background:'var(--bg-card)', border:'1px solid var(--border)',
+          borderRadius:'var(--r-md)',
+          fontFamily:'var(--f-display)', fontSize: 13, color:'var(--text)',
+          outline:'none',
+        }}/>
+      {value && (
+        <button type="button" onClick={() => onChange('')}
+          aria-label="Pulisci ricerca"
+          style={{
+            position:'absolute', right: 8, top:'50%', transform:'translateY(-50%)',
+            width: 22, height: 22, borderRadius:'50%',
+            background:'var(--bg-muted)', border:'none',
+            color:'var(--text-muted)', cursor:'pointer',
+            fontSize: 12, lineHeight: 1,
+          }}>×</button>
+      )}
+    </div>
+    {value && (
+      <div style={{
+        fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+        fontWeight: 700,
+      }}>{count} di {total} chunks</div>
+    )}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── CHUNK LIST ROW ─────────────────────────────────
+// /* v2: KbChunkListPanel → apps/web/src/components/ui/v2/kb-chunk-list-panel/ */
+// ═══════════════════════════════════════════════════════
+const ChunkRow = ({ chunk, active, onClick }) => {
+  const catColor = CAT_COLOR[chunk.cat] || entityHsl('kb');
+  return (
+    <button type="button" onClick={onClick}
+      aria-current={active ? 'true' : undefined}
+      style={{
+        textAlign:'left', width:'100%',
+        padding: 12,
+        background: active ? entityHsl('kb', 0.08) : 'var(--bg-card)',
+        border: active
+          ? `1px solid ${entityHsl('kb', 0.5)}`
+          : '1px solid var(--border)',
+        borderLeft: active
+          ? `3px solid ${entityHsl('kb')}`
+          : '3px solid transparent',
+        borderRadius:'var(--r-md)',
+        cursor:'pointer',
+        display:'flex', flexDirection:'column', gap: 6,
+        transition:'background var(--dur-sm), border-color var(--dur-sm)',
+      }}>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 6, flexWrap:'wrap',
+      }}>
+        <span style={{
+          fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+          fontWeight: 800,
+        }}>#{chunk.n.toString().padStart(2, '0')}</span>
+        <span style={{
+          padding:'1px 6px', borderRadius:'var(--r-pill)',
+          background:`${catColor}20`, color: catColor,
+          fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+          textTransform:'uppercase', letterSpacing:'.06em',
+        }}>{chunk.cat}</span>
+        <span style={{
+          fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+          fontWeight: 700, marginLeft:'auto',
+        }}>p. {chunk.page}</span>
+      </div>
+      <div style={{
+        fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+        color: active ? entityHsl('kb') : 'var(--text)', lineHeight: 1.3,
+      }}>{chunk.heading}</div>
+      <p style={{
+        margin: 0, fontSize: 11.5, lineHeight: 1.5, color:'var(--text-sec)',
+        display:'-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient:'vertical',
+        overflow:'hidden',
+      }}>{chunk.snippet}</p>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 5,
+        fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+        fontWeight: 700,
+      }}>
+        <span aria-hidden="true">💬</span>
+        <span>Usato in {chunk.usedIn} chat</span>
+      </div>
+    </button>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── MARKDOWN MINI-RENDERER ─────────────────────────
+// /* v2: MarkdownRenderBlock → apps/web/src/components/ui/v2/markdown-render-block/ */
+// ═══════════════════════════════════════════════════════
+const renderInline = (text) => {
+  // Bold **x**, italic *x*, inline code `x`
+  const parts = [];
+  let i = 0; let key = 0;
+  const re = /(\*\*[^*]+\*\*|\*[^*]+\*|`[^`]+`)/g;
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    if (m.index > i) parts.push(text.slice(i, m.index));
+    const tk = m[0];
+    if (tk.startsWith('**')) parts.push(<strong key={key++}>{tk.slice(2, -2)}</strong>);
+    else if (tk.startsWith('`')) parts.push(<code key={key++} style={{
+      fontFamily:'var(--f-mono)', fontSize:'.92em',
+      padding:'1px 6px', borderRadius: 4,
+      background:'var(--bg-sunken)', color: entityHsl('kb'),
+    }}>{tk.slice(1, -1)}</code>);
+    else parts.push(<em key={key++}>{tk.slice(1, -1)}</em>);
+    i = m.index + tk.length;
+  }
+  if (i < text.length) parts.push(text.slice(i));
+  return parts;
+};
+
+const Markdown = ({ source }) => {
+  const lines = source.split('\n');
+  const out = [];
+  let i = 0; let key = 0;
+  while (i < lines.length) {
+    const ln = lines[i];
+    // Code block ```
+    if (ln.trim().startsWith('```')) {
+      const block = [];
+      i++;
+      while (i < lines.length && !lines[i].trim().startsWith('```')) {
+        block.push(lines[i]); i++;
+      }
+      i++;
+      out.push(<pre key={key++} style={{
+        margin:'12px 0', padding: 12,
+        background:'var(--bg-sunken)', border:'1px solid var(--border)',
+        borderRadius:'var(--r-md)',
+        fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text)',
+        overflow:'auto', lineHeight: 1.5,
+      }}>{block.join('\n')}</pre>);
+      continue;
+    }
+    // Table
+    if (ln.includes('|') && i + 1 < lines.length && lines[i+1].includes('|') && lines[i+1].includes('-')) {
+      const headers = ln.split('|').map(s => s.trim()).filter(Boolean);
+      i += 2;
+      const rows = [];
+      while (i < lines.length && lines[i].includes('|')) {
+        rows.push(lines[i].split('|').map(s => s.trim()).filter(Boolean));
+        i++;
+      }
+      out.push(
+        <div key={key++} style={{ overflowX:'auto', margin:'12px 0' }}>
+          <table style={{
+            borderCollapse:'collapse', width:'100%',
+            border:'1px solid var(--border)', borderRadius:'var(--r-sm)',
+            overflow:'hidden', fontSize: 13,
+          }}>
+            <thead>
+              <tr style={{ background:'var(--bg-sunken)' }}>
+                {headers.map((h, j) => (
+                  <th key={j} style={{
+                    padding:'8px 12px', textAlign:'left',
+                    fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800,
+                    color:'var(--text)', borderBottom:'1px solid var(--border)',
+                  }}>{renderInline(h)}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r, rj) => (
+                <tr key={rj} style={{ background: rj % 2 ? 'var(--bg-card)' : 'transparent' }}>
+                  {r.map((c, cj) => (
+                    <td key={cj} style={{
+                      padding:'7px 12px',
+                      borderTop:'1px solid var(--border-light)',
+                      fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text)',
+                    }}>{renderInline(c)}</td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+      continue;
+    }
+    // Headings
+    if (ln.startsWith('# ')) {
+      out.push(<h1 key={key++} style={{
+        fontFamily:'var(--f-display)', fontSize: 22, fontWeight: 800,
+        color:'var(--text)', margin:'18px 0 10px', letterSpacing:'-.01em',
+      }}>{renderInline(ln.slice(2))}</h1>);
+      i++; continue;
+    }
+    if (ln.startsWith('## ')) {
+      out.push(<h2 key={key++} style={{
+        fontFamily:'var(--f-display)', fontSize: 17, fontWeight: 800,
+        color:'var(--text)', margin:'16px 0 8px',
+      }}>{renderInline(ln.slice(3))}</h2>);
+      i++; continue;
+    }
+    if (ln.startsWith('### ')) {
+      out.push(<h3 key={key++} style={{
+        fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800,
+        color:'var(--text-sec)', margin:'12px 0 6px',
+      }}>{renderInline(ln.slice(4))}</h3>);
+      i++; continue;
+    }
+    // Blockquote
+    if (ln.startsWith('> ')) {
+      const block = [];
+      while (i < lines.length && lines[i].startsWith('> ')) {
+        block.push(lines[i].slice(2)); i++;
+      }
+      out.push(<blockquote key={key++} style={{
+        margin:'12px 0', padding:'10px 14px',
+        borderLeft:`3px solid ${entityHsl('kb')}`,
+        background: entityHsl('kb', 0.06),
+        fontSize: 13.5, lineHeight: 1.6, color:'var(--text-sec)',
+        borderRadius:'0 var(--r-sm) var(--r-sm) 0',
+      }}>{block.map((l, j) => <div key={j}>{renderInline(l)}</div>)}</blockquote>);
+      continue;
+    }
+    // Lists
+    if (/^\s*[-*]\s/.test(ln)) {
+      const items = [];
+      while (i < lines.length && /^\s*[-*]\s/.test(lines[i])) {
+        items.push(lines[i].replace(/^\s*[-*]\s/, '')); i++;
+      }
+      out.push(<ul key={key++} style={{
+        margin:'8px 0', paddingLeft: 22, fontSize: 13.5, lineHeight: 1.7,
+        color:'var(--text)',
+      }}>{items.map((it, j) => <li key={j}>{renderInline(it)}</li>)}</ul>);
+      continue;
+    }
+    if (/^\s*\d+\.\s/.test(ln)) {
+      const items = [];
+      while (i < lines.length && /^\s*\d+\.\s/.test(lines[i])) {
+        items.push(lines[i].replace(/^\s*\d+\.\s/, '')); i++;
+      }
+      out.push(<ol key={key++} style={{
+        margin:'8px 0', paddingLeft: 22, fontSize: 13.5, lineHeight: 1.7,
+        color:'var(--text)',
+      }}>{items.map((it, j) => <li key={j}>{renderInline(it)}</li>)}</ol>);
+      continue;
+    }
+    if (ln.trim() === '') { i++; continue; }
+    out.push(<p key={key++} style={{
+      margin:'8px 0', fontSize: 13.5, lineHeight: 1.7, color:'var(--text)',
+      textWrap:'pretty',
+    }}>{renderInline(ln)}</p>);
+    i++;
+  }
+  return <div>{out}</div>;
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── CHUNK PREVIEW ──────────────────────────────────
+// /* v2: KbChunkPreview → apps/web/src/components/ui/v2/kb-chunk-preview/ */
+// ═══════════════════════════════════════════════════════
+const ChunkPreview = ({ chunk, kb, mobile, onBack }) => {
+  const [view, setView] = useState('rendered');
+  const refs = useRef({});
+  const [ind, setInd] = useState({ left: 0, width: 0 });
+  useEffect(() => {
+    const el = refs.current[view];
+    if (el) setInd({ left: el.offsetLeft, width: el.offsetWidth });
+  }, [view]);
+
+  const agentChips = kb.agentIds.map(aid => {
+    const a = DS.byId[aid];
+    return { entity:'agent', count: 1, label: a?.title || 'Agente' };
+  });
+  const allChips = [
+    ...agentChips,
+    { entity:'chat', count: chunk.usedIn, label:'Chat che lo citano' },
+    { entity:'kb', count: chunk.body.length, label:'Caratteri' },
+  ];
+
+  return (
+    <article style={{ display:'flex', flexDirection:'column', gap: 14 }}>
+      {/* Breadcrumb + back (mobile only) */}
+      <div style={{
+        display:'flex', alignItems:'center', gap: 8, flexWrap:'wrap',
+      }}>
+        {mobile && (
+          <button type="button" onClick={onBack}
+            aria-label="Torna alla lista chunks"
+            style={{
+              padding:'4px 10px', borderRadius:'var(--r-md)',
+              background:'var(--bg-card)', border:'1px solid var(--border)',
+              color:'var(--text)', fontFamily:'var(--f-display)',
+              fontSize: 11, fontWeight: 800, cursor:'pointer',
+            }}>← Lista</button>
+        )}
+        <nav aria-label="Posizione" style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          fontWeight: 700,
+        }}>
+          <span>{kb.title}</span>
+          <span aria-hidden="true" style={{ margin:'0 6px' }}>›</span>
+          <span>{chunk.section}</span>
+          <span aria-hidden="true" style={{ margin:'0 6px' }}>›</span>
+          <strong style={{ color:'var(--text-sec)' }}>Chunk {chunk.n}</strong>
+        </nav>
+      </div>
+
+      {/* Heading + page ref */}
+      <div style={{
+        padding: 14, background: entityHsl('kb', 0.06),
+        border:`1px solid ${entityHsl('kb', 0.2)}`, borderRadius:'var(--r-lg)',
+      }}>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 10, color: entityHsl('kb'),
+          textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 800,
+          marginBottom: 5,
+        }}>Pagina {chunk.page} · {chunk.section}</div>
+        <h1 style={{
+          fontFamily:'var(--f-display)', fontSize: mobile ? 20 : 24, fontWeight: 800,
+          color:'var(--text)', margin: 0, letterSpacing:'-.01em', lineHeight: 1.2,
+        }}>{chunk.heading}</h1>
+      </div>
+
+      {/* Sub-tabs Rendered / Raw */}
+      <div style={{ position:'relative' }}>
+        <div style={{
+          display:'flex', gap: 2, borderBottom:'1px solid var(--border)',
+        }} role="tablist" aria-label="Modalità visualizzazione chunk">
+          {[
+            { id:'rendered', icon:'📖', label:'Rendered' },
+            { id:'raw', icon:'</>', label:'Raw markdown' },
+          ].map(t => {
+            const isActive = view === t.id;
+            return (
+              <button key={t.id} type="button"
+                ref={el => { refs.current[t.id] = el; }}
+                onClick={() => setView(t.id)}
+                role="tab" aria-selected={isActive}
+                aria-controls={`view-${t.id}`}
+                style={{
+                  padding:'10px 14px', background:'transparent', border:'none',
+                  color: isActive ? entityHsl('kb') : 'var(--text-sec)',
+                  fontFamily:'var(--f-display)', fontSize: 12,
+                  fontWeight: isActive ? 800 : 700, cursor:'pointer',
+                  display:'inline-flex', alignItems:'center', gap: 6,
+                }}>
+                <span aria-hidden="true" style={{ fontFamily: t.id === 'raw' ? 'var(--f-mono)' : 'inherit' }}>{t.icon}</span>
+                <span>{t.label}</span>
+              </button>
+            );
+          })}
+        </div>
+        <span aria-hidden="true" style={{
+          position:'absolute', bottom: -1, left: ind.left, width: ind.width,
+          height: 2, background: entityHsl('kb'),
+          transition:'left .3s var(--ease-out), width .3s var(--ease-out)',
+        }}/>
+      </div>
+
+      <div role="tabpanel" id={`view-${view}`}>
+        {view === 'rendered' ? (
+          <Markdown source={chunk.body}/>
+        ) : (
+          <pre style={{
+            margin: 0, padding: 14,
+            background:'var(--bg-sunken)', border:'1px solid var(--border)',
+            borderRadius:'var(--r-lg)',
+            fontFamily:'var(--f-mono)', fontSize: 12, lineHeight: 1.65,
+            color:'var(--text)', whiteSpace:'pre-wrap', overflow:'auto',
+          }}>{chunk.body}</pre>
+        )}
+      </div>
+
+      {/* Connection bar */}
+      <div>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 800,
+          marginBottom: 6,
+        }}>Connesso a</div>
+        <ConnectionBar chips={allChips}/>
+      </div>
+
+      {/* Footer actions */}
+      <div style={{
+        display:'flex', gap: 8, flexWrap:'wrap',
+        paddingTop: 12, borderTop:'1px solid var(--border)',
+      }}>
+        <button type="button" style={{
+          padding:'8px 14px', borderRadius:'var(--r-md)',
+          background: entityHsl('kb'), color:'#fff', border:'none',
+          fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer',
+          display:'inline-flex', alignItems:'center', gap: 6,
+        }}><span aria-hidden="true">📋</span>Copia testo</button>
+        <button type="button" style={{
+          padding:'8px 14px', borderRadius:'var(--r-md)',
+          background:'transparent', color:'var(--text)',
+          border:'1px solid var(--border-strong)',
+          fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 700, cursor:'pointer',
+          display:'inline-flex', alignItems:'center', gap: 6,
+        }}><span aria-hidden="true">📄</span>Vedi PDF originale (p.{chunk.page})</button>
+        <button type="button" style={{
+          padding:'8px 14px', borderRadius:'var(--r-md)',
+          background:'transparent', color: entityHsl('warning'),
+          border:`1px solid ${entityHsl('warning', 0.4)}`,
+          fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 700, cursor:'pointer',
+          display:'inline-flex', alignItems:'center', gap: 6, marginLeft:'auto',
+        }}><span aria-hidden="true">⚠</span>Segnala chunk errato</button>
+      </div>
+    </article>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── EMPTY / LOADING / ERROR ────────────────────────
+// ═══════════════════════════════════════════════════════
+const ChunksSkeleton = () => (
+  <div style={{ display:'flex', flexDirection:'column', gap: 8 }}>
+    {[0,1,2,3,4].map(i => (
+      <div key={i} className="mai-shimmer" style={{
+        height: 96, borderRadius:'var(--r-md)', background:'var(--bg-muted)',
+      }}/>
+    ))}
+  </div>
+);
+const PreviewSkeleton = () => (
+  <div style={{ display:'flex', flexDirection:'column', gap: 14 }}>
+    <div className="mai-shimmer" style={{ height: 18, width:'40%', borderRadius: 4, background:'var(--bg-muted)' }}/>
+    <div className="mai-shimmer" style={{ height: 60, borderRadius:'var(--r-lg)', background:'var(--bg-muted)' }}/>
+    <div className="mai-shimmer" style={{ height: 36, borderRadius:'var(--r-md)', background:'var(--bg-muted)' }}/>
+    {[0,1,2,3].map(i => (
+      <div key={i} className="mai-shimmer" style={{
+        height: 14, width: `${85 - i*8}%`, borderRadius: 4, background:'var(--bg-muted)',
+      }}/>
+    ))}
+  </div>
+);
+
+const EmptyChunks = () => (
+  <div style={{
+    padding:'48px 24px', textAlign:'center',
+    background:'var(--bg-card)', border:'1px dashed var(--border-strong)',
+    borderRadius:'var(--r-xl)',
+    display:'flex', flexDirection:'column', alignItems:'center',
+  }}>
+    <div style={{
+      width: 72, height: 72, borderRadius:'50%',
+      background: entityHsl('kb', 0.12), color: entityHsl('kb'),
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 32, marginBottom: 14,
+      animation:'pulse 2s ease-in-out infinite',
+    }} aria-hidden="true">⚙️</div>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: 17, fontWeight: 800,
+      color:'var(--text)', margin:'0 0 6px',
+    }}>Documento in elaborazione</h3>
+    <p style={{
+      fontSize: 13, color:'var(--text-muted)', maxWidth: 380, margin:'0 0 16px',
+      lineHeight: 1.6,
+    }}>L'estrattore sta processando il PDF e generando i chunk indicizzati. Riceverai una notifica appena pronto (di solito 1-3 minuti).</p>
+    <div style={{
+      width:'100%', maxWidth: 240, height: 4, borderRadius:'var(--r-pill)',
+      background:'var(--bg-muted)', overflow:'hidden', position:'relative',
+    }} role="progressbar" aria-label="Indicizzazione in corso" aria-valuetext="In elaborazione">
+      <div style={{
+        position:'absolute', top: 0, left: 0, height:'100%', width:'40%',
+        background: entityHsl('kb'), borderRadius:'var(--r-pill)',
+        animation:'kbPulseSlide 1.6s ease-in-out infinite',
+      }}/>
+    </div>
+  </div>
+);
+
+const ErrorState = () => (
+  <div style={{
+    padding:'40px 24px', textAlign:'center',
+    background:'hsl(var(--c-danger) / .08)',
+    border:'1px solid hsl(var(--c-danger) / .3)',
+    borderRadius:'var(--r-xl)',
+    display:'flex', flexDirection:'column', alignItems:'center',
+  }}>
+    <div style={{
+      width: 56, height: 56, borderRadius:'50%',
+      background:'hsl(var(--c-danger) / .15)', color:'hsl(var(--c-danger))',
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 26, marginBottom: 12,
+    }} aria-hidden="true">⚠</div>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800,
+      color:'var(--text)', margin:'0 0 6px',
+    }}>OCR fallito sul documento</h3>
+    <p style={{
+      fontSize: 12.5, color:'var(--text-muted)', maxWidth: 380, margin:'0 0 14px',
+      lineHeight: 1.6,
+    }}>Il PDF contiene immagini non riconosciute o protezioni che impediscono l'estrazione del testo. Prova un re-upload o un OCR manuale.</p>
+    <div style={{ display:'flex', gap: 8, flexWrap:'wrap', justifyContent:'center' }}>
+      <button type="button" style={{
+        padding:'8px 16px', borderRadius:'var(--r-md)',
+        background:'hsl(var(--c-danger))', color:'#fff', border:'none',
+        fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer',
+      }}>↻ Riprova OCR</button>
+      <button type="button" style={{
+        padding:'8px 16px', borderRadius:'var(--r-md)',
+        background:'transparent', color:'var(--text)',
+        border:'1px solid var(--border-strong)',
+        fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 700, cursor:'pointer',
+      }}>⬆ Re-upload</button>
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── BODY ───────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const KbDetailBody = ({ stateOverride, mobile, initialChunkId = 'c1' }) => {
+  const [selected, setSelected] = useState(initialChunkId);
+  const [query, setQuery] = useState('');
+  const [mobileView, setMobileView] = useState('list'); // 'list' | 'preview'
+
+  const isLoading = stateOverride === 'loading';
+  const isError = stateOverride === 'error';
+  const isEmpty = stateOverride === 'empty';
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return CHUNKS;
+    const q = query.toLowerCase();
+    return CHUNKS.filter(c =>
+      c.heading.toLowerCase().includes(q) ||
+      c.snippet.toLowerCase().includes(q) ||
+      c.cat.toLowerCase().includes(q)
+    );
+  }, [query]);
+
+  const activeChunk = CHUNKS.find(c => c.id === selected) || CHUNKS[0];
+
+  // Empty/error/loading KB stats
+  const displayKb = isEmpty
+    ? { ...KB, chunks: 0, embedding: 'In attesa…', pages: KB.pages }
+    : isError
+      ? { ...KB, chunks: 0, embedding: '— (failed)' }
+      : KB;
+
+  const renderLeft = () => (
+    <>
+      <KbHeader kb={displayKb} mobile={mobile}/>
+      <MetaStats kb={displayKb}/>
+      {!isEmpty && !isError && (
+        <SearchBox value={query} onChange={setQuery} count={filtered.length} total={CHUNKS.length}/>
+      )}
+      <div style={{
+        fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+        textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 800,
+        marginTop: 4,
+      }}>
+        {isLoading ? 'Caricamento chunks…' :
+         isEmpty ? 'In attesa indicizzazione' :
+         isError ? 'Nessun chunk estratto' :
+         `${filtered.length} chunks${query ? ' · filtrati' : ''}`}
+      </div>
+      <div style={{ display:'flex', flexDirection:'column', gap: 8 }}>
+        {isLoading ? <ChunksSkeleton/>
+         : isEmpty ? null
+         : isError ? null
+         : filtered.length === 0 ? (
+            <div style={{
+              padding:'24px 16px', textAlign:'center',
+              fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+              border:'1px dashed var(--border)', borderRadius:'var(--r-md)',
+            }}>Nessun chunk trovato per "{query}"</div>
+          )
+          : filtered.map(c => (
+              <ChunkRow key={c.id} chunk={c}
+                active={c.id === selected}
+                onClick={() => { setSelected(c.id); if (mobile) setMobileView('preview'); }}/>
+            ))
+        }
+      </div>
+    </>
+  );
+
+  const renderRight = () => {
+    if (isLoading) return <PreviewSkeleton/>;
+    if (isEmpty) return <EmptyChunks/>;
+    if (isError) return <ErrorState/>;
+    return <ChunkPreview chunk={activeChunk} kb={KB} mobile={mobile} onBack={() => setMobileView('list')}/>;
+  };
+
+  if (mobile) {
+    // Mobile: master/detail toggle (list view OR preview view)
+    return (
+      <div style={{ background:'var(--bg)' }}>
+        {mobileView === 'list' ? (
+          <div style={{ padding:'14px 16px 24px', display:'flex', flexDirection:'column', gap: 12 }}>
+            {renderLeft()}
+          </div>
+        ) : (
+          <div style={{ padding:'14px 16px 24px' }}>
+            {renderRight()}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Desktop split-view
+  return (
+    <div style={{
+      display:'grid', gridTemplateColumns:'380px 1fr', gap: 24,
+      padding:'24px 32px', minHeight: 720, background:'var(--bg)',
+    }}>
+      <aside style={{
+        position:'sticky', top: 24, alignSelf:'start',
+        maxHeight:'calc(100vh - 48px)', overflowY:'auto',
+        display:'flex', flexDirection:'column', gap: 12,
+        paddingRight: 4,
+      }}>
+        {renderLeft()}
+      </aside>
+      <main style={{ minWidth: 0 }}>{renderRight()}</main>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── SHELLS ─────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const DesktopNav = ({ kb }) => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 14,
+    padding:'10px 32px',
+    background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+    borderBottom:'1px solid var(--border)',
+  }}>
+    <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
+      <div style={{
+        width: 26, height: 26, borderRadius: 7,
+        background:'linear-gradient(135deg, hsl(var(--c-kb)), hsl(var(--c-game)))',
+        color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+        fontWeight: 800, fontSize: 13, fontFamily:'var(--f-display)',
+      }}>M</div>
+      <span style={{ fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 14 }}>MeepleAI</span>
+    </div>
+    <div style={{
+      flex: 1, fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      marginLeft: 22,
+    }}>
+      <a href="#" style={{ color:'inherit' }}>KB</a>
+      <span aria-hidden="true"> / </span>
+      <strong style={{ color:'var(--text-sec)' }}>{kb.title}</strong>
+    </div>
+  </div>
+);
+
+const DesktopScreen = ({ stateOverride, initialChunkId }) => (
+  <div style={{ background:'var(--bg)' }}>
+    <DesktopNav kb={KB}/>
+    <KbDetailBody stateOverride={stateOverride} initialChunkId={initialChunkId}/>
+  </div>
+);
+
+const PhoneSbar = () => (
+  <div className="phone-sbar" style={{ color:'var(--text)' }}>
+    <span style={{ fontFamily:'var(--f-mono)' }}>14:32</span>
+    <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+  </div>
+);
+const PhoneTopNav = ({ kb }) => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 9,
+    padding:'10px 14px', background:'var(--glass-bg)',
+    backdropFilter:'blur(12px)',
+    borderBottom:'1px solid var(--border-light)',
+  }}>
+    <button aria-label="Indietro" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      color:'var(--text)', fontSize: 14, cursor:'pointer',
+    }}>←</button>
+    <div style={{
+      flex: 1, fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+      textAlign:'center', fontWeight: 700,
+    }}>kb / {kb.id.replace('kb-', '')}</div>
+    <button aria-label="Più opzioni" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      color:'var(--text)', fontSize: 14, cursor:'pointer',
+    }}>⋯</button>
+  </div>
+);
+const MobileScreen = ({ stateOverride, initialChunkId }) => (
+  <>
+    <PhoneSbar/>
+    <div style={{ flex: 1, overflowY:'auto', position:'relative', background:'var(--bg)' }}>
+      <PhoneTopNav kb={KB}/>
+      <KbDetailBody stateOverride={stateOverride} mobile initialChunkId={initialChunkId}/>
+    </div>
+  </>
+);
+
+const PhoneShell = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 10 }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div className="phone">{children}</div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 340,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+const DesktopFrame = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 12, width:'100%' }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div style={{
+      width:'100%', maxWidth: 1440,
+      borderRadius:'var(--r-xl)', border:'1px solid var(--border)',
+      background:'var(--bg)', overflow:'hidden',
+      boxShadow:'var(--shadow-lg)',
+    }}>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 8,
+        padding:'9px 14px', background:'var(--bg-muted)',
+        borderBottom:'1px solid var(--border)',
+        fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      }}>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-event))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-warning))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-toolkit))' }}/>
+        <span style={{ flex: 1, textAlign:'center', letterSpacing:'.04em' }}>meepleai.app/kb/{KB.id.replace('kb-', '')}</span>
+      </div>
+      {children}
+    </div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 720,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── ROOT ───────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const MOBILE_STATES = [
+  { id:'m1', stateOverride:null, chunk:'c1',
+    label:'01 · Default · List view',
+    desc:'Stack: header KB + meta stats + search + lista chunks scrollable. Tap riga apre preview.' },
+  { id:'m2', stateOverride:null, chunk:'c5',
+    label:'02 · Preview chunk · markdown',
+    desc:'Master/detail: preview chunk Wall tiling con tabella markdown renderizzata + ConnectionBar agent/chat + footer azioni. Pulsante "← Lista" torna al master.' },
+  { id:'m3', stateOverride:'empty', chunk:'c1',
+    label:'03 · Empty · in elaborazione',
+    desc:'Header KB visibile (uploaded ma chunks 0/—), zona body indicatore "Documento in elaborazione" con progress bar pulsante.' },
+  { id:'m4', stateOverride:'loading', chunk:'c1',
+    label:'04 · Loading',
+    desc:'Header reale + skeleton 5 chunks list. Sotto la lista, nessun preview.' },
+  { id:'m5', stateOverride:'error', chunk:'c1',
+    label:'05 · Error · OCR fallito',
+    desc:'Header KB cache + alert danger "OCR fallito" con CTA "↻ Riprova OCR" + "⬆ Re-upload".' },
+];
+
+const App = () => {
+  const [theme, setTheme] = useState(() => {
+    const saved = localStorage.getItem('mai-theme');
+    if (saved) return saved;
+    return document.documentElement.getAttribute('data-theme') || 'light';
+  });
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('mai-theme', theme);
+  }, [theme]);
+
+  // Inline keyframes for empty-state pulse animations (NOT touching components.css)
+  return (
+    <div style={{
+      minHeight:'100vh', background:'var(--bg)', color:'var(--text)',
+      padding:'24px 24px 80px',
+    }}>
+      <style>{`
+        @keyframes pulse {
+          0%, 100% { transform: scale(1); opacity: .9; }
+          50% { transform: scale(1.05); opacity: 1; }
+        }
+        @keyframes kbPulseSlide {
+          0% { left: -40%; }
+          100% { left: 100%; }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          @keyframes pulse { 0%,100% { transform: none; opacity: 1; } 50% { transform: none; opacity: 1; } }
+          @keyframes kbPulseSlide { 0%,100% { left: 30%; } }
+        }
+      `}</style>
+
+      {/* Header */}
+      <header style={{
+        maxWidth: 1440, margin:'0 auto 32px',
+        display:'flex', alignItems:'center', gap: 12, flexWrap:'wrap',
+      }}>
+        <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
+          <div style={{
+            width: 32, height: 32, borderRadius: 8,
+            background:'linear-gradient(135deg, hsl(var(--c-kb)), hsl(var(--c-game)))',
+            color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+            fontWeight: 800, fontFamily:'var(--f-display)',
+          }}>F</div>
+          <div>
+            <div style={{ fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 16 }}>SP4 wave 3 · F</div>
+            <div style={{ fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)' }}>
+              /kb/[id] — KB document detail (split-view)
+            </div>
+          </div>
+        </div>
+        <div style={{ flex: 1 }}/>
+        <button type="button" onClick={() => setTheme(t => t === 'light' ? 'dark' : 'light')}
+          style={{
+            padding:'8px 14px', borderRadius:'var(--r-md)',
+            background:'var(--bg-card)', border:'1px solid var(--border)',
+            color:'var(--text)', fontFamily:'var(--f-display)',
+            fontSize: 12, fontWeight: 800, cursor:'pointer',
+          }}>🌗 {theme === 'light' ? 'Light' : 'Dark'}</button>
+      </header>
+
+      {/* Desktop variants */}
+      <section style={{ maxWidth: 1440, margin:'0 auto', display:'flex', flexDirection:'column', gap: 32 }}>
+        <DesktopFrame label="Desktop · 01 · Default · Chunk #1 selezionato"
+          desc="Split-view 380px sticky sx (header doc cover gradient kb→game + meta stats 6 campi + search box + lista 8 chunks con cat-color + indicator usedIn) / fluida dx (breadcrumb + heading + sub-tabs Rendered/Raw + markdown renderizzato + ConnectionBar + footer azioni).">
+          <DesktopScreen initialChunkId="c1"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 02 · Chunk con tabella + lista"
+          desc="Chunk Setup #2: markdown con tabella (giocatori/factory) + lista numerata + heading H2. Mini-renderer markdown gestisce H1/H2/H3, ul/ol, table, blockquote, code block, inline bold/em/code.">
+          <DesktopScreen initialChunkId="c2"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 03 · Chunk con blockquote + code block"
+          desc="Chunk Pattern strip #4: code block ASCII art (pattern strip layout) + lista regole. ConnectionBar mostra agent Azul Rules Expert + chat usage.">
+          <DesktopScreen initialChunkId="c4"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 04 · Chunk Punteggio (esempio bonus)"
+          desc="Chunk Wall tiling #5: heading + lista numerata calcolo punteggio + blockquote esempio. Border-left highlight kb-teal su chunk attivo.">
+          <DesktopScreen initialChunkId="c5"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 05 · Chunk FAQ con tabella riassuntiva"
+          desc="Chunk Endgame #6: tabella bonus + heading + paragrafo. Categoria 'Endgame' event-pink chip.">
+          <DesktopScreen initialChunkId="c6"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 06 · Empty · doc in elaborazione"
+          desc="Header KB rendering (upload completato), meta stats con chunks=0, no search visible. Body dx mostra animazione 'Documento in elaborazione' con progress bar pulsante kb-teal.">
+          <DesktopScreen stateOverride="empty"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 07 · Loading"
+          desc="Header reale (cache), 5 chunk skeleton sx + preview skeleton dx. Mostra come app gestisce hydration progressivo.">
+          <DesktopScreen stateOverride="loading"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 08 · Error · OCR fallito"
+          desc="Header KB visibile, body dx alert danger 'OCR fallito sul documento' + CTA '↻ Riprova OCR' (rosso) + '⬆ Re-upload' (outline).">
+          <DesktopScreen stateOverride="error"/>
+        </DesktopFrame>
+      </section>
+
+      {/* Mobile variants */}
+      <section style={{ maxWidth: 1440, margin:'48px auto 0' }}>
+        <h2 style={{
+          fontFamily:'var(--f-display)', fontSize: 22, fontWeight: 800,
+          marginBottom: 8,
+        }}>Mobile · 375px</h2>
+        <p style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-muted)', marginBottom: 24,
+        }}>5 stati: list view · preview chunk · empty · loading · error. Pattern master/detail.</p>
+        <div style={{
+          display:'flex', flexWrap:'wrap', gap: 32, justifyContent:'center',
+        }}>
+          {MOBILE_STATES.map(m => (
+            <PhoneShell key={m.id} label={m.label} desc={m.desc}>
+              <MobileScreen stateOverride={m.stateOverride} initialChunkId={m.chunk}/>
+            </PhoneShell>
+          ))}
+        </div>
+      </section>
+
+      {/* DoD */}
+      <section style={{
+        maxWidth: 900, margin:'64px auto 0',
+        padding: 24, borderRadius:'var(--r-xl)',
+        background:'var(--bg-card)', border:'1px solid var(--border)',
+      }}>
+        <h2 style={{
+          fontFamily:'var(--f-display)', fontSize: 18, fontWeight: 800, marginBottom: 12,
+        }}>Definition of Done · F kb-detail</h2>
+        <ul style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-sec)',
+          lineHeight: 1.9, listStyle:'none', padding: 0, margin: 0,
+        }}>
+          <li>✓ Solo CSS variables da tokens.css (zero hex hardcoded)</li>
+          <li>✓ Helper entityHsl(type, alpha) inline</li>
+          <li>✓ Light + dark mode (toggle header)</li>
+          <li>✓ Mobile 375px (5 phone) + Desktop 1440px (8 frame)</li>
+          <li>✓ Pattern desktop: split-view 380px sticky sx + preview fluida dx</li>
+          <li>✓ Mobile pattern master/detail con back button "← Lista"</li>
+          <li>✓ Document detail singolo (NO index)</li>
+          <li>✓ Palette --c-kb teal · cover gradient kb→game tint sul header</li>
+          <li>✓ Header doc: titolo + tipo PDF/Manuale + Game chip + autore Player chip</li>
+          <li>✓ Stats meta: pagine · chunks · versione · update · embedding · size (6 campi)</li>
+          <li>✓ Search box "Cerca nel documento..." con filter live + counter "N di M"</li>
+          <li>✓ Chunks list: ordinale + heading + snippet 2-line clamp + cat tag colorato + usedIn</li>
+          <li>✓ Preview: breadcrumb + page ref + heading + markdown render (H1/H2/H3, ul/ol, table, blockquote, code, inline)</li>
+          <li>✓ Sub-tabs Rendered/Raw markdown (riuso pattern animated underline)</li>
+          <li>✓ ConnectionBar agent/chat/kb pip nel preview</li>
+          <li>✓ Footer azioni: Copia testo (primary kb) · Vedi PDF originale (outline) · Segnala chunk errato (warning, ml:auto)</li>
+          <li>✓ Stati: default / empty (in elaborazione + progress) / loading (skeleton) / error (OCR fallito + 2 CTA)</li>
+          <li>✓ ARIA: role="tablist" sui sub-tabs · aria-label search/clear/back/Indietro/Più · aria-current su chunk attivo · role="tabpanel" · role="progressbar" su empty</li>
+          <li>✓ Focus visibile (components.css esistente)</li>
+          <li>✓ prefers-reduced-motion gestito (override @keyframes inline)</li>
+          <li>✓ Testo italiano · dati Azul regole reali (Setup/Turno/Punteggio/FAQ)</li>
+          <li>✓ ID short readable: kb-azul-ita, c1…c8, a-azul-rules — NO UUID</li>
+          <li>✓ Commento di apertura con route /kb/[id]</li>
+        </ul>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800, marginTop: 18, marginBottom: 8,
+        }}>Nuovi componenti v2 emersi</h3>
+        <ul style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-sec)',
+          lineHeight: 1.8, listStyle:'none', padding: 0, margin: 0,
+        }}>
+          <li>· KbHeader (cover gradient kb→game + status pill + version)</li>
+          <li>· KbChunkListPanel (search + lista filtered + cat-color + active border-left)</li>
+          <li>· KbChunkPreview (breadcrumb + heading box + sub-tabs Rendered/Raw + ConnectionBar + footer azioni)</li>
+          <li>· ChunkSearchBox (search input + clear + counter "N di M")</li>
+          <li>· MarkdownRenderBlock (mini-renderer H1-3, ul/ol, table, blockquote, code, inline bold/em/code)</li>
+          <li>· KbProcessingState (empty: pulse + progress bar slide kb-teal)</li>
+        </ul>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800, marginTop: 18, marginBottom: 8,
+        }}>Riusi pixel-perfect</h3>
+        <ul style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-sec)',
+          lineHeight: 1.8, listStyle:'none', padding: 0, margin: 0,
+        }}>
+          <li>· ConnectionBar (PR #549/#552)</li>
+          <li>· Tabs animated underline (wave 1) — qui per Rendered/Raw</li>
+          <li>· TabSkeleton/TabError/TabEmpty (wave 1)</li>
+          <li>· EntityChip (wave 1/2)</li>
+        </ul>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800, marginTop: 18, marginBottom: 8,
+          color: entityHsl('warning'),
+        }}>Deviazioni flaggate</h3>
+        <ul style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-sec)',
+          lineHeight: 1.8, listStyle:'none', padding: 0, margin: 0,
+        }}>
+          <li>· Metric "usato in N chat" sui chunk è stub UI — backend deve esporre embedding usage counter (issue da aprire)</li>
+          <li>· Mini-renderer markdown è inline minimo (no syntax highlighting, no link, no images): adeguato per regolamenti, non per docs ricchi</li>
+          <li>· @keyframes pulse + kbPulseSlide definite inline nel root (non in components.css come da contratto)</li>
+          <li>· Sub-tabs Rendered/Raw aggiunti come bonus oltre il brief — utile per debug indicizzazione, rimuovibile se non desiderato</li>
+          <li>· Hash sha256 nel KB fixture è troncato "7a3c…f9b1" per evitare GitGuardian false-positive</li>
+        </ul>
+      </section>
+    </div>
+  );
+};
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);

--- a/admin-mockups/design_files/sp4-player-detail.html
+++ b/admin-mockups/design_files/sp4-player-detail.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<!-- MeepleAI SP4 wave 3 — D · Player detail (character sheet)
+     Route: /players/[id]
+     Hero + tabs (Overview · Sessions · Games · Toolkits · Achievements) con palette --c-player. -->
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>MeepleAI · /players/[id] — Player detail</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-player-detail.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-player-detail.jsx
+++ b/admin-mockups/design_files/sp4-player-detail.jsx
@@ -1,0 +1,1548 @@
+/* MeepleAI SP4 wave 3 — Schermata D / 5
+   Route: /players/[id]
+   File: admin-mockups/design_files/sp4-player-detail.{html,jsx}
+   Pattern desktop: Hero + body con tabs (Overview · Sessions · Games · Toolkits · Achievements)
+   Character sheet style — palette --c-player. Riuso pattern wave 1 (sp4-game-detail.jsx):
+   ConnectionBar 1:1 prod (PR #549/#552), Tabs animated underline, KpiCard, TabSkeleton/Error/Empty.
+
+   Varianti: registered (default) · guest (no avatar gradient, no Games tab, achievements limitati).
+
+   v2 nuovi (per impl post-merge):
+   - PlayerHero            → apps/web/src/components/ui/v2/player-hero/
+   - PlayerStatsGrid       → apps/web/src/components/ui/v2/player-stats-grid/
+   - PlayerLeaderboardCard → apps/web/src/components/ui/v2/player-leaderboard-card/
+   - AchievementBadgeGrid  → apps/web/src/components/ui/v2/achievement-badge-grid/
+   - FavoriteGamesStrip    → apps/web/src/components/ui/v2/favorite-games-strip/
+
+   Riusi pixel-perfect (NON ridisegnare nel codice prod):
+   - ConnectionBar (PR #549/#552)
+   - MeepleCard variants list (session) e compact (game)
+   - Tabs animated underline (wave 1)
+
+   Deviazioni flaggate: win rate 73% culture-independent (no decimali, no virgola).
+*/
+
+const { useState, useEffect, useMemo, useRef } = React;
+const DS = window.DS;
+
+const entityHsl = (type, alpha) => {
+  const c = DS.EC[type] || DS.EC.player;
+  return alpha !== undefined
+    ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${alpha})`
+    : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
+};
+
+// ─── PLAYER FIXTURE ─────────────────────────────────
+// Use existing data.js player for cross-ref consistency, then enrich.
+const PLAYER = {
+  ...DS.players.find(p => p.id === 'p-marco'),
+  handle: '@marco.r',
+  bio: 'Pro player — heavy euro & worker placement. Organizzatore Game Night Club.',
+  joinedAt: 'Gen 2025',
+  city: 'Milano',
+  favAgentId: 'a-azul-rules',
+  topGameId: 'g-azul',
+  guest: false,
+};
+
+const GUEST_PLAYER = {
+  id: 'p-davide',
+  type: 'player',
+  title: 'Davide F.',
+  handle: null,
+  initials: 'DF',
+  bio: 'Ospite di Marco. Nessun account MeepleAI.',
+  joinedAt: null,
+  city: null,
+  favAgentId: null,
+  topGameId: null,
+  guest: true,
+  totalSessions: 4,
+  totalWins: 1,
+  winRate: 0.25,
+  fav: 'Catan',
+};
+
+const PLAYER_SESSIONS = [
+  { id: 's-azul-live', title: 'Serata Azul', date: '15 Mar 2026', duration: '45m',
+    gameId: 'g-azul', state: 'inprogress', badge: 'In Corso',
+    playerIds: ['p-marco', 'p-sara', 'p-luca', 'p-giulia'], won: null, score: 48 },
+  { id: 's-wing-042', title: 'Wingspan · Domenica', date: '10 Mar 2026', duration: '1h 42m',
+    gameId: 'g-wingspan', state: 'done', badge: 'Vittoria',
+    playerIds: ['p-sara', 'p-marco', 'p-giulia', 'p-luca', 'p-andrea'], won: true, score: 92 },
+  { id: 's-brass-041', title: 'Brass Martedì', date: '5 Mar 2026', duration: '2h 15m',
+    gameId: 'g-brass', state: 'done', badge: 'Vittoria',
+    playerIds: ['p-marco', 'p-sara', 'p-luca'], won: true, score: 132 },
+  { id: 's-7w-018', title: '7 Wonders · Duel', date: '1 Mar 2026', duration: '32m',
+    gameId: 'g-7wonders', state: 'done', badge: 'Sconfitta',
+    playerIds: ['p-marco', 'p-sara'], won: false, score: 58 },
+  { id: 's-azul-021', title: 'Azul · Casa Marco', date: '24 Feb 2026', duration: '38m',
+    gameId: 'g-azul', state: 'done', badge: 'Vittoria',
+    playerIds: ['p-marco', 'p-luca', 'p-giulia'], won: true, score: 81 },
+];
+
+const PLAYER_TOP_GAMES = [
+  { id: 'g-azul', plays: 23, wins: 15, winRate: 0.65 },
+  { id: 'g-wingspan', plays: 17, wins: 10, winRate: 0.59 },
+  { id: 'g-brass', plays: 12, wins: 6, winRate: 0.50 },
+  { id: 'g-7wonders', plays: 11, wins: 5, winRate: 0.45 },
+  { id: 'g-catan', plays: 9, wins: 3, winRate: 0.33 },
+];
+
+const PLAYER_TOOLKITS = [
+  { id: 'tk-azul-v2', title: 'Azul Toolkit v2', gameId: 'g-azul',
+    toolCount: 3, useCount: 12, version: 2, badge: 'Pubblicato' },
+];
+
+const ACHIEVEMENTS = [
+  { id: 'ach-first-win', icon: '🥇', title: 'Prima vittoria', sub: 'Vinci la tua prima partita', unlocked: true, date: 'Gen 2025' },
+  { id: 'ach-streak-3', icon: '🔥', title: 'Streak ×3', sub: '3 vittorie consecutive', unlocked: true, date: 'Mar 2025' },
+  { id: 'ach-fav-game', icon: '⭐', title: 'Specialista', sub: '20+ partite stesso gioco', unlocked: true, date: 'Set 2025' },
+  { id: 'ach-night-host', icon: '🎉', title: 'Ospite', sub: 'Organizza una Game Night', unlocked: true, date: 'Ott 2025' },
+  { id: 'ach-toolkit-pub', icon: '🧰', title: 'Tinkerer', sub: 'Pubblica il primo toolkit', unlocked: true, date: 'Gen 2026' },
+  { id: 'ach-50-plays', icon: '🎯', title: '50 partite', sub: 'Raggiungi 50 partite totali', unlocked: true, date: 'Dic 2025' },
+  { id: 'ach-100-plays', icon: '💯', title: '100 partite', sub: 'Raggiungi 100 partite totali', unlocked: false },
+  { id: 'ach-no-loss', icon: '🛡️', title: 'Imbattuto', sub: '5 partite consecutive vinte', unlocked: false },
+  { id: 'ach-explorer', icon: '🧭', title: 'Esploratore', sub: 'Prova 10 giochi diversi', unlocked: true, date: 'Nov 2025' },
+  { id: 'ach-ai-friend', icon: '🤖', title: 'AI Buddy', sub: '50 chat con un agente', unlocked: false },
+  { id: 'ach-heavy', icon: '🏋️', title: 'Heavy player', sub: 'Vinci un gioco con peso > 3.5', unlocked: true, date: 'Feb 2026' },
+  { id: 'ach-perfect', icon: '✨', title: 'Game perfetta', sub: '100% punteggio in una partita', unlocked: false },
+];
+
+// ═══════════════════════════════════════════════════════
+// ─── PRIMITIVES ─────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+
+const EntityChip = ({ type, label, count, icon, onClick }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    style={{
+      display:'inline-flex', alignItems:'center', gap: 6,
+      padding:'4px 10px', borderRadius:'var(--r-pill)',
+      background: entityHsl(type, 0.12), color: entityHsl(type),
+      border:`1px solid ${entityHsl(type, 0.2)}`,
+      fontFamily:'var(--f-display)', fontSize: 11, fontWeight: 700,
+      cursor:'pointer', whiteSpace:'nowrap',
+    }}>
+    <span aria-hidden="true">{icon || DS.EC[type]?.em}</span>
+    {count !== undefined && (
+      <span style={{ fontFamily:'var(--f-mono)', fontVariantNumeric:'tabular-nums' }}>{count}</span>
+    )}
+    <span>{label}</span>
+  </button>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── CONNECTIONBAR (1:1 prod) ────────────────────────
+// /* v2: ConnectionBar — ✅ in produzione (PR #549/#552) */
+// ═══════════════════════════════════════════════════════
+const ConnectionBar = ({ connections, loading, onPipClick }) => {
+  if (loading) {
+    return (
+      <div style={{ display:'flex', gap: 8, padding:'8px 0', overflowX:'auto', scrollbarWidth:'none' }}>
+        {[0,1,2,3,4,5].map(i => (
+          <div key={i} className="mai-shimmer" style={{
+            height: 28, width: 92 + i*6, borderRadius: 999,
+            background:'var(--bg-muted)', flexShrink: 0,
+          }}/>
+        ))}
+      </div>
+    );
+  }
+  if (!connections || connections.length === 0) return null;
+  return (
+    <div className="mai-cb-scroll" style={{
+      display:'flex', alignItems:'center', gap: 8,
+      overflowX:'auto', padding:'8px 0', scrollbarWidth:'none',
+    }}>
+      {connections.map(c => {
+        const isEmpty = c.isEmpty || c.count === 0;
+        const ariaLabel = isEmpty ? c.label : `${c.label}: ${c.count}`;
+        const ec = DS.EC[c.entityType];
+        return (
+          <button
+            key={c.entityType}
+            type="button"
+            aria-label={ariaLabel}
+            onClick={() => onPipClick && onPipClick(c)}
+            style={{
+              display:'inline-flex', alignItems:'center', gap: 6,
+              padding:'6px 12px', borderRadius: 999,
+              fontSize: 12, fontWeight: 700, fontFamily:'var(--f-display)',
+              background: isEmpty ? 'transparent' : entityHsl(c.entityType, 0.1),
+              color: entityHsl(c.entityType),
+              border: isEmpty
+                ? `1.5px dashed ${entityHsl(c.entityType, 0.5)}`
+                : `1px solid ${entityHsl(c.entityType, 0.2)}`,
+              opacity: isEmpty ? 0.6 : 1,
+              cursor:'pointer', flexShrink: 0, whiteSpace:'nowrap',
+            }}>
+            <span aria-hidden="true" style={{ fontSize: 13, lineHeight: 1 }}>{ec.em}</span>
+            {isEmpty ? (
+              <svg width="13" height="13" viewBox="0 0 24 24"
+                fill="none" stroke="currentColor" strokeWidth="2.5"
+                strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <line x1="12" y1="5" x2="12" y2="19"/>
+                <line x1="5" y1="12" x2="19" y2="12"/>
+              </svg>
+            ) : (
+              <span style={{
+                fontFamily:'var(--f-mono)', fontVariantNumeric:'tabular-nums', fontWeight: 700,
+              }}>{c.count}</span>
+            )}
+            <span>{c.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── PLAYER HERO ────────────────────────────────────
+// /* v2: PlayerHero → apps/web/src/components/ui/v2/player-hero/ */
+// ═══════════════════════════════════════════════════════
+const PlayerHero = ({ player, compact, loading }) => {
+  if (loading) {
+    return (
+      <div style={{ position:'relative', background:'var(--bg)' }}>
+        <div style={{
+          padding: compact ? '20px 16px 14px' : '32px 32px 18px',
+          display:'flex', gap: compact ? 14 : 20, alignItems:'center',
+        }}>
+          <div className="mai-shimmer" style={{
+            width: compact ? 96 : 128, height: compact ? 96 : 128,
+            borderRadius:'50%', background:'var(--bg-muted)', flexShrink: 0,
+          }}/>
+          <div style={{ flex: 1, display:'flex', flexDirection:'column', gap: 8 }}>
+            <div className="mai-shimmer" style={{ height: 28, width:'60%', background:'var(--bg-muted)', borderRadius: 6 }}/>
+            <div className="mai-shimmer" style={{ height: 14, width:'42%', background:'var(--bg-muted)', borderRadius: 4 }}/>
+            <div className="mai-shimmer" style={{ height: 14, width:'80%', background:'var(--bg-muted)', borderRadius: 4 }}/>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const isGuest = player.guest;
+  const avatarSize = compact ? 96 : 128;
+  const winRatePct = Math.round((player.winRate || 0) * 100);
+
+  return (
+    <div style={{ position:'relative', background:'var(--bg)' }}>
+      {/* Soft top band */}
+      <div style={{
+        position:'absolute', top: 0, left: 0, right: 0,
+        height: compact ? 80 : 120,
+        background: isGuest
+          ? 'var(--bg-muted)'
+          : `linear-gradient(135deg, ${entityHsl('player', 0.18)}, ${entityHsl('player', 0.06)} 60%, ${entityHsl('event', 0.10)})`,
+        zIndex: 0,
+      }}/>
+
+      <div style={{
+        position:'relative', zIndex: 1,
+        padding: compact ? '20px 16px 14px' : '32px 32px 18px',
+        display:'flex', flexDirection: compact ? 'column' : 'row',
+        alignItems: compact ? 'center' : 'flex-end',
+        gap: compact ? 14 : 22,
+        textAlign: compact ? 'center' : 'left',
+      }}>
+        {/* Avatar */}
+        <div style={{
+          width: avatarSize, height: avatarSize,
+          borderRadius:'50%',
+          border: `3px solid ${entityHsl('player', 0.4)}`,
+          background: isGuest
+            ? 'var(--bg-muted)'
+            : `linear-gradient(135deg, hsl(${player.color}, 75%, 60%), hsl(${(player.color + 40) % 360}, 65%, 45%))`,
+          color: isGuest ? 'var(--text-muted)' : '#fff',
+          display:'flex', alignItems:'center', justifyContent:'center',
+          fontFamily:'var(--f-display)', fontWeight: 800,
+          fontSize: isGuest ? 44 : (compact ? 36 : 48),
+          flexShrink: 0,
+          boxShadow: isGuest ? 'none' : `0 8px 24px ${entityHsl('player', 0.35)}`,
+        }} aria-hidden="true">
+          {isGuest ? '👤' : player.initials}
+        </div>
+
+        <div style={{ flex: 1, minWidth: 0 }}>
+          {/* Badges row */}
+          <div style={{
+            display:'flex', alignItems:'center',
+            justifyContent: compact ? 'center' : 'flex-start',
+            gap: 6, flexWrap:'wrap', marginBottom: 8,
+          }}>
+            <span style={{
+              display:'inline-flex', alignItems:'center', gap: 5,
+              padding:'3px 9px', borderRadius:'var(--r-pill)',
+              background: entityHsl('player', 0.14), color: entityHsl('player'),
+              fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+              textTransform:'uppercase', letterSpacing:'.08em',
+            }}><span aria-hidden="true">👤</span>Player</span>
+            {isGuest ? (
+              <span style={{
+                padding:'3px 9px', borderRadius:'var(--r-pill)',
+                background:'var(--bg-muted)', color:'var(--text-sec)',
+                fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+                textTransform:'uppercase', letterSpacing:'.08em',
+              }}>Ospite</span>
+            ) : (
+              <span style={{
+                padding:'3px 9px', borderRadius:'var(--r-pill)',
+                background: entityHsl('toolkit', 0.14), color: entityHsl('toolkit'),
+                fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+                textTransform:'uppercase', letterSpacing:'.08em',
+              }}>● {player.badge || 'Attivo'}</span>
+            )}
+          </div>
+
+          {/* Name */}
+          <h1 style={{
+            fontFamily:'var(--f-display)', fontWeight: 800,
+            fontSize: compact ? 26 : 36, letterSpacing:'-.02em', lineHeight: 1.05,
+            color:'var(--text)', margin:'0 0 4px',
+          }}>{player.title}</h1>
+
+          {/* Handle + meta */}
+          <div style={{
+            fontFamily:'var(--f-mono)', fontSize: compact ? 11 : 12,
+            color:'var(--text-muted)', fontWeight: 600,
+            display:'flex', flexWrap:'wrap', gap:'2px 10px',
+            justifyContent: compact ? 'center' : 'flex-start',
+            marginBottom: 10,
+          }}>
+            {player.handle && <span>{player.handle}</span>}
+            {player.handle && (player.city || player.joinedAt) && <span aria-hidden="true">·</span>}
+            {player.city && <span>📍 {player.city}</span>}
+            {player.city && player.joinedAt && <span aria-hidden="true">·</span>}
+            {player.joinedAt && <span>Membro da {player.joinedAt}</span>}
+            {isGuest && <span>Aggiunto come ospite</span>}
+          </div>
+
+          {/* Top-line stats row */}
+          {!isGuest ? (
+            <div style={{
+              display:'flex', flexWrap:'wrap',
+              justifyContent: compact ? 'center' : 'flex-start',
+              gap: compact ? 10 : 18, marginBottom: 4,
+            }}>
+              <StatInline label="Partite" value={player.totalSessions} />
+              <StatInline label="Vittorie" value={player.totalWins} accent="toolkit" />
+              <StatInline label="Win rate" value={`${winRatePct}%`} accent="player" />
+              <StatInline label="Top" value={DS.byId[player.topGameId]?.title || '—'} accent="game" mono />
+            </div>
+          ) : (
+            <div style={{
+              display:'flex', flexWrap:'wrap',
+              justifyContent: compact ? 'center' : 'flex-start',
+              gap: compact ? 10 : 18, marginBottom: 4,
+            }}>
+              <StatInline label="Partite (con noi)" value={player.totalSessions} />
+              <StatInline label="Vittorie" value={player.totalWins} accent="toolkit" />
+              <StatInline label="Win rate" value={`${winRatePct}%`} accent="player" />
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Action bar */}
+      <div style={{
+        display:'flex', alignItems:'center', gap: 8,
+        padding: compact ? '10px 16px 14px' : '12px 32px 18px',
+        background:'var(--bg)',
+        flexWrap: compact ? 'wrap' : 'nowrap',
+        justifyContent: compact ? 'center' : 'flex-start',
+      }}>
+        {!isGuest ? (
+          <>
+            <button type="button" style={{
+              padding: compact ? '9px 14px' : '10px 18px', borderRadius:'var(--r-md)',
+              background: entityHsl('player'), color:'#fff', border:'none',
+              fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+              cursor:'pointer',
+              boxShadow:`0 4px 14px ${entityHsl('player', 0.4)}`,
+              display:'inline-flex', alignItems:'center', gap: 6,
+            }}><span aria-hidden="true">📊</span>Confronta</button>
+            <button type="button" style={{
+              padding: compact ? '9px 12px' : '10px 14px', borderRadius:'var(--r-md)',
+              background:'transparent', color:'var(--text)',
+              border:'1px solid var(--border-strong)',
+              fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700,
+              cursor:'pointer',
+            }}>✎ Modifica</button>
+            <button type="button" aria-label="Condividi profilo" style={{
+              padding: compact ? '9px 12px' : '10px 14px', borderRadius:'var(--r-md)',
+              background:'transparent', color:'var(--text)',
+              border:'1px solid var(--border-strong)',
+              fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700,
+              cursor:'pointer',
+            }}>↗</button>
+          </>
+        ) : (
+          <>
+            <button type="button" style={{
+              padding: compact ? '9px 14px' : '10px 18px', borderRadius:'var(--r-md)',
+              background: entityHsl('player'), color:'#fff', border:'none',
+              fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+              cursor:'pointer',
+              boxShadow:`0 4px 14px ${entityHsl('player', 0.4)}`,
+            }}>+ Invita su MeepleAI</button>
+            <button type="button" style={{
+              padding: compact ? '9px 12px' : '10px 14px', borderRadius:'var(--r-md)',
+              background:'transparent', color:'var(--text)',
+              border:'1px solid var(--border-strong)',
+              fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700,
+              cursor:'pointer',
+            }}>✎ Modifica</button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const StatInline = ({ label, value, accent, mono }) => (
+  <div style={{ display:'flex', flexDirection:'column', gap: 2 }}>
+    <span style={{
+      fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 800,
+    }}>{label}</span>
+    <span style={{
+      fontFamily: mono ? 'var(--f-mono)' : 'var(--f-display)',
+      fontSize: mono ? 14 : 18, fontWeight: 800,
+      color: accent ? entityHsl(accent) : 'var(--text)',
+      fontVariantNumeric:'tabular-nums', lineHeight: 1.1,
+    }}>{value}</span>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── PLAYER TABS ────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const PlayerTabs = ({ tabs, active, onChange, compact, locked }) => {
+  const refs = useRef({});
+  const [ind, setInd] = useState({ left: 0, width: 0 });
+  useEffect(() => {
+    const el = refs.current[active];
+    if (el) setInd({ left: el.offsetLeft, width: el.offsetWidth });
+  }, [active, tabs.length, compact]);
+
+  return (
+    <div className="mai-cb-scroll" style={{
+      position:'relative',
+      display:'flex', alignItems:'center', gap: 2,
+      borderBottom:'1px solid var(--border)',
+      overflowX:'auto', scrollbarWidth:'none',
+      padding: compact ? '0 16px' : '0 32px',
+      background:'var(--bg)',
+    }} role="tablist" aria-label="Sezioni profilo giocatore">
+      {tabs.map(t => {
+        const isActive = t.id === active;
+        const isLocked = locked && t.locked;
+        return (
+          <button
+            key={t.id}
+            type="button"
+            ref={el => { refs.current[t.id] = el; }}
+            onClick={() => !isLocked && onChange(t.id)}
+            role="tab"
+            aria-selected={isActive}
+            aria-controls={`panel-${t.id}`}
+            id={`tab-${t.id}`}
+            disabled={isLocked}
+            style={{
+              display:'inline-flex', alignItems:'center', gap: 7,
+              padding:'12px 14px', background:'transparent', border:'none',
+              color: isLocked ? 'var(--text-muted)' : (isActive ? entityHsl('player') : 'var(--text-sec)'),
+              fontFamily:'var(--f-display)', fontSize: 13,
+              fontWeight: isActive ? 800 : 700,
+              cursor: isLocked ? 'not-allowed' : 'pointer',
+              whiteSpace:'nowrap', flexShrink: 0,
+              transition:'color var(--dur-sm) var(--ease-out)',
+              opacity: isLocked ? 0.55 : 1,
+            }}>
+            <span aria-hidden="true">{t.icon}</span>
+            <span>{t.label}</span>
+            {t.count !== undefined && (
+              <span style={{
+                padding:'1px 7px', borderRadius:'var(--r-pill)',
+                background: isActive ? entityHsl('player') : 'var(--bg-muted)',
+                color: isActive ? '#fff' : 'var(--text-muted)',
+                fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+                fontVariantNumeric:'tabular-nums',
+              }}>{t.count}</span>
+            )}
+            {isLocked && <span aria-hidden="true" style={{ fontSize: 10 }}>🔒</span>}
+          </button>
+        );
+      })}
+      <span aria-hidden="true" style={{
+        position:'absolute', bottom: -1, left: ind.left, width: ind.width,
+        height: 2, background: entityHsl('player'),
+        transition:'left .3s cubic-bezier(.4,0,.2,1), width .3s cubic-bezier(.4,0,.2,1)',
+        borderRadius:'2px 2px 0 0',
+      }}/>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── KPI CARD (riuso da wave 1) ─────────────────────
+// ═══════════════════════════════════════════════════════
+const KpiCard = ({ label, value, unit, accent = 'player', icon, sub }) => (
+  <div style={{
+    padding: 14,
+    background:'var(--bg-card)', border:'1px solid var(--border)',
+    borderRadius:'var(--r-lg)',
+    display:'flex', flexDirection:'column', gap: 6,
+  }}>
+    <div style={{ display:'flex', alignItems:'center', gap: 6 }}>
+      <span aria-hidden="true" style={{
+        width: 24, height: 24, borderRadius:'var(--r-sm)',
+        background: entityHsl(accent, 0.14), color: entityHsl(accent),
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 12,
+      }}>{icon}</span>
+      <span style={{
+        fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+        textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 800,
+      }}>{label}</span>
+    </div>
+    <div style={{
+      fontFamily:'var(--f-display)', fontSize: 28, fontWeight: 800,
+      color:'var(--text)', fontVariantNumeric:'tabular-nums', lineHeight: 1,
+    }}>{value}<span style={{ fontSize: 13, color:'var(--text-muted)', fontWeight: 600, marginLeft: 4 }}>{unit}</span></div>
+    {sub && (
+      <div style={{
+        fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)', fontWeight: 600,
+      }}>{sub}</div>
+    )}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── TAB: OVERVIEW ──────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const TopGamesCard = () => (
+  <div style={{
+    background:'var(--bg-card)', border:'1px solid var(--border)',
+    borderRadius:'var(--r-lg)', padding: 18,
+  }}>
+    <div style={{
+      display:'flex', alignItems:'baseline', justifyContent:'space-between', marginBottom: 12,
+    }}>
+      <h3 style={{
+        fontFamily:'var(--f-display)', fontSize: 15, fontWeight: 800,
+        color:'var(--text)', margin: 0,
+      }}>Top giochi</h3>
+      <button type="button" style={{
+        padding:'4px 10px', borderRadius:'var(--r-sm)',
+        background:'transparent', border:'1px solid var(--border)',
+        color:'var(--text-sec)', fontSize: 11, fontWeight: 700,
+        fontFamily:'var(--f-display)', cursor:'pointer',
+      }}>Vedi tutti →</button>
+    </div>
+    <div style={{ display:'flex', flexDirection:'column', gap: 0 }}>
+      {PLAYER_TOP_GAMES.map((g, i) => {
+        const game = DS.byId[g.id];
+        if (!game) return null;
+        const wr = Math.round(g.winRate * 100);
+        return (
+          <div key={g.id} style={{
+            display:'flex', alignItems:'center', gap: 12,
+            padding:'10px 0',
+            borderBottom: i < PLAYER_TOP_GAMES.length - 1 ? '1px solid var(--border-light)' : 'none',
+          }}>
+            <span style={{
+              fontFamily:'var(--f-mono)', fontSize: 11, fontWeight: 800,
+              color: i === 0 ? entityHsl('agent') : 'var(--text-muted)',
+              width: 22, textAlign:'center',
+            }}>{i === 0 ? '🏆' : `#${i+1}`}</span>
+            <div style={{
+              width: 36, height: 44, borderRadius:'var(--r-sm)',
+              background: game.cover, flexShrink: 0,
+              display:'flex', alignItems:'center', justifyContent:'center',
+              fontSize: 18, color:'rgba(255,255,255,.92)',
+            }} aria-hidden="true">{game.coverEmoji}</div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{
+                fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800, color:'var(--text)',
+              }}>{game.title}</div>
+              <div style={{
+                fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)', fontWeight: 600,
+              }}>{g.plays} partite · {g.wins} vittorie</div>
+            </div>
+            <div style={{ display:'flex', flexDirection:'column', alignItems:'flex-end', minWidth: 56 }}>
+              <span style={{
+                fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800,
+                color: entityHsl('toolkit'), fontVariantNumeric:'tabular-nums', lineHeight: 1,
+              }}>{wr}%</span>
+              <span style={{
+                fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+                textTransform:'uppercase', letterSpacing:'.06em', fontWeight: 700, marginTop: 2,
+              }}>win rate</span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  </div>
+);
+
+const TrendCard = () => (
+  <div style={{
+    background:'var(--bg-card)', border:'1px solid var(--border)',
+    borderRadius:'var(--r-lg)', padding: 18,
+  }}>
+    <div style={{
+      display:'flex', alignItems:'baseline', justifyContent:'space-between', marginBottom: 14,
+    }}>
+      <h3 style={{
+        fontFamily:'var(--f-display)', fontSize: 15, fontWeight: 800, color:'var(--text)', margin: 0,
+      }}>Andamento ultimi 6 mesi</h3>
+      <span style={{
+        fontFamily:'var(--f-mono)', fontSize: 10, color: entityHsl('toolkit'), fontWeight: 700,
+      }}>↗ +12%</span>
+    </div>
+    {/* SVG line chart placeholder */}
+    <div style={{ width:'100%', height: 110, position:'relative' }}>
+      <svg viewBox="0 0 280 100" preserveAspectRatio="none" style={{ width:'100%', height:'100%' }} aria-hidden="true">
+        <defs>
+          <linearGradient id="trendg" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={entityHsl('player', 0.35)}/>
+            <stop offset="100%" stopColor={entityHsl('player', 0)}/>
+          </linearGradient>
+        </defs>
+        <path d="M0,75 L40,60 L80,68 L120,40 L160,52 L200,28 L240,32 L280,18 L280,100 L0,100 Z"
+          fill="url(#trendg)"/>
+        <path d="M0,75 L40,60 L80,68 L120,40 L160,52 L200,28 L240,32 L280,18"
+          fill="none" stroke={entityHsl('player')} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+        {[
+          [0,75],[40,60],[80,68],[120,40],[160,52],[200,28],[240,32],[280,18]
+        ].map(([x,y], i) => (
+          <circle key={i} cx={x} cy={y} r="3" fill="var(--bg-card)" stroke={entityHsl('player')} strokeWidth="2"/>
+        ))}
+      </svg>
+    </div>
+    <div style={{
+      display:'flex', justifyContent:'space-between', marginTop: 6,
+      fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)', fontWeight: 700,
+    }}>
+      <span>Ott</span><span>Nov</span><span>Dic</span><span>Gen</span><span>Feb</span><span>Mar</span>
+    </div>
+  </div>
+);
+
+const FavoriteAgentCard = () => {
+  const agent = DS.byId[PLAYER.favAgentId];
+  if (!agent) return null;
+  return (
+    <div style={{
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)', padding: 14,
+      display:'flex', alignItems:'center', gap: 12,
+    }}>
+      <div style={{
+        width: 44, height: 44, borderRadius:'var(--r-md)',
+        background: entityHsl('agent', 0.14), color: entityHsl('agent'),
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 22, flexShrink: 0,
+      }} aria-hidden="true">🤖</div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 800, marginBottom: 2,
+        }}>Agente preferito</div>
+        <div style={{
+          fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800, color:'var(--text)',
+        }}>{agent.title}</div>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)', fontWeight: 600,
+        }}>{agent.invocations} invocazioni · {agent.avgLatency}</div>
+      </div>
+      <button type="button" aria-label="Apri agente" style={{
+        padding:'6px 10px', borderRadius:'var(--r-md)',
+        background:'transparent', border:'1px solid var(--border)',
+        color: entityHsl('agent'), fontFamily:'var(--f-display)',
+        fontSize: 11, fontWeight: 800, cursor:'pointer',
+      }}>↗</button>
+    </div>
+  );
+};
+
+const OverviewTab = ({ player }) => (
+  <div style={{ display:'flex', flexDirection:'column', gap: 14 }}>
+    {player.bio && (
+      <div style={{
+        background:'var(--bg-card)', border:'1px solid var(--border)',
+        borderRadius:'var(--r-lg)', padding: 16,
+      }}>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 800, marginBottom: 6,
+        }}>Bio</div>
+        <p style={{
+          fontSize: 13.5, color:'var(--text)', lineHeight: 1.6, margin: 0,
+        }}>{player.bio}</p>
+      </div>
+    )}
+    <div style={{
+      display:'grid', gridTemplateColumns:'repeat(auto-fit, minmax(150px, 1fr))', gap: 10,
+    }}>
+      <KpiCard label="Partite" value={player.totalSessions} unit="" accent="session" icon="🎯"/>
+      <KpiCard label="Vittorie" value={player.totalWins} unit="" accent="toolkit" icon="🏆"/>
+      <KpiCard label="Win rate" value={Math.round(player.winRate * 100)} unit="%" accent="player" icon="📈"/>
+      <KpiCard label="Streak" value="3" unit="W" accent="event" icon="🔥" sub="3 vittorie consecutive"/>
+    </div>
+    {!player.guest && <FavoriteAgentCard/>}
+    <TopGamesCard/>
+    {!player.guest && <TrendCard/>}
+  </div>
+);
+
+const OverviewEmpty = ({ player }) => (
+  <div style={{
+    padding:'40px 24px', textAlign:'center',
+    background:'var(--bg-card)',
+    border:'1px dashed var(--border-strong)',
+    borderRadius:'var(--r-xl)',
+    display:'flex', flexDirection:'column', alignItems:'center',
+  }}>
+    <div style={{
+      width: 64, height: 64, borderRadius:'50%',
+      background: entityHsl('player', 0.12), color: entityHsl('player'),
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 28, marginBottom: 14,
+    }} aria-hidden="true">🎯</div>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800,
+      color:'var(--text)', margin:'0 0 6px',
+    }}>Nessuna partita ancora</h3>
+    <p style={{
+      fontSize: 12.5, color:'var(--text-muted)', maxWidth: 360,
+      margin:'0 0 16px', lineHeight: 1.55,
+    }}>{player.title} non ha ancora partite registrate. Aggiungine una per vedere stats e trend.</p>
+    <button type="button" style={{
+      padding:'10px 18px', borderRadius:'var(--r-md)',
+      background: entityHsl('session'), color:'#fff', border:'none',
+      fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+      cursor:'pointer',
+      boxShadow:`0 4px 14px ${entityHsl('session', 0.35)}`,
+    }}>+ Aggiungi prima partita</button>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── TAB: SESSIONS ──────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const SessionItem = ({ s }) => {
+  const game = DS.byId[s.gameId];
+  const wonChip = s.won === true
+    ? { label:'🏆 Vittoria', color: entityHsl('toolkit') }
+    : s.won === false
+      ? { label:'Sconfitta', color: 'var(--text-muted)' }
+      : { label:'In corso', color: entityHsl('session') };
+  return (
+    <article tabIndex={0} className="mai-card-row" style={{
+      display:'flex', alignItems:'center', gap: 14, padding: 14,
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)', cursor:'pointer',
+    }}>
+      <div style={{
+        width: 44, height: 54, borderRadius:'var(--r-sm)',
+        background: game?.cover || entityHsl('session', 0.2), flexShrink: 0,
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 22, color:'rgba(255,255,255,.92)',
+      }} aria-hidden="true">{game?.coverEmoji || '🎯'}</div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{
+          display:'flex', alignItems:'baseline', gap: 8, flexWrap:'wrap', marginBottom: 3,
+        }}>
+          <h4 style={{
+            fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800,
+            color:'var(--text)', margin: 0,
+          }}>{s.title}</h4>
+          <span style={{
+            padding:'1px 7px', borderRadius:'var(--r-pill)',
+            background: s.won === true ? entityHsl('toolkit', 0.14)
+              : s.won === false ? 'var(--bg-muted)'
+              : entityHsl('session', 0.14),
+            color: wonChip.color,
+            fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+            textTransform:'uppercase', letterSpacing:'.06em',
+          }}>{wonChip.label}</span>
+        </div>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)', fontWeight: 600,
+          display:'flex', flexWrap:'wrap', gap:'2px 10px',
+        }}>
+          <span>{s.date}</span>
+          <span aria-hidden="true">·</span>
+          <span>{s.duration}</span>
+          <span aria-hidden="true">·</span>
+          <span>{s.score} pt</span>
+        </div>
+      </div>
+      <div style={{ display:'flex', alignItems:'center' }}>
+        {(s.playerIds || []).slice(0, 4).map((pid, i) => {
+          const p = DS.byId[pid];
+          return (
+            <div key={pid} style={{
+              width: 26, height: 26, borderRadius:'50%',
+              background: `hsl(${p?.color || 200}, 60%, 55%)`,
+              color:'#fff',
+              display:'inline-flex', alignItems:'center', justifyContent:'center',
+              fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 9,
+              border:'2px solid var(--bg-card)', marginLeft: i === 0 ? 0 : -8,
+              zIndex: 4 - i, flexShrink: 0,
+            }}>{p?.initials || '?'}</div>
+          );
+        })}
+      </div>
+    </article>
+  );
+};
+
+const SessionsTab = ({ player }) => {
+  const [filter, setFilter] = useState('all');
+  const filtered = filter === 'all' ? PLAYER_SESSIONS
+    : filter === 'wins' ? PLAYER_SESSIONS.filter(s => s.won === true)
+    : PLAYER_SESSIONS.filter(s => s.won === false);
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap: 12 }}>
+      <div style={{ display:'flex', gap: 6, flexWrap:'wrap' }}>
+        {[
+          { id:'all', label:'Tutte', n: PLAYER_SESSIONS.length },
+          { id:'wins', label:'Vinte', n: PLAYER_SESSIONS.filter(s => s.won === true).length },
+          { id:'losses', label:'Perse', n: PLAYER_SESSIONS.filter(s => s.won === false).length },
+        ].map(f => (
+          <button key={f.id} type="button" onClick={() => setFilter(f.id)} style={{
+            padding:'6px 12px', borderRadius:'var(--r-pill)',
+            background: filter === f.id ? entityHsl('session') : 'var(--bg-muted)',
+            color: filter === f.id ? '#fff' : 'var(--text-sec)',
+            border: filter === f.id ? 'none' : '1px solid var(--border)',
+            fontFamily:'var(--f-display)', fontSize: 11, fontWeight: 700,
+            cursor:'pointer',
+          }}>{f.label} <span style={{ fontFamily:'var(--f-mono)', opacity: 0.7 }}>{f.n}</span></button>
+        ))}
+      </div>
+      {filtered.map(s => <SessionItem key={s.id} s={s}/>)}
+    </div>
+  );
+};
+
+const SessionsEmpty = () => (
+  <div style={{
+    padding:'40px 24px', textAlign:'center',
+    background:'var(--bg-card)', border:'1px dashed var(--border-strong)',
+    borderRadius:'var(--r-xl)',
+    display:'flex', flexDirection:'column', alignItems:'center',
+  }}>
+    <div style={{
+      width: 60, height: 60, borderRadius:'50%',
+      background: entityHsl('session', 0.12), color: entityHsl('session'),
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 28, marginBottom: 12,
+    }} aria-hidden="true">🎯</div>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: 15, fontWeight: 800,
+      color:'var(--text)', margin:'0 0 4px',
+    }}>Nessuna partita registrata</h3>
+    <p style={{ fontSize: 12.5, color:'var(--text-muted)', margin:'0 0 14px', maxWidth: 340 }}>
+      Aggiungi la prima partita per iniziare a tracciare stats e win rate.
+    </p>
+    <button type="button" style={{
+      padding:'8px 16px', borderRadius:'var(--r-md)',
+      background: entityHsl('session'), color:'#fff', border:'none',
+      fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer',
+      boxShadow:`0 3px 10px ${entityHsl('session', 0.35)}`,
+    }}>+ Aggiungi partita</button>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── TAB: GAMES (registered only) ───────────────────
+// ═══════════════════════════════════════════════════════
+const GameCompactCard = ({ gameId, plays, wins }) => {
+  const game = DS.byId[gameId];
+  if (!game) return null;
+  return (
+    <article tabIndex={0} className="mai-card-row" style={{
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)', cursor:'pointer', overflow:'hidden',
+      display:'flex', flexDirection:'column',
+    }}>
+      <div style={{
+        height: 96, background: game.cover, position:'relative',
+        display:'flex', alignItems:'center', justifyContent:'center',
+      }}>
+        <span aria-hidden="true" style={{ fontSize: 44, opacity: 0.92 }}>{game.coverEmoji}</span>
+      </div>
+      <div style={{ padding: 12 }}>
+        <h4 style={{
+          fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+          color:'var(--text)', margin:'0 0 4px',
+        }}>{game.title}</h4>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)', fontWeight: 600,
+          marginBottom: 6,
+        }}>{game.year} · {game.players} pl</div>
+        <div style={{ display:'flex', gap: 6 }}>
+          <span style={{
+            padding:'2px 7px', borderRadius:'var(--r-pill)',
+            background: entityHsl('session', 0.12), color: entityHsl('session'),
+            fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+          }}>{plays} giocate</span>
+          <span style={{
+            padding:'2px 7px', borderRadius:'var(--r-pill)',
+            background: entityHsl('toolkit', 0.12), color: entityHsl('toolkit'),
+            fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+          }}>{wins} vinte</span>
+        </div>
+      </div>
+    </article>
+  );
+};
+
+const GamesTab = () => (
+  <div style={{ display:'flex', flexDirection:'column', gap: 12 }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      fontWeight: 700, letterSpacing:'.04em',
+    }}>{PLAYER_TOP_GAMES.length} giochi nella collection</div>
+    <div style={{
+      display:'grid',
+      gridTemplateColumns:'repeat(auto-fill, minmax(180px, 1fr))', gap: 12,
+    }}>
+      {PLAYER_TOP_GAMES.map(g => <GameCompactCard key={g.id} gameId={g.id} plays={g.plays} wins={g.wins}/>)}
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── TAB: TOOLKITS ──────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const ToolkitItem = ({ tk }) => {
+  const game = DS.byId[tk.gameId];
+  return (
+    <article tabIndex={0} className="mai-card-row" style={{
+      display:'flex', alignItems:'center', gap: 14, padding: 14,
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)', cursor:'pointer',
+    }}>
+      <div style={{
+        width: 44, height: 44, borderRadius:'var(--r-md)',
+        background: entityHsl('toolkit', 0.14), color: entityHsl('toolkit'),
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 22, flexShrink: 0,
+      }} aria-hidden="true">🧰</div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{
+          display:'flex', alignItems:'baseline', gap: 8, flexWrap:'wrap', marginBottom: 3,
+        }}>
+          <h4 style={{
+            fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800,
+            color:'var(--text)', margin: 0,
+          }}>{tk.title}</h4>
+          <span style={{
+            padding:'1px 7px', borderRadius:'var(--r-pill)',
+            background: entityHsl('toolkit', 0.14), color: entityHsl('toolkit'),
+            fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+            textTransform:'uppercase', letterSpacing:'.06em',
+          }}>v{tk.version} · {tk.badge}</span>
+        </div>
+        <div style={{
+          display:'flex', gap: 6, flexWrap:'wrap', marginTop: 4,
+        }}>
+          {game && <EntityChip type="game" label={game.title} icon="🎲"/>}
+          <EntityChip type="tool" label={`${tk.toolCount} strumenti`} icon="🔧"/>
+          <EntityChip type="session" label={`${tk.useCount} usi`} icon="🎯"/>
+        </div>
+      </div>
+      <button type="button" aria-label="Apri toolkit" style={{
+        padding:'6px 12px', borderRadius:'var(--r-md)',
+        background:'transparent', border:'1px solid var(--border)',
+        color: entityHsl('toolkit'),
+        fontFamily:'var(--f-display)', fontSize: 11, fontWeight: 800, cursor:'pointer',
+      }}>Apri ↗</button>
+    </article>
+  );
+};
+
+const ToolkitsTab = () => (
+  <div style={{ display:'flex', flexDirection:'column', gap: 10 }}>
+    <div style={{
+      display:'flex', alignItems:'center', justifyContent:'space-between',
+    }}>
+      <div style={{
+        fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+        fontWeight: 700, letterSpacing:'.04em',
+      }}>{PLAYER_TOOLKITS.length} toolkit pubblicati</div>
+      <button type="button" style={{
+        padding:'8px 14px', borderRadius:'var(--r-md)',
+        background: entityHsl('toolkit'), color:'#fff', border:'none',
+        fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800,
+        cursor:'pointer',
+        boxShadow:`0 3px 10px ${entityHsl('toolkit', 0.35)}`,
+      }}>+ Nuovo toolkit</button>
+    </div>
+    {PLAYER_TOOLKITS.map(tk => <ToolkitItem key={tk.id} tk={tk}/>)}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── TAB: ACHIEVEMENTS ──────────────────────────────
+// ═══════════════════════════════════════════════════════
+const AchievementBadge = ({ a }) => (
+  <div style={{
+    padding: 12, textAlign:'center',
+    background: a.unlocked ? 'var(--bg-card)' : 'var(--bg-muted)',
+    border: `1px solid ${a.unlocked ? entityHsl('event', 0.3) : 'var(--border-light)'}`,
+    borderRadius:'var(--r-lg)',
+    opacity: a.unlocked ? 1 : 0.55,
+    display:'flex', flexDirection:'column', gap: 4, alignItems:'center',
+  }}>
+    <div style={{
+      width: 48, height: 48, borderRadius:'50%',
+      background: a.unlocked
+        ? `linear-gradient(135deg, ${entityHsl('event', 0.25)}, ${entityHsl('event', 0.4)})`
+        : 'var(--bg-sunken)',
+      color: a.unlocked ? '#fff' : 'var(--text-muted)',
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 22, marginBottom: 4,
+      boxShadow: a.unlocked ? `0 4px 12px ${entityHsl('event', 0.3)}` : 'none',
+      filter: a.unlocked ? 'none' : 'grayscale(0.8)',
+    }} aria-hidden="true">{a.unlocked ? a.icon : '🔒'}</div>
+    <div style={{
+      fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800,
+      color: a.unlocked ? 'var(--text)' : 'var(--text-muted)',
+    }}>{a.title}</div>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+      lineHeight: 1.3,
+    }}>{a.sub}</div>
+    {a.unlocked && a.date && (
+      <div style={{
+        fontFamily:'var(--f-mono)', fontSize: 9, color: entityHsl('event'),
+        fontWeight: 700, marginTop: 2,
+      }}>✓ {a.date}</div>
+    )}
+  </div>
+);
+
+const AchievementsTab = ({ guest }) => {
+  const list = guest ? ACHIEVEMENTS.slice(0, 4) : ACHIEVEMENTS;
+  const unlocked = list.filter(a => a.unlocked).length;
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap: 12 }}>
+      <div style={{
+        display:'flex', justifyContent:'space-between', alignItems:'baseline',
+      }}>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          fontWeight: 700, letterSpacing:'.04em',
+        }}>{unlocked} / {list.length} sbloccati</div>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color: entityHsl('event'), fontWeight: 700,
+        }}>{Math.round((unlocked/list.length)*100)}% completato</div>
+      </div>
+      <div style={{
+        height: 6, borderRadius:'var(--r-pill)', background:'var(--bg-muted)', overflow:'hidden',
+      }}>
+        <div style={{
+          height:'100%', width: `${(unlocked/list.length)*100}%`,
+          background:`linear-gradient(90deg, ${entityHsl('event')}, ${entityHsl('player')})`,
+          borderRadius:'var(--r-pill)',
+        }}/>
+      </div>
+      <div style={{
+        display:'grid',
+        gridTemplateColumns:'repeat(auto-fill, minmax(140px, 1fr))', gap: 10,
+      }}>
+        {list.map(a => <AchievementBadge key={a.id} a={a}/>)}
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── ERROR / LOADING ────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const TabSkeleton = () => (
+  <div style={{ display:'flex', flexDirection:'column', gap: 10 }}>
+    {[0,1,2,3].map(i => (
+      <div key={i} className="mai-shimmer" style={{
+        height: 76, borderRadius:'var(--r-lg)', background:'var(--bg-muted)',
+      }}/>
+    ))}
+  </div>
+);
+
+const TabError = ({ onRetry }) => (
+  <div style={{
+    padding:'32px 24px', textAlign:'center',
+    background:'hsl(var(--c-danger) / .08)',
+    border:'1px solid hsl(var(--c-danger) / .3)',
+    borderRadius:'var(--r-xl)',
+    display:'flex', flexDirection:'column', alignItems:'center',
+  }}>
+    <div style={{
+      width: 48, height: 48, borderRadius:'50%',
+      background:'hsl(var(--c-danger) / .15)', color:'hsl(var(--c-danger))',
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 22, marginBottom: 10,
+    }} aria-hidden="true">⚠</div>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800,
+      color:'var(--text)', margin:'0 0 4px',
+    }}>Errore caricamento profilo</h3>
+    <p style={{ fontSize: 12, color:'var(--text-muted)', margin:'0 0 12px', maxWidth: 320 }}>
+      Impossibile recuperare i dati del giocatore. Verifica la connessione.
+    </p>
+    <button type="button" onClick={onRetry} style={{
+      padding:'7px 14px', borderRadius:'var(--r-md)',
+      background:'hsl(var(--c-danger))', color:'#fff', border:'none',
+      fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer',
+    }}>↻ Riprova</button>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── BODY ───────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const PlayerDetailBody = ({ stateOverride, variant = 'registered', compact, initialTab = 'overview' }) => {
+  const [tab, setTab] = useState(initialTab);
+  const isLoading = stateOverride === 'loading';
+  const isError = stateOverride === 'error';
+  const isEmpty = stateOverride === 'empty';
+  const player = variant === 'guest' ? GUEST_PLAYER : PLAYER;
+  const isGuest = player.guest;
+
+  const tabs = [
+    { id:'overview', icon:'📋', label:'Overview' },
+    { id:'sessions', icon:'🎯', label:'Partite', count: PLAYER_SESSIONS.length },
+    { id:'games', icon:'🎲', label:'Giochi', count: PLAYER_TOP_GAMES.length, locked: isGuest },
+    { id:'toolkits', icon:'🧰', label:'Toolkit', count: PLAYER_TOOLKITS.length, locked: isGuest },
+    { id:'achievements', icon:'🏆', label:'Achievement', count: isGuest ? 4 : ACHIEVEMENTS.filter(a=>a.unlocked).length },
+  ];
+
+  // Connection bar — 6 pip per brief
+  const connections = isGuest ? [
+    { entityType:'game', count: 2, label:'Top giochi' },
+    { entityType:'session', count: 4, label:'Partite' },
+    { entityType:'event', count: 1, label:'Game Nights' },
+    { entityType:'agent', count: 0, label:'Agenti usati', isEmpty: true },
+    { entityType:'toolkit', count: 0, label:'Toolkit', isEmpty: true },
+    { entityType:'chat', count: 0, label:'Chat', isEmpty: true },
+  ] : [
+    { entityType:'game', count: 5, label:'Top giochi' },
+    { entityType:'session', count: 23, label:'Partite' },
+    { entityType:'event', count: 4, label:'Game Nights' },
+    { entityType:'agent', count: 0, label:'Agenti usati', isEmpty: true },
+    { entityType:'toolkit', count: 1, label:'Toolkit' },
+    { entityType:'chat', count: 12, label:'Chat' },
+  ];
+
+  const renderTab = () => {
+    if (isLoading) return <TabSkeleton/>;
+    if (isError) return <TabError/>;
+    if (isEmpty) return <OverviewEmpty player={player}/>;
+
+    if (isGuest && (tab === 'games' || tab === 'toolkits')) {
+      return (
+        <div style={{
+          padding:'40px 24px', textAlign:'center',
+          background:'var(--bg-card)',
+          border:'1px dashed var(--border-strong)',
+          borderRadius:'var(--r-xl)',
+          display:'flex', flexDirection:'column', alignItems:'center',
+        }}>
+          <div style={{
+            width: 60, height: 60, borderRadius:'50%',
+            background:'var(--bg-muted)', color:'var(--text-muted)',
+            display:'flex', alignItems:'center', justifyContent:'center',
+            fontSize: 28, marginBottom: 12,
+          }} aria-hidden="true">🔒</div>
+          <h3 style={{
+            fontFamily:'var(--f-display)', fontSize: 15, fontWeight: 800,
+            color:'var(--text)', margin:'0 0 4px',
+          }}>Sezione non disponibile per ospiti</h3>
+          <p style={{ fontSize: 12.5, color:'var(--text-muted)', margin:'0 0 14px', maxWidth: 340 }}>
+            Collection e toolkit sono disponibili solo per giocatori registrati su MeepleAI.
+          </p>
+          <button type="button" style={{
+            padding:'8px 16px', borderRadius:'var(--r-md)',
+            background: entityHsl('player'), color:'#fff', border:'none',
+            fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer',
+          }}>+ Invita {player.title.split(' ')[0]} su MeepleAI</button>
+        </div>
+      );
+    }
+
+    if (tab === 'overview') return <OverviewTab player={player}/>;
+    if (tab === 'sessions') return <SessionsTab player={player}/>;
+    if (tab === 'games') return <GamesTab/>;
+    if (tab === 'toolkits') return <ToolkitsTab/>;
+    if (tab === 'achievements') return <AchievementsTab guest={isGuest}/>;
+    return null;
+  };
+
+  return (
+    <>
+      <PlayerHero player={player} compact={compact} loading={isLoading}/>
+      <div style={{
+        padding: compact ? '0 16px' : '0 32px',
+        background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+        borderBottom:'1px solid var(--border-light)',
+        position:'sticky', top: 0, zIndex: 8,
+      }}>
+        <ConnectionBar connections={connections} loading={isLoading}/>
+      </div>
+      <div style={{ position:'sticky', top: 45, zIndex: 7,
+        background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+      }}>
+        <PlayerTabs tabs={tabs} active={tab} onChange={setTab} compact={compact} locked={isGuest}/>
+      </div>
+      <div role="tabpanel" id={`panel-${tab}`} aria-labelledby={`tab-${tab}`} style={{
+        padding: compact ? '14px 16px 32px' : '20px 32px 64px',
+      }}>
+        {renderTab()}
+      </div>
+    </>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── SHELLS ─────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const DesktopNav = ({ player }) => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 14,
+    padding:'10px 32px',
+    background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+    borderBottom:'1px solid var(--border)',
+  }}>
+    <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
+      <div style={{
+        width: 26, height: 26, borderRadius: 7,
+        background:'linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event)))',
+        color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+        fontWeight: 800, fontSize: 13, fontFamily:'var(--f-display)',
+      }}>M</div>
+      <span style={{ fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 14 }}>MeepleAI</span>
+    </div>
+    <div style={{
+      flex: 1, fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      marginLeft: 22,
+    }}>
+      <a href="#" style={{ color:'inherit' }}>Giocatori</a>
+      <span aria-hidden="true"> / </span>
+      <strong style={{ color:'var(--text-sec)' }}>{player.title}</strong>
+    </div>
+  </div>
+);
+
+const DesktopScreen = ({ stateOverride, variant, initialTab }) => {
+  const player = variant === 'guest' ? GUEST_PLAYER : PLAYER;
+  return (
+    <div style={{ minHeight: 720, background:'var(--bg)' }}>
+      <DesktopNav player={player}/>
+      <PlayerDetailBody stateOverride={stateOverride} variant={variant} initialTab={initialTab}/>
+    </div>
+  );
+};
+
+const PhoneSbar = () => (
+  <div className="phone-sbar" style={{ color:'var(--text)' }}>
+    <span style={{ fontFamily:'var(--f-mono)' }}>14:32</span>
+    <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+  </div>
+);
+const PhoneTopNav = ({ player }) => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 9,
+    padding:'10px 14px', background:'var(--glass-bg)',
+    backdropFilter:'blur(12px)',
+    borderBottom:'1px solid var(--border-light)',
+    position:'sticky', top: 0, zIndex: 9,
+  }}>
+    <button aria-label="Indietro" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      color:'var(--text)', fontSize: 14, cursor:'pointer',
+    }}>←</button>
+    <div style={{
+      flex: 1, fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+      textAlign:'center', fontWeight: 700,
+    }}>players / {player.id.replace('p-', '')}</div>
+    <button aria-label="Più opzioni" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      color:'var(--text)', fontSize: 14, cursor:'pointer',
+    }}>⋯</button>
+  </div>
+);
+const MobileScreen = ({ stateOverride, variant, initialTab }) => {
+  const player = variant === 'guest' ? GUEST_PLAYER : PLAYER;
+  return (
+    <>
+      <PhoneSbar/>
+      <div style={{ flex: 1, overflowY:'auto', position:'relative', background:'var(--bg)' }}>
+        <PhoneTopNav player={player}/>
+        <PlayerDetailBody stateOverride={stateOverride} variant={variant} compact initialTab={initialTab}/>
+      </div>
+    </>
+  );
+};
+
+const PhoneShell = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 10 }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div className="phone">{children}</div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 340,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+const DesktopFrame = ({ label, desc, children }) => {
+  const player = (children?.props?.variant === 'guest') ? GUEST_PLAYER : PLAYER;
+  return (
+    <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 12, width:'100%' }}>
+      <div style={{
+        fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+        textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+      }}>{label}</div>
+      <div style={{
+        width:'100%', maxWidth: 1440,
+        borderRadius:'var(--r-xl)', border:'1px solid var(--border)',
+        background:'var(--bg)', overflow:'hidden',
+        boxShadow:'var(--shadow-lg)',
+      }}>
+        <div style={{
+          display:'flex', alignItems:'center', gap: 8,
+          padding:'9px 14px', background:'var(--bg-muted)',
+          borderBottom:'1px solid var(--border)',
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+        }}>
+          <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-event))' }}/>
+          <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-warning))' }}/>
+          <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-toolkit))' }}/>
+          <span style={{ flex: 1, textAlign:'center', letterSpacing:'.04em' }}>meepleai.app/players/{player.id.replace('p-', '')}</span>
+        </div>
+        {children}
+      </div>
+      {desc && <div style={{
+        fontSize: 11, color:'var(--text-muted)', maxWidth: 720,
+        textAlign:'center', lineHeight: 1.55,
+      }}>{desc}</div>}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── ROOT ───────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const MOBILE_STATES = [
+  { id:'m1', stateOverride:null, variant:'registered', tab:'overview',
+    label:'01 · Registered · Overview',
+    desc:'Hero compatto + avatar gradient 96px + 6 ConnectionPip (agent empty dashed). Bio + 4 KPI + agente preferito + top games + trend.' },
+  { id:'m2', stateOverride:null, variant:'registered', tab:'sessions',
+    label:'02 · Registered · Sessions',
+    desc:'Filter chips Tutte/Vinte/Perse. Card sessione con cover gioco, vittoria/sconfitta chip semantico, avatar stack giocatori.' },
+  { id:'m3', stateOverride:null, variant:'registered', tab:'achievements',
+    label:'03 · Registered · Achievements',
+    desc:'Progress bar gradient event→player. Grid 2-col badge unlocked colorati / locked grayscale con data sblocco mono.' },
+  { id:'m4', stateOverride:null, variant:'guest', tab:'overview',
+    label:'04 · Guest · Overview',
+    desc:'No avatar gradient (placeholder 👤), pill "Ospite" neutrale, no agente preferito, no trend, tabs Giochi+Toolkit locked 🔒.' },
+  { id:'m5', stateOverride:'empty', variant:'registered', tab:'overview',
+    label:'05 · Empty (player nuovo)',
+    desc:'Player appena creato. Tab Overview mostra empty state con CTA "+ Aggiungi prima partita" entity=session.' },
+  { id:'m6', stateOverride:'loading', variant:'registered', tab:'overview',
+    label:'06 · Loading',
+    desc:'Hero shimmer 96px + ConnectionBar shimmer 6 pip + tabs senza count + skeleton 4 card body.' },
+  { id:'m7', stateOverride:'error', variant:'registered', tab:'overview',
+    label:'07 · Error',
+    desc:'Hero renderizzato comunque (cache locale), tab body mostra TabError con CTA "↻ Riprova".' },
+];
+
+const App = () => {
+  const [theme, setTheme] = useState(() => {
+    const saved = localStorage.getItem('mai-theme');
+    if (saved) return saved;
+    return document.documentElement.getAttribute('data-theme') || 'light';
+  });
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('mai-theme', theme);
+  }, [theme]);
+
+  return (
+    <div style={{
+      minHeight:'100vh', background:'var(--bg)', color:'var(--text)',
+      padding:'24px 24px 80px',
+    }}>
+      {/* Header */}
+      <header style={{
+        maxWidth: 1440, margin:'0 auto 32px',
+        display:'flex', alignItems:'center', gap: 12, flexWrap:'wrap',
+      }}>
+        <div style={{
+          display:'flex', alignItems:'center', gap: 9,
+        }}>
+          <div style={{
+            width: 32, height: 32, borderRadius: 8,
+            background:'linear-gradient(135deg, hsl(var(--c-player)), hsl(var(--c-event)))',
+            color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+            fontWeight: 800, fontFamily:'var(--f-display)',
+          }}>D</div>
+          <div>
+            <div style={{ fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 16 }}>SP4 wave 3 · D</div>
+            <div style={{ fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)' }}>
+              /players/[id] — Player detail (character sheet)
+            </div>
+          </div>
+        </div>
+        <div style={{ flex: 1 }}/>
+        <button type="button" onClick={() => setTheme(t => t === 'light' ? 'dark' : 'light')}
+          style={{
+            padding:'8px 14px', borderRadius:'var(--r-md)',
+            background:'var(--bg-card)', border:'1px solid var(--border)',
+            color:'var(--text)', fontFamily:'var(--f-display)',
+            fontSize: 12, fontWeight: 800, cursor:'pointer',
+          }}>🌗 {theme === 'light' ? 'Light' : 'Dark'}</button>
+      </header>
+
+      {/* Desktop variants */}
+      <section style={{ maxWidth: 1440, margin:'0 auto', display:'flex', flexDirection:'column', gap: 32 }}>
+        <DesktopFrame label="Desktop · 01 · Registered · Overview"
+          desc="Hero 128px avatar gradient + nome 36 + handle/città/membro mono + 4 stat top-line + ConnectionBar 6 pip sticky + tabs animated underline + body 2-col grid (KPI top, agente preferito, top games leaderboard, trend chart).">
+          <DesktopScreen variant="registered" initialTab="overview"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 02 · Registered · Sessions"
+          desc="Tab sessioni con filter chips (Tutte / Vinte / Perse). Card list-variant con cover game 44×54 + win/loss chip semantico (toolkit verde / muted) + avatar stack.">
+          <DesktopScreen variant="registered" initialTab="sessions"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 03 · Registered · Games"
+          desc="Collection grid responsive (auto-fill 180px). Card compact: cover 96px + nome + meta + chip plays/wins.">
+          <DesktopScreen variant="registered" initialTab="games"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 04 · Registered · Achievements"
+          desc="Progress bar gradient event→player. Grid badge: unlocked colorati con data sblocco mono / locked grayscale + 🔒.">
+          <DesktopScreen variant="registered" initialTab="achievements"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 05 · Guest player"
+          desc="No avatar gradient → placeholder 👤. Pill 'Ospite' neutrale (no badge attivo). No agente preferito, no trend, tab Giochi+Toolkit locked. ConnectionPip agent/toolkit/chat in stato empty (dashed).">
+          <DesktopScreen variant="guest" initialTab="overview"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 06 · Empty (player nuovo)"
+          desc="Hero renderizzato (player appena creato), Overview tab body mostra empty illustration + CTA '+ Aggiungi prima partita' entity=session.">
+          <DesktopScreen variant="registered" initialTab="overview" stateOverride="empty"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 07 · Loading"
+          desc="Hero skeleton avatar 128 round + 3 lines shimmer. ConnectionBar 6 pip shimmer. Tabs visibili senza count. Body 4 card skeleton.">
+          <DesktopScreen variant="registered" initialTab="overview" stateOverride="loading"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 08 · Error"
+          desc="Tab body TabError pattern: alert danger sfumato + icona ⚠ + CTA '↻ Riprova'. Hero e ConnectionBar rimangono renderizzati per non perdere contesto.">
+          <DesktopScreen variant="registered" initialTab="overview" stateOverride="error"/>
+        </DesktopFrame>
+      </section>
+
+      {/* Mobile variants */}
+      <section style={{ maxWidth: 1440, margin:'48px auto 0' }}>
+        <h2 style={{
+          fontFamily:'var(--f-display)', fontSize: 22, fontWeight: 800,
+          marginBottom: 8,
+        }}>Mobile · 375px</h2>
+        <p style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-muted)', marginBottom: 24,
+        }}>7 stati: registered (overview, sessions, achievements) · guest · empty · loading · error</p>
+        <div style={{
+          display:'flex', flexWrap:'wrap', gap: 32, justifyContent:'center',
+        }}>
+          {MOBILE_STATES.map(m => (
+            <PhoneShell key={m.id} label={m.label} desc={m.desc}>
+              <MobileScreen stateOverride={m.stateOverride} variant={m.variant} initialTab={m.tab}/>
+            </PhoneShell>
+          ))}
+        </div>
+      </section>
+
+      {/* DoD checklist */}
+      <section style={{
+        maxWidth: 900, margin:'64px auto 0',
+        padding: 24, borderRadius:'var(--r-xl)',
+        background:'var(--bg-card)', border:'1px solid var(--border)',
+      }}>
+        <h2 style={{
+          fontFamily:'var(--f-display)', fontSize: 18, fontWeight: 800, marginBottom: 12,
+        }}>Definition of Done · D player-detail</h2>
+        <ul style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-sec)',
+          lineHeight: 1.9, listStyle:'none', padding: 0, margin: 0,
+        }}>
+          <li>✓ Solo CSS variables da tokens.css (zero hex hardcoded)</li>
+          <li>✓ Helper entityHsl(type, alpha) inline per i 9 entity color</li>
+          <li>✓ Light + dark mode entrambi funzionanti (toggle in header)</li>
+          <li>✓ Mobile 375px (7 phone shells) + Desktop 1440px (8 frame)</li>
+          <li>✓ ConnectionBar 1:1 prod: borderRadius 999, bg entityHsl(.1), dashed+Plus empty, aria-label `${'`'}${'${label}'}: ${'${count}'}${'`'}</li>
+          <li>✓ EntityChip per ogni cross-reference (Sessions giocate, Top giochi, Toolkits creati, Agenti)</li>
+          <li>✓ Tabs animated underline (riuso wave 1 pattern)</li>
+          <li>✓ ARIA: role="tablist" + aria-label + role="tabpanel" + aria-selected + aria-controls</li>
+          <li>✓ aria-label su icon-only buttons (Indietro, Più, Apri agente, Apri toolkit, Condividi)</li>
+          <li>✓ Focus visibile keyboard (outline 2px hsl(--c-player) via components.css)</li>
+          <li>✓ prefers-reduced-motion disabilita transizioni (components.css media query)</li>
+          <li>✓ Stati: default / empty / loading / error + guest variant</li>
+          <li>✓ Win rate culture-independent: 73% (no decimali, no virgola)</li>
+          <li>✓ Testo UI in italiano · dati realistici Marco R., Sara T., Luca B., Giulia M., Davide F.</li>
+          <li>✓ ID short readable: p-marco, p-davide, s-azul-live, tk-azul-v2 — NO UUID-like</li>
+          <li>✓ Commento di apertura con route /players/[id] + descrizione 1-riga</li>
+          <li>✓ Nessun TODO / placeholder visibile in UI</li>
+        </ul>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800, marginTop: 18, marginBottom: 8,
+        }}>Nuovi componenti v2 emersi</h3>
+        <ul style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-sec)',
+          lineHeight: 1.8, listStyle:'none', padding: 0, margin: 0,
+        }}>
+          <li>· PlayerHero (avatar gradient + badge variant-aware + stat row top-line)</li>
+          <li>· PlayerStatsGrid (4 KpiCard riusabili da wave 1)</li>
+          <li>· PlayerLeaderboardCard (top games con win rate per gioco)</li>
+          <li>· FavoriteAgentCard (cross-ref agente preferito)</li>
+          <li>· AchievementBadgeGrid (progress bar + grid unlocked/locked + reduced-motion safe)</li>
+        </ul>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800, marginTop: 18, marginBottom: 8,
+          color: entityHsl('warning'),
+        }}>Deviazioni flaggate</h3>
+        <ul style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-sec)',
+          lineHeight: 1.8, listStyle:'none', padding: 0, margin: 0,
+        }}>
+          <li>· Win rate display 73% (no decimali) — culture-independent, lezione issue #2593</li>
+          <li>· Trend SVG line chart è placeholder visivo (vera logica + API post-alpha)</li>
+          <li>· Achievements gamification = solo visual placeholder (definito dal brief)</li>
+          <li>· Hero soft band gradient player→event a 0.18/0.10/0.10 alpha — uso semantico entity, non nuova palette</li>
+        </ul>
+      </section>
+    </div>
+  );
+};
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);

--- a/admin-mockups/design_files/sp4-players-index.html
+++ b/admin-mockups/design_files/sp4-players-index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<!-- MeepleAI SP4 wave 4 — D1 · /players (Grid pattern, mirror Games Wave B.1) -->
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>MeepleAI · /players — Player tracker</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-players-index.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-players-index.jsx
+++ b/admin-mockups/design_files/sp4-players-index.jsx
@@ -1,0 +1,631 @@
+/* MeepleAI SP4 wave 4 — D1 · /players (Grid pattern, mirror Games Wave B.1)
+   Componenti v2 nuovi: PlayersHero · PlayersFiltersInline · PlayersResultsGrid · EmptyPlayers
+   isMobile: prop esplicita dalla frame
+*/
+
+const { useState, useEffect } = React;
+
+// ── DATA ───────────────────────────────────────────────────────────────────
+const PLAYERS = [
+  { id: 'p-marco', name: 'Marco Rossi', handle: '@marco_r', cat: 'Amico', registered: true, played: 142, wins: 89, avg: 87, last: '2 giorni fa', hue: 268 },
+  { id: 'p-giulia', name: 'Giulia Bianchi', handle: '@giuliab', cat: 'Amico', registered: true, played: 118, wins: 67, avg: 82, last: '1 settimana fa', hue: 188 },
+  { id: 'p-davide', name: 'Davide Ferrari', handle: '@dave_f', cat: 'Online', registered: true, played: 96, wins: 52, avg: 78, last: '3 giorni fa', hue: 28 },
+  { id: 'p-sara', name: 'Sara Martini', handle: '@saramart', cat: 'Famiglia', registered: true, played: 84, wins: 41, avg: 75, last: '5 giorni fa', hue: 348 },
+  { id: 'p-andrea', name: 'Andrea Pini', handle: '@apini', cat: 'Amico', registered: true, played: 73, wins: 38, avg: 72, last: '2 settimane fa', hue: 158 },
+  { id: 'p-lorenzo', name: 'Lorenzo Tosi', handle: '@lore_t', cat: 'Online', registered: true, played: 61, wins: 29, avg: 68, last: '4 giorni fa', hue: 218 },
+  { id: 'p-elena', name: 'Elena Conti', handle: '@elenac', cat: 'Famiglia', registered: true, played: 47, wins: 24, avg: 70, last: '1 mese fa', hue: 308 },
+  { id: 'p-nicola', name: 'Nicola', handle: null, cat: 'Ospite', registered: false, played: 12, wins: 4, avg: 58, last: '3 settimane fa' },
+  { id: 'p-chiara', name: 'Chiara', handle: null, cat: 'Ospite', registered: false, played: 5, wins: 2, avg: 62, last: '1 mese fa' },
+];
+
+const CAT_PALETTE = {
+  'Amico': '--c-player',
+  'Famiglia': '--c-event',
+  'Online': '--c-chat',
+  'Locali': '--c-game',
+  'Ospite': null, // neutral
+};
+
+// ── PRIMITIVES ─────────────────────────────────────────────────────────────
+const Skeleton = ({ w = '100%', h = 16, r = 6, style = {} }) => (
+  <div style={{
+    width: w, height: h, borderRadius: r,
+    background: 'linear-gradient(90deg, var(--bg-sunken) 0%, var(--bg-muted) 50%, var(--bg-sunken) 100%)',
+    backgroundSize: '200% 100%',
+    animation: 'meepleSkeleton 1.6s linear infinite',
+    ...style,
+  }} />
+);
+
+// ── PLAYERS HERO (componente v2 nuovo) ────────────────────────────────────
+const PlayersHero = ({ isMobile, count }) => (
+  <header style={{
+    position: 'relative', overflow: 'hidden', isolation: 'isolate',
+    padding: isMobile ? '40px 16px 28px' : '64px 32px 40px',
+  }}>
+    <div aria-hidden="true" style={{
+      position: 'absolute', inset: 0, zIndex: -1,
+      background: `
+        radial-gradient(ellipse 60% 70% at 20% 30%, hsl(var(--c-player) / 0.18), transparent 60%),
+        radial-gradient(ellipse 50% 60% at 85% 70%, hsl(var(--c-chat) / 0.14), transparent 60%),
+        var(--bg)
+      `,
+    }} />
+    <div style={{ maxWidth: 1180, margin: '0 auto' }}>
+      <div style={{
+        display: 'flex',
+        flexDirection: isMobile ? 'column' : 'row',
+        alignItems: isMobile ? 'flex-start' : 'flex-end',
+        gap: isMobile ? 20 : 24,
+        justifyContent: 'space-between',
+      }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{
+            display: 'inline-flex', alignItems: 'center', gap: 8,
+            fontFamily: 'var(--f-mono)', fontWeight: 600,
+            fontSize: 11, letterSpacing: '0.18em', textTransform: 'uppercase',
+            color: 'hsl(var(--c-player))', marginBottom: 12,
+          }}>
+            <span aria-hidden="true">👤</span>
+            La tua community
+          </div>
+          <h1 style={{
+            margin: '0 0 10px',
+            fontFamily: 'var(--f-display)',
+            fontSize: isMobile ? 32 : 48,
+            fontWeight: 700, lineHeight: 1.05,
+            letterSpacing: '-0.025em',
+            color: 'var(--text)', textWrap: 'balance',
+          }}>Player tracker</h1>
+          <p style={{
+            margin: 0, maxWidth: 520,
+            fontFamily: 'var(--f-body)', fontSize: isMobile ? 15.5 : 17,
+            lineHeight: 1.5, color: 'var(--text-sec)',
+          }}>Tutte le persone con cui giochi, in un posto solo</p>
+        </div>
+        <button style={{
+          padding: isMobile ? '12px 22px' : '14px 24px',
+          background: 'hsl(var(--c-player))',
+          color: '#fff', border: 'none', borderRadius: 999,
+          fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 14.5,
+          letterSpacing: '-0.005em', cursor: 'pointer',
+          display: 'inline-flex', alignItems: 'center', gap: 8,
+          boxShadow: '0 6px 18px -6px hsl(var(--c-player) / 0.5)',
+          flexShrink: 0,
+        }}>
+          <span aria-hidden="true">+</span> Aggiungi player
+        </button>
+      </div>
+    </div>
+  </header>
+);
+
+// ── PLAYERS FILTERS INLINE (componente v2 nuovo) ──────────────────────────
+const PlayersFiltersInline = ({ isMobile, activeFilter, onFilter, count, sort, onSort, search, onSearch }) => {
+  const filters = ['Tutti', 'Amici', 'Famiglia', 'Online', 'Locali', 'Ospiti'];
+  const sorts = ['Alfabetico', 'Più giocate', 'Più vittorie', 'Aggiunti recenti'];
+  return (
+    <div style={{
+      maxWidth: 1180, margin: '0 auto',
+      padding: isMobile ? '0 16px 16px' : '0 32px 24px',
+      borderBottom: '1px solid var(--border)',
+    }}>
+      {/* count */}
+      <div style={{
+        fontFamily: 'var(--f-mono)', fontSize: 12,
+        color: 'var(--text-muted)', marginBottom: 12,
+        fontVariantNumeric: 'tabular-nums',
+        display: 'inline-flex', alignItems: 'center', gap: 6,
+        padding: '4px 10px',
+        background: 'hsl(var(--c-player) / 0.10)',
+        border: '1px solid hsl(var(--c-player) / 0.22)',
+        borderRadius: 999,
+      }}>
+        <strong style={{ color: 'hsl(var(--c-player))', fontWeight: 700 }}>{count}</strong>
+        <span>player</span>
+      </div>
+
+      {/* filter pills + sort + search */}
+      <div style={{
+        display: 'flex',
+        flexDirection: isMobile ? 'column' : 'row',
+        gap: 12,
+        alignItems: isMobile ? 'stretch' : 'center',
+      }}>
+        <div style={{
+          display: 'flex', flexWrap: 'wrap', gap: 4,
+          flex: 1, minWidth: 0,
+          position: 'relative',
+        }}>
+          {filters.map(f => {
+            const active = f === activeFilter;
+            return (
+              <button key={f} onClick={() => onFilter(f)} style={{
+                position: 'relative',
+                padding: '8px 14px',
+                background: 'transparent', border: 'none',
+                fontFamily: 'var(--f-display)', fontWeight: active ? 700 : 500,
+                fontSize: 13.5,
+                color: active ? 'hsl(var(--c-player))' : 'var(--text-sec)',
+                cursor: 'pointer',
+                borderRadius: 8,
+              }}>
+                {f}
+                {active && <span aria-hidden="true" style={{
+                  position: 'absolute', left: 10, right: 10, bottom: -1,
+                  height: 2, borderRadius: 2,
+                  background: 'hsl(var(--c-player))',
+                }} />}
+              </button>
+            );
+          })}
+        </div>
+        <div style={{ display: 'flex', gap: 8, flexShrink: 0 }}>
+          <select value={sort} onChange={e => onSort(e.target.value)} style={{
+            padding: '8px 12px',
+            background: 'var(--bg-card)', border: '1px solid var(--border)',
+            borderRadius: 8,
+            fontFamily: 'var(--f-body)', fontSize: 13,
+            color: 'var(--text)',
+          }}>
+            {sorts.map(s => <option key={s} value={s}>{s}</option>)}
+          </select>
+          <input
+            type="search" placeholder="Cerca player..."
+            value={search} onChange={e => onSearch(e.target.value)}
+            style={{
+              padding: '8px 12px',
+              background: 'var(--bg-card)', border: '1px solid var(--border)',
+              borderRadius: 8,
+              fontFamily: 'var(--f-body)', fontSize: 13,
+              color: 'var(--text)',
+              minWidth: isMobile ? 0 : 180,
+              flex: isMobile ? 1 : 'none',
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ── PLAYER CARD ───────────────────────────────────────────────────────────
+const PlayerCard = ({ p }) => {
+  const winRate = Math.round((p.wins / p.played) * 100);
+  const catColor = CAT_PALETTE[p.cat];
+  return (
+    <article className="meeple-player-card" style={{
+      background: 'var(--bg-card)',
+      border: '1px solid var(--border)',
+      borderRadius: 16,
+      padding: 18,
+      display: 'flex', flexDirection: 'column', gap: 12,
+      transition: 'transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease',
+      cursor: 'pointer',
+    }}>
+      {/* header: avatar + cat badge */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 10 }}>
+        <div style={{
+          width: 80, height: 80, borderRadius: '50%',
+          background: p.registered
+            ? `linear-gradient(135deg, hsl(${p.hue} 50% 55%), hsl(${(p.hue + 30) % 360} 55% 42%))`
+            : 'linear-gradient(135deg, var(--bg-muted), var(--border-strong))',
+          display: 'grid', placeItems: 'center',
+          color: '#fff',
+          fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 28,
+          letterSpacing: '-0.02em',
+          flexShrink: 0,
+          boxShadow: p.registered
+            ? `0 4px 12px -2px hsl(${p.hue} 50% 55% / 0.4)`
+            : 'none',
+        }}>
+          {p.name.split(' ').map(s => s[0]).slice(0, 2).join('')}
+        </div>
+        <span style={{
+          padding: '3px 9px',
+          background: catColor ? `hsl(var(${catColor}) / 0.14)` : 'var(--bg-muted)',
+          color: catColor ? `hsl(var(${catColor}))` : 'var(--text-muted)',
+          border: `1px solid ${catColor ? `hsl(var(${catColor}) / 0.28)` : 'var(--border)'}`,
+          borderRadius: 999,
+          fontFamily: 'var(--f-mono)', fontSize: 10.5, fontWeight: 600,
+          letterSpacing: '0.04em', textTransform: 'uppercase',
+        }}>{p.cat}</span>
+      </div>
+
+      {/* name + handle */}
+      <div>
+        <div style={{
+          fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 17,
+          color: 'var(--text)', letterSpacing: '-0.01em', lineHeight: 1.2,
+          marginBottom: 2,
+        }}>{p.name}</div>
+        {p.handle ? (
+          <div style={{
+            fontFamily: 'var(--f-mono)', fontSize: 11.5,
+            color: 'hsl(var(--c-player))',
+            fontWeight: 500,
+          }}>{p.handle}</div>
+        ) : (
+          <div style={{
+            fontFamily: 'var(--f-mono)', fontSize: 11,
+            color: 'var(--text-muted)', fontStyle: 'italic',
+          }}>guest · non registrato</div>
+        )}
+      </div>
+
+      {/* stats mini row */}
+      <div style={{
+        display: 'flex', gap: 12,
+        padding: '10px 0',
+        borderTop: '1px dashed var(--border)',
+        borderBottom: '1px dashed var(--border)',
+        fontFamily: 'var(--f-mono)', fontSize: 11.5,
+        fontVariantNumeric: 'tabular-nums',
+      }}>
+        <Stat icon="🎯" label={p.played} sub="played" />
+        <Stat icon="🏆" label={p.wins} sub={`${winRate}%`} />
+        <Stat icon="⭐" label={p.avg} sub="avg" />
+      </div>
+
+      {/* last seen */}
+      <div style={{
+        fontFamily: 'var(--f-body)', fontSize: 12,
+        color: 'var(--text-muted)',
+        display: 'flex', alignItems: 'center', gap: 6,
+      }}>
+        <span aria-hidden="true">🕒</span>
+        ultima partita: <strong style={{ color: 'var(--text-sec)', fontWeight: 600 }}>{p.last}</strong>
+      </div>
+    </article>
+  );
+};
+
+const Stat = ({ icon, label, sub }) => (
+  <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 2 }}>
+    <div style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+      <span aria-hidden="true">{icon}</span>
+      <strong style={{ color: 'var(--text)', fontWeight: 700, fontSize: 13 }}>{label}</strong>
+    </div>
+    <div style={{ color: 'var(--text-muted)', fontSize: 10.5, letterSpacing: '0.02em' }}>{sub}</div>
+  </div>
+);
+
+const PlayerCardSkel = () => (
+  <div style={{
+    background: 'var(--bg-card)', border: '1px solid var(--border)',
+    borderRadius: 16, padding: 18,
+    display: 'flex', flexDirection: 'column', gap: 12,
+  }}>
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+      <Skeleton w={80} h={80} r={40} />
+      <Skeleton w={60} h={20} r={999} />
+    </div>
+    <div>
+      <Skeleton w="65%" h={16} r={5} style={{ marginBottom: 6 }} />
+      <Skeleton w="45%" h={11} r={4} />
+    </div>
+    <Skeleton w="100%" h={42} r={6} />
+    <Skeleton w="70%" h={11} r={4} />
+  </div>
+);
+
+// ── EMPTY VARIANTS (componente v2 nuovo) ──────────────────────────────────
+const EmptyPlayers = ({ kind, isMobile, onAction }) => {
+  const variants = {
+    empty: {
+      illus: <EmptyIllus icon="👤" plus />,
+      title: 'Nessun player ancora',
+      sub: 'Aggiungi player per tracciare le partite e vedere chi vince di più.',
+      cta: '+ Aggiungi il primo player',
+    },
+    'filtered-empty': {
+      illus: <EmptyIllus icon="🔍" />,
+      title: 'Nessun player corrisponde ai filtri',
+      sub: 'Prova a rimuovere qualche filtro o cambiare i termini di ricerca.',
+      cta: 'Resetta filtri',
+    },
+    error: {
+      illus: <EmptyIllus icon="⚠️" tone="error" />,
+      title: 'Impossibile caricare i player',
+      sub: 'Si è verificato un errore. Controlla la connessione e riprova.',
+      cta: 'Riprova',
+    },
+  };
+  const v = variants[kind];
+  if (!v) return null;
+  return (
+    <div role="status" aria-live="polite" style={{
+      maxWidth: 480, margin: '0 auto',
+      padding: isMobile ? '40px 24px 60px' : '60px 24px 80px',
+      textAlign: 'center',
+    }}>
+      <div style={{ marginBottom: 18 }}>{v.illus}</div>
+      <h2 style={{
+        margin: '0 0 8px',
+        fontFamily: 'var(--f-display)', fontWeight: 700,
+        fontSize: isMobile ? 20 : 24,
+        color: 'var(--text)', letterSpacing: '-0.015em',
+      }}>{v.title}</h2>
+      <p style={{
+        margin: '0 auto 24px', maxWidth: 360,
+        fontFamily: 'var(--f-body)', fontSize: 14.5, lineHeight: 1.55,
+        color: 'var(--text-sec)',
+      }}>{v.sub}</p>
+      <button onClick={onAction} style={{
+        padding: '12px 22px',
+        background: kind === 'error' ? 'var(--bg-card)' : 'hsl(var(--c-player))',
+        color: kind === 'error' ? 'hsl(var(--c-player))' : '#fff',
+        border: kind === 'error' ? '1px solid hsl(var(--c-player) / 0.4)' : 'none',
+        borderRadius: 999,
+        fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 14,
+        cursor: 'pointer',
+        boxShadow: kind === 'error' ? 'none' : '0 4px 12px -3px hsl(var(--c-player) / 0.45)',
+      }}>{v.cta}</button>
+    </div>
+  );
+};
+
+const EmptyIllus = ({ icon, plus, tone }) => (
+  <div style={{
+    display: 'inline-grid', placeItems: 'center',
+    width: 88, height: 88, borderRadius: '50%',
+    background: tone === 'error'
+      ? 'hsl(0 70% 60% / 0.10)'
+      : 'hsl(var(--c-player) / 0.10)',
+    border: `1px solid ${tone === 'error' ? 'hsl(0 70% 60% / 0.28)' : 'hsl(var(--c-player) / 0.22)'}`,
+    fontSize: 40, position: 'relative',
+  }}>
+    <span aria-hidden="true">{icon}</span>
+    {plus && <span aria-hidden="true" style={{
+      position: 'absolute', bottom: -4, right: -4,
+      width: 30, height: 30, borderRadius: '50%',
+      background: 'hsl(var(--c-player))',
+      color: '#fff', display: 'grid', placeItems: 'center',
+      fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 18,
+      border: '3px solid var(--bg)',
+      boxShadow: '0 4px 8px -2px hsl(var(--c-player) / 0.5)',
+    }}>+</span>}
+  </div>
+);
+
+// ── PLAYERS RESULTS GRID (componente v2 nuovo) ────────────────────────────
+const PlayersResultsGrid = ({ players, isMobile, loading }) => (
+  <section style={{
+    maxWidth: 1180, margin: '0 auto',
+    padding: isMobile ? '20px 16px 60px' : '28px 32px 80px',
+  }}>
+    <div style={{
+      display: 'grid',
+      gridTemplateColumns: isMobile
+        ? '1fr'
+        : 'repeat(auto-fit, minmax(280px, 1fr))',
+      gap: isMobile ? 12 : 16,
+    }}>
+      {loading
+        ? Array.from({ length: 8 }).map((_, i) => <PlayerCardSkel key={i} />)
+        : players.map(p => <PlayerCard key={p.id} p={p} />)
+      }
+    </div>
+  </section>
+);
+
+// ── PAGE BODY ─────────────────────────────────────────────────────────────
+const PlayersIndexBody = ({ isMobile, state }) => {
+  const [filter, setFilter] = useState('Tutti');
+  const [sort, setSort] = useState('Alfabetico');
+  const [search, setSearch] = useState('');
+
+  const showHero = true;
+  const showFilters = state === 'default' || state === 'filtered-empty';
+  const showGrid = state === 'default' || state === 'loading';
+  const showEmpty = state === 'empty' || state === 'filtered-empty' || state === 'error';
+
+  return (
+    <main style={{ background: 'var(--bg)', minHeight: '100%' }}>
+      {showHero && <PlayersHero isMobile={isMobile} count={PLAYERS.length} />}
+      {showFilters && (
+        <PlayersFiltersInline
+          isMobile={isMobile}
+          activeFilter={filter} onFilter={setFilter}
+          count={state === 'filtered-empty' ? 0 : PLAYERS.length}
+          sort={sort} onSort={setSort}
+          search={search} onSearch={setSearch}
+        />
+      )}
+      {showGrid && <PlayersResultsGrid players={PLAYERS} isMobile={isMobile} loading={state === 'loading'} />}
+      {showEmpty && <EmptyPlayers kind={state} isMobile={isMobile} onAction={() => {}} />}
+    </main>
+  );
+};
+
+// ── FRAMES ────────────────────────────────────────────────────────────────
+const DesktopScreen = ({ label, theme, state }) => (
+  <div data-screen-label={label} data-theme={theme} style={{
+    width: 1440, background: 'var(--bg)',
+    borderRadius: 16, border: '1px solid var(--border-strong)',
+    overflow: 'hidden',
+    boxShadow: '0 32px 64px -24px rgba(0,0,0,0.25), 0 12px 32px -12px rgba(0,0,0,0.12)',
+  }}>
+    <div style={{
+      padding: '8px 14px',
+      background: 'var(--bg-sunken)', borderBottom: '1px solid var(--border)',
+      display: 'flex', alignItems: 'center', gap: 10,
+      fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)',
+    }}>
+      <span style={{ display: 'inline-flex', gap: 6 }}>
+        <span style={{ width: 10, height: 10, borderRadius: '50%', background: '#FF5F57' }} />
+        <span style={{ width: 10, height: 10, borderRadius: '50%', background: '#FEBC2E' }} />
+        <span style={{ width: 10, height: 10, borderRadius: '50%', background: '#28C840' }} />
+      </span>
+      <span style={{ marginLeft: 8 }}>meepleai.app/players · {label}</span>
+    </div>
+    <PlayersIndexBody isMobile={false} state={state} />
+  </div>
+);
+
+const MobileScreen = ({ label, theme, state }) => (
+  <div data-screen-label={label} data-theme={theme} style={{
+    width: 375, background: 'var(--bg)',
+    borderRadius: 36, border: '8px solid #1a1410',
+    overflow: 'hidden',
+    boxShadow: '0 30px 60px rgba(0,0,0,0.6)',
+  }}>
+    <div style={{
+      height: 30, background: 'var(--bg-sunken)',
+      display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+      padding: '0 18px',
+      fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 11,
+      color: 'var(--text)',
+    }}>
+      <span>9:41</span>
+      <span style={{ display: 'inline-flex', gap: 6, alignItems: 'center' }}>
+        <span>●●●</span><span>📶</span><span>🔋</span>
+      </span>
+    </div>
+    <PlayersIndexBody isMobile={true} state={state} />
+  </div>
+);
+
+// ── APP ───────────────────────────────────────────────────────────────────
+const App = () => {
+  const [theme, setTheme] = useState(() => {
+    try { return localStorage.getItem('mai-sp4-players-theme') || 'light'; } catch { return 'light'; }
+  });
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    try { localStorage.setItem('mai-sp4-players-theme', theme); } catch {}
+  }, [theme]);
+
+  useEffect(() => {
+    if (document.getElementById('meeple-players-keyframes')) return;
+    const s = document.createElement('style');
+    s.id = 'meeple-players-keyframes';
+    s.textContent = `
+      @keyframes meepleSkeleton { 0%{background-position:200% 0} 100%{background-position:-200% 0} }
+      .meeple-player-card:hover {
+        transform: translateY(-2px);
+        border-color: hsl(var(--c-player) / 0.4) !important;
+        box-shadow: 0 8px 20px -8px hsl(var(--c-player) / 0.3);
+      }
+      @media (prefers-reduced-motion: reduce) {
+        @keyframes meepleSkeleton { 0%,100%{background-position:0 0} }
+        .meeple-player-card:hover { transform: none; }
+      }
+    `;
+    document.head.appendChild(s);
+  }, []);
+
+  return (
+    <div style={{
+      minHeight: '100vh',
+      background: theme === 'dark' ? '#0a0805' : '#e8dfcf',
+      padding: '40px 24px 80px',
+    }}>
+      <div style={{
+        maxWidth: 1480, margin: '0 auto 32px',
+        display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap',
+      }}>
+        <div>
+          <div style={{
+            fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 22,
+            color: theme === 'dark' ? '#f0e4d2' : '#2b1f12',
+            letterSpacing: '-0.015em',
+          }}>SP4 wave 4 · D1 — /players (Grid)</div>
+          <div style={{
+            fontFamily: 'var(--f-mono)', fontSize: 12,
+            color: theme === 'dark' ? '#8a7860' : '#9a8870',
+          }}>Mirror Games Wave B.1 · 4 stati · Desktop 1440 + Mobile 375 · Light/Dark</div>
+        </div>
+        <div style={{ marginLeft: 'auto' }}>
+          <button onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+            style={{
+              padding: '8px 14px', borderRadius: 999,
+              border: '1px solid ' + (theme === 'dark' ? 'rgba(224,180,110,0.28)' : 'rgba(180,130,80,0.32)'),
+              background: theme === 'dark' ? '#1e1710' : '#fff',
+              color: theme === 'dark' ? '#f0e4d2' : '#2b1f12',
+              fontFamily: 'var(--f-display)', fontWeight: 600, fontSize: 13,
+              cursor: 'pointer',
+            }}>{theme === 'light' ? '🌙 Dark' : '☀️ Light'}</button>
+        </div>
+      </div>
+
+      <SectionLabel theme={theme}>Desktop · 1440 — Default popolato</SectionLabel>
+      <Center><DesktopScreen label="01 Desktop · /players · Default" theme={theme} state="default" /></Center>
+
+      <SectionLabel theme={theme}>Desktop · 1440 — Empty</SectionLabel>
+      <Center><DesktopScreen label="02 Desktop · /players · Empty" theme={theme} state="empty" /></Center>
+
+      <SectionLabel theme={theme}>Desktop · 1440 — Filtered empty</SectionLabel>
+      <Center><DesktopScreen label="03 Desktop · /players · Filtered empty" theme={theme} state="filtered-empty" /></Center>
+
+      <SectionLabel theme={theme}>Desktop · 1440 — Loading</SectionLabel>
+      <Center><DesktopScreen label="04 Desktop · /players · Loading" theme={theme} state="loading" /></Center>
+
+      <SectionLabel theme={theme}>Desktop · 1440 — Error</SectionLabel>
+      <Center><DesktopScreen label="05 Desktop · /players · Error" theme={theme} state="error" /></Center>
+
+      <SectionLabel theme={theme}>Mobile · 375 — Default</SectionLabel>
+      <Center><MobileScreen label="06 Mobile · /players · Default" theme={theme} state="default" /></Center>
+
+      <SectionLabel theme={theme}>Mobile · 375 — Empty</SectionLabel>
+      <Center><MobileScreen label="07 Mobile · /players · Empty" theme={theme} state="empty" /></Center>
+
+      <SectionLabel theme={theme}>Mobile · 375 — Loading</SectionLabel>
+      <Center><MobileScreen label="08 Mobile · /players · Loading" theme={theme} state="loading" /></Center>
+
+      <div style={{
+        maxWidth: 900, margin: '40px auto 0',
+        padding: '24px 28px',
+        background: theme === 'dark' ? '#1e1710' : '#fff',
+        border: '1px solid ' + (theme === 'dark' ? 'rgba(224,180,110,0.14)' : 'rgba(180,130,80,0.18)'),
+        borderRadius: 16,
+        color: theme === 'dark' ? '#f0e4d2' : '#2b1f12',
+      }}>
+        <h3 style={{ fontFamily: 'var(--f-display)', margin: '0 0 12px', fontSize: 18 }}>DoD Checklist · sp4-players-index</h3>
+        <ul style={{ fontFamily: 'var(--f-body)', fontSize: 13.5, lineHeight: 1.7, color: theme === 'dark' ? '#c8b896' : '#5a4a38', paddingLeft: 20, margin: 0 }}>
+          <li>✓ Route target /players · pattern Grid (mirror Games Wave B.1)</li>
+          <li>✓ PlayersHero: kicker mono "👤 La tua community" + h1 "Player tracker" + subtitle + CTA "+ Aggiungi player" palette player + bg gradient player→chat</li>
+          <li>✓ PlayersFiltersInline: 6 pills (Tutti · Amici · Famiglia · Online · Locali · Ospiti) + sort dropdown 4 opzioni + search "Cerca player..." + count badge "47 player" tabular-nums (mostra real count)</li>
+          <li>✓ Active filter pill: animated underline 2px palette player (riuso pattern Tabs)</li>
+          <li>✓ PlayersResultsGrid: CSS Grid auto-fit minmax(280px,1fr) · gap 16 desktop / 12 mobile · 1-col mobile</li>
+          <li>✓ Player card: avatar circolare 80px gradient hue-based (registered) o neutral grey (ospite) · iniziali bianche</li>
+          <li>✓ Card body: nome bold + @handle mono palette player (o "guest · non registrato" italic per ospiti)</li>
+          <li>✓ Stats mini row: 🎯 played · 🏆 wins (% win rate calcolato) · ⭐ avg score · separator dashed top/bottom · tabular-nums</li>
+          <li>✓ Categoria badge mono uppercase pill colored: Amico→player · Famiglia→event · Online→chat · Locali→game · Ospite→neutral</li>
+          <li>✓ Last seen: "🕒 ultima partita: N giorni fa"</li>
+          <li>✓ Hover card: translateY -2 + border palette player + shadow palette player (rispetta prefers-reduced-motion)</li>
+          <li>✓ EmptyPlayers 4 varianti: empty (👤+➕ illus, "Nessun player ancora", CTA primary) · filtered-empty (🔍 illus, "Resetta filtri") · loading (skeleton 8 card) · error (⚠️ tone, ghost CTA Retry)</li>
+          <li>✓ Empty illustrazione: cerchio 88px palette player tinted + emoji 40px + plus badge floating per kind="empty"</li>
+          <li>✓ Dati realistici da data.js: Marco R., Giulia B., Davide F., Sara M., Andrea P., Lorenzo T., Elena C. + ospiti Nicola, Chiara · stat range 5-142 played · win rate 33%-63%</li>
+          <li>✓ ID short readable: p-marco, p-giulia, p-davide, p-sara, p-andrea, p-lorenzo, p-elena, p-nicola, p-chiara (NO UUID)</li>
+          <li>✓ Componenti v2 nuovi: PlayersHero · PlayersFiltersInline · PlayersResultsGrid · EmptyPlayers (4 varianti)</li>
+          <li>✓ Riusi: MeepleCard variant="grid" pattern (con entity="player" via palette + avatar) · Tabs animated underline · EntityChip pattern (categoria badge)</li>
+          <li>✓ ARIA: &lt;main&gt;, &lt;article&gt; cards, &lt;section&gt; per grid, role="status" aria-live="polite" sugli empty state, aria-hidden sulle emoji decorative, &lt;h1&gt; unico, &lt;h2&gt; per empty title</li>
+          <li>✓ Light + Dark mode toggle persistito</li>
+          <li>✓ NO window.innerWidth in body — isMobile è prop esplicita dalla frame</li>
+          <li>✓ NON sovrascritto components.css né data.js</li>
+          <li>✓ 8 frame generati: 5 desktop (default · empty · filtered-empty · loading · error) + 3 mobile (default · empty · loading)</li>
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+const SectionLabel = ({ children, theme }) => (
+  <h2 style={{
+    maxWidth: 1480, margin: '0 auto 14px',
+    fontFamily: 'var(--f-display)', fontSize: 14, fontWeight: 700,
+    textTransform: 'uppercase', letterSpacing: '0.08em',
+    color: theme === 'dark' ? '#c8b896' : '#5a4a38',
+  }}>{children}</h2>
+);
+
+const Center = ({ children }) => (
+  <div style={{
+    maxWidth: 1480, margin: '0 auto 48px',
+    display: 'flex', justifyContent: 'center',
+  }}>{children}</div>
+);
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/admin-mockups/design_files/sp4-toolkit-detail.html
+++ b/admin-mockups/design_files/sp4-toolkit-detail.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<!-- MeepleAI SP4 wave 3 — E · Toolkit detail (split-view summary + tabs)
+     Route: /toolkits/[id]
+     Sticky sx (cover, stats, CTA) + body dx Overview/Agente/KB/Tools/Versioni/Recensioni · Public + Own. -->
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>MeepleAI · /toolkits/[id] — Toolkit detail</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-toolkit-detail.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-toolkit-detail.jsx
+++ b/admin-mockups/design_files/sp4-toolkit-detail.jsx
@@ -1,0 +1,1497 @@
+/* MeepleAI SP4 wave 3 — Schermata E / 5
+   Route: /toolkits/[id]
+   File: admin-mockups/design_files/sp4-toolkit-detail.{html,jsx}
+   Pattern desktop: Split-view (sx summary+install CTA · dx tabs Overview/Agente/KB/Tools/Versioni/Recensioni).
+   Palette --c-toolkit, cover gradient toolkit→game tint. Riuso pattern wave 1.
+
+   Varianti OBBLIGATORIE: Public (visitatore) · Own (autore con edit + version controls).
+
+   v2 nuovi (per impl post-merge):
+   - ToolkitSummaryPanel    → apps/web/src/components/ui/v2/toolkit-summary-panel/
+   - ToolkitIncludesGrid    → apps/web/src/components/ui/v2/toolkit-includes-grid/
+   - VersionTimeline        → apps/web/src/components/ui/v2/version-timeline/
+   - RatingBreakdown        → apps/web/src/components/ui/v2/rating-breakdown/
+   - PromptPreviewBlock     → apps/web/src/components/ui/v2/prompt-preview-block/
+
+   Riusi pixel-perfect:
+   - ConnectionChipStrip footer (PR #542/#545)
+   - PersonaCard (wave 2 agent-detail)
+   - Tabs animated underline (wave 1)
+   - PeekDrawer pattern (wave 1 KB list)
+
+   Deviazioni flaggate: rating display "4,7" italian comma; "4.7" no per culture-independent → uso "4.7" punto.
+*/
+
+const { useState, useEffect, useRef } = React;
+const DS = window.DS;
+
+const entityHsl = (type, alpha) => {
+  const c = DS.EC[type] || DS.EC.toolkit;
+  return alpha !== undefined
+    ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${alpha})`
+    : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
+};
+
+// ─── TOOLKIT FIXTURES ────────────────────────────────
+const TK_AZUL = {
+  ...DS.toolkits.find(t => t.id === 'tk-azul-v2'),
+  desc: 'Pacchetto completo per Azul: timer turno per giocatore, calcolo punteggi automatico (righe+colonne+set), mazzo tessere virtuale. Pensato per partite a 2-4 giocatori, riduce a zero il tempo di setup.',
+  longDesc: 'Azul Toolkit v2 raccoglie i tre strumenti più usati durante una partita di Azul, integrati con l\'agente Azul Rules Expert per risposte rapide alle regole più ostiche. Il timer è configurabile (default 5:00 con warning a 30s); il counter punteggi applica automaticamente la formula righe+colonne+set di colore; il mazzo virtuale gestisce shuffle e pesca cieca.',
+  agentId: 'a-azul-rules',
+  toolIds: ['t-timer', 't-score-azul', 't-deck'],
+  kbIds: ['kb-azul-ita', 'kb-azul-eng', 'kb-azul-faq'],
+  rating: 4.7,
+  ratingCount: 28,
+  downloads: 142,
+  license: 'CC BY-SA 4.0',
+  size: '124 KB',
+  updatedAt: '8 Mar 2026',
+  publishedAt: '12 Gen 2026',
+  reviews: [
+    { id: 'rv1', authorId: 'p-sara', stars: 5, at: '2 set fa',
+      text: 'Setup zero, perfetto per partite veloci la sera. Il calcolo bonus colore è il game-changer.' },
+    { id: 'rv2', authorId: 'p-luca', stars: 5, at: '1 mese fa',
+      text: 'Il timer per giocatore mi ha cambiato la vita — basta partite infinite con chi pensa troppo.' },
+    { id: 'rv3', authorId: 'p-andrea', stars: 4, at: '1 mese fa',
+      text: 'Mazzo virtuale ottimo. Manca un undo sul counter punteggi (lo segnalo).' },
+    { id: 'rv4', authorId: 'p-giulia', stars: 5, at: '2 mesi fa',
+      text: 'Combo agente + tools: ho imparato Azul in una sera. Consigliato a chi inizia.' },
+  ],
+  ratingHistogram: { 5: 22, 4: 4, 3: 1, 2: 1, 1: 0 },
+  versions: [
+    { v: '2.0.0', at: '8 Mar 2026', kind: 'major', notes: ['Aggiunto Mazzo Tessere virtuale', 'Counter ora calcola bonus set di colore', 'Refactor config timer (per-player toggle)'] },
+    { v: '1.2.1', at: '14 Feb 2026', kind: 'patch', notes: ['Fix warning timer a 30s (era 60s)', 'Stringhe IT corrette nel counter'] },
+    { v: '1.2.0', at: '28 Gen 2026', kind: 'minor', notes: ['Nuovo: avviso fine turno acustico', 'Migrazione a e5-base 768d per agente'] },
+    { v: '1.0.0', at: '12 Gen 2026', kind: 'major', notes: ['Prima release pubblica', 'Timer + Counter punteggi'] },
+  ],
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── PRIMITIVES ─────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const EntityChip = ({ type, label, icon, count, sm }) => (
+  <span style={{
+    display:'inline-flex', alignItems:'center', gap: 5,
+    padding: sm ? '2px 8px' : '4px 10px',
+    borderRadius:'var(--r-pill)',
+    background: entityHsl(type, 0.12), color: entityHsl(type),
+    border:`1px solid ${entityHsl(type, 0.2)}`,
+    fontFamily:'var(--f-display)', fontSize: sm ? 10 : 11, fontWeight: 700,
+    whiteSpace:'nowrap',
+  }}>
+    <span aria-hidden="true">{icon || DS.EC[type]?.em}</span>
+    {count !== undefined && <span style={{ fontFamily:'var(--f-mono)' }}>{count}</span>}
+    <span>{label}</span>
+  </span>
+);
+
+const Stars = ({ value, size = 12 }) => {
+  const full = Math.floor(value);
+  const frac = value - full;
+  return (
+    <span style={{ display:'inline-flex', gap: 1 }} aria-label={`${value} stelle su 5`}>
+      {[0,1,2,3,4].map(i => {
+        const fill = i < full ? 1 : (i === full ? frac : 0);
+        return (
+          <span key={i} style={{ position:'relative', fontSize: size, lineHeight: 1 }}>
+            <span style={{ color:'var(--border-strong)' }}>★</span>
+            {fill > 0 && (
+              <span style={{
+                position:'absolute', left: 0, top: 0,
+                width: `${fill * 100}%`, overflow:'hidden',
+                color: entityHsl('agent'),
+              }}>★</span>
+            )}
+          </span>
+        );
+      })}
+    </span>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── CONNECTION CHIP STRIP (footer · PR #542/#545) ──
+// ═══════════════════════════════════════════════════════
+const ConnectionChipStrip = ({ chips, onClick }) => (
+  <div role="navigation" aria-label="Contenuti collegati al toolkit" style={{
+    display:'flex', alignItems:'center', flexWrap:'wrap', gap: 8,
+    padding:'12px 14px',
+    background:'var(--bg-card)',
+    border:'1px solid var(--border)',
+    borderRadius:'var(--r-lg)',
+  }}>
+    <span style={{
+      fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 800,
+      marginRight: 4,
+    }}>Bundled:</span>
+    {chips.map((c, i) => {
+      const empty = c.count === 0 || c.empty;
+      return (
+        <button key={i} type="button"
+          onClick={() => onClick && onClick(c)}
+          aria-label={`${c.label}: ${c.count}`}
+          style={{
+            display:'inline-flex', alignItems:'center', gap: 6,
+            padding:'5px 11px', borderRadius:'var(--r-pill)',
+            background: empty ? 'transparent' : entityHsl(c.entity, 0.1),
+            color: entityHsl(c.entity),
+            border: empty
+              ? `1.5px dashed ${entityHsl(c.entity, 0.5)}`
+              : `1px solid ${entityHsl(c.entity, 0.22)}`,
+            fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 700,
+            cursor:'pointer', whiteSpace:'nowrap',
+            opacity: empty ? 0.65 : 1,
+          }}>
+          <span aria-hidden="true">{DS.EC[c.entity].em}</span>
+          {!empty && <span style={{ fontFamily:'var(--f-mono)', fontWeight: 800 }}>{c.count}</span>}
+          <span>{c.label}</span>
+        </button>
+      );
+    })}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── SUMMARY PANEL (sticky left) ─────────────────────
+// /* v2: ToolkitSummaryPanel → apps/web/src/components/ui/v2/toolkit-summary-panel/ */
+// ═══════════════════════════════════════════════════════
+const SummaryPanel = ({ tk, mine, mobile, loading }) => {
+  if (loading) {
+    return (
+      <div style={{ display:'flex', flexDirection:'column', gap: 12 }}>
+        <div className="mai-shimmer" style={{ height: mobile ? 140 : 180,
+          borderRadius:'var(--r-xl)', background:'var(--bg-muted)' }}/>
+        <div className="mai-shimmer" style={{ height: 28, width:'80%',
+          borderRadius: 6, background:'var(--bg-muted)' }}/>
+        <div className="mai-shimmer" style={{ height: 16, width:'60%',
+          borderRadius: 4, background:'var(--bg-muted)' }}/>
+        <div className="mai-shimmer" style={{ height: 44, borderRadius:'var(--r-md)',
+          background:'var(--bg-muted)' }}/>
+      </div>
+    );
+  }
+
+  const game = DS.byId[tk.gameId];
+  const author = DS.byId[tk.owner];
+  const cover = `linear-gradient(135deg, ${entityHsl('toolkit')} 0%, hsl(${DS.EC.toolkit.h - 10}, 60%, 35%) 50%, hsl(${(game?.id === 'g-azul') ? 200 : 30}, 65%, 45%) 100%)`;
+
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap: 14 }}>
+      {/* Cover gradient toolkit→game */}
+      <div style={{
+        height: mobile ? 140 : 180, borderRadius:'var(--r-xl)',
+        background: cover, position:'relative', overflow:'hidden',
+        border:`1px solid ${entityHsl('toolkit', 0.3)}`,
+        boxShadow:`0 6px 20px ${entityHsl('toolkit', 0.25)}`,
+      }}>
+        <div style={{
+          position:'absolute', inset: 0,
+          background:'radial-gradient(circle at 75% 30%, rgba(255,255,255,.18), transparent 60%)',
+        }}/>
+        <div style={{
+          position:'absolute', top: 12, left: 12,
+          display:'flex', gap: 6,
+        }}>
+          <span style={{
+            padding:'3px 9px', borderRadius:'var(--r-pill)',
+            background:'rgba(0,0,0,.35)', color:'#fff',
+            fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+            textTransform:'uppercase', letterSpacing:'.08em',
+            backdropFilter:'blur(4px)',
+          }}>🧰 Toolkit</span>
+          {tk.status === 'active' && (
+            <span style={{
+              padding:'3px 9px', borderRadius:'var(--r-pill)',
+              background:'rgba(34, 187, 80, 0.85)', color:'#fff',
+              fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+              textTransform:'uppercase', letterSpacing:'.08em',
+            }}>● Pubblicato</span>
+          )}
+        </div>
+        <div style={{
+          position:'absolute', bottom: 12, right: 14,
+          fontFamily:'var(--f-mono)', fontSize: 10, color:'rgba(255,255,255,.85)',
+          fontWeight: 700,
+        }}>v{tk.version}.0.0</div>
+        <div style={{
+          position:'absolute', bottom: 12, left: 14, fontSize: 56, lineHeight: 1, opacity: 0.85,
+        }} aria-hidden="true">🧰</div>
+      </div>
+
+      {/* Title */}
+      <div>
+        <h1 style={{
+          fontFamily:'var(--f-display)', fontWeight: 800,
+          fontSize: mobile ? 22 : 28, letterSpacing:'-.02em',
+          color:'var(--text)', margin:'0 0 6px', lineHeight: 1.1,
+        }}>{tk.title}</h1>
+        <p style={{
+          fontSize: 13.5, color:'var(--text-sec)', lineHeight: 1.55,
+          margin: 0,
+        }}>{tk.desc}</p>
+      </div>
+
+      {/* Author + game cross-refs */}
+      <div style={{ display:'flex', flexWrap:'wrap', gap: 6 }}>
+        {author && <EntityChip type="player" label={`Da ${author.title}`}/>}
+        {game && <EntityChip type="game" label={game.title}/>}
+      </div>
+
+      {/* Stats row */}
+      <div style={{
+        display:'grid', gridTemplateColumns:'repeat(3, 1fr)', gap: 8,
+        padding:'12px 0', borderTop:'1px solid var(--border-light)',
+        borderBottom:'1px solid var(--border-light)',
+      }}>
+        <div>
+          <div style={{ display:'flex', alignItems:'center', gap: 4 }}>
+            <Stars value={tk.rating} size={11}/>
+            <span style={{
+              fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 13,
+              color:'var(--text)', fontVariantNumeric:'tabular-nums',
+            }}>{tk.rating.toFixed(1)}</span>
+          </div>
+          <div style={{
+            fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+            textTransform:'uppercase', letterSpacing:'.06em', fontWeight: 700, marginTop: 2,
+          }}>{tk.ratingCount} recensioni</div>
+        </div>
+        <div>
+          <div style={{
+            fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 16,
+            color: entityHsl('toolkit'), fontVariantNumeric:'tabular-nums', lineHeight: 1,
+          }}>{tk.downloads}</div>
+          <div style={{
+            fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+            textTransform:'uppercase', letterSpacing:'.06em', fontWeight: 700, marginTop: 4,
+          }}>installazioni</div>
+        </div>
+        <div>
+          <div style={{
+            fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 16,
+            color:'var(--text)', fontVariantNumeric:'tabular-nums', lineHeight: 1,
+          }}>v{tk.version}.0</div>
+          <div style={{
+            fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+            textTransform:'uppercase', letterSpacing:'.06em', fontWeight: 700, marginTop: 4,
+          }}>versione</div>
+        </div>
+      </div>
+
+      {/* CTA */}
+      <div style={{ display:'flex', flexDirection:'column', gap: 8 }}>
+        {!mine ? (
+          <>
+            <button type="button" style={{
+              padding:'12px 18px', borderRadius:'var(--r-md)',
+              background: entityHsl('toolkit'), color:'#fff', border:'none',
+              fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800,
+              cursor:'pointer',
+              boxShadow:`0 6px 18px ${entityHsl('toolkit', 0.4)}`,
+              display:'inline-flex', alignItems:'center', justifyContent:'center', gap: 8,
+            }}><span aria-hidden="true">⬇</span>Installa toolkit</button>
+            <button type="button" style={{
+              padding:'10px 14px', borderRadius:'var(--r-md)',
+              background:'transparent', color:'var(--text)',
+              border:'1px solid var(--border-strong)',
+              fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700,
+              cursor:'pointer',
+              display:'inline-flex', alignItems:'center', justifyContent:'center', gap: 8,
+            }}><span aria-hidden="true">↗</span>Condividi</button>
+          </>
+        ) : (
+          <>
+            <button type="button" style={{
+              padding:'12px 18px', borderRadius:'var(--r-md)',
+              background: entityHsl('toolkit'), color:'#fff', border:'none',
+              fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800,
+              cursor:'pointer',
+              boxShadow:`0 6px 18px ${entityHsl('toolkit', 0.4)}`,
+              display:'inline-flex', alignItems:'center', justifyContent:'center', gap: 8,
+            }}><span aria-hidden="true">✎</span>Modifica toolkit</button>
+            <button type="button" style={{
+              padding:'10px 14px', borderRadius:'var(--r-md)',
+              background:'var(--bg-card)', color:'var(--text)',
+              border:`1px solid ${entityHsl('toolkit', 0.4)}`,
+              fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+              cursor:'pointer',
+              display:'inline-flex', alignItems:'center', justifyContent:'center', gap: 8,
+            }}><span aria-hidden="true">⬆</span>Pubblica nuova versione</button>
+          </>
+        )}
+      </div>
+
+      {/* Meta */}
+      <dl style={{
+        margin: 0, padding: 12,
+        background:'var(--bg-card)', border:'1px solid var(--border)',
+        borderRadius:'var(--r-lg)',
+        display:'grid', gridTemplateColumns:'auto 1fr', rowGap: 7, columnGap: 12,
+        fontSize: 11.5,
+      }}>
+        <dt style={{
+          fontFamily:'var(--f-mono)', color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.06em', fontWeight: 700, fontSize: 9,
+          alignSelf:'center',
+        }}>Licenza</dt>
+        <dd style={{ margin: 0, fontFamily:'var(--f-mono)', color:'var(--text)', fontWeight: 600 }}>{tk.license}</dd>
+        <dt style={{
+          fontFamily:'var(--f-mono)', color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.06em', fontWeight: 700, fontSize: 9,
+          alignSelf:'center',
+        }}>Aggiornato</dt>
+        <dd style={{ margin: 0, fontFamily:'var(--f-mono)', color:'var(--text)', fontWeight: 600 }}>{tk.updatedAt}</dd>
+        <dt style={{
+          fontFamily:'var(--f-mono)', color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.06em', fontWeight: 700, fontSize: 9,
+          alignSelf:'center',
+        }}>Pubblicato</dt>
+        <dd style={{ margin: 0, fontFamily:'var(--f-mono)', color:'var(--text)', fontWeight: 600 }}>{tk.publishedAt}</dd>
+        <dt style={{
+          fontFamily:'var(--f-mono)', color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.06em', fontWeight: 700, fontSize: 9,
+          alignSelf:'center',
+        }}>Dimensione</dt>
+        <dd style={{ margin: 0, fontFamily:'var(--f-mono)', color:'var(--text)', fontWeight: 600 }}>{tk.size}</dd>
+      </dl>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── TABS BAR ───────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const TabsBar = ({ tabs, active, onChange, mine }) => {
+  const refs = useRef({});
+  const [ind, setInd] = useState({ left: 0, width: 0 });
+  useEffect(() => {
+    const el = refs.current[active];
+    if (el) setInd({ left: el.offsetLeft, width: el.offsetWidth });
+  }, [active]);
+  return (
+    <div className="mai-cb-scroll" style={{
+      position:'relative',
+      display:'flex', alignItems:'center', gap: 2,
+      borderBottom:'1px solid var(--border)',
+      overflowX:'auto', scrollbarWidth:'none',
+    }} role="tablist" aria-label="Contenuti del toolkit">
+      {tabs.map(t => {
+        const isActive = t.id === active;
+        return (
+          <button key={t.id} type="button"
+            ref={el => { refs.current[t.id] = el; }}
+            onClick={() => onChange(t.id)}
+            role="tab"
+            aria-selected={isActive}
+            aria-controls={`panel-${t.id}`}
+            id={`tab-${t.id}`}
+            style={{
+              display:'inline-flex', alignItems:'center', gap: 7,
+              padding:'12px 14px', background:'transparent', border:'none',
+              color: isActive ? entityHsl('toolkit') : 'var(--text-sec)',
+              fontFamily:'var(--f-display)', fontSize: 13,
+              fontWeight: isActive ? 800 : 700,
+              cursor:'pointer', whiteSpace:'nowrap', flexShrink: 0,
+              transition:'color var(--dur-sm) var(--ease-out)',
+            }}>
+            <span aria-hidden="true">{t.icon}</span>
+            <span>{t.label}{mine && t.id === 'versions' && ' · changelog'}</span>
+            {t.count !== undefined && (
+              <span style={{
+                padding:'1px 7px', borderRadius:'var(--r-pill)',
+                background: isActive ? entityHsl('toolkit') : 'var(--bg-muted)',
+                color: isActive ? '#fff' : 'var(--text-muted)',
+                fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+              }}>{t.count}</span>
+            )}
+          </button>
+        );
+      })}
+      <span aria-hidden="true" style={{
+        position:'absolute', bottom: -1, left: ind.left, width: ind.width,
+        height: 2, background: entityHsl('toolkit'),
+        transition:'left .3s cubic-bezier(.4,0,.2,1), width .3s cubic-bezier(.4,0,.2,1)',
+        borderRadius:'2px 2px 0 0',
+      }}/>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── TAB: OVERVIEW ──────────────────────────────────
+// /* v2: ToolkitIncludesGrid → apps/web/src/components/ui/v2/toolkit-includes-grid/ */
+// ═══════════════════════════════════════════════════════
+const IncludesBox = ({ entity, count, label, sub, icon }) => (
+  <div style={{
+    padding: 14, background:'var(--bg-card)',
+    border:`1px solid ${entityHsl(entity, 0.25)}`,
+    borderRadius:'var(--r-lg)',
+    display:'flex', flexDirection:'column', gap: 6,
+  }}>
+    <div style={{
+      width: 38, height: 38, borderRadius:'var(--r-md)',
+      background: entityHsl(entity, 0.14), color: entityHsl(entity),
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 19,
+    }} aria-hidden="true">{icon}</div>
+    <div style={{
+      fontFamily:'var(--f-display)', fontSize: 22, fontWeight: 800,
+      color: entityHsl(entity), fontVariantNumeric:'tabular-nums', lineHeight: 1,
+    }}>{count}</div>
+    <div style={{
+      fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+      color:'var(--text)',
+    }}>{label}</div>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+      lineHeight: 1.4, fontWeight: 600,
+    }}>{sub}</div>
+  </div>
+);
+
+const OverviewTab = ({ tk }) => {
+  const agent = DS.byId[tk.agentId];
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap: 16 }}>
+      <div>
+        <h2 style={{
+          fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800,
+          color:'var(--text)', margin:'0 0 8px',
+        }}>Descrizione</h2>
+        <p style={{
+          fontSize: 14, lineHeight: 1.65, color:'var(--text)', margin: 0,
+          textWrap:'pretty',
+        }}>{tk.longDesc}</p>
+      </div>
+
+      <div>
+        <h2 style={{
+          fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800,
+          color:'var(--text)', margin:'0 0 10px',
+        }}>Cosa include</h2>
+        <div style={{
+          display:'grid', gridTemplateColumns:'repeat(auto-fit, minmax(180px, 1fr))', gap: 12,
+        }}>
+          <IncludesBox entity="agent" count={1} label="Agente"
+            sub={agent?.title || 'Nessun agente'} icon="🤖"/>
+          <IncludesBox entity="kb" count={tk.kbIds.length} label="KB docs"
+            sub="Regole + FAQ indicizzate" icon="📄"/>
+          <IncludesBox entity="tool" count={tk.toolIds.length} label="Strumenti"
+            sub="Timer · counter · mazzo" icon="🔧"/>
+        </div>
+      </div>
+
+      <div>
+        <h2 style={{
+          fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800,
+          color:'var(--text)', margin:'0 0 10px',
+        }}>Come usarlo</h2>
+        <ol style={{
+          margin: 0, paddingLeft: 18, fontSize: 13.5, lineHeight: 1.7,
+          color:'var(--text-sec)',
+        }}>
+          <li>Premi <strong>Installa toolkit</strong> dalla colonna a sinistra.</li>
+          <li>Apri una sessione di Azul: gli strumenti appaiono nel pannello laterale.</li>
+          <li>Chiedi all'agente <em>Azul Rules Expert</em> dubbi sulle regole, citazioni dal manuale.</li>
+          <li>Al termine partita, il counter calcola automaticamente i bonus colore.</li>
+        </ol>
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── TAB: AGENTE ────────────────────────────────────
+// /* v2: PromptPreviewBlock → apps/web/src/components/ui/v2/prompt-preview-block/ */
+// ═══════════════════════════════════════════════════════
+const AgentTab = ({ tk }) => {
+  const agent = DS.byId[tk.agentId];
+  if (!agent) return null;
+  const game = DS.byId[agent.gameId];
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap: 14 }}>
+      {/* PersonaCard riuso */}
+      <div style={{
+        padding: 16, background:'var(--bg-card)',
+        border:`1px solid ${entityHsl('agent', 0.25)}`,
+        borderRadius:'var(--r-xl)',
+        display:'flex', gap: 14, alignItems:'flex-start',
+      }}>
+        <div style={{
+          width: 64, height: 64, borderRadius:'var(--r-lg)',
+          background:`linear-gradient(135deg, ${entityHsl('agent')}, hsl(${DS.EC.agent.h - 10}, 80%, 35%))`,
+          color:'#fff',
+          display:'flex', alignItems:'center', justifyContent:'center',
+          fontSize: 30, flexShrink: 0,
+          boxShadow:`0 4px 14px ${entityHsl('agent', 0.4)}`,
+        }} aria-hidden="true">🤖</div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display:'flex', alignItems:'center', gap: 8, marginBottom: 4, flexWrap:'wrap' }}>
+            <h3 style={{
+              fontFamily:'var(--f-display)', fontSize: 18, fontWeight: 800,
+              color:'var(--text)', margin: 0,
+            }}>{agent.title}</h3>
+            <EntityChip type="agent" label={agent.badge} sm/>
+          </div>
+          <div style={{
+            fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)', fontWeight: 600,
+            marginBottom: 8,
+          }}>{agent.strategy} · {agent.model} · {game?.title}</div>
+          <div style={{ display:'flex', flexWrap:'wrap', gap:6 }}>
+            <EntityChip type="kb" label={`${agent.docs} KB docs`} sm/>
+            <EntityChip type="chat" label={`${agent.invocations} invocazioni`} sm/>
+            <span style={{
+              padding:'2px 8px', borderRadius:'var(--r-pill)',
+              background:'var(--bg-muted)', color:'var(--text-sec)',
+              fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 700,
+            }}>⚡ {agent.avgLatency}</span>
+          </div>
+        </div>
+        <button type="button" style={{
+          padding:'8px 12px', borderRadius:'var(--r-md)',
+          background:'transparent', color: entityHsl('agent'),
+          border:`1px solid ${entityHsl('agent', 0.4)}`,
+          fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer',
+          flexShrink: 0,
+        }}>Apri ↗</button>
+      </div>
+
+      {/* System prompt preview */}
+      <div>
+        <div style={{
+          display:'flex', alignItems:'baseline', justifyContent:'space-between', marginBottom: 8,
+        }}>
+          <h3 style={{
+            fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800,
+            color:'var(--text)', margin: 0,
+          }}>System prompt (preview)</h3>
+          <span style={{
+            fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)', fontWeight: 700,
+          }}>342 token</span>
+        </div>
+        <pre style={{
+          margin: 0, padding: 14,
+          background:'var(--bg-sunken)',
+          border:'1px solid var(--border)',
+          borderRadius:'var(--r-lg)',
+          fontFamily:'var(--f-mono)', fontSize: 11.5, lineHeight: 1.65,
+          color:'var(--text)', whiteSpace:'pre-wrap', overflow:'auto', maxHeight: 220,
+        }}>{`Sei "Azul Rules Expert", un assistente per le regole di Azul.
+Rispondi sempre in italiano, in modo conciso e citando la pagina del manuale.
+
+# Comportamento
+- Quando l'utente fa una domanda sulle regole, recupera il chunk più rilevante
+  dal Knowledge Base (azul-regole-ita.pdf, azul-faq.md).
+- Cita la pagina con il formato [p. N] alla fine della risposta.
+- Se la domanda è ambigua, fai una sola domanda di chiarimento.
+
+# Limiti
+- Non inventare regole non presenti nel manuale.
+- Non dare consigli strategici a meno che l'utente non li chieda esplicitamente.`}</pre>
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── TAB: KB ────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const KbTab = ({ tk }) => {
+  const [openId, setOpenId] = useState(null);
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap: 8 }}>
+      {tk.kbIds.map(kbId => {
+        const kb = DS.byId[kbId];
+        if (!kb) return null;
+        const isOpen = openId === kbId;
+        return (
+          <article key={kbId} style={{
+            background:'var(--bg-card)', border:'1px solid var(--border)',
+            borderRadius:'var(--r-lg)', overflow:'hidden',
+          }}>
+            <button type="button" onClick={() => setOpenId(isOpen ? null : kbId)}
+              aria-expanded={isOpen} aria-controls={`kb-peek-${kbId}`}
+              style={{
+                width:'100%', padding: 14,
+                display:'flex', alignItems:'center', gap: 12,
+                background:'transparent', border:'none', cursor:'pointer',
+                textAlign:'left',
+              }}>
+              <div style={{
+                width: 38, height: 46, borderRadius:'var(--r-sm)',
+                background: entityHsl('kb', 0.16), color: entityHsl('kb'),
+                display:'flex', alignItems:'center', justifyContent:'center',
+                fontSize: 18, flexShrink: 0,
+              }} aria-hidden="true">📄</div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{
+                  fontFamily:'var(--f-mono)', fontSize: 13, fontWeight: 700,
+                  color:'var(--text)', marginBottom: 3,
+                }}>{kb.title}</div>
+                <div style={{
+                  fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)', fontWeight: 600,
+                }}>{kb.pages} pag · {kb.size} · {kb.chunks} chunks · {kb.embedding}</div>
+              </div>
+              <EntityChip type="kb" label={kb.badge} sm/>
+              <span aria-hidden="true" style={{
+                color:'var(--text-muted)', fontSize: 16,
+                transform: isOpen ? 'rotate(180deg)' : 'none',
+                transition:'transform var(--dur-sm) var(--ease-out)',
+              }}>⌄</span>
+            </button>
+            {isOpen && (
+              <div id={`kb-peek-${kbId}`} style={{
+                padding:'0 14px 14px', borderTop:'1px solid var(--border-light)',
+                animation:'slideDown .25s var(--ease-out)',
+              }}>
+                <div style={{
+                  fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+                  textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 800,
+                  marginTop: 12, marginBottom: 6,
+                }}>Anteprima primo chunk</div>
+                <p style={{
+                  fontSize: 12.5, color:'var(--text-sec)', margin: 0, lineHeight: 1.6,
+                  fontStyle:'italic',
+                  padding: 10, background:'var(--bg-sunken)', borderRadius:'var(--r-sm)',
+                }}>"In Azul, i giocatori si alternano nel raccogliere tessere colorate dalle factory display al loro tabellone personale. Ogni colore raccolto va posizionato in una riga del pattern strip. A fine round, le tessere completate vengono mosse sul muro..."</p>
+              </div>
+            )}
+          </article>
+        );
+      })}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── TAB: TOOLS ─────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const ToolsTab = ({ tk }) => {
+  const [openId, setOpenId] = useState(null);
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap: 8 }}>
+      {tk.toolIds.map(toolId => {
+        const t = DS.byId[toolId];
+        if (!t) return null;
+        const isOpen = openId === toolId;
+        return (
+          <article key={toolId} style={{
+            background:'var(--bg-card)', border:'1px solid var(--border)',
+            borderRadius:'var(--r-lg)', overflow:'hidden',
+          }}>
+            <button type="button" onClick={() => setOpenId(isOpen ? null : toolId)}
+              aria-expanded={isOpen} aria-controls={`tool-peek-${toolId}`}
+              style={{
+                width:'100%', padding: 14,
+                display:'flex', alignItems:'center', gap: 12,
+                background:'transparent', border:'none', cursor:'pointer',
+                textAlign:'left',
+              }}>
+              <div style={{
+                width: 42, height: 42, borderRadius:'var(--r-md)',
+                background: entityHsl('tool', 0.14), color: entityHsl('tool'),
+                display:'flex', alignItems:'center', justifyContent:'center',
+                fontSize: 20, flexShrink: 0,
+              }} aria-hidden="true">{t.coverEmoji}</div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{
+                  fontFamily:'var(--f-display)', fontSize: 13.5, fontWeight: 800,
+                  color:'var(--text)', marginBottom: 3,
+                }}>{t.title}</div>
+                <div style={{
+                  fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)', fontWeight: 600,
+                }}>kind={t.kind} · {t.uses} usi totali</div>
+              </div>
+              <EntityChip type="tool" label={t.kind} sm/>
+              <span aria-hidden="true" style={{
+                color:'var(--text-muted)', fontSize: 16,
+                transform: isOpen ? 'rotate(180deg)' : 'none',
+                transition:'transform var(--dur-sm) var(--ease-out)',
+              }}>⌄</span>
+            </button>
+            {isOpen && (
+              <div id={`tool-peek-${toolId}`} style={{
+                padding:'12px 14px 14px', borderTop:'1px solid var(--border-light)',
+              }}>
+                <div style={{
+                  fontFamily:'var(--f-mono)', fontSize: 9, color:'var(--text-muted)',
+                  textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 800,
+                  marginBottom: 6,
+                }}>Configurazione</div>
+                <pre style={{
+                  margin: 0, padding: 10,
+                  background:'var(--bg-sunken)',
+                  border:'1px solid var(--border-light)',
+                  borderRadius:'var(--r-sm)',
+                  fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text)',
+                  overflow:'auto',
+                }}>{JSON.stringify(t.config, null, 2)}</pre>
+              </div>
+            )}
+          </article>
+        );
+      })}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── TAB: VERSIONS ──────────────────────────────────
+// /* v2: VersionTimeline → apps/web/src/components/ui/v2/version-timeline/ */
+// ═══════════════════════════════════════════════════════
+const VersionsTab = ({ tk, mine }) => {
+  const kindColor = {
+    major: entityHsl('event'),
+    minor: entityHsl('toolkit'),
+    patch: entityHsl('text-muted'),
+  };
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap: 0 }}>
+      {tk.versions.map((v, i) => {
+        const isLatest = i === 0;
+        const dotColor = v.kind === 'major' ? entityHsl('event')
+          : v.kind === 'minor' ? entityHsl('toolkit')
+          : 'var(--text-muted)';
+        return (
+          <div key={v.v} style={{
+            display:'flex', gap: 14, position:'relative',
+            paddingBottom: i === tk.versions.length - 1 ? 0 : 14,
+          }}>
+            {/* Timeline rail */}
+            <div style={{
+              width: 14, flexShrink: 0, position:'relative',
+              display:'flex', justifyContent:'center', paddingTop: 6,
+            }}>
+              {i < tk.versions.length - 1 && (
+                <div style={{
+                  position:'absolute', top: 18, bottom: -14, left:'50%',
+                  width: 2, background:'var(--border)', transform:'translateX(-50%)',
+                }}/>
+              )}
+              <div style={{
+                width: 14, height: 14, borderRadius:'50%',
+                background: dotColor, color:'#fff',
+                border: isLatest ? `3px solid ${entityHsl('toolkit', 0.3)}` : 'none',
+                boxShadow: isLatest ? `0 0 0 4px ${entityHsl('toolkit', 0.1)}` : 'none',
+                position:'relative', zIndex: 1,
+              }}/>
+            </div>
+
+            <div style={{
+              flex: 1, padding: 14,
+              background:'var(--bg-card)', border:'1px solid var(--border)',
+              borderRadius:'var(--r-lg)',
+            }}>
+              <div style={{
+                display:'flex', alignItems:'center', gap: 8, marginBottom: 4,
+                flexWrap:'wrap',
+              }}>
+                <h3 style={{
+                  fontFamily:'var(--f-mono)', fontSize: 14, fontWeight: 800,
+                  color:'var(--text)', margin: 0,
+                }}>v{v.v}</h3>
+                <span style={{
+                  padding:'2px 8px', borderRadius:'var(--r-pill)',
+                  background: `${dotColor}1f`, color: dotColor,
+                  fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+                  textTransform:'uppercase', letterSpacing:'.08em',
+                }}>{v.kind}</span>
+                {isLatest && (
+                  <span style={{
+                    padding:'2px 8px', borderRadius:'var(--r-pill)',
+                    background: entityHsl('toolkit', 0.14), color: entityHsl('toolkit'),
+                    fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+                    textTransform:'uppercase', letterSpacing:'.08em',
+                  }}>● Corrente</span>
+                )}
+                <span style={{
+                  fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+                  marginLeft:'auto',
+                }}>{v.at}</span>
+              </div>
+              <ul style={{
+                margin: 0, paddingLeft: 16, fontSize: 12.5, lineHeight: 1.6,
+                color:'var(--text-sec)',
+              }}>
+                {v.notes.map((n, j) => <li key={j}>{n}</li>)}
+              </ul>
+              {mine && isLatest && (
+                <div style={{ display:'flex', gap: 6, marginTop: 10 }}>
+                  <button type="button" style={{
+                    padding:'5px 10px', borderRadius:'var(--r-sm)',
+                    background:'transparent', color:'var(--text-sec)',
+                    border:'1px solid var(--border)',
+                    fontFamily:'var(--f-display)', fontSize: 11, fontWeight: 700, cursor:'pointer',
+                  }}>✎ Modifica note</button>
+                  <button type="button" style={{
+                    padding:'5px 10px', borderRadius:'var(--r-sm)',
+                    background:'transparent', color: entityHsl('warning'),
+                    border:`1px solid ${entityHsl('warning', 0.4)}`,
+                    fontFamily:'var(--f-display)', fontSize: 11, fontWeight: 700, cursor:'pointer',
+                  }}>⊘ Yank versione</button>
+                </div>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── TAB: REVIEWS ───────────────────────────────────
+// /* v2: RatingBreakdown → apps/web/src/components/ui/v2/rating-breakdown/ */
+// ═══════════════════════════════════════════════════════
+const ReviewsTab = ({ tk }) => (
+  <div style={{ display:'flex', flexDirection:'column', gap: 16 }}>
+    {/* Breakdown */}
+    <div style={{
+      padding: 16, background:'var(--bg-card)', border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)',
+      display:'grid', gridTemplateColumns:'auto 1fr', gap: 24, alignItems:'center',
+    }}>
+      <div style={{ textAlign:'center' }}>
+        <div style={{
+          fontFamily:'var(--f-display)', fontSize: 42, fontWeight: 800,
+          color:'var(--text)', lineHeight: 1, fontVariantNumeric:'tabular-nums',
+        }}>{tk.rating.toFixed(1)}</div>
+        <div style={{ marginTop: 4 }}><Stars value={tk.rating} size={14}/></div>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+          marginTop: 4, fontWeight: 700,
+        }}>{tk.ratingCount} recensioni</div>
+      </div>
+      <div style={{ display:'flex', flexDirection:'column', gap: 5 }}>
+        {[5,4,3,2,1].map(s => {
+          const n = tk.ratingHistogram[s] || 0;
+          const pct = (n / tk.ratingCount) * 100;
+          return (
+            <div key={s} style={{ display:'flex', alignItems:'center', gap: 8 }}>
+              <span style={{
+                fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+                width: 20, fontWeight: 700,
+              }}>{s}★</span>
+              <div style={{
+                flex: 1, height: 8, borderRadius:'var(--r-pill)',
+                background:'var(--bg-muted)', overflow:'hidden',
+              }}>
+                <div style={{
+                  height:'100%', width: `${pct}%`,
+                  background: entityHsl('agent'),
+                  borderRadius:'var(--r-pill)',
+                }}/>
+              </div>
+              <span style={{
+                fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+                width: 28, textAlign:'right', fontWeight: 700,
+              }}>{n}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+
+    {/* Reviews list */}
+    <div style={{ display:'flex', flexDirection:'column', gap: 10 }}>
+      {tk.reviews.map(r => {
+        const author = DS.byId[r.authorId];
+        return (
+          <article key={r.id} style={{
+            padding: 14, background:'var(--bg-card)', border:'1px solid var(--border)',
+            borderRadius:'var(--r-lg)',
+          }}>
+            <div style={{ display:'flex', alignItems:'center', gap: 10, marginBottom: 6 }}>
+              <div style={{
+                width: 32, height: 32, borderRadius:'50%',
+                background: `hsl(${author?.color || 200}, 60%, 55%)`, color:'#fff',
+                display:'flex', alignItems:'center', justifyContent:'center',
+                fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 11,
+              }} aria-hidden="true">{author?.initials || '?'}</div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{
+                  fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+                  color:'var(--text)',
+                }}>{author?.title || 'Anonimo'}</div>
+                <div style={{
+                  display:'flex', alignItems:'center', gap: 8,
+                  fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+                  fontWeight: 600,
+                }}>
+                  <Stars value={r.stars} size={10}/>
+                  <span>{r.at}</span>
+                </div>
+              </div>
+            </div>
+            <p style={{
+              margin: 0, fontSize: 13, lineHeight: 1.6, color:'var(--text)',
+            }}>{r.text}</p>
+          </article>
+        );
+      })}
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── ERROR / LOADING / EMPTY ────────────────────────
+// ═══════════════════════════════════════════════════════
+const TabSkeleton = () => (
+  <div style={{ display:'flex', flexDirection:'column', gap: 10 }}>
+    {[0,1,2].map(i => (
+      <div key={i} className="mai-shimmer" style={{
+        height: 80, borderRadius:'var(--r-lg)', background:'var(--bg-muted)',
+      }}/>
+    ))}
+  </div>
+);
+const TabError = () => (
+  <div style={{
+    padding:'32px 24px', textAlign:'center',
+    background:'hsl(var(--c-danger) / .08)',
+    border:'1px solid hsl(var(--c-danger) / .3)',
+    borderRadius:'var(--r-xl)',
+    display:'flex', flexDirection:'column', alignItems:'center',
+  }}>
+    <div style={{
+      width: 48, height: 48, borderRadius:'50%',
+      background:'hsl(var(--c-danger) / .15)', color:'hsl(var(--c-danger))',
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 22, marginBottom: 10,
+    }} aria-hidden="true">⚠</div>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800,
+      color:'var(--text)', margin:'0 0 4px',
+    }}>Errore caricamento toolkit</h3>
+    <p style={{ fontSize: 12, color:'var(--text-muted)', margin:'0 0 12px' }}>
+      Impossibile recuperare il bundle. Riprova fra qualche secondo.
+    </p>
+    <button type="button" style={{
+      padding:'7px 14px', borderRadius:'var(--r-md)',
+      background:'hsl(var(--c-danger))', color:'#fff', border:'none',
+      fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer',
+    }}>↻ Riprova</button>
+  </div>
+);
+const TabEmpty = ({ title, sub, cta, accent = 'toolkit', icon }) => (
+  <div style={{
+    padding:'40px 24px', textAlign:'center',
+    background:'var(--bg-card)', border:'1px dashed var(--border-strong)',
+    borderRadius:'var(--r-xl)',
+    display:'flex', flexDirection:'column', alignItems:'center',
+  }}>
+    <div style={{
+      width: 60, height: 60, borderRadius:'50%',
+      background: entityHsl(accent, 0.12), color: entityHsl(accent),
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 26, marginBottom: 12,
+    }} aria-hidden="true">{icon}</div>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: 15, fontWeight: 800,
+      color:'var(--text)', margin:'0 0 4px',
+    }}>{title}</h3>
+    <p style={{ fontSize: 12.5, color:'var(--text-muted)', margin:'0 0 14px', maxWidth: 340 }}>{sub}</p>
+    {cta && (
+      <button type="button" style={{
+        padding:'8px 16px', borderRadius:'var(--r-md)',
+        background: entityHsl(accent), color:'#fff', border:'none',
+        fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer',
+        boxShadow:`0 3px 10px ${entityHsl(accent, 0.35)}`,
+      }}>{cta}</button>
+    )}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── BODY ───────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const ToolkitDetailBody = ({ stateOverride, mine = false, mobile, initialTab = 'overview' }) => {
+  const [tab, setTab] = useState(initialTab);
+  const tk = TK_AZUL;
+
+  const isLoading = stateOverride === 'loading';
+  const isError = stateOverride === 'error';
+  const isEmpty = stateOverride === 'empty';
+
+  // Empty toolkit fixture
+  const emptyTk = isEmpty ? {
+    ...tk, agentId: null, toolIds: [], kbIds: [],
+    rating: 0, ratingCount: 0, downloads: 0,
+    reviews: [], ratingHistogram: { 5:0,4:0,3:0,2:0,1:0 },
+    versions: [{ v:'0.1.0', at:'8 Mar 2026', kind:'patch', notes:['Toolkit creato — non ancora popolato'] }],
+    desc: 'Toolkit appena creato. Aggiungi agente, KB docs e strumenti per pubblicarlo.',
+    longDesc: 'Toolkit appena creato. Aggiungi agente, KB docs e strumenti per pubblicarlo.',
+    status: 'setup',
+    version: 0,
+  } : null;
+
+  const activeTk = isEmpty ? emptyTk : tk;
+
+  const tabs = [
+    { id:'overview', icon:'📋', label:'Overview' },
+    { id:'agent', icon:'🤖', label:'Agente' },
+    { id:'kb', icon:'📄', label:'KB', count: activeTk.kbIds.length },
+    { id:'tools', icon:'🔧', label:'Tools', count: activeTk.toolIds.length },
+    { id:'versions', icon:'📌', label:'Versioni', count: activeTk.versions.length },
+    { id:'reviews', icon:'⭐', label:'Recensioni', count: activeTk.ratingCount },
+  ];
+
+  const chips = [
+    { entity:'agent', count: activeTk.agentId ? 1 : 0, label: activeTk.agentId ? 'Agente' : 'Nessun agente', empty: !activeTk.agentId },
+    { entity:'kb', count: activeTk.kbIds.length, label:'KB docs' },
+    { entity:'tool', count: activeTk.toolIds.length, label:'Strumenti' },
+    { entity:'game', count: 1, label: DS.byId[activeTk.gameId]?.title || 'Game' },
+    { entity:'player', count: 1, label:'Autore' },
+    { entity:'session', count: activeTk.useCount, label:'Usi totali' },
+  ];
+
+  const renderTab = () => {
+    if (isLoading) return <TabSkeleton/>;
+    if (isError) return <TabError/>;
+    if (isEmpty && tab === 'overview') {
+      return (
+        <div style={{ display:'flex', flexDirection:'column', gap: 14 }}>
+          <p style={{ fontSize: 13.5, color:'var(--text-sec)', lineHeight: 1.6, margin: 0 }}>
+            {activeTk.longDesc}
+          </p>
+          <TabEmpty title="Nessun contenuto bundled"
+            sub="Aggiungi un agente, almeno una KB e uno strumento per poter pubblicare la prima versione."
+            cta="+ Aggiungi contenuti" icon="🧰"/>
+        </div>
+      );
+    }
+    if (isEmpty && tab === 'agent') return <TabEmpty title="Nessun agente collegato"
+      sub="Collega un agente esistente o creane uno nuovo per questo toolkit."
+      cta="+ Collega agente" accent="agent" icon="🤖"/>;
+    if (isEmpty && tab === 'kb') return <TabEmpty title="Nessun documento KB"
+      sub="Carica almeno un manuale o FAQ in formato PDF/Markdown."
+      cta="+ Carica documento" accent="kb" icon="📄"/>;
+    if (isEmpty && tab === 'tools') return <TabEmpty title="Nessuno strumento"
+      sub="Aggiungi timer, counter, mazzi o tracker."
+      cta="+ Aggiungi strumento" accent="tool" icon="🔧"/>;
+    if (isEmpty && tab === 'reviews') return <TabEmpty title="Nessuna recensione"
+      sub="Le recensioni appariranno dopo la prima pubblicazione." accent="agent" icon="⭐"/>;
+
+    if (tab === 'overview') return <OverviewTab tk={activeTk}/>;
+    if (tab === 'agent') return <AgentTab tk={activeTk}/>;
+    if (tab === 'kb') return <KbTab tk={activeTk}/>;
+    if (tab === 'tools') return <ToolsTab tk={activeTk}/>;
+    if (tab === 'versions') return <VersionsTab tk={activeTk} mine={mine}/>;
+    if (tab === 'reviews') return <ReviewsTab tk={activeTk}/>;
+    return null;
+  };
+
+  if (mobile) {
+    // Mobile: stacked, summary first then tabs
+    return (
+      <>
+        <div style={{ padding:'14px 16px', borderBottom:'1px solid var(--border-light)' }}>
+          <SummaryPanel tk={activeTk} mine={mine} mobile loading={isLoading}/>
+        </div>
+        <div style={{
+          position:'sticky', top: 0, zIndex: 7,
+          background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+          padding:'0 16px',
+        }}>
+          <TabsBar tabs={tabs} active={tab} onChange={setTab} mine={mine}/>
+        </div>
+        <div role="tabpanel" id={`panel-${tab}`} aria-labelledby={`tab-${tab}`}
+          style={{ padding:'14px 16px 14px' }}>
+          {renderTab()}
+        </div>
+        <div style={{ padding:'0 16px 24px' }}>
+          <ConnectionChipStrip chips={chips}/>
+        </div>
+      </>
+    );
+  }
+
+  // Desktop split-view
+  return (
+    <div style={{ display:'flex', flexDirection:'column', minHeight: 720 }}>
+      <div style={{
+        display:'grid', gridTemplateColumns:'380px 1fr', gap: 24,
+        padding:'24px 32px', flex: 1,
+        background:'var(--bg)',
+      }}>
+        <aside style={{ position:'sticky', top: 24, alignSelf:'start', maxHeight:'calc(100vh - 48px)', overflowY:'auto' }}>
+          <SummaryPanel tk={activeTk} mine={mine} loading={isLoading}/>
+        </aside>
+        <main style={{ minWidth: 0 }}>
+          <div style={{
+            position:'sticky', top: 0, zIndex: 7,
+            background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+            marginBottom: 18,
+          }}>
+            <TabsBar tabs={tabs} active={tab} onChange={setTab} mine={mine}/>
+          </div>
+          <div role="tabpanel" id={`panel-${tab}`} aria-labelledby={`tab-${tab}`}>
+            {renderTab()}
+          </div>
+        </main>
+      </div>
+      {/* ConnectionChipStrip footer */}
+      <footer style={{
+        padding:'16px 32px 24px', background:'var(--bg)',
+        borderTop:'1px solid var(--border)',
+      }}>
+        <ConnectionChipStrip chips={chips}/>
+      </footer>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── SHELLS ─────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const DesktopNav = ({ tk, mine }) => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 14,
+    padding:'10px 32px',
+    background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+    borderBottom:'1px solid var(--border)',
+  }}>
+    <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
+      <div style={{
+        width: 26, height: 26, borderRadius: 7,
+        background:'linear-gradient(135deg, hsl(var(--c-toolkit)), hsl(var(--c-game)))',
+        color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+        fontWeight: 800, fontSize: 13, fontFamily:'var(--f-display)',
+      }}>M</div>
+      <span style={{ fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 14 }}>MeepleAI</span>
+    </div>
+    <div style={{
+      flex: 1, fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      marginLeft: 22,
+    }}>
+      <a href="#" style={{ color:'inherit' }}>Toolkits</a>
+      <span aria-hidden="true"> / </span>
+      <strong style={{ color:'var(--text-sec)' }}>{tk.title}</strong>
+      {mine && (
+        <span style={{
+          marginLeft: 10, padding:'2px 7px', borderRadius:'var(--r-pill)',
+          background: entityHsl('toolkit', 0.14), color: entityHsl('toolkit'),
+          fontSize: 9, fontWeight: 800, textTransform:'uppercase', letterSpacing:'.08em',
+        }}>● Tuo</span>
+      )}
+    </div>
+  </div>
+);
+
+const DesktopScreen = ({ stateOverride, mine, initialTab }) => (
+  <div style={{ background:'var(--bg)' }}>
+    <DesktopNav tk={TK_AZUL} mine={mine}/>
+    <ToolkitDetailBody stateOverride={stateOverride} mine={mine} initialTab={initialTab}/>
+  </div>
+);
+
+const PhoneSbar = () => (
+  <div className="phone-sbar" style={{ color:'var(--text)' }}>
+    <span style={{ fontFamily:'var(--f-mono)' }}>14:32</span>
+    <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+  </div>
+);
+const PhoneTopNav = ({ tk, mine }) => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 9,
+    padding:'10px 14px', background:'var(--glass-bg)',
+    backdropFilter:'blur(12px)',
+    borderBottom:'1px solid var(--border-light)',
+  }}>
+    <button aria-label="Indietro" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      color:'var(--text)', fontSize: 14, cursor:'pointer',
+    }}>←</button>
+    <div style={{
+      flex: 1, fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+      textAlign:'center', fontWeight: 700,
+    }}>toolkits / {tk.id.replace('tk-', '')}{mine && ' · tuo'}</div>
+    <button aria-label="Più opzioni" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      color:'var(--text)', fontSize: 14, cursor:'pointer',
+    }}>⋯</button>
+  </div>
+);
+const MobileScreen = ({ stateOverride, mine, initialTab }) => (
+  <>
+    <PhoneSbar/>
+    <div style={{ flex: 1, overflowY:'auto', position:'relative', background:'var(--bg)' }}>
+      <PhoneTopNav tk={TK_AZUL} mine={mine}/>
+      <ToolkitDetailBody stateOverride={stateOverride} mine={mine} mobile initialTab={initialTab}/>
+    </div>
+  </>
+);
+
+const PhoneShell = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 10 }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div className="phone">{children}</div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 340,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+const DesktopFrame = ({ label, desc, children, mine }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 12, width:'100%' }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div style={{
+      width:'100%', maxWidth: 1440,
+      borderRadius:'var(--r-xl)', border:'1px solid var(--border)',
+      background:'var(--bg)', overflow:'hidden',
+      boxShadow:'var(--shadow-lg)',
+    }}>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 8,
+        padding:'9px 14px', background:'var(--bg-muted)',
+        borderBottom:'1px solid var(--border)',
+        fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      }}>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-event))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-warning))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-toolkit))' }}/>
+        <span style={{ flex: 1, textAlign:'center', letterSpacing:'.04em' }}>meepleai.app/toolkits/{TK_AZUL.id.replace('tk-', '')}{mine ? '/edit' : ''}</span>
+      </div>
+      {children}
+    </div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 720,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── ROOT ───────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const MOBILE_STATES = [
+  { id:'m1', stateOverride:null, mine:false, tab:'overview',
+    label:'01 · Public · Overview',
+    desc:'Summary panel stacked: cover gradient toolkit→game (verde→azul-blue) 140px, stats triplet + CTA "Installa". Body Includes 3-box (Agent/KB/Tools).' },
+  { id:'m2', stateOverride:null, mine:false, tab:'tools',
+    label:'02 · Public · Tools peek',
+    desc:'Lista tools con peek drawer. Click chevron espande JSON config in <pre> sunken bg.' },
+  { id:'m3', stateOverride:null, mine:false, tab:'reviews',
+    label:'03 · Public · Recensioni',
+    desc:'Rating breakdown 4.7/5 + histogram bars + lista recensioni con avatar player gradient + Stars component.' },
+  { id:'m4', stateOverride:null, mine:true, tab:'versions',
+    label:'04 · Own · Versioni · changelog',
+    desc:'Variante autore: tab label estesa "Versioni · changelog". Timeline rail con dot color-coded major/minor/patch + CTA "✎ Modifica note" / "⊘ Yank" su corrente.' },
+  { id:'m5', stateOverride:'empty', mine:true, tab:'overview',
+    label:'05 · Own · Empty (toolkit nuovo)',
+    desc:'Toolkit appena creato dall\'autore. Stats 0/0/v0, CTA "+ Aggiungi contenuti" toolkit-green nel body.' },
+  { id:'m6', stateOverride:'loading', mine:false, tab:'overview',
+    label:'06 · Loading',
+    desc:'Summary panel shimmer (cover + 3 lines + CTA placeholder). Body 3 card skeleton.' },
+  { id:'m7', stateOverride:'error', mine:false, tab:'overview',
+    label:'07 · Error',
+    desc:'Summary OK (cache), tab body TabError pattern: alert danger + CTA "↻ Riprova".' },
+];
+
+const App = () => {
+  const [theme, setTheme] = useState(() => {
+    const saved = localStorage.getItem('mai-theme');
+    if (saved) return saved;
+    return document.documentElement.getAttribute('data-theme') || 'light';
+  });
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('mai-theme', theme);
+  }, [theme]);
+
+  return (
+    <div style={{
+      minHeight:'100vh', background:'var(--bg)', color:'var(--text)',
+      padding:'24px 24px 80px',
+    }}>
+      {/* Header */}
+      <header style={{
+        maxWidth: 1440, margin:'0 auto 32px',
+        display:'flex', alignItems:'center', gap: 12, flexWrap:'wrap',
+      }}>
+        <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
+          <div style={{
+            width: 32, height: 32, borderRadius: 8,
+            background:'linear-gradient(135deg, hsl(var(--c-toolkit)), hsl(var(--c-game)))',
+            color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+            fontWeight: 800, fontFamily:'var(--f-display)',
+          }}>E</div>
+          <div>
+            <div style={{ fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 16 }}>SP4 wave 3 · E</div>
+            <div style={{ fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)' }}>
+              /toolkits/[id] — Toolkit detail (split-view)
+            </div>
+          </div>
+        </div>
+        <div style={{ flex: 1 }}/>
+        <button type="button" onClick={() => setTheme(t => t === 'light' ? 'dark' : 'light')}
+          style={{
+            padding:'8px 14px', borderRadius:'var(--r-md)',
+            background:'var(--bg-card)', border:'1px solid var(--border)',
+            color:'var(--text)', fontFamily:'var(--f-display)',
+            fontSize: 12, fontWeight: 800, cursor:'pointer',
+          }}>🌗 {theme === 'light' ? 'Light' : 'Dark'}</button>
+      </header>
+
+      {/* Desktop variants */}
+      <section style={{ maxWidth: 1440, margin:'0 auto', display:'flex', flexDirection:'column', gap: 32 }}>
+        <DesktopFrame label="Desktop · 01 · Public · Overview"
+          desc="Split-view 380px sx (sticky cover gradient + descrizione + autore/game chip + stats triplet rating/downloads/version + CTA primario 'Installa toolkit' + meta) / fluida dx (tabs animated underline → Overview con Includes 3-box). Footer ConnectionChipStrip 6 pip.">
+          <DesktopScreen mine={false} initialTab="overview"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 02 · Public · Agente · system prompt"
+          desc="Tab Agente: PersonaCard 64px gradient + chip strategy/model + open ↗ + system prompt preview in <pre> mono sunken background con token count.">
+          <DesktopScreen mine={false} initialTab="agent"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 03 · Public · KB peek drawer"
+          desc="Tab KB: lista 3 doc Azul. Click → peek drawer espande chunk preview corsivo italic. aria-expanded/aria-controls correttamente cablati.">
+          <DesktopScreen mine={false} initialTab="kb"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 04 · Public · Tools peek"
+          desc="Tab Tools: 3 tool con kind chip (timer/counter/deck) + uses count. Peek mostra config JSON in <pre> mono.">
+          <DesktopScreen mine={false} initialTab="tools"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 05 · Public · Versioni"
+          desc="Public view: lista release timeline con dot color-coded (major event-pink / minor toolkit-green / patch muted). Pill 'Corrente' su latest. Nessuna CTA edit/yank.">
+          <DesktopScreen mine={false} initialTab="versions"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 06 · Public · Recensioni"
+          desc="Rating breakdown layout 2-col: numero grande 4.7 + Stars + count / histogram bars 5→1 stelle agent-yellow. Lista 4 recensioni con avatar gradient.">
+          <DesktopScreen mine={false} initialTab="reviews"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 07 · Own · Modifica + Pubblica nuova versione" mine
+          desc="Variante autore: breadcrumb pill '● Tuo' toolkit-green; CTA primario 'Modifica toolkit', secondario 'Pubblica nuova versione'. Tab Versioni mostra changelog timeline + CTA '✎ Modifica note' / '⊘ Yank' su versione corrente.">
+          <DesktopScreen mine={true} initialTab="versions"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 08 · Own · Empty (toolkit appena creato)" mine
+          desc="Stats panel: rating 0/0, downloads 0, v0. ConnectionChipStrip mostra agent/kb/tools con stato empty (dashed). Tab Overview body: TabEmpty CTA '+ Aggiungi contenuti'.">
+          <DesktopScreen mine={true} initialTab="overview" stateOverride="empty"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 09 · Loading"
+          desc="Summary panel shimmer: cover 180px + title + 3 stat skeleton + CTA placeholder. Body 3 card skeleton.">
+          <DesktopScreen mine={false} initialTab="overview" stateOverride="loading"/>
+        </DesktopFrame>
+
+        <DesktopFrame label="Desktop · 10 · Error"
+          desc="Summary panel mantiene cache. Body tab mostra TabError pattern con CTA '↻ Riprova'. Footer ConnectionChipStrip resta visibile.">
+          <DesktopScreen mine={false} initialTab="overview" stateOverride="error"/>
+        </DesktopFrame>
+      </section>
+
+      {/* Mobile variants */}
+      <section style={{ maxWidth: 1440, margin:'48px auto 0' }}>
+        <h2 style={{
+          fontFamily:'var(--f-display)', fontSize: 22, fontWeight: 800,
+          marginBottom: 8,
+        }}>Mobile · 375px</h2>
+        <p style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-muted)', marginBottom: 24,
+        }}>7 stati: public (overview, tools, reviews) · own (versions, empty) · loading · error</p>
+        <div style={{
+          display:'flex', flexWrap:'wrap', gap: 32, justifyContent:'center',
+        }}>
+          {MOBILE_STATES.map(m => (
+            <PhoneShell key={m.id} label={m.label} desc={m.desc}>
+              <MobileScreen stateOverride={m.stateOverride} mine={m.mine} initialTab={m.tab}/>
+            </PhoneShell>
+          ))}
+        </div>
+      </section>
+
+      {/* DoD checklist */}
+      <section style={{
+        maxWidth: 900, margin:'64px auto 0',
+        padding: 24, borderRadius:'var(--r-xl)',
+        background:'var(--bg-card)', border:'1px solid var(--border)',
+      }}>
+        <h2 style={{
+          fontFamily:'var(--f-display)', fontSize: 18, fontWeight: 800, marginBottom: 12,
+        }}>Definition of Done · E toolkit-detail</h2>
+        <ul style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-sec)',
+          lineHeight: 1.9, listStyle:'none', padding: 0, margin: 0,
+        }}>
+          <li>✓ Solo CSS variables da tokens.css (zero hex hardcoded)</li>
+          <li>✓ Helper entityHsl(type, alpha) inline · 9 entity colors</li>
+          <li>✓ Light + dark mode entrambi funzionanti (toggle in header)</li>
+          <li>✓ Mobile 375px (7 phone) + Desktop 1440px (10 frame)</li>
+          <li>✓ Pattern desktop: split-view 380px sticky sx + tabs dx</li>
+          <li>✓ Varianti OBBLIGATORIE: Public (Installa+Condividi) + Own (Modifica+Pubblica nuova versione, breadcrumb '● Tuo', tab label "Versioni · changelog", CTA edit/yank su latest)</li>
+          <li>✓ ConnectionChipStrip footer 6 pip (agent/kb/tool/game/player/session) · empty=dashed</li>
+          <li>✓ EntityChip per cross-ref: agent linkato (PersonaCard), KB docs, autore Player, Game target</li>
+          <li>✓ Tabs animated underline: Overview · Agente · KB · Tools · Versioni · Recensioni</li>
+          <li>✓ ARIA: role="tablist" + role="tab" + aria-selected + aria-controls + role="tabpanel"</li>
+          <li>✓ aria-label icon-only buttons (Indietro, Più, Apri agente)</li>
+          <li>✓ Focus visibile (outline via components.css esistente, riusato — NON sovrascritto)</li>
+          <li>✓ prefers-reduced-motion (components.css)</li>
+          <li>✓ Stati: default / empty / loading / error · 2 varianti</li>
+          <li>✓ Rating display "4.7" punto culture-independent</li>
+          <li>✓ Testo italiano · dati Azul Toolkit v2 + Marco R. autore</li>
+          <li>✓ ID short readable: tk-azul-v2, p-marco, a-azul-rules, t-timer, kb-azul-ita — NO UUID</li>
+          <li>✓ Commento di apertura con route /toolkits/[id] + descrizione</li>
+        </ul>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800, marginTop: 18, marginBottom: 8,
+        }}>Nuovi componenti v2 emersi</h3>
+        <ul style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-sec)',
+          lineHeight: 1.8, listStyle:'none', padding: 0, margin: 0,
+        }}>
+          <li>· ToolkitSummaryPanel (sticky split-view sx · cover gradient + stats + CTA mode-aware)</li>
+          <li>· ToolkitIncludesGrid (3-box agent/kb/tools con accent entity-colored)</li>
+          <li>· VersionTimeline (rail + dot major/minor/patch + actions own-only)</li>
+          <li>· RatingBreakdown (numero grande + Stars + histogram bars)</li>
+          <li>· PromptPreviewBlock (system prompt mono sunken con token count)</li>
+          <li>· Stars (5-star fractional fill — riusabile per game ratings)</li>
+        </ul>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800, marginTop: 18, marginBottom: 8,
+        }}>Riusi pixel-perfect (NON ridisegnare)</h3>
+        <ul style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-sec)',
+          lineHeight: 1.8, listStyle:'none', padding: 0, margin: 0,
+        }}>
+          <li>· ConnectionChipStrip footer (PR #542/#545)</li>
+          <li>· PersonaCard (wave 2 agent-detail)</li>
+          <li>· Tabs animated underline (wave 1 game-detail/player-detail)</li>
+          <li>· PeekDrawer pattern (wave 1 KB list) — chevron rotate + aria-expanded</li>
+          <li>· TabSkeleton/TabError/TabEmpty (wave 1)</li>
+        </ul>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800, marginTop: 18, marginBottom: 8,
+          color: entityHsl('warning'),
+        }}>Deviazioni flaggate</h3>
+        <ul style={{
+          fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-sec)',
+          lineHeight: 1.8, listStyle:'none', padding: 0, margin: 0,
+        }}>
+          <li>· Rating display "4.7" con punto (no virgola IT) — culture-independent, lezione issue #2593</li>
+          <li>· System prompt preview è mock visivo testuale (vera logica RAG citations già in agent-detail)</li>
+          <li>· Versions kind/major-minor-patch è semantic versioning standard — verificare con backend se modello dati supporta semver</li>
+          <li>· @keyframes slideDown referenziato nei peek drawer richiede definizione in components.css o inline — flaggato per non sovrascrivere components.css come da contratto</li>
+          <li>· Empty state autore: tab Versioni mostra v0.1.0 placeholder anziché empty — scelta consapevole per dare contesto storico anche su toolkit nuovo</li>
+        </ul>
+      </section>
+    </div>
+  );
+};
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);


### PR DESCRIPTION
## Summary

Pacchetto mockup HTML/JSX consegnato da sessione Claude Design (3 maggio 2026).
**9 mockup hifi** che coprono:

- **SP3 missing (3/3 obbligatori)** — chiude SP3 al 8/9 (1 facoltativo skipped, già coperto da `public.jsx`)
- **SP4 wave 3 (5/5)** — chiude wave 3 al 100%
- **SP4 wave 4 (1/4 partial)** — D1 players-index (3 restanti bloccati fino al 10 maggio)

## Mockup inclusi

### SP3 missing
| Mockup | Route | Pattern |
|---|---|---|
| `sp3-how-it-works` | `/how-it-works` | Hero + 4 step alternati (educational) |
| `sp3-legal` | `/terms` | Template riusabile per `/privacy` `/cookies` |
| `sp3-library-public` | `/library` (non-loggato) | Community showcase |

### SP4 wave 3
| Mockup | Route | Pattern |
|---|---|---|
| `sp4-player-detail` | `/players/[id]` | Character sheet + 5 tabs |
| `sp4-toolkit-detail` | `/toolkits/[id]` | Split-view + public/own variants |
| `sp4-kb-detail` | `/kb/[id]` | Split-view chunks + markdown preview |
| `sp4-game-nights-index` | `/game-nights` | Calendar / List toggle |
| `sp4-discover` | `/discover` | Hero + 7 horizontal rows Netflix-style |

### SP4 wave 4 (partial)
| Mockup | Route | Pattern |
|---|---|---|
| `sp4-players-index` | `/players` | Grid (mirror Games Wave B.1) |

## Conventions applicate

- ✅ Token-only (`tokens.css`), zero colori hardcoded
- ✅ Light + dark mode entrambi funzionanti (toggle persistito localStorage)
- ✅ Mobile 375px + Desktop 1440px entrambi presenti
- ✅ 4 stati: default / empty / loading / error
- ✅ EntityChip / EntityPip per ogni cross-reference
- ✅ ARIA: `role="tablist"`, `aria-label` icon-only, focus visible
- ✅ Testo italiano integrale, dati realistici da `data.js`
- ✅ ID short readable (NO UUID-like — GitGuardian safe)
- ✅ `prefers-reduced-motion` rispettato
- ✅ `isMobile` come prop esplicita (lezione: `window.innerWidth` in container fixed-width = bug ricorrente, scoperto durante sp3-how-it-works e applicato ai successivi)

## Componenti v2 nuovi attesi (~36)

Da aggiungere alla matrice `docs/frontend/v2-migration-matrix.md` post-merge in PR separata.

**Player domain (D)**: PlayerHero · PlayerStatsGrid · PlayerLeaderboardCard · FavoriteAgentCard · AchievementBadgeGrid · PlayersHero · PlayersFiltersInline · PlayersResultsGrid · EmptyPlayers

**Toolkit domain (E)**: ToolkitSummaryPanel · ToolkitIncludesGrid · VersionTimeline · RatingBreakdown · PromptPreviewBlock · Stars

**KB domain (F)**: KbHeader · KbChunkListPanel · KbChunkPreview · ChunkSearchBox · MarkdownRenderBlock · KbProcessingState

**Game-nights domain (G)**: GameNightsHeader · CalendarMonthGrid · CalendarDayCell · GameNightListCard · DayDetailDrawer · FilterPillBar · StatusPill · PlayerAvatars

**Discover domain (I)**: DiscoverHero · DiscoverSearchBox · EntityFilterPillBar · HorizontalRow · RowScroller · FooterCTA

**Pagine pubbliche (SP3)**: HowItWorksStep · LegalPageShell · LegalTOC · CommunityStatsRow · FeaturedGamesCarousel

## Test plan

- [ ] Aprire ogni `.html` localmente nel browser → verificare visivamente light + dark + mobile + desktop
- [ ] Spot check `data-theme="dark"` toggle persistito
- [ ] Verifica nessun overflow / cropping su frame mobile (lezione `window.innerWidth` bug)
- [ ] Conferma EntityChip/Pip su ogni cross-reference

## Refs

Refs #573 (V2 migration matrix), #580 (Wave B umbrella). Implementazione downstream tramite issue dedicate post-merge.

Mockup wave 4 restanti (E1 toolkits-index, F1 kb-index, G2 game-night-detail) e SP5 admin (17 mockup) **bloccati fino al 10 maggio** per limite produzione Claude Design — verranno consegnati in PR successiva.