### PR TITLE
feat(infra): #795 harden against Docker UFW bypass with DOCKER-USER chain

### DIFF
--- a/.github/workflows/security-audit-staging.yml
+++ b/.github/workflows/security-audit-staging.yml
@@ -1,0 +1,115 @@
+name: Security Audit — Staging external port scan
+
+# Runs daily at 04:00 UTC. Verifies that only port 22 is reachable from the
+# public Internet on the staging server. Opens an issue on drift.
+#
+# Spec: docs/superpowers/specs/2026-05-06-database-network-isolation-design.md
+# Issue: #795
+
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Target IP/hostname (default: staging 204.168.135.69)"
+        required: false
+        default: "204.168.135.69"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  port-scan:
+    name: External nmap scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install nmap
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq nmap
+
+      - name: Run security-audit.sh against staging
+        id: audit
+        env:
+          SECURITY_AUDIT_TARGET: ${{ inputs.target || '204.168.135.69' }}
+        run: |
+          set +e
+          OUTPUT=$(bash infra/scripts/security-audit.sh 2>&1)
+          RC=$?
+          echo "rc=$RC" >> "$GITHUB_OUTPUT"
+          # Save output to file (escape multiline for GH Actions output)
+          {
+            echo "audit_output<<EOF_AUDIT"
+            echo "$OUTPUT"
+            echo "EOF_AUDIT"
+          } >> "$GITHUB_OUTPUT"
+          # Display in workflow logs
+          echo "$OUTPUT"
+          exit $RC
+
+      - name: Open issue on drift detected
+        if: failure() && steps.audit.outputs.rc != '0'
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const target = process.env.TARGET || '204.168.135.69';
+            const output = `${{ steps.audit.outputs.audit_output }}`;
+            const today = new Date().toISOString().slice(0,10);
+            const title = `[Security Drift] Unauthorized open ports detected on ${target} — ${today}`;
+            const body = [
+              '## 🚨 Security audit drift detected',
+              '',
+              `**Target**: \`${target}\``,
+              `**Date**: ${today}`,
+              `**Workflow run**: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              '',
+              '### Audit output',
+              '',
+              '```',
+              output,
+              '```',
+              '',
+              '### Reference',
+              '- Spec: `docs/superpowers/specs/2026-05-06-database-network-isolation-design.md`',
+              '- Original incident: #795',
+              '',
+              '### Triage',
+              '1. SSH to target: `ssh deploy@${target}`',
+              '2. Check listeners: `sudo ss -tlnp | grep -vE "127\\.0\\.0\\.1:|\\[::1\\]:"`',
+              '3. Check Docker port maps: `docker ps --format "table {{.Names}}\\t{{.Ports}}"`',
+              '4. Verify DOCKER-USER chain: `sudo iptables -L DOCKER-USER -n -v --line-numbers`',
+            ].join('\n');
+            // De-duplicate: search for an existing open issue with same title pattern
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'security-drift',
+              per_page: 50
+            });
+            const sameDay = existing.data.find(i => i.title.includes(today) && i.title.includes('Security Drift'));
+            if (sameDay) {
+              core.info(`Issue already exists for today: #${sameDay.number}`);
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: sameDay.number,
+                body: `New audit run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\n\`\`\`\n${output}\n\`\`\``
+              });
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['security-drift', 'priority:high', 'type:security']
+              });
+              core.info(`Issue created: #${created.data.number}`);
+            }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
@@ -745,7 +745,12 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
                 PageNumber = chunk.Page,
                 Content = chunk.Text,
                 CharacterCount = chunk.Text.Length,
-                CreatedAt = _timeProvider.GetUtcNow().UtcDateTime
+                CreatedAt = _timeProvider.GetUtcNow().UtcDateTime,
+                // Issue #730: persist chunk hierarchy fields from chunking pipeline
+                Heading = chunk.Heading,
+                Level = chunk.Level,
+                ParentChunkId = chunk.ParentChunkId,
+                ElementType = chunk.ElementType
             })
             .ToList();
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs
@@ -392,7 +392,12 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
                 ChunkIndex = index,
                 PageNumber = chunk.Page,
                 CharacterCount = chunk.Text.Length,
-                CreatedAt = _timeProvider.GetUtcNow().UtcDateTime
+                CreatedAt = _timeProvider.GetUtcNow().UtcDateTime,
+                // Issue #730: persist chunk hierarchy fields from chunking pipeline
+                Heading = chunk.Heading,
+                Level = chunk.Level,
+                ParentChunkId = chunk.ParentChunkId,
+                ElementType = chunk.ElementType
             })
             .ToList();
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs
@@ -270,6 +270,9 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
                 return (false, null, "Embedding count mismatch", PdfIndexingErrorCode.EmbeddingFailed);
             }
 
+            // Issue #730 / spec §5.3 forward-wiring: hierarchy fields (Heading, Level, ParentChunkId, ElementType)
+            // are intentionally not mapped here because the basic ITextChunkingService.ChunkText path does not
+            // produce them. When AdvancedChunkingService is integrated upstream, propagate from the source TextChunk.
             // Prepare document chunks with embeddings
             var batchChunks = textChunks.Skip(i).Take(batchSize)
                 .Select((chunk, index) => new DocumentChunk

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Helpers.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Helpers.cs
@@ -210,17 +210,3 @@ internal partial class UploadPdfCommandHandler
         });
     }
 }
-
-// Helper class for document chunk input
-internal class DocumentChunkInput
-{
-    public required string Text { get; init; }
-    public int Page { get; init; }
-    public int CharStart { get; init; }
-    public int CharEnd { get; init; }
-    // Issue #730: hierarchy fields — null/defaults when not set by chunking pipeline
-    public string? Heading { get; init; }
-    public short Level { get; init; } = 1;
-    public Guid? ParentChunkId { get; init; }
-    public string ElementType { get; init; } = "NarrativeText";
-}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Helpers.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Helpers.cs
@@ -218,4 +218,9 @@ internal class DocumentChunkInput
     public int Page { get; init; }
     public int CharStart { get; init; }
     public int CharEnd { get; init; }
+    // Issue #730: hierarchy fields — null/defaults when not set by chunking pipeline
+    public string? Heading { get; init; }
+    public short Level { get; init; } = 1;
+    public Guid? ParentChunkId { get; init; }
+    public string ElementType { get; init; } = "NarrativeText";
 }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
@@ -560,7 +560,12 @@ internal partial class UploadPdfCommandHandler
                 ChunkIndex = index,
                 PageNumber = chunk.Page,
                 CharacterCount = chunk.Text.Length,
-                CreatedAt = _timeProvider.GetUtcNow().UtcDateTime
+                CreatedAt = _timeProvider.GetUtcNow().UtcDateTime,
+                // Issue #730: persist chunk hierarchy fields from chunking pipeline
+                Heading = chunk.Heading,
+                Level = chunk.Level,
+                ParentChunkId = chunk.ParentChunkId,
+                ElementType = chunk.ElementType
             })
             .ToList();
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -607,7 +607,12 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                 ChunkIndex = index,
                 PageNumber = chunk.Page,
                 CharacterCount = chunk.Text.Length,
-                CreatedAt = now
+                CreatedAt = now,
+                // Issue #730: persist chunk hierarchy fields from chunking pipeline
+                Heading = chunk.Heading,
+                Level = chunk.Level,
+                ParentChunkId = chunk.ParentChunkId,
+                ElementType = chunk.ElementType
             })
             .ToList();
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -167,6 +167,9 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                         if (!string.IsNullOrWhiteSpace(t.TranslatedText))
                         {
                             var origChunk = chunks[t.OriginalIndex];
+                            // Issue #730 / spec §5.3 forward-wiring: hierarchy fields are not yet propagated from origChunk
+                            // to the translated chunk because the upstream chunking pipeline does not currently populate them.
+                            // Once AdvancedChunkingService is wired, copy origChunk.Heading/Level/ParentChunkId/ElementType here.
                             translatedChunks.Add((
                                 new DocumentChunkInput
                                 {

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkById/GetKbChunkByIdHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkById/GetKbChunkByIdHandler.cs
@@ -1,0 +1,161 @@
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunkById;
+
+/// <summary>
+/// Handles <see cref="GetKbChunkByIdQuery"/>.
+///
+/// Returns the full content of a single text chunk identified by (DocumentId, ChunkId).
+/// A 404 is thrown when the chunk does not exist or belongs to a different document —
+/// preventing cross-document chunk enumeration leakage.
+///
+/// Prev/next navigation IDs are resolved by looking for chunks at ChunkIndex ± 1 in the
+/// same document. This is a simple indexed lookup (one extra query each), consistent with
+/// the offset-pagination approach used by <c>GetKbChunksHandler</c>.
+///
+/// <c>HeadingPath</c> is built by walking up <c>ParentChunkId</c> via a single recursive
+/// CTE on PostgreSQL (one SQL round-trip). When the database is the InMemory provider
+/// (unit tests), the CTE is skipped and an empty array is returned — matching the pattern
+/// established in <c>GetKbChunksHandler.LoadHeadingPathsAsync</c>.
+/// </summary>
+internal sealed class GetKbChunkByIdHandler : IQueryHandler<GetKbChunkByIdQuery, KbChunkDetailDto>
+{
+    /// <summary>Maximum ancestor depth traversed by the recursive CTE.</summary>
+    private const int MaxCteDepth = 10;
+
+    // Recursive CTE that climbs the parent_chunk_id chain for a single seed chunk
+    // and collects non-null headings ordered from root to leaf (depth DESC).
+    // Column names are PascalCase — EF Core convention matches the migration
+    // 20260506111654_AddChunkHierarchyToTextChunkEntity.
+    private static readonly string HeadingPathCte = @"
+        WITH RECURSIVE chunk_path(id, ""Heading"", parent_chunk_id, depth) AS (
+          SELECT
+            t.""Id"",
+            t.""Heading"",
+            t.""ParentChunkId"",
+            1 AS depth
+          FROM text_chunks t
+          WHERE t.""Id"" = {0}
+          UNION ALL
+          SELECT
+            t.""Id"",
+            t.""Heading"",
+            t.""ParentChunkId"",
+            cp.depth + 1
+          FROM text_chunks t
+          JOIN chunk_path cp ON t.""Id"" = cp.parent_chunk_id
+          WHERE cp.depth < " + MaxCteDepth + @"
+        )
+        SELECT ""Heading"" AS ""Value""
+        FROM chunk_path
+        WHERE ""Heading"" IS NOT NULL
+        ORDER BY depth DESC;";
+
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetKbChunkByIdHandler> _logger;
+
+    public GetKbChunkByIdHandler(MeepleAiDbContext dbContext, ILogger<GetKbChunkByIdHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<KbChunkDetailDto> Handle(GetKbChunkByIdQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        _logger.LogDebug(
+            "Fetching KB chunk {ChunkId} from doc {DocId} (admin={IsAdmin})",
+            query.ChunkId, query.DocumentId, query.UserIsAdmin);
+
+        // Primary fetch — also validates that the chunk belongs to the requested document.
+        var chunk = await _dbContext.TextChunks.AsNoTracking()
+            .Where(c => c.Id == query.ChunkId && c.PdfDocumentId == query.DocumentId)
+            .Select(c => new
+            {
+                c.Id,
+                c.Content,
+                c.PageNumber,
+                c.ChunkIndex,
+                c.Level,
+                c.Heading,
+                c.ParentChunkId,
+                c.CharacterCount,
+                c.ElementType
+            })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (chunk is null)
+        {
+            throw new NotFoundException(
+                $"Chunk {query.ChunkId} not found in document {query.DocumentId}");
+        }
+
+        // Prev/next navigation — look for chunks at ChunkIndex ± 1 in the same document.
+        var prevChunkId = await _dbContext.TextChunks.AsNoTracking()
+            .Where(c => c.PdfDocumentId == query.DocumentId && c.ChunkIndex == chunk.ChunkIndex - 1)
+            .Select(c => (Guid?)c.Id)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var nextChunkId = await _dbContext.TextChunks.AsNoTracking()
+            .Where(c => c.PdfDocumentId == query.DocumentId && c.ChunkIndex == chunk.ChunkIndex + 1)
+            .Select(c => (Guid?)c.Id)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var headingPath = await LoadHeadingPathAsync(chunk.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new KbChunkDetailDto(
+            ChunkId: chunk.Id,
+            Content: chunk.Content,
+            PageNumber: chunk.PageNumber,
+            Position: chunk.ChunkIndex,
+            Level: chunk.Level,
+            HeadingPath: headingPath,
+            PrevChunkId: prevChunkId,
+            NextChunkId: nextChunkId,
+            VectorId: query.UserIsAdmin ? chunk.Id : (Guid?)null,
+            CharacterCount: query.UserIsAdmin ? chunk.CharacterCount : (int?)null,
+            ElementType: query.UserIsAdmin ? chunk.ElementType : null,
+            EmbeddingStatus: query.UserIsAdmin ? "indexed" : null,
+            ParentChunkId: query.UserIsAdmin ? chunk.ParentChunkId : null
+        );
+    }
+
+    /// <summary>
+    /// Executes a recursive CTE on PostgreSQL to build the heading path for a single chunk
+    /// in a single round-trip.  Returns an empty list when running against the EF InMemory
+    /// provider (unit-test context) because raw SQL is not supported there.
+    /// </summary>
+    private async Task<IReadOnlyList<string>> LoadHeadingPathAsync(
+        Guid chunkId,
+        CancellationToken cancellationToken)
+    {
+        // InMemory provider does not support raw SQL — return empty paths so unit tests pass.
+        // Use string comparison (same pattern as GetKbChunksHandler) because the InMemory
+        // package is not referenced by the main project, making IsInMemory() unavailable.
+        if (string.Equals(
+                _dbContext.Database.ProviderName,
+                "Microsoft.EntityFrameworkCore.InMemory",
+                StringComparison.Ordinal))
+        {
+            return Array.Empty<string>();
+        }
+
+        var rows = await _dbContext.Database
+            .SqlQueryRaw<HeadingPathRow>(HeadingPathCte, chunkId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return rows.Select(r => r.Value).ToList();
+    }
+
+    /// <summary>Projection type for the scalar heading-path CTE result.</summary>
+    private sealed record HeadingPathRow(string Value);
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkById/GetKbChunkByIdQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkById/GetKbChunkByIdQuery.cs
@@ -1,0 +1,16 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunkById;
+
+/// <summary>
+/// Query to retrieve a single text chunk with full content, prev/next navigation IDs,
+/// and a hierarchical heading breadcrumb.
+/// Used by <c>GET /api/v1/kb-docs/{id}/chunks/{chunkId}</c> (G2 goal).
+/// Admin-only fields (VectorId, CharacterCount, ElementType, EmbeddingStatus, ParentChunkId)
+/// are gated via <see cref="UserIsAdmin"/>.
+/// </summary>
+internal sealed record GetKbChunkByIdQuery(
+    Guid DocumentId,
+    Guid ChunkId,
+    bool UserIsAdmin
+) : IQuery<KbChunkDetailDto>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkById/KbChunkDetailDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkById/KbChunkDetailDto.cs
@@ -1,0 +1,35 @@
+using System.Text.Json.Serialization;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunkById;
+
+/// <summary>
+/// Full-content DTO for a single text chunk, including prev/next navigation IDs
+/// and a hierarchical heading breadcrumb (headingPath).
+/// Returned by <c>GET /api/v1/kb-docs/{id}/chunks/{chunkId}</c> (G2 goal).
+///
+/// Admin-only fields are decorated with <see cref="JsonIgnoreAttribute"/> so that
+/// they are omitted from the JSON response when <c>null</c>.  The global
+/// <c>ConfigureHttpJsonOptions</c> does NOT set <c>DefaultIgnoreCondition</c>, so
+/// each admin-gated field must carry the annotation independently (Decision D4).
+/// </summary>
+internal sealed record KbChunkDetailDto(
+    Guid ChunkId,
+    string Content,
+    int? PageNumber,
+    int Position,
+    short Level,
+    IReadOnlyList<string> HeadingPath,
+    Guid? PrevChunkId,
+    Guid? NextChunkId,
+
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    Guid? VectorId,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    int? CharacterCount,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? ElementType,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? EmbeddingStatus,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    Guid? ParentChunkId
+);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/GetKbChunksHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/GetKbChunksHandler.cs
@@ -1,0 +1,102 @@
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
+
+/// <summary>
+/// Handles <see cref="GetKbChunksQuery"/>.
+///
+/// Returns a paginated list of text chunks for the given document, ordered by ChunkIndex.
+/// Offset pagination is clamped to <see cref="MaxTake"/> = 100 per page.
+///
+/// Admin-only fields (<c>VectorId</c>, <c>CharacterCount</c>, <c>ElementType</c>, <c>EmbeddingStatus</c>)
+/// are populated only when <see cref="GetKbChunksQuery.UserIsAdmin"/> is <c>true</c>.
+///
+/// <c>HeadingPath</c> returns an empty array in this skeleton; recursive CTE to be
+/// added in the next commit (Task 7).
+/// </summary>
+internal sealed class GetKbChunksHandler : IQueryHandler<GetKbChunksQuery, KbChunkListDto>
+{
+    private const int MaxTake = 100;
+    private const int SnippetMaxLength = 200;
+
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetKbChunksHandler> _logger;
+
+    public GetKbChunksHandler(MeepleAiDbContext dbContext, ILogger<GetKbChunksHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<KbChunkListDto> Handle(GetKbChunksQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var skip = Math.Max(0, query.Skip);
+        var take = Math.Clamp(query.Take, 1, MaxTake);
+
+        _logger.LogDebug(
+            "Fetching KB chunks for doc {DocId} (skip={Skip}, take={Take}, admin={IsAdmin})",
+            query.DocumentId, skip, take, query.UserIsAdmin);
+
+        var processingState = await _dbContext.PdfDocuments.AsNoTracking()
+            .Where(p => p.Id == query.DocumentId)
+            .Select(p => p.ProcessingState)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var processingStateLower = processingState?.ToLowerInvariant() ?? "unknown";
+
+        var totalCount = await _dbContext.TextChunks.AsNoTracking()
+            .CountAsync(c => c.PdfDocumentId == query.DocumentId, cancellationToken)
+            .ConfigureAwait(false);
+
+        var rows = await _dbContext.TextChunks.AsNoTracking()
+            .Where(c => c.PdfDocumentId == query.DocumentId)
+            .OrderBy(c => c.ChunkIndex)
+            .Skip(skip)
+            .Take(take)
+            .Select(c => new
+            {
+                c.Id,
+                c.PageNumber,
+                c.ChunkIndex,
+                c.Level,
+                c.Heading,
+                c.ParentChunkId,
+                c.Content,
+                c.CharacterCount,
+                c.ElementType
+            })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var chunks = rows.Select(r => new KbChunkSummaryDto(
+            ChunkId: r.Id,
+            PageNumber: r.PageNumber,
+            Position: r.ChunkIndex,
+            Level: r.Level,
+            HeadingPath: Array.Empty<string>(), // Stub: recursive CTE heading path populated in Task 7
+            Snippet: TruncateSnippet(r.Content),
+            VectorId: query.UserIsAdmin ? r.Id : (Guid?)null,
+            CharacterCount: query.UserIsAdmin ? r.CharacterCount : (int?)null,
+            ElementType: query.UserIsAdmin ? r.ElementType : null,
+            EmbeddingStatus: query.UserIsAdmin ? "indexed" : null
+        )).ToList();
+
+        return new KbChunkListDto(
+            Chunks: chunks,
+            TotalCount: totalCount,
+            Skip: skip,
+            Take: take,
+            HasMore: skip + take < totalCount,
+            ProcessingState: processingStateLower
+        );
+    }
+
+    private static string TruncateSnippet(string content) =>
+        content.Length <= SnippetMaxLength ? content : content[..SnippetMaxLength];
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/GetKbChunksHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/GetKbChunksHandler.cs
@@ -14,13 +14,49 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
 /// Admin-only fields (<c>VectorId</c>, <c>CharacterCount</c>, <c>ElementType</c>, <c>EmbeddingStatus</c>)
 /// are populated only when <see cref="GetKbChunksQuery.UserIsAdmin"/> is <c>true</c>.
 ///
-/// <c>HeadingPath</c> returns an empty array in this skeleton; recursive CTE to be
-/// added in the next commit (Task 7).
+/// <c>HeadingPath</c> is built by walking up <c>ParentChunkId</c> via a single recursive
+/// CTE on PostgreSQL (one SQL round-trip for the whole page).  When the database is an
+/// InMemory provider (unit tests), the CTE is skipped and an empty array is returned.
 /// </summary>
 internal sealed class GetKbChunksHandler : IQueryHandler<GetKbChunksQuery, KbChunkListDto>
 {
     private const int MaxTake = 100;
     private const int SnippetMaxLength = 200;
+
+    /// <summary>Maximum ancestor depth traversed by the recursive CTE.</summary>
+    private const int MaxCteDepth = 10;
+
+    // Recursive CTE that, for every seed id in the input array, climbs the
+    // parent_chunk_id chain up to MaxCteDepth levels and collects non-null headings.
+    // Column names are PascalCase — EF Core convention maps C# property names to
+    // identical DB column names unless [Column(...)] is used (confirmed: migration
+    // 20260506111654_AddChunkHierarchyToTextChunkEntity uses PascalCase names).
+    // Static readonly (not const) because C# does not allow string concatenation in const fields.
+    private static readonly string HeadingPathCte = @"
+        WITH RECURSIVE chunk_path(start_id, id, ""Heading"", parent_chunk_id, depth) AS (
+          SELECT
+            t.""Id"" AS start_id,
+            t.""Id"",
+            t.""Heading"",
+            t.""ParentChunkId"",
+            1 AS depth
+          FROM text_chunks t
+          WHERE t.""Id"" = ANY({0})
+          UNION ALL
+          SELECT
+            cp.start_id,
+            t.""Id"",
+            t.""Heading"",
+            t.""ParentChunkId"",
+            cp.depth + 1
+          FROM text_chunks t
+          JOIN chunk_path cp ON t.""Id"" = cp.parent_chunk_id
+          WHERE cp.depth < " + MaxCteDepth + @"
+        )
+        SELECT start_id AS ""StartId"", ""Heading"", depth AS ""Depth""
+        FROM chunk_path
+        WHERE ""Heading"" IS NOT NULL
+        ORDER BY start_id, depth DESC;";
 
     private readonly MeepleAiDbContext _dbContext;
     private readonly ILogger<GetKbChunksHandler> _logger;
@@ -74,12 +110,18 @@ internal sealed class GetKbChunksHandler : IQueryHandler<GetKbChunksQuery, KbChu
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
+        // Phase 2: load heading paths for this page in a single SQL round-trip.
+        var chunkIds = rows.Select(r => r.Id).ToList();
+        var headingPaths = chunkIds.Count == 0
+            ? new Dictionary<Guid, IReadOnlyList<string>>()
+            : await LoadHeadingPathsAsync(chunkIds, cancellationToken).ConfigureAwait(false);
+
         var chunks = rows.Select(r => new KbChunkSummaryDto(
             ChunkId: r.Id,
             PageNumber: r.PageNumber,
             Position: r.ChunkIndex,
             Level: r.Level,
-            HeadingPath: Array.Empty<string>(), // Stub: recursive CTE heading path populated in Task 7
+            HeadingPath: headingPaths.TryGetValue(r.Id, out var path) ? path : Array.Empty<string>(),
             Snippet: TruncateSnippet(r.Content),
             VectorId: query.UserIsAdmin ? r.Id : (Guid?)null,
             CharacterCount: query.UserIsAdmin ? r.CharacterCount : (int?)null,
@@ -97,6 +139,44 @@ internal sealed class GetKbChunksHandler : IQueryHandler<GetKbChunksQuery, KbChu
         );
     }
 
+    /// <summary>
+    /// Executes a recursive CTE on PostgreSQL to build heading paths for all chunk IDs
+    /// in a single round-trip.  Returns an empty dictionary when running against the
+    /// EF InMemory provider (unit-test context) because raw SQL is not supported there.
+    /// </summary>
+    private async Task<Dictionary<Guid, IReadOnlyList<string>>> LoadHeadingPathsAsync(
+        IReadOnlyList<Guid> chunkIds,
+        CancellationToken cancellationToken)
+    {
+        // InMemory provider does not support raw SQL — return empty paths so unit tests pass.
+        // Use provider name comparison (same pattern as HandleOAuthCallbackCommandHandler) because
+        // the InMemory package is not referenced by the main project, making IsInMemory() unavailable.
+        if (string.Equals(
+                _dbContext.Database.ProviderName,
+                "Microsoft.EntityFrameworkCore.InMemory",
+                StringComparison.Ordinal))
+        {
+            return new Dictionary<Guid, IReadOnlyList<string>>();
+        }
+
+        var raw = await _dbContext.Database
+            .SqlQueryRaw<HeadingPathRow>(HeadingPathCte, chunkIds.ToArray())
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return raw
+            .GroupBy(r => r.StartId)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<string>)g
+                    .OrderByDescending(x => x.Depth)   // root (deepest depth value) first
+                    .Select(x => x.Heading!)
+                    .ToList());
+    }
+
     private static string TruncateSnippet(string content) =>
         content.Length <= SnippetMaxLength ? content : content[..SnippetMaxLength];
+
+    /// <summary>Projection type for the heading-path recursive CTE result.</summary>
+    private sealed record HeadingPathRow(Guid StartId, string? Heading, int Depth);
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/GetKbChunksQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/GetKbChunksQuery.cs
@@ -1,0 +1,16 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
+
+/// <summary>
+/// Query to retrieve a paginated list of text chunks for a single KB document.
+/// Used by <c>GET /api/v1/kb-docs/{id}/chunks</c> (G1 goal).
+/// Admin-only fields (VectorId, CharacterCount, ElementType, EmbeddingStatus) are gated via <see cref="UserIsAdmin"/>.
+/// headingPath returns an empty array in this skeleton — recursive CTE populated in next commit.
+/// </summary>
+internal sealed record GetKbChunksQuery(
+    Guid DocumentId,
+    int Skip,
+    int Take,
+    bool UserIsAdmin
+) : IQuery<KbChunkListDto>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/KbChunkListDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/KbChunkListDto.cs
@@ -1,0 +1,14 @@
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
+
+/// <summary>
+/// Paginated list of text chunk summaries for a single KB document.
+/// Returned by <c>GET /api/v1/kb-docs/{id}/chunks</c> (G1 goal).
+/// </summary>
+internal sealed record KbChunkListDto(
+    IReadOnlyList<KbChunkSummaryDto> Chunks,
+    int TotalCount,
+    int Skip,
+    int Take,
+    bool HasMore,
+    string ProcessingState
+);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/KbChunkSummaryDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/KbChunkSummaryDto.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
+
+/// <summary>
+/// Summary DTO for a single text chunk in a paginated list.
+/// Returned as items within <see cref="KbChunkListDto"/>.
+///
+/// Admin-only fields are decorated with <see cref="JsonIgnoreAttribute"/> so that
+/// they are omitted from the JSON response when <c>null</c>.  The global
+/// <c>ConfigureHttpJsonOptions</c> does NOT set <c>DefaultIgnoreCondition</c>, so
+/// each admin-gated field must carry the annotation independently (Decision D4).
+/// </summary>
+internal sealed record KbChunkSummaryDto(
+    Guid ChunkId,
+    int? PageNumber,
+    int Position,
+    short Level,
+    IReadOnlyList<string> HeadingPath,
+    string Snippet,
+
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    Guid? VectorId,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    int? CharacterCount,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? ElementType,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? EmbeddingStatus
+);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/GetKbDocumentByIdHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/GetKbDocumentByIdHandler.cs
@@ -66,7 +66,7 @@ internal sealed class GetKbDocumentByIdHandler : IQueryHandler<GetKbDocumentById
             Language: data.pdf.Language,
             VersionLabel: data.pdf.VersionLabel,
             ProcessingError: query.UserIsAdmin ? data.pdf.ProcessingError : null,
-            RetryCount: query.UserIsAdmin ? data.pdf.RetryCount : null,
+            RetryCount: query.UserIsAdmin && data.pdf.RetryCount > 0 ? data.pdf.RetryCount : (int?)null,
             FailedAtState: query.UserIsAdmin ? data.pdf.FailedAtState : null
         );
     }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/GetKbDocumentByIdHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/GetKbDocumentByIdHandler.cs
@@ -1,0 +1,73 @@
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbDocumentById;
+
+/// <summary>
+/// Handles <see cref="GetKbDocumentByIdQuery"/>.
+///
+/// Joins <c>PdfDocumentEntity</c> (primary) with <c>VectorDocumentEntity</c> (optional LEFT JOIN)
+/// so that documents still being processed (no VectorDocument yet) are returned with
+/// <c>TotalChunks = 0</c> and <c>IndexedAt = null</c> rather than a 404.
+///
+/// Admin-only fields (<c>ProcessingError</c>, <c>RetryCount</c>, <c>FailedAtState</c>) are
+/// populated only when <see cref="GetKbDocumentByIdQuery.UserIsAdmin"/> is <c>true</c>.
+/// </summary>
+internal sealed class GetKbDocumentByIdHandler : IQueryHandler<GetKbDocumentByIdQuery, KbDocumentDto>
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetKbDocumentByIdHandler> _logger;
+
+    public GetKbDocumentByIdHandler(MeepleAiDbContext dbContext, ILogger<GetKbDocumentByIdHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<KbDocumentDto> Handle(GetKbDocumentByIdQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        _logger.LogDebug("Fetching KB document {DocId} (admin={IsAdmin})", query.DocumentId, query.UserIsAdmin);
+
+        var data = await (
+            from pdf in _dbContext.PdfDocuments.AsNoTracking()
+            join vd in _dbContext.VectorDocuments.AsNoTracking()
+                on pdf.Id equals vd.PdfDocumentId into vdj
+            from vd in vdj.DefaultIfEmpty()
+            where pdf.Id == query.DocumentId
+            select new
+            {
+                pdf,
+                TotalChunks = vd != null ? vd.ChunkCount : 0,
+                IndexedAt = vd != null ? vd.IndexedAt : (DateTime?)null,
+                GameId = vd != null ? vd.GameId : (Guid?)null
+            }
+        ).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+
+        if (data is null)
+        {
+            throw new NotFoundException($"KB document {query.DocumentId} not found");
+        }
+
+        return new KbDocumentDto(
+            Id: data.pdf.Id,
+            Title: data.pdf.FileName,
+            GameId: data.GameId,
+            SharedGameId: data.pdf.SharedGameId,
+            DocumentCategory: data.pdf.DocumentCategory,
+            ProcessingState: data.pdf.ProcessingState.ToLowerInvariant(),
+            TotalChunks: data.TotalChunks,
+            PageCount: data.pdf.PageCount ?? 0,
+            IndexedAt: data.IndexedAt,
+            UploadedAt: data.pdf.UploadedAt,
+            Language: data.pdf.Language,
+            VersionLabel: data.pdf.VersionLabel,
+            ProcessingError: query.UserIsAdmin ? data.pdf.ProcessingError : null,
+            RetryCount: query.UserIsAdmin ? data.pdf.RetryCount : null,
+            FailedAtState: query.UserIsAdmin ? data.pdf.FailedAtState : null
+        );
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/GetKbDocumentByIdQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/GetKbDocumentByIdQuery.cs
@@ -1,0 +1,13 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbDocumentById;
+
+/// <summary>
+/// Query to retrieve full metadata for a single KB document by its PDF document ID.
+/// Used by <c>GET /api/v1/kb-docs/{id}</c> (G4 goal).
+/// Admin-only fields (processingError, retryCount, failedAtState) are gated via <see cref="UserIsAdmin"/>.
+/// </summary>
+internal sealed record GetKbDocumentByIdQuery(
+    Guid DocumentId,
+    bool UserIsAdmin
+) : IQuery<KbDocumentDto>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/KbDocumentDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/KbDocumentDto.cs
@@ -1,0 +1,36 @@
+using System.Text.Json.Serialization;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbDocumentById;
+
+/// <summary>
+/// Full metadata DTO for a single KB document.
+/// Returned by <c>GET /api/v1/kb-docs/{id}</c> (G4 goal).
+///
+/// Admin-only fields are decorated with <see cref="JsonIgnoreAttribute"/> so that
+/// they are omitted from the JSON response when <c>null</c>.  The global
+/// <c>ConfigureHttpJsonOptions</c> does NOT set <c>DefaultIgnoreCondition</c>, so
+/// each admin-gated field must carry the annotation independently (Decision D4).
+/// </summary>
+internal sealed record KbDocumentDto(
+    Guid Id,
+    string Title,
+    Guid? GameId,
+    Guid? SharedGameId,
+    string DocumentCategory,
+    string ProcessingState,
+    int TotalChunks,
+    int PageCount,
+    DateTime? IndexedAt,
+    DateTime UploadedAt,
+    string Language,
+    string? VersionLabel,
+
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? ProcessingError,
+
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    int? RetryCount,
+
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? FailedAtState
+);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchKbChunks/KbChunkMatchDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchKbChunks/KbChunkMatchDto.cs
@@ -1,0 +1,15 @@
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.SearchKbChunks;
+
+/// <summary>
+/// Represents a single chunk match returned by the G3 FTS search.
+/// <see cref="Snippet"/> contains ts_headline output with <c>&lt;mark&gt;</c> tags
+/// wrapping the matched terms.
+/// </summary>
+internal sealed record KbChunkMatchDto(
+    Guid ChunkId,
+    IReadOnlyList<string> HeadingPath,
+    string Snippet,
+    float Rank,
+    int? PageNumber,
+    int Position
+);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchKbChunks/KbChunkSearchResultDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchKbChunks/KbChunkSearchResultDto.cs
@@ -1,0 +1,11 @@
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.SearchKbChunks;
+
+/// <summary>
+/// Paginated result of a full-text search within a KB document (G3, Issue #730).
+/// </summary>
+internal sealed record KbChunkSearchResultDto(
+    IReadOnlyList<KbChunkMatchDto> Matches,
+    int TotalCount,
+    int Skip,
+    int Take
+);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchKbChunks/SearchKbChunksHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchKbChunks/SearchKbChunksHandler.cs
@@ -1,0 +1,192 @@
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.SearchKbChunks;
+
+/// <summary>
+/// Handles <see cref="SearchKbChunksQuery"/>.
+///
+/// Performs PostgreSQL full-text search within a single KB document using:
+/// <list type="bullet">
+///   <item><c>plainto_tsquery('simple', ...)</c> — sanitises user input, preventing tsquery operator injection</item>
+///   <item><c>ts_rank_cd</c> — cover-density ranking for result ordering</item>
+///   <item><c>ts_headline</c> — generates text snippets with <c>&lt;mark&gt;</c> tags</item>
+/// </list>
+///
+/// <para>
+/// <b>InMemory note</b>: PostgreSQL FTS functions (<c>ts_rank_cd</c>, <c>ts_headline</c>,
+/// <c>plainto_tsquery</c>) are not available in the EF InMemory provider.
+/// All G3 tests must be integration tests using the Testcontainers fixture.
+/// </para>
+///
+/// <para>
+/// <b>Validation</b>: query length is validated to 1–200 characters by the endpoint before
+/// reaching this handler, but is re-validated here defensively.
+/// </para>
+/// </summary>
+internal sealed class SearchKbChunksHandler : IQueryHandler<SearchKbChunksQuery, KbChunkSearchResultDto>
+{
+    private const int MaxQueryLength = 200;
+    private const int MaxTake = 100;
+
+    /// <summary>Maximum ancestor depth traversed by the heading-path recursive CTE.</summary>
+    private const int MaxCteDepth = 10;
+
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<SearchKbChunksHandler> _logger;
+
+    public SearchKbChunksHandler(MeepleAiDbContext dbContext, ILogger<SearchKbChunksHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<KbChunkSearchResultDto> Handle(SearchKbChunksQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        if (string.IsNullOrWhiteSpace(query.Query) || query.Query.Length > MaxQueryLength)
+        {
+            throw new ArgumentException("query must be between 1 and 200 characters", nameof(query));
+        }
+
+        var skip = Math.Max(0, query.Skip);
+        var take = Math.Clamp(query.Take, 1, MaxTake);
+
+        _logger.LogDebug(
+            "SearchKbChunks for doc {DocId} query='{Query}' skip={Skip} take={Take}",
+            query.DocumentId, query.Query, skip, take);
+
+        // Verify document exists before issuing the FTS query.
+        var docExists = await _dbContext.PdfDocuments.AsNoTracking()
+            .AnyAsync(p => p.Id == query.DocumentId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!docExists)
+        {
+            throw new NotFoundException("Document", query.DocumentId.ToString());
+        }
+
+        // FTS ranked query using plainto_tsquery (prevents operator injection).
+        // Column names: PdfDocumentId, Id, PageNumber, ChunkIndex are PascalCase (migration convention).
+        // search_vector is lowercase snake_case via [Column("search_vector")] on the entity.
+        const string ftsSQL = @"
+            WITH ranked AS (
+              SELECT
+                tc.""Id"",
+                tc.""PageNumber"",
+                tc.""ChunkIndex"",
+                ts_rank_cd(tc.search_vector, q) AS ""Rank"",
+                ts_headline('simple', tc.""Content"", q,
+                  'StartSel=<mark>, StopSel=</mark>, MaxFragments=2, MaxWords=20, MinWords=5') AS ""Snippet""
+              FROM text_chunks tc, plainto_tsquery('simple', {1}) q
+              WHERE tc.""PdfDocumentId"" = {0}
+                AND tc.search_vector @@ q
+            )
+            SELECT ""Id"", ""PageNumber"", ""ChunkIndex"", ""Rank"", ""Snippet""
+            FROM ranked
+            ORDER BY ""Rank"" DESC
+            OFFSET {2} LIMIT {3};";
+
+        var rows = await _dbContext.Database
+            .SqlQueryRaw<SearchRow>(ftsSQL, query.DocumentId, query.Query, skip, take)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Count total matches (without pagination).
+        const string countSQL = @"
+            SELECT COUNT(*)::int AS ""Value""
+            FROM text_chunks tc, plainto_tsquery('simple', {1}) q
+            WHERE tc.""PdfDocumentId"" = {0} AND tc.search_vector @@ q;";
+
+        var totalCount = await _dbContext.Database
+            .SqlQueryRaw<IntValueRow>(countSQL, query.DocumentId, query.Query)
+            .Select(r => r.Value)
+            .FirstAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Build heading paths for matched chunks in a single round-trip (same CTE pattern as G1/G2).
+        var matchIds = rows.Select(r => r.Id).ToList();
+        var headingPaths = matchIds.Count == 0
+            ? new Dictionary<Guid, IReadOnlyList<string>>()
+            : await LoadHeadingPathsAsync(matchIds, cancellationToken).ConfigureAwait(false);
+
+        var matches = rows.Select(r => new KbChunkMatchDto(
+            ChunkId: r.Id,
+            HeadingPath: headingPaths.TryGetValue(r.Id, out var hp) ? hp : Array.Empty<string>(),
+            Snippet: r.Snippet,
+            Rank: r.Rank,
+            PageNumber: r.PageNumber,
+            Position: r.ChunkIndex
+        )).ToList();
+
+        return new KbChunkSearchResultDto(matches, totalCount, skip, take);
+    }
+
+    /// <summary>
+    /// Builds heading paths for a batch of chunk IDs using a recursive CTE (one SQL round-trip).
+    /// Matches the pattern established in <c>GetKbChunksHandler.LoadHeadingPathsAsync</c>.
+    /// </summary>
+    private async Task<Dictionary<Guid, IReadOnlyList<string>>> LoadHeadingPathsAsync(
+        IReadOnlyList<Guid> chunkIds,
+        CancellationToken cancellationToken)
+    {
+        var headingPathCte = @"
+            WITH RECURSIVE chunk_path(start_id, id, ""Heading"", parent_chunk_id, depth) AS (
+              SELECT
+                t.""Id"" AS start_id,
+                t.""Id"",
+                t.""Heading"",
+                t.""ParentChunkId"",
+                1 AS depth
+              FROM text_chunks t
+              WHERE t.""Id"" = ANY({0})
+              UNION ALL
+              SELECT
+                cp.start_id,
+                t.""Id"",
+                t.""Heading"",
+                t.""ParentChunkId"",
+                cp.depth + 1
+              FROM text_chunks t
+              JOIN chunk_path cp ON t.""Id"" = cp.parent_chunk_id
+              WHERE cp.depth < " + MaxCteDepth + @"
+            )
+            SELECT start_id AS ""StartId"", ""Heading"", depth AS ""Depth""
+            FROM chunk_path
+            WHERE ""Heading"" IS NOT NULL
+            ORDER BY start_id, depth DESC;";
+
+        var raw = await _dbContext.Database
+            .SqlQueryRaw<HeadingPathRow>(headingPathCte, chunkIds.ToArray())
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return raw
+            .GroupBy(r => r.StartId)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<string>)g
+                    .OrderByDescending(x => x.Depth)
+                    .Select(x => x.Heading!)
+                    .ToList());
+    }
+
+    // ─── Raw SQL projection types ─────────────────────────────────────────────
+
+    /// <summary>Projection for the FTS ranked query result row.</summary>
+    private sealed record SearchRow(
+        Guid Id,
+        int? PageNumber,
+        int ChunkIndex,
+        float Rank,
+        string Snippet);
+
+    /// <summary>Projection for the scalar COUNT query using SqlQueryRaw&lt;T&gt;.</summary>
+    private sealed record IntValueRow(int Value);
+
+    /// <summary>Projection for the heading-path recursive CTE result.</summary>
+    private sealed record HeadingPathRow(Guid StartId, string? Heading, int Depth);
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchKbChunks/SearchKbChunksQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchKbChunks/SearchKbChunksQuery.cs
@@ -1,0 +1,20 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.SearchKbChunks;
+
+/// <summary>
+/// Query to perform full-text search within a single KB document using PostgreSQL FTS.
+/// Used by <c>POST /api/v1/kb-docs/{id}/chunks/search</c> (G3 goal, Issue #730).
+///
+/// <para>
+/// The query is sanitized by <c>plainto_tsquery</c> which treats the input as plain text
+/// (no tsquery operator injection possible). Ranking uses <c>ts_rank_cd</c> and snippets
+/// are generated with <c>ts_headline</c> producing <c>&lt;mark&gt;</c> tags.
+/// </para>
+/// </summary>
+internal sealed record SearchKbChunksQuery(
+    Guid DocumentId,
+    string Query,
+    int Skip,
+    int Take
+) : IQuery<KbChunkSearchResultDto>;

--- a/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/TextChunkEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/TextChunkEntity.cs
@@ -30,6 +30,8 @@ public class TextChunkEntity
     // Issue #730: Chunk hierarchy fields (heading_path derivation)
     public string? Heading { get; set; }
     public Guid? ParentChunkId { get; set; }
+    // Defaults below are migration fill values for pre-existing rows.
+    // Real values are populated from ChunkPayload by AdvancedChunkingService on new ingestions.
     public short Level { get; set; } = 1;
     public string ElementType { get; set; } = "NarrativeText";
 

--- a/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/TextChunkEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/TextChunkEntity.cs
@@ -27,6 +27,12 @@ public class TextChunkEntity
     public int CharacterCount { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
+    // Issue #730: Chunk hierarchy fields (heading_path derivation)
+    public string? Heading { get; set; }
+    public Guid? ParentChunkId { get; set; }
+    public short Level { get; set; } = 1;
+    public string ElementType { get; set; } = "NarrativeText";
+
     // PostgreSQL full-text search vector (automatically maintained by trigger)
     // This column is populated by the tsvector_update_text_chunks trigger
     [Column("search_vector")]

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/TextChunkEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/TextChunkEntityConfiguration.cs
@@ -21,6 +21,15 @@ internal class TextChunkEntityConfiguration : IEntityTypeConfiguration<TextChunk
         builder.Property(e => e.CharacterCount).IsRequired();
         builder.Property(e => e.CreatedAt).IsRequired();
 
+        // Issue #730: Chunk hierarchy fields
+        builder.Property(e => e.Heading).HasMaxLength(500).IsRequired(false);
+        builder.Property(e => e.ParentChunkId).IsRequired(false);
+        builder.Property(e => e.Level).IsRequired().HasDefaultValue<short>(1);
+        builder.Property(e => e.ElementType).IsRequired().HasMaxLength(20).HasDefaultValue("NarrativeText");
+
+        builder.HasIndex(e => e.ParentChunkId);
+        builder.HasIndex(e => new { e.PdfDocumentId, e.ChunkIndex }).HasDatabaseName("ix_text_chunks_pdf_chunk_index");
+
         // AI-14: Hybrid search - PostgreSQL GENERATED stored tsvector column
         // Computed from "Content" via migration AddSearchVectorColumns. Ignored by EF Core since it's DB-managed.
         builder.Ignore(e => e.SearchVector);

--- a/apps/api/src/Api/Infrastructure/Migrations/20260506111654_AddChunkHierarchyToTextChunkEntity.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260506111654_AddChunkHierarchyToTextChunkEntity.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260506111654_AddChunkHierarchyToTextChunkEntity")]
+    partial class AddChunkHierarchyToTextChunkEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260506111654_AddChunkHierarchyToTextChunkEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260506111654_AddChunkHierarchyToTextChunkEntity.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChunkHierarchyToTextChunkEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ElementType",
+                table: "text_chunks",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "NarrativeText");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Heading",
+                table: "text_chunks",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true);
+
+            migrationBuilder.AddColumn<short>(
+                name: "Level",
+                table: "text_chunks",
+                type: "smallint",
+                nullable: false,
+                defaultValue: (short)1);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ParentChunkId",
+                table: "text_chunks",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_text_chunks_ParentChunkId",
+                table: "text_chunks",
+                column: "ParentChunkId");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_text_chunks_pdf_chunk_index",
+                table: "text_chunks",
+                columns: new[] { "PdfDocumentId", "ChunkIndex" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_text_chunks_ParentChunkId",
+                table: "text_chunks");
+
+            migrationBuilder.DropIndex(
+                name: "ix_text_chunks_pdf_chunk_index",
+                table: "text_chunks");
+
+            migrationBuilder.DropColumn(
+                name: "ElementType",
+                table: "text_chunks");
+
+            migrationBuilder.DropColumn(
+                name: "Heading",
+                table: "text_chunks");
+
+            migrationBuilder.DropColumn(
+                name: "Level",
+                table: "text_chunks");
+
+            migrationBuilder.DropColumn(
+                name: "ParentChunkId",
+                table: "text_chunks");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs
+++ b/apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs
@@ -6,6 +6,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetGameDocuments;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbDocumentById;
 using Api.Extensions;
 using Api.Helpers;
 using Api.Infrastructure.Entities;
@@ -39,6 +40,7 @@ internal static class KnowledgeBaseEndpoints
         MapSharedGameKbStatusEndpoint(group);
         MapGameDocumentsEndpoint(group);
         MapLinkKbEndpoint(group);
+        MapKbDocumentEndpoints(group);
 
         return group;
     }
@@ -887,6 +889,33 @@ internal static class KnowledgeBaseEndpoints
             .WithDescription("Returns the list of KB documents linked to a game, ordered by creation date descending.")
             .Produces<IReadOnlyList<GameDocumentDto>>()
             .Produces(StatusCodes.Status401Unauthorized);
+    }
+
+    private static void MapKbDocumentEndpoints(RouteGroupBuilder group)
+    {
+        // Issue #730: G4 single doc metadata
+        group.MapGet("/kb-docs/{id:guid}", HandleGetKbDocumentById)
+            .WithName("GetKbDocumentById")
+            .RequireSession()
+            .WithTags("KnowledgeBase")
+            .WithSummary("Get KB document metadata")
+            .WithDescription("Returns metadata for a single KB document (title, processing state, total chunks, page count). Admin users see additional diagnostic fields.")
+            .Produces<KbDocumentDto>()
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status403Forbidden);
+    }
+
+    private static async Task<IResult> HandleGetKbDocumentById(
+        Guid id,
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var session = (SessionStatusDto)context.Items[nameof(SessionStatusDto)]!;
+        var userIsAdmin = string.Equals(session.User!.Role, UserRole.Admin.ToString(), StringComparison.OrdinalIgnoreCase);
+        var query = new GetKbDocumentByIdQuery(id, userIsAdmin);
+        var dto = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
+        return Results.Ok(dto);
     }
 
     private static void MapLinkKbEndpoint(RouteGroupBuilder group)

--- a/apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs
+++ b/apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs
@@ -6,6 +6,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetGameDocuments;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbDocumentById;
 using Api.Extensions;
 using Api.Helpers;
@@ -903,6 +904,17 @@ internal static class KnowledgeBaseEndpoints
             .Produces<KbDocumentDto>()
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status403Forbidden);
+
+        // Issue #730: G1 paginated chunks list
+        group.MapGet("/kb-docs/{id:guid}/chunks", HandleGetKbChunks)
+            .WithName("GetKbChunks")
+            .RequireSession()
+            .WithTags("KnowledgeBase")
+            .WithSummary("Get paginated chunks list with hierarchical headings")
+            .WithDescription("Returns chunks ordered by position with breadcrumb headingPath. Admin users see vectorId, characterCount, elementType, embeddingStatus.")
+            .Produces<KbChunkListDto>()
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status404NotFound);
     }
 
     private static async Task<IResult> HandleGetKbDocumentById(
@@ -916,6 +928,29 @@ internal static class KnowledgeBaseEndpoints
         var query = new GetKbDocumentByIdQuery(id, userIsAdmin);
         var dto = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
         return Results.Ok(dto);
+    }
+
+    private static async Task<IResult> HandleGetKbChunks(
+        Guid id,
+        int? skip,
+        int? take,
+        HttpContext httpContext,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var skipValue = skip ?? 0;
+        var takeValue = take ?? 50;
+
+        if (takeValue < 1 || takeValue > 100)
+        {
+            return Results.BadRequest(new { error = "take must be between 1 and 100" });
+        }
+
+        var session = (SessionStatusDto)httpContext.Items[nameof(SessionStatusDto)]!;
+        var isAdmin = string.Equals(session.User!.Role, UserRole.Admin.ToString(), StringComparison.OrdinalIgnoreCase);
+        var query = new GetKbChunksQuery(id, skipValue, takeValue, UserIsAdmin: isAdmin);
+        var result = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
     }
 
     private static void MapLinkKbEndpoint(RouteGroupBuilder group)

--- a/apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs
+++ b/apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs
@@ -6,6 +6,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetGameDocuments;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunkById;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbDocumentById;
 using Api.Extensions;
@@ -915,6 +916,16 @@ internal static class KnowledgeBaseEndpoints
             .Produces<KbChunkListDto>()
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status404NotFound);
+
+        // Issue #730: G2 single chunk full content
+        group.MapGet("/kb-docs/{id:guid}/chunks/{chunkId:guid}", HandleGetKbChunkById)
+            .WithName("GetKbChunkById")
+            .RequireSession()
+            .WithTags("KnowledgeBase")
+            .WithSummary("Get a single chunk with full content + prev/next navigation")
+            .WithDescription("Returns chunk content as markdown, with hierarchical breadcrumb and prev/next chunk IDs for navigation.")
+            .Produces<KbChunkDetailDto>()
+            .Produces(StatusCodes.Status404NotFound);
     }
 
     private static async Task<IResult> HandleGetKbDocumentById(
@@ -951,6 +962,23 @@ internal static class KnowledgeBaseEndpoints
         var query = new GetKbChunksQuery(id, skipValue, takeValue, UserIsAdmin: isAdmin);
         var result = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
         return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleGetKbChunkById(
+        Guid id,
+        Guid chunkId,
+        HttpContext httpContext,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var session = (SessionStatusDto)httpContext.Items[nameof(SessionStatusDto)]!;
+        var isAdmin = string.Equals(
+            session.User!.Role,
+            UserRole.Admin.ToString(),
+            StringComparison.OrdinalIgnoreCase);
+        var query = new GetKbChunkByIdQuery(id, chunkId, UserIsAdmin: isAdmin);
+        var dto = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
+        return Results.Ok(dto);
     }
 
     private static void MapLinkKbEndpoint(RouteGroupBuilder group)

--- a/apps/api/src/Api/Services/TextChunkingService.cs
+++ b/apps/api/src/Api/Services/TextChunkingService.cs
@@ -351,4 +351,9 @@ internal record DocumentChunkInput
     public int Page { get; init; }
     public int CharStart { get; init; }
     public int CharEnd { get; init; }
+    // Issue #730: hierarchy fields — null/defaults when not set by chunking pipeline
+    public string? Heading { get; init; }
+    public short Level { get; init; } = 1;
+    public Guid? ParentChunkId { get; init; }
+    public string ElementType { get; init; } = "NarrativeText";
 }

--- a/apps/api/src/Api/Services/VectorSearchModels.cs
+++ b/apps/api/src/Api/Services/VectorSearchModels.cs
@@ -11,6 +11,11 @@ internal record DocumentChunk
     public int Page { get; init; }
     public int CharStart { get; init; }
     public int CharEnd { get; init; }
+    // Issue #730: hierarchy fields — null/defaults when not set by chunking pipeline
+    public string? Heading { get; init; }
+    public short Level { get; init; } = 1;
+    public Guid? ParentChunkId { get; init; }
+    public string ElementType { get; init; } = "NarrativeText";
 }
 
 /// <summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkByIdHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkByIdHandlerTests.cs
@@ -1,0 +1,149 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunkById;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class GetKbChunkByIdHandlerTests
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetKbChunkByIdHandler> _logger;
+    private readonly GetKbChunkByIdHandler _handler;
+
+    public GetKbChunkByIdHandlerTests()
+    {
+        _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
+        _logger = Substitute.For<ILogger<GetKbChunkByIdHandler>>();
+        _handler = new GetKbChunkByIdHandler(_dbContext, _logger);
+    }
+
+    [Fact]
+    public async Task Handle_MiddleChunk_ReturnsContentWithPrevNext()
+    {
+        var docId = Guid.NewGuid();
+        var (chunk0, chunk1, chunk2) = await SeedThreeChunksAsync(docId);
+
+        var query = new GetKbChunkByIdQuery(docId, chunk1, UserIsAdmin: false);
+        var dto = await _handler.Handle(query, CancellationToken.None);
+
+        dto.ChunkId.Should().Be(chunk1);
+        dto.PrevChunkId.Should().Be(chunk0);
+        dto.NextChunkId.Should().Be(chunk2);
+    }
+
+    [Fact]
+    public async Task Handle_FirstChunk_PrevIsNull()
+    {
+        var docId = Guid.NewGuid();
+        var (chunk0, _, _) = await SeedThreeChunksAsync(docId);
+
+        var query = new GetKbChunkByIdQuery(docId, chunk0, UserIsAdmin: false);
+        var dto = await _handler.Handle(query, CancellationToken.None);
+
+        dto.PrevChunkId.Should().BeNull();
+        dto.NextChunkId.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Handle_LastChunk_NextIsNull()
+    {
+        var docId = Guid.NewGuid();
+        var (_, _, chunk2) = await SeedThreeChunksAsync(docId);
+
+        var query = new GetKbChunkByIdQuery(docId, chunk2, UserIsAdmin: false);
+        var dto = await _handler.Handle(query, CancellationToken.None);
+
+        dto.NextChunkId.Should().BeNull();
+        dto.PrevChunkId.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Handle_ChunkBelongsToOtherDoc_ThrowsNotFound()
+    {
+        var docA = Guid.NewGuid();
+        var docB = Guid.NewGuid();
+        var (_, _, _) = await SeedThreeChunksAsync(docA);
+        var (chunkB, _, _) = await SeedThreeChunksAsync(docB);
+
+        // Request chunk from docB but specifying docA — must 404
+        var query = new GetKbChunkByIdQuery(docA, chunkB, UserIsAdmin: false);
+        var act = () => _handler.Handle(query, CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_NonExistentChunk_ThrowsNotFound()
+    {
+        var docId = Guid.NewGuid();
+        await SeedThreeChunksAsync(docId);
+
+        var query = new GetKbChunkByIdQuery(docId, Guid.NewGuid(), UserIsAdmin: false);
+        var act = () => _handler.Handle(query, CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    private async Task<(Guid chunk0, Guid chunk1, Guid chunk2)> SeedThreeChunksAsync(Guid docId)
+    {
+        var pdf = new PdfDocumentEntity
+        {
+            Id = docId,
+            FileName = $"doc-{docId}.pdf",
+            ProcessingState = "Ready",
+            UploadedAt = DateTime.UtcNow,
+            Language = "en",
+            DocumentCategory = "Rulebook",
+            UploadedByUserId = Guid.NewGuid(),
+            FilePath = "/tmp/doc.pdf"
+        };
+        _dbContext.PdfDocuments.Add(pdf);
+
+        var chunk0 = Guid.NewGuid();
+        var chunk1 = Guid.NewGuid();
+        var chunk2 = Guid.NewGuid();
+        _dbContext.TextChunks.AddRange(
+            new TextChunkEntity
+            {
+                Id = chunk0,
+                PdfDocumentId = docId,
+                Content = "first content",
+                ChunkIndex = 0,
+                CharacterCount = 13,
+                ElementType = "NarrativeText",
+                Level = 1
+            },
+            new TextChunkEntity
+            {
+                Id = chunk1,
+                PdfDocumentId = docId,
+                Content = "middle content",
+                ChunkIndex = 1,
+                CharacterCount = 14,
+                ElementType = "NarrativeText",
+                Level = 1
+            },
+            new TextChunkEntity
+            {
+                Id = chunk2,
+                PdfDocumentId = docId,
+                Content = "last content",
+                ChunkIndex = 2,
+                CharacterCount = 12,
+                ElementType = "NarrativeText",
+                Level = 1
+            }
+        );
+        await _dbContext.SaveChangesAsync();
+        return (chunk0, chunk1, chunk2);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunksHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunksHandlerTests.cs
@@ -1,0 +1,130 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class GetKbChunksHandlerTests
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetKbChunksHandler> _logger;
+    private readonly GetKbChunksHandler _handler;
+
+    public GetKbChunksHandlerTests()
+    {
+        _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
+        _logger = Substitute.For<ILogger<GetKbChunksHandler>>();
+        _handler = new GetKbChunksHandler(_dbContext, _logger);
+    }
+
+    [Fact]
+    public async Task Handle_WhenDocHas120Chunks_ReturnsFirstPage()
+    {
+        var docId = await SeedDocumentWithChunksAsync(120, processingState: "Ready");
+        var query = new GetKbChunksQuery(docId, Skip: 0, Take: 50, UserIsAdmin: false);
+
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        result.Chunks.Should().HaveCount(50);
+        result.Chunks.Select(c => c.Position).Should().BeInAscendingOrder();
+        result.TotalCount.Should().Be(120);
+        result.HasMore.Should().BeTrue();
+        result.Chunks.First().Snippet.Length.Should().BeLessThanOrEqualTo(200);
+        result.ProcessingState.Should().Be("ready");
+    }
+
+    [Fact]
+    public async Task Handle_LastPagePartial_HasMoreFalse()
+    {
+        var docId = await SeedDocumentWithChunksAsync(120, processingState: "Ready");
+        var query = new GetKbChunksQuery(docId, Skip: 100, Take: 50, UserIsAdmin: false);
+
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        result.Chunks.Should().HaveCount(20);
+        result.HasMore.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_DocStillProcessing_ReturnsEmptyChunks()
+    {
+        var docId = await SeedDocumentWithChunksAsync(0, processingState: "Embedding");
+        var query = new GetKbChunksQuery(docId, Skip: 0, Take: 50, UserIsAdmin: false);
+
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        result.Chunks.Should().BeEmpty();
+        result.ProcessingState.Should().Be("embedding");
+    }
+
+    [Fact]
+    public async Task Handle_AdminSeesDiagnosticFields()
+    {
+        var docId = await SeedDocumentWithChunksAsync(5, processingState: "Ready");
+        var query = new GetKbChunksQuery(docId, Skip: 0, Take: 5, UserIsAdmin: true);
+
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        result.Chunks.Should().HaveCount(5);
+        result.Chunks.First().VectorId.Should().NotBeNull();
+        result.Chunks.First().CharacterCount.Should().NotBeNull();
+        result.Chunks.First().ElementType.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_NonAdminGetsAdminFieldsNulled()
+    {
+        var docId = await SeedDocumentWithChunksAsync(5, processingState: "Ready");
+        var query = new GetKbChunksQuery(docId, Skip: 0, Take: 5, UserIsAdmin: false);
+
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        result.Chunks.Should().HaveCount(5);
+        result.Chunks.First().VectorId.Should().BeNull();
+        result.Chunks.First().CharacterCount.Should().BeNull();
+        result.Chunks.First().ElementType.Should().BeNull();
+        result.Chunks.First().EmbeddingStatus.Should().BeNull();
+    }
+
+    private async Task<Guid> SeedDocumentWithChunksAsync(int chunkCount, string processingState)
+    {
+        var docId = Guid.NewGuid();
+        var pdf = new PdfDocumentEntity
+        {
+            Id = docId,
+            FileName = $"test-{chunkCount}.pdf",
+            ProcessingState = processingState,
+            UploadedAt = DateTime.UtcNow,
+            Language = "en",
+            DocumentCategory = "Rulebook",
+            UploadedByUserId = Guid.NewGuid(),
+            FilePath = "/tmp/test.pdf"
+        };
+        _dbContext.PdfDocuments.Add(pdf);
+
+        for (int i = 0; i < chunkCount; i++)
+        {
+            _dbContext.TextChunks.Add(new TextChunkEntity
+            {
+                Id = Guid.NewGuid(),
+                PdfDocumentId = docId,
+                Content = $"Chunk content {i} - some text to make a snippet",
+                ChunkIndex = i,
+                PageNumber = (i / 4) + 1,
+                CharacterCount = 50,
+                ElementType = "NarrativeText",
+                Level = 1
+            });
+        }
+        await _dbContext.SaveChangesAsync();
+        return docId;
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentByIdHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentByIdHandlerTests.cs
@@ -1,0 +1,144 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbDocumentById;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class GetKbDocumentByIdHandlerTests
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetKbDocumentByIdHandler> _logger;
+    private readonly GetKbDocumentByIdHandler _handler;
+
+    public GetKbDocumentByIdHandlerTests()
+    {
+        _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
+        _logger = Substitute.For<ILogger<GetKbDocumentByIdHandler>>();
+        _handler = new GetKbDocumentByIdHandler(_dbContext, _logger);
+    }
+
+    [Fact]
+    public async Task Handle_WhenDocReady_ReturnsFullMetadata()
+    {
+        // Arrange
+        var docId = Guid.NewGuid();
+        var pdf = new PdfDocumentEntity
+        {
+            Id = docId,
+            FileName = "Catan rulebook.pdf",
+            ProcessingState = "Ready",
+            PageCount = 32,
+            UploadedAt = DateTime.UtcNow.AddHours(-1),
+            Language = "it",
+            DocumentCategory = "Rulebook",
+            UploadedByUserId = Guid.NewGuid(),
+            FilePath = "/tmp/test.pdf"
+        };
+        var vd = new VectorDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = docId,
+            GameId = Guid.NewGuid(),
+            ChunkCount = 120,
+            IndexedAt = DateTime.UtcNow,
+            IndexingStatus = "Completed"
+        };
+        _dbContext.PdfDocuments.Add(pdf);
+        _dbContext.VectorDocuments.Add(vd);
+        await _dbContext.SaveChangesAsync();
+
+        var query = new GetKbDocumentByIdQuery(docId, UserIsAdmin: false);
+
+        // Act
+        var dto = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto!.Title.Should().Be("Catan rulebook.pdf");
+        dto.ProcessingState.Should().Be("ready");
+        dto.TotalChunks.Should().Be(120);
+        dto.PageCount.Should().Be(32);
+        dto.ProcessingError.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_WhenDocFailed_AdminSeesError()
+    {
+        var docId = Guid.NewGuid();
+        var pdf = new PdfDocumentEntity
+        {
+            Id = docId,
+            FileName = "BrokenDoc.pdf",
+            ProcessingState = "Failed",
+            ProcessingError = "Embedding API timeout",
+            RetryCount = 2,
+            FailedAtState = "Embedding",
+            UploadedAt = DateTime.UtcNow,
+            Language = "en",
+            DocumentCategory = "Rulebook",
+            UploadedByUserId = Guid.NewGuid(),
+            FilePath = "/tmp/broken.pdf"
+        };
+        _dbContext.PdfDocuments.Add(pdf);
+        await _dbContext.SaveChangesAsync();
+
+        var query = new GetKbDocumentByIdQuery(docId, UserIsAdmin: true);
+
+        var dto = await _handler.Handle(query, CancellationToken.None);
+
+        dto.Should().NotBeNull();
+        dto!.ProcessingError.Should().Be("Embedding API timeout");
+        dto.RetryCount.Should().Be(2);
+        dto.FailedAtState.Should().Be("Embedding");
+    }
+
+    [Fact]
+    public async Task Handle_WhenNonAdminViewsFailedDoc_ErrorFieldsAreNull()
+    {
+        var docId = Guid.NewGuid();
+        var pdf = new PdfDocumentEntity
+        {
+            Id = docId,
+            FileName = "BrokenDoc.pdf",
+            ProcessingState = "Failed",
+            ProcessingError = "Embedding API timeout",
+            RetryCount = 2,
+            FailedAtState = "Embedding",
+            UploadedAt = DateTime.UtcNow,
+            Language = "en",
+            DocumentCategory = "Rulebook",
+            UploadedByUserId = Guid.NewGuid(),
+            FilePath = "/tmp/broken.pdf"
+        };
+        _dbContext.PdfDocuments.Add(pdf);
+        await _dbContext.SaveChangesAsync();
+
+        var query = new GetKbDocumentByIdQuery(docId, UserIsAdmin: false);
+
+        var dto = await _handler.Handle(query, CancellationToken.None);
+
+        dto!.ProcessingState.Should().Be("failed");
+        dto.ProcessingError.Should().BeNull();
+        dto.RetryCount.Should().BeNull();
+        dto.FailedAtState.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_WhenDocNotFound_ThrowsNotFoundException()
+    {
+        var query = new GetKbDocumentByIdQuery(Guid.NewGuid(), UserIsAdmin: false);
+
+        var act = () => _handler.Handle(query, CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentByIdHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentByIdHandlerTests.cs
@@ -141,4 +141,46 @@ public sealed class GetKbDocumentByIdHandlerTests
 
         await act.Should().ThrowAsync<NotFoundException>();
     }
+
+    [Fact]
+    public async Task Handle_WhenReadyDocAndAdmin_AdminFieldsAreNull()
+    {
+        // Arrange: Ready doc with RetryCount=0 (default, no retries occurred)
+        var docId = Guid.NewGuid();
+        var pdf = new PdfDocumentEntity
+        {
+            Id = docId,
+            FileName = "Ready.pdf",
+            ProcessingState = "Ready",
+            PageCount = 10,
+            UploadedAt = DateTime.UtcNow,
+            Language = "en",
+            DocumentCategory = "Rulebook",
+            UploadedByUserId = Guid.NewGuid(),
+            FilePath = "/tmp/ready.pdf"
+        };
+        var vd = new VectorDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = docId,
+            GameId = Guid.NewGuid(),
+            ChunkCount = 50,
+            IndexedAt = DateTime.UtcNow,
+            IndexingStatus = "Completed"
+        };
+        _dbContext.PdfDocuments.Add(pdf);
+        _dbContext.VectorDocuments.Add(vd);
+        await _dbContext.SaveChangesAsync();
+
+        var query = new GetKbDocumentByIdQuery(docId, UserIsAdmin: true);
+
+        // Act
+        var dto = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert: admin viewing a Ready doc — all admin fields should be null/omitted
+        dto!.ProcessingState.Should().Be("ready");
+        dto.ProcessingError.Should().BeNull();
+        dto.RetryCount.Should().BeNull();
+        dto.FailedAtState.Should().BeNull();
+    }
 }

--- a/apps/api/tests/Api.Tests/Integration/KbChunkEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KbChunkEndpointsIntegrationTests.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration;
+
+/// <summary>
+/// Integration tests for KB chunk/document endpoints (Issue #730).
+/// Tests: GET /api/v1/kb-docs/{id} (G4 single doc metadata).
+/// </summary>
+[Collection("Integration-GroupB")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class KbChunkEndpointsIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    public KbChunkEndpointsIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"kb_chunk_endpoints_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<Api.Infrastructure.MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+        }
+
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    // ========================================
+    // GET /api/v1/kb-docs/{id}  (G4)
+    // ========================================
+
+    [Fact]
+    public async Task GetKbDocument_WhenNotAuthenticated_Returns401()
+    {
+        // A fresh client without a session cookie hitting a RequireSession() endpoint
+        // should be rejected before the handler even attempts to find the document.
+        var response = await _client.GetAsync($"/api/v1/kb-docs/{Guid.NewGuid()}");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/KbChunkEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KbChunkEndpointsIntegrationTests.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
 using Api.Tests.Constants;
 using Api.Tests.Infrastructure;
 using FluentAssertions;
@@ -11,7 +13,8 @@ namespace Api.Tests.Integration;
 
 /// <summary>
 /// Integration tests for KB chunk/document endpoints (Issue #730).
-/// Tests: GET /api/v1/kb-docs/{id} (G4 single doc metadata).
+/// Tests: GET /api/v1/kb-docs/{id} (G4 single doc metadata),
+///        GET /api/v1/kb-docs/{id}/chunks (G1 chunk list + heading paths).
 /// </summary>
 [Collection("Integration-GroupB")]
 [Trait("Category", TestCategories.Integration)]
@@ -61,5 +64,137 @@ public sealed class KbChunkEndpointsIntegrationTests : IAsyncLifetime
         // should be rejected before the handler even attempts to find the document.
         var response = await _client.GetAsync($"/api/v1/kb-docs/{Guid.NewGuid()}");
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // ========================================
+    // GET /api/v1/kb-docs/{id}/chunks  (G1)
+    // ========================================
+
+    /// <summary>
+    /// Verifies that the recursive CTE in <c>GetKbChunksHandler.LoadHeadingPathsAsync</c>
+    /// correctly walks the parent chain and returns headings ordered from root to leaf.
+    ///
+    /// Seed hierarchy (ChunkIndex order):
+    ///   chunk0 (level 0, heading "Setup",        no parent)
+    ///   chunk1 (level 1, heading "Players",      parent = chunk0)
+    ///   chunk2 (level 2, heading "Distribution", parent = chunk1)
+    ///
+    /// Expected headingPath for leaf (chunk2): ["Setup", "Players", "Distribution"]
+    /// </summary>
+    /// <remarks>
+    /// Skipped until Task 8 wires the G1 endpoint (GET /api/v1/kb-docs/{id}/chunks).
+    /// Without the route registration the request returns 404 before reaching the handler.
+    /// Remove the Skip once the endpoint is registered.
+    /// </remarks>
+    [Fact(Skip = "Wire GET /api/v1/kb-docs/{id}/chunks endpoint in Task 8 before enabling")]
+    public async Task GetKbChunks_NestedHeadings_ReturnsHeadingPath()
+    {
+        // Arrange — seed a doc with 3 chained chunks
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var docId = await SeedDocWithNestedChunksAsync(dbContext);
+
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/kb-docs/{docId}/chunks?skip=0&take=10",
+            sessionToken);
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = System.Text.Json.JsonDocument.Parse(json);
+        var chunks = doc.RootElement.GetProperty("chunks");
+        chunks.GetArrayLength().Should().Be(3);
+
+        // Leaf is the chunk at position (ChunkIndex) 2
+        var leaf = chunks.EnumerateArray()
+            .Single(c => c.GetProperty("position").GetInt32() == 2);
+
+        var headingPath = leaf.GetProperty("headingPath")
+            .EnumerateArray()
+            .Select(e => e.GetString()!)
+            .ToArray();
+
+        headingPath.Should().BeEquivalentTo(
+            new[] { "Setup", "Players", "Distribution" },
+            options => options.WithStrictOrdering());
+    }
+
+    // ─── Seed helpers ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Seeds a PdfDocumentEntity with 3 chained TextChunkEntities that form the
+    /// hierarchy: "Setup" (root) → "Players" (child) → "Distribution" (leaf).
+    /// </summary>
+    private static async Task<Guid> SeedDocWithNestedChunksAsync(MeepleAiDbContext dbContext)
+    {
+        var docId = Guid.NewGuid();
+        var uploadedBy = Guid.NewGuid();
+
+        dbContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = docId,
+            FileName = "nested-headings-test.pdf",
+            ProcessingState = "Ready",
+            UploadedAt = DateTime.UtcNow,
+            Language = "en",
+            DocumentCategory = "Rulebook",
+            UploadedByUserId = uploadedBy,
+            FilePath = "/tmp/nested-headings-test.pdf"
+        });
+
+        var chunk0Id = Guid.NewGuid();
+        var chunk1Id = Guid.NewGuid();
+        var chunk2Id = Guid.NewGuid();
+
+        dbContext.TextChunks.Add(new TextChunkEntity
+        {
+            Id = chunk0Id,
+            PdfDocumentId = docId,
+            Content = "Setup content",
+            ChunkIndex = 0,
+            PageNumber = 1,
+            CharacterCount = 13,
+            ElementType = "Title",
+            Level = 0,
+            Heading = "Setup",
+            ParentChunkId = null
+        });
+
+        dbContext.TextChunks.Add(new TextChunkEntity
+        {
+            Id = chunk1Id,
+            PdfDocumentId = docId,
+            Content = "Players content",
+            ChunkIndex = 1,
+            PageNumber = 1,
+            CharacterCount = 15,
+            ElementType = "Title",
+            Level = 1,
+            Heading = "Players",
+            ParentChunkId = chunk0Id
+        });
+
+        dbContext.TextChunks.Add(new TextChunkEntity
+        {
+            Id = chunk2Id,
+            PdfDocumentId = docId,
+            Content = "Distribution content",
+            ChunkIndex = 2,
+            PageNumber = 2,
+            CharacterCount = 20,
+            ElementType = "NarrativeText",
+            Level = 2,
+            Heading = "Distribution",
+            ParentChunkId = chunk1Id
+        });
+
+        await dbContext.SaveChangesAsync();
+        return docId;
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/KbChunkEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KbChunkEndpointsIntegrationTests.cs
@@ -154,7 +154,81 @@ public sealed class KbChunkEndpointsIntegrationTests : IAsyncLifetime
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
+    // ========================================
+    // GET /api/v1/kb-docs/{id}/chunks/{chunkId}  (G2)
+    // ========================================
+
+    /// <summary>
+    /// Verifies that requesting a chunk from a different document returns 404,
+    /// preventing cross-document chunk enumeration leakage.
+    /// The unit test <c>Handle_ChunkBelongsToOtherDoc_ThrowsNotFound</c> already
+    /// covers the handler logic; this integration test validates the full HTTP stack.
+    /// </summary>
+    [Fact]
+    public async Task GetKbChunk_ChunkBelongsToOtherDoc_Returns404()
+    {
+        // Arrange — seed two separate documents, each with one chunk
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var (docAId, _) = await SeedDocWithSingleChunkAsync(dbContext, userId);
+        var (_, chunkBId) = await SeedDocWithSingleChunkAsync(dbContext, userId);
+
+        // Request chunk from docB while specifying docA in the URL
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/kb-docs/{docAId}/chunks/{chunkBId}",
+            sessionToken);
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
     // ─── Seed helpers ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Seeds a PdfDocumentEntity with a single TextChunkEntity.
+    /// Returns (docId, chunkId) for use in G2 tests.
+    /// </summary>
+    private static async Task<(Guid DocId, Guid ChunkId)> SeedDocWithSingleChunkAsync(
+        MeepleAiDbContext dbContext,
+        Guid uploadedByUserId)
+    {
+        var docId = Guid.NewGuid();
+        var chunkId = Guid.NewGuid();
+
+        dbContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = docId,
+            FileName = $"single-chunk-{docId:N}.pdf",
+            ProcessingState = "Ready",
+            UploadedAt = DateTime.UtcNow,
+            Language = "en",
+            DocumentCategory = "Rulebook",
+            UploadedByUserId = uploadedByUserId,
+            FilePath = $"/tmp/single-{docId:N}.pdf"
+        });
+
+        dbContext.TextChunks.Add(new TextChunkEntity
+        {
+            Id = chunkId,
+            PdfDocumentId = docId,
+            Content = "Only chunk content",
+            ChunkIndex = 0,
+            PageNumber = 1,
+            CharacterCount = 18,
+            ElementType = "NarrativeText",
+            Level = 1
+        });
+
+        await dbContext.SaveChangesAsync();
+        return (docId, chunkId);
+    }
 
     /// <summary>
     /// Seeds a PdfDocumentEntity with 3 chained TextChunkEntities that form the

--- a/apps/api/tests/Api.Tests/Integration/KbChunkEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KbChunkEndpointsIntegrationTests.cs
@@ -3,6 +3,7 @@ using Api.Infrastructure;
 using Api.Infrastructure.Entities;
 using Api.Tests.Constants;
 using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
@@ -86,15 +87,17 @@ public sealed class KbChunkEndpointsIntegrationTests : IAsyncLifetime
     /// Without the route registration the request returns 404 before reaching the handler.
     /// Remove the Skip once the endpoint is registered.
     /// </remarks>
-    [Fact(Skip = "Wire GET /api/v1/kb-docs/{id}/chunks endpoint in Task 8 before enabling")]
+    [Fact]
     public async Task GetKbChunks_NestedHeadings_ReturnsHeadingPath()
     {
         // Arrange — seed a doc with 3 chained chunks
         using var scope = _factory.Services.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
-        var docId = await SeedDocWithNestedChunksAsync(dbContext);
 
-        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        // Create a real user first — PdfDocument.UploadedByUserId has a FK constraint to users
+        var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var docId = await SeedDocWithNestedChunksAsync(dbContext, uploadedByUserId: userId);
+
         var request = TestSessionHelper.CreateAuthenticatedRequest(
             HttpMethod.Get,
             $"/api/v1/kb-docs/{docId}/chunks?skip=0&take=10",
@@ -125,16 +128,48 @@ public sealed class KbChunkEndpointsIntegrationTests : IAsyncLifetime
             options => options.WithStrictOrdering());
     }
 
+    /// <summary>
+    /// Verifies the endpoint returns 400 Bad Request when take exceeds the maximum of 100.
+    /// The take validation happens before the document lookup, so no seed is required.
+    /// An unauthenticated client will get 401 before the handler runs; use an authenticated
+    /// request so the validation code path is exercised.
+    /// </summary>
+    [Fact]
+    public async Task GetKbChunks_TakeExceedsLimit_Returns400()
+    {
+        // Arrange — create an authenticated session so we reach the validation code
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/kb-docs/{Guid.NewGuid()}/chunks?take=500",
+            sessionToken);
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert — 400 because take=500 > 100 (validation fires before document lookup)
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
     // ─── Seed helpers ────────────────────────────────────────────────────────
 
     /// <summary>
     /// Seeds a PdfDocumentEntity with 3 chained TextChunkEntities that form the
     /// hierarchy: "Setup" (root) → "Players" (child) → "Distribution" (leaf).
     /// </summary>
-    private static async Task<Guid> SeedDocWithNestedChunksAsync(MeepleAiDbContext dbContext)
+    /// <param name="dbContext">Test database context.</param>
+    /// <param name="uploadedByUserId">
+    /// The ID of a user that already exists in the database.
+    /// PdfDocument.UploadedByUserId has a FK constraint — a random Guid will fail.
+    /// </param>
+    private static async Task<Guid> SeedDocWithNestedChunksAsync(
+        MeepleAiDbContext dbContext,
+        Guid uploadedByUserId)
     {
         var docId = Guid.NewGuid();
-        var uploadedBy = Guid.NewGuid();
 
         dbContext.PdfDocuments.Add(new PdfDocumentEntity
         {
@@ -144,7 +179,7 @@ public sealed class KbChunkEndpointsIntegrationTests : IAsyncLifetime
             UploadedAt = DateTime.UtcNow,
             Language = "en",
             DocumentCategory = "Rulebook",
-            UploadedByUserId = uploadedBy,
+            UploadedByUserId = uploadedByUserId,
             FilePath = "/tmp/nested-headings-test.pdf"
         });
 

--- a/docs/superpowers/plans/2026-05-06-kb-chunk-endpoints-plan.md
+++ b/docs/superpowers/plans/2026-05-06-kb-chunk-endpoints-plan.md
@@ -1,0 +1,2236 @@
+# KB Chunk-Level Retrieval Endpoints — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement 5 backend endpoints (4 queries + 1 search) for chunk-level retrieval to unblock V2 migration Wave 3 child #684 (`/kb/[id]` split-view).
+
+**Architecture:** Extend `TextChunkEntity` with hierarchy fields (`heading`, `parent_chunk_id`, `level`, `element_type`), expose chunk metadata via 4 MediatR query handlers + 1 search handler with PostgreSQL FTS, gate admin-only fields per-DTO via `[JsonIgnore(WhenWritingNull)]`. Frontend gets Zod schemas + React Query hooks.
+
+**Tech Stack:** .NET 9 · ASP.NET Minimal APIs · MediatR · EF Core 9 (PostgreSQL 16 + pgvector) · xUnit + FluentAssertions + NSubstitute · Next.js 16 · React Query · Zod
+
+**Spec:** `docs/superpowers/specs/2026-05-06-kb-chunk-endpoints-design.md`
+
+---
+
+## File Structure
+
+### Backend — Created
+
+| File | Responsibility |
+|------|----------------|
+| `apps/api/src/Api/Infrastructure/Migrations/<timestamp>_AddChunkHierarchyToTextChunkEntity.cs` | EF Core migration adding 4 columns + 2 indexes |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/GetKbDocumentByIdQuery.cs` | Query record |
+| `…/GetKbDocumentById/GetKbDocumentByIdHandler.cs` | Handler (G4) |
+| `…/GetKbDocumentById/KbDocumentDto.cs` | DTO |
+| `…/GetKbChunks/GetKbChunksQuery.cs` | Query record + paging params |
+| `…/GetKbChunks/GetKbChunksHandler.cs` | Handler (G1) with recursive CTE for headingPath |
+| `…/GetKbChunks/KbChunkSummaryDto.cs` | DTO with admin-only fields nullable |
+| `…/GetKbChunks/KbChunkListDto.cs` | Wrapper DTO with pagination meta |
+| `…/GetKbChunkById/GetKbChunkByIdQuery.cs` | Query record |
+| `…/GetKbChunkById/GetKbChunkByIdHandler.cs` | Handler (G2) with prev/next |
+| `…/GetKbChunkById/KbChunkDetailDto.cs` | DTO with full content + admin fields |
+| `…/SearchKbChunks/SearchKbChunksQuery.cs` | Query record + validation |
+| `…/SearchKbChunks/SearchKbChunksHandler.cs` | Handler (G3) with FTS |
+| `…/SearchKbChunks/KbChunkMatchDto.cs` | DTO with rank + highlighted snippet |
+| `…/SearchKbChunks/KbChunkSearchResultDto.cs` | Wrapper DTO |
+| `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentByIdHandlerTests.cs` | Unit tests |
+| `…/GetKbChunksHandlerTests.cs` | Unit tests |
+| `…/GetKbChunkByIdHandlerTests.cs` | Unit tests |
+| `…/SearchKbChunksHandlerTests.cs` | Unit tests |
+| `apps/api/tests/Api.Tests/Integration/KbChunkEndpointsIntegrationTests.cs` | Testcontainers PostgreSQL integration tests |
+
+### Backend — Modified
+
+| File | Change |
+|------|--------|
+| `apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/TextChunkEntity.cs` | Add 4 properties (`Heading`, `ParentChunkId`, `Level`, `ElementType`) |
+| `apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/TextChunkEntityConfiguration.cs` | Configure new properties + indexes |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/AdvancedChunkingService.cs` | Persist new fields when writing `TextChunkEntity` rows |
+| `apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs` | Register 4 new endpoint methods + handlers |
+
+### Frontend — Created
+
+| File | Responsibility |
+|------|----------------|
+| `apps/web/src/lib/api/schemas/kb-document.schemas.ts` | Zod schemas for the 4 DTOs |
+| `apps/web/src/hooks/queries/useKbDocument.ts` | React Query hook for G4 |
+| `apps/web/src/hooks/queries/useKbChunks.ts` | React Query hook for G1 (paginated) |
+| `apps/web/src/hooks/queries/useKbChunk.ts` | React Query hook for G2 |
+| `apps/web/src/hooks/queries/useKbChunkSearch.ts` | React Query hook for G3 |
+
+### Frontend — Modified
+
+| File | Change |
+|------|--------|
+| `apps/web/src/lib/api/clients/knowledgeBaseClient.ts` | Add 4 client methods (`getKbDocument`, `getKbChunks`, `getKbChunk`, `searchKbChunks`) |
+| `apps/web/src/hooks/queries/index.ts` | Export new hooks |
+| `apps/web/src/lib/api/schemas/index.ts` | Export new schemas |
+
+---
+
+## Task 1: Extend TextChunkEntity with hierarchy fields
+
+**Files:**
+- Modify: `apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/TextChunkEntity.cs`
+- Modify: `apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/TextChunkEntityConfiguration.cs`
+
+- [ ] **Step 1: Add 4 properties to TextChunkEntity**
+
+Edit `TextChunkEntity.cs` after `CreatedAt` (line 28), before `SearchVector`:
+
+```csharp
+// Issue #730: Chunk hierarchy fields (heading_path derivation)
+public string? Heading { get; set; }
+public Guid? ParentChunkId { get; set; }
+public short Level { get; set; } = 1;
+public string ElementType { get; set; } = "NarrativeText";
+```
+
+- [ ] **Step 2: Configure new properties in TextChunkEntityConfiguration**
+
+Edit `TextChunkEntityConfiguration.cs`, append before the existing `HasIndex` calls (after line 22 `builder.Property(e => e.CreatedAt).IsRequired();`):
+
+```csharp
+// Issue #730: Chunk hierarchy fields
+builder.Property(e => e.Heading).HasMaxLength(500).IsRequired(false);
+builder.Property(e => e.ParentChunkId).IsRequired(false);
+builder.Property(e => e.Level).IsRequired().HasDefaultValue<short>(1);
+builder.Property(e => e.ElementType).IsRequired().HasMaxLength(20).HasDefaultValue("NarrativeText");
+
+builder.HasIndex(e => e.ParentChunkId);
+builder.HasIndex(e => new { e.PdfDocumentId, e.ChunkIndex }).HasDatabaseName("ix_text_chunks_pdf_chunk_index");
+```
+
+- [ ] **Step 3: Build to verify no compile errors**
+
+```bash
+cd apps/api/src/Api && dotnet build
+```
+
+Expected: build succeeds with zero errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/TextChunkEntity.cs apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/TextChunkEntityConfiguration.cs
+git commit -m "feat(kb): #730 add chunk hierarchy fields to TextChunkEntity
+
+Adds Heading, ParentChunkId, Level, ElementType properties + EF Core
+configuration. Indexes on ParentChunkId and (PdfDocumentId, ChunkIndex)
+for recursive CTE traversal and ordered chunk navigation.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Generate and apply EF Core migration
+
+**Files:**
+- Create: `apps/api/src/Api/Infrastructure/Migrations/<timestamp>_AddChunkHierarchyToTextChunkEntity.cs` (auto-generated)
+
+- [ ] **Step 1: Generate migration**
+
+```bash
+cd apps/api/src/Api
+dotnet ef migrations add AddChunkHierarchyToTextChunkEntity
+```
+
+Expected: new migration file appears in `Infrastructure/Migrations/` with `Up()` adding 4 columns + 2 indexes.
+
+- [ ] **Step 2: Review the generated SQL**
+
+Inspect the migration file (`Infrastructure/Migrations/<timestamp>_AddChunkHierarchyToTextChunkEntity.cs`). Verify the `Up()` method contains:
+- 4 `AddColumn<>` calls for `Heading`, `ParentChunkId`, `Level`, `ElementType`
+- 2 `CreateIndex` calls
+- A `Down()` method with reverse operations
+
+If anything looks off (e.g., wrong column types or missing defaults), do NOT edit the migration. Instead, adjust the entity configuration in Task 1 and regenerate.
+
+- [ ] **Step 3: Apply migration to dev database**
+
+```bash
+cd apps/api/src/Api
+dotnet ef database update
+```
+
+Expected: "Done." with no errors. Existing rows have `Heading=NULL`, `ParentChunkId=NULL`, `Level=1`, `ElementType='NarrativeText'`.
+
+- [ ] **Step 4: Verify schema in PostgreSQL**
+
+```bash
+docker exec meepleai-postgres psql -U meepleai -d meepleai -c "\d text_chunks" | grep -E "heading|parent_chunk|level|element_type"
+```
+
+Expected output includes 4 lines with the new columns.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Migrations/
+git commit -m "feat(kb): #730 EF migration AddChunkHierarchyToTextChunkEntity
+
+Adds heading, parent_chunk_id, level, element_type columns to
+text_chunks plus indexes ix_text_chunks_parent_chunk_id and
+ix_text_chunks_pdf_chunk_index.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Persist chunk hierarchy in AdvancedChunkingService (forward path)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/AdvancedChunkingService.cs`
+
+**Note:** This task ensures NEW ingestions populate the 4 new columns. Backfill of legacy rows is out-of-scope (separate follow-up issue).
+
+- [ ] **Step 1: Locate the TextChunkEntity persistence point**
+
+Read `AdvancedChunkingService.cs`. Find where `TextChunkEntity` instances are created and added to `DbContext` (look for `new TextChunkEntity` or `_dbContext.TextChunks.Add`).
+
+If the persistence is delegated to a collaborator (`ITextChunkRepository`, `IPersistChunksService`, etc.), follow the chain to the actual write site.
+
+- [ ] **Step 2: Map ChunkPayload → TextChunkEntity new fields**
+
+At the persistence site, for each chunk being written, populate the new properties from the corresponding `ChunkPayload` or `ChunkMetadata` source:
+
+```csharp
+var entity = new TextChunkEntity
+{
+    Id = chunk.Id,
+    GameId = chunk.GameId,
+    PdfDocumentId = chunk.PdfDocumentId,
+    Content = chunk.Content,
+    ChunkIndex = chunk.ChunkIndex,
+    PageNumber = chunk.PageNumber,
+    CharacterCount = chunk.Content.Length,
+    CreatedAt = DateTime.UtcNow,
+    // Issue #730: hierarchy fields
+    Heading = payload.Heading,
+    ParentChunkId = string.IsNullOrEmpty(payload.ParentChunkId) ? null : Guid.Parse(payload.ParentChunkId),
+    Level = (short)payload.Level,
+    ElementType = payload.ElementType ?? "NarrativeText"
+};
+```
+
+(Adapt to the actual variable names found in step 1; the field-mapping is what matters.)
+
+- [ ] **Step 3: Add a unit test (or extend an existing one) asserting new fields are set**
+
+If a unit test already covers the persistence (`AdvancedChunkingServiceTests.cs` or similar), add an assertion:
+
+```csharp
+[Fact]
+public async Task ChunkAsync_PersistsHierarchyFields()
+{
+    // Arrange: existing test setup with synthetic chunks
+    // Act: invoke ChunkAsync
+    // Assert:
+    var saved = await _dbContext.TextChunks.FirstAsync();
+    saved.Heading.Should().NotBeNullOrEmpty();
+    saved.Level.Should().BeInRange((short)0, (short)2);
+    saved.ElementType.Should().NotBeNullOrEmpty();
+}
+```
+
+If no such test exists, create `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/Chunking/AdvancedChunkingServicePersistenceTests.cs` with an integration test using Testcontainers (skip if pattern is too unfamiliar; integration coverage in Task 12 catches this).
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd apps/api/src/Api
+dotnet test --filter "FullyQualifiedName~AdvancedChunkingService" --logger "console;verbosity=normal"
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/AdvancedChunkingService.cs apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/Chunking/
+git commit -m "feat(kb): #730 persist chunk hierarchy on ingestion
+
+AdvancedChunkingService now writes Heading, ParentChunkId, Level,
+ElementType to TextChunkEntity (mirror of Qdrant ChunkPayload).
+Backfill of legacy rows tracked separately.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: G4 — `GetKbDocumentByIdQuery` (smallest endpoint, sets auth pattern)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/GetKbDocumentByIdQuery.cs`
+- Create: `…/KbDocumentDto.cs`
+- Create: `…/GetKbDocumentByIdHandler.cs`
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentByIdHandlerTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create the test file with three scenarios from G4 Gherkin:
+
+```csharp
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbDocumentById;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class GetKbDocumentByIdHandlerTests
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetKbDocumentByIdHandler> _logger;
+    private readonly GetKbDocumentByIdHandler _handler;
+
+    public GetKbDocumentByIdHandlerTests()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _dbContext = new MeepleAiDbContext(options);
+        _logger = Substitute.For<ILogger<GetKbDocumentByIdHandler>>();
+        _handler = new GetKbDocumentByIdHandler(_dbContext, _logger);
+    }
+
+    [Fact]
+    public async Task Handle_WhenDocReady_ReturnsFullMetadata()
+    {
+        // Arrange
+        var docId = Guid.NewGuid();
+        var pdf = new PdfDocumentEntity
+        {
+            Id = docId,
+            FileName = "Catan rulebook.pdf",
+            ProcessingState = "Ready",
+            PageCount = 32,
+            UploadedAt = DateTime.UtcNow.AddHours(-1),
+            Language = "it",
+            DocumentCategory = "Rulebook",
+            UploadedByUserId = Guid.NewGuid(),
+            FilePath = "/tmp/test.pdf"
+        };
+        var vd = new VectorDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = docId,
+            GameId = Guid.NewGuid(),
+            TotalChunks = 120,
+            IndexedAt = DateTime.UtcNow,
+            IndexingStatus = "Completed",
+            Language = "it"
+        };
+        _dbContext.PdfDocuments.Add(pdf);
+        _dbContext.VectorDocuments.Add(vd);
+        await _dbContext.SaveChangesAsync();
+
+        var query = new GetKbDocumentByIdQuery(docId, UserIsAdmin: false);
+
+        // Act
+        var dto = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto!.Title.Should().Be("Catan rulebook.pdf");
+        dto.ProcessingState.Should().Be("ready");
+        dto.TotalChunks.Should().Be(120);
+        dto.PageCount.Should().Be(32);
+        dto.ProcessingError.Should().BeNull();  // not admin → admin field nulled
+    }
+
+    [Fact]
+    public async Task Handle_WhenDocFailed_AdminSeesError()
+    {
+        // Arrange (similar setup with ProcessingState="Failed", ProcessingError="...")
+        // Act with UserIsAdmin: true
+        // Assert: dto.ProcessingError.Should().Be("Embedding API timeout");
+    }
+
+    [Fact]
+    public async Task Handle_WhenDocNotFound_ThrowsNotFoundException()
+    {
+        // Arrange
+        var query = new GetKbDocumentByIdQuery(Guid.NewGuid(), UserIsAdmin: false);
+
+        // Act
+        var act = () => _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify compile failure (handler not implemented)**
+
+```bash
+cd apps/api/src/Api
+dotnet build
+```
+
+Expected: compile error referencing missing types `GetKbDocumentByIdQuery`, `GetKbDocumentByIdHandler`, `KbDocumentDto`.
+
+- [ ] **Step 3: Create the Query record**
+
+`apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/GetKbDocumentByIdQuery.cs`:
+
+```csharp
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbDocumentById;
+
+internal sealed record GetKbDocumentByIdQuery(
+    Guid DocumentId,
+    bool UserIsAdmin
+) : IQuery<KbDocumentDto?>;
+```
+
+- [ ] **Step 4: Create the DTO**
+
+`…/KbDocumentDto.cs`:
+
+```csharp
+using System.Text.Json.Serialization;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbDocumentById;
+
+internal sealed record KbDocumentDto(
+    Guid Id,
+    string Title,
+    Guid? GameId,
+    Guid? SharedGameId,
+    string DocumentCategory,
+    string ProcessingState,
+    int TotalChunks,
+    int PageCount,
+    DateTime? IndexedAt,
+    DateTime UploadedAt,
+    string Language,
+    string? VersionLabel,
+
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? ProcessingError,
+
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    int? RetryCount,
+
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? FailedAtState
+);
+```
+
+- [ ] **Step 5: Create the Handler**
+
+`…/GetKbDocumentByIdHandler.cs`:
+
+```csharp
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbDocumentById;
+
+internal sealed class GetKbDocumentByIdHandler : IQueryHandler<GetKbDocumentByIdQuery, KbDocumentDto?>
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetKbDocumentByIdHandler> _logger;
+
+    public GetKbDocumentByIdHandler(MeepleAiDbContext dbContext, ILogger<GetKbDocumentByIdHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<KbDocumentDto?> Handle(GetKbDocumentByIdQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        _logger.LogDebug("Fetching KB document {DocId} (admin={IsAdmin})", query.DocumentId, query.UserIsAdmin);
+
+        var data = await (
+            from pdf in _dbContext.PdfDocuments.AsNoTracking()
+            join vd in _dbContext.VectorDocuments.AsNoTracking()
+                on pdf.Id equals vd.PdfDocumentId into vdj
+            from vd in vdj.DefaultIfEmpty()
+            where pdf.Id == query.DocumentId
+            select new
+            {
+                pdf,
+                TotalChunks = vd != null ? vd.TotalChunks : 0,
+                IndexedAt = vd != null ? vd.IndexedAt : (DateTime?)null,
+                GameId = vd != null ? vd.GameId : (Guid?)null
+            }
+        ).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+
+        if (data is null)
+        {
+            throw new NotFoundException($"KB document {query.DocumentId} not found");
+        }
+
+        return new KbDocumentDto(
+            Id: data.pdf.Id,
+            Title: data.pdf.FileName,
+            GameId: data.GameId,
+            SharedGameId: data.pdf.SharedGameId,
+            DocumentCategory: data.pdf.DocumentCategory,
+            ProcessingState: data.pdf.ProcessingState.ToLowerInvariant(),
+            TotalChunks: data.TotalChunks,
+            PageCount: data.pdf.PageCount ?? 0,
+            IndexedAt: data.IndexedAt,
+            UploadedAt: data.pdf.UploadedAt,
+            Language: data.pdf.Language,
+            VersionLabel: data.pdf.VersionLabel,
+            ProcessingError: query.UserIsAdmin ? data.pdf.ProcessingError : null,
+            RetryCount: query.UserIsAdmin ? data.pdf.RetryCount : null,
+            FailedAtState: query.UserIsAdmin ? data.pdf.FailedAtState : null
+        );
+    }
+}
+```
+
+- [ ] **Step 6: Run tests, expect pass**
+
+```bash
+cd apps/api/src/Api
+dotnet test --filter "FullyQualifiedName~GetKbDocumentByIdHandler" --logger "console;verbosity=normal"
+```
+
+Expected: all 3 tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/ apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentByIdHandlerTests.cs
+git commit -m "feat(kb): #730 G4 GetKbDocumentByIdQuery handler
+
+Returns full doc metadata (title, gameId, processingState, totalChunks,
+pageCount, indexedAt, language, versionLabel) for /api/v1/kb-docs/{id}.
+Admin-only fields (processingError, retryCount, failedAtState) gated
+via UserIsAdmin flag and serialized with [JsonIgnore(WhenWritingNull)].
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: G4 — Wire endpoint in KnowledgeBaseEndpoints + integration test
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs`
+- Create: `apps/api/tests/Api.Tests/Integration/KbChunkEndpointsIntegrationTests.cs` (initial scaffolding for the suite)
+
+- [ ] **Step 1: Add `MapKbDocumentEndpoints` private method to KnowledgeBaseEndpoints.cs**
+
+Add to the file, near other Map methods:
+
+```csharp
+private static void MapKbDocumentEndpoints(RouteGroupBuilder group)
+{
+    // Issue #730: G4 single doc metadata
+    group.MapGet("/kb-docs/{id:guid}", HandleGetKbDocumentById)
+        .WithName("GetKbDocumentById")
+        .RequireSession()
+        .WithTags("KnowledgeBase")
+        .WithSummary("Get KB document metadata")
+        .WithDescription("Returns metadata for a single KB document (title, processing state, total chunks, page count). Admin users see additional diagnostic fields.")
+        .Produces<KbDocumentDto>()
+        .Produces(StatusCodes.Status404NotFound)
+        .Produces(StatusCodes.Status403Forbidden);
+}
+
+private static async Task<IResult> HandleGetKbDocumentById(
+    Guid id,
+    HttpContext httpContext,
+    IMediator mediator,
+    CancellationToken cancellationToken)
+{
+    var session = httpContext.GetSession();
+    var query = new GetKbDocumentByIdQuery(id, UserIsAdmin: session.User.Role == "Admin");
+    var dto = await mediator.Send(query, cancellationToken);
+    return dto is not null ? Results.Ok(dto) : Results.NotFound();
+}
+```
+
+(Adjust the `httpContext.GetSession()` and `session.User.Role` calls to match the project's actual session API — check the existing `HandleGetKnowledgeBaseStatus` for the canonical pattern.)
+
+- [ ] **Step 2: Add the `using` for the new namespace**
+
+At the top of `KnowledgeBaseEndpoints.cs`:
+
+```csharp
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbDocumentById;
+```
+
+- [ ] **Step 3: Register the new mapping in `MapKnowledgeBaseEndpoints`**
+
+Add to the chain (around line 40 next to `MapGameDocumentsEndpoint`):
+
+```csharp
+MapKbDocumentEndpoints(group);
+```
+
+- [ ] **Step 4: Build to verify compile**
+
+```bash
+cd apps/api/src/Api && dotnet build
+```
+
+Expected: builds cleanly.
+
+- [ ] **Step 5: Write the integration test scaffold**
+
+Create `apps/api/tests/Api.Tests/Integration/KbChunkEndpointsIntegrationTests.cs`:
+
+```csharp
+using System.Net;
+using System.Net.Http.Json;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbDocumentById;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Integration;
+
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class KbChunkEndpointsIntegrationTests : IClassFixture<MeepleAiWebApplicationFactory>
+{
+    private readonly MeepleAiWebApplicationFactory _factory;
+
+    public KbChunkEndpointsIntegrationTests(MeepleAiWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GetKbDocument_WhenAuthenticated_Returns200()
+    {
+        // Arrange
+        var (client, docId) = await _factory.CreateAuthenticatedClientWithSeededDocumentAsync(role: "User");
+
+        // Act
+        var response = await client.GetAsync($"/api/v1/kb-docs/{docId}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<KbDocumentDto>();
+        dto.Should().NotBeNull();
+        dto!.Id.Should().Be(docId);
+        dto.ProcessingError.Should().BeNull();  // not admin
+    }
+
+    [Fact]
+    public async Task GetKbDocument_AsAdmin_ReturnsErrorField()
+    {
+        // Similar but with role:"Admin" + a Failed doc seed
+    }
+
+    [Fact]
+    public async Task GetKbDocument_WhenNotFound_Returns404()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync($"/api/v1/kb-docs/{Guid.NewGuid()}");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}
+```
+
+(If `MeepleAiWebApplicationFactory` doesn't expose `CreateAuthenticatedClientWithSeededDocumentAsync`, follow the existing integration test pattern in `Api.Tests/Integration/` — look at any existing endpoint integration test and copy the seed/auth helpers.)
+
+- [ ] **Step 6: Run integration tests**
+
+```bash
+cd apps/api/src/Api
+dotnet test --filter "FullyQualifiedName~KbChunkEndpointsIntegrationTests" --logger "console;verbosity=normal"
+```
+
+Expected: 3 tests pass (initially the second admin test may use a stub; that's fine for now).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs apps/api/tests/Api.Tests/Integration/KbChunkEndpointsIntegrationTests.cs
+git commit -m "feat(kb): #730 G4 endpoint /api/v1/kb-docs/{id}
+
+Routing wiring + integration test scaffold. Admin role drives
+ProcessingError/RetryCount/FailedAtState population in DTO.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: G1 — `GetKbChunksQuery` DTOs + handler skeleton (no CTE yet)
+
+**Files:**
+- Create: `…/GetKbChunks/GetKbChunksQuery.cs`
+- Create: `…/GetKbChunks/KbChunkSummaryDto.cs`
+- Create: `…/GetKbChunks/KbChunkListDto.cs`
+- Create: `…/GetKbChunks/GetKbChunksHandler.cs`
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunksHandlerTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class GetKbChunksHandlerTests
+{
+    // ctor wires _dbContext (InMemory) + _handler (similar to GetKbDocumentByIdHandlerTests)
+
+    [Fact]
+    public async Task Handle_WhenDocHas120Chunks_ReturnsFirstPage()
+    {
+        // Arrange: seed 120 TextChunkEntity rows for one PdfDocumentId, with chunkIndex 0..119
+        // and varying heading values
+        var docId = await SeedDocumentWithChunksAsync(120);
+        var query = new GetKbChunksQuery(docId, Skip: 0, Take: 50, UserIsAdmin: false);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Chunks.Should().HaveCount(50);
+        result.Chunks.Select(c => c.Position).Should().BeInAscendingOrder();
+        result.TotalCount.Should().Be(120);
+        result.HasMore.Should().BeTrue();
+        result.Chunks.First().Snippet.Length.Should().BeLessThanOrEqualTo(200);
+    }
+
+    [Fact]
+    public async Task Handle_LastPagePartial_HasMoreFalse()
+    {
+        var docId = await SeedDocumentWithChunksAsync(120);
+        var query = new GetKbChunksQuery(docId, Skip: 100, Take: 50, UserIsAdmin: false);
+
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        result.Chunks.Should().HaveCount(20);
+        result.HasMore.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_DocStillProcessing_ReturnsEmptyChunks()
+    {
+        // Arrange: seed PdfDocument in state=Embedding with 0 chunks
+        // Act + Assert: result.Chunks empty, ProcessingState="embedding"
+    }
+
+    [Fact]
+    public async Task Handle_AdminSeesDiagnosticFields()
+    {
+        // Arrange: 5 chunks, each with elementType+characterCount populated
+        // Act with UserIsAdmin: true
+        // Assert: vectorId equals chunkId, characterCount > 0, elementType non-null
+    }
+
+    [Fact]
+    public async Task Handle_NonAdminGetsAdminFieldsNulled()
+    {
+        // Same seed
+        // Act with UserIsAdmin: false
+        // Assert: vectorId, characterCount, elementType, embeddingStatus all null
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify compile failure**
+
+Expected: missing types.
+
+- [ ] **Step 3: Create Query, DTOs, and Handler skeleton**
+
+`GetKbChunksQuery.cs`:
+
+```csharp
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
+
+internal sealed record GetKbChunksQuery(
+    Guid DocumentId,
+    int Skip,
+    int Take,
+    bool UserIsAdmin
+) : IQuery<KbChunkListDto>;
+```
+
+`KbChunkSummaryDto.cs`:
+
+```csharp
+using System.Text.Json.Serialization;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
+
+internal sealed record KbChunkSummaryDto(
+    Guid ChunkId,
+    int? PageNumber,
+    int Position,
+    short Level,
+    IReadOnlyList<string> HeadingPath,
+    string Snippet,
+
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    Guid? VectorId,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    int? CharacterCount,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? ElementType,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? EmbeddingStatus
+);
+```
+
+`KbChunkListDto.cs`:
+
+```csharp
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
+
+internal sealed record KbChunkListDto(
+    IReadOnlyList<KbChunkSummaryDto> Chunks,
+    int TotalCount,
+    int Skip,
+    int Take,
+    bool HasMore,
+    string ProcessingState
+);
+```
+
+`GetKbChunksHandler.cs` (skeleton, headingPath returns empty array for now):
+
+```csharp
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
+
+internal sealed class GetKbChunksHandler : IQueryHandler<GetKbChunksQuery, KbChunkListDto>
+{
+    private const int MaxTake = 100;
+    private const int SnippetMaxLength = 200;
+
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetKbChunksHandler> _logger;
+
+    public GetKbChunksHandler(MeepleAiDbContext dbContext, ILogger<GetKbChunksHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<KbChunkListDto> Handle(GetKbChunksQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var skip = Math.Max(0, query.Skip);
+        var take = Math.Clamp(query.Take, 1, MaxTake);
+
+        var processingState = await _dbContext.PdfDocuments.AsNoTracking()
+            .Where(p => p.Id == query.DocumentId)
+            .Select(p => p.ProcessingState.ToLower())
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false) ?? "unknown";
+
+        var totalCount = await _dbContext.TextChunks.AsNoTracking()
+            .CountAsync(c => c.PdfDocumentId == query.DocumentId, cancellationToken)
+            .ConfigureAwait(false);
+
+        var rows = await _dbContext.TextChunks.AsNoTracking()
+            .Where(c => c.PdfDocumentId == query.DocumentId)
+            .OrderBy(c => c.ChunkIndex)
+            .Skip(skip)
+            .Take(take)
+            .Select(c => new
+            {
+                c.Id,
+                c.PageNumber,
+                c.ChunkIndex,
+                c.Level,
+                c.Heading,
+                c.ParentChunkId,
+                c.Content,
+                c.CharacterCount,
+                c.ElementType
+            })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var chunks = rows.Select(r => new KbChunkSummaryDto(
+            ChunkId: r.Id,
+            PageNumber: r.PageNumber,
+            Position: r.ChunkIndex,
+            Level: r.Level,
+            HeadingPath: Array.Empty<string>(), // TODO: filled in Task 7 (CTE)
+            Snippet: TruncateSnippet(r.Content),
+            VectorId: query.UserIsAdmin ? r.Id : (Guid?)null,
+            CharacterCount: query.UserIsAdmin ? r.CharacterCount : (int?)null,
+            ElementType: query.UserIsAdmin ? r.ElementType : null,
+            EmbeddingStatus: query.UserIsAdmin ? "indexed" : null  // simple stub; refine if richer status is tracked
+        )).ToList();
+
+        return new KbChunkListDto(
+            Chunks: chunks,
+            TotalCount: totalCount,
+            Skip: skip,
+            Take: take,
+            HasMore: skip + take < totalCount,
+            ProcessingState: processingState
+        );
+    }
+
+    private static string TruncateSnippet(string content) =>
+        content.Length <= SnippetMaxLength ? content : content[..SnippetMaxLength];
+}
+```
+
+- [ ] **Step 4: Run unit tests, expect 4/5 pass (one will fail because headingPath is empty array)**
+
+```bash
+cd apps/api/src/Api
+dotnet test --filter "FullyQualifiedName~GetKbChunksHandlerTests" --logger "console;verbosity=normal"
+```
+
+Expected: 4 tests pass; the test asserting `headingPath` content (if you wrote one) fails. We'll fix this in Task 7.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/ apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunksHandlerTests.cs
+git commit -m "feat(kb): #730 G1 GetKbChunksQuery skeleton (headingPath stub)
+
+Paginated chunks list with offset pagination (max 100), DTO field
+gating for admin diagnostic fields. headingPath returns empty array
+pending CTE implementation in next commit.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: G1 — Implement headingPath via recursive CTE
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/GetKbChunksHandler.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `GetKbChunksHandlerTests.cs`:
+
+```csharp
+[Fact]
+public async Task Handle_NestedHeadings_ReturnsHeadingPathTraversal()
+{
+    // Arrange: seed 3 chunks where:
+    //   chunk1 (level=0, heading="Setup",       parent=null)
+    //   chunk2 (level=1, heading="Players",     parent=chunk1.Id)
+    //   chunk3 (level=2, heading="Distribution",parent=chunk2.Id)
+    // (and a few extra chunks at level=2 referencing chunk3 indirectly is overkill;
+    //  3 levels deep covers the recursive CTE)
+
+    var docId = Guid.NewGuid();
+    // ... seed PdfDocument + 3 TextChunks chained via ParentChunkId
+    await _dbContext.SaveChangesAsync();
+
+    var query = new GetKbChunksQuery(docId, Skip: 0, Take: 50, UserIsAdmin: false);
+
+    // Act
+    var result = await _handler.Handle(query, CancellationToken.None);
+
+    // Assert
+    var leaf = result.Chunks.Single(c => c.Position == 2);  // chunk3
+    leaf.HeadingPath.Should().BeEquivalentTo(new[] { "Setup", "Players", "Distribution" });
+}
+```
+
+**Note**: this test requires PostgreSQL to exercise the recursive CTE. EF InMemory does NOT support `WITH RECURSIVE`. Mark this test with `[Trait("Category", TestCategories.Integration)]` and use the Testcontainers fixture instead — or move it to `KbChunkEndpointsIntegrationTests.cs` where the suite already has DB access.
+
+- [ ] **Step 2: Run test, expect fail (CTE not implemented)**
+
+```bash
+cd apps/api/src/Api
+dotnet test --filter "FullyQualifiedName~Handle_NestedHeadings_ReturnsHeadingPathTraversal" --logger "console;verbosity=normal"
+```
+
+Expected: assertion fails (`HeadingPath` is empty array).
+
+- [ ] **Step 3: Implement the CTE in the handler**
+
+Replace the `chunks = rows.Select(...)` block in `GetKbChunksHandler.cs` with a two-phase approach:
+
+```csharp
+// Phase 1: load chunk rows (already done above)
+// Phase 2: load heading paths in a single SQL call using FromSqlRaw
+
+var chunkIds = rows.Select(r => r.Id).ToList();
+var headingPaths = chunkIds.Count == 0
+    ? new Dictionary<Guid, IReadOnlyList<string>>()
+    : await LoadHeadingPathsAsync(chunkIds, cancellationToken);
+
+var chunks = rows.Select(r => new KbChunkSummaryDto(
+    // ...same as before, but:
+    HeadingPath: headingPaths.TryGetValue(r.Id, out var path) ? path : Array.Empty<string>(),
+    // ...
+)).ToList();
+```
+
+Add the helper method to the handler class:
+
+```csharp
+private async Task<Dictionary<Guid, IReadOnlyList<string>>> LoadHeadingPathsAsync(
+    IReadOnlyList<Guid> chunkIds,
+    CancellationToken cancellationToken)
+{
+    // Use parameterized SQL with WITH RECURSIVE
+    const string sql = @"
+        WITH RECURSIVE chunk_path(start_id, id, heading, parent_chunk_id, depth) AS (
+          SELECT t.id AS start_id, t.id, t.heading, t.parent_chunk_id, 1 AS depth
+          FROM text_chunks t
+          WHERE t.id = ANY({0})
+          UNION ALL
+          SELECT cp.start_id, t.id, t.heading, t.parent_chunk_id, cp.depth + 1
+          FROM text_chunks t
+          JOIN chunk_path cp ON t.id = cp.parent_chunk_id
+          WHERE cp.depth < 10
+        )
+        SELECT start_id, heading, depth
+        FROM chunk_path
+        WHERE heading IS NOT NULL
+        ORDER BY start_id, depth DESC;";
+
+    var raw = await _dbContext.Database
+        .SqlQueryRaw<HeadingPathRow>(sql, new[] { chunkIds.ToArray() })
+        .ToListAsync(cancellationToken)
+        .ConfigureAwait(false);
+
+    return raw
+        .GroupBy(r => r.StartId)
+        .ToDictionary(
+            g => g.Key,
+            g => (IReadOnlyList<string>)g.Select(x => x.Heading!).ToList());
+}
+
+private sealed record HeadingPathRow(Guid StartId, string? Heading, int Depth);
+```
+
+(If `SqlQueryRaw` overload signatures differ in the project's EF version, fall back to `_dbContext.Database.GetDbConnection()` + an Npgsql command — but try `SqlQueryRaw` first since EF 9 supports it.)
+
+- [ ] **Step 4: Run integration test, expect pass**
+
+```bash
+cd apps/api/src/Api
+dotnet test --filter "FullyQualifiedName~Handle_NestedHeadings_ReturnsHeadingPathTraversal" --logger "console;verbosity=normal"
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Run all G1 tests to confirm no regression**
+
+```bash
+dotnet test --filter "FullyQualifiedName~GetKbChunksHandler" --logger "console;verbosity=normal"
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/GetKbChunksHandler.cs apps/api/tests/Api.Tests/Integration/KbChunkEndpointsIntegrationTests.cs
+git commit -m "feat(kb): #730 G1 headingPath via recursive CTE
+
+Loads heading_path arrays for all chunks in one SQL roundtrip using
+WITH RECURSIVE on text_chunks, capped at depth 10. Empty array when
+no heading exists in the parent chain.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: G1 — Wire `/kb-docs/{id}/chunks` endpoint
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs`
+
+- [ ] **Step 1: Add endpoint mapping inside `MapKbDocumentEndpoints`**
+
+```csharp
+// Issue #730: G1 paginated chunks list
+group.MapGet("/kb-docs/{id:guid}/chunks", HandleGetKbChunks)
+    .WithName("GetKbChunks")
+    .RequireSession()
+    .WithTags("KnowledgeBase")
+    .WithSummary("Get paginated chunks list with hierarchical headings")
+    .WithDescription("Returns chunks ordered by position with breadcrumb headingPath. Admin users see vectorId, characterCount, elementType, embeddingStatus.")
+    .Produces<KbChunkListDto>()
+    .Produces(StatusCodes.Status400BadRequest)
+    .Produces(StatusCodes.Status404NotFound);
+```
+
+- [ ] **Step 2: Add the handler method**
+
+```csharp
+private static async Task<IResult> HandleGetKbChunks(
+    Guid id,
+    int? skip,
+    int? take,
+    HttpContext httpContext,
+    IMediator mediator,
+    CancellationToken cancellationToken)
+{
+    var skipValue = skip ?? 0;
+    var takeValue = take ?? 50;
+
+    if (takeValue < 1 || takeValue > 100)
+    {
+        return Results.BadRequest(new { error = "take must be between 1 and 100" });
+    }
+
+    var session = httpContext.GetSession();
+    var query = new GetKbChunksQuery(id, skipValue, takeValue, UserIsAdmin: session.User.Role == "Admin");
+    var result = await mediator.Send(query, cancellationToken);
+    return Results.Ok(result);
+}
+```
+
+- [ ] **Step 3: Add `using` for the new namespace**
+
+```csharp
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
+```
+
+- [ ] **Step 4: Add an integration test for the take=500 boundary**
+
+In `KbChunkEndpointsIntegrationTests.cs`:
+
+```csharp
+[Fact]
+public async Task GetKbChunks_TakeExceedsLimit_Returns400()
+{
+    var (client, docId) = await _factory.CreateAuthenticatedClientWithSeededDocumentAsync(role: "User");
+
+    var response = await client.GetAsync($"/api/v1/kb-docs/{docId}/chunks?take=500");
+
+    response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+}
+```
+
+- [ ] **Step 5: Run integration tests**
+
+```bash
+cd apps/api/src/Api
+dotnet test --filter "FullyQualifiedName~KbChunkEndpointsIntegrationTests" --logger "console;verbosity=normal"
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs apps/api/tests/Api.Tests/Integration/KbChunkEndpointsIntegrationTests.cs
+git commit -m "feat(kb): #730 G1 endpoint /api/v1/kb-docs/{id}/chunks
+
+Wires GetKbChunksQuery with take∈[1,100] validation. Returns 400 if
+take is out of range, 404 if doc not found.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: G2 — `GetKbChunkByIdQuery` handler with prev/next navigation
+
+**Files:**
+- Create: `…/GetKbChunkById/GetKbChunkByIdQuery.cs`
+- Create: `…/GetKbChunkById/KbChunkDetailDto.cs`
+- Create: `…/GetKbChunkById/GetKbChunkByIdHandler.cs`
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkByIdHandlerTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+[Trait("Category", TestCategories.Unit)]
+public sealed class GetKbChunkByIdHandlerTests
+{
+    // ctor as before
+
+    [Fact]
+    public async Task Handle_MiddleChunk_ReturnsContentWithPrevNext()
+    {
+        // Arrange: seed 3 chunks (chunkIndex 0, 1, 2)
+        // Act: query for chunk at index 1
+        // Assert: prevChunkId = chunk0.Id, nextChunkId = chunk2.Id
+    }
+
+    [Fact]
+    public async Task Handle_FirstChunk_PrevIsNull()
+    {
+        // Arrange: 3 chunks, query for index 0
+        // Assert: prevChunkId is null, nextChunkId is chunk1.Id
+    }
+
+    [Fact]
+    public async Task Handle_LastChunk_NextIsNull()
+    {
+        // Same seed, query for index 2
+        // Assert: nextChunkId is null
+    }
+
+    [Fact]
+    public async Task Handle_ChunkBelongsToDifferentDoc_ThrowsNotFound()
+    {
+        // Seed two docs A, B. Query (A.Id, B.chunkId) -> 404
+    }
+
+    [Fact]
+    public async Task Handle_NonExistentChunk_ThrowsNotFound()
+    {
+        // Query (validDocId, randomGuid) -> 404
+    }
+}
+```
+
+- [ ] **Step 2: Build, expect compile errors**
+
+- [ ] **Step 3: Create Query record**
+
+```csharp
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunkById;
+
+internal sealed record GetKbChunkByIdQuery(
+    Guid DocumentId,
+    Guid ChunkId,
+    bool UserIsAdmin
+) : IQuery<KbChunkDetailDto>;
+```
+
+- [ ] **Step 4: Create the DTO**
+
+```csharp
+using System.Text.Json.Serialization;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunkById;
+
+internal sealed record KbChunkDetailDto(
+    Guid ChunkId,
+    string Content,
+    int? PageNumber,
+    int Position,
+    short Level,
+    IReadOnlyList<string> HeadingPath,
+    Guid? PrevChunkId,
+    Guid? NextChunkId,
+
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    Guid? VectorId,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    int? CharacterCount,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? ElementType,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? EmbeddingStatus,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    Guid? ParentChunkId
+);
+```
+
+- [ ] **Step 5: Create the Handler**
+
+```csharp
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunkById;
+
+internal sealed class GetKbChunkByIdHandler : IQueryHandler<GetKbChunkByIdQuery, KbChunkDetailDto>
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetKbChunkByIdHandler> _logger;
+
+    public GetKbChunkByIdHandler(MeepleAiDbContext dbContext, ILogger<GetKbChunkByIdHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<KbChunkDetailDto> Handle(GetKbChunkByIdQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var chunk = await _dbContext.TextChunks.AsNoTracking()
+            .Where(c => c.Id == query.ChunkId && c.PdfDocumentId == query.DocumentId)
+            .Select(c => new
+            {
+                c.Id,
+                c.Content,
+                c.PageNumber,
+                c.ChunkIndex,
+                c.Level,
+                c.Heading,
+                c.ParentChunkId,
+                c.CharacterCount,
+                c.ElementType,
+                c.PdfDocumentId
+            })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (chunk is null)
+        {
+            throw new NotFoundException($"Chunk {query.ChunkId} not found in document {query.DocumentId}");
+        }
+
+        // Prev / Next chunks (by chunkIndex)
+        var prevChunkId = await _dbContext.TextChunks.AsNoTracking()
+            .Where(c => c.PdfDocumentId == query.DocumentId && c.ChunkIndex == chunk.ChunkIndex - 1)
+            .Select(c => (Guid?)c.Id)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var nextChunkId = await _dbContext.TextChunks.AsNoTracking()
+            .Where(c => c.PdfDocumentId == query.DocumentId && c.ChunkIndex == chunk.ChunkIndex + 1)
+            .Select(c => (Guid?)c.Id)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Heading path via the same CTE pattern as G1 (TODO: extract to a shared service if duplication grows)
+        var headingPath = await LoadHeadingPathAsync(chunk.Id, cancellationToken);
+
+        return new KbChunkDetailDto(
+            ChunkId: chunk.Id,
+            Content: chunk.Content,
+            PageNumber: chunk.PageNumber,
+            Position: chunk.ChunkIndex,
+            Level: chunk.Level,
+            HeadingPath: headingPath,
+            PrevChunkId: prevChunkId,
+            NextChunkId: nextChunkId,
+            VectorId: query.UserIsAdmin ? chunk.Id : (Guid?)null,
+            CharacterCount: query.UserIsAdmin ? chunk.CharacterCount : (int?)null,
+            ElementType: query.UserIsAdmin ? chunk.ElementType : null,
+            EmbeddingStatus: query.UserIsAdmin ? "indexed" : null,
+            ParentChunkId: query.UserIsAdmin ? chunk.ParentChunkId : null
+        );
+    }
+
+    private async Task<IReadOnlyList<string>> LoadHeadingPathAsync(Guid chunkId, CancellationToken cancellationToken)
+    {
+        const string sql = @"
+            WITH RECURSIVE chunk_path(id, heading, parent_chunk_id, depth) AS (
+              SELECT t.id, t.heading, t.parent_chunk_id, 1 AS depth
+              FROM text_chunks t WHERE t.id = {0}
+              UNION ALL
+              SELECT t.id, t.heading, t.parent_chunk_id, cp.depth + 1
+              FROM text_chunks t
+              JOIN chunk_path cp ON t.id = cp.parent_chunk_id
+              WHERE cp.depth < 10
+            )
+            SELECT heading FROM chunk_path
+            WHERE heading IS NOT NULL
+            ORDER BY depth DESC;";
+
+        var headings = await _dbContext.Database
+            .SqlQueryRaw<string>(sql, new object[] { chunkId })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return headings;
+    }
+}
+```
+
+- [ ] **Step 6: Run unit tests**
+
+```bash
+cd apps/api/src/Api
+dotnet test --filter "FullyQualifiedName~GetKbChunkByIdHandler" --logger "console;verbosity=normal"
+```
+
+Expected: all 5 tests pass (heading path test may need to move to integration suite — see Task 7 step 1 note).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkById/ apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkByIdHandlerTests.cs
+git commit -m "feat(kb): #730 G2 GetKbChunkByIdQuery handler
+
+Single-chunk fetch with full content + prev/next chunkId lookup by
+ChunkIndex offset and recursive headingPath. 404 when chunk doesn't
+exist or belongs to a different document.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: G2 — Wire `/kb-docs/{id}/chunks/{chunkId}` endpoint
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs`
+
+- [ ] **Step 1: Add endpoint mapping**
+
+```csharp
+// Issue #730: G2 single chunk full content
+group.MapGet("/kb-docs/{id:guid}/chunks/{chunkId:guid}", HandleGetKbChunkById)
+    .WithName("GetKbChunkById")
+    .RequireSession()
+    .WithTags("KnowledgeBase")
+    .WithSummary("Get a single chunk with full content + prev/next navigation")
+    .WithDescription("Returns chunk content as markdown, with hierarchical breadcrumb and prev/next chunk IDs for navigation.")
+    .Produces<KbChunkDetailDto>()
+    .Produces(StatusCodes.Status404NotFound);
+```
+
+- [ ] **Step 2: Add the handler**
+
+```csharp
+private static async Task<IResult> HandleGetKbChunkById(
+    Guid id,
+    Guid chunkId,
+    HttpContext httpContext,
+    IMediator mediator,
+    CancellationToken cancellationToken)
+{
+    var session = httpContext.GetSession();
+    var query = new GetKbChunkByIdQuery(id, chunkId, UserIsAdmin: session.User.Role == "Admin");
+    var dto = await mediator.Send(query, cancellationToken);
+    return Results.Ok(dto);
+}
+```
+
+(NotFoundException is mapped to 404 by the global exception middleware; no manual handling needed.)
+
+- [ ] **Step 3: Add `using`**
+
+```csharp
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunkById;
+```
+
+- [ ] **Step 4: Add integration test**
+
+```csharp
+[Fact]
+public async Task GetKbChunk_ChunkBelongsToOtherDoc_Returns404()
+{
+    var (client, docAId) = await _factory.CreateAuthenticatedClientWithSeededDocumentAsync(role: "User");
+    var (_, docBId, chunkBId) = await _factory.SeedAnotherDocumentWithOneChunkAsync();
+
+    var response = await client.GetAsync($"/api/v1/kb-docs/{docAId}/chunks/{chunkBId}");
+
+    response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+}
+```
+
+- [ ] **Step 5: Run all KB integration tests**
+
+```bash
+cd apps/api/src/Api
+dotnet test --filter "FullyQualifiedName~KbChunkEndpointsIntegrationTests" --logger "console;verbosity=normal"
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs apps/api/tests/Api.Tests/Integration/KbChunkEndpointsIntegrationTests.cs
+git commit -m "feat(kb): #730 G2 endpoint /api/v1/kb-docs/{id}/chunks/{chunkId}
+
+Wires GetKbChunkByIdQuery. Cross-doc chunkId returns 404 (no leak of
+chunk existence in other docs).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: G3 — `SearchKbChunksQuery` with PostgreSQL FTS
+
+**Files:**
+- Create: `…/SearchKbChunks/SearchKbChunksQuery.cs`
+- Create: `…/SearchKbChunks/KbChunkMatchDto.cs`
+- Create: `…/SearchKbChunks/KbChunkSearchResultDto.cs`
+- Create: `…/SearchKbChunks/SearchKbChunksHandler.cs`
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/SearchKbChunksHandlerTests.cs`
+
+- [ ] **Step 1: Write failing tests (integration only — FTS requires real PostgreSQL)**
+
+Add to the integration suite:
+
+```csharp
+[Fact]
+public async Task SearchChunks_KeywordPresent_ReturnsRankedMatches()
+{
+    var (client, docId) = await _factory.SeedDocumentWithKeywordChunksAsync(
+        keyword: "initiative", occurrencesPerChunk: new[] { 3, 1, 0, 5, 2 });
+
+    var response = await client.PostAsJsonAsync(
+        $"/api/v1/kb-docs/{docId}/chunks/search",
+        new { query = "initiative", skip = 0, take = 20 });
+
+    response.StatusCode.Should().Be(HttpStatusCode.OK);
+    var result = await response.Content.ReadFromJsonAsync<KbChunkSearchResultDto>();
+    result!.TotalCount.Should().Be(4);  // 4 chunks with the keyword
+    result.Matches.Should().BeInDescendingOrder(m => m.Rank);
+    result.Matches.First().Snippet.Should().Contain("<mark>initiative</mark>");
+}
+
+[Fact]
+public async Task SearchChunks_NoMatches_ReturnsEmpty()
+{
+    var (client, docId) = await _factory.CreateAuthenticatedClientWithSeededDocumentAsync(role: "User");
+
+    var response = await client.PostAsJsonAsync(
+        $"/api/v1/kb-docs/{docId}/chunks/search",
+        new { query = "xyzzyx", skip = 0, take = 20 });
+
+    var result = await response.Content.ReadFromJsonAsync<KbChunkSearchResultDto>();
+    result!.TotalCount.Should().Be(0);
+    result.Matches.Should().BeEmpty();
+}
+
+[Fact]
+public async Task SearchChunks_QueryTooLong_Returns400()
+{
+    var (client, docId) = await _factory.CreateAuthenticatedClientWithSeededDocumentAsync(role: "User");
+
+    var longQuery = new string('a', 250);
+    var response = await client.PostAsJsonAsync(
+        $"/api/v1/kb-docs/{docId}/chunks/search",
+        new { query = longQuery, skip = 0, take = 20 });
+
+    response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+}
+
+[Fact]
+public async Task SearchChunks_OperatorInjection_TreatedAsLiteral()
+{
+    var (client, docId) = await _factory.SeedDocumentWithKeywordChunksAsync(
+        keyword: "initiative", occurrencesPerChunk: new[] { 1 });
+
+    var response = await client.PostAsJsonAsync(
+        $"/api/v1/kb-docs/{docId}/chunks/search",
+        new { query = "initiative | drop", skip = 0, take = 20 });
+
+    response.StatusCode.Should().Be(HttpStatusCode.OK);
+    // Should NOT throw "syntax error in tsquery"; the | is treated as a separator.
+}
+```
+
+- [ ] **Step 2: Build, expect missing types**
+
+- [ ] **Step 3: Create Query, DTOs, Handler**
+
+`SearchKbChunksQuery.cs`:
+
+```csharp
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.SearchKbChunks;
+
+internal sealed record SearchKbChunksQuery(
+    Guid DocumentId,
+    string Query,
+    int Skip,
+    int Take
+) : IQuery<KbChunkSearchResultDto>;
+```
+
+`KbChunkMatchDto.cs`:
+
+```csharp
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.SearchKbChunks;
+
+internal sealed record KbChunkMatchDto(
+    Guid ChunkId,
+    IReadOnlyList<string> HeadingPath,
+    string Snippet,         // ts_headline output with <mark> tags
+    float Rank,
+    int? PageNumber,
+    int Position
+);
+```
+
+`KbChunkSearchResultDto.cs`:
+
+```csharp
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.SearchKbChunks;
+
+internal sealed record KbChunkSearchResultDto(
+    IReadOnlyList<KbChunkMatchDto> Matches,
+    int TotalCount,
+    int Skip,
+    int Take
+);
+```
+
+`SearchKbChunksHandler.cs`:
+
+```csharp
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.SearchKbChunks;
+
+internal sealed class SearchKbChunksHandler : IQueryHandler<SearchKbChunksQuery, KbChunkSearchResultDto>
+{
+    private const int MaxQueryLength = 200;
+    private const int MaxTake = 100;
+
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<SearchKbChunksHandler> _logger;
+
+    public SearchKbChunksHandler(MeepleAiDbContext dbContext, ILogger<SearchKbChunksHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<KbChunkSearchResultDto> Handle(SearchKbChunksQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        if (string.IsNullOrWhiteSpace(query.Query) || query.Query.Length > MaxQueryLength)
+        {
+            throw new ValidationException("query must be between 1 and 200 characters");
+        }
+
+        var skip = Math.Max(0, query.Skip);
+        var take = Math.Clamp(query.Take, 1, MaxTake);
+
+        // Verify doc exists
+        var docExists = await _dbContext.PdfDocuments.AsNoTracking()
+            .AnyAsync(p => p.Id == query.DocumentId, cancellationToken)
+            .ConfigureAwait(false);
+        if (!docExists)
+        {
+            throw new NotFoundException($"Document {query.DocumentId} not found");
+        }
+
+        // FTS query: plainto_tsquery sanitizes user input (no operator injection)
+        const string sql = @"
+            WITH ranked AS (
+              SELECT
+                tc.id,
+                tc.heading,
+                tc.parent_chunk_id,
+                tc.page_number,
+                tc.chunk_index,
+                ts_rank_cd(tc.search_vector, q) AS rank,
+                ts_headline('simple', tc.content, q,
+                  'StartSel=<mark>, StopSel=</mark>, MaxFragments=2, MaxWords=20, MinWords=5') AS snippet
+              FROM text_chunks tc, plainto_tsquery('simple', {1}) q
+              WHERE tc.pdf_document_id = {0}
+                AND tc.search_vector @@ q
+            )
+            SELECT id, heading, parent_chunk_id, page_number, chunk_index, rank, snippet
+            FROM ranked
+            ORDER BY rank DESC
+            OFFSET {2} LIMIT {3};";
+
+        var rows = await _dbContext.Database
+            .SqlQueryRaw<SearchRow>(sql, new object[] { query.DocumentId, query.Query, skip, take })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Total count (separate query for accuracy with skip/take)
+        const string countSql = @"
+            SELECT COUNT(*)::int AS Value
+            FROM text_chunks tc, plainto_tsquery('simple', {1}) q
+            WHERE tc.pdf_document_id = {0} AND tc.search_vector @@ q;";
+
+        var totalCount = await _dbContext.Database
+            .SqlQueryRaw<int>(countSql, new object[] { query.DocumentId, query.Query })
+            .FirstAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Build heading paths for the matched chunks
+        var matchIds = rows.Select(r => r.Id).ToList();
+        var headingPaths = matchIds.Count == 0
+            ? new Dictionary<Guid, IReadOnlyList<string>>()
+            : await LoadHeadingPathsAsync(matchIds, cancellationToken);
+
+        var matches = rows.Select(r => new KbChunkMatchDto(
+            ChunkId: r.Id,
+            HeadingPath: headingPaths.TryGetValue(r.Id, out var hp) ? hp : Array.Empty<string>(),
+            Snippet: r.Snippet,
+            Rank: r.Rank,
+            PageNumber: r.PageNumber,
+            Position: r.ChunkIndex
+        )).ToList();
+
+        return new KbChunkSearchResultDto(matches, totalCount, skip, take);
+    }
+
+    // (LoadHeadingPathsAsync — copy from GetKbChunksHandler or extract to a shared service)
+
+    private sealed record SearchRow(
+        Guid Id, string? Heading, Guid? ParentChunkId,
+        int? PageNumber, int ChunkIndex, float Rank, string Snippet);
+}
+```
+
+- [ ] **Step 4: Add `ValidationException` mapping if not already present**
+
+If `ValidationException` doesn't already map to 400 in the global middleware, the simplest fix is to wrap the validation in the routing handler instead. But check `Middleware/Exceptions/` first.
+
+- [ ] **Step 5: Run integration tests**
+
+```bash
+cd apps/api/src/Api
+dotnet test --filter "FullyQualifiedName~SearchChunks" --logger "console;verbosity=normal"
+```
+
+Expected: 4 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchKbChunks/ apps/api/tests/Api.Tests/Integration/KbChunkEndpointsIntegrationTests.cs
+git commit -m "feat(kb): #730 G3 SearchKbChunksQuery handler
+
+In-document keyword search using plainto_tsquery + ts_rank_cd +
+ts_headline (StartSel=<mark>, MaxFragments=2). Operator injection
+mitigated by plainto_tsquery (treats input as plain text, not tsquery
+syntax). Validation: query length 1-200 chars.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: G3 — Wire `POST /kb-docs/{id}/chunks/search` endpoint
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs`
+
+- [ ] **Step 1: Add endpoint mapping**
+
+```csharp
+// Issue #730: G3 in-document FTS
+group.MapPost("/kb-docs/{id:guid}/chunks/search", HandleSearchKbChunks)
+    .WithName("SearchKbChunks")
+    .RequireSession()
+    .WithTags("KnowledgeBase")
+    .WithSummary("Search chunks within a single document by keyword")
+    .WithDescription("PostgreSQL ts_rank_cd ranking with ts_headline highlighting (<mark> tags). Query length 1-200 chars.")
+    .Produces<KbChunkSearchResultDto>()
+    .Produces(StatusCodes.Status400BadRequest)
+    .Produces(StatusCodes.Status404NotFound);
+```
+
+- [ ] **Step 2: Define request DTO + handler**
+
+```csharp
+internal sealed record SearchKbChunksRequest(string Query, int? Skip, int? Take);
+
+private static async Task<IResult> HandleSearchKbChunks(
+    Guid id,
+    [FromBody] SearchKbChunksRequest body,
+    HttpContext httpContext,
+    IMediator mediator,
+    CancellationToken cancellationToken)
+{
+    if (body is null || string.IsNullOrWhiteSpace(body.Query) || body.Query.Length > 200)
+    {
+        return Results.BadRequest(new { error = "query must be between 1 and 200 characters" });
+    }
+
+    var query = new SearchKbChunksQuery(id, body.Query, body.Skip ?? 0, body.Take ?? 20);
+    var result = await mediator.Send(query, cancellationToken);
+    return Results.Ok(result);
+}
+```
+
+- [ ] **Step 3: Add `using`**
+
+```csharp
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.SearchKbChunks;
+```
+
+- [ ] **Step 4: Run all KB tests**
+
+```bash
+cd apps/api/src/Api
+dotnet test --filter "FullyQualifiedName~KnowledgeBase|FullyQualifiedName~KbChunk" --logger "console;verbosity=normal"
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Run full test suite to confirm no regression**
+
+```bash
+cd apps/api/src/Api
+dotnet test --logger "console;verbosity=minimal"
+```
+
+Expected: full suite passes (existing 13,000+ tests + new ones).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs
+git commit -m "feat(kb): #730 G3 endpoint POST /api/v1/kb-docs/{id}/chunks/search
+
+Wires SearchKbChunksQuery with body validation (query length 1-200).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 13: Frontend — Zod schemas + client methods
+
+**Files:**
+- Create: `apps/web/src/lib/api/schemas/kb-document.schemas.ts`
+- Modify: `apps/web/src/lib/api/clients/knowledgeBaseClient.ts`
+- Modify: `apps/web/src/lib/api/schemas/index.ts`
+
+- [ ] **Step 1: Create the Zod schemas**
+
+`apps/web/src/lib/api/schemas/kb-document.schemas.ts`:
+
+```typescript
+import { z } from 'zod';
+
+export const kbDocumentSchema = z.object({
+  id: z.string().uuid(),
+  title: z.string(),
+  gameId: z.string().uuid().nullable().optional(),
+  sharedGameId: z.string().uuid().nullable().optional(),
+  documentCategory: z.string(),
+  processingState: z.enum([
+    'pending', 'uploading', 'extracting', 'chunking',
+    'embedding', 'indexing', 'ready', 'failed',
+  ]),
+  totalChunks: z.number().int().nonnegative(),
+  pageCount: z.number().int().nonnegative(),
+  indexedAt: z.string().datetime().nullable().optional(),
+  uploadedAt: z.string().datetime(),
+  language: z.string(),
+  versionLabel: z.string().nullable().optional(),
+  // Admin-only:
+  processingError: z.string().nullable().optional(),
+  retryCount: z.number().int().nullable().optional(),
+  failedAtState: z.string().nullable().optional(),
+});
+export type KbDocument = z.infer<typeof kbDocumentSchema>;
+
+export const kbChunkSummarySchema = z.object({
+  chunkId: z.string().uuid(),
+  pageNumber: z.number().int().nullable().optional(),
+  position: z.number().int().nonnegative(),
+  level: z.number().int().min(0).max(2),
+  headingPath: z.array(z.string()),
+  snippet: z.string(),
+  // Admin-only:
+  vectorId: z.string().uuid().nullable().optional(),
+  characterCount: z.number().int().nullable().optional(),
+  elementType: z.string().nullable().optional(),
+  embeddingStatus: z.string().nullable().optional(),
+});
+export type KbChunkSummary = z.infer<typeof kbChunkSummarySchema>;
+
+export const kbChunkListSchema = z.object({
+  chunks: z.array(kbChunkSummarySchema),
+  totalCount: z.number().int().nonnegative(),
+  skip: z.number().int().nonnegative(),
+  take: z.number().int().positive(),
+  hasMore: z.boolean(),
+  processingState: z.string(),
+});
+export type KbChunkList = z.infer<typeof kbChunkListSchema>;
+
+export const kbChunkDetailSchema = z.object({
+  chunkId: z.string().uuid(),
+  content: z.string(),
+  pageNumber: z.number().int().nullable().optional(),
+  position: z.number().int().nonnegative(),
+  level: z.number().int().min(0).max(2),
+  headingPath: z.array(z.string()),
+  prevChunkId: z.string().uuid().nullable().optional(),
+  nextChunkId: z.string().uuid().nullable().optional(),
+  // Admin-only:
+  vectorId: z.string().uuid().nullable().optional(),
+  characterCount: z.number().int().nullable().optional(),
+  elementType: z.string().nullable().optional(),
+  embeddingStatus: z.string().nullable().optional(),
+  parentChunkId: z.string().uuid().nullable().optional(),
+});
+export type KbChunkDetail = z.infer<typeof kbChunkDetailSchema>;
+
+export const kbChunkMatchSchema = z.object({
+  chunkId: z.string().uuid(),
+  headingPath: z.array(z.string()),
+  snippet: z.string(),
+  rank: z.number(),
+  pageNumber: z.number().int().nullable().optional(),
+  position: z.number().int().nonnegative(),
+});
+export type KbChunkMatch = z.infer<typeof kbChunkMatchSchema>;
+
+export const kbChunkSearchResultSchema = z.object({
+  matches: z.array(kbChunkMatchSchema),
+  totalCount: z.number().int().nonnegative(),
+  skip: z.number().int().nonnegative(),
+  take: z.number().int().positive(),
+});
+export type KbChunkSearchResult = z.infer<typeof kbChunkSearchResultSchema>;
+```
+
+- [ ] **Step 2: Re-export from schemas/index.ts**
+
+Append to `apps/web/src/lib/api/schemas/index.ts`:
+
+```typescript
+export * from './kb-document.schemas';
+```
+
+- [ ] **Step 3: Extend knowledgeBaseClient.ts with 4 methods**
+
+Open `apps/web/src/lib/api/clients/knowledgeBaseClient.ts`. Find the existing pattern (e.g. `getGameDocuments`) and add four sibling methods:
+
+```typescript
+import {
+  kbDocumentSchema, type KbDocument,
+  kbChunkListSchema, type KbChunkList,
+  kbChunkDetailSchema, type KbChunkDetail,
+  kbChunkSearchResultSchema, type KbChunkSearchResult,
+} from '@/lib/api/schemas/kb-document.schemas';
+
+export const knowledgeBaseClient = {
+  // ... existing methods,
+
+  async getKbDocument(docId: string): Promise<KbDocument> {
+    const res = await fetchJson(`/api/v1/kb-docs/${docId}`);
+    return kbDocumentSchema.parse(res);
+  },
+
+  async getKbChunks(docId: string, params: { skip?: number; take?: number } = {}): Promise<KbChunkList> {
+    const search = new URLSearchParams();
+    if (params.skip !== undefined) search.set('skip', String(params.skip));
+    if (params.take !== undefined) search.set('take', String(params.take));
+    const qs = search.toString();
+    const url = `/api/v1/kb-docs/${docId}/chunks${qs ? `?${qs}` : ''}`;
+    const res = await fetchJson(url);
+    return kbChunkListSchema.parse(res);
+  },
+
+  async getKbChunk(docId: string, chunkId: string): Promise<KbChunkDetail> {
+    const res = await fetchJson(`/api/v1/kb-docs/${docId}/chunks/${chunkId}`);
+    return kbChunkDetailSchema.parse(res);
+  },
+
+  async searchKbChunks(
+    docId: string,
+    body: { query: string; skip?: number; take?: number },
+  ): Promise<KbChunkSearchResult> {
+    const res = await fetchJson(`/api/v1/kb-docs/${docId}/chunks/search`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    return kbChunkSearchResultSchema.parse(res);
+  },
+};
+```
+
+(Adapt the `fetchJson` import and the structure of the existing client to the actual file — the four methods above are the new additions.)
+
+- [ ] **Step 4: Run frontend typecheck**
+
+```bash
+cd apps/web
+pnpm typecheck
+```
+
+Expected: zero errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/api/schemas/kb-document.schemas.ts apps/web/src/lib/api/schemas/index.ts apps/web/src/lib/api/clients/knowledgeBaseClient.ts
+git commit -m "feat(kb): #730 frontend Zod schemas + client methods
+
+Adds kb-document.schemas.ts mirroring backend DTOs, plus four client
+methods (getKbDocument, getKbChunks, getKbChunk, searchKbChunks).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 14: Frontend — React Query hooks
+
+**Files:**
+- Create: `apps/web/src/hooks/queries/useKbDocument.ts`
+- Create: `apps/web/src/hooks/queries/useKbChunks.ts`
+- Create: `apps/web/src/hooks/queries/useKbChunk.ts`
+- Create: `apps/web/src/hooks/queries/useKbChunkSearch.ts`
+- Modify: `apps/web/src/hooks/queries/index.ts`
+
+- [ ] **Step 1: Create useKbDocument**
+
+`apps/web/src/hooks/queries/useKbDocument.ts`:
+
+```typescript
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { knowledgeBaseClient } from '@/lib/api/clients/knowledgeBaseClient';
+import type { KbDocument } from '@/lib/api/schemas/kb-document.schemas';
+
+export const kbDocumentKeys = {
+  all: ['kb-document'] as const,
+  byId: (docId: string) => ['kb-document', docId] as const,
+} as const;
+
+export function useKbDocument(docId: string | undefined, enabled = true) {
+  return useQuery<KbDocument, Error>({
+    queryKey: kbDocumentKeys.byId(docId ?? ''),
+    queryFn: () => knowledgeBaseClient.getKbDocument(docId!),
+    enabled: enabled && !!docId,
+    staleTime: 60_000,    // 60s — metadata may change during ingestion
+    gcTime: 5 * 60_000,
+  });
+}
+```
+
+- [ ] **Step 2: Create useKbChunks**
+
+```typescript
+'use client';
+
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
+import { knowledgeBaseClient } from '@/lib/api/clients/knowledgeBaseClient';
+import type { KbChunkList } from '@/lib/api/schemas/kb-document.schemas';
+
+export const kbChunksKeys = {
+  all: ['kb-chunks'] as const,
+  list: (docId: string, skip: number, take: number) =>
+    ['kb-chunks', docId, { skip, take }] as const,
+} as const;
+
+export function useKbChunks(
+  docId: string | undefined,
+  skip = 0,
+  take = 50,
+  enabled = true,
+) {
+  return useQuery<KbChunkList, Error>({
+    queryKey: kbChunksKeys.list(docId ?? '', skip, take),
+    queryFn: () => knowledgeBaseClient.getKbChunks(docId!, { skip, take }),
+    enabled: enabled && !!docId,
+    staleTime: 5 * 60_000,
+    gcTime: 10 * 60_000,
+    placeholderData: keepPreviousData,
+  });
+}
+```
+
+- [ ] **Step 3: Create useKbChunk**
+
+```typescript
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { knowledgeBaseClient } from '@/lib/api/clients/knowledgeBaseClient';
+import type { KbChunkDetail } from '@/lib/api/schemas/kb-document.schemas';
+
+export const kbChunkKeys = {
+  all: ['kb-chunk'] as const,
+  byId: (docId: string, chunkId: string) =>
+    ['kb-chunk', docId, chunkId] as const,
+} as const;
+
+export function useKbChunk(
+  docId: string | undefined,
+  chunkId: string | undefined,
+  enabled = true,
+) {
+  return useQuery<KbChunkDetail, Error>({
+    queryKey: kbChunkKeys.byId(docId ?? '', chunkId ?? ''),
+    queryFn: () => knowledgeBaseClient.getKbChunk(docId!, chunkId!),
+    enabled: enabled && !!docId && !!chunkId,
+    staleTime: 10 * 60_000, // chunk content immutable post-ingest
+    gcTime: 30 * 60_000,
+  });
+}
+```
+
+- [ ] **Step 4: Create useKbChunkSearch**
+
+```typescript
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+import { knowledgeBaseClient } from '@/lib/api/clients/knowledgeBaseClient';
+import type { KbChunkSearchResult } from '@/lib/api/schemas/kb-document.schemas';
+
+export function useKbChunkSearch() {
+  return useMutation<
+    KbChunkSearchResult,
+    Error,
+    { docId: string; query: string; skip?: number; take?: number }
+  >({
+    mutationFn: ({ docId, query, skip, take }) =>
+      knowledgeBaseClient.searchKbChunks(docId, { query, skip, take }),
+  });
+}
+```
+
+(Search is a mutation rather than a query: each call has a different `query` string, results don't naturally cache, and the user typically triggers it explicitly.)
+
+- [ ] **Step 5: Re-export from hooks/queries/index.ts**
+
+Append:
+
+```typescript
+export * from './useKbDocument';
+export * from './useKbChunks';
+export * from './useKbChunk';
+export * from './useKbChunkSearch';
+```
+
+- [ ] **Step 6: Run frontend typecheck and lint**
+
+```bash
+cd apps/web
+pnpm typecheck && pnpm lint
+```
+
+Expected: zero errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/hooks/queries/useKbDocument.ts apps/web/src/hooks/queries/useKbChunks.ts apps/web/src/hooks/queries/useKbChunk.ts apps/web/src/hooks/queries/useKbChunkSearch.ts apps/web/src/hooks/queries/index.ts
+git commit -m "feat(kb): #730 frontend React Query hooks for chunk endpoints
+
+useKbDocument (60s TTL), useKbChunks (5min TTL with keepPreviousData),
+useKbChunk (10min TTL — immutable), useKbChunkSearch (mutation).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 15: PR creation + close-out
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feature/issue-730-kb-chunk-endpoints
+```
+
+- [ ] **Step 2: Open the PR against `main-dev` (NOT main)**
+
+```bash
+gh pr create --base main-dev --title "feat(kb): #730 chunk-level retrieval endpoints (Wave 3 prereq)" --body "$(cat <<'EOF'
+## Summary
+
+- 4 new endpoints + 1 search endpoint under `/api/v1/kb-docs/{id}` to unblock Wave 3 child #684 `/kb/[id]` split-view UI
+- Migration adds `heading`, `parent_chunk_id`, `level`, `element_type` to `text_chunks` (normalized hierarchy mirroring Qdrant payload)
+- DTO field gating: admin-only fields (`vectorId`, `characterCount`, `elementType`, `embeddingStatus`, `processingError`, `retryCount`, `failedAtState`) gated server-side and stripped from JSON wire via `[JsonIgnore(WhenWritingNull)]`
+- Frontend Zod schemas + 4 React Query hooks ready for migration wave consumption
+- Spec: `docs/superpowers/specs/2026-05-06-kb-chunk-endpoints-design.md`
+- Plan: `docs/superpowers/plans/2026-05-06-kb-chunk-endpoints-plan.md`
+
+## Out of scope (follow-up issues)
+- Backfill of legacy `text_chunks` rows from Qdrant (new issue to be filed)
+- Cursor-based pagination (only if offset becomes a perf problem)
+- Vector semantic search inside a single doc (YAGNI)
+
+## Test plan
+- [ ] `dotnet test --filter "BoundedContext=KnowledgeBase"` passes
+- [ ] `dotnet test --filter "Category=Integration"` passes (Testcontainers)
+- [ ] `pnpm typecheck` passes
+- [ ] Manual: hit `/api/v1/kb-docs/{id}` via Scalar and verify DTO shape
+- [ ] Manual: search for a known keyword in an ingested doc and verify `<mark>` highlighting
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Comment on issue #684 to unblock the FE migration wave**
+
+```bash
+gh issue comment 684 --body "Backend prerequisites for /kb/[id] (#730) are now in PR \$(gh pr view --json url -q .url). New hooks available:
+
+- \`useKbDocument(docId)\` — header metadata
+- \`useKbChunks(docId, skip, take)\` — paginated list with hierarchical breadcrumb
+- \`useKbChunk(docId, chunkId)\` — full markdown content + prev/next nav
+- \`useKbChunkSearch()\` — in-doc keyword search (mutation)
+
+Zod schemas in \`apps/web/src/lib/api/schemas/kb-document.schemas.ts\`.
+Phase 0.5 contract for \`/kb/[id]\` can now be written referencing these endpoints."
+```
+
+- [ ] **Step 4: Close-out comment on #730**
+
+```bash
+gh issue comment 730 --body "PR opened: \$(gh pr view --json url -q .url)
+
+5 endpoints delivered:
+- \`GET /api/v1/kb-docs/{id}\`
+- \`GET /api/v1/kb-docs/{id}/chunks?skip&take\`
+- \`GET /api/v1/kb-docs/{id}/chunks/{chunkId}\`
+- \`POST /api/v1/kb-docs/{id}/chunks/search\`
+- (G5 admin diagnostic fields embedded in chunk endpoints via DTO gating)
+
+Migration: \`AddChunkHierarchyToTextChunkEntity\` adds heading + parent_chunk_id + level + element_type to text_chunks. Backfill of legacy rows tracked separately.
+
+Closes #730 once PR merges."
+```
+
+---
+
+## Spec coverage note: Caching (D8) deferred
+
+D8 of the spec proposes HybridCache wrapping (G1 list 5min · G2 single-chunk 10min · G4 metadata 60s). This plan **defers caching wiring** to a follow-up commit/issue — rationale:
+
+- Caching is a non-functional optimization (latency), not a correctness requirement
+- Cold P95 targets in the spec (`<200ms` for G1, `<250ms` for G2, `<200ms` for G4) are likely achievable without cache given that the queries are simple SELECTs against indexed columns. Measure first, add cache only if SLO is missed
+- Adding cache later is a straightforward wrap of `mediator.Send(...)` in the routing handler; no DTO/migration changes needed
+- Avoids early commitment to cache invalidation logic on re-ingestion (which would complicate Task 3)
+
+If post-merge measurements show cold P95 exceeding spec targets, file a follow-up issue and add `IHybridCacheService.GetOrCreateAsync` wraps in `KnowledgeBaseEndpoints.cs` for G1, G2, G4 (search remains uncached).
+
+---
+
+## Summary of commits (15 total)
+
+1. `feat(kb): #730 add chunk hierarchy fields to TextChunkEntity`
+2. `feat(kb): #730 EF migration AddChunkHierarchyToTextChunkEntity`
+3. `feat(kb): #730 persist chunk hierarchy on ingestion`
+4. `feat(kb): #730 G4 GetKbDocumentByIdQuery handler`
+5. `feat(kb): #730 G4 endpoint /api/v1/kb-docs/{id}`
+6. `feat(kb): #730 G1 GetKbChunksQuery skeleton (headingPath stub)`
+7. `feat(kb): #730 G1 headingPath via recursive CTE`
+8. `feat(kb): #730 G1 endpoint /api/v1/kb-docs/{id}/chunks`
+9. `feat(kb): #730 G2 GetKbChunkByIdQuery handler`
+10. `feat(kb): #730 G2 endpoint /api/v1/kb-docs/{id}/chunks/{chunkId}`
+11. `feat(kb): #730 G3 SearchKbChunksQuery handler`
+12. `feat(kb): #730 G3 endpoint POST /api/v1/kb-docs/{id}/chunks/search`
+13. `feat(kb): #730 frontend Zod schemas + client methods`
+14. `feat(kb): #730 frontend React Query hooks for chunk endpoints`
+15. (PR open, no extra commit)

--- a/docs/superpowers/specs/2026-05-06-database-network-isolation-design.md
+++ b/docs/superpowers/specs/2026-05-06-database-network-isolation-design.md
@@ -1,0 +1,153 @@
+# Database Network Isolation — Specification
+
+**Data**: 2026-05-06
+**Autore**: Claude (incident response sc:spec-panel)
+**Scope**: Garantire che PostgreSQL e altri servizi interni non siano mai raggiungibili dalla rete pubblica, indipendentemente da errori operativi o regressioni di Docker.
+**Status**: APPROVED (post-incident response, utente sign-off 2026-05-06)
+**Issue**: #795
+**Trigger**: BSI/CERT-Bund report 2026-05-05 14:44:45 UTC — `204.168.135.69:5432` raggiungibile da Internet pubblica.
+
+---
+
+## 1. Context
+
+### 1.1 Incident summary
+
+| Dato | Valore |
+|------|--------|
+| Reporter | German Federal Office for Information Security (BSI / CERT-Bund), via `abuse@hetzner.com` |
+| Target | `204.168.135.69:5432` (TCP, PostgreSQL) — staging server (Hetzner CAX21 ARM64) |
+| Timestamp rilevazione | 2026-05-05 14:44:45 UTC |
+| Indicator correlato | brute-force su filebrowser/8090 da `156.146.59.27` iniziato 13:52 UTC stesso giorno |
+| Esposizione confermata? | Sì — BSI è autoritativo |
+| Compromissione confermata? | No — nessuna evidenza nei log applicativi né del DB |
+
+### 1.2 Forensics findings (2026-05-06)
+
+Triage SSH eseguito su staging. Risultati:
+
+- ❌ Nessun compose-file dichiara `5432:5432` in pubblicazione host (né in `infra/repo/`, né nei legacy `/opt/meepleai/*.yml` top-level)
+- ❌ Nessun PostgreSQL host-installato (`apt list --installed | grep postgresql` → solo `postgresql-client*`)
+- ❌ Nessun cron job o systemd timer che lanci container PG temporanei
+- ❌ Nessuna evidenza in `~/.bash_history` di `docker run -p 5432`
+- ⚠️ Docker event log: non persistente di default → trigger esatto dell'esposizione **non ricostruibile**
+- 🚨 `filebrowser` running, esposto su `0.0.0.0:8090`, con **mount read-write di `/opt/meepleai`** (avrebbe esposto tutti i secret se l'auth fosse stata bypassata)
+
+### 1.3 Root cause architetturale
+
+**Docker bypassa UFW**. Quando un container pubblica una porta tramite `docker run -p X:X` o tramite `ports:` in compose **senza** prefisso `127.0.0.1:`, Docker inserisce regole nella catena `DOCKER` di iptables **prima** che la catena `ufw-user-input` venga valutata.
+
+Questo significa che le regole UFW non si applicano al traffico verso container Docker. Fino a oggi il sistema aveva:
+
+- ✅ UFW: `default deny incoming`, `allow 22, 80, 443`
+- ❌ DOCKER chain: ACCEPT per qualsiasi porta pubblicata (bypass UFW)
+- ❌ Nessuna regola in `DOCKER-USER` (l'unica chain che Docker non sovrascrive)
+- ❌ Nessun firewall a livello edge (Hetzner Cloud Firewall non configurato)
+
+→ Single-layer firewall. Il bug operativo (qualcosa ha pubblicato 5432 temporaneamente) ha avuto impatto pubblico immediato.
+
+---
+
+## 2. Decision
+
+Adottiamo **defense-in-depth a tre livelli**:
+
+### Layer 1 — Edge firewall (Hetzner Cloud Firewall)
+
+Configurazione manuale dal pannello Hetzner Cloud Console:
+
+- Inbound: TCP 22 (SSH); ICMP
+- Tutto il resto: drop
+- Attaccato al server staging (`204.168.135.69`)
+
+**Rationale**: protegge anche se UFW e iptables si rompono o vengono accidentalmente flushati. Tracciamento separato (manuale UI), riferimento in `docs/operations/operations-manual.md`.
+
+### Layer 2 — Host firewall (`DOCKER-USER` chain in iptables)
+
+`DOCKER-USER` è l'unica catena iptables che Docker **non** sovrascrive. Inserire regole DROP per tutte le porte interne dell'applicazione:
+
+```bash
+sudo iptables -I DOCKER-USER -i <ext-if> -p tcp -m multiport --dports \
+  5432,6379,9000,9001,9090,9093,3000,3001,8000,8001,8002,8003,8004,8025,1025 -j DROP
+sudo iptables -I DOCKER-USER -i <ext-if> -p tcp -m multiport --dports \
+  5678,3100,11434,8090 -j DROP
+```
+
+Persistenza tramite `iptables-persistent` + `netfilter-persistent save`.
+
+**Rationale**: anche se domani qualcuno fa `docker run -p 5432:5432` per errore, il traffico in ingresso da `eth0` viene droppato in DOCKER-USER prima che le regole DOCKER lo accettino.
+
+### Layer 3 — Service-level (Docker compose convention)
+
+Convention codificata in code review:
+
+- ✅ `ports: ["127.0.0.1:5432:5432"]` per dev/integration (loopback only)
+- ❌ `ports: ["5432:5432"]` o `ports: ["0.0.0.0:5432:5432"]` — **PROIBITO**, anche per servizi non-DB
+
+Lint check (futuro): aggiungere a `infra/scripts/security-audit.sh` un grep su tutti i compose `*.yml` che fallisce se trova `ports:` sul servizio postgres senza loopback prefix.
+
+### Layer 4 — Continuous verification (security-audit + GitHub Action)
+
+- `infra/scripts/security-audit.sh` (bash) e `.ps1` (PowerShell) — esegue scan esterno con `nmap`/`Test-NetConnection`, fallisce se porte non-whitelisted sono open
+- `make security-audit` — target Makefile per esecuzione locale
+- `.github/workflows/security-audit-staging.yml` — schedule daily, esegue lo scan da GitHub-hosted runner; apre issue su drift
+
+**Rationale**: i requisiti di sicurezza non testabili sono speranza, non specifica (Wiegers). Trasformiamo l'invariante "DB MUST NOT be publicly reachable" in un *executable contract*.
+
+---
+
+## 3. Implementation checklist
+
+- [x] Containment server-side (DOCKER-USER rules + persistenza) — applicato 2026-05-06
+- [x] Issue GitHub #795 aperta
+- [ ] PR `feature/issue-795-postgres-exposure-hardening` → `main-dev`:
+  - [ ] Questo documento ADR
+  - [ ] `infra/scripts/security-audit.sh`
+  - [ ] `infra/scripts/security-audit.ps1`
+  - [ ] `.github/workflows/security-audit-staging.yml`
+  - [ ] `infra/Makefile` target `security-audit`
+  - [ ] `infra/hetzner/cax31-bootstrap.sh` aggiornato con DOCKER-USER chain (+ pacchetto iptables-persistent)
+- [ ] Hetzner Cloud Firewall configurato (manuale UI, fuori repo)
+- [ ] Filebrowser: decisione (rimuovere vs CF Tunnel + Access)
+
+---
+
+## 4. Consequences
+
+### Positive
+
+- **Triple-layer defense**: edge firewall + host iptables + service convention
+- **Detection automatica**: drift di porte rilevato entro 24h dal cron daily
+- **Idempotenza**: il bootstrap script può essere rieseguito senza duplicare regole
+- **Auditability**: l'invariante è dichiarata in spec e verificata da tooling
+
+### Negative / trade-off
+
+- **UFW rimosso**: durante il containment `apt install iptables-persistent` ha rimosso `ufw` (Ubuntu 24.04 li mette in conflict). Non è un problema funzionale (le ufw-* chains residue funzionano e iptables-persistent salva tutto), ma perdiamo la CLI friendly. Decisione: gestire iptables direttamente via script idempotenti.
+- **Coupling con Hetzner Cloud Firewall**: configurato manualmente fuori repo. Mitigazione: documentazione in `docs/operations/operations-manual.md` con screenshot/checklist.
+- **Cost del cron daily**: ~10 sec/giorno di GitHub Actions minutes, trascurabile.
+
+### Neutral
+
+- Le regole DOCKER-USER si applicano solo al traffico **da** `eth0`. Il traffico container-to-container resta libero (corretto: API → PG sulla rete `meepleai` deve funzionare).
+- L'IPv6 non è esplicitamente coperto da queste regole. Aggiungere `ip6tables` con stesse regole nel bootstrap. ⚠️ TODO.
+
+---
+
+## 5. References
+
+- BSI / CERT-Bund report: forwarded by `abuse@hetzner.com` 2026-05-06 12:23 CET
+- Attacker IP filebrowser brute-force: `156.146.59.27`
+- ASN: 24940 (Hetzner Online GmbH)
+- Server: `ubuntu-8gb-hel1-1` (CAX21 ARM64)
+- Docker UFW bypass — known issue: <https://github.com/moby/moby/issues/22054>
+- Hetzner Cloud Firewall docs: <https://docs.hetzner.com/cloud/firewalls/>
+- iptables `DOCKER-USER` chain reference: <https://docs.docker.com/network/packet-filtering-firewalls/>
+
+---
+
+## 6. Spec-panel review log
+
+| Data | Trigger | Amendments |
+|------|---------|-----------|
+| 2026-05-06 | Initial sign-off post-incident | Spec approved, all 4 layers committed |

--- a/docs/superpowers/specs/2026-05-06-kb-chunk-endpoints-design.md
+++ b/docs/superpowers/specs/2026-05-06-kb-chunk-endpoints-design.md
@@ -210,9 +210,9 @@ Feature: In-document keyword search with relevance ranking
 > **so that** I can decide if the KB is ready or needs to be retried/diagnosed.
 
 **SMART criteria**:
-- **S**: `GET /api/v1/kb-docs/{id}` returns `KbDocumentDto { id, title, gameId, sharedGameId?, documentCategory, processingState, totalChunks, pageCount, indexedAt?, uploadedAt, language, versionLabel?, processingError? (admin), retryCount? (admin) }`
+- **S**: `GET /api/v1/kb-docs/{id}` returns `KbDocumentDto { id, title, gameId, sharedGameId?, documentCategory, processingState, totalChunks, pageCount, indexedAt?, uploadedAt, language, versionLabel?, processingError? (admin), retryCount? (admin), failedAtState? (admin) }`
 - **M**: P95 < 80ms (cache hit), < 200ms (cold); cache TTL 60s
-- **A**: join `VectorDocument` + `PdfDocument` + count `TextChunkEntity` (denormalized `TotalChunks` already in `VectorDocument`)
+- **A**: join `VectorDocument` + `PdfDocument`; read `TotalChunks` from `VectorDocument` (already denormalized at indexing time, no extra count query needed)
 - **R**: powers `KbHeader` mockup
 - **T**: this PR
 
@@ -261,9 +261,9 @@ Feature: Document metadata overview
 > **so that** I can identify in **≤ 30 seconds** which chunk caused issues (e.g. embedding mismatch, OCR parsing failure).
 
 **SMART criteria**:
-- **S**: G1/G2 endpoints include `vectorId`, `characterCount`, `elementType`, `embeddingStatus` ONLY if `currentUser.IsAdmin === true`. Server-side field gating; fields `null` in DTO for non-admin
+- **S**: G1/G2 endpoints include `vectorId`, `characterCount`, `elementType`, `embeddingStatus` ONLY if `currentUser.IsAdmin === true`. Server-side field gating: handler sets fields to null in DTO for non-admin; per-field `[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]` annotations cause those fields to be omitted from the JSON wire payload
 - **M**: zero leak of admin fields to non-admin (audit log on attempts); 100% test coverage of gating logic
-- **A**: handler checks `currentUser.HasRole("Admin")` post-MediatR, populates/null-ifies fields in projection
+- **A**: handler checks `currentUser.HasRole("Admin")` post-MediatR, populates fields only for admin (defaults to null otherwise)
 - **R**: enables admin debug UI without creating duplicate endpoints
 - **T**: this PR
 
@@ -282,8 +282,8 @@ Feature: Admin chunk-level diagnostics
     Given the same doc as G5.1
     And currentUser has role=User (not admin)
     When the reader calls GET /api/v1/kb-docs/{docId}/chunks?skip=0&take=10
-    Then each chunk DTO has vectorId=null, characterCount=null, elementType=null, embeddingStatus=null
-    And the JSON serializer omits null fields (JsonIgnoreCondition.WhenWritingNull is global)
+    Then each chunk DTO has the four admin fields set to null in the projection
+    And the JSON wire payload omits those fields (per-field [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] annotation on KbChunkSummaryDto)
 
   Scenario: Admin views chunk with failed embedding
     Given a doc with processingState=Failed

--- a/docs/superpowers/specs/2026-05-06-kb-chunk-endpoints-design.md
+++ b/docs/superpowers/specs/2026-05-06-kb-chunk-endpoints-design.md
@@ -1,0 +1,580 @@
+# KB Chunk-Level Retrieval Endpoints — Design
+
+**Issue**: #730 (Backend audit prerequisite for #684 `/kb/[id]` Wave 3 v2 migration)
+**Branch**: `feature/issue-730-kb-chunk-endpoints` (parent: `main-dev`)
+**Author**: brainstorming session 2026-05-06
+**Status**: Draft → User review pending
+
+---
+
+## 1. Context & Problem Statement
+
+V2 migration Wave 3 child #684 must implement the route `/kb/[id]` from mockup `sp4-kb-detail.{html,jsx}`: a split-view UI (left panel: chunks list; right panel: markdown preview) for inspecting KB documents at chunk granularity.
+
+The audit (#681 Wave 3 Step 1) revealed that **5 backend capabilities are missing** for this UI:
+
+| # | Capability | Endpoint |
+|---|-----------|----------|
+| 1 | Single document metadata fetch | `GET /api/v1/kb-docs/{id}` |
+| 2 | Paginated chunks list with hierarchical breadcrumbs | `GET /api/v1/kb-docs/{id}/chunks` |
+| 3 | Single chunk full content with prev/next navigation | `GET /api/v1/kb-docs/{id}/chunks/{chunkId}` |
+| 4 | In-document keyword search with highlighted snippets | `POST /api/v1/kb-docs/{id}/chunks/search` |
+| 5 | Admin diagnostics fields (vectorId, embeddingStatus, ...) | embedded in (2) and (3) via DTO gating |
+
+This document specifies the design before implementation begins.
+
+### Key constraint: data layer asymmetry
+
+The chunking pipeline already produces full hierarchical metadata (`Heading`, `ParentChunkId`, `Level`, `ElementType`) and persists it to **Qdrant** via `ChunkPayload`. However, **PostgreSQL `TextChunkEntity` only persists `ChunkIndex`, `PageNumber`, `Content`, `search_vector`** — heading/parent/level data is missing from the relational store.
+
+This is the root reason behind the architectural decisions below.
+
+---
+
+## 2. Architectural Decisions
+
+| # | Decision | Choice | Rationale |
+|---|----------|--------|-----------|
+| **D1** | Primary actor | **Mix of admin + game owner + reader** with server-side field gating | Real usage spans all three personas; single API with conditional fields beats role-specific endpoints |
+| **D2** | Job-to-be-done scope | **Combo 1 — Full feature** (5 JTBD: verify chunking, browse-as-book, citation jump, keyword search, admin diagnostics) | Wave 3 needs full unblocking; partial delivery would force a follow-up PR before #684 is mergeable |
+| **D3** | Migration scope | **Option B — FULL normalized**: add `heading varchar`, `parent_chunk_id uuid?`, `level smallint`, `element_type varchar(20)` to `TextChunkEntity` | Combo 1 requires nested headingPath; normalized model avoids drift vs Qdrant payload (single source of truth = Qdrant) |
+| **D4** | DTO gating strategy | **Option A — Single DTO with nullable admin fields**, populated server-side based on `currentUser.IsAdmin OR currentUser.OwnsGame(gameId)`. Admin-only fields are decorated with `[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]` (per-field, since the global `ConfigureHttpJsonOptions` does **not** set `DefaultIgnoreCondition`). | Single contract for FE; coherent with existing pattern (`GameDocumentDto.VersionLabel?`); per-field annotation avoids changing global JSON behavior for other endpoints |
+| **D5** | Search ranking | PostgreSQL `ts_rank_cd` + `plainto_tsquery('simple', query)` + `ts_headline` | Built-in (no new infra); `simple` config avoids stemming false-positives across languages |
+| **D6** | Pagination | Offset-based `?skip=&take=` with `take ∈ [1, 100]` | Coherent with codebase (`HandleGetMyChatHistory`); CTE-recursive joins handle 1000+ chunks fine |
+| **D7** | `vectorId` mapping | Alias of `TextChunkEntity.Id` (Guid) | Already the foreign key into `PgVectorEmbeddingEntity`; no separate identifier exists |
+| **D8** | Caching | HybridCache: G1 list 5min · G2 single-chunk 10min · G3 search no-cache · G4 metadata 60s. Tags: `gameId:{guid}`, `pdfDocumentId:{guid}` | Chunks are immutable post-ingest (long TTL safe); metadata may change during ingest (short TTL); search results vary per query |
+
+---
+
+## 3. SMART User Goals
+
+### G1 — Browse-and-jump as a book (JTBD-B)
+
+> **As** a reader (logged in, with access to a public or owned KB doc),
+> **I want** to scroll a paginated list of chunks ordered by narrative position, with a hierarchical breadcrumb (`Chapter → Section → Subsection`) for each,
+> **so that** I can find a chunk of interest in **≤ 3 clicks** without reading the entire document.
+
+**SMART criteria**:
+- **S**: `GET /api/v1/kb-docs/{id}/chunks` returns `chunkId`, `headingPath: string[]`, `snippet` (≤200 char), `pageNumber`, `position`, `level`
+- **M**: P95 latency < 200ms for 50-chunk page; `headingPath` populated (≥1 element) for ≥80% of chunks in typical rulebooks
+- **A**: backfill from Qdrant payload + recursive CTE on `parent_chunk_id`
+- **R**: unblocks `KbChunkListPanel` mockup `sp4-kb-detail`
+- **T**: this PR (5–7 days)
+
+**Gherkin scenarios**:
+
+```gherkin
+Feature: Browse-and-jump chunks as a book
+
+  Scenario: Reader scrolls paginated chunks with hierarchical breadcrumbs
+    Given a PDF "Catan rulebook" was ingested with processingState=Ready
+    And the document has 120 chunks distributed across 32 pages
+    And chunks have heading nested up to level=2
+    When the reader calls GET /api/v1/kb-docs/{docId}/chunks?skip=0&take=50
+    Then the response is 200 OK in <200ms (P95)
+    And contains exactly 50 chunks ordered by chunkIndex asc
+    And each chunk has headingPath as array (e.g. ["3. Setup", "Card distribution"])
+    And each chunk has snippet of at most 200 characters
+    And the response includes hasMore=true (skip+take < totalCount)
+    And totalCount=120
+
+  Scenario: Reader navigates to second page
+    Given the state from the previous scenario
+    When the reader calls GET /api/v1/kb-docs/{docId}/chunks?skip=50&take=50
+    Then the response contains 50 chunks with chunkIndex 50-99
+
+  Scenario: Reader views final partial page
+    When the reader calls GET /api/v1/kb-docs/{docId}/chunks?skip=100&take=50
+    Then the response contains 20 chunks (chunkIndex 100-119)
+    And hasMore=false
+
+  Scenario: Document still being processed
+    Given a PDF is in state processingState=Embedding
+    When the reader calls GET /api/v1/kb-docs/{docId}/chunks
+    Then the response is 200 OK with empty array
+    And the response includes processingState="embedding" so FE renders empty state
+
+  Scenario: take exceeds maximum limit
+    When the reader calls GET /api/v1/kb-docs/{docId}/chunks?take=500
+    Then the response is 400 Bad Request
+    And the message is "take must be between 1 and 100"
+```
+
+---
+
+### G2 — Citation jump (trust-but-verify) (JTBD-C)
+
+> **As** a reader who just received a citation from the AI agent in chat,
+> **I want** to click the citation and see the **specific cited chunk** with full markdown content, breadcrumb, and prev/next navigation,
+> **so that** I can verify in **1 click** that the AI's answer matches the original text.
+
+**SMART criteria**:
+- **S**: `GET /api/v1/kb-docs/{id}/chunks/{chunkId}` returns `content` (markdown), `headingPath`, `pageNumber`, `level`, `prevChunkId?`, `nextChunkId?`, `vectorId` (admin only)
+- **M**: P95 < 100ms (cached), < 250ms (cold); cached in HybridCache 10min (immutable post-ingest)
+- **A**: direct lookup `TextChunkEntity` by Id + 2 auxiliary queries for prev/next chunkId
+- **R**: enables `KbChunkPreview` panel + chat citation deep-link
+- **T**: this PR
+
+**Gherkin scenarios**:
+
+```gherkin
+Feature: Citation jump to specific chunk
+
+  Scenario: Reader clicks citation and sees full markdown content
+    Given a "Mage Knight" doc ingested with 200 chunks
+    And the chat agent answered citing chunkId=abc-123 (chunkIndex=42)
+    When the reader calls GET /api/v1/kb-docs/{docId}/chunks/abc-123
+    Then the response is 200 OK in <250ms (P95 cold), <100ms (cached)
+    And contains content as markdown (heading, ul/ol, table preserved)
+    And contains headingPath ["Combat", "Attack phase", "Resolving damage"]
+    And contains prevChunkId (chunkIndex=41), nextChunkId (chunkIndex=43)
+    And vectorId equals chunkId (alias of the ID)
+
+  Scenario: First chunk of doc (no prev)
+    When the reader calls GET with chunkId of chunkIndex=0
+    Then prevChunkId is null
+    And nextChunkId is populated
+
+  Scenario: Last chunk of doc (no next)
+    When the reader calls GET with chunkId of last chunkIndex
+    Then nextChunkId is null
+
+  Scenario: chunkId does not exist or belongs to another doc
+    Given a valid chunkId from another doc
+    When the reader calls GET /api/v1/kb-docs/{docId}/chunks/{otherDocChunkId}
+    Then the response is 404 Not Found
+    And the message does not leak chunk existence in the other doc
+
+  Scenario: Reader without permission on private doc
+    Given the doc is private (PrivateGameId set, owned by another user)
+    When the reader calls GET /api/v1/kb-docs/{docId}/chunks/{chunkId}
+    Then the response is 403 Forbidden
+```
+
+---
+
+### G3 — Search keyword in-document with highlight (JTBD-D)
+
+> **As** a reader or admin who wants to find a specific term inside a document (e.g. "initiative" in Mage Knight),
+> **I want** a search box with results ranked by relevance and snippets with the keyword highlighted,
+> **so that** I can find the relevant chunk in **≤ 5 seconds** without scrolling the full list.
+
+**SMART criteria**:
+- **S**: `POST /api/v1/kb-docs/{id}/chunks/search` body `{ query, skip, take }` returns `{ matches: [{ chunkId, headingPath, snippet (with `<mark>` tags), rank }], totalCount }`
+- **M**: P95 < 300ms on 500-chunk doc; deterministic rank ordering (`ts_rank_cd`); ≥1 match returned if keyword exists in ≥1 chunk
+- **A**: `plainto_tsquery('simple', query)` + `ts_rank_cd(search_vector, ts_query)` + `ts_headline(content, ts_query)` for highlighted snippet
+- **R**: powers `ChunkSearchBox` mockup
+- **T**: this PR
+
+**Gherkin scenarios**:
+
+```gherkin
+Feature: In-document keyword search with relevance ranking
+
+  Scenario: Search keyword present in multiple chunks
+    Given a "Mage Knight" doc with 500 chunks ingested
+    And the keyword "initiative" appears in 7 chunks
+    When the reader posts to /api/v1/kb-docs/{docId}/chunks/search body {"query":"initiative","skip":0,"take":20}
+    Then the response is 200 OK in <300ms (P95)
+    And contains matches=7 chunks ordered by rank desc (ts_rank_cd)
+    And each snippet contains the keyword wrapped in <mark>...</mark>
+    And totalCount=7
+
+  Scenario: Search keyword does not exist
+    When the reader posts with query="xyzzyx"
+    Then the response is 200 OK with matches=[] and totalCount=0
+
+  Scenario: Multi-word query with stemming
+    Given the doc is language="it"
+    And the keyword "initial cards" appears with variants
+    When the reader posts with query="initial card"
+    Then ts_query uses configuration "simple" (no language-specific stemming) to avoid cross-language false positives
+
+  Scenario: Query too long
+    When the reader posts with query of 250 characters
+    Then the response is 400 Bad Request
+    And the message is "query must be between 1 and 200 characters"
+
+  Scenario: Query with special tsquery characters (operator injection)
+    When the reader posts with query="initiative | drop"
+    Then the backend escapes the query using plainto_tsquery (no operator injection)
+    And the response treats "|" as a word separator, not the OR operator
+```
+
+---
+
+### G4 — Document metadata overview (JTBD-A foundation)
+
+> **As** a game owner or admin opening a freshly ingested document,
+> **I want** to see in **a single call** the full doc metadata (title, gameId, granular processing state, total chunks, page count, lastIngestedAt, language),
+> **so that** I can decide if the KB is ready or needs to be retried/diagnosed.
+
+**SMART criteria**:
+- **S**: `GET /api/v1/kb-docs/{id}` returns `KbDocumentDto { id, title, gameId, sharedGameId?, documentCategory, processingState, totalChunks, pageCount, indexedAt?, uploadedAt, language, versionLabel?, processingError? (admin), retryCount? (admin) }`
+- **M**: P95 < 80ms (cache hit), < 200ms (cold); cache TTL 60s
+- **A**: join `VectorDocument` + `PdfDocument` + count `TextChunkEntity` (denormalized `TotalChunks` already in `VectorDocument`)
+- **R**: powers `KbHeader` mockup
+- **T**: this PR
+
+**Gherkin scenarios**:
+
+```gherkin
+Feature: Document metadata overview
+
+  Scenario: Game owner views Ready doc
+    Given a "Catan rulebook" doc just ingested with state Ready
+    When the game owner calls GET /api/v1/kb-docs/{docId}
+    Then the response is 200 OK in <200ms (P95 cold)
+    And contains title, gameId, processingState="ready", totalChunks=120, pageCount=32
+    And processingError is null/omitted (Ready state)
+
+  Scenario: Owner views in-progress doc
+    Given a doc is in state processingState="Embedding"
+    When the game owner calls GET /api/v1/kb-docs/{docId}
+    Then the response contains processingState="embedding" (lowercase canonical)
+    And totalChunks may be 0 or partial count
+    And the FE can render a progress indicator
+
+  Scenario: Admin views Failed doc
+    Given a doc is in state processingState="Failed" with processingError="Embedding API timeout"
+    When the admin calls GET /api/v1/kb-docs/{docId}
+    Then the response contains processingError="Embedding API timeout"
+    And contains retryCount=2, failedAtState="Embedding"
+
+  Scenario: Reader (non-admin) views Failed doc
+    Given the same Failed doc
+    When the reader (no admin) calls GET /api/v1/kb-docs/{docId}
+    Then the response does NOT contain processingError, retryCount, failedAtState (null/omitted)
+    And contains processingState="failed" (state-level info is OK to share)
+
+  Scenario: Doc does not exist
+    When calling GET /api/v1/kb-docs/{nonExistentId}
+    Then the response is 404 Not Found
+```
+
+---
+
+### G5 — Admin diagnostics: chunk-level processing state (JTBD-E)
+
+> **As** an admin diagnosing a failed or low-quality ingestion,
+> **I want** to see diagnostic fields on chunks (`vectorId`, `embeddingStatus`, `characterCount`, `elementType`),
+> **so that** I can identify in **≤ 30 seconds** which chunk caused issues (e.g. embedding mismatch, OCR parsing failure).
+
+**SMART criteria**:
+- **S**: G1/G2 endpoints include `vectorId`, `characterCount`, `elementType`, `embeddingStatus` ONLY if `currentUser.IsAdmin === true`. Server-side field gating; fields `null` in DTO for non-admin
+- **M**: zero leak of admin fields to non-admin (audit log on attempts); 100% test coverage of gating logic
+- **A**: handler checks `currentUser.HasRole("Admin")` post-MediatR, populates/null-ifies fields in projection
+- **R**: enables admin debug UI without creating duplicate endpoints
+- **T**: this PR
+
+**Gherkin scenarios**:
+
+```gherkin
+Feature: Admin chunk-level diagnostics
+
+  Scenario: Admin sees full diagnostic fields
+    Given a "Tainted Grail" doc with 250 chunks
+    And currentUser has role=Admin
+    When the admin calls GET /api/v1/kb-docs/{docId}/chunks?skip=0&take=10
+    Then each chunk DTO contains vectorId, characterCount, elementType, embeddingStatus
+
+  Scenario: Reader (non-admin) does NOT see admin fields
+    Given the same doc as G5.1
+    And currentUser has role=User (not admin)
+    When the reader calls GET /api/v1/kb-docs/{docId}/chunks?skip=0&take=10
+    Then each chunk DTO has vectorId=null, characterCount=null, elementType=null, embeddingStatus=null
+    And the JSON serializer omits null fields (JsonIgnoreCondition.WhenWritingNull is global)
+
+  Scenario: Admin views chunk with failed embedding
+    Given a doc with processingState=Failed
+    And 12 chunks of 250 have embeddingStatus="failed"
+    When the admin calls GET /api/v1/kb-docs/{docId}/chunks/{failedChunkId}
+    Then the chunk DTO contains embeddingStatus="failed"
+    And the FE can render a diagnostic indicator
+```
+
+---
+
+## 4. API Contract — Endpoint Specifications
+
+### 4.1 `GET /api/v1/kb-docs/{id}`
+
+**Auth**: `RequireSession()` + handler `userOwnsGame OR docIsPublic OR userIsAdmin`
+**Response 200** (`KbDocumentDto`):
+
+```ts
+{
+  id: string (guid),
+  title: string,            // pdf.FileName
+  gameId: string (guid)?,   // private game
+  sharedGameId: string (guid)?, // community
+  documentCategory: "Rulebook" | "Expansion" | "Errata" | "Homerule",
+  processingState: "pending" | "uploading" | "extracting" | "chunking" |
+                   "embedding" | "indexing" | "ready" | "failed",  // lowercase canonical
+  totalChunks: number,
+  pageCount: number,
+  indexedAt: string (iso8601)?,
+  uploadedAt: string (iso8601),
+  language: string,         // e.g. "it", "en"
+  versionLabel: string?,
+  // Admin-only fields:
+  processingError: string?,
+  retryCount: number?,
+  failedAtState: string?
+}
+```
+
+**Errors**: 404 (not found) · 403 (no access)
+
+---
+
+### 4.2 `GET /api/v1/kb-docs/{id}/chunks?skip&take`
+
+**Query params**: `skip` (default 0), `take` (default 50, max 100)
+**Auth**: same as 4.1
+**Response 200** (`KbChunkListDto`):
+
+```ts
+{
+  chunks: KbChunkSummaryDto[],
+  totalCount: number,
+  skip: number,
+  take: number,
+  hasMore: boolean,
+  processingState: string  // mirrored from doc, for FE empty state UX
+}
+
+KbChunkSummaryDto = {
+  chunkId: string (guid),
+  pageNumber: number?,
+  position: number,         // chunkIndex
+  level: number,            // 0=Title, 1=Section, 2=Paragraph
+  headingPath: string[],    // recursive parent traversal, may be []
+  snippet: string,          // first 200 chars of content
+  // Admin-only:
+  vectorId: string (guid)?,         // alias of chunkId
+  characterCount: number?,
+  elementType: string?,             // "NarrativeText" | "Title" | "Table" | "List"
+  embeddingStatus: string?          // "indexed" | "pending" | "failed"
+}
+```
+
+**Errors**: 400 (`take` out of range) · 404 (doc not found) · 403 (no access)
+
+---
+
+### 4.3 `GET /api/v1/kb-docs/{id}/chunks/{chunkId}`
+
+**Auth**: same as 4.1
+**Response 200** (`KbChunkDetailDto`):
+
+```ts
+{
+  chunkId: string (guid),
+  content: string,          // full markdown
+  pageNumber: number?,
+  position: number,
+  level: number,
+  headingPath: string[],
+  prevChunkId: string (guid)?,
+  nextChunkId: string (guid)?,
+  // Admin-only:
+  vectorId: string (guid)?,
+  characterCount: number?,
+  elementType: string?,
+  embeddingStatus: string?,
+  parentChunkId: string (guid)?
+}
+```
+
+**Errors**: 404 (chunk not found OR cross-doc) · 403 (no access)
+
+---
+
+### 4.4 `POST /api/v1/kb-docs/{id}/chunks/search`
+
+**Auth**: same as 4.1
+**Request body**:
+
+```ts
+{
+  query: string,    // 1-200 chars
+  skip: number?,    // default 0
+  take: number?     // default 20, max 100
+}
+```
+
+**Response 200** (`KbChunkSearchResultDto`):
+
+```ts
+{
+  matches: KbChunkMatchDto[],
+  totalCount: number,
+  skip: number,
+  take: number
+}
+
+KbChunkMatchDto = {
+  chunkId: string (guid),
+  headingPath: string[],
+  snippet: string,         // ts_headline output with <mark> tags
+  rank: number,            // ts_rank_cd score (0..1)
+  pageNumber: number?,
+  position: number
+}
+```
+
+**Errors**: 400 (query length out of range) · 404 (doc not found) · 403 (no access)
+
+---
+
+## 5. Data Model Changes
+
+### 5.1 Migration: `20260506_AddChunkHierarchyToTextChunkEntity`
+
+```sql
+ALTER TABLE text_chunks
+  ADD COLUMN heading varchar(500) NULL,
+  ADD COLUMN parent_chunk_id uuid NULL,
+  ADD COLUMN level smallint NOT NULL DEFAULT 1,
+  ADD COLUMN element_type varchar(20) NOT NULL DEFAULT 'NarrativeText';
+
+CREATE INDEX ix_text_chunks_parent_chunk_id ON text_chunks(parent_chunk_id);
+CREATE INDEX ix_text_chunks_pdf_chunk_index ON text_chunks(pdf_document_id, chunk_index);
+-- existing search_vector GIN index remains
+```
+
+**Note on `headingPath` (DTO array) vs `heading` (column)**: the database stores a single `heading` per chunk (the nearest section heading, as already produced by `ChunkMetadata.Heading`). The DTO field `headingPath: string[]` is **derived at query time** via a recursive CTE that traverses `parent_chunk_id` from the chunk up to the root, collecting the `heading` of each ancestor. Example projection:
+
+```sql
+WITH RECURSIVE chunk_path AS (
+  SELECT id, heading, parent_chunk_id, 1 AS depth
+  FROM text_chunks WHERE id = @chunkId
+  UNION ALL
+  SELECT t.id, t.heading, t.parent_chunk_id, cp.depth + 1
+  FROM text_chunks t
+  JOIN chunk_path cp ON t.id = cp.parent_chunk_id
+  WHERE cp.depth < 10  -- depth cap (R2 mitigation)
+)
+SELECT array_agg(heading ORDER BY depth DESC)
+       FILTER (WHERE heading IS NOT NULL) AS heading_path
+FROM chunk_path;
+```
+
+The application layer materializes this into a `string[]` (empty array when no headings exist along the chain).
+
+### 5.2 Backfill strategy
+
+A one-shot backfill job (idempotent, runnable as a hosted service or a CLI command) reads `ChunkPayload` from Qdrant for each `pdf_document_id` and projects:
+
+- `Heading` → `heading`
+- `Level` → `level`
+- `ParentChunkId` (string in Qdrant) → `parent_chunk_id` (Guid in PostgreSQL, after parsing)
+- `ElementType` → `element_type`
+
+If Qdrant payload is missing for a chunk (legacy data), fallback values: `heading = null`, `parent_chunk_id = null`, `level = 1`, `element_type = "NarrativeText"`.
+
+Backfill is **out of scope of the API PR** but tracked as a follow-up issue (Section 8).
+
+### 5.3 Pipeline going forward
+
+`AdvancedChunkingService` already populates `ChunkMetadata` with `Heading`, `Level`, `ParentChunkId`, `ElementType`. The persistence layer (currently writes only to Qdrant via `ChunkPayload`) must be extended to also write the new columns to `TextChunkEntity`.
+
+This change is small and lives in the existing chunking service. Tracked as part of this PR.
+
+---
+
+## 6. Implementation Strategy
+
+### 6.1 Sequencing (TDD-driven)
+
+1. **Migration + entity update**
+   - Add columns to `TextChunkEntity`
+   - Update EF Core mapping configuration
+   - `dotnet ef migrations add AddChunkHierarchyToTextChunkEntity`
+   - Unit test: entity round-trip with new fields
+
+2. **Chunking pipeline writes new fields**
+   - Extend `AdvancedChunkingService` (or its persistence collaborator) to populate `heading`, `parent_chunk_id`, `level`, `element_type` when writing to PostgreSQL
+   - Integration test (Testcontainers): ingest a synthetic PDF, verify all four columns are populated
+
+3. **G4 — `GetKbDocumentByIdQuery`** (smallest endpoint, sets the auth/gating pattern)
+4. **G1 — `GetKbChunksQuery`** with offset pagination + headingPath CTE
+5. **G2 — `GetKbChunkByIdQuery`** with prev/next computation
+6. **G3 — `SearchKbChunksQuery`** with `plainto_tsquery` + `ts_rank_cd` + `ts_headline`
+7. **G5 — DTO field gating** (cross-cutting; applied in handlers G1/G2 projections)
+8. **Routing wiring** in `KnowledgeBaseEndpoints.cs` (or new `KbDocumentEndpoints.cs` partial)
+9. **Frontend Zod schemas + hook templates** (`apps/web/src/lib/api/schemas/kb-document.ts`, `apps/web/src/hooks/queries/useKbChunks.ts` etc.) — coordinate with the parallel terminal to avoid divergence
+
+### 6.2 Test strategy
+
+- **Unit tests** (Domain + Application): handler logic with mocked `DbContext` (`InMemoryDb` or `Substitute`)
+- **Integration tests** (Testcontainers PostgreSQL): full CTE recursive query, full-text search, pagination boundaries
+- **Contract tests**: DTO field gating for admin vs non-admin
+- Target coverage: 90%+ for new code (project standard)
+
+### 6.3 Observability
+
+- Structured log per query: `_logger.LogDebug("Fetching KB chunks for doc {DocId} by user {UserId} skip={Skip} take={Take}")`
+- HybridCache metrics already exposed
+- New metric: `kb_chunk_search_duration_seconds` histogram (Prometheus) for G3 latency tracking
+
+---
+
+## 7. Risks & Mitigations
+
+| # | Risk | Likelihood | Impact | Mitigation |
+|---|------|-----------|--------|------------|
+| R1 | Backfill fails for legacy docs (Qdrant payload missing/corrupted) | Medium | Medium | Fallback values (`heading=null`, `level=1`); follow-up issue tracks re-ingestion of broken docs |
+| R2 | Recursive CTE on `parent_chunk_id` performs poorly on deeply-nested chunks (>10 levels) | Low | Medium | Cap recursion depth at 10 in CTE; index `parent_chunk_id`; rulebook headings rarely exceed 4 levels |
+| R3 | `ts_headline` produces oversized snippets that bloat response | Low | Low | Configure `MaxFragments=2, MaxWords=20` in `ts_headline` options |
+| R4 | DTO field gating leaks admin fields due to handler bug | Low | High | 100% test coverage of gating; integration test asserting non-admin response is sanitized |
+| R5 | DTO contract divergence with parallel terminal (FE migration wave) | Medium | High | Publish schema contract early; Zod schemas committed in this PR; coordinate via PR comment + Slack ping when DTOs land |
+| R6 | Response payload too large for docs with 1000+ chunks (when listing) | Low | Medium | `take` capped at 100; FE always paginates |
+| R7 | Search query operator injection via `to_tsquery` syntax | Low | High | Use `plainto_tsquery` (sanitizes user input) instead of `to_tsquery` |
+
+---
+
+## 8. Out of Scope (follow-up issues)
+
+The following are intentionally not part of this PR:
+
+| Topic | Tracked as |
+|-------|------------|
+| Backfill job for legacy `text_chunks` rows | New issue: "Backfill chunk hierarchy from Qdrant to PostgreSQL" |
+| Admin diagnostic search filter (e.g., `?embeddingStatus=failed`) | Future issue when admin UI requires it |
+| Cursor-based pagination (only if offset becomes a perf problem) | Future issue (reactive) |
+| Vector semantic search inside a single doc | Already covered by `SearchQuery` at game-level; in-doc semantic is YAGNI for now |
+| Real-time chunk update via SSE/WebSocket (e.g., during ingestion) | Future, depends on processing pipeline progress events |
+| Visual highlighting/diff of chunks (admin debug) | Future admin UI epic |
+
+---
+
+## 9. Definition of Done
+
+- [ ] EF Core migration `AddChunkHierarchyToTextChunkEntity` applied (dev DB upgraded)
+- [ ] `AdvancedChunkingService` writes 4 new columns on chunk persistence
+- [ ] 4 query handlers + 4 DTOs implemented (G1, G2, G3, G4)
+- [ ] DTO field gating for admin vs non-admin (G5) tested with both roles
+- [ ] All endpoints wired in `KnowledgeBaseEndpoints.cs` with `RequireSession()` + access control
+- [ ] OpenAPI/Scalar annotations present (`Produces<...>()`, `WithSummary`, `WithDescription`)
+- [ ] Unit + integration test coverage ≥ 90% on new code
+- [ ] Frontend Zod schemas in `apps/web/src/lib/api/schemas/kb-document.ts`
+- [ ] Frontend hook templates in `apps/web/src/hooks/queries/useKbChunks.ts` (and siblings)
+- [ ] PR opened against `main-dev` (parent branch)
+- [ ] Close-out comment on #684 with endpoint list + sample response payloads
+- [ ] Issue #730 closed
+
+---
+
+## 10. References
+
+- Issue #730 — backend audit
+- Issue #684 — Wave 3 child `/kb/[id]`
+- Issue #681 — Wave 3 umbrella
+- Migration spec — `docs/superpowers/specs/2026-04-26-v2-design-migration.md` §3.4 (Phase 0.5 contract pattern)
+- Mockup — `admin-mockups/design_files/sp4-kb-detail.{html,jsx}`
+- Stub components — `apps/web/src/components/v2/kb-detail/`
+- Existing chunk pipeline — `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/Chunking/AdvancedChunkingService.cs`
+- Existing entity — `apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/TextChunkEntity.cs`
+- Existing query pattern — `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetGameDocuments/`

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -319,6 +319,11 @@ sec-pentest: ## 2FA penetration tests — mirrors security-pentest.yml
 	cd $(API) && dotnet test $(API_TESTS) --filter "FullyQualifiedName~TwoFactorSecurityPenetrationTests" --nologo -v q
 	@echo "✅ Security pentest passed"
 
+security-audit: ## External port-scan against staging (default) — verifies only port 22 is publicly reachable. Override with SECURITY_AUDIT_TARGET=ip
+	@echo "🔵 Security audit (external port scan)..."
+	bash scripts/security-audit.sh
+	@echo "✅ Security audit passed"
+
 test-e2e: ## Playwright E2E tests (requires make dev + api + web running) — mirrors test-e2e.yml
 	@echo "🔵 E2E Playwright tests..."
 	cd $(WEB) && pnpm test:e2e
@@ -348,6 +353,6 @@ validate-workflows: ## Validate GitHub Actions workflows — mirrors auto-valida
         snapshot restore-staging restore-local seed-games \
         logs logging logging-down logs-ui ps build clean help \
         ci ci-fe ci-be-unit ci-be-integration ci-be-e2e ci-all \
-        sec-scan sec-pentest test-e2e test-visual test-perf validate-workflows \
+        sec-scan sec-pentest security-audit test-e2e test-visual test-perf validate-workflows \
         backup backup-verify backup-restore-test backup-status backup-cron-install backup-cron-show \
         db-snapshot db-snapshot-sanitized db-reset-migrations db-restore-snapshot db-rollback-safetynet

--- a/infra/hetzner/cax31-bootstrap.sh
+++ b/infra/hetzner/cax31-bootstrap.sh
@@ -1,4 +1,15 @@
 #!/usr/bin/env bash
+# =============================================================================
+# CAX21/CAX31 ARM64 server bootstrap (Hetzner Cloud)
+# =============================================================================
+# Applies to: meepleai-app staging/prod servers on Hetzner CAX21 (8GB) or
+# CAX31 (16GB) ARM64. Same hardening rules apply.
+#
+# This script is idempotent: safe to run multiple times.
+#
+# Spec: docs/superpowers/specs/2026-05-06-database-network-isolation-design.md
+# Issue: #795
+# =============================================================================
 set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
@@ -7,9 +18,12 @@ echo "==> System update"
 apt-get update && apt-get upgrade -y
 
 echo "==> Install essential tools"
+# Note: ufw is intentionally NOT installed here. On Ubuntu 24.04 it is in
+# conflict with iptables-persistent (apt removes ufw when installing
+# iptables-persistent). We use iptables directly for full Docker bypass control.
 apt-get install -y \
   curl wget git ca-certificates gnupg lsb-release \
-  cifs-utils ufw fail2ban htop ncdu jq \
+  cifs-utils iptables-persistent fail2ban htop ncdu jq \
   postgresql-client-common age
 
 echo "==> Install Docker (ARM64)"
@@ -22,13 +36,50 @@ curl -SL https://github.com/docker/compose/releases/latest/download/docker-compo
   -o ~/.docker/cli-plugins/docker-compose
 chmod +x ~/.docker/cli-plugins/docker-compose
 
-echo "==> Firewall (only 22, 80, 443 from internet)"
-ufw default deny incoming
-ufw default allow outgoing
-ufw allow 22/tcp
-ufw allow 80/tcp
-ufw allow 443/tcp
-ufw --force enable
+echo "==> Firewall: INPUT chain — public-facing rules"
+# Default policy: drop incoming, allow loopback + established.
+iptables -P INPUT DROP
+iptables -P FORWARD DROP
+iptables -P OUTPUT ACCEPT
+iptables -A INPUT -i lo -j ACCEPT
+iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
+# Allow SSH (only entrypoint we want public)
+iptables -C INPUT -p tcp --dport 22 -j ACCEPT 2>/dev/null \
+  || iptables -A INPUT -p tcp --dport 22 -j ACCEPT
+
+# IPv6 mirror (drop everything except SSH and established/loopback)
+ip6tables -P INPUT DROP
+ip6tables -P FORWARD DROP
+ip6tables -P OUTPUT ACCEPT
+ip6tables -A INPUT -i lo -j ACCEPT
+ip6tables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+ip6tables -C INPUT -p tcp --dport 22 -j ACCEPT 2>/dev/null \
+  || ip6tables -A INPUT -p tcp --dport 22 -j ACCEPT
+
+echo "==> Firewall: DOCKER-USER chain — bypass-proof (Issue #795)"
+# Docker bypasses the INPUT chain via its own DOCKER chain. The DOCKER-USER
+# chain is the only one Docker does NOT overwrite. We DROP all inbound traffic
+# to internal application ports here, so even an accidental `docker run -p X:X`
+# (without 127.0.0.1: prefix) cannot expose the service to the public.
+EXT_IF="$(ip route get 8.8.8.8 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="dev") print $(i+1)}' | head -1)"
+EXT_IF="${EXT_IF:-eth0}"
+echo "    External interface detected: $EXT_IF"
+
+# Application ports that MUST NOT be reachable from public Internet.
+# Split in two groups because iptables `multiport --dports` is limited to 15.
+APP_PORTS_GROUP1="5432,6379,9000,9001,9090,9093,3000,3001,8000,8001,8002,8003,8004,8025,1025"
+APP_PORTS_GROUP2="5678,3100,11434,8090"
+
+for PORTS in "$APP_PORTS_GROUP1" "$APP_PORTS_GROUP2"; do
+  iptables -C DOCKER-USER -i "$EXT_IF" -p tcp -m multiport --dports "$PORTS" -j DROP 2>/dev/null \
+    || iptables -I DOCKER-USER -i "$EXT_IF" -p tcp -m multiport --dports "$PORTS" -j DROP
+  ip6tables -C DOCKER-USER -i "$EXT_IF" -p tcp -m multiport --dports "$PORTS" -j DROP 2>/dev/null \
+    || ip6tables -I DOCKER-USER -i "$EXT_IF" -p tcp -m multiport --dports "$PORTS" -j DROP || true
+done
+
+echo "==> Persist iptables rules"
+netfilter-persistent save
 
 echo "==> Fail2ban for SSH brute-force protection"
 systemctl enable --now fail2ban

--- a/infra/scripts/security-audit.ps1
+++ b/infra/scripts/security-audit.ps1
@@ -1,0 +1,75 @@
+#!/usr/bin/env pwsh
+# =============================================================================
+# security-audit.ps1 — External port scan against staging/prod with whitelist
+# =============================================================================
+# Usage:
+#   pwsh infra/scripts/security-audit.ps1
+#   pwsh infra/scripts/security-audit.ps1 -Target 1.2.3.4
+#
+# Default target: staging (204.168.135.69)
+# Whitelist: only TCP/22 (SSH) is expected to be OPEN from public Internet.
+# Exit 1 on drift.
+#
+# Spec: docs/superpowers/specs/2026-05-06-database-network-isolation-design.md
+# Issue: #795
+# =============================================================================
+
+[CmdletBinding()]
+param(
+    [string]$Target = $(if ($env:SECURITY_AUDIT_TARGET) { $env:SECURITY_AUDIT_TARGET } else { "204.168.135.69" }),
+    [int]$TimeoutSeconds = 5
+)
+
+$ErrorActionPreference = "Stop"
+
+$AllPorts = @(22, 80, 443, 5432, 6379, 8080, 8090, 3000, 3001, 8000, 8001, 8002, 8003, 8004, 8025, 1025, 5678, 3100, 9000, 9001, 9090, 9093, 11434)
+$Whitelist = @(22)
+
+Write-Host "=== Security Audit: external port scan ===" -ForegroundColor Blue
+Write-Host "Target:    $Target"
+Write-Host "Scanner:   Test-NetConnection (PowerShell)"
+Write-Host "Whitelist: $($Whitelist -join ', ')"
+Write-Host "Total checked: $($AllPorts.Count) ports"
+Write-Host ""
+
+$OpenPorts = @()
+$Drift = @()
+$WhitelistVerified = @()
+
+foreach ($p in $AllPorts) {
+    $isOpen = Test-NetConnection -ComputerName $Target -Port $p `
+        -WarningAction SilentlyContinue -InformationLevel Quiet
+
+    if ($Whitelist -contains $p) {
+        if ($isOpen) {
+            $WhitelistVerified += $p
+            Write-Host ("  ✓ {0} OPEN (whitelisted)" -f $p) -ForegroundColor Green
+        } else {
+            Write-Host ("  ! {0} whitelisted but NOT open — expected open" -f $p) -ForegroundColor Yellow
+        }
+    } else {
+        if ($isOpen) {
+            $Drift += $p
+            $OpenPorts += $p
+            Write-Host ("  ✗ {0} OPEN — DRIFT (should be filtered/closed)" -f $p) -ForegroundColor Red
+        } else {
+            Write-Host ("  ✓ {0} closed/filtered" -f $p) -ForegroundColor Green
+        }
+    }
+}
+
+Write-Host ""
+Write-Host "=== Summary ===" -ForegroundColor Blue
+Write-Host "Whitelist verified: $($WhitelistVerified.Count) / $($Whitelist.Count)"
+Write-Host "Drift detected:     $($Drift.Count)"
+
+if ($Drift.Count -gt 0) {
+    Write-Host "❌ FAIL — unauthorized open ports: $($Drift -join ', ')" -ForegroundColor Red
+    Write-Host ""
+    Write-Host "Run on staging:"
+    Write-Host "  ssh deploy@${Target} 'sudo ss -tlnp 2>/dev/null | grep -E `":(`"$($Drift[0])`")`"'"
+    exit 1
+}
+
+Write-Host "✅ PASS — only whitelisted ports are reachable" -ForegroundColor Green
+exit 0

--- a/infra/scripts/security-audit.sh
+++ b/infra/scripts/security-audit.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# =============================================================================
+# security-audit.sh — External port scan against staging/prod with whitelist
+# =============================================================================
+# Usage:
+#   bash infra/scripts/security-audit.sh [TARGET_IP]
+#
+# Default target: staging (204.168.135.69)
+# Override:       SECURITY_AUDIT_TARGET=1.2.3.4 bash infra/scripts/security-audit.sh
+#                 bash infra/scripts/security-audit.sh 1.2.3.4
+#
+# Whitelist: only TCP/22 (SSH) is expected to be OPEN from public Internet.
+# All other ports MUST be filtered/closed. Exit 1 on drift.
+#
+# Required: nmap (apt install nmap) OR fallback to /dev/tcp (limited)
+#
+# Spec: docs/superpowers/specs/2026-05-06-database-network-isolation-design.md
+# Issue: #795
+# =============================================================================
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+TARGET="${SECURITY_AUDIT_TARGET:-${1:-204.168.135.69}}"
+
+# Ports we explicitly check. Each must be in either WHITELIST or BLACKLIST.
+ALL_PORTS=(22 80 443 5432 6379 8080 8090 3000 3001 8000 8001 8002 8003 8004 8025 1025 5678 3100 9000 9001 9090 9093 11434)
+
+# Ports allowed to be open from public Internet
+WHITELIST=(22)
+
+# Pretty colors (only when stdout is a TTY)
+if [[ -t 1 ]]; then
+  RED='\033[0;31m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[1;33m'
+  BLUE='\033[0;34m'
+  NC='\033[0m'
+else
+  RED=''; GREEN=''; YELLOW=''; BLUE=''; NC=''
+fi
+
+# ---------------------------------------------------------------------------
+# Detect scanner
+# ---------------------------------------------------------------------------
+USE_NMAP=false
+if command -v nmap >/dev/null 2>&1; then
+  USE_NMAP=true
+fi
+
+is_whitelisted() {
+  local p="$1"
+  for w in "${WHITELIST[@]}"; do
+    [[ "$w" == "$p" ]] && return 0
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Scan with nmap (preferred)
+# ---------------------------------------------------------------------------
+scan_nmap() {
+  local ports
+  ports=$(IFS=,; echo "${ALL_PORTS[*]}")
+  # -Pn: skip host discovery (Hetzner blocks ICMP, would falsely mark host down)
+  # -T4: aggressive timing
+  # --open: omit closed/filtered from raw output (we parse separately)
+  # -oG: grepable output, easy to parse
+  nmap -Pn -T4 -p "$ports" -oG - "$TARGET" 2>/dev/null | grep -E '^Host:'
+}
+
+parse_nmap_open_ports() {
+  # Extract open ports from nmap grepable output
+  local nmap_output="$1"
+  echo "$nmap_output" | sed -n 's/.*Ports: //p' | tr ',' '\n' | \
+    awk -F'/' '$2 == "open" { gsub(/^[ \t]+/, "", $1); print $1 }'
+}
+
+# ---------------------------------------------------------------------------
+# Fallback scan with /dev/tcp (no nmap installed)
+# ---------------------------------------------------------------------------
+scan_fallback() {
+  local opens=()
+  for p in "${ALL_PORTS[@]}"; do
+    if timeout 3 bash -c ">/dev/tcp/$TARGET/$p" 2>/dev/null; then
+      opens+=("$p")
+    fi
+  done
+  printf '%s\n' "${opens[@]}"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+echo -e "${BLUE}=== Security Audit: external port scan ===${NC}"
+echo "Target:    $TARGET"
+echo "Scanner:   $([[ $USE_NMAP == true ]] && echo "nmap" || echo "/dev/tcp fallback")"
+echo "Whitelist: ${WHITELIST[*]}"
+echo "Total checked: ${#ALL_PORTS[@]} ports"
+echo ""
+
+OPEN_PORTS=()
+if [[ "$USE_NMAP" == "true" ]]; then
+  raw=$(scan_nmap)
+  if [[ -z "$raw" ]]; then
+    echo -e "${RED}ERROR: nmap returned no output (host unreachable?)${NC}" >&2
+    exit 2
+  fi
+  while IFS= read -r p; do
+    [[ -n "$p" ]] && OPEN_PORTS+=("$p")
+  done < <(parse_nmap_open_ports "$raw")
+else
+  while IFS= read -r p; do
+    [[ -n "$p" ]] && OPEN_PORTS+=("$p")
+  done < <(scan_fallback)
+fi
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+DRIFT=()
+WHITELIST_VERIFIED=()
+
+for p in "${ALL_PORTS[@]}"; do
+  is_open=false
+  for op in "${OPEN_PORTS[@]:-}"; do
+    [[ "$op" == "$p" ]] && is_open=true && break
+  done
+
+  if is_whitelisted "$p"; then
+    if [[ "$is_open" == "true" ]]; then
+      WHITELIST_VERIFIED+=("$p")
+      echo -e "  ${GREEN}✓${NC} $p OPEN (whitelisted)"
+    else
+      echo -e "  ${YELLOW}!${NC} $p whitelisted but NOT open — expected open"
+    fi
+  else
+    if [[ "$is_open" == "true" ]]; then
+      DRIFT+=("$p")
+      echo -e "  ${RED}✗${NC} $p OPEN — DRIFT (should be filtered/closed)"
+    else
+      echo -e "  ${GREEN}✓${NC} $p closed/filtered"
+    fi
+  fi
+done
+
+echo ""
+echo -e "${BLUE}=== Summary ===${NC}"
+echo "Whitelist verified: ${#WHITELIST_VERIFIED[@]} / ${#WHITELIST[@]}"
+echo "Drift detected:     ${#DRIFT[@]}"
+if [[ ${#DRIFT[@]} -gt 0 ]]; then
+  echo -e "${RED}❌ FAIL — unauthorized open ports: ${DRIFT[*]}${NC}"
+  echo ""
+  echo "Run on staging:"
+  echo "  ssh deploy@$TARGET 'sudo ss -tlnp 2>/dev/null | grep -E \":(${DRIFT[0]})\"'"
+  echo "  ssh deploy@$TARGET 'docker ps --format \"{{.Names}} {{.Ports}}\" | grep -E \"0.0.0.0:|::\"'"
+  exit 1
+fi
+
+echo -e "${GREEN}✅ PASS — only whitelisted ports are reachable${NC}"
+exit 0


### PR DESCRIPTION
Closes #795

## Summary

Codify defense-in-depth hardening for the staging server after BSI/CERT-Bund detected `postgresql/5432` reachable from public Internet on 2026-05-05.

## Why

Docker bypasses UFW. When a container publishes a port (\`docker run -p X:X\` or compose \`ports: ["X:X"]\` without \`127.0.0.1:\` prefix), Docker injects rules into the \`DOCKER\` iptables chain *before* \`ufw-user-input\` runs. UFW rules don't apply.

Containment was applied server-side on 2026-05-06 (DOCKER-USER chain rules + iptables-persistent + filebrowser stop). This PR codifies the same hardening in the repo so it survives reboots, redeploys, and human turnover.

## What

### Defense-in-depth — 4 layers

| Layer | Where | What this PR adds |
|-------|-------|-------------------|
| Edge | Hetzner Cloud Firewall | (manual UI step — tracked in spec, out of repo) |
| Host iptables | \`infra/hetzner/cax31-bootstrap.sh\` | DOCKER-USER chain DROP rules (idempotent), ip6tables mirror, removed UFW (Ubuntu 24.04 conflict) |
| Service convention | code review | spec rule: \`ports: ["127.0.0.1:X:X"]\` only |
| Continuous verification | \`infra/scripts/security-audit.{sh,ps1}\`, \`.github/workflows/security-audit-staging.yml\` | nmap whitelist + daily scheduled scan + auto-issue on drift |

### Files

- **\`docs/superpowers/specs/2026-05-06-database-network-isolation-design.md\`** — ADR documenting incident, root cause, decision, consequences.
- **\`infra/scripts/security-audit.sh\`** — external port scan with whitelist (only \`:22\` expected open). nmap-based with \`/dev/tcp\` fallback. Exit non-zero on drift. Override target via \`SECURITY_AUDIT_TARGET=ip\` or positional arg.
- **\`infra/scripts/security-audit.ps1\`** — Windows equivalent using \`Test-NetConnection\`.
- **\`infra/Makefile\`** — new \`make security-audit\` target.
- **\`.github/workflows/security-audit-staging.yml\`** — daily 04:00 UTC scheduled scan from GitHub-hosted runner. Auto-opens issue on drift, deduplicating per-day.
- **\`infra/hetzner/cax31-bootstrap.sh\`** — applies to both CAX21 (staging) and CAX31. UFW removed (Ubuntu 24.04 conflict with iptables-persistent). Direct iptables INPUT (drop, allow 22) + DOCKER-USER chain rules for all internal app ports + ip6tables mirror + persistence via \`netfilter-persistent save\`. Idempotent.

## Test plan

- [x] Branch builds locally (no compile-affecting changes).
- [ ] \`make security-audit\` from local: expect \`PASS — only whitelisted ports are reachable\` (PowerShell version validated end-to-end during incident: external scan from local machine confirmed only 22/tcp open).
- [ ] GitHub Action \`security-audit-staging\` runs once on \`workflow_dispatch\` after merge.
- [ ] Bootstrap script idempotent (re-running on existing staging would not duplicate iptables rules — \`-C\` check before \`-I\` insert).
- [ ] Verify ADR linked in CLAUDE.md security section in a follow-up PR (not this one).

## Containment status (already applied 2026-05-06)

- ✅ DOCKER-USER chain rules inserted on \`ubuntu-8gb-hel1-1\` and persisted to \`/etc/iptables/rules.v4\`
- ✅ \`filebrowser\` stopped + autostart disabled (mounted \`/opt/meepleai\` rw — would have leaked all secrets)
- ✅ \`sleepy_black\` debug container removed; Exited containers pruned
- ✅ External nmap-equivalent verified: only \`22/tcp\` open from public
- ✅ Brute-force from \`156.146.59.27\` against filebrowser/8090 terminated

## Out of scope (follow-up issues)

- Decision on \`filebrowser\` (remove permanently vs reintroduce behind CF Tunnel + Access)
- Hetzner Cloud Firewall configuration (manual UI step — to be done by maintainer)
- UFW reinstall (deferred — direct iptables management is acceptable; revisit if friction)
- Reboot for kernel \`6.8.0-106 → 6.8.0-111\` + 33 pending updates
- Cleanup \`/opt/meepleai/*.yml\` legacy top-level files
- Precautionary \`POSTGRES_PASSWORD\` rotation

## References

- BSI report timestamp: 2026-05-05 14:44:45 UTC
- Attacker IP (filebrowser brute-force): \`156.146.59.27\`
- Hetzner abuse ticket: forwarded by \`abuse@hetzner.com\`
- Server: \`ubuntu-8gb-hel1-1\` (CAX21 ARM64)
- Docker UFW bypass — known issue: <https://github.com/moby/moby/issues/22054>

🤖 Generated with [Claude Code](https://claude.com/claude-code)