### PR TITLE
fix(api): getApiBase reads API_BASE_URL for SSR (resolves #676)

### DIFF
--- a/apps/web/src/lib/api/core/httpClient.ts
+++ b/apps/web/src/lib/api/core/httpClient.ts
@@ -55,7 +55,16 @@ export function getApiBase(): string {
     return '';
   }
 
-  // Server-side (SSR) / Test: Use absolute URL from environment
+  // Server-side (SSR) / Test: Use absolute URL from environment.
+  // Prefer API_BASE_URL (Docker-network hostname like http://api:8080) over
+  // NEXT_PUBLIC_API_BASE (which is browser-facing — e.g. http://localhost:8080
+  // — and is not reachable from inside the web container).
+  // Issue #676: fixes SSR fetch failures during E2E smoke real-backend run.
+  const serverBase = process.env.API_BASE_URL?.trim();
+  if (serverBase && serverBase !== 'undefined' && serverBase !== 'null') {
+    return serverBase;
+  }
+
   const envBase = process.env.NEXT_PUBLIC_API_BASE?.trim();
   if (envBase && envBase !== 'undefined' && envBase !== 'null') {
     return envBase;


### PR DESCRIPTION
## Root cause investigation for #676

Smoke spec `invites.smoke.spec.ts:13` was timing out on `[data-slot="invite-not-found"]` even after PR #674 added the data-slot.

Investigation revealed: SSR fetch in `apps/web/src/lib/api/game-night-invitations.ts:144` calls `getApiBase()`, which returned `process.env.NEXT_PUBLIC_API_BASE` (= `http://localhost:8080`, baked at build time for the browser). Inside the web container, `localhost:8080` is the container itself, not the API container — fetch fails with ECONNREFUSED, surfaces as `InvitationFetchError`, and `page.tsx:80-84` returns `initialBannerState=null` → page-client renders default surface, never the TokenInvalidShell.

## Fix

Server-side `getApiBase()` now prefers `API_BASE_URL` env var (Docker-network hostname `http://api:8080`, set in `api.env.dev`) over `NEXT_PUBLIC_API_BASE`. This matches the existing convention in `apps/web/src/app/api/v1/[...path]/route.ts:23`.

Browser path is unchanged (returns empty string → uses Next.js proxy).

## Verification plan

After merge, re-trigger workflow_dispatch `E2E Smoke Real Backend`. Expected: invites.smoke spec passes (all 8 specs green, 1 skipped).

Closes #676