### PR TITLE
fix(smoke): generate placeholder env files for CI

### DIFF
--- a/.github/workflows/e2e-smoke-real-backend.yml
+++ b/.github/workflows/e2e-smoke-real-backend.yml
@@ -23,6 +23,45 @@ jobs:
         working-directory: infra
         run: make secrets-setup
 
+      - name: Generate placeholder env files for CI (gitignored locally, missing in runner)
+        working-directory: infra/env
+        run: |
+          # web.env.dev — frontend container env
+          cat > web.env.dev <<'WEBENV'
+          NEXT_PUBLIC_API_URL=http://localhost:8080
+          NEXT_PUBLIC_WS_URL=ws://localhost:8080
+          API_BASE_URL=http://api:8080
+          NODE_ENV=production
+          NEXT_TELEMETRY_DISABLED=1
+          NEXT_PUBLIC_HYPERDX_API_KEY=demo
+          WEBENV
+          # api.env.dev — backend container env
+          cat > api.env.dev <<'APIENV'
+          POSTGRES_HOST=postgres
+          POSTGRES_PORT=5432
+          REDIS_HOST=redis
+          REDIS_PORT=6379
+          OLLAMA_URL=http://ollama:11434
+          EMBEDDING_SERVICE_URL=http://embedding-service:8000
+          UNSTRUCTURED_SERVICE_URL=http://unstructured-service:8001
+          SMOLDOCLING_SERVICE_URL=http://smoldocling-service:8002
+          RERANKER_SERVICE_URL=http://reranker-service:8003
+          N8N_URL=http://n8n:5678
+          Email__EnableSsl=false
+          HYPERDX_OTLP_ENDPOINT=http://meepleai-hyperdx:4317
+          HYPERDX_API_KEY=demo
+          APIENV
+          # n8n.env.dev — minimal (n8n unused by smoke specs but referenced by compose)
+          cat > n8n.env.dev <<'N8NENV'
+          N8N_HOST=0.0.0.0
+          N8N_PORT=5678
+          N8N_PROTOCOL=http
+          WEBHOOK_URL=http://localhost:5678/
+          N8N_EDITOR_BASE_URL=http://localhost:5678/
+          GENERIC_TIMEZONE=Europe/Rome
+          N8NENV
+          ls -la
+
       - name: Boot dev stack (postgres + redis + api)
         working-directory: infra
         run: |


### PR DESCRIPTION
Second pass on smoke workflow boot. PR #666 fixed secrets, this fixes env files. Both required for clean CI boot.

After merge will manual workflow_dispatch to validate boot proceeds + smoke specs run.