### PR TITLE
docs(security): #745 Phase 1 — restore 6 security docs from git history

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Authentication/README.md
+++ b/apps/api/src/Api/BoundedContexts/Authentication/README.md
@@ -110,6 +110,6 @@ Questo context è stato completamente migrato alla nuova architettura DDD/CQRS. 
 
 ## Related Documentation
 
-- `docs/security/oauth-security.md` (pending restoration — see #745)
-- `docs/security/environment-variables-production.md` (pending restoration — see #745)
+- `docs/security/oauth-security.md`
+- `docs/security/environment-variables-production.md`
 - `SECURITY.md` (pending restoration — see #745)

--- a/apps/api/src/Api/BoundedContexts/SystemConfiguration/README.md
+++ b/apps/api/src/Api/BoundedContexts/SystemConfiguration/README.md
@@ -327,5 +327,5 @@ Questo context è stato completamente migrato alla nuova architettura DDD/CQRS. 
 ## Related Documentation
 
 - `docs/01-architecture/overview/system-architecture.md` (Configuration section)
-- `docs/security/environment-variables-production.md` (pending restoration — see #745)
+- `docs/security/environment-variables-production.md`
 - `docs/02-development/configuration-management.md`

--- a/apps/web/src/lib/security/README.md
+++ b/apps/web/src/lib/security/README.md
@@ -137,7 +137,7 @@ Tests cover:
 
 ## Documentation
 
-See: `docs/security/frontend-security-best-practices.md` (pending restoration — see #745)
+See: `docs/security/frontend-security-best-practices.md`
 
 ---
 

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -233,7 +233,7 @@ function getApiOrigins(): string[] {
  * Security headers configuration
  * Applied to all responses for defense-in-depth protection
  *
- * See: docs/security/client-side-encryption.md (pending restoration — see #745)
+ * See: docs/security/client-side-encryption.md
  *
  * @param requestOrigin - The origin of the incoming request (for CSP deduplication)
  */

--- a/docs/security/KNOWN_VULNERABILITIES.md
+++ b/docs/security/KNOWN_VULNERABILITIES.md
@@ -115,4 +115,4 @@ For security concerns, contact:
 - **Security Team**: [security@meepleai.com]
 - **Development Lead**: [dev@meepleai.com]
 
-For reporting new vulnerabilities, see [SECURITY.md](../SECURITY.md)
+For reporting new vulnerabilities, see `SECURITY.md` (root — pending restoration, see #745)

--- a/docs/security/client-side-encryption.md
+++ b/docs/security/client-side-encryption.md
@@ -1,0 +1,652 @@
+# Client-Side API Key Encryption
+
+**Issue**: CodeQL Alert `js/clear-text-storage-of-sensitive-data`
+**Status**: ✅ Fixed
+**Date**: 2025-11-22
+**Priority**: 🔴 CRITICAL
+**Component**: Web Frontend (`apps/web`)
+
+## Overview
+
+MeepleAI implements **AES-GCM encryption** for API keys stored in browser `sessionStorage` to protect against casual inspection, forensic recovery, and basic XSS attempts. This provides **defense-in-depth** security alongside Content Security Policy (CSP), input validation, and output encoding.
+
+### What This Protects Against ✅
+
+1. **Casual Inspection**: API keys are not visible in plaintext in browser DevTools
+2. **Browser Extensions**: Non-malicious extensions cannot read plaintext keys from storage
+3. **Forensic Recovery**: After logout, encrypted keys cannot be decrypted (keys are destroyed)
+4. **Basic XSS Attacks**: Simple storage read attacks won't retrieve plaintext keys
+
+### What This Does NOT Protect Against ❌
+
+1. **JavaScript Execution**: XSS attacks that can execute JavaScript can call decrypt functions
+2. **Memory Dumps**: Keys exist in memory while the page is active
+3. **Debugger Access**: Developer tools can still access decrypted values in memory
+4. **Advanced XSS**: Sophisticated attacks can hook into JavaScript APIs
+5. **Man-in-the-Middle**: This is transport-layer security, not client-storage security
+
+**CRITICAL**: This encryption is **not a substitute** for comprehensive XSS prevention. It's one layer in a defense-in-depth strategy.
+
+---
+
+## Architecture
+
+### Implementation
+
+**Location**: `apps/web/src/lib/api/core/`
+
+```
+├── secureStorage.ts        # AES-GCM encryption utility
+├── apiKeyStore.ts          # Encrypted API key storage
+├── httpClient.ts           # Uses encrypted keys for Authorization headers
+└── __tests__/
+    ├── secureStorage.test.ts    # 15 tests
+    └── apiKeyStore.test.ts       # 19 tests
+```
+
+### Encryption Flow
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1. User Logs In with API Key                                │
+└────────────────┬────────────────────────────────────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 2. setStoredApiKey(apiKey)                                  │
+│    • Stores plaintext in memory (for headers)               │
+│    • Calls encrypt(apiKey)                                  │
+└────────────────┬────────────────────────────────────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 3. encrypt() - Uses Web Crypto API                          │
+│    a. Generate or load session encryption key (AES-GCM 256) │
+│    b. Generate random 12-byte IV                            │
+│    c. Encrypt plaintext with key + IV                       │
+│    d. Prepend IV to ciphertext                              │
+│    e. Base64 encode: IV || ciphertext                       │
+└────────────────┬────────────────────────────────────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 4. sessionStorage.setItem('meepleai:apiKey', encrypted)     │
+│    sessionStorage.setItem('meepleai:encryption:key', key)   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Decryption Flow (Page Reload)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1. Page Loads / Refresh                                     │
+└────────────────┬────────────────────────────────────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 2. getStoredApiKey()                                        │
+│    • Reads encrypted value from sessionStorage              │
+│    • Calls decrypt(encrypted)                               │
+└────────────────┬────────────────────────────────────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 3. decrypt() - Uses Web Crypto API                          │
+│    a. Load session encryption key from sessionStorage       │
+│    b. Base64 decode: IV || ciphertext                       │
+│    c. Extract IV (first 12 bytes)                           │
+│    d. Extract ciphertext (remaining bytes)                  │
+│    e. Decrypt ciphertext with key + IV                      │
+│    f. Return plaintext API key                              │
+└────────────────┬────────────────────────────────────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 4. Store plaintext in memory                                │
+│    • memoryApiKey = decrypted                               │
+│    • Used for Authorization headers (getStoredApiKeySync()) │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Logout Flow
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1. User Logs Out                                            │
+└────────────────┬────────────────────────────────────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 2. clearStoredApiKey()                                      │
+│    • Clears in-memory key (memoryApiKey = null)             │
+│    • Removes sessionStorage.removeItem('meepleai:apiKey')   │
+│    • Calls clearEncryptionKey()                             │
+└────────────────┬────────────────────────────────────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 3. clearEncryptionKey()                                     │
+│    • Removes encryption key from sessionStorage             │
+│    • Old encrypted data cannot be decrypted anymore         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Security Model
+
+### Encryption Details
+
+**Algorithm**: AES-GCM (Galois/Counter Mode)
+- **Key Size**: 256 bits (32 bytes)
+- **IV Size**: 96 bits (12 bytes) - recommended for AES-GCM
+- **Authentication**: Built-in AEAD (Authenticated Encryption with Associated Data)
+
+**Why AES-GCM?**
+1. **Authenticated Encryption**: Detects tampering automatically
+2. **NIST Approved**: FIPS 140-2 compliant
+3. **Modern**: Supported by all modern browsers via Web Crypto API
+4. **Performance**: Hardware-accelerated on most devices
+
+### Key Management
+
+**Key Generation**: Per-session random key
+```typescript
+const key = await window.crypto.subtle.generateKey(
+  { name: 'AES-GCM', length: 256 },
+  true,  // extractable (needed for storage)
+  ['encrypt', 'decrypt']
+);
+```
+
+**Key Storage**: Session-bound
+- **Location**: `sessionStorage['meepleai:encryption:key']`
+- **Format**: Base64-encoded raw key bytes
+- **Lifetime**: Until browser tab closes or logout
+- **Regeneration**: New key generated each session
+
+**Key Security**:
+- ✅ Never leaves the browser
+- ✅ Automatically cleared on logout
+- ✅ Lost when tab/browser closes
+- ❌ Still accessible to JavaScript in the same origin
+
+### IV (Initialization Vector) Management
+
+**IV Generation**: Random per encryption
+```typescript
+const iv = window.crypto.getRandomValues(new Uint8Array(12));
+```
+
+**IV Storage**: Prepended to ciphertext
+```
+Encrypted Data Format: [ IV (12 bytes) ][ Ciphertext (variable) ]
+                        └─── Random ───┘  └─── Encrypted API Key ──┘
+```
+
+**Why Prepend IV?**
+- Standard practice in cryptography
+- No need for separate storage
+- Easy to extract during decryption
+
+---
+
+## XSS Prevention Strategy
+
+### Defense-in-Depth Layers
+
+Client-side encryption is **Layer 3** in a multi-layer security strategy:
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ Layer 1: Input Validation & Sanitization                   │
+│ ─────────────────────────────────────────────────────────  │
+│ • Validate all user input on client and server             │
+│ • Sanitize HTML/JavaScript before rendering                │
+│ • Use allowlists for permitted values                      │
+└────────────────────────────────────────────────────────────┘
+                         ▼
+┌────────────────────────────────────────────────────────────┐
+│ Layer 2: Content Security Policy (CSP)                     │
+│ ─────────────────────────────────────────────────────────  │
+│ • Restrict script sources (script-src 'self')              │
+│ • Block inline event handlers (no 'unsafe-inline')         │
+│ • Prevent data: URIs in scripts                            │
+│ • Frame ancestors control (frame-ancestors 'none')         │
+│                                                             │
+│ See: docs/security/security-headers.md (pending — #745)    │
+└────────────────────────────────────────────────────────────┘
+                         ▼
+┌────────────────────────────────────────────────────────────┐
+│ Layer 3: Client-Side Encryption (THIS LAYER)               │
+│ ─────────────────────────────────────────────────────────  │
+│ • Encrypt sensitive data before storage                    │
+│ • Use session-bound encryption keys                        │
+│ • Clear keys on logout                                     │
+│ • Minimal exposure window (in-memory only)                 │
+└────────────────────────────────────────────────────────────┘
+                         ▼
+┌────────────────────────────────────────────────────────────┐
+│ Layer 4: HTTPS/TLS                                         │
+│ ─────────────────────────────────────────────────────────  │
+│ • Encrypt all network traffic                              │
+│ • HSTS (HTTP Strict Transport Security)                    │
+│ • Certificate pinning (future enhancement)                 │
+└────────────────────────────────────────────────────────────┘
+                         ▼
+┌────────────────────────────────────────────────────────────┐
+│ Layer 5: Server-Side Validation                            │
+│ ─────────────────────────────────────────────────────────  │
+│ • Validate API keys on every request                       │
+│ • Rate limiting per API key                                │
+│ • Audit logging for suspicious activity                    │
+└────────────────────────────────────────────────────────────┘
+```
+
+### Threat Model
+
+| Attack Vector | Risk Without Encryption | Risk With Encryption | Primary Defense |
+|--------------|------------------------|---------------------|-----------------|
+| **Casual DevTools Inspection** | 🔴 High | 🟢 Low | Layer 3 (Encryption) |
+| **Basic Browser Extension** | 🔴 High | 🟢 Low | Layer 3 (Encryption) |
+| **Forensic Disk Recovery** | 🟡 Medium | 🟢 Low | Layer 3 (Encryption) |
+| **Simple XSS (Read Storage)** | 🔴 High | 🟡 Medium | Layer 3 (Encryption) |
+| **Advanced XSS (Call Decrypt)** | 🔴 High | 🔴 High | Layer 1 & 2 (CSP, Validation) |
+| **Memory Dump (Active Session)** | 🔴 High | 🔴 High | Layer 4 & 5 (HTTPS, Validation) |
+| **MITM Attack** | 🔴 High | 🔴 High | Layer 4 (HTTPS/TLS) |
+
+### XSS Mitigation Checklist
+
+#### ✅ Implemented
+- [x] Content Security Policy (CSP) headers
+- [x] Client-side encryption for API keys
+- [x] Input validation on API boundaries
+- [x] Output encoding in React components
+- [x] HTTPS/TLS for all traffic
+- [x] Session-bound encryption keys
+- [x] Automatic key clearing on logout
+
+#### ⚠️ Recommended Enhancements
+- [ ] **CSP Nonces**: Replace `'unsafe-inline'` with nonces for scripts
+- [ ] **CSP Hashes**: Use SHA-256 hashes for inline scripts
+- [ ] **Subresource Integrity (SRI)**: Add integrity checks to CDN resources
+- [ ] **Trusted Types**: Enable Trusted Types API for DOM XSS prevention
+- [ ] **DOM Purify**: Add DOMPurify library for HTML sanitization
+- [ ] **CSP Reporting**: Set up CSP violation reporting endpoint
+
+#### 📋 Best Practices
+1. **Never Use** `dangerouslySetInnerHTML` without sanitization
+2. **Always Validate** user input on both client and server
+3. **Escape Output** when rendering user-generated content
+4. **Use Framework Features**: React escapes by default, use it
+5. **Review Dependencies**: Audit npm packages for vulnerabilities
+6. **Monitor CSP Violations**: Set up alerts for CSP reports
+
+---
+
+## Implementation Details
+
+### API
+
+```typescript
+// secureStorage.ts - Low-level encryption
+export async function encrypt(plaintext: string): Promise<string>
+export async function decrypt(encryptedData: string): Promise<string>
+export function clearEncryptionKey(): void
+
+// apiKeyStore.ts - High-level API key management
+export async function setStoredApiKey(apiKey: string): Promise<void>
+export async function getStoredApiKey(): Promise<string | null>
+export function getStoredApiKeySync(): string | null  // For headers
+export function clearStoredApiKey(): void
+export function hasStoredApiKey(): boolean
+```
+
+### Usage Example
+
+```typescript
+// Login flow
+import { setStoredApiKey } from '@/lib/api/core/apiKeyStore';
+
+async function login(apiKey: string) {
+  // Validate API key with server
+  const response = await authClient.loginWithApiKey(apiKey);
+
+  // Store encrypted (happens automatically)
+  await setStoredApiKey(apiKey);
+
+  // API key is now:
+  // 1. Encrypted in sessionStorage
+  // 2. Available in memory for headers
+}
+
+// Making authenticated requests
+import { getStoredApiKeySync } from '@/lib/api/core/apiKeyStore';
+
+function getHeaders(): HeadersInit {
+  const headers: HeadersInit = {};
+
+  // Synchronous access from memory (no decryption needed)
+  const apiKey = getStoredApiKeySync();
+  if (apiKey) {
+    headers['Authorization'] = `ApiKey ${apiKey}`;
+  }
+
+  return headers;
+}
+
+// Logout flow
+import { clearStoredApiKey } from '@/lib/api/core/apiKeyStore';
+
+function logout() {
+  // Clear everything (API key + encryption key)
+  clearStoredApiKey();
+
+  // Old encrypted data is now useless
+  // (encryption key is destroyed)
+}
+```
+
+### Error Handling
+
+```typescript
+// Graceful fallback to in-memory storage
+try {
+  const encrypted = await encrypt(apiKey);
+  sessionStorage.setItem(STORAGE_KEY, encrypted);
+} catch (error) {
+  console.error('Failed to encrypt API key, using in-memory storage only:', error);
+  // Key still works for current session, just not persisted
+}
+
+// Graceful handling of corrupted data
+try {
+  const decrypted = await decrypt(encryptedValue);
+  return decrypted;
+} catch (error) {
+  console.error('Failed to decrypt API key, clearing storage:', error);
+  sessionStorage.removeItem(STORAGE_KEY);
+  return null;  // User will need to log in again
+}
+```
+
+### SSR Compatibility
+
+```typescript
+function isCryptoAvailable(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.crypto !== 'undefined' &&
+    typeof window.crypto.subtle !== 'undefined' &&
+    typeof window.sessionStorage !== 'undefined'
+  );
+}
+
+// Fallback for SSR / old browsers
+if (!isCryptoAvailable()) {
+  console.warn('Web Crypto API not available, storing data unencrypted');
+  return plaintext;  // No encryption possible
+}
+```
+
+---
+
+## Testing
+
+### Test Coverage
+
+**Total Tests**: 34 tests (15 + 19)
+**Coverage**: >95% (both modules)
+
+#### secureStorage.test.ts (15 tests)
+
+1. **Encryption** (4 tests)
+   - ✅ Encrypts plaintext successfully
+   - ✅ Generates encryption key on first use
+   - ✅ Reuses existing encryption key
+   - ✅ Handles encryption errors gracefully
+
+2. **Decryption** (3 tests)
+   - ✅ Decrypts encrypted data successfully
+   - ✅ Handles decryption errors gracefully
+   - ✅ Handles corrupted data gracefully
+
+3. **Round-Trip** (2 tests)
+   - ✅ Encrypts and decrypts API key correctly
+   - ✅ Handles multiple encryption/decryption cycles
+
+4. **Edge Cases** (3 tests)
+   - ✅ Handles empty strings
+   - ✅ Handles special characters
+   - ✅ Handles Unicode characters (测试 🔐 тест)
+
+5. **Fallback** (2 tests)
+   - ✅ Warns when crypto API unavailable
+   - ✅ Returns plaintext when crypto unavailable
+
+6. **Key Management** (1 test)
+   - ✅ Clears encryption key from storage
+
+#### apiKeyStore.test.ts (19 tests)
+
+1. **Storage** (3 tests)
+   - ✅ Encrypts and stores API key
+   - ✅ Stores in memory regardless of encryption
+   - ✅ Handles encryption failure gracefully
+
+2. **Retrieval** (4 tests)
+   - ✅ Decrypts and returns stored API key
+   - ✅ Updates memory cache when retrieving
+   - ✅ Returns null if no key stored
+   - ✅ Handles decryption failure gracefully
+
+3. **Synchronous Access** (2 tests)
+   - ✅ Returns memory cache synchronously
+   - ✅ Returns null if no key in memory
+
+4. **Clearing** (2 tests)
+   - ✅ Clears API key from memory and storage
+   - ✅ Safe to call multiple times
+
+5. **State Management** (3 tests)
+   - ✅ Returns true when API key exists
+   - ✅ Returns false when no API key
+   - ✅ Returns false after clearing
+
+6. **Integration** (3 tests)
+   - ✅ Full login/logout flow
+   - ✅ Page refresh simulation
+   - ✅ Rapid successive calls
+
+7. **SSR** (1 test)
+   - ✅ Handles missing window object gracefully
+
+8. **Memory Management** (1 test)
+   - ✅ Returns memory cache if no sessionStorage
+
+### Running Tests
+
+```bash
+# Run all encryption tests
+cd apps/web
+pnpm test src/lib/api/core/__tests__/secureStorage.test.ts
+
+# Run all API key store tests
+pnpm test src/lib/api/core/__tests__/apiKeyStore.test.ts
+
+# Run with coverage
+pnpm test:coverage
+```
+
+---
+
+## Browser Compatibility
+
+| Feature | Chrome | Firefox | Safari | Edge | Fallback |
+|---------|--------|---------|--------|------|----------|
+| **Web Crypto API** | ✅ 37+ | ✅ 34+ | ✅ 11+ | ✅ 12+ | In-memory only |
+| **AES-GCM** | ✅ 37+ | ✅ 34+ | ✅ 11+ | ✅ 12+ | N/A |
+| **TextEncoder/Decoder** | ✅ 38+ | ✅ 19+ | ✅ 10.1+ | ✅ 79+ | Node.js util |
+| **sessionStorage** | ✅ 5+ | ✅ 2+ | ✅ 4+ | ✅ 12+ | In-memory only |
+
+**Support**: All modern browsers (2015+)
+**Fallback**: Graceful degradation to in-memory storage
+
+---
+
+## Performance Impact
+
+**Encryption**: ~0.5ms per operation (varies by device)
+**Decryption**: ~0.5ms per operation
+**Memory**: ~100 bytes overhead per encrypted key
+
+**Benchmarks** (M1 MacBook Pro):
+- Encrypt 100-char string: 0.3ms
+- Decrypt 100-char string: 0.2ms
+- Key generation: 1.2ms (once per session)
+
+**Recommendation**: Negligible impact. The security benefits far outweigh the minimal performance cost.
+
+---
+
+## Security Considerations
+
+### Limitations
+
+1. **XSS Attacks**: Encryption does NOT prevent XSS. If an attacker can execute JavaScript, they can call `decrypt()` or read `memoryApiKey`.
+
+2. **Memory Exposure**: Decrypted keys exist in memory. Memory dumps or debugger access can still retrieve them.
+
+3. **Same-Origin Policy**: JavaScript in the same origin can access encrypted storage and encryption keys.
+
+4. **Key Storage**: The encryption key is stored in `sessionStorage`, not in a secure enclave. Advanced attackers can access it.
+
+### Best Practices
+
+1. **Defense-in-Depth**: Always combine with CSP, input validation, and HTTPS
+2. **Short-Lived Keys**: Use short session timeouts (e.g., 30 minutes)
+3. **Rotation**: Consider rotating encryption keys periodically
+4. **Monitoring**: Log suspicious API key usage patterns
+5. **Rate Limiting**: Implement rate limiting on API endpoints
+6. **Audit**: Regularly audit code for XSS vulnerabilities
+
+### Threat Scenarios
+
+#### Scenario 1: Casual User Inspection
+**Attack**: User opens DevTools to inspect storage
+**Defense**: ✅ Encryption prevents easy reading
+**Mitigation**: Encrypted data is not human-readable
+
+#### Scenario 2: Non-Malicious Browser Extension
+**Attack**: Extension reads all `sessionStorage` keys
+**Defense**: ✅ Encryption prevents plaintext access
+**Mitigation**: Extension gets encrypted blob, not API key
+
+#### Scenario 3: Forensic Recovery After Logout
+**Attack**: Attacker recovers deleted sessionStorage files from disk
+**Defense**: ✅ Encryption key is destroyed on logout
+**Mitigation**: Encrypted data is useless without key
+
+#### Scenario 4: Basic XSS (Storage Read)
+**Attack**: `<script>alert(sessionStorage.getItem('meepleai:apiKey'))</script>`
+**Defense**: 🟡 Partial - attacker gets encrypted data
+**Mitigation**: Still needs to call `decrypt()` and access key
+
+#### Scenario 5: Advanced XSS (Function Call)
+**Attack**: `<script>import('./secureStorage').then(m => m.decrypt(sessionStorage.getItem('meepleai:apiKey')))</script>`
+**Defense**: ❌ Encryption does NOT prevent this
+**Mitigation**: CSP blocks script injection, input validation prevents XSS
+
+---
+
+## Compliance
+
+### OWASP Top 10 (2021)
+
+| Risk | Mitigation | Status |
+|------|-----------|--------|
+| **A01: Broken Access Control** | Server-side API key validation | ✅ |
+| **A02: Cryptographic Failures** | AES-GCM encryption | ✅ |
+| **A03: Injection** | Input validation, CSP | ✅ |
+| **A05: Security Misconfiguration** | Secure defaults | ✅ |
+| **A07: XSS** | CSP + Encryption + Validation | 🟡 Partial |
+
+### CodeQL Remediation
+
+**Alert**: `js/clear-text-storage-of-sensitive-data`
+**Severity**: Warning
+**CWE**: CWE-312 (Cleartext Storage of Sensitive Information)
+
+**Remediation**: ✅ Complete
+- API keys are encrypted before `sessionStorage.setItem()`
+- Encryption happens in the same data flow
+- CodeQL recognizes `encrypt()` as a sanitizer
+
+---
+
+## Future Enhancements
+
+### Short-Term (Next Sprint)
+- [ ] **Key Rotation**: Rotate encryption keys every 30 minutes
+- [ ] **CSP Nonces**: Remove `'unsafe-inline'` from CSP
+- [ ] **Metrics**: Track encryption failures in telemetry
+
+### Medium-Term (Next Quarter)
+- [ ] **Web Workers**: Move encryption to Web Worker for non-blocking
+- [ ] **IndexedDB**: Consider IndexedDB for larger encrypted data
+- [ ] **Key Derivation**: Derive encryption key from user password
+- [ ] **HMAC**: Add HMAC for additional integrity checking
+
+### Long-Term (Future)
+- [ ] **Hardware Security**: Use WebAuthn for key storage
+- [ ] **Secure Enclaves**: Explore browser secure enclaves
+- [ ] **Post-Quantum**: Prepare for post-quantum cryptography
+
+---
+
+## References
+
+### Standards
+- [NIST SP 800-38D](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf) - AES-GCM Specification
+- [Web Crypto API](https://www.w3.org/TR/WebCryptoAPI/) - W3C Recommendation
+- [OWASP ASVS](https://owasp.org/www-project-application-security-verification-standard/) - Security Verification Standard
+
+### Security Resources
+- [OWASP XSS Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+- [Content Security Policy Reference](https://content-security-policy.com/)
+- [Web Crypto API Examples](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API)
+
+### Related Documentation
+- [Security Headers](./security-headers.md) - CSP and other HTTP headers
+- [OAuth Security](./oauth-security.md) - OAuth token encryption
+- [Security Patterns](./security-patterns.md) - General security patterns
+
+---
+
+## Changelog
+
+### Version 1.0 (2025-11-22) - Initial Implementation
+
+**Added**:
+- AES-GCM encryption for API keys in sessionStorage
+- Session-bound encryption key management
+- Graceful fallbacks for SSR and old browsers
+- 34 comprehensive tests (15 + 19)
+- Full documentation
+
+**Security Improvements**:
+- ✅ Mitigates CodeQL alert `js/clear-text-storage-of-sensitive-data`
+- ✅ Protects against casual inspection and forensic recovery
+- ✅ Defense-in-depth layer alongside CSP
+
+**Issue**: CodeQL Security Alert
+**Status**: ✅ Fixed
+**Test Coverage**: >95%
+
+---
+
+**Document Version**: 1.0
+**Last Updated**: 2025-12-13T10:59:23.970Z
+**Author**: MeepleAI Engineering Team
+**Review Status**: Approved
+

--- a/docs/security/client-side-encryption.md
+++ b/docs/security/client-side-encryption.md
@@ -214,7 +214,7 @@ Client-side encryption is **Layer 3** in a multi-layer security strategy:
 │ • Prevent data: URIs in scripts                            │
 │ • Frame ancestors control (frame-ancestors 'none')         │
 │                                                             │
-│ See: docs/security/security-headers.md (pending — #745)    │
+│ See: security-headers.md (pending — #745)                  │
 └────────────────────────────────────────────────────────────┘
                          ▼
 ┌────────────────────────────────────────────────────────────┐
@@ -617,9 +617,9 @@ pnpm test:coverage
 - [Web Crypto API Examples](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API)
 
 ### Related Documentation
-- [Security Headers](./security-headers.md) - CSP and other HTTP headers
+- `security-headers.md` - CSP and other HTTP headers (pending restoration — see #745)
 - [OAuth Security](./oauth-security.md) - OAuth token encryption
-- [Security Patterns](./security-patterns.md) - General security patterns
+- `security-patterns.md` - General security patterns (pending restoration — see #745)
 
 ---
 

--- a/docs/security/codeql-false-positive-management.md
+++ b/docs/security/codeql-false-positive-management.md
@@ -1,0 +1,381 @@
+# CodeQL False Positive Management
+
+**Date**: 2025-11-23
+**Purpose**: Document strategy for managing CodeQL false positives
+**Status**: Active
+
+---
+
+## Executive Summary
+
+MeepleAI codebase has **98.2% false positive rate** (1,293 out of 1,316 warnings) due to:
+- Robust security policies that CodeQL doesn't recognize
+- Defense-in-depth architecture
+- Proper use of established patterns
+
+This document explains our approach to managing these false positives.
+
+---
+
+## Automated Filtering (CodeQL Configuration)
+
+### Configuration File
+
+File: `.github/codeql/codeql-config.yml`
+
+**Automatically Excludes:**
+1. **Log Forging (CWE-117)** - 426 false positives
+   - Reason: Global `LogForgingSanitizationPolicy` sanitizes all logs
+   - Verification: 100% structured logging, zero string interpolation
+
+2. **Generic Exception Handling (CA1031)** - 220 false positives
+   - Reason: All instances properly documented with `#pragma warning disable`
+   - Verification: 9 documented architectural patterns
+
+**Path Exclusions:**
+- Test files (`**/Tests/**`, `**/test/**`)
+- Build artifacts (`**/obj/**`, `**/bin/**`)
+- Generated code (`**/*.Designer.cs`, `**/Migrations/**`)
+- Frontend build (`**/node_modules/**`, `**/dist/**`, `**/.next/**`)
+
+---
+
+## Manual Suppression Strategy
+
+### When to Suppress
+
+Suppress a CodeQL alert when:
+
+1. ✅ **Security control exists** but CodeQL doesn't recognize it
+2. ✅ **Pattern is intentional** and properly documented
+3. ✅ **False positive is verified** through manual code review
+4. ✅ **Documentation exists** explaining why it's safe
+
+### When NOT to Suppress
+
+Never suppress if:
+
+1. ❌ **Real vulnerability** exists, even if low probability
+2. ❌ **Quick fix available** - fix instead of suppressing
+3. ❌ **Unsure** - review with security team first
+4. ❌ **No documentation** - document first, then suppress
+
+---
+
+## False Positive Categories
+
+### 1. Log Forging (CWE-117) - 426 Instances
+
+**Status**: ✅ **SAFE - Automated suppression via config**
+
+**Why False Positive:**
+- Global `LogForgingSanitizationPolicy` configured in `LoggingConfiguration.cs`
+- Automatically removes `\r\n` from ALL logged strings
+- 100% structured logging compliance (verified via grep)
+
+**Evidence:**
+```bash
+# Zero string interpolation in logs
+grep -r 'logger\.Log.*\$"' apps/api/src/Api --include="*.cs"  # 0 results
+
+# Zero string concatenation in logs
+grep -r '_logger\.Log.*\+ ' apps/api/src/Api --include="*.cs"  # 0 results
+```
+
+**Action**: Automated suppression via `.github/codeql/codeql-config.yml`
+
+**Reference**: `code-scanning-remediation-summary.md:76-115`
+
+---
+
+### 2. Generic Exception Handling (CA1031) - 220 Instances
+
+**Status**: ✅ **JUSTIFIED - Automated suppression via config**
+
+**Why False Positive:**
+- All 220 instances have `#pragma warning disable CA1031` with justification
+- 9 documented architectural patterns:
+  - SERVICE BOUNDARY (45 instances, 54%)
+  - RESILIENCE (8 instances, 10%)
+  - NON-CRITICAL (7 instances, 8%)
+  - DATA ROBUSTNESS (6 instances, 7%)
+  - Others (154 instances, 21%)
+- All use Result<T> pattern or proper logging
+- Critical exceptions are never swallowed
+
+**Action**: Automated suppression via `.github/codeql/codeql-config.yml`
+
+**Reference**: `generic-catch-analysis.md`
+
+---
+
+### 3. IDisposable Resource Leaks (CWE-404) - 589 False Positives
+
+**Status**: ⚠️ **PARTIALLY FALSE** - Keep enabled, manual review
+
+**Real Issues**: 12 (fixed)
+**False Positives**: 589 (98%)
+
+**Why False Positives:**
+Most are from proper patterns:
+- `IHttpClientFactory` managed instances (framework disposes)
+- `using` statements (compiler disposes)
+- Dependency injection scoped services (container disposes)
+
+**Real Issues (FIXED):**
+- ✅ HttpResponseMessage in loops (3 in EmbeddingService.cs)
+- ✅ BGG API responses (2 in BggApiService.cs)
+- ✅ LLM responses (1 in LlmService.cs, 1 in OllamaLlmService.cs)
+- ✅ StringContent (1 in N8nTemplateService.cs)
+- ✅ FormUrlEncodedContent (2 in OAuthService.cs)
+
+**Action**:
+- Keep query ENABLED (catches new real leaks)
+- Dismiss false positives manually on GitHub
+- Use `#pragma warning disable CA2000` for known safe patterns with justification
+
+**Reference**: `disposable-resource-leak-remediation.md`
+
+---
+
+### 4. Null Reference Warnings (CS8602) - 50 False Positives
+
+**Status**: ⚠️ **PARTIALLY FALSE** - Keep enabled, manual review
+
+**Real Issues**: 6 (fixed)
+**False Positives**: 50 (89%)
+
+**Why False Positives:**
+- Nullable reference context prevents most issues
+- Many warnings on already-validated properties
+- EF Core navigation properties (framework ensures non-null)
+
+**Real Issues (FIXED):**
+- ✅ Dictionary access without TryGetValue (QdrantVectorSearcher.cs)
+- ✅ Nullable Email in LINQ queries (RuleSpecService.cs - 2 fixes)
+- ✅ Email in mention resolution (RuleCommentService.cs)
+- ✅ Email in user search (UserManagementService.cs - LEGACY, removed in DDD migration)
+- ✅ Email split without guard (OAuthService.cs)
+
+**Action**:
+- Keep query ENABLED (catches new real issues)
+- Dismiss false positives manually on GitHub
+- Add null checks only where truly needed
+
+**Reference**: `null-reference-remediation.md`
+
+---
+
+### 5. Path Injection (CWE-22, CWE-73) - 2 False Positives
+
+**Status**: ✅ **MITIGATED** - Keep enabled
+
+**Real Issues**: 2 (fixed with defense-in-depth)
+**False Positives**: 2 (already have validation)
+
+**Why CodeQL Still Reports:**
+- CodeQL doesn't recognize `PathSecurity` utility methods
+- Reports even when defense-in-depth layers exist
+
+**Mitigation Layers:**
+1. Entry point: `PathSecurity.SanitizeFilename()`
+2. Service layer: `PathSecurity.ValidateIdentifier()`
+3. Storage layer: `PathSecurity.ValidatePathIsInDirectory()`
+
+**Action**:
+- Keep query ENABLED (important security control)
+- Dismiss after verifying PathSecurity utilities are used
+- Never suppress without validation
+
+**Reference**: `code-scanning-remediation-summary.md:16-41`
+
+---
+
+### 6. Sensitive Information Exposure (CWE-532) - 6 False Positives
+
+**Status**: ✅ **MITIGATED** - Keep enabled
+
+**Real Issues**: 3 (fixed)
+**False Positives**: 6 (already redacted)
+
+**Why CodeQL Still Reports:**
+- CodeQL doesn't recognize `SensitiveDataDestructuringPolicy`
+- Reports even when global redaction policies exist
+
+**Mitigation:**
+- Global `SensitiveDataDestructuringPolicy` redacts 67 property names
+- 4 regex patterns for sensitive data detection
+- `IsSensitiveConfigurationKey()` in ConfigurationHelper.cs (26 patterns)
+
+**Action**:
+- Keep query ENABLED (important security control)
+- Dismiss after verifying redaction policies cover the case
+- Never suppress without verification
+
+**Reference**: `code-scanning-remediation-summary.md:43-73`
+
+---
+
+## Manual Dismissal Process on GitHub
+
+### Using GitHub UI
+
+1. Navigate to: `https://github.com/DegrassiAaron/meepleai-monorepo/security/code-scanning`
+
+2. For each false positive:
+   - Click on the alert
+   - Click "Dismiss alert" button
+   - Select reason:
+     - **"Used in tests"** - for test file warnings
+     - **"False positive"** - for security-controlled warnings
+     - **"Won't fix"** - for intentional patterns
+   - Add comment referencing this document
+
+3. **Comment Template:**
+   ```
+   False positive - [Category] is mitigated by [Security Control].
+   See: docs/security/codeql-false-positive-management.md
+   Evidence: [Reference to security utility/policy]
+   ```
+
+### Using GitHub CLI (if available)
+
+```bash
+# List all open alerts
+gh api repos/DegrassiAaron/meepleai-monorepo/code-scanning/alerts
+
+# Dismiss specific alert
+gh api \
+  --method PATCH \
+  repos/DegrassiAaron/meepleai-monorepo/code-scanning/alerts/{alert_number} \
+  -f state=dismissed \
+  -f dismissed_reason="false positive" \
+  -f dismissed_comment="Mitigated by LogForgingSanitizationPolicy"
+```
+
+---
+
+## Bulk Dismissal Strategy
+
+### Priority Order
+
+1. **Highest Priority**: Log Forging (426) - Automated via config ✅
+2. **High Priority**: Generic Exceptions (220) - Automated via config ✅
+3. **Medium Priority**: IDisposable Leaks (589 false positives) - Manual
+4. **Low Priority**: Null References (50 false positives) - Manual
+
+### Bulk Dismissal Script (Recommended)
+
+Create a script to dismiss multiple alerts at once:
+
+```bash
+#!/bin/bash
+# File: tools/dismiss-false-positives.sh
+
+# Dismiss all Log Forging alerts (after config is applied, these should not appear)
+# Dismiss all Generic Exception alerts (after config is applied, these should not appear)
+
+# For remaining categories, use selective dismissal with proper documentation
+echo "See docs/security/codeql-false-positive-management.md for dismissal guidelines"
+```
+
+---
+
+## Monitoring & Maintenance
+
+### Monthly Review
+
+- Review dismissed alerts for any new patterns
+- Verify automated suppressions are still valid
+- Update this document with new categories if found
+
+### After Each Scan
+
+- Review NEW alerts only (not dismissed ones)
+- Apply triage process:
+  1. Real vulnerability? → Fix immediately
+  2. False positive with existing control? → Dismiss with comment
+  3. Unsure? → Review with team
+
+### Quarterly Audit
+
+- Re-verify all suppression reasons
+- Update CodeQL config if needed
+- Review GitHub Security advisories for related issues
+
+---
+
+## Verification Commands
+
+### Verify Log Forging Mitigation
+
+```bash
+# No string interpolation in logs
+grep -r 'logger\.Log.*\$"' apps/api/src/Api --include="*.cs"
+# Expected: 0 results
+
+# No string concatenation in logs
+grep -r '_logger\.Log.*\+ ' apps/api/src/Api --include="*.cs"
+# Expected: 0 results
+
+# Verify LogForgingSanitizationPolicy is configured
+grep -r "LogForgingSanitizationPolicy" apps/api/src/Api --include="*.cs"
+# Expected: Configuration in LoggingConfiguration.cs
+```
+
+### Verify Generic Exception Handling
+
+```bash
+# All generic catches have pragma
+grep -B2 "catch (Exception" apps/api/src/Api --include="*.cs" | grep "#pragma warning disable CA1031"
+# Expected: All instances have pragma
+
+# Count documented patterns
+grep -A1 "#pragma warning disable CA1031" apps/api/src/Api --include="*.cs" | grep "//"
+# Expected: 220+ justification comments
+```
+
+### Verify Path Security
+
+```bash
+# Find all PathSecurity usages
+grep -r "PathSecurity\." apps/api/src/Api --include="*.cs"
+# Expected: Multiple usages in file operations
+
+# Verify all file operations use validation
+grep -r "File\." apps/api/src/Api --include="*.cs" | wc -l
+# Compare with PathSecurity usage count
+```
+
+---
+
+## Related Documentation
+
+- `codeql-csharp-status-2025-11-18.md` - Comprehensive C# security analysis
+- `security-issue-audit.md` - Full security audit report
+- `code-scanning-remediation-summary.md` - P0 vulnerability fixes
+- `generic-catch-analysis.md` - Exception handling patterns
+- `.github/codeql/codeql-config.yml` - CodeQL configuration
+
+---
+
+## Summary
+
+**Automated Suppressions**: 646 false positives (Log Forging + Generic Exceptions)
+**Manual Review Needed**: 647 warnings (IDisposable + Null References + Others)
+**Real Vulnerabilities Fixed**: 25/25 (100%)
+
+**Recommendation**:
+1. ✅ Use automated config for Log Forging and Generic Exceptions
+2. ⚠️ Manually review and dismiss IDisposable and Null Reference false positives
+3. ✅ Keep all security queries ENABLED to catch new issues
+4. 📋 Document all dismissals with proper justification
+
+**Security Posture**: ✅ **10/10 PERFECT** (for C# codebase)
+
+---
+
+**Last Updated**: 2025-12-13T10:59:23.970Z
+**Owner**: Security Team
+**Review Cycle**: Monthly
+

--- a/docs/security/environment-variables-production.md
+++ b/docs/security/environment-variables-production.md
@@ -1,0 +1,1080 @@
+# Variabili d'Ambiente per Produzione - MeepleAI
+
+**Versione**: 1.0
+**Ultimo aggiornamento**: 2025-11-22
+**Stato**: Production Ready
+
+Questa guida fornisce un elenco completo di tutte le variabili d'ambiente da valorizzare in produzione, organizzate per categoria.
+
+---
+
+## Indice
+
+1. [Database (PostgreSQL)](#1-database-postgresql)
+2. [Cache (Redis)](#2-cache-redis)
+3. [Vector Database (Qdrant)](#3-vector-database-qdrant)
+4. [API Backend (ASP.NET)](#4-api-backend-aspnet)
+5. [Frontend Web (Next.js)](#5-frontend-web-nextjs)
+6. [AI/ML Services](#6-aiml-services)
+7. [PDF Processing Services](#7-pdf-processing-services)
+8. [Workflow Automation (n8n)](#8-workflow-automation-n8n)
+9. [Observability Stack](#9-observability-stack)
+10. [Security & Authentication](#10-security--authentication)
+11. [Email & Alerting](#11-email--alerting)
+12. [Docker Secrets](#12-docker-secrets)
+
+---
+
+## 1. Database (PostgreSQL)
+
+### `POSTGRES_USER`
+- **Descrizione**: Nome utente per accesso al database PostgreSQL
+- **Dove**: Variabile d'ambiente Docker, file `infra/env/api.env.prod`
+- **Obbligatorio**: ✅ Sì
+- **Default**: `meeple`
+- **Esempio**: `POSTGRES_USER=meepleai_prod`
+- **Note**: Usare un nome utente diverso da quello di default in produzione
+
+### `POSTGRES_DB`
+- **Descrizione**: Nome del database PostgreSQL
+- **Dove**: Variabile d'ambiente Docker, file `infra/env/api.env.prod`
+- **Obbligatorio**: ✅ Sì
+- **Default**: `meepleai`
+- **Esempio**: `POSTGRES_DB=meepleai_production`
+- **Note**: Separare database per staging/production
+
+### `POSTGRES_PASSWORD` (via Docker Secret)
+- **Descrizione**: Password per l'utente PostgreSQL
+- **Dove**: Docker Secret in `infra/secrets/postgres-password.txt`
+- **Obbligatorio**: ✅ Sì (via Docker Secret)
+- **Default**: Nessuno (generato)
+- **Esempio**: File `postgres-password.txt` contiene: `9x$kL2m#Pq8vR@nT5w`
+- **Note**:
+  - CRITICO: Usare password complessa (min 16 caratteri, lettere, numeri, simboli)
+  - Gestire via Docker Secrets (`POSTGRES_PASSWORD_FILE=/run/secrets/postgres-password`)
+  - Rotazione ogni 90 giorni raccomandata
+  - Tool: `tools/secrets/rotate-secret.sh postgres-password`
+
+### `POSTGRES_HOST`
+- **Descrizione**: Hostname del server PostgreSQL
+- **Dove**: Connection string in `ConnectionStrings__Postgres`
+- **Obbligatorio**: ✅ Sì
+- **Default**: `localhost` (dev), `meepleai-postgres` (Docker)
+- **Esempio**: `postgres.meepleai.internal` oppure RDS endpoint
+- **Note**: Per managed services (AWS RDS, Azure Database) usare endpoint fornito
+
+### `POSTGRES_PORT`
+- **Descrizione**: Porta del server PostgreSQL
+- **Dove**: Connection string
+- **Obbligatorio**: No
+- **Default**: `5432`
+- **Esempio**: `POSTGRES_PORT=5432`
+
+### `ConnectionStrings__Postgres`
+- **Descrizione**: Connection string completa per EF Core
+- **Dove**: Variabile d'ambiente API, `appsettings.Production.json` (override)
+- **Obbligatorio**: ✅ Sì (o componenti separati)
+- **Default**: Auto-costruita da variabili separate
+- **Esempio**:
+  ```
+  Host=postgres.prod.meepleai.internal;Database=meepleai_production;Username=meepleai_app;Password_File=/run/secrets/postgres-password;Port=5432;Pooling=true;Minimum Pool Size=10;Maximum Pool Size=100;SSL Mode=Require;Trust Server Certificate=false
+  ```
+- **Note**:
+  - In produzione SEMPRE usare `SSL Mode=Require`
+  - Connection pooling configurato (10-100 connessioni)
+  - Preferire `Password_File` (Docker Secret) invece di `Password`
+
+---
+
+## 2. Cache (Redis)
+
+### `REDIS_URL`
+- **Descrizione**: URL di connessione a Redis (per cache L2, HybridCache)
+- **Dove**: Variabile d'ambiente API in `infra/env/api.env.prod`
+- **Obbligatorio**: ✅ Sì (per HybridCache L2)
+- **Default**: `localhost:6379` (dev), `redis:6379` (Docker)
+- **Esempio**:
+  - Docker: `REDIS_URL=redis:6379`
+  - Managed: `REDIS_URL=redis.meepleai.cache.windows.net:6380,ssl=true,password=<secret>`
+  - ElastiCache: `REDIS_URL=meepleai.abc123.0001.use1.cache.amazonaws.com:6379`
+- **Note**:
+  - In produzione abilitare SSL/TLS se supportato
+  - Per Azure Redis Cache: porta 6380 con SSL
+  - Connection timeout configurabile via `StackExchange.Redis`
+
+### `REDIS_PASSWORD`
+- **Descrizione**: Password per autenticazione Redis (se richiesta)
+- **Dove**: Docker Secret `infra/secrets/redis-password.txt` o variabile d'ambiente
+- **Obbligatorio**: ⚠️ Consigliato in produzione
+- **Default**: Nessuna (Redis senza auth in dev)
+- **Esempio**: `REDIS_PASSWORD=sK9$mP2x@nQ7vT3w`
+- **Note**:
+  - Configurare `requirepass` in redis.conf
+  - Managed services (Azure, AWS) forniscono password automaticamente
+
+### `REDIS_CONFIGURATION`
+- **Descrizione**: Stringa di configurazione completa StackExchange.Redis
+- **Dove**: Variabile d'ambiente API
+- **Obbligatorio**: No (alternativa a REDIS_URL)
+- **Default**: Costruita da `REDIS_URL`
+- **Esempio**:
+  ```
+  redis:6379,password=<secret>,connectTimeout=5000,connectRetry=3,abortConnect=false,ssl=true
+  ```
+
+---
+
+## 3. Vector Database (Qdrant)
+
+### `QDRANT_URL`
+- **Descrizione**: URL base per API REST di Qdrant
+- **Dove**: Variabile d'ambiente API in `infra/env/api.env.prod`, `appsettings.json`
+- **Obbligatorio**: ✅ Sì
+- **Default**: `http://localhost:6333` (dev)
+- **Esempio**:
+  - Docker: `QDRANT_URL=http://qdrant:6333`
+  - Qdrant Cloud: `QDRANT_URL=https://xyz-abc123.eu-central.aws.cloud.qdrant.io`
+- **Note**:
+  - Qdrant Cloud richiede API key (vedere `QDRANT_API_KEY`)
+  - Self-hosted: considerare HTTPS con reverse proxy
+
+### `QDRANT_API_KEY`
+- **Descrizione**: API key per Qdrant Cloud (managed service)
+- **Dove**: Docker Secret `infra/secrets/qdrant-api-key.txt` o variabile d'ambiente
+- **Obbligatorio**: ⚠️ Sì per Qdrant Cloud, No per self-hosted
+- **Default**: Nessuna
+- **Esempio**: `QDRANT_API_KEY=qd_<CHANGE_ME>`
+- **Note**: Ottenibile da Qdrant Cloud console
+
+### `QDRANT_COLLECTION_NAME`
+- **Descrizione**: Nome della collection Qdrant per vectors
+- **Dove**: Configurazione applicazione
+- **Obbligatorio**: No (creata automaticamente)
+- **Default**: `game_rules`
+- **Esempio**: `QDRANT_COLLECTION_NAME=meepleai_rules_prod`
+
+---
+
+## 4. API Backend (ASP.NET)
+
+### `ASPNETCORE_ENVIRONMENT`
+- **Descrizione**: Ambiente di esecuzione ASP.NET Core
+- **Dove**: Variabile d'ambiente Docker/sistema
+- **Obbligatorio**: ✅ Sì
+- **Default**: `Development`
+- **Esempio**: `ASPNETCORE_ENVIRONMENT=Production`
+- **Note**: Valori validi: `Development`, `Staging`, `Production`
+
+### `ASPNETCORE_URLS`
+- **Descrizione**: URL di ascolto del server Kestrel
+- **Dove**: Variabile d'ambiente Docker
+- **Obbligatorio**: ✅ Sì
+- **Default**: `http://localhost:8080`
+- **Esempio**:
+  - HTTP: `ASPNETCORE_URLS=http://+:8080`
+  - HTTPS: `ASPNETCORE_URLS=https://+:8080;http://+:8180`
+- **Note**: In produzione dietro reverse proxy (Nginx, Traefik) o usare HTTPS diretto
+
+### `ASPNETCORE_HTTPS_PORT`
+- **Descrizione**: Porta HTTPS per redirect automatico
+- **Dove**: Variabile d'ambiente
+- **Obbligatorio**: ⚠️ Consigliato se si usa HTTPS
+- **Default**: `443`
+- **Esempio**: `ASPNETCORE_HTTPS_PORT=443`
+
+### `ASPNETCORE_Kestrel__Certificates__Default__Path`
+- **Descrizione**: Path al certificato SSL/TLS (per HTTPS diretto)
+- **Dove**: Variabile d'ambiente o `appsettings.Production.json`
+- **Obbligatorio**: ⚠️ Solo se HTTPS diretto (no reverse proxy)
+- **Default**: Nessuno
+- **Esempio**: `ASPNETCORE_Kestrel__Certificates__Default__Path=/etc/ssl/certs/meepleai.pfx`
+
+### `ASPNETCORE_Kestrel__Certificates__Default__Password`
+- **Descrizione**: Password per certificato SSL/TLS
+- **Dove**: Docker Secret `infra/secrets/ssl-cert-password.txt`
+- **Obbligatorio**: ⚠️ Se certificato protetto da password
+- **Default**: Nessuno
+- **Esempio**: File contiene: `CertP@ssw0rd123`
+
+### `JWT_ISSUER` / `JwtIssuer`
+- **Descrizione**: Issuer per token JWT (per API key validation)
+- **Dove**: `appsettings.json` o variabile d'ambiente
+- **Obbligatorio**: ✅ Sì
+- **Default**: `http://localhost:8080`
+- **Esempio**: `JwtIssuer=https://api.meepleai.dev`
+- **Note**: Deve corrispondere al dominio pubblico dell'API
+
+### `ALLOW_ORIGIN` / `AllowedOrigins`
+- **Descrizione**: Origini consentite per CORS (frontend URLs)
+- **Dove**: `appsettings.json` (array) o variabile d'ambiente
+- **Obbligatorio**: ✅ Sì
+- **Default**: `["http://localhost:3000"]`
+- **Esempio**:
+  - Singolo: `ALLOW_ORIGIN=https://app.meepleai.dev`
+  - Multipli in appsettings.json: `"AllowedOrigins": ["https://app.meepleai.dev", "https://www.meepleai.dev"]`
+- **Note**: NON usare `*` in produzione per sicurezza
+
+### `SEQ_URL`
+- **Descrizione**: URL per Seq log aggregation
+- **Dove**: Variabile d'ambiente API, `appsettings.json`
+- **Obbligatorio**: ⚠️ Consigliato per produzione
+- **Default**: `http://seq:5341`
+- **Esempio**:
+  - Docker: `SEQ_URL=http://seq:5341`
+  - Cloud: `SEQ_URL=https://logs.meepleai.dev`
+- **Note**: Porta 5341 per ingestion HTTP
+
+### `SEQ_API_KEY`
+- **Descrizione**: API key per autenticazione Seq
+- **Dove**: Docker Secret o variabile d'ambiente
+- **Obbligatorio**: ⚠️ Se Seq richiede autenticazione
+- **Default**: Nessuna
+- **Esempio**: `SEQ_API_KEY=<CHANGE_ME>`
+
+---
+
+## 5. Frontend Web (Next.js)
+
+### `NODE_ENV`
+- **Descrizione**: Ambiente Node.js
+- **Dove**: Variabile d'ambiente Docker
+- **Obbligatorio**: ✅ Sì
+- **Default**: `development`
+- **Esempio**: `NODE_ENV=production`
+- **Note**: Impatta build optimization, logging, error reporting
+
+### `NEXT_PUBLIC_API_BASE`
+- **Descrizione**: URL base dell'API backend (pubblico, usato lato client)
+- **Dove**: File `infra/env/web.env.prod` o variabile d'ambiente
+- **Obbligatorio**: ✅ Sì
+- **Default**: `http://localhost:8080`
+- **Esempio**:
+  - Docker interno: `NEXT_PUBLIC_API_BASE=http://api:8080`
+  - Pubblico: `NEXT_PUBLIC_API_BASE=https://api.meepleai.dev`
+- **Note**: Prefisso `NEXT_PUBLIC_` espone variabile lato client
+
+### `NEXT_PUBLIC_TENANT_ID`
+- **Descrizione**: Identificatore tenant (per multi-tenancy futura)
+- **Dove**: File `infra/env/web.env.prod`
+- **Obbligatorio**: No
+- **Default**: `dev`
+- **Esempio**: `NEXT_PUBLIC_TENANT_ID=production`
+
+### `NEXT_PUBLIC_SENTRY_DSN`
+- **Descrizione**: Sentry DSN per error tracking frontend
+- **Dove**: File `.env.production` in `apps/web/`
+- **Obbligatorio**: ⚠️ Consigliato per produzione
+- **Default**: Nessuno
+- **Esempio**: `NEXT_PUBLIC_SENTRY_DSN=https://abc123@o123456.ingest.sentry.io/987654`
+- **Note**: Ottenibile da Sentry.io project settings
+
+### `NEXT_PUBLIC_SENTRY_ENVIRONMENT`
+- **Descrizione**: Environment per Sentry (filtrare errori per ambiente)
+- **Dove**: File `.env.production`
+- **Obbligatorio**: ⚠️ Se si usa Sentry
+- **Default**: `development`
+- **Esempio**: `NEXT_PUBLIC_SENTRY_ENVIRONMENT=production`
+
+### `SENTRY_AUTH_TOKEN`
+- **Descrizione**: Token per upload source maps a Sentry
+- **Dove**: Variabile d'ambiente CI/CD o Docker Secret
+- **Obbligatorio**: No (solo per source maps)
+- **Default**: Nessuno
+- **Esempio**: `SENTRY_AUTH_TOKEN=sntrys_<CHANGE_ME>`
+
+### `SENTRY_ORG` / `SENTRY_PROJECT`
+- **Descrizione**: Organization e Project Sentry (per source maps upload)
+- **Dove**: File `.env.production` o CI/CD
+- **Obbligatorio**: No (solo se si uploadano source maps)
+- **Default**: Nessuno
+- **Esempio**:
+  ```
+  SENTRY_ORG=meepleai
+  SENTRY_PROJECT=web-frontend
+  ```
+
+### Resilience Configuration (Client API)
+
+### `NEXT_PUBLIC_RETRY_ENABLED`
+- **Descrizione**: Abilita retry automatico per chiamate API
+- **Dove**: File `apps/web/.env.production`
+- **Obbligatorio**: No
+- **Default**: `true`
+- **Esempio**: `NEXT_PUBLIC_RETRY_ENABLED=true`
+
+### `NEXT_PUBLIC_RETRY_MAX_ATTEMPTS`
+- **Descrizione**: Numero massimo tentativi retry
+- **Dove**: File `apps/web/.env.production`
+- **Obbligatorio**: No
+- **Default**: `3`
+- **Esempio**: `NEXT_PUBLIC_RETRY_MAX_ATTEMPTS=5`
+
+### `NEXT_PUBLIC_RETRY_BASE_DELAY`
+- **Descrizione**: Delay iniziale tra retry (ms)
+- **Dove**: File `apps/web/.env.production`
+- **Obbligatorio**: No
+- **Default**: `1000`
+- **Esempio**: `NEXT_PUBLIC_RETRY_BASE_DELAY=2000`
+
+### `NEXT_PUBLIC_RETRY_MAX_DELAY`
+- **Descrizione**: Delay massimo tra retry (ms, per exponential backoff)
+- **Dove**: File `apps/web/.env.production`
+- **Obbligatorio**: No
+- **Default**: `10000`
+- **Esempio**: `NEXT_PUBLIC_RETRY_MAX_DELAY=30000`
+
+### `NEXT_PUBLIC_CIRCUIT_BREAKER_ENABLED`
+- **Descrizione**: Abilita circuit breaker per API calls
+- **Dove**: File `apps/web/.env.production`
+- **Obbligatorio**: No
+- **Default**: `true`
+- **Esempio**: `NEXT_PUBLIC_CIRCUIT_BREAKER_ENABLED=true`
+
+### `NEXT_PUBLIC_CIRCUIT_BREAKER_FAILURE_THRESHOLD`
+- **Descrizione**: Numero errori prima di aprire circuito
+- **Dove**: File `apps/web/.env.production`
+- **Obbligatorio**: No
+- **Default**: `5`
+- **Esempio**: `NEXT_PUBLIC_CIRCUIT_BREAKER_FAILURE_THRESHOLD=10`
+
+### `NEXT_PUBLIC_CIRCUIT_BREAKER_SUCCESS_THRESHOLD`
+- **Descrizione**: Successi necessari per chiudere circuito
+- **Dove**: File `apps/web/.env.production`
+- **Obbligatorio**: No
+- **Default**: `2`
+- **Esempio**: `NEXT_PUBLIC_CIRCUIT_BREAKER_SUCCESS_THRESHOLD=3`
+
+### `NEXT_PUBLIC_CIRCUIT_BREAKER_TIMEOUT`
+- **Descrizione**: Timeout circuito aperto (ms)
+- **Dove**: File `apps/web/.env.production`
+- **Obbligatorio**: No
+- **Default**: `60000`
+- **Esempio**: `NEXT_PUBLIC_CIRCUIT_BREAKER_TIMEOUT=120000`
+
+### `NEXT_PUBLIC_REQUEST_DEDUP_ENABLED`
+- **Descrizione**: Abilita deduplicazione richieste identiche
+- **Dove**: File `apps/web/.env.production`
+- **Obbligatorio**: No
+- **Default**: `true`
+- **Esempio**: `NEXT_PUBLIC_REQUEST_DEDUP_ENABLED=true`
+
+### `NEXT_PUBLIC_REQUEST_DEDUP_TTL`
+- **Descrizione**: TTL cache deduplicazione (ms)
+- **Dove**: File `apps/web/.env.production`
+- **Obbligatorio**: No
+- **Default**: `100`
+- **Esempio**: `NEXT_PUBLIC_REQUEST_DEDUP_TTL=500`
+
+---
+
+## 6. AI/ML Services
+
+### `EMBEDDING_PROVIDER`
+- **Descrizione**: Provider per generazione embeddings
+- **Dove**: Variabile d'ambiente API
+- **Obbligatorio**: ✅ Sì
+- **Default**: `ollama`
+- **Esempio**: `EMBEDDING_PROVIDER=openrouter` oppure `ollama`
+- **Note**: Valori: `ollama` (locale, free), `openrouter` (cloud, paid via OpenRouter)
+
+### `EMBEDDING_MODEL`
+- **Descrizione**: Nome modello per embeddings
+- **Dove**: Variabile d'ambiente API, `appsettings.json`
+- **Obbligatorio**: ✅ Sì
+- **Default**: `mxbai-embed-large`
+- **Esempio**:
+  - Ollama: `EMBEDDING_MODEL=mxbai-embed-large`
+  - OpenRouter: `EMBEDDING_MODEL=mxbai-embed-large`
+
+### `OLLAMA_URL`
+- **Descrizione**: URL server Ollama (per embeddings e LLM locali)
+- **Dove**: Variabile d'ambiente API
+- **Obbligatorio**: ⚠️ Sì se `EMBEDDING_PROVIDER=ollama`
+- **Default**: `http://localhost:11434`
+- **Esempio**:
+  - Docker: `OLLAMA_URL=http://ollama:11434`
+  - Remote: `OLLAMA_URL=https://ollama.meepleai.internal`
+
+### `OPENROUTER_API_KEY`
+- **Descrizione**: API key OpenRouter (per LLM chat completions, embeddings cloud, e modelli AI multi-provider)
+- **Dove**: Docker Secret `infra/secrets/openrouter-api-key.txt`
+- **Obbligatorio**: ✅ Sì (core feature: RAG chat, cloud embeddings)
+- **Default**: Nessuno
+- **Esempio**: File contiene: `sk-or-v1-abc123xyz456...`
+- **Note**:
+  - Ottenibile da https://openrouter.ai/keys
+  - Gestire via Docker Secret: `OPENROUTER_API_KEY_FILE=/run/secrets/openrouter-api-key`
+  - Monitorare crediti/quota
+  - Usato per embeddings quando `EMBEDDING_PROVIDER=openrouter`
+
+### `LOCAL_EMBEDDING_URL`
+- **Descrizione**: URL servizio embedding locale custom (AI-09)
+- **Dove**: Variabile d'ambiente API
+- **Obbligatorio**: No (fallback)
+- **Default**: `http://embedding-service:8000`
+- **Esempio**: `LOCAL_EMBEDDING_URL=http://embedding:8000`
+
+### `EMBEDDING_FALLBACK_ENABLED`
+- **Descrizione**: Abilita fallback tra provider embeddings
+- **Dove**: Variabile d'ambiente API
+- **Obbligatorio**: No
+- **Default**: `true`
+- **Esempio**: `EMBEDDING_FALLBACK_ENABLED=true`
+
+---
+
+## 7. PDF Processing Services
+
+### Unstructured Service (Stage 1)
+
+### `UNSTRUCTURED_STRATEGY`
+- **Descrizione**: Strategia estrazione Unstructured
+- **Dove**: Variabile d'ambiente `unstructured-service`
+- **Obbligatorio**: No
+- **Default**: `fast`
+- **Esempio**: `UNSTRUCTURED_STRATEGY=hi_res`
+- **Note**: Valori: `fast` (veloce, 80% accuracy), `hi_res` (lento, 95% accuracy)
+
+### `LANGUAGE`
+- **Descrizione**: Lingua documento per OCR/estrazione
+- **Dove**: Variabile d'ambiente `unstructured-service`
+- **Obbligatorio**: No
+- **Default**: `ita`
+- **Esempio**: `LANGUAGE=ita`
+
+### SmolDocling Service (Stage 2)
+
+### `DEVICE`
+- **Descrizione**: Device per inferenza PyTorch (cpu/cuda)
+- **Dove**: Variabile d'ambiente `smoldocling-service`
+- **Obbligatorio**: ✅ Sì
+- **Default**: `cpu`
+- **Esempio**: `DEVICE=cuda` (con GPU NVIDIA)
+- **Note**: In produzione con GPU usare `cuda` per prestazioni
+
+### `MODEL_NAME`
+- **Descrizione**: Nome modello Hugging Face per SmolDocling
+- **Dove**: Variabile d'ambiente `smoldocling-service`
+- **Obbligatorio**: No
+- **Default**: `docling-project/SmolDocling-256M-preview`
+- **Esempio**: `MODEL_NAME=docling-project/SmolDocling-256M-preview`
+
+### `TORCH_DTYPE`
+- **Descrizione**: Data type per tensori PyTorch
+- **Dove**: Variabile d'ambiente `smoldocling-service`
+- **Obbligatorio**: No
+- **Default**: `bfloat16`
+- **Esempio**: `TORCH_DTYPE=float16`
+- **Note**: `bfloat16` per GPU moderne, `float32` per CPU
+
+### `IMAGE_DPI`
+- **Descrizione**: DPI per conversione PDF → immagini
+- **Dove**: Variabile d'ambiente `smoldocling-service`
+- **Obbligatorio**: No
+- **Default**: `300`
+- **Esempio**: `IMAGE_DPI=150`
+- **Note**: DPI più alto = migliore qualità ma più lento
+
+### `MAX_FILE_SIZE`
+- **Descrizione**: Dimensione massima file PDF (bytes)
+- **Dove**: Variabile d'ambiente entrambi i servizi PDF
+- **Obbligatorio**: No
+- **Default**: `52428800` (50MB)
+- **Esempio**: `MAX_FILE_SIZE=104857600` (100MB)
+
+### `QUALITY_THRESHOLD`
+- **Descrizione**: Soglia qualità minima estrazione (0.0-1.0)
+- **Dove**: Variabile d'ambiente servizi PDF
+- **Obbligatorio**: No
+- **Default**: `0.80` (Unstructured), `0.70` (SmolDocling)
+- **Esempio**: `QUALITY_THRESHOLD=0.85`
+
+---
+
+## 8. Workflow Automation (n8n)
+
+### `N8N_BASIC_AUTH_USER`
+- **Descrizione**: Username per autenticazione n8n UI
+- **Dove**: Variabile d'ambiente `infra/env/n8n.env.prod`
+- **Obbligatorio**: ✅ Sì
+- **Default**: `admin`
+- **Esempio**: `N8N_BASIC_AUTH_USER=admin_prod`
+
+### `N8N_BASIC_AUTH_PASSWORD`
+- **Descrizione**: Password per autenticazione n8n UI
+- **Dove**: Docker Secret `infra/secrets/n8n-basic-auth-password.txt`
+- **Obbligatorio**: ✅ Sì
+- **Default**: Nessuno (generato)
+- **Esempio**: File contiene: `N8n!Pr0d@Pass123`
+- **Note**: Password forte, rotazione 90 giorni
+
+### `N8N_ENCRYPTION_KEY`
+- **Descrizione**: Chiave crittografia per credenziali n8n
+- **Dove**: Docker Secret `infra/secrets/n8n-encryption-key.txt`
+- **Obbligatorio**: ✅ Sì
+- **Default**: Nessuno (generato)
+- **Esempio**: File contiene: `a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6` (32 bytes hex)
+- **Note**:
+  - CRITICO: non perdere questa chiave (credenziali irrecuperabili)
+  - Backup sicuro richiesto
+  - Generare con: `openssl rand -hex 32`
+
+### `DB_POSTGRESDB_HOST`
+- **Descrizione**: Host database PostgreSQL per n8n
+- **Dove**: Variabile d'ambiente n8n
+- **Obbligatorio**: ✅ Sì (se `DB_TYPE=postgresdb`)
+- **Default**: `postgres`
+- **Esempio**: `DB_POSTGRESDB_HOST=postgres.internal`
+
+### `DB_POSTGRESDB_DATABASE`
+- **Descrizione**: Nome database n8n
+- **Dove**: Variabile d'ambiente n8n
+- **Obbligatorio**: ✅ Sì
+- **Default**: `meepleai`
+- **Esempio**: `DB_POSTGRESDB_DATABASE=meepleai_n8n`
+
+### `DB_POSTGRESDB_PASSWORD`
+- **Descrizione**: Password database PostgreSQL per n8n
+- **Dove**: Docker Secret (stesso di `POSTGRES_PASSWORD`)
+- **Obbligatorio**: ✅ Sì
+- **Default**: Nessuno
+- **Esempio**: Letto da `/run/secrets/postgres-password`
+
+### `N8N_HOST`
+- **Descrizione**: Hostname pubblico n8n (per webhooks)
+- **Dove**: Variabile d'ambiente n8n
+- **Obbligatorio**: ✅ Sì
+- **Default**: `localhost`
+- **Esempio**: `N8N_HOST=workflows.meepleai.dev`
+
+### `N8N_PROTOCOL`
+- **Descrizione**: Protocollo per URL webhooks
+- **Dove**: Variabile d'ambiente n8n
+- **Obbligatorio**: No
+- **Default**: `http`
+- **Esempio**: `N8N_PROTOCOL=https`
+
+### `WEBHOOK_URL`
+- **Descrizione**: URL base per webhook n8n
+- **Dove**: Variabile d'ambiente n8n
+- **Obbligatorio**: ✅ Sì
+- **Default**: `http://localhost:5678/`
+- **Esempio**: `WEBHOOK_URL=https://workflows.meepleai.dev/`
+
+### `MEEPLEAI_API_URL`
+- **Descrizione**: URL API MeepleAI (per workflow HTTP requests)
+- **Dove**: Variabile d'ambiente n8n
+- **Obbligatorio**: ✅ Sì
+- **Default**: `http://api:8080`
+- **Esempio**: `MEEPLEAI_API_URL=https://api.meepleai.dev`
+
+### `N8N_SERVICE_SESSION`
+- **Descrizione**: Session token service account n8n
+- **Dove**: Variabile d'ambiente n8n
+- **Obbligatorio**: ⚠️ Sì per workflow automatici
+- **Default**: Nessuno
+- **Esempio**: `N8N_SERVICE_SESSION=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...`
+- **Note**: Generare con `tools/setup-n8n-service-account.ps1`
+
+---
+
+## 9. Observability Stack
+
+### Seq (Log Aggregation)
+
+### `SEQ_FIRSTRUN_ADMINPASSWORDHASH`
+- **Descrizione**: Hash password admin Seq (primo avvio)
+- **Dove**: Variabile d'ambiente Seq
+- **Obbligatorio**: ⚠️ Consigliato in produzione
+- **Default**: Nessuno (no autenticazione)
+- **Esempio**: `SEQ_FIRSTRUN_ADMINPASSWORDHASH=$2a$10$abc123...`
+- **Note**: Generare con Seq CLI: `seq hash <password>`
+
+### Prometheus (Metrics)
+
+### `PROMETHEUS_RETENTION_TIME`
+- **Descrizione**: Durata retention metriche Prometheus
+- **Dove**: Command args Docker Compose (`--storage.tsdb.retention.time`)
+- **Obbligatorio**: No
+- **Default**: `30d` (dev), `90d` (prod)
+- **Esempio**: `--storage.tsdb.retention.time=180d`
+
+### `PROMETHEUS_RETENTION_SIZE`
+- **Descrizione**: Dimensione massima storage Prometheus
+- **Dove**: Command args Docker Compose (`--storage.tsdb.retention.size`)
+- **Obbligatorio**: No
+- **Default**: `50GB` (prod)
+- **Esempio**: `--storage.tsdb.retention.size=100GB`
+
+### Grafana (Dashboards)
+
+### `GF_SECURITY_ADMIN_USER`
+- **Descrizione**: Username admin Grafana
+- **Dove**: Variabile d'ambiente Grafana
+- **Obbligatorio**: No
+- **Default**: `admin`
+- **Esempio**: `GF_SECURITY_ADMIN_USER=grafana_admin`
+
+### `GF_SECURITY_ADMIN_PASSWORD`
+- **Descrizione**: Password admin Grafana
+- **Dove**: Docker Secret `infra/secrets/grafana-admin-password.txt`
+- **Obbligatorio**: ✅ Sì
+- **Default**: `admin` (CAMBIARE!)
+- **Esempio**: File contiene: `Gr@f@na!Pr0d123`
+- **Note**: Grafana forza cambio password al primo login se default
+
+### `GF_SERVER_ROOT_URL`
+- **Descrizione**: URL pubblico Grafana (per link esterni)
+- **Dove**: Variabile d'ambiente Grafana
+- **Obbligatorio**: ⚠️ Consigliato
+- **Default**: `http://localhost:3001`
+- **Esempio**: `GF_SERVER_ROOT_URL=https://metrics.meepleai.dev`
+
+### `GF_USERS_ALLOW_SIGN_UP`
+- **Descrizione**: Permetti registrazione utenti Grafana
+- **Dove**: Variabile d'ambiente Grafana
+- **Obbligatorio**: No
+- **Default**: `false`
+- **Esempio**: `GF_USERS_ALLOW_SIGN_UP=false`
+- **Note**: In produzione SEMPRE `false`
+
+### Jaeger (Tracing)
+
+### `COLLECTOR_OTLP_ENABLED`
+- **Descrizione**: Abilita collector OTLP in Jaeger
+- **Dove**: Variabile d'ambiente Jaeger
+- **Obbligatorio**: ✅ Sì (per OpenTelemetry)
+- **Default**: `true`
+- **Esempio**: `COLLECTOR_OTLP_ENABLED=true`
+
+### `SPAN_STORAGE_TYPE`
+- **Descrizione**: Tipo storage span Jaeger
+- **Dove**: Variabile d'ambiente Jaeger
+- **Obbligatorio**: ✅ Sì
+- **Default**: `badger` (dev), `elasticsearch` (prod consigliato)
+- **Esempio**: `SPAN_STORAGE_TYPE=elasticsearch`
+- **Note**: Produzione: usare Elasticsearch/Cassandra per persistence
+
+---
+
+## 10. Security & Authentication
+
+### `INITIAL_ADMIN_EMAIL`
+- **Descrizione**: Email utente admin iniziale (bootstrap)
+- **Dove**: Variabile d'ambiente API
+- **Obbligatorio**: ✅ Sì (primo avvio)
+- **Default**: `admin@meepleai.dev`
+- **Esempio**: `INITIAL_ADMIN_EMAIL=admin@production.meepleai.dev`
+- **Note**: Creato solo se nessun admin esiste
+
+### `INITIAL_ADMIN_PASSWORD`
+- **Descrizione**: Password utente admin iniziale
+- **Dove**: Docker Secret `infra/secrets/initial-admin-password.txt`
+- **Obbligatorio**: ✅ Sì (primo avvio)
+- **Default**: Nessuno (generato)
+- **Esempio**: File contiene: `Adm1n!Pr0d@2025`
+- **Note**:
+  - Requisiti: min 8 caratteri, 1 maiuscola, 1 cifra
+  - Cambiare dopo primo login
+
+### `INITIAL_ADMIN_DISPLAY_NAME`
+- **Descrizione**: Nome visualizzato admin iniziale
+- **Dove**: Variabile d'ambiente API
+- **Obbligatorio**: No
+- **Default**: `System Admin`
+- **Esempio**: `INITIAL_ADMIN_DISPLAY_NAME=Production Administrator`
+
+### OAuth Providers
+
+### `GOOGLE_OAUTH_CLIENT_ID`
+- **Descrizione**: Client ID Google OAuth 2.0
+- **Dove**: Variabile d'ambiente API (sostituita in appsettings.json)
+- **Obbligatorio**: ⚠️ Sì per Google OAuth
+- **Default**: Nessuno
+- **Esempio**: `GOOGLE_OAUTH_CLIENT_ID=123456789-abc.apps.googleusercontent.com`
+- **Note**: Ottenibile da Google Cloud Console
+
+### `GOOGLE_OAUTH_CLIENT_SECRET`
+- **Descrizione**: Client Secret Google OAuth 2.0
+- **Dove**: Docker Secret `infra/secrets/google-oauth-secret.txt` o variabile d'ambiente
+- **Obbligatorio**: ⚠️ Sì per Google OAuth
+- **Default**: Nessuno
+- **Esempio**: File contiene: `GOCSPX-abc123xyz456...`
+- **Note**: Mantenere segreto, rotazione se compromesso
+
+### `DISCORD_OAUTH_CLIENT_ID`
+- **Descrizione**: Client ID Discord OAuth 2.0
+- **Dove**: Variabile d'ambiente API
+- **Obbligatorio**: ⚠️ Sì per Discord OAuth
+- **Default**: Nessuno
+- **Esempio**: `DISCORD_OAUTH_CLIENT_ID=1234567890123456789`
+- **Note**: Ottenibile da Discord Developer Portal
+
+### `DISCORD_OAUTH_CLIENT_SECRET`
+- **Descrizione**: Client Secret Discord OAuth 2.0
+- **Dove**: Docker Secret o variabile d'ambiente
+- **Obbligatorio**: ⚠️ Sì per Discord OAuth
+- **Default**: Nessuno
+- **Esempio**: `DISCORD_OAUTH_CLIENT_SECRET=<CHANGE_ME>`
+
+### `GITHUB_OAUTH_CLIENT_ID`
+- **Descrizione**: Client ID GitHub OAuth
+- **Dove**: Variabile d'ambiente API
+- **Obbligatorio**: ⚠️ Sì per GitHub OAuth
+- **Default**: Nessuno
+- **Esempio**: `GITHUB_OAUTH_CLIENT_ID=Iv1.<CHANGE_ME>`
+- **Note**: Ottenibile da GitHub Developer Settings
+
+### `GITHUB_OAUTH_CLIENT_SECRET`
+- **Descrizione**: Client Secret GitHub OAuth
+- **Dove**: Docker Secret o variabile d'ambiente
+- **Obbligatorio**: ⚠️ Sì per GitHub OAuth
+- **Default**: Nessuno
+- **Esempio**: `GITHUB_OAUTH_CLIENT_SECRET=<CHANGE_ME>`
+
+### `OAuth__CallbackBaseUrl`
+- **Descrizione**: URL base per callback OAuth (redirect URI)
+- **Dove**: `appsettings.Production.json` o variabile d'ambiente
+- **Obbligatorio**: ✅ Sì se si usa OAuth
+- **Default**: `http://localhost:8080`
+- **Esempio**: `https://api.meepleai.dev`
+- **Note**: Deve essere registrato nelle console OAuth providers
+
+---
+
+## 11. Email & Alerting
+
+### `GMAIL_APP_PASSWORD`
+- **Descrizione**: App Password Gmail per invio email alert
+- **Dove**: Docker Secret `infra/secrets/gmail-app-password.txt`
+- **Obbligatorio**: ⚠️ Sì per email alerts
+- **Default**: Nessuno
+- **Esempio**: File contiene: `abcdefghijklmnop` (16 caratteri, no spazi)
+- **Note**:
+  - NON usare password Gmail normale
+  - Creare App Password: https://myaccount.google.com/apppasswords
+  - Richiede 2FA abilitato
+
+### `SMTP_HOST`
+- **Descrizione**: Server SMTP per invio email
+- **Dove**: `appsettings.Production.json` (sezione `Alerting.Email`)
+- **Obbligatorio**: ⚠️ Sì per email alerts
+- **Default**: `smtp.gmail.com`
+- **Esempio**:
+  - Gmail: `smtp.gmail.com`
+  - SendGrid: `smtp.sendgrid.net`
+  - AWS SES: `email-smtp.eu-west-1.amazonaws.com`
+
+### `SMTP_PORT`
+- **Descrizione**: Porta server SMTP
+- **Dove**: `appsettings.Production.json`
+- **Obbligatorio**: No
+- **Default**: `587` (TLS)
+- **Esempio**: `587` (TLS) o `465` (SSL)
+
+### `SMTP_USERNAME`
+- **Descrizione**: Username autenticazione SMTP
+- **Dove**: `appsettings.Production.json` o variabile d'ambiente
+- **Obbligatorio**: ⚠️ Sì per la maggior parte dei provider
+- **Default**: Nessuno
+- **Esempio**:
+  - Gmail: email completa `alerts@meepleai.dev`
+  - SendGrid: `apikey`
+
+### `SMTP_PASSWORD`
+- **Descrizione**: Password autenticazione SMTP
+- **Dove**: Docker Secret o variabile d'ambiente
+- **Obbligatorio**: ⚠️ Sì
+- **Default**: Nessuno
+- **Esempio**: App Password o API key del provider
+
+### `ALERTING_EMAIL_FROM`
+- **Descrizione**: Indirizzo email mittente alert
+- **Dove**: `appsettings.Production.json` (sezione `Alerting.Email.From`)
+- **Obbligatorio**: ⚠️ Sì per email alerts
+- **Default**: `alerts@meepleai.dev`
+- **Esempio**: `alerts@meepleai.dev`
+
+### `ALERTING_EMAIL_TO`
+- **Descrizione**: Lista destinatari email alert (array)
+- **Dove**: `appsettings.Production.json` (sezione `Alerting.Email.To`)
+- **Obbligatorio**: ⚠️ Sì per email alerts
+- **Default**: `["ops@meepleai.dev"]`
+- **Esempio**: `["ops@meepleai.dev", "admin@meepleai.dev"]`
+
+### `SLACK_WEBHOOK_URL`
+- **Descrizione**: Webhook URL Slack per notifiche alert
+- **Dove**: `appsettings.Production.json` (sezione `Alerting.Slack.WebhookUrl`) o variabile d'ambiente
+- **Obbligatorio**: ⚠️ Sì per Slack alerts
+- **Default**: Nessuno
+- **Esempio**: `https://hooks.slack.com/services/T123/B456/abc123xyz456`
+- **Note**: Ottenibile creando Incoming Webhook in Slack workspace
+
+### `PAGERDUTY_INTEGRATION_KEY`
+- **Descrizione**: Integration key PagerDuty per alert critici
+- **Dove**: `appsettings.Production.json` (sezione `Alerting.PagerDuty.IntegrationKey`)
+- **Obbligatorio**: ⚠️ Sì per PagerDuty integration
+- **Default**: Nessuno
+- **Esempio**: `PAGERDUTY_INTEGRATION_KEY=<CHANGE_ME>`
+- **Note**: Ottenibile da PagerDuty service integration
+
+---
+
+## 12. Docker Secrets
+
+MeepleAI usa Docker Secrets per gestire credenziali sensibili. I secret sono file in `infra/secrets/` (gitignored).
+
+### Inizializzazione Secrets
+
+```bash
+# Generare tutti i secret necessari
+cd infra
+./tools/secrets/init-secrets.sh
+
+# Verificare secret creati
+./tools/secrets/list-secrets.sh
+
+# Rotazione singolo secret
+./tools/secrets/rotate-secret.sh postgres-password
+```
+
+### Lista Secret Richiesti
+
+| Secret File | Descrizione | Obbligatorio | Tool Generazione |
+|-------------|-------------|--------------|------------------|
+| `postgres-password.txt` | Password PostgreSQL | ✅ Sì | `init-secrets.sh` |
+| `openrouter-api-key.txt` | API key OpenRouter (LLM + embeddings cloud) | ✅ Sì | Manuale (da OpenRouter) |
+| `initial-admin-password.txt` | Password admin iniziale | ✅ Sì | `init-secrets.sh` |
+| `n8n-encryption-key.txt` | Chiave crittografia n8n | ✅ Sì | `init-secrets.sh` |
+| `n8n-basic-auth-password.txt` | Password n8n UI | ✅ Sì | `init-secrets.sh` |
+| `grafana-admin-password.txt` | Password admin Grafana | ✅ Sì | `init-secrets.sh` |
+| `gmail-app-password.txt` | App Password Gmail | ⚠️ Per email | Manuale (Google) |
+| `google-oauth-secret.txt` | Client Secret Google OAuth | ⚠️ Per OAuth | Manuale (Google Cloud) |
+| `discord-oauth-secret.txt` | Client Secret Discord OAuth | ⚠️ Per OAuth | Manuale (Discord) |
+| `github-oauth-secret.txt` | Client Secret GitHub OAuth | ⚠️ Per OAuth | Manuale (GitHub) |
+| `redis-password.txt` | Password Redis | ⚠️ Consigliato | `init-secrets.sh` |
+| `qdrant-api-key.txt` | API key Qdrant Cloud | ⚠️ Per Qdrant Cloud | Manuale (Qdrant) |
+| `ssl-cert-password.txt` | Password certificato SSL | ⚠️ Se HTTPS diretto | Manuale |
+
+### Esempio Mount Secret in Docker Compose
+
+```yaml
+services:
+  api:
+    secrets:
+      - postgres-password
+      - openrouter-api-key
+    environment:
+      POSTGRES_PASSWORD_FILE: /run/secrets/postgres-password
+      OPENROUTER_API_KEY_FILE: /run/secrets/openrouter-api-key
+
+secrets:
+  postgres-password:
+    file: ./secrets/postgres-password.txt
+  openrouter-api-key:
+    file: ./secrets/openrouter-api-key.txt
+```
+
+---
+
+## Checklist Pre-Produzione
+
+### ✅ Database
+- [ ] `POSTGRES_USER` diverso da default
+- [ ] `POSTGRES_DB` production-specific
+- [ ] `POSTGRES_PASSWORD` forte (16+ caratteri) via Docker Secret
+- [ ] Connection string con `SSL Mode=Require`
+- [ ] Connection pooling configurato (10-100)
+- [ ] Backup automatici configurati
+
+### ✅ API Backend
+- [ ] `ASPNETCORE_ENVIRONMENT=Production`
+- [ ] `ASPNETCORE_URLS` con HTTPS o dietro reverse proxy
+- [ ] `AllowedOrigins` limitate a domini frontend reali
+- [ ] `JwtIssuer` corrisponde a URL pubblico
+- [ ] `OPENROUTER_API_KEY` valorizzato e con crediti sufficienti
+- [ ] `INITIAL_ADMIN_PASSWORD` forte e cambiato dopo primo login
+
+### ✅ Frontend
+- [ ] `NODE_ENV=production`
+- [ ] `NEXT_PUBLIC_API_BASE` punta a URL API pubblico
+- [ ] `NEXT_PUBLIC_SENTRY_DSN` configurato (error tracking)
+- [ ] Circuit breaker e retry abilitati
+
+### ✅ Caching & Performance
+- [ ] `REDIS_URL` configurato con SSL se managed service
+- [ ] `HybridCache.EnableL2Cache=true`
+- [ ] `QDRANT_URL` con HTTPS se pubblico
+
+### ✅ Observability
+- [ ] `SEQ_URL` configurato o log shipping alternativo
+- [ ] Grafana password cambiata da default
+- [ ] Prometheus retention configurato (90d+ produzione)
+- [ ] Jaeger storage persistente (Elasticsearch)
+
+### ✅ Security
+- [ ] Tutti i secret gestiti via Docker Secrets (no plaintext)
+- [ ] OAuth client secrets valorizzati se OAuth abilitato
+- [ ] SSL/TLS abilitato per tutti i servizi pubblici
+- [ ] CORS configurato (no `*`)
+- [ ] Rate limiting configurato
+- [ ] Security headers abilitati
+
+### ✅ Email & Alerting
+- [ ] `GMAIL_APP_PASSWORD` configurato o provider SMTP alternativo
+- [ ] `ALERTING_EMAIL_TO` con email operative reali
+- [ ] Slack webhook configurato (opzionale)
+- [ ] PagerDuty integration per alert critici (opzionale)
+
+### ✅ n8n Workflows
+- [ ] `N8N_ENCRYPTION_KEY` generato e salvato in backup sicuro
+- [ ] `N8N_BASIC_AUTH_PASSWORD` forte
+- [ ] `WEBHOOK_URL` con HTTPS
+- [ ] Service account session token configurato
+
+### ✅ PDF Processing
+- [ ] `DEVICE=cuda` se disponibile GPU (performance 10x)
+- [ ] `MAX_FILE_SIZE` adeguato (100MB+ se necessario)
+- [ ] Quality thresholds configurati (0.80/0.70)
+
+---
+
+## Best Practices
+
+### 1. Gestione Secret
+- ✅ Usare Docker Secrets o secret manager (AWS Secrets Manager, Azure Key Vault, HashiCorp Vault)
+- ✅ Rotazione periodica (90 giorni consigliati)
+- ✅ Backup sicuro delle chiavi critiche (encryption keys)
+- ❌ MAI committare `.env` files con valori reali
+- ❌ MAI loggare valori secret
+
+### 2. Sicurezza
+- Usare HTTPS per tutte le comunicazioni esterne
+- Abilitare SSL/TLS per database e cache
+- Limitare CORS a domini specifici
+- Implementare rate limiting
+- Monitorare accessi anomali
+
+### 3. Monitoring
+- Configurare alerting per:
+  - API errors (5xx > 1%)
+  - Database connection failures
+  - Redis cache failures
+  - LLM API quota exhausted
+  - Disk space < 20%
+- Retention logs: 30-90 giorni
+- Dashboards Grafana per metriche chiave
+
+### 4. Performance
+- Abilitare HybridCache L2 (Redis)
+- Connection pooling per database
+- CDN per static assets frontend
+- Compressione Brotli/Gzip
+- Caching CDN per API responses (se applicabile)
+
+### 5. Disaster Recovery
+- Backup database automatici (daily, retention 30d+)
+- Backup Qdrant vectors (weekly)
+- Backup n8n workflows (git repository)
+- Backup configurazioni (Infrastructure as Code)
+- Testare restore procedure (quarterly)
+
+---
+
+## Appendici
+
+### A. Esempio Configurazione Completa Produzione
+
+```bash
+# File: infra/env/api.env.prod
+
+# Environment
+ASPNETCORE_ENVIRONMENT=Production
+ASPNETCORE_URLS=https://+:8080
+
+# Database
+POSTGRES_USER=meepleai_app
+POSTGRES_DB=meepleai_production
+POSTGRES_PASSWORD_FILE=/run/secrets/postgres-password
+ConnectionStrings__Postgres=Host=postgres.prod.internal;Database=meepleai_production;Username=meepleai_app;Password_File=/run/secrets/postgres-password;SSL Mode=Require;Pooling=true;Minimum Pool Size=10;Maximum Pool Size=100
+
+# Cache & Vectors
+REDIS_URL=redis.prod.internal:6379
+QDRANT_URL=https://meepleai-prod.cloud.qdrant.io
+
+# AI Services
+EMBEDDING_PROVIDER=ollama
+OLLAMA_URL=http://ollama.prod.internal:11434
+EMBEDDING_MODEL=nomic-embed-text
+OPENROUTER_API_KEY_FILE=/run/secrets/openrouter-api-key
+
+# Application
+JWT_ISSUER=https://api.meepleai.dev
+ALLOW_ORIGIN=https://app.meepleai.dev,https://www.meepleai.dev
+
+# Observability
+SEQ_URL=https://logs.meepleai.internal:5341
+
+# Bootstrap
+INITIAL_ADMIN_EMAIL=admin@meepleai.dev
+INITIAL_ADMIN_PASSWORD_FILE=/run/secrets/initial-admin-password
+INITIAL_ADMIN_DISPLAY_NAME=Production Administrator
+```
+
+### B. Tool per Validazione Configurazione
+
+```bash
+# Validare che tutti i secret richiesti esistano
+cd infra
+./tools/secrets/validate-secrets.sh
+
+# Output esempio:
+# ✅ postgres-password.txt exists
+# ✅ openrouter-api-key.txt exists
+# ❌ gmail-app-password.txt MISSING (required for email alerts)
+# ...
+```
+
+### C. Template Docker Compose Produzione
+
+Vedere `infra/compose.prod.yml` per configurazione completa con:
+- Resource limits (CPU, RAM)
+- Health checks
+- Restart policies
+- Secrets management
+- Network isolation
+- Volume persistence
+
+---
+
+## Support & Troubleshooting
+
+### Problema: API non si avvia, errore connection string
+**Soluzione**: Verificare che `POSTGRES_PASSWORD_FILE` punti al secret corretto e che il file esista:
+```bash
+docker exec meepleai-api cat /run/secrets/postgres-password
+```
+
+### Problema: n8n perde credenziali salvate dopo restart
+**Soluzione**: `N8N_ENCRYPTION_KEY` cambiato o perso. Ripristinare chiave originale da backup.
+
+### Problema: OpenRouter API ritorna 401 Unauthorized
+**Soluzione**:
+1. Verificare `OPENROUTER_API_KEY` corretto
+2. Controllare crediti account: https://openrouter.ai/credits
+
+### Problema: Email alerts non funzionano
+**Soluzione**:
+1. Verificare `GMAIL_APP_PASSWORD` corretto (16 caratteri, no spazi)
+2. Controllare 2FA abilitato su account Gmail
+3. Testare credenziali SMTP manualmente
+
+---
+
+**Domande?** Consultare:
+- `docs/INDEX.md` - Indice completo documentazione (path: `../INDEX.md`)
+- `docs/security/docker-secrets-migration.md` - Migrazione a Docker Secrets (pending restoration — see #745)
+- `SECURITY.md` (root) - Security policy generale (pending restoration — see #745)
+
+**Maintainer**: Engineering Team
+**Contact**: ops@meepleai.dev

--- a/docs/security/frontend-security-best-practices.md
+++ b/docs/security/frontend-security-best-practices.md
@@ -1,0 +1,524 @@
+# Frontend Security Best Practices
+
+**Date**: 2025-11-23
+**Status**: ✅ ACTIVE
+**Owner**: Engineering Team
+
+---
+
+## Executive Summary
+
+This document outlines security best practices for the MeepleAI frontend to prevent common web vulnerabilities (XSS, injection, prototype pollution, etc.). Following these guidelines ensures that CodeQL and other security scanners will not flag security warnings.
+
+**Key Achievement**: Systematic prevention of security vulnerabilities through:
+- ESLint security plugins (automatic detection)
+- Centralized sanitization utilities
+- Pre-commit hooks (blocks unsafe code)
+- TypeScript strict mode (type safety)
+
+---
+
+## Table of Contents
+
+1. [XSS Prevention](#xss-prevention)
+2. [Input Sanitization](#input-sanitization)
+3. [URL Validation](#url-validation)
+4. [TypeScript Type Safety](#typescript-type-safety)
+5. [ESLint Security Rules](#eslint-security-rules)
+6. [Pre-commit Hooks](#pre-commit-hooks)
+7. [Common Pitfalls](#common-pitfalls)
+8. [Appendix](#appendix)
+
+---
+
+## XSS Prevention
+
+### ❌ NEVER Do This
+
+```tsx
+// BAD: Unsafe - allows XSS attacks
+function UnsafeComponent({ userContent }: { userContent: string }) {
+  return <div dangerouslySetInnerHTML={{ __html: userContent }} />;
+}
+
+// BAD: Unsafe - direct DOM manipulation
+function UnsafeComponent2({ html }: { html: string }) {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.innerHTML = html; // XSS vulnerability
+    }
+  }, [html]);
+  return <div ref={ref} />;
+}
+
+// BAD: Unsafe - eval is a security risk
+function UnsafeCode({ code }: { code: string }) {
+  eval(code); // NEVER use eval
+  return null;
+}
+```
+
+### ✅ Always Do This
+
+```tsx
+import { createSafeMarkup, sanitizeHtml } from '@/lib/security';
+
+// GOOD: Sanitized HTML
+function SafeComponent({ userContent }: { userContent: string }) {
+  return <div dangerouslySetInnerHTML={createSafeMarkup(userContent)} />;
+}
+
+// BEST: Use React children instead (no dangerouslySetInnerHTML)
+function BestComponent({ text }: { text: string }) {
+  return <div>{text}</div>;
+}
+
+// GOOD: Sanitize before using
+function SafeComponent2({ html }: { html: string }) {
+  const safeHtml = sanitizeHtml(html);
+  return <div dangerouslySetInnerHTML={{ __html: safeHtml }} />;
+}
+```
+
+---
+
+## Input Sanitization
+
+### Use Case: Board Game Rules (Trusted Content)
+
+```tsx
+import { sanitizeHtml } from '@/lib/security';
+
+function GameRules({ rulesHtml }: { rulesHtml: string }) {
+  // Rules from PDF extraction - sanitize with default config
+  // Allows tables, lists, formatting
+  return <div dangerouslySetInnerHTML={createSafeMarkup(rulesHtml)} />;
+}
+```
+
+### Use Case: User Comments (Untrusted Content)
+
+```tsx
+import { sanitizeUserContent } from '@/lib/security';
+
+function UserComment({ comment }: { comment: string }) {
+  // User-generated content - use strict sanitization
+  // Removes links, images, only allows basic formatting
+  const safeComment = sanitizeUserContent(comment);
+  return <div dangerouslySetInnerHTML={{ __html: safeComment }} />;
+}
+```
+
+### Use Case: Plain Text Output
+
+```tsx
+import { htmlToPlainText } from '@/lib/security';
+
+function MetaDescription({ html }: { html: string }) {
+  // Convert HTML to plain text for meta tags
+  const text = htmlToPlainText(html);
+  return <meta name="description" content={text} />;
+}
+```
+
+---
+
+## URL Validation
+
+### ❌ NEVER Do This
+
+```tsx
+// BAD: Unsafe - allows javascript: URLs
+function UnsafeLink({ url, text }: { url: string; text: string }) {
+  return <a href={url}>{text}</a>;
+}
+
+// Usage:
+// <UnsafeLink url="javascript:alert('XSS')" text="Click me" />
+// Result: XSS attack when user clicks
+```
+
+### ✅ Always Do This
+
+```tsx
+import { sanitizeUrl, isSafeUrl } from '@/lib/security';
+
+// GOOD: Sanitized URL
+function SafeLink({ url, text }: { url: string; text: string }) {
+  return <a href={sanitizeUrl(url)}>{text}</a>;
+}
+
+// BETTER: Validate before rendering
+function SaferLink({ url, text }: { url: string; text: string }) {
+  if (!isSafeUrl(url)) {
+    return <span title="Invalid URL">{text}</span>;
+  }
+  return <a href={url} target="_blank" rel="noopener noreferrer">{text}</a>;
+}
+```
+
+---
+
+## TypeScript Type Safety
+
+### Strict Null Checks
+
+TypeScript strict mode is already enabled (`tsconfig.json: "strict": true`). This prevents many common errors:
+
+```tsx
+// ❌ BAD: Nullable type without check
+function UnsafeComponent({ user }: { user: User | null }) {
+  return <div>{user.name}</div>; // TypeScript error: user might be null
+}
+
+// ✅ GOOD: Null check
+function SafeComponent({ user }: { user: User | null }) {
+  if (!user) return <div>No user</div>;
+  return <div>{user.name}</div>;
+}
+
+// ✅ BEST: Optional chaining
+function BestComponent({ user }: { user: User | null }) {
+  return <div>{user?.name ?? 'Anonymous'}</div>;
+}
+```
+
+### Avoid `any` Type
+
+```tsx
+// ❌ BAD: any type disables type checking
+function unsafeFunction(data: any) {
+  return data.property; // No type safety
+}
+
+// ✅ GOOD: Proper typing
+interface GameData {
+  name: string;
+  players: number;
+}
+
+function safeFunction(data: GameData) {
+  return data.name; // Type-safe
+}
+
+// ✅ BEST: Generic types
+function bestFunction<T extends { name: string }>(data: T) {
+  return data.name;
+}
+```
+
+---
+
+## ESLint Security Rules
+
+### Enabled Rules
+
+The following ESLint security rules are automatically enforced:
+
+#### XSS Prevention
+- `no-unsanitized/property`: Error - Prevents unsafe dangerouslySetInnerHTML
+- `no-unsanitized/method`: Error - Prevents unsafe innerHTML assignments
+
+#### Code Injection
+- `no-eval`: Error - Prevents eval()
+- `no-implied-eval`: Error - Prevents setTimeout/setInterval with strings
+- `no-new-func`: Error - Prevents new Function()
+
+#### Security Patterns (security plugin)
+- `security/detect-eval-with-expression`: Error
+- `security/detect-unsafe-regex`: Error - Prevents ReDoS
+- `security/detect-pseudoRandomBytes`: Error - Requires crypto.randomBytes
+- `security/detect-object-injection`: Warn - Prevents prototype pollution
+- `security/detect-non-literal-regexp`: Warn
+- `security/detect-possible-timing-attacks`: Warn
+
+#### Prototype Pollution
+- `no-proto`: Error - Prevents __proto__ usage
+- `no-extend-native`: Error - Prevents extending native prototypes
+
+#### TypeScript Safety
+- `@typescript-eslint/no-explicit-any`: Error - Prevents any type
+- `@typescript-eslint/no-non-null-assertion`: Warn - Prevents ! operator
+- `@typescript-eslint/prefer-nullish-coalescing`: Warn
+- `@typescript-eslint/prefer-optional-chain`: Warn
+
+### Example Violations
+
+```tsx
+// ❌ Violation: no-unsanitized/property
+<div dangerouslySetInnerHTML={{ __html: userInput }} />
+
+// ✅ Fix: Use sanitization utility
+<div dangerouslySetInnerHTML={createSafeMarkup(userInput)} />
+
+// ❌ Violation: security/detect-unsafe-regex
+const regex = new RegExp(userInput);
+
+// ✅ Fix: Validate/sanitize regex pattern
+const regex = new RegExp(escapeRegExp(userInput));
+
+// ❌ Violation: @typescript-eslint/no-explicit-any
+function process(data: any) { ... }
+
+// ✅ Fix: Proper typing
+function process(data: GameData) { ... }
+```
+
+---
+
+## Pre-commit Hooks
+
+Pre-commit hooks automatically run before each commit to prevent insecure code from being committed.
+
+### What Gets Checked
+
+1. **ESLint** (max-warnings=0): No security warnings allowed
+2. **TypeScript**: No type errors
+3. **Prettier**: Code formatting
+4. **Staged Files Only**: Fast execution
+
+### Bypassing Hooks (EMERGENCY ONLY)
+
+```bash
+# ⚠️ Only use in emergency situations (never for security warnings)
+git commit --no-verify -m "Emergency fix"
+```
+
+**Rule**: NEVER bypass security warnings. Fix the issue instead.
+
+---
+
+## Common Pitfalls
+
+### Pitfall #1: Rendering User Content Without Sanitization
+
+```tsx
+// ❌ WRONG
+function Comment({ text }: { text: string }) {
+  return <div dangerouslySetInnerHTML={{ __html: text }} />;
+}
+
+// ✅ CORRECT
+import { sanitizeUserContent } from '@/lib/security';
+
+function Comment({ text }: { text: string }) {
+  const safe = sanitizeUserContent(text);
+  return <div dangerouslySetInnerHTML={{ __html: safe }} />;
+}
+```
+
+### Pitfall #2: Client-Side Redirects
+
+```tsx
+// ❌ WRONG: Open redirect vulnerability
+function RedirectComponent() {
+  const url = new URLSearchParams(window.location.search).get('redirect');
+  window.location.href = url; // Unsafe: could redirect to evil.com
+}
+
+// ✅ CORRECT: Validate redirect URL
+import { isSafeUrl } from '@/lib/security';
+
+function RedirectComponent() {
+  const url = new URLSearchParams(window.location.search).get('redirect');
+  if (url && isSafeUrl(url)) {
+    window.location.href = url;
+  } else {
+    console.error('Invalid redirect URL');
+  }
+}
+```
+
+### Pitfall #3: Dynamic Property Access
+
+```tsx
+// ❌ WRONG: Prototype pollution
+function updateObject(obj: Record<string, any>, key: string, value: any) {
+  obj[key] = value; // Unsafe if key = "__proto__"
+}
+
+// ✅ CORRECT: Validate key
+function updateObject(obj: Record<string, any>, key: string, value: any) {
+  if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+    throw new Error('Invalid key');
+  }
+  obj[key] = value;
+}
+
+// ✅ BEST: Use Map instead
+function updateObject(map: Map<string, any>, key: string, value: any) {
+  map.set(key, value); // Safe: Map doesn't have prototype pollution issues
+}
+```
+
+### Pitfall #4: Regular Expression Denial of Service (ReDoS)
+
+```tsx
+// ❌ WRONG: Catastrophic backtracking
+const regex = /(a+)+$/;
+const result = regex.test('aaaaaaaaaaaaaaaaaaaaaaa!'); // Hangs
+
+// ✅ CORRECT: Use simple patterns or timeout
+const regex = /a+$/; // No nested quantifiers
+
+// ✅ BEST: Validate input length first
+function validateInput(input: string): boolean {
+  if (input.length > 1000) return false; // Limit input size
+  return /^[a-zA-Z0-9]+$/.test(input);
+}
+```
+
+---
+
+## Sanitization API Reference
+
+### `sanitizeHtml(html, config?)`
+
+Sanitizes HTML with default configuration (allows tables, lists, formatting).
+
+**Use for**: Board game rules, markdown rendering, trusted content
+
+```tsx
+import { sanitizeHtml } from '@/lib/security';
+
+const clean = sanitizeHtml('<script>alert(1)</script><p>Safe</p>');
+// Result: '<p>Safe</p>'
+```
+
+### `sanitizeUserContent(html)`
+
+Sanitizes HTML with strict configuration (removes links, images).
+
+**Use for**: User comments, forum posts, untrusted user input
+
+```tsx
+import { sanitizeUserContent } from '@/lib/security';
+
+const clean = sanitizeUserContent('<a href="evil.com">Link</a><b>Text</b>');
+// Result: '<b>Text</b>'
+```
+
+### `htmlToPlainText(html)`
+
+Strips all HTML tags, returns plain text.
+
+**Use for**: Meta descriptions, search indexing, notifications
+
+```tsx
+import { htmlToPlainText } from '@/lib/security';
+
+const text = htmlToPlainText('<p>Hello <b>world</b>!</p>');
+// Result: 'Hello world!'
+```
+
+### `createSafeMarkup(html, config?)`
+
+Creates a sanitized object for `dangerouslySetInnerHTML`.
+
+**Use for**: React components that need to render HTML
+
+```tsx
+import { createSafeMarkup } from '@/lib/security';
+
+function Component({ content }: { content: string }) {
+  return <div dangerouslySetInnerHTML={createSafeMarkup(content)} />;
+}
+```
+
+### `isSafeUrl(url)`
+
+Checks if a URL is safe (blocks javascript:, data:, vbscript:, file:).
+
+**Use for**: Link validation before rendering
+
+```tsx
+import { isSafeUrl } from '@/lib/security';
+
+if (isSafeUrl(userUrl)) {
+  return <a href={userUrl}>Link</a>;
+}
+```
+
+### `sanitizeUrl(url)`
+
+Sanitizes a URL, returns '#' if unsafe.
+
+**Use for**: href attributes with user input
+
+```tsx
+import { sanitizeUrl } from '@/lib/security';
+
+<a href={sanitizeUrl(userUrl)}>Link</a>
+```
+
+---
+
+## Testing
+
+### Unit Tests
+
+All sanitization functions have comprehensive unit tests:
+
+```bash
+cd apps/web
+pnpm test src/lib/security/__tests__/sanitize.test.ts
+```
+
+Tests cover:
+- XSS prevention (script tags, onclick handlers, javascript: URLs)
+- Safe HTML tags (tables, lists, formatting)
+- URL validation (safe vs dangerous protocols)
+- Edge cases (mXSS, DOM clobbering, prototype pollution)
+
+### Integration Testing
+
+Use Playwright for E2E security testing:
+
+```tsx
+// e2e/security.spec.ts
+test('should prevent XSS in user comments', async ({ page }) => {
+  await page.goto('/game/123');
+  await page.fill('[data-testid="comment-input"]', '<script>alert(1)</script>');
+  await page.click('[data-testid="submit-comment"]');
+
+  // Verify script tag is removed
+  const comment = await page.textContent('[data-testid="comment-text"]');
+  expect(comment).not.toContain('<script>');
+});
+```
+
+---
+
+## Appendix
+
+### References
+
+- **OWASP Top 10 (2021)**: https://owasp.org/Top10/
+- **DOMPurify**: https://github.com/cure53/DOMPurify
+- **ESLint Security Plugin**: https://github.com/eslint-community/eslint-plugin-security
+- **ESLint No Unsanitized**: https://github.com/mozilla/eslint-plugin-no-unsanitized
+
+### CWE Mappings
+
+| Vulnerability | CWE | Prevention |
+|---------------|-----|------------|
+| XSS | CWE-79 | DOMPurify sanitization |
+| Code Injection | CWE-94 | No eval, ESLint rules |
+| SQL Injection | CWE-89 | Backend: EF Core parameterization |
+| Path Traversal | CWE-22 | Backend: PathSecurity utilities |
+| Prototype Pollution | CWE-1321 | ESLint no-proto, object validation |
+| ReDoS | CWE-400 | ESLint detect-unsafe-regex |
+
+### Security Contacts
+
+- **Security Issues**: Create issue with `security` label
+- **Critical Vulnerabilities**: Email security@meepleai.dev (when available)
+- **CodeQL Alerts**: Visible at GitHub Security > Code Scanning
+
+---
+
+**Last Updated**: 2025-12-13T10:59:23.970Z
+**Version**: 1.0
+**Status**: ✅ ACTIVE
+

--- a/docs/security/generic-catch-analysis.md
+++ b/docs/security/generic-catch-analysis.md
@@ -1,0 +1,496 @@
+# Generic Exception Handling Analysis (Issue #738 - P2)
+
+**Date**: 2025-11-05
+**Branch**: `claude/code-scanning-remediation-011CUq3dfY88y7ZzQ8tdkfuf`
+**Status**: ✅ EXCELLENT COMPLIANCE - No Fixes Needed
+
+## Executive Summary
+
+Analyzed **220 reported generic catch clauses** (CWE-396, CA1031) in the codebase.
+
+**Result**: **ZERO problematic catches found** - 100% compliant with best practices.
+
+Every `catch(Exception)` block is:
+1. ✅ Properly suppressed with `#pragma warning disable CA1031`
+2. ✅ Documented with detailed justification comments
+3. ✅ Placed at appropriate architectural boundaries
+4. ✅ Combined with proper logging
+
+**Conclusion**: **No remediation required.** Codebase demonstrates exemplary exception handling practices.
+
+---
+
+## Analysis Methodology
+
+### Criteria for Problematic Catches
+
+❌ **Report as problematic if**:
+- Generic catch WITHOUT logging
+- Generic catch that swallows exceptions silently
+- Generic catch in business logic (not at boundaries)
+- Generic catch without re-throw or error result
+- Generic catch in loops (hiding repeated failures)
+
+✅ **Accept as justified if**:
+- API endpoint boundaries with proper logging
+- Background services/hosted services
+- Service boundaries returning Result<T> objects
+- Middleware boundaries (fail-open patterns)
+- Already suppressed with `#pragma warning disable CA1031` + justification
+
+---
+
+## Findings: Zero Problematic Catches
+
+After analyzing **84 files** containing `catch(Exception)` blocks, **ZERO** violations were found.
+
+---
+
+## Justifiable Patterns Found (All Properly Documented)
+
+The codebase correctly implements **9 standard exception handling patterns**:
+
+### 1. SERVICE BOUNDARY PATTERN ⭐ (Most Common)
+
+**Purpose**: Services return Result objects instead of throwing exceptions
+
+**Why Justified**:
+- Service layer isolates exceptions from API layer
+- All specific exceptions caught separately first
+- Generic catch handles truly unexpected infrastructure errors
+- Proper logging + Result<T> pattern prevents exception propagation
+
+**Examples**:
+```csharp
+// LlmService.cs, OllamaLlmService.cs, RagService.cs, EmbeddingService.cs, etc.
+
+#pragma warning disable CA1031 // Do not catch general exception types
+// Justification: SERVICE BOUNDARY PATTERN - Service layer returning Result<T>
+// All known exceptions (TaskCanceledException, HttpRequestException, JsonException)
+// caught separately. Generic catch handles unexpected infrastructure failures.
+catch (Exception ex)
+{
+    _logger.LogError(ex, "Unexpected error in {Method}", nameof(GenerateCompletionAsync));
+    return LlmCompletionResult.CreateFailure($"Unexpected error: {ex.Message}");
+}
+#pragma warning restore CA1031
+```
+
+**Files**: LlmService, OllamaLlmService, RagService, EmbeddingService, BggApiService, N8nTemplateService, TesseractOcrService, PromptEvaluationService, QualityReportService, and 30+ other services
+
+---
+
+### 2. MIDDLEWARE BOUNDARY PATTERN 🛡️
+
+**Purpose**: Prevent middleware from blocking request pipeline on errors
+
+**Why Justified**:
+- Middleware failures shouldn't crash entire application
+- "Fail-open" pattern prevents self-DOS scenarios
+- Authentication/rate limiting errors should allow request to proceed (unauthenticated/unthrottled)
+- Proper logging for monitoring
+
+**Examples**:
+```csharp
+// RateLimitingMiddleware.cs
+#pragma warning disable CA1031
+// Justification: MIDDLEWARE BOUNDARY PATTERN - Fail-open on rate limit errors
+// Rate limiting is defensive; if Redis/config fails, allow requests through
+// rather than blocking all traffic (self-DOS). Errors are logged for monitoring.
+catch (Exception ex)
+{
+    _logger.LogWarning(ex, "Rate limiting failed, allowing request (fail-open)");
+    await _next(context); // Continue request processing
+}
+#pragma warning restore CA1031
+```
+
+**Files**: RateLimitingMiddleware, SessionAuthenticationMiddleware, ApiExceptionHandlerMiddleware
+
+---
+
+### 3. RESILIENCE PATTERN 🔄 (Multi-Component Systems)
+
+**Purpose**: Prevent cascading failures in multi-channel/multi-component operations
+
+**Why Justified**:
+- One channel failure shouldn't block others
+- Alert delivery to Slack failure shouldn't prevent PagerDuty alerts
+- Template loading failure shouldn't block entire gallery
+- Fault isolation with comprehensive logging
+
+**Examples**:
+```csharp
+// AlertingService.cs
+#pragma warning disable CA1031
+// Justification: RESILIENCE PATTERN - Multi-channel alert delivery
+// One channel failure (e.g., Slack API down) shouldn't prevent other channels
+// (Email, PagerDuty) from delivering. Each channel isolated with logging.
+catch (Exception ex)
+{
+    _logger.LogError(ex, "Alert channel {Channel} failed", channel.Name);
+    failedChannels.Add(channel.Name);
+    // Continue to next channel
+}
+#pragma warning restore CA1031
+```
+
+**Files**: AlertingService, SlackAlertChannel, EmailAlertChannel, PagerDutyAlertChannel, N8nTemplateService
+
+---
+
+### 4. DATA ROBUSTNESS PATTERN 📊 (Malformed Data Handling)
+
+**Purpose**: Skip invalid external data items without stopping batch processing
+
+**Why Justified**:
+- External API data (BGG XML) can be malformed
+- Schema changes in third-party APIs
+- Graceful degradation: Skip bad items, continue processing good ones
+- Comprehensive error logging for monitoring
+
+**Examples**:
+```csharp
+// BggApiService.cs - ParseGameDetails
+#pragma warning disable CA1031
+// Justification: DATA ROBUSTNESS PATTERN - BGG API XML parsing
+// BGG API can return malformed XML or change schema. Generic catch prevents
+// one bad game entry from breaking entire search. Return null for invalid items.
+catch (Exception ex)
+{
+    _logger.LogWarning(ex, "Failed to parse BGG game details for ID {BggId}", bggId);
+    return null; // Skip this item
+}
+#pragma warning restore CA1031
+```
+
+**Files**: BggApiService, ImageExtractionStrategy, PdfMetadataExtractor
+
+---
+
+### 5. CLEANUP PATTERN 🧹 (Best-Effort Operations)
+
+**Purpose**: Non-critical cleanup operations shouldn't fail main operations
+
+**Why Justified**:
+- Cache invalidation failure shouldn't block PDF deletion
+- Temp file cleanup failure shouldn't block main operation
+- Vector deletion failure shouldn't prevent database deletion
+- Main operation succeeds; cleanup is best-effort
+
+**Examples**:
+```csharp
+// PdfStorageService.cs - DeletePdfAsync
+#pragma warning disable CA1031
+// Justification: CLEANUP PATTERN - Best-effort vector deletion
+// Main PDF deletion succeeds even if vector cleanup fails. Vector orphans are
+// acceptable; blocking PDF deletion is not. Error logged for manual cleanup.
+catch (Exception ex)
+{
+    _logger.LogWarning(ex, "Vector deletion failed for PDF {PdfId}, continuing", pdfId);
+    // Main deletion continues
+}
+#pragma warning restore CA1031
+```
+
+**Files**: PdfStorageService, PdfValidationService, CacheInvalidationService
+
+---
+
+### 6. BACKGROUND TASK PATTERN ⏰
+
+**Purpose**: Background/async tasks must handle all errors gracefully
+
+**Why Justified**:
+- Background tasks have no user to report errors to
+- Must log errors and update status tracking
+- Cannot crash background worker
+- Task-specific error handling (mark PDF as failed, retry later)
+
+**Examples**:
+```csharp
+// PdfStorageService.cs - Background PDF processing
+#pragma warning disable CA1031
+// Justification: BACKGROUND TASK PATTERN - Async PDF processing
+// Background task must not crash. All errors caught, logged, PDF marked as failed
+// for user visibility. Specific retries handled at higher level.
+catch (Exception ex)
+{
+    _logger.LogError(ex, "Background PDF processing failed for {PdfId}", pdfId);
+    await MarkPdfAsFailedAsync(pdfId, ex.Message);
+}
+#pragma warning restore CA1031
+```
+
+**Files**: PdfStorageService, BackgroundTaskService, SessionAutoRevocationService
+
+---
+
+### 7. NON-CRITICAL OPERATION PATTERN 📝
+
+**Purpose**: Telemetry/info operations shouldn't block main flow
+
+**Why Justified**:
+- Configuration fallback chain (DB → appsettings → default)
+- Webhook notification best-effort
+- Cache warming failures
+- Main operation succeeds regardless
+
+**Examples**:
+```csharp
+// ConfigurationHelper.cs - 3-tier fallback
+#pragma warning disable CA1031
+// Justification: NON-CRITICAL OPERATION PATTERN - Configuration fallback
+// Database config failures fall back to appsettings. Generic catch required
+// because DB errors vary (connection, timeout, serialization). Logged for monitoring.
+catch (Exception ex)
+{
+    _logger.LogWarning(ex, "Failed to load config {Key} from DB, trying appsettings", key);
+    // Fall back to next tier
+}
+#pragma warning restore CA1031
+```
+
+**Files**: ConfigurationHelper, WorkflowErrorLoggingService, CacheWarmingService
+
+---
+
+### 8. CONFIGURATION/FALLBACK PATTERN ⚙️
+
+**Purpose**: Handle DB/config layer failures with multi-tier fallback
+
+**Why Justified**:
+- 3-tier configuration system (DB → appsettings → defaults)
+- Database exceptions vary widely (connection, timeout, serialization)
+- Must gracefully degrade through fallback tiers
+- Each tier logged for monitoring
+
+**Examples**:
+```csharp
+// ConfigurationService.cs
+#pragma warning disable CA1031
+// Justification: CONFIGURATION/FALLBACK PATTERN - 3-tier config system
+// Database → appsettings → defaults. DB exceptions vary (network, serialization).
+// Must catch all to enable fallback. Proper logging at each tier.
+catch (Exception ex)
+{
+    _logger.LogWarning(ex, "Config tier 1 (DB) failed, falling back to tier 2");
+    // Try next tier
+}
+#pragma warning restore CA1031
+```
+
+**Files**: ConfigurationHelper, ConfigurationService, FeatureFlagService
+
+---
+
+### 9. EXTERNAL API PARSING PATTERN 🌐
+
+**Purpose**: Gracefully handle malformed external API responses
+
+**Why Justified**:
+- BGG API can change schema without notice
+- XML parsing can fail in various ways
+- Return null/empty rather than crashing entire feature
+- Comprehensive error logging
+
+**Examples**:
+```csharp
+// BggApiService.cs - ParseSearchResult
+#pragma warning disable CA1031
+// Justification: EXTERNAL API PARSING PATTERN - BGG XML parsing
+// BGG API schema can change. Various parsing exceptions possible (XmlException,
+// NullReferenceException on unexpected structure). Return null to skip bad items.
+catch (Exception ex)
+{
+    _logger.LogWarning(ex, "Failed to parse BGG search result");
+    return null; // Skip malformed item
+}
+#pragma warning restore CA1031
+```
+
+**Files**: BggApiService, OAuthService (provider response parsing)
+
+---
+
+## Code Quality Metrics
+
+### Pragma Warning Compliance
+- **Files with `catch(Exception)`**: 84
+- **Files with `#pragma warning disable CA1031`**: 84 (100%)
+- **Files with justification comments**: 84 (100%)
+
+### Pattern Distribution
+| Pattern | Count | % of Total |
+|---------|-------|------------|
+| SERVICE BOUNDARY | 45 | 54% |
+| MIDDLEWARE BOUNDARY | 3 | 4% |
+| RESILIENCE | 8 | 10% |
+| DATA ROBUSTNESS | 6 | 7% |
+| CLEANUP | 5 | 6% |
+| BACKGROUND TASK | 4 | 5% |
+| NON-CRITICAL | 7 | 8% |
+| CONFIGURATION/FALLBACK | 4 | 5% |
+| EXTERNAL API | 2 | 2% |
+
+---
+
+## Best Practices Observed
+
+### ✅ Proper Exception Handling Hierarchy
+
+All services follow this pattern:
+```csharp
+try
+{
+    // Operation
+}
+catch (TaskCanceledException ex)  // ✅ Specific catch first
+{
+    _logger.LogWarning("Operation cancelled");
+    return Result.Failure("Cancelled");
+}
+catch (HttpRequestException ex)   // ✅ Known exception types
+{
+    _logger.LogError(ex, "HTTP request failed");
+    return Result.Failure($"HTTP error: {ex.StatusCode}");
+}
+catch (JsonException ex)          // ✅ Anticipated errors
+{
+    _logger.LogError(ex, "JSON parsing failed");
+    return Result.Failure("Invalid response format");
+}
+#pragma warning disable CA1031
+catch (Exception ex)              // ✅ Generic catch LAST
+{
+    // Only reached if unexpected error
+    _logger.LogError(ex, "Unexpected error");
+    return Result.Failure("Unexpected error");
+}
+#pragma warning restore CA1031
+```
+
+---
+
+### ✅ Consistent Justification Format
+
+Every generic catch includes:
+1. **Pattern name**: `// Justification: SERVICE BOUNDARY PATTERN`
+2. **Rationale**: Why generic catch is appropriate
+3. **Context**: What errors are expected/unexpected
+4. **Error handling**: How errors are logged/returned
+
+Example:
+```csharp
+#pragma warning disable CA1031 // Do not catch general exception types
+// Justification: SERVICE BOUNDARY PATTERN - Service layer returning Result<T>
+// All known exceptions (TaskCanceledException, HttpRequestException, JsonException)
+// caught separately above. Generic catch handles unexpected infrastructure failures
+// (DB errors, memory, etc.) to prevent exception propagation to API layer.
+catch (Exception ex)
+{
+    _logger.LogError(ex, "Unexpected error in {Method}", nameof(MethodName));
+    return Result.CreateFailure($"Unexpected error: {ex.Message}");
+}
+#pragma warning restore CA1031
+```
+
+---
+
+### ✅ Result Pattern Usage
+
+Services use Result<T> objects instead of throwing:
+```csharp
+public class LlmCompletionResult
+{
+    public bool Success { get; init; }
+    public string? Content { get; init; }
+    public string? ErrorMessage { get; init; }
+
+    public static LlmCompletionResult CreateSuccess(string content) => new() { Success = true, Content = content };
+    public static LlmCompletionResult CreateFailure(string error) => new() { Success = false, ErrorMessage = error };
+}
+```
+
+**Benefit**: Exceptions only for truly exceptional cases; expected failures use Result pattern.
+
+---
+
+## Recommendations
+
+### ✅ Current State is Excellent
+
+The codebase requires **NO changes** to exception handling. Developers clearly understand:
+1. When generic exception handling is appropriate
+2. How to document justifications properly
+3. Architectural boundaries for exception handling
+4. The balance between safety and resilience
+
+### 📚 Documentation Enhancement (Optional)
+
+Consider adding exception handling guidelines to `CLAUDE.md`:
+
+```markdown
+## Generic Exception Handling Patterns (CA1031 Compliance)
+
+All catch(Exception) blocks require #pragma warning disable CA1031 and must use one of:
+
+1. **SERVICE BOUNDARY**: Service layer returning Result<T> objects
+2. **MIDDLEWARE BOUNDARY**: Request pipeline safeguards (auth, rate limiting)
+3. **RESILIENCE**: Multi-channel operations preventing cascading failures
+4. **DATA ROBUSTNESS**: Skipping malformed items in loops/batches
+5. **CLEANUP**: Best-effort non-critical operations
+6. **BACKGROUND TASK**: Async processing with status tracking
+7. **NON-CRITICAL**: Telemetry/info operations
+8. **CONFIGURATION/FALLBACK**: Multi-tier config system
+9. **EXTERNAL API**: Third-party API parsing
+
+Required format:
+\`\`\`csharp
+#pragma warning disable CA1031
+// Justification: [PATTERN NAME] - [Rationale]
+// [Context: What errors are expected/unexpected]
+// [Error handling: How errors are logged/returned]
+catch (Exception ex)
+{
+    _logger.LogError(ex, "Context");
+    return ErrorResult; // or continue, or fail-open
+}
+#pragma warning restore CA1031
+\`\`\`
+```
+
+---
+
+## False Positive Analysis
+
+### Why 220 Instances Reported
+
+Code scanners flag **all** `catch(Exception)` blocks as potential issues without understanding:
+1. Architectural boundaries (services, middleware)
+2. Proper justification comments
+3. Logging patterns
+4. Result<T> return patterns
+5. Fail-open vs fail-closed requirements
+
+### Actual Status
+
+- **Reported**: 220 generic catch clauses
+- **Problematic**: 0 (0%)
+- **Properly justified**: 220 (100%)
+- **Require changes**: 0
+
+---
+
+## References
+
+- **CWE-396**: Declaration of Catch for Generic Exception
+- **CA1031**: Do not catch general exception types
+- **Issue #738**: [META] Code Scanning Remediation Tracker
+- **Microsoft Docs**: [CA1031 Rule](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1031)
+
+---
+
+**Generated**: 2025-11-05
+**Status**: ✅ EXCELLENT - 100% Compliant, Zero Issues
+**Action Required**: None - codebase demonstrates best practices

--- a/docs/security/oauth-security.md
+++ b/docs/security/oauth-security.md
@@ -1,0 +1,484 @@
+# OAuth 2.0 Security Documentation
+
+**Feature**: AUTH-06 OAuth Providers (Google, Discord, GitHub)
+**Status**: Production
+**Last Updated**: 2025-12-13T10:59:23.970Z
+**Security Classification**: CRITICAL
+
+---
+
+## Executive Summary
+
+This document details the security architecture and implementation of OAuth 2.0 authentication for MeepleAI, covering token encryption, CSRF protection, account linking security, and operational security procedures.
+
+**Threat Model**: OAuth implementation protects against:
+- CSRF attacks via state parameter manipulation
+- Token theft via encryption at rest
+- Account takeover via provider compromise
+- OAuth flow abuse via rate limiting
+- Session hijacking via secure cookie handling
+
+---
+
+## Security Architecture
+
+### 1. Token Encryption (CRITICAL)
+
+**Implementation**: ASP.NET Core Data Protection API
+
+**Encryption Spec**:
+- **Algorithm**: AES-256-CBC with HMAC-SHA256 authentication
+- **Key Management**: Managed by Data Protection API (automatic key rotation)
+- **Purpose Strings**: `"OAuthTokens"` for OAuth token encryption
+- **Storage**: Encrypted tokens stored in `oauth_accounts.access_token_encrypted` and `refresh_token_encrypted`
+
+**Code Reference**:
+```csharp
+// apps/api/src/Api/Services/EncryptionService.cs:22-42
+private const string EncryptionPurpose = "OAuthTokens";
+
+var accessTokenEncrypted = await _encryption.EncryptAsync(
+    tokenResponse.AccessToken,
+    EncryptionPurpose);
+```
+
+**Key Rotation**:
+- Data Protection API automatically rotates keys every 90 days
+- Old keys retained for 90 days to decrypt existing tokens
+- No manual intervention required for key rotation
+- **Production Requirement**: Configure persistent key storage (Azure Key Vault, Redis, or file system)
+
+**Security Validation**:
+- ✅ Tokens never logged in plaintext
+- ✅ Purpose-based encryption prevents cross-context decryption
+- ✅ Automatic key rotation with backward compatibility
+- ⚠️ **Action Required**: Configure production key storage location
+
+---
+
+### 2. CSRF Protection (CRITICAL)
+
+**Implementation**: OAuth State Parameter
+
+**CSRF Flow**:
+1. **State Generation**: 32-byte cryptographically secure random value
+   ```csharp
+   // apps/api/src/Api/Program.cs:1209
+   var state = Convert.ToBase64String(
+       System.Security.Cryptography.RandomNumberGenerator.GetBytes(32));
+   ```
+
+2. **State Storage**: In-memory dictionary with 10-minute expiration
+   ```csharp
+   // apps/api/src/Api/Services/OAuthService.cs:25-26
+   private static readonly Dictionary<string, DateTime> _stateStore = new();
+   private static readonly TimeSpan StateLifetime = TimeSpan.FromMinutes(10);
+   ```
+
+3. **Single-Use Enforcement**: State removed immediately after validation
+   ```csharp
+   // apps/api/src/Api/Services/OAuthService.cs:180-183
+   if (now <= expiresAt)
+   {
+       _stateStore.Remove(state); // Single-use enforcement
+       return Task.FromResult(true);
+   }
+   ```
+
+4. **Validation**: State validated on OAuth callback before token exchange
+
+**Security Properties**:
+- ✅ 2^256 possible state values (cryptographically secure)
+- ✅ Single-use enforcement prevents replay attacks
+- ✅ 10-minute expiration limits attack window
+- ✅ Automatic cleanup of expired states
+- ⚠️ **Production Limitation**: In-memory storage lost on app restart
+
+**Production Recommendation**:
+```csharp
+// Migrate to Redis for production
+// apps/api/src/Api/Services/OAuthService.cs (future enhancement)
+// Use IDistributedCache instead of in-memory dictionary
+await _cache.SetStringAsync($"oauth:state:{state}", expiresAt.ToString(),
+    new DistributedCacheEntryOptions { AbsoluteExpiration = expiresAt });
+```
+
+---
+
+### 3. Rate Limiting
+
+**Implementation**: Token bucket algorithm via `IRateLimitService`
+
+**Limits**:
+- **OAuth Login**: 10 requests per minute per IP address
+- **OAuth Callback**: 10 requests per minute per IP address
+- **Rate Limit Key**: `oauth:login:{ipAddress}` or `oauth:callback:{ipAddress}`
+
+**Configuration**:
+```json
+// appsettings.json
+{
+  "RateLimit": {
+    "OAuth": {
+      "MaxTokens": 10,
+      "RefillRate": 0.16667  // 10 tokens per minute
+    }
+  }
+}
+```
+
+**Code Reference**:
+```csharp
+// apps/api/src/Api/Program.cs:1192-1206
+var rateLimitResult = await rateLimiter.CheckRateLimitAsync(
+    $"oauth:login:{ipAddress}",
+    oauthRateLimit.MaxTokens,
+    oauthRateLimit.RefillRate);
+
+if (!rateLimitResult.Allowed)
+{
+    context.Response.Headers["Retry-After"] = "60";
+    return Results.StatusCode(429); // Too Many Requests
+}
+```
+
+**Protection Against**:
+- ✅ OAuth flow abuse (excessive authorization requests)
+- ✅ CSRF brute force attempts (state guessing)
+- ✅ Token exchange flooding
+- ✅ DoS attacks on OAuth endpoints
+
+---
+
+### 4. Account Linking Security
+
+**Auto-Linking Strategy**: Trust OAuth provider's email verification (MVP)
+
+**Flow**:
+1. User authenticates via OAuth provider (Google/Discord/GitHub)
+2. System retrieves verified email from provider
+3. If user exists with same email → link OAuth account
+4. If user doesn't exist → create new user + OAuth account
+
+**Security Assumptions**:
+- OAuth provider (Google/Discord/GitHub) has verified the email address
+- Provider's OAuth implementation is secure
+- Email is unique identifier across users
+
+**Code Reference**:
+```csharp
+// apps/api/src/Api/Services/OAuthService.cs:98-106
+// Check if user exists with same email (auto-link for MVP)
+user = await _db.Users.FirstOrDefaultAsync(u => u.Email == userInfo.Email.ToLowerInvariant());
+
+if (user == null)
+{
+    // Create new user
+    user = new UserEntity { /* ... */ };
+}
+else
+{
+    // Link to existing user
+}
+```
+
+**Risk Assessment**:
+- **Risk**: If OAuth provider is compromised, attacker could link to existing accounts
+- **Mitigation**: Trust reputable providers (Google, Discord, GitHub)
+- **Future Enhancement**: Optional email verification before linking (AUTH-06-P6)
+
+**Account Takeover Scenarios**:
+| Scenario | Risk | Mitigation |
+|----------|------|------------|
+| Provider compromised | HIGH | Multi-factor auth on provider side |
+| Email spoofing | LOW | Providers validate email ownership |
+| Account enumeration | LOW | Generic error messages on login |
+
+---
+
+### 5. Session Security
+
+**Session Creation**: After successful OAuth callback
+
+**Flow**:
+1. OAuth provider validates user
+2. System validates CSRF state
+3. System creates session via `AuthService.CreateSessionForUserAsync()`
+4. Session cookie set with `HttpOnly`, `Secure`, `SameSite=Strict`
+
+**Code Reference**:
+```csharp
+// apps/api/src/Api/Program.cs:1247-1258
+var authResult = await authService.CreateSessionForUserAsync(
+    result.User.Id, sessionIpAddress, userAgent, ct);
+
+// Set session cookie
+WriteSessionCookie(context, authResult.SessionToken, authResult.ExpiresAt);
+```
+
+**Session Properties**:
+- ✅ HttpOnly: JavaScript cannot access session token
+- ✅ Secure: Only transmitted over HTTPS
+- ✅ SameSite=Strict: CSRF protection
+- ✅ IP address tracking: Session hijacking detection
+- ✅ User agent tracking: Device fingerprinting
+
+---
+
+### 6. Error Handling
+
+**Principle**: Never expose sensitive information to frontend
+
+**Implementation**:
+- **Frontend**: Generic error messages (`error=oauth_failed`, `error=rate_limit`)
+- **Backend Logs**: Detailed error messages with stack traces
+- **No Token Exposure**: Access/refresh tokens never logged
+
+**Code Reference**:
+```csharp
+// apps/api/src/Api/Program.cs:1265-1272
+catch (Exception ex)
+{
+    var logger = context.RequestServices.GetRequiredService<ILogger<Program>>();
+    logger.LogError(ex, "OAuth callback failed for provider: {Provider}", provider);
+
+    // Generic error to frontend
+    var redirectUrl = $"{frontendUrl}/auth/callback?error=oauth_failed";
+    return Results.Redirect(redirectUrl);
+}
+```
+
+**Error Types**:
+| Error | Frontend Message | Backend Log |
+|-------|------------------|-------------|
+| Invalid state | `error=oauth_failed` | "Invalid OAuth state parameter for provider: {Provider}" |
+| Rate limit | `error=rate_limit` | - |
+| Token exchange failed | `error=oauth_failed` | "Failed to exchange OAuth code for token. Provider: {Provider}" (HttpRequestException) |
+| User info failed | `error=oauth_failed` | "Failed to get user info from OAuth provider. Provider: {Provider}" (HttpRequestException) |
+
+---
+
+### 7. HTTPS Enforcement
+
+**Development**: Localhost exemption (HTTP allowed)
+
+**Production Requirements**:
+- ✅ `CallbackBaseUrl` must use HTTPS
+- ✅ OAuth provider callback URLs must use HTTPS
+- ✅ ASP.NET Core HTTPS redirection middleware enabled
+
+**Configuration**:
+```json
+// appsettings.Production.json
+{
+  "Authentication": {
+    "OAuth": {
+      "CallbackBaseUrl": "https://app.meepleai.com"  // HTTPS required
+    }
+  }
+}
+```
+
+**⚠️ Security Gap**: No explicit validation of HTTPS in code
+
+**Recommendation**:
+```csharp
+// apps/api/src/Api/Services/OAuthService.cs (future enhancement)
+private string GetCallbackUrl(string provider)
+{
+    var baseUrl = _config.CallbackBaseUrl.TrimEnd('/');
+
+    // Production HTTPS enforcement
+    if (!_env.IsDevelopment() && !baseUrl.StartsWith("https://"))
+    {
+        throw new InvalidOperationException(
+            "OAuth CallbackBaseUrl must use HTTPS in production");
+    }
+
+    return $"{baseUrl}/api/v1/auth/oauth/{provider.ToLowerInvariant()}/callback";
+}
+```
+
+---
+
+### 8. Audit Logging
+
+**Logged Events**:
+- ✅ OAuth login attempts (all providers)
+- ✅ OAuth callback success/failure
+- ✅ Account creation via OAuth
+- ✅ Account linking via OAuth
+- ✅ OAuth account unlinking
+- ✅ Token refresh attempts
+- ✅ Rate limit violations
+
+**Log Level Mapping**:
+```csharp
+// apps/api/src/Api/Services/OAuthService.cs
+_logger.LogDebug("Generated OAuth authorization URL");        // Line 59
+_logger.LogWarning("Invalid OAuth state parameter");          // Line 74
+_logger.LogInformation("OAuth login for existing account");   // Line 96
+_logger.LogInformation("Created new user via OAuth");         // Line 115
+_logger.LogInformation("Linking OAuth to existing user");     // Line 119
+_logger.LogError(ex, "Failed to exchange OAuth code");        // Line 296
+```
+
+**Audit Trail**:
+- All logs include timestamp, provider, user ID (if applicable)
+- Errors include exception details and stack traces
+- IP addresses logged for rate limit enforcement
+- User agents logged for session tracking
+
+---
+
+## Security Checklist (Production Deployment)
+
+### Pre-Deployment
+
+- [ ] **Key Storage**: Configure Data Protection key persistence (Azure Key Vault, Redis, or file system)
+- [ ] **HTTPS Enforcement**: Verify `CallbackBaseUrl` uses HTTPS
+- [ ] **OAuth Apps**: Register OAuth apps with production callback URLs
+- [ ] **Environment Variables**: Set `GOOGLE_OAUTH_CLIENT_SECRET`, `DISCORD_OAUTH_CLIENT_SECRET`, `GITHUB_OAUTH_CLIENT_SECRET`
+- [ ] **Rate Limiting**: Verify rate limits configured in `appsettings.Production.json`
+- [ ] **State Storage**: Consider migrating from in-memory to Redis for multi-instance deployments
+
+### Post-Deployment
+
+- [ ] **Token Encryption**: Verify tokens encrypted in database (`AccessTokenEncrypted` column)
+- [ ] **CSRF Protection**: Test invalid state parameter returns error
+- [ ] **Rate Limiting**: Test 11th request returns 429 status
+- [ ] **Error Handling**: Verify no sensitive data in frontend error messages
+- [ ] **Session Creation**: Verify session cookie set with `HttpOnly`, `Secure`, `SameSite=Strict`
+- [ ] **Audit Logs**: Verify OAuth events logged in Seq/Jaeger
+- [ ] **Token Refresh**: Test refresh token mechanism for Google/Discord
+
+---
+
+## Incident Response Procedures
+
+### Compromised OAuth Provider
+
+**Scenario**: OAuth provider (Google/Discord/GitHub) reports security breach
+
+**Actions**:
+1. **Immediate**: Revoke all OAuth tokens via provider's admin console
+2. **Within 1 hour**: Force re-authentication for all users with linked accounts
+3. **Within 24 hours**: Audit all account linking events during breach window
+4. **Communication**: Notify affected users via email
+
+**Code**:
+```sql
+-- Force re-auth by deleting OAuth accounts for compromised provider
+DELETE FROM oauth_accounts WHERE provider = 'google';  -- Example: Google breach
+```
+
+### Token Leakage
+
+**Scenario**: Encrypted tokens exposed (database dump, backup leak)
+
+**Actions**:
+1. **Immediate**: Rotate Data Protection keys
+   ```bash
+   # Force key rotation (generates new key, retires old ones)
+   dotnet run --rotate-keys
+   ```
+2. **Within 1 hour**: Decrypt and re-encrypt all tokens with new key
+3. **Within 24 hours**: Revoke all OAuth tokens via provider APIs
+4. **Communication**: Security advisory to users
+
+### CSRF Attack Detected
+
+**Scenario**: Large volume of invalid state parameters in logs
+
+**Actions**:
+1. **Immediate**: Review rate limit configuration
+2. **Within 1 hour**: Increase rate limits if legitimate traffic
+3. **Within 24 hours**: Analyze attack patterns (IP addresses, timing)
+4. **Mitigation**: Add IP-based blocking for repeat offenders
+
+---
+
+## Security Testing
+
+### Automated Tests
+
+**Test Coverage** (23 tests total):
+- ✅ `EncryptionServiceTests.cs`: 10 tests (encrypt, decrypt, purposes, error handling)
+- ✅ `OAuthServiceTests.cs`: 13 tests (URL generation, callback, state validation, account linking)
+
+**Security Test Cases**:
+```csharp
+// apps/api/tests/Api.Tests/OAuthServiceTests.cs
+[Fact] public async Task ValidateStateAsync_InvalidState_ReturnsFalse()
+[Fact] public async Task ValidateStateAsync_ExpiredState_ReturnsFalse()
+[Fact] public async Task ValidateStateAsync_ValidState_RemovesStateAfterValidation()
+[Fact] public async Task HandleCallbackAsync_InvalidState_ThrowsUnauthorizedAccessException()
+```
+
+### Manual Security Testing
+
+**Penetration Testing Checklist**:
+- [ ] **CSRF**: Attempt state parameter manipulation
+- [ ] **Token Theft**: Verify tokens encrypted in database
+- [ ] **Rate Limit Bypass**: Send >10 requests per minute
+- [ ] **Account Takeover**: Attempt linking with unverified email
+- [ ] **Session Hijacking**: Attempt cookie theft/replay
+- [ ] **Error Enumeration**: Verify generic error messages
+
+---
+
+## Known Limitations
+
+### 1. State Storage (In-Memory)
+
+**Limitation**: State dictionary lost on app restart, doesn't scale across instances
+
+**Impact**:
+- Users mid-OAuth flow will get "Invalid state" error after app restart
+- Multi-instance deployments will fail (state stored on different server)
+
+**Mitigation**: Migrate to Redis for production (AUTH-06-P7)
+
+### 2. Auto-Linking Without Verification
+
+**Limitation**: Trusts OAuth provider's email verification
+
+**Impact**: If provider compromised, attacker could link to existing accounts
+
+**Mitigation**:
+- Use reputable providers (Google, Discord, GitHub)
+- Consider optional email verification (AUTH-06-P6)
+
+### 3. No Token Expiry Validation
+
+**Limitation**: Tokens not validated before use (relies on provider's TTL)
+
+**Impact**: Expired tokens may cause API calls to fail
+
+**Mitigation**: Implement proactive token refresh before expiry (AUTH-06-P8)
+
+---
+
+## Security Contacts
+
+**Security Issues**: Report to security@meepleai.com
+**OAuth Provider Incidents**:
+- Google: https://security.google.com/settings/security/securitycheckup
+- Discord: https://support.discord.com/hc/en-us/requests/new
+- GitHub: https://support.github.com/contact/security
+
+---
+
+## References
+
+- [OAuth 2.0 RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749)
+- [OAuth 2.0 Security Best Practices](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics)
+- [ASP.NET Core Data Protection](https://docs.microsoft.com/en-us/aspnet/core/security/data-protection/)
+- [OWASP OAuth 2.0 Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/OAuth2_Cheat_Sheet.html)
+
+---
+
+**Document Status**: ✅ COMPLETE
+**Security Review**: ✅ PASSED (2025-10-27)
+**Next Review**: 2026-01-27 (Quarterly)
+

--- a/tools/dismiss-codeql-false-positives.sh
+++ b/tools/dismiss-codeql-false-positives.sh
@@ -123,13 +123,13 @@ case $choice in
         dismiss_alerts \
             "cs/log-forging" \
             "false positive" \
-            "False positive - Log forging is mitigated by global LogForgingSanitizationPolicy. See: docs/security/codeql-false-positive-management.md (pending restoration — see #745). Evidence: 100% structured logging, zero string interpolation, automatic newline sanitization in LoggingConfiguration.cs"
+            "False positive - Log forging is mitigated by global LogForgingSanitizationPolicy. See: docs/security/codeql-false-positive-management.md. Evidence: 100% structured logging, zero string interpolation, automatic newline sanitization in LoggingConfiguration.cs"
         ;;
     2)
         dismiss_alerts \
             "cs/catch-of-all-exceptions" \
             "won't fix" \
-            "Intentional pattern - All 220 instances are properly documented with #pragma warning disable CA1031 and architectural justifications. See: docs/security/codeql-false-positive-management.md and docs/security/generic-catch-analysis.md (both pending restoration — see #745)"
+            "Intentional pattern - All 220 instances are properly documented with #pragma warning disable CA1031 and architectural justifications. See: docs/security/codeql-false-positive-management.md and docs/security/generic-catch-analysis.md"
         ;;
     3)
         echo -e "${BLUE}Fetching all open alerts...${NC}"
@@ -167,7 +167,7 @@ echo ""
 echo "Next steps:"
 echo "1. Verify dismissals at: https://github.com/${REPO}/security/code-scanning"
 echo "2. Review remaining alerts and categorize them"
-echo "3. Update docs/security/codeql-false-positive-management.md if needed (pending restoration — see #745)"
+echo "3. Update docs/security/codeql-false-positive-management.md if needed"
 echo ""
 echo "Note: Automated config (.github/codeql/codeql-config.yml) will prevent"
 echo "      new Log Forging and Generic Exception alerts in future scans."


### PR DESCRIPTION
## Summary

Phase 1 of #745 restoration plan: bulk restore of 6 security documents that were dropped in commit `51ad45ed0` (2026-01-01 docs reorganization) without being re-created in the new flat `docs/security/` structure.

## Files restored

All 6 from `git show 51ad45ed0^:docs/06-security/<file>.md`:

| File | Lines | gitleaks |
|------|-------|----------|
| `client-side-encryption.md` | 652 | ✅ 0 leaks |
| `codeql-false-positive-management.md` | 381 | ✅ 0 leaks |
| `generic-catch-analysis.md` | 496 | ✅ 0 leaks |
| `frontend-security-best-practices.md` | 524 | ✅ 0 leaks |
| `oauth-security.md` | 484 | ✅ 0 leaks |
| `environment-variables-production.md` | 1079 | 🔧 7 redacted, then 0 leaks |

**Total**: 193 KB scanned, **0 leaks** post-redaction.

## 🔐 Security: secrets redaction in `environment-variables-production.md`

The Hightower critique in the spec-panel review (C-1) predicted this file would carry sample-but-realistic credentials. Confirmed:

| Line | Variable | Original | Redacted to |
|------|----------|----------|-------------|
| 146 | `QDRANT_API_KEY` | `qd_abc123xyz456...` | `qd_<CHANGE_ME>` |
| 232 | `SEQ_API_KEY` | `abc123xyz456` | `<CHANGE_ME>` |
| 283 | `SENTRY_AUTH_TOKEN` | `sntrys_abc123xyz456...` | `sntrys_<CHANGE_ME>` |
| 718 | `DISCORD_OAUTH_CLIENT_SECRET` | `abc123xyz456_secret` | `<CHANGE_ME>` |
| 725 | `GITHUB_OAUTH_CLIENT_ID` | `Iv1.abc123xyz456` | `Iv1.<CHANGE_ME>` |
| 733 | `GITHUB_OAUTH_CLIENT_SECRET` | `abc123xyz456secret789...` | `<CHANGE_ME>` |
| 818 | `PAGERDUTY_INTEGRATION_KEY` | `abc123xyz456def789...` | `<CHANGE_ME>` |

Informative prefixes (`qd_`, `sntrys_`, `Iv1.`) preserved to keep format guidance for users.

## 🔧 Drift fixes

3 files had stale `docs/06-security/` self-references (from before the 2026-01-01 reorg):
- `client-side-encryption.md:217` → updated path + new target marker (security-headers.md)
- `codeql-false-positive-management.md:237,279` → self-references updated (file is now restored at this path)
- `environment-variables-production.md:1076-1077` → 2 broken refs marked with #745

## 🧹 Marker cleanup (companion to restoration)

The 6 restored files were referenced from various source files with `(see #745)` markers. Now that the files exist, markers removed from:
- `apps/web/src/proxy.ts` (1)
- `tools/dismiss-codeql-false-positives.sh` (3)
- `apps/web/src/lib/security/README.md` (1)
- `apps/api/src/Api/BoundedContexts/Authentication/README.md` (2)
- `apps/api/src/Api/BoundedContexts/SystemConfiguration/README.md` (1)

## 🆕 Newly discovered #745 targets

During the drift review I noticed 2 more broken refs that point to files the restored docs themselves reference. Adding to #745 scope:
- `docs/security/security-headers.md` (referenced by `client-side-encryption.md`)
- `docs/security/docker-secrets-migration.md` (referenced by `environment-variables-production.md`)

I'll update the #745 plan after this PR merges.

## Test plan

- [ ] CI: GitGuardian + lychee link check pass
- [ ] Manual: open each restored file on GitHub and confirm rendering
- [ ] Manual: `gitleaks detect --source docs/security/ --no-git` returns 0 leaks (already verified locally)
- [ ] Manual: `grep -rn "(see #745)" docs/security/` shows only references to **un-restored** files (security-headers, docker-secrets-migration, secrets-management, audit-trail, SECURITY.md)

## Phase progress

After this PR merges:
- ✅ Phase 1 complete (6 of 9 files restored)
- ⏳ Phase 2 next: `secrets-management.md`, `SECURITY.md` root, `adr-010-security-headers-middleware.md`
- ⏳ Phase 2.5: audit-trail BC discovery
- ⏳ Phase 3: author `audit-trail.md`
- ⏳ Phase 4: validation + final marker cleanup

Closes part of #745 (Phase 1)
Refs #186