### PR TITLE
chore(ci): sync 5 deploy-staging workflow fixes from main-staging

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -378,7 +378,7 @@ jobs:
         if: needs.detect-changes.outputs.deploy_api == 'true'
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
-          context: ./apps/api
+          context: .
           file: ./apps/api/src/Api/Dockerfile
           push: true
           tags: ${{ steps.meta-api.outputs.tags }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -138,6 +138,7 @@ jobs:
           fetch-depth: 0  # Full history needed to compare against github.event.before on merge commits
           # sparse-checkout excludes data/ (1.3GB PDFs) — runner disk is limited
           # PDFs are managed via S3 blob storage, not git
+          # data/rulebook/golden/ (~52K) IS included: Api.csproj embeds these JSON fixtures (ADR-051)
           sparse-checkout: |
             apps/
             infra/
@@ -145,6 +146,7 @@ jobs:
             tests/
             scripts/
             packages/
+            data/rulebook/golden/
           sparse-checkout-cone-mode: true
 
       # IMPORTANT: explicitly set `base` to github.event.before for push events.
@@ -300,9 +302,11 @@ jobs:
         with:
           ref: ${{ env.DEPLOY_SHA }}  # Spec R2: pin to actual deploy SHA
           # sparse-checkout excludes data/ (1.3GB PDFs) — runner disk is limited
+          # data/rulebook/golden/ (~52K) IS included: Api.csproj embeds these JSON fixtures (ADR-051)
           sparse-checkout: |
             apps/
             .github/
+            data/rulebook/golden/
           sparse-checkout-cone-mode: true
 
       - name: Generate Version

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -224,9 +224,11 @@ jobs:
         with:
           ref: ${{ env.DEPLOY_SHA }}  # Spec R2: pin to actual deploy SHA
           # sparse-checkout excludes data/ (1.3GB PDFs) — runner disk is limited
+          # data/rulebook/golden/ (~52K) IS included: Api.csproj embeds these JSON fixtures (ADR-051)
           sparse-checkout: |
             apps/
             .github/
+            data/rulebook/golden/
           sparse-checkout-cone-mode: true
 
       - name: Verify CI passed on this commit

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -402,9 +402,13 @@ jobs:
           platforms: linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          # Note: No environment build-args. NODE_ENV is set in Dockerfile,
-          # NEXT_PUBLIC_ENV has no ARG in Dockerfile (was silently ignored).
-          # Environment config is injected at runtime via compose files.
+          # NEXT_PUBLIC_* are baked into JS bundle at build time by Next.js.
+          # Without these args the Dockerfile defaults to http://localhost:* and
+          # client-side OAuth/API calls hit smartphone localhost (broken).
+          build-args: |
+            NEXT_PUBLIC_API_BASE=https://meepleai.app
+            NEXT_PUBLIC_APP_URL=https://meepleai.app
+            NEXT_PUBLIC_SITE_URL=https://meepleai.app
 
       - name: Build Summary
         run: |

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -619,7 +619,13 @@ jobs:
           username: ${{ secrets.STAGING_USER }}
           key: ${{ secrets.STAGING_SSH_KEY }}
           script: |
-            cd /opt/meepleai/repo/infra
+            # Sync /opt/meepleai/repo to the deploy SHA so compose files
+            # match the workflow context (compose.traefik.yml, etc.)
+            cd /opt/meepleai/repo
+            git fetch origin main-staging
+            git reset --hard ${{ env.DEPLOY_SHA }}
+            echo "✅ Repo synced to $(git rev-parse --short HEAD)"
+            cd infra
 
             # Pre-deploy port cleanup — kill any stale process holding :8080
             # (see memory: feedback_staging_stale_api_host_process)


### PR DESCRIPTION
## Summary

Sync di 5 fix CI commit da `main-staging` (cherry-pick chronologico) verso `main-dev`. Le modifiche erano state applicate direttamente su `main-staging` durante il deploy session del 2026-05-05/06 per sbloccare il rollout del fix migration `AddPhotoIngestionTables` (PR #726). Riportandole su `main-dev` per evitare drift permanente nei workflow.

## Commits cherry-picked (chronologico)

| SHA | Date | Subject |
|-----|------|---------|
| b01f5a1fd | 2026-05-05 20:08 | `fix(ci): add data/rulebook/golden/ to sparse-checkout for backend build` |
| 7b49b59a4 | 2026-05-05 20:28 | `fix(ci): add data/rulebook/golden to pre-deploy-check sparse-checkout` |
| a55a4ad50 | 2026-05-05 20:51 | `fix(ci): use repo root as Docker build context for API image` |
| 41b04242c | 2026-05-05 21:57 | `fix(ci): sync staging repo to deploy SHA before docker compose` |
| 38c08d693 | 2026-05-06 09:55 | `fix(ci): pass NEXT_PUBLIC_* build args to web image for staging` |

## Why each fix

1. **sparse-checkout `data/rulebook/golden/`** (×2): senza questa directory, il backend build CI falliva su `LargePdfStreamingTests` golden fixtures missing. Aggiunto a 3 job (`detect-changes`, `pre-deploy-check`, `build`).
2. **Docker build context = repo root**: il workflow usava `context: ./apps/api`, ma il `Dockerfile` ha path monorepo-root (es. `COPY ../shared`). Cambiato a `context: .`.
3. **`git fetch + git reset --hard $DEPLOY_SHA` su staging**: senza questo, lo staging server clonava sempre HEAD del branch, perdendo l'allineamento col SHA del docker image deployato.
4. **NEXT_PUBLIC_API_BASE/APP_URL/SITE_URL build-args**: il bundle web viene buildato a build-time, e senza i build-args i `process.env.NEXT_PUBLIC_*` defaultano ai valori del Dockerfile (`http://localhost:8080`). In staging questo causava traffic to localhost invece che a `https://meepleai.app`.

## Files touched

Solo `.github/workflows/deploy-staging.yml` — 5 cherry-pick, no conflicts (`Auto-merging` clean).

## Test plan

- [x] Cherry-pick clean su tutti e 5 i commit
- [ ] PR CI green (workflow file changes don't trigger backend/frontend tests, just YAML lint)
- [ ] Post-merge: prossimo deploy verso staging valida runtime

## Background

Aaron eseguiva fix-deploy iterativi su `main-staging` direttamente per non bloccare il deploy del migration fix. Questo PR riassorbe quei fix per evitare divergenza permanente — `main-dev` resta source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)