### PR TITLE
fix(pdf-indexing): resolve text_chunks.GameId via PdfGameIdResolver helper

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.DocumentProcessing.Application.Commands;
 using Api.BoundedContexts.DocumentProcessing.Application.DTOs;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.Configuration;
 using Api.Infrastructure;
@@ -94,7 +95,9 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
             }
 
             // Step 4: Save text chunks to PostgreSQL for hybrid search
-            await SaveTextChunksToPostgresAsync(pdfId, effectiveGameId, pdf.SharedGameId, documentChunks!, cancellationToken).ConfigureAwait(false);
+            // text_chunks.GameId is FK to games.Id (NOT shared_games.id) — resolve via PdfGameIdResolver.
+            var chunkGameId = await PdfGameIdResolver.ResolveAsync(_db, pdf, cancellationToken).ConfigureAwait(false);
+            await SaveTextChunksToPostgresAsync(pdfId, chunkGameId, pdf.SharedGameId, documentChunks!, cancellationToken).ConfigureAwait(false);
 
             // Mark processing complete
             pdf.ProcessingState = "Ready";
@@ -367,7 +370,7 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
     /// </summary>
     private async Task SaveTextChunksToPostgresAsync(
         string pdfId,
-        Guid gameId,
+        Guid? gameId,
         Guid? sharedGameId,
         List<DocumentChunk> documentChunks,
         CancellationToken cancellationToken)

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
@@ -549,12 +549,15 @@ internal partial class UploadPdfCommandHandler
         }
 
         // Create TextChunkEntity for each document chunk (for FTS)
-        var textChunkGameId = pdfDoc.PrivateGameId ?? pdfDoc.SharedGameId ?? Guid.Empty;
+        // text_chunks.GameId is FK to games.Id (NOT shared_games.id) — see PdfGameIdResolver.
+        var textChunkGameId = await PdfGameIdResolver.ResolveAsync(db, pdfDoc, cancellationToken)
+            .ConfigureAwait(false);
         var textChunkEntities = allDocumentChunks
             .Select((chunk, index) => new TextChunkEntity
             {
                 Id = Guid.NewGuid(),
                 GameId = textChunkGameId,
+                SharedGameId = pdfDoc.SharedGameId,
                 PdfDocumentId = pdfGuid,
                 Content = chunk.Text,
                 ChunkIndex = index,

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
@@ -503,10 +503,15 @@ internal partial class UploadPdfCommandHandler
 
         if (vectorDoc == null)
         {
+            // vector_documents.GameId is FK to games.Id (NOT shared_games.id) — see PdfGameIdResolver.
+            // Same constraint that applies to text_chunks.GameId.
+            var resolvedGameId = await PdfGameIdResolver.ResolveAsync(db, pdfDoc, cancellationToken)
+                .ConfigureAwait(false);
+
             vectorDoc = new VectorDocumentEntity
             {
                 Id = Guid.NewGuid(),
-                GameId = pdfDoc.SharedGameId,
+                GameId = resolvedGameId,
                 SharedGameId = pdfDoc.SharedGameId, // Issue #5185: propagate SharedGameId from PDF
                 PdfDocumentId = pdfGuid,
                 IndexingStatus = "completed",

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfGameIdResolver.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfGameIdResolver.cs
@@ -1,0 +1,49 @@
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// Resolves the <c>games.Id</c> to use as <c>text_chunks.GameId</c> for a <see cref="PdfDocumentEntity"/>.
+/// </summary>
+/// <remarks>
+/// <c>text_chunks.GameId</c> is a foreign key to <c>games.Id</c>, NOT to <c>shared_games.id</c>.
+/// Naively using <c>pdf.SharedGameId</c> as the chunk's GameId triggers
+/// <c>FK_text_chunks_games_GameId</c> violations whenever the shared catalog id and the games row id
+/// differ (the common case once Issue #2373 wiring runs).
+///
+/// Resolution strategy:
+/// - Private PDF: return <c>PrivateGameId</c> directly (it already references <c>games.Id</c>'s
+///   private-game peer table, which the EF model treats as a separate FK target).
+/// - Shared PDF: look up the <c>GameEntity</c> whose <c>SharedGameId</c> matches the PDF's shared-game id.
+/// - Neither set, or no matching games row: return <c>null</c> (callers decide whether to default to
+///   <see cref="System.Guid.Empty"/> or skip persistence).
+/// </remarks>
+public static class PdfGameIdResolver
+{
+    public static async Task<Guid?> ResolveAsync(
+        MeepleAiDbContext db,
+        PdfDocumentEntity pdf,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(pdf);
+
+        if (pdf.PrivateGameId.HasValue)
+        {
+            return pdf.PrivateGameId.Value;
+        }
+
+        if (!pdf.SharedGameId.HasValue)
+        {
+            return null;
+        }
+
+        return await db.Games
+            .Where(g => g.SharedGameId == pdf.SharedGameId.Value)
+            .Select(g => (Guid?)g.Id)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -598,12 +598,15 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
             _db.TextChunks.RemoveRange(existingChunks);
         }
 
+        // text_chunks.GameId is FK to games.Id (NOT shared_games.id) — see PdfGameIdResolver.
+        var resolvedGameId = await PdfGameIdResolver.ResolveAsync(_db, pdfDoc, cancellationToken)
+            .ConfigureAwait(false);
+
         var textChunkEntities = chunks
             .Select((chunk, index) => new TextChunkEntity
             {
                 Id = Guid.NewGuid(),
-                // GameId resolution: same strategy as IndexPdfCommandHandler.effectiveGameId
-                GameId = pdfDoc.PrivateGameId ?? pdfDoc.SharedGameId,
+                GameId = resolvedGameId,
                 SharedGameId = pdfDoc.SharedGameId,
                 PdfDocumentId = pdfDoc.Id,
                 Content = chunk.Text,

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/IndexPdfCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/IndexPdfCommandHandlerTests.cs
@@ -666,13 +666,24 @@ public class IndexPdfCommandHandlerTests
     [Fact]
     [Trait("Category", TestCategories.Unit)]
     [Trait("BoundedContext", "DocumentProcessing")]
-    public async Task Handle_SharedGamePdf_StoresSharedGameIdOnTextChunks()
+    public async Task Handle_SharedGamePdf_ResolvesGameIdFromGamesTable()
     {
-        // Arrange — SharedGame PDF has null GameId and PrivateGameId, only SharedGameId set
+        // Arrange — SharedGame PDF has null PrivateGameId, only SharedGameId set.
+        // text_chunks.GameId is FK to games.Id (NOT shared_games.id) — see PdfGameIdResolver.
+        // We seed a matching GameEntity so the resolver can map SharedGameId → games.Id.
         using var context = CreateFreshDbContext();
         var (chunkingServiceMock, embeddingServiceMock, loggerMock, indexingSettingsMock) = CreateMocks();
 
         var sharedGameId = Guid.NewGuid();
+        var gamesId = Guid.NewGuid();
+        await context.Games.AddAsync(new GameEntity
+        {
+            Id = gamesId,
+            Name = "Shared Game Mirror",
+            SharedGameId = sharedGameId,
+            CreatedAt = DateTime.UtcNow
+        });
+
         var pdfId = Guid.NewGuid();
         var pdf = new PdfDocumentEntity
         {
@@ -717,7 +728,7 @@ public class IndexPdfCommandHandlerTests
         // Assert — indexing succeeds
         result.Success.Should().BeTrue();
 
-        // Assert — text chunks have SharedGameId set AND GameId equals SharedGameId (not Guid.Empty)
+        // Assert — text chunks have SharedGameId propagated AND GameId resolved to games.Id
         var savedChunks = await context.TextChunks
             .Where(tc => tc.PdfDocumentId == pdfId)
             .ToListAsync();
@@ -726,7 +737,7 @@ public class IndexPdfCommandHandlerTests
         savedChunks.Should().AllSatisfy(chunk =>
         {
             chunk.SharedGameId.Should().Be(sharedGameId, "SharedGameId must propagate from PDF to text chunks");
-            chunk.GameId.Should().Be(sharedGameId, "effectiveGameId should fall through to SharedGameId, not Guid.Empty");
+            chunk.GameId.Should().Be(gamesId, "GameId must resolve to games.Id via SharedGameId (FK to games, not shared_games)");
         });
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfGameIdResolverTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfGameIdResolverTests.cs
@@ -1,0 +1,176 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// Unit tests for <see cref="PdfGameIdResolver"/>.
+/// Verifies FK-correct resolution of <c>text_chunks.GameId</c> from a <see cref="PdfDocumentEntity"/>:
+/// private path returns PrivateGameId; shared path looks up <c>games.Id</c> via SharedGameId.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+public class PdfGameIdResolverTests
+{
+    private static MeepleAiDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new MeepleAiDbContext(
+            options,
+            new Mock<IMediator>().Object,
+            new Mock<IDomainEventCollector>().Object);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_PrivateGameSet_ReturnsPrivateGameId()
+    {
+        using var db = CreateDbContext();
+        var privateGameId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            PrivateGameId = privateGameId,
+            FileName = "x.pdf",
+            FilePath = "/tmp/x.pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            ProcessingState = "Ready"
+        };
+
+        var result = await PdfGameIdResolver.ResolveAsync(db, pdf, TestContext.Current.CancellationToken);
+
+        result.Should().Be(privateGameId);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_NoPrivateNoShared_ReturnsNull()
+    {
+        using var db = CreateDbContext();
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            FileName = "x.pdf",
+            FilePath = "/tmp/x.pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            ProcessingState = "Ready"
+        };
+
+        var result = await PdfGameIdResolver.ResolveAsync(db, pdf, TestContext.Current.CancellationToken);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_SharedGameWithoutMatchingGamesRow_ReturnsNull()
+    {
+        using var db = CreateDbContext();
+        var sharedGameId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            SharedGameId = sharedGameId,
+            FileName = "x.pdf",
+            FilePath = "/tmp/x.pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            ProcessingState = "Ready"
+        };
+
+        var result = await PdfGameIdResolver.ResolveAsync(db, pdf, TestContext.Current.CancellationToken);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_SharedGameWithMatchingGamesRow_ReturnsGamesId()
+    {
+        using var db = CreateDbContext();
+        var sharedGameId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+        var gamesId = Guid.Parse("44444444-4444-4444-4444-444444444444");
+
+        db.Games.Add(new GameEntity
+        {
+            Id = gamesId,
+            Name = "Test",
+            SharedGameId = sharedGameId,
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            SharedGameId = sharedGameId,
+            FileName = "x.pdf",
+            FilePath = "/tmp/x.pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            ProcessingState = "Ready"
+        };
+
+        var result = await PdfGameIdResolver.ResolveAsync(db, pdf, TestContext.Current.CancellationToken);
+
+        result.Should().Be(gamesId);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_PrivateOverridesShared_ReturnsPrivateGameId()
+    {
+        using var db = CreateDbContext();
+        var privateGameId = Guid.Parse("55555555-5555-5555-5555-555555555555");
+        var sharedGameId = Guid.Parse("66666666-6666-6666-6666-666666666666");
+        var gamesId = Guid.Parse("77777777-7777-7777-7777-777777777777");
+
+        db.Games.Add(new GameEntity
+        {
+            Id = gamesId,
+            Name = "Should not be returned",
+            SharedGameId = sharedGameId,
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            PrivateGameId = privateGameId,
+            SharedGameId = sharedGameId,
+            FileName = "x.pdf",
+            FilePath = "/tmp/x.pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            ProcessingState = "Ready"
+        };
+
+        var result = await PdfGameIdResolver.ResolveAsync(db, pdf, TestContext.Current.CancellationToken);
+
+        result.Should().Be(privateGameId);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_NullDb_Throws()
+    {
+        var pdf = new PdfDocumentEntity { Id = Guid.NewGuid() };
+
+        var act = async () => await PdfGameIdResolver.ResolveAsync(null!, pdf, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_NullPdf_Throws()
+    {
+        using var db = CreateDbContext();
+
+        var act = async () => await PdfGameIdResolver.ResolveAsync(db, null!, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## Summary

`text_chunks.GameId` è una FK a `games.Id`, **non** a `shared_games.id`. Tre callsite scrivevano direttamente `pdf.SharedGameId` (o `PrivateGameId`) in `text_chunks.GameId`. Per i PDF di shared game l'INSERT raise-ava `FK_text_chunks_games_GameId` ogni volta che il catalog id e il games row id divergevano (caso comune dopo Issue #2373).

Scoperto durante test Q&A Nanolith su staging tunnel: chat streaming indicizzava 0 chunk perché il bulk INSERT veniva fatto rollback.

## Fix

Estratto un helper unico **`PdfGameIdResolver.ResolveAsync`** che ritorna `Guid?`:
- Private PDF → `PrivateGameId` direttamente
- Shared PDF → lookup `GameEntity.SharedGameId == pdf.SharedGameId` per ottenere `games.Id`
- Né private né shared, o no matching games row → `null` (caller decide se default a `Guid.Empty` o skip)

Tre callsite ora routano tutti per l'helper:
- `PdfProcessingPipelineService.SaveTextChunksAsync` (line 603)
- `UploadPdfCommandHandler.Processing.SaveTextChunksToPostgresAsync` (line 552)
- `IndexPdfCommandHandler.SaveTextChunksToPostgresAsync` (line 87 → new `chunkGameId` var)

`IndexPdfCommandHandler` mantiene `effectiveGameId` per vector-store tagging e semantic-cache invalidation (entrambi non FK-bound). Solo `chunkGameId` viene usato per il `text_chunks` INSERT.

## Test plan

- [x] `dotnet build` Api.csproj — verde (Avvisi: 0, Errori: 0)
- [x] `PdfGameIdResolverTests` — 7 nuovi unit (private/shared/null/no-match/override/2 null-arg validation)
- [x] `IndexPdfCommandHandlerTests.Handle_SharedGamePdf_ResolvesGameIdFromGamesTable` aggiornato: ora seed-a una `GameEntity` matching e asserisce `chunk.GameId == games.Id` (era asserting il bug)
- [x] DocumentProcessing unit suite: **244/244 verdi**

## Files changed

**+254 / -9** in 6 file:
- `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfGameIdResolver.cs` (new)
- `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs`
- `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs`
- `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs`
- `apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfGameIdResolverTests.cs` (new)
- `apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/IndexPdfCommandHandlerTests.cs` (1 test updated)

## Discovery context

Aaron stava facendo E2E Q&A Nanolith su staging via SSH tunnel. Logs API mostravano `FK_text_chunks_games_GameId violation` durante upload+index. Lookup `text_chunks` post-mortem rivelava 0 row per il PDF shared. Uno spike sul callsite ha confermato che `pdf.SharedGameId ?? pdf.PrivateGameId` veniva usato come `text_chunks.GameId` mentre la FK punta a `games.Id` (il record duplicato che esiste in entrambe le tabelle ha id diversi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)