### PR TITLE
fix(agents): expose GET /api/v1/agents/recent user-facing route (#650)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentAgentsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentAgentsQueryHandler.cs
@@ -1,0 +1,94 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using MediatR;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Handler for <see cref="GetRecentAgentsQuery"/> — returns the top-N active <see cref="AgentDto"/>
+/// list ordered by <c>LastInvokedAt</c> descending. Powers the dashboard recent-agents widget
+/// (frontend <c>useRecentAgents</c>). Issue #650 (Phase γ.3).
+/// </summary>
+/// <remarks>
+/// Mirrors the GameName drift-fix lookup pattern from <see cref="GetAllAgentsQueryHandler"/>
+/// and <see cref="GetAgentByIdQueryHandler"/> (PR #662). The <c>UserId</c> field on the query is
+/// reserved for a future user-owned-agent feature; current schema scopes agents per game (or
+/// globally), not per user, so it is intentionally unused at this time.
+/// </remarks>
+internal sealed class GetRecentAgentsQueryHandler
+    : IRequestHandler<GetRecentAgentsQuery, IReadOnlyList<AgentDto>>
+{
+    private readonly IAgentDefinitionRepository _repository;
+    private readonly ISharedGameRepository _sharedGameRepository;
+
+    public GetRecentAgentsQueryHandler(
+        IAgentDefinitionRepository repository,
+        ISharedGameRepository sharedGameRepository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _sharedGameRepository = sharedGameRepository
+            ?? throw new ArgumentNullException(nameof(sharedGameRepository));
+    }
+
+    public async Task<IReadOnlyList<AgentDto>> Handle(
+        GetRecentAgentsQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Defensive clamp: dashboard widget caller passes default 10; protect against runaway
+        // payloads when client supplies large limit values.
+        var safeLimit = Math.Clamp(request.Limit, 1, 50);
+
+        var agents = await _repository
+            .GetAllActiveAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var ordered = agents
+            .OrderByDescending(a => a.LastInvokedAt ?? DateTime.MinValue)
+            .ThenByDescending(a => a.CreatedAt)
+            .Take(safeLimit)
+            .ToList();
+
+        // Bulk-fetch GameName for ordered slice only (single SQL call, no N+1) — mirrors PR #662.
+        var gameIds = ordered
+            .Where(a => a.GameId.HasValue)
+            .Select(a => a.GameId!.Value)
+            .Distinct()
+            .ToList();
+
+        var gameNames = gameIds.Count > 0
+            ? await _sharedGameRepository
+                .GetNamesByIdsAsync(gameIds, cancellationToken)
+                .ConfigureAwait(false)
+            : new Dictionary<Guid, string>();
+
+        var recentThreshold = DateTime.UtcNow.AddHours(-24);
+        var idleThreshold = DateTime.UtcNow.AddDays(-7);
+
+        return ordered.Select(agent =>
+        {
+            var gameName = agent.GameId.HasValue
+                && gameNames.TryGetValue(agent.GameId.Value, out var name)
+                    ? name
+                    : null;
+
+            return new AgentDto(
+                Id: agent.Id,
+                Name: agent.Name,
+                Type: agent.Type.Value,
+                StrategyName: agent.Strategy.Name,
+                StrategyParameters: agent.Strategy.Parameters,
+                IsActive: agent.IsActive,
+                CreatedAt: agent.CreatedAt,
+                LastInvokedAt: agent.LastInvokedAt,
+                InvocationCount: agent.InvocationCount,
+                IsRecentlyUsed: agent.LastInvokedAt.HasValue && agent.LastInvokedAt.Value > recentThreshold,
+                IsIdle: !agent.LastInvokedAt.HasValue || agent.LastInvokedAt.Value < idleThreshold,
+                GameId: agent.GameId,
+                GameName: gameName,
+                CreatedByUserId: null);
+        }).ToList();
+    }
+}

--- a/apps/api/src/Api/Routing/AgentsEndpoints.cs
+++ b/apps/api/src/Api/Routing/AgentsEndpoints.cs
@@ -7,17 +7,23 @@ using Microsoft.AspNetCore.Mvc;
 namespace Api.Routing;
 
 /// <summary>
-/// User-facing Agents endpoints (read-only listing + by-id lookup).
+/// User-facing Agents endpoints (read-only listing + by-id lookup + recent widget).
 /// Issue #641 (Wave B.2 hotfix): expose existing GetAllAgentsQuery handler over HTTP
 /// so the frontend <c>useAgents</c> hook can resolve agents at <c>GET /api/v1/agents</c>.
 /// Issue #647 (Phase γ.1): expose <c>GET /api/v1/agents/{id}</c> for the single-agent
 /// detail surface consumed by the frontend <c>agentsClient.getById</c> helper.
+/// Issue #650 (Phase γ.3): expose <c>GET /api/v1/agents/recent</c> for the dashboard
+/// recent-agents widget consumed by the frontend <c>useRecentAgents</c> hook.
 /// </summary>
 internal static class AgentsEndpoints
 {
     public static RouteGroupBuilder MapAgentsEndpoints(this RouteGroupBuilder group)
     {
         MapGetAgentsEndpoint(group);
+        // Recent must be registered before the {id:guid} route so that the literal "recent"
+        // segment never reaches the GUID-constrained handler. The :guid constraint already
+        // disambiguates at the matcher level, but explicit ordering keeps intent obvious.
+        MapGetRecentAgentsEndpoint(group);
         MapGetAgentByIdEndpoint(group);
         return group;
     }
@@ -79,6 +85,30 @@ internal static class AgentsEndpoints
         .WithTags("Agents")
         .WithSummary("Get agent by ID")
         .WithDescription("Returns a single agent definition by id, mapped to AgentDto with GameName resolved via SharedGame catalog (PR #662 drift-fix). Issue #647 (Phase γ.1).")
+        .WithOpenApi();
+    }
+
+    private static void MapGetRecentAgentsEndpoint(RouteGroupBuilder group)
+    {
+        group.MapGet("/agents/recent", async (
+            [FromQuery] int? limit,
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, _, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+
+            var query = new GetRecentAgentsQuery(Limit: limit ?? 10);
+            var agents = await mediator.Send(query, ct).ConfigureAwait(false);
+            return Results.Ok(agents);
+        })
+        .RequireAuthenticatedUser()
+        .Produces<IReadOnlyList<AgentDto>>(200)
+        .Produces(401)
+        .WithTags("Agents")
+        .WithSummary("Get recently used agents")
+        .WithDescription("Returns active agents ordered by LastInvokedAt desc (limit clamped 1..50, default 10). Powers the dashboard recent-agents widget (frontend useRecentAgents hook). Issue #650 (Phase γ.3).")
         .WithOpenApi();
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/Agents/AgentsEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Agents/AgentsEndpointsIntegrationTests.cs
@@ -221,6 +221,67 @@ public sealed class AgentsEndpointsIntegrationTests : IAsyncLifetime
         dto.GameId.Should().Be(gameId);
         dto.GameName.Should().Be("Wingspan");
     }
+
+    // Issue #650: Phase γ.3 — GET /api/v1/agents/recent dashboard widget route.
+    [Fact]
+    public async Task GetRecentAgents_WithoutAuth_ReturnsUnauthorized()
+    {
+        // Act
+        var response = await _client.GetAsync("/api/v1/agents/recent");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetRecentAgents_WithEmptyDb_ReturnsEmptyArray()
+    {
+        // Arrange: authenticated user, no agents seeded.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/agents/recent",
+            sessionToken);
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert: route MUST return a JSON array body (frontend expects z.array(AgentDtoSchema))
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<List<AgentDto>>();
+        body.Should().NotBeNull();
+        body!.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetRecentAgents_OrdersByLastInvokedDescAndRespectsLimit()
+    {
+        // Arrange: seed 3 active agents and verify limit=2 returns only the top 2.
+        // Recent-agents widget contract: only active agents, ordered by LastInvokedAt desc.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        await TestSessionHelper.SeedAgentDefinitionsAsync(dbContext, activeCount: 3, inactiveCount: 0);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/agents/recent?limit=2",
+            sessionToken);
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert: limit honored at 2, all returned agents are active.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<List<AgentDto>>();
+        body.Should().NotBeNull();
+        body!.Should().HaveCount(2);
+        body.Should().OnlyContain(a => a.IsActive);
+    }
 }
 
 /// <summary>

--- a/apps/web/src/lib/api/clients/agentsClient.ts
+++ b/apps/web/src/lib/api/clients/agentsClient.ts
@@ -180,7 +180,7 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
     /**
      * Get recent agents for dashboard widget
      * Issue #4126: API Integration
-     * @todo BACKEND MISSING: No route registered for GET /api/v1/agents/recent. Returns empty array via fallback. See: endpoint audit 2026-04-15
+     * Resolved by #650 (2026-05-04) — route registered in AgentsEndpoints.cs.
      */
     async getRecent(limit: number = 10): Promise<AgentDto[]> {
       const response = await httpClient.get<AgentDto[]>(


### PR DESCRIPTION
## Summary
- New `GetRecentAgentsQueryHandler` returns top-N active agents ordered by `LastInvokedAt` desc (then `CreatedAt` desc)
- New route `GET /api/v1/agents/recent?limit=N` (clamped 1..50, default 10)
- Fourth BACKEND MISSING annotation resolved (audit 2026-04-15)

## Impact
Powers `useRecentAgents` dashboard widget — was returning empty fallback in prod.

## Implementation notes
- Mirrors PR #662 GameName drift-fix lookup via `ISharedGameRepository.GetNamesByIdsAsync` (single SQL, no N+1)
- Route ordering: `/agents/recent` registered **before** `/agents/{id:guid}` so the literal `recent` segment never reaches the GUID-constrained handler (the `:guid` constraint already disambiguates at the matcher level, but explicit ordering keeps intent obvious)
- Handler uses `IRequestHandler<TQuery, TResult>` (MediatR) consistent with sibling handlers; `IQuery<T>` extends `IRequest<T>` in this codebase

## Test plan
- [x] Integration tests: 3 new (Unauthorized, EmptyDb, RespectsLimit)
- [x] Frontend typecheck after JSDoc cleanup
- [x] Build clean
- [x] CI: Backend Unit + Integration + Frontend Build & Test

## TDD trail
- `bfabf7a25` test(agents): integration tests for GET /api/v1/agents/recent (red)
- `464816cf7` feat(agents): expose GET /api/v1/agents/recent user-facing route (green)
- `03e3a1947` chore(agents): remove BACKEND MISSING todo from getRecent annotation

Closes #650