### PR TITLE
feat(sessions): /sessions v2 brownfield migration (Wave D.1, #735)

### DIFF
--- a/apps/web/e2e/a11y/sessions-index.spec.ts
+++ b/apps/web/e2e/a11y/sessions-index.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Accessibility tests — /sessions (Wave D.1, Issue #735).
+ *
+ * Combines:
+ *   - axe-core WCAG 2.1 AA scan su default state (results list populated)
+ *   - axe-core WCAG 2.1 AA scan su filtered-empty state (per coprire
+ *     CTA + empty-state markup, sezioni che non sono presenti su default)
+ *   - prefers-reduced-motion contract: AC-8 spec §5 — verifica che la route
+ *     `/sessions` rispetti l'override globale CSS (`globals.css:388-396` riduce
+ *     `transition-duration` a 0.01ms !important sotto `@media
+ *     (prefers-reduced-motion: reduce)`). Le card transitions su
+ *     SessionCardList/SessionCardGrid (default transition-shadow 150ms) devono
+ *     collassare a sub-millisecondo durations.
+ *   - WAI-ARIA tablist keyboard nav: status filter pills (data-slot="sessions-filter-chip",
+ *     role="tab") support ArrowRight/ArrowLeft cycling via useTablistKeyboardNav hook
+ *     (Wave A.6 PR #623).
+ *
+ * Comprehensive unit-level coverage del 5-state FSM + ?state= override matrix
+ * lives in `_components/__tests__/SessionsLibraryView.test.tsx`.
+ * This e2e suite verifies the contract holds against the real prod build.
+ *
+ * Auth bypass: `(authenticated)` route renders senza session perché
+ * `(authenticated)/layout.tsx` non gate-keepa server-side e
+ * `PLAYWRIGHT_AUTH_BYPASS=true` è settato dal webServer di playwright.config.ts.
+ *
+ * Visual-test fixture: i test passano contro Next.js prod build con
+ * `NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED=1` in modo che `useActiveSessions`
+ * venga short-circuitato dal fixture deterministico (6 entries: Brass: Birmingham,
+ * Wingspan×2, Azul, Ark Nova, 7 Wonders).
+ */
+import AxeBuilder from '@axe-core/playwright';
+import { test, expect, type Page } from '@playwright/test';
+
+import { mockAuthEndpoints, seedAuthSession } from '../_helpers/seedAuthSession';
+import { seedCookieConsent } from '../_helpers/seedCookieConsent';
+
+const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'] as const;
+
+async function gotoSessionsReady(page: Page, search = ''): Promise<void> {
+  await seedAuthSession(page);
+  await seedCookieConsent(page);
+  await mockAuthEndpoints(page);
+  await page.goto(`/sessions${search}`, { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('[data-slot="sessions-library-view"]', { timeout: 30_000 });
+}
+
+test.describe('Sessions index — accessibility @a11y', () => {
+  test('axe-core: no WCAG 2.1 AA violations on default state', async ({ page }) => {
+    await gotoSessionsReady(page);
+    // Default state expects hero + filters visible (list view populated with fixture entries).
+    await expect(page.locator('[data-slot="sessions-hero"]')).toBeVisible();
+    await expect(page.locator('[data-slot="sessions-filters"]')).toBeVisible();
+
+    const results = await new AxeBuilder({ page })
+      .withTags(WCAG_TAGS)
+      .exclude('#webpack-dev-server-client-overlay')
+      .analyze();
+
+    if (results.violations.length > 0) {
+      const summary = results.violations
+        .map(v => `[${v.impact}] ${v.id}: ${v.help} (${v.nodes.length} nodes)`)
+        .join('\n');
+      console.log('axe violations (default):\n' + summary);
+    }
+    expect(results.violations).toEqual([]);
+  });
+
+  test('axe-core: no WCAG 2.1 AA violations on filtered-empty state', async ({ page }) => {
+    await gotoSessionsReady(page, '?state=filtered-empty');
+    // Filtered-empty state expects EmptySessions con clearFilters CTA visible.
+    await expect(page.locator('[data-slot="sessions-empty-filtered-empty"]')).toBeVisible();
+
+    const results = await new AxeBuilder({ page })
+      .withTags(WCAG_TAGS)
+      .exclude('#webpack-dev-server-client-overlay')
+      .analyze();
+
+    if (results.violations.length > 0) {
+      const summary = results.violations
+        .map(v => `[${v.impact}] ${v.id}: ${v.help} (${v.nodes.length} nodes)`)
+        .join('\n');
+      console.log('axe violations (filtered-empty):\n' + summary);
+    }
+    expect(results.violations).toEqual([]);
+  });
+
+  test('prefers-reduced-motion: card transitions collapse to sub-ms', async ({ page }) => {
+    // Emulate reduced-motion BEFORE goto so the global CSS rule
+    // (globals.css:388-396) applies on first paint. Without this the
+    // SessionCardList `transition-shadow` runs at full duration.
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await gotoSessionsReady(page);
+    await expect(page.locator('[data-slot="sessions-hero"]')).toBeVisible();
+
+    // Inspect computed transition-duration on the first SessionCardList element.
+    // Under reduced motion the global override forces every element's
+    // `transition-duration: 0.01ms !important`. The default card CSS sets
+    // transition-shadow durations; we expect <= 50ms to confirm the override.
+    // Sessions uses <button data-slot="session-card-list"> as the card wrapper.
+    const transitionDurationMs = await page.evaluate(() => {
+      const card = document.querySelector('[data-slot="session-card-list"]') as HTMLElement | null;
+      if (!card) {
+        // Fallback: try grid card variant
+        const gridCard = document.querySelector(
+          '[data-slot="session-card-grid"]'
+        ) as HTMLElement | null;
+        if (!gridCard) return null;
+        const cs = window.getComputedStyle(gridCard);
+        const durations = cs.transitionDuration.split(',').map((s: string) => {
+          const trimmed = s.trim();
+          if (trimmed.endsWith('ms')) return parseFloat(trimmed);
+          if (trimmed.endsWith('s')) return parseFloat(trimmed) * 1000;
+          return parseFloat(trimmed) * 1000;
+        });
+        return Math.max(...durations);
+      }
+      const cs = window.getComputedStyle(card);
+      // transition-duration may be a comma-separated list (e.g. "0.01s, 0.01s").
+      // Take the max value.
+      const durations = cs.transitionDuration.split(',').map((s: string) => {
+        const trimmed = s.trim();
+        if (trimmed.endsWith('ms')) return parseFloat(trimmed);
+        if (trimmed.endsWith('s')) return parseFloat(trimmed) * 1000;
+        return parseFloat(trimmed) * 1000; // fallback: assume seconds
+      });
+      return Math.max(...durations);
+    });
+
+    // Only assert if a card was found (fixture build required; skip gracefully otherwise).
+    if (transitionDurationMs !== null) {
+      expect(transitionDurationMs).toBeLessThanOrEqual(50);
+    }
+  });
+
+  test('keyboard nav: ArrowRight cycles status filter chips', async ({ page }) => {
+    await gotoSessionsReady(page);
+    // Status filter chips: role="tab" + data-slot="sessions-filter-chip"
+    // Rendered in order: all | active | completed | abandoned
+    // First chip ('all') is active by default, tabIndex=0.
+    await page.waitForSelector('[data-slot="sessions-filters"]', { timeout: 10_000 });
+
+    const firstChip = page.locator('[role="tab"][data-slot="sessions-filter-chip"]').first();
+    await firstChip.focus();
+    // Verify first chip ('all') is focused.
+    await expect(firstChip).toBeFocused();
+
+    // ArrowRight should move focus to the second chip ('active').
+    await page.keyboard.press('ArrowRight');
+    const secondChip = page.locator('[role="tab"][data-slot="sessions-filter-chip"]').nth(1);
+    await expect(secondChip).toBeFocused();
+  });
+});

--- a/apps/web/e2e/v2-states/sessions-index.spec.ts
+++ b/apps/web/e2e/v2-states/sessions-index.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * V2 State Coverage — /sessions route (Issue #735, Wave D.1).
+ *
+ * Captures 4 surface states del 5-state FSM:
+ *   `default | loading | empty | filtered-empty`
+ *
+ * Il quinto state `error` è escluso dalla coverage visual perché surface
+ * dipendente da `sessionsQuery.isError` (TanStack Query), che richiede un mock
+ * di network failure non riproducibile in modo deterministico via URL
+ * override. Coperto invece dal unit test orchestratore
+ * (`_components/__tests__/SessionsLibraryView.test.tsx`).
+ *
+ * Uses test-only `?state=...` query param, gated da
+ * `NODE_ENV !== 'production' || IS_VISUAL_TEST_BUILD` in
+ * `lib/sessions/sessions-visual-test-fixture.ts`.
+ *
+ * Test ID strategy:
+ *   - In CI bootstrap workflow `NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED=1` è
+ *     settato pre-build, attivando il fixture deterministico
+ *     (`VISUAL_TEST_FIXTURE_SESSIONS` da `@/lib/sessions/sessions-visual-test-fixture`).
+ *   - `?state=empty` instructa il fixture a tornare `[]` invece di 6 entries
+ *     E imposta effectiveKind='empty' → EmptySessions con kind='empty';
+ *     gli altri override sovrascrivono solo `effectiveKind`, mantenendo il
+ *     fixture default.
+ *   - Loading state usa il `data-slot="sessions-empty-loading"` skeleton inline
+ *     nell'EmptySessions component (kind='loading'). Gli altri stati terminali
+ *     (empty/filtered-empty/error) usano EmptySessions con
+ *     `data-slot="sessions-empty-{kind}"`.
+ *
+ * Snapshots written to `apps/web/e2e/v2-states/sessions-index.spec.ts-snapshots/`.
+ * Run via CI bootstrap workflow (Linux x86-64 canonical baselines):
+ *   `gh workflow run visual-regression-migrated.yml --ref <branch> \
+ *     -f mode=bootstrap -f project_filter=both`
+ */
+import { test, expect, type Page } from '@playwright/test';
+
+import { mockAuthEndpoints, seedAuthSession } from '../_helpers/seedAuthSession';
+import { seedCookieConsent } from '../_helpers/seedCookieConsent';
+
+async function waitForViewReady(page: Page): Promise<void> {
+  await page.waitForSelector('[data-slot="sessions-library-view"]', { timeout: 30_000 });
+
+  await page.evaluate(async () => {
+    if (typeof document !== 'undefined' && 'fonts' in document) {
+      await (document as Document & { fonts: { ready: Promise<void> } }).fonts.ready;
+    }
+  });
+
+  await page.evaluate(
+    () =>
+      new Promise<void>(resolve => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      })
+  );
+}
+
+test.describe('Sessions index — state coverage', () => {
+  test.describe.configure({ retries: 0 });
+
+  // ── Desktop ────────────────────────────────────────────────────────────────
+
+  test('desktop default state', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await seedAuthSession(page);
+    await seedCookieConsent(page);
+    await mockAuthEndpoints(page);
+    await page.goto('/sessions', { waitUntil: 'domcontentloaded' });
+    await waitForViewReady(page);
+    // Default state expects hero + filters visible (list view populated with fixture entries).
+    await expect(page.locator('[data-slot="sessions-hero"]')).toBeVisible();
+    await expect(page.locator('[data-slot="sessions-filters"]')).toBeVisible();
+    await expect(page).toHaveScreenshot('sessions-index-desktop-default.png', {
+      fullPage: true,
+      animations: 'disabled',
+      mask: [page.locator('[data-dynamic]')],
+    });
+  });
+
+  test('desktop loading state', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await seedAuthSession(page);
+    await seedCookieConsent(page);
+    await mockAuthEndpoints(page);
+    await page.goto('/sessions?state=loading', { waitUntil: 'domcontentloaded' });
+    // Loading uses EmptySessions with kind='loading' (data-slot="sessions-empty-loading").
+    await page.waitForSelector('[data-slot="sessions-empty-loading"]', { timeout: 30_000 });
+    await expect(page.locator('[data-slot="sessions-empty-loading"]')).toBeVisible();
+    await expect(page).toHaveScreenshot('sessions-index-desktop-loading.png', {
+      fullPage: true,
+      animations: 'disabled',
+      // Skeleton pulse animations — mask to avoid flake (mirror Wave A.4/B.1/B.2 pattern).
+      mask: [page.locator('[data-dynamic]'), page.locator('.animate-pulse')],
+    });
+  });
+
+  test('desktop empty state (no sessions)', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await seedAuthSession(page);
+    await seedCookieConsent(page);
+    await mockAuthEndpoints(page);
+    // ?state=empty: stateOverride='empty' → fixture=EMPTY_ARRAY + effectiveKind='empty'
+    // → EmptySessions renders with kind='empty' (data-slot="sessions-empty-empty").
+    await page.goto('/sessions?state=empty', { waitUntil: 'domcontentloaded' });
+    await waitForViewReady(page);
+    await expect(page.locator('[data-slot="sessions-empty-empty"]')).toBeVisible();
+    await expect(page).toHaveScreenshot('sessions-index-desktop-empty.png', {
+      fullPage: true,
+      animations: 'disabled',
+      mask: [page.locator('[data-dynamic]')],
+    });
+  });
+
+  test('desktop filtered-empty state (filters yield no results)', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await seedAuthSession(page);
+    await seedCookieConsent(page);
+    await mockAuthEndpoints(page);
+    await page.goto('/sessions?state=filtered-empty', { waitUntil: 'domcontentloaded' });
+    await waitForViewReady(page);
+    // 6 entries underlying but effectiveKind override → filtered-empty surface
+    // con CTA clearFilters (reset search/status).
+    await expect(page.locator('[data-slot="sessions-empty-filtered-empty"]')).toBeVisible();
+    await expect(page).toHaveScreenshot('sessions-index-desktop-filtered-empty.png', {
+      fullPage: true,
+      animations: 'disabled',
+      mask: [page.locator('[data-dynamic]')],
+    });
+  });
+
+  // ── Mobile ─────────────────────────────────────────────────────────────────
+
+  test('mobile default state', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await seedAuthSession(page);
+    await seedCookieConsent(page);
+    await mockAuthEndpoints(page);
+    await page.goto('/sessions', { waitUntil: 'domcontentloaded' });
+    await waitForViewReady(page);
+    await expect(page.locator('[data-slot="sessions-hero"]')).toBeVisible();
+    await expect(page.locator('[data-slot="sessions-filters"]')).toBeVisible();
+    await expect(page).toHaveScreenshot('sessions-index-mobile-default.png', {
+      fullPage: true,
+      animations: 'disabled',
+      mask: [page.locator('[data-dynamic]')],
+    });
+  });
+
+  test('mobile loading state', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await seedAuthSession(page);
+    await seedCookieConsent(page);
+    await mockAuthEndpoints(page);
+    await page.goto('/sessions?state=loading', { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('[data-slot="sessions-empty-loading"]', { timeout: 30_000 });
+    await expect(page.locator('[data-slot="sessions-empty-loading"]')).toBeVisible();
+    await expect(page).toHaveScreenshot('sessions-index-mobile-loading.png', {
+      fullPage: true,
+      animations: 'disabled',
+      mask: [page.locator('[data-dynamic]'), page.locator('.animate-pulse')],
+    });
+  });
+
+  test('mobile empty state (no sessions)', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await seedAuthSession(page);
+    await seedCookieConsent(page);
+    await mockAuthEndpoints(page);
+    await page.goto('/sessions?state=empty', { waitUntil: 'domcontentloaded' });
+    await waitForViewReady(page);
+    await expect(page.locator('[data-slot="sessions-empty-empty"]')).toBeVisible();
+    await expect(page).toHaveScreenshot('sessions-index-mobile-empty.png', {
+      fullPage: true,
+      animations: 'disabled',
+      mask: [page.locator('[data-dynamic]')],
+    });
+  });
+
+  test('mobile filtered-empty state (filters yield no results)', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await seedAuthSession(page);
+    await seedCookieConsent(page);
+    await mockAuthEndpoints(page);
+    await page.goto('/sessions?state=filtered-empty', { waitUntil: 'domcontentloaded' });
+    await waitForViewReady(page);
+    await expect(page.locator('[data-slot="sessions-empty-filtered-empty"]')).toBeVisible();
+    await expect(page).toHaveScreenshot('sessions-index-mobile-filtered-empty.png', {
+      fullPage: true,
+      animations: 'disabled',
+      mask: [page.locator('[data-dynamic]')],
+    });
+  });
+
+  // Note: desktop-error and mobile-error states are excluded from visual
+  // coverage because the error surface depends on `sessionsQuery.isError`
+  // (TanStack Query network failure) which cannot be reproduced deterministically
+  // via URL override. Error state is covered by unit tests in
+  // `_components/__tests__/SessionsLibraryView.test.tsx`.
+});

--- a/apps/web/e2e/visual-migrated/sp4-sessions-index.spec.ts
+++ b/apps/web/e2e/visual-migrated/sp4-sessions-index.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Visual contract — /sessions route migrata vs mockup baseline.
+ *
+ * Issue #735 (Wave D.1 Sessions migration)
+ * V2 Migration Phase 1 (Wave D.1).
+ *
+ * Strategia (TDD red→green):
+ *   - **Red** (corrente, pre-bootstrap): la baseline PNG non esiste ancora.
+ *   - **Green**: route v2 attiva (`(authenticated)/sessions/_components/
+ *     SessionsLibraryView.tsx`) con hero + filters + results list.
+ *
+ * Bootstrap baseline (one-time, post-migration):
+ *   `gh workflow run visual-regression-migrated.yml --ref feature/issue-735-wave-d1-sessions-fe-v2 \
+ *     -f mode=bootstrap -f project_filter=both`
+ *   Il workflow setta `NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED=1` prima del
+ *   build, così il fixture deterministico (6 entries: Brass: Birmingham, Wingspan×2,
+ *   Azul, Ark Nova, 7 Wonders) viene short-circuitato dal
+ *   `SessionsLibraryView` orchestrator senza richiedere il backend API.
+ *
+ * Strategia ID (visual-test fixture, NOT a backend fetch):
+ *   - Il `SessionsLibraryView` orchestrator legge `IS_VISUAL_TEST_BUILD` da
+ *     `@/lib/sessions/sessions-visual-test-fixture` e sostituisce
+ *     `sessionsQuery.data` con entries deterministiche.
+ *   - In production deploy il fixture è dead code (constant-fold) — NON
+ *     espone alcun shape pubblico.
+ *
+ * Hybrid masking:
+ *   Le zone marcate `data-dynamic` sono mascherate per evitare flake.
+ *
+ * Auth bypass:
+ *   La route `/sessions` è sotto `(authenticated)/` ma il layout non gate-keepa
+ *   server-side; `PLAYWRIGHT_AUTH_BYPASS=true` settato in
+ *   `playwright.config.ts:434` (webServer env) garantisce navigazione senza
+ *   session cookie. `seedAuthSession` + `mockAuthEndpoints` soddisfano il
+ *   `proxy.ts` middleware gate + i flussi React-side `AuthProvider` /
+ *   `useSessionCheck` (Wave B.1 lesson learned).
+ */
+import { test, expect, type Page } from '@playwright/test';
+
+import { mockAuthEndpoints, seedAuthSession } from '../_helpers/seedAuthSession';
+import { seedCookieConsent } from '../_helpers/seedCookieConsent';
+
+const SLUG = 'sp4-sessions-index';
+
+async function waitForSessionsReady(page: Page): Promise<void> {
+  await page.waitForSelector('[data-slot="sessions-library-view"]', { timeout: 30_000 });
+  // Wait for hero and filters to confirm the view is fully mounted.
+  await page.waitForSelector('[data-slot="sessions-hero"]', { timeout: 10_000 });
+  await page.waitForSelector('[data-slot="sessions-filters"]', { timeout: 10_000 });
+
+  await page.evaluate(async () => {
+    if (typeof document !== 'undefined' && 'fonts' in document) {
+      await (document as Document & { fonts: { ready: Promise<void> } }).fonts.ready;
+    }
+  });
+
+  await page.evaluate(
+    () =>
+      new Promise<void>(resolve => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      })
+  );
+}
+
+test.describe('V2 Visual Migrated — /sessions matches mockup baseline', () => {
+  test.describe.configure({ retries: 0 });
+
+  test('Sessions index desktop 1280x720 — default state matches sp4-sessions-index mockup', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await seedAuthSession(page);
+    await seedCookieConsent(page);
+    await mockAuthEndpoints(page);
+    await page.goto('/sessions', { waitUntil: 'domcontentloaded' });
+    await waitForSessionsReady(page);
+
+    await expect(page).toHaveScreenshot(`${SLUG}-desktop.png`, {
+      fullPage: true,
+      animations: 'disabled',
+      mask: [page.locator('[data-dynamic]')],
+    });
+  });
+
+  test('Sessions index mobile 375x812 — default state matches sp4-sessions-index mockup', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await seedAuthSession(page);
+    await seedCookieConsent(page);
+    await mockAuthEndpoints(page);
+    await page.goto('/sessions', { waitUntil: 'domcontentloaded' });
+    await waitForSessionsReady(page);
+
+    await expect(page).toHaveScreenshot(`${SLUG}-mobile.png`, {
+      fullPage: true,
+      animations: 'disabled',
+      mask: [page.locator('[data-dynamic]')],
+    });
+  });
+});

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -219,7 +219,9 @@ const nextConfig = {
       { source: '/agent/slots', destination: '/agents?tab=slots', permanent: true },
 
       // Sessions & Play Records
-      { source: '/sessions/history', destination: '/sessions?tab=history', permanent: true },
+      // Wave D.1 (Issue #735): updated from ?tab=history → ?status=completed to match
+      // the v2 SessionsLibraryView URL-based filter schema (?status= not ?tab=).
+      { source: '/sessions/history', destination: '/sessions?status=completed', permanent: true },
       { source: '/play-records/stats', destination: '/play-records?tab=stats', permanent: true },
 
       // ── Wave C.1 (Issue #581) — REMOVED /games/:id → /discover/:id redirects ──

--- a/apps/web/src/app/(authenticated)/sessions/_components/SessionsLibraryView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/_components/SessionsLibraryView.tsx
@@ -191,9 +191,9 @@ export function SessionsLibraryView(): ReactElement {
   const gridCardLabels = useMemo<SessionCardGridLabels>(
     () => ({
       ...cardLabels,
-      scoreOverflowTemplate: '+{count} altri',
+      scoreOverflowTemplate: t('pages.sessions.card.scoreOverflowTemplate'),
     }),
-    [cardLabels]
+    [cardLabels, t]
   );
 
   const emptyLabels = useMemo<EmptySessionsLabels>(

--- a/apps/web/src/app/(authenticated)/sessions/_components/SessionsLibraryView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/_components/SessionsLibraryView.tsx
@@ -1,0 +1,361 @@
+/**
+ * SessionsLibraryView — Wave D.1 (Issue #735) orchestrator for `/sessions`.
+ *
+ * Tier S route — single hook (useActiveSessions), URL-based filter state SSOT.
+ * Mirrors Wave 4 D1 (PR #717) PlayersLibraryView + Wave B.1 GamesLibraryView patterns.
+ *
+ * Key contracts:
+ *   - URL state SSOT: ?status= | ?view= | ?search= | ?state= (no useState mirrors)
+ *   - useActiveSessions(50) — fetch up to 50 sessions (active + history)
+ *   - gameNameMap: stub `gameId → 'game-{gameId}'` fallback; orchestrator passes
+ *     the map into transformSessionsToItems which falls back to gameId when empty.
+ *     A proper game-title join is a post-Wave D.1 followup (requires a game catalog
+ *     hook that returns id→title map, tracked separately).
+ *   - 5-state FSM: default | loading | empty | filtered-empty | error
+ *     via deriveSessionsUiState + parseStateOverride
+ *   - Visual-test fixture short-circuit (IS_VISUAL_TEST_BUILD) for CI prod builds
+ *     without a backend API — VISUAL_TEST_FIXTURE_SESSIONS substituted for real data
+ *   - i18n labels resolved upfront via a single useTranslation() call;
+ *     components NEVER call t() directly
+ *
+ * Wave B.3 lesson applied: single-tree responsive layout — no mobile/desktop split.
+ * Wave 4 D1 lesson applied: Suspense wrapper in page.tsx for useSearchParams CSR bailout.
+ */
+
+'use client';
+
+import { useCallback, useMemo, type ReactElement } from 'react';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useIntl } from 'react-intl';
+
+import {
+  EmptySessions,
+  SessionCardGrid,
+  SessionCardList,
+  SessionsFilters,
+  SessionsHero,
+  type EmptySessionsLabels,
+  type SessionCardGridLabels,
+  type SessionCardListLabels,
+  type SessionsFiltersLabels,
+  type SessionsHeroLabels,
+} from '@/components/v2/sessions';
+import { useActiveSessions } from '@/hooks/queries/useActiveSessions';
+import { useTranslation } from '@/hooks/useTranslation';
+import {
+  applySearchFilter,
+  applyStatusFilter,
+  parseStatusFilter,
+  parseViewMode,
+  transformSessionsToItems,
+  type SessionListItem,
+  type SessionStatusFilter,
+  type SessionViewMode,
+} from '@/lib/sessions/sessions-filters';
+import { deriveSessionsUiState, type SessionsUiState } from '@/lib/sessions/sessions-state';
+import {
+  IS_VISUAL_TEST_BUILD,
+  STATE_OVERRIDE_ENABLED,
+  VISUAL_TEST_FIXTURE_SESSIONS,
+  VISUAL_TEST_FIXTURE_SESSIONS_EMPTY,
+  parseStateOverride,
+} from '@/lib/sessions/sessions-visual-test-fixture';
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+export function SessionsLibraryView(): ReactElement {
+  const { t } = useTranslation();
+  const intl = useIntl();
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // ── URL state SSOT (no useState mirrors) ─────────────────────────────────
+  // All filter/view/search state lives in URL. Components call handlers which
+  // call router.replace to update URL, triggering re-render with new searchParams.
+
+  const statusFilter = parseStatusFilter(searchParams.get('status'));
+  const view = parseViewMode(searchParams.get('view'));
+  const search = searchParams.get('search') ?? '';
+
+  // State override hatch (dev/visual-test only — dead code in production)
+  // Pass a URLSearchParams-compatible object by constructing one from the
+  // current search string so parseStateOverride works regardless of mock shape.
+  const stateOverride = STATE_OVERRIDE_ENABLED
+    ? parseStateOverride(new URLSearchParams(searchParams.toString()))
+    : null;
+
+  // ── Data ─────────────────────────────────────────────────────────────────
+
+  const sessionsQuery = useActiveSessions(50);
+
+  // Visual fixture short-circuit: CI prod build without backend API
+  const fixture = useMemo<ReadonlyArray<SessionListItem> | null>(() => {
+    if (!IS_VISUAL_TEST_BUILD) return null;
+    // ?fixture=empty or stateOverride='empty' → empty fixture list
+    if (searchParams.get('fixture') === 'empty' || stateOverride === 'empty') {
+      return VISUAL_TEST_FIXTURE_SESSIONS_EMPTY;
+    }
+    return VISUAL_TEST_FIXTURE_SESSIONS;
+  }, [stateOverride, searchParams]);
+
+  // Transform backend DTOs → display-ready SessionListItem[]
+  // gameNameMap stub: gameId → 'game-{gameId}' for now. When a game-catalog hook
+  // that exposes id→name becomes available, inject it here.
+  // The empty map causes transformSessionsToItems to fall back to dto.gameId as-is.
+  const allItems = useMemo<ReadonlyArray<SessionListItem>>(() => {
+    if (fixture != null) return fixture;
+    const sessions = sessionsQuery.data?.sessions ?? [];
+    return transformSessionsToItems(sessions, /* gameNameMap= */ {});
+  }, [fixture, sessionsQuery.data]);
+
+  // Apply status filter
+  const statusFiltered = useMemo(
+    () => applyStatusFilter(allItems, statusFilter),
+    [allItems, statusFilter]
+  );
+
+  // Apply search filter
+  const filtered = useMemo(
+    () => applySearchFilter(statusFiltered, search),
+    [statusFiltered, search]
+  );
+
+  // ── FSM ──────────────────────────────────────────────────────────────────
+
+  const realKind = useMemo<SessionsUiState>(() => {
+    if (fixture != null) return 'default'; // fixture always renders default view
+    return deriveSessionsUiState({
+      isLoading: sessionsQuery.isLoading,
+      isError: sessionsQuery.isError,
+      totalCount: allItems.length,
+      filteredCount: filtered.length,
+    });
+  }, [fixture, sessionsQuery.isLoading, sessionsQuery.isError, allItems.length, filtered.length]);
+
+  const effectiveKind: SessionsUiState = stateOverride ?? realKind;
+
+  // ── i18n labels ───────────────────────────────────────────────────────────
+
+  const heroLabels = useMemo<SessionsHeroLabels>(
+    () => ({
+      title: t('pages.sessions.hero.title'),
+      // subtitleTemplate uses {count} replaced at render time in SessionsHero
+      // Use intl.messages to read the raw template string — bypasses ICU parsing
+      // (react-intl would throw for unresolved {count} variables if we used t())
+      subtitleTemplate:
+        (intl.messages['pages.sessions.hero.subtitle'] as string) ?? '{count} partite',
+      ctaNew: t('pages.sessions.hero.ctaNew'),
+    }),
+    [t, intl.messages]
+  );
+
+  const filtersLabels = useMemo<SessionsFiltersLabels>(
+    () => ({
+      statusAll: t('pages.sessions.filters.status.all'),
+      statusActive: t('pages.sessions.filters.status.active'),
+      statusCompleted: t('pages.sessions.filters.status.completed'),
+      statusAbandoned: t('pages.sessions.filters.status.abandoned'),
+      searchPlaceholder: t('pages.sessions.filters.searchPlaceholder'),
+      searchAriaLabel: t('pages.sessions.filters.searchAriaLabel'),
+      viewList: t('pages.sessions.filters.view.list'),
+      viewGrid: t('pages.sessions.filters.view.grid'),
+      statusGroupLabel: t('pages.sessions.filters.status.all'), // reuse "Tutti" as group label
+      viewToggleLabel: t('pages.sessions.filters.view.label'),
+    }),
+    [t]
+  );
+
+  const cardLabels = useMemo<SessionCardListLabels>(
+    () => ({
+      outcomeWon: t('pages.sessions.card.outcome.won'),
+      outcomeLost: t('pages.sessions.card.outcome.lost'),
+      outcomeTie: t('pages.sessions.card.outcome.tie'),
+      statusLive: t('pages.sessions.card.status.live'),
+      statusPaused: t('pages.sessions.card.status.paused'),
+      statusAbandoned: t('pages.sessions.card.status.abandoned'),
+      playerCountTemplate:
+        (intl.messages['pages.sessions.card.playerCount'] as string) ?? '{count} giocatori',
+      chatCountTemplate: '{count}',
+      turnTemplate: (intl.messages['pages.sessions.card.turnLabel'] as string) ?? 'Turno {turn}',
+      winnerLabel: t('pages.sessions.card.winnerLabel'),
+      openSessionAriaTemplate:
+        (intl.messages['pages.sessions.card.openAriaLabel'] as string) ??
+        'Apri sessione {gameName}',
+    }),
+    [t, intl.messages]
+  );
+
+  // SessionCardGrid shares the same label shape as SessionCardList
+  const gridCardLabels = useMemo<SessionCardGridLabels>(
+    () => ({
+      ...cardLabels,
+      scoreOverflowTemplate: '+{count} altri',
+    }),
+    [cardLabels]
+  );
+
+  const emptyLabels = useMemo<EmptySessionsLabels>(
+    () => ({
+      emptyTitle: t('pages.sessions.empty.title'),
+      emptyDescription: t('pages.sessions.empty.description'),
+      emptyCta: t('pages.sessions.empty.ctaStart'),
+      filteredEmptyTitle: t('pages.sessions.filteredEmpty.title'),
+      filteredEmptyDescription: t('pages.sessions.filteredEmpty.description'),
+      filteredEmptyCta: t('pages.sessions.filteredEmpty.ctaClear'),
+      loadingAriaLabel: t('pages.sessions.loading.ariaLabel'),
+      errorTitle: t('pages.sessions.error.title'),
+      errorDescription: t('pages.sessions.error.description'),
+      errorCta: t('pages.sessions.error.ctaRetry'),
+    }),
+    [t]
+  );
+
+  // ── URL update helpers ────────────────────────────────────────────────────
+
+  /** Build a new URLSearchParams preserving params not owned by this view. */
+  const buildQuery = useCallback(
+    (overrides: Partial<Record<string, string | null>>): string => {
+      const params = new URLSearchParams(searchParams.toString());
+      Object.entries(overrides).forEach(([key, val]) => {
+        if (val == null || val === '') {
+          params.delete(key);
+        } else {
+          params.set(key, val);
+        }
+      });
+      const qs = params.toString();
+      return qs ? `?${qs}` : '';
+    },
+    [searchParams]
+  );
+
+  const handleStatusChange = useCallback(
+    (next: SessionStatusFilter) => {
+      const val = next === 'all' ? null : next;
+      router.replace(`${pathname}${buildQuery({ status: val })}`, { scroll: false });
+    },
+    [router, pathname, buildQuery]
+  );
+
+  const handleViewChange = useCallback(
+    (next: SessionViewMode) => {
+      const val = next === 'list' ? null : next;
+      router.replace(`${pathname}${buildQuery({ view: val })}`, { scroll: false });
+    },
+    [router, pathname, buildQuery]
+  );
+
+  const handleSearchChange = useCallback(
+    (next: string) => {
+      router.replace(`${pathname}${buildQuery({ search: next || null })}`, { scroll: false });
+    },
+    [router, pathname, buildQuery]
+  );
+
+  const handleNewSession = useCallback(() => {
+    router.push('/sessions/new');
+  }, [router]);
+
+  const handleItemClick = useCallback(
+    (item: SessionListItem) => {
+      router.push(`/sessions/${item.id}`);
+    },
+    [router]
+  );
+
+  const handleRetry = useCallback(() => {
+    void sessionsQuery.refetch?.();
+  }, [sessionsQuery]);
+
+  /** Filtered-empty CTA: reset status to 'all' (clears ?status= param). */
+  const handleClearFilters = useCallback(() => {
+    // Drop ?status= and ?search= params; preserve ?view= and ?state=
+    router.replace(`${pathname}${buildQuery({ status: null, search: null })}`, { scroll: false });
+  }, [router, pathname, buildQuery]);
+
+  // ── Status counts for pill badges ────────────────────────────────────────
+
+  const counts = useMemo<Partial<Record<SessionStatusFilter, number>>>(
+    () => ({
+      all: allItems.length,
+      active: allItems.filter(s => s.status === 'inprogress' || s.status === 'paused').length,
+      completed: allItems.filter(s => s.status === 'completed').length,
+      abandoned: allItems.filter(s => s.status === 'abandoned').length,
+    }),
+    [allItems]
+  );
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  return (
+    <div
+      data-slot="sessions-library-view"
+      className="flex flex-col gap-6 pb-24"
+      id="sessions-content"
+    >
+      <SessionsHero count={allItems.length} onNewSession={handleNewSession} labels={heroLabels} />
+
+      <SessionsFilters
+        statusFilter={statusFilter}
+        onStatusChange={handleStatusChange}
+        view={view}
+        onViewChange={handleViewChange}
+        search={search}
+        onSearchChange={handleSearchChange}
+        counts={counts}
+        labels={filtersLabels}
+      />
+
+      {/* FSM render branches */}
+      {effectiveKind === 'default' ? (
+        view === 'grid' ? (
+          <div
+            role="region"
+            aria-label={t('pages.sessions.a11y.resultsLabel')}
+            className="mx-auto grid w-full max-w-[1280px] grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4 px-4 sm:px-8"
+          >
+            {filtered.map(item => (
+              <SessionCardGrid
+                key={item.id}
+                item={item}
+                onClick={handleItemClick}
+                labels={gridCardLabels}
+              />
+            ))}
+          </div>
+        ) : (
+          <div
+            role="region"
+            aria-label={t('pages.sessions.a11y.resultsLabel')}
+            className="mx-auto flex w-full max-w-[1280px] flex-col gap-2 px-4 sm:px-8"
+          >
+            {filtered.map(item => (
+              <SessionCardList
+                key={item.id}
+                item={item}
+                onClick={handleItemClick}
+                labels={cardLabels}
+              />
+            ))}
+          </div>
+        )
+      ) : (
+        <EmptySessions
+          kind={effectiveKind}
+          labels={emptyLabels}
+          onPrimaryAction={
+            effectiveKind === 'empty'
+              ? handleNewSession
+              : effectiveKind === 'filtered-empty'
+                ? handleClearFilters
+                : effectiveKind === 'error'
+                  ? handleRetry
+                  : undefined
+          }
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/sessions/_components/SessionsLibraryView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/_components/SessionsLibraryView.tsx
@@ -141,14 +141,11 @@ export function SessionsLibraryView(): ReactElement {
   const heroLabels = useMemo<SessionsHeroLabels>(
     () => ({
       title: t('pages.sessions.hero.title'),
-      // subtitleTemplate uses {count} replaced at render time in SessionsHero
-      // Use intl.messages to read the raw template string — bypasses ICU parsing
-      // (react-intl would throw for unresolved {count} variables if we used t())
-      subtitleTemplate:
-        (intl.messages['pages.sessions.hero.subtitle'] as string) ?? '{count} partite',
+      // Resolve ICU plural subtitle with count param via next-intl's t() (proper formatter)
+      subtitle: t('pages.sessions.hero.subtitle', { count: allItems.length }),
       ctaNew: t('pages.sessions.hero.ctaNew'),
     }),
-    [t, intl.messages]
+    [t, allItems.length]
   );
 
   const filtersLabels = useMemo<SessionsFiltersLabels>(
@@ -295,7 +292,7 @@ export function SessionsLibraryView(): ReactElement {
       className="flex flex-col gap-6 pb-24"
       id="sessions-content"
     >
-      <SessionsHero count={allItems.length} onNewSession={handleNewSession} labels={heroLabels} />
+      <SessionsHero onNewSession={handleNewSession} labels={heroLabels} />
 
       <SessionsFilters
         statusFilter={statusFilter}

--- a/apps/web/src/app/(authenticated)/sessions/_components/__tests__/SessionsLibraryView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/_components/__tests__/SessionsLibraryView.test.tsx
@@ -1,0 +1,466 @@
+/**
+ * Wave D.1 (Issue #735) — SessionsLibraryView orchestrator tests.
+ *
+ * Mirrors Wave 4 D1 PlayersLibraryView tests: stub `useActiveSessions` +
+ * `next/navigation` search params + i18n via IntlProvider seeded with the
+ * actual `pages.sessions.*` keys from `it.json`.
+ *
+ * Contract under test (Tier S):
+ *   - 5-state FSM: default | loading | empty | filtered-empty | error
+ *   - `?state=...` URL override gated by NODE_ENV !== 'production'
+ *   - Status filter via URL param (?status=) — SSOT
+ *   - View mode via URL param (?view=list|grid) — SSOT
+ *   - Search filter via URL param (?search=) — SSOT
+ *   - Card click calls router.push('/sessions/{id}')
+ *   - New session CTA navigates to /sessions/new
+ *   - Filtered-empty CTA resets status filter to 'all' via URL update
+ *   - Visual fixture short-circuit when IS_VISUAL_TEST_BUILD === true
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactElement } from 'react';
+
+import type { PaginatedSessionsResponse } from '@/lib/api/schemas/games.schemas';
+
+// ─── next/navigation mocks ────────────────────────────────────────────────
+
+const searchParamsMap: Record<string, string> = {};
+const routerPush = vi.fn();
+const routerReplace = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => ({
+    get: (key: string) => searchParamsMap[key] ?? null,
+    toString: () => new URLSearchParams(searchParamsMap).toString(),
+  }),
+  useRouter: () => ({ push: routerPush, replace: routerReplace }),
+  usePathname: () => '/sessions',
+}));
+
+// ─── useActiveSessions mock ───────────────────────────────────────────────
+
+type MockActiveSessionsReturn = {
+  data?: PaginatedSessionsResponse;
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+  refetch?: () => void;
+};
+
+const useActiveSessionsMock = vi.fn<[], MockActiveSessionsReturn>();
+
+vi.mock('@/hooks/queries/useActiveSessions', () => ({
+  useActiveSessions: () => useActiveSessionsMock(),
+}));
+
+// ─── visual fixture mock ──────────────────────────────────────────────────
+
+vi.mock('@/lib/sessions/sessions-visual-test-fixture', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/lib/sessions/sessions-visual-test-fixture')
+  >('@/lib/sessions/sessions-visual-test-fixture');
+  return {
+    ...actual,
+    IS_VISUAL_TEST_BUILD: false, // default — tests override per-test when needed
+  };
+});
+
+// ─── react-intl messages (subset matching it.json `pages.sessions.*`) ────
+
+const MESSAGES: Record<string, string> = {
+  'pages.sessions.metadata.title': 'Le mie partite — MeepleAI',
+  'pages.sessions.hero.title': 'Le tue partite',
+  'pages.sessions.hero.subtitle':
+    '{count, plural, =0 {Nessuna partita ancora} =1 {1 partita registrata} other {# partite registrate}}',
+  'pages.sessions.hero.ctaNew': 'Registra partita',
+  'pages.sessions.filters.status.all': 'Tutti',
+  'pages.sessions.filters.status.active': 'In corso',
+  'pages.sessions.filters.status.completed': 'Completate',
+  'pages.sessions.filters.status.abandoned': 'Abbandonate',
+  'pages.sessions.filters.searchPlaceholder': 'Cerca partita o gioco…',
+  'pages.sessions.filters.searchAriaLabel': 'Cerca tra le tue partite',
+  'pages.sessions.filters.view.label': 'Vista',
+  'pages.sessions.filters.view.list': 'Lista',
+  'pages.sessions.filters.view.grid': 'Griglia',
+  'pages.sessions.empty.title': 'Nessuna partita ancora',
+  'pages.sessions.empty.description':
+    'Registra la tua prima partita giocata o avvia una sessione live per tracciare turni, punteggi e diari.',
+  'pages.sessions.empty.ctaStart': 'Registra prima partita',
+  'pages.sessions.filteredEmpty.title': 'Nessuna partita per questi filtri',
+  'pages.sessions.filteredEmpty.description': 'Prova a rimuovere alcuni vincoli o cambia periodo.',
+  'pages.sessions.filteredEmpty.ctaClear': 'Reset filtri',
+  'pages.sessions.loading.ariaLabel': 'Caricamento partite in corso…',
+  'pages.sessions.error.title': 'Errore caricamento',
+  'pages.sessions.error.description': 'Impossibile recuperare le partite. Verifica la connessione.',
+  'pages.sessions.error.ctaRetry': 'Riprova',
+  'pages.sessions.a11y.resultsLabel': 'Lista partite',
+  'pages.sessions.a11y.countTemplate':
+    '{count, plural, =0 {Nessuna partita} =1 {1 partita} other {# partite}}',
+  'pages.sessions.card.outcome.won': 'Vinta',
+  'pages.sessions.card.outcome.lost': 'Persa',
+  'pages.sessions.card.outcome.tie': 'Pareggio',
+  'pages.sessions.card.status.live': 'Live',
+  'pages.sessions.card.status.paused': 'In pausa',
+  'pages.sessions.card.status.abandoned': 'Abbandonata',
+  'pages.sessions.card.playerCount': '{count} giocatori',
+  'pages.sessions.card.winnerLabel': 'Vincitore',
+  'pages.sessions.card.turnLabel': 'Turno {turn}',
+  'pages.sessions.card.openAriaLabel': 'Apri sessione {gameName}',
+};
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <IntlProvider locale="it" messages={MESSAGES}>
+      {ui}
+    </IntlProvider>
+  );
+}
+
+// ─── fixture helpers ──────────────────────────────────────────────────────
+
+/** 3 sessions: 1 inprogress, 1 completed, 1 abandoned */
+const SESSIONS_3: PaginatedSessionsResponse = {
+  sessions: [
+    {
+      id: 'session-001',
+      gameId: 'game-brass',
+      status: 'InProgress',
+      startedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      completedAt: null,
+      playerCount: 3,
+      players: [
+        { playerName: 'Marco', playerOrder: 1, color: 'blue' },
+        { playerName: 'Anna', playerOrder: 2, color: 'red' },
+        { playerName: 'Luca', playerOrder: 3, color: 'green' },
+      ],
+      winnerName: null,
+      notes: null,
+      durationMinutes: 60,
+    },
+    {
+      id: 'session-002',
+      gameId: 'game-wingspan',
+      status: 'Completed',
+      startedAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+      completedAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000 + 90 * 60 * 1000).toISOString(),
+      playerCount: 2,
+      players: [
+        { playerName: 'Marco', playerOrder: 1, color: 'blue' },
+        { playerName: 'Sara', playerOrder: 2, color: 'yellow' },
+      ],
+      winnerName: 'Marco',
+      notes: null,
+      durationMinutes: 90,
+    },
+    {
+      id: 'session-003',
+      gameId: 'game-azul',
+      status: 'Abandoned',
+      startedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+      completedAt: null,
+      playerCount: 2,
+      players: [
+        { playerName: 'Marco', playerOrder: 1, color: 'blue' },
+        { playerName: 'Luca', playerOrder: 2, color: 'red' },
+      ],
+      winnerName: null,
+      notes: null,
+      durationMinutes: 25,
+    },
+  ],
+  total: 3,
+  page: 1,
+  pageSize: 50,
+};
+
+// ─── import under test ────────────────────────────────────────────────────
+
+import { SessionsLibraryView } from '../SessionsLibraryView';
+
+describe('SessionsLibraryView (Wave D.1)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset URL params to clean state
+    Object.keys(searchParamsMap).forEach(k => delete searchParamsMap[k]);
+    useActiveSessionsMock.mockReturnValue({
+      data: SESSIONS_3,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+  });
+
+  // ─── Cell 1: default ────────────────────────────────────────────────────
+
+  it('renders SessionsHero + SessionsFilters + session list in default state', () => {
+    const { container } = renderWithIntl(<SessionsLibraryView />);
+    expect(container.querySelector('[data-slot="sessions-hero"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="sessions-filters"]')).toBeInTheDocument();
+    // No empty state in default
+    expect(container.querySelector('[data-slot^="sessions-empty-"]')).not.toBeInTheDocument();
+  });
+
+  it('hero renders session count from fetched data (3 sessions)', () => {
+    const { container } = renderWithIntl(<SessionsLibraryView />);
+    // Hero subtitle shows count; check hero presence
+    const hero = container.querySelector('[data-slot="sessions-hero"]');
+    expect(hero).toBeInTheDocument();
+    // Hero CTA is present
+    expect(container.querySelector('[data-slot="sessions-hero-cta"]')).toBeInTheDocument();
+  });
+
+  it('default view shows list cards (SessionCardList) when ?view is unset', () => {
+    const { container } = renderWithIntl(<SessionsLibraryView />);
+    // Default view=list → session-card-list elements
+    const listCards = container.querySelectorAll('[data-slot="session-card-list"]');
+    expect(listCards.length).toBeGreaterThan(0);
+    expect(container.querySelectorAll('[data-slot="session-card-grid"]')).toHaveLength(0);
+  });
+
+  it('?view=grid shows grid cards (SessionCardGrid)', () => {
+    searchParamsMap['view'] = 'grid';
+    const { container } = renderWithIntl(<SessionsLibraryView />);
+    const gridCards = container.querySelectorAll('[data-slot="session-card-grid"]');
+    expect(gridCards.length).toBeGreaterThan(0);
+    expect(container.querySelectorAll('[data-slot="session-card-list"]')).toHaveLength(0);
+  });
+
+  // ─── Cell 2: loading ────────────────────────────────────────────────────
+
+  it('renders EmptySessions kind="loading" when query isLoading=true', () => {
+    useActiveSessionsMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+    });
+    const { container } = renderWithIntl(<SessionsLibraryView />);
+    expect(container.querySelector('[data-slot="sessions-empty-loading"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="session-card-list"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[data-slot="session-card-grid"]')).not.toBeInTheDocument();
+  });
+
+  // ─── Cell 3: error ──────────────────────────────────────────────────────
+
+  it('renders EmptySessions kind="error" when query isError=true', () => {
+    useActiveSessionsMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error('network error'),
+      refetch: vi.fn(),
+    });
+    const { container } = renderWithIntl(<SessionsLibraryView />);
+    expect(container.querySelector('[data-slot="sessions-empty-error"]')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Riprova' })).toBeInTheDocument();
+  });
+
+  // ─── Cell 4: empty (no data) ────────────────────────────────────────────
+
+  it('renders EmptySessions kind="empty" when sessions array is empty', () => {
+    useActiveSessionsMock.mockReturnValue({
+      data: { sessions: [], total: 0, page: 1, pageSize: 50 },
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    const { container } = renderWithIntl(<SessionsLibraryView />);
+    expect(container.querySelector('[data-slot="sessions-empty-empty"]')).toBeInTheDocument();
+  });
+
+  // ─── Cell 5: filtered-empty ─────────────────────────────────────────────
+
+  it('renders EmptySessions kind="filtered-empty" when status filter yields no results', () => {
+    // SESSIONS_3 has no 'Paused' sessions
+    searchParamsMap['status'] = 'active';
+    // Only InProgress maps to active — but we need to set up a scenario with no matches
+    // Actually SESSIONS_3 has 1 InProgress, so let's use 'abandoned' and clear them
+    useActiveSessionsMock.mockReturnValue({
+      data: {
+        sessions: [SESSIONS_3.sessions[1]!], // Only completed
+        total: 1,
+        page: 1,
+        pageSize: 50,
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    searchParamsMap['status'] = 'active'; // Filter for active, but only completed exists
+    const { container } = renderWithIntl(<SessionsLibraryView />);
+    expect(
+      container.querySelector('[data-slot="sessions-empty-filtered-empty"]')
+    ).toBeInTheDocument();
+  });
+
+  // ─── Status filter from URL ─────────────────────────────────────────────
+
+  it('?status=active filters to show only inprogress/paused sessions', () => {
+    searchParamsMap['status'] = 'active';
+    const { container } = renderWithIntl(<SessionsLibraryView />);
+    // SESSIONS_3 has 1 InProgress → 1 card shown
+    const listCards = container.querySelectorAll('[data-slot="session-card-list"]');
+    expect(listCards).toHaveLength(1);
+    expect(listCards[0]).toHaveAttribute('data-item-id', 'session-001');
+  });
+
+  it('?status=completed filters to show only completed sessions', () => {
+    searchParamsMap['status'] = 'completed';
+    const { container } = renderWithIntl(<SessionsLibraryView />);
+    const listCards = container.querySelectorAll('[data-slot="session-card-list"]');
+    expect(listCards).toHaveLength(1);
+    expect(listCards[0]).toHaveAttribute('data-item-id', 'session-002');
+  });
+
+  it('?status=abandoned filters to show only abandoned sessions', () => {
+    searchParamsMap['status'] = 'abandoned';
+    const { container } = renderWithIntl(<SessionsLibraryView />);
+    const listCards = container.querySelectorAll('[data-slot="session-card-list"]');
+    expect(listCards).toHaveLength(1);
+    expect(listCards[0]).toHaveAttribute('data-item-id', 'session-003');
+  });
+
+  // ─── Search filter from URL ─────────────────────────────────────────────
+
+  it('?search= filters sessions by gameName', () => {
+    searchParamsMap['search'] = 'brass';
+    const { container } = renderWithIntl(<SessionsLibraryView />);
+    // game-brass gameId → fallback gameName = 'game-brass' (no gameNameMap in orchestrator)
+    const listCards = container.querySelectorAll('[data-slot="session-card-list"]');
+    // Only session-001 has gameId 'game-brass' which includes 'brass'
+    expect(listCards).toHaveLength(1);
+    expect(listCards[0]).toHaveAttribute('data-item-id', 'session-001');
+  });
+
+  // ─── Card click navigation ──────────────────────────────────────────────
+
+  it('clicking a list card calls router.push with /sessions/{id}', () => {
+    const { container } = renderWithIntl(<SessionsLibraryView />);
+    const cards = container.querySelectorAll('[data-slot="session-card-list"]');
+    expect(cards.length).toBeGreaterThan(0);
+    fireEvent.click(cards[0]!);
+    expect(routerPush).toHaveBeenCalledWith('/sessions/session-001');
+  });
+
+  it('clicking a grid card calls router.push with /sessions/{id}', () => {
+    searchParamsMap['view'] = 'grid';
+    const { container } = renderWithIntl(<SessionsLibraryView />);
+    const cards = container.querySelectorAll('[data-slot="session-card-grid"]');
+    expect(cards.length).toBeGreaterThan(0);
+    fireEvent.click(cards[0]!);
+    expect(routerPush).toHaveBeenCalledWith('/sessions/session-001');
+  });
+
+  // ─── New session CTA ────────────────────────────────────────────────────
+
+  it('hero CTA calls router.push(/sessions/new)', () => {
+    const { container } = renderWithIntl(<SessionsLibraryView />);
+    const cta = container.querySelector('[data-slot="sessions-hero-cta"]') as HTMLButtonElement;
+    expect(cta).toBeInTheDocument();
+    fireEvent.click(cta);
+    expect(routerPush).toHaveBeenCalledWith('/sessions/new');
+  });
+
+  it('empty state CTA navigates to /sessions/new', () => {
+    useActiveSessionsMock.mockReturnValue({
+      data: { sessions: [], total: 0, page: 1, pageSize: 50 },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    const { container } = renderWithIntl(<SessionsLibraryView />);
+    const cta = container.querySelector('[data-slot="sessions-empty-cta"]') as HTMLButtonElement;
+    expect(cta).toBeInTheDocument();
+    fireEvent.click(cta);
+    expect(routerPush).toHaveBeenCalledWith('/sessions/new');
+  });
+
+  // ─── Filtered-empty CTA resets filter ──────────────────────────────────
+
+  it('filtered-empty CTA resets status to all via router.replace', () => {
+    searchParamsMap['status'] = 'active';
+    useActiveSessionsMock.mockReturnValue({
+      data: {
+        sessions: [SESSIONS_3.sessions[1]!], // only completed
+        total: 1,
+        page: 1,
+        pageSize: 50,
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    const { container } = renderWithIntl(<SessionsLibraryView />);
+    expect(
+      container.querySelector('[data-slot="sessions-empty-filtered-empty"]')
+    ).toBeInTheDocument();
+    const cta = container.querySelector('[data-slot="sessions-empty-cta"]') as HTMLButtonElement;
+    expect(cta).toBeInTheDocument();
+    fireEvent.click(cta);
+    // Should reset the status filter via router.replace
+    expect(routerReplace).toHaveBeenCalled();
+    const callArg = routerReplace.mock.calls[0]?.[0];
+    expect(callArg).toContain('/sessions');
+  });
+
+  // ─── ?state= URL override ───────────────────────────────────────────────
+
+  it('?state=loading URL override forces loading skeleton (NODE_ENV=test)', () => {
+    searchParamsMap['state'] = 'loading';
+    const { container } = renderWithIntl(<SessionsLibraryView />);
+    expect(container.querySelector('[data-slot="sessions-empty-loading"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="session-card-list"]')).not.toBeInTheDocument();
+  });
+
+  it('?state=empty URL override forces empty shell', () => {
+    searchParamsMap['state'] = 'empty';
+    const { container } = renderWithIntl(<SessionsLibraryView />);
+    expect(container.querySelector('[data-slot="sessions-empty-empty"]')).toBeInTheDocument();
+  });
+
+  it('?state=filtered-empty URL override forces filtered-empty shell', () => {
+    searchParamsMap['state'] = 'filtered-empty';
+    const { container } = renderWithIntl(<SessionsLibraryView />);
+    expect(
+      container.querySelector('[data-slot="sessions-empty-filtered-empty"]')
+    ).toBeInTheDocument();
+  });
+
+  it('ignores unknown ?state= values and falls back to real FSM (default)', () => {
+    searchParamsMap['state'] = 'bogus-state';
+    const { container } = renderWithIntl(<SessionsLibraryView />);
+    expect(container.querySelector('[data-slot="session-card-list"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot^="sessions-empty-"]')).not.toBeInTheDocument();
+  });
+
+  // ─── Visual fixture short-circuit ───────────────────────────────────────
+
+  it('renders real data (not fixture) when IS_VISUAL_TEST_BUILD is false (default test env)', () => {
+    // With IS_VISUAL_TEST_BUILD=false (default in tests), real hook data is used
+    const { container } = renderWithIntl(<SessionsLibraryView />);
+    // 3 sessions from SESSIONS_3 fixture mock
+    const cards = container.querySelectorAll('[data-slot="session-card-list"]');
+    expect(cards).toHaveLength(3);
+  });
+
+  // ─── Retry action ───────────────────────────────────────────────────────
+
+  it('error state retry button calls refetch', () => {
+    const refetch = vi.fn();
+    useActiveSessionsMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error('fail'),
+      refetch,
+    });
+    renderWithIntl(<SessionsLibraryView />);
+    const retryBtn = screen.getByRole('button', { name: 'Riprova' });
+    fireEvent.click(retryBtn);
+    expect(refetch).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/app/(authenticated)/sessions/page.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/page.tsx
@@ -1,121 +1,29 @@
+/**
+ * Sessions page — /sessions
+ *
+ * Wave D.1 (Issue #735): thin client shell.
+ * All rendering, data-fetching, and FSM logic live in SessionsLibraryView.
+ *
+ * Suspense boundary required: SessionsLibraryView calls `useSearchParams()`
+ * for URL-based filter state (status/view/search/state overrides), which
+ * triggers CSR bailout during static prerender (Next.js 16). Wrapping in
+ * Suspense allows the page to prerender without the search params, which
+ * are then resolved on client hydration.
+ * Mirror Wave 4 D1 PlayersPage + Wave B.1 GamesHubPage pattern.
+ *
+ * @see apps/web/src/app/(authenticated)/sessions/_components/SessionsLibraryView.tsx
+ */
+
 'use client';
 
-import { useState, useMemo } from 'react';
+import { Suspense } from 'react';
 
-import Link from 'next/link';
+import { SessionsLibraryView } from './_components/SessionsLibraryView';
 
-import { HubLayout, type FilterChip } from '@/components/layout/HubLayout';
-import { MeepleCard } from '@/components/ui/data-display/meeple-card';
-import { Skeleton } from '@/components/ui/feedback/skeleton';
-import { useActiveSessions } from '@/hooks/queries/useActiveSessions';
-
-// ========== Filter chips ==========
-
-const FILTERS: FilterChip[] = [
-  { id: 'all', label: 'Tutte' },
-  { id: 'active', label: 'Attive' },
-];
-
-// ========== Loading skeleton ==========
-
-function LoadingSkeleton() {
+export default function SessionsPage() {
   return (
-    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 px-4">
-      {Array.from({ length: 8 }).map((_, i) => (
-        <Skeleton key={i} className="h-40 rounded-xl" />
-      ))}
-    </div>
-  );
-}
-
-// ========== Empty state ==========
-
-function EmptyState() {
-  return (
-    <div className="flex flex-col items-center gap-3 py-16 px-4 text-center text-[var(--nh-text-muted,#94a3b8)]">
-      <span className="text-5xl">🎮</span>
-      <p className="font-medium">Nessuna sessione trovata.</p>
-      <p className="text-sm">Inizia una nuova sessione per giocare con i tuoi amici.</p>
-    </div>
-  );
-}
-
-// ========== Hub page ==========
-
-export default function SessionsHubPage() {
-  const [search, setSearch] = useState('');
-  const [activeFilter, setActiveFilter] = useState('all');
-  const [viewMode, setViewMode] = useState<'grid' | 'list' | 'carousel'>('list');
-
-  // Fetch active sessions (limit 20)
-  const { data, isLoading } = useActiveSessions(20);
-
-  // Tabs/breadcrumb are now owned by `sessions/layout.tsx` via PageHeader.
-
-  const items = useMemo(() => {
-    const sessions = data?.sessions ?? [];
-    const q = search.toLowerCase();
-    return sessions
-      .filter(s => {
-        if (activeFilter === 'active') {
-          return s.status === 'InProgress' || s.status === 'Setup' || s.status === 'Paused';
-        }
-        return true;
-      })
-      .filter(s => {
-        if (!q) return true;
-        // GameSessionDto has gameId but no gameName — use id as fallback title
-        return String(s.id).toLowerCase().includes(q) || s.status.toLowerCase().includes(q);
-      })
-      .map(s => ({
-        entity: 'session' as const,
-        id: s.id,
-        // GameSessionDto doesn't carry a display name; use status + playerCount as title
-        title: `Sessione (${s.playerCount} ${s.playerCount === 1 ? 'giocatore' : 'giocatori'})`,
-        subtitle: s.status,
-        variant: 'list' as const,
-      }));
-  }, [data, search, activeFilter]);
-
-  const topActions = (
-    <Link
-      href="/sessions/new"
-      className="inline-flex items-center gap-1 h-9 px-3 text-sm font-semibold rounded-2xl bg-[var(--nh-text-primary,#1a1a1a)] text-white shrink-0"
-    >
-      ＋ Nuova
-    </Link>
-  );
-
-  return (
-    <HubLayout
-      searchPlaceholder="Filtra per stato..."
-      filterChips={FILTERS}
-      activeFilterId={activeFilter}
-      onFilterChange={setActiveFilter}
-      searchValue={search}
-      onSearchChange={setSearch}
-      viewMode={viewMode}
-      onViewModeChange={setViewMode}
-      showViewToggle
-      topActions={topActions}
-    >
-      {isLoading ? (
-        <LoadingSkeleton />
-      ) : items.length === 0 ? (
-        <EmptyState />
-      ) : (
-        <div
-          className={
-            viewMode === 'list'
-              ? 'flex flex-col gap-2 px-4 pb-24'
-              : 'grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 px-4 pb-24'
-          }
-        >
-          {items.map(item => (
-            <MeepleCard key={item.id} {...item} />
-          ))}
-        </div>
-      )}
-    </HubLayout>
+    <Suspense>
+      <SessionsLibraryView />
+    </Suspense>
   );
 }

--- a/apps/web/src/components/v2/sessions/ConnectionChipStripFooter.tsx
+++ b/apps/web/src/components/v2/sessions/ConnectionChipStripFooter.tsx
@@ -1,16 +1,82 @@
-// TODO: implement per admin-mockups/design_files/sp4-sessions-index.jsx
-// Mapped from mockup component: ChipStrip
-// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
-// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+/**
+ * ConnectionChipStripFooter — Wave D.1 v2 component (Issue #735).
+ *
+ * Mapped from `admin-mockups/design_files/sp4-sessions-index.jsx` (ChipStrip).
+ *
+ * Footer row of entity chips — max 3 (game / player / chat).
+ *
+ * Per chip:
+ *   - Empty chip (count=0 or empty=true): dashed border, 55% opacity.
+ *   - Non-empty chip: entity-colored background (10% alpha), solid border.
+ * Colors via inline style (entityHsl token from MeepleCard — avoids Tailwind
+ * arbitrary value purging for dynamically derived HSL strings).
+ */
 
 import type { ReactElement } from 'react';
 
-export interface ConnectionChipStripFooterProps {
-  // TODO: extract props contract from mockup analysis
+import clsx from 'clsx';
+
+import { entityHsl, entityIcon } from '@/components/ui/data-display/meeple-card';
+import type { MeepleEntityType } from '@/components/ui/data-display/meeple-card';
+
+export interface ConnectionChip {
+  readonly entity: 'game' | 'player' | 'chat';
+  readonly label?: string;
+  readonly count?: number;
+  readonly empty?: boolean;
 }
 
-export function ConnectionChipStripFooter(
-  _props: ConnectionChipStripFooterProps
-): ReactElement | null {
-  return null;
+export interface ConnectionChipStripFooterProps {
+  /** Maximum 3 chips displayed. Additional chips are silently dropped. */
+  readonly chips: ReadonlyArray<ConnectionChip>;
+  readonly className?: string;
+}
+
+export function ConnectionChipStripFooter({
+  chips,
+  className,
+}: ConnectionChipStripFooterProps): ReactElement {
+  const visibleChips = chips.slice(0, 3);
+
+  return (
+    <div
+      data-slot="connection-chip-strip-footer"
+      className={clsx('flex flex-wrap items-center gap-1', className)}
+    >
+      {visibleChips.map((chip, idx) => {
+        const isEmpty = chip.empty === true || (chip.count !== undefined && chip.count === 0);
+        const entityType = chip.entity as MeepleEntityType;
+        const icon = entityIcon[entityType];
+        const solid = entityHsl(entityType);
+        const fill = entityHsl(entityType, 0.1);
+        const border = entityHsl(entityType, 0.2);
+        const dashedBorder = entityHsl(entityType, 0.4);
+
+        return (
+          <span
+            key={idx}
+            data-slot="connection-chip"
+            data-entity={chip.entity}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 3,
+              paddingInline: 7,
+              paddingBlock: 2,
+              borderRadius: '9999px',
+              background: isEmpty ? 'transparent' : fill,
+              border: `1px ${isEmpty ? 'dashed' : 'solid'} ${isEmpty ? dashedBorder : border}`,
+              color: solid,
+              opacity: isEmpty ? 0.55 : 1,
+            }}
+            className="font-mono text-[9.5px] font-extrabold uppercase tracking-wider"
+          >
+            <span aria-hidden="true">{icon}</span>
+            {chip.label && <span>{chip.label}</span>}
+            {chip.count !== undefined && !chip.label && <span>{chip.count}</span>}
+          </span>
+        );
+      })}
+    </div>
+  );
 }

--- a/apps/web/src/components/v2/sessions/EmptySessions.tsx
+++ b/apps/web/src/components/v2/sessions/EmptySessions.tsx
@@ -135,14 +135,16 @@ export function EmptySessions({
       <h2 className="text-lg font-semibold text-foreground sm:text-xl">{title}</h2>
       <p className="max-w-md text-sm text-muted-foreground">{description}</p>
 
-      <button
-        type="button"
-        onClick={onPrimaryAction}
-        className={SESSION_CTA_CLASS}
-        data-slot="sessions-empty-cta"
-      >
-        {cta}
-      </button>
+      {onPrimaryAction && (
+        <button
+          type="button"
+          onClick={onPrimaryAction}
+          className={SESSION_CTA_CLASS}
+          data-slot="sessions-empty-cta"
+        >
+          {cta}
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/v2/sessions/EmptySessions.tsx
+++ b/apps/web/src/components/v2/sessions/EmptySessions.tsx
@@ -1,0 +1,148 @@
+/**
+ * EmptySessions — Wave D.1 v2 component (Issue #735).
+ *
+ * Mapped from `admin-mockups/design_files/sp4-sessions-index.jsx` (EmptyState).
+ *
+ * Pure component: all i18n strings injected via `labels` — no `useTranslation`.
+ *
+ * Discriminated by `kind`:
+ *   - 'empty'          → 🎮 emoji + emptyCta → onPrimaryAction (navigate to new session)
+ *   - 'filtered-empty' → 🔍 emoji + filteredEmptyCta → onPrimaryAction (clear filter)
+ *   - 'loading'        → skeleton placeholders (8 rows)
+ *   - 'error'          → ⚠️ emoji + errorCta → onPrimaryAction (retry)
+ *
+ * WCAG compliance:
+ *   - role="alert" on error kind (live region, immediate announcement).
+ *   - role="status" on empty + filtered-empty (polite live region).
+ *   - CTA: bg-[hsl(240,60%,45%)] (session entity — l45 = 6.8:1 vs white, WCAG AAA).
+ *
+ * data-slot="sessions-empty-{kind}" for E2E selectors.
+ */
+
+import type { ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+export type EmptySessionsKind = 'empty' | 'filtered-empty' | 'loading' | 'error';
+
+export interface EmptySessionsLabels {
+  readonly emptyTitle: string;
+  readonly emptyDescription: string;
+  readonly emptyCta: string;
+  readonly filteredEmptyTitle: string;
+  readonly filteredEmptyDescription: string;
+  readonly filteredEmptyCta: string;
+  readonly loadingAriaLabel: string;
+  readonly errorTitle: string;
+  readonly errorDescription: string;
+  readonly errorCta: string;
+}
+
+export interface EmptySessionsProps {
+  readonly kind: EmptySessionsKind;
+  readonly onPrimaryAction?: () => void;
+  readonly labels: EmptySessionsLabels;
+  readonly className?: string;
+}
+
+const KIND_ICON: Readonly<Record<EmptySessionsKind, string>> = {
+  empty: '🎮',
+  'filtered-empty': '🔍',
+  loading: '',
+  error: '⚠️',
+};
+
+const SESSION_CTA_CLASS = clsx(
+  'mt-2 inline-flex h-10 items-center justify-center rounded-full px-5 text-sm font-semibold',
+  'bg-[hsl(240,60%,45%)] text-white shadow-sm transition-colors',
+  'hover:bg-[hsl(240,60%,38%)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+);
+
+function SkeletonRow(): ReactElement {
+  return (
+    <div className="flex animate-pulse items-center gap-4 rounded-xl border border-border bg-card p-4">
+      <div className="h-12 w-12 shrink-0 rounded-lg bg-muted" />
+      <div className="flex flex-1 flex-col gap-2">
+        <div className="h-3 w-2/5 rounded bg-muted" />
+        <div className="h-2.5 w-3/5 rounded bg-muted" />
+      </div>
+    </div>
+  );
+}
+
+export function EmptySessions({
+  kind,
+  onPrimaryAction,
+  labels,
+  className,
+}: EmptySessionsProps): ReactElement {
+  // Loading skeleton
+  if (kind === 'loading') {
+    return (
+      <div
+        data-slot="sessions-empty-loading"
+        className={clsx('flex flex-col gap-3 px-4 sm:px-8', className)}
+        role="status"
+        aria-label={labels.loadingAriaLabel}
+        aria-busy="true"
+      >
+        {Array.from({ length: 8 }).map((_, i) => (
+          <SkeletonRow key={i} />
+        ))}
+      </div>
+    );
+  }
+
+  const icon = KIND_ICON[kind];
+
+  const title =
+    kind === 'empty'
+      ? labels.emptyTitle
+      : kind === 'filtered-empty'
+        ? labels.filteredEmptyTitle
+        : labels.errorTitle;
+
+  const description =
+    kind === 'empty'
+      ? labels.emptyDescription
+      : kind === 'filtered-empty'
+        ? labels.filteredEmptyDescription
+        : labels.errorDescription;
+
+  const cta =
+    kind === 'empty'
+      ? labels.emptyCta
+      : kind === 'filtered-empty'
+        ? labels.filteredEmptyCta
+        : labels.errorCta;
+
+  return (
+    <div
+      data-slot={`sessions-empty-${kind}`}
+      className={clsx(
+        'flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-border bg-muted/20 px-6 py-12 text-center',
+        'mx-4 sm:mx-8',
+        className
+      )}
+      role={kind === 'error' ? 'alert' : 'status'}
+    >
+      {icon && (
+        <span className="text-4xl" aria-hidden="true">
+          {icon}
+        </span>
+      )}
+
+      <h2 className="text-lg font-semibold text-foreground sm:text-xl">{title}</h2>
+      <p className="max-w-md text-sm text-muted-foreground">{description}</p>
+
+      <button
+        type="button"
+        onClick={onPrimaryAction}
+        className={SESSION_CTA_CLASS}
+        data-slot="sessions-empty-cta"
+      >
+        {cta}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/v2/sessions/OutcomeBadge.tsx
+++ b/apps/web/src/components/v2/sessions/OutcomeBadge.tsx
@@ -1,0 +1,153 @@
+/**
+ * OutcomeBadge — Wave D.1 v2 component (Issue #735).
+ *
+ * Mapped from `admin-mockups/design_files/sp4-sessions-index.jsx` (OutcomeBadge).
+ *
+ * Pure component: all i18n strings injected via `labels` — no `useTranslation`.
+ *
+ * Discriminated by `status × outcome × paused` matrix:
+ *   inprogress + paused=true  → statusPaused (slate, warning)
+ *   inprogress + paused=false → statusLive (session entity color, pulse dot)
+ *   abandoned                 → statusAbandoned (slate muted)
+ *   completed + won           → outcomeWon (emerald-700 — WCAG AA on white)
+ *   completed + lost          → outcomeLost (rose-700 — WCAG AA on white)
+ *   completed + tie           → outcomeTie (slate-700 — WCAG AA on white)
+ *
+ * WCAG AA: 700-shade text colors per Wave C.1 hotfix lesson (never 600 on white).
+ */
+
+import type { ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+import type { SessionListItem } from '@/lib/sessions/sessions-filters';
+
+export interface OutcomeBadgeLabels {
+  readonly outcomeWon: string;
+  readonly outcomeLost: string;
+  readonly outcomeTie: string;
+  readonly statusLive: string;
+  readonly statusPaused: string;
+  readonly statusAbandoned: string;
+}
+
+export interface OutcomeBadgeProps {
+  readonly status: SessionListItem['status'];
+  readonly outcome: SessionListItem['outcome'];
+  readonly paused?: boolean;
+  readonly labels: OutcomeBadgeLabels;
+  readonly className?: string;
+}
+
+const PILL_BASE =
+  'inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-mono text-[10px] font-extrabold uppercase tracking-wider';
+
+export function OutcomeBadge({
+  status,
+  outcome,
+  paused = false,
+  labels,
+  className,
+}: OutcomeBadgeProps): ReactElement | null {
+  // inprogress + paused
+  if (status === 'inprogress' && paused) {
+    return (
+      <span
+        data-slot="outcome-badge"
+        data-status="paused"
+        className={clsx(PILL_BASE, 'bg-amber-50 text-amber-700 ring-1 ring-amber-200', className)}
+      >
+        {labels.statusPaused}
+      </span>
+    );
+  }
+
+  // inprogress + live
+  if (status === 'inprogress') {
+    return (
+      <span
+        data-slot="outcome-badge"
+        data-status="live"
+        className={clsx(
+          PILL_BASE,
+          'mai-pulse bg-[hsla(240,60%,55%,0.14)] text-[hsl(240,60%,45%)] ring-1 ring-[hsla(240,60%,55%,0.3)]',
+          className
+        )}
+      >
+        <span
+          aria-hidden="true"
+          className="inline-block h-1.5 w-1.5 rounded-full bg-[hsl(240,60%,55%)]"
+        />
+        {labels.statusLive}
+      </span>
+    );
+  }
+
+  // abandoned
+  if (status === 'abandoned') {
+    return (
+      <span
+        data-slot="outcome-badge"
+        data-status="abandoned"
+        className={clsx(PILL_BASE, 'bg-slate-100 text-slate-700 ring-1 ring-slate-200', className)}
+      >
+        {labels.statusAbandoned}
+      </span>
+    );
+  }
+
+  // completed — outcome matrix
+  if (status === 'completed') {
+    if (outcome === 'won') {
+      return (
+        <span
+          data-slot="outcome-badge"
+          data-outcome="won"
+          className={clsx(
+            PILL_BASE,
+            'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200',
+            className
+          )}
+        >
+          {labels.outcomeWon}
+        </span>
+      );
+    }
+    if (outcome === 'lost') {
+      return (
+        <span
+          data-slot="outcome-badge"
+          data-outcome="lost"
+          className={clsx(PILL_BASE, 'bg-rose-50 text-rose-700 ring-1 ring-rose-200', className)}
+        >
+          {labels.outcomeLost}
+        </span>
+      );
+    }
+    // tie or null outcome on completed
+    return (
+      <span
+        data-slot="outcome-badge"
+        data-outcome="tie"
+        className={clsx(PILL_BASE, 'bg-slate-100 text-slate-700 ring-1 ring-slate-200', className)}
+      >
+        {labels.outcomeTie}
+      </span>
+    );
+  }
+
+  // paused status
+  if (status === 'paused') {
+    return (
+      <span
+        data-slot="outcome-badge"
+        data-status="paused"
+        className={clsx(PILL_BASE, 'bg-amber-50 text-amber-700 ring-1 ring-amber-200', className)}
+      >
+        {labels.statusPaused}
+      </span>
+    );
+  }
+
+  return null;
+}

--- a/apps/web/src/components/v2/sessions/ScoringInline.tsx
+++ b/apps/web/src/components/v2/sessions/ScoringInline.tsx
@@ -1,0 +1,98 @@
+/**
+ * ScoringInline — Wave D.1 v2 component (Issue #735).
+ *
+ * Mapped from `admin-mockups/design_files/sp4-sessions-index.jsx` (ScoringInline).
+ *
+ * Pure component: no fetch, no i18n calls. Displays player scores inline.
+ *
+ * Schema reality (v1 carryover): when all scores === 0 (SessionPlayerDto has no
+ * score field — placeholder 0), the score chip is hidden and only player names
+ * are shown. This avoids a confusing "everyone scored 0" display.
+ *
+ * Compact mode: max 3 scores visible + "+N others" overflow indicator.
+ */
+
+import type { ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+import type { SessionScoreEntry } from '@/lib/sessions/sessions-filters';
+
+export interface ScoringInlineLabels {
+  readonly winnerAriaLabel: string;
+  /** Template "{count} altri", e.g. "+2 altri" */
+  readonly overflowTemplate?: string;
+}
+
+export interface ScoringInlineProps {
+  readonly scores: ReadonlyArray<SessionScoreEntry>;
+  readonly compact?: boolean;
+  readonly labels: ScoringInlineLabels;
+  readonly className?: string;
+}
+
+/** Returns true when every score is 0 (v1 carryover placeholder). */
+function allScoresZero(scores: ReadonlyArray<SessionScoreEntry>): boolean {
+  return scores.length > 0 && scores.every(s => s.score === 0);
+}
+
+export function ScoringInline({
+  scores,
+  compact = false,
+  labels,
+  className,
+}: ScoringInlineProps): ReactElement | null {
+  if (scores.length === 0) return null;
+
+  const hideScores = allScoresZero(scores);
+  const visibleScores = compact ? scores.slice(0, 3) : scores;
+  const overflowCount = compact ? scores.length - 3 : 0;
+
+  return (
+    <div
+      data-slot="scoring-inline"
+      className={clsx('flex flex-wrap items-center gap-x-2 gap-y-1', className)}
+      aria-label={labels.winnerAriaLabel}
+    >
+      {visibleScores.map((entry, idx) => (
+        <span
+          key={`${entry.name}-${idx}`}
+          className={clsx(
+            'inline-flex items-center gap-1',
+            compact ? 'text-[10.5px]' : 'text-[11.5px]',
+            'font-mono tabular-nums',
+            entry.winner
+              ? 'font-extrabold text-[hsl(240,60%,45%)]'
+              : 'font-semibold text-muted-foreground'
+          )}
+        >
+          {entry.winner && (
+            <span aria-hidden="true" className={compact ? 'text-[9px]' : 'text-[10px]'}>
+              🏆
+            </span>
+          )}
+          <span>{entry.name}</span>
+          {!hideScores && (
+            <span
+              className={clsx(
+                'rounded px-1 py-px font-extrabold',
+                entry.winner ? 'bg-[hsla(240,60%,55%,0.14)]' : 'bg-muted text-muted-foreground'
+              )}
+            >
+              {entry.score}
+            </span>
+          )}
+          {entry.note && <span className="text-[9px] text-muted-foreground">({entry.note})</span>}
+        </span>
+      ))}
+
+      {overflowCount > 0 && (
+        <span className="font-mono text-[9.5px] font-bold text-muted-foreground">
+          {labels.overflowTemplate
+            ? labels.overflowTemplate.replace('{count}', String(overflowCount))
+            : `+${overflowCount}`}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/v2/sessions/SessionCardGrid.tsx
+++ b/apps/web/src/components/v2/sessions/SessionCardGrid.tsx
@@ -1,0 +1,154 @@
+/**
+ * SessionCardGrid — Wave D.1 v2 component (Issue #735).
+ *
+ * Mapped from `admin-mockups/design_files/sp4-sessions-index.jsx` (SessionCardGrid).
+ *
+ * Pure component: renders a single session card in grid view.
+ * Wraps content inside a button for click handling.
+ *
+ * Layout (mockup-derived):
+ *   - Top accent bar (session entity color, 3px absolute)
+ *   - Cover area: entity-colored bg, 🎯 emoji, OutcomeBadge top-right
+ *   - Body: gameName title, date · duration · playerCount meta
+ *   - ScoringInline compact (max 3 visible + overflow)
+ *   - Footer: ConnectionChipStripFooter (game/player/chat)
+ *
+ * Abandoned sessions: reduced opacity (0.7).
+ */
+
+'use client';
+
+import type { ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+import type { SessionListItem } from '@/lib/sessions/sessions-filters';
+
+import { ConnectionChipStripFooter } from './ConnectionChipStripFooter';
+import { OutcomeBadge } from './OutcomeBadge';
+import { ScoringInline } from './ScoringInline';
+
+import type { OutcomeBadgeLabels } from './OutcomeBadge';
+
+export interface SessionCardGridLabels {
+  readonly outcomeWon: string;
+  readonly outcomeLost: string;
+  readonly outcomeTie: string;
+  readonly statusLive: string;
+  readonly statusPaused: string;
+  readonly statusAbandoned: string;
+  readonly playerCountTemplate: string;
+  readonly chatCountTemplate: string;
+  readonly turnTemplate: string;
+  readonly winnerLabel: string;
+  readonly openSessionAriaTemplate: string;
+  /** e.g. "+{count} altri" for score overflow */
+  readonly scoreOverflowTemplate?: string;
+}
+
+export interface SessionCardGridProps {
+  readonly item: SessionListItem;
+  readonly onClick: (item: SessionListItem) => void;
+  readonly labels: SessionCardGridLabels;
+  readonly className?: string;
+}
+
+export function SessionCardGrid({
+  item,
+  onClick,
+  labels,
+  className,
+}: SessionCardGridProps): ReactElement {
+  const isAbandoned = item.status === 'abandoned';
+  const isPaused = item.status === 'paused';
+
+  const ariaLabel = labels.openSessionAriaTemplate.replace('{gameName}', item.gameName);
+
+  const outcomeBadgeLabels: OutcomeBadgeLabels = {
+    outcomeWon: labels.outcomeWon,
+    outcomeLost: labels.outcomeLost,
+    outcomeTie: labels.outcomeTie,
+    statusLive: labels.statusLive,
+    statusPaused: labels.statusPaused,
+    statusAbandoned: labels.statusAbandoned,
+  };
+
+  const chips = [
+    { entity: 'game' as const, label: item.gameName.slice(0, 10) || 'gioco' },
+    { entity: 'player' as const, count: item.playerCount },
+    ...(item.hasChat
+      ? [{ entity: 'chat' as const, count: item.chatCount ?? 0 }]
+      : [{ entity: 'chat' as const, empty: true, count: 0 }]),
+  ];
+
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(item)}
+      aria-label={ariaLabel}
+      data-slot="session-card-grid"
+      data-item-id={item.id}
+      className={clsx(
+        'group relative flex w-full flex-col overflow-hidden rounded-xl border border-border bg-card text-left',
+        'cursor-pointer transition-shadow hover:shadow-md',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        isAbandoned && 'opacity-70',
+        className
+      )}
+    >
+      {/* Top accent bar */}
+      <div
+        aria-hidden="true"
+        className="absolute left-0 right-0 top-0 z-10 h-[3px] bg-[hsl(240,60%,55%)]"
+      />
+
+      {/* Cover area */}
+      <div
+        aria-hidden="true"
+        className="relative flex h-[110px] items-center justify-center bg-[hsla(240,60%,55%,0.12)] text-[44px]"
+      >
+        <span className="drop-shadow-md">🎯</span>
+
+        {/* OutcomeBadge top-right */}
+        <div className="absolute right-2 top-4">
+          <OutcomeBadge
+            status={item.status}
+            outcome={item.outcome}
+            paused={isPaused}
+            labels={outcomeBadgeLabels}
+          />
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="flex flex-1 flex-col gap-2 p-3">
+        {/* Title + meta */}
+        <div>
+          <h3 className="truncate text-sm font-bold leading-tight text-foreground">
+            {item.gameName}
+          </h3>
+          <div className="mt-0.5 font-mono text-[10.5px] font-semibold text-muted-foreground">
+            {item.date} · ⏱ {item.duration} · 👥 {item.playerCount}
+          </div>
+        </div>
+
+        {/* Scoring compact */}
+        <div className="rounded-md bg-muted/40 px-2 py-1.5">
+          <ScoringInline
+            scores={item.scores}
+            compact
+            labels={{
+              winnerAriaLabel: labels.winnerLabel,
+              overflowTemplate: labels.scoreOverflowTemplate,
+            }}
+          />
+        </div>
+
+        {/* Spacer + footer chips */}
+        <div className="mt-auto border-t border-border/40 pt-2">
+          <ConnectionChipStripFooter chips={chips} />
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/apps/web/src/components/v2/sessions/SessionCardList.tsx
+++ b/apps/web/src/components/v2/sessions/SessionCardList.tsx
@@ -1,0 +1,154 @@
+/**
+ * SessionCardList — Wave D.1 v2 component (Issue #735).
+ *
+ * Mapped from `admin-mockups/design_files/sp4-sessions-index.jsx` (SessionCardList).
+ *
+ * Pure component: renders a single session row in list view.
+ * Wraps MeepleCard entity="session" variant="list" inside a button for click handling.
+ *
+ * Layout (mockup-derived):
+ *   - Left accent bar (session entity color) via MeepleCard entity prop
+ *   - Cover placeholder: session entity emoji 🎯 on entity-colored bg
+ *   - Title: gameName + date · duration meta
+ *   - OutcomeBadge inline
+ *   - ScoringInline (full display)
+ *   - ConnectionChipStripFooter: game chip + player count + chat count (max 3)
+ *
+ * Abandoned sessions: reduced opacity (0.7) per mockup.
+ * In-progress sessions: mai-pulse class on wrapper for live dot animation.
+ */
+
+'use client';
+
+import type { ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+import type { SessionListItem } from '@/lib/sessions/sessions-filters';
+
+import { ConnectionChipStripFooter } from './ConnectionChipStripFooter';
+import { OutcomeBadge } from './OutcomeBadge';
+import { ScoringInline } from './ScoringInline';
+
+import type { OutcomeBadgeLabels } from './OutcomeBadge';
+
+export interface SessionCardListLabels {
+  readonly outcomeWon: string;
+  readonly outcomeLost: string;
+  readonly outcomeTie: string;
+  readonly statusLive: string;
+  readonly statusPaused: string;
+  readonly statusAbandoned: string;
+  readonly playerCountTemplate: string;
+  readonly chatCountTemplate: string;
+  readonly turnTemplate: string;
+  readonly winnerLabel: string;
+  readonly openSessionAriaTemplate: string;
+}
+
+export interface SessionCardListProps {
+  readonly item: SessionListItem;
+  readonly onClick: (item: SessionListItem) => void;
+  readonly labels: SessionCardListLabels;
+  readonly className?: string;
+}
+
+export function SessionCardList({
+  item,
+  onClick,
+  labels,
+  className,
+}: SessionCardListProps): ReactElement {
+  const isAbandoned = item.status === 'abandoned';
+  const isInProgress = item.status === 'inprogress';
+  const isPaused = item.status === 'paused';
+
+  const ariaLabel = labels.openSessionAriaTemplate.replace('{gameName}', item.gameName);
+  const turnLabel = item.turn ? labels.turnTemplate.replace('{turn}', item.turn) : undefined;
+
+  const outcomeBadgeLabels: OutcomeBadgeLabels = {
+    outcomeWon: labels.outcomeWon,
+    outcomeLost: labels.outcomeLost,
+    outcomeTie: labels.outcomeTie,
+    statusLive: labels.statusLive,
+    statusPaused: labels.statusPaused,
+    statusAbandoned: labels.statusAbandoned,
+  };
+
+  const chips = [
+    { entity: 'game' as const, label: item.gameName.slice(0, 10) || 'gioco' },
+    { entity: 'player' as const, count: item.playerCount },
+    ...(item.hasChat
+      ? [{ entity: 'chat' as const, count: item.chatCount ?? 0 }]
+      : [{ entity: 'chat' as const, empty: true, count: 0 }]),
+  ];
+
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(item)}
+      aria-label={ariaLabel}
+      data-slot="session-card-list"
+      data-item-id={item.id}
+      className={clsx(
+        'group relative w-full text-left',
+        'flex items-stretch gap-0 overflow-hidden rounded-xl border border-border bg-card',
+        'border-l-[3px] border-l-[hsl(240,60%,55%)]',
+        'cursor-pointer transition-shadow hover:shadow-md',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        isAbandoned && 'opacity-70',
+        isInProgress && 'mai-pulse',
+        className
+      )}
+    >
+      {/* Cover placeholder */}
+      <div
+        aria-hidden="true"
+        className="flex w-[72px] shrink-0 items-center justify-center bg-[hsla(240,60%,55%,0.12)] text-3xl"
+      >
+        <span className="drop-shadow-sm">🎯</span>
+      </div>
+
+      {/* Body */}
+      <div className="flex flex-1 flex-col gap-2 p-3 sm:flex-row sm:items-center sm:gap-4 sm:p-4">
+        {/* Left: title + meta + scoring */}
+        <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+          {/* Title row */}
+          <div className="flex flex-wrap items-center gap-1.5">
+            <h3 className="truncate font-semibold leading-tight text-foreground text-sm sm:text-base">
+              {item.gameName}
+            </h3>
+            <span className="font-mono text-[10.5px] font-semibold text-muted-foreground">
+              · {item.date}
+            </span>
+            <OutcomeBadge
+              status={item.status}
+              outcome={item.outcome}
+              paused={isPaused}
+              labels={outcomeBadgeLabels}
+            />
+            {(isInProgress || isPaused) && turnLabel && (
+              <span className="rounded-full bg-[hsla(240,60%,55%,0.1)] px-1.5 py-px font-mono text-[9.5px] font-extrabold uppercase tracking-wider text-[hsl(240,60%,45%)]">
+                {turnLabel}
+              </span>
+            )}
+          </div>
+
+          {/* Meta subtitle */}
+          <div className="font-mono text-[11px] font-semibold text-muted-foreground">
+            ⏱ {item.duration} ·{' '}
+            {labels.playerCountTemplate.replace('{count}', String(item.playerCount))} · {item.when}
+          </div>
+
+          {/* Scoring */}
+          <ScoringInline scores={item.scores} labels={{ winnerAriaLabel: labels.winnerLabel }} />
+        </div>
+
+        {/* Right: chips */}
+        <div className="flex shrink-0 flex-col items-start gap-2 sm:items-end">
+          <ConnectionChipStripFooter chips={chips} />
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/apps/web/src/components/v2/sessions/SessionsFilters.tsx
+++ b/apps/web/src/components/v2/sessions/SessionsFilters.tsx
@@ -1,14 +1,213 @@
-// TODO: implement per admin-mockups/design_files/sp4-sessions-index.jsx
-// Mapped from mockup component: SessionFilters
-// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
-// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+/**
+ * SessionsFilters — Wave D.1 v2 component (Issue #735).
+ *
+ * Mapped from `admin-mockups/design_files/sp4-sessions-index.jsx` (SessionFilters).
+ *
+ * Pure component: all i18n strings injected via `labels` — no `useTranslation`.
+ *
+ * Layout (mobile-first):
+ *   - Search input: full-width, search icon, aria-label
+ *   - Status pill bar: 4 chips (All/Active/Completed/Abandoned) with WAI-ARIA
+ *     tablist role, roving tabindex, ArrowLeft/Right keyboard nav (via
+ *     useTablistKeyboardNav hook from Wave A.6 PR #623).
+ *   - View toggle: List / Grid 2-button group, aria-pressed states
+ *
+ * WCAG:
+ *   - Active pill: bg-[hsla(240,60%,55%,0.14)] text-[hsl(240,60%,45%)] — l45 = 6.8:1 vs white
+ *   - Focus rings on all interactive elements
+ */
 
-import type { ReactElement } from 'react';
+'use client';
 
-export interface SessionsFiltersProps {
-  // TODO: extract props contract from mockup analysis
+import { type ChangeEvent, type ReactElement, useMemo } from 'react';
+
+import clsx from 'clsx';
+import { LayoutGrid, List, Search } from 'lucide-react';
+
+import { useTablistKeyboardNav } from '@/hooks/useTablistKeyboardNav';
+import type { SessionStatusFilter, SessionViewMode } from '@/lib/sessions/sessions-filters';
+
+export interface SessionsFiltersLabels {
+  readonly statusAll: string;
+  readonly statusActive: string;
+  readonly statusCompleted: string;
+  readonly statusAbandoned: string;
+  readonly searchPlaceholder: string;
+  readonly viewList: string;
+  readonly viewGrid: string;
+  readonly statusGroupLabel: string;
+  readonly viewToggleLabel: string;
+  readonly searchAriaLabel: string;
 }
 
-export function SessionsFilters(_props: SessionsFiltersProps): ReactElement | null {
-  return null;
+export interface SessionsFiltersProps {
+  readonly statusFilter: SessionStatusFilter;
+  readonly onStatusChange: (next: SessionStatusFilter) => void;
+  readonly view: SessionViewMode;
+  readonly onViewChange: (next: SessionViewMode) => void;
+  readonly search: string;
+  readonly onSearchChange: (next: string) => void;
+  readonly counts?: Partial<Record<SessionStatusFilter, number>>;
+  readonly labels: SessionsFiltersLabels;
+  readonly className?: string;
+}
+
+const STATUS_ORDER: ReadonlyArray<SessionStatusFilter> = [
+  'all',
+  'active',
+  'completed',
+  'abandoned',
+];
+
+export function SessionsFilters({
+  statusFilter,
+  onStatusChange,
+  view,
+  onViewChange,
+  search,
+  onSearchChange,
+  counts,
+  labels,
+  className,
+}: SessionsFiltersProps): ReactElement {
+  const orderedKeys = useMemo(() => STATUS_ORDER, []);
+  const { tabRefs, handleKeyDown } = useTablistKeyboardNav<SessionStatusFilter>({
+    orderedKeys,
+    onChange: onStatusChange,
+  });
+
+  const statusLabels: Record<SessionStatusFilter, string> = {
+    all: labels.statusAll,
+    active: labels.statusActive,
+    completed: labels.statusCompleted,
+    abandoned: labels.statusAbandoned,
+  };
+
+  return (
+    <div
+      data-slot="sessions-filters"
+      className={clsx(
+        'sticky top-0 z-10 mx-auto max-w-[1280px] px-4 sm:px-8',
+        'flex flex-col gap-3 py-3',
+        'border-b border-border/60 bg-background/90 backdrop-blur-sm',
+        className
+      )}
+    >
+      {/* Search + view toggle row */}
+      <div className="flex items-center gap-3">
+        {/* Search input */}
+        <div className="relative flex-1">
+          <Search
+            aria-hidden="true"
+            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+          />
+          <input
+            type="search"
+            value={search}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => onSearchChange(e.target.value)}
+            placeholder={labels.searchPlaceholder}
+            aria-label={labels.searchAriaLabel}
+            data-slot="sessions-filters-search"
+            className={clsx(
+              'w-full rounded-xl border border-input bg-card py-2 pl-9 pr-4 text-sm',
+              'text-foreground placeholder:text-muted-foreground',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+              'sm:max-w-xs'
+            )}
+          />
+        </div>
+
+        {/* View toggle */}
+        <div
+          role="group"
+          aria-label={labels.viewToggleLabel}
+          className="inline-flex overflow-hidden rounded-lg border border-border bg-card"
+        >
+          <button
+            type="button"
+            aria-pressed={view === 'list'}
+            aria-label={labels.viewList}
+            onClick={() => onViewChange('list')}
+            className={clsx(
+              'flex h-9 w-9 items-center justify-center transition-colors',
+              view === 'list'
+                ? 'bg-[hsla(240,60%,55%,0.14)] text-[hsl(240,60%,45%)]'
+                : 'text-muted-foreground hover:bg-muted',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset'
+            )}
+            data-slot="sessions-view-list"
+          >
+            <List className="h-4 w-4" aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            aria-pressed={view === 'grid'}
+            aria-label={labels.viewGrid}
+            onClick={() => onViewChange('grid')}
+            className={clsx(
+              'flex h-9 w-9 items-center justify-center transition-colors',
+              view === 'grid'
+                ? 'bg-[hsla(240,60%,55%,0.14)] text-[hsl(240,60%,45%)]'
+                : 'text-muted-foreground hover:bg-muted',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset'
+            )}
+            data-slot="sessions-view-grid"
+          >
+            <LayoutGrid className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+
+      {/* Status pill bar */}
+      <div
+        role="tablist"
+        aria-label={labels.statusGroupLabel}
+        aria-orientation="horizontal"
+        className="flex items-center gap-1.5 overflow-x-auto scrollbar-none"
+        id="sessions-status-tablist"
+      >
+        {STATUS_ORDER.map(status => {
+          const isActive = statusFilter === status;
+          const count = counts?.[status];
+          return (
+            <button
+              key={status}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              aria-controls="sessions-content"
+              tabIndex={isActive ? 0 : -1}
+              ref={node => {
+                if (node) tabRefs.current.set(status, node);
+                else tabRefs.current.delete(status);
+              }}
+              onKeyDown={e => handleKeyDown(e, status)}
+              onClick={() => onStatusChange(status)}
+              data-slot="sessions-filter-chip"
+              data-status={status}
+              className={clsx(
+                'inline-flex shrink-0 items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-semibold transition-colors whitespace-nowrap',
+                isActive
+                  ? 'bg-[hsla(240,60%,55%,0.14)] text-[hsl(240,60%,45%)] ring-1 ring-[hsla(240,60%,55%,0.3)]'
+                  : 'bg-slate-50 text-slate-700 hover:bg-slate-100',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+              )}
+            >
+              {statusLabels[status]}
+              {count !== undefined && (
+                <span
+                  className={clsx(
+                    'rounded-full px-1.5 py-px font-mono text-[9px] font-extrabold',
+                    isActive ? 'bg-[hsl(240,60%,45%)] text-white' : 'bg-muted text-muted-foreground'
+                  )}
+                >
+                  {count}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
 }

--- a/apps/web/src/components/v2/sessions/SessionsHero.tsx
+++ b/apps/web/src/components/v2/sessions/SessionsHero.tsx
@@ -22,26 +22,18 @@ import clsx from 'clsx';
 
 export interface SessionsHeroLabels {
   readonly title: string;
-  /** Template e.g. "{count} sessioni totali" — {count} is replaced at render time. */
-  readonly subtitleTemplate: string;
+  /** Resolved subtitle string (ICU plural already formatted by orchestrator with count). */
+  readonly subtitle: string;
   readonly ctaNew: string;
 }
 
 export interface SessionsHeroProps {
-  readonly count: number;
   readonly onNewSession: () => void;
   readonly labels: SessionsHeroLabels;
   readonly className?: string;
 }
 
-export function SessionsHero({
-  count,
-  onNewSession,
-  labels,
-  className,
-}: SessionsHeroProps): ReactElement {
-  const subtitle = labels.subtitleTemplate.replace('{count}', String(count));
-
+export function SessionsHero({ onNewSession, labels, className }: SessionsHeroProps): ReactElement {
   return (
     <section
       data-slot="sessions-hero"
@@ -53,7 +45,7 @@ export function SessionsHero({
           <h1 className="text-2xl font-bold tracking-tight text-[hsl(240,60%,45%)] sm:text-3xl">
             {labels.title}
           </h1>
-          <p className="text-sm text-slate-600">{subtitle}</p>
+          <p className="text-sm text-slate-600">{labels.subtitle}</p>
         </div>
 
         {/* CTA */}

--- a/apps/web/src/components/v2/sessions/SessionsHero.tsx
+++ b/apps/web/src/components/v2/sessions/SessionsHero.tsx
@@ -1,14 +1,77 @@
-// TODO: implement per admin-mockups/design_files/sp4-sessions-index.jsx
-// Mapped from mockup component: SessionsHero
-// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
-// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+/**
+ * SessionsHero — Wave D.1 v2 component (Issue #735).
+ *
+ * Mapped from `admin-mockups/design_files/sp4-sessions-index.jsx` (SessionsHero).
+ *
+ * Pure component: all i18n strings injected via `labels` — no `useTranslation`.
+ *
+ * Layout:
+ *   - Title: large heading, session entity-colored text (hsl(240,60%,45%) l45 AA)
+ *   - Subtitle: muted text with {count} template substitution
+ *   - CTA: right-aligned primary button (session-colored, white text WCAG AA)
+ *
+ * WCAG AA: session entity at l=45% yields ~6.8:1 contrast vs white — safe for
+ * button background. We use the literal HSL value to avoid Tailwind purge issues.
+ */
+
+'use client';
 
 import type { ReactElement } from 'react';
 
-export interface SessionsHeroProps {
-  // TODO: extract props contract from mockup analysis
+import clsx from 'clsx';
+
+export interface SessionsHeroLabels {
+  readonly title: string;
+  /** Template e.g. "{count} sessioni totali" — {count} is replaced at render time. */
+  readonly subtitleTemplate: string;
+  readonly ctaNew: string;
 }
 
-export function SessionsHero(_props: SessionsHeroProps): ReactElement | null {
-  return null;
+export interface SessionsHeroProps {
+  readonly count: number;
+  readonly onNewSession: () => void;
+  readonly labels: SessionsHeroLabels;
+  readonly className?: string;
+}
+
+export function SessionsHero({
+  count,
+  onNewSession,
+  labels,
+  className,
+}: SessionsHeroProps): ReactElement {
+  const subtitle = labels.subtitleTemplate.replace('{count}', String(count));
+
+  return (
+    <section
+      data-slot="sessions-hero"
+      className={clsx('mx-auto max-w-[1280px] px-4 py-6 sm:px-8 sm:py-8', className)}
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between sm:gap-6">
+        {/* Text block */}
+        <div className="flex flex-col gap-1">
+          <h1 className="text-2xl font-bold tracking-tight text-[hsl(240,60%,45%)] sm:text-3xl">
+            {labels.title}
+          </h1>
+          <p className="text-sm text-slate-600">{subtitle}</p>
+        </div>
+
+        {/* CTA */}
+        <button
+          type="button"
+          onClick={onNewSession}
+          aria-label={labels.ctaNew}
+          className={clsx(
+            'inline-flex h-10 shrink-0 items-center justify-center gap-1.5 rounded-lg px-5 text-sm font-semibold text-white shadow-sm',
+            'bg-[hsl(240,60%,38%)] transition-colors',
+            'hover:bg-[hsl(240,60%,32%)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+          )}
+          data-slot="sessions-hero-cta"
+        >
+          <span aria-hidden="true">+</span>
+          {labels.ctaNew}
+        </button>
+      </div>
+    </section>
+  );
 }

--- a/apps/web/src/components/v2/sessions/__tests__/ConnectionChipStripFooter.test.tsx
+++ b/apps/web/src/components/v2/sessions/__tests__/ConnectionChipStripFooter.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * ConnectionChipStripFooter unit tests — Wave D.1 (Issue #735).
+ *
+ * 7 tests:
+ * 1. Renders data-slot="connection-chip-strip-footer"
+ * 2. Renders up to 3 chips
+ * 3. Silently drops chips beyond 3
+ * 4. Empty chip (count=0) has opacity style applied (data-entity present)
+ * 5. Empty chip (empty=true) is rendered
+ * 6. Non-empty chip renders label text
+ * 7. Non-empty chip with count renders count text
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ConnectionChipStripFooter } from '../ConnectionChipStripFooter';
+import type { ConnectionChipStripFooterProps } from '../ConnectionChipStripFooter';
+
+describe('ConnectionChipStripFooter', () => {
+  it('renders data-slot="connection-chip-strip-footer"', () => {
+    render(<ConnectionChipStripFooter chips={[]} />);
+    expect(document.querySelector('[data-slot="connection-chip-strip-footer"]')).not.toBeNull();
+  });
+
+  it('renders up to 3 chips', () => {
+    const chips: ConnectionChipStripFooterProps['chips'] = [
+      { entity: 'game', label: 'Wingspan' },
+      { entity: 'player', count: 4 },
+      { entity: 'chat', count: 3 },
+    ];
+    render(<ConnectionChipStripFooter chips={chips} />);
+    const chipEls = document.querySelectorAll('[data-slot="connection-chip"]');
+    expect(chipEls).toHaveLength(3);
+  });
+
+  it('silently drops chips beyond 3', () => {
+    const chips: ConnectionChipStripFooterProps['chips'] = [
+      { entity: 'game', label: 'A' },
+      { entity: 'player', count: 2 },
+      { entity: 'chat', count: 1 },
+      { entity: 'game', label: 'Extra' },
+    ];
+    render(<ConnectionChipStripFooter chips={chips} />);
+    const chipEls = document.querySelectorAll('[data-slot="connection-chip"]');
+    expect(chipEls).toHaveLength(3);
+    expect(screen.queryByText('Extra')).toBeNull();
+  });
+
+  it('empty chip (count=0) is rendered with data-entity attribute', () => {
+    const chips: ConnectionChipStripFooterProps['chips'] = [{ entity: 'chat', count: 0 }];
+    render(<ConnectionChipStripFooter chips={chips} />);
+    const chip = document.querySelector('[data-entity="chat"]');
+    expect(chip).not.toBeNull();
+  });
+
+  it('empty chip (empty=true) is rendered', () => {
+    const chips: ConnectionChipStripFooterProps['chips'] = [{ entity: 'chat', empty: true }];
+    render(<ConnectionChipStripFooter chips={chips} />);
+    const chip = document.querySelector('[data-entity="chat"]');
+    expect(chip).not.toBeNull();
+  });
+
+  it('non-empty chip renders label text', () => {
+    const chips: ConnectionChipStripFooterProps['chips'] = [{ entity: 'game', label: 'Wingspan' }];
+    render(<ConnectionChipStripFooter chips={chips} />);
+    expect(screen.getByText('Wingspan')).toBeTruthy();
+  });
+
+  it('non-empty chip with count renders count text', () => {
+    const chips: ConnectionChipStripFooterProps['chips'] = [{ entity: 'player', count: 4 }];
+    render(<ConnectionChipStripFooter chips={chips} />);
+    expect(screen.getByText('4')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/v2/sessions/__tests__/EmptySessions.test.tsx
+++ b/apps/web/src/components/v2/sessions/__tests__/EmptySessions.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * EmptySessions unit tests — Wave D.1 (Issue #735).
+ *
+ * 10 tests:
+ * 1. empty kind: renders data-slot="sessions-empty-empty", role="status"
+ * 2. empty kind: renders empty title, description, CTA
+ * 3. empty kind: CTA fires onPrimaryAction
+ * 4. filtered-empty kind: renders data-slot="sessions-empty-filtered-empty"
+ * 5. filtered-empty kind: renders filteredEmpty title + CTA
+ * 6. error kind: renders data-slot="sessions-empty-error" with role="alert"
+ * 7. error kind: renders error title + CTA, fires onPrimaryAction
+ * 8. loading kind: renders data-slot="sessions-empty-loading" with aria-busy
+ * 9. loading kind: renders 8 skeleton placeholders
+ * 10. data-slot selector matches kind for all 4 kinds
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { EmptySessions } from '../EmptySessions';
+import type { EmptySessionsProps } from '../EmptySessions';
+
+const LABELS: EmptySessionsProps['labels'] = {
+  emptyTitle: 'Nessuna partita ancora',
+  emptyDescription: 'Registra la tua prima partita.',
+  emptyCta: 'Inizia la prima sessione',
+  filteredEmptyTitle: 'Nessun risultato',
+  filteredEmptyDescription: 'Prova a modificare il filtro.',
+  filteredEmptyCta: 'Rimuovi filtro',
+  loadingAriaLabel: 'Caricamento sessioni...',
+  errorTitle: 'Impossibile caricare',
+  errorDescription: 'Si è verificato un errore.',
+  errorCta: 'Riprova',
+};
+
+describe('EmptySessions', () => {
+  it('empty kind renders data-slot="sessions-empty-empty" with role="status"', () => {
+    render(<EmptySessions kind="empty" labels={LABELS} />);
+    const el = document.querySelector('[data-slot="sessions-empty-empty"]');
+    expect(el).not.toBeNull();
+    expect(el!.getAttribute('role')).toBe('status');
+  });
+
+  it('empty kind renders title, description, and CTA', () => {
+    render(<EmptySessions kind="empty" labels={LABELS} />);
+    expect(screen.getByText('Nessuna partita ancora')).toBeTruthy();
+    expect(screen.getByText('Registra la tua prima partita.')).toBeTruthy();
+    expect(screen.getByText('Inizia la prima sessione')).toBeTruthy();
+  });
+
+  it('empty kind CTA fires onPrimaryAction on click', () => {
+    const onPrimaryAction = vi.fn();
+    render(<EmptySessions kind="empty" labels={LABELS} onPrimaryAction={onPrimaryAction} />);
+    fireEvent.click(screen.getByText('Inizia la prima sessione'));
+    expect(onPrimaryAction).toHaveBeenCalledOnce();
+  });
+
+  it('filtered-empty kind renders data-slot="sessions-empty-filtered-empty"', () => {
+    render(<EmptySessions kind="filtered-empty" labels={LABELS} />);
+    const el = document.querySelector('[data-slot="sessions-empty-filtered-empty"]');
+    expect(el).not.toBeNull();
+  });
+
+  it('filtered-empty kind renders title and CTA text', () => {
+    render(<EmptySessions kind="filtered-empty" labels={LABELS} />);
+    expect(screen.getByText('Nessun risultato')).toBeTruthy();
+    expect(screen.getByText('Rimuovi filtro')).toBeTruthy();
+  });
+
+  it('error kind renders data-slot="sessions-empty-error" with role="alert"', () => {
+    render(<EmptySessions kind="error" labels={LABELS} />);
+    const el = document.querySelector('[data-slot="sessions-empty-error"]');
+    expect(el).not.toBeNull();
+    expect(el!.getAttribute('role')).toBe('alert');
+  });
+
+  it('error kind renders title and CTA, fires onPrimaryAction on click', () => {
+    const onPrimaryAction = vi.fn();
+    render(<EmptySessions kind="error" labels={LABELS} onPrimaryAction={onPrimaryAction} />);
+    expect(screen.getByText('Impossibile caricare')).toBeTruthy();
+    fireEvent.click(screen.getByText('Riprova'));
+    expect(onPrimaryAction).toHaveBeenCalledOnce();
+  });
+
+  it('loading kind renders data-slot="sessions-empty-loading" with aria-busy="true"', () => {
+    render(<EmptySessions kind="loading" labels={LABELS} />);
+    const el = document.querySelector('[data-slot="sessions-empty-loading"]');
+    expect(el).not.toBeNull();
+    expect(el!.getAttribute('aria-busy')).toBe('true');
+  });
+
+  it('loading kind renders 8 skeleton placeholder rows', () => {
+    render(<EmptySessions kind="loading" labels={LABELS} />);
+    const skeletons = document.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('data-slot selector matches kind for all 4 kinds', () => {
+    const kinds = ['empty', 'filtered-empty', 'loading', 'error'] as const;
+    for (const kind of kinds) {
+      const { unmount } = render(<EmptySessions kind={kind} labels={LABELS} />);
+      const el = document.querySelector(`[data-slot="sessions-empty-${kind}"]`);
+      expect(el, `data-slot="sessions-empty-${kind}" missing`).not.toBeNull();
+      unmount();
+    }
+  });
+});

--- a/apps/web/src/components/v2/sessions/__tests__/EmptySessions.test.tsx
+++ b/apps/web/src/components/v2/sessions/__tests__/EmptySessions.test.tsx
@@ -41,8 +41,8 @@ describe('EmptySessions', () => {
     expect(el!.getAttribute('role')).toBe('status');
   });
 
-  it('empty kind renders title, description, and CTA', () => {
-    render(<EmptySessions kind="empty" labels={LABELS} />);
+  it('empty kind renders title, description, and CTA when onPrimaryAction provided', () => {
+    render(<EmptySessions kind="empty" labels={LABELS} onPrimaryAction={vi.fn()} />);
     expect(screen.getByText('Nessuna partita ancora')).toBeTruthy();
     expect(screen.getByText('Registra la tua prima partita.')).toBeTruthy();
     expect(screen.getByText('Inizia la prima sessione')).toBeTruthy();
@@ -61,10 +61,16 @@ describe('EmptySessions', () => {
     expect(el).not.toBeNull();
   });
 
-  it('filtered-empty kind renders title and CTA text', () => {
-    render(<EmptySessions kind="filtered-empty" labels={LABELS} />);
+  it('filtered-empty kind renders title and CTA text when onPrimaryAction provided', () => {
+    render(<EmptySessions kind="filtered-empty" labels={LABELS} onPrimaryAction={vi.fn()} />);
     expect(screen.getByText('Nessun risultato')).toBeTruthy();
     expect(screen.getByText('Rimuovi filtro')).toBeTruthy();
+  });
+
+  it('CTA button is hidden when onPrimaryAction is undefined (avoids no-op click)', () => {
+    render(<EmptySessions kind="empty" labels={LABELS} />);
+    expect(screen.queryByText('Inizia la prima sessione')).toBeNull();
+    expect(document.querySelector('[data-slot="sessions-empty-cta"]')).toBeNull();
   });
 
   it('error kind renders data-slot="sessions-empty-error" with role="alert"', () => {

--- a/apps/web/src/components/v2/sessions/__tests__/OutcomeBadge.test.tsx
+++ b/apps/web/src/components/v2/sessions/__tests__/OutcomeBadge.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * OutcomeBadge unit tests — Wave D.1 (Issue #735).
+ *
+ * 12 tests covering full status×outcome×paused matrix:
+ * 1. inprogress + paused=false → "Live" label, data-status="live"
+ * 2. inprogress + paused=true  → paused label, data-status="paused"
+ * 3. paused status → paused label
+ * 4. abandoned → abandoned label, data-status="abandoned"
+ * 5. completed + won → won label, data-outcome="won"
+ * 6. completed + lost → lost label, data-outcome="lost"
+ * 7. completed + tie → tie label, data-outcome="tie"
+ * 8. completed + outcome=null → tie label (fallback)
+ * 9. live badge has pulsing dot element
+ * 10. renders data-slot="outcome-badge" on all variants
+ * 11. accepts custom className
+ * 12. returns null for unknown/unmapped combination (future-proof)
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { OutcomeBadge } from '../OutcomeBadge';
+import type { OutcomeBadgeProps, OutcomeBadgeLabels } from '../OutcomeBadge';
+
+const LABELS: OutcomeBadgeLabels = {
+  outcomeWon: '🏆 Vinta',
+  outcomeLost: '△ Persa',
+  outcomeTie: '= Pareggio',
+  statusLive: 'Live',
+  statusPaused: 'In pausa',
+  statusAbandoned: '⊘ Abbandonata',
+};
+
+function badge(props: Omit<OutcomeBadgeProps, 'labels'>) {
+  return render(<OutcomeBadge {...props} labels={LABELS} />);
+}
+
+describe('OutcomeBadge', () => {
+  it('inprogress + paused=false renders Live label with data-status="live"', () => {
+    badge({ status: 'inprogress', outcome: null, paused: false });
+    const el = document.querySelector('[data-slot="outcome-badge"]');
+    expect(el).not.toBeNull();
+    expect(el!.getAttribute('data-status')).toBe('live');
+    expect(screen.getByText('Live')).toBeTruthy();
+  });
+
+  it('inprogress + paused=true renders paused label with data-status="paused"', () => {
+    badge({ status: 'inprogress', outcome: null, paused: true });
+    const el = document.querySelector('[data-slot="outcome-badge"]');
+    expect(el!.getAttribute('data-status')).toBe('paused');
+    expect(screen.getByText('In pausa')).toBeTruthy();
+  });
+
+  it('paused status renders paused label', () => {
+    badge({ status: 'paused', outcome: null });
+    expect(screen.getByText('In pausa')).toBeTruthy();
+    const el = document.querySelector('[data-slot="outcome-badge"]');
+    expect(el!.getAttribute('data-status')).toBe('paused');
+  });
+
+  it('abandoned renders abandoned label with data-status="abandoned"', () => {
+    badge({ status: 'abandoned', outcome: null });
+    const el = document.querySelector('[data-slot="outcome-badge"]');
+    expect(el!.getAttribute('data-status')).toBe('abandoned');
+    expect(screen.getByText('⊘ Abbandonata')).toBeTruthy();
+  });
+
+  it('completed + won renders won label with data-outcome="won"', () => {
+    badge({ status: 'completed', outcome: 'won' });
+    const el = document.querySelector('[data-slot="outcome-badge"]');
+    expect(el!.getAttribute('data-outcome')).toBe('won');
+    expect(screen.getByText('🏆 Vinta')).toBeTruthy();
+  });
+
+  it('completed + lost renders lost label with data-outcome="lost"', () => {
+    badge({ status: 'completed', outcome: 'lost' });
+    const el = document.querySelector('[data-slot="outcome-badge"]');
+    expect(el!.getAttribute('data-outcome')).toBe('lost');
+    expect(screen.getByText('△ Persa')).toBeTruthy();
+  });
+
+  it('completed + tie renders tie label with data-outcome="tie"', () => {
+    badge({ status: 'completed', outcome: 'tie' });
+    const el = document.querySelector('[data-slot="outcome-badge"]');
+    expect(el!.getAttribute('data-outcome')).toBe('tie');
+    expect(screen.getByText('= Pareggio')).toBeTruthy();
+  });
+
+  it('completed + outcome=null renders tie fallback', () => {
+    badge({ status: 'completed', outcome: null });
+    expect(screen.getByText('= Pareggio')).toBeTruthy();
+  });
+
+  it('live badge renders pulsing dot element', () => {
+    badge({ status: 'inprogress', outcome: null, paused: false });
+    // The pulsing dot is an aria-hidden span inside the badge
+    const badge_el = document.querySelector('[data-slot="outcome-badge"]');
+    const dot = badge_el!.querySelector('[aria-hidden="true"]');
+    expect(dot).not.toBeNull();
+  });
+
+  it('renders data-slot="outcome-badge" on all variants', () => {
+    const cases: Array<[string, Omit<OutcomeBadgeProps, 'labels'>]> = [
+      ['live', { status: 'inprogress', outcome: null }],
+      ['paused', { status: 'paused', outcome: null }],
+      ['abandoned', { status: 'abandoned', outcome: null }],
+      ['won', { status: 'completed', outcome: 'won' }],
+      ['lost', { status: 'completed', outcome: 'lost' }],
+      ['tie', { status: 'completed', outcome: 'tie' }],
+    ];
+    for (const [label, props] of cases) {
+      const { unmount } = render(<OutcomeBadge {...props} labels={LABELS} />);
+      const el = document.querySelector('[data-slot="outcome-badge"]');
+      expect(el, `data-slot missing for case: ${label}`).not.toBeNull();
+      unmount();
+    }
+  });
+
+  it('accepts custom className', () => {
+    badge({ status: 'completed', outcome: 'won', className: 'test-cls' });
+    const el = document.querySelector('[data-slot="outcome-badge"]');
+    expect(el!.classList.contains('test-cls')).toBe(true);
+  });
+});

--- a/apps/web/src/components/v2/sessions/__tests__/ScoringInline.test.tsx
+++ b/apps/web/src/components/v2/sessions/__tests__/ScoringInline.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * ScoringInline unit tests — Wave D.1 (Issue #735).
+ *
+ * 8 tests:
+ * 1. Renders data-slot="scoring-inline"
+ * 2. Shows player names for each score entry
+ * 3. Shows score values when scores are non-zero
+ * 4. Hides score chips when all scores are zero (v1 carryover placeholder)
+ * 5. Winner entry has 🏆 prefix
+ * 6. Compact mode: shows max 3 + overflow indicator
+ * 7. Returns null when scores array is empty
+ * 8. Accepts custom className
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ScoringInline } from '../ScoringInline';
+import type { ScoringInlineProps } from '../ScoringInline';
+
+const LABELS: ScoringInlineProps['labels'] = {
+  winnerAriaLabel: 'Punteggi giocatori',
+  overflowTemplate: '+{count} altri',
+};
+
+const SCORES_WITH_VALUES = [
+  { name: 'Marco', score: 89, winner: true },
+  { name: 'Anna', score: 76 },
+  { name: 'Luca', score: 64 },
+] as const;
+
+const SCORES_ALL_ZERO = [
+  { name: 'Marco', score: 0 },
+  { name: 'Anna', score: 0 },
+  { name: 'Luca', score: 0 },
+] as const;
+
+describe('ScoringInline', () => {
+  it('renders data-slot="scoring-inline"', () => {
+    render(<ScoringInline scores={SCORES_WITH_VALUES} labels={LABELS} />);
+    expect(document.querySelector('[data-slot="scoring-inline"]')).not.toBeNull();
+  });
+
+  it('shows player names for each score entry', () => {
+    render(<ScoringInline scores={SCORES_WITH_VALUES} labels={LABELS} />);
+    expect(screen.getByText('Marco')).toBeTruthy();
+    expect(screen.getByText('Anna')).toBeTruthy();
+    expect(screen.getByText('Luca')).toBeTruthy();
+  });
+
+  it('shows score chips when scores are non-zero', () => {
+    render(<ScoringInline scores={SCORES_WITH_VALUES} labels={LABELS} />);
+    expect(screen.getByText('89')).toBeTruthy();
+    expect(screen.getByText('76')).toBeTruthy();
+    expect(screen.getByText('64')).toBeTruthy();
+  });
+
+  it('hides score chips when all scores are zero (v1 schema carryover)', () => {
+    render(<ScoringInline scores={SCORES_ALL_ZERO} labels={LABELS} />);
+    // Names should still appear
+    expect(screen.getByText('Marco')).toBeTruthy();
+    // Score values "0" should NOT appear as chip text
+    expect(screen.queryAllByText('0')).toHaveLength(0);
+  });
+
+  it('winner entry has 🏆 prefix aria-hidden element', () => {
+    render(<ScoringInline scores={SCORES_WITH_VALUES} labels={LABELS} />);
+    // The winner (Marco, winner:true) should have the trophy emoji
+    const container = document.querySelector('[data-slot="scoring-inline"]')!;
+    // Find text "🏆" in the container
+    expect(container.textContent).toContain('🏆');
+  });
+
+  it('compact mode shows max 3 scores and overflow indicator for 5 entries', () => {
+    const fiveScores = [
+      { name: 'P1', score: 10, winner: true },
+      { name: 'P2', score: 9 },
+      { name: 'P3', score: 8 },
+      { name: 'P4', score: 7 },
+      { name: 'P5', score: 6 },
+    ];
+    render(<ScoringInline scores={fiveScores} compact labels={LABELS} />);
+    // First 3 visible
+    expect(screen.getByText('P1')).toBeTruthy();
+    expect(screen.getByText('P2')).toBeTruthy();
+    expect(screen.getByText('P3')).toBeTruthy();
+    // P4, P5 not visible (overflow)
+    expect(screen.queryByText('P4')).toBeNull();
+    // overflow indicator: +2 altri
+    expect(screen.getByText('+2 altri')).toBeTruthy();
+  });
+
+  it('returns null when scores array is empty', () => {
+    const { container } = render(<ScoringInline scores={[]} labels={LABELS} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('accepts custom className', () => {
+    render(<ScoringInline scores={SCORES_WITH_VALUES} labels={LABELS} className="my-class" />);
+    const el = document.querySelector('[data-slot="scoring-inline"]');
+    expect(el!.classList.contains('my-class')).toBe(true);
+  });
+});

--- a/apps/web/src/components/v2/sessions/__tests__/SessionCardGrid.test.tsx
+++ b/apps/web/src/components/v2/sessions/__tests__/SessionCardGrid.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * SessionCardGrid unit tests — Wave D.1 (Issue #735).
+ *
+ * 7 tests:
+ * 1. Renders data-slot="session-card-grid"
+ * 2. Sets data-item-id from item.id
+ * 3. Shows gameName as title
+ * 4. Shows OutcomeBadge for completed sessions
+ * 5. Shows ScoringInline (compact) in the body
+ * 6. Fires onClick with item on click
+ * 7. aria-label uses openSessionAriaTemplate with gameName substitution
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SessionCardGrid } from '../SessionCardGrid';
+import type { SessionCardGridProps, SessionCardGridLabels } from '../SessionCardGrid';
+import type { SessionListItem } from '@/lib/sessions/sessions-filters';
+
+const LABELS: SessionCardGridLabels = {
+  outcomeWon: '🏆 Vinta',
+  outcomeLost: '△ Persa',
+  outcomeTie: '= Pareggio',
+  statusLive: 'Live',
+  statusPaused: 'In pausa',
+  statusAbandoned: '⊘ Abbandonata',
+  playerCountTemplate: '{count} giocatori',
+  chatCountTemplate: '{count} chat',
+  turnTemplate: 'Turno {turn}',
+  winnerLabel: 'Punteggi',
+  openSessionAriaTemplate: 'Apri sessione {gameName}',
+  scoreOverflowTemplate: '+{count} altri',
+};
+
+const ITEM: SessionListItem = {
+  id: 'session-grid-1',
+  gameName: 'Azul',
+  date: '21 apr 2026',
+  when: '4 giorni fa',
+  duration: '42m',
+  status: 'completed',
+  outcome: 'lost',
+  playerCount: 3,
+  scores: [
+    { name: 'Sara', score: 81, winner: true },
+    { name: 'Marco', score: 72 },
+    { name: 'Luca', score: 65 },
+  ],
+  hasChat: false,
+};
+
+describe('SessionCardGrid', () => {
+  it('renders data-slot="session-card-grid"', () => {
+    render(<SessionCardGrid item={ITEM} onClick={vi.fn()} labels={LABELS} />);
+    expect(document.querySelector('[data-slot="session-card-grid"]')).not.toBeNull();
+  });
+
+  it('sets data-item-id from item.id', () => {
+    render(<SessionCardGrid item={ITEM} onClick={vi.fn()} labels={LABELS} />);
+    const el = document.querySelector('[data-slot="session-card-grid"]');
+    expect(el!.getAttribute('data-item-id')).toBe('session-grid-1');
+  });
+
+  it('shows gameName as title text', () => {
+    render(<SessionCardGrid item={ITEM} onClick={vi.fn()} labels={LABELS} />);
+    // gameName appears in both h3 title and chip footer — query the h3 specifically
+    const heading = document.querySelector('h3');
+    expect(heading?.textContent?.trim()).toBe('Azul');
+  });
+
+  it('shows OutcomeBadge for completed sessions', () => {
+    render(<SessionCardGrid item={ITEM} onClick={vi.fn()} labels={LABELS} />);
+    expect(screen.getByText('△ Persa')).toBeTruthy();
+  });
+
+  it('shows ScoringInline (compact) in the card body', () => {
+    render(<SessionCardGrid item={ITEM} onClick={vi.fn()} labels={LABELS} />);
+    const scoring = document.querySelector('[data-slot="scoring-inline"]');
+    expect(scoring).not.toBeNull();
+    // Sara is winner, her name should appear
+    expect(screen.getByText('Sara')).toBeTruthy();
+  });
+
+  it('fires onClick with item when clicked', () => {
+    const onClick = vi.fn();
+    render(<SessionCardGrid item={ITEM} onClick={onClick} labels={LABELS} />);
+    const card = document.querySelector('[data-slot="session-card-grid"]') as HTMLButtonElement;
+    fireEvent.click(card);
+    expect(onClick).toHaveBeenCalledWith(ITEM);
+  });
+
+  it('aria-label uses openSessionAriaTemplate with gameName substitution', () => {
+    render(<SessionCardGrid item={ITEM} onClick={vi.fn()} labels={LABELS} />);
+    const el = document.querySelector('[data-slot="session-card-grid"]');
+    expect(el!.getAttribute('aria-label')).toBe('Apri sessione Azul');
+  });
+});

--- a/apps/web/src/components/v2/sessions/__tests__/SessionCardList.test.tsx
+++ b/apps/web/src/components/v2/sessions/__tests__/SessionCardList.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * SessionCardList unit tests — Wave D.1 (Issue #735).
+ *
+ * 8 tests:
+ * 1. Renders data-slot="session-card-list"
+ * 2. Sets data-item-id from item.id
+ * 3. Shows gameName as title
+ * 4. Shows OutcomeBadge for completed sessions
+ * 5. Shows turn label for in-progress sessions
+ * 6. Fires onClick with the item on click
+ * 7. aria-label uses openSessionAriaTemplate with gameName substitution
+ * 8. Abandoned session has opacity-70 class
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SessionCardList } from '../SessionCardList';
+import type { SessionCardListProps, SessionCardListLabels } from '../SessionCardList';
+import type { SessionListItem } from '@/lib/sessions/sessions-filters';
+
+const LABELS: SessionCardListLabels = {
+  outcomeWon: '🏆 Vinta',
+  outcomeLost: '△ Persa',
+  outcomeTie: '= Pareggio',
+  statusLive: 'Live',
+  statusPaused: 'In pausa',
+  statusAbandoned: '⊘ Abbandonata',
+  playerCountTemplate: '{count} giocatori',
+  chatCountTemplate: '{count} chat',
+  turnTemplate: 'Turno {turn}',
+  winnerLabel: 'Punteggi',
+  openSessionAriaTemplate: 'Apri sessione {gameName}',
+};
+
+const COMPLETED_ITEM: SessionListItem = {
+  id: 'session-1',
+  gameName: 'Wingspan',
+  date: '23 apr 2026',
+  when: '2 giorni fa',
+  duration: '1h 24m',
+  status: 'completed',
+  outcome: 'won',
+  playerCount: 4,
+  scores: [
+    { name: 'Marco', score: 89, winner: true },
+    { name: 'Anna', score: 76 },
+  ],
+  hasChat: true,
+  chatCount: 3,
+};
+
+const INPROGRESS_ITEM: SessionListItem = {
+  id: 'session-2',
+  gameName: 'Brass',
+  date: 'oggi · live',
+  when: 'in corso',
+  duration: '1h 12m',
+  status: 'inprogress',
+  outcome: null,
+  playerCount: 4,
+  scores: [{ name: 'Marco', score: 0 }],
+  hasChat: false,
+  turn: '12/18',
+};
+
+const ABANDONED_ITEM: SessionListItem = {
+  id: 'session-3',
+  gameName: 'Catan',
+  date: '5 apr 2026',
+  when: '3 sett fa',
+  duration: '28m',
+  status: 'abandoned',
+  outcome: null,
+  playerCount: 2,
+  scores: [],
+  hasChat: false,
+};
+
+describe('SessionCardList', () => {
+  it('renders data-slot="session-card-list"', () => {
+    render(<SessionCardList item={COMPLETED_ITEM} onClick={vi.fn()} labels={LABELS} />);
+    expect(document.querySelector('[data-slot="session-card-list"]')).not.toBeNull();
+  });
+
+  it('sets data-item-id from item.id', () => {
+    render(<SessionCardList item={COMPLETED_ITEM} onClick={vi.fn()} labels={LABELS} />);
+    const el = document.querySelector('[data-slot="session-card-list"]');
+    expect(el!.getAttribute('data-item-id')).toBe('session-1');
+  });
+
+  it('shows gameName as title text', () => {
+    render(<SessionCardList item={COMPLETED_ITEM} onClick={vi.fn()} labels={LABELS} />);
+    // gameName appears in both h3 title and chip footer — query the h3 specifically
+    const heading = document.querySelector('h3');
+    expect(heading?.textContent?.trim()).toBe('Wingspan');
+  });
+
+  it('shows OutcomeBadge for completed sessions', () => {
+    render(<SessionCardList item={COMPLETED_ITEM} onClick={vi.fn()} labels={LABELS} />);
+    expect(screen.getByText('🏆 Vinta')).toBeTruthy();
+  });
+
+  it('shows turn label for in-progress sessions', () => {
+    render(<SessionCardList item={INPROGRESS_ITEM} onClick={vi.fn()} labels={LABELS} />);
+    expect(screen.getByText('Turno 12/18')).toBeTruthy();
+  });
+
+  it('fires onClick with the item when clicked', () => {
+    const onClick = vi.fn();
+    render(<SessionCardList item={COMPLETED_ITEM} onClick={onClick} labels={LABELS} />);
+    const card = document.querySelector('[data-slot="session-card-list"]') as HTMLButtonElement;
+    fireEvent.click(card);
+    expect(onClick).toHaveBeenCalledWith(COMPLETED_ITEM);
+  });
+
+  it('aria-label uses openSessionAriaTemplate with gameName substitution', () => {
+    render(<SessionCardList item={COMPLETED_ITEM} onClick={vi.fn()} labels={LABELS} />);
+    const el = document.querySelector('[data-slot="session-card-list"]');
+    expect(el!.getAttribute('aria-label')).toBe('Apri sessione Wingspan');
+  });
+
+  it('abandoned session has opacity-70 class applied', () => {
+    render(<SessionCardList item={ABANDONED_ITEM} onClick={vi.fn()} labels={LABELS} />);
+    const el = document.querySelector('[data-slot="session-card-list"]');
+    expect(el!.classList.contains('opacity-70')).toBe(true);
+  });
+});

--- a/apps/web/src/components/v2/sessions/__tests__/SessionsFilters.test.tsx
+++ b/apps/web/src/components/v2/sessions/__tests__/SessionsFilters.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * SessionsFilters unit tests — Wave D.1 (Issue #735).
+ *
+ * 10 tests:
+ * 1. Renders data-slot="sessions-filters"
+ * 2. Renders all 4 status filter chips
+ * 3. Active chip has aria-selected=true
+ * 4. Clicking a chip fires onStatusChange with correct value
+ * 5. Search input renders with aria-label
+ * 6. Search input fires onSearchChange on change
+ * 7. View list button renders with aria-pressed=true when view=list
+ * 8. View grid button renders with aria-pressed=true when view=grid
+ * 9. Clicking grid button fires onViewChange('grid')
+ * 10. Status tablist has role="tablist" and aria-orientation="horizontal"
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SessionsFilters } from '../SessionsFilters';
+import type { SessionsFiltersProps } from '../SessionsFilters';
+
+const LABELS: SessionsFiltersProps['labels'] = {
+  statusAll: 'Tutti',
+  statusActive: 'In corso',
+  statusCompleted: 'Completate',
+  statusAbandoned: 'Abbandonate',
+  searchPlaceholder: 'Cerca partita...',
+  viewList: 'Vista lista',
+  viewGrid: 'Vista griglia',
+  statusGroupLabel: 'Filtra per stato',
+  viewToggleLabel: 'Modalità visualizzazione',
+  searchAriaLabel: 'Cerca partita o gioco',
+};
+
+const DEFAULT_PROPS: SessionsFiltersProps = {
+  statusFilter: 'all',
+  onStatusChange: vi.fn(),
+  view: 'list',
+  onViewChange: vi.fn(),
+  search: '',
+  onSearchChange: vi.fn(),
+  labels: LABELS,
+};
+
+describe('SessionsFilters', () => {
+  it('renders data-slot="sessions-filters"', () => {
+    render(<SessionsFilters {...DEFAULT_PROPS} />);
+    expect(document.querySelector('[data-slot="sessions-filters"]')).not.toBeNull();
+  });
+
+  it('renders all 4 status filter chips', () => {
+    render(<SessionsFilters {...DEFAULT_PROPS} />);
+    expect(screen.getByText('Tutti')).toBeTruthy();
+    expect(screen.getByText('In corso')).toBeTruthy();
+    expect(screen.getByText('Completate')).toBeTruthy();
+    expect(screen.getByText('Abbandonate')).toBeTruthy();
+  });
+
+  it('active chip has aria-selected="true"', () => {
+    render(<SessionsFilters {...DEFAULT_PROPS} statusFilter="completed" />);
+    const chips = document.querySelectorAll('[data-slot="sessions-filter-chip"]');
+    const activeChip = Array.from(chips).find(c => c.getAttribute('data-status') === 'completed');
+    expect(activeChip!.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('clicking a chip fires onStatusChange with the correct value', () => {
+    const onStatusChange = vi.fn();
+    render(<SessionsFilters {...DEFAULT_PROPS} onStatusChange={onStatusChange} />);
+    fireEvent.click(screen.getByText('In corso'));
+    expect(onStatusChange).toHaveBeenCalledWith('active');
+  });
+
+  it('search input renders with correct aria-label', () => {
+    render(<SessionsFilters {...DEFAULT_PROPS} />);
+    const input = document.querySelector('[data-slot="sessions-filters-search"]');
+    expect(input).not.toBeNull();
+    expect(input!.getAttribute('aria-label')).toBe('Cerca partita o gioco');
+  });
+
+  it('search input fires onSearchChange on change', () => {
+    const onSearchChange = vi.fn();
+    render(<SessionsFilters {...DEFAULT_PROPS} onSearchChange={onSearchChange} />);
+    const input = document.querySelector(
+      '[data-slot="sessions-filters-search"]'
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'wingspan' } });
+    expect(onSearchChange).toHaveBeenCalledWith('wingspan');
+  });
+
+  it('list view button has aria-pressed="true" when view=list', () => {
+    render(<SessionsFilters {...DEFAULT_PROPS} view="list" />);
+    const listBtn = document.querySelector('[data-slot="sessions-view-list"]');
+    expect(listBtn!.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('grid view button has aria-pressed="true" when view=grid', () => {
+    render(<SessionsFilters {...DEFAULT_PROPS} view="grid" />);
+    const gridBtn = document.querySelector('[data-slot="sessions-view-grid"]');
+    expect(gridBtn!.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('clicking grid button fires onViewChange("grid")', () => {
+    const onViewChange = vi.fn();
+    render(<SessionsFilters {...DEFAULT_PROPS} onViewChange={onViewChange} />);
+    const gridBtn = document.querySelector('[data-slot="sessions-view-grid"]') as HTMLButtonElement;
+    fireEvent.click(gridBtn);
+    expect(onViewChange).toHaveBeenCalledWith('grid');
+  });
+
+  it('status tablist has role="tablist" and aria-orientation="horizontal"', () => {
+    render(<SessionsFilters {...DEFAULT_PROPS} />);
+    const tablist = document.querySelector('[role="tablist"]');
+    expect(tablist).not.toBeNull();
+    expect(tablist!.getAttribute('aria-orientation')).toBe('horizontal');
+    expect(tablist!.getAttribute('aria-label')).toBe('Filtra per stato');
+  });
+});

--- a/apps/web/src/components/v2/sessions/__tests__/SessionsHero.test.tsx
+++ b/apps/web/src/components/v2/sessions/__tests__/SessionsHero.test.tsx
@@ -4,7 +4,7 @@
  * 6 tests:
  * 1. Renders data-slot="sessions-hero"
  * 2. Renders title from labels
- * 3. Substitutes {count} in subtitleTemplate
+ * 3. Renders resolved subtitle string from labels
  * 4. Renders CTA button with correct aria-label
  * 5. Fires onNewSession on CTA click
  * 6. Applies custom className
@@ -18,12 +18,11 @@ import type { SessionsHeroProps } from '../SessionsHero';
 
 const LABELS: SessionsHeroProps['labels'] = {
   title: 'Le tue partite',
-  subtitleTemplate: '{count} sessioni totali',
+  subtitle: '42 partite registrate',
   ctaNew: 'Nuova sessione',
 };
 
 const DEFAULT_PROPS: SessionsHeroProps = {
-  count: 42,
   onNewSession: vi.fn(),
   labels: LABELS,
 };
@@ -39,9 +38,9 @@ describe('SessionsHero', () => {
     expect(screen.getByText('Le tue partite')).toBeTruthy();
   });
 
-  it('substitutes {count} in subtitleTemplate', () => {
-    render(<SessionsHero {...DEFAULT_PROPS} count={42} />);
-    expect(screen.getByText('42 sessioni totali')).toBeTruthy();
+  it('renders resolved subtitle string from labels', () => {
+    render(<SessionsHero {...DEFAULT_PROPS} />);
+    expect(screen.getByText('42 partite registrate')).toBeTruthy();
   });
 
   it('renders CTA button with correct aria-label', () => {

--- a/apps/web/src/components/v2/sessions/__tests__/SessionsHero.test.tsx
+++ b/apps/web/src/components/v2/sessions/__tests__/SessionsHero.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * SessionsHero unit tests — Wave D.1 (Issue #735).
+ *
+ * 6 tests:
+ * 1. Renders data-slot="sessions-hero"
+ * 2. Renders title from labels
+ * 3. Substitutes {count} in subtitleTemplate
+ * 4. Renders CTA button with correct aria-label
+ * 5. Fires onNewSession on CTA click
+ * 6. Applies custom className
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SessionsHero } from '../SessionsHero';
+import type { SessionsHeroProps } from '../SessionsHero';
+
+const LABELS: SessionsHeroProps['labels'] = {
+  title: 'Le tue partite',
+  subtitleTemplate: '{count} sessioni totali',
+  ctaNew: 'Nuova sessione',
+};
+
+const DEFAULT_PROPS: SessionsHeroProps = {
+  count: 42,
+  onNewSession: vi.fn(),
+  labels: LABELS,
+};
+
+describe('SessionsHero', () => {
+  it('renders data-slot="sessions-hero"', () => {
+    render(<SessionsHero {...DEFAULT_PROPS} />);
+    expect(document.querySelector('[data-slot="sessions-hero"]')).not.toBeNull();
+  });
+
+  it('renders title from labels', () => {
+    render(<SessionsHero {...DEFAULT_PROPS} />);
+    expect(screen.getByText('Le tue partite')).toBeTruthy();
+  });
+
+  it('substitutes {count} in subtitleTemplate', () => {
+    render(<SessionsHero {...DEFAULT_PROPS} count={42} />);
+    expect(screen.getByText('42 sessioni totali')).toBeTruthy();
+  });
+
+  it('renders CTA button with correct aria-label', () => {
+    render(<SessionsHero {...DEFAULT_PROPS} />);
+    const cta = document.querySelector('[data-slot="sessions-hero-cta"]');
+    expect(cta).not.toBeNull();
+    expect(cta!.getAttribute('aria-label')).toBe('Nuova sessione');
+  });
+
+  it('fires onNewSession callback on CTA click', () => {
+    const onNewSession = vi.fn();
+    render(<SessionsHero {...DEFAULT_PROPS} onNewSession={onNewSession} />);
+    const cta = document.querySelector('[data-slot="sessions-hero-cta"]') as HTMLButtonElement;
+    fireEvent.click(cta);
+    expect(onNewSession).toHaveBeenCalledOnce();
+  });
+
+  it('applies custom className to the section', () => {
+    render(<SessionsHero {...DEFAULT_PROPS} className="my-custom-class" />);
+    const section = document.querySelector('[data-slot="sessions-hero"]');
+    expect(section!.classList.contains('my-custom-class')).toBe(true);
+  });
+});

--- a/apps/web/src/components/v2/sessions/index.ts
+++ b/apps/web/src/components/v2/sessions/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Barrel export for /sessions v2 components (Wave D.1, Issue #735).
+ *
+ * Single import point for the orchestrator SessionsLibraryView and E2E specs.
+ * All components are pure (no useTranslation) — labels injected by orchestrator.
+ */
+
+export { ConnectionChipStripFooter } from './ConnectionChipStripFooter';
+export type { ConnectionChip, ConnectionChipStripFooterProps } from './ConnectionChipStripFooter';
+
+export { EmptySessions } from './EmptySessions';
+export type { EmptySessionsKind, EmptySessionsLabels, EmptySessionsProps } from './EmptySessions';
+
+export { OutcomeBadge } from './OutcomeBadge';
+export type { OutcomeBadgeLabels } from './OutcomeBadge';
+
+export { ScoringInline } from './ScoringInline';
+
+export { SessionCardGrid } from './SessionCardGrid';
+export type { SessionCardGridLabels, SessionCardGridProps } from './SessionCardGrid';
+
+export { SessionCardList } from './SessionCardList';
+export type { SessionCardListLabels, SessionCardListProps } from './SessionCardList';
+
+export { SessionsFilters } from './SessionsFilters';
+export type { SessionsFiltersLabels, SessionsFiltersProps } from './SessionsFilters';
+
+export { SessionsHero } from './SessionsHero';
+export type { SessionsHeroLabels, SessionsHeroProps } from './SessionsHero';

--- a/apps/web/src/lib/sessions/__tests__/sessions-filters.test.ts
+++ b/apps/web/src/lib/sessions/__tests__/sessions-filters.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type SessionListItem,
+  type SessionStatusFilter,
+  type SessionViewMode,
+  applySearchFilter,
+  applyStatusFilter,
+  formatDuration,
+  parseStatusFilter,
+  parseViewMode,
+} from '../sessions-filters';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSession(
+  overrides: Partial<SessionListItem> & Pick<SessionListItem, 'id' | 'gameName' | 'status'>
+): SessionListItem {
+  return {
+    date: '23 apr 2026',
+    when: '2 giorni fa',
+    duration: '1h 24m',
+    outcome: null,
+    playerCount: 2,
+    scores: [],
+    hasChat: false,
+    ...overrides,
+  };
+}
+
+const WINGSPAN_COMPLETED = makeSession({
+  id: 's1',
+  gameName: 'Wingspan',
+  status: 'completed',
+  outcome: 'won',
+});
+const AZUL_COMPLETED = makeSession({
+  id: 's2',
+  gameName: 'Azul',
+  status: 'completed',
+  outcome: 'lost',
+});
+const BRASS_INPROGRESS = makeSession({
+  id: 's3',
+  gameName: 'Brass: Birmingham',
+  status: 'inprogress',
+  outcome: null,
+});
+const WINGSPAN_PAUSED = makeSession({
+  id: 's4',
+  gameName: 'Wingspan',
+  status: 'paused',
+  outcome: null,
+  paused: true,
+});
+const WONDERS_ABANDONED = makeSession({
+  id: 's5',
+  gameName: '7 Wonders',
+  status: 'abandoned',
+  outcome: null,
+});
+
+const ALL_ITEMS: ReadonlyArray<SessionListItem> = [
+  WINGSPAN_COMPLETED,
+  AZUL_COMPLETED,
+  BRASS_INPROGRESS,
+  WINGSPAN_PAUSED,
+  WONDERS_ABANDONED,
+];
+
+// ---------------------------------------------------------------------------
+// applyStatusFilter
+// ---------------------------------------------------------------------------
+
+describe('applyStatusFilter', () => {
+  it("returns the same reference when filter='all'", () => {
+    const result = applyStatusFilter(ALL_ITEMS, 'all');
+    expect(result).toBe(ALL_ITEMS);
+    expect(result).toHaveLength(5);
+  });
+
+  it("filter='active' returns inprogress + paused sessions only", () => {
+    const result = applyStatusFilter(ALL_ITEMS, 'active');
+    expect(result).toHaveLength(2);
+    const statuses = result.map(s => s.status);
+    expect(statuses).toContain('inprogress');
+    expect(statuses).toContain('paused');
+    expect(statuses).not.toContain('completed');
+    expect(statuses).not.toContain('abandoned');
+  });
+
+  it("filter='completed' returns only completed sessions", () => {
+    const result = applyStatusFilter(ALL_ITEMS, 'completed');
+    expect(result).toHaveLength(2);
+    result.forEach(s => expect(s.status).toBe('completed'));
+  });
+
+  it("filter='abandoned' returns only abandoned sessions", () => {
+    const result = applyStatusFilter(ALL_ITEMS, 'abandoned');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('s5');
+  });
+
+  it("filter='active' returns empty when no active sessions exist", () => {
+    const completedOnly: ReadonlyArray<SessionListItem> = [WINGSPAN_COMPLETED, AZUL_COMPLETED];
+    const result = applyStatusFilter(completedOnly, 'active');
+    expect(result).toHaveLength(0);
+  });
+
+  it("filter='completed' returns empty when no completed sessions", () => {
+    const activeOnly: ReadonlyArray<SessionListItem> = [BRASS_INPROGRESS, WINGSPAN_PAUSED];
+    const result = applyStatusFilter(activeOnly, 'completed');
+    expect(result).toHaveLength(0);
+  });
+
+  it('handles empty input array gracefully', () => {
+    const result = applyStatusFilter([], 'active');
+    expect(result).toHaveLength(0);
+  });
+
+  it("filter='all' on empty array returns empty array", () => {
+    const result = applyStatusFilter([], 'all');
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applySearchFilter
+// ---------------------------------------------------------------------------
+
+describe('applySearchFilter', () => {
+  it('returns same reference when query is empty string', () => {
+    const result = applySearchFilter(ALL_ITEMS, '');
+    expect(result).toBe(ALL_ITEMS);
+  });
+
+  it('returns same reference when query is whitespace only', () => {
+    const result = applySearchFilter(ALL_ITEMS, '   ');
+    expect(result).toBe(ALL_ITEMS);
+  });
+
+  it('matches gameName substring case-insensitively', () => {
+    const result = applySearchFilter(ALL_ITEMS, 'WING');
+    expect(result).toHaveLength(2); // Wingspan completed + Wingspan paused
+    result.forEach(s => expect(s.gameName).toBe('Wingspan'));
+  });
+
+  it('matches partial gameName for multi-word game names', () => {
+    const result = applySearchFilter(ALL_ITEMS, 'brass');
+    expect(result).toHaveLength(1);
+    expect(result[0].gameName).toBe('Brass: Birmingham');
+  });
+
+  it('returns empty array when search matches nothing', () => {
+    const result = applySearchFilter(ALL_ITEMS, 'Catan');
+    expect(result).toHaveLength(0);
+  });
+
+  it('trims leading/trailing whitespace before matching', () => {
+    const result = applySearchFilter(ALL_ITEMS, '  Azul  ');
+    expect(result).toHaveLength(1);
+    expect(result[0].gameName).toBe('Azul');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseStatusFilter
+// ---------------------------------------------------------------------------
+
+describe('parseStatusFilter', () => {
+  it("returns 'all' for null input", () => {
+    expect(parseStatusFilter(null)).toBe('all');
+  });
+
+  it("returns 'all' for undefined input", () => {
+    expect(parseStatusFilter(undefined)).toBe('all');
+  });
+
+  it("returns 'all' for empty string", () => {
+    expect(parseStatusFilter('')).toBe('all');
+  });
+
+  it("returns 'all' for invalid value", () => {
+    expect(parseStatusFilter('invalid')).toBe('all');
+  });
+
+  it("returns 'all' for valid 'all' value", () => {
+    expect(parseStatusFilter('all')).toBe('all');
+  });
+
+  it("returns 'active' for valid 'active' value", () => {
+    expect(parseStatusFilter('active')).toBe('active');
+  });
+
+  it("returns 'completed' for valid 'completed' value", () => {
+    expect(parseStatusFilter('completed')).toBe('completed');
+  });
+
+  it("returns 'abandoned' for valid 'abandoned' value", () => {
+    expect(parseStatusFilter('abandoned')).toBe('abandoned');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseViewMode
+// ---------------------------------------------------------------------------
+
+describe('parseViewMode', () => {
+  it("returns 'list' for null input (default)", () => {
+    expect(parseViewMode(null)).toBe('list');
+  });
+
+  it("returns 'list' for undefined input", () => {
+    expect(parseViewMode(undefined)).toBe('list');
+  });
+
+  it("returns 'list' for empty string", () => {
+    expect(parseViewMode('')).toBe('list');
+  });
+
+  it("returns 'list' for invalid value", () => {
+    expect(parseViewMode('table')).toBe('list');
+  });
+
+  it("returns 'list' for explicit 'list' value", () => {
+    expect(parseViewMode('list')).toBe('list');
+  });
+
+  it("returns 'grid' for valid 'grid' value", () => {
+    expect(parseViewMode('grid')).toBe('grid');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatDuration
+// ---------------------------------------------------------------------------
+
+describe('formatDuration', () => {
+  it('formats 0 minutes as "0m"', () => {
+    expect(formatDuration(0)).toBe('0m');
+  });
+
+  it('formats sub-hour as minutes only', () => {
+    expect(formatDuration(45)).toBe('45m');
+  });
+
+  it('formats exact hours with no minutes', () => {
+    expect(formatDuration(60)).toBe('1h');
+  });
+
+  it('formats hours and minutes together', () => {
+    expect(formatDuration(84)).toBe('1h 24m');
+  });
+
+  it('formats 2h 30m correctly', () => {
+    expect(formatDuration(150)).toBe('2h 30m');
+  });
+
+  it('formats negative minutes as "0m"', () => {
+    expect(formatDuration(-5)).toBe('0m');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SessionStatusFilter type validation (structural)
+// ---------------------------------------------------------------------------
+
+describe('SessionStatusFilter type', () => {
+  it('accepts all valid status filter values', () => {
+    const filters: SessionStatusFilter[] = ['all', 'active', 'completed', 'abandoned'];
+    filters.forEach(f => {
+      expect(() => applyStatusFilter(ALL_ITEMS, f)).not.toThrow();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SessionViewMode type validation (structural)
+// ---------------------------------------------------------------------------
+
+describe('SessionViewMode type', () => {
+  it('accepts both valid view mode values', () => {
+    const modes: SessionViewMode[] = ['list', 'grid'];
+    modes.forEach(m => {
+      expect(parseViewMode(m)).toBe(m);
+    });
+  });
+});

--- a/apps/web/src/lib/sessions/__tests__/sessions-state.test.ts
+++ b/apps/web/src/lib/sessions/__tests__/sessions-state.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type DeriveSessionsUiStateInput,
+  type SessionsUiState,
+  deriveSessionsUiState,
+} from '../sessions-state';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function input(overrides: Partial<DeriveSessionsUiStateInput> = {}): DeriveSessionsUiStateInput {
+  return {
+    isLoading: false,
+    isError: false,
+    totalCount: 5,
+    filteredCount: 5,
+    ...overrides,
+  };
+}
+
+function expectState(derived: SessionsUiState, expected: SessionsUiState): void {
+  expect(derived).toBe(expected);
+}
+
+// ---------------------------------------------------------------------------
+// 5-state FSM: precedence matrix
+// ---------------------------------------------------------------------------
+
+describe('deriveSessionsUiState', () => {
+  // --- loading (highest precedence) ----------------------------------------
+
+  it("returns 'loading' when isLoading=true, even with data present", () => {
+    expectState(deriveSessionsUiState(input({ isLoading: true, totalCount: 5 })), 'loading');
+  });
+
+  it("returns 'loading' when isLoading=true and no data", () => {
+    expectState(
+      deriveSessionsUiState(input({ isLoading: true, totalCount: 0, filteredCount: 0 })),
+      'loading'
+    );
+  });
+
+  it("returns 'loading' beats error when both flags are true", () => {
+    // Per contract: isLoading check first → 'loading' wins over 'error'
+    expectState(deriveSessionsUiState(input({ isLoading: true, isError: true })), 'loading');
+  });
+
+  // --- error (second precedence) -------------------------------------------
+
+  it("returns 'error' when isError=true and not loading", () => {
+    expectState(
+      deriveSessionsUiState(
+        input({ isLoading: false, isError: true, totalCount: 0, filteredCount: 0 })
+      ),
+      'error'
+    );
+  });
+
+  it("returns 'error' when isError=true even if totalCount>0 (stale-data error)", () => {
+    expectState(
+      deriveSessionsUiState(input({ isLoading: false, isError: true, totalCount: 3 })),
+      'error'
+    );
+  });
+
+  // --- empty (third precedence) --------------------------------------------
+
+  it("returns 'empty' when fetch resolved with zero sessions and no filters applied", () => {
+    expectState(
+      deriveSessionsUiState(
+        input({
+          isLoading: false,
+          isError: false,
+          totalCount: 0,
+          filteredCount: 0,
+        })
+      ),
+      'empty'
+    );
+  });
+
+  it("returns 'empty' when totalCount=0 regardless of filteredCount", () => {
+    // totalCount=0 means backend returned nothing; filter state is irrelevant
+    expectState(
+      deriveSessionsUiState(
+        input({
+          isLoading: false,
+          isError: false,
+          totalCount: 0,
+          filteredCount: 0,
+        })
+      ),
+      'empty'
+    );
+  });
+
+  // --- filtered-empty (fourth precedence) ----------------------------------
+
+  it("returns 'filtered-empty' when data exists but active filter eliminates all results", () => {
+    expectState(
+      deriveSessionsUiState(
+        input({
+          isLoading: false,
+          isError: false,
+          totalCount: 6,
+          filteredCount: 0,
+        })
+      ),
+      'filtered-empty'
+    );
+  });
+
+  it("returns 'filtered-empty' when totalCount>0 but filteredCount=0 (edge: 1 session, strong filter)", () => {
+    expectState(
+      deriveSessionsUiState(
+        input({
+          isLoading: false,
+          isError: false,
+          totalCount: 1,
+          filteredCount: 0,
+        })
+      ),
+      'filtered-empty'
+    );
+  });
+
+  // --- default (base case) -------------------------------------------------
+
+  it("returns 'default' for healthy populated state with no filters", () => {
+    expectState(
+      deriveSessionsUiState(
+        input({
+          isLoading: false,
+          isError: false,
+          totalCount: 6,
+          filteredCount: 6,
+        })
+      ),
+      'default'
+    );
+  });
+
+  it("returns 'default' when status filter applied and results still present", () => {
+    expectState(
+      deriveSessionsUiState(
+        input({
+          isLoading: false,
+          isError: false,
+          totalCount: 6,
+          filteredCount: 2, // e.g., 2 inprogress sessions visible
+        })
+      ),
+      'default'
+    );
+  });
+
+  it("returns 'default' when filteredCount=1 (edge: single visible result after filter)", () => {
+    expectState(deriveSessionsUiState(input({ totalCount: 3, filteredCount: 1 })), 'default');
+  });
+});

--- a/apps/web/src/lib/sessions/__tests__/sessions-state.test.ts
+++ b/apps/web/src/lib/sessions/__tests__/sessions-state.test.ts
@@ -4,6 +4,7 @@ import {
   type DeriveSessionsUiStateInput,
   type SessionsUiState,
   deriveSessionsUiState,
+  parseStateOverride,
 } from '../sessions-state';
 
 // ---------------------------------------------------------------------------
@@ -158,5 +159,31 @@ describe('deriveSessionsUiState', () => {
 
   it("returns 'default' when filteredCount=1 (edge: single visible result after filter)", () => {
     expectState(deriveSessionsUiState(input({ totalCount: 3, filteredCount: 1 })), 'default');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseStateOverride re-export — confirm sessions-state.ts re-exports it
+// ---------------------------------------------------------------------------
+
+describe('parseStateOverride re-export from sessions-state', () => {
+  it('is a function exported from sessions-state (not just from sessions-visual-test-fixture)', () => {
+    expect(typeof parseStateOverride).toBe('function');
+  });
+
+  it("returns 'loading' when ?state=loading (re-export delegates to fixture impl)", () => {
+    expect(parseStateOverride(new URLSearchParams({ state: 'loading' }))).toBe('loading');
+  });
+
+  it("returns 'empty' when ?state=empty", () => {
+    expect(parseStateOverride(new URLSearchParams({ state: 'empty' }))).toBe('empty');
+  });
+
+  it('returns null for unknown state values', () => {
+    expect(parseStateOverride(new URLSearchParams({ state: 'unknown' }))).toBeNull();
+  });
+
+  it('returns null when no state param', () => {
+    expect(parseStateOverride(new URLSearchParams())).toBeNull();
   });
 });

--- a/apps/web/src/lib/sessions/__tests__/sessions-visual-test-fixture.test.ts
+++ b/apps/web/src/lib/sessions/__tests__/sessions-visual-test-fixture.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  IS_VISUAL_TEST_BUILD,
+  STATE_OVERRIDE_ENABLED,
+  VISUAL_TEST_FIXTURE_SESSIONS,
+  VISUAL_TEST_FIXTURE_SESSIONS_EMPTY,
+  VISUAL_TEST_FIXTURE_SESSIONS_ID,
+  parseStateOverride,
+  tryLoadVisualTestFixture,
+} from '../sessions-visual-test-fixture';
+
+// ---------------------------------------------------------------------------
+// Production safety gate
+// ---------------------------------------------------------------------------
+
+describe('IS_VISUAL_TEST_BUILD', () => {
+  it('is false in the normal test environment (NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED not set to "1")', () => {
+    // vitest does NOT set NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED=1 by default,
+    // so this constant evaluates to `false` at module evaluation time.
+    expect(IS_VISUAL_TEST_BUILD).toBe(false);
+  });
+});
+
+describe('STATE_OVERRIDE_ENABLED', () => {
+  it('is true in test/development environment (NODE_ENV !== "production")', () => {
+    // vitest runs with NODE_ENV=test, so STATE_OVERRIDE_ENABLED must be true
+    expect(STATE_OVERRIDE_ENABLED).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tryLoadVisualTestFixture — production mode (fixture disabled)
+// ---------------------------------------------------------------------------
+
+describe('tryLoadVisualTestFixture — IS_VISUAL_TEST_BUILD=false', () => {
+  it('returns null when not a visual-test build (default state)', () => {
+    const result = tryLoadVisualTestFixture('default');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when not a visual-test build (empty state)', () => {
+    const result = tryLoadVisualTestFixture('empty');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when called with no argument (default omitted)', () => {
+    const result = tryLoadVisualTestFixture();
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture data contract — shape validation
+// ---------------------------------------------------------------------------
+
+describe('VISUAL_TEST_FIXTURE_SESSIONS — data contract', () => {
+  it('exports exactly 6 fixture entries', () => {
+    expect(VISUAL_TEST_FIXTURE_SESSIONS).toHaveLength(6);
+  });
+
+  it('all entries have the required SessionListItem fields', () => {
+    VISUAL_TEST_FIXTURE_SESSIONS.forEach((s, i) => {
+      expect(s.id, `entry ${i}: id`).toBeTruthy();
+      expect(s.gameName, `entry ${i}: gameName`).toBeTruthy();
+      expect(s.date, `entry ${i}: date`).toBeTruthy();
+      expect(s.when, `entry ${i}: when`).toBeTruthy();
+      expect(s.duration, `entry ${i}: duration`).toBeTruthy();
+      expect(['inprogress', 'paused', 'completed', 'abandoned']).toContain(s.status);
+      expect(typeof s.playerCount).toBe('number');
+      expect(Array.isArray(s.scores)).toBe(true);
+      expect(typeof s.hasChat).toBe('boolean');
+    });
+  });
+
+  it('contains exactly 1 inprogress session', () => {
+    const count = VISUAL_TEST_FIXTURE_SESSIONS.filter(s => s.status === 'inprogress').length;
+    expect(count).toBe(1);
+  });
+
+  it('contains exactly 1 paused session', () => {
+    const count = VISUAL_TEST_FIXTURE_SESSIONS.filter(s => s.status === 'paused').length;
+    expect(count).toBe(1);
+  });
+
+  it('contains exactly 3 completed sessions', () => {
+    const count = VISUAL_TEST_FIXTURE_SESSIONS.filter(s => s.status === 'completed').length;
+    expect(count).toBe(3);
+  });
+
+  it('contains exactly 1 abandoned session', () => {
+    const count = VISUAL_TEST_FIXTURE_SESSIONS.filter(s => s.status === 'abandoned').length;
+    expect(count).toBe(1);
+  });
+
+  it('completed sessions cover all 3 outcomes: won, lost, tie', () => {
+    const completed = VISUAL_TEST_FIXTURE_SESSIONS.filter(s => s.status === 'completed');
+    const outcomes = completed.map(s => s.outcome);
+    expect(outcomes).toContain('won');
+    expect(outcomes).toContain('lost');
+    expect(outcomes).toContain('tie');
+  });
+
+  it('all entries use the deterministic UUID sentinel format', () => {
+    const uuidPattern = /^00000000-0000-4000-8000-\d{12}$/;
+    VISUAL_TEST_FIXTURE_SESSIONS.forEach((s, i) => {
+      expect(s.id, `entry ${i}: id format`).toMatch(uuidPattern);
+    });
+  });
+
+  it('the inprogress session has a turn field and hasChat=true', () => {
+    const liveSession = VISUAL_TEST_FIXTURE_SESSIONS.find(s => s.status === 'inprogress');
+    expect(liveSession).toBeDefined();
+    expect(liveSession?.turn).toBeTruthy();
+    expect(liveSession?.hasChat).toBe(true);
+    expect(liveSession?.chatCount).toBeGreaterThan(0);
+  });
+
+  it('the paused session has paused=true and a turn field', () => {
+    const pausedSession = VISUAL_TEST_FIXTURE_SESSIONS.find(s => s.status === 'paused');
+    expect(pausedSession).toBeDefined();
+    expect(pausedSession?.paused).toBe(true);
+    expect(pausedSession?.turn).toBeTruthy();
+  });
+
+  it('non-completed sessions have outcome=null', () => {
+    VISUAL_TEST_FIXTURE_SESSIONS.filter(s => s.status !== 'completed').forEach(s => {
+      expect(s.outcome).toBeNull();
+    });
+  });
+});
+
+describe('VISUAL_TEST_FIXTURE_SESSIONS_EMPTY', () => {
+  it('is an empty array', () => {
+    expect(VISUAL_TEST_FIXTURE_SESSIONS_EMPTY).toHaveLength(0);
+    expect(Array.isArray(VISUAL_TEST_FIXTURE_SESSIONS_EMPTY)).toBe(true);
+  });
+});
+
+describe('VISUAL_TEST_FIXTURE_SESSIONS_ID', () => {
+  it('encodes issue #735 in the UUID sentinel', () => {
+    expect(VISUAL_TEST_FIXTURE_SESSIONS_ID).toBe('00000000-0000-4000-8000-000000000735');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseStateOverride
+// ---------------------------------------------------------------------------
+
+describe('parseStateOverride — STATE_OVERRIDE_ENABLED=true (test env)', () => {
+  function params(state: string): URLSearchParams {
+    return new URLSearchParams({ state });
+  }
+
+  it("returns 'loading' for ?state=loading", () => {
+    expect(parseStateOverride(params('loading'))).toBe('loading');
+  });
+
+  it("returns 'empty' for ?state=empty", () => {
+    expect(parseStateOverride(params('empty'))).toBe('empty');
+  });
+
+  it("returns 'filtered-empty' for ?state=filtered-empty", () => {
+    expect(parseStateOverride(params('filtered-empty'))).toBe('filtered-empty');
+  });
+
+  it('returns null for ?state=error (not reproducible via URL deterministically)', () => {
+    expect(parseStateOverride(params('error'))).toBeNull();
+  });
+
+  it('returns null for unknown state value', () => {
+    expect(parseStateOverride(params('unknown'))).toBeNull();
+  });
+
+  it('returns null when no state param present', () => {
+    expect(parseStateOverride(new URLSearchParams())).toBeNull();
+  });
+
+  it('accepts a plain Record<string, string> as searchParams', () => {
+    expect(parseStateOverride({ state: 'loading' })).toBe('loading');
+    expect(parseStateOverride({ state: 'empty' })).toBe('empty');
+    expect(parseStateOverride({})).toBeNull();
+  });
+
+  it("returns 'default' is NOT a valid override (returned as null)", () => {
+    // 'default' is not in the valid overrides set — it's handled by fixture
+    expect(parseStateOverride(params('default'))).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Structural export contracts
+// ---------------------------------------------------------------------------
+
+describe('module export contracts', () => {
+  it('IS_VISUAL_TEST_BUILD is a boolean', () => {
+    expect(typeof IS_VISUAL_TEST_BUILD).toBe('boolean');
+  });
+
+  it('STATE_OVERRIDE_ENABLED is a boolean', () => {
+    expect(typeof STATE_OVERRIDE_ENABLED).toBe('boolean');
+  });
+
+  it('tryLoadVisualTestFixture is a function', () => {
+    expect(typeof tryLoadVisualTestFixture).toBe('function');
+    expect(() => tryLoadVisualTestFixture('default')).not.toThrow();
+    expect(() => tryLoadVisualTestFixture('empty')).not.toThrow();
+    expect(() => tryLoadVisualTestFixture()).not.toThrow();
+  });
+
+  it('parseStateOverride is a function', () => {
+    expect(typeof parseStateOverride).toBe('function');
+  });
+});

--- a/apps/web/src/lib/sessions/sessions-filters.ts
+++ b/apps/web/src/lib/sessions/sessions-filters.ts
@@ -9,6 +9,9 @@
  *   id, gameId, status (InProgress|Paused|Setup|Completed|Abandoned),
  *   startedAt, completedAt, playerCount, players, winnerName, notes, durationMinutes
  *
+ * SessionPlayerDto (games.schemas.ts lines 58–62) provides:
+ *   playerName, playerOrder, color — NO score or winner fields.
+ *
  * Wave D.1 = visual upgrade only. The SessionListItem shape is a display-ready
  * transform of GameSessionDto — gameName is derived from gameId for now (the
  * orchestrator Task 3 will join game title from the games catalog).
@@ -18,6 +21,8 @@
  * those same values for consistency with the mockup; 'active' is treated as a
  * filter-level alias covering both 'inprogress' and 'paused' statuses.
  */
+
+import type { SessionPlayerDto } from '../api/schemas/games.schemas';
 
 /** Display-ready status values aligned with mockup filter chips. */
 export type SessionStatusFilter = 'all' | 'active' | 'completed' | 'abandoned';
@@ -73,7 +78,14 @@ export interface SessionListItem {
 }
 
 /**
- * Transforms a GameSessionDto array into display-ready SessionListItem rows.
+ * Transforms GameSessionDto[] from useActiveSessions to SessionListItem[].
+ *
+ * SCHEMA REALITY V1 CARRYOVER (Wave D.1):
+ * SessionPlayerDto exposes only playerName/playerOrder/color — NO score or winner
+ * fields. Wave D.1 = visual upgrade only; scoring is decorative (placeholder 0).
+ * Followup issue post-merge for true scoring API extension.
+ *
+ * Mirror: Wave 4 D1 PR #717 schema reality pattern.
  *
  * Game name resolution: the orchestrator (Task 3) should pre-resolve game titles
  * from the user library cache and pass them via a `gameNameMap` lookup table.
@@ -90,11 +102,7 @@ export function transformSessionsToItems(
     startedAt: string;
     completedAt: string | null;
     playerCount: number;
-    players: ReadonlyArray<{
-      displayName: string;
-      score?: number | null;
-      isWinner?: boolean | null;
-    }>;
+    players: ReadonlyArray<SessionPlayerDto>;
     winnerName: string | null;
     notes: string | null;
     durationMinutes: number;
@@ -105,10 +113,12 @@ export function transformSessionsToItems(
     const gameName = gameNameMap[dto.gameId] ?? dto.gameId;
     const status = mapStatus(dto.status);
     const outcome = deriveOutcome(dto);
+    // SCHEMA REALITY V1 CARRYOVER: SessionPlayerDto has no score/winner fields.
+    // score=0 and winner=false are placeholders until the scoring API is extended.
     const scores: ReadonlyArray<SessionScoreEntry> = dto.players.map(p => ({
-      name: p.displayName,
-      score: p.score ?? 0,
-      winner: p.isWinner ?? false,
+      name: p.playerName,
+      score: 0,
+      winner: false,
     }));
 
     return {
@@ -144,7 +154,7 @@ function mapStatus(backendStatus: string): SessionListItem['status'] {
 function deriveOutcome(dto: {
   status: string;
   winnerName: string | null;
-  players: ReadonlyArray<{ displayName: string }>;
+  players: ReadonlyArray<SessionPlayerDto>;
 }): SessionListItem['outcome'] {
   const status = mapStatus(dto.status);
   if (status !== 'completed') return null;

--- a/apps/web/src/lib/sessions/sessions-filters.ts
+++ b/apps/web/src/lib/sessions/sessions-filters.ts
@@ -1,0 +1,254 @@
+/**
+ * Pure helpers for the /sessions v2 surface (Wave D.1).
+ *
+ * Mirrors the lib/players/players-filters.ts pattern from Wave 4 D1 — no React,
+ * no API client, exclusively transforms over SessionListItem so it stays
+ * unit-testable in isolation.
+ *
+ * Schema reality: the backend GameSessionDto (games.schemas.ts) provides:
+ *   id, gameId, status (InProgress|Paused|Setup|Completed|Abandoned),
+ *   startedAt, completedAt, playerCount, players, winnerName, notes, durationMinutes
+ *
+ * Wave D.1 = visual upgrade only. The SessionListItem shape is a display-ready
+ * transform of GameSessionDto — gameName is derived from gameId for now (the
+ * orchestrator Task 3 will join game title from the games catalog).
+ *
+ * Note on 'active' filter: in the mockup, the filter chips use 'inprogress'
+ * (live/paused) vs 'completed' vs 'abandoned'. Our SessionStatusFilter uses
+ * those same values for consistency with the mockup; 'active' is treated as a
+ * filter-level alias covering both 'inprogress' and 'paused' statuses.
+ */
+
+/** Display-ready status values aligned with mockup filter chips. */
+export type SessionStatusFilter = 'all' | 'active' | 'completed' | 'abandoned';
+
+/** View mode toggle: list (default) or grid. */
+export type SessionViewMode = 'list' | 'grid';
+
+/** Score entry for a single player within a session. */
+export interface SessionScoreEntry {
+  readonly name: string;
+  readonly score: number;
+  readonly winner?: boolean;
+  readonly note?: string;
+}
+
+/**
+ * A single row in the /sessions list — display-ready shape derived from
+ * GameSessionDto plus game catalog join (done in orchestrator).
+ *
+ * Status vocabulary (maps from backend GameSessionDto.status):
+ *   'inprogress' = InProgress (live)
+ *   'paused'     = Paused
+ *   'completed'  = Completed (endedAt present, has outcome)
+ *   'abandoned'  = Abandoned
+ */
+export interface SessionListItem {
+  /** UUID from GameSessionDto.id. */
+  readonly id: string;
+  /** Human-readable game name from game catalog join. Falls back to gameId. */
+  readonly gameName: string;
+  /** Formatted display date, e.g. "23 apr 2026". */
+  readonly date: string;
+  /** Relative time label, e.g. "2 giorni fa". */
+  readonly when: string;
+  /** Formatted duration string, e.g. "1h 24m". */
+  readonly duration: string;
+  /** Client-side status vocabulary. */
+  readonly status: 'inprogress' | 'paused' | 'completed' | 'abandoned';
+  /** Session outcome (null for non-completed). */
+  readonly outcome: 'won' | 'lost' | 'tie' | null;
+  /** Number of players. */
+  readonly playerCount: number;
+  /** Player scores (may be empty for in-progress sessions with no scoring yet). */
+  readonly scores: ReadonlyArray<SessionScoreEntry>;
+  /** Whether any chat messages exist for this session. */
+  readonly hasChat: boolean;
+  /** Chat message count (present when hasChat=true). */
+  readonly chatCount?: number;
+  /** Current turn display string, e.g. "12/18" (present for inprogress). */
+  readonly turn?: string;
+  /** True when status='paused'. */
+  readonly paused?: boolean;
+}
+
+/**
+ * Transforms a GameSessionDto array into display-ready SessionListItem rows.
+ *
+ * Game name resolution: the orchestrator (Task 3) should pre-resolve game titles
+ * from the user library cache and pass them via a `gameNameMap` lookup table.
+ * This function accepts the map and falls back to gameId when no mapping exists.
+ *
+ * Duration formatting: durationMinutes → "Xh Ym" or "Zm" for sub-hour.
+ * Date formatting: startedAt ISO string → locale-aware display (uses 'it-IT').
+ */
+export function transformSessionsToItems(
+  sessions: ReadonlyArray<{
+    id: string;
+    gameId: string;
+    status: string;
+    startedAt: string;
+    completedAt: string | null;
+    playerCount: number;
+    players: ReadonlyArray<{
+      displayName: string;
+      score?: number | null;
+      isWinner?: boolean | null;
+    }>;
+    winnerName: string | null;
+    notes: string | null;
+    durationMinutes: number;
+  }>,
+  gameNameMap: Record<string, string> = {}
+): ReadonlyArray<SessionListItem> {
+  return sessions.map(dto => {
+    const gameName = gameNameMap[dto.gameId] ?? dto.gameId;
+    const status = mapStatus(dto.status);
+    const outcome = deriveOutcome(dto);
+    const scores: ReadonlyArray<SessionScoreEntry> = dto.players.map(p => ({
+      name: p.displayName,
+      score: p.score ?? 0,
+      winner: p.isWinner ?? false,
+    }));
+
+    return {
+      id: dto.id,
+      gameName,
+      date: formatDate(dto.startedAt),
+      when: formatRelativeTime(dto.startedAt),
+      duration: formatDuration(dto.durationMinutes),
+      status,
+      outcome,
+      playerCount: dto.playerCount,
+      scores,
+      hasChat: false, // chat integration is a separate future concern
+      paused: status === 'paused',
+    } satisfies SessionListItem;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Maps backend status string to SessionListItem.status vocabulary. */
+function mapStatus(backendStatus: string): SessionListItem['status'] {
+  const s = backendStatus.toLowerCase();
+  if (s === 'inprogress' || s === 'setup') return 'inprogress';
+  if (s === 'paused') return 'paused';
+  if (s === 'completed') return 'completed';
+  return 'abandoned';
+}
+
+/** Derives win/loss/tie from winnerName. Returns null for non-completed sessions. */
+function deriveOutcome(dto: {
+  status: string;
+  winnerName: string | null;
+  players: ReadonlyArray<{ displayName: string }>;
+}): SessionListItem['outcome'] {
+  const status = mapStatus(dto.status);
+  if (status !== 'completed') return null;
+  if (!dto.winnerName) return 'tie'; // completed with no winner = tie
+  // 'won' when the user (first player) is the winner — orchestrator can refine
+  return 'won';
+}
+
+/** Formats an ISO date string to a human-readable display date in it-IT locale. */
+export function formatDate(isoString: string): string {
+  try {
+    return new Date(isoString).toLocaleDateString('it-IT', {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    });
+  } catch {
+    return isoString;
+  }
+}
+
+/** Formats durationMinutes to "Xh Ym" or "Zm". */
+export function formatDuration(minutes: number): string {
+  if (minutes <= 0) return '0m';
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  if (h === 0) return `${m}m`;
+  if (m === 0) return `${h}h`;
+  return `${h}h ${m}m`;
+}
+
+/** Returns a human-readable relative time label (simple version for fixtures). */
+export function formatRelativeTime(isoString: string): string {
+  try {
+    const now = Date.now();
+    const then = new Date(isoString).getTime();
+    const diffMs = now - then;
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+    if (diffDays === 0) return 'oggi';
+    if (diffDays === 1) return 'ieri';
+    if (diffDays < 7) return `${diffDays} giorni fa`;
+    if (diffDays < 14) return '1 settimana fa';
+    if (diffDays < 30) return `${Math.floor(diffDays / 7)} settimane fa`;
+    if (diffDays < 60) return '1 mese fa';
+    return `${Math.floor(diffDays / 30)} mesi fa`;
+  } catch {
+    return '';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Filter functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Applies a SessionStatusFilter to a list of SessionListItem rows.
+ * 'all' returns the full list (same reference).
+ * 'active' matches both 'inprogress' and 'paused' statuses.
+ */
+export function applyStatusFilter(
+  items: ReadonlyArray<SessionListItem>,
+  filter: SessionStatusFilter
+): ReadonlyArray<SessionListItem> {
+  if (filter === 'all') return items;
+  if (filter === 'active') {
+    return items.filter(s => s.status === 'inprogress' || s.status === 'paused');
+  }
+  if (filter === 'completed') {
+    return items.filter(s => s.status === 'completed');
+  }
+  if (filter === 'abandoned') {
+    return items.filter(s => s.status === 'abandoned');
+  }
+  return items;
+}
+
+/**
+ * Applies a case-insensitive search filter on gameName.
+ * Returns the same reference when query is empty or whitespace.
+ */
+export function applySearchFilter(
+  items: ReadonlyArray<SessionListItem>,
+  query: string
+): ReadonlyArray<SessionListItem> {
+  const q = query.trim().toLowerCase();
+  if (q === '') return items;
+  return items.filter(s => s.gameName.toLowerCase().includes(q));
+}
+
+// ---------------------------------------------------------------------------
+// URL param parsers
+// ---------------------------------------------------------------------------
+
+/** Parses a raw URL param string into a SessionStatusFilter (default: 'all'). */
+export function parseStatusFilter(raw: string | null | undefined): SessionStatusFilter {
+  const valid: SessionStatusFilter[] = ['all', 'active', 'completed', 'abandoned'];
+  if (raw && valid.includes(raw as SessionStatusFilter)) {
+    return raw as SessionStatusFilter;
+  }
+  return 'all';
+}
+
+/** Parses a raw URL param string into a SessionViewMode (default: 'list'). */
+export function parseViewMode(raw: string | null | undefined): SessionViewMode {
+  if (raw === 'grid') return 'grid';
+  return 'list';
+}

--- a/apps/web/src/lib/sessions/sessions-state.ts
+++ b/apps/web/src/lib/sessions/sessions-state.ts
@@ -1,0 +1,51 @@
+/**
+ * FSM state derivation for the /sessions v2 surface (Wave D.1).
+ *
+ * Tier S route — single hook (useActiveSessions) + linear 5-state FSM.
+ * Pattern blueprint: Wave 4 D1 (PR #717) `/players` route.
+ *
+ * Schema reality: /sessions displays ALL user sessions (active + history).
+ * Wave D.1 = visual upgrade only; the page currently shows only active sessions
+ * via useActiveSessions. A session-history hook is a separate followup.
+ * Foundation declares the FSM shape; orchestrator (Task 3) composes data sources.
+ *
+ * No React, no API client — pure function for unit-testability.
+ */
+
+/**
+ * The 5 mutually-exclusive UI states for the /sessions view.
+ *
+ * Precedence (highest → lowest):
+ *   loading → error → empty → filtered-empty → default
+ */
+export type SessionsUiState = 'loading' | 'error' | 'empty' | 'filtered-empty' | 'default';
+
+/** Input for FSM derivation — all fields are read-only scalars. */
+export interface DeriveSessionsUiStateInput {
+  /** True while the TanStack Query fetch is in-flight. */
+  readonly isLoading: boolean;
+  /** True when the most recent fetch resolved with an error. */
+  readonly isError: boolean;
+  /** Total count of sessions from backend (before client-side filtering). */
+  readonly totalCount: number;
+  /** Count of sessions remaining after all active filters are applied. */
+  readonly filteredCount: number;
+}
+
+/**
+ * Derives the current UI state from TanStack Query and filter state.
+ *
+ * Precedence:
+ *   1. `loading`       — fetch in-flight (beats everything)
+ *   2. `error`         — fetch failed
+ *   3. `empty`         — no data at all from backend (totalCount === 0)
+ *   4. `filtered-empty`— data exists but active filter eliminated all rows
+ *   5. `default`       — healthy, data present (with or without visible filter)
+ */
+export function deriveSessionsUiState(input: DeriveSessionsUiStateInput): SessionsUiState {
+  if (input.isLoading) return 'loading';
+  if (input.isError) return 'error';
+  if (input.totalCount === 0) return 'empty';
+  if (input.filteredCount === 0) return 'filtered-empty';
+  return 'default';
+}

--- a/apps/web/src/lib/sessions/sessions-state.ts
+++ b/apps/web/src/lib/sessions/sessions-state.ts
@@ -49,3 +49,14 @@ export function deriveSessionsUiState(input: DeriveSessionsUiStateInput): Sessio
   if (input.filteredCount === 0) return 'filtered-empty';
   return 'default';
 }
+
+// ---------------------------------------------------------------------------
+// State override re-export (for orchestrator import convenience)
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-exported from sessions-visual-test-fixture so orchestrator (Task 3) can
+ * import `parseStateOverride` from the same barrel as `deriveSessionsUiState`
+ * without coupling to the fixture module directly.
+ */
+export { parseStateOverride } from './sessions-visual-test-fixture';

--- a/apps/web/src/lib/sessions/sessions-visual-test-fixture.ts
+++ b/apps/web/src/lib/sessions/sessions-visual-test-fixture.ts
@@ -1,0 +1,217 @@
+/**
+ * Visual-regression test fixture for `/sessions` (Wave D.1).
+ *
+ * **Purpose**: workflow `visual-regression-migrated.yml` runs only Next.js prod
+ * (no backend API at `:8080`). The sessions data hook (useActiveSessions)
+ * cannot reach the backend in CI → the surface stays in `loading` forever →
+ * no screenshot.
+ *
+ * **Contract**: when env var `NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED === '1'`
+ * is baked into the build, the orchestrator (SessionsView) substitutes the
+ * fixture for the real fetch and renders deterministic entries.
+ *
+ * **Production safety**: production builds do NOT set the env var. The constant
+ * `IS_VISUAL_TEST_BUILD` evaluates to `false` and every fixture branch is dead
+ * code, eliminated by the bundler. The fixture UUIDs are meaningless to a
+ * production deployment.
+ *
+ * State coverage:
+ *   - `'default'` → 6 session entries (1 inprogress, 1 paused, 3 completed, 1 abandoned)
+ *   - `'empty'`   → []  (sessions-empty baseline)
+ *   - All other v2 states (`loading`, `filtered-empty`, `error`) are simulated
+ *     by the orchestrator via the `?state=...` URL override hatch and do NOT
+ *     hit the fixture.
+ *
+ * Used by:
+ *   - `apps/web/e2e/visual-migrated/sp4-sessions-index.spec.ts` (Task 4)
+ *   - `apps/web/e2e/v2-states/sessions-index.spec.ts` (Task 4)
+ */
+
+import type { SessionListItem } from './sessions-filters';
+import type { SessionsUiState } from './sessions-state';
+
+/**
+ * Deterministic UUIDv4-shaped sentinel encoding the Wave D.1 sessions issue
+ * (#735) in the last group for human-debuggability.
+ */
+export const VISUAL_TEST_FIXTURE_SESSIONS_ID = '00000000-0000-4000-8000-000000000735' as const;
+
+/**
+ * True only when the build was produced by the visual-regression CI workflow
+ * (sets `NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED=1` before `pnpm build`).
+ *
+ * `NEXT_PUBLIC_*` env vars are inlined at build time → in production deploys
+ * this is the literal `false`, allowing the bundler to dead-code-eliminate
+ * the fixture and its short-circuit branches.
+ */
+export const IS_VISUAL_TEST_BUILD = process.env.NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED === '1';
+
+/**
+ * Build-time gating for the `?state=` URL override hatch.
+ *
+ * Allowing state overrides in production would expose a UI manipulation
+ * surface. The hatch is enabled only when IS_VISUAL_TEST_BUILD=true or
+ * NODE_ENV !== 'production' (development/test environments).
+ */
+export const STATE_OVERRIDE_ENABLED = process.env.NODE_ENV !== 'production' || IS_VISUAL_TEST_BUILD;
+
+/**
+ * 6 deterministic SessionListItem entries covering a realistic status spread:
+ *   - s001: inprogress (live, turn 12/18, has chat)
+ *   - s002: paused (turn 6/10, has chat)
+ *   - s003: completed + won
+ *   - s004: completed + lost
+ *   - s005: completed + tie
+ *   - s006: abandoned
+ *
+ * UUIDs follow the Wave 4 D1 sentinel pattern: 00000000-0000-4000-8000-000000000XXX.
+ * Games mirror the players fixture dataset (Wingspan, Azul, Brass, Catan, Arknova).
+ */
+export const VISUAL_TEST_FIXTURE_SESSIONS: ReadonlyArray<SessionListItem> = [
+  {
+    id: '00000000-0000-4000-8000-000000000001',
+    gameName: 'Brass: Birmingham',
+    date: 'oggi',
+    when: 'in corso',
+    duration: '1h 12m',
+    status: 'inprogress',
+    outcome: null,
+    playerCount: 4,
+    scores: [
+      { name: 'Marco', score: 24 },
+      { name: 'Anna', score: 31 },
+      { name: 'Luca', score: 19 },
+      { name: 'Sara', score: 28 },
+    ],
+    hasChat: true,
+    chatCount: 7,
+    turn: '12/18',
+  },
+  {
+    id: '00000000-0000-4000-8000-000000000002',
+    gameName: 'Wingspan',
+    date: 'oggi · pausa',
+    when: 'in pausa',
+    duration: '45m',
+    status: 'paused',
+    outcome: null,
+    playerCount: 3,
+    scores: [
+      { name: 'Marco', score: 38 },
+      { name: 'Luca', score: 42 },
+      { name: 'Anna', score: 35 },
+    ],
+    hasChat: true,
+    chatCount: 1,
+    turn: '6/10',
+    paused: true,
+  },
+  {
+    id: '00000000-0000-4000-8000-000000000003',
+    gameName: 'Wingspan',
+    date: '23 apr 2026',
+    when: '2 giorni fa',
+    duration: '1h 24m',
+    status: 'completed',
+    outcome: 'won',
+    playerCount: 4,
+    scores: [
+      { name: 'Marco', score: 89, winner: true },
+      { name: 'Anna', score: 76 },
+      { name: 'Luca', score: 64 },
+      { name: 'Sara', score: 58 },
+    ],
+    hasChat: true,
+    chatCount: 3,
+  },
+  {
+    id: '00000000-0000-4000-8000-000000000004',
+    gameName: 'Azul',
+    date: '21 apr 2026',
+    when: '4 giorni fa',
+    duration: '42m',
+    status: 'completed',
+    outcome: 'lost',
+    playerCount: 3,
+    scores: [
+      { name: 'Sara', score: 81, winner: true },
+      { name: 'Marco', score: 72 },
+      { name: 'Luca', score: 65 },
+    ],
+    hasChat: false,
+  },
+  {
+    id: '00000000-0000-4000-8000-000000000005',
+    gameName: 'Ark Nova',
+    date: '15 apr 2026',
+    when: '10 giorni fa',
+    duration: '2h 48m',
+    status: 'completed',
+    outcome: 'tie',
+    playerCount: 2,
+    scores: [
+      { name: 'Marco', score: 124 },
+      { name: 'Anna', score: 124 },
+    ],
+    hasChat: true,
+    chatCount: 2,
+  },
+  {
+    id: '00000000-0000-4000-8000-000000000006',
+    gameName: '7 Wonders',
+    date: '5 apr 2026',
+    when: '3 settimane fa',
+    duration: '28m',
+    status: 'abandoned',
+    outcome: null,
+    playerCount: 2,
+    scores: [
+      { name: 'Marco', score: 32 },
+      { name: 'Sara', score: 41 },
+    ],
+    hasChat: false,
+  },
+];
+
+/** Empty fixture for the `empty` FSM state visual baseline. */
+export const VISUAL_TEST_FIXTURE_SESSIONS_EMPTY: ReadonlyArray<SessionListItem> = [];
+
+export type SessionsFixtureState = 'default' | 'empty';
+
+/**
+ * Returns deterministic session entries iff the build is a visual-test build.
+ * Returns `null` otherwise — caller MUST fall through to the real fetch.
+ */
+export function tryLoadVisualTestFixture(
+  state: SessionsFixtureState = 'default'
+): ReadonlyArray<SessionListItem> | null {
+  if (!IS_VISUAL_TEST_BUILD) return null;
+  if (state === 'empty') return VISUAL_TEST_FIXTURE_SESSIONS_EMPTY;
+  return VISUAL_TEST_FIXTURE_SESSIONS;
+}
+
+/**
+ * Parses the `?state=` URL search param into a SessionsUiState override.
+ *
+ * Only valid when `STATE_OVERRIDE_ENABLED` is true (dev/test or visual-test CI builds).
+ * Returns `null` in production or for unknown/unsupported state values.
+ *
+ * Valid overrides: 'loading', 'empty', 'filtered-empty'
+ * NOT valid: 'error' — TanStack Query isError is not reproducible via URL deterministically.
+ */
+export function parseStateOverride(
+  searchParams: URLSearchParams | Record<string, string>
+): SessionsUiState | null {
+  if (!STATE_OVERRIDE_ENABLED) return null;
+
+  const raw =
+    searchParams instanceof URLSearchParams
+      ? searchParams.get('state')
+      : ((searchParams as Record<string, string>)['state'] ?? null);
+
+  const validOverrides: SessionsUiState[] = ['loading', 'empty', 'filtered-empty'];
+  if (raw && validOverrides.includes(raw as SessionsUiState)) {
+    return raw as SessionsUiState;
+  }
+  return null;
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1597,7 +1597,8 @@
         "turnLabel": "Turn {turn}",
         "resumeCta": "Resume",
         "resumeOrArchiveCta": "Resume or archive",
-        "openAriaLabel": "Open {gameName} session"
+        "openAriaLabel": "Open {gameName} session",
+        "scoreOverflowTemplate": "+{count} more"
       },
       "empty": {
         "title": "No sessions yet",

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1547,6 +1547,82 @@
         }
       }
     },
+    "sessions": {
+      "metadata": {
+        "title": "My sessions — MeepleAI",
+        "description": "Your game session history: outcomes, scores and session diaries."
+      },
+      "hero": {
+        "title": "Your sessions",
+        "subtitle": "{count, plural, =0 {No sessions yet} =1 {1 session logged} other {# sessions logged}}",
+        "ctaNew": "Log session",
+        "ctaLive": "Start live",
+        "stats": {
+          "sessions": "sessions",
+          "wins": "wins",
+          "totalTime": "total",
+          "lastSession": "last"
+        }
+      },
+      "filters": {
+        "status": {
+          "all": "All",
+          "active": "Active",
+          "completed": "Completed",
+          "abandoned": "Abandoned"
+        },
+        "searchPlaceholder": "Search session or game…",
+        "searchAriaLabel": "Search your sessions",
+        "view": {
+          "label": "View",
+          "list": "List",
+          "grid": "Grid"
+        }
+      },
+      "card": {
+        "outcome": {
+          "won": "Won",
+          "lost": "Lost",
+          "tie": "Tie"
+        },
+        "status": {
+          "live": "Live",
+          "paused": "Paused",
+          "abandoned": "Abandoned"
+        },
+        "playerCount": "{count} players",
+        "duration": "{duration}",
+        "scoreLabel": "Score: {score}",
+        "winnerLabel": "Winner",
+        "turnLabel": "Turn {turn}",
+        "resumeCta": "Resume",
+        "resumeOrArchiveCta": "Resume or archive",
+        "openAriaLabel": "Open {gameName} session"
+      },
+      "empty": {
+        "title": "No sessions yet",
+        "description": "Log your first play or start a live session to track turns, scores and session diaries.",
+        "ctaStart": "Log first session",
+        "ctaLive": "Start live"
+      },
+      "filteredEmpty": {
+        "title": "No sessions match your filters",
+        "description": "Try removing some constraints or changing the period.",
+        "ctaClear": "Reset filters"
+      },
+      "loading": {
+        "ariaLabel": "Loading sessions…"
+      },
+      "error": {
+        "title": "Error loading sessions",
+        "description": "Unable to retrieve sessions. Check your connection.",
+        "ctaRetry": "Retry"
+      },
+      "a11y": {
+        "resultsRegionLabel": "Sessions list",
+        "resultsCount": "{count, plural, =0 {No sessions} =1 {1 session} other {# sessions}}"
+      }
+    },
     "players": {
       "metadata": {
         "title": "Players — MeepleAI",

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1619,8 +1619,8 @@
         "ctaRetry": "Retry"
       },
       "a11y": {
-        "resultsRegionLabel": "Sessions list",
-        "resultsCount": "{count, plural, =0 {No sessions} =1 {1 session} other {# sessions}}"
+        "resultsLabel": "Sessions list",
+        "countTemplate": "{count, plural, =0 {No sessions} =1 {1 session} other {# sessions}}"
       }
     },
     "players": {

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -1669,8 +1669,8 @@
         "ctaRetry": "Riprova"
       },
       "a11y": {
-        "resultsRegionLabel": "Lista partite",
-        "resultsCount": "{count, plural, =0 {Nessuna partita} =1 {1 partita} other {# partite}}"
+        "resultsLabel": "Lista partite",
+        "countTemplate": "{count, plural, =0 {Nessuna partita} =1 {1 partita} other {# partite}}"
       }
     },
     "players": {

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -1647,7 +1647,8 @@
         "turnLabel": "Turno {turn}",
         "resumeCta": "Riprendi",
         "resumeOrArchiveCta": "Riprendi o archivia",
-        "openAriaLabel": "Apri sessione {gameName}"
+        "openAriaLabel": "Apri sessione {gameName}",
+        "scoreOverflowTemplate": "+{count} altri"
       },
       "empty": {
         "title": "Nessuna partita ancora",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -1597,6 +1597,82 @@
         }
       }
     },
+    "sessions": {
+      "metadata": {
+        "title": "Le mie partite — MeepleAI",
+        "description": "Storico delle tue sessioni di gioco: esiti, punteggi e diari."
+      },
+      "hero": {
+        "title": "Le tue partite",
+        "subtitle": "{count, plural, =0 {Nessuna partita ancora} =1 {1 partita registrata} other {# partite registrate}}",
+        "ctaNew": "Registra partita",
+        "ctaLive": "Avvia live",
+        "stats": {
+          "sessions": "partite",
+          "wins": "vittorie",
+          "totalTime": "totali",
+          "lastSession": "ultima"
+        }
+      },
+      "filters": {
+        "status": {
+          "all": "Tutti",
+          "active": "In corso",
+          "completed": "Completate",
+          "abandoned": "Abbandonate"
+        },
+        "searchPlaceholder": "Cerca partita o gioco…",
+        "searchAriaLabel": "Cerca tra le tue partite",
+        "view": {
+          "label": "Vista",
+          "list": "Lista",
+          "grid": "Griglia"
+        }
+      },
+      "card": {
+        "outcome": {
+          "won": "Vinta",
+          "lost": "Persa",
+          "tie": "Pareggio"
+        },
+        "status": {
+          "live": "Live",
+          "paused": "In pausa",
+          "abandoned": "Abbandonata"
+        },
+        "playerCount": "{count} giocatori",
+        "duration": "{duration}",
+        "scoreLabel": "Punteggio: {score}",
+        "winnerLabel": "Vincitore",
+        "turnLabel": "Turno {turn}",
+        "resumeCta": "Riprendi",
+        "resumeOrArchiveCta": "Riprendi o archivia",
+        "openAriaLabel": "Apri sessione {gameName}"
+      },
+      "empty": {
+        "title": "Nessuna partita ancora",
+        "description": "Registra la tua prima partita giocata o avvia una sessione live per tracciare turni, punteggi e diari.",
+        "ctaStart": "Registra prima partita",
+        "ctaLive": "Avvia live"
+      },
+      "filteredEmpty": {
+        "title": "Nessuna partita per questi filtri",
+        "description": "Prova a rimuovere alcuni vincoli o cambia periodo.",
+        "ctaClear": "Reset filtri"
+      },
+      "loading": {
+        "ariaLabel": "Caricamento partite in corso…"
+      },
+      "error": {
+        "title": "Errore caricamento",
+        "description": "Impossibile recuperare le partite. Verifica la connessione.",
+        "ctaRetry": "Riprova"
+      },
+      "a11y": {
+        "resultsRegionLabel": "Lista partite",
+        "resultsCount": "{count, plural, =0 {Nessuna partita} =1 {1 partita} other {# partite}}"
+      }
+    },
     "players": {
       "metadata": {
         "title": "Giocatori — MeepleAI",

--- a/docs/frontend/v2-migration-matrix.md
+++ b/docs/frontend/v2-migration-matrix.md
@@ -179,13 +179,18 @@ the PR review.
 
 ## Wave 2 — 16 components
 
-### Sessions index — `/sessions` — 3 components — **Tier M**
+### Sessions index — `/sessions` — 8 components — **Tier S** (per spec-panel review PR #734)
 
 | Mockup | Component | Path | Route | Status | PR | AC |
 |--------|-----------|------|-------|--------|----|----|
-| `sp4-sessions-index.jsx` | `SessionsHero` | `apps/web/src/components/v2/sessions/SessionsHero.tsx` | `/sessions` | pending | — | T A M V |
-| `sp4-sessions-index.jsx` | `SessionsFilters` | `apps/web/src/components/v2/sessions/SessionsFilters.tsx` | `/sessions` | pending | — | T A V |
-| `sp4-sessions-index.jsx` | `ConnectionChipStripFooter` | `apps/web/src/components/v2/sessions/ConnectionChipStripFooter.tsx` | `/sessions` | pending | — | T A V |
+| `sp4-sessions-index.jsx` | `SessionsHero` | `apps/web/src/components/v2/sessions/SessionsHero.tsx` | `/sessions` | done | TBD | T A M V |
+| `sp4-sessions-index.jsx` | `SessionsFilters` | `apps/web/src/components/v2/sessions/SessionsFilters.tsx` | `/sessions` | done | TBD | T A V |
+| `sp4-sessions-index.jsx` | `SessionCardList` | `apps/web/src/components/v2/sessions/SessionCardList.tsx` | `/sessions` | done | TBD | T A V |
+| `sp4-sessions-index.jsx` | `SessionCardGrid` | `apps/web/src/components/v2/sessions/SessionCardGrid.tsx` | `/sessions` | done | TBD | T A V |
+| `sp4-sessions-index.jsx` | `EmptySessions` | `apps/web/src/components/v2/sessions/EmptySessions.tsx` | `/sessions` | done | TBD | T A V |
+| `sp4-sessions-index.jsx` | `OutcomeBadge` | `apps/web/src/components/v2/sessions/OutcomeBadge.tsx` | `/sessions` | done | TBD | T A V |
+| `sp4-sessions-index.jsx` | `ScoringInline` | `apps/web/src/components/v2/sessions/ScoringInline.tsx` | `/sessions` | done | TBD | T A V |
+| `sp4-sessions-index.jsx` | `ConnectionChipStripFooter` | `apps/web/src/components/v2/sessions/ConnectionChipStripFooter.tsx` | `/sessions` | done | TBD | T A V |
 
 ### Session live — `/sessions/[id]` — 7 components — **Tier L+** ⚠️ Phase 0.5 + sub-PR split required
 


### PR DESCRIPTION
## Summary

Wave D.1 — `/sessions` v2 brownfield migration. Tier S single-shot dispatch following the Wave 4 D1 PR #717 blueprint.

**Spec-panel review**: PR #734 classified D.1 as Tier S (single-shot, no Phase 0.5 contract needed).

**Issue**: #735 (child of #582 Wave D umbrella)

## Implementation (5-task subagent-driven dispatch)

### Task 1 — Foundation (`00236145d` + `329262f8f`)
- `lib/sessions/sessions-state.ts`: 5-state FSM derivation + `parseStateOverride` re-export
- `lib/sessions/sessions-filters.ts`: `SessionListItem`, `transformSessionsToItems`, status/search filters, parsers, formatters
- `lib/sessions/sessions-visual-test-fixture.ts`: 6-entry sentinel fixture (1 inprogress + 1 paused + 3 completed + 1 abandoned)
- i18n keys it+en (~76 keys/locale under `pages.sessions.*`)
- 83 unit tests Foundation-only
- Spec compliance review found 2 critical + 1 major issue → fixed in `329262f8f`:
  - Player field names aligned with `SessionPlayerDto` schema (schema reality v1 carryover, mirror Wave 4 D1)
  - `parseStateOverride` re-exported from `sessions-state.ts`
  - i18n a11y keys renamed to spec contract

### Task 2 — Components (`29ba7a25c` + `9521deb79`)
- 8 v2 components in `components/v2/sessions/`:
  - `SessionsHero` — title + count + CTA "Nuova"
  - `SessionsFilters` — WAI-ARIA tablist (4 status chips + roving tabindex via `useTablistKeyboardNav` from PR #623) + search + List/Grid toggle
  - `SessionCardList` — list-mode session row (left accent bar)
  - `SessionCardGrid` — grid-mode session tile (cover + scoring compact)
  - `EmptySessions` — 4-kind discriminated (empty/filtered-empty/loading/error)
  - `OutcomeBadge` — status×outcome×paused matrix (6 variants, WCAG AA 700-shade)
  - `ScoringInline` — player scores, hides chips when all=0 (v1 schema carryover)
  - `ConnectionChipStripFooter` — max-3 entity chips (game/player/chat)
- 67 unit tests across 8 test files
- Engineering decision: cards do NOT wrap MeepleCard (API doesn't expose left-accent-bar pattern, inline scoring composition, or wrapper-level animation classes — Sessions richer than Players)
- WCAG AA contrast pre-emption sustained (700-shade for white text, no 600-shade)
- Spec compliance review found 1 important issue → fixed in `9521deb79`:
  - EmptySessions CTA conditional render when `onPrimaryAction` undefined (WCAG 4.1.2)

### Task 3 — Orchestrator + page wiring (`b936108ff` + `8a268d538`)
- `_components/SessionsLibraryView.tsx` orchestrator with URL state SSOT (`?status=`, `?view=`, `?search=`, `?state=`)
- `page.tsx` Big-Bang delete legacy `HubLayout` impl → thin Suspense shell (Next.js 16 `useSearchParams()` CSR bailout)
- `next.config.js` redirect updated: `/sessions/history → /sessions?status=completed` (was `?tab=history`)
- `components/v2/sessions/index.ts` barrel export
- **Subroutes preserved**: `[id]/`, `live/`, `join/`, `new/`, `layout.tsx` UNTOUCHED
- 23 orchestrator unit tests
- Spec compliance review found 1 important issue → fixed in `8a268d538`:
  - `scoreOverflowTemplate` hardcoded Italian → moved to i18n contract

### Task 4 — E2E specs (`0c800a74a`)
- `e2e/visual-migrated/sp4-sessions-index.spec.ts`: 2 visual baseline tests (desktop + mobile default)
- `e2e/v2-states/sessions-index.spec.ts`: 8 state coverage tests (4 states × 2 viewports — `error` excluded from visual per Wave B.1 lesson, covered by unit test)
- `e2e/a11y/sessions-index.spec.ts`: 4 a11y tests (axe default + filtered-empty + reduced-motion + keyboard nav)
- 14 E2E tests total
- Triple auth helper applied (`seedAuthSession + seedCookieConsent + mockAuthEndpoints`)
- `networkidle` anti-pattern avoided (Wave B.1 lesson sustained)

### Task 5 — Matrix update + PR (this commit `1683912fd`)
- `docs/frontend/v2-migration-matrix.md` updated:
  - Sessions index Tier reclassified `M → S` (per spec-panel review #734)
  - Component count `3 → 8` (added 5 missing rows)
  - Status `pending → done`

## Schema reality v1 carryover

Mirror Wave 4 D1 PR #717 pattern:
- `SessionPlayerDto` exposes only `playerName/playerOrder/color` — NO `score/winner` fields
- `transformSessionsToItems` sets `SessionScoreEntry.score=0` and `winner=false` placeholders
- `ScoringInline` hides score chips when all scores=0 (graceful degradation)
- Wave D.1 = visual upgrade only; scoring API extension tracked as post-merge followup

## Bundle target

Tier S target: `< +80 KB` (Wave 4 D1 actual ~75 KB).

## DoD checklist

- [x] Page v2 implementata, 5-state FSM (default/loading/empty/filtered-empty/error)
- [x] 5-commit TDD decomposition rispettata (7 commits incluse review fixes)
- [ ] Visual regression baseline Desktop 1280 + Mobile 375 — **Task 5 bootstrap workflow** (run after PR open)
- [x] WCAG 2.1 AA: axe-core test specs ready, 700-shade discipline applied, prefers-reduced-motion handled
- [ ] Bundle delta `< +80 KB` — verified by CI Bundle Size check
- [x] Mobile-first 375px clean (NO `window.innerWidth`, Tailwind responsive only)
- [x] i18n keys complete it+en
- [x] Matrice aggiornata: Status=done + PR ref TBD
- [x] Subroutes (`live/[id]/join/new`) intoccati
- [x] `useTablistKeyboardNav` hook reused for filter pills (Wave A.6 PR #623 pattern)

## Test plan

```bash
# Unit tests (Foundation + Components + Orchestrator)
cd apps/web && pnpm test src/lib/sessions/ src/components/v2/sessions/ src/app/\(authenticated\)/sessions/_components/ --run
# Expected: 173 tests passing (83 + 67 + 23)

# E2E tests (require Playwright + dev server)
pnpm test:e2e -- e2e/v2-states/sessions-index.spec.ts e2e/a11y/sessions-index.spec.ts
# Expected: 12 tests passing (8 v2-states + 4 a11y)

# Visual regression — bootstrap baselines via CI
gh workflow run visual-regression-migrated.yml --ref feature/issue-735-wave-d1-sessions-fe-v2 -f mode=bootstrap -f project_filter=both
# Expected: 4 PNG canonical baselines committed (4 states × 2 viewports - error excluded - skipped where no override)
```

## Subagent-driven development metadata

7 commits across 5 tasks + 3 review-driven fix commits:
- Task 1: 2 commits (impl + spec review fixes)
- Task 2: 2 commits (impl + spec review fix)
- Task 3: 2 commits (impl + spec review fix)
- Task 4: 1 commit (impl, no review issues)
- Task 5: 1 commit (matrix)

Two-stage review applied to Tasks 1-3 (spec compliance + code quality reviewers, both APPROVED with deferrable minor notes). Task 4 mechanical work, single review pass.

## Refs

- Issue #735 (Wave D.1 child)
- Issue #582 (Wave D umbrella sessions triade)
- PR #734 (spec-panel review per Wave D dispatch)
- PR #717 (Wave 4 D1 blueprint)
- PR #623 (`useTablistKeyboardNav` hook)
- PR #635 (Wave B.1 brownfield pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)