### PR TITLE
fix(chat-ui): typing indicator on assistant placeholder during qaStream

### DIFF
--- a/apps/web/src/components/chat-unified/ChatMessageList.tsx
+++ b/apps/web/src/components/chat-unified/ChatMessageList.tsx
@@ -165,6 +165,10 @@ export function ChatMessageList({
             const isLastAssistant =
               !streamState.isStreaming && isLastAssistantMessage(messages, msgIndex);
             const showFeedback = msg.role === 'assistant' && !!gameId && !!threadId;
+            // Show the typing indicator on the assistant placeholder bubble
+            // (empty content) while a send is in flight. This covers the
+            // qaStream path which doesn't drive `streamState.currentAnswer`.
+            const isAssistantPlaceholder = msg.role === 'assistant' && !msg.content && !!isSending;
 
             return (
               <div
@@ -181,6 +185,7 @@ export function ChatMessageList({
                     onFeedbackChange: async (value, comment) => {
                       await handleFeedback(msg.id, value, comment);
                     },
+                    isTyping: isAssistantPlaceholder,
                   })}
                 />
 

--- a/apps/web/src/components/chat-unified/__tests__/ChatMessageList.test.tsx
+++ b/apps/web/src/components/chat-unified/__tests__/ChatMessageList.test.tsx
@@ -352,3 +352,34 @@ describe('ChatMessageList — streaming characterization', () => {
     expect(status).toHaveTextContent('Collegamento in corso...');
   });
 });
+
+// ── Tests: Typing indicator on assistant placeholder bubble ───────────────────
+
+describe('ChatMessageList — typing indicator on assistant placeholder', () => {
+  it('shows typing indicator on empty assistant message while isSending', () => {
+    const messages: ChatMessageItem[] = [
+      { id: 'u-1', role: 'user', content: 'Q?' },
+      { id: 'a-1', role: 'assistant', content: '' },
+    ];
+    render(<ChatMessageList {...defaultProps} messages={messages} isSending />);
+    expect(screen.getByTestId('chat-typing-indicator')).toBeInTheDocument();
+  });
+
+  it('hides typing indicator once the assistant message has content', () => {
+    const messages: ChatMessageItem[] = [
+      { id: 'u-1', role: 'user', content: 'Q?' },
+      { id: 'a-1', role: 'assistant', content: 'Risposta in arrivo' },
+    ];
+    render(<ChatMessageList {...defaultProps} messages={messages} isSending />);
+    expect(screen.queryByTestId('chat-typing-indicator')).toBeNull();
+  });
+
+  it('does not show typing indicator when isSending is false', () => {
+    const messages: ChatMessageItem[] = [
+      { id: 'u-1', role: 'user', content: 'Q?' },
+      { id: 'a-1', role: 'assistant', content: '' },
+    ];
+    render(<ChatMessageList {...defaultProps} messages={messages} isSending={false} />);
+    expect(screen.queryByTestId('chat-typing-indicator')).toBeNull();
+  });
+});

--- a/apps/web/src/components/chat-unified/utils/__tests__/toChatMessageProps.test.ts
+++ b/apps/web/src/components/chat-unified/utils/__tests__/toChatMessageProps.test.ts
@@ -119,9 +119,23 @@ describe('toChatMessageProps', () => {
       expect(toChatMessageProps(item, baseCtx).agentType).toBeUndefined();
     });
 
-    it('does NOT set isTyping (handled by separate streaming bubble)', () => {
+    it('defaults isTyping to false when not provided', () => {
       const item: ChatMessageItem = { id: 'a', role: 'assistant', content: 'A' };
-      expect(toChatMessageProps(item, baseCtx).isTyping).toBeUndefined();
+      expect(toChatMessageProps(item, baseCtx).isTyping).toBe(false);
+    });
+  });
+
+  describe('isTyping propagation', () => {
+    it('passes isTyping=true when ctx.isTyping is true', () => {
+      const item: ChatMessageItem = { id: 'a', role: 'assistant', content: '' };
+      const result = toChatMessageProps(item, { ...baseCtx, isTyping: true });
+      expect(result.isTyping).toBe(true);
+    });
+
+    it('passes isTyping=false when ctx.isTyping is false', () => {
+      const item: ChatMessageItem = { id: 'a', role: 'assistant', content: 'A' };
+      const result = toChatMessageProps(item, { ...baseCtx, isTyping: false });
+      expect(result.isTyping).toBe(false);
     });
   });
 });

--- a/apps/web/src/components/chat-unified/utils/toChatMessageProps.ts
+++ b/apps/web/src/components/chat-unified/utils/toChatMessageProps.ts
@@ -29,6 +29,13 @@ export interface ToChatMessagePropsContext {
   showFeedback: boolean;
   /** Curried feedback handler with messageId already bound */
   onFeedbackChange: (value: FeedbackValue, comment?: string) => Promise<void>;
+  /**
+   * Render the typing indicator instead of the message body. Used for the
+   * assistant placeholder bubble between optimistic append and the first
+   * token arrival on the qaStream path (which doesn't drive
+   * `streamState.currentAnswer`).
+   */
+  isTyping?: boolean;
 }
 
 export function toChatMessageProps(
@@ -43,6 +50,7 @@ export function toChatMessageProps(
     isFeedbackLoading: ctx.isFeedbackLoading,
     showFeedback: ctx.showFeedback,
     onFeedbackChange: ctx.onFeedbackChange,
+    isTyping: ctx.isTyping ?? false,
   };
 
   if (item.role === 'user') {
@@ -51,7 +59,6 @@ export function toChatMessageProps(
 
   // NOTE: citations deliberately NOT passed — kept outside as <RuleSourceCard>
   // NOTE: confidence/agentType not yet available from ChatMessageItem
-  // NOTE: isTyping is handled separately via the streaming bubble, not per message
 
   return base;
 }

--- a/apps/web/src/components/ui/meeple/chat-message.tsx
+++ b/apps/web/src/components/ui/meeple/chat-message.tsx
@@ -159,10 +159,11 @@ const TypingIndicator = React.memo<TypingIndicatorProps>(({ className }) => {
       className={cn('flex items-center gap-1', className)}
       aria-label="AI is typing"
       aria-live="polite"
+      data-testid="chat-typing-indicator"
     >
-      <span className="w-2 h-2 bg-gray-400 rounded-full animate-bounce [animation-delay:-0.3s]" />
-      <span className="w-2 h-2 bg-gray-400 rounded-full animate-bounce [animation-delay:-0.15s]" />
-      <span className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" />
+      <span className="w-2 h-2 bg-amber-500 rounded-full animate-bounce [animation-delay:-0.3s]" />
+      <span className="w-2 h-2 bg-amber-500 rounded-full animate-bounce [animation-delay:-0.15s]" />
+      <span className="w-2 h-2 bg-amber-500 rounded-full animate-bounce" />
     </div>
   );
 });


### PR DESCRIPTION
## Summary

Sul path `qaStream` (sempre attivo quando `thread.gameId` è presente — flow standard per testare il KB di un gioco) `ChatThreadView` aggiungeva un assistant message con `content: ''` come placeholder ottimistico **prima** del primo evento `Token` dal backend. Tra l'append e il primo token possono passare 200-2000ms (`await api.chat.addMessage` + RAG search + LLM TTFB) e l'utente vedeva una **bubble grigia vuota**, non un "thinking" affordance.

Causa: `streamState.isStreaming` / `streamState.currentAnswer` sono pilotati esclusivamente da `useAgentChatStream`. Il path `qaStream` aggiorna i messaggi via `patchMessageById` direttamente, quindi il "streaming bubble" in `ChatMessageList` (linea 317) non si attiva mai, e `<ChatMessage>` riceveva sempre `isTyping=false` per via del commento "isTyping is handled separately via the streaming bubble" in `toChatMessageProps`.

## Fix

- `toChatMessageProps`: aggiunto `isTyping?: boolean` opzionale al context, default `false`.
- `ChatMessageList`: per ogni messaggio calcola `isAssistantPlaceholder = role==='assistant' && !content && !!isSending` e passa come `isTyping` all'atom.
- `ChatMessage` atom: `TypingIndicator` ora usa `bg-amber-500` (Hybrid Warm-Modern accent — coerente con il pulse della streaming bubble e con `admin-mockups/mockup/chatDesktop.png`) al posto di `bg-gray-400`. Aggiunto `data-testid="chat-typing-indicator"` per i test.

Atom già supportava `isTyping` (`mb 261` switch tra TypingIndicator e content) — qui viene solo cablato il seam mancante per l'adapter.

## Test plan

- [x] `pnpm typecheck` verde
- [x] `pnpm lint` 0 errori (32 warning preesistenti)
- [x] Vitest: 6 nuovi (3 toChatMessageProps + 3 ChatMessageList placeholder cases)
- [x] Vitest: 295 test esistenti su chat-unified + chat-message atom restano verdi (302/302 totali nelle suite toccate)
- [ ] Smoke browser: chat Nanolith — al primo invio il bubble assistant mostra 3 puntini amber pulsanti finché non arriva il primo token

## Files changed

- `apps/web/src/components/chat-unified/utils/toChatMessageProps.ts` — `isTyping` opzionale nel context
- `apps/web/src/components/chat-unified/ChatMessageList.tsx` — calcolo `isAssistantPlaceholder` per messaggio
- `apps/web/src/components/ui/meeple/chat-message.tsx` — TypingIndicator amber + testid
- `apps/web/src/components/chat-unified/utils/__tests__/toChatMessageProps.test.ts` — 3 nuovi test
- `apps/web/src/components/chat-unified/__tests__/ChatMessageList.test.tsx` — 3 nuovi test

🤖 Generated with [Claude Code](https://claude.com/claude-code)