### PR TITLE
fix(agents): expose GET /api/v1/agents/{id}/status user-facing route (#648)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetAgentStatusQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetAgentStatusQueryHandler.cs
@@ -1,0 +1,80 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using MediatR;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Handler for <see cref="GetAgentStatusQuery"/> — returns an <see cref="AgentStatusDto"/> for the
+/// user-facing <c>GET /api/v1/agents/{id}/status</c> route. Issue #648 (Phase γ.2).
+/// </summary>
+/// <remarks>
+/// MVP readiness derived from <see cref="Domain.Entities.AgentDefinition"/> entity flags only:
+/// <list type="bullet">
+///   <item><description><c>IsActive</c>: from <c>agent.IsActive</c></description></item>
+///   <item><description><c>HasConfiguration</c>: <c>true</c> when <c>agent.Strategy.Name</c> is non-empty</description></item>
+///   <item><description><c>IsReady</c>: <c>IsActive AND HasConfiguration</c></description></item>
+///   <item><description><c>RagStatus</c>: <c>"inactive"</c> | <c>"misconfigured"</c> | <c>"ready"</c></description></item>
+/// </list>
+/// <c>HasDocuments</c> precise count is deferred (would require a SelectedDocuments query
+/// repository). Frontend contract satisfied with shape correctness; file a follow-up issue if
+/// downstream consumers require precise counts.
+/// </remarks>
+internal sealed class GetAgentStatusQueryHandler
+    : IRequestHandler<GetAgentStatusQuery, AgentStatusDto?>
+{
+    private readonly IAgentDefinitionRepository _repository;
+
+    public GetAgentStatusQueryHandler(IAgentDefinitionRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public async Task<AgentStatusDto?> Handle(
+        GetAgentStatusQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var agent = await _repository
+            .GetByIdAsync(request.AgentId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (agent is null)
+        {
+            return null;
+        }
+
+        var hasConfiguration = !string.IsNullOrWhiteSpace(agent.Strategy.Name);
+        const bool hasDocuments = false;
+        const int documentCount = 0;
+
+        var isReady = agent.IsActive && hasConfiguration;
+        var ragStatus = !agent.IsActive
+            ? "inactive"
+            : !hasConfiguration
+                ? "misconfigured"
+                : "ready";
+
+        string? blockingReason = null;
+        if (!agent.IsActive)
+        {
+            blockingReason = "Agent is not active";
+        }
+        else if (!hasConfiguration)
+        {
+            blockingReason = "Agent strategy is not configured";
+        }
+
+        return new AgentStatusDto(
+            AgentId: agent.Id,
+            Name: agent.Name,
+            IsActive: agent.IsActive,
+            IsReady: isReady,
+            HasConfiguration: hasConfiguration,
+            HasDocuments: hasDocuments,
+            DocumentCount: documentCount,
+            RagStatus: ragStatus,
+            BlockingReason: blockingReason);
+    }
+}

--- a/apps/api/src/Api/Routing/AgentsEndpoints.cs
+++ b/apps/api/src/Api/Routing/AgentsEndpoints.cs
@@ -7,13 +7,15 @@ using Microsoft.AspNetCore.Mvc;
 namespace Api.Routing;
 
 /// <summary>
-/// User-facing Agents endpoints (read-only listing + by-id lookup + recent widget).
+/// User-facing Agents endpoints (read-only listing + by-id lookup + recent widget + readiness status).
 /// Issue #641 (Wave B.2 hotfix): expose existing GetAllAgentsQuery handler over HTTP
 /// so the frontend <c>useAgents</c> hook can resolve agents at <c>GET /api/v1/agents</c>.
 /// Issue #647 (Phase γ.1): expose <c>GET /api/v1/agents/{id}</c> for the single-agent
 /// detail surface consumed by the frontend <c>agentsClient.getById</c> helper.
 /// Issue #650 (Phase γ.3): expose <c>GET /api/v1/agents/recent</c> for the dashboard
 /// recent-agents widget consumed by the frontend <c>useRecentAgents</c> hook.
+/// Issue #648 (Phase γ.2): expose <c>GET /api/v1/agents/{id}/status</c> for the
+/// readiness widget consumed by the frontend <c>useAgentStatus</c> hook.
 /// </summary>
 internal static class AgentsEndpoints
 {
@@ -25,6 +27,7 @@ internal static class AgentsEndpoints
         // disambiguates at the matcher level, but explicit ordering keeps intent obvious.
         MapGetRecentAgentsEndpoint(group);
         MapGetAgentByIdEndpoint(group);
+        MapGetAgentStatusEndpoint(group);
         return group;
     }
 
@@ -109,6 +112,31 @@ internal static class AgentsEndpoints
         .WithTags("Agents")
         .WithSummary("Get recently used agents")
         .WithDescription("Returns active agents ordered by LastInvokedAt desc (limit clamped 1..50, default 10). Powers the dashboard recent-agents widget (frontend useRecentAgents hook). Issue #650 (Phase γ.3).")
+        .WithOpenApi();
+    }
+
+    private static void MapGetAgentStatusEndpoint(RouteGroupBuilder group)
+    {
+        group.MapGet("/agents/{id:guid}/status", async (
+            Guid id,
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, _, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+
+            var query = new GetAgentStatusQuery(id);
+            var dto = await mediator.Send(query, ct).ConfigureAwait(false);
+            return dto is null ? Results.NotFound() : Results.Ok(dto);
+        })
+        .RequireAuthenticatedUser()
+        .Produces<AgentStatusDto>(200)
+        .Produces(401)
+        .Produces(404)
+        .WithTags("Agents")
+        .WithSummary("Get agent readiness status")
+        .WithDescription("Returns readiness derived from AgentDefinition flags (IsActive AND Strategy.Name presence). HasDocuments precise count is deferred to a follow-up if needed. Issue #648 — useAgentStatus widget.")
         .WithOpenApi();
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/Agents/AgentsEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Agents/AgentsEndpointsIntegrationTests.cs
@@ -282,6 +282,73 @@ public sealed class AgentsEndpointsIntegrationTests : IAsyncLifetime
         body!.Should().HaveCount(2);
         body.Should().OnlyContain(a => a.IsActive);
     }
+
+    // Issue #648: Phase γ.2 — GET /api/v1/agents/{id}/status useAgentStatus widget route.
+    [Fact]
+    public async Task GetAgentStatus_WithoutAuth_ReturnsUnauthorized()
+    {
+        // Act
+        var response = await _client.GetAsync($"/api/v1/agents/{Guid.NewGuid()}/status");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetAgentStatus_WithUnknownId_ReturnsNotFound()
+    {
+        // Arrange: authenticated user, no agents seeded.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/agents/{Guid.NewGuid()}/status",
+            sessionToken);
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetAgentStatus_WithActiveSeededAgent_ReturnsReady()
+    {
+        // Arrange: seed 1 active agent. Issue #648 MVP readiness derives IsReady from
+        // IsActive AND HasConfiguration (Strategy.Name presence). HasDocuments precise count
+        // deferred (would require SelectedDocuments query repository).
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        await TestSessionHelper.SeedAgentDefinitionsAsync(dbContext, activeCount: 1, inactiveCount: 0);
+        var seededId = await dbContext.AgentDefinitions
+            .AsNoTracking()
+            .Select(a => a.Id)
+            .FirstAsync();
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/agents/{seededId}/status",
+            sessionToken);
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<AgentStatusDto>();
+        dto.Should().NotBeNull();
+        dto!.AgentId.Should().Be(seededId);
+        dto.IsActive.Should().BeTrue();
+        dto.IsReady.Should().BeTrue();
+        dto.HasConfiguration.Should().BeTrue();
+        dto.RagStatus.Should().Be("ready");
+        dto.BlockingReason.Should().BeNull();
+    }
 }
 
 /// <summary>

--- a/apps/web/src/lib/api/clients/agentsClient.ts
+++ b/apps/web/src/lib/api/clients/agentsClient.ts
@@ -118,7 +118,7 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
      * Get agent chat readiness status
      * Validates KB populated and RAG initialized
      * @param id Agent ID (GUID format)
-     * @todo BACKEND MISSING: No route registered for GET /api/v1/agents/{id}/status. Throws on null response. See: endpoint audit 2026-04-15
+     * Resolved by #648 (2026-05-04) — route registered in AgentsEndpoints.cs.
      */
     async getStatus(id: string): Promise<{
       agentId: string;


### PR DESCRIPTION
## Summary
- New `GetAgentStatusQueryHandler` returns MVP readiness DTO (IsReady = IsActive AND HasConfiguration)
- New route `GET /api/v1/agents/{id:guid}/status` returns 404 for unknown id
- Fifth BACKEND MISSING annotation resolved (audit 2026-04-15)

## Scope note (deliberate MVP)
HasDocuments precise count deferred — would require SelectedDocuments query repository. Frontend contract satisfied with shape correctness. File followup if precise count needed downstream.

## Test plan
- [x] Integration tests: 3 new (Unauthorized, NotFound, ActiveAgent→Ready)
- [x] Frontend typecheck after JSDoc cleanup

Closes #648