### PR TITLE
fix(agents): expose PUT /api/v1/agents/{id}/user user-edit route (#656)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateUserAgentCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateUserAgentCommand.cs
@@ -1,0 +1,18 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using MediatR;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
+
+/// <summary>
+/// Command for updating a user-owned agent's name and/or strategy.
+/// Issue #656: supports <c>PUT /api/v1/agents/{id}/user</c> from the frontend
+/// <c>agentsClient.updateUserAgent</c> helper.
+/// Returns <c>null</c> when the agent is not found, <c>AgentDto</c> on success.
+/// </summary>
+internal sealed record UpdateUserAgentCommand(
+    Guid UserId,
+    Guid AgentId,
+    string? Name = null,
+    string? StrategyName = null,
+    IReadOnlyDictionary<string, object>? StrategyParameters = null
+) : IRequest<AgentDto?>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateUserAgentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateUserAgentCommandHandler.cs
@@ -1,0 +1,128 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
+
+/// <summary>
+/// Handler for <see cref="UpdateUserAgentCommand"/>.
+/// Issue #656: updates name and/or strategy of an existing AgentDefinition and returns
+/// an <see cref="AgentDto"/> with GameName resolved (drift-fix lookup pattern from PR #662).
+/// </summary>
+/// <remarks>
+/// Persistence pattern mirrors <c>CreateUserAgentCommandHandler</c>: repository's
+/// <c>UpdateAsync</c> calls <c>DbContext.SaveChangesAsync</c> internally, so no
+/// <c>IUnitOfWork</c> is required.
+/// Returns <c>null</c> when the agent ID is not found (endpoint maps to 404).
+/// Strategy resolution mirrors the preset-or-Custom pattern used by
+/// <see cref="CreateUserAgentCommandHandler"/>.
+/// </remarks>
+internal sealed class UpdateUserAgentCommandHandler
+    : IRequestHandler<UpdateUserAgentCommand, AgentDto?>
+{
+    private readonly IAgentDefinitionRepository _repository;
+    private readonly ISharedGameRepository _sharedGameRepository;
+    private readonly ILogger<UpdateUserAgentCommandHandler> _logger;
+
+    public UpdateUserAgentCommandHandler(
+        IAgentDefinitionRepository repository,
+        ISharedGameRepository sharedGameRepository,
+        ILogger<UpdateUserAgentCommandHandler> logger)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _sharedGameRepository = sharedGameRepository ?? throw new ArgumentNullException(nameof(sharedGameRepository));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<AgentDto?> Handle(UpdateUserAgentCommand request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var agent = await _repository.GetByIdAsync(request.AgentId, cancellationToken).ConfigureAwait(false);
+        if (agent is null)
+        {
+            return null;
+        }
+
+        var changed = false;
+
+        if (!string.IsNullOrWhiteSpace(request.Name) &&
+            !string.Equals(agent.Name, request.Name, StringComparison.Ordinal))
+        {
+            agent.UpdateNameAndDescription(request.Name, agent.Description);
+            changed = true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.StrategyName))
+        {
+            var newStrategy = ResolveStrategy(request.StrategyName, request.StrategyParameters);
+            agent.UpdateStrategy(newStrategy);
+            changed = true;
+        }
+
+        if (changed)
+        {
+            await _repository.UpdateAsync(agent, cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Updated user-owned AgentDefinition {Id} (Name='{Name}', Strategy='{Strategy}') for user {UserId}",
+                agent.Id,
+                agent.Name,
+                agent.Strategy.Name,
+                request.UserId);
+        }
+
+        // Map to AgentDto with GameName (drift-fix lookup PR #662 pattern).
+        string? gameName = null;
+        if (agent.GameId.HasValue)
+        {
+            var names = await _sharedGameRepository
+                .GetNamesByIdsAsync(new[] { agent.GameId.Value }, cancellationToken)
+                .ConfigureAwait(false);
+            names.TryGetValue(agent.GameId.Value, out gameName);
+        }
+
+        var recentThreshold = DateTime.UtcNow.AddHours(-24);
+        var idleThreshold = DateTime.UtcNow.AddDays(-7);
+
+        return new AgentDto(
+            Id: agent.Id,
+            Name: agent.Name,
+            Type: agent.Type.Value,
+            StrategyName: agent.Strategy.Name,
+            StrategyParameters: agent.Strategy.Parameters,
+            IsActive: agent.IsActive,
+            CreatedAt: agent.CreatedAt,
+            LastInvokedAt: agent.LastInvokedAt,
+            InvocationCount: agent.InvocationCount,
+            IsRecentlyUsed: agent.LastInvokedAt.HasValue && agent.LastInvokedAt.Value > recentThreshold,
+            IsIdle: !agent.LastInvokedAt.HasValue || agent.LastInvokedAt.Value < idleThreshold,
+            GameId: agent.GameId,
+            GameName: gameName,
+            CreatedByUserId: request.UserId
+        );
+    }
+
+    private static AgentStrategy ResolveStrategy(
+        string? name,
+        IReadOnlyDictionary<string, object>? parameters)
+    {
+        // Mirror CreateUserAgentCommandHandler.ResolveStrategy preset support,
+        // then fall back to Custom for arbitrary names with caller-supplied parameters.
+        return name switch
+        {
+            "RetrievalOnly" => AgentStrategy.RetrievalOnly(),
+            "HybridSearch" => AgentStrategy.HybridSearch(),
+            "SentenceWindowRAG" => AgentStrategy.SentenceWindowRAG(),
+            "ColBERTReranking" => AgentStrategy.ColBERTReranking(),
+            _ => AgentStrategy.Custom(
+                name!,
+                parameters is null
+                    ? null
+                    : new Dictionary<string, object>(parameters, StringComparer.Ordinal))
+        };
+    }
+}

--- a/apps/api/src/Api/Routing/AgentsEndpoints.cs
+++ b/apps/api/src/Api/Routing/AgentsEndpoints.cs
@@ -43,6 +43,7 @@ internal static class AgentsEndpoints
         MapCreateUserAgentEndpoint(group);
         MapCreateAgentWithSetupEndpoint(group);
         MapQuickCreateAgentEndpoint(group);
+        MapUpdateUserAgentEndpoint(group);
         return group;
     }
 
@@ -83,6 +84,18 @@ internal static class AgentsEndpoints
     private sealed record QuickCreateAgentRequest(
         Guid GameId,
         Guid? SharedGameId = null
+    );
+
+    /// <summary>
+    /// Frontend <c>agentsClient.updateUserAgent</c> request body shape.
+    /// Mirrors <c>UpdateUserAgentRequest</c> in
+    /// <c>apps/web/src/lib/api/clients/agentsClient.ts</c>. Issue #656.
+    /// All fields optional — handler treats missing/blank values as no-op for that field.
+    /// </summary>
+    private sealed record UpdateUserAgentRequest(
+        string? Name = null,
+        string? StrategyName = null,
+        Dictionary<string, object>? StrategyParameters = null
     );
 
     private static void MapGetAgentsEndpoint(RouteGroupBuilder group)
@@ -326,6 +339,48 @@ internal static class AgentsEndpoints
         .WithTags("Agents")
         .WithSummary("Quick-create a Tutor agent")
         .WithDescription("Fast 1-click Tutor onboarding: creates AgentDefinition with type=Tutor and HybridSearch strategy. Auto-derived name 'Tutor for {GameName}'. ChatThreadId placeholder (chat-thread BC integration deferred — same as PR #693) and KbCardCount=0 (KB query deferred). Issue #659 (Phase δ.1).")
+        .WithOpenApi();
+    }
+
+    private static void MapUpdateUserAgentEndpoint(RouteGroupBuilder group)
+    {
+        group.MapPut("/agents/{id:guid}/user", async (
+            Guid id,
+            [FromBody] UpdateUserAgentRequest request,
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, session, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+            if (!UserLibraryCoreEndpoints.TryGetUserId(context, session, out var userId))
+                return Results.Unauthorized();
+
+            try
+            {
+                var command = new UpdateUserAgentCommand(
+                    UserId: userId,
+                    AgentId: id,
+                    Name: request.Name,
+                    StrategyName: request.StrategyName,
+                    StrategyParameters: request.StrategyParameters);
+
+                var dto = await mediator.Send(command, ct).ConfigureAwait(false);
+                return dto is null ? Results.NotFound() : Results.Ok(dto);
+            }
+            catch (ArgumentException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        })
+        .RequireAuthenticatedUser()
+        .Produces<AgentDto>(200)
+        .Produces(400)
+        .Produces(401)
+        .Produces(404)
+        .WithTags("Agents")
+        .WithSummary("Update user-owned agent")
+        .WithDescription("Updates name and/or strategy of a user-owned agent. Returns 404 if agent not found, AgentDto with GameName resolved on success. All request fields optional; missing/blank values are no-ops for that field. Issue #656.")
         .WithOpenApi();
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/Agents/AgentsEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Agents/AgentsEndpointsIntegrationTests.cs
@@ -583,6 +583,71 @@ public sealed class AgentsEndpointsIntegrationTests : IAsyncLifetime
         body.AgentName.Should().Be("Tutor for Splendor");
         body.KbCardCount.Should().Be(0);
     }
+
+    // -------------------------------------------------------------------------
+    // PUT /api/v1/agents/{id}/user — Issue #656
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task UpdateUserAgent_WithoutAuth_ReturnsUnauthorized()
+    {
+        // Act
+        var response = await _client.PutAsJsonAsync(
+            $"/api/v1/agents/{Guid.NewGuid()}/user",
+            new { name = "Updated" });
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task UpdateUserAgent_WithUnknownId_ReturnsNotFound()
+    {
+        // Arrange
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Put,
+            $"/api/v1/agents/{Guid.NewGuid()}/user",
+            sessionToken,
+            new { name = "Updated" });
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task UpdateUserAgent_WithValidNameChange_ReturnsUpdatedAgentDto()
+    {
+        // Arrange
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        await TestSessionHelper.SeedAgentDefinitionsAsync(dbContext, activeCount: 1, inactiveCount: 0);
+        var seededId = await dbContext.AgentDefinitions.AsNoTracking().Select(a => a.Id).FirstAsync();
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Put,
+            $"/api/v1/agents/{seededId}/user",
+            sessionToken,
+            new { name = "Renamed Agent" });
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<AgentDto>();
+        dto.Should().NotBeNull();
+        dto!.Id.Should().Be(seededId);
+        dto.Name.Should().Be("Renamed Agent");
+    }
 }
 
 /// <summary>

--- a/apps/web/src/lib/api/clients/agentsClient.ts
+++ b/apps/web/src/lib/api/clients/agentsClient.ts
@@ -523,7 +523,7 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
      * Update a user-owned agent (name, strategy)
      * PUT /api/v1/agents/{id}/user
      * Issue #4683: User Agent CRUD Endpoints
-     * @todo BACKEND MISSING: No route registered for PUT /api/v1/agents/{id}/user. Throws on null response. See: endpoint audit 2026-04-15
+     * Resolved by #656 (2026-05-04) — route registered in AgentsEndpoints.cs.
      */
     async updateUserAgent(
       agentId: string,


### PR DESCRIPTION
## Summary
- New `UpdateUserAgentCommand` + `Handler` updates name and/or strategy of an existing AgentDefinition via domain methods (`UpdateNameAndDescription`, `UpdateStrategy`).
- New route `PUT /api/v1/agents/{id:guid}/user` returns `404 NotFound` for unknown id, `200 OK` with `AgentDto` (GameName resolved via PR #662 lookup pattern) on success.
- Strategy resolver mirrors `CreateUserAgentCommandHandler` preset-or-`Custom` pattern (RetrievalOnly / HybridSearch / SentenceWindowRAG / ColBERTReranking presets, otherwise `AgentStrategy.Custom`).
- Frontend `agentsClient.updateUserAgent` JSDoc `@todo BACKEND MISSING` annotation cleared (audit 2026-04-15) — ninth resolved.

## Test plan
- [x] Integration tests: 3 new (`UpdateUserAgent_WithoutAuth_ReturnsUnauthorized`, `..._WithUnknownId_ReturnsNotFound`, `..._WithValidNameChange_ReturnsUpdatedAgentDto`) — red→green confirmed locally
- [x] `dotnet build apps/api/src/Api/Api.csproj` clean
- [x] `pnpm typecheck` clean
- [ ] CI green on `main-dev` target

Closes #656