### PR TITLE
feat(libro-game): Phase 2 Task 2.4 + 2.5 — QA Complexity + House Rule Matcher

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/HeuristicQAComplexityClassifier.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/HeuristicQAComplexityClassifier.cs
@@ -1,0 +1,39 @@
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// Keyword-heuristic implementation. Sync, allocation-efficient, Singleton-safe.
+/// Extends QueryComplexityAnalyzer pattern for Q&amp;A-specific classification.
+/// </summary>
+internal sealed class HeuristicQAComplexityClassifier : IQAComplexityClassifier
+{
+    private static readonly string[] SynthesisKeywords =
+        ["differenza", "difference", "confronta", "compare", "versus", "vs",
+         "meglio", "better", "ottimale", "optimal", "confronto", "comparison"];
+
+    private static readonly string[] MultiStepKeywords =
+        ["se poi", "if then", "after", "before", "quando", "durante",
+         "combina", "combine", "insieme", "together", "e poi", "and then"];
+
+    private static readonly string[] SimplePatterns =
+        ["quanti", "quanto", "how many", "what is", "cosa è", "dove", "where",
+         "quando", "when", "chi", "who", "qual è", "which"];
+
+    public QAComplexityResult Classify(string question)
+    {
+        if (string.IsNullOrWhiteSpace(question))
+            return new QAComplexityResult(QAComplexityLevel.Simple, 1.0f, "empty_input");
+
+        var lower = question.ToLowerInvariant();
+
+        if (SynthesisKeywords.Any(k => lower.Contains(k, StringComparison.OrdinalIgnoreCase)))
+            return new QAComplexityResult(QAComplexityLevel.Synthesis, 0.85f, "synthesis_keyword");
+
+        if (MultiStepKeywords.Any(k => lower.Contains(k, StringComparison.OrdinalIgnoreCase)))
+            return new QAComplexityResult(QAComplexityLevel.MultiStep, 0.80f, "multistep_keyword");
+
+        if (SimplePatterns.Any(k => lower.StartsWith(k, StringComparison.OrdinalIgnoreCase)))
+            return new QAComplexityResult(QAComplexityLevel.Simple, 0.90f, "simple_prefix");
+
+        return new QAComplexityResult(QAComplexityLevel.MultiStep, 0.60f, "default_multistep");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/IQAComplexityClassifier.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/IQAComplexityClassifier.cs
@@ -1,0 +1,18 @@
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
+
+internal enum QAComplexityLevel { Simple, MultiStep, Synthesis }
+
+internal sealed record QAComplexityResult(
+    QAComplexityLevel Level,
+    float Confidence,
+    string Reason);
+
+/// <summary>
+/// Classifies Q&amp;A answering complexity for photo-batch book assistant context.
+/// Distinct from IQueryComplexityClassifier (RAG routing) and QueryComplexityAnalyzer (model routing).
+/// Used to select chain-of-thought prompting and model tier for Q&amp;A over photo-indexed content.
+/// </summary>
+internal interface IQAComplexityClassifier
+{
+    QAComplexityResult Classify(string question);
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
@@ -81,6 +81,9 @@ internal static class DocumentProcessingServiceExtensions
         // Issue #5445: Language detection for PDF pipeline routing
         services.AddSingleton<ILanguageDetector, LanguageDetector>();
 
+        // Libro Game AI Assistant Phase 2 — Task 2.4: Q&A complexity classifier (stateless, Singleton-safe)
+        services.AddSingleton<IQAComplexityClassifier, HeuristicQAComplexityClassifier>();
+
         // RAG translation: LLM-based chunk translation for cross-language retrieval
         services.AddScoped<IChunkTranslationService, ChunkTranslationService>();
 

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/HeuristicHouseRuleMatcher.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/HeuristicHouseRuleMatcher.cs
@@ -1,0 +1,69 @@
+using Api.BoundedContexts.AgentMemory.Domain.Repositories;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Services;
+
+/// <summary>
+/// Heuristic implementation of <see cref="IHouseRuleMatcher"/> that uses word-overlap
+/// scoring to detect whether the user's question relates to a stored house rule.
+/// Cross-BC read: reads from AgentMemory.IGameMemoryRepository.
+/// Degrades gracefully (returns null) on any repository failure.
+/// </summary>
+internal sealed class HeuristicHouseRuleMatcher(
+    IGameMemoryRepository gameMemoryRepository,
+    ILogger<HeuristicHouseRuleMatcher> logger) : IHouseRuleMatcher
+{
+    private const float MinOverlapThreshold = 0.30f;
+
+    public async Task<string?> FindMatchingHouseRuleAsync(
+        Guid gameId, Guid? userId, string question, CancellationToken ct = default)
+    {
+        if (!userId.HasValue) return null;
+
+        try
+        {
+            var memory = await gameMemoryRepository
+                .GetByGameAndOwnerAsync(gameId, userId.Value, ct).ConfigureAwait(false);
+
+            if (memory is null || memory.HouseRules.Count == 0) return null;
+
+            var questionWords = ExtractWords(question);
+            if (questionWords.Count == 0) return null;
+
+            foreach (var rule in memory.HouseRules)
+            {
+                var ruleWords = ExtractWords(rule.Description);
+                var overlap = ComputeOverlap(questionWords, ruleWords);
+                if (overlap >= MinOverlapThreshold)
+                {
+                    logger.LogDebug(
+                        "[HouseRuleMatcher] Matched rule (overlap={Overlap:P0}): {Rule}",
+                        overlap, rule.Description);
+                    return rule.Description;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "[HouseRuleMatcher] Failed to read house rules for game {GameId}", gameId);
+        }
+
+        return null;
+    }
+
+    private static HashSet<string> ExtractWords(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        return text.ToLowerInvariant()
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(w => w.Length > 3)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static float ComputeOverlap(HashSet<string> a, HashSet<string> b)
+    {
+        if (a.Count == 0 || b.Count == 0) return 0f;
+        var intersection = a.Count(w => b.Contains(w));
+        return (float)intersection / Math.Min(a.Count, b.Count);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/IHouseRuleMatcher.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/IHouseRuleMatcher.cs
@@ -1,0 +1,15 @@
+namespace Api.BoundedContexts.KnowledgeBase.Application.Services;
+
+/// <summary>
+/// Checks if user's question relates to a house rule stored in AgentMemory.
+/// Cross-BC read: reads from AgentMemory.IGameMemoryRepository.
+/// Returns the most relevant house rule description, or null if none applies.
+/// </summary>
+internal interface IHouseRuleMatcher
+{
+    Task<string?> FindMatchingHouseRuleAsync(
+        Guid gameId,
+        Guid? userId,
+        string question,
+        CancellationToken ct = default);
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs
@@ -488,6 +488,9 @@ internal static class KnowledgeBaseServiceExtensions
 
         // RAG Pipeline Hardening P1-4: heuristic query complexity analyzer for LLM model routing
         services.AddSingleton<QueryComplexityAnalyzer>();
+
+        // Phase 2 Task 2.5: House rule matcher — cross-BC read from AgentMemory, heuristic word-overlap
+        services.AddScoped<IHouseRuleMatcher, HeuristicHouseRuleMatcher>();
     }
 
     private static void AddChunkingAndRerankingServices(IServiceCollection services, IConfiguration? configuration)

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/HeuristicQAComplexityClassifierTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/HeuristicQAComplexityClassifierTests.cs
@@ -1,0 +1,82 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// Unit tests for HeuristicQAComplexityClassifier (Phase 2 Task 2.4).
+/// Validates keyword-heuristic Q&amp;A complexity classification for the libro game assistant context.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+public class HeuristicQAComplexityClassifierTests
+{
+    private readonly HeuristicQAComplexityClassifier _sut = new();
+
+    [Fact]
+    public void Classify_SynthesisKeyword_ReturnsSynthesis()
+    {
+        var result = _sut.Classify("Qual è la differenza tra esplorazione e combattimento?");
+        result.Level.Should().Be(QAComplexityLevel.Synthesis);
+        result.Confidence.Should().BeGreaterThanOrEqualTo(0.80f);
+    }
+
+    [Fact]
+    public void Classify_MultiStepKeyword_ReturnsMultiStep()
+    {
+        var result = _sut.Classify("Se uso il modulo Stealth e poi esploro, cosa succede?");
+        result.Level.Should().Be(QAComplexityLevel.MultiStep);
+    }
+
+    [Fact]
+    public void Classify_SimpleFactualPattern_ReturnsSimple()
+    {
+        var result = _sut.Classify("Quanti dadi tira il mago?");
+        result.Level.Should().Be(QAComplexityLevel.Simple);
+        result.Confidence.Should().BeGreaterThanOrEqualTo(0.85f);
+    }
+
+    [Fact]
+    public void Classify_EmptyInput_ReturnsSimpleWithoutThrowing()
+    {
+        var result = _sut.Classify("");
+        result.Level.Should().Be(QAComplexityLevel.Simple);
+        result.Confidence.Should().Be(1.0f);
+        result.Reason.Should().Be("empty_input");
+    }
+
+    [Fact]
+    public void Classify_NullInput_ReturnsSimpleWithoutThrowing()
+    {
+        var result = _sut.Classify(null!);
+        result.Level.Should().Be(QAComplexityLevel.Simple);
+    }
+
+    [Fact]
+    public void Classify_SameInput_ReturnsSameResult()
+    {
+        var question = "Come funziona il combat?";
+        var r1 = _sut.Classify(question);
+        var r2 = _sut.Classify(question);
+        r1.Should().BeEquivalentTo(r2);
+    }
+
+    [Fact]
+    public void Classify_MixedLanguage_DoesNotThrow()
+    {
+        var act = () => _sut.Classify("Come si usa il Stealth module durante l'exploration?");
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [InlineData("compare X with Y")]
+    [InlineData("differenza tra A e B")]
+    [InlineData("X versus Y")]
+    public void Classify_ComparisonQuestions_ReturnSynthesis(string question)
+    {
+        var result = _sut.Classify(question);
+        result.Level.Should().Be(QAComplexityLevel.Synthesis);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/HeuristicHouseRuleMatcherTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/HeuristicHouseRuleMatcherTests.cs
@@ -1,0 +1,181 @@
+using Api.BoundedContexts.AgentMemory.Domain.Entities;
+using Api.BoundedContexts.AgentMemory.Domain.Enums;
+using Api.BoundedContexts.AgentMemory.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Services;
+
+/// <summary>
+/// Unit tests for HeuristicHouseRuleMatcher (Phase 2 Task 2.5).
+/// Validates heuristic word-overlap house rule matching for libro game assistant context.
+/// Cross-BC read from AgentMemory.IGameMemoryRepository with graceful degradation.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public class HeuristicHouseRuleMatcherTests
+{
+    private readonly Mock<IGameMemoryRepository> _repo = new();
+
+    private HeuristicHouseRuleMatcher CreateSut() =>
+        new(_repo.Object, NullLogger<HeuristicHouseRuleMatcher>.Instance);
+
+    // ─── Null/Empty guards ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FindMatchingHouseRuleAsync_NullUserId_ReturnsNullWithoutRepoCall()
+    {
+        var sut = CreateSut();
+
+        var result = await sut.FindMatchingHouseRuleAsync(
+            Guid.NewGuid(), null, "test question", CancellationToken.None);
+
+        result.Should().BeNull();
+        _repo.Verify(
+            r => r.GetByGameAndOwnerAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task FindMatchingHouseRuleAsync_NoMemory_ReturnsNull()
+    {
+        _repo.Setup(r => r.GetByGameAndOwnerAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GameMemory?)null);
+
+        var sut = CreateSut();
+        var result = await sut.FindMatchingHouseRuleAsync(
+            Guid.NewGuid(), Guid.NewGuid(), "test", CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FindMatchingHouseRuleAsync_EmptyHouseRules_ReturnsNull()
+    {
+        var memory = GameMemory.Create(Guid.NewGuid(), Guid.NewGuid());
+        _repo.Setup(r => r.GetByGameAndOwnerAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(memory);
+
+        var sut = CreateSut();
+        var result = await sut.FindMatchingHouseRuleAsync(
+            Guid.NewGuid(), Guid.NewGuid(), "fireball costs mana", CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    // ─── Matching ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FindMatchingHouseRuleAsync_HighOverlap_ReturnsRuleDescription()
+    {
+        var memory = BuildMemoryWithRule("Fireball costs 2 mana instead of standard 3");
+        _repo.Setup(r => r.GetByGameAndOwnerAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(memory);
+
+        var sut = CreateSut();
+        var result = await sut.FindMatchingHouseRuleAsync(
+            Guid.NewGuid(), Guid.NewGuid(),
+            "How much mana does fireball cost?",
+            CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.Should().Contain("mana");
+    }
+
+    [Fact]
+    public async Task FindMatchingHouseRuleAsync_NoOverlap_ReturnsNull()
+    {
+        var memory = BuildMemoryWithRule("Fireball costs 2 mana instead of standard 3");
+        _repo.Setup(r => r.GetByGameAndOwnerAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(memory);
+
+        var sut = CreateSut();
+        var result = await sut.FindMatchingHouseRuleAsync(
+            Guid.NewGuid(), Guid.NewGuid(),
+            "How many players can play?",
+            CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FindMatchingHouseRuleAsync_MultipleRules_ReturnsFirstMatch()
+    {
+        var memory = BuildMemoryWithRules(new[]
+        {
+            "Players draw 5 cards at start instead of 4",
+            "Fireball costs 2 mana instead of standard 3",
+            "Critical hits deal triple damage"
+        });
+        _repo.Setup(r => r.GetByGameAndOwnerAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(memory);
+
+        var sut = CreateSut();
+        var result = await sut.FindMatchingHouseRuleAsync(
+            Guid.NewGuid(), Guid.NewGuid(),
+            "How much mana does fireball cost?",
+            CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.Should().Contain("Fireball");
+    }
+
+    // ─── Graceful degradation ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FindMatchingHouseRuleAsync_RepositoryThrows_ReturnsNullGracefully()
+    {
+        _repo.Setup(r => r.GetByGameAndOwnerAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("DB down"));
+
+        var sut = CreateSut();
+        var result = await sut.FindMatchingHouseRuleAsync(
+            Guid.NewGuid(), Guid.NewGuid(), "test question", CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    // ─── Edge cases ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FindMatchingHouseRuleAsync_ShortWordsOnlyQuestion_ReturnsNull()
+    {
+        // Words with length <= 3 are excluded from the word set (stop-word heuristic).
+        // "can you win" → all words <= 3 chars → empty set → no match possible.
+        var memory = BuildMemoryWithRule("Players draw 5 cards at start instead of 4");
+        _repo.Setup(r => r.GetByGameAndOwnerAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(memory);
+
+        var sut = CreateSut();
+        var result = await sut.FindMatchingHouseRuleAsync(
+            Guid.NewGuid(), Guid.NewGuid(),
+            "can you win",
+            CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private static GameMemory BuildMemoryWithRule(string description) =>
+        BuildMemoryWithRules(new[] { description });
+
+    private static GameMemory BuildMemoryWithRules(IEnumerable<string> descriptions)
+    {
+        var memory = GameMemory.Create(Guid.NewGuid(), Guid.NewGuid());
+        foreach (var desc in descriptions)
+            memory.AddHouseRule(desc, HouseRuleSource.UserAdded);
+        return memory;
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 Task 2.4 (QA Complexity Classifier) + Task 2.5 (House Rule Matcher) — entrambi indipendenti, bundled in 1 PR.

**Stats**: 2 commit, 8 files, 18 unit tests pass.

## Tasks

| Task | Status | Commit | Tests |
|------|--------|--------|-------|
| 2.4 — IQAComplexityClassifier + Heuristic | ✅ | `8a3d0f1cb` | 10/10 unit |
| 2.5 — IHouseRuleMatcher + Heuristic (cross-BC AgentMemory read) | ✅ | `923774e8c` | 8/8 unit |

## Task 2.4 — IQAComplexityClassifier (DocumentProcessing BC)

3-level classification: `Simple` / `MultiStep` / `Synthesis` per Q&A answering complexity. Distinct concept dal pre-existing `IQueryComplexityClassifier` (RAG routing) e `QueryComplexityAnalyzer` (model routing).

**Heuristics**:
- Synthesis keywords: `differenza`, `compare`, `versus`, `confronta`, etc. (IT + EN)
- MultiStep keywords: `se poi`, `if then`, `combina`, `quando`, etc.
- Simple patterns (prefix-based): `quanti`, `how many`, `chi`, `dove`, etc.
- Default fallback: MultiStep with 0.60 confidence

Registered as `AddSingleton<IQAComplexityClassifier, HeuristicQAComplexityClassifier>()` (stateless + thread-safe).

## Task 2.5 — IHouseRuleMatcher (KnowledgeBase BC)

Cross-BC keyword-overlap matcher between user question and house rules in `AgentMemory`. Pattern: cross-BC read-only via `IGameMemoryRepository.GetByGameAndOwnerAsync` (same precedent: `AgentMemoryContextBuilder`).

**Drift dal plan v2 noted**: `IHouseRuleMatcher` interface era pianificata in Task 2.3b ma poiché 2.3b è deferred, l'interface è stata creata qui in Task 2.5 scope.

**Algorithm**:
- Threshold 30% word overlap (Jaccard-like, normalized to min count)
- Stop words: words ≤ 3 chars excluded
- First match wins (insertion order); Phase 3 può aggiungere `Priority` field
- `userId = null` → early return (no repo call)
- Repository failure → graceful degradation (`null` + warning log, no exception propagation)

## Spike findings

**Task 2.4**:
- FluentAssertions method: `BeGreaterThanOrEqualTo` (NOT `BeGreaterOrEqualTo` as plan had)
- AddSingleton registration verified per AC-2.4.6

**Task 2.5**:
- `IGameMemoryRepository.GetByGameAndOwnerAsync(Guid, Guid, CancellationToken)` confirmed
- `GameMemory.HouseRules` is `IReadOnlyList<HouseRule>` (private backing `List<HouseRule>`)
- `HouseRule.Description` private set, `string.Empty` default
- HouseRule construction via `GameMemory.Create(Guid, Guid).AddHouseRule(description, source)` — no direct ctor
- Cross-BC usage precedent: `AgentMemoryContextBuilder` in KB BC already imports `IGameMemoryRepository` (same assembly internal access)
- Existing IGameMemoryRepository tests use **Moq** (not NSubstitute) — matched existing pattern for consistency

## Acceptance Criteria

**Task 2.4** (6/6 AC):
- AC-2.4.1: Synthesis keyword classification ✅
- AC-2.4.2: MultiStep keyword classification ✅
- AC-2.4.3: Simple factual prefix classification ✅
- AC-2.4.4: Empty input returns Simple without throwing ✅
- AC-2.4.5: Deterministic same-input same-output ✅
- AC-2.4.6: AddSingleton DI registration ✅

**Task 2.5** (6/6 AC):
- AC-2.5.1: ≥30% overlap returns rule description ✅
- AC-2.5.2: null userId returns null without repo call ✅
- AC-2.5.3: No house rules returns null ✅
- AC-2.5.4: Repository failure returns null gracefully ✅
- AC-2.5.5: Stop words (≤3 chars) excluded ✅
- AC-2.5.6: At most 1 repo call per invocation ✅

## Pattern compliance

- ✅ `internal sealed class/record/interface`, `internal enum`
- ✅ `[Trait("Category", TestCategories.Unit)]` + `[Trait("BoundedContext", "...")]`
- ✅ Cross-BC graceful degradation (try/catch + warning log)
- ✅ NO Polly explicit
- ✅ AddSingleton (stateless) vs AddScoped (per-request) decision per task

## Reference

- Phase 2 detailed plan: `docs/superpowers/plans/2026-05-04-libro-game-assistant-phase2-detailed.md` lines 1048-1325
- Cross-BC precedent: `AgentMemoryContextBuilder` in KB BC

## Next up

- **Task 2.3b** — `AskQuestionQueryHandler` extension (now unblocked: IGenericTranslationService #708 + IHouseRuleMatcher #710 + KB indexing services #709 ready, only IPricingEngine stub still needs creation)
- **Task 2.6** — `GameGlossaryEntry` + auto-bootstrap NER (SpaCy)
- **Task 2.7** — Hallucination CI gate (LLM-as-judge GPT-4o, ⚠️ HARD BLOCKER golden set ≥50 questions)
- **Task 2.8** — `infra/compose.test.yml` E2E env
- **Task 2.9** — Phase 2 acceptance gate

## Test Plan

- [x] Backend unit tests: 18/18 pass (10 QAComplexity + 8 HouseRuleMatcher)
- [x] dotnet build: 0 errors, 0 warnings
- [ ] Aaron review + approve
- [ ] Aaron confirm Task 2.3b strategy (AskQuestionQueryHandler extension)

🤖 Generated with [Claude Code](https://claude.com/claude-code)