### PR TITLE
feat(libro-game): Phase 2 Task 2.3b + 2.6 + 2.8 — handler ext + glossary + test compose

### DIFF
--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Commands/AddGlossaryEntryCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Commands/AddGlossaryEntryCommand.cs
@@ -1,0 +1,16 @@
+using Api.BoundedContexts.AgentMemory.Domain.Enums;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.AgentMemory.Application.Commands;
+
+/// <summary>
+/// Command to add a glossary entry to a game's memory. Creates GameMemory if none exists.
+/// </summary>
+internal record AddGlossaryEntryCommand(
+    Guid GameId,
+    Guid OwnerId,
+    string Term,
+    string Definition,
+    string Language,
+    GlossaryEntrySource Source = GlossaryEntrySource.UserDefined
+) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Commands/AddGlossaryEntryCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Commands/AddGlossaryEntryCommandHandler.cs
@@ -1,0 +1,87 @@
+using Api.BoundedContexts.AgentMemory.Domain.Entities;
+using Api.BoundedContexts.AgentMemory.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.AgentMemory.Application.Commands;
+
+/// <summary>
+/// Handles adding a glossary entry to a game's memory. Creates GameMemory if none exists.
+/// </summary>
+internal sealed class AddGlossaryEntryCommandHandler : ICommandHandler<AddGlossaryEntryCommand>
+{
+    private readonly IGameMemoryRepository _gameMemoryRepo;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IFeatureFlagService _featureFlags;
+    private readonly ILogger<AddGlossaryEntryCommandHandler> _logger;
+
+    public AddGlossaryEntryCommandHandler(
+        IGameMemoryRepository gameMemoryRepo,
+        IUnitOfWork unitOfWork,
+        IFeatureFlagService featureFlags,
+        ILogger<AddGlossaryEntryCommandHandler> logger)
+    {
+        _gameMemoryRepo = gameMemoryRepo ?? throw new ArgumentNullException(nameof(gameMemoryRepo));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _featureFlags = featureFlags ?? throw new ArgumentNullException(nameof(featureFlags));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(AddGlossaryEntryCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var isEnabled = await _featureFlags
+            .IsEnabledAsync("Features:AgentMemory.Enabled")
+            .ConfigureAwait(false);
+
+        if (!isEnabled)
+            throw new ConflictException("Feature AgentMemory.Enabled is disabled");
+
+        var memory = await _gameMemoryRepo
+            .GetByGameAndOwnerAsync(command.GameId, command.OwnerId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (memory == null)
+        {
+            memory = GameMemory.Create(command.GameId, command.OwnerId);
+
+            try
+            {
+                memory.AddGlossaryEntry(command.Term, command.Definition, command.Language, command.Source);
+            }
+            catch (InvalidOperationException ex) when (ex.Message.Contains("already exists"))
+            {
+                throw new ConflictException(ex.Message);
+            }
+
+            await _gameMemoryRepo.AddAsync(memory, cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Created new game memory for game {GameId}, owner {OwnerId} with glossary entry '{Term}' ({Language})",
+                command.GameId, command.OwnerId, command.Term, command.Language);
+        }
+        else
+        {
+            try
+            {
+                memory.AddGlossaryEntry(command.Term, command.Definition, command.Language, command.Source);
+            }
+            catch (InvalidOperationException ex) when (ex.Message.Contains("already exists"))
+            {
+                throw new ConflictException(ex.Message);
+            }
+
+            await _gameMemoryRepo.UpdateAsync(memory, cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Added glossary entry '{Term}' ({Language}) to existing game memory for game {GameId}, owner {OwnerId}",
+                command.Term, command.Language, command.GameId, command.OwnerId);
+        }
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/DTOs/GlossaryEntryDto.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/DTOs/GlossaryEntryDto.cs
@@ -1,0 +1,11 @@
+namespace Api.BoundedContexts.AgentMemory.Application.DTOs;
+
+/// <summary>
+/// DTO representing a single game glossary entry.
+/// </summary>
+internal record GlossaryEntryDto(
+    string Term,
+    string Definition,
+    string Language,
+    string Source,
+    DateTime AddedAt);

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Queries/GetGlossaryQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Queries/GetGlossaryQuery.cs
@@ -1,0 +1,10 @@
+using Api.BoundedContexts.AgentMemory.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.AgentMemory.Application.Queries;
+
+/// <summary>
+/// Query to retrieve all glossary entries for a game's memory by game and owner IDs.
+/// </summary>
+internal record GetGlossaryQuery(Guid GameId, Guid OwnerId)
+    : IQuery<IReadOnlyList<GlossaryEntryDto>>;

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Queries/GetGlossaryQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Queries/GetGlossaryQueryHandler.cs
@@ -1,0 +1,41 @@
+using Api.BoundedContexts.AgentMemory.Application.DTOs;
+using Api.BoundedContexts.AgentMemory.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.AgentMemory.Application.Queries;
+
+/// <summary>
+/// Handles retrieving glossary entries for a game's memory by game and owner IDs.
+/// </summary>
+internal sealed class GetGlossaryQueryHandler : IQueryHandler<GetGlossaryQuery, IReadOnlyList<GlossaryEntryDto>>
+{
+    private readonly IGameMemoryRepository _gameMemoryRepo;
+
+    public GetGlossaryQueryHandler(IGameMemoryRepository gameMemoryRepo)
+    {
+        _gameMemoryRepo = gameMemoryRepo ?? throw new ArgumentNullException(nameof(gameMemoryRepo));
+    }
+
+    public async Task<IReadOnlyList<GlossaryEntryDto>> Handle(
+        GetGlossaryQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var memory = await _gameMemoryRepo
+            .GetByGameAndOwnerAsync(query.GameId, query.OwnerId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (memory is null)
+            return Array.Empty<GlossaryEntryDto>();
+
+        return memory.GlossaryEntries
+            .Select(e => new GlossaryEntryDto(
+                e.Term,
+                e.Definition,
+                e.Language,
+                e.Source.ToString(),
+                e.AddedAt))
+            .ToList();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Domain/Entities/GameMemory.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Domain/Entities/GameMemory.cs
@@ -6,7 +6,7 @@ using Api.SharedKernel.Domain.Entities;
 namespace Api.BoundedContexts.AgentMemory.Domain.Entities;
 
 /// <summary>
-/// Aggregate root storing per-game, per-owner memory: house rules, setup checklists, and notes.
+/// Aggregate root storing per-game, per-owner memory: house rules, setup checklists, notes, and glossary entries.
 /// </summary>
 internal sealed class GameMemory : AggregateRoot<Guid>
 {
@@ -20,6 +20,9 @@ internal sealed class GameMemory : AggregateRoot<Guid>
 
     private readonly List<MemoryNote> _notes = new();
     public IReadOnlyList<MemoryNote> Notes => _notes.AsReadOnly();
+
+    private readonly List<GlossaryEntry> _glossaryEntries = new();
+    public IReadOnlyList<GlossaryEntry> GlossaryEntries => _glossaryEntries.AsReadOnly();
 
     public DateTime CreatedAt { get; private set; }
 
@@ -53,5 +56,21 @@ internal sealed class GameMemory : AggregateRoot<Guid>
     public void AddNote(string content, Guid? addedByUserId)
     {
         _notes.Add(MemoryNote.Create(content, addedByUserId));
+    }
+
+    /// <summary>
+    /// Adds a glossary entry for the game. Throws if a term with the same name already exists for the same language.
+    /// </summary>
+    public void AddGlossaryEntry(string term, string definition, string language, GlossaryEntrySource source)
+    {
+        if (_glossaryEntries.Any(e =>
+            string.Equals(e.Term, term, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(e.Language, language, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new InvalidOperationException(
+                $"Glossary term '{term}' already exists for language '{language}'.");
+        }
+
+        _glossaryEntries.Add(GlossaryEntry.Create(term, definition, language, source));
     }
 }

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Domain/Enums/GlossaryEntrySource.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Domain/Enums/GlossaryEntrySource.cs
@@ -1,0 +1,16 @@
+namespace Api.BoundedContexts.AgentMemory.Domain.Enums;
+
+/// <summary>
+/// Indicates the origin of a glossary entry.
+/// </summary>
+internal enum GlossaryEntrySource
+{
+    /// <summary>Manually added by a user.</summary>
+    Manual,
+
+    /// <summary>Defined by the user (alias for Manual, kept for API compatibility).</summary>
+    UserDefined,
+
+    /// <summary>Auto-bootstrapped by NER pipeline (Phase 3).</summary>
+    NerBootstrap
+}

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Domain/Models/GlossaryEntry.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Domain/Models/GlossaryEntry.cs
@@ -1,0 +1,62 @@
+using Api.BoundedContexts.AgentMemory.Domain.Enums;
+
+namespace Api.BoundedContexts.AgentMemory.Domain.Models;
+
+/// <summary>
+/// Represents a game glossary term added to a game's memory.
+/// </summary>
+internal sealed class GlossaryEntry
+{
+    private GlossaryEntry() { } // Required for JSON deserialization
+
+    public string Term { get; private set; } = string.Empty;
+    public string Definition { get; private set; } = string.Empty;
+    public string Language { get; private set; } = "en";
+    public GlossaryEntrySource Source { get; private set; }
+    public DateTime AddedAt { get; private set; }
+
+    public static GlossaryEntry Create(
+        string term,
+        string definition,
+        string language,
+        GlossaryEntrySource source)
+    {
+        if (string.IsNullOrWhiteSpace(term))
+            throw new ArgumentException("Term cannot be empty.", nameof(term));
+
+        if (string.IsNullOrWhiteSpace(definition))
+            throw new ArgumentException("Definition cannot be empty.", nameof(definition));
+
+        if (string.IsNullOrWhiteSpace(language))
+            throw new ArgumentException("Language cannot be empty.", nameof(language));
+
+        return new GlossaryEntry
+        {
+            Term = term.Trim(),
+            Definition = definition.Trim(),
+            Language = language.ToLowerInvariant(),
+            Source = source,
+            AddedAt = DateTime.UtcNow
+        };
+    }
+
+    /// <summary>
+    /// Restores from persistence with the original AddedAt timestamp.
+    /// </summary>
+    internal static GlossaryEntry Restore(
+        string term,
+        string definition,
+        string language,
+        GlossaryEntrySource source,
+        DateTime addedAt)
+    {
+        return new GlossaryEntry
+        {
+            Term = term,
+            Definition = definition,
+            Language = language,
+            Source = source,
+            AddedAt = addedAt
+        };
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Configurations/GameMemoryEntityConfiguration.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Configurations/GameMemoryEntityConfiguration.cs
@@ -50,6 +50,10 @@ internal sealed class GameMemoryEntityConfiguration : IEntityTypeConfiguration<G
             .HasColumnName("notes_json")
             .HasColumnType("jsonb");
 
+        builder.Property(e => e.GlossaryEntriesJson)
+            .HasColumnName("glossary_entries_json")
+            .HasColumnType("jsonb");
+
         // --- Indexes ---
 
         builder.HasIndex(e => new { e.GameId, e.OwnerId })

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Entities/GameMemoryEntity.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Entities/GameMemoryEntity.cs
@@ -12,6 +12,7 @@ public class GameMemoryEntity
     public string? HouseRulesJson { get; set; }  // JSONB
     public string? CustomSetupJson { get; set; }  // JSONB
     public string? NotesJson { get; set; }  // JSONB
+    public string? GlossaryEntriesJson { get; set; }  // JSONB
     public DateTime CreatedAt { get; set; }
     public DateTime? UpdatedAt { get; set; }
 }

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Persistence/GameMemoryRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Persistence/GameMemoryRepository.cs
@@ -122,6 +122,25 @@ internal sealed class GameMemoryRepository : RepositoryBase, IGameMemoryReposito
             }
         }
 
+        // Restore glossary entries from JSONB
+        if (entity.GlossaryEntriesJson != null)
+        {
+            var glossaryDtos = JsonSerializer.Deserialize<List<GlossaryEntryDto>>(entity.GlossaryEntriesJson);
+            if (glossaryDtos != null)
+            {
+#pragma warning disable S3011 // Reflection needed for domain reconstruction from persistence
+                var glossaryList = (List<GlossaryEntry>)typeof(GameMemory)
+                    .GetField("_glossaryEntries", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+                    .GetValue(memory)!;
+#pragma warning restore S3011
+
+                foreach (var dto in glossaryDtos)
+                {
+                    glossaryList.Add(GlossaryEntry.Restore(dto.Term, dto.Definition, dto.Language, (GlossaryEntrySource)dto.Source, dto.AddedAt));
+                }
+            }
+        }
+
         return memory;
     }
 
@@ -168,6 +187,20 @@ internal sealed class GameMemoryRepository : RepositoryBase, IGameMemoryReposito
             entity.NotesJson = JsonSerializer.Serialize(dtos);
         }
 
+        // Serialize glossary entries to JSONB
+        if (memory.GlossaryEntries.Count > 0)
+        {
+            var dtos = memory.GlossaryEntries.Select(e => new GlossaryEntryDto
+            {
+                Term = e.Term,
+                Definition = e.Definition,
+                Language = e.Language,
+                Source = (int)e.Source,
+                AddedAt = e.AddedAt,
+            }).ToList();
+            entity.GlossaryEntriesJson = JsonSerializer.Serialize(dtos);
+        }
+
         return entity;
     }
 
@@ -194,5 +227,15 @@ internal sealed class GameMemoryRepository : RepositoryBase, IGameMemoryReposito
         public string Content { get; set; } = string.Empty;
         public DateTime AddedAt { get; set; }
         public Guid? AddedByUserId { get; set; }
+    }
+
+    /// <summary>DTO for JSON serialization of GlossaryEntry.</summary>
+    private sealed class GlossaryEntryDto
+    {
+        public string Term { get; set; } = string.Empty;
+        public string Definition { get; set; } = string.Empty;
+        public string Language { get; set; } = "en";
+        public int Source { get; set; }
+        public DateTime AddedAt { get; set; }
     }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQuery.cs
@@ -17,5 +17,6 @@ internal record AskQuestionQuery(
     string Language = "en",
     bool BypassCache = false,
     Guid? UserId = null,
-    string? UserRole = null
+    string? UserRole = null,
+    string? ResponseLanguage = null // Phase 2: If set and differs from Language, response is translated post-LLM
 ) : IQuery<QaResponseDto>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandler.cs
@@ -8,6 +8,7 @@ using Api.BoundedContexts.KnowledgeBase.Domain.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.BoundedContexts.KnowledgeBase.Infrastructure.Persistence.Mappers;
 using Api.Infrastructure.Entities;
+using Api.Infrastructure.Translation;
 using Api.Middleware.Exceptions;
 using Api.Services;
 using Api.SharedKernel.Application.Interfaces;
@@ -45,6 +46,9 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
     private readonly QueryComplexityAnalyzer _complexityAnalyzer;
     private readonly ISemanticResponseCache _responseCache;
     private readonly IEmbeddingService _embeddingService;
+    private readonly IHouseRuleMatcher _houseRuleMatcher;
+    private readonly IPricingEngine _pricingEngine;
+    private readonly IGenericTranslationService _genericTranslationService;
     private readonly ILogger<AskQuestionQueryHandler> _logger;
 
     public AskQuestionQueryHandler(
@@ -61,6 +65,9 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
         QueryComplexityAnalyzer complexityAnalyzer,
         ISemanticResponseCache responseCache,
         IEmbeddingService embeddingService,
+        IHouseRuleMatcher houseRuleMatcher,
+        IPricingEngine pricingEngine,
+        IGenericTranslationService genericTranslationService,
         ILogger<AskQuestionQueryHandler> logger)
     {
         _searchQueryHandler = searchQueryHandler ?? throw new ArgumentNullException(nameof(searchQueryHandler));
@@ -76,6 +83,9 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
         _complexityAnalyzer = complexityAnalyzer ?? throw new ArgumentNullException(nameof(complexityAnalyzer));
         _responseCache = responseCache ?? throw new ArgumentNullException(nameof(responseCache));
         _embeddingService = embeddingService ?? throw new ArgumentNullException(nameof(embeddingService));
+        _houseRuleMatcher = houseRuleMatcher ?? throw new ArgumentNullException(nameof(houseRuleMatcher));
+        _pricingEngine = pricingEngine ?? throw new ArgumentNullException(nameof(pricingEngine));
+        _genericTranslationService = genericTranslationService ?? throw new ArgumentNullException(nameof(genericTranslationService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -111,6 +121,35 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
         _logger.LogInformation(
             "[AskQuestionHandler] ENTRY - Processing AskQuestionQuery: GameId={GameId}, Question={Question}",
             query.GameId, query.Question);
+
+        // PHASE 2: House rule check (graceful degradation per AC-2.5.4)
+        // Cross-BC read from AgentMemory — failure must not abort Q&A (R-23 mitigation).
+        string? houseRuleMatch = null;
+        if (query.UserId.HasValue)
+        {
+            try
+            {
+                houseRuleMatch = await _houseRuleMatcher.FindMatchingHouseRuleAsync(
+                    query.GameId, query.UserId, query.Question, cancellationToken).ConfigureAwait(false);
+                if (houseRuleMatch is not null)
+                    _logger.LogInformation(
+                        "[AskQuestionHandler] House rule matched for game {GameId}",
+                        query.GameId);
+            }
+            catch (Exception ex)
+            {
+                // R-23 mitigation: cross-BC failure should not abort Q&A
+                _logger.LogWarning(ex,
+                    "[AskQuestionHandler] House rule lookup failed for game {GameId}, proceeding without",
+                    query.GameId);
+            }
+        }
+
+        // PHASE 2: Pricing quota check — throws ForbiddenException if daily quota exhausted.
+        var quotaAllowed = await _pricingEngine.ConsumeQuotaAsync(
+            query.UserId, "qa_question", cancellationToken).ConfigureAwait(false);
+        if (!quotaAllowed)
+            throw new ForbiddenException("Quota giornaliera esaurita. Acquista crediti per continuare.");
 
         // P1-5: Semantic cache lookup — generate query vector and check for a cached response.
         // Issue #563: The vector produced here is now also forwarded to SearchQueryHandler via
@@ -246,7 +285,14 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
         var context = string.Join("\n\n", searchResults.Select(sr =>
             $"[Page {sr.PageNumber}] {sr.TextContent}"));
 
-        var baseQuestion = $"Question: {query.Question}\n\nContext:\n{context}";
+        // PHASE 2: Prepend house rule context to the user prompt when a matching house rule was found.
+        // This augments the RAG context with group-specific rules stored in AgentMemory, ensuring the
+        // LLM answers relative to the user's actual table rules rather than the rulebook alone.
+        var houseRulePrefix = houseRuleMatch is not null
+            ? $"[House Rule for this group]\n{houseRuleMatch}\n\n"
+            : string.Empty;
+
+        var baseQuestion = $"{houseRulePrefix}Question: {query.Question}\n\nContext:\n{context}";
         var userPrompt = !string.IsNullOrWhiteSpace(chatHistoryContext)
             ? _chatContextService.EnrichPromptWithHistory(baseQuestion, chatHistoryContext)
             : baseQuestion;
@@ -307,6 +353,37 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
             CacheHit: false,
             NoRelevantContext: false);
         await _qualityTracker.TrackQueryAsync(successMetrics, cancellationToken).ConfigureAwait(false);
+
+        // PHASE 2: Translate response if ResponseLanguage differs from the query language.
+        // Graceful degradation: on any failure, return the original answer with a warning logged.
+        if (query.ResponseLanguage is not null
+            && !string.Equals(query.ResponseLanguage, query.Language, StringComparison.OrdinalIgnoreCase)
+            && !string.IsNullOrWhiteSpace(response.Answer))
+        {
+            try
+            {
+                var translationResult = await _genericTranslationService.TranslateGenericAsync(
+                    response.Answer, query.Language, query.ResponseLanguage, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (translationResult.Success)
+                {
+                    response = response with { Answer = translationResult.TranslatedText };
+                }
+                else
+                {
+                    _logger.LogWarning(
+                        "[AskQuestionHandler] Translation failed for game {GameId}, returning original: {Error}",
+                        query.GameId, translationResult.ErrorCode);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "[AskQuestionHandler] Translation threw for game {GameId}, returning original",
+                    query.GameId);
+            }
+        }
 
         return response;
     }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/IPricingEngine.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/IPricingEngine.cs
@@ -1,0 +1,18 @@
+namespace Api.BoundedContexts.KnowledgeBase.Application.Services;
+
+/// <summary>
+/// Enforces pricing quotas for KB operations.
+/// Phase 2: NullPricingEngine stub (always allows).
+/// Phase 3 Task 3.2: CreditBasedPricingEngine implementation.
+/// </summary>
+internal interface IPricingEngine
+{
+    /// <summary>
+    /// Consumes quota for an operation.
+    /// Returns true if the operation is allowed, false if quota is exhausted.
+    /// </summary>
+    Task<bool> ConsumeQuotaAsync(
+        Guid? userId,
+        string operationType,
+        CancellationToken ct = default);
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/NullPricingEngine.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/NullPricingEngine.cs
@@ -1,0 +1,11 @@
+namespace Api.BoundedContexts.KnowledgeBase.Application.Services;
+
+/// <summary>
+/// Phase 2 stub: always allows quota consumption.
+/// PHASE 3 REPLACE with CreditBasedPricingEngine in Phase 3 Task 3.2.
+/// </summary>
+internal sealed class NullPricingEngine : IPricingEngine
+{
+    public Task<bool> ConsumeQuotaAsync(Guid? userId, string operationType, CancellationToken ct = default)
+        => Task.FromResult(true);
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs
@@ -491,6 +491,10 @@ internal static class KnowledgeBaseServiceExtensions
 
         // Phase 2 Task 2.5: House rule matcher — cross-BC read from AgentMemory, heuristic word-overlap
         services.AddScoped<IHouseRuleMatcher, HeuristicHouseRuleMatcher>();
+
+        // Phase 2 Task 2.3b: Pricing engine — NullPricingEngine stub (always allows).
+        // PHASE 3 REPLACE with CreditBasedPricingEngine in Phase 3 Task 3.2.
+        services.AddScoped<IPricingEngine, NullPricingEngine>();
     }
 
     private static void AddChunkingAndRerankingServices(IServiceCollection services, IConfiguration? configuration)

--- a/apps/api/src/Api/Infrastructure/Migrations/20260505090846_AddGlossaryEntriesToGameMemory.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260505090846_AddGlossaryEntriesToGameMemory.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260505090846_AddGlossaryEntriesToGameMemory")]
+    partial class AddGlossaryEntriesToGameMemory
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260505090846_AddGlossaryEntriesToGameMemory.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260505090846_AddGlossaryEntriesToGameMemory.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGlossaryEntriesToGameMemory : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "glossary_entries_json",
+                table: "game_memories",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "glossary_entries_json",
+                table: "game_memories");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/AgentMemoryEndpoints.cs
+++ b/apps/api/src/Api/Routing/AgentMemoryEndpoints.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.AgentMemory.Application.Commands;
 using Api.BoundedContexts.AgentMemory.Application.DTOs;
 using Api.BoundedContexts.AgentMemory.Application.Queries;
+using Api.BoundedContexts.AgentMemory.Domain.Enums;
 using Api.Extensions;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
@@ -64,6 +65,20 @@ internal static class AgentMemoryEndpoints
             .Produces(400)
             .Produces(401)
             .WithSummary("Add a memory note");
+
+        agentMemory.MapPost("/games/{gameId:guid}/memory/glossary", HandleAddGlossaryEntry)
+            .RequireAuthenticatedUser()
+            .Produces(204)
+            .Produces(400)
+            .Produces(401)
+            .Produces(409)
+            .WithSummary("Add a glossary entry");
+
+        agentMemory.MapGet("/games/{gameId:guid}/memory/glossary", HandleGetGlossary)
+            .RequireAuthenticatedUser()
+            .Produces<List<GlossaryEntryDto>>(200)
+            .Produces(401)
+            .WithSummary("Get all glossary entries for a game");
 
         // === Player Stats ===
 
@@ -169,6 +184,32 @@ internal static class AgentMemoryEndpoints
         return Results.NoContent();
     }
 
+    private static async Task<IResult> HandleAddGlossaryEntry(
+        Guid gameId,
+        [FromBody] AddGlossaryEntryRequest request,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+        var command = new AddGlossaryEntryCommand(
+            gameId, userId, request.Term, request.Definition, request.Language);
+
+        await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> HandleGetGlossary(
+        Guid gameId,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+        var result = await mediator.Send(new GetGlossaryQuery(gameId, userId), cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
     // === Player Stats Handlers ===
 
     private static async Task<IResult> HandleGetMyStats(
@@ -220,6 +261,8 @@ internal static class AgentMemoryEndpoints
     internal record AddHouseRuleRequest(string Description);
 
     internal record AddNoteRequest(string Content);
+
+    internal record AddGlossaryEntryRequest(string Term, string Definition, string Language = "en");
 
     internal record ClaimGuestRequest(Guid PlayerMemoryId);
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/AgentMemory/Application/Handlers/AddGlossaryEntryCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/AgentMemory/Application/Handlers/AddGlossaryEntryCommandHandlerTests.cs
@@ -1,0 +1,173 @@
+using Api.BoundedContexts.AgentMemory.Application.Commands;
+using Api.BoundedContexts.AgentMemory.Domain.Entities;
+using Api.BoundedContexts.AgentMemory.Domain.Enums;
+using Api.BoundedContexts.AgentMemory.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.AgentMemory.Application.Handlers;
+
+/// <summary>
+/// Tests for AddGlossaryEntryCommandHandler covering find-or-create pattern, duplicate detection, and cross-language rules.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "AgentMemory")]
+public class AddGlossaryEntryCommandHandlerTests
+{
+    private readonly Mock<IGameMemoryRepository> _gameMemoryRepoMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly Mock<IFeatureFlagService> _featureFlagsMock = new();
+    private readonly AddGlossaryEntryCommandHandler _handler;
+
+    public AddGlossaryEntryCommandHandlerTests()
+    {
+        var loggerMock = new Mock<ILogger<AddGlossaryEntryCommandHandler>>();
+
+        _featureFlagsMock
+            .Setup(f => f.IsEnabledAsync("Features:AgentMemory.Enabled", null))
+            .ReturnsAsync(true);
+
+        _handler = new AddGlossaryEntryCommandHandler(
+            _gameMemoryRepoMock.Object,
+            _unitOfWorkMock.Object,
+            _featureFlagsMock.Object,
+            loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_NoExistingMemory_CreatesNewGameMemoryWithGlossaryEntry()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        var command = new AddGlossaryEntryCommand(gameId, ownerId, "Meeple", "A playing piece shaped like a person", "en");
+
+        _gameMemoryRepoMock
+            .Setup(r => r.GetByGameAndOwnerAsync(gameId, ownerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GameMemory?)null);
+
+        GameMemory? capturedMemory = null;
+        _gameMemoryRepoMock
+            .Setup(r => r.AddAsync(It.IsAny<GameMemory>(), It.IsAny<CancellationToken>()))
+            .Callback<GameMemory, CancellationToken>((m, _) => capturedMemory = m)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        capturedMemory.Should().NotBeNull();
+        capturedMemory!.GameId.Should().Be(gameId);
+        capturedMemory.OwnerId.Should().Be(ownerId);
+        capturedMemory.GlossaryEntries.Should().ContainSingle();
+        capturedMemory.GlossaryEntries[0].Term.Should().Be("Meeple");
+        capturedMemory.GlossaryEntries[0].Definition.Should().Be("A playing piece shaped like a person");
+        capturedMemory.GlossaryEntries[0].Language.Should().Be("en");
+        capturedMemory.GlossaryEntries[0].Source.Should().Be(GlossaryEntrySource.UserDefined);
+
+        _gameMemoryRepoMock.Verify(r => r.AddAsync(It.IsAny<GameMemory>(), It.IsAny<CancellationToken>()), Times.Once);
+        _gameMemoryRepoMock.Verify(r => r.UpdateAsync(It.IsAny<GameMemory>(), It.IsAny<CancellationToken>()), Times.Never);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ExistingMemory_AddsGlossaryEntryToExisting()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        var existingMemory = GameMemory.Create(gameId, ownerId);
+        existingMemory.AddGlossaryEntry("Worker", "A game piece used for resource gathering", "en", GlossaryEntrySource.Manual);
+
+        _gameMemoryRepoMock
+            .Setup(r => r.GetByGameAndOwnerAsync(gameId, ownerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingMemory);
+
+        var command = new AddGlossaryEntryCommand(gameId, ownerId, "Resource", "A commodity collected during play", "en");
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        existingMemory.GlossaryEntries.Count.Should().Be(2);
+        existingMemory.GlossaryEntries[1].Term.Should().Be("Resource");
+
+        _gameMemoryRepoMock.Verify(r => r.UpdateAsync(existingMemory, It.IsAny<CancellationToken>()), Times.Once);
+        _gameMemoryRepoMock.Verify(r => r.AddAsync(It.IsAny<GameMemory>(), It.IsAny<CancellationToken>()), Times.Never);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DuplicateTermSameLanguage_ThrowsConflictException()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        var existingMemory = GameMemory.Create(gameId, ownerId);
+        existingMemory.AddGlossaryEntry("Meeple", "Original definition", "en", GlossaryEntrySource.Manual);
+
+        _gameMemoryRepoMock
+            .Setup(r => r.GetByGameAndOwnerAsync(gameId, ownerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingMemory);
+
+        // Duplicate — same term, same language
+        var command = new AddGlossaryEntryCommand(gameId, ownerId, "Meeple", "Another definition", "en");
+
+        // Act & Assert
+        var act = () => _handler.Handle(command, CancellationToken.None);
+        await act.Should().ThrowAsync<ConflictException>();
+
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_SameTermDifferentLanguage_Succeeds()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        var existingMemory = GameMemory.Create(gameId, ownerId);
+        existingMemory.AddGlossaryEntry("Meeple", "A playing piece shaped like a person", "en", GlossaryEntrySource.Manual);
+
+        _gameMemoryRepoMock
+            .Setup(r => r.GetByGameAndOwnerAsync(gameId, ownerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingMemory);
+
+        _gameMemoryRepoMock
+            .Setup(r => r.UpdateAsync(It.IsAny<GameMemory>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Same term but different language — should succeed
+        var command = new AddGlossaryEntryCommand(gameId, ownerId, "Meeple", "Peça de jogo em formato de pessoa", "it");
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        existingMemory.GlossaryEntries.Count.Should().Be(2);
+        existingMemory.GlossaryEntries[1].Language.Should().Be("it");
+
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_FeatureDisabled_ThrowsConflictException()
+    {
+        // Arrange
+        _featureFlagsMock
+            .Setup(f => f.IsEnabledAsync("Features:AgentMemory.Enabled", null))
+            .ReturnsAsync(false);
+
+        var command = new AddGlossaryEntryCommand(Guid.NewGuid(), Guid.NewGuid(), "Term", "Definition", "en");
+
+        // Act & Assert
+        var act = () => _handler.Handle(command, CancellationToken.None);
+        await act.Should().ThrowAsync<ConflictException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/AgentMemory/Application/Handlers/GetGlossaryQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/AgentMemory/Application/Handlers/GetGlossaryQueryHandlerTests.cs
@@ -1,0 +1,100 @@
+using Api.BoundedContexts.AgentMemory.Application.Queries;
+using Api.BoundedContexts.AgentMemory.Domain.Entities;
+using Api.BoundedContexts.AgentMemory.Domain.Enums;
+using Api.BoundedContexts.AgentMemory.Domain.Repositories;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.AgentMemory.Application.Handlers;
+
+/// <summary>
+/// Tests for GetGlossaryQueryHandler covering all memory states.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "AgentMemory")]
+public class GetGlossaryQueryHandlerTests
+{
+    private readonly Mock<IGameMemoryRepository> _gameMemoryRepoMock = new();
+    private readonly GetGlossaryQueryHandler _handler;
+
+    public GetGlossaryQueryHandlerTests()
+    {
+        _handler = new GetGlossaryQueryHandler(_gameMemoryRepoMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_MemoryExistsWithEntries_ReturnsMappedDtoList()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        var memory = GameMemory.Create(gameId, ownerId);
+        memory.AddGlossaryEntry("Meeple", "A playing piece shaped like a person", "en", GlossaryEntrySource.Manual);
+        memory.AddGlossaryEntry("Worker", "A resource-gathering game piece", "en", GlossaryEntrySource.UserDefined);
+
+        _gameMemoryRepoMock
+            .Setup(r => r.GetByGameAndOwnerAsync(gameId, ownerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(memory);
+
+        var query = new GetGlossaryQuery(gameId, ownerId);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(2);
+        result[0].Term.Should().Be("Meeple");
+        result[0].Definition.Should().Be("A playing piece shaped like a person");
+        result[0].Language.Should().Be("en");
+        result[0].Source.Should().Be(GlossaryEntrySource.Manual.ToString());
+        result[1].Term.Should().Be("Worker");
+        result[1].Source.Should().Be(GlossaryEntrySource.UserDefined.ToString());
+    }
+
+    [Fact]
+    public async Task Handle_MemoryNotFound_ReturnsEmptyList()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+
+        _gameMemoryRepoMock
+            .Setup(r => r.GetByGameAndOwnerAsync(gameId, ownerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GameMemory?)null);
+
+        var query = new GetGlossaryQuery(gameId, ownerId);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_MemoryExistsWithEmptyGlossary_ReturnsEmptyList()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        // Memory exists but no glossary entries
+        var memory = GameMemory.Create(gameId, ownerId);
+        memory.AddHouseRule("No phones at table", HouseRuleSource.UserAdded);
+
+        _gameMemoryRepoMock
+            .Setup(r => r.GetByGameAndOwnerAsync(gameId, ownerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(memory);
+
+        var query = new GetGlossaryQuery(gameId, ownerId);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AskQuestionQueryHandlerSecurityTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AskQuestionQueryHandlerSecurityTests.cs
@@ -1,4 +1,5 @@
 using Api.Infrastructure.Entities;
+using Api.Infrastructure.Translation;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
@@ -223,6 +224,9 @@ public class AskQuestionQueryHandlerSecurityTests
             new QueryComplexityAnalyzer(),
             _mockResponseCache.Object,
             _mockAskEmbeddingService.Object,
+            CreatePermissiveHouseRuleMatcherMock(),
+            CreatePermissivePricingEngineMock(),
+            CreateNoOpTranslationServiceMock(),
             _mockLogger.Object);
     }
 
@@ -536,6 +540,31 @@ public class AskQuestionQueryHandlerSecurityTests
     {
         var mock = new Mock<IRagAccessService>();
         mock.Setup(s => s.CanAccessRagAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<UserRole>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        return mock.Object;
+    }
+
+    private static IHouseRuleMatcher CreatePermissiveHouseRuleMatcherMock()
+    {
+        var mock = new Mock<IHouseRuleMatcher>();
+        mock.Setup(m => m.FindMatchingHouseRuleAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+        return mock.Object;
+    }
+
+    private static IPricingEngine CreatePermissivePricingEngineMock()
+    {
+        var mock = new Mock<IPricingEngine>();
+        mock.Setup(p => p.ConsumeQuotaAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        return mock.Object;
+    }
+
+    private static IGenericTranslationService CreateNoOpTranslationServiceMock()
+    {
+        var mock = new Mock<IGenericTranslationService>();
+        mock.Setup(t => t.TranslateGenericAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string text, string src, string tgt, CancellationToken _) =>
+                TranslationResult.CreateSuccess(text, src, tgt, 0m));
         return mock.Object;
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerPhase2Tests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerPhase2Tests.cs
@@ -1,0 +1,596 @@
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Translation;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using Api.Tests.Constants;
+using FluentAssertions;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Phase 2 tests for AskQuestionQueryHandler: ResponseLanguage translation,
+/// IPricingEngine quota enforcement, and IHouseRuleMatcher integration.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public class AskQuestionQueryHandlerPhase2Tests
+{
+    private readonly SearchQueryHandler _searchHandler;
+    private readonly Mock<QualityTrackingDomainService> _mockQualityService;
+    private readonly Mock<ChatContextDomainService> _mockChatContextService;
+    private readonly Mock<IChatThreadRepository> _mockThreadRepository;
+    private readonly Mock<IPdfDocumentRepository> _mockPdfDocumentRepository;
+    private readonly Mock<ILlmService> _mockLlmService;
+    private readonly Mock<IPromptTemplateService> _mockPromptTemplateService;
+    private readonly Mock<IRagValidationPipelineService> _mockValidationPipeline;
+    private readonly Mock<ISemanticResponseCache> _mockResponseCache;
+    private readonly Mock<IEmbeddingService> _mockEmbeddingService;
+    private readonly Mock<IHouseRuleMatcher> _mockHouseRuleMatcher;
+    private readonly Mock<IPricingEngine> _mockPricingEngine;
+    private readonly Mock<IGenericTranslationService> _mockTranslationService;
+    private readonly Mock<ILogger<AskQuestionQueryHandler>> _mockLogger;
+    private readonly Mock<RrfFusionDomainService> _mockRrfService;
+
+    public AskQuestionQueryHandlerPhase2Tests()
+    {
+        // Build real SearchQueryHandler with mocked dependencies
+        var mockEmbeddingRepo = new Mock<IEmbeddingRepository>();
+        var mockVectorSearchService = new Mock<VectorSearchDomainService>();
+        _mockRrfService = new Mock<RrfFusionDomainService>();
+        var mockSearchEmbeddingService = new Mock<IEmbeddingService>();
+        var mockHybridSearchService = new Mock<IHybridSearchService>();
+        var mockSearchLogger = new Mock<ILogger<SearchQueryHandler>>();
+
+        mockSearchEmbeddingService
+            .Setup(e => e.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EmbeddingResult
+            {
+                Success = true,
+                Embeddings = new List<float[]> { new float[768] }
+            });
+
+        mockEmbeddingRepo
+            .Setup(r => r.SearchByVectorAsync(It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Embedding>());
+
+        mockVectorSearchService
+            .Setup(v => v.ValidateSearchParameters(It.IsAny<int>(), It.IsAny<double>()))
+            .Callback((int _, double _) => { });
+
+        mockVectorSearchService
+            .Setup(v => v.Search(It.IsAny<Vector>(), It.IsAny<List<Embedding>>(), It.IsAny<int>(), It.IsAny<double>()))
+            .Returns(new List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>());
+
+        _mockRrfService
+            .Setup(r => r.FuseResults(It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(), It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(), It.IsAny<int>()))
+            .Returns(new List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>());
+
+        mockHybridSearchService
+            .Setup(h => h.SearchAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<SearchMode>(), It.IsAny<int>(), It.IsAny<List<Guid>?>(), It.IsAny<float>(), It.IsAny<float>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<HybridSearchResult>());
+
+        _searchHandler = new SearchQueryHandler(
+            mockEmbeddingRepo.Object,
+            mockVectorSearchService.Object,
+            _mockRrfService.Object,
+            mockSearchEmbeddingService.Object,
+            mockHybridSearchService.Object,
+            CreatePermissiveRagAccessServiceMock(),
+            mockSearchLogger.Object);
+
+        _mockQualityService = new Mock<QualityTrackingDomainService>();
+        _mockChatContextService = new Mock<ChatContextDomainService>();
+        _mockThreadRepository = new Mock<IChatThreadRepository>();
+        _mockPdfDocumentRepository = new Mock<IPdfDocumentRepository>();
+        _mockLlmService = new Mock<ILlmService>();
+        _mockPromptTemplateService = new Mock<IPromptTemplateService>();
+        _mockValidationPipeline = new Mock<IRagValidationPipelineService>();
+        _mockResponseCache = new Mock<ISemanticResponseCache>();
+        _mockEmbeddingService = new Mock<IEmbeddingService>();
+        _mockHouseRuleMatcher = new Mock<IHouseRuleMatcher>();
+        _mockPricingEngine = new Mock<IPricingEngine>();
+        _mockTranslationService = new Mock<IGenericTranslationService>();
+        _mockLogger = new Mock<ILogger<AskQuestionQueryHandler>>();
+
+        // Default: cache miss
+        _mockResponseCache
+            .Setup(c => c.TryGetAsync(It.IsAny<Guid>(), It.IsAny<float[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CachedRagResponse?)null);
+
+        _mockEmbeddingService
+            .Setup(e => e.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EmbeddingResult { Success = true, Embeddings = new List<float[]> { new float[768] } });
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 1: ResponseLanguage triggers translation when it differs from Language
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WithResponseLanguageDifferentFromLanguage_TranslatesAnswer()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        const string originalAnswer = "The pawn moves forward one space.";
+        const string translatedAnswer = "Il pedone avanza di una casella.";
+
+        SetupDefaultMocksWithSearchResults(gameId, originalAnswer);
+
+        _mockPricingEngine
+            .Setup(p => p.ConsumeQuotaAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _mockHouseRuleMatcher
+            .Setup(m => m.FindMatchingHouseRuleAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        _mockTranslationService
+            .Setup(t => t.TranslateGenericAsync(originalAnswer, "en", "it", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TranslationResult.CreateSuccess(translatedAnswer, "en", "it", 0.001m));
+
+        var query = new AskQuestionQuery(
+            GameId: gameId,
+            Question: "How does the pawn move?",
+            Language: "en",
+            ResponseLanguage: "it");
+
+        var handler = BuildHandler();
+
+        // Act
+        var result = await handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Answer.Should().Be(translatedAnswer);
+        _mockTranslationService.Verify(
+            t => t.TranslateGenericAsync(originalAnswer, "en", "it", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 2: ResponseLanguage = null skips translation entirely
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WithResponseLanguageNull_SkipsTranslation()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        const string answer = "The pawn moves forward one space.";
+
+        SetupDefaultMocksWithSearchResults(gameId, answer);
+
+        _mockPricingEngine
+            .Setup(p => p.ConsumeQuotaAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _mockHouseRuleMatcher
+            .Setup(m => m.FindMatchingHouseRuleAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        var query = new AskQuestionQuery(
+            GameId: gameId,
+            Question: "How does the pawn move?",
+            Language: "en",
+            ResponseLanguage: null);
+
+        var handler = BuildHandler();
+
+        // Act
+        var result = await handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Answer.Should().Be(answer);
+        _mockTranslationService.Verify(
+            t => t.TranslateGenericAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 3: Quota denied throws ForbiddenException and no LLM call is made
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WhenQuotaDenied_ThrowsForbiddenExceptionWithoutLlmCall()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+
+        SetupDefaultMocks(gameId);
+
+        _mockPricingEngine
+            .Setup(p => p.ConsumeQuotaAsync(It.IsAny<Guid?>(), "qa_question", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _mockHouseRuleMatcher
+            .Setup(m => m.FindMatchingHouseRuleAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        var query = new AskQuestionQuery(
+            GameId: gameId,
+            Question: "How does the pawn move?",
+            Language: "en");
+
+        var handler = BuildHandler();
+
+        // Act
+        var act = () => handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        await act.Should().ThrowAsync<ForbiddenException>()
+            .WithMessage("*Quota*");
+
+        _mockLlmService.Verify(
+            s => s.GenerateCompletionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "LLM must not be called when quota is denied");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 4: HouseRuleMatcher returns a rule — it is prepended to the user prompt
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WhenHouseRuleMatched_PrependedToUserPrompt()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        const string houseRule = "In our group, the pawn can also move diagonally.";
+        const string answer = "Based on your house rule, the pawn moves diagonally.";
+
+        SetupDefaultMocksWithSearchResults(gameId, answer);
+
+        _mockPricingEngine
+            .Setup(p => p.ConsumeQuotaAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _mockHouseRuleMatcher
+            .Setup(m => m.FindMatchingHouseRuleAsync(gameId, userId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(houseRule);
+
+        _mockTranslationService
+            .Setup(t => t.TranslateGenericAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string text, string src, string tgt, CancellationToken _) =>
+                TranslationResult.CreateSuccess(text, src, tgt, 0m));
+
+        string? capturedUserPrompt = null;
+        _mockLlmService
+            .Setup(s => s.GenerateCompletionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, RequestSource, CancellationToken>((sys, user, src, ct) => capturedUserPrompt = user)
+            .ReturnsAsync(LlmCompletionResult.CreateSuccess(
+                response: answer,
+                usage: new LlmUsage(10, 10, 20),
+                cost: new LlmCost { InputCost = 0.001m, OutputCost = 0.002m, ModelId = "test-model", Provider = "test" }));
+
+        var query = new AskQuestionQuery(
+            GameId: gameId,
+            Question: "How does the pawn move?",
+            Language: "en",
+            UserId: userId);
+
+        var handler = BuildHandler();
+
+        // Act
+        await handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        capturedUserPrompt.Should().Contain("[House Rule for this group]");
+        capturedUserPrompt.Should().Contain(houseRule);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 5: HouseRuleMatcher throws — warning logged, flow continues
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WhenHouseRuleMatcherThrows_LogsWarningAndContinues()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        const string answer = "The pawn moves forward one space.";
+
+        SetupDefaultMocksWithSearchResults(gameId, answer);
+
+        _mockPricingEngine
+            .Setup(p => p.ConsumeQuotaAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _mockHouseRuleMatcher
+            .Setup(m => m.FindMatchingHouseRuleAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("AgentMemory BC unavailable"));
+
+        _mockTranslationService
+            .Setup(t => t.TranslateGenericAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string text, string src, string tgt, CancellationToken _) =>
+                TranslationResult.CreateSuccess(text, src, tgt, 0m));
+
+        var query = new AskQuestionQuery(
+            GameId: gameId,
+            Question: "How does the pawn move?",
+            Language: "en",
+            UserId: userId);
+
+        var handler = BuildHandler();
+
+        // Act — must not throw despite HouseRuleMatcher failure (graceful degradation)
+        var result = await handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert: flow continued and returned a response
+        result.Should().NotBeNull();
+
+        // Warning was logged for the failure
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((o, _) => o.ToString()!.Contains("House rule lookup failed")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "A warning should be logged when house rule lookup fails");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 6: Translation service fails — original answer returned + warning logged
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WhenTranslationFails_ReturnsOriginalAnswerWithWarning()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        const string originalAnswer = "The pawn moves forward one space.";
+
+        SetupDefaultMocksWithSearchResults(gameId, originalAnswer);
+
+        _mockPricingEngine
+            .Setup(p => p.ConsumeQuotaAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _mockHouseRuleMatcher
+            .Setup(m => m.FindMatchingHouseRuleAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        _mockTranslationService
+            .Setup(t => t.TranslateGenericAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TranslationResult.CreateFailure("en", "fr", "PROVIDER_ERROR", "LLM unreachable"));
+
+        var query = new AskQuestionQuery(
+            GameId: gameId,
+            Question: "How does the pawn move?",
+            Language: "en",
+            ResponseLanguage: "fr");
+
+        var handler = BuildHandler();
+
+        // Act
+        var result = await handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert: original answer preserved
+        result.Answer.Should().Be(originalAnswer);
+
+        // Warning was logged
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((o, _) => o.ToString()!.Contains("Translation failed")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "A warning should be logged when translation fails");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 7: ResponseLanguage same as Language — translation skipped (no-op)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WithResponseLanguageSameAsLanguage_SkipsTranslation()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        const string answer = "The pawn moves forward one space.";
+
+        SetupDefaultMocksWithSearchResults(gameId, answer);
+
+        _mockPricingEngine
+            .Setup(p => p.ConsumeQuotaAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _mockHouseRuleMatcher
+            .Setup(m => m.FindMatchingHouseRuleAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        var query = new AskQuestionQuery(
+            GameId: gameId,
+            Question: "How does the pawn move?",
+            Language: "en",
+            ResponseLanguage: "en"); // same as Language
+
+        var handler = BuildHandler();
+
+        // Act
+        var result = await handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Answer.Should().Be(answer);
+        _mockTranslationService.Verify(
+            t => t.TranslateGenericAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private AskQuestionQueryHandler BuildHandler() =>
+        new(
+            _searchHandler,
+            _mockQualityService.Object,
+            _mockChatContextService.Object,
+            _mockThreadRepository.Object,
+            _mockPdfDocumentRepository.Object,
+            _mockLlmService.Object,
+            _mockPromptTemplateService.Object,
+            _mockValidationPipeline.Object,
+            CreatePermissiveRagAccessServiceMock(),
+            Mock.Of<IRagQualityTracker>(),
+            new QueryComplexityAnalyzer(),
+            _mockResponseCache.Object,
+            _mockEmbeddingService.Object,
+            _mockHouseRuleMatcher.Object,
+            _mockPricingEngine.Object,
+            _mockTranslationService.Object,
+            _mockLogger.Object);
+
+    private void SetupDefaultMocks(Guid gameId)
+    {
+        _mockQualityService
+            .Setup(s => s.CalculateSearchConfidence(It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>()))
+            .Returns(new Confidence(0.8));
+        _mockQualityService
+            .Setup(s => s.CalculateLlmConfidence(It.IsAny<string>(), It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>()))
+            .Returns(new Confidence(0.75));
+        _mockQualityService
+            .Setup(s => s.CalculateOverallConfidence(It.IsAny<Confidence>(), It.IsAny<Confidence>()))
+            .Returns(new Confidence(0.77));
+        _mockQualityService
+            .Setup(s => s.IsLowQuality(It.IsAny<Confidence>()))
+            .Returns(false);
+
+        _mockChatContextService
+            .Setup(s => s.ShouldIncludeChatHistory(It.IsAny<ChatThread>()))
+            .Returns(false);
+        _mockChatContextService
+            .Setup(s => s.EnrichPromptWithHistory(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns<string, string>((b, _) => b);
+
+        _mockPromptTemplateService
+            .Setup(s => s.GetActivePromptAsync("rag-system-prompt", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("Test system prompt");
+
+        _mockValidationPipeline
+            .Setup(v => v.ValidateWithMultiModelAsync(
+                It.IsAny<Api.Models.QaResponse>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RagValidationResult
+            {
+                IsValid = true,
+                LayersPassed = 4,
+                TotalLayers = 4,
+                ConfidenceValidation = new ConfidenceValidationResult
+                {
+                    IsValid = true,
+                    ValidationMessage = "Confidence is acceptable",
+                    Severity = ValidationSeverity.Pass,
+                    ActualConfidence = 0.8,
+                    RequiredThreshold = 0.7
+                },
+                MultiModelConsensus = new MultiModelConsensusResult
+                {
+                    HasConsensus = true,
+                    SimilarityScore = 0.95,
+                    RequiredThreshold = 0.90,
+                    Gpt4Response = new ModelResponse
+                    {
+                        ModelId = "gpt-4",
+                        ResponseText = "Test response",
+                        IsSuccess = true,
+                        DurationMs = 100,
+                        Usage = new LlmUsage(50, 25, 75)
+                    },
+                    ClaudeResponse = new ModelResponse
+                    {
+                        ModelId = "claude-3",
+                        ResponseText = "Test response",
+                        IsSuccess = true,
+                        DurationMs = 100,
+                        Usage = new LlmUsage(50, 25, 75)
+                    },
+                    ConsensusResponse = "Test response",
+                    Message = "Consensus achieved",
+                    TotalDurationMs = 200,
+                    Severity = ConsensusSeverity.High
+                },
+                CitationValidation = new CitationValidationResult
+                {
+                    IsValid = true,
+                    TotalCitations = 3,
+                    ValidCitations = 3,
+                    Errors = new List<CitationValidationError>(),
+                    Message = "All citations valid"
+                },
+                HallucinationDetection = new HallucinationValidationResult
+                {
+                    IsValid = true,
+                    DetectedKeywords = new List<string>(),
+                    Language = "en",
+                    TotalKeywordsChecked = 0,
+                    Message = "No hallucinations detected",
+                    Severity = HallucinationSeverity.None
+                },
+                ValidationAccuracyMetrics = "Validation accuracy tracking enabled",
+                Message = "All validations passed",
+                Severity = RagValidationSeverity.Pass,
+                DurationMs = 10
+            });
+    }
+
+    private void SetupDefaultMocksWithSearchResults(Guid gameId, string llmAnswer)
+    {
+        SetupDefaultMocks(gameId);
+
+        // Return one search result so the handler doesn't early-exit at "no context"
+        var oneResult = new List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>
+        {
+            new(id: Guid.NewGuid(),
+                vectorDocumentId: Guid.NewGuid(),
+                textContent: "Sample rulebook text for testing.",
+                pageNumber: 1,
+                relevanceScore: new Confidence(0.85),
+                rank: 1,
+                searchMethod: "hybrid")
+        };
+        _mockRrfService
+            .Setup(r => r.FuseResults(
+                It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(),
+                It.IsAny<List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.SearchResult>>(),
+                It.IsAny<int>()))
+            .Returns(oneResult);
+
+        _mockLlmService
+            .Setup(s => s.GenerateCompletionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(LlmCompletionResult.CreateSuccess(
+                response: llmAnswer,
+                usage: new LlmUsage(10, 10, 20),
+                cost: new LlmCost
+                {
+                    InputCost = 0.001m,
+                    OutputCost = 0.002m,
+                    ModelId = "test-model",
+                    Provider = "test"
+                }));
+    }
+
+    private static IRagAccessService CreatePermissiveRagAccessServiceMock()
+    {
+        var mock = new Mock<IRagAccessService>();
+        mock.Setup(s => s.CanAccessRagAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<UserRole>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        return mock.Object;
+    }
+}

--- a/infra/compose.test.yml
+++ b/infra/compose.test.yml
@@ -1,0 +1,86 @@
+# E2E test environment for Libro Game AI Assistant Phase 2
+# Isolated stack for testing translation + Q&A flows
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f compose.test.yml up -d
+#
+# Tests run against this isolated environment.
+# Postgres binds to :5433, Redis binds to :6380 (no dev conflict).
+# Data is in-memory (tmpfs) — destroyed on stack down.
+
+services:
+  # ===========================================================================
+  # Core Infrastructure (Test Overrides)
+  # ===========================================================================
+
+  postgres:
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_DB: meepleai_test
+      POSTGRES_USER: meepleai_test
+      POSTGRES_PASSWORD: test_password
+    ports:
+      - "127.0.0.1:5433:5432"
+    tmpfs:
+      - /var/lib/postgresql/data
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "127.0.0.1:6380:6379"
+    command: ["redis-server", "--save", ""]
+    tmpfs:
+      - /data
+
+  # ===========================================================================
+  # Application Services (Test Configuration)
+  # ===========================================================================
+
+  api:
+    env_file:
+      - ./secrets/test.secret
+    ports:
+      - "127.0.0.1:8080:8080"
+    environment:
+      ASPNETCORE_ENVIRONMENT: Testing
+      ASPNETCORE_URLS: http://+:8080
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: "5432"
+      POSTGRES_DB: meepleai_test
+      POSTGRES_USER: meepleai_test
+      REDIS_HOST: redis
+      REDIS_PORT: "6379"
+      # Translation service flags
+      TRANSLATION_SERVICE_ENABLED: "true"
+      # Pricing engine disabled in test (use NullPricingEngine)
+      PRICING_ENGINE_MODE: "null"
+      # Hallucination gate disabled for test determinism
+      HALLUCINATION_GATE_ENABLED: "false"
+      # Embedding: use local test instance (if available) or mock
+      EMBEDDING_PROVIDER: external
+      Embedding__Provider: External
+      EMBEDDING_MODEL: intfloat/multilingual-e5-base
+      Embedding__Model: intfloat/multilingual-e5-base
+      EMBEDDING_DIMENSIONS: 768
+      Embedding__Dimensions: 768
+      EMBEDDING_FALLBACK_ENABLED: "false"
+      Embedding__FallbackEnabled: "false"
+    volumes:
+      - ./secrets:/app/infra/secrets:ro
+
+  web:
+    ports:
+      - "127.0.0.1:3000:3000"
+    build:
+      args:
+        NEXT_PUBLIC_API_BASE: http://localhost:8080
+        NEXT_PUBLIC_ALPHA_MODE: "false"
+    environment:
+      NODE_ENV: test
+      API_BASE_URL: http://api:8080
+      NEXT_PUBLIC_API_BASE: http://localhost:8080
+
+# =============================================================================
+# Test-specific volumes (separate to avoid conflicts)
+# =============================================================================
+volumes: {}

--- a/infra/secrets/test.secret.example
+++ b/infra/secrets/test.secret.example
@@ -1,0 +1,57 @@
+# Test environment secrets — copy to test.secret and fill in values.
+# DO NOT commit test.secret (it's in .gitignore).
+#
+# This file enables compose.test.yml stack startup.
+# Test environment uses stub/mock values for external services.
+
+# ===========================================================================
+# Database
+# ===========================================================================
+POSTGRES_CONNECTION_STRING=Host=postgres;Port=5432;Database=meepleai_test;Username=meepleai_test;Password=test_password
+POSTGRES_USER=meepleai_test
+POSTGRES_PASSWORD=test_password
+POSTGRES_DB=meepleai_test
+
+# ===========================================================================
+# Redis
+# ===========================================================================
+REDIS_CONNECTION_STRING=redis:6379
+REDIS_PASSWORD=
+
+# ===========================================================================
+# JWT & Session (Test-Only Keys — Not Secure)
+# ===========================================================================
+JWT_SECRET_KEY=test_only_not_secure_32_char_min_kkkkkkkkkkkkkkkkkkkkkk
+JWT_ISSUER=meepleai-test
+JWT_AUDIENCE=meepleai-web-test
+
+# ===========================================================================
+# LLM API Keys (Stub Values — Tests Should Mock)
+# ===========================================================================
+# Real keys not needed in test; configure mocks in test fixtures
+OPENROUTER_API_KEY=test-stub-key-openrouter
+ANTHROPIC_API_KEY=test-stub-key-anthropic
+OPENAI_API_KEY=test-stub-key-openai
+DEEPSEEK_API_KEY=test-stub-key-deepseek
+
+# ===========================================================================
+# Embedding Service (Test Stub)
+# ===========================================================================
+# Leave blank or use mock provider — tests should not require real embeddings
+EMBEDDING_SERVICE_API_KEY=test-stub-embedding
+
+# ===========================================================================
+# Admin Credentials (Test-Only)
+# ===========================================================================
+ADMIN_USERNAME=admin
+ADMIN_EMAIL=admin@test.local
+ADMIN_PASSWORD=test_password_123
+
+# ===========================================================================
+# Storage Provider (Test: Local)
+# ===========================================================================
+STORAGE_PROVIDER=local
+S3_ENDPOINT=http://minio:9000
+S3_ACCESS_KEY=test-key
+S3_SECRET_KEY=test-secret
+S3_BUCKET_NAME=meepleai-test


### PR DESCRIPTION
## Summary

Phase 2 bundle: Task 2.3b (`AskQuestionQueryHandler` extension) + Task 2.6 (`GameGlossaryEntry` — NER deferred) + Task 2.8 (`compose.test.yml`).

**Stats**: 3 commit, 26 files, 17643 insertions, 8 deletions, 15 new unit tests pass.

## Tasks

| Task | Status | Commit | Tests |
|------|--------|--------|-------|
| 2.3b — AskQuestionQueryHandler ext (ResponseLang + house rule + quota) | ✅ | `2b2a03a1c` | 7+5 unit (no regression) |
| 2.6 — GlossaryEntry entity + commands + endpoints (NER deferred Phase 3) | ✅ | `f30706828` | 5+3 unit |
| 2.8 — `infra/compose.test.yml` E2E env + test.secret template | ✅ | `43e45ca08` | infra config |

## Task 2.3b — AskQuestionQueryHandler Phase 2 extension

Estende il KB Q&A handler con 3 nuove dipendenze:
- **`IHouseRuleMatcher`**: cross-BC AgentMemory read, augmenta user prompt con `[House Rule for this group]\n{rule}\n\n` prefix
- **`IPricingEngine`** + `NullPricingEngine` (stub Phase 3 replace): chiamato come `ConsumeQuotaAsync(userId, "qa_question")`, throws `ForbiddenException(409)` if denied
- **`IGenericTranslationService`**: post-response translation when `query.ResponseLanguage` differs from `query.Language`

`AskQuestionQuery` esteso: aggiunto `string? ResponseLanguage = null` come 9° optional record param.

**Graceful degradation**:
- House rule lookup failure → log warning + continue (cross-BC failure non blocca Q&A)
- Translation failure → log warning + return original answer

**Constructor params**: 14 → 17 (boundary; Phase 3 può raggruppare in `QaEnrichmentServices` record).

## Task 2.6 — GlossaryEntry (scope-reduced)

⚠️ **Scope reduction**: NER auto-bootstrap (SpaCy + Quartz job) deferred Phase 3.

Implementato:
- `GlossaryEntry` value object in `AgentMemory.Domain.Models` (mirror HouseRule pattern)
- `GlossaryEntrySource` enum (Manual, UserDefined, NerBootstrap — Phase 3 readiness)
- `GameMemory.AddGlossaryEntry()` con duplicate guard same-language
- `AddGlossaryEntryCommand` + handler (throws `ConflictException` on duplicate)
- `GetGlossaryQuery` + handler + `GlossaryEntryDto`
- Endpoints: `POST` + `GET /api/v1/agent-memory/games/{gameId}/memory/glossary`
- Migration `20260505090846_AddGlossaryEntriesToGameMemory.cs` adds `glossary_entries_json` JSONB column

**Persistence pattern**: `GameMemoryEntity` infrastructure entity + manual JSON ser/deser via reflection (matched existing `HouseRule` pattern, NOT direct EF JSONB on domain).

## Task 2.8 — compose.test.yml E2E

- `infra/compose.test.yml`: postgres :5433 + redis :6380 (no dev conflict), tmpfs in-memory storage
- `ASPNETCORE_ENVIRONMENT=Testing` + `PRICING_ENGINE_MODE=null` + `HALLUCINATION_GATE_ENABLED=false`
- `infra/secrets/test.secret.example` template

## Spike findings cumulative (Sprint 0+1 + Phase 2)

Pattern compliance verified:
- `IGameMemoryRepository.GetByGameAndOwnerAsync` confirmed
- `GameMemory` separate persistence entity pattern (NOT direct EF JSONB on domain)
- Auth helper: `httpContext.User.GetUserId()` (NOT `TryGetAuthenticatedUser`) per AgentMemoryEndpoints existing pattern
- `ICommand` (NOT `ICommand<Unit>`) per existing void command convention
- `compose.*.yml` naming (NOT `docker-compose.*.yml`)

## Acceptance Criteria

**Task 2.3b** (5/5 AC verified):
- ResponseLanguage triggers translation ✅
- ResponseLanguage = null skips translation ✅
- ConsumeQuotaAsync false → ForbiddenException ✅
- HouseRule match injected in prompt ✅
- Translation failure → original answer + warning ✅

**Task 2.6** (7/7 AC verified):
- AddGlossaryEntry creates entry ✅
- Duplicate term same language → ConflictException ✅
- GetGlossary returns DTO list ✅
- Cross-language allowed ✅
- glossary_entries_json JSONB column ✅
- Cross-game scoping via (game_id, owner_id) ✅
- Endpoints POST + GET registered ✅

**Task 2.8** (6/6 AC verified):
- compose.test.yml stack startup ✅
- Postgres :5433 (no dev conflict) ✅
- Redis :6380 (no dev conflict) ✅
- ASPNETCORE_ENVIRONMENT=Testing ✅
- test.secret.example committed, *.secret in .gitignore ✅
- API endpoint accessibility ✅

## Pattern compliance

- ✅ `internal sealed class/record/interface/enum` (Sprint 0+1 lesson)
- ✅ Snake_case migrations (Sprint 0+1 lesson)
- ✅ Existing test framework matched (Moq for AgentMemory tests, NSubstitute for KB)
- ✅ Cross-BC graceful degradation (try/catch returns null + warning log)
- ✅ ConflictException for domain rule violations (NOT InvalidOperationException to caller)

## Reference

- Phase 2 detailed plan: `docs/superpowers/plans/2026-05-04-libro-game-assistant-phase2-detailed.md`
- Forward dep IPricingEngine: Phase 3 Task 3.2 (`CreditBasedPricingEngine` will replace `NullPricingEngine`)
- NER deferred: Phase 3 (Task 2.6 NER bootstrap features)

## Phase 2 progress

| Task | Status |
|------|--------|
| 2.1 — TranslationService + OpenRouter | ✅ Mergiato |
| 2.2 — TranslationCache Redis | ✅ Mergiato |
| 2.3a — KB Indexing Services | ✅ Mergiato |
| 2.4 — IQAComplexityClassifier | ✅ Mergiato |
| 2.5 — IHouseRuleMatcher | ✅ Mergiato |
| **2.3b** — AskQuestionQueryHandler ext | 🔍 **This PR** |
| **2.6** — GlossaryEntry (NER deferred) | 🔍 **This PR** |
| **2.8** — compose.test.yml | 🔍 **This PR** |
| 2.7 — Hallucination CI gate | 🔵 HARD BLOCKER B-3 (golden set ≥50) |
| 2.9 — Phase 2 acceptance gate | ⚪ Pending 2.7 |

## Test Plan

- [x] Backend unit tests: 15 new + no regression (Phase 2 tests + 92 AgentMemory pre-existing)
- [x] dotnet build: 0 errors, 4 pre-existing warnings only
- [ ] Aaron review + approve
- [ ] Aaron confirm NER deferral strategy (Phase 3 Task 2.6 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)