### PR TITLE
fix(agents): expose GET /api/v1/agents/{id} user-facing route (#647)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetAgentByIdQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetAgentByIdQueryHandler.cs
@@ -1,0 +1,77 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using MediatR;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Handler for <see cref="GetAgentByIdQuery"/> — returns a single <see cref="AgentDto"/> for the
+/// user-facing <c>GET /api/v1/agents/{id}</c> route. Issue #647 (Phase γ.1).
+/// </summary>
+/// <remarks>
+/// Mirrors the mapping in <see cref="GetAllAgentsQueryHandler"/>, including the GameName drift-fix
+/// lookup against <see cref="ISharedGameRepository.GetNamesByIdsAsync"/> introduced in PR #662.
+/// Returns <c>null</c> when no agent matches the supplied id (route surfaces 404).
+/// </remarks>
+internal sealed class GetAgentByIdQueryHandler
+    : IRequestHandler<GetAgentByIdQuery, AgentDto?>
+{
+    private readonly IAgentDefinitionRepository _repository;
+    private readonly ISharedGameRepository _sharedGameRepository;
+
+    public GetAgentByIdQueryHandler(
+        IAgentDefinitionRepository repository,
+        ISharedGameRepository sharedGameRepository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _sharedGameRepository = sharedGameRepository
+            ?? throw new ArgumentNullException(nameof(sharedGameRepository));
+    }
+
+    public async Task<AgentDto?> Handle(
+        GetAgentByIdQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var agent = await _repository
+            .GetByIdAsync(request.AgentId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (agent is null)
+        {
+            return null;
+        }
+
+        // GameName drift-fix lookup (PR #662 pattern): single bulk call even for one id keeps
+        // the resolution path identical to GetAllAgentsQueryHandler.
+        string? gameName = null;
+        if (agent.GameId.HasValue)
+        {
+            var names = await _sharedGameRepository
+                .GetNamesByIdsAsync(new[] { agent.GameId.Value }, cancellationToken)
+                .ConfigureAwait(false);
+            names.TryGetValue(agent.GameId.Value, out gameName);
+        }
+
+        var recentThreshold = DateTime.UtcNow.AddHours(-24);
+        var idleThreshold = DateTime.UtcNow.AddDays(-7);
+
+        return new AgentDto(
+            Id: agent.Id,
+            Name: agent.Name,
+            Type: agent.Type.Value,
+            StrategyName: agent.Strategy.Name,
+            StrategyParameters: agent.Strategy.Parameters,
+            IsActive: agent.IsActive,
+            CreatedAt: agent.CreatedAt,
+            LastInvokedAt: agent.LastInvokedAt,
+            InvocationCount: agent.InvocationCount,
+            IsRecentlyUsed: agent.LastInvokedAt.HasValue && agent.LastInvokedAt.Value > recentThreshold,
+            IsIdle: !agent.LastInvokedAt.HasValue || agent.LastInvokedAt.Value < idleThreshold,
+            GameId: agent.GameId,
+            GameName: gameName,
+            CreatedByUserId: null);
+    }
+}

--- a/apps/api/src/Api/Routing/AgentsEndpoints.cs
+++ b/apps/api/src/Api/Routing/AgentsEndpoints.cs
@@ -7,15 +7,18 @@ using Microsoft.AspNetCore.Mvc;
 namespace Api.Routing;
 
 /// <summary>
-/// User-facing Agents endpoints (read-only listing).
+/// User-facing Agents endpoints (read-only listing + by-id lookup).
 /// Issue #641 (Wave B.2 hotfix): expose existing GetAllAgentsQuery handler over HTTP
 /// so the frontend <c>useAgents</c> hook can resolve agents at <c>GET /api/v1/agents</c>.
+/// Issue #647 (Phase γ.1): expose <c>GET /api/v1/agents/{id}</c> for the single-agent
+/// detail surface consumed by the frontend <c>agentsClient.getById</c> helper.
 /// </summary>
 internal static class AgentsEndpoints
 {
     public static RouteGroupBuilder MapAgentsEndpoints(this RouteGroupBuilder group)
     {
         MapGetAgentsEndpoint(group);
+        MapGetAgentByIdEndpoint(group);
         return group;
     }
 
@@ -50,6 +53,32 @@ internal static class AgentsEndpoints
         .WithTags("Agents")
         .WithSummary("List all agents")
         .WithDescription("Returns all agents with optional activeOnly and type filters. Issue #641 Wave B.2 hotfix.")
+        .WithOpenApi();
+    }
+
+    private static void MapGetAgentByIdEndpoint(RouteGroupBuilder group)
+    {
+        group.MapGet("/agents/{id:guid}", async (
+            Guid id,
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, _, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+
+            var query = new GetAgentByIdQuery(id);
+            var dto = await mediator.Send(query, ct).ConfigureAwait(false);
+
+            return dto is null ? Results.NotFound() : Results.Ok(dto);
+        })
+        .RequireAuthenticatedUser()
+        .Produces<AgentDto>(200)
+        .Produces(401)
+        .Produces(404)
+        .WithTags("Agents")
+        .WithSummary("Get agent by ID")
+        .WithDescription("Returns a single agent definition by id, mapped to AgentDto with GameName resolved via SharedGame catalog (PR #662 drift-fix). Issue #647 (Phase γ.1).")
         .WithOpenApi();
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/Agents/AgentsEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Agents/AgentsEndpointsIntegrationTests.cs
@@ -148,6 +148,79 @@ public sealed class AgentsEndpointsIntegrationTests : IAsyncLifetime
         body.Agents[0].GameId.Should().Be(gameId);
         body.Agents[0].GameName.Should().Be("Catan");
     }
+
+    // Issue #647: Phase γ.1 — GET /api/v1/agents/{id} user-facing route.
+    [Fact]
+    public async Task GetAgentById_WithoutAuth_ReturnsUnauthorized()
+    {
+        // Act
+        var response = await _client.GetAsync($"/api/v1/agents/{Guid.NewGuid()}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetAgentById_WithUnknownId_ReturnsNotFound()
+    {
+        // Arrange: authenticated user, no agents seeded.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/agents/{Guid.NewGuid()}",
+            sessionToken);
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetAgentById_WithSeededAgent_ReturnsAgentDto()
+    {
+        // Arrange: seed 1 active agent linked to a SharedGame, retrieve its id from DbContext.
+        // Issue #647: verifies the route returns AgentDto with GameName drift-fix lookup
+        // (PR #662 pattern) when the agent has a non-null GameId.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(dbContext, title: "Wingspan");
+        await TestSessionHelper.SeedAgentDefinitionsAsync(
+            dbContext,
+            activeCount: 1,
+            inactiveCount: 0,
+            gameId: gameId);
+
+        // SeedAgentDefinitionsAsync doesn't return ids, so we query the DbContext for the seeded agent.
+        // GameId is mapped via shadow property "_gameId" (see AgentDefinitionConfiguration), so we
+        // resolve it via EF.Property to keep the query translatable to SQL.
+        var seededAgent = await dbContext.AgentDefinitions
+            .AsNoTracking()
+            .FirstAsync(a => EF.Property<Guid?>(a, "_gameId") == gameId);
+        var agentId = seededAgent.Id;
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/agents/{agentId}",
+            sessionToken);
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<AgentDto>();
+        dto.Should().NotBeNull();
+        dto!.Id.Should().Be(agentId);
+        dto.GameId.Should().Be(gameId);
+        dto.GameName.Should().Be("Wingspan");
+    }
 }
 
 /// <summary>

--- a/apps/web/src/lib/api/clients/agentsClient.ts
+++ b/apps/web/src/lib/api/clients/agentsClient.ts
@@ -108,7 +108,7 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
      * Get agent by ID
      * Implements GetAgentByIdQuery from backend
      * @param id Agent ID (GUID format)
-     * @todo BACKEND MISSING: No route registered for GET /api/v1/agents/{id}. Returns null via fallback. See: endpoint audit 2026-04-15
+     * Resolved by #647 (2026-05-04) — route registered in AgentsEndpoints.cs.
      */
     async getById(id: string): Promise<AgentDto | null> {
       return httpClient.get(`/api/v1/agents/${encodeURIComponent(id)}`, AgentDtoSchema);


### PR DESCRIPTION
## Summary
- New `GetAgentByIdQueryHandler` maps `AgentDefinition` → `AgentDto` with `GameName` drift-fix lookup (PR #662 pattern, mirrors `GetAllAgentsQueryHandler`)
- New route `GET /api/v1/agents/{id:guid}` in `AgentsEndpoints.cs`, returns 404 when handler resolves null
- Frontend `agentsClient.getById` JSDoc cleaned: BACKEND MISSING todo replaced with reference to this issue
- Resolves third BACKEND MISSING annotation from audit 2026-04-15 (after #641 list, #649 typologies)

## Impact
Sblocca futura `/agents/[id]` agent detail page (Wave C umbrella #581) — frontend client already wires the call via `httpClient.get` against the registered route.

## Test plan
- [x] Integration tests: 3 new (`GetAgentById_WithoutAuth_ReturnsUnauthorized`, `GetAgentById_WithUnknownId_ReturnsNotFound`, `GetAgentById_WithSeededAgent_ReturnsAgentDto`) — all green; existing 4 tests still green (7/7)
- [x] Frontend `pnpm typecheck` clean after JSDoc cleanup
- [x] TDD red→green decomposition: red commit asserts route absence (404 instead of expected 401), green commit registers route + handler

Closes #647