### PR TITLE
fix(smoke): correct shared-game data-slot selectors + drop test.skip (#677)

### DIFF
--- a/apps/web/e2e/smoke-real-backend/shared-game-detail.smoke.spec.ts
+++ b/apps/web/e2e/smoke-real-backend/shared-game-detail.smoke.spec.ts
@@ -2,6 +2,16 @@ import { test, expect } from '@playwright/test';
 
 const API_BASE = process.env.SMOKE_API_BASE ?? 'http://localhost:8080';
 
+/**
+ * Deterministic UUID that NEVER exists in any environment — used to drive the
+ * frontend not-found shell without needing a seeded shared game.
+ *
+ * If `SMOKE_SHARED_GAME_ID` is set in the workflow env (Option A from #677
+ * audit), the second test instead navigates to that real id and asserts the
+ * hero shell renders.
+ */
+const NEVER_EXISTS_ID = '00000000-0000-4000-8000-000000000677' as const;
+
 test.describe('SMOKE — /shared-games/[id] real backend (public, no auth)', () => {
   test('GET /api/v1/shared-games/top-contributors returns array', async ({ request }) => {
     const res = await request.get(`${API_BASE}/api/v1/shared-games/top-contributors?limit=8`);
@@ -10,14 +20,15 @@ test.describe('SMOKE — /shared-games/[id] real backend (public, no auth)', () 
     expect(Array.isArray(body)).toBe(true);
   });
 
-  test('frontend /shared-games/{seeded-id} renders hero or notFound (seed-aware)', async ({
-    page,
-  }) => {
-    const SEEDED_ID = process.env.SMOKE_SHARED_GAME_ID ?? '';
-    test.skip(!SEEDED_ID, 'SMOKE_SHARED_GAME_ID not seeded');
-    await page.goto(`/shared-games/${SEEDED_ID}`, { waitUntil: 'domcontentloaded' });
+  test('frontend /shared-games/{id} renders hero or not-found shell', async ({ page }) => {
+    // If a real seeded id is provided, prefer it (covers the hero-render path).
+    // Otherwise fall back to a deterministic non-existent UUID and assert the
+    // not-found shell renders — symmetric coverage to invites.smoke + removes
+    // the need for a seeded shared game in CI (resolves #677).
+    const targetId = process.env.SMOKE_SHARED_GAME_ID || NEVER_EXISTS_ID;
+    await page.goto(`/shared-games/${targetId}`, { waitUntil: 'domcontentloaded' });
     await page.waitForSelector(
-      '[data-slot="shared-game-hero"], [data-slot="shared-game-not-found"]',
+      '[data-slot="shared-game-detail-hero"], [data-slot="shared-game-detail-not-found-state"]',
       {
         timeout: 30_000,
       }


### PR DESCRIPTION
## Investigation findings

Smoke spec `shared-game-detail.smoke.spec.ts` had two issues:

1. **Selector mismatch**: spec used `[data-slot="shared-game-hero"]` and `[data-slot="shared-game-not-found"]`, but production source uses `shared-game-detail-hero` (Hero.tsx:181) and `shared-game-detail-not-found-state` (not-found-state.tsx:45) respectively.
2. **test.skip prevented any coverage**: `SMOKE_SHARED_GAME_ID` was never set in the workflow → always skipped.

## Fix

Aligns selectors with production data-slots (no source code change — both already exist) and replaces test.skip with a deterministic UUID `00000000-0000-4000-8000-000000000677` that never exists in any DB, forcing the frontend not-found path.

Backwards compat: `SMOKE_SHARED_GAME_ID` env var still honored when set (covers hero render path).

## Test plan

After merge, re-trigger workflow_dispatch. Expected: 9 passed, 0 skipped (no longer 1 skipped).

Closes #677