### PR TITLE
feat(infra): single-tester implementation (Phase 1-4 + CF Tunnel runbooks)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -615,6 +615,18 @@ jobs:
           script: |
             cd /opt/meepleai/repo/infra
 
+            # Pre-deploy port cleanup — kill any stale process holding :8080
+            # (see memory: feedback_staging_stale_api_host_process)
+            # Refs: docs/superpowers/specs/2026-05-05-infrastructure-single-tester-design.md G1.C1
+            STALE_PIDS=$(sudo fuser 8080/tcp 2>/dev/null | tr -d ':' | xargs || true)
+            if [ -n "$STALE_PIDS" ]; then
+              echo "🧹 Killing stale processes on :8080 — PIDs: $STALE_PIDS"
+              sudo kill -9 $STALE_PIDS 2>/dev/null || true
+              sleep 2
+            else
+              echo "✅ Port :8080 is clean"
+            fi
+
             # Load secrets for docker compose
             set -a
             for f in secrets/*.secret; do source "$f" 2>/dev/null; done

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -666,8 +666,12 @@ jobs:
             done
 
             # Deploy only changed services (--force-recreate ensures container restarts even if image digest unchanged)
+            # Single-tester profiles: ai-essential (embedding+reranker) + monitoring-essential
+            # + proxy (traefik). NO orchestration, NO n8n, NO seq/cadvisor.
+            # See docs/superpowers/specs/2026-05-05-infrastructure-single-tester-design.md G3
             docker compose -f docker-compose.yml -f compose.staging.yml -f compose.traefik.yml \
-              --profile minimal up -d --no-deps --force-recreate $SERVICES
+              --profile ai-essential --profile monitoring-essential --profile proxy \
+              up -d --no-deps --force-recreate $SERVICES
 
             # Health check via docker exec (port not exposed on host)
             echo "⏳ Waiting for API health..."

--- a/docs/operations/cf-tunnel-migration.md
+++ b/docs/operations/cf-tunnel-migration.md
@@ -1,0 +1,176 @@
+# Cloudflare Tunnel Migration Runbook
+
+> **Goal**: Migrate `meepleai.app` from Traefik+Let's Encrypt edge to Cloudflare Tunnel.
+> **Audience**: project owner (single tester).
+> **Prerequisites**: Cloudflare account with `meepleai.app` zone; SSH access to staging.
+> **Estimated time**: 3-4 hours. Reversible via `cf-tunnel-rollback.md` in <30 min.
+> **Pre-migration smoke test**: `make -C infra smoke-staging` must pass automated set.
+
+## Phase 0 — Pre-flight
+
+1. Confirm staging is healthy:
+   ```bash
+   curl -sf https://meepleai.app/health | jq .
+   bash infra/scripts/smoke-set.sh https://meepleai.app
+   ```
+2. Backup current Traefik config:
+   ```bash
+   ssh -i ~/.ssh/meepleai-staging deploy@204.168.135.69 \
+     'cd /opt/meepleai/repo/infra && tar czf /tmp/traefik-backup-$(date +%Y%m%d).tgz traefik/ compose.traefik.yml'
+   ```
+3. Take DB backup:
+   ```bash
+   ssh -i ~/.ssh/meepleai-staging deploy@204.168.135.69 \
+     'cd /opt/meepleai/repo/infra && bash scripts/backup.sh'
+   ```
+4. Capture downtime baseline (for G2 measurable):
+   ```bash
+   # Terminal 1: continuous probe (run during migration window)
+   while true; do
+     printf "%s %s %s\n" "$(date -u +%H:%M:%S)" \
+       "$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 https://meepleai.app/health)" \
+       "$(curl -s -o /dev/null -w '%{time_total}s' --max-time 5 https://meepleai.app/health)"
+     sleep 1
+   done | tee /tmp/cf-cutover-probe.log
+   ```
+
+## Phase 1 — Cloudflare setup (web UI)
+
+1. Log into Cloudflare dashboard → Zero Trust → Networks → Tunnels.
+2. Create a new tunnel named `meepleai-staging`.
+3. Copy the `cloudflared` install command (includes the tunnel token).
+4. Configure routes (web UI):
+   - `meepleai.app` → `http://localhost:3000` (web)
+   - `api.meepleai.app` → `http://localhost:8080` (api)
+5. **REQUIRED for single-tester alpha (Fix #2 from spec-panel review)**: Configure CF Access policy:
+   - Application: `meepleai.app` (and `api.meepleai.app`)
+   - Policy: "owner-only" with email match → your email only.
+   - Identity provider: Google SSO (preferito; alternativa: One-time PIN via email).
+   - **NOTA**: senza CF Access, dopo Phase 5 (UFW chiude 80/443) gli endpoint non-auth (`/health`, `/api/v1/games`, `/metrics`) diventano pubblici via tunnel — single point of compromise per single-tester. Mandatory.
+
+## Phase 2 — Install `cloudflared` on VPS
+
+1. SSH to staging.
+2. Install daemon (the tunnel token from Phase 1 is embedded):
+   ```bash
+   sudo curl -L --output /tmp/cloudflared.deb \
+     https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm64.deb
+   sudo dpkg -i /tmp/cloudflared.deb
+   sudo cloudflared service install <TOKEN_FROM_PHASE_1>
+   sudo systemctl enable --now cloudflared
+   ```
+3. Verify daemon is running:
+   ```bash
+   sudo systemctl status cloudflared
+   sudo journalctl -u cloudflared -n 20
+   ```
+4. Verify tunnel is up in CF dashboard (status: Healthy).
+
+## Phase 3 — Expose API to localhost
+
+The API container currently does NOT bind a host port (only Traefik routes traffic). Add a temporary host bind so cloudflared can reach it.
+
+1. Edit `infra/compose.staging.yml` to add `ports: ["127.0.0.1:8080:8080"]` to the `api` service.
+2. Edit `infra/compose.staging.yml` to add `ports: ["127.0.0.1:3000:3000"]` to the `web` service.
+3. Restart:
+   ```bash
+   make -C /opt/meepleai/repo/infra staging-minimal
+   ```
+4. Verify:
+   ```bash
+   curl -sf http://localhost:8080/health | jq .
+   curl -sf http://localhost:3000 | head -3
+   ```
+
+## Phase 4 — Cutover
+
+1. Test traffic flow via CF Tunnel (DNS still on Traefik):
+   - In CF dashboard, temporarily map `dr-test.meepleai.app` → tunnel routes.
+   - `curl -sf https://dr-test.meepleai.app/health | jq .`
+   - If 200 OK with same payload as current, cutover is safe.
+   - **Cleanup**: remove `dr-test.meepleai.app` route from CF dashboard after verification.
+2. Switch DNS in CF dashboard:
+   - Replace A record `meepleai.app` → 204.168.135.69 with CNAME `meepleai.app` → `<tunnel-id>.cfargotunnel.com` (proxied).
+   - Same for `api.meepleai.app`.
+3. Wait for DNS propagation (target ≤5 min, but verify don't assume):
+   ```bash
+   # Loop until CF tunnel CNAME resolves
+   until dig +short meepleai.app | grep -q cfargotunnel; do
+     echo "$(date -u +%H:%M:%S) waiting DNS..."; sleep 10
+   done
+   echo "✅ DNS propagated to CF tunnel"
+   ```
+4. Run smoke set:
+   ```bash
+   bash infra/scripts/smoke-set.sh https://meepleai.app
+   ```
+   All automated checks must PASS.
+5. Stop the downtime probe (Phase 0 step 4) and review `/tmp/cf-cutover-probe.log` for the count of non-200 responses (this is the **measured downtime**).
+
+## Phase 5 — Lock down ports
+
+1. Enable UFW firewall:
+   ```bash
+   sudo ufw allow 22/tcp comment 'SSH'
+   sudo ufw deny 80/tcp  comment 'HTTP — closed (CF Tunnel)'
+   sudo ufw deny 443/tcp comment 'HTTPS — closed (CF Tunnel)'
+   sudo ufw enable
+   sudo ufw status verbose
+   ```
+2. Verify from external host:
+   ```bash
+   nmap -p 80,443,22 204.168.135.69
+   ```
+   Expected: 22 open, 80/443 filtered or closed.
+3. **Verify CF Access auth gate is active** (Fix #2 from spec-panel review):
+   ```bash
+   # Without auth header — should be 401/403 redirect to CF login
+   curl -si https://meepleai.app/api/v1/admin/health | head -3
+   curl -si https://meepleai.app/metrics            | head -3
+   ```
+   Expected: HTTP 302/401/403 (CF Access challenge) o HTML login page. **NOT** 200 con payload applicativo. Se 200, la CF Access policy non è attiva su quel route — torna a Phase 1 step 5.
+
+## Phase 6 — Decommission Traefik (after 7-day soak)
+
+After 7 days of CF Tunnel running with smoke set passing:
+
+1. Stop Traefik:
+   ```bash
+   docker compose -f docker-compose.yml -f compose.staging.yml -f compose.traefik.yml \
+     --profile proxy stop traefik docker-socket-proxy
+   ```
+2. Remove Traefik labels from `compose.staging.yml` (api, web, embedding, reranker, grafana, prometheus blocks).
+3. Remove Traefik secrets from `infra/secrets/`:
+   ```bash
+   rm infra/secrets/traefik.secret  # backup first if anything custom
+   ```
+4. Update `Makefile`:
+   - Remove `--profile proxy` from `staging-minimal` and `staging-with-tutor` targets.
+5. Commit:
+   ```bash
+   git add infra/compose.staging.yml infra/Makefile
+   git rm infra/secrets/traefik.secret
+   git commit -m "ops(infra): decommission Traefik after CF Tunnel migration"
+   ```
+
+## Phase 7 — Validation
+
+1. `bash infra/scripts/smoke-set.sh https://meepleai.app` → automated PASS.
+2. Manual UI checklist (`docs/operations/smoke-manual-ui-checklist.md`) → A4 + C5 PASS.
+3. `nmap -p 80,443 204.168.135.69` → filtered/closed.
+4. `free -m` on VPS → ≥6GB available (Traefik freed ~512MB).
+5. Add entry to `docs/operations/dr-walkthrough-log.md` with date + "CF Tunnel migration completed".
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `cloudflared` shows "DNS resolution failed" | Routes not configured in CF dashboard | Re-check Phase 1 step 4 |
+| `curl https://meepleai.app/health` returns 502 | API container not bound to localhost | Verify Phase 3 step 1 + restart |
+| Smoke set A1 fails (login) | CF Access blocking POST | Add CF Access bypass for `/api/v1/auth/*` paths or disable Access for staging |
+| `nmap` still shows 80/443 open | UFW not enabled or rule order wrong | `sudo ufw status verbose` and re-check Phase 5 |
+| `/metrics` returns 200 instead of 401/403 | CF Access policy not configured for that route | Add wildcard `*meepleai.app/*` policy in CF dashboard |
+
+## Rollback
+
+If anything breaks: `docs/operations/cf-tunnel-rollback.md`.

--- a/docs/operations/cf-tunnel-rollback.md
+++ b/docs/operations/cf-tunnel-rollback.md
@@ -1,0 +1,67 @@
+# Cloudflare Tunnel Rollback Runbook
+
+> **Goal**: Revert from Cloudflare Tunnel back to Traefik+Let's Encrypt edge.
+> **Estimated time**: 30 min.
+> **When to use**: smoke set fails after migration; CF Tunnel adds unacceptable latency; CF outage.
+
+## Phase 0 — Verify Traefik config still in repo
+
+```bash
+ls infra/traefik/ infra/compose.traefik.yml
+```
+Expected: files exist. If not, restore from `/tmp/traefik-backup-*.tgz` (created in cf-tunnel-migration.md Phase 0).
+
+## Phase 1 — Disable cloudflared
+
+```bash
+ssh -i ~/.ssh/meepleai-staging deploy@204.168.135.69
+sudo systemctl stop cloudflared
+sudo systemctl disable cloudflared
+```
+
+## Phase 2 — Re-open ports
+
+```bash
+sudo ufw allow 80/tcp  comment 'HTTP — Traefik'
+sudo ufw allow 443/tcp comment 'HTTPS — Traefik'
+sudo ufw status verbose
+```
+
+## Phase 3 — Restart Traefik
+
+```bash
+cd /opt/meepleai/repo/infra
+make staging-minimal  # or 'make staging' if you reverted Makefile changes
+docker ps --format "{{.Names}}" | grep traefik
+```
+Expected: `meepleai-traefik` and `meepleai-docker-socket-proxy` running.
+
+## Phase 4 — Switch DNS back
+
+In CF dashboard:
+- `meepleai.app` CNAME → A record pointing to 204.168.135.69 (proxied: orange cloud).
+- `api.meepleai.app` same.
+
+Wait for DNS propagation:
+```bash
+until dig +short meepleai.app | grep -q '^204\.168\.135\.69$'; do
+  echo "$(date -u +%H:%M:%S) waiting DNS revert..."; sleep 10
+done
+echo "✅ DNS reverted to direct A record"
+```
+
+## Phase 5 — Validate
+
+```bash
+curl -sf https://meepleai.app/health | jq .
+bash infra/scripts/smoke-set.sh https://meepleai.app
+```
+Expected: automated smoke PASS.
+
+## Phase 6 — Document the rollback
+
+Add an entry to `docs/operations/dr-walkthrough-log.md`:
+
+| Date | Action | Reason | Notes |
+|------|--------|--------|-------|
+| _yyyy-mm-dd_ | CF Tunnel rollback | _e.g., latency >300ms_ | _details_ |

--- a/docs/operations/dr-walkthrough-log.md
+++ b/docs/operations/dr-walkthrough-log.md
@@ -1,0 +1,22 @@
+# DR Walkthrough Log
+
+> Quarterly review log for `docs/operations/disaster-recovery-runbook.md`.
+> Triggered by `infra/scripts/dr-walkthrough-reminder.sh` (cron: 1st jan/apr/jul/oct).
+
+## How to log a walkthrough
+
+After receiving a quarterly reminder:
+
+1. Open `docs/operations/disaster-recovery-runbook.md`.
+2. Read end-to-end. For each step, verify:
+   - Commands still work as written (no deprecated flags, no removed scripts).
+   - Service names, paths, env vars match current `infra/docker-compose.yml`.
+   - Required secrets are listed in `infra/secrets/*.secret.example`.
+3. Note any **drift** (runbook says X, reality is Y).
+4. Add a row to the table below (most recent first).
+5. If drift was found, open a separate PR to fix the runbook.
+
+## Walkthrough Entries (most recent first)
+
+| Date | Drift Found | Status | Notes |
+|------|-------------|--------|-------|

--- a/docs/operations/smoke-manual-ui-checklist.md
+++ b/docs/operations/smoke-manual-ui-checklist.md
@@ -1,0 +1,73 @@
+# Smoke Set — Manual UI Checklist
+
+> Companion to `infra/scripts/smoke-set.sh` (automated) and `infra/scripts/pg-readback.sh` (DB-direct).
+> Covers the 2/9 G1 scenarios that cannot be automated reliably from a shell script: **A4** (SSE chat with citations) and **C5** (real RAG query latency).
+>
+> Added per Fix #1 from spec-panel review (2026-05-05).
+> Refs: `docs/superpowers/specs/2026-05-05-infrastructure-single-tester-design.md` G1.
+
+## When to run
+
+- Before promoting `main-staging` → `main` (release readiness)
+- After CF Tunnel migration cutover
+- After any change to `/chat` UI, RAG pipeline, SSE streaming, or citations rendering
+
+## Pre-conditions
+
+- `bash infra/scripts/smoke-set.sh https://meepleai.app` returns exit 0 (automated smoke green)
+- `bash infra/scripts/pg-readback.sh` returns exit 0 (migrations applied)
+- Logged in as test owner with `Catan` (or any) game indexed in personal library
+
+## A4 — Chat with citations (SSE streaming)
+
+**Goal**: verify that `/chat` produces a non-empty response via Server-Sent Events with at least one valid `[citation:N]` tag, and that each citation has snippet + page + source_doc_id.
+
+| Step | Action | Expected | Pass? |
+|------|--------|----------|-------|
+| A4.1 | Open `https://meepleai.app/chat` | Page loads, login persists, game picker visible | ☐ |
+| A4.2 | Select an indexed game (e.g. Catan) | Chat input enabled, history empty (or recent) | ☐ |
+| A4.3 | Send: `Quanti dadi servono per il primo turno?` | SSE response streams in within ~3s (TTFT), progressive tokens visible | ☐ |
+| A4.4 | Wait for stream completion (≤10s total) | Response complete, no SSE error, no console errors | ☐ |
+| A4.5 | Verify citations present | At least 1 `[citation:N]` tag in body, rendered as clickable | ☐ |
+| A4.6 | Hover/click citation 1 | Tooltip/expansion shows `snippet` + `page_number` + `source_doc_id` | ☐ |
+| A4.7 | Verify snippet is real | Text in snippet matches a passage findable in the rulebook PDF | ☐ |
+
+**Result**: ☐ PASS  ☐ FAIL — note: ____________________
+
+## C5 — RAG real query <10s end-to-end
+
+**Goal**: verify the spec G1.C5 invariant ("RAG query <10s end-to-end via SSE"). The automated smoke uses a perf proxy on `/api/v1/shared-games`; this checklist measures the real RAG path.
+
+| Step | Action | Expected | Pass? |
+|------|--------|----------|-------|
+| C5.1 | Open browser DevTools → Network tab, filter "EventSource" | Empty | ☐ |
+| C5.2 | Open `/chat`, select an indexed game | Page ready | ☐ |
+| C5.3 | Note current time (T0) | T0 = wall-clock | ☐ |
+| C5.4 | Send any RAG-eligible question (rule-related) | Submit, watch Network tab | ☐ |
+| C5.5 | Note time when first SSE token arrives (TTFT) | TTFT = T1 - T0, **target ≤3s** | ☐ |
+| C5.6 | Note time when stream closes (T2) | Total = T2 - T0, **target ≤10s** | ☐ |
+| C5.7 | (Optional) Verify Prometheus counter incremented | `rag_query_duration_seconds_bucket{le="10"}` +1 | ☐ |
+
+**Measurement**:
+- TTFT (T1 - T0): _____ s (≤3s pass)
+- Total (T2 - T0): _____ s (≤10s pass)
+
+**Result**: ☐ PASS  ☐ FAIL — note: ____________________
+
+## Logging the run
+
+After completing both A4 and C5 manually, record outcome in the DR walkthrough log
+(`docs/operations/dr-walkthrough-log.md`) or in your release checklist:
+
+```
+| YYYY-MM-DD | Manual smoke (A4+C5) | PASS/FAIL | TTFT=Xs, Total=Ys, notes |
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Action |
+|---------|--------------|--------|
+| SSE never starts (TTFT > 10s) | DeepSeek/OpenRouter unreachable, embedding service down | Check `make staging-with-tutor` logs; verify outbound network |
+| Citations missing | KB not indexed for selected game, or RAG fallback hit | Run `pg-readback.sh`; check `/admin/knowledge-base` for game status |
+| Console errors during stream | Auth cookie expired, CSRF mismatch | Re-login; clear cookies |
+| TTFT >3s but Total <10s | LLM cold start (DeepSeek warmup) | Acceptable on first query of a session; re-run for warm-cache measurement |

--- a/docs/superpowers/plans/2026-05-05-infrastructure-single-tester.md
+++ b/docs/superpowers/plans/2026-05-05-infrastructure-single-tester.md
@@ -1414,9 +1414,11 @@ Path: `docs/operations/cf-tunnel-migration.md`
 4. Configure routes (web UI):
    - `meepleai.app` → `http://localhost:3000` (web)
    - `api.meepleai.app` → `http://localhost:8080` (api)
-5. Configure CF Access policy (optional but recommended):
-   - Application: `meepleai.app`
+5. **REQUIRED for single-tester alpha**: Configure CF Access policy:
+   - Application: `meepleai.app` (and `api.meepleai.app`)
    - Policy: "owner-only" with email match → your email only.
+   - Identity provider: Google SSO (preferito; alternativa: One-time PIN via email).
+   - **NOTA**: senza CF Access, dopo Phase 5 (UFW chiude 80/443) gli endpoint non-auth (`/health`, `/api/v1/games`, `/metrics`) diventano pubblici via tunnel — single point of compromise per single-tester. Mandatory.
 
 ## Phase 2 — Install `cloudflared` on VPS
 
@@ -1483,6 +1485,13 @@ The API container currently does NOT bind a host port (only Traefik routes traff
    nmap -p 80,443,22 204.168.135.69
    ```
    Expected: 22 open, 80/443 filtered or closed.
+3. **Verify CF Access auth gate is active** (Fix #2 from spec-panel review):
+   ```bash
+   # Without auth header — should be 401/403 redirect to CF login
+   curl -si https://meepleai.app/api/v1/admin/health | head -3
+   curl -si https://meepleai.app/metrics            | head -3
+   ```
+   Expected: HTTP 302/401/403 (CF Access challenge) o HTML login page. **NOT** 200 con payload applicativo. Se 200, la CF Access policy non è attiva su quel route — torna a Phase 1 step 5.
 
 ## Phase 6 — Decommission Traefik (after 7-day soak)
 

--- a/docs/superpowers/specs/2026-05-05-infrastructure-single-tester-design.md
+++ b/docs/superpowers/specs/2026-05-05-infrastructure-single-tester-design.md
@@ -32,7 +32,7 @@ Questo design risponde alla domanda: *"qual è il minimo di infrastruttura neces
 
 **Specific**: I 9 scenari smoke (A1-A5 + C1+C2+C3+C5) passano sia su `dev` (locale o tramite `make work`) sia su `staging` (`meepleai.app`).
 
-**Measurable**: 9/9 pass, esecuzione sequenziale ≤15 min totali, RAG query ≤10s end-to-end.
+**Measurable**: 7/9 automated PASS via `smoke-set.sh` (A2, A3-via-status, A5, C1, C3-endpoint, C5-perf-proxy, plus A1+login se TEST_EMAIL/PASSWORD provided) + 2/9 manual UI checklist (A4 SSE chat con citations, C5 RAG real query <10s end-to-end via `/chat` UI). Esecuzione automated set ≤2 min; manual checklist ≤5 min totali. C2 (migration applied) validato da `pg-readback.sh` (DB direct via tunnel) — è uno smoke separato perché richiede tunnel.
 
 **Achievable**: Smoke automation parziale già esiste (`smoke_test()` nel deploy workflow); estendere copertura.
 
@@ -120,7 +120,7 @@ Scenario: C5 — RAG query end-to-end <10s
 
 **Specific**: `meepleai.app` servito tramite `cloudflared` daemon su VPS, Traefik+Let's Encrypt rimossi dall'edge, porte 80/443 chiuse a internet pubblico, accesso staging limitato a CF Access (Google SSO, solo email proprietario).
 
-**Measurable**: `nmap -p 80,443 204.168.135.69` ritorna `filtered/closed`, smoke set G1 continua a passare 9/9, downtime durante migrazione <30 min.
+**Measurable**: `nmap -p 80,443 204.168.135.69` ritorna `filtered/closed`; smoke set G1 continua a passare (7/9 automated + 2/9 manual checklist); downtime durante migrazione <30 min misurato via `curl` polling pre/durante/post; **CF Access policy "owner-only" attiva** (Google SSO con email proprietario) — verificata pre-cutover via `cloudflared access curl https://meepleai.app` che ritorna 401/403 per identity non autorizzata.
 
 **Achievable**: setup `cloudflared` ~2h + reconfig service routing ~2h + test ~1h.
 
@@ -280,7 +280,8 @@ Scenario: Monthly auto-restore test passa
   When cron esegue scripts/backup-restore-test.sh --with-smoke-readback
   Then crea container Postgres temp da backup
   And esegue 3 query smoke (SELECT count FROM games, users, sessions)
-  And ogni query restituisce row count >0
+  And users e games row count > 0 (proprietario + game catalog seedato)
+  And sessions row count >= 0 (legitimate vuoto su single-tester fresh; query MUST succeed senza errori)
   And cleanup del container temp avviene
   And log finale "✅ Restore + smoke read-back PASSED" in /var/log/meepleai-restore-test.log
 

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -35,6 +35,12 @@ integration-down: ## Stop integration (local processes + tunnels)
 	bash scripts/integration-start.sh stop
 	bash scripts/integration-tunnel.sh stop
 
+work: ## Hybrid dev loop: tunnel + local API+Web + watchdog (single command)
+	bash scripts/work.sh start
+
+work-stop: ## Stop work session cleanly (alternative to Ctrl+C)
+	bash scripts/work.sh stop
+
 staging: ## Deploy staging — core + AI + monitoring (CAX31+ recommended, ~14GB reservation)
 	$(COMPOSE) -f compose.staging.yml -f compose.traefik.yml \
 		--profile ai --profile monitoring --profile proxy up -d
@@ -327,7 +333,7 @@ validate-workflows: ## Validate GitHub Actions workflows — mirrors auto-valida
 
 .PHONY: dev dev-core dev-down \
         tunnel tunnel-stop tunnel-status integration-check integration \
-        integration-down staging staging-minimal staging-with-tutor staging-tutor-down staging-core staging-down prod prod-down \
+        integration-down work work-stop staging staging-minimal staging-with-tutor staging-tutor-down staging-core staging-down prod prod-down \
         alpha alpha-core alpha-down \
         secrets-setup secrets-sync \
         snapshot restore-staging restore-local seed-games \

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -41,6 +41,15 @@ work: ## Hybrid dev loop: tunnel + local API+Web + watchdog (single command)
 work-stop: ## Stop work session cleanly (alternative to Ctrl+C)
 	bash scripts/work.sh stop
 
+smoke: ## Run automated smoke set against BASE_URL (default localhost:8080) — set TEST_EMAIL/TEST_PASSWORD for auth scenarios
+	bash scripts/smoke-set.sh $(BASE_URL) $(TEST_EMAIL) $(TEST_PASSWORD)
+
+smoke-staging: ## Run automated smoke set against staging (https://meepleai.app)
+	bash scripts/smoke-set.sh https://meepleai.app $(TEST_EMAIL) $(TEST_PASSWORD)
+
+smoke-pg-readback: ## Run pg-readback.sh DB-direct migration validation (requires open tunnel)
+	bash scripts/pg-readback.sh
+
 staging: ## Deploy staging — core + AI + monitoring (CAX31+ recommended, ~14GB reservation)
 	$(COMPOSE) -f compose.staging.yml -f compose.traefik.yml \
 		--profile ai --profile monitoring --profile proxy up -d
@@ -333,7 +342,7 @@ validate-workflows: ## Validate GitHub Actions workflows — mirrors auto-valida
 
 .PHONY: dev dev-core dev-down \
         tunnel tunnel-stop tunnel-status integration-check integration \
-        integration-down work work-stop staging staging-minimal staging-with-tutor staging-tutor-down staging-core staging-down prod prod-down \
+        integration-down work work-stop smoke smoke-staging smoke-pg-readback staging staging-minimal staging-with-tutor staging-tutor-down staging-core staging-down prod prod-down \
         alpha alpha-core alpha-down \
         secrets-setup secrets-sync \
         snapshot restore-staging restore-local seed-games \

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -39,7 +39,19 @@ staging: ## Deploy staging — core + AI + monitoring (CAX31+ recommended, ~14GB
 	$(COMPOSE) -f compose.staging.yml -f compose.traefik.yml \
 		--profile ai --profile monitoring --profile proxy up -d
 
-staging-core: ## Deploy staging core only — no AI services (safe for CAX21, ~6GB reservation)
+staging-minimal: ## Deploy staging single-tester profile (~3GB RAM, no orchestration/n8n/seq/cadvisor)
+	$(COMPOSE) -f compose.staging.yml -f compose.traefik.yml \
+		--profile ai-essential --profile monitoring-essential --profile proxy up -d
+
+staging-with-tutor: ## Deploy staging single-tester + orchestration-service for tutor agents (~5GB RAM)
+	$(COMPOSE) -f compose.staging.yml -f compose.traefik.yml \
+		--profile ai-essential --profile monitoring-essential --profile proxy --profile tutor-agents up -d
+
+staging-tutor-down: ## Stop only orchestration-service (keep rest of staging running)
+	$(COMPOSE) -f compose.staging.yml --profile tutor-agents stop orchestration-service
+	$(COMPOSE) -f compose.staging.yml --profile tutor-agents rm -f orchestration-service
+
+staging-core: ## (Deprecated, use staging-minimal) Deploy staging core only — no AI services
 	$(COMPOSE) -f compose.staging.yml -f compose.traefik.yml \
 		--profile monitoring --profile proxy up -d
 
@@ -315,7 +327,7 @@ validate-workflows: ## Validate GitHub Actions workflows — mirrors auto-valida
 
 .PHONY: dev dev-core dev-down \
         tunnel tunnel-stop tunnel-status integration-check integration \
-        integration-down staging staging-down prod prod-down \
+        integration-down staging staging-minimal staging-with-tutor staging-tutor-down staging-core staging-down prod prod-down \
         alpha alpha-core alpha-down \
         secrets-setup secrets-sync \
         snapshot restore-staging restore-local seed-games \

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -126,13 +126,20 @@ backup-status: ## Show latest backup info
 	@echo "📊 Disk usage:"
 	@du -sh /backups/meepleai/ 2>/dev/null || echo "  No backup directory"
 
-backup-cron-install: ## Install daily backup cron job (3 AM)
-	@echo "Installing backup cron job..."
-	@(crontab -l 2>/dev/null | grep -v "meepleai.*backup"; \
+backup-cron-install: ## Install all infrastructure cron jobs (backup, verify, prune, DR)
+	@echo "Installing infrastructure cron jobs..."
+	@(crontab -l 2>/dev/null | grep -vE "meepleai.*(backup|prune|dr-walkthrough|restore-test)"; \
 	  echo "0 3 * * * cd /opt/meepleai/repo/infra && bash scripts/backup.sh >> /var/log/meepleai-backup.log 2>&1"; \
 	  echo "30 3 * * * cd /opt/meepleai/repo/infra && bash scripts/backup-verify.sh >> /var/log/meepleai-backup-verify.log 2>&1"; \
-	  echo "0 4 * * 0 cd /opt/meepleai/repo/infra && bash scripts/backup-restore-test.sh >> /var/log/meepleai-restore-test.log 2>&1") | crontab -
-	@echo "✅ Cron installed: backup daily 3:00, verify 3:30, restore test weekly Sunday 4:00"
+	  echo "0 5 * * * cd /opt/meepleai/repo/infra && bash scripts/daily-disk-prune.sh >> /var/log/meepleai-disk-prune.log 2>&1"; \
+	  echo "0 4 1 * * cd /opt/meepleai/repo/infra && bash scripts/backup-restore-test.sh --with-smoke-readback >> /var/log/meepleai-restore-test.log 2>&1"; \
+	  echo "0 9 1 1,4,7,10 * cd /opt/meepleai/repo/infra && bash scripts/dr-walkthrough-reminder.sh >> /var/log/meepleai-dr-reminder.log 2>&1") | crontab -
+	@echo "✅ Cron installed:"
+	@echo "  daily 03:00  → backup"
+	@echo "  daily 03:30  → backup-verify"
+	@echo "  daily 05:00  → disk-prune"
+	@echo "  monthly 1st 04:00  → restore-test (with smoke read-back)"
+	@echo "  quarterly 09:00    → DR walkthrough reminder"
 
 backup-cron-show: ## Show installed backup cron jobs
 	@crontab -l 2>/dev/null | grep meepleai || echo "No MeepleAI cron jobs found"

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -183,7 +183,7 @@ services:
       dockerfile: ./Dockerfile
     container_name: meepleai-embedding
     restart: unless-stopped
-    profiles: [ai]
+    profiles: [ai, ai-essential]
     environment:
       # Model selection: e5-large (quality), e5-base (2x faster), e5-small (4x faster)
       # Model: e5-base (768d, 3.7x faster than e5-large on ARM64)
@@ -264,7 +264,7 @@ services:
       dockerfile: ./Dockerfile
     container_name: meepleai-reranker
     restart: unless-stopped
-    profiles: [ai]
+    profiles: [ai, ai-essential]
     volumes:
       - reranker_models:/home/reranker/.cache/huggingface
     healthcheck:
@@ -290,7 +290,7 @@ services:
       dockerfile: ./Dockerfile
     container_name: meepleai-orchestrator
     restart: unless-stopped
-    profiles: [ai]
+    profiles: [ai, tutor-agents]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8004/health"]
       interval: 30s
@@ -325,7 +325,7 @@ services:
     image: prom/prometheus:v3.7.0
     container_name: meepleai-prometheus
     restart: unless-stopped
-    profiles: [monitoring]
+    profiles: [monitoring, monitoring-essential]
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
@@ -356,7 +356,7 @@ services:
     image: grafana/grafana:11.4.0
     container_name: meepleai-grafana
     restart: unless-stopped
-    profiles: [monitoring]
+    profiles: [monitoring, monitoring-essential]
     entrypoint: ["/scripts/load-secrets-env.sh"]
     command: ["/run.sh"]
     volumes:
@@ -388,7 +388,7 @@ services:
     image: prom/alertmanager:v0.27.0
     container_name: meepleai-alertmanager
     restart: unless-stopped
-    profiles: [monitoring]
+    profiles: [monitoring, monitoring-essential]
     volumes:
       - ./scripts/load-secrets-env.sh:/scripts/load-secrets-env.sh:ro
       - ./alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
@@ -445,7 +445,7 @@ services:
     image: prom/node-exporter:v1.8.2
     container_name: meepleai-node-exporter
     restart: unless-stopped
-    profiles: [monitoring]
+    profiles: [monitoring, monitoring-essential]
     command:
       - '--path.rootfs=/host'
       - '--path.procfs=/host/proc'

--- a/infra/scripts/backup-restore-test.sh
+++ b/infra/scripts/backup-restore-test.sh
@@ -140,6 +140,45 @@ else
   exit 1
 fi
 
+# ─── Smoke read-back (only with --with-smoke-readback flag) ──────────────────
+
+if [[ " $* " == *" --with-smoke-readback "* ]]; then
+  echo ""
+  echo "--- Smoke read-back ---"
+
+  SMOKE_FAIL=0
+
+  # Reuse already-computed counts from earlier verification block
+  for pair in "users:${USERS_COUNT}" "games:${GAMES_COUNT}"; do
+    label="${pair%:*}"
+    count="${pair#*:}"
+    if [[ "$count" =~ ^[0-9]+$ ]] && [ "$count" -gt 0 ]; then
+      echo "  ✅ $label: $count rows"
+    else
+      echo "  ❌ $label: got '$count' (expected positive integer)"
+      SMOKE_FAIL=1
+    fi
+  done
+
+  # Third query: GameSessions (>=0 accepted per Fix #3 — legitimate vuoto su single-tester fresh)
+  SESSIONS_COUNT=$(docker exec "${TEMP_CONTAINER}" psql -U "${DB_USER}" -d "${DB_NAME}" -t -c \
+    'SELECT COUNT(*) FROM "GameSessions";' 2>/dev/null | tr -d '[:space:]' || echo "ERROR")
+  if [[ "$SESSIONS_COUNT" =~ ^[0-9]+$ ]]; then
+    echo "  ✅ sessions: $SESSIONS_COUNT rows (>=0 accepted, table may be empty)"
+  else
+    echo "  ❌ sessions: query failed (got '$SESSIONS_COUNT')"
+    SMOKE_FAIL=1
+  fi
+
+  if [ "$SMOKE_FAIL" -ne 0 ]; then
+    echo ""
+    echo "❌ Restore OK but smoke read-back FAILED" >&2
+    exit 1
+  fi
+
+  echo "  ✅ Restore + smoke read-back PASSED"
+fi
+
 # ─── Done ─────────────────────────────────────────────────────────────────────
 
 echo ""

--- a/infra/scripts/backup-restore-test.sh
+++ b/infra/scripts/backup-restore-test.sh
@@ -106,13 +106,13 @@ echo "Restore completed in ${RESTORE_TIME}s"
 
 echo "Verifying restored data..."
 
-# Query Administration.Users count
+# Query users count (lowercase, default schema — actual table name in EF migrations)
 USERS_COUNT=$(docker exec "${TEMP_CONTAINER}" psql -U "${DB_USER}" -d meepleai -t -c \
-  'SELECT COUNT(*) FROM "Administration"."Users";' 2>/dev/null | tr -d '[:space:]' || echo "ERROR")
+  'SELECT COUNT(*) FROM users;' 2>/dev/null | tr -d '[:space:]' || echo "ERROR")
 
-# Query GameManagement.Games count
+# Query games count (lowercase, default schema — actual table name in EF migrations)
 GAMES_COUNT=$(docker exec "${TEMP_CONTAINER}" psql -U "${DB_USER}" -d meepleai -t -c \
-  'SELECT COUNT(*) FROM "GameManagement"."Games";' 2>/dev/null | tr -d '[:space:]' || echo "ERROR")
+  'SELECT COUNT(*) FROM games;' 2>/dev/null | tr -d '[:space:]' || echo "ERROR")
 
 # Query schema count (exclude pg_catalog, information_schema, pg_toast, public)
 SCHEMA_COUNT=$(docker exec "${TEMP_CONTAINER}" psql -U "${DB_USER}" -d meepleai -t -c \
@@ -123,8 +123,8 @@ SCHEMA_COUNT=$(docker exec "${TEMP_CONTAINER}" psql -U "${DB_USER}" -d meepleai 
 
 echo ""
 echo "--- Data Verification ---"
-echo "  Administration.Users count : ${USERS_COUNT}"
-echo "  GameManagement.Games count : ${GAMES_COUNT}"
+echo "  users count                : ${USERS_COUNT}"
+echo "  games count                : ${GAMES_COUNT}"
 echo "  Custom schema count        : ${SCHEMA_COUNT} (expected >= 5, up to 18 bounded contexts)"
 
 # ─── Check schema count >= 5 ─────────────────────────────────────────────────

--- a/infra/scripts/daily-disk-prune.sh
+++ b/infra/scripts/daily-disk-prune.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Daily Docker prune — keep VPS disk under control
+# Runs from cron at 05:00 (after 03:00 backup, before any morning activity)
+#
+# Cron: 0 5 * * * cd /opt/meepleai/repo/infra && bash scripts/daily-disk-prune.sh >> /var/log/meepleai-disk-prune.log 2>&1
+
+set -euo pipefail
+
+log() {
+  echo "[$(date '+%Y-%m-%dT%H:%M:%S')] $*"
+}
+
+log "=== Disk prune starting ==="
+log "Disk before: $(df -h / | tail -1 | awk '{print $4}') free"
+
+# Prune images not used in 72 hours; keeps recent build cache for fast rebuilds.
+# --filter "until=72h" excludes anything created/used in last 3 days.
+docker image prune -af --filter "until=72h" 2>&1 || log "WARN: image prune had non-zero exit"
+
+# Prune builder cache older than 24h (BuildKit layers)
+docker builder prune -f --filter "until=24h" 2>&1 || log "WARN: builder prune had non-zero exit"
+
+# Prune stopped containers (any age — they should not accumulate)
+docker container prune -f 2>&1 || log "WARN: container prune had non-zero exit"
+
+# Networks: prune unused
+docker network prune -f 2>&1 || log "WARN: network prune had non-zero exit"
+
+# DO NOT prune volumes — they contain pgdata/redis/etc.
+# Only manual `docker volume prune` allowed.
+
+log "Disk after: $(df -h / | tail -1 | awk '{print $4}') free"
+log "=== Disk prune complete ==="

--- a/infra/scripts/dr-walkthrough-reminder.sh
+++ b/infra/scripts/dr-walkthrough-reminder.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# dr-walkthrough-reminder.sh — Quarterly notification to walk through DR runbook
+#
+# Cron: 0 9 1 1,4,7,10 * cd /opt/meepleai/repo/infra && bash scripts/dr-walkthrough-reminder.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SECRETS_DIR="${SCRIPT_DIR}/../secrets"
+
+log() { echo "[$(date '+%Y-%m-%dT%H:%M:%S')] $*"; }
+
+# Load webhook URL from backup.secret (reuse same channel as backup notifications)
+if [ -f "${SECRETS_DIR}/backup.secret" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "${SECRETS_DIR}/backup.secret"
+  set +a
+fi
+
+WEBHOOK_URL="${BACKUP_WEBHOOK_URL:-}"
+LOG_FILE="${SCRIPT_DIR}/../../docs/operations/dr-walkthrough-log.md"
+
+# Check last walkthrough date from log file
+LAST_WALKTHROUGH=$(grep -oE '^\| [0-9]{4}-[0-9]{2}-[0-9]{2}' "$LOG_FILE" 2>/dev/null | head -1 | tr -d '|' | xargs || echo "")
+DAYS_SINCE="?"
+if [ -n "$LAST_WALKTHROUGH" ]; then
+  LAST_EPOCH=$(date -d "$LAST_WALKTHROUGH" +%s 2>/dev/null || echo "0")
+  NOW_EPOCH=$(date +%s)
+  DAYS_SINCE=$(( (NOW_EPOCH - LAST_EPOCH) / 86400 ))
+fi
+
+PAYLOAD=$(cat <<EOF
+{
+  "status": "action_required",
+  "task": "DR runbook walkthrough due",
+  "runbook": "docs/operations/disaster-recovery-runbook.md",
+  "log_file": "docs/operations/dr-walkthrough-log.md",
+  "last_walkthrough": "${LAST_WALKTHROUGH:-never}",
+  "days_since": "${DAYS_SINCE}",
+  "instructions": "Read the runbook end-to-end. Verify each step still matches the current infrastructure. Add an entry to dr-walkthrough-log.md."
+}
+EOF
+)
+
+log "DR walkthrough reminder triggered (last: ${LAST_WALKTHROUGH:-never}, days_since: ${DAYS_SINCE})"
+
+if [ -z "$WEBHOOK_URL" ]; then
+  log "WARN: BACKUP_WEBHOOK_URL not set — reminder logged only"
+  echo "$PAYLOAD" | python3 -m json.tool 2>/dev/null || echo "$PAYLOAD"
+  exit 0
+fi
+
+curl -sf --max-time 10 \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD" \
+  "$WEBHOOK_URL" \
+  && log "✅ Webhook delivered" \
+  || log "❌ Webhook delivery failed"

--- a/infra/scripts/pg-readback.sh
+++ b/infra/scripts/pg-readback.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# pg-readback.sh — DB-direct smoke read-back for migration validation (G1.C2)
+#
+# Validates that the latest EF Core migration has been applied to the staging DB.
+# Requires SSH tunnel to staging postgres (default: localhost:25432).
+#
+# Usage:
+#   make work          # opens tunnel
+#   bash infra/scripts/pg-readback.sh
+#
+# Or with explicit connection:
+#   PG_HOST=localhost PG_PORT=25432 PG_USER=meepleai PG_DB=meepleai bash pg-readback.sh
+#
+# Exit code: 0 on success, 1 on failure.
+#
+# Refs: docs/superpowers/specs/2026-05-05-infrastructure-single-tester-design.md G1.C2
+# Added per Fix #1 from spec-panel review (2026-05-05).
+
+set -euo pipefail
+
+PG_HOST="${PG_HOST:-localhost}"
+PG_PORT="${PG_PORT:-25432}"
+PG_USER="${PG_USER:-meepleai}"
+PG_DB="${PG_DB:-meepleai}"
+PGPASSWORD="${PGPASSWORD:-${POSTGRES_PASSWORD:-}}"
+
+log() { echo "[$(date '+%H:%M:%S')] $*"; }
+fail() { echo "❌ $*" >&2; exit 1; }
+
+if ! command -v psql >/dev/null; then
+  fail "psql not found in PATH (install postgresql-client)"
+fi
+
+if [ -z "$PGPASSWORD" ]; then
+  fail "PGPASSWORD or POSTGRES_PASSWORD must be set (read from infra/secrets/postgres.secret)"
+fi
+
+export PGPASSWORD
+
+# ─────────────────────────────────────────────
+# Connectivity check
+# ─────────────────────────────────────────────
+log "🔗 Connecting to ${PG_USER}@${PG_HOST}:${PG_PORT}/${PG_DB}"
+if ! psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -tAc "SELECT 1" >/dev/null 2>&1; then
+  fail "Cannot connect — verify tunnel is open (make tunnel-status) and credentials"
+fi
+log "✅ Connected"
+
+# ─────────────────────────────────────────────
+# Migration history check (G1.C2)
+# ─────────────────────────────────────────────
+log "📋 Checking __EFMigrationsHistory..."
+MIGRATION_COUNT=$(psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -tAc \
+  'SELECT COUNT(*) FROM "__EFMigrationsHistory"' 2>/dev/null || echo "0")
+
+if ! [[ "$MIGRATION_COUNT" =~ ^[0-9]+$ ]] || [ "$MIGRATION_COUNT" -lt 1 ]; then
+  fail "__EFMigrationsHistory has 0 rows — migrations have not been applied"
+fi
+
+log "✅ ${MIGRATION_COUNT} migrations applied"
+
+LATEST_MIGRATION=$(psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -tAc \
+  'SELECT "MigrationId" FROM "__EFMigrationsHistory" ORDER BY "MigrationId" DESC LIMIT 1' 2>/dev/null || echo "")
+
+if [ -z "$LATEST_MIGRATION" ]; then
+  fail "Could not read latest migration ID"
+fi
+
+log "✅ Latest migration: $LATEST_MIGRATION"
+
+# ─────────────────────────────────────────────
+# Smoke read-back queries (sanity, optional)
+# ─────────────────────────────────────────────
+log "📊 Smoke read-back queries..."
+for table in "Users" "Games"; do
+  COUNT=$(psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -tAc \
+    "SELECT COUNT(*) FROM \"$table\"" 2>/dev/null || echo "ERROR")
+  if [[ "$COUNT" =~ ^[0-9]+$ ]] && [ "$COUNT" -gt 0 ]; then
+    log "  ✅ $table: $COUNT rows"
+  else
+    log "  ⚠️  $table: got '$COUNT' (expected positive integer)"
+  fi
+done
+
+# Sessions accepted >=0 per Fix #3 (legitimate empty on fresh single-tester)
+SESSIONS_COUNT=$(psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -tAc \
+  'SELECT COUNT(*) FROM "GameSessions"' 2>/dev/null || echo "ERROR")
+if [[ "$SESSIONS_COUNT" =~ ^[0-9]+$ ]]; then
+  log "  ✅ GameSessions: $SESSIONS_COUNT rows (>=0 accepted)"
+else
+  fail "GameSessions query failed (got '$SESSIONS_COUNT')"
+fi
+
+log "✅ pg-readback PASSED"

--- a/infra/scripts/pg-readback.sh
+++ b/infra/scripts/pg-readback.sh
@@ -70,11 +70,13 @@ log "✅ Latest migration: $LATEST_MIGRATION"
 
 # ─────────────────────────────────────────────
 # Smoke read-back queries (sanity, optional)
+# Identifiers are lowercase per EF Core migrations
+# (MeepleAiDbContextModelSnapshot: ToTable("users"), ToTable("games")).
 # ─────────────────────────────────────────────
 log "📊 Smoke read-back queries..."
-for table in "Users" "Games"; do
+for table in users games; do
   COUNT=$(psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -tAc \
-    "SELECT COUNT(*) FROM \"$table\"" 2>/dev/null || echo "ERROR")
+    "SELECT COUNT(*) FROM $table" 2>/dev/null || echo "ERROR")
   if [[ "$COUNT" =~ ^[0-9]+$ ]] && [ "$COUNT" -gt 0 ]; then
     log "  ✅ $table: $COUNT rows"
   else
@@ -83,6 +85,7 @@ for table in "Users" "Games"; do
 done
 
 # Sessions accepted >=0 per Fix #3 (legitimate empty on fresh single-tester)
+# Table is "GameSessions" (PascalCase quoted) per EF migration
 SESSIONS_COUNT=$(psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -tAc \
   'SELECT COUNT(*) FROM "GameSessions"' 2>/dev/null || echo "ERROR")
 if [[ "$SESSIONS_COUNT" =~ ^[0-9]+$ ]]; then

--- a/infra/scripts/smoke-set.sh
+++ b/infra/scripts/smoke-set.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# smoke-set.sh — Run automated G1 smoke scenarios against an endpoint
+#
+# Usage:
+#   bash infra/scripts/smoke-set.sh [BASE_URL] [TEST_EMAIL] [TEST_PASSWORD]
+#   bash infra/scripts/smoke-set.sh http://localhost:8080 user@test.local pass123
+#   bash infra/scripts/smoke-set.sh https://meepleai.app
+#
+# Env overrides:
+#   BASE_URL, TEST_EMAIL, TEST_PASSWORD (alternative to positional args)
+#   TEST_GAME_ID (opt-in for A3 KB-status scenario)
+#
+# Coverage (post spec-panel review Fix #1):
+#   AUTOMATED here   → A1, A2, A3, A5, C1, C3-endpoint, C5-perf-proxy
+#   SEPARATE script  → C2 migration validation via pg-readback.sh (DB direct, requires tunnel)
+#   MANUAL checklist → A4 SSE chat citations, C5 RAG real query <10s
+#                      (see docs/operations/smoke-manual-ui-checklist.md)
+#
+# Exit code: 0 if all automated PASS, 1 if any FAIL.
+#
+# Refs: docs/superpowers/specs/2026-05-05-infrastructure-single-tester-design.md G1
+
+set -uo pipefail
+
+BASE_URL="${1:-${BASE_URL:-http://localhost:8080}}"
+TEST_EMAIL="${2:-${TEST_EMAIL:-}}"
+TEST_PASSWORD="${3:-${TEST_PASSWORD:-}}"
+
+PASS=0
+FAIL=0
+COOKIE_JAR="$(mktemp)"
+trap 'rm -f "$COOKIE_JAR"' EXIT
+
+log() { echo "[$(date '+%H:%M:%S')] $*"; }
+ok() { echo "  ✅ PASS — $1"; PASS=$((PASS+1)); }
+ko() { echo "  ❌ FAIL — $1 ($2)"; FAIL=$((FAIL+1)); }
+
+# ─────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────
+check_status() {
+  local name="$1" url="$2" expected="$3"
+  local status
+  status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 -b "$COOKIE_JAR" -c "$COOKIE_JAR" "$url" 2>/dev/null || echo "000")
+  if [ "$status" = "$expected" ]; then
+    ok "$name (HTTP $status)"
+  else
+    ko "$name" "got $status, expected $expected"
+  fi
+}
+
+# ─────────────────────────────────────────────
+# Smoke scenarios
+# ─────────────────────────────────────────────
+log "🧪 Smoke set against: $BASE_URL"
+
+# A1 — Login → Library mostra giochi (skipped if no creds)
+if [ -n "$TEST_EMAIL" ] && [ -n "$TEST_PASSWORD" ]; then
+  log "A1: Login + GET /api/v1/library/me"
+  LOGIN_RES=$(curl -sf -X POST "$BASE_URL/api/v1/auth/login" \
+    -H "Content-Type: application/json" \
+    -d "{\"email\":\"$TEST_EMAIL\",\"password\":\"$TEST_PASSWORD\"}" \
+    -c "$COOKIE_JAR" -w "\n%{http_code}" 2>/dev/null || echo "000")
+  STATUS=$(echo "$LOGIN_RES" | tail -1)
+  if [ "$STATUS" = "200" ]; then
+    ok "A1.login (HTTP 200)"
+    check_status "A1.library_me" "$BASE_URL/api/v1/library/me" "200"
+  else
+    ko "A1.login" "got $STATUS"
+  fi
+else
+  log "A1: SKIPPED (TEST_EMAIL/TEST_PASSWORD not set)"
+fi
+
+# A2 — Search BGG
+log "A2: GET /api/v1/bgg/search?query=Catan"
+check_status "A2.bgg_search" "$BASE_URL/api/v1/bgg/search?query=Catan" "200"
+
+# A3 — KB status of test game (skipped if no test game ID)
+if [ -n "${TEST_GAME_ID:-}" ]; then
+  log "A3: GET /api/v1/games/$TEST_GAME_ID/kb-status"
+  check_status "A3.kb_status" "$BASE_URL/api/v1/games/$TEST_GAME_ID/kb-status" "200"
+else
+  log "A3: SKIPPED (TEST_GAME_ID env not set — set to validate KB indexing)"
+fi
+
+# A4 — Chat citations (manual UI — see docs/operations/smoke-manual-ui-checklist.md)
+log "A4: SKIPPED here (manual UI — see smoke-manual-ui-checklist.md)"
+
+# A5 — Logout
+if [ -n "$TEST_EMAIL" ]; then
+  log "A5: POST /api/v1/auth/logout"
+  check_status "A5.logout" "$BASE_URL/api/v1/auth/logout" "200"
+fi
+
+# C1 — Deploy senza rotture (validated by health endpoint)
+log "C1: GET /health (deploy proxy)"
+check_status "C1.health" "$BASE_URL/health" "200"
+
+# C2 — Migration applicata: separate validation via pg-readback.sh (requires tunnel)
+log "C2: SKIPPED here (use pg-readback.sh for DB-direct migration validation)"
+
+# C3 — Backup: validated by backup-verify cron, smoke check that endpoint exists
+log "C3: GET /api/v1/admin/rag-backup/snapshots/latest"
+# May 401 if not admin — accept 200 OR 401 (endpoint reachable)
+RES_C3=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 -b "$COOKIE_JAR" "$BASE_URL/api/v1/admin/rag-backup/snapshots/latest" 2>/dev/null || echo "000")
+if [ "$RES_C3" = "200" ] || [ "$RES_C3" = "401" ]; then
+  ok "C3.backup_endpoint (HTTP $RES_C3)"
+else
+  ko "C3.backup_endpoint" "got $RES_C3"
+fi
+
+# C5 — RAG perf <10s (light heuristic: shared-games endpoint <2s as proxy)
+# Real RAG query measurement is in manual UI checklist (see smoke-manual-ui-checklist.md)
+log "C5: GET /api/v1/shared-games?pageNumber=1&pageSize=1 (perf proxy — real RAG via manual)"
+START=$(date +%s%N)
+check_status "C5.perf_proxy" "$BASE_URL/api/v1/shared-games?pageNumber=1&pageSize=1" "200"
+END=$(date +%s%N)
+ELAPSED_MS=$(( (END - START) / 1000000 ))
+if [ "$ELAPSED_MS" -lt 2000 ]; then
+  ok "C5.perf_under_2s (${ELAPSED_MS}ms)"
+else
+  ko "C5.perf_under_2s" "${ELAPSED_MS}ms (expected <2000ms)"
+fi
+
+# ─────────────────────────────────────────────
+# Summary
+# ─────────────────────────────────────────────
+echo ""
+log "📊 Summary: $PASS PASS / $FAIL FAIL"
+log "ℹ️  Manual checklist (A4 chat, C5 real RAG) — see docs/operations/smoke-manual-ui-checklist.md"
+log "ℹ️  C2 migration validation — run pg-readback.sh"
+if [ "$FAIL" -eq 0 ]; then
+  log "✅ Automated smoke set passed"
+  exit 0
+else
+  log "❌ Automated smoke set FAILED"
+  exit 1
+fi

--- a/infra/scripts/smoke-set.sh
+++ b/infra/scripts/smoke-set.sh
@@ -87,10 +87,16 @@ fi
 # A4 — Chat citations (manual UI — see docs/operations/smoke-manual-ui-checklist.md)
 log "A4: SKIPPED here (manual UI — see smoke-manual-ui-checklist.md)"
 
-# A5 — Logout
+# A5 — Logout (POST-only endpoint per AuthenticationEndpoints.cs)
 if [ -n "$TEST_EMAIL" ]; then
   log "A5: POST /api/v1/auth/logout"
-  check_status "A5.logout" "$BASE_URL/api/v1/auth/logout" "200"
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+    -X POST -b "$COOKIE_JAR" -c "$COOKIE_JAR" "$BASE_URL/api/v1/auth/logout" 2>/dev/null || echo "000")
+  if [ "$STATUS" = "200" ]; then
+    ok "A5.logout (HTTP 200)"
+  else
+    ko "A5.logout" "got $STATUS"
+  fi
 fi
 
 # C1 — Deploy senza rotture (validated by health endpoint)
@@ -100,10 +106,11 @@ check_status "C1.health" "$BASE_URL/health" "200"
 # C2 — Migration applicata: separate validation via pg-readback.sh (requires tunnel)
 log "C2: SKIPPED here (use pg-readback.sh for DB-direct migration validation)"
 
-# C3 — Backup: validated by backup-verify cron, smoke check that endpoint exists
-log "C3: GET /api/v1/admin/rag-backup/snapshots/latest"
+# C3 — Backup: validated by backup-verify cron. Smoke checks the list endpoint
+# (avoids 404 on /snapshots/latest where "latest" is treated as a Guid id).
+log "C3: GET /api/v1/admin/rag-backup/snapshots"
 # May 401 if not admin — accept 200 OR 401 (endpoint reachable)
-RES_C3=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 -b "$COOKIE_JAR" "$BASE_URL/api/v1/admin/rag-backup/snapshots/latest" 2>/dev/null || echo "000")
+RES_C3=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 -b "$COOKIE_JAR" "$BASE_URL/api/v1/admin/rag-backup/snapshots" 2>/dev/null || echo "000")
 if [ "$RES_C3" = "200" ] || [ "$RES_C3" = "401" ]; then
   ok "C3.backup_endpoint (HTTP $RES_C3)"
 else

--- a/infra/scripts/work.sh
+++ b/infra/scripts/work.sh
@@ -79,7 +79,9 @@ do_start() {
   ) &
   echo $! > "$WATCHDOG_PID_FILE"
 
-  trap 'do_stop; exit 0' INT TERM
+  # Trap on EXIT too — ensures cleanup if integration-start.sh exits naturally
+  # (e.g., dotnet/pnpm crash) and not via Ctrl+C. do_stop is idempotent.
+  trap 'do_stop; exit 0' INT TERM EXIT
 
   log "✅ make work running"
   log "   API: http://localhost:8080"

--- a/infra/scripts/work.sh
+++ b/infra/scripts/work.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# work.sh — Hybrid dev loop: SSH tunnel + local API+Web + watchdog
+#
+# Usage:
+#   bash infra/scripts/work.sh         # Start everything
+#   bash infra/scripts/work.sh stop    # Stop everything (also via Ctrl+C in foreground)
+#
+# Pre-flight checks SSH key permissions, then:
+#   1. Opens SSH tunnels to staging (postgres+redis+AI services)
+#   2. Starts API + Web locally in Integration mode
+#   3. Watchdog loop: re-opens tunnel if SSH socket dies
+#   4. Trap on SIGINT/SIGTERM: clean teardown of all processes
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SSH_KEY="${HOME}/.ssh/meepleai-staging"
+WATCHDOG_PID_FILE="/tmp/meepleai-work-watchdog.pid"
+MAX_WATCHDOG_RETRIES=5
+
+ACTION="${1:-start}"
+
+log() { echo "[$(date '+%H:%M:%S')] $*"; }
+fail() { log "❌ $*"; exit 1; }
+
+# ─────────────────────────────────────────────
+# Pre-flight checks
+# ─────────────────────────────────────────────
+preflight() {
+  log "🔍 Pre-flight checks..."
+
+  [ -f "$SSH_KEY" ] || fail "SSH key not found: $SSH_KEY"
+
+  local perms
+  perms=$(stat -c '%a' "$SSH_KEY" 2>/dev/null || stat -f '%A' "$SSH_KEY" 2>/dev/null)
+  if [ "$perms" != "600" ] && [ "$perms" != "400" ]; then
+    fail "SSH key permissions: chmod 600 required (current: $perms)"
+  fi
+
+  command -v dotnet >/dev/null || fail "dotnet not found in PATH"
+  command -v pnpm >/dev/null || fail "pnpm not found in PATH"
+
+  # Quick connectivity check
+  ssh -o ConnectTimeout=5 -o BatchMode=yes -i "$SSH_KEY" deploy@204.168.135.69 'echo ok' >/dev/null 2>&1 \
+    || fail "SSH to staging failed (check VPN/network)"
+
+  log "✅ Pre-flight OK"
+}
+
+# ─────────────────────────────────────────────
+# Start tunnel + watchdog + API + Web
+# ─────────────────────────────────────────────
+do_start() {
+  preflight
+
+  log "🚇 Opening SSH tunnels..."
+  bash "$SCRIPT_DIR/integration-tunnel.sh" start || fail "tunnel start failed"
+
+  log "🚀 Starting API + Web (integration mode)..."
+  bash "$SCRIPT_DIR/integration-start.sh" all &
+  local INT_PID=$!
+
+  # Watchdog loop: re-opens tunnel if it dies
+  (
+    local retries=0
+    while true; do
+      sleep 10
+      if ! ssh -O check -S "${HOME}/.ssh/meepleai-tunnel.sock" deploy@204.168.135.69 2>/dev/null; then
+        retries=$((retries+1))
+        if [ "$retries" -gt "$MAX_WATCHDOG_RETRIES" ]; then
+          log "❌ Watchdog: max retries ($MAX_WATCHDOG_RETRIES) exceeded, giving up"
+          break
+        fi
+        log "⚠️  Tunnel dropped, restarting (retry $retries/$MAX_WATCHDOG_RETRIES)..."
+        bash "$SCRIPT_DIR/integration-tunnel.sh" start && log "✅ Tunnel restored" \
+          || log "❌ Tunnel restart failed"
+      fi
+    done
+  ) &
+  echo $! > "$WATCHDOG_PID_FILE"
+
+  trap 'do_stop; exit 0' INT TERM
+
+  log "✅ make work running"
+  log "   API: http://localhost:8080"
+  log "   Web: http://localhost:3000"
+  log "   Stop with Ctrl+C or 'make work-stop'"
+
+  wait $INT_PID
+}
+
+# ─────────────────────────────────────────────
+# Stop everything cleanly
+# ─────────────────────────────────────────────
+do_stop() {
+  log "🛑 Stopping make work..."
+
+  if [ -f "$WATCHDOG_PID_FILE" ]; then
+    local wpid
+    wpid=$(cat "$WATCHDOG_PID_FILE")
+    kill "$wpid" 2>/dev/null || true
+    rm -f "$WATCHDOG_PID_FILE"
+    log "  Watchdog stopped (PID $wpid)"
+  fi
+
+  bash "$SCRIPT_DIR/integration-start.sh" stop || true
+  bash "$SCRIPT_DIR/integration-tunnel.sh" stop || true
+
+  # Force-kill any orphan processes on integration ports
+  if command -v lsof >/dev/null; then
+    lsof -ti:8080 2>/dev/null | xargs -r kill -9 2>/dev/null || true
+    lsof -ti:3000 2>/dev/null | xargs -r kill -9 2>/dev/null || true
+  fi
+
+  log "✅ All stopped"
+}
+
+case "$ACTION" in
+  start) do_start ;;
+  stop)  do_stop ;;
+  *) fail "Usage: $0 [start|stop]" ;;
+esac


### PR DESCRIPTION
## Summary

Implements `docs/superpowers/plans/2026-05-05-infrastructure-single-tester.md`
(approved via PR #723), with three spec-panel review fixes applied first.

**Reduces staging surface for single-tester alpha** — recovers ~5GB RAM on CAX21,
provides hybrid dev loop, automated smoke set, DR validation cron, and CF Tunnel
migration/rollback runbooks.

## Spec-panel review fixes (3 commits, applied first)

- **Fix #1** — Smoke fidelity: spec G1 now declares "7/9 automated + 2/9 manual UI checklist"; C2 delegated to `pg-readback.sh` (DB-direct)
- **Fix #2** — CF Access policy MANDATORY for single-tester (was "optional"); added explicit auth-gate verification step in Phase 5
- **Fix #3** — G5 row count consistency: `sessions >=0` accepted (legitimate vuoto on fresh tester)

## Plan tasks implemented (15/18)

| Phase | Task | Status |
|-------|------|--------|
| 1 — Quick Wins | T1: pre-deploy port cleanup | ✅ |
| | T2: daily-disk-prune.sh | ✅ |
| | T3: cron-install Makefile target | ✅ |
| | T4: single-tester compose profiles | ✅ |
| | T5: staging-minimal/with-tutor/tutor-down | ✅ |
| | T6: deploy-staging uses minimal profile | ✅ |
| 2 — make work | T7: work.sh wrapper | ✅ |
| | T8: make work / work-stop targets | ✅ |
| | T9: manual smoke test | 🟡 MANUAL |
| 3 — Smoke set | T10: smoke-set.sh (7 automated scenarios) | ✅ |
| | T10b: pg-readback.sh + manual UI checklist | ✅ (from Fix #1) |
| | T11: make smoke / smoke-staging / smoke-pg-readback | ✅ |
| 4 — DR validation | T12: --with-smoke-readback flag | ✅ |
| | T13: dr-walkthrough-reminder.sh | ✅ |
| | T14: dr-walkthrough-log.md | ✅ |
| | T15: install cron jobs on server | 🟡 MANUAL |
| 5 — CF Tunnel | T16: migration runbook | ✅ |
| | T17: rollback runbook | ✅ |
| | T18: execute migration | 🟡 MANUAL |

🟡 **MANUAL** = requires interactive shell on staging server / browser actions on CF dashboard.

## Files changed (15 files, +884 lines)

- `.github/workflows/deploy-staging.yml`: pre-deploy port cleanup + minimal profile
- `infra/docker-compose.yml`: 7 profile changes (ai-essential, monitoring-essential, tutor-agents)
- `infra/Makefile`: +9 targets (work, work-stop, smoke{,−staging,-pg-readback}, staging-minimal, staging-with-tutor, staging-tutor-down)
- `infra/scripts/`: +4 new scripts (work.sh, smoke-set.sh, pg-readback.sh, daily-disk-prune.sh, dr-walkthrough-reminder.sh) + extension of backup-restore-test.sh
- `docs/operations/`: +4 new docs (cf-tunnel-{migration,rollback}.md, dr-walkthrough-log.md, smoke-manual-ui-checklist.md)
- `docs/superpowers/{specs,plans}/2026-05-05-infrastructure-single-tester*.md`: 3 spec-panel fixes

## Test plan

### Pre-merge (CI)
- [ ] All workflow YAMLs parse (validate-workflows job)
- [ ] All bash scripts pass `bash -n` syntax check
- [ ] Makefile targets parse (`make -n`)
- [ ] No regressions in existing CI jobs

### Post-merge (manual on staging — Task 9, 15, 18)
- [ ] Task 9: `make work` cold-start ≤90s on local laptop
- [ ] Task 15: SSH to staging, `make backup-cron-install`, verify 5 cron entries via `crontab -l | grep meepleai`
- [ ] Task 18: schedule maintenance window for CF Tunnel migration (per cf-tunnel-migration.md)

### Acceptance criteria (post all manual tasks)
- [ ] G1: `make smoke-staging` exits 0 (automated 7-scenario set) + manual UI checklist A4+C5 PASS
- [ ] G2: `nmap -p 80,443 204.168.135.69` filtered/closed; CF Access policy active (curl /metrics → 401/403)
- [ ] G3: `ssh deploy@... 'free -m'` shows ≥5GB available; `docker ps` ≤10 containers
- [ ] G4: `make work` cold-start ≤90s; Ctrl+C teardown clean
- [ ] G5: 5 cron entries; `/var/log/meepleai-restore-test.log` updated monthly with PASS

## Notes for reviewer

- Branch parent: `main-dev` (per CLAUDE.md PR rule)
- Plan's "REQUIRED SUB-SKILL: superpowers:subagent-driven-development" was followed for orchestration; tasks dispatched as direct edits where simple (1-line YAML/Makefile) and as Write operations for new scripts. No subagent delegation was needed beyond plan reading.
- 3 manual tasks (9, 15, 18) are explicitly out of scope for this PR — they require interactive shell on staging or CF dashboard browser actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)