### PR TITLE
fix(typologies): expose GET /api/v1/agent-typologies user-facing route (#649)

### DIFF
--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -701,6 +701,7 @@ v1Api.MapModelEndpoints(); // Issue #3377: AI model configuration endpoints
 v1Api.MapLlmEndpoints(); // ISSUE-2391: Sprint 2 - LLM provider management
 v1Api.MapAiEndpoints();
 v1Api.MapAgentsEndpoints(); // Issue #641 (Wave B.2 hotfix): user-facing agent listing
+v1Api.MapAgentTypologiesEndpoints(); // Issue #649: user-facing typology dropdown
 v1Api.MapRulebookAnalysisEndpoints(); // ISSUE-2402: Rulebook analysis service
 
 // User Library

--- a/apps/api/src/Api/Routing/AgentTypologiesEndpoints.cs
+++ b/apps/api/src/Api/Routing/AgentTypologiesEndpoints.cs
@@ -1,0 +1,57 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs.AgentDefinition;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.AgentDefinition;
+using Api.Extensions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Routing;
+
+/// <summary>
+/// User-facing agent typologies endpoint (Issue #649).
+/// "Typologies" was collapsed into AgentDefinition during system simplification —
+/// this route exposes Published agent definitions as the user-facing typology dropdown source.
+/// </summary>
+internal static class AgentTypologiesEndpoints
+{
+    public static RouteGroupBuilder MapAgentTypologiesEndpoints(this RouteGroupBuilder group)
+    {
+        MapGetTypologiesEndpoint(group);
+        return group;
+    }
+
+    private static void MapGetTypologiesEndpoint(RouteGroupBuilder group)
+    {
+        group.MapGet("/agent-typologies", async (
+            [FromQuery] string? status,
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, _, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+
+            // Frontend sends ?status=Approved (legacy term) → map to Published.
+            // Default behavior: only return Published typologies (user-facing).
+            var publishedOnly = string.IsNullOrEmpty(status) ||
+                                string.Equals(status, "Approved", StringComparison.OrdinalIgnoreCase) ||
+                                string.Equals(status, "Published", StringComparison.OrdinalIgnoreCase);
+
+            var query = new GetAllAgentDefinitionsQuery(PublishedOnly: publishedOnly);
+            var typologies = await mediator.Send(query, ct).ConfigureAwait(false);
+
+            return Results.Ok(new
+            {
+                success = true,
+                typologies,
+                total = typologies.Count
+            });
+        })
+        .RequireAuthenticatedUser()
+        .Produces(200)
+        .Produces(401)
+        .WithTags("AgentTypologies")
+        .WithSummary("List agent typologies")
+        .WithDescription("Returns Published agent definitions used as user-facing typology dropdown source. Issue #649.")
+        .WithOpenApi();
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/Agents/AgentTypologiesEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Agents/AgentTypologiesEndpointTests.cs
@@ -1,0 +1,128 @@
+using System.Net;
+using System.Net.Http.Json;
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs.AgentDefinition;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.Agents;
+
+/// <summary>
+/// Integration tests for user-facing AgentTypologies HTTP endpoint (Issue #649).
+/// Verifies <c>GET /api/v1/agent-typologies</c> wraps the existing <c>GetAllAgentDefinitionsQueryHandler</c>
+/// MediatR handler over HTTP with proper authentication and Published-only filter support.
+///
+/// "Typologies" was collapsed into AgentDefinition during system simplification —
+/// this route exposes Published agent definitions as the user-facing typology dropdown source.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class AgentTypologiesEndpointTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    public AgentTypologiesEndpointTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"agent_typologies_endpoints_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+        }
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        await _factory.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task GetTypologies_WithoutAuth_ReturnsUnauthorized()
+    {
+        // Act
+        var response = await _client.GetAsync("/api/v1/agent-typologies");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetTypologies_WithValidSession_ReturnsEmptyList()
+    {
+        // Arrange: authenticated user, no agent definitions seeded
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/agent-typologies",
+            sessionToken);
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<GetAgentTypologiesResponse>();
+        body.Should().NotBeNull();
+        body!.Success.Should().BeTrue();
+        body.Typologies.Should().BeEmpty();
+        body.Total.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetTypologies_WithSeededAgentDefinitions_ReturnsOnlyPublished()
+    {
+        // Arrange: seed 2 Published + 1 Draft agent definitions
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        await TestSessionHelper.SeedAgentDefinitionsByStatusAsync(
+            dbContext,
+            publishedCount: 2,
+            draftCount: 1);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/agent-typologies?status=Approved",
+            sessionToken);
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<GetAgentTypologiesResponse>();
+        body.Should().NotBeNull();
+        body!.Success.Should().BeTrue();
+        body.Typologies.Should().HaveCount(2);
+        body.Typologies.Should().OnlyContain(t => t.IsActive);
+        body.Total.Should().Be(2);
+    }
+}
+
+/// <summary>
+/// HTTP response shape returned by <c>GET /api/v1/agent-typologies</c>.
+/// Mirrors anonymous object created in <c>AgentTypologiesEndpoints.MapGetTypologiesEndpoint</c>.
+/// </summary>
+internal record GetAgentTypologiesResponse(bool Success, List<AgentDefinitionDto> Typologies, int Total);

--- a/apps/api/tests/Api.Tests/Integration/Agents/AgentTypologiesEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Agents/AgentTypologiesEndpointTests.cs
@@ -1,5 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs.AgentDefinition;
 using Api.Infrastructure;
 using Api.Tests.Constants;
@@ -30,6 +32,16 @@ public sealed class AgentTypologiesEndpointTests : IAsyncLifetime
     private readonly string _testDbName;
     private WebApplicationFactory<Program> _factory = null!;
     private HttpClient _client = null!;
+
+    /// <summary>
+    /// JsonSerializerOptions that mirror the API's ConfigureHttpJsonOptions configuration
+    /// (Program.cs line 416 registers JsonStringEnumConverter globally).
+    /// Required because AgentDefinitionDto.Status is an enum serialized as a string.
+    /// </summary>
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() }
+    };
 
     public AgentTypologiesEndpointTests(SharedTestcontainersFixture fixture)
     {
@@ -83,7 +95,7 @@ public sealed class AgentTypologiesEndpointTests : IAsyncLifetime
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var body = await response.Content.ReadFromJsonAsync<GetAgentTypologiesResponse>();
+        var body = await response.Content.ReadFromJsonAsync<GetAgentTypologiesResponse>(JsonOptions);
         body.Should().NotBeNull();
         body!.Success.Should().BeTrue();
         body.Typologies.Should().BeEmpty();
@@ -112,7 +124,7 @@ public sealed class AgentTypologiesEndpointTests : IAsyncLifetime
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var body = await response.Content.ReadFromJsonAsync<GetAgentTypologiesResponse>();
+        var body = await response.Content.ReadFromJsonAsync<GetAgentTypologiesResponse>(JsonOptions);
         body.Should().NotBeNull();
         body!.Success.Should().BeTrue();
         body.Typologies.Should().HaveCount(2);

--- a/apps/api/tests/Api.Tests/TestHelpers/TestSessionHelper.cs
+++ b/apps/api/tests/Api.Tests/TestHelpers/TestSessionHelper.cs
@@ -253,6 +253,50 @@ internal static class TestSessionHelper
     }
 
     /// <summary>
+    /// Seeds AgentDefinition aggregates by Status for integration tests.
+    /// Issue #649: used by AgentTypologiesEndpoints integration tests to verify PublishedOnly filter.
+    /// Published path: Create() → StartTesting() → Publish() (auto-sets IsActive=true).
+    /// Draft path: Create() only (default state IsActive=false / Status=Draft).
+    /// </summary>
+    /// <param name="dbContext">Test database context.</param>
+    /// <param name="publishedCount">Number of Published agents to seed.</param>
+    /// <param name="draftCount">Number of Draft agents to seed.</param>
+    public static async Task SeedAgentDefinitionsByStatusAsync(
+        MeepleAiDbContext dbContext,
+        int publishedCount,
+        int draftCount)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+
+        for (var i = 0; i < publishedCount; i++)
+        {
+            var agent = AgentDefinition.Create(
+                name: $"Published Agent {i}",
+                description: $"Test published agent #{i}",
+                type: AgentType.RagAgent,
+                config: AgentDefinitionConfig.Create("gpt-4", 1000, 0.7f));
+            agent.StartTesting();
+            agent.Publish();
+
+            dbContext.AgentDefinitions.Add(agent);
+        }
+
+        for (var i = 0; i < draftCount; i++)
+        {
+            var agent = AgentDefinition.Create(
+                name: $"Draft Agent {i}",
+                description: $"Test draft agent #{i}",
+                type: AgentType.RulesInterpreter,
+                config: AgentDefinitionConfig.Create("gpt-4", 1000, 0.7f));
+            // Default state from Create() is IsActive=false / Status=Draft
+
+            dbContext.AgentDefinitions.Add(agent);
+        }
+
+        await dbContext.SaveChangesAsync();
+    }
+
+    /// <summary>
     /// Seeds a SharedGame entity with the given title for integration tests.
     /// Issue #660: Used by AgentsEndpointsIntegrationTests to assert AgentDto.GameName population
     /// when an agent definition is linked to a game in the SharedGame catalog.

--- a/apps/web/src/lib/api/clients/agentsClient.ts
+++ b/apps/web/src/lib/api/clients/agentsClient.ts
@@ -154,7 +154,7 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
      * Get approved agent typologies (authenticated endpoint)
      * Issue #3186 (AGT-012): Agent Config Modal
      * @param status Filter by status (default: 'Approved')
-     * @todo BACKEND MISSING: No route registered for GET /api/v1/agent-typologies. Returns empty array via fallback. See: endpoint audit 2026-04-15
+     * Resolved by #649 (2026-05-04) — route registered in AgentTypologiesEndpoints.cs.
      */
     async getTypologies(status: 'Approved' = 'Approved'): Promise<Typology[]> {
       const params = new URLSearchParams();


### PR DESCRIPTION
## Summary
- Wraps existing `GetAllAgentDefinitionsQuery(PublishedOnly: true)` MediatR handler over HTTP
- Maps legacy `?status=Approved` query param to `Published` filter for backwards compat
- Resolves second BACKEND MISSING annotation from audit 2026-04-15 (after #641 GET /agents)

## Impact
Wave B.2 modal "Crea agente" was showing empty typology dropdown — now populated.

## Test plan
- [x] Integration tests `AgentTypologiesEndpointTests` (3 tests: 401/empty/PublishedOnly filter)
- [x] Frontend typecheck after JSDoc cleanup

Closes #649