### PR TITLE
fix(smoke): seed admin via INITIAL_ADMIN_* env + add invite data-slots

### DIFF
--- a/.github/workflows/e2e-smoke-real-backend.yml
+++ b/.github/workflows/e2e-smoke-real-backend.yml
@@ -36,6 +36,8 @@ jobs:
           NEXT_PUBLIC_HYPERDX_API_KEY=demo
           WEBENV
           # api.env.dev — backend container env
+          # Seed initial admin matching SMOKE_USER_* in workflow env so smoke
+          # specs can login without registering (gated by Registration:PublicEnabled).
           cat > api.env.dev <<'APIENV'
           POSTGRES_HOST=postgres
           POSTGRES_PORT=5432
@@ -50,6 +52,9 @@ jobs:
           Email__EnableSsl=false
           HYPERDX_OTLP_ENDPOINT=http://meepleai-hyperdx:4317
           HYPERDX_API_KEY=demo
+          INITIAL_ADMIN_EMAIL=smoke-user@meepleai.test
+          INITIAL_ADMIN_PASSWORD=SmokeUser1!
+          INITIAL_ADMIN_DISPLAY_NAME=Smoke User
           APIENV
           # n8n.env.dev — minimal (n8n unused by smoke specs but referenced by compose)
           cat > n8n.env.dev <<'N8NENV'
@@ -110,6 +115,7 @@ jobs:
             fi
             sleep 5
           done
+
 
       - name: Run smoke specs
         working-directory: apps/web

--- a/apps/web/e2e/smoke-real-backend/_helpers/auth.ts
+++ b/apps/web/e2e/smoke-real-backend/_helpers/auth.ts
@@ -1,9 +1,11 @@
 /**
  * Real-backend auth helper for smoke tests.
  *
- * Differs from visual-test fixtures: makes a REAL POST /api/v1/auth/register
- * (idempotent — ignores 409) + POST /api/v1/auth/login against backend at :8080
- * with a known smoke user. Cookie returned applies to subsequent page nav.
+ * The CI workflow seeds an initial admin user via API container env vars
+ * INITIAL_ADMIN_EMAIL / INITIAL_ADMIN_PASSWORD matching the SMOKE_USER_*
+ * env vars below. We login directly with those credentials — no register
+ * step needed (registration is fail-closed gated by Registration:PublicEnabled
+ * config and we don't enable it in CI).
  *
  * Used by smoke-real-backend specs to detect endpoint binding regressions
  * (404, schema mismatch) that visual-test fixtures hide.
@@ -14,22 +16,7 @@ const API_BASE = process.env.SMOKE_API_BASE ?? 'http://localhost:8080';
 const SEED_EMAIL = process.env.SMOKE_USER_EMAIL ?? 'smoke-user@meepleai.test';
 const SEED_PASSWORD = process.env.SMOKE_USER_PASSWORD ?? 'SmokeUser1!';
 
-/**
- * Idempotent register — returns regardless of whether user exists.
- */
-async function ensureUser(request: APIRequestContext): Promise<void> {
-  const res = await request.post(`${API_BASE}/api/v1/auth/register`, {
-    data: { email: SEED_EMAIL, password: SEED_PASSWORD, displayName: 'Smoke User' },
-    failOnStatusCode: false,
-  });
-  // 200/201 OK or 409/422 already-exists — both acceptable.
-  if (res.status() >= 500) {
-    throw new Error(`smoke ensureUser failed ${res.status()} for ${SEED_EMAIL}`);
-  }
-}
-
 export async function smokeLogin(request: APIRequestContext): Promise<{ cookieHeader: string }> {
-  await ensureUser(request);
   const res = await request.post(`${API_BASE}/api/v1/auth/login`, {
     data: { email: SEED_EMAIL, password: SEED_PASSWORD },
   });

--- a/apps/web/src/app/(public)/invites/[token]/page-client.tsx
+++ b/apps/web/src/app/(public)/invites/[token]/page-client.tsx
@@ -553,7 +553,7 @@ interface TokenExpiredShellProps {
 
 function TokenExpiredShell({ t, hostName }: TokenExpiredShellProps): JSX.Element {
   return (
-    <div className="flex flex-col items-center px-5 py-8 text-center">
+    <div data-slot="invite-expired" className="flex flex-col items-center px-5 py-8 text-center">
       <div
         aria-hidden="true"
         className="mb-3.5 flex h-[60px] w-[60px] items-center justify-center rounded-full border bg-[hsl(var(--bg-muted))] text-[26px]"
@@ -580,7 +580,7 @@ function TokenExpiredShell({ t, hostName }: TokenExpiredShellProps): JSX.Element
 
 function TokenInvalidShell({ t }: { readonly t: T }): JSX.Element {
   return (
-    <div className="flex flex-col items-center px-5 py-8 text-center">
+    <div data-slot="invite-not-found" className="flex flex-col items-center px-5 py-8 text-center">
       <div
         aria-hidden="true"
         className="mb-3.5 flex h-[60px] w-[60px] items-center justify-center rounded-full border bg-[hsl(var(--bg-muted))] text-[26px]"


### PR DESCRIPTION
Combined iteration 5 fix surfacing nightly E2E smoke green.

After PR #666/#668/#670/#672 fixed boot stage, the smoke specs themselves failed on:
1. Login 400 — registration is fail-closed gated by `Registration:PublicEnabled` config; ensureUser() couldn't bypass.
2. Selector timeouts on `[data-slot=invite-not-found]` / `[data-slot=invite-expired]` — those data-slots didn't exist in production source (concern from PR #664).

This PR:
- Sets `INITIAL_ADMIN_*` in api.env.dev placeholder so the API auto-seeds the smoke admin user at startup (no registration needed)
- Drops `ensureUser()` from the smoke auth helper (login direct)
- Adds the two invite data-slots to TokenInvalidShell + TokenExpiredShell

After merge: re-trigger workflow_dispatch (5th pass).