### PR TITLE
fix(kb): #730 access control + 404 + G3 routing wired (post-#797)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkById/GetKbChunkByIdHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkById/GetKbChunkByIdHandler.cs
@@ -71,6 +71,25 @@ internal sealed class GetKbChunkByIdHandler : IQueryHandler<GetKbChunkByIdQuery,
             "Fetching KB chunk {ChunkId} from doc {DocId} (admin={IsAdmin})",
             query.ChunkId, query.DocumentId, query.UserIsAdmin);
 
+        // Issue #730 final review: enforce access control — check document ownership before chunk fetch.
+        var docAccess = await _dbContext.PdfDocuments.AsNoTracking()
+            .Where(p => p.Id == query.DocumentId)
+            .Select(p => new { p.IsPublic, p.UploadedByUserId })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (docAccess is null)
+        {
+            throw new NotFoundException($"KB document {query.DocumentId} not found");
+        }
+
+        if (!docAccess.IsPublic
+            && docAccess.UploadedByUserId != query.RequestingUserId
+            && !query.UserIsAdmin)
+        {
+            throw new ForbiddenException($"Access denied to document {query.DocumentId}");
+        }
+
         // Primary fetch — also validates that the chunk belongs to the requested document.
         var chunk = await _dbContext.TextChunks.AsNoTracking()
             .Where(c => c.Id == query.ChunkId && c.PdfDocumentId == query.DocumentId)
@@ -123,7 +142,7 @@ internal sealed class GetKbChunkByIdHandler : IQueryHandler<GetKbChunkByIdQuery,
             VectorId: query.UserIsAdmin ? chunk.Id : (Guid?)null,
             CharacterCount: query.UserIsAdmin ? chunk.CharacterCount : (int?)null,
             ElementType: query.UserIsAdmin ? chunk.ElementType : null,
-            EmbeddingStatus: query.UserIsAdmin ? "indexed" : null,
+            EmbeddingStatus: null,  // Issue #730: source field not yet in TextChunkEntity (follow-up)
             ParentChunkId: query.UserIsAdmin ? chunk.ParentChunkId : null
         );
     }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkById/GetKbChunkByIdQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkById/GetKbChunkByIdQuery.cs
@@ -8,9 +8,12 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunkById;
 /// Used by <c>GET /api/v1/kb-docs/{id}/chunks/{chunkId}</c> (G2 goal).
 /// Admin-only fields (VectorId, CharacterCount, ElementType, EmbeddingStatus, ParentChunkId)
 /// are gated via <see cref="UserIsAdmin"/>.
+/// Access is denied (ForbiddenException) when the document is not public, not owned by
+/// <see cref="RequestingUserId"/>, and the requester is not an admin.
 /// </summary>
 internal sealed record GetKbChunkByIdQuery(
     Guid DocumentId,
+    Guid RequestingUserId,
     Guid ChunkId,
     bool UserIsAdmin
 ) : IQuery<KbChunkDetailDto>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/GetKbChunksHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/GetKbChunksHandler.cs
@@ -1,4 +1,5 @@
 using Api.Infrastructure;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -78,13 +79,27 @@ internal sealed class GetKbChunksHandler : IQueryHandler<GetKbChunksQuery, KbChu
             "Fetching KB chunks for doc {DocId} (skip={Skip}, take={Take}, admin={IsAdmin})",
             query.DocumentId, skip, take, query.UserIsAdmin);
 
-        var processingState = await _dbContext.PdfDocuments.AsNoTracking()
+        // Issue #730 fix: fetch document first to validate existence + enforce access control
+        var doc = await _dbContext.PdfDocuments.AsNoTracking()
             .Where(p => p.Id == query.DocumentId)
-            .Select(p => p.ProcessingState)
+            .Select(p => new { p.ProcessingState, p.IsPublic, p.UploadedByUserId })
             .FirstOrDefaultAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        var processingStateLower = processingState?.ToLowerInvariant() ?? "unknown";
+        if (doc is null)
+        {
+            throw new NotFoundException($"KB document {query.DocumentId} not found");
+        }
+
+        // Issue #730 final review: enforce access control
+        if (!doc.IsPublic
+            && doc.UploadedByUserId != query.RequestingUserId
+            && !query.UserIsAdmin)
+        {
+            throw new ForbiddenException($"Access denied to document {query.DocumentId}");
+        }
+
+        var processingStateLower = doc.ProcessingState.ToLowerInvariant();
 
         var totalCount = await _dbContext.TextChunks.AsNoTracking()
             .CountAsync(c => c.PdfDocumentId == query.DocumentId, cancellationToken)
@@ -126,7 +141,7 @@ internal sealed class GetKbChunksHandler : IQueryHandler<GetKbChunksQuery, KbChu
             VectorId: query.UserIsAdmin ? r.Id : (Guid?)null,
             CharacterCount: query.UserIsAdmin ? r.CharacterCount : (int?)null,
             ElementType: query.UserIsAdmin ? r.ElementType : null,
-            EmbeddingStatus: query.UserIsAdmin ? "indexed" : null
+            EmbeddingStatus: null  // Issue #730: source field not yet in TextChunkEntity (follow-up)
         )).ToList();
 
         return new KbChunkListDto(

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/GetKbChunksQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/GetKbChunksQuery.cs
@@ -7,9 +7,12 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
 /// Used by <c>GET /api/v1/kb-docs/{id}/chunks</c> (G1 goal).
 /// Admin-only fields (VectorId, CharacterCount, ElementType, EmbeddingStatus) are gated via <see cref="UserIsAdmin"/>.
 /// headingPath returns an empty array in this skeleton — recursive CTE populated in next commit.
+/// Access is denied (ForbiddenException) when the document is not public, not owned by
+/// <see cref="RequestingUserId"/>, and the requester is not an admin.
 /// </summary>
 internal sealed record GetKbChunksQuery(
     Guid DocumentId,
+    Guid RequestingUserId,
     int Skip,
     int Take,
     bool UserIsAdmin

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/GetKbDocumentByIdHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/GetKbDocumentByIdHandler.cs
@@ -52,6 +52,14 @@ internal sealed class GetKbDocumentByIdHandler : IQueryHandler<GetKbDocumentById
             throw new NotFoundException($"KB document {query.DocumentId} not found");
         }
 
+        // Issue #730 final review: enforce access control
+        if (!data.pdf.IsPublic
+            && data.pdf.UploadedByUserId != query.RequestingUserId
+            && !query.UserIsAdmin)
+        {
+            throw new ForbiddenException($"Access denied to document {query.DocumentId}");
+        }
+
         return new KbDocumentDto(
             Id: data.pdf.Id,
             Title: data.pdf.FileName,

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/GetKbDocumentByIdQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/GetKbDocumentByIdQuery.cs
@@ -6,8 +6,11 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbDocumentByI
 /// Query to retrieve full metadata for a single KB document by its PDF document ID.
 /// Used by <c>GET /api/v1/kb-docs/{id}</c> (G4 goal).
 /// Admin-only fields (processingError, retryCount, failedAtState) are gated via <see cref="UserIsAdmin"/>.
+/// Access is denied (ForbiddenException) when the document is not public, not owned by
+/// <see cref="RequestingUserId"/>, and the requester is not an admin.
 /// </summary>
 internal sealed record GetKbDocumentByIdQuery(
     Guid DocumentId,
+    Guid RequestingUserId,
     bool UserIsAdmin
 ) : IQuery<KbDocumentDto>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchKbChunks/SearchKbChunksHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchKbChunks/SearchKbChunksHandler.cs
@@ -59,14 +59,24 @@ internal sealed class SearchKbChunksHandler : IQueryHandler<SearchKbChunksQuery,
             "SearchKbChunks for doc {DocId} query='{Query}' skip={Skip} take={Take}",
             query.DocumentId, query.Query, skip, take);
 
-        // Verify document exists before issuing the FTS query.
-        var docExists = await _dbContext.PdfDocuments.AsNoTracking()
-            .AnyAsync(p => p.Id == query.DocumentId, cancellationToken)
+        // Verify document exists and enforce access control before issuing the FTS query.
+        // Issue #730 final review: fetch ownership fields alongside existence check.
+        var docAccess = await _dbContext.PdfDocuments.AsNoTracking()
+            .Where(p => p.Id == query.DocumentId)
+            .Select(p => new { p.IsPublic, p.UploadedByUserId })
+            .FirstOrDefaultAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        if (!docExists)
+        if (docAccess is null)
         {
             throw new NotFoundException("Document", query.DocumentId.ToString());
+        }
+
+        if (!docAccess.IsPublic
+            && docAccess.UploadedByUserId != query.RequestingUserId
+            && !query.UserIsAdmin)
+        {
+            throw new ForbiddenException($"Access denied to document {query.DocumentId}");
         }
 
         // FTS ranked query using plainto_tsquery (prevents operator injection).

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchKbChunks/SearchKbChunksQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchKbChunks/SearchKbChunksQuery.cs
@@ -11,10 +11,17 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.SearchKbChunks;
 /// (no tsquery operator injection possible). Ranking uses <c>ts_rank_cd</c> and snippets
 /// are generated with <c>ts_headline</c> producing <c>&lt;mark&gt;</c> tags.
 /// </para>
+///
+/// <para>
+/// Access is denied (ForbiddenException) when the document is not public, not owned by
+/// <see cref="RequestingUserId"/>, and the requester is not an admin.
+/// </para>
 /// </summary>
 internal sealed record SearchKbChunksQuery(
     Guid DocumentId,
+    Guid RequestingUserId,
     string Query,
     int Skip,
-    int Take
+    int Take,
+    bool UserIsAdmin
 ) : IQuery<KbChunkSearchResultDto>;

--- a/apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs
+++ b/apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs
@@ -9,6 +9,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetGameDocuments;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunkById;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbDocumentById;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.SearchKbChunks;
 using Api.Extensions;
 using Api.Helpers;
 using Api.Infrastructure.Entities;
@@ -1114,3 +1115,8 @@ internal record AssembleContextRequest(
 /// Request model for linking an existing KB (processed PDF) to a different game.
 /// </summary>
 internal record LinkKbRequest(Guid PdfDocumentId);
+
+/// <summary>
+/// Request body for POST /api/v1/kb-docs/{id}/chunks/search (G3 in-document FTS).
+/// </summary>
+internal sealed record SearchKbChunksRequest(string Query, int? Skip, int? Take);

--- a/apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs
+++ b/apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs
@@ -915,7 +915,8 @@ internal static class KnowledgeBaseEndpoints
             .WithDescription("Returns chunks ordered by position with breadcrumb headingPath. Admin users see vectorId, characterCount, elementType, embeddingStatus.")
             .Produces<KbChunkListDto>()
             .Produces(StatusCodes.Status400BadRequest)
-            .Produces(StatusCodes.Status404NotFound);
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status403Forbidden);
 
         // Issue #730: G2 single chunk full content
         group.MapGet("/kb-docs/{id:guid}/chunks/{chunkId:guid}", HandleGetKbChunkById)
@@ -925,7 +926,20 @@ internal static class KnowledgeBaseEndpoints
             .WithSummary("Get a single chunk with full content + prev/next navigation")
             .WithDescription("Returns chunk content as markdown, with hierarchical breadcrumb and prev/next chunk IDs for navigation.")
             .Produces<KbChunkDetailDto>()
-            .Produces(StatusCodes.Status404NotFound);
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status403Forbidden);
+
+        // Issue #730: G3 in-document FTS
+        group.MapPost("/kb-docs/{id:guid}/chunks/search", HandleSearchKbChunks)
+            .WithName("SearchKbChunks")
+            .RequireSession()
+            .WithTags("KnowledgeBase")
+            .WithSummary("Search chunks within a single document by keyword")
+            .WithDescription("PostgreSQL ts_rank_cd ranking with ts_headline highlighting (<mark> tags). Query length 1-200 chars.")
+            .Produces<KbChunkSearchResultDto>()
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status403Forbidden);
     }
 
     private static async Task<IResult> HandleGetKbDocumentById(
@@ -935,8 +949,9 @@ internal static class KnowledgeBaseEndpoints
         CancellationToken cancellationToken)
     {
         var session = (SessionStatusDto)context.Items[nameof(SessionStatusDto)]!;
+        var userId = session.User!.Id;
         var userIsAdmin = string.Equals(session.User!.Role, UserRole.Admin.ToString(), StringComparison.OrdinalIgnoreCase);
-        var query = new GetKbDocumentByIdQuery(id, userIsAdmin);
+        var query = new GetKbDocumentByIdQuery(id, RequestingUserId: userId, UserIsAdmin: userIsAdmin);
         var dto = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
         return Results.Ok(dto);
     }
@@ -958,8 +973,9 @@ internal static class KnowledgeBaseEndpoints
         }
 
         var session = (SessionStatusDto)httpContext.Items[nameof(SessionStatusDto)]!;
+        var userId = session.User!.Id;
         var isAdmin = string.Equals(session.User!.Role, UserRole.Admin.ToString(), StringComparison.OrdinalIgnoreCase);
-        var query = new GetKbChunksQuery(id, skipValue, takeValue, UserIsAdmin: isAdmin);
+        var query = new GetKbChunksQuery(id, RequestingUserId: userId, Skip: skipValue, Take: takeValue, UserIsAdmin: isAdmin);
         var result = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
         return Results.Ok(result);
     }
@@ -972,13 +988,34 @@ internal static class KnowledgeBaseEndpoints
         CancellationToken cancellationToken)
     {
         var session = (SessionStatusDto)httpContext.Items[nameof(SessionStatusDto)]!;
+        var userId = session.User!.Id;
         var isAdmin = string.Equals(
             session.User!.Role,
             UserRole.Admin.ToString(),
             StringComparison.OrdinalIgnoreCase);
-        var query = new GetKbChunkByIdQuery(id, chunkId, UserIsAdmin: isAdmin);
+        var query = new GetKbChunkByIdQuery(id, RequestingUserId: userId, ChunkId: chunkId, UserIsAdmin: isAdmin);
         var dto = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
         return Results.Ok(dto);
+    }
+
+    private static async Task<IResult> HandleSearchKbChunks(
+        Guid id,
+        [FromBody] SearchKbChunksRequest body,
+        HttpContext httpContext,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        if (body is null || string.IsNullOrWhiteSpace(body.Query) || body.Query.Length > 200)
+        {
+            return Results.BadRequest(new { error = "query must be between 1 and 200 characters" });
+        }
+
+        var session = (SessionStatusDto)httpContext.Items[nameof(SessionStatusDto)]!;
+        var userId = session.User!.Id;
+        var isAdmin = string.Equals(session.User!.Role, UserRole.Admin.ToString(), StringComparison.OrdinalIgnoreCase);
+        var query = new SearchKbChunksQuery(id, RequestingUserId: userId, Query: body.Query, Skip: body.Skip ?? 0, Take: body.Take ?? 20, UserIsAdmin: isAdmin);
+        var result = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
     }
 
     private static void MapLinkKbEndpoint(RouteGroupBuilder group)

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkByIdHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkByIdHandlerTests.cs
@@ -32,7 +32,7 @@ public sealed class GetKbChunkByIdHandlerTests
         var docId = Guid.NewGuid();
         var (chunk0, chunk1, chunk2) = await SeedThreeChunksAsync(docId);
 
-        var query = new GetKbChunkByIdQuery(docId, chunk1, UserIsAdmin: false);
+        var query = new GetKbChunkByIdQuery(docId, RequestingUserId: Guid.NewGuid(), ChunkId: chunk1, UserIsAdmin: false);
         var dto = await _handler.Handle(query, CancellationToken.None);
 
         dto.ChunkId.Should().Be(chunk1);
@@ -46,7 +46,7 @@ public sealed class GetKbChunkByIdHandlerTests
         var docId = Guid.NewGuid();
         var (chunk0, _, _) = await SeedThreeChunksAsync(docId);
 
-        var query = new GetKbChunkByIdQuery(docId, chunk0, UserIsAdmin: false);
+        var query = new GetKbChunkByIdQuery(docId, RequestingUserId: Guid.NewGuid(), ChunkId: chunk0, UserIsAdmin: false);
         var dto = await _handler.Handle(query, CancellationToken.None);
 
         dto.PrevChunkId.Should().BeNull();
@@ -59,7 +59,7 @@ public sealed class GetKbChunkByIdHandlerTests
         var docId = Guid.NewGuid();
         var (_, _, chunk2) = await SeedThreeChunksAsync(docId);
 
-        var query = new GetKbChunkByIdQuery(docId, chunk2, UserIsAdmin: false);
+        var query = new GetKbChunkByIdQuery(docId, RequestingUserId: Guid.NewGuid(), ChunkId: chunk2, UserIsAdmin: false);
         var dto = await _handler.Handle(query, CancellationToken.None);
 
         dto.NextChunkId.Should().BeNull();
@@ -75,7 +75,7 @@ public sealed class GetKbChunkByIdHandlerTests
         var (chunkB, _, _) = await SeedThreeChunksAsync(docB);
 
         // Request chunk from docB but specifying docA — must 404
-        var query = new GetKbChunkByIdQuery(docA, chunkB, UserIsAdmin: false);
+        var query = new GetKbChunkByIdQuery(docA, RequestingUserId: Guid.NewGuid(), ChunkId: chunkB, UserIsAdmin: false);
         var act = () => _handler.Handle(query, CancellationToken.None);
 
         await act.Should().ThrowAsync<NotFoundException>();
@@ -87,7 +87,7 @@ public sealed class GetKbChunkByIdHandlerTests
         var docId = Guid.NewGuid();
         await SeedThreeChunksAsync(docId);
 
-        var query = new GetKbChunkByIdQuery(docId, Guid.NewGuid(), UserIsAdmin: false);
+        var query = new GetKbChunkByIdQuery(docId, RequestingUserId: Guid.NewGuid(), ChunkId: Guid.NewGuid(), UserIsAdmin: false);
         var act = () => _handler.Handle(query, CancellationToken.None);
 
         await act.Should().ThrowAsync<NotFoundException>();
@@ -104,7 +104,8 @@ public sealed class GetKbChunkByIdHandlerTests
             Language = "en",
             DocumentCategory = "Rulebook",
             UploadedByUserId = Guid.NewGuid(),
-            FilePath = "/tmp/doc.pdf"
+            FilePath = "/tmp/doc.pdf",
+            IsPublic = true
         };
         _dbContext.PdfDocuments.Add(pdf);
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunksHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunksHandlerTests.cs
@@ -29,7 +29,7 @@ public sealed class GetKbChunksHandlerTests
     public async Task Handle_WhenDocHas120Chunks_ReturnsFirstPage()
     {
         var docId = await SeedDocumentWithChunksAsync(120, processingState: "Ready");
-        var query = new GetKbChunksQuery(docId, Skip: 0, Take: 50, UserIsAdmin: false);
+        var query = new GetKbChunksQuery(docId, RequestingUserId: Guid.NewGuid(), Skip: 0, Take: 50, UserIsAdmin: false);
 
         var result = await _handler.Handle(query, CancellationToken.None);
 
@@ -45,7 +45,7 @@ public sealed class GetKbChunksHandlerTests
     public async Task Handle_LastPagePartial_HasMoreFalse()
     {
         var docId = await SeedDocumentWithChunksAsync(120, processingState: "Ready");
-        var query = new GetKbChunksQuery(docId, Skip: 100, Take: 50, UserIsAdmin: false);
+        var query = new GetKbChunksQuery(docId, RequestingUserId: Guid.NewGuid(), Skip: 100, Take: 50, UserIsAdmin: false);
 
         var result = await _handler.Handle(query, CancellationToken.None);
 
@@ -57,7 +57,7 @@ public sealed class GetKbChunksHandlerTests
     public async Task Handle_DocStillProcessing_ReturnsEmptyChunks()
     {
         var docId = await SeedDocumentWithChunksAsync(0, processingState: "Embedding");
-        var query = new GetKbChunksQuery(docId, Skip: 0, Take: 50, UserIsAdmin: false);
+        var query = new GetKbChunksQuery(docId, RequestingUserId: Guid.NewGuid(), Skip: 0, Take: 50, UserIsAdmin: false);
 
         var result = await _handler.Handle(query, CancellationToken.None);
 
@@ -69,7 +69,7 @@ public sealed class GetKbChunksHandlerTests
     public async Task Handle_AdminSeesDiagnosticFields()
     {
         var docId = await SeedDocumentWithChunksAsync(5, processingState: "Ready");
-        var query = new GetKbChunksQuery(docId, Skip: 0, Take: 5, UserIsAdmin: true);
+        var query = new GetKbChunksQuery(docId, RequestingUserId: Guid.NewGuid(), Skip: 0, Take: 5, UserIsAdmin: true);
 
         var result = await _handler.Handle(query, CancellationToken.None);
 
@@ -83,7 +83,7 @@ public sealed class GetKbChunksHandlerTests
     public async Task Handle_NonAdminGetsAdminFieldsNulled()
     {
         var docId = await SeedDocumentWithChunksAsync(5, processingState: "Ready");
-        var query = new GetKbChunksQuery(docId, Skip: 0, Take: 5, UserIsAdmin: false);
+        var query = new GetKbChunksQuery(docId, RequestingUserId: Guid.NewGuid(), Skip: 0, Take: 5, UserIsAdmin: false);
 
         var result = await _handler.Handle(query, CancellationToken.None);
 
@@ -106,7 +106,8 @@ public sealed class GetKbChunksHandlerTests
             Language = "en",
             DocumentCategory = "Rulebook",
             UploadedByUserId = Guid.NewGuid(),
-            FilePath = "/tmp/test.pdf"
+            FilePath = "/tmp/test.pdf",
+            IsPublic = true
         };
         _dbContext.PdfDocuments.Add(pdf);
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentByIdHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentByIdHandlerTests.cs
@@ -41,7 +41,8 @@ public sealed class GetKbDocumentByIdHandlerTests
             Language = "it",
             DocumentCategory = "Rulebook",
             UploadedByUserId = Guid.NewGuid(),
-            FilePath = "/tmp/test.pdf"
+            FilePath = "/tmp/test.pdf",
+            IsPublic = true
         };
         var vd = new VectorDocumentEntity
         {
@@ -56,7 +57,7 @@ public sealed class GetKbDocumentByIdHandlerTests
         _dbContext.VectorDocuments.Add(vd);
         await _dbContext.SaveChangesAsync();
 
-        var query = new GetKbDocumentByIdQuery(docId, UserIsAdmin: false);
+        var query = new GetKbDocumentByIdQuery(docId, RequestingUserId: Guid.NewGuid(), UserIsAdmin: false);
 
         // Act
         var dto = await _handler.Handle(query, CancellationToken.None);
@@ -86,12 +87,13 @@ public sealed class GetKbDocumentByIdHandlerTests
             Language = "en",
             DocumentCategory = "Rulebook",
             UploadedByUserId = Guid.NewGuid(),
-            FilePath = "/tmp/broken.pdf"
+            FilePath = "/tmp/broken.pdf",
+            IsPublic = true
         };
         _dbContext.PdfDocuments.Add(pdf);
         await _dbContext.SaveChangesAsync();
 
-        var query = new GetKbDocumentByIdQuery(docId, UserIsAdmin: true);
+        var query = new GetKbDocumentByIdQuery(docId, RequestingUserId: Guid.NewGuid(), UserIsAdmin: true);
 
         var dto = await _handler.Handle(query, CancellationToken.None);
 
@@ -117,12 +119,13 @@ public sealed class GetKbDocumentByIdHandlerTests
             Language = "en",
             DocumentCategory = "Rulebook",
             UploadedByUserId = Guid.NewGuid(),
-            FilePath = "/tmp/broken.pdf"
+            FilePath = "/tmp/broken.pdf",
+            IsPublic = true
         };
         _dbContext.PdfDocuments.Add(pdf);
         await _dbContext.SaveChangesAsync();
 
-        var query = new GetKbDocumentByIdQuery(docId, UserIsAdmin: false);
+        var query = new GetKbDocumentByIdQuery(docId, RequestingUserId: Guid.NewGuid(), UserIsAdmin: false);
 
         var dto = await _handler.Handle(query, CancellationToken.None);
 
@@ -135,7 +138,7 @@ public sealed class GetKbDocumentByIdHandlerTests
     [Fact]
     public async Task Handle_WhenDocNotFound_ThrowsNotFoundException()
     {
-        var query = new GetKbDocumentByIdQuery(Guid.NewGuid(), UserIsAdmin: false);
+        var query = new GetKbDocumentByIdQuery(Guid.NewGuid(), RequestingUserId: Guid.NewGuid(), UserIsAdmin: false);
 
         var act = () => _handler.Handle(query, CancellationToken.None);
 
@@ -157,7 +160,8 @@ public sealed class GetKbDocumentByIdHandlerTests
             Language = "en",
             DocumentCategory = "Rulebook",
             UploadedByUserId = Guid.NewGuid(),
-            FilePath = "/tmp/ready.pdf"
+            FilePath = "/tmp/ready.pdf",
+            IsPublic = true
         };
         var vd = new VectorDocumentEntity
         {
@@ -172,7 +176,7 @@ public sealed class GetKbDocumentByIdHandlerTests
         _dbContext.VectorDocuments.Add(vd);
         await _dbContext.SaveChangesAsync();
 
-        var query = new GetKbDocumentByIdQuery(docId, UserIsAdmin: true);
+        var query = new GetKbDocumentByIdQuery(docId, RequestingUserId: Guid.NewGuid(), UserIsAdmin: true);
 
         // Act
         var dto = await _handler.Handle(query, CancellationToken.None);

--- a/apps/api/tests/Api.Tests/Integration/KbChunkEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KbChunkEndpointsIntegrationTests.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using System.Net.Http.Json;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.SearchKbChunks;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
 using Api.Tests.Constants;

--- a/apps/api/tests/Api.Tests/Integration/KbChunkEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KbChunkEndpointsIntegrationTests.cs
@@ -189,6 +189,37 @@ public sealed class KbChunkEndpointsIntegrationTests : IAsyncLifetime
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
+    // ========================================
+    // Access control regression (Critical 1)
+    // ========================================
+
+    /// <summary>
+    /// Verifies that a private document owned by another user returns 403 Forbidden
+    /// when accessed by a different authenticated (non-admin) user.
+    /// This is the regression test for Issue #730 final review Critical 1.
+    /// </summary>
+    [Fact]
+    public async Task GetKbDocument_PrivateDocOwnedByOtherUser_Returns403()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        // Seed user A (owner) and a private doc owned by user A
+        var (ownerUserId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (docId, _) = await SeedPrivateDocWithSingleChunkAsync(dbContext, ownerUserId);
+
+        // Authenticate as user B (not the owner, not admin)
+        var (_, userBSessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/kb-docs/{docId}",
+            userBSessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
     // ─── Seed helpers ────────────────────────────────────────────────────────
 
     /// <summary>
@@ -305,5 +336,229 @@ public sealed class KbChunkEndpointsIntegrationTests : IAsyncLifetime
 
         await dbContext.SaveChangesAsync();
         return docId;
+    }
+
+    // ========================================
+    // POST /api/v1/kb-docs/{id}/chunks/search  (G3)
+    // ========================================
+
+    /// <summary>
+    /// Verifies that chunks containing the keyword are returned in descending rank order
+    /// and that the snippet contains the expected &lt;mark&gt; highlight tags.
+    ///
+    /// The seed helper manually populates search_vector via to_tsvector('simple', ...) because
+    /// the tsvector trigger is not installed in the Testcontainers-migrated database.
+    /// </summary>
+    [Fact]
+    public async Task SearchChunks_KeywordPresent_ReturnsRankedMatches()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (docId, _) = await SeedDocWithKeywordChunksAsync(dbContext, userId, "initiative", new[] { 3, 0, 2, 1 });
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/kb-docs/{docId}/chunks/search",
+            sessionToken,
+            new { query = "initiative", skip = 0, take = 20 });
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<KbChunkSearchResultDto>();
+        result.Should().NotBeNull();
+        // 3 chunks contain the keyword (occurrences 3, 2, 1 — the 0-occurrence chunk is excluded)
+        result!.TotalCount.Should().Be(3);
+        result.Matches.Should().HaveCount(3);
+        // Results are in descending rank order
+        result.Matches.Should().BeInDescendingOrder(m => m.Rank);
+        // The highest-ranked snippet should contain a <mark> tag
+        result.Matches.First().Snippet.Should().Contain("<mark>");
+    }
+
+    /// <summary>
+    /// Verifies that a search with no matching keyword returns an empty result with TotalCount=0.
+    /// </summary>
+    [Fact]
+    public async Task SearchChunks_NoMatches_ReturnsEmpty()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (docId, _) = await SeedDocWithSingleChunkAsync(dbContext, userId);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/kb-docs/{docId}/chunks/search",
+            sessionToken,
+            new { query = "xyzzyx", skip = 0, take = 20 });
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<KbChunkSearchResultDto>();
+        result.Should().NotBeNull();
+        result!.TotalCount.Should().Be(0);
+        result.Matches.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Verifies that a query longer than 200 characters is rejected with 400 Bad Request
+    /// by the endpoint body validation (before the handler is reached).
+    /// </summary>
+    [Fact]
+    public async Task SearchChunks_QueryTooLong_Returns400()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var longQuery = new string('a', 250);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/kb-docs/{Guid.NewGuid()}/chunks/search",
+            sessionToken,
+            new { query = longQuery, skip = 0, take = 20 });
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    /// <summary>
+    /// Verifies that a query containing the tsquery pipe operator '|' is treated as literal text
+    /// (plainto_tsquery sanitises the input — no "syntax error in tsquery" exception).
+    /// The test documents contain "initiative" so a match should still be found.
+    /// </summary>
+    [Fact]
+    public async Task SearchChunks_OperatorInjection_TreatedAsLiteral()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (docId, _) = await SeedDocWithKeywordChunksAsync(dbContext, userId, "initiative", new[] { 1 });
+
+        // Submit a query that contains the tsquery '|' operator.
+        // If plainto_tsquery is NOT used this would throw "syntax error in tsquery".
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/kb-docs/{docId}/chunks/search",
+            sessionToken,
+            new { query = "initiative | drop", skip = 0, take = 20 });
+
+        var response = await _client.SendAsync(request);
+
+        // plainto_tsquery treats '|' as a literal character (part of the lexeme), not a tsquery operator.
+        // The response must NOT be 500 (no "syntax error in tsquery").
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // ─── G3 seed helpers ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Seeds a document with N text chunks, where chunk[i].Content contains the keyword
+    /// repeated <paramref name="occurrencesPerChunk"/>[i] times.
+    /// After inserting, manually populates <c>search_vector</c> using
+    /// <c>to_tsvector('simple', ...)</c> (the trigger is not installed in test DBs).
+    /// Chunks with 0 occurrences still have a valid search_vector but no match for the keyword.
+    /// </summary>
+    /// <returns>(docId, firstChunkId)</returns>
+    private static async Task<(Guid DocId, Guid FirstChunkId)> SeedDocWithKeywordChunksAsync(
+        MeepleAiDbContext dbContext,
+        Guid uploadedByUserId,
+        string keyword,
+        int[] occurrencesPerChunk)
+    {
+        var docId = Guid.NewGuid();
+
+        dbContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = docId,
+            FileName = $"fts-test-{docId:N}.pdf",
+            ProcessingState = "Ready",
+            UploadedAt = DateTime.UtcNow,
+            Language = "en",
+            DocumentCategory = "Rulebook",
+            UploadedByUserId = uploadedByUserId,
+            FilePath = $"/tmp/fts-{docId:N}.pdf"
+        });
+
+        var firstChunkId = Guid.Empty;
+
+        for (var i = 0; i < occurrencesPerChunk.Length; i++)
+        {
+            var chunkId = Guid.NewGuid();
+            if (i == 0) firstChunkId = chunkId;
+
+            // Build content: repeat keyword N times, padded with filler text so the lexer has tokens
+            var keywordPart = occurrencesPerChunk[i] > 0
+                ? string.Join(" ", Enumerable.Repeat(keyword, occurrencesPerChunk[i]))
+                : "filler text without any matching content";
+
+            dbContext.TextChunks.Add(new TextChunkEntity
+            {
+                Id = chunkId,
+                PdfDocumentId = docId,
+                Content = $"Chunk {i}: {keywordPart} some additional context here.",
+                ChunkIndex = i,
+                PageNumber = i + 1,
+                CharacterCount = 50,
+                ElementType = "NarrativeText",
+                Level = 1
+            });
+        }
+
+        await dbContext.SaveChangesAsync();
+        // search_vector is a GENERATED ALWAYS AS (to_tsvector('simple', "Content")) STORED column
+        // added by InitializeAsync, so it is automatically populated on INSERT.
+
+        return (docId, firstChunkId);
+    }
+
+    /// <summary>
+    /// Seeds a private (IsPublic=false) PdfDocumentEntity owned by <paramref name="ownedByUserId"/>
+    /// with a single TextChunkEntity. Used by the Critical 1 regression test.
+    /// </summary>
+    private static async Task<(Guid DocId, Guid ChunkId)> SeedPrivateDocWithSingleChunkAsync(
+        MeepleAiDbContext dbContext,
+        Guid ownedByUserId)
+    {
+        var docId = Guid.NewGuid();
+        var chunkId = Guid.NewGuid();
+
+        dbContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = docId,
+            FileName = $"private-{docId:N}.pdf",
+            ProcessingState = "Ready",
+            UploadedAt = DateTime.UtcNow,
+            Language = "en",
+            DocumentCategory = "Rulebook",
+            UploadedByUserId = ownedByUserId,
+            FilePath = $"/tmp/private-{docId:N}.pdf",
+            IsPublic = false
+        });
+
+        dbContext.TextChunks.Add(new TextChunkEntity
+        {
+            Id = chunkId,
+            PdfDocumentId = docId,
+            Content = "Private document content",
+            ChunkIndex = 0,
+            PageNumber = 1,
+            CharacterCount = 24,
+            ElementType = "NarrativeText",
+            Level = 1
+        });
+
+        await dbContext.SaveChangesAsync();
+        return (docId, chunkId);
     }
 }


### PR DESCRIPTION
## Context

PR #797 (Docker UFW) inadvertently merged the `feat/issue-730` work into `main-dev` at the **pre-security-fix state**. This PR brings the missing security/correctness fixes that were lost in the merge.

## What's missing on `main-dev` (this PR fixes)

1. **CRITICAL — Access control**: all 4 KB chunk endpoints (`GET /kb-docs/{id}`, `GET /kb-docs/{id}/chunks`, `GET /kb-docs/{id}/chunks/{chunkId}`, `POST /kb-docs/{id}/chunks/search`) are open to any authenticated user, leaking private documents owned by other users. Adds `RequestingUserId` to all 4 query records + ownership check (`IsPublic OR uploaded-by-user OR admin`) + `ForbiddenException` when denied.

2. **CRITICAL — 404 missing on G1**: `GET /kb-docs/{id}/chunks` silently returns `200 { chunks: [], totalCount: 0, processingState: "unknown" }` for non-existent doc IDs. Now throws `NotFoundException` at doc-existence check before counting chunks.

3. **IMPORTANT — `EmbeddingStatus` hardcoded to `"indexed"`**: misleading for failed/pending chunks since the source field doesn't exist yet on `TextChunkEntity`. Returns `null` until a real status source is wired (follow-up).

4. **IMPORTANT — G3 routing missing**: `POST /kb-docs/{id}/chunks/search` was never registered in `KnowledgeBaseEndpoints.cs.MapKbDocumentEndpoints`. Adds the endpoint registration + handler. Without this, the G3 search endpoint is dead code on `main-dev`.

5. **IMPORTANT — Missing `.Produces(StatusCodes.Status403Forbidden)`** on G1, G2, G3 OpenAPI metadata.

## Tests added

- `GetKbDocument_PrivateDocOwnedByOtherUser_Returns403` (regression test for Critical #1)
- 4 G3 integration tests (keyword present, no matches, query too long, operator injection) — these previously couldn't pass on `main-dev` because G3 was unwired

## Why a new PR (not #798)

PR #798 was 20 commits on top of an outdated base. After PR #797 absorbed most of that work into `main-dev`, rebasing #798 was 805+ files of irrelevant churn. Cleaner to open this targeted fix-only PR (3 commits, 14 files) and close #798 as superseded.

## Test plan

- [x] `dotnet build` clean (0 errors, only pre-existing analyzer warnings)
- [ ] CI integration tests pass
- [ ] Manual: confirm private doc owned by user A returns 403 to user B (no admin)
- [ ] Manual: confirm `POST /kb-docs/{id}/chunks/search` works (smoke check via Scalar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)