### PR TITLE
docs(claude): #806 branch hygiene safeguard for AI agentic sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,21 @@ git push -u origin feature/issue-123-desc
 # PR to frontend-dev (NOT main!) → merge → git branch -D feature/issue-123-desc
 ```
 
+**🔴 Branch Hygiene Rule** (issue #806): ALWAYS switch to the parent branch BEFORE creating a feature branch. Never run `git checkout -b feature/...` while HEAD is on another in-progress feature branch — it absorbs the other branch's commits into your new branch's ancestry. Concurrent multi-terminal workflows (incl. AI agentic sessions) are particularly prone to this.
+
+**Pre-creation safety check** — run before `git checkout -b`:
+
+```bash
+# Verify HEAD is on the intended parent (main-dev / frontend-dev / main),
+# NOT on another feature/* branch
+git branch --show-current  # MUST print main-dev, frontend-dev, or main
+git status                 # MUST show clean tree
+git pull --ff-only         # MUST succeed (no divergence)
+git checkout -b feature/issue-{n}-{desc}
+```
+
+If `git branch --show-current` prints `feature/...`, STOP. Run `git checkout main-dev && git pull` first.
+
 **Commits**: `feat|fix|docs|refactor|test|chore(scope): description`
 
 ### Feature Development Flow


### PR DESCRIPTION
## Summary

Implements the **Tier 1 / item 2** safeguard from issue #806: adds explicit branch hygiene guidance to \`CLAUDE.md\` so future AI agentic sessions catch the \"\`git checkout -b\` while HEAD is on another feature branch\" footgun before pushing.

## Context

PR #797 (Docker UFW) inadvertently absorbed 17 commits from #730 because the feature branch \`feature/issue-795-postgres-exposure-hardening\` was created from HEAD = \`65578d6d8\`, which was the in-progress tip of \`feature/issue-730-kb-chunk-endpoints\`. Reflog: \`branch: Created from HEAD\`.

The contamination was caught only at PR #804 review time (3.5 hours of \`main-dev\` exposure to access-control vulnerability).

## Change

Adds a new \"🔴 Branch Hygiene Rule\" section in \`CLAUDE.md\` (under Git Workflow), with a 3-line pre-creation safety check:

\`\`\`bash
git branch --show-current  # MUST print main-dev, frontend-dev, or main
git status                 # MUST show clean tree
git pull --ff-only         # MUST succeed (no divergence)
git checkout -b feature/issue-{n}-{desc}
\`\`\`

Concurrent multi-terminal workflows (incl. AI agentic sessions) are explicitly called out as particularly prone to this footgun.

## Out of scope (tracked in #806)

- Tier 1 / CONTRIBUTING.md update — separate PR
- Tier 2 / pre-push hook scope check — separate PR after design discussion
- Tier 2 / GitHub Action PR scope check — separate PR

## Test plan

- [x] CLAUDE.md renders correctly (preview)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)