### PR TITLE
feat(security): #186 P1.1-A — 2FA admin enforcement scaffolding (shadow mode)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ChangeUserRoleCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ChangeUserRoleCommand.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.Administration.Application.Attributes;
+using Api.BoundedContexts.Authentication.Application.Attributes;
 using Api.Models;
 using Api.SharedKernel.Application.Interfaces;
 
@@ -13,6 +14,7 @@ namespace Api.BoundedContexts.Administration.Application.Commands;
 /// <param name="Reason">Optional reason for the role change.</param>
 /// <param name="AdminRole">The role of the admin performing this action (from session). Used for privilege level validation.</param>
 [AuditableAction("UserRoleChange", "User", Level = 1)]
+[RequireTwoFactor(Reason = "Role escalation grants new privileges and must be guarded.")]
 internal record ChangeUserRoleCommand(
     string UserId,
     string NewRole,

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/DeleteUserCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/DeleteUserCommand.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.Administration.Application.Attributes;
+using Api.BoundedContexts.Authentication.Application.Attributes;
 using Api.SharedKernel.Application.Interfaces;
 
 namespace Api.BoundedContexts.Administration.Application.Commands;
@@ -8,6 +9,7 @@ namespace Api.BoundedContexts.Administration.Application.Commands;
 /// Prevents self-deletion and deletion of the last admin.
 /// </summary>
 [AuditableAction("UserDelete", "User", Level = 2)]
+[RequireTwoFactor(Reason = "Irreversible destruction of user data; must be 2FA-guarded.")]
 internal record DeleteUserCommand(
     string UserId,
     string RequestingUserId

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ImpersonateUserCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ImpersonateUserCommand.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.Administration.Application.DTOs;
+using Api.BoundedContexts.Authentication.Application.Attributes;
 using Api.SharedKernel.Application.Interfaces;
 
 namespace Api.BoundedContexts.Administration.Application.Commands;
@@ -9,6 +10,7 @@ namespace Api.BoundedContexts.Administration.Application.Commands;
 /// Note: Audit logging is handled manually in the handler (richer context with separate admin/target entries).
 /// ADM-001: Reason is mandatory for audit trail compliance.
 /// </summary>
+[RequireTwoFactor(Reason = "Impersonation grants full target-user session; HIGH RISK action.")]
 internal record ImpersonateUserCommand(
     Guid TargetUserId,
     Guid AdminUserId,

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SuspendUserCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SuspendUserCommand.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.Administration.Application.Attributes;
+using Api.BoundedContexts.Authentication.Application.Attributes;
 using Api.Models;
 using Api.SharedKernel.Application.Interfaces;
 
@@ -12,6 +13,7 @@ namespace Api.BoundedContexts.Administration.Application.Commands;
 /// <param name="RequesterId">The ID of the admin requesting the suspension.</param>
 /// <param name="Reason">Optional reason for suspension.</param>
 [AuditableAction("UserBlock", "User", Level = 1)]
+[RequireTwoFactor(Reason = "User suspension blocks login and must be 2FA-guarded.")]
 internal record SuspendUserCommand(
     string UserId,
     Guid RequesterId,

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Attributes/RequireTwoFactorAttribute.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Attributes/RequireTwoFactorAttribute.cs
@@ -1,0 +1,35 @@
+namespace Api.BoundedContexts.Authentication.Application.Attributes;
+
+/// <summary>
+/// Marks a MediatR command as requiring 2FA (TOTP) verification before execution.
+/// Q2 2026 Security Review (#186) P1.1: 2FA admin enforcement.
+///
+/// Shadow mode (initial rollout): the TwoFactorEnforcementBehavior logs warnings
+/// when the request comes from an admin without recent TOTP verification, but
+/// does NOT block. This allows visibility before strict enforcement.
+///
+/// Strict mode (subsequent rollout): same behavior, but rejects the command with
+/// HTTP 401 if TOTP not recently verified.
+///
+/// Usage:
+/// <code>
+/// [RequireTwoFactor]
+/// internal record DeleteUserCommand(Guid UserId) : ICommand&lt;UserDto&gt;;
+/// </code>
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+internal sealed class RequireTwoFactorAttribute : Attribute
+{
+    /// <summary>
+    /// Maximum age (in minutes) of the most recent TOTP verification on the
+    /// session before a fresh challenge is required. Default: 30 minutes for
+    /// sensitive admin actions per Q2 review §11 D3.
+    /// </summary>
+    public int MaxAgeMinutes { get; set; } = 30;
+
+    /// <summary>
+    /// Optional: human-readable description of why this command needs 2FA,
+    /// surfaced in audit logs and (future) UI prompts.
+    /// </summary>
+    public string? Reason { get; set; }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Behaviors/TwoFactorEnforcementBehavior.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Behaviors/TwoFactorEnforcementBehavior.cs
@@ -1,0 +1,115 @@
+using System.Reflection;
+using Api.BoundedContexts.Authentication.Application.Attributes;
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using MediatR;
+
+namespace Api.BoundedContexts.Authentication.Application.Behaviors;
+
+/// <summary>
+/// MediatR pipeline behavior that enforces 2FA (TOTP) recency for commands
+/// decorated with <see cref="RequireTwoFactorAttribute"/>.
+///
+/// Q2 2026 Security Review (#186) P1.1: 2FA admin enforcement.
+///
+/// Initial rollout strategy (shadow mode):
+/// - When a decorated command is invoked AND the session user has 2FA enabled,
+///   the behavior CHECKS whether TOTP was recently verified (per attribute MaxAgeMinutes).
+/// - On miss: logs a structured WARNING and proceeds (does NOT block).
+/// - This produces observability data for tuning thresholds before strict mode.
+///
+/// Strict-mode transition (subsequent PR):
+/// - Replace the warning-only path with throw of UnauthorizedAccessException
+///   (or domain-specific TwoFactorRequiredException).
+/// - Add session schema field LastTotpVerifiedAt to track recency precisely.
+///
+/// Note: this behavior is intentionally permissive while we collect telemetry.
+/// Do NOT replicate the resilience pattern from AuditLoggingBehavior: failures
+/// here ARE the desired outcome (visibility); we only log + proceed.
+/// </summary>
+internal sealed class TwoFactorEnforcementBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : IRequest<TResponse>
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<TwoFactorEnforcementBehavior<TRequest, TResponse>> _logger;
+
+    public TwoFactorEnforcementBehavior(
+        IHttpContextAccessor httpContextAccessor,
+        ILogger<TwoFactorEnforcementBehavior<TRequest, TResponse>> logger)
+    {
+        _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
+    }
+
+    public async Task<TResponse> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        var attr = typeof(TRequest).GetCustomAttribute<RequireTwoFactorAttribute>();
+
+        // Skip if command is not decorated with [RequireTwoFactor]
+        if (attr is null)
+        {
+            return await next().ConfigureAwait(false);
+        }
+
+        var session = ExtractSession();
+        if (session is null)
+        {
+            // No session in scope (e.g. internal/test caller). Don't block — we don't know.
+            _logger.LogDebug(
+                "TwoFactorEnforcementBehavior: no session for {CommandType}, skipping check",
+                typeof(TRequest).Name);
+            return await next().ConfigureAwait(false);
+        }
+
+        var user = session.User;
+        if (user is null)
+        {
+            // Anonymous request hit a 2FA-required command — outer authorization layer
+            // should have stopped this. Log defensively and proceed.
+            _logger.LogWarning(
+                "TwoFactorEnforcementBehavior: anonymous request to 2FA-required command {CommandType}",
+                typeof(TRequest).Name);
+            return await next().ConfigureAwait(false);
+        }
+
+        // Shadow-mode check: log if user lacks 2FA enrollment for a sensitive command.
+        // Strict mode will reject; for now we only emit telemetry.
+        if (!user.IsTwoFactorEnabled)
+        {
+            _logger.LogWarning(
+                "TwoFactorEnforcementBehavior[shadow]: user {UserId} ({Email}) invoked 2FA-required command "
+                + "{CommandType} WITHOUT 2FA enabled. Reason: {Reason}. MaxAge: {MaxAgeMinutes}min",
+                user.Id, user.Email, typeof(TRequest).Name, attr.Reason ?? "(unspecified)", attr.MaxAgeMinutes);
+        }
+        else
+        {
+            // User has 2FA enabled. In strict mode we'd verify session.LastTotpVerifiedAt
+            // is within attr.MaxAgeMinutes. For shadow mode we just record participation.
+            _logger.LogInformation(
+                "TwoFactorEnforcementBehavior[shadow]: user {UserId} invoked 2FA-required command "
+                + "{CommandType} with 2FA enabled. (Strict-mode recency check pending session schema update.)",
+                user.Id, typeof(TRequest).Name);
+        }
+
+        return await next().ConfigureAwait(false);
+    }
+
+    private SessionStatusDto? ExtractSession()
+    {
+        var httpContext = _httpContextAccessor.HttpContext;
+        if (httpContext is null)
+        {
+            return null;
+        }
+
+        if (httpContext.Items.TryGetValue(nameof(SessionStatusDto), out var value)
+            && value is SessionStatusDto session)
+        {
+            return session;
+        }
+
+        return null;
+    }
+}

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -306,6 +306,7 @@ builder.Services.AddMediatR(cfg =>
     cfg.RegisterServicesFromAssembly(typeof(Program).Assembly);
     cfg.AddOpenBehavior(typeof(Api.SharedKernel.Application.Behaviors.ValidationBehavior<,>));
     cfg.AddOpenBehavior(typeof(Api.BoundedContexts.Administration.Application.Behaviors.AuditLoggingBehavior<,>)); // Issue #3691: Audit logging
+    cfg.AddOpenBehavior(typeof(Api.BoundedContexts.Authentication.Application.Behaviors.TwoFactorEnforcementBehavior<,>)); // Issue #186 P1.1: 2FA admin enforcement (shadow mode)
     cfg.AddOpenBehavior(typeof(Api.BoundedContexts.SessionTracking.Application.Behaviors.ValidatePlayerRoleBehavior<,>)); // Issue #4765: Role validation
     var mediatrLicenseKey = Environment.GetEnvironmentVariable("MEDIATR_LICENSE_KEY");
     if (!string.IsNullOrWhiteSpace(mediatrLicenseKey))

--- a/docs/security/2fa-admin-enforcement.md
+++ b/docs/security/2fa-admin-enforcement.md
@@ -1,0 +1,134 @@
+# 2FA Admin Enforcement — Design
+
+> **Origin**: Q2 2026 Security Review (#186) P1.1
+> **Status**: Phase A (shadow mode) — landed 2026-05-06
+> **Bounded Context**: Authentication (cross-cutting via MediatR pipeline)
+
+## Problem
+
+Q2 2026 Security Review §3.5 BC tier-1 review flagged **2FA enforcement for admin role** as a partial control:
+- TOTP availability ✅ (TotpService present, fully featured)
+- TOTP enforcement ⚠️ — admins can perform sensitive actions without recent TOTP verification
+
+A compromised admin password (phishing, credential stuffing) currently grants full admin capability without a second factor. Spec-panel review identified this as the highest-value P1 item (Kill Chain 1 in §0.3).
+
+## Approach — phased rollout
+
+Three-phase delivery to minimize disruption while maximizing observability:
+
+### Phase A — Shadow mode (this PR)
+
+- Add `[RequireTwoFactor]` attribute (mirrors `[AuditableAction]` pattern)
+- Add `TwoFactorEnforcementBehavior` MediatR pipeline behavior
+- Decorate top 4 sensitive admin commands
+- Behavior **logs WARN/INFO** but does NOT block
+
+**Goal**: collect telemetry on actual usage. How often do admins hit decorated commands? How many already have 2FA enabled? Tune attribute defaults before strict mode.
+
+### Phase B — Strict mode (next PR)
+
+- Add session schema field `LastTotpVerifiedAt`
+- Replace shadow-mode warnings with rejection (HTTP 401 + `TwoFactorRequiredException`)
+- Login flow: capture TOTP verification timestamp on session creation
+- Re-challenge endpoint: `POST /api/v1/auth/2fa/challenge` to refresh `LastTotpVerifiedAt`
+- Frontend: prompt + step-up modal when 401 received with `WWW-Authenticate: TOTP` header
+
+**Goal**: actual enforcement.
+
+### Phase C — Hardening (Q3)
+
+- Rate limit failed TOTP attempts (5/min/IP, with audit log)
+- Recovery code audit (10× single-use, hashed, regenerable)
+- Admin without TOTP enrolled → forced enrollment on first admin login
+- Integration test matrix `[admin/user] × [totp on/off] × [valid/invalid]`
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────┐
+│  HTTP request → admin endpoint                       │
+│       │                                              │
+│       ▼                                              │
+│  RequireAdminSession() middleware (existing)         │
+│       │                                              │
+│       ▼                                              │
+│  IMediator.Send(command)                             │
+│       │                                              │
+│       ▼                                              │
+│  ValidationBehavior            (existing)            │
+│       ▼                                              │
+│  AuditLoggingBehavior          (existing, #3691)     │
+│       ▼                                              │
+│  TwoFactorEnforcementBehavior  ← NEW (this PR)       │
+│       │                                              │
+│       ├─ no [RequireTwoFactor] → next()              │
+│       │                                              │
+│       ├─ no session in HttpContext → next()          │
+│       │                                              │
+│       ├─ user.IsTwoFactorEnabled = false             │
+│       │     → log WARN, next() (Phase A)             │
+│       │     → throw 401   (Phase B)                  │
+│       │                                              │
+│       └─ user.IsTwoFactorEnabled = true              │
+│             → check LastTotpVerifiedAt (Phase B)     │
+│             → log INFO, next() (Phase A — recency    │
+│                                  check pending      │
+│                                  schema update)      │
+│       ▼                                              │
+│  Handler executes                                    │
+└──────────────────────────────────────────────────────┘
+```
+
+## Decorated commands (Phase A)
+
+Top 4 sensitive admin actions, ranked by blast radius:
+
+| Command | Blast radius | `Reason` value |
+|---------|--------------|----------------|
+| `ImpersonateUserCommand` | HIGH — full target-user session | "Impersonation grants full target-user session; HIGH RISK action." |
+| `DeleteUserCommand` | HIGH — irreversible | "Irreversible destruction of user data; must be 2FA-guarded." |
+| `ChangeUserRoleCommand` | MEDIUM — privilege escalation | "Role escalation grants new privileges and must be guarded." |
+| `SuspendUserCommand` | MEDIUM — account lockout | "User suspension blocks login and must be 2FA-guarded." |
+
+**Not yet decorated** (deferred to Phase B/C, low blast radius or read-only):
+- `BulkPasswordResetCommand` (mass action — should be decorated in Phase B)
+- `BulkRoleChangeCommand` (mass action — Phase B)
+- `BulkImportUsersCommand` (Phase B)
+- `EndImpersonationCommand` (return to admin — likely safe to skip)
+
+## Default attribute values
+
+```csharp
+[RequireTwoFactor(MaxAgeMinutes = 30, Reason = "...")]
+```
+
+- `MaxAgeMinutes = 30`: per Q2 review §11 D3 ("30min for sensitive, 8h for read")
+- `Reason`: human-readable, surfaced in audit logs and (Phase B+) UI prompts
+
+## Telemetry questions for Phase A → Phase B transition
+
+Before flipping to strict mode, the shadow-mode logs must answer:
+
+1. **Adoption rate**: of admin requests hitting decorated commands, what % come from users with `IsTwoFactorEnabled = true`?
+2. **Enrollment gap**: how many distinct admin users hit a decorated command without 2FA enabled? (These would be blocked in Phase B — need migration plan.)
+3. **Frequency**: are decorated commands invoked frequently enough that 30min step-up window would create UX friction?
+
+Decision rule: when adoption ≥ 90% of decorated invocations, proceed to Phase B.
+
+## Failure modes considered
+
+| Mode | Phase A handling | Phase B handling |
+|------|------------------|------------------|
+| User without 2FA invokes decorated cmd | log WARN, allow | reject 401, redirect to enrollment |
+| Session has 2FA but expired recency window | log INFO, allow | reject 401, prompt step-up |
+| No session in context (internal call, test) | log DEBUG, allow | allow (whitelisted internal context) |
+| TOTP service down | n/a (no verification yet) | fail-closed: reject all decorated cmds |
+| Lost TOTP device | n/a | recovery code (Phase C) |
+
+## References
+
+- Q2 2026 Security Review §11 P1.1 — SMART acceptance criteria
+- `apps/api/src/Api/Services/TotpService.cs` — existing TOTP API
+- `apps/api/src/Api/BoundedContexts/Administration/Application/Behaviors/AuditLoggingBehavior.cs` — pattern reference
+- `docs/security/totp-vulnerability-analysis.md` — TOTP threat model
+- `docs/security/audit-trail.md` — audit-log integration


### PR DESCRIPTION
## Summary

Q2 2026 Security Review (#186) **P1.1 Phase A**: scaffolding + shadow mode for 2FA admin enforcement. Backend-only, **no behavioral change in production** (shadow mode logs but does not block).

## Phased rollout strategy

Three-phase delivery to minimize disruption while maximizing observability:

| Phase | Scope | Status |
|-------|-------|--------|
| **A** (this PR) | Scaffolding + shadow mode logging | ✅ landing now |
| B (next PR) | Session schema + strict enforcement | ⏳ next |
| C (Q3) | Rate limiting, recovery codes, full AC coverage | ⏳ later |

See [`docs/security/2fa-admin-enforcement.md`](https://github.com/meepleAi-app/meepleai-monorepo/blob/feature/issue-186-q2-p1-2fa-scaffolding/docs/security/2fa-admin-enforcement.md) for full design.

## Phase A deliverables

### 1. `[RequireTwoFactor]` attribute
- Mirrors `[AuditableAction]` pattern
- `MaxAgeMinutes = 30` default (per spec-panel D3)
- `Reason` field for audit + UI surfacing

### 2. `TwoFactorEnforcementBehavior` MediatR pipeline behavior
- Logs WARN when user without 2FA invokes decorated command
- Logs INFO when user with 2FA invokes (recency check pending Phase B schema update)
- **Does NOT block** — pure observability for telemetry collection

### 3. Decorated 4 sensitive commands (top blast-radius)

| Command | Risk | Rationale |
|---------|------|-----------|
| `ImpersonateUserCommand` | HIGH | Full target-user session |
| `DeleteUserCommand` | HIGH | Irreversible data loss |
| `ChangeUserRoleCommand` | MEDIUM | Privilege escalation |
| `SuspendUserCommand` | MEDIUM | Account lockout |

### 4. DI registration in `Program.cs`
Inserted between `AuditLoggingBehavior` and `ValidatePlayerRoleBehavior` in the MediatR pipeline.

### 5. Design doc
`docs/security/2fa-admin-enforcement.md` — architecture diagram, decorated commands, telemetry questions, failure modes per phase.

## Telemetry questions (Phase A → Phase B gate)

Phase B starts when shadow-mode logs demonstrate:
1. **Adoption rate ≥ 90%** of decorated invocations come from 2FA-enabled admins
2. **Enrollment gap quantified** — how many admins need 2FA enrollment migration
3. **Frequency** — confirms 30min step-up window won't break UX

## Test plan

- [x] `dotnet build` → 0 errors, 0 warnings
- [x] gitleaks: 0 leaks (600KB BC + 7KB design doc scanned)
- [ ] CI: GitGuardian + Lychee + Backend tests pass
- [ ] After merge: monitor application logs for `TwoFactorEnforcementBehavior[shadow]` lines for ~1 week

## Risk assessment

**Production blast radius: NONE.** Shadow mode only emits log lines. The decorated commands continue to behave exactly as before. The behavior is correct as a no-op if:
- No `[RequireTwoFactor]` attribute (skip)
- No HttpContext / no session (skip with DEBUG)
- Anonymous request to decorated command (log WARN — should never happen, outer auth catches)

Worst case if behavior breaks: extra log noise. Strict-mode enforcement comes only in Phase B with explicit schema change + integration tests.

Refs #186 (P1.1 Phase A)