### PR TITLE
chore(sp6): finalize SP6 — bundle rebaseline + matrix update (#786)

### DIFF
--- a/apps/web/bundle-size-baseline.json
+++ b/apps/web/bundle-size-baseline.json
@@ -1,6 +1,6 @@
 {
-  "description": "Baseline JS bundle size for prod build (no mock). Update manually in dedicated PRs. Last bump rebaselines post-Wave D.2 v2 brownfield migration (#749 Foundation + #753 Interactions) which added 14 new session-live components + SSE hook + reducer composition.",
+  "description": "Baseline JS bundle size for prod build (no mock). Update manually in dedicated PRs. Last bump rebaselines post-SP6 Libro Game migration: Phase A Nanolith demo (#790) + Phase B /gamebook index Tier M (#792) + Phase C contract (#794) + Phase C.1 Foundation (#796) + Phase C.2 Interactions (#800) — 11 new gamebook components + 14-state wizard FSM + camera/offline/confidence libs.",
   "updatedAt": "2026-05-06",
-  "totalBytes": 13718922,
+  "totalBytes": 13797614,
   "toleranceBytes": 10240
 }

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -93,6 +93,8 @@ Each route is classified by **Tier** (S/M/L) which gates implementation strategy
 | `/players/[id]` | **M** | usePlayerStatistics single hook (current user only — schema reality v1 carryover) | ✅ done (Wave 3, PR #724) |
 | `/toolkits/[id]` | **M** | Toolkit summary + version timeline | pending |
 | `/gamebook` | **M** | Libro-game index: Hero + QuotaWidget + Card grid + EmptyState | ✅ done (SP6 Phase B, PR #792) |
+| `/gamebook/upload` | **L** | 3-step wizard: game search + camera + indexing — 14-state FSM + camera permission matrix + offline retry | ✅ done (SP6 Phase C, contract PR #794 + Foundation PR #796 + Interactions PR #800) — [`contracts/gamebook-upload-hooks.md`](contracts/gamebook-upload-hooks.md) |
+| `/library/games/[gameId]/translate` | **S** | Nanolith demo — paragraph translate via chat-stream workaround | ✅ done (SP6 Phase A, PR #790) |
 | `/kb/[id]` | **M** | KB header + chunks + search | pending |
 
 **Anti-pattern**: dispatchare implementation subagent senza Phase 0.5 per route Tier L. Wave C.1 PR #697 ha esattamente questo come root cause (vedi [post-mortem](../superpowers/specs/2026-04-26-v2-design-migration.md#34-phase-05--sub-hook-contract-per-tier-l-routes-only)).


### PR DESCRIPTION
## Summary

Finalize SP6 Libro Game migration — bundle rebaseline + v2-migration-matrix update for the 4 routes shipped across Phase A/B/C.

## Resolves

Refs #786 (SP6 umbrella, ready to close after this merge)

## Changes

**Bundle rebaseline**: 13,718,922 → 13,797,614 bytes (+78,692 ≈ +77 KB)
- Phase A Nanolith demo: ~+5 KB
- Phase B gamebook index: ~+50 KB
- Phase C Foundation + Interactions: ~+22 KB
- Total within plan target ≤+170 KB

**Matrix update** (\`docs/for-developers/frontend/v2-migration-matrix.md\`):
- \`/gamebook/upload\` Tier L → ✅ done (PR #794 contract + #796 Foundation + #800 Interactions)
- \`/library/games/[gameId]/translate\` Tier S → ✅ done (PR #790)

## Test plan

- [ ] Bundle Size CI green (within new tolerance)
- [ ] Lychee link check green (matrix has proper markdown links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)