### PR TITLE
fix(agents): expose GET+PATCH /api/v1/agents/{id}/configuration (#657 #658)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateAgentConfigurationCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateAgentConfigurationCommand.cs
@@ -1,0 +1,25 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using MediatR;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
+
+/// <summary>
+/// Patches the LLM configuration of an <see cref="Domain.Entities.AgentDefinition"/>.
+/// Issue #658 (Phase δ): exposes the partial-update contract consumed by the frontend
+/// <c>agentsClient.updateAgentConfiguration</c> helper at
+/// <c>PATCH /api/v1/agents/{id}/configuration</c>.
+/// </summary>
+/// <remarks>
+/// Only non-null fields are applied; missing fields preserve the current value (mirror
+/// of the <c>UpdateUserAgentCommand</c> partial-update contract from PR #695).
+/// SelectedDocumentIds is accepted on the wire to align with the frontend request shape but
+/// not yet persisted (KB linking deferred to a follow-up — same MVP scope as PR #695).
+/// Returns <c>null</c> when the agent ID is not found (endpoint maps to 404).
+/// </remarks>
+internal sealed record UpdateAgentConfigurationCommand(
+    Guid AgentId,
+    string? ModelId = null,
+    decimal? Temperature = null,
+    int? MaxTokens = null,
+    IReadOnlyList<Guid>? SelectedDocumentIds = null
+) : IRequest<AgentConfigurationDto?>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateAgentConfigurationCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateAgentConfigurationCommandHandler.cs
@@ -1,0 +1,77 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
+
+/// <summary>
+/// Handler for <see cref="UpdateAgentConfigurationCommand"/>. Issue #658 (Phase δ).
+/// Applies a partial update to the LLM configuration of an
+/// <see cref="Domain.Entities.AgentDefinition"/> and returns the updated view.
+/// </summary>
+/// <remarks>
+/// Persistence pattern mirrors <c>UpdateUserAgentCommandHandler</c>: the repository
+/// <c>UpdateAsync</c> calls <c>DbContext.SaveChangesAsync</c> internally so no explicit
+/// <c>IUnitOfWork</c> is required.
+/// Range validation is delegated to <see cref="AgentDefinitionConfig.Create"/>; invalid
+/// inputs surface as <see cref="ArgumentException"/> which the route maps to <c>400</c>.
+/// SelectedDocumentIds is accepted on the wire but not persisted in MVP (same as PR #695).
+/// </remarks>
+internal sealed class UpdateAgentConfigurationCommandHandler
+    : IRequestHandler<UpdateAgentConfigurationCommand, AgentConfigurationDto?>
+{
+    private readonly IAgentDefinitionRepository _repository;
+    private readonly ILogger<UpdateAgentConfigurationCommandHandler> _logger;
+
+    public UpdateAgentConfigurationCommandHandler(
+        IAgentDefinitionRepository repository,
+        ILogger<UpdateAgentConfigurationCommandHandler> logger)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<AgentConfigurationDto?> Handle(
+        UpdateAgentConfigurationCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var agent = await _repository
+            .GetByIdAsync(request.AgentId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (agent is null)
+        {
+            return null;
+        }
+
+        var newModel = string.IsNullOrWhiteSpace(request.ModelId)
+            ? agent.Config.Model
+            : request.ModelId;
+        var newMaxTokens = request.MaxTokens ?? agent.Config.MaxTokens;
+        var newTemperature = request.Temperature.HasValue
+            ? (float)request.Temperature.Value
+            : agent.Config.Temperature;
+
+        // AgentDefinitionConfig.Create enforces model length, maxTokens range (100-32000),
+        // and temperature range (0.0-2.0); throws ArgumentException on violation which
+        // the route catches and maps to 400.
+        var newConfig = AgentDefinitionConfig.Create(newModel, newMaxTokens, newTemperature);
+        agent.UpdateConfig(newConfig);
+
+        await _repository.UpdateAsync(agent, cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Updated AgentDefinition {Id} configuration (Model='{Model}', MaxTokens={MaxTokens}, Temperature={Temperature})",
+            agent.Id,
+            agent.Config.Model,
+            agent.Config.MaxTokens,
+            agent.Config.Temperature);
+
+        return GetAgentConfigurationQueryHandler.BuildViewDto(agent);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetAgentConfigurationQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetAgentConfigurationQuery.cs
@@ -5,9 +5,15 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
 
 /// <summary>
 /// Query to retrieve the current LLM configuration for an agent.
+/// Issue #657 (Phase δ): exposes the view consumed by the frontend
+/// <c>agentsClient.getAgentConfiguration</c> helper at
+/// <c>GET /api/v1/agents/{id}/configuration</c>.
 /// </summary>
-internal record GetAgentConfigurationQuery(
-    Guid AgentId,
-    Guid UserId,
-    string UserRole
-) : IRequest<AgentConfigurationDto>;
+/// <remarks>
+/// Auth (session existence) is enforced at the route layer via
+/// <c>HttpContext.TryGetAuthenticatedUser()</c>; ownership / role-gating is deferred to a
+/// follow-up (MVP returns the configuration for any authenticated session, mirroring
+/// <see cref="GetAgentByIdQuery"/>).
+/// </remarks>
+internal sealed record GetAgentConfigurationQuery(Guid AgentId)
+    : IRequest<AgentConfigurationDto?>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetAgentConfigurationQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetAgentConfigurationQueryHandler.cs
@@ -1,0 +1,89 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using MediatR;
+using AgentDefinitionEntity = Api.BoundedContexts.KnowledgeBase.Domain.Entities.AgentDefinition;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Handler for <see cref="GetAgentConfigurationQuery"/>. Returns the current LLM
+/// configuration view for an <see cref="AgentDefinition"/>. Issue #657 (Phase δ).
+/// </summary>
+/// <remarks>
+/// MVP scope decisions (see PR #696 description):
+/// <list type="bullet">
+///   <item><c>Id</c> mirrors <c>AgentId</c> (no separate AgentConfiguration aggregate exposed).</item>
+///   <item><c>LlmProvider</c> is heuristically derived from the model name prefix.</item>
+///   <item><c>SelectedDocumentIds</c> is empty (KB linking deferred — same as PR #695).</item>
+///   <item><c>IsCurrent</c> is always <c>true</c> (single config per agent in MVP).</item>
+/// </list>
+/// Returns <c>null</c> when no agent matches the supplied id (route surfaces 404).
+/// </remarks>
+internal sealed class GetAgentConfigurationQueryHandler
+    : IRequestHandler<GetAgentConfigurationQuery, AgentConfigurationDto?>
+{
+    private readonly IAgentDefinitionRepository _repository;
+
+    public GetAgentConfigurationQueryHandler(IAgentDefinitionRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public async Task<AgentConfigurationDto?> Handle(
+        GetAgentConfigurationQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var agent = await _repository
+            .GetByIdAsync(request.AgentId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return agent is null ? null : BuildViewDto(agent);
+    }
+
+    /// <summary>
+    /// Maps an <see cref="AgentDefinitionEntity"/> aggregate to <see cref="AgentConfigurationDto"/>.
+    /// Shared with <c>UpdateAgentConfigurationCommandHandler</c> so the PATCH route returns
+    /// the same view shape as GET. Internal so the sibling handler can call it directly.
+    /// </summary>
+    internal static AgentConfigurationDto BuildViewDto(AgentDefinitionEntity agent)
+    {
+        ArgumentNullException.ThrowIfNull(agent);
+
+        return new AgentConfigurationDto(
+            Id: agent.Id,
+            AgentId: agent.Id,
+            LlmModel: agent.Config.Model,
+            LlmProvider: InferProvider(agent.Config.Model),
+            Temperature: (decimal)agent.Config.Temperature,
+            MaxTokens: agent.Config.MaxTokens,
+            SelectedDocumentIds: Array.Empty<Guid>(),
+            IsCurrent: true,
+            CreatedAt: agent.CreatedAt);
+    }
+
+    /// <summary>
+    /// Heuristic provider lookup keyed off the model identifier prefix.
+    /// Falls back to "openai" when no rule matches (most common production model).
+    /// </summary>
+    private static string InferProvider(string model)
+    {
+        if (string.IsNullOrEmpty(model))
+            return "openai";
+
+        if (model.StartsWith("gpt", StringComparison.OrdinalIgnoreCase))
+            return "openai";
+
+        if (model.StartsWith("claude", StringComparison.OrdinalIgnoreCase))
+            return "anthropic";
+
+        if (model.Contains("llama", StringComparison.OrdinalIgnoreCase))
+            return "ollama";
+
+        if (model.Contains("mistral", StringComparison.OrdinalIgnoreCase))
+            return "mistral";
+
+        return "openai";
+    }
+}

--- a/apps/api/src/Api/Routing/AgentsEndpoints.cs
+++ b/apps/api/src/Api/Routing/AgentsEndpoints.cs
@@ -44,6 +44,8 @@ internal static class AgentsEndpoints
         MapCreateAgentWithSetupEndpoint(group);
         MapQuickCreateAgentEndpoint(group);
         MapUpdateUserAgentEndpoint(group);
+        MapGetAgentConfigurationEndpoint(group);
+        MapUpdateAgentConfigurationEndpoint(group);
         return group;
     }
 
@@ -96,6 +98,18 @@ internal static class AgentsEndpoints
         string? Name = null,
         string? StrategyName = null,
         Dictionary<string, object>? StrategyParameters = null
+    );
+
+    /// <summary>
+    /// Frontend <c>agentsClient.updateAgentConfiguration</c> request body shape.
+    /// Mirrors <c>UpdateAgentConfigurationRequest</c> in
+    /// <c>apps/web/src/lib/api/clients/agentsClient.ts</c>. Issue #658.
+    /// </summary>
+    private sealed record UpdateAgentConfigurationRequest(
+        string? ModelId = null,
+        decimal? Temperature = null,
+        int? MaxTokens = null,
+        List<Guid>? SelectedDocumentIds = null
     );
 
     private static void MapGetAgentsEndpoint(RouteGroupBuilder group)
@@ -381,6 +395,71 @@ internal static class AgentsEndpoints
         .WithTags("Agents")
         .WithSummary("Update user-owned agent")
         .WithDescription("Updates name and/or strategy of a user-owned agent. Returns 404 if agent not found, AgentDto with GameName resolved on success. All request fields optional; missing/blank values are no-ops for that field. Issue #656.")
+        .WithOpenApi();
+    }
+
+    private static void MapGetAgentConfigurationEndpoint(RouteGroupBuilder group)
+    {
+        group.MapGet("/agents/{id:guid}/configuration", async (
+            Guid id,
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, _, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+
+            var query = new GetAgentConfigurationQuery(id);
+            var dto = await mediator.Send(query, ct).ConfigureAwait(false);
+            return dto is null ? Results.NotFound() : Results.Ok(dto);
+        })
+        .RequireAuthenticatedUser()
+        .Produces<AgentConfigurationDto>(200)
+        .Produces(401)
+        .Produces(404)
+        .WithTags("Agents")
+        .WithSummary("Get agent LLM configuration")
+        .WithDescription("Returns the current LLM configuration view (model, provider, temperature, maxTokens, selectedDocumentIds). LlmProvider is heuristically inferred from the model name; SelectedDocumentIds is empty in MVP (KB linking deferred). Issue #657.")
+        .WithOpenApi();
+    }
+
+    private static void MapUpdateAgentConfigurationEndpoint(RouteGroupBuilder group)
+    {
+        group.MapPatch("/agents/{id:guid}/configuration", async (
+            Guid id,
+            [FromBody] UpdateAgentConfigurationRequest request,
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, _, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+
+            try
+            {
+                var command = new UpdateAgentConfigurationCommand(
+                    AgentId: id,
+                    ModelId: request.ModelId,
+                    Temperature: request.Temperature,
+                    MaxTokens: request.MaxTokens,
+                    SelectedDocumentIds: request.SelectedDocumentIds);
+
+                var dto = await mediator.Send(command, ct).ConfigureAwait(false);
+                return dto is null ? Results.NotFound() : Results.Ok(dto);
+            }
+            catch (ArgumentException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        })
+        .RequireAuthenticatedUser()
+        .Produces<AgentConfigurationDto>(200)
+        .Produces(400)
+        .Produces(401)
+        .Produces(404)
+        .WithTags("Agents")
+        .WithSummary("Update agent LLM configuration")
+        .WithDescription("Partial update (PATCH) of agent LLM configuration: modelId, temperature, maxTokens. Range validation delegated to AgentDefinitionConfig.Create (temperature 0.0-2.0, maxTokens 100-32000). SelectedDocumentIds accepted but not persisted (KB linking deferred). Issue #658.")
         .WithOpenApi();
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/Agents/AgentsEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Agents/AgentsEndpointsIntegrationTests.cs
@@ -648,6 +648,139 @@ public sealed class AgentsEndpointsIntegrationTests : IAsyncLifetime
         dto!.Id.Should().Be(seededId);
         dto.Name.Should().Be("Renamed Agent");
     }
+
+    // -------------------------------------------------------------------------
+    // GET /api/v1/agents/{id}/configuration — Issue #657
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetAgentConfiguration_WithoutAuth_ReturnsUnauthorized()
+    {
+        // Act
+        var response = await _client.GetAsync($"/api/v1/agents/{Guid.NewGuid()}/configuration");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetAgentConfiguration_WithUnknownId_ReturnsNotFound()
+    {
+        // Arrange
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/agents/{Guid.NewGuid()}/configuration",
+            sessionToken);
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetAgentConfiguration_WithSeededAgent_ReturnsConfigurationView()
+    {
+        // Arrange
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        await TestSessionHelper.SeedAgentDefinitionsAsync(dbContext, activeCount: 1, inactiveCount: 0);
+        var seededId = await dbContext.AgentDefinitions.AsNoTracking().Select(a => a.Id).FirstAsync();
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/agents/{seededId}/configuration",
+            sessionToken);
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<AgentConfigurationDto>();
+        dto.Should().NotBeNull();
+        dto!.AgentId.Should().Be(seededId);
+        dto.LlmModel.Should().Be("gpt-4");
+        dto.LlmProvider.Should().Be("openai");
+        dto.MaxTokens.Should().Be(1000);
+        dto.Temperature.Should().BeApproximately(0.7m, 0.001m);
+        dto.IsCurrent.Should().BeTrue();
+        dto.SelectedDocumentIds.Should().BeEmpty();
+    }
+
+    // -------------------------------------------------------------------------
+    // PATCH /api/v1/agents/{id}/configuration — Issue #658
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task UpdateAgentConfiguration_WithoutAuth_ReturnsUnauthorized()
+    {
+        // Act
+        var response = await _client.PatchAsJsonAsync(
+            $"/api/v1/agents/{Guid.NewGuid()}/configuration",
+            new { temperature = 0.5m });
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task UpdateAgentConfiguration_WithUnknownId_ReturnsNotFound()
+    {
+        // Arrange
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Patch,
+            $"/api/v1/agents/{Guid.NewGuid()}/configuration",
+            sessionToken,
+            new { temperature = 0.5m });
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task UpdateAgentConfiguration_WithValidPatch_ReturnsUpdatedView()
+    {
+        // Arrange
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        await TestSessionHelper.SeedAgentDefinitionsAsync(dbContext, activeCount: 1, inactiveCount: 0);
+        var seededId = await dbContext.AgentDefinitions.AsNoTracking().Select(a => a.Id).FirstAsync();
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Patch,
+            $"/api/v1/agents/{seededId}/configuration",
+            sessionToken,
+            new { temperature = 0.42m, maxTokens = 1234 });
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<AgentConfigurationDto>();
+        dto.Should().NotBeNull();
+        dto!.AgentId.Should().Be(seededId);
+        dto.Temperature.Should().BeApproximately(0.42m, 0.001m);
+        dto.MaxTokens.Should().Be(1234);
+        dto.LlmModel.Should().Be("gpt-4"); // unchanged
+    }
 }
 
 /// <summary>

--- a/apps/web/src/lib/api/clients/agentsClient.ts
+++ b/apps/web/src/lib/api/clients/agentsClient.ts
@@ -637,7 +637,7 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
 
     /**
      * Get current LLM configuration for an agent
-     * @todo BACKEND MISSING: No route registered for GET /api/v1/agents/{id}/configuration. Throws on null response. See: endpoint audit 2026-04-15
+     * Resolved by #657 (2026-05-04) — route registered in AgentsEndpoints.cs.
      */
     async getAgentConfiguration(agentId: string): Promise<BackendAgentConfigurationDto> {
       const response = await httpClient.get<BackendAgentConfigurationDto>(
@@ -651,7 +651,7 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
 
     /**
      * Patch LLM configuration for an agent (partial update)
-     * @todo BACKEND MISSING: No route registered for PATCH /api/v1/agents/{id}/configuration. Throws on null response. See: endpoint audit 2026-04-15
+     * Resolved by #658 (2026-05-04) — route registered in AgentsEndpoints.cs.
      */
     async updateAgentConfiguration(
       agentId: string,


### PR DESCRIPTION
## Summary
- New `GetAgentConfigurationQuery` returns LLM config view (model/provider/temperature/maxTokens) — replaces unused stub query (UserId/UserRole dropped to mirror `GetAgentByIdQuery` MVP shape; auth enforced at the route layer)
- New `UpdateAgentConfigurationCommand` applies partial PATCH via `agent.UpdateConfig(...)` — range validation delegated to `AgentDefinitionConfig.Create`
- Two `BACKEND MISSING` annotations resolved in `agentsClient.ts` (#657 GET + #658 PATCH)
- Mirrors `BackendAgentConfigurationDto` frontend shape; reuses existing `AgentConfigurationDto` (`decimal Temperature` serializes correctly to JS `number`)

## MVP scope
- `selectedDocumentIds`: empty array (KB linking deferred — same pattern as PR #695)
- `isCurrent`: `true` (single config per agent in MVP)
- `id`: mirrors `agentId` (no separate AgentConfiguration aggregate exposed)
- `llmProvider`: heuristic from model name prefix (`gpt-` → openai, `claude-` → anthropic, `llama` → ollama, `mistral` → mistral, fallback openai)
- Pre-existing orphaned `UpdateAgentLlmConfigurationCommand` + validator (no handler, no route) left untouched per scope discipline — separate cleanup PR

## Test plan
- [x] 6 integration tests added (3 GET + 3 PATCH covering Unauthorized, NotFound, ValidPayload)
- [x] All 6 pass locally against Testcontainers Postgres
- [x] Build clean (no warnings, no errors)
- [x] Frontend `pnpm typecheck` green

Closes #657
Closes #658