### PR TITLE
fix(agents): expose POST /api/v1/agents/create-with-setup orchestration (#655)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/CreateAgentWithSetupCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/CreateAgentWithSetupCommand.cs
@@ -1,0 +1,40 @@
+using MediatR;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
+
+/// <summary>
+/// Command for the orchestrated agent creation flow consumed by the frontend
+/// <c>agentsClient.createWithSetup</c> wizard helper. Issue #655 (Phase β.3).
+/// </summary>
+/// <remarks>
+/// Orchestration sequence:
+/// <list type="number">
+///   <item>Optional library add via <c>AddGameToLibraryCommand</c> (idempotent: <c>"already in"</c>
+///   DomainException is treated as success).</item>
+///   <item>Agent creation via <c>CreateUserAgentCommand</c> (β.2 reuse).</item>
+///   <item>Result includes placeholder <c>ThreadId</c> (chat-thread BC integration deferred) and
+///   <c>SlotUsed = 0</c> (tier/quota deferred to Issue #4771).</item>
+/// </list>
+/// </remarks>
+internal sealed record CreateAgentWithSetupCommand(
+    Guid UserId,
+    Guid GameId,
+    bool AddToCollection,
+    string AgentType,
+    string? AgentName = null,
+    string? StrategyName = null,
+    IReadOnlyDictionary<string, object>? StrategyParameters = null,
+    IReadOnlyList<Guid>? DocumentIds = null
+) : IRequest<CreateAgentWithSetupResult>;
+
+/// <summary>
+/// Result returned by <see cref="CreateAgentWithSetupCommand"/>. Mirrors the frontend
+/// <c>CreateAgentWithSetupResponse</c> shape consumed by the AgentCreationSheet wizard.
+/// </summary>
+internal sealed record CreateAgentWithSetupResult(
+    Guid AgentId,
+    string AgentName,
+    Guid ThreadId,
+    int SlotUsed,
+    bool GameAddedToCollection
+);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/CreateAgentWithSetupCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/CreateAgentWithSetupCommandHandler.cs
@@ -1,0 +1,86 @@
+using Api.BoundedContexts.UserLibrary.Application.Commands;
+using Api.SharedKernel.Domain.Exceptions;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
+
+/// <summary>
+/// Handler for <see cref="CreateAgentWithSetupCommand"/>. Orchestrates:
+/// <list type="number">
+///   <item>Optional <c>AddGameToLibraryCommand</c> when <c>AddToCollection</c> is true
+///   (idempotent: <c>"already in"</c> <see cref="DomainException"/> caught and treated
+///   as success — orchestration semantics).</item>
+///   <item><c>CreateUserAgentCommand</c> (β.2 reuse) — returns the resolved agent DTO.</item>
+///   <item>Placeholder <c>ThreadId</c> (chat-thread BC integration deferred) +
+///   <c>SlotUsed = 0</c> (tier/quota deferred to Issue #4771).</item>
+/// </list>
+/// MVP shape sufficient for the frontend AgentCreationSheet setup wizard. Issue #655.
+/// </summary>
+internal sealed class CreateAgentWithSetupCommandHandler
+    : IRequestHandler<CreateAgentWithSetupCommand, CreateAgentWithSetupResult>
+{
+    private readonly IMediator _mediator;
+    private readonly ILogger<CreateAgentWithSetupCommandHandler> _logger;
+
+    public CreateAgentWithSetupCommandHandler(
+        IMediator mediator,
+        ILogger<CreateAgentWithSetupCommandHandler> logger)
+    {
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<CreateAgentWithSetupResult> Handle(
+        CreateAgentWithSetupCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Step 1: optional library add (idempotent via "already in" DomainException catch).
+        var gameAddedToCollection = false;
+        if (request.AddToCollection)
+        {
+            try
+            {
+                var addCommand = new AddGameToLibraryCommand(
+                    UserId: request.UserId,
+                    GameId: request.GameId,
+                    Notes: null,
+                    IsFavorite: false);
+                await _mediator.Send(addCommand, cancellationToken).ConfigureAwait(false);
+                gameAddedToCollection = true;
+            }
+            catch (DomainException ex) when (ex.Message.Contains("already in", StringComparison.OrdinalIgnoreCase))
+            {
+                // Game already in library — count as success for orchestration semantics.
+                gameAddedToCollection = true;
+                _logger.LogInformation(
+                    ex,
+                    "Game {GameId} already in library for user {UserId}; treating as success",
+                    request.GameId,
+                    request.UserId);
+            }
+        }
+
+        // Step 2: create the agent (β.2 reuse).
+        var createAgentCommand = new CreateUserAgentCommand(
+            UserId: request.UserId,
+            GameId: request.GameId,
+            AgentType: request.AgentType,
+            Name: request.AgentName,
+            StrategyName: request.StrategyName,
+            StrategyParameters: request.StrategyParameters,
+            DocumentIds: request.DocumentIds);
+
+        var agentDto = await _mediator.Send(createAgentCommand, cancellationToken).ConfigureAwait(false);
+
+        // Step 3+4: placeholder thread + slot (deferred BC integrations).
+        return new CreateAgentWithSetupResult(
+            AgentId: agentDto.Id,
+            AgentName: agentDto.Name,
+            ThreadId: Guid.NewGuid(),
+            SlotUsed: 0,
+            GameAddedToCollection: gameAddedToCollection);
+    }
+}

--- a/apps/api/src/Api/Routing/AgentsEndpoints.cs
+++ b/apps/api/src/Api/Routing/AgentsEndpoints.cs
@@ -20,6 +20,10 @@ namespace Api.Routing;
 /// Issue #654 (Phase β.2): expose <c>POST /api/v1/agents/user</c> for the
 /// frontend <c>agentsClient.createUserAgent</c> helper. MVP defers documentIds
 /// linking and tier/quota validation.
+/// Issue #655 (Phase β.3): expose <c>POST /api/v1/agents/create-with-setup</c>
+/// orchestration route consumed by the AgentCreationSheet wizard. Optional
+/// addToCollection step + agent creation (β.2 reuse). Placeholder threadId
+/// (chat-thread BC integration deferred) + slotUsed=0 (Issue #4771 deferred).
 /// </summary>
 internal static class AgentsEndpoints
 {
@@ -33,6 +37,7 @@ internal static class AgentsEndpoints
         MapGetAgentByIdEndpoint(group);
         MapGetAgentStatusEndpoint(group);
         MapCreateUserAgentEndpoint(group);
+        MapCreateAgentWithSetupEndpoint(group);
         return group;
     }
 
@@ -44,6 +49,21 @@ internal static class AgentsEndpoints
         Guid GameId,
         string AgentType,
         string? Name = null,
+        string? StrategyName = null,
+        Dictionary<string, object>? StrategyParameters = null,
+        List<Guid>? DocumentIds = null
+    );
+
+    /// <summary>
+    /// Frontend <c>agentsClient.createWithSetup</c> request body shape.
+    /// Mirrors <c>CreateAgentWithSetupRequest</c> in
+    /// <c>apps/web/src/lib/api/clients/agentsClient.ts</c>. Issue #655 (Phase β.3).
+    /// </summary>
+    private sealed record CreateAgentWithSetupRequest(
+        Guid GameId,
+        bool AddToCollection,
+        string AgentType,
+        string? AgentName = null,
         string? StrategyName = null,
         Dictionary<string, object>? StrategyParameters = null,
         List<Guid>? DocumentIds = null
@@ -202,6 +222,53 @@ internal static class AgentsEndpoints
         .WithTags("Agents")
         .WithSummary("Create a user-owned agent")
         .WithDescription("Creates a custom agent linked to a SharedGame, returning AgentDto with GameName resolved. MVP: documentIds parameter accepted but not linked (deferred); tier/quota validation deferred (Issue #4771). Issue #654 (Phase β.2).")
+        .WithOpenApi();
+    }
+
+    private static void MapCreateAgentWithSetupEndpoint(RouteGroupBuilder group)
+    {
+        group.MapPost("/agents/create-with-setup", async (
+            [FromBody] CreateAgentWithSetupRequest request,
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, session, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+            if (!UserLibraryCoreEndpoints.TryGetUserId(context, session, out var userId))
+                return Results.Unauthorized();
+
+            try
+            {
+                var command = new CreateAgentWithSetupCommand(
+                    UserId: userId,
+                    GameId: request.GameId,
+                    AddToCollection: request.AddToCollection,
+                    AgentType: request.AgentType,
+                    AgentName: request.AgentName,
+                    StrategyName: request.StrategyName,
+                    StrategyParameters: request.StrategyParameters,
+                    DocumentIds: request.DocumentIds);
+
+                var result = await mediator.Send(command, ct).ConfigureAwait(false);
+                return Results.Created($"/api/v1/agents/{result.AgentId}", result);
+            }
+            catch (ArgumentException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+            catch (InvalidOperationException ex) when (ex.Message.Contains("not found", StringComparison.OrdinalIgnoreCase))
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        })
+        .RequireAuthenticatedUser()
+        .Produces<CreateAgentWithSetupResult>(201)
+        .Produces(400)
+        .Produces(401)
+        .WithTags("Agents")
+        .WithSummary("Create agent with optional library add + thread")
+        .WithDescription("Orchestrates: optional addToCollection → AddGameToLibraryCommand (idempotent: 'already in' counts as success) → CreateUserAgentCommand → result with placeholder threadId (chat-thread BC integration deferred) and slotUsed=0 (tier/quota Issue #4771 deferred). Issue #655 (Phase β.3).")
         .WithOpenApi();
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/Agents/AgentsEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Agents/AgentsEndpointsIntegrationTests.cs
@@ -427,6 +427,89 @@ public sealed class AgentsEndpointsIntegrationTests : IAsyncLifetime
         dto.GameName.Should().Be("Catan");
         dto.IsActive.Should().BeTrue();
     }
+
+    // Issue #655: Phase β.3 — POST /api/v1/agents/create-with-setup orchestration.
+    [Fact]
+    public async Task CreateAgentWithSetup_WithoutAuth_ReturnsUnauthorized()
+    {
+        // Act
+        var response = await _client.PostAsJsonAsync("/api/v1/agents/create-with-setup", new
+        {
+            gameId = Guid.NewGuid(),
+            addToCollection = false,
+            agentType = "Strategist"
+        });
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task CreateAgentWithSetup_WithoutAddToCollection_ReturnsAgentResultGameAddedFalse()
+    {
+        // Arrange: seed SharedGame "Wingspan", authenticated user, addToCollection=false.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(dbContext, title: "Wingspan");
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            "/api/v1/agents/create-with-setup",
+            sessionToken,
+            new
+            {
+                gameId,
+                addToCollection = false,
+                agentType = "Strategist",
+                agentName = "Wingspan Coach"
+            });
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert: 201 Created or 200 OK with orchestration result body.
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.Created);
+        var body = await response.Content.ReadFromJsonAsync<CreateAgentWithSetupResponse>();
+        body.Should().NotBeNull();
+        body!.AgentName.Should().Be("Wingspan Coach");
+        body.GameAddedToCollection.Should().BeFalse();
+        body.SlotUsed.Should().Be(0);
+        body.AgentId.Should().NotBe(Guid.Empty);
+        body.ThreadId.Should().NotBe(Guid.Empty);
+    }
+
+    [Fact]
+    public async Task CreateAgentWithSetup_WithAddToCollection_AddsGameAndReturnsTrue()
+    {
+        // Arrange: seed SharedGame "Azul", authenticated user, addToCollection=true.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(dbContext, title: "Azul");
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            "/api/v1/agents/create-with-setup",
+            sessionToken,
+            new
+            {
+                gameId,
+                addToCollection = true,
+                agentType = "Tutor"
+            });
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert: gameAddedToCollection=true after successful AddGameToLibraryCommand step.
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.Created);
+        var body = await response.Content.ReadFromJsonAsync<CreateAgentWithSetupResponse>();
+        body.Should().NotBeNull();
+        body!.GameAddedToCollection.Should().BeTrue();
+    }
 }
 
 /// <summary>
@@ -434,3 +517,15 @@ public sealed class AgentsEndpointsIntegrationTests : IAsyncLifetime
 /// Mirrors anonymous object created in <c>AgentsEndpoints.MapGetAgentsEndpoint</c>.
 /// </summary>
 internal record GetAllAgentsResponse(bool Success, List<AgentDto> Agents, int Count);
+
+/// <summary>
+/// HTTP response shape returned by <c>POST /api/v1/agents/create-with-setup</c>.
+/// Mirrors <c>CreateAgentWithSetupResult</c> in
+/// <c>Api.BoundedContexts.KnowledgeBase.Application.Commands</c>. Issue #655 (Phase β.3).
+/// </summary>
+internal record CreateAgentWithSetupResponse(
+    Guid AgentId,
+    string AgentName,
+    Guid ThreadId,
+    int SlotUsed,
+    bool GameAddedToCollection);

--- a/apps/api/tests/Api.Tests/Integration/Agents/AgentsEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Agents/AgentsEndpointsIntegrationTests.cs
@@ -498,7 +498,7 @@ public sealed class AgentsEndpointsIntegrationTests : IAsyncLifetime
             {
                 gameId,
                 addToCollection = true,
-                agentType = "Tutor"
+                agentType = "Narrator"
             });
 
         // Act

--- a/apps/web/src/lib/api/clients/agentsClient.ts
+++ b/apps/web/src/lib/api/clients/agentsClient.ts
@@ -458,7 +458,7 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
     /**
      * Orchestrated agent creation with auto-setup
      * Issue #4772: Agent Creation Orchestration Flow
-     * @todo BACKEND MISSING: No route registered for POST /api/v1/agents/create-with-setup. Throws on null response. See: endpoint audit 2026-04-15
+     * Resolved by #655 (2026-05-04) — route registered in AgentsEndpoints.cs.
      */
     async createWithSetup(request: {
       gameId: string;


### PR DESCRIPTION
## Summary
- New `CreateAgentWithSetupCommand` orchestration handler:
  1. Optional `addToCollection` → `AddGameToLibraryCommand` (idempotent: "already in" `DomainException` treated as success)
  2. `CreateUserAgentCommand` (β.2 reuse) → returns `AgentDto`
  3. `ThreadId` + `SlotUsed` placeholders (chat-thread BC + tier #4771 deferred)
- New route `POST /api/v1/agents/create-with-setup` returns 201 Created with `CreateAgentWithSetupResult`
- Seventh BACKEND MISSING annotation resolved (audit 2026-04-15)

## Impact
Wave B.2 modal `AgentCreationSheet` save flow (setup-wizard variant) now end-to-end functional.

## MVP scope (deliberate)
- `threadId`: placeholder `Guid.NewGuid()` (chat-thread BC integration deferred)
- `slotUsed`: 0 (tier/quota Issue #4771 deferred)
- `gameAddedToCollection`: true on success or "already in"; false when `addToCollection=false`

## Test plan
- [x] Integration tests: 3 new (Unauthorized, no-add, with-add) — all green
- [x] Full `AgentsEndpointsIntegrationTests` (16 pre-existing + 3 new) green
- [x] Frontend typecheck after JSDoc cleanup

Closes #655