### PR TITLE
ops(infra): expose grafana+prometheus on localhost for CF Tunnel ingress

### DIFF
--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -196,10 +196,13 @@ services:
   grafana:
     restart: always
     env_file: [./secrets/monitoring.secret]
-    # Traefik labels removed (post CF Tunnel cutover). For external grafana access add a CF tunnel public hostname.
+    # External access via Cloudflare Tunnel: grafana.meepleai.app → localhost:3001 → container :3000.
+    # Behind CF Access policy meepleai-prod (owner-only).
+    ports:
+      - "127.0.0.1:3001:3000"
     environment:
-      GF_SERVER_ROOT_URL: "https://meepleai.app/grafana"
-      GF_SERVER_SERVE_FROM_SUB_PATH: "true"
+      GF_SERVER_ROOT_URL: "https://grafana.meepleai.app"
+      GF_SERVER_SERVE_FROM_SUB_PATH: "false"
     volumes:
       - grafana-staging:/var/lib/grafana
       - ./grafana-datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml:ro
@@ -208,7 +211,10 @@ services:
 
   prometheus:
     restart: always
-    # Traefik labels removed (post CF Tunnel cutover). For external prometheus access add a CF tunnel public hostname.
+    # External access via Cloudflare Tunnel: prometheus.meepleai.app → localhost:9090 → container :9090.
+    # Behind CF Access policy meepleai-prod (owner-only).
+    ports:
+      - "127.0.0.1:9090:9090"
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'


### PR DESCRIPTION
## Summary

Adds host port bindings for Grafana (127.0.0.1:3001) and Prometheus (127.0.0.1:9090) so cloudflared can route external traffic to them. Updates Grafana env to subdomain mode (https://grafana.meepleai.app instead of /grafana sub-path).

## CF dashboard changes (manual, in parallel)

User adds 2 public hostnames to tunnel meepleai-staging + extends Access app meepleai-prod with 2 new destinations.

## Verification (already done on VPS)

- Container restarted, ports bound: 3001 → 200, 9090 → 200
- Pending CF dashboard config + curl test from external

🤖 Generated with [Claude Code](https://claude.com/claude-code)