### PR TITLE
fix(deps): #186 P0 — bump axios to >=1.15.1 + re-enable Dependabot

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -277,7 +277,7 @@
     "overrides": {
       "@babel/runtime": ">=7.26.10",
       "@isaacs/brace-expansion": ">=5.0.1",
-      "axios": ">=1.13.5",
+      "axios": ">=1.15.1",
       "dompurify": ">=3.2.4",
       "glob": ">=10.5.0",
       "js-yaml": ">=4.1.1",

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@babel/runtime': '>=7.26.10'
   '@isaacs/brace-expansion': '>=5.0.1'
-  axios: '>=1.13.5'
+  axios: '>=1.15.1'
   dompurify: '>=3.2.4'
   glob: '>=10.5.0'
   js-yaml: '>=4.1.1'
@@ -4928,7 +4928,7 @@ packages:
   '@zodios/core@10.9.6':
     resolution: {integrity: sha512-aH4rOdb3AcezN7ws8vDgBfGboZMk2JGGzEq/DtW65MhnRxyTGRuLJRWVQ/2KxDgWvV2F5oTkAS+5pnjKbl0n+A==}
     peerDependencies:
-      axios: '>=1.13.5'
+      axios: '>=1.15.1'
       zod: ^3.x
 
   abort-controller@3.0.0:
@@ -5168,8 +5168,8 @@ packages:
     resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
     engines: {node: '>=4'}
 
-  axios@1.13.5:
-    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -6602,8 +6602,8 @@ packages:
   focus-trap@8.0.0:
     resolution: {integrity: sha512-Aa84FOGHs99vVwufDMdq2qgOwXPC2e9U66GcqBhn1/jEHPDhJaP8PYhkIbqG9lhfL5Kddk/567lj46LLHYCRUw==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -8512,6 +8512,10 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
@@ -15039,9 +15043,9 @@ snapshots:
       d3-selection: 3.0.0
       d3-zoom: 3.0.0
 
-  '@zodios/core@10.9.6(axios@1.13.5)(zod@3.25.76)':
+  '@zodios/core@10.9.6(axios@1.16.0)(zod@3.25.76)':
     dependencies:
-      axios: 1.13.5
+      axios: 1.16.0
       zod: 3.25.76
 
   abort-controller@3.0.0:
@@ -15284,11 +15288,11 @@ snapshots:
 
   axe-core@4.11.3: {}
 
-  axios@1.13.5:
+  axios@1.16.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -16964,7 +16968,7 @@ snapshots:
     dependencies:
       tabbable: 6.4.0
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:
@@ -18732,8 +18736,8 @@ snapshots:
     dependencies:
       '@apidevtools/swagger-parser': 10.1.1(openapi-types@12.1.3)
       '@liuli-util/fs-extra': 0.1.0
-      '@zodios/core': 10.9.6(axios@1.13.5)(zod@3.25.76)
-      axios: 1.13.5
+      '@zodios/core': 10.9.6(axios@1.16.0)(zod@3.25.76)
+      axios: 1.16.0
       cac: 6.7.14
       handlebars: 4.7.8
       openapi-types: 12.1.3
@@ -19254,6 +19258,8 @@ snapshots:
       - supports-color
 
   proxy-from-env@1.1.0: {}
+
+  proxy-from-env@2.1.0: {}
 
   psl@1.15.0:
     dependencies:


### PR DESCRIPTION
## Summary

Q2 2026 Security Review (#186) **P0 action items** — first batch:

1. ✅ **axios bump** to `>=1.15.1` (committed in this PR) — closes 4 HIGH advisories
2. ✅ **Dependabot re-enabled** at repo level (operational change via API, no file diff)

## 1. axios bump (file change in this PR)

| Before | After |
|--------|-------|
| `pnpm.overrides.axios = ">=1.13.5"` | `pnpm.overrides.axios = ">=1.15.1"` |
| Resolved: `axios@1.13.5` | Resolved: `axios@1.16.0` |

### 4 HIGH advisories closed
- GHSA-xx6v-rp6x-q39c — XSRF Token Cross-Origin Leakage via Prototype Pollution Gadget in `withXSRFToken` Boolean Coercion
- GHSA-vf2m-468p-8v99 — Header Injection via Prototype Pollution
- Incomplete CVE-2025-62718 fix — NO_PROXY Bypassed via RFC 1122 Loopback Subnet (127.0.0.0/8) in Axios 1.15.0
- Prototype pollution read-side gadgets in HTTP adapter (credential injection / request hijacking)

### Audit before/after

| Severity | Before | After | Δ |
|----------|--------|-------|----|
| Critical | 2 | 2 | 0 |
| High     | 16 | **12** | **−4** |
| Moderate | 27 | 16 | −11 |
| Low      | 3 | 2 | −1 |
| **Total** | **48** | **32** | **−16** |

The −16 total reflects axios bump (4 HIGH directly) plus cascading transitive resolutions cleared by the same `pnpm install`. Q2 review action items P0/2 (protobufjs/handlebars CRITICAL) will be addressed in a follow-up PR — they require pnpm overrides on packages that may have less obvious upstream constraints.

### Runtime impact assessment
- axios is in the **runtime path** (consumed by `openapi-zod-client`)
- Bump is semver-minor (1.13.x → 1.16.x): expected source-compatible
- No code changes needed in `apps/web/src/`
- Pre-push hooks verified: typecheck ✅, frontend build ✅, backend build ✅

## 2. Dependabot re-enabled (operational, no file diff)

```bash
# Vulnerability alerts (security alerts)
gh api -X PUT repos/meepleAi-app/meepleai-monorepo/vulnerability-alerts
# → HTTP 204 No Content (success)

# Automated security fixes (auto-PRs for security updates)
gh api -X PUT repos/meepleAi-app/meepleai-monorepo/automated-security-fixes
# → HTTP 204 No Content (success)
```

`.github/dependabot.yml` was **already correctly configured** (NuGet, npm, GitHub Actions, Docker ecosystems) — repo-level disable was the only blocker. Now back online; weekly Monday 02:00 UTC schedule will produce the first scan automatically.

This addresses Q2 review §2.5 finding "Dependabot is DISABLED for this repo".

## Test plan

- [x] `pnpm audit --audit-level=high` shows 12 HIGH (down from 16) — no axios HIGH remaining
- [x] `grep "^  axios@" pnpm-lock.yaml` returns `axios@1.16.0`
- [x] Frontend typecheck passes (pre-commit hook)
- [x] Frontend build passes (pre-push hook)
- [x] Backend build passes (pre-push hook)
- [ ] CI: GitGuardian + Lychee + Backend tests pass
- [ ] After merge: verify Dependabot security alerts UI shows live alerts within 24h
- [ ] After merge: confirm Dependabot scheduled scan on Monday 2026-05-12 produces any expected security PRs

## Q2 review progress

After this PR merges:
- ✅ P0/1: Re-enable Dependabot (this PR)
- ✅ P0/2: Bump axios (this PR)
- ⏳ P0/3: Bulk-dismiss `cs/log-forging` 87 alerts (separate PR/script run)
- ⏳ P0/4: Fix protobufjs + handlebars CRITICAL (separate PR via `pnpm.overrides`)

Refs #186 (P0 action items)