### PR TITLE
fix(agents): populate AgentDto.GameName from SharedGame catalog (drift fix)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/AgentDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/AgentDto.cs
@@ -16,5 +16,6 @@ internal record AgentDto(
     bool IsRecentlyUsed,
     bool IsIdle,
     Guid? GameId = null,
+    string? GameName = null,
     Guid? CreatedByUserId = null
 );

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetAllAgentsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetAllAgentsQueryHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using MediatR;
 
 namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
@@ -8,14 +9,23 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
 /// Handler for GetAllAgentsQuery — returns lightweight AgentDto list for user-facing endpoints.
 /// Used by GET /api/v1/games/{id}/agents (chat panel agent resolution).
 /// </summary>
+/// <remarks>
+/// Issue #660: AgentDto.GameName populated via single bulk lookup against SharedGame catalog
+/// (avoids N+1 queries when listing all agents).
+/// </remarks>
 internal sealed class GetAllAgentsQueryHandler
     : IRequestHandler<GetAllAgentsQuery, List<AgentDto>>
 {
     private readonly IAgentDefinitionRepository _repository;
+    private readonly ISharedGameRepository _sharedGameRepository;
 
-    public GetAllAgentsQueryHandler(IAgentDefinitionRepository repository)
+    public GetAllAgentsQueryHandler(
+        IAgentDefinitionRepository repository,
+        ISharedGameRepository sharedGameRepository)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _sharedGameRepository = sharedGameRepository
+            ?? throw new ArgumentNullException(nameof(sharedGameRepository));
     }
 
     public async Task<List<AgentDto>> Handle(
@@ -42,13 +52,31 @@ internal sealed class GetAllAgentsQueryHandler
             agents = agents.Where(a => a.GameId == request.GameId.Value).ToList();
         }
 
-        return agents.Select(MapToDto).ToList();
+        // Issue #660: Bulk-fetch game names for all agents linked to a game (single query, no N+1)
+        var gameIds = agents
+            .Where(a => a.GameId.HasValue)
+            .Select(a => a.GameId!.Value)
+            .Distinct()
+            .ToList();
+
+        var gameNames = gameIds.Count > 0
+            ? await _sharedGameRepository.GetNamesByIdsAsync(gameIds, cancellationToken).ConfigureAwait(false)
+            : new Dictionary<Guid, string>();
+
+        return agents.Select(a => MapToDto(a, gameNames)).ToList();
     }
 
-    private static AgentDto MapToDto(Domain.Entities.AgentDefinition agent)
+    private static AgentDto MapToDto(
+        Domain.Entities.AgentDefinition agent,
+        IReadOnlyDictionary<Guid, string> gameNames)
     {
         var recentThreshold = DateTime.UtcNow.AddHours(-24);
         var idleThreshold = DateTime.UtcNow.AddDays(-7);
+
+        var gameName = agent.GameId.HasValue
+            && gameNames.TryGetValue(agent.GameId.Value, out var name)
+                ? name
+                : null;
 
         return new AgentDto(
             Id: agent.Id,
@@ -63,6 +91,7 @@ internal sealed class GetAllAgentsQueryHandler
             IsRecentlyUsed: agent.LastInvokedAt.HasValue && agent.LastInvokedAt.Value > recentThreshold,
             IsIdle: !agent.LastInvokedAt.HasValue || agent.LastInvokedAt.Value < idleThreshold,
             GameId: agent.GameId,
+            GameName: gameName,
             CreatedByUserId: null
         );
     }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/AgentDefinition.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/AgentDefinition.cs
@@ -515,4 +515,22 @@ public sealed class AgentDefinition : AggregateRoot<Guid>
         _lastInvokedAt = DateTime.UtcNow;
         _updatedAt = DateTime.UtcNow;
     }
+
+    /// <summary>
+    /// Associates this agent definition with an optional shared game.
+    /// Issue #660: Enables AgentDto.GameName population via bulk SharedGame lookup
+    /// in GetAllAgentsQueryHandler. Pass <c>null</c> to clear the association.
+    /// </summary>
+    public void SetGameId(Guid? gameId)
+    {
+        if (_gameId == gameId)
+            return;
+
+        _gameId = gameId;
+        _updatedAt = DateTime.UtcNow;
+
+        AddDomainEvent(new AgentDefinitionUpdatedEvent(Id, gameId.HasValue
+            ? $"GameId set to '{gameId.Value}'"
+            : "GameId cleared"));
+    }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/ISharedGameRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/ISharedGameRepository.cs
@@ -33,6 +33,18 @@ public interface ISharedGameRepository
     Task<IReadOnlyDictionary<Guid, SharedGame>> GetByIdsAsync(IEnumerable<Guid> ids, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets a lightweight title-only lookup for the given game IDs.
+    /// Issue #660: Used by GetAllAgentsQueryHandler to populate AgentDto.GameName without
+    /// hydrating full SharedGame aggregates (avoids unnecessary domain reconstitution overhead).
+    /// </summary>
+    /// <param name="ids">The game IDs to retrieve names for</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Dictionary mapping game ID to title (only includes found, non-deleted games)</returns>
+    Task<IReadOnlyDictionary<Guid, string>> GetNamesByIdsAsync(
+        IReadOnlyCollection<Guid> ids,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets a shared game by its BoardGameGeek ID.
     /// </summary>
     /// <param name="bggId">The BGG ID</param>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameRepository.cs
@@ -83,6 +83,25 @@ internal sealed class SharedGameRepository : RepositoryBase, ISharedGameReposito
             e => MapToDomain(e));
     }
 
+    public async Task<IReadOnlyDictionary<Guid, string>> GetNamesByIdsAsync(
+        IReadOnlyCollection<Guid> ids,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(ids);
+
+        if (ids.Count == 0)
+            return new Dictionary<Guid, string>();
+
+        var rows = await DbContext.Set<SharedGameEntity>()
+            .AsNoTracking()
+            .Where(g => ids.Contains(g.Id) && !g.IsDeleted)
+            .Select(g => new { g.Id, g.Title })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return rows.ToDictionary(r => r.Id, r => r.Title);
+    }
+
     // Mapping methods
 
     private static SharedGame MapToDomain(SharedGameEntity entity)

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/GetAllAgentsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/GetAllAgentsQueryHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Tests.Constants;
 using FluentAssertions;
 using Moq;
@@ -18,12 +19,18 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Handlers;
 public sealed class GetAllAgentsQueryHandlerTests
 {
     private readonly Mock<IAgentDefinitionRepository> _mockRepository;
+    private readonly Mock<ISharedGameRepository> _mockSharedGameRepository;
     private readonly GetAllAgentsQueryHandler _handler;
 
     public GetAllAgentsQueryHandlerTests()
     {
         _mockRepository = new Mock<IAgentDefinitionRepository>();
-        _handler = new GetAllAgentsQueryHandler(_mockRepository.Object);
+        _mockSharedGameRepository = new Mock<ISharedGameRepository>();
+        // Default: no agents have a GameId, so handler should not call GetNamesByIdsAsync at all.
+        // Tests that exercise the GameName population path override this setup explicitly.
+        _handler = new GetAllAgentsQueryHandler(
+            _mockRepository.Object,
+            _mockSharedGameRepository.Object);
     }
 
     [Fact]
@@ -107,6 +114,61 @@ public sealed class GetAllAgentsQueryHandlerTests
 
         // Assert
         result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_AgentLinkedToGame_PopulatesGameNameFromBulkLookup()
+    {
+        // Arrange (Issue #660): one agent linked to a game, repository returns matching name.
+        var gameId = Guid.NewGuid();
+        var agent = CreateAgent("Catan Helper");
+        agent.SetGameId(gameId);
+
+        _mockRepository
+            .Setup(r => r.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AgentDefinitionEntity> { agent });
+
+        _mockSharedGameRepository
+            .Setup(r => r.GetNamesByIdsAsync(
+                It.Is<IReadOnlyCollection<Guid>>(ids => ids.Count == 1 && ids.Contains(gameId)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, string> { [gameId] = "Catan" });
+
+        var query = new GetAllAgentsQuery(ActiveOnly: true);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().ContainSingle();
+        result[0].GameId.Should().Be(gameId);
+        result[0].GameName.Should().Be("Catan");
+        _mockSharedGameRepository.Verify(
+            r => r.GetNamesByIdsAsync(It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NoAgentsLinkedToGame_SkipsBulkNameLookup()
+    {
+        // Arrange (Issue #660): zero agents have GameId, so handler must NOT call GetNamesByIdsAsync.
+        var agent = CreateAgent("Standalone Agent"); // no SetGameId call
+        _mockRepository
+            .Setup(r => r.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AgentDefinitionEntity> { agent });
+
+        var query = new GetAllAgentsQuery(ActiveOnly: true);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().ContainSingle();
+        result[0].GameId.Should().BeNull();
+        result[0].GameName.Should().BeNull();
+        _mockSharedGameRepository.Verify(
+            r => r.GetNamesByIdsAsync(It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     private static AgentDefinitionEntity CreateAgent(string name)

--- a/apps/api/tests/Api.Tests/Integration/Agents/AgentsEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Agents/AgentsEndpointsIntegrationTests.cs
@@ -113,6 +113,41 @@ public sealed class AgentsEndpointsIntegrationTests : IAsyncLifetime
         body.Agents.Should().OnlyContain(a => a.IsActive);
         body.Count.Should().Be(2);
     }
+
+    [Fact]
+    public async Task GetAgents_WithSeededAgentLinkedToGame_PopulatesGameName()
+    {
+        // Arrange: authenticated user, seed a SharedGame, then seed 1 active agent linked to it.
+        // Issue #660: Asserts that AgentDto.GameName is populated via bulk SharedGame lookup
+        // when an agent definition has a non-null GameId.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(dbContext, title: "Catan");
+        await TestSessionHelper.SeedAgentDefinitionsAsync(
+            dbContext,
+            activeCount: 1,
+            inactiveCount: 0,
+            gameId: gameId);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/agents",
+            sessionToken);
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<GetAllAgentsResponse>();
+        body.Should().NotBeNull();
+        body!.Success.Should().BeTrue();
+        body.Agents.Should().HaveCount(1);
+        body.Agents[0].GameId.Should().Be(gameId);
+        body.Agents[0].GameName.Should().Be("Catan");
+    }
 }
 
 /// <summary>

--- a/apps/api/tests/Api.Tests/TestHelpers/TestSessionHelper.cs
+++ b/apps/api/tests/Api.Tests/TestHelpers/TestSessionHelper.cs
@@ -5,6 +5,7 @@ using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
 using Microsoft.EntityFrameworkCore;
 
 namespace Api.Tests.TestHelpers;
@@ -224,10 +225,8 @@ internal static class TestSessionHelper
 
             if (gameId.HasValue)
             {
-                // GameId is read-only on the aggregate; seed via persistence by attaching to the entity
-                // is not supported via current entity API. The optional gameId parameter is accepted for
-                // Phase 6 forward-compat but ignored at runtime until a SetGameId method is added.
-                // Tests that need GameId association should use a future entity API.
+                // Issue #660: Use SetGameId domain method to associate seeded agents with a SharedGame.
+                agent.SetGameId(gameId.Value);
             }
 
             dbContext.AgentDefinitions.Add(agent);
@@ -242,9 +241,52 @@ internal static class TestSessionHelper
                 config: AgentDefinitionConfig.Create("gpt-4", 1000, 0.7f));
             // Default state from Create() is IsActive=false / Status=Draft
 
+            if (gameId.HasValue)
+            {
+                agent.SetGameId(gameId.Value);
+            }
+
             dbContext.AgentDefinitions.Add(agent);
         }
 
         await dbContext.SaveChangesAsync();
+    }
+
+    /// <summary>
+    /// Seeds a SharedGame entity with the given title for integration tests.
+    /// Issue #660: Used by AgentsEndpointsIntegrationTests to assert AgentDto.GameName population
+    /// when an agent definition is linked to a game in the SharedGame catalog.
+    /// </summary>
+    /// <param name="dbContext">Test database context.</param>
+    /// <param name="title">SharedGame title (e.g. "Catan").</param>
+    /// <returns>The newly seeded SharedGame ID.</returns>
+    public static async Task<Guid> SeedSharedGameAsync(
+        MeepleAiDbContext dbContext,
+        string title)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        if (string.IsNullOrWhiteSpace(title))
+            throw new ArgumentException("Title cannot be empty", nameof(title));
+
+        var sharedGameId = Guid.NewGuid();
+        dbContext.SharedGames.Add(new SharedGameEntity
+        {
+            Id = sharedGameId,
+            Title = title,
+            Description = "Integration test game",
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            YearPublished = 2024,
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 45,
+            MinAge = 8,
+            Status = 1, // Approved — queryable in default ISharedGameRepository.GetByIds/Names paths
+            CreatedBy = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+        });
+        await dbContext.SaveChangesAsync();
+        dbContext.ChangeTracker.Clear();
+        return sharedGameId;
     }
 }


### PR DESCRIPTION
## Summary
Resolves Wave B.2 followup #660: drift fix.

- Adds `GameName` property to backend `AgentDto` record
- Bulk-fetches SharedGame names via new `ISharedGameRepository.GetNamesByIdsAsync` (single query, no N+1)
- Handler populates per `agent.GameId`
- Adds `AgentDefinition.SetGameId()` domain method (replaces previous test stub)
- Integration test asserts populated when agent linked to game
- Unit tests assert bulk-lookup contract (called only when GameId present)

## Test plan
- [x] Backend build clean (0 errors, 0 warnings)
- [x] 6 unit tests in `GetAllAgentsQueryHandlerTests` PASS (4 baseline + 2 new GameName)
- [ ] CI: 4 integration tests in `AgentsEndpointsIntegrationTests` PASS (3 baseline + 1 new GameName) — Docker not available locally, runs in CI
- [ ] CI: full backend build/test green

Closes #660