### PR TITLE
ops(infra): decommission Traefik post CF Tunnel cutover (T18 Phase 6)

### DIFF
--- a/docs/operations/dr-walkthrough-log.md
+++ b/docs/operations/dr-walkthrough-log.md
@@ -20,3 +20,4 @@ After receiving a quarterly reminder:
 
 | Date | Drift Found | Status | Notes |
 |------|-------------|--------|-------|
+| 2026-05-05 | none | ok | T18 CF Tunnel cutover completed (Phase 2-6 hard-cutover, no soak — no app in use). cloudflared 2026.3.0 installed (POP fra18). Tunnel routes: meepleai.app, api.meepleai.app, dr-test.meepleai.app. CF Access policy `meepleai-prod` covers production hostnames (owner-only). UFW deny 80/443 + Traefik containers stopped → external nmap shows 22 OPEN, 80/443 CLOSED. Auth gate verified: curl /api/v1/admin/* + /metrics return 302 to CF login. Free RAM +500MB post-Traefik-stop. Backup pre-cutover: /backups/meepleai/20260505-150004 (DB 43.2MB + PDF + Redis). Smoke automated against tunnel returns 302 (expected behavior under owner-only policy); for monitoring add CF Access bypass for /health or use service token. Production drift on VPS (6 commits, untracked files) deferred to follow-up reconciliation session. |

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -54,13 +54,13 @@ staging: ## Deploy staging — core + AI + monitoring (CAX31+ recommended, ~14GB
 	$(COMPOSE) -f compose.staging.yml -f compose.traefik.yml \
 		--profile ai --profile monitoring --profile proxy up -d
 
-staging-minimal: ## Deploy staging single-tester profile (~3GB RAM, no orchestration/n8n/seq/cadvisor)
-	$(COMPOSE) -f compose.staging.yml -f compose.traefik.yml \
-		--profile ai-essential --profile monitoring-essential --profile proxy up -d
+staging-minimal: ## Deploy staging single-tester profile (~3GB RAM) — edge via Cloudflare Tunnel (cloudflared on VPS, not Traefik)
+	$(COMPOSE) -f compose.staging.yml \
+		--profile ai-essential --profile monitoring-essential up -d
 
 staging-with-tutor: ## Deploy staging single-tester + orchestration-service for tutor agents (~5GB RAM)
-	$(COMPOSE) -f compose.staging.yml -f compose.traefik.yml \
-		--profile ai-essential --profile monitoring-essential --profile proxy --profile tutor-agents up -d
+	$(COMPOSE) -f compose.staging.yml \
+		--profile ai-essential --profile monitoring-essential --profile tutor-agents up -d
 
 staging-tutor-down: ## Stop only orchestration-service (keep rest of staging running)
 	$(COMPOSE) -f compose.staging.yml --profile tutor-agents stop orchestration-service

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -1,8 +1,11 @@
 # Staging: meepleai.app deployment
 # Server: deploy@204.168.135.69 (Hetzner CAX21 ARM64)
 #
-# Usage: docker compose -f docker-compose.yml -f compose.staging.yml -f compose.traefik.yml \
-#          --profile ai --profile monitoring --profile proxy up -d
+# Usage (post CF Tunnel cutover, T18 Phase 6):
+#   docker compose -f docker-compose.yml -f compose.staging.yml \
+#     --profile ai-essential --profile monitoring-essential up -d
+# Edge ingress is via cloudflared service on VPS (not via Traefik in compose).
+# For rollback see docs/operations/cf-tunnel-rollback.md.
 
 services:
   # ===========================================================================
@@ -77,19 +80,8 @@ services:
       PdfProcessing__Extractor__Unstructured__ApiUrl: "http://unstructured-service:8001"
     volumes:
       - ./secrets:/app/infra/secrets:ro
-    labels:
-      - "traefik.enable=true"
-      # Primary route: meepleai.app/api/* → API (production path)
-      - "traefik.http.routers.api.rule=Host(`meepleai.app`) && PathPrefix(`/api`)"
-      - "traefik.http.routers.api.entrypoints=websecure"
-      - "traefik.http.routers.api.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.api.middlewares=security-headers@file,rate-limit-api@file,compress@file"
-      - "traefik.http.services.api.loadbalancer.server.port=8080"
-      # Direct subdomain route: api.meepleai.app/* → API (health checks, staging tools)
-      - "traefik.http.routers.api-direct.rule=Host(`api.meepleai.app`)"
-      - "traefik.http.routers.api-direct.entrypoints=websecure"
-      - "traefik.http.routers.api-direct.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.api-direct.service=api"
+    # Traefik labels removed — staging now via Cloudflare Tunnel (cloudflared service on VPS).
+    # Routes meepleai.app/* and api.meepleai.app/* are configured in CF dashboard tunnel public hostnames.
     logging:
       driver: "json-file"
       options: { max-size: "10m", max-file: "3" }
@@ -115,13 +107,7 @@ services:
       LOKI_URL: http://loki:3100
       NEXT_PUBLIC_GRAFANA_URL: /grafana
       NEXT_PUBLIC_MECHANIC_VALIDATION_ENABLED: "${NEXT_PUBLIC_MECHANIC_VALIDATION_ENABLED:-false}"
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.web.rule=Host(`meepleai.app`)"
-      - "traefik.http.routers.web.entrypoints=websecure"
-      - "traefik.http.routers.web.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.web.middlewares=security-headers@file,compress@file"
-      - "traefik.http.services.web.loadbalancer.server.port=3000"
+    # Traefik labels removed — see api block above.
     logging:
       driver: "json-file"
       options: { max-size: "10m", max-file: "3" }
@@ -142,14 +128,7 @@ services:
         reservations:
           cpus: '0.5'
           memory: 512M
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.embedding.rule=Host(`meepleai.app`) && PathPrefix(`/services/embedding`)"
-      - "traefik.http.routers.embedding.entrypoints=websecure"
-      - "traefik.http.routers.embedding.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.embedding.middlewares=integration-auth,strip-services-embedding"
-      - "traefik.http.middlewares.strip-services-embedding.stripprefix.prefixes=/services/embedding"
-      - "traefik.http.services.embedding.loadbalancer.server.port=8000"
+    # Traefik labels removed (post CF Tunnel cutover). Internal service exposed only on docker network.
 
   reranker-service:
     restart: always
@@ -161,14 +140,7 @@ services:
         reservations:
           cpus: '0.5'
           memory: 512M
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.reranker.rule=Host(`meepleai.app`) && PathPrefix(`/services/reranker`)"
-      - "traefik.http.routers.reranker.entrypoints=websecure"
-      - "traefik.http.routers.reranker.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.reranker.middlewares=integration-auth,strip-services-reranker"
-      - "traefik.http.middlewares.strip-services-reranker.stripprefix.prefixes=/services/reranker"
-      - "traefik.http.services.reranker.loadbalancer.server.port=8003"
+    # Traefik labels removed (post CF Tunnel cutover). Internal service exposed only on docker network.
 
   # Disabled in staging — PDF extraction uses local Docnet (see api.environment).
   # Re-enable with profile 'pdf-cloud-extractors' if switching Extractor:Provider.
@@ -183,14 +155,7 @@ services:
         reservations:
           cpus: '0.5'
           memory: 512M
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.unstructured.rule=Host(`meepleai.app`) && PathPrefix(`/services/unstructured`)"
-      - "traefik.http.routers.unstructured.entrypoints=websecure"
-      - "traefik.http.routers.unstructured.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.unstructured.middlewares=integration-auth,strip-services-unstructured"
-      - "traefik.http.middlewares.strip-services-unstructured.stripprefix.prefixes=/services/unstructured"
-      - "traefik.http.services.unstructured.loadbalancer.server.port=8001"
+    # Traefik labels removed (post CF Tunnel cutover). Internal service exposed only on docker network.
 
   smoldocling-service:
     profiles: [pdf-cloud-extractors]
@@ -203,14 +168,7 @@ services:
         reservations:
           cpus: '0.5'
           memory: 1G
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.smoldocling.rule=Host(`meepleai.app`) && PathPrefix(`/services/smoldocling`)"
-      - "traefik.http.routers.smoldocling.entrypoints=websecure"
-      - "traefik.http.routers.smoldocling.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.smoldocling.middlewares=integration-auth,strip-services-smoldocling"
-      - "traefik.http.middlewares.strip-services-smoldocling.stripprefix.prefixes=/services/smoldocling"
-      - "traefik.http.services.smoldocling.loadbalancer.server.port=8002"
+    # Traefik labels removed (post CF Tunnel cutover). Internal service exposed only on docker network.
 
   orchestration-service:
     restart: always
@@ -238,13 +196,7 @@ services:
   grafana:
     restart: always
     env_file: [./secrets/monitoring.secret]
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.grafana.rule=Host(`meepleai.app`) && PathPrefix(`/grafana`)"
-      - "traefik.http.routers.grafana.entrypoints=websecure"
-      - "traefik.http.routers.grafana.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.grafana.middlewares=integration-auth"
-      - "traefik.http.services.grafana.loadbalancer.server.port=3000"
+    # Traefik labels removed (post CF Tunnel cutover). For external grafana access add a CF tunnel public hostname.
     environment:
       GF_SERVER_ROOT_URL: "https://meepleai.app/grafana"
       GF_SERVER_SERVE_FROM_SUB_PATH: "true"
@@ -256,13 +208,7 @@ services:
 
   prometheus:
     restart: always
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.prometheus.rule=Host(`meepleai.app`) && PathPrefix(`/prometheus`)"
-      - "traefik.http.routers.prometheus.entrypoints=websecure"
-      - "traefik.http.routers.prometheus.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.prometheus.middlewares=integration-auth"
-      - "traefik.http.services.prometheus.loadbalancer.server.port=9090"
+    # Traefik labels removed (post CF Tunnel cutover). For external prometheus access add a CF tunnel public hostname.
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
@@ -284,14 +230,8 @@ services:
   # Traefik overrides — basic auth middleware + staging config mount
   # ===========================================================================
 
-  traefik:
-    volumes:
-      - ./traefik/traefik.staging.yml:/etc/traefik/traefik.yml:ro
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.middlewares.integration-auth.basicauth.users=${INTEGRATION_BASIC_AUTH}"
-      - "traefik.http.middlewares.rate-limit.ratelimit.average=100"
-      - "traefik.http.middlewares.rate-limit.ratelimit.burst=50"
+# Traefik service definition removed (post CF Tunnel cutover, T18 Phase 6).
+# For rollback see docs/operations/cf-tunnel-rollback.md (compose.traefik.yml is preserved).
 
 # =============================================================================
 # Preserve existing staging volume names to avoid data loss


### PR DESCRIPTION
## Summary

Cleans up repo state after T18 hard-cutover from Traefik to Cloudflare Tunnel.

## Operational state already done (live on VPS)

- ✅ Phase 2: cloudflared 2026.3.0 installed on VPS, registered at POP fra18
- ✅ Phase 3: api+web exposed on 127.0.0.1:8080/3000 for tunnel ingress
- ✅ Phase 4: CF dashboard hostnames meepleai.app + api.meepleai.app added, Access policy 'meepleai-prod' (owner-only) covers both
- ✅ Phase 5: UFW deny 80/443 (effective post Traefik stop due to Docker iptables bypass)
- ✅ Phase 6: Traefik containers stopped on VPS

## This PR (repo cleanup)

- Remove Traefik labels from 8 services in compose.staging.yml (api, web, embedding, reranker, unstructured, smoldocling, grafana, prometheus)
- Remove Traefik service definition from compose.staging.yml
- Drop -f compose.traefik.yml and --profile proxy from Makefile staging-minimal/with-tutor
- Update header comment with new usage
- DR walkthrough log entry documenting the cutover

## Verification (already done)

- External nmap: 22 OPEN, 80/443 CLOSED ✅
- curl /api/v1/admin/* + /metrics → 302 CF login (auth gate active, Fix #2) ✅
- Free RAM +500MB post-Traefik-stop ✅
- Backup pre-cutover: /backups/meepleai/20260505-150004 (DB 43.2MB + PDF + Redis) ✅

## Rollback

cf-tunnel-rollback.md is the playbook. compose.traefik.yml is intentionally preserved in repo.

## Production drift

VPS has 6 local commits + untracked files (compose.staging.yml local mods, traefik certs/secrets backups). Deferred to a separate reconciliation session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)