### PR TITLE
feat(document-processing): G2 wire PhotoBatchProcessor → KB indexing

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/PhotoBatchProcessor.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/PhotoBatchProcessor.cs
@@ -10,25 +10,28 @@ namespace Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
 
 /// <summary>
 /// Parallel batch processor for photo uploads in the Libro Game AI Assistant pipeline.
-/// Retrieves page blobs, preprocesses each via OCR, and records indexed pages on the aggregate.
-/// Libro Game AI Assistant MVP Phase 1 — Task 1.6.
+/// Retrieves page blobs, preprocesses each via OCR, chunks the extracted text, and
+/// indexes chunks into the KB vector store before recording page state on the aggregate.
+/// Libro Game AI Assistant MVP Phase 1 — Task 1.6 / Phase 2 — Task 2.3.
 /// </summary>
 /// <remarks>
-/// Thread-safety: IO operations (blob retrieve + preprocess) run in parallel up to
-/// <c>PhotoBatch:MaxParallelism</c>. Aggregate state mutations
+/// Thread-safety: IO operations (blob retrieve + preprocess + chunk + KB index) run in
+/// parallel up to <c>PhotoBatch:MaxParallelism</c>. Aggregate state mutations
 /// (<see cref="PhotoBatchUpload.AttachPage"/> and <see cref="PhotoBatchUpload.RecordPageIndexed"/>)
 /// are serialized via <see cref="_aggregateMutex"/> to avoid race conditions on the
 /// <see cref="PhotoBatchUpload"/> entity collections.
 ///
-/// KB indexing (IDocumentChunker, IEmbeddingService, IKnowledgeBaseIndexer) is intentionally
-/// excluded from this class — deferred to Phase 2 Task 2.3 once those KnowledgeBase BC
-/// services are implemented.
+/// KB indexing failure is treated as a non-fatal degradation: if <see cref="IKnowledgeBaseIndexer"/>
+/// throws, the error is logged and page state is still recorded normally (batch completes).
+/// Vector store persistence is stubbed in <see cref="KnowledgeBaseIndexer"/> pending Gap G3.
 /// </remarks>
 internal sealed class PhotoBatchProcessor : IPhotoBatchProcessor, IDisposable
 {
     private readonly IPhotoBatchUploadRepository _repo;
     private readonly IBlobStorageService _blob;
     private readonly IPhotoPreprocessor _preprocessor;
+    private readonly IDocumentChunker _chunker;
+    private readonly IKnowledgeBaseIndexer _kbIndexer;
     private readonly IUnitOfWork _uow;
     private readonly int _maxParallelism;
     private readonly ILogger<PhotoBatchProcessor> _logger;
@@ -40,6 +43,8 @@ internal sealed class PhotoBatchProcessor : IPhotoBatchProcessor, IDisposable
         IPhotoBatchUploadRepository repo,
         IBlobStorageService blob,
         IPhotoPreprocessor preprocessor,
+        IDocumentChunker chunker,
+        IKnowledgeBaseIndexer kbIndexer,
         IUnitOfWork uow,
         IConfiguration config,
         ILogger<PhotoBatchProcessor> logger)
@@ -47,6 +52,8 @@ internal sealed class PhotoBatchProcessor : IPhotoBatchProcessor, IDisposable
         _repo = repo;
         _blob = blob;
         _preprocessor = preprocessor;
+        _chunker = chunker;
+        _kbIndexer = kbIndexer;
         _uow = uow;
         _maxParallelism = config.GetValue<int?>("PhotoBatch:MaxParallelism") ?? 4;
         _logger = logger;
@@ -155,18 +162,41 @@ internal sealed class PhotoBatchProcessor : IPhotoBatchProcessor, IDisposable
             warnings: preprocessed.Warnings,
             extractedText: preprocessed.ExtractedText);
 
-        // 5. Serialize aggregate state mutations to avoid concurrent list/counter corruption.
+        // 5. Chunk + index extracted text into KB (outside mutex — parallel-safe IO).
+        //    Skip blank pages and pages with no extracted text.
+        //    KB indexing failure is non-fatal: log and continue so page state is still recorded.
+        if (!preprocessed.IsBlankPage && !string.IsNullOrWhiteSpace(preprocessed.ExtractedText))
+        {
+            try
+            {
+                var chunks = _chunker.ChunkPage(
+                    batch.Id, page.Id, page.PageNumber,
+                    preprocessed.ExtractedText, batch.SourceLanguage, (float)preprocessed.ConfidenceScore);
+
+                if (chunks.Count > 0)
+                {
+                    var indexed = await _kbIndexer.IndexBatchAsync(
+                        batch.Id, batch.GameId, chunks, progress: null, ct).ConfigureAwait(false);
+
+                    _logger.LogDebug(
+                        "[PhotoBatchProcessor] Page {PageNumber} of batch {BatchId}: {ChunkCount} chunks, {IndexedCount} indexed",
+                        page.PageNumber, batch.Id, chunks.Count, indexed);
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // KB indexing failure must NOT abort the batch — page state still recorded below.
+                _logger.LogError(ex,
+                    "[PhotoBatchProcessor] KB indexing failed for page {PageNumber} of batch {BatchId} — continuing",
+                    page.PageNumber, batch.Id);
+            }
+        }
+
+        // 6. Serialize aggregate state mutations to avoid concurrent list/counter corruption.
         await _aggregateMutex.WaitAsync(ct).ConfigureAwait(false);
         try
         {
             batch.AttachPage(page);
-
-#pragma warning disable S1135, MA0026
-            // TODO Phase 2 Task 2.3: chunk + embed + KB index here when KnowledgeBase BC
-            // services are ready (IDocumentChunker, IEmbeddingService, IKnowledgeBaseIndexer
-            // are not yet implemented in Phase 1). The extracted text is already on `page`.
-#pragma warning restore S1135, MA0026
-
             batch.RecordPageIndexed(page.PageNumber, preprocessed.ConfidenceScore, preprocessed.Warnings);
         }
         finally

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/PhotoBatchProcessorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/PhotoBatchProcessorTests.cs
@@ -10,13 +10,14 @@ using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Api.Tests.BoundedContexts.DocumentProcessing.Infrastructure.Services;
 
 /// <summary>
 /// Unit tests for <see cref="PhotoBatchProcessor"/>.
-/// Libro Game AI Assistant MVP Phase 1 — Task 1.6.
+/// Libro Game AI Assistant MVP Phase 1 — Task 1.6 / Phase 2 — Task 2.3.
 /// </summary>
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "DocumentProcessing")]
@@ -25,6 +26,8 @@ public class PhotoBatchProcessorTests
     private readonly IPhotoBatchUploadRepository _repo = Substitute.For<IPhotoBatchUploadRepository>();
     private readonly IBlobStorageService _blob = Substitute.For<IBlobStorageService>();
     private readonly IPhotoPreprocessor _preprocessor = Substitute.For<IPhotoPreprocessor>();
+    private readonly IDocumentChunker _chunker = Substitute.For<IDocumentChunker>();
+    private readonly IKnowledgeBaseIndexer _kbIndexer = Substitute.For<IKnowledgeBaseIndexer>();
     private readonly IUnitOfWork _uow = Substitute.For<IUnitOfWork>();
 
     private PhotoBatchProcessor CreateSut(int maxParallelism = 4)
@@ -40,6 +43,8 @@ public class PhotoBatchProcessorTests
             _repo,
             _blob,
             _preprocessor,
+            _chunker,
+            _kbIndexer,
             _uow,
             config,
             NullLogger<PhotoBatchProcessor>.Instance);
@@ -57,6 +62,9 @@ public class PhotoBatchProcessorTests
             IsBlankPage: isBlank,
             Warnings: Array.Empty<string>());
 
+    private static KnowledgeChunk MakeChunk(Guid batchId, Guid pageId, int pageNumber = 1)
+        => KnowledgeChunk.Create(batchId, pageId, pageNumber, "test chunk text", 0, 0, 16, "en", 0.9f);
+
     [Fact]
     public async Task ProcessAsync_BatchOf3Pages_IndexesAllAndCompletes()
     {
@@ -71,6 +79,11 @@ public class PhotoBatchProcessorTests
 
         _preprocessor.PreprocessAsync(Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
             .Returns(MakePreprocessResult());
+
+        // Chunker returns empty list by default (no chunks → indexer not called)
+        _chunker.ChunkPage(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<int>(),
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<float>())
+            .Returns(Array.Empty<KnowledgeChunk>());
 
         var sut = CreateSut(maxParallelism: 4);
 
@@ -100,6 +113,10 @@ public class PhotoBatchProcessorTests
         _preprocessor.PreprocessAsync(Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
             .Returns(MakePreprocessResult());
 
+        _chunker.ChunkPage(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<int>(),
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<float>())
+            .Returns(Array.Empty<KnowledgeChunk>());
+
         var sut = CreateSut();
 
         // Act — should NOT throw even though StartProcessing would throw on Processing status
@@ -127,6 +144,10 @@ public class PhotoBatchProcessorTests
 
         _preprocessor.PreprocessAsync(Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
             .Returns(MakePreprocessResult());
+
+        _chunker.ChunkPage(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<int>(),
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<float>())
+            .Returns(Array.Empty<KnowledgeChunk>());
 
         // Use parallelism=1 for deterministic page ordering
         var sut = CreateSut(maxParallelism: 1);
@@ -168,6 +189,10 @@ public class PhotoBatchProcessorTests
         _preprocessor.PreprocessAsync(Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
             .Returns(MakePreprocessResult(confidence: 0.95));
 
+        _chunker.ChunkPage(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<int>(),
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<float>())
+            .Returns(Array.Empty<KnowledgeChunk>());
+
         var sut = CreateSut();
 
         // Act
@@ -191,10 +216,14 @@ public class PhotoBatchProcessorTests
         _preprocessor.PreprocessAsync(Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
             .Returns(MakePreprocessResult());
 
+        _chunker.ChunkPage(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<int>(),
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<float>())
+            .Returns(Array.Empty<KnowledgeChunk>());
+
         // Empty config → no MaxParallelism key
         var config = new ConfigurationBuilder().Build();
         var sut = new PhotoBatchProcessor(
-            _repo, _blob, _preprocessor, _uow, config,
+            _repo, _blob, _preprocessor, _chunker, _kbIndexer, _uow, config,
             NullLogger<PhotoBatchProcessor>.Instance);
 
         // Act — should not throw, default parallelism applied
@@ -203,5 +232,107 @@ public class PhotoBatchProcessorTests
 
         batch.IndexedPages.Should().Be(1);
         batch.Status.Should().Be(PhotoBatchStatus.Completed);
+    }
+
+    // ── New tests: G2 wiring (IDocumentChunker + IKnowledgeBaseIndexer) ──────────────────
+
+    [Fact]
+    public async Task ProcessAsync_WithExtractedText_CallsChunkerAndIndexer()
+    {
+        // Arrange: 1 non-blank page with extracted text
+        var batch = PhotoBatchUpload.Create(Guid.NewGuid(), Guid.NewGuid(), "en", 1);
+        var batchId = batch.Id;
+
+        _repo.FindByIdWithPagesAsync(batchId, Arg.Any<CancellationToken>()).Returns(batch);
+        _blob.RetrieveAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ => (Stream)new MemoryStream(new byte[] { 1, 2, 3 }));
+        _preprocessor.PreprocessAsync(Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(MakePreprocessResult(text: "Move your piece forward three spaces.", confidence: 0.9, isBlank: false));
+
+        // Chunker returns 1 chunk → indexer should be called
+        _chunker.ChunkPage(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<int>(),
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<float>())
+            .Returns(ci => new[] { MakeChunk(ci.ArgAt<Guid>(0), ci.ArgAt<Guid>(1)) });
+
+        _kbIndexer.IndexBatchAsync(Arg.Any<Guid>(), Arg.Any<Guid>(),
+                Arg.Any<IReadOnlyList<KnowledgeChunk>>(), Arg.Any<IProgress<int>?>(), Arg.Any<CancellationToken>())
+            .Returns(1);
+
+        var sut = CreateSut(maxParallelism: 1);
+
+        // Act
+        await sut.ProcessAsync(batchId, CancellationToken.None);
+
+        // Assert: chunker called once, indexer called once
+        _chunker.Received(1).ChunkPage(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<int>(),
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<float>());
+        await _kbIndexer.Received(1).IndexBatchAsync(Arg.Any<Guid>(), Arg.Any<Guid>(),
+            Arg.Any<IReadOnlyList<KnowledgeChunk>>(), Arg.Any<IProgress<int>?>(), Arg.Any<CancellationToken>());
+
+        // Batch still completes normally
+        batch.Status.Should().Be(PhotoBatchStatus.Completed);
+        batch.IndexedPages.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WithBlankPage_DoesNotCallChunkerOrIndexer()
+    {
+        // Arrange: 1 page where IsBlankPage=true
+        var batch = PhotoBatchUpload.Create(Guid.NewGuid(), Guid.NewGuid(), "en", 1);
+        var batchId = batch.Id;
+
+        _repo.FindByIdWithPagesAsync(batchId, Arg.Any<CancellationToken>()).Returns(batch);
+        _blob.RetrieveAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ => (Stream)new MemoryStream(new byte[] { 1 }));
+        _preprocessor.PreprocessAsync(Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(MakePreprocessResult(text: "", confidence: 0.3, isBlank: true));
+
+        var sut = CreateSut(maxParallelism: 1);
+
+        // Act
+        await sut.ProcessAsync(batchId, CancellationToken.None);
+
+        // Assert: neither chunker nor indexer called
+        _chunker.DidNotReceive().ChunkPage(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<int>(),
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<float>());
+        await _kbIndexer.DidNotReceive().IndexBatchAsync(Arg.Any<Guid>(), Arg.Any<Guid>(),
+            Arg.Any<IReadOnlyList<KnowledgeChunk>>(), Arg.Any<IProgress<int>?>(), Arg.Any<CancellationToken>());
+
+        // Batch still completes (blank page still recorded via RecordPageIndexed)
+        batch.IndexedPages.Should().Be(1);
+        batch.Status.Should().Be(PhotoBatchStatus.Completed);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_KbIndexingThrows_DoesNotAbortBatch()
+    {
+        // Arrange: chunker returns 1 chunk, indexer throws a non-cancellation exception
+        var batch = PhotoBatchUpload.Create(Guid.NewGuid(), Guid.NewGuid(), "en", 1);
+        var batchId = batch.Id;
+
+        _repo.FindByIdWithPagesAsync(batchId, Arg.Any<CancellationToken>()).Returns(batch);
+        _blob.RetrieveAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ => (Stream)new MemoryStream(new byte[] { 1, 2, 3 }));
+        _preprocessor.PreprocessAsync(Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+            .Returns(MakePreprocessResult(text: "Some board game text.", confidence: 0.85));
+
+        _chunker.ChunkPage(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<int>(),
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<float>())
+            .Returns(ci => new[] { MakeChunk(ci.ArgAt<Guid>(0), ci.ArgAt<Guid>(1)) });
+
+        // Indexer throws a transient infrastructure error
+        _kbIndexer.IndexBatchAsync(Arg.Any<Guid>(), Arg.Any<Guid>(),
+                Arg.Any<IReadOnlyList<KnowledgeChunk>>(), Arg.Any<IProgress<int>?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Embedding service unavailable"));
+
+        var sut = CreateSut(maxParallelism: 1);
+
+        // Act — must not propagate the indexer exception
+        Func<Task> act = () => sut.ProcessAsync(batchId, CancellationToken.None);
+        await act.Should().NotThrowAsync();
+
+        // Assert: batch still reaches Completed (graceful degradation)
+        batch.Status.Should().Be(PhotoBatchStatus.Completed);
+        batch.IndexedPages.Should().Be(1);
     }
 }


### PR DESCRIPTION
## Summary

**Smartphone E2E Sprint Gap G2** — wire PhotoBatchProcessor to call IDocumentChunker + IKnowledgeBaseIndexer dopo preprocessing per ogni page. Sblocca G3 (vector persistence) + smartphone E2E flow Q&A.

**Stats**: 1 commit, 2 files, 9/9 tests pass.

## Context

Pre-G2: `PhotoBatchProcessor.cs` (Sprint 1 Task 1.6, mergiato PR #705) had TODO comment:
```csharp
// TODO Phase 2 Task 2.3: chunk + embed + KB index here when KB BC services are ready
```

`IDocumentChunker` + `IKnowledgeBaseIndexer` services existed (PR #709 mergiato Phase 2 Task 2.3a) ma NON erano wired in PhotoBatchProcessor. Conseguenza: photo batch processing extracted text → preprocess → page records ✅ **MA** chunks NEVER generated, embeddings NEVER calculated, KB NEVER indexed → Q&A vector search returns 0 results.

## Refactor

**Constructor**: 2 new dependencies (`IDocumentChunker chunker`, `IKnowledgeBaseIndexer kbIndexer`).

**ProcessSinglePageAsync flow**:
1. Retrieve blob → preprocess (existing)
2. Create PhotoBatchPage VO (existing)
3. **NEW**: if non-blank + extracted text non-empty → call `chunker.ChunkPage(...)` → call `kbIndexer.IndexBatchAsync(...)` (BEFORE mutex acquisition, parallel-safe)
4. Acquire aggregate mutex → AttachPage + RecordPageIndexed (existing)

**Graceful degradation**: KB indexing failure logged but does NOT abort batch processing. `OperationCanceledException` propagates correctly via `when (ex is not OperationCanceledException)` filter.

**Skip path**: blank pages OR empty extracted text → skip chunking entirely (no LLM cost wasted).

## Tests (9/9 pass)

**6 existing tests updated** with new mock dependencies:
- `_chunker = Substitute.For<IDocumentChunker>()`
- `_kbIndexer = Substitute.For<IKnowledgeBaseIndexer>()`
- `MakeChunk(...)` helper for default chunk return value

**3 new tests**:
- `ProcessAsync_WithExtractedText_CallsChunkerAndIndexer` — verifies happy path
- `ProcessAsync_WithBlankPage_DoesNotCallChunkerOrIndexer` — verifies skip
- `ProcessAsync_KbIndexingThrows_DoesNotAbortBatch` — graceful degradation

## Spike findings

- `IDocumentChunker.ChunkPage(...)` returns `IReadOnlyList<KnowledgeChunk>` ✅
- `IKnowledgeBaseIndexer.IndexBatchAsync(...)` returns `Task<int>` ✅
- DI registration already present (lines 149-150 of `DocumentProcessingServiceExtensions.cs` from PR #709)
- TODO comment at lines 164-168 of PhotoBatchProcessor.cs

## Status

**Wiring complete end-to-end**:
- PhotoBatch upload → photo storage → preprocess (smoldocling) → chunking → embedding generation → ~~persistence~~ (still TODO Phase 3 / G3)

**G3 next**: vector store persistence via cross-BC ACL pattern. Once G3 done:
- ✅ Q&A vector search returns real results
- ✅ Smartphone E2E test flow viable

## Reference

- Phase 2 detailed plan: `docs/superpowers/plans/2026-05-04-libro-game-assistant-phase2-detailed.md`
- Sprint 1 Task 1.6 (PhotoBatchProcessor): mergiato PR #705
- Phase 2 Task 2.3a (KB Indexing Services): mergiato PR #709
- Smartphone E2E sprint: Gap analysis ULTRATHINK
- KnowledgeBaseIndexer persistence stub: TODO line 60 (G3 fix)

## Test Plan

- [x] Backend unit tests: 9/9 pass (6 existing updated + 3 new)
- [x] dotnet build: 0 errors, 4 pre-existing warnings only
- [x] No regression on existing PhotoBatchProcessor tests
- [ ] Aaron review + approve
- [ ] G3 vector persistence implementation (next gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)