### PR TITLE
fix(ops): smoke-set A2 accepts 200 OR 401 for admin-only BGG endpoint

### DIFF
--- a/infra/scripts/smoke-set.sh
+++ b/infra/scripts/smoke-set.sh
@@ -72,9 +72,17 @@ else
   log "A1: SKIPPED (TEST_EMAIL/TEST_PASSWORD not set)"
 fi
 
-# A2 — Search BGG
+# A2 — Search BGG (admin-only endpoint per BggEndpoints.cs:49 — RequireAdminSession,
+# BGG licensing constraint). Accept 200 (admin authenticated via cookie) OR
+# 401 (unauthenticated/non-admin) — both prove endpoint is reachable and auth works.
+# Same pattern as C3.
 log "A2: GET /api/v1/bgg/search?query=Catan"
-check_status "A2.bgg_search" "$BASE_URL/api/v1/bgg/search?query=Catan" "200"
+RES_A2=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 -b "$COOKIE_JAR" -c "$COOKIE_JAR" "$BASE_URL/api/v1/bgg/search?query=Catan" 2>/dev/null || echo "000")
+if [ "$RES_A2" = "200" ] || [ "$RES_A2" = "401" ]; then
+  ok "A2.bgg_search (HTTP $RES_A2)"
+else
+  ko "A2.bgg_search" "got $RES_A2"
+fi
 
 # A3 — KB status of test game (skipped if no test game ID)
 if [ -n "${TEST_GAME_ID:-}" ]; then


### PR DESCRIPTION
## Summary

Hotfix for smoke-set.sh discovered during T18 pre-flight (Phase 0.2 of cf-tunnel-migration runbook).

`/api/v1/bgg/search` is admin-only (`RequireAdminSession` in BggEndpoints.cs:49, BGG licensing constraint). Without admin credentials it returns 401 — same case as C3 which already accepts `200 OR 401`.

A2 was missed in the prior review (PR #725).

## Verification

```
$ bash infra/scripts/smoke-set.sh https://meepleai.app
[...]
[16:54:35] 📊 Summary: 5 PASS / 0 FAIL
[16:54:35] ✅ Automated smoke set passed
```

## Test plan
- [ ] CI green
- [x] Manual smoke against https://meepleai.app: 5/5 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)