### PR TITLE
fix(smoke): generate placeholder secrets before make dev-core in CI

### DIFF
--- a/.github/workflows/e2e-smoke-real-backend.yml
+++ b/.github/workflows/e2e-smoke-real-backend.yml
@@ -19,6 +19,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Generate placeholder secrets (CI cannot secrets-sync — no SSH key)
+        working-directory: infra
+        run: make secrets-setup
+
       - name: Boot dev stack (postgres + redis + api)
         working-directory: infra
         run: |
@@ -30,6 +34,11 @@ jobs:
             fi
             sleep 5
           done
+
+      - name: Dump API logs on stack-up failure
+        if: failure()
+        working-directory: infra
+        run: docker compose -f docker-compose.yml -f compose.dev.yml logs --tail=200 api postgres redis || true
 
       - name: Setup pnpm + Node
         uses: pnpm/action-setup@v3


### PR DESCRIPTION
## Summary

Fixes first-run failure of the nightly E2E smoke workflow (#664).

**Root cause** (verified via `workflow_dispatch` run #25291530019):

```
env file infra/secrets/database.secret not found
make: *** [Makefile:12: dev-core] Error 1
```

CI runners don't have the SSH key needed for `make secrets-sync` (which pulls real values from staging). Without `make secrets-setup` run first, the `.secret` files don't exist and `docker compose` aborts.

## Changes

1. Add step `make secrets-setup` before `make dev-core` — generates placeholder secrets from `.example` templates so docker compose can boot.
2. Add `Dump API logs on stack-up failure` step (gated `if: failure()`) for diagnosability of future boot issues.

## Test plan

- [ ] After merge, manually trigger `workflow_dispatch` of `e2e-smoke-real-backend.yml` to validate boot proceeds past secrets gate
- [ ] If boot succeeds, smoke specs will run — expected to surface the data-slot mismatch concern from PR #664 (invite/shared-game selectors)