### PR TITLE
fix(sonar): rewrite GetTopContributors privacy-guard comment to clear S125

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetTopContributors/GetTopContributorsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetTopContributors/GetTopContributorsQueryHandler.cs
@@ -138,11 +138,12 @@ internal sealed class GetTopContributorsQueryHandler
             .ToList();
 
         // Step 4: fetch user profile details and apply privacy guards.
-        //   - !IsSuspended  → don't surface suspended accounts on public widget.
-        //   - Status == "Active" → exclude banned/deleted (Epic #4068).
-        //   - DisplayName != null → spec §5.4 requires non-null DisplayName;
-        //     users who never set a display name shouldn't leak email-derived
-        //     identifiers on a public leaderboard.
+        // Privacy guards applied below: skip suspended accounts (don't surface
+        // them on the public widget), require Active status (exclude banned and
+        // deleted users per Epic 4068), require a non-null DisplayName (spec
+        // section 5.4 requires non-null DisplayName so that users who never set
+        // a display name don't leak email-derived identifiers on a public
+        // leaderboard).
         var candidateIds = ranked.Select(r => r.UserId).ToList();
         var users = await _context.Users
             .AsNoTracking()


### PR DESCRIPTION
Pre-existing Sonar S125 false positive in main-dev that prevents Release docker build (used by smoke nightly + any prod-style image build). Discovered via run #25291732644 boot failure.

Rewriting the inline-list comment in prose preserves intent and clears the false positive. Verified locally: `dotnet publish src/Api/Api.csproj -c Release` now succeeds.

After merge: re-trigger smoke workflow_dispatch (third pass).