### PR TITLE
fix(smoke): skip Playwright webServer (compose already serves :3000)

### DIFF
--- a/.github/workflows/e2e-smoke-real-backend.yml
+++ b/.github/workflows/e2e-smoke-real-backend.yml
@@ -101,12 +101,25 @@ jobs:
         working-directory: apps/web
         run: pnpm build
 
+      - name: Wait for web container ready
+        run: |
+          for i in {1..30}; do
+            if curl -fs http://localhost:3000 2>/dev/null; then
+              echo "Web up on :3000"
+              break
+            fi
+            sleep 5
+          done
+
       - name: Run smoke specs
         working-directory: apps/web
         env:
           SMOKE_API_BASE: http://localhost:8080
           SMOKE_USER_EMAIL: smoke-user@meepleai.test
           SMOKE_USER_PASSWORD: SmokeUser1!
+          # docker compose already provides web on :3000 (see infra/compose.dev.yml:72)
+          # — skip Playwright's own webServer to avoid port collision
+          PLAYWRIGHT_SKIP_WEB_SERVER: '1'
         run: pnpm playwright test smoke-real-backend/ --project=desktop-chrome
 
       - name: Upload report on failure


### PR DESCRIPTION
Third pass on smoke workflow. Boot now succeeds (PR #666 secrets, #668 env files, #670 Sonar S125), but specs hit port 3000 collision because compose dev profile and Playwright both want to serve frontend.

Sets `PLAYWRIGHT_SKIP_WEB_SERVER=1` (existing config escape hatch) and adds wait-loop for web container readiness.

After merge: re-trigger workflow_dispatch (fourth pass) — expecting either pass OR data-slot mismatch concern from PR #664 to surface.