### PR TITLE
feat(discover): #728 /discover composite endpoint (Wave 3 prereq)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/GetTopContributors/GetTopContributorsHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/GetTopContributors/GetTopContributorsHandler.cs
@@ -1,0 +1,76 @@
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.Authentication.Application.Queries.GetTopContributors;
+
+/// <summary>
+/// Handler for <see cref="GetTopContributorsQuery"/>.
+///
+/// Ranking formula (equal-weight sum):
+///   ContributionCount = kbUploads (public PdfDocuments uploaded by user)
+///                     + distinctAgentSessions (distinct AgentDefinitionIds per user)
+///
+/// faqCount is excluded: GameFaqEntity has no user FK, so per-user FAQ count
+/// is uncomputable. Suspended users and zero-contribution users are excluded.
+///
+/// Issue #728.
+/// </summary>
+internal sealed class GetTopContributorsHandler
+    : IQueryHandler<GetTopContributorsQuery, IReadOnlyList<TopContributorDto>>
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetTopContributorsHandler> _logger;
+
+    public GetTopContributorsHandler(
+        MeepleAiDbContext dbContext,
+        ILogger<GetTopContributorsHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<IReadOnlyList<TopContributorDto>> Handle(
+        GetTopContributorsQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var limit = Math.Clamp(query.Limit, 1, 20);
+
+        _logger.LogDebug("Fetching top {Limit} contributors", limit);
+
+        // Project per-user aggregates in a single round-trip.
+        // EF Core translates the subquery COUNT() calls to correlated SQL aggregates.
+        // GameFaqEntity excluded: no user FK available on that entity.
+        var results = await (
+            from u in _dbContext.Users.AsNoTracking()
+            where !u.IsSuspended
+            let kbCount = _dbContext.PdfDocuments
+                .Count(p => p.UploadedByUserId == u.Id && p.IsPublic)
+            let agentCount = _dbContext.AgentSessions
+                .Where(a => a.UserId == u.Id)
+                .Select(a => a.AgentDefinitionId)
+                .Distinct()
+                .Count()
+            let total = kbCount + agentCount
+            where total > 0
+            orderby total descending, u.DisplayName
+            select new TopContributorDto(
+                u.Id,
+                u.DisplayName ?? string.Empty,
+                u.AvatarUrl,
+                total,
+                kbCount,
+                agentCount)
+        )
+        .Take(limit)
+        .ToListAsync(cancellationToken)
+        .ConfigureAwait(false);
+
+        _logger.LogDebug("Top contributors query returned {Count} results", results.Count);
+
+        return results;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/GetTopContributors/GetTopContributorsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/GetTopContributors/GetTopContributorsQuery.cs
@@ -1,0 +1,11 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Authentication.Application.Queries.GetTopContributors;
+
+/// <summary>
+/// Query to retrieve the top contributors for the Discover dashboard.
+/// Ranking formula: kbUploads + distinct agent definition sessions per user.
+/// Issue #728.
+/// </summary>
+/// <param name="Limit">Maximum number of contributors to return (clamped to 1–20).</param>
+internal sealed record GetTopContributorsQuery(int Limit) : IQuery<IReadOnlyList<TopContributorDto>>;

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/GetTopContributors/TopContributorDto.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/GetTopContributors/TopContributorDto.cs
@@ -2,12 +2,17 @@ namespace Api.BoundedContexts.Authentication.Application.Queries.GetTopContribut
 
 /// <summary>
 /// DTO for a top contributor entry on the Discover dashboard.
-/// Stub placeholder — full implementation in Task D (GetTopContributorsQuery handler).
 /// Issue #728.
+///
+/// Note: faqCount is intentionally absent — GameFaqEntity has no user FK,
+/// making per-user FAQ count uncomputable. Contribution score uses
+/// equal-weight sum: kbUploads + distinct agent definition sessions.
 /// </summary>
 internal sealed record TopContributorDto(
     Guid UserId,
-    string Username,
+    string DisplayName,
+    string? AvatarUrl,
     int ContributionCount,
-    DateTime LastContributedAt
+    int KbUploadCount,
+    int AgentCount
 );

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/GetTopContributors/TopContributorDto.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/GetTopContributors/TopContributorDto.cs
@@ -1,0 +1,13 @@
+namespace Api.BoundedContexts.Authentication.Application.Queries.GetTopContributors;
+
+/// <summary>
+/// DTO for a top contributor entry on the Discover dashboard.
+/// Stub placeholder — full implementation in Task D (GetTopContributorsQuery handler).
+/// Issue #728.
+/// </summary>
+internal sealed record TopContributorDto(
+    Guid UserId,
+    string Username,
+    int ContributionCount,
+    DateTime LastContributedAt
+);

--- a/apps/api/src/Api/BoundedContexts/Discover/Application/Queries/GetDiscoverData/DiscoverDto.cs
+++ b/apps/api/src/Api/BoundedContexts/Discover/Application/Queries/GetDiscoverData/DiscoverDto.cs
@@ -1,0 +1,15 @@
+using Api.BoundedContexts.Authentication.Application.Queries.GetTopContributors;
+using Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetRecentKbDocuments;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetTopAgents;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetNewGames;
+
+namespace Api.BoundedContexts.Discover.Application.Queries.GetDiscoverData;
+
+internal sealed record DiscoverDto(
+    IReadOnlyList<NewGameDto> NewGames,
+    IReadOnlyList<TopAgentDto> TopAgents,
+    IReadOnlyList<RecommendedToolkitDto> RecommendedToolkits,
+    IReadOnlyList<RecentKbDocDto> RecentKb,
+    IReadOnlyList<TopContributorDto> TopContributors
+);

--- a/apps/api/src/Api/BoundedContexts/Discover/Application/Queries/GetDiscoverData/GetDiscoverDataHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Discover/Application/Queries/GetDiscoverData/GetDiscoverDataHandler.cs
@@ -1,0 +1,30 @@
+using Api.SharedKernel.Application.Interfaces;
+using Api.BoundedContexts.Authentication.Application.Queries.GetTopContributors;
+using Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetRecentKbDocuments;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetTopAgents;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetNewGames;
+
+namespace Api.BoundedContexts.Discover.Application.Queries.GetDiscoverData;
+
+internal sealed class GetDiscoverDataHandler : IQueryHandler<GetDiscoverDataQuery, DiscoverDto>
+{
+    private readonly ILogger<GetDiscoverDataHandler> _logger;
+
+    public GetDiscoverDataHandler(ILogger<GetDiscoverDataHandler> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public Task<DiscoverDto> Handle(GetDiscoverDataQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        return Task.FromResult(new DiscoverDto(
+            NewGames: Array.Empty<NewGameDto>(),
+            TopAgents: Array.Empty<TopAgentDto>(),
+            RecommendedToolkits: Array.Empty<RecommendedToolkitDto>(),
+            RecentKb: Array.Empty<RecentKbDocDto>(),
+            TopContributors: Array.Empty<TopContributorDto>()
+        ));
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Discover/Application/Queries/GetDiscoverData/GetDiscoverDataHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Discover/Application/Queries/GetDiscoverData/GetDiscoverDataHandler.cs
@@ -1,23 +1,56 @@
-using Api.SharedKernel.Application.Interfaces;
 using Api.BoundedContexts.Authentication.Application.Queries.GetTopContributors;
 using Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetRecentKbDocuments;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetTopAgents;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetNewGames;
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.Discover.Application.Queries.GetDiscoverData;
 
 internal sealed class GetDiscoverDataHandler : IQueryHandler<GetDiscoverDataQuery, DiscoverDto>
 {
-    public Task<DiscoverDto> Handle(GetDiscoverDataQuery query, CancellationToken cancellationToken)
+    private readonly IMediator _mediator;
+    private readonly ILogger<GetDiscoverDataHandler> _logger;
+
+    public GetDiscoverDataHandler(IMediator mediator, ILogger<GetDiscoverDataHandler> logger)
+    {
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<DiscoverDto> Handle(GetDiscoverDataQuery query, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(query);
-        return Task.FromResult(new DiscoverDto(
-            NewGames: Array.Empty<NewGameDto>(),
-            TopAgents: Array.Empty<TopAgentDto>(),
-            RecommendedToolkits: Array.Empty<RecommendedToolkitDto>(),
-            RecentKb: Array.Empty<RecentKbDocDto>(),
-            TopContributors: Array.Empty<TopContributorDto>()
-        ));
+
+        var newGamesTask = SafeRun("newGames", () => _mediator.Send(new GetNewGamesQuery(query.Limit), cancellationToken), Array.Empty<NewGameDto>());
+        var topAgentsTask = SafeRun("topAgents", () => _mediator.Send(new GetTopAgentsQuery(query.Limit), cancellationToken), Array.Empty<TopAgentDto>());
+        var toolkitsTask = SafeRun("recommendedToolkits", () => _mediator.Send(new GetRecommendedToolkitsQuery(query.Limit), cancellationToken), Array.Empty<RecommendedToolkitDto>());
+        var recentKbTask = SafeRun("recentKb", () => _mediator.Send(new GetRecentKbDocumentsQuery(query.Limit), cancellationToken), Array.Empty<RecentKbDocDto>());
+        var contributorsTask = SafeRun("topContributors", () => _mediator.Send(new GetTopContributorsQuery(query.Limit), cancellationToken), Array.Empty<TopContributorDto>());
+
+        await Task.WhenAll(newGamesTask, topAgentsTask, toolkitsTask, recentKbTask, contributorsTask).ConfigureAwait(false);
+
+        return new DiscoverDto(
+            NewGames: await newGamesTask.ConfigureAwait(false),
+            TopAgents: await topAgentsTask.ConfigureAwait(false),
+            RecommendedToolkits: await toolkitsTask.ConfigureAwait(false),
+            RecentKb: await recentKbTask.ConfigureAwait(false),
+            TopContributors: await contributorsTask.ConfigureAwait(false)
+        );
+    }
+
+    private async Task<IReadOnlyList<T>> SafeRun<T>(string rowName, Func<Task<IReadOnlyList<T>>> factory, IReadOnlyList<T> fallback)
+    {
+        try
+        {
+            return await factory().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Discover row {RowName} failed", rowName);
+            return fallback;
+        }
     }
 }

--- a/apps/api/src/Api/BoundedContexts/Discover/Application/Queries/GetDiscoverData/GetDiscoverDataHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Discover/Application/Queries/GetDiscoverData/GetDiscoverDataHandler.cs
@@ -9,13 +9,6 @@ namespace Api.BoundedContexts.Discover.Application.Queries.GetDiscoverData;
 
 internal sealed class GetDiscoverDataHandler : IQueryHandler<GetDiscoverDataQuery, DiscoverDto>
 {
-    private readonly ILogger<GetDiscoverDataHandler> _logger;
-
-    public GetDiscoverDataHandler(ILogger<GetDiscoverDataHandler> logger)
-    {
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-    }
-
     public Task<DiscoverDto> Handle(GetDiscoverDataQuery query, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(query);

--- a/apps/api/src/Api/BoundedContexts/Discover/Application/Queries/GetDiscoverData/GetDiscoverDataQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Discover/Application/Queries/GetDiscoverData/GetDiscoverDataQuery.cs
@@ -1,0 +1,5 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Discover.Application.Queries.GetDiscoverData;
+
+internal sealed record GetDiscoverDataQuery(int Limit) : IQuery<DiscoverDto>;

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/GetRecommendedToolkitsHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/GetRecommendedToolkitsHandler.cs
@@ -1,0 +1,52 @@
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
+
+/// <summary>
+/// Returns published toolkits ordered by CreatedAt DESC.
+/// GameToolkitEntity has no InstallCount field — MVP uses freshness as ranking proxy.
+/// InstallCount is always 0 in the DTO. GameName is resolved via the Game navigation
+/// property (GameEntity.Name). Limit is clamped to [1, 20].
+/// Issue #728: Discover dashboard — "Recommended Toolkits" widget.
+/// </summary>
+internal sealed class GetRecommendedToolkitsHandler : IQueryHandler<GetRecommendedToolkitsQuery, IReadOnlyList<RecommendedToolkitDto>>
+{
+    private const int MaxLimit = 20;
+    private const int MinLimit = 1;
+
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetRecommendedToolkitsHandler> _logger;
+
+    public GetRecommendedToolkitsHandler(MeepleAiDbContext dbContext, ILogger<GetRecommendedToolkitsHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<IReadOnlyList<RecommendedToolkitDto>> Handle(GetRecommendedToolkitsQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var limit = Math.Clamp(query.Limit, MinLimit, MaxLimit);
+
+        _logger.LogInformation("Fetching top {Limit} recommended toolkits ordered by CreatedAt DESC", limit);
+
+        return await _dbContext.GameToolkits.AsNoTracking()
+            .Where(t => t.IsPublished)
+            .OrderByDescending(t => t.CreatedAt)
+            .Take(limit)
+            .Select(t => new RecommendedToolkitDto(
+                t.Id,
+                t.Name,
+                t.Game != null ? t.Game.Name : string.Empty,
+                t.Version,
+                0,          // InstallCount — entity has no such field; MVP default
+                t.CreatedAt
+            ))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/GetRecommendedToolkitsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/GetRecommendedToolkitsQuery.cs
@@ -1,0 +1,11 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
+
+/// <summary>
+/// Query to retrieve the most recently published toolkits for the Discover dashboard.
+/// Ranked by CreatedAt DESC (freshness) since GameToolkitEntity has no install-count field.
+/// Limit is clamped to [1, 20].
+/// Issue #728.
+/// </summary>
+internal sealed record GetRecommendedToolkitsQuery(int Limit) : IQuery<IReadOnlyList<RecommendedToolkitDto>>;

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/RecommendedToolkitDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/RecommendedToolkitDto.cs
@@ -1,0 +1,14 @@
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
+
+/// <summary>
+/// DTO for a recommended toolkit entry on the Discover dashboard.
+/// Stub placeholder — full implementation in Task C (GetRecommendedToolkitsQuery handler).
+/// Issue #728.
+/// </summary>
+internal sealed record RecommendedToolkitDto(
+    Guid Id,
+    string Name,
+    string GameName,
+    int UsageCount,
+    DateTime CreatedAt
+);

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/RecommendedToolkitDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/RecommendedToolkitDto.cs
@@ -2,13 +2,14 @@ namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedTool
 
 /// <summary>
 /// DTO for a recommended toolkit entry on the Discover dashboard.
-/// Stub placeholder — full implementation in Task C (GetRecommendedToolkitsQuery handler).
-/// Issue #728.
+/// InstallCount is always 0 — GameToolkitEntity has no install-count field.
+/// MVP ranking uses CreatedAt DESC (freshness). Issue #728.
 /// </summary>
 internal sealed record RecommendedToolkitDto(
     Guid Id,
     string Name,
     string GameName,
-    int UsageCount,
+    int Version,
+    int InstallCount,
     DateTime CreatedAt
 );

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocuments/GetRecentKbDocumentsHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocuments/GetRecentKbDocumentsHandler.cs
@@ -1,0 +1,59 @@
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetRecentKbDocuments;
+
+/// <summary>
+/// Returns public, Ready-state KB documents ordered by IndexedAt DESC.
+/// Joins VectorDocument → SharedGame (via VectorDocument.SharedGameId) to resolve GameName.
+/// Language comes from PdfDocumentEntity.Language.
+/// Limit is clamped to [1, 20].
+/// Issue #728: Discover dashboard — "Recent KB Documents" widget.
+/// </summary>
+internal sealed class GetRecentKbDocumentsHandler : IQueryHandler<GetRecentKbDocumentsQuery, IReadOnlyList<RecentKbDocDto>>
+{
+    private const int MaxLimit = 20;
+    private const int MinLimit = 1;
+    private const string ReadyState = "Ready";
+
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetRecentKbDocumentsHandler> _logger;
+
+    public GetRecentKbDocumentsHandler(MeepleAiDbContext dbContext, ILogger<GetRecentKbDocumentsHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<IReadOnlyList<RecentKbDocDto>> Handle(GetRecentKbDocumentsQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var limit = Math.Clamp(query.Limit, MinLimit, MaxLimit);
+
+        _logger.LogInformation("Fetching top {Limit} recent KB documents ordered by IndexedAt DESC", limit);
+
+        return await (
+            from pdf in _dbContext.PdfDocuments.AsNoTracking()
+            join vd in _dbContext.VectorDocuments.AsNoTracking()
+                on pdf.Id equals vd.PdfDocumentId
+            join game in _dbContext.SharedGames.AsNoTracking()
+                on vd.SharedGameId equals game.Id into gameJoin
+            from game in gameJoin.DefaultIfEmpty()
+            where pdf.IsPublic
+                  && pdf.ProcessingState == ReadyState
+                  && vd.IndexedAt != null
+            orderby vd.IndexedAt descending
+            select new RecentKbDocDto(
+                pdf.Id,
+                pdf.FileName,
+                game != null ? game.Title : string.Empty,
+                pdf.DocumentCategory,
+                vd.IndexedAt!.Value,
+                pdf.Language
+            )
+        ).Take(limit).ToListAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocuments/GetRecentKbDocumentsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocuments/GetRecentKbDocumentsQuery.cs
@@ -1,0 +1,11 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetRecentKbDocuments;
+
+/// <summary>
+/// Query to retrieve the most recently indexed public KB documents for the Discover dashboard.
+/// Filters to IsPublic + ProcessingState == "Ready" + IndexedAt != null.
+/// Ordered by IndexedAt DESC. Limit is clamped to [1, 20].
+/// Issue #728.
+/// </summary>
+internal sealed record GetRecentKbDocumentsQuery(int Limit) : IQuery<IReadOnlyList<RecentKbDocDto>>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocuments/RecentKbDocDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocuments/RecentKbDocDto.cs
@@ -2,12 +2,14 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetRecentKbDocum
 
 /// <summary>
 /// DTO for a recently indexed KB document on the Discover dashboard.
-/// Stub placeholder — full implementation in Task C (GetRecentKbDocumentsQuery handler).
+/// GameName is resolved from SharedGameEntity.Title via VectorDocument.SharedGameId.
 /// Issue #728.
 /// </summary>
 internal sealed record RecentKbDocDto(
     Guid Id,
     string Title,
     string GameName,
-    DateTime IndexedAt
+    string DocumentCategory,
+    DateTime IndexedAt,
+    string Language
 );

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocuments/RecentKbDocDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocuments/RecentKbDocDto.cs
@@ -1,0 +1,13 @@
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetRecentKbDocuments;
+
+/// <summary>
+/// DTO for a recently indexed KB document on the Discover dashboard.
+/// Stub placeholder — full implementation in Task C (GetRecentKbDocumentsQuery handler).
+/// Issue #728.
+/// </summary>
+internal sealed record RecentKbDocDto(
+    Guid Id,
+    string Title,
+    string GameName,
+    DateTime IndexedAt
+);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetTopAgents/GetTopAgentsHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetTopAgents/GetTopAgentsHandler.cs
@@ -1,0 +1,64 @@
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetTopAgents;
+
+/// <summary>
+/// Returns agent definitions ranked by distinct user count (Approach A — AgentSession proxy).
+/// Limit is clamped to [1, 20].
+///
+/// MVP: Name, GameName and AgentType are empty strings because there is no AgentDefinition
+/// entity joinable from AgentSessionEntity. Follow-up issue once the KB BC introduces
+/// a proper install/agent-definition model.
+/// Issue #728: Discover dashboard — "Top Agents" widget.
+/// </summary>
+internal sealed class GetTopAgentsHandler : IQueryHandler<GetTopAgentsQuery, IReadOnlyList<TopAgentDto>>
+{
+    private const int MaxLimit = 20;
+    private const int MinLimit = 1;
+
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetTopAgentsHandler> _logger;
+
+    public GetTopAgentsHandler(MeepleAiDbContext dbContext, ILogger<GetTopAgentsHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<IReadOnlyList<TopAgentDto>> Handle(GetTopAgentsQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var limit = Math.Clamp(query.Limit, MinLimit, MaxLimit);
+
+        _logger.LogInformation("Fetching top {Limit} agents by distinct user count", limit);
+
+        // Aggregate AgentSessionEntity by AgentDefinitionId.
+        // Install count = distinct UserId per AgentDefinitionId.
+        var aggregated = await _dbContext.AgentSessions.AsNoTracking()
+            .GroupBy(s => s.AgentDefinitionId)
+            .Select(g => new
+            {
+                AgentDefinitionId = g.Key,
+                InstallCount = g.Select(s => s.UserId).Distinct().Count(),
+                LatestActivity = g.Max(s => s.StartedAt)
+            })
+            .OrderByDescending(x => x.InstallCount)
+            .ThenByDescending(x => x.LatestActivity)
+            .Take(limit)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return aggregated.Select(x => new TopAgentDto(
+            Id: x.AgentDefinitionId,
+            Name: string.Empty,
+            GameName: string.Empty,
+            AgentType: string.Empty,
+            InstallCount: x.InstallCount,
+            CreatedAt: x.LatestActivity
+        )).ToList();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetTopAgents/GetTopAgentsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetTopAgents/GetTopAgentsQuery.cs
@@ -1,0 +1,11 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetTopAgents;
+
+/// <summary>
+/// Query to retrieve the most-used agent definitions, ranked by distinct user count.
+/// Used by the Discover dashboard "Top Agents" widget.
+/// Approach A: aggregates AgentSessionEntity (proxy for install count).
+/// Issue #728.
+/// </summary>
+internal sealed record GetTopAgentsQuery(int Limit) : IQuery<IReadOnlyList<TopAgentDto>>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetTopAgents/TopAgentDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetTopAgents/TopAgentDto.cs
@@ -1,0 +1,17 @@
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetTopAgents;
+
+/// <summary>
+/// DTO for a top agent entry on the Discover dashboard.
+/// Name, GameName and AgentType are empty in the MVP because there is no
+/// AgentDefinition entity directly joinable in AgentSession.
+/// Follow-up when the KB BC introduces a proper install model.
+/// Issue #728.
+/// </summary>
+internal sealed record TopAgentDto(
+    Guid Id,
+    string Name,
+    string GameName,
+    string AgentType,
+    int InstallCount,
+    DateTime CreatedAt
+);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/GetNewGamesHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/GetNewGamesHandler.cs
@@ -1,0 +1,49 @@
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetNewGames;
+
+/// <summary>
+/// Returns the most recently added non-deleted shared games, ordered by CreatedAt descending.
+/// Limit is clamped to [1, 20].
+/// Issue #728: Discover dashboard — "New Games" widget.
+/// </summary>
+internal sealed class GetNewGamesHandler : IQueryHandler<GetNewGamesQuery, IReadOnlyList<NewGameDto>>
+{
+    private const int MaxLimit = 20;
+    private const int MinLimit = 1;
+
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetNewGamesHandler> _logger;
+
+    public GetNewGamesHandler(MeepleAiDbContext dbContext, ILogger<GetNewGamesHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<IReadOnlyList<NewGameDto>> Handle(GetNewGamesQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var limit = Math.Clamp(query.Limit, MinLimit, MaxLimit);
+
+        _logger.LogInformation("Fetching {Limit} new shared games", limit);
+
+        return await _dbContext.SharedGames.AsNoTracking()
+            .Where(g => !g.IsDeleted)
+            .OrderByDescending(g => g.CreatedAt)
+            .Take(limit)
+            .Select(g => new NewGameDto(
+                g.Id,
+                g.Title,
+                g.ImageUrl,
+                g.CreatedAt,
+                g.AverageRating
+            ))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/GetNewGamesQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/GetNewGamesQuery.cs
@@ -1,0 +1,10 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetNewGames;
+
+/// <summary>
+/// Query to retrieve the most recently added shared games.
+/// Used by the Discover dashboard "New Games" widget.
+/// Issue #728.
+/// </summary>
+internal sealed record GetNewGamesQuery(int Limit) : IQuery<IReadOnlyList<NewGameDto>>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/NewGameDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/NewGameDto.cs
@@ -1,0 +1,14 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetNewGames;
+
+/// <summary>
+/// DTO for a recently added shared game.
+/// Publisher is omitted — SharedGameEntity exposes it as a navigation collection,
+/// not as a scalar property.
+/// </summary>
+internal sealed record NewGameDto(
+    Guid Id,
+    string Title,
+    string? ImageUrl,
+    DateTime CreatedAt,
+    decimal? RatingAverage
+);

--- a/apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs
+++ b/apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Discover.Application.Queries.GetDiscoverData;
 using Api.BoundedContexts.KnowledgeBase.Application.Commands;
 using Api.BoundedContexts.KnowledgeBase.Application.ContextEngineering.Commands;
 using Api.BoundedContexts.KnowledgeBase.Application.ContextEngineering.Queries;
@@ -44,6 +45,7 @@ internal static class KnowledgeBaseEndpoints
         MapGameDocumentsEndpoint(group);
         MapLinkKbEndpoint(group);
         MapKbDocumentEndpoints(group);
+        MapDiscoverEndpoints(group);
 
         return group;
     }
@@ -892,6 +894,37 @@ internal static class KnowledgeBaseEndpoints
             .WithDescription("Returns the list of KB documents linked to a game, ordered by creation date descending.")
             .Produces<IReadOnlyList<GameDocumentDto>>()
             .Produces(StatusCodes.Status401Unauthorized);
+    }
+
+    private static void MapDiscoverEndpoints(RouteGroupBuilder group)
+    {
+        // Issue #728: composite discovery dashboard
+        group.MapGet("/discover", HandleGetDiscover)
+            .WithName("GetDiscover")
+            .RequireSession()
+            .WithTags("Discover")
+            .WithSummary("Get composite /discover dashboard data (5 cross-BC rows)")
+            .WithDescription("Returns newGames, topAgents, recommendedToolkits, recentKb, topContributors arrays. Partial-success: a failed sub-query returns empty array (logged); endpoint never returns 500 due to single-row failure.")
+            .Produces<DiscoverDto>()
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status401Unauthorized);
+    }
+
+    private static async Task<IResult> HandleGetDiscover(
+        int? limit,
+        HttpContext httpContext,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var limitValue = limit ?? 10;
+
+        if (limitValue < 1 || limitValue > 20)
+        {
+            return Results.BadRequest(new { error = "limit must be between 1 and 20" });
+        }
+
+        var dto = await mediator.Send(new GetDiscoverDataQuery(limitValue), cancellationToken).ConfigureAwait(false);
+        return Results.Ok(dto);
     }
 
     private static void MapKbDocumentEndpoints(RouteGroupBuilder group)

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Queries/GetTopContributorsHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Queries/GetTopContributorsHandlerTests.cs
@@ -1,0 +1,362 @@
+using Api.BoundedContexts.Authentication.Application.Queries.GetTopContributors;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Authentication.Application.Queries;
+
+/// <summary>
+/// Unit tests for <see cref="GetTopContributorsHandler"/>.
+/// Issue #728 — Discover dashboard top contributors sub-query.
+///
+/// Covers:
+/// - Ranking by equal-weight sum: kbUploads + distinct agent definition sessions
+/// - Tie ordering (descending total, then DisplayName ASC)
+/// - Exclusion of zero-contribution users
+/// - Distinct agent count de-duplication by AgentDefinitionId
+/// - Exclusion of suspended users
+/// - Limit clamping (1–20)
+/// - Constructor null-argument guards
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+public sealed class GetTopContributorsHandlerTests : IDisposable
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly Mock<ILogger<GetTopContributorsHandler>> _loggerMock;
+    private readonly GetTopContributorsHandler _handler;
+
+    public GetTopContributorsHandlerTests()
+    {
+        _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
+        _loggerMock = new Mock<ILogger<GetTopContributorsHandler>>();
+        _handler = new GetTopContributorsHandler(_dbContext, _loggerMock.Object);
+    }
+
+    // ── Ranking formula ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_RanksByEqualWeightSum_KbUploadsAndDistinctAgentSessions()
+    {
+        // Arrange
+        var u1 = SeedUser("Alice");   // 5 kb + 3 distinct agents = 8
+        var u2 = SeedUser("Bob");     // 0 kb + 8 distinct agents = 8 (tie with u1)
+        var u3 = SeedUser("Charlie"); // 3 kb + 2 distinct agents = 5
+        SeedUser("NoContrib");        // 0 contributions → excluded
+
+        for (int i = 0; i < 5; i++) SeedKbUpload(u1);
+        for (int i = 0; i < 3; i++) SeedAgentSession(u1, Guid.NewGuid());
+
+        for (int i = 0; i < 8; i++) SeedAgentSession(u2, Guid.NewGuid());
+
+        for (int i = 0; i < 3; i++) SeedKbUpload(u3);
+        for (int i = 0; i < 2; i++) SeedAgentSession(u3, Guid.NewGuid());
+
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var result = await _handler.Handle(
+            new GetTopContributorsQuery(10), CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(3, "zero-contribution user must be excluded");
+        result[0].ContributionCount.Should().Be(8);
+        result[1].ContributionCount.Should().Be(8);
+        result[2].ContributionCount.Should().Be(5);
+        result[2].UserId.Should().Be(u3);
+    }
+
+    [Fact]
+    public async Task Handle_TiedContributors_OrderedByDisplayNameAscending()
+    {
+        // Arrange — two users with identical totals; "Alice" should come before "Bob"
+        var uAlice = SeedUser("Alice");
+        var uBob = SeedUser("Bob");
+
+        SeedKbUpload(uAlice);
+        SeedKbUpload(uBob);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var result = await _handler.Handle(
+            new GetTopContributorsQuery(10), CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(2);
+        result[0].DisplayName.Should().Be("Alice");
+        result[1].DisplayName.Should().Be("Bob");
+    }
+
+    // ── Zero-contribution exclusion ────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_ExcludesZeroContributionUsers()
+    {
+        // Arrange
+        SeedUser("NoContributions");
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var result = await _handler.Handle(
+            new GetTopContributorsQuery(10), CancellationToken.None);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    // ── Distinct agent count ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_CountsDistinctAgentDefinitionIds_NotSessionCount()
+    {
+        // Arrange — 5 sessions with the SAME AgentDefinitionId → should count as 1
+        var user = SeedUser("Marco");
+        var singleAgentDefId = Guid.NewGuid();
+        for (int i = 0; i < 5; i++) SeedAgentSession(user, singleAgentDefId);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var result = await _handler.Handle(
+            new GetTopContributorsQuery(10), CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result.Single().AgentCount.Should().Be(1);
+        result.Single().ContributionCount.Should().Be(1); // 0 kb + 1 distinct agent
+    }
+
+    [Fact]
+    public async Task Handle_MultipleDistinctAgentDefinitions_CountedCorrectly()
+    {
+        // Arrange — 3 distinct AgentDefinitionIds, 2 sessions each → agentCount = 3
+        var user = SeedUser("Julia");
+        for (int i = 0; i < 3; i++)
+        {
+            var defId = Guid.NewGuid();
+            SeedAgentSession(user, defId);
+            SeedAgentSession(user, defId); // duplicate session, same def
+        }
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var result = await _handler.Handle(
+            new GetTopContributorsQuery(10), CancellationToken.None);
+
+        // Assert
+        result.Single().AgentCount.Should().Be(3);
+        result.Single().KbUploadCount.Should().Be(0);
+        result.Single().ContributionCount.Should().Be(3);
+    }
+
+    // ── Suspended users ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_ExcludesSuspendedUsers()
+    {
+        // Arrange
+        var activeUser = SeedUser("ActiveUser");
+        var suspendedUser = SeedUser("SuspendedUser", isSuspended: true);
+
+        SeedKbUpload(activeUser);
+        SeedKbUpload(suspendedUser); // suspended user's uploads must not appear
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var result = await _handler.Handle(
+            new GetTopContributorsQuery(10), CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result.Single().DisplayName.Should().Be("ActiveUser");
+    }
+
+    // ── Limit clamping ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_RespectsLimit()
+    {
+        // Arrange — seed 5 users, each with 1 upload
+        for (int i = 0; i < 5; i++)
+        {
+            var u = SeedUser($"User{i}");
+            SeedKbUpload(u);
+        }
+        await _dbContext.SaveChangesAsync();
+
+        // Act — request only 3
+        var result = await _handler.Handle(
+            new GetTopContributorsQuery(3), CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task Handle_ClampsLimitToMaximumTwenty()
+    {
+        // Arrange — seed 25 users
+        for (int i = 0; i < 25; i++)
+        {
+            var u = SeedUser($"User{i:00}");
+            SeedKbUpload(u);
+        }
+        await _dbContext.SaveChangesAsync();
+
+        // Act — request 100 (above max)
+        var result = await _handler.Handle(
+            new GetTopContributorsQuery(100), CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(20);
+    }
+
+    // ── DTO field mapping ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_MapsAllDtoFields_Correctly()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        _dbContext.Users.Add(new UserEntity
+        {
+            Id = userId,
+            Email = "test@example.com",
+            DisplayName = "Detailed User",
+            AvatarUrl = "https://example.com/avatar.png"
+        });
+
+        _dbContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            UploadedByUserId = userId,
+            IsPublic = true,
+            FileName = "rulebook.pdf",
+            FilePath = "/tmp/rulebook.pdf",
+            DocumentCategory = "Rulebook"
+        });
+
+        var agentDefId = Guid.NewGuid();
+        _dbContext.AgentSessions.Add(new AgentSessionEntity
+        {
+            Id = Guid.NewGuid(),
+            AgentDefinitionId = agentDefId,
+            UserId = userId,
+            GameSessionId = Guid.NewGuid(),
+            GameId = Guid.NewGuid(),
+            CurrentGameStateJson = "{}",
+            IsActive = true,
+            StartedAt = DateTime.UtcNow
+        });
+
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var result = await _handler.Handle(
+            new GetTopContributorsQuery(10), CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(1);
+        var dto = result.Single();
+        dto.UserId.Should().Be(userId);
+        dto.DisplayName.Should().Be("Detailed User");
+        dto.AvatarUrl.Should().Be("https://example.com/avatar.png");
+        dto.KbUploadCount.Should().Be(1);
+        dto.AgentCount.Should().Be(1);
+        dto.ContributionCount.Should().Be(2); // 1 kb + 1 agent
+    }
+
+    [Fact]
+    public async Task Handle_NullDisplayName_ReturnsEmptyString()
+    {
+        // Arrange — user with no DisplayName set
+        var userId = Guid.NewGuid();
+        _dbContext.Users.Add(new UserEntity
+        {
+            Id = userId,
+            Email = "nodisplay@example.com",
+            DisplayName = null
+        });
+        SeedKbUpload(userId);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var result = await _handler.Handle(
+            new GetTopContributorsQuery(10), CancellationToken.None);
+
+        // Assert
+        result.Single().DisplayName.Should().Be(string.Empty);
+    }
+
+    // ── Constructor null guards ────────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_NullDbContext_ThrowsArgumentNullException()
+    {
+        var act = () => new GetTopContributorsHandler(null!, _loggerMock.Object);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("dbContext");
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_ThrowsArgumentNullException()
+    {
+        var act = () => new GetTopContributorsHandler(_dbContext, null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
+    }
+
+    [Fact]
+    public async Task Handle_NullQuery_ThrowsArgumentNullException()
+    {
+        var act = async () => await _handler.Handle(null!, CancellationToken.None);
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    // ── Seed helpers ───────────────────────────────────────────────────────────
+
+    private Guid SeedUser(string displayName, bool isSuspended = false)
+    {
+        var id = Guid.NewGuid();
+        _dbContext.Users.Add(new UserEntity
+        {
+            Id = id,
+            Email = $"{displayName.ToLowerInvariant().Replace(" ", ".")}@test.com",
+            DisplayName = displayName,
+            IsSuspended = isSuspended
+        });
+        return id;
+    }
+
+    private void SeedKbUpload(Guid uploaderId)
+    {
+        _dbContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            UploadedByUserId = uploaderId,
+            IsPublic = true,
+            FileName = $"doc-{Guid.NewGuid():N}.pdf",
+            FilePath = $"/tmp/{Guid.NewGuid():N}.pdf",
+            DocumentCategory = "Rulebook"
+        });
+    }
+
+    private void SeedAgentSession(Guid userId, Guid agentDefId)
+    {
+        _dbContext.AgentSessions.Add(new AgentSessionEntity
+        {
+            Id = Guid.NewGuid(),
+            AgentDefinitionId = agentDefId,
+            UserId = userId,
+            GameSessionId = Guid.NewGuid(),
+            GameId = Guid.NewGuid(),
+            CurrentGameStateJson = "{}",
+            IsActive = true,
+            StartedAt = DateTime.UtcNow
+        });
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Discover/Application/Queries/GetDiscoverDataHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Discover/Application/Queries/GetDiscoverDataHandlerTests.cs
@@ -1,0 +1,115 @@
+using Api.BoundedContexts.Authentication.Application.Queries.GetTopContributors;
+using Api.BoundedContexts.Discover.Application.Queries.GetDiscoverData;
+using Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetRecentKbDocuments;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetTopAgents;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetNewGames;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Discover.Application.Queries;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Discover")]
+public sealed class GetDiscoverDataHandlerTests
+{
+    private readonly Mock<IMediator> _mediator;
+    private readonly Mock<ILogger<GetDiscoverDataHandler>> _logger;
+    private readonly GetDiscoverDataHandler _handler;
+
+    public GetDiscoverDataHandlerTests()
+    {
+        _mediator = new Mock<IMediator>();
+        _logger = new Mock<ILogger<GetDiscoverDataHandler>>();
+        _handler = new GetDiscoverDataHandler(_mediator.Object, _logger.Object);
+    }
+
+    [Fact]
+    public async Task Handle_AllSubQueriesSucceed_ReturnsFullPayload()
+    {
+        var newGames = new[] { new NewGameDto(Guid.NewGuid(), "G1", null, DateTime.UtcNow, null) };
+        var topAgents = new[] { new TopAgentDto(Guid.NewGuid(), "", "", "", 5, DateTime.UtcNow) };
+        var toolkits = new[] { new RecommendedToolkitDto(Guid.NewGuid(), "TK", "Game", 1, 0, DateTime.UtcNow) };
+        var recentKb = new[] { new RecentKbDocDto(Guid.NewGuid(), "Doc", "Game", "Rulebook", DateTime.UtcNow, "en") };
+        var contributors = new[] { new TopContributorDto(Guid.NewGuid(), "Marco", null, 13, 10, 1) };
+
+        _mediator.Setup(m => m.Send(It.IsAny<GetNewGamesQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<NewGameDto>)newGames);
+        _mediator.Setup(m => m.Send(It.IsAny<GetTopAgentsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<TopAgentDto>)topAgents);
+        _mediator.Setup(m => m.Send(It.IsAny<GetRecommendedToolkitsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<RecommendedToolkitDto>)toolkits);
+        _mediator.Setup(m => m.Send(It.IsAny<GetRecentKbDocumentsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<RecentKbDocDto>)recentKb);
+        _mediator.Setup(m => m.Send(It.IsAny<GetTopContributorsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<TopContributorDto>)contributors);
+
+        var result = await _handler.Handle(new GetDiscoverDataQuery(10), CancellationToken.None);
+
+        result.NewGames.Should().HaveCount(1);
+        result.TopAgents.Should().HaveCount(1);
+        result.RecommendedToolkits.Should().HaveCount(1);
+        result.RecentKb.Should().HaveCount(1);
+        result.TopContributors.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Handle_OneSubQueryFails_PartialSuccessReturnsEmptyForFailedRow()
+    {
+        _mediator.Setup(m => m.Send(It.IsAny<GetNewGamesQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<NewGameDto>)Array.Empty<NewGameDto>());
+        _mediator.Setup(m => m.Send(It.IsAny<GetTopAgentsQuery>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("simulated DB error"));
+        _mediator.Setup(m => m.Send(It.IsAny<GetRecommendedToolkitsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<RecommendedToolkitDto>)Array.Empty<RecommendedToolkitDto>());
+        _mediator.Setup(m => m.Send(It.IsAny<GetRecentKbDocumentsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<RecentKbDocDto>)Array.Empty<RecentKbDocDto>());
+        _mediator.Setup(m => m.Send(It.IsAny<GetTopContributorsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<TopContributorDto>)Array.Empty<TopContributorDto>());
+
+        var result = await _handler.Handle(new GetDiscoverDataQuery(10), CancellationToken.None);
+
+        result.TopAgents.Should().BeEmpty();
+        result.NewGames.Should().NotBeNull();
+        result.RecommendedToolkits.Should().NotBeNull();
+        result.RecentKb.Should().NotBeNull();
+        result.TopContributors.Should().NotBeNull();
+
+        // Verify error log
+        _logger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<InvalidOperationException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task Handle_AllSubQueriesFail_ReturnsAllEmptyArrays_NoException()
+    {
+        _mediator.Setup(m => m.Send(It.IsAny<GetNewGamesQuery>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("fail"));
+        _mediator.Setup(m => m.Send(It.IsAny<GetTopAgentsQuery>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("fail"));
+        _mediator.Setup(m => m.Send(It.IsAny<GetRecommendedToolkitsQuery>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("fail"));
+        _mediator.Setup(m => m.Send(It.IsAny<GetRecentKbDocumentsQuery>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("fail"));
+        _mediator.Setup(m => m.Send(It.IsAny<GetTopContributorsQuery>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("fail"));
+
+        var result = await _handler.Handle(new GetDiscoverDataQuery(10), CancellationToken.None);
+
+        result.NewGames.Should().BeEmpty();
+        result.TopAgents.Should().BeEmpty();
+        result.RecommendedToolkits.Should().BeEmpty();
+        result.RecentKb.Should().BeEmpty();
+        result.TopContributors.Should().BeEmpty();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkitsHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkitsHandlerTests.cs
@@ -1,0 +1,93 @@
+using Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameToolkit;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameToolkit.Application.Queries;
+
+/// <summary>
+/// Unit tests for GetRecommendedToolkitsHandler.
+/// Verifies IsPublished filter and CreatedAt DESC ordering.
+/// Uses InMemoryDatabase — no external dependencies.
+/// Issue #728.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameToolkit")]
+public sealed class GetRecommendedToolkitsHandlerTests
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetRecommendedToolkitsHandler> _logger;
+    private readonly GetRecommendedToolkitsHandler _handler;
+
+    public GetRecommendedToolkitsHandlerTests()
+    {
+        _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
+        _logger = Substitute.For<ILogger<GetRecommendedToolkitsHandler>>();
+        _handler = new GetRecommendedToolkitsHandler(_dbContext, _logger);
+    }
+
+    [Fact]
+    public async Task Handle_FiltersOutUnpublishedToolkits()
+    {
+        // Arrange — seed 3 published + 2 unpublished
+        for (int i = 0; i < 3; i++)
+            SeedToolkit($"Published {i}", isPublished: true, createdAt: DateTime.UtcNow.AddDays(-i));
+        SeedToolkit("Unpublished 1", isPublished: false, createdAt: DateTime.UtcNow);
+        SeedToolkit("Unpublished 2", isPublished: false, createdAt: DateTime.UtcNow);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var result = await _handler.Handle(new GetRecommendedToolkitsQuery(10), CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(3);
+        result.Select(r => r.Name).Should().NotContain(n => n.StartsWith("Unpublished"));
+    }
+
+    [Fact]
+    public async Task Handle_OrdersByCreatedAtDesc()
+    {
+        // Arrange
+        SeedToolkit("Old", isPublished: true, createdAt: DateTime.UtcNow.AddDays(-30));
+        SeedToolkit("Recent", isPublished: true, createdAt: DateTime.UtcNow.AddDays(-1));
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var result = await _handler.Handle(new GetRecommendedToolkitsQuery(10), CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.First().Name.Should().Be("Recent");
+    }
+
+    [Fact]
+    public async Task Handle_EmptyState_ReturnsEmptyList()
+    {
+        // Act
+        var result = await _handler.Handle(new GetRecommendedToolkitsQuery(10), CancellationToken.None);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    private void SeedToolkit(string name, bool isPublished, DateTime createdAt)
+    {
+        _dbContext.GameToolkits.Add(new GameToolkitEntity
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            IsPublished = isPublished,
+            CreatedAt = createdAt,
+            UpdatedAt = DateTime.UtcNow,
+            Version = 1,
+            GameId = Guid.NewGuid(),
+            CreatedByUserId = Guid.NewGuid(),
+            RowVersion = Array.Empty<byte>()
+        });
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocumentsHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocumentsHandlerTests.cs
@@ -1,0 +1,112 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetRecentKbDocuments;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Unit tests for GetRecentKbDocumentsHandler.
+/// Verifies IsPublic + ProcessingState filter, IndexedAt!=null filter, and ordering.
+/// Uses InMemoryDatabase — no external dependencies.
+/// Issue #728.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class GetRecentKbDocumentsHandlerTests
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetRecentKbDocumentsHandler> _logger;
+    private readonly GetRecentKbDocumentsHandler _handler;
+
+    public GetRecentKbDocumentsHandlerTests()
+    {
+        _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
+        _logger = Substitute.For<ILogger<GetRecentKbDocumentsHandler>>();
+        _handler = new GetRecentKbDocumentsHandler(_dbContext, _logger);
+    }
+
+    [Fact]
+    public async Task Handle_FiltersOutNonReadyDocs()
+    {
+        // Arrange — seed one Ready doc, two with other states
+        var readyDoc = SeedPdfDoc("Ready", isPublic: true, indexedAt: DateTime.UtcNow);
+        SeedPdfDoc("Embedding", isPublic: true, indexedAt: DateTime.UtcNow);
+        SeedPdfDoc("Failed", isPublic: true, indexedAt: DateTime.UtcNow);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var result = await _handler.Handle(new GetRecentKbDocumentsQuery(10), CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result.Single().Id.Should().Be(readyDoc.Id);
+    }
+
+    [Fact]
+    public async Task Handle_FiltersOutPrivateDocs()
+    {
+        // Arrange
+        SeedPdfDoc("Ready", isPublic: false, indexedAt: DateTime.UtcNow);
+        var publicDoc = SeedPdfDoc("Ready", isPublic: true, indexedAt: DateTime.UtcNow);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var result = await _handler.Handle(new GetRecentKbDocumentsQuery(10), CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result.Single().Id.Should().Be(publicDoc.Id);
+    }
+
+    [Fact]
+    public async Task Handle_OrdersByIndexedAtDesc()
+    {
+        // Arrange
+        var older = SeedPdfDoc("Ready", isPublic: true, indexedAt: DateTime.UtcNow.AddDays(-5));
+        var newer = SeedPdfDoc("Ready", isPublic: true, indexedAt: DateTime.UtcNow.AddDays(-1));
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var result = await _handler.Handle(new GetRecentKbDocumentsQuery(10), CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.First().Id.Should().Be(newer.Id);
+    }
+
+    private PdfDocumentEntity SeedPdfDoc(string processingState, bool isPublic, DateTime indexedAt)
+    {
+        var doc = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            FileName = "test.pdf",
+            FilePath = "/tmp/test.pdf",
+            ProcessingState = processingState,
+            IsPublic = isPublic,
+            UploadedAt = DateTime.UtcNow,
+            Language = "en",
+            DocumentCategory = "Rulebook",
+            UploadedByUserId = Guid.NewGuid()
+        };
+        _dbContext.PdfDocuments.Add(doc);
+
+        var vd = new VectorDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = doc.Id,
+            GameId = Guid.NewGuid(),
+            ChunkCount = 10,
+            IndexedAt = indexedAt,
+            IndexingStatus = "completed"
+        };
+        _dbContext.VectorDocuments.Add(vd);
+
+        return doc;
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetTopAgentsHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetTopAgentsHandlerTests.cs
@@ -1,0 +1,87 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetTopAgents;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Unit tests for GetTopAgentsHandler.
+/// Verifies ranking by distinct user count and empty state behavior.
+/// Uses InMemoryDatabase — no external dependencies.
+/// Issue #728.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class GetTopAgentsHandlerTests
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetTopAgentsHandler> _logger;
+    private readonly GetTopAgentsHandler _handler;
+
+    public GetTopAgentsHandlerTests()
+    {
+        _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
+        _logger = Substitute.For<ILogger<GetTopAgentsHandler>>();
+        _handler = new GetTopAgentsHandler(_dbContext, _logger);
+    }
+
+    [Fact]
+    public async Task Handle_RanksByDistinctUserCount()
+    {
+        // Arrange
+        var agentA = Guid.NewGuid();
+        var agentB = Guid.NewGuid();
+
+        // agentA: 5 distinct users
+        for (int i = 0; i < 5; i++)
+            SeedAgentSession(agentDefinitionId: agentA, userId: Guid.NewGuid());
+
+        // agentB: 1 distinct user (3 sessions)
+        var sharedUserB = Guid.NewGuid();
+        for (int i = 0; i < 3; i++)
+            SeedAgentSession(agentDefinitionId: agentB, userId: sharedUserB);
+
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var result = await _handler.Handle(new GetTopAgentsQuery(10), CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.First().Id.Should().Be(agentA);
+        result.First().InstallCount.Should().Be(5);
+        result.Last().Id.Should().Be(agentB);
+        result.Last().InstallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyState_ReturnsEmptyList()
+    {
+        // Act
+        var result = await _handler.Handle(new GetTopAgentsQuery(10), CancellationToken.None);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    private void SeedAgentSession(Guid agentDefinitionId, Guid userId)
+    {
+        _dbContext.AgentSessions.Add(new AgentSessionEntity
+        {
+            Id = Guid.NewGuid(),
+            AgentDefinitionId = agentDefinitionId,
+            UserId = userId,
+            GameSessionId = Guid.NewGuid(),
+            GameId = Guid.NewGuid(),
+            CurrentGameStateJson = "{}",
+            IsActive = true,
+            StartedAt = DateTime.UtcNow
+        });
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGamesHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGamesHandlerTests.cs
@@ -1,0 +1,99 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetNewGames;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+/// <summary>
+/// Unit tests for GetNewGamesHandler.
+/// Verifies ordering, soft-delete exclusion, and empty catalog behavior.
+/// Uses InMemoryDatabase — no external dependencies.
+/// Issue #728.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class GetNewGamesHandlerTests
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetNewGamesHandler> _logger;
+    private readonly GetNewGamesHandler _handler;
+
+    public GetNewGamesHandlerTests()
+    {
+        _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
+        _logger = Substitute.For<ILogger<GetNewGamesHandler>>();
+        _handler = new GetNewGamesHandler(_dbContext, _logger);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsLatestGamesByCreatedAtDesc()
+    {
+        // Arrange: 15 games, each 1 day older than the previous
+        for (int i = 0; i < 15; i++)
+        {
+            _dbContext.SharedGames.Add(new SharedGameEntity
+            {
+                Id = Guid.NewGuid(),
+                Title = $"Game {i}",
+                CreatedAt = DateTime.UtcNow.AddDays(-i),
+                CreatedBy = Guid.NewGuid(),
+                IsDeleted = false
+            });
+        }
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var result = await _handler.Handle(new GetNewGamesQuery(Limit: 10), CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(10);
+        result.Select(r => r.CreatedAt).Should().BeInDescendingOrder();
+        result.First().Title.Should().Be("Game 0");
+    }
+
+    [Fact]
+    public async Task Handle_ExcludesSoftDeletedGames()
+    {
+        // Arrange
+        _dbContext.SharedGames.Add(new SharedGameEntity
+        {
+            Id = Guid.NewGuid(),
+            Title = "Visible",
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid(),
+            IsDeleted = false
+        });
+        _dbContext.SharedGames.Add(new SharedGameEntity
+        {
+            Id = Guid.NewGuid(),
+            Title = "Hidden",
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid(),
+            IsDeleted = true
+        });
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var result = await _handler.Handle(new GetNewGamesQuery(10), CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result.Single().Title.Should().Be("Visible");
+    }
+
+    [Fact]
+    public async Task Handle_EmptyCatalog_ReturnsEmptyList()
+    {
+        // Act
+        var result = await _handler.Handle(new GetNewGamesQuery(10), CancellationToken.None);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/DiscoverEndpointIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DiscoverEndpointIntegrationTests.cs
@@ -1,0 +1,104 @@
+using System.Net;
+using System.Net.Http.Json;
+using Api.BoundedContexts.Discover.Application.Queries.GetDiscoverData;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration;
+
+/// <summary>
+/// Integration tests for the GET /api/v1/discover endpoint (Issue #728).
+/// Tests: 401 unauthenticated, 400 limit out-of-range, 200 happy-path with all 5 arrays.
+/// </summary>
+[Collection("Integration-GroupB")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "Discover")]
+public sealed class DiscoverEndpointIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    public DiscoverEndpointIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"discover_endpoint_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+        }
+
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    [Fact]
+    public async Task GetDiscover_WhenNotAuthenticated_Returns401()
+    {
+        var response = await _client.GetAsync("/api/v1/discover");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetDiscover_LimitOutOfRange_Returns400()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/discover?limit=50",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task GetDiscover_HappyPath_ReturnsAll5Arrays()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/discover?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<DiscoverDto>();
+        dto.Should().NotBeNull();
+        dto!.NewGames.Should().NotBeNull();
+        dto.TopAgents.Should().NotBeNull();
+        dto.RecommendedToolkits.Should().NotBeNull();
+        dto.RecentKb.Should().NotBeNull();
+        dto.TopContributors.Should().NotBeNull();
+    }
+}

--- a/apps/web/src/hooks/queries/index.ts
+++ b/apps/web/src/hooks/queries/index.ts
@@ -233,6 +233,9 @@ export {
   snapshotKeys,
 } from './useSessionSnapshots';
 
+// Discover dashboard (Issue #728)
+export { useDiscover, discoverKeys } from './useDiscover';
+
 // Re-export from @tanstack/react-query for convenience
 export {
   useQuery,

--- a/apps/web/src/hooks/queries/useDiscover.ts
+++ b/apps/web/src/hooks/queries/useDiscover.ts
@@ -1,0 +1,36 @@
+'use client';
+
+/**
+ * useDiscover — React Query hook for the /discover dashboard payload (Issue #728)
+ *
+ * Fetches the composite discover response (new games, top agents, recommended toolkits,
+ * recent KB docs, top contributors) with a 10-minute stale time — conservative across
+ * the five row TTLs to avoid stale data on the community dashboard.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type { Discover } from '@/lib/api/schemas/discover.schemas';
+
+export const discoverKeys = {
+  all: ['discover'] as const,
+  byLimit: (limit: number) => ['discover', { limit }] as const,
+} as const;
+
+/**
+ * Hook to fetch the composite discover dashboard data.
+ *
+ * @param limit Items per row (1-20, default 10).
+ * @param enabled Whether to run the query (default: true).
+ * @returns UseQueryResult with composite Discover data or null.
+ */
+export function useDiscover(limit: number = 10, enabled: boolean = true) {
+  return useQuery<Discover | null, Error>({
+    queryKey: discoverKeys.byLimit(limit),
+    queryFn: () => api.discover.getDiscover(limit),
+    enabled,
+    staleTime: 10 * 60_000, // 10 min — conservative across 5 row TTLs
+    gcTime: 30 * 60_000,
+  });
+}

--- a/apps/web/src/lib/api/clients/discoverClient.ts
+++ b/apps/web/src/lib/api/clients/discoverClient.ts
@@ -1,0 +1,43 @@
+/**
+ * Discover API Client (Issue #728)
+ *
+ * Client for the composite /discover dashboard endpoint.
+ * Used by useDiscover hook for community discovery dashboard.
+ */
+
+import { discoverSchema, type Discover } from '../schemas/discover.schemas';
+
+import type { HttpClient } from '../core/httpClient';
+
+// ============================================================================
+// Client Interface
+// ============================================================================
+
+export interface DiscoverClient {
+  /**
+   * Fetch the composite /discover dashboard payload.
+   * @param limit Items per row (1-20, default 10).
+   */
+  getDiscover(limit?: number): Promise<Discover | null>;
+}
+
+// ============================================================================
+// Client Factory
+// ============================================================================
+
+export interface DiscoverClientConfig {
+  httpClient: HttpClient;
+}
+
+/**
+ * Create Discover API client
+ */
+export function createDiscoverClient({ httpClient }: DiscoverClientConfig): DiscoverClient {
+  return {
+    async getDiscover(limit = 10) {
+      const data = await httpClient.get<Discover>(`/api/v1/discover?limit=${limit}`);
+      if (!data) return null;
+      return discoverSchema.parse(data);
+    },
+  };
+}

--- a/apps/web/src/lib/api/clients/index.ts
+++ b/apps/web/src/lib/api/clients/index.ts
@@ -57,3 +57,4 @@ export * from './infrastructureClient'; // AI Infrastructure Dashboard
 export * from './toolkit'; // Default Game Toolkit — session events & dice presets
 export * from './sessionSnapshotsClient'; // Session Vision AI — snapshot CRUD
 export * from '../session-flow'; // Session Flow v2.1 — typed client + DTOs
+export * from './discoverClient'; // Discover dashboard (Issue #728)

--- a/apps/web/src/lib/api/index.ts
+++ b/apps/web/src/lib/api/index.ts
@@ -71,6 +71,7 @@ import {
   createAgentDocumentsClient,
   createInfrastructureClient,
   createSessionFlowClient,
+  createDiscoverClient,
   type AuthClient,
   type GamesClient,
   type SessionsClient,
@@ -122,6 +123,7 @@ import {
   type AgentDocumentsClient,
   type InfrastructureClient,
   type SessionFlowClient,
+  type DiscoverClient,
 } from './clients';
 import { HttpClient, type HttpClientConfig } from './core/httpClient';
 
@@ -363,6 +365,9 @@ export interface ApiClient {
   /** Session Flow v2.1 — lifecycle, turns, scores, diary */
   sessionFlow: SessionFlowClient;
 
+  /** Discover dashboard — community discovery composite endpoint (Issue #728) */
+  discover: DiscoverClient;
+
   /** Generic DELETE helper (used in some legacy tests) */
   delete: (path: string) => Promise<void>;
 }
@@ -464,6 +469,7 @@ export function createApiClient(config?: ApiClientConfig): ApiClient {
     agentDocuments: createAgentDocumentsClient({ httpClient }), // User agent document selection
     infrastructure: createInfrastructureClient({ httpClient }), // AI Infrastructure Dashboard
     sessionFlow: createSessionFlowClient({ httpClient }), // Session Flow v2.1
+    discover: createDiscoverClient({ httpClient }), // Discover dashboard (Issue #728)
     delete: (path: string) => httpClient.delete(path),
   };
 

--- a/apps/web/src/lib/api/schemas/discover.schemas.ts
+++ b/apps/web/src/lib/api/schemas/discover.schemas.ts
@@ -1,0 +1,70 @@
+/**
+ * Discover API Schemas (Issue #728)
+ *
+ * Zod schemas for the composite /discover dashboard payload.
+ * Mirrors the backend DiscoverDto and its row DTOs.
+ */
+
+import { z } from 'zod';
+
+// ========== Row Schemas ==========
+
+export const newGameSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  imageUrl: z.string().nullable().optional(),
+  createdAt: z.string().datetime({ offset: true }),
+  ratingAverage: z.number().nullable().optional(),
+});
+export type NewGame = z.infer<typeof newGameSchema>;
+
+export const topAgentSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  gameName: z.string(),
+  agentType: z.string(),
+  installCount: z.number().int().nonnegative(),
+  createdAt: z.string().datetime({ offset: true }),
+});
+export type TopAgent = z.infer<typeof topAgentSchema>;
+
+export const recommendedToolkitSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  gameName: z.string(),
+  version: z.number().int().nonnegative(),
+  installCount: z.number().int().nonnegative(),
+  createdAt: z.string().datetime({ offset: true }),
+});
+export type RecommendedToolkit = z.infer<typeof recommendedToolkitSchema>;
+
+export const recentKbDocSchema = z.object({
+  id: z.string().uuid(),
+  title: z.string(),
+  gameName: z.string(),
+  documentCategory: z.string(),
+  indexedAt: z.string().datetime({ offset: true }),
+  language: z.string(),
+});
+export type RecentKbDoc = z.infer<typeof recentKbDocSchema>;
+
+export const topContributorSchema = z.object({
+  userId: z.string().uuid(),
+  displayName: z.string(),
+  avatarUrl: z.string().nullable().optional(),
+  contributionCount: z.number().int().nonnegative(),
+  kbUploadCount: z.number().int().nonnegative(),
+  agentCount: z.number().int().nonnegative(),
+});
+export type TopContributor = z.infer<typeof topContributorSchema>;
+
+// ========== Composite Schema ==========
+
+export const discoverSchema = z.object({
+  newGames: z.array(newGameSchema),
+  topAgents: z.array(topAgentSchema),
+  recommendedToolkits: z.array(recommendedToolkitSchema),
+  recentKb: z.array(recentKbDocSchema),
+  topContributors: z.array(topContributorSchema),
+});
+export type Discover = z.infer<typeof discoverSchema>;

--- a/apps/web/src/lib/api/schemas/index.ts
+++ b/apps/web/src/lib/api/schemas/index.ts
@@ -143,3 +143,6 @@ export * from './ownership.schemas';
 
 // Agent Documents schemas (user-scoped document selection)
 export * from './agent-documents.schemas';
+
+// Discover dashboard schemas (Issue #728)
+export * from './discover.schemas';

--- a/docs/superpowers/plans/2026-05-06-discover-endpoints-plan.md
+++ b/docs/superpowers/plans/2026-05-06-discover-endpoints-plan.md
@@ -1,0 +1,1814 @@
+# `/discover` Composite Endpoint Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `GET /api/v1/discover` composite endpoint returning 5 cross-BC discovery rows (newGames, topAgents, recommendedToolkits, recentKb, topContributors), with resilient partial-success failure semantics, to unblock V2 migration Wave 3 child #687.
+
+**Architecture:** New `Discover` BC owns the composer; 5 sub-queries each live in their native BC (`SharedGameCatalog`, `KnowledgeBase`-x2, `GameToolkit`, `Authentication`). Composer dispatches via MediatR `Task.WhenAll` with per-row try-catch. HybridCache wraps each row with row-specific TTL.
+
+**Tech Stack:** .NET 9 · ASP.NET Minimal APIs · MediatR · EF Core 9 (PostgreSQL 16) · HybridCache · xUnit + FluentAssertions + NSubstitute · Next.js 16 · React Query · Zod
+
+**Spec:** `docs/superpowers/specs/2026-05-06-discover-endpoints-design.md`
+
+---
+
+## File Structure
+
+### Backend — Created
+
+| File | Responsibility |
+|------|----------------|
+| `apps/api/src/Api/BoundedContexts/Discover/Application/Queries/GetDiscoverData/GetDiscoverDataQuery.cs` | Composer query record (input: `int Limit`) |
+| `apps/api/src/Api/BoundedContexts/Discover/Application/Queries/GetDiscoverData/DiscoverDto.cs` | Composite DTO with 5 row arrays |
+| `apps/api/src/Api/BoundedContexts/Discover/Application/Queries/GetDiscoverData/GetDiscoverDataHandler.cs` | Composer with `Task.WhenAll` + per-row try-catch + Prometheus counter |
+| `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/GetNewGamesQuery.cs` | Sub-query record |
+| `…/GetNewGames/NewGameDto.cs` | Per-row DTO |
+| `…/GetNewGames/GetNewGamesHandler.cs` | Sub-query handler |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetTopAgents/GetTopAgentsQuery.cs` | Sub-query record |
+| `…/GetTopAgents/TopAgentDto.cs` | Per-row DTO |
+| `…/GetTopAgents/GetTopAgentsHandler.cs` | Sub-query handler (uses AgentSessionEntity proxy) |
+| `apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/GetRecommendedToolkitsQuery.cs` | Sub-query record |
+| `…/GetRecommendedToolkits/RecommendedToolkitDto.cs` | Per-row DTO |
+| `…/GetRecommendedToolkits/GetRecommendedToolkitsHandler.cs` | Sub-query handler |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocuments/GetRecentKbDocumentsQuery.cs` | Sub-query record |
+| `…/GetRecentKbDocuments/RecentKbDocDto.cs` | Per-row DTO |
+| `…/GetRecentKbDocuments/GetRecentKbDocumentsHandler.cs` | Sub-query handler |
+| `apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/GetTopContributors/GetTopContributorsQuery.cs` | Sub-query record |
+| `…/GetTopContributors/TopContributorDto.cs` | Per-row DTO |
+| `…/GetTopContributors/GetTopContributorsHandler.cs` | Sub-query handler |
+| `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGamesHandlerTests.cs` | Unit tests |
+| `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetTopAgentsHandlerTests.cs` | Unit tests |
+| `apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkitsHandlerTests.cs` | Unit tests |
+| `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocumentsHandlerTests.cs` | Unit tests |
+| `apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Queries/GetTopContributorsHandlerTests.cs` | Unit tests |
+| `apps/api/tests/Api.Tests/BoundedContexts/Discover/Application/Queries/GetDiscoverDataHandlerTests.cs` | Composer unit test (NSubstitute IMediator) |
+| `apps/api/tests/Api.Tests/Integration/DiscoverEndpointIntegrationTests.cs` | E2E test (Testcontainers) |
+
+### Backend — Modified
+
+| File | Change |
+|------|--------|
+| `apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs` (or new `DiscoverEndpoints.cs`) | Register `MapDiscoverEndpoints` (decision in Task 9) |
+| `apps/api/src/Api/Program.cs` | (Optional) Register Prometheus counter `discover_row_failure_total` if not auto-registered |
+
+### Frontend — Created
+
+| File | Responsibility |
+|------|----------------|
+| `apps/web/src/lib/api/schemas/discover.schemas.ts` | 6 Zod schemas (5 row + composite) |
+| `apps/web/src/lib/api/clients/discoverClient.ts` | `getDiscover(limit?)` method |
+| `apps/web/src/hooks/queries/useDiscover.ts` | React Query hook (10min staleTime) |
+
+### Frontend — Modified
+
+| File | Change |
+|------|--------|
+| `apps/web/src/lib/api/schemas/index.ts` | Re-export discover schemas |
+| `apps/web/src/lib/api/clients/index.ts` | Re-export discoverClient |
+| `apps/web/src/hooks/queries/index.ts` | Re-export useDiscover |
+
+---
+
+## Task 0: Verify entity assumptions (BLOCKER)
+
+This task validates the spec's §5 assumptions before implementation. If any of the assumptions fail, the affected sub-query needs scope adjustment (defer or proxy strategy).
+
+**No commit at this stage** — this is investigation, results inform Tasks 2-6.
+
+- [ ] **Step 1: Verify `GameFaqEntity` exists and has `AuthorId`**
+
+```bash
+cd D:/Repositories/meepleai-monorepo-main
+grep -n "class GameFaqEntity\|AuthorId\|public Guid" apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/GameFaqEntity.cs | head -20
+```
+
+Expected: file exists; class has properties including `AuthorId` (Guid). If `AuthorId` is missing or named differently (e.g., `CreatedBy`), note the actual name for Task 6.
+
+- [ ] **Step 2: Verify `AgentSessionEntity` has `AgentId` + `CreatedBy`/`UserId`**
+
+```bash
+grep -n "class AgentSessionEntity\|AgentId\|UserId\|CreatedBy" apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/AgentSessionEntity.cs | head -20
+```
+
+Expected: file exists; class has `AgentId` and a user-foreign-key field. Note the actual user-fk field name (likely `UserId`, may be `CreatedBy`) for Tasks 3 and 6.
+
+- [ ] **Step 3: Confirm DbContext registers all referenced DbSets**
+
+```bash
+grep -n "DbSet<.*Faq\|DbSet<.*Agent\|DbSet<SharedGameEntity\|DbSet<GameToolkit\|DbSet<PdfDocument\|DbSet<VectorDocument\|DbSet<UserEntity" apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs | head -15
+```
+
+Note the **actual DbSet property names** for use in handler LINQ (e.g., `_dbContext.GameFaqs` vs `_dbContext.Faqs`). The exact names go into Tasks 2-7.
+
+- [ ] **Step 4: Decision point — Top Agents row**
+
+Based on Step 2 findings, choose:
+
+- **Approach A** (proxy via AgentSessionEntity): aggregate by `AgentId`, count distinct `UserId` per `AgentId` as install proxy. Use this if `AgentSessionEntity.AgentId` exists and represents an agent definition reference.
+- **Approach B** (skip in MVP): if no clean proxy is available, return empty array `[]` for `topAgents` row in MVP. Document as out-of-scope follow-up. Tasks 3 (handler) and Task 7 (composer wiring) become trivial (handler returns `Array.Empty<TopAgentDto>()`).
+
+Document the decision in a comment in `GetTopAgentsQuery.cs` (created in Task 3).
+
+- [ ] **Step 5: Document findings**
+
+Write a short summary (3-5 lines) in this file by editing this Task 0 section, replacing this checkbox with: `- [x] Findings: <field-name-corrections>; agent install approach: <A|B>`. Investigation is then complete.
+
+---
+
+## Task 1: Discover BC scaffolding + composite DTO
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Discover/Application/Queries/GetDiscoverData/GetDiscoverDataQuery.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Discover/Application/Queries/GetDiscoverData/DiscoverDto.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Discover/Application/Queries/GetDiscoverData/GetDiscoverDataHandler.cs` (skeleton — full impl in Task 7)
+
+- [ ] **Step 1: Create GetDiscoverDataQuery**
+
+`apps/api/src/Api/BoundedContexts/Discover/Application/Queries/GetDiscoverData/GetDiscoverDataQuery.cs`:
+
+```csharp
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Discover.Application.Queries.GetDiscoverData;
+
+internal sealed record GetDiscoverDataQuery(int Limit) : IQuery<DiscoverDto>;
+```
+
+- [ ] **Step 2: Create composite DTO (referencing per-row DTOs that will be created in Tasks 2-6)**
+
+`DiscoverDto.cs`:
+
+```csharp
+using Api.BoundedContexts.Authentication.Application.Queries.GetTopContributors;
+using Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetRecentKbDocuments;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetTopAgents;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetNewGames;
+
+namespace Api.BoundedContexts.Discover.Application.Queries.GetDiscoverData;
+
+internal sealed record DiscoverDto(
+    IReadOnlyList<NewGameDto> NewGames,
+    IReadOnlyList<TopAgentDto> TopAgents,
+    IReadOnlyList<RecommendedToolkitDto> RecommendedToolkits,
+    IReadOnlyList<RecentKbDocDto> RecentKb,
+    IReadOnlyList<TopContributorDto> TopContributors
+);
+```
+
+(File will not compile until per-row DTOs are created in Tasks 2-6. That is expected and OK — Task 1 is scaffolding only. The composer in Step 3 returns empty arrays so the project compiles end-to-end after Tasks 2-6 land.)
+
+- [ ] **Step 3: Create skeleton Handler returning empty composite**
+
+`GetDiscoverDataHandler.cs`:
+
+```csharp
+using Api.SharedKernel.Application.Interfaces;
+using Api.BoundedContexts.Authentication.Application.Queries.GetTopContributors;
+using Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetRecentKbDocuments;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetTopAgents;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetNewGames;
+
+namespace Api.BoundedContexts.Discover.Application.Queries.GetDiscoverData;
+
+internal sealed class GetDiscoverDataHandler : IQueryHandler<GetDiscoverDataQuery, DiscoverDto>
+{
+    private readonly ILogger<GetDiscoverDataHandler> _logger;
+
+    public GetDiscoverDataHandler(ILogger<GetDiscoverDataHandler> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public Task<DiscoverDto> Handle(GetDiscoverDataQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        // Skeleton — full implementation in Task 7
+        return Task.FromResult(new DiscoverDto(
+            NewGames: Array.Empty<NewGameDto>(),
+            TopAgents: Array.Empty<TopAgentDto>(),
+            RecommendedToolkits: Array.Empty<RecommendedToolkitDto>(),
+            RecentKb: Array.Empty<RecentKbDocDto>(),
+            TopContributors: Array.Empty<TopContributorDto>()
+        ));
+    }
+}
+```
+
+(Will not compile until Tasks 2-6 create the per-row DTOs.)
+
+- [ ] **Step 4: Defer build verification to Task 6**
+
+The composite DTO references types that don't exist yet. Tasks 2-6 will create them in dependency order. Build will succeed after Task 6 completes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Discover/
+git commit -m "feat(discover): #728 BC scaffolding + composite DTO skeleton
+
+Creates new Discover BC with empty composer that will be filled
+in Task 7 once all 5 per-row sub-queries land. Composite DTO
+references types created in Tasks 2-6.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: G2 sub-query — `GetNewGamesQuery` (newGames row)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/GetNewGamesQuery.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/NewGameDto.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/GetNewGamesHandler.cs`
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGamesHandlerTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetNewGames;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class GetNewGamesHandlerTests
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetNewGamesHandler> _logger;
+    private readonly GetNewGamesHandler _handler;
+
+    public GetNewGamesHandlerTests()
+    {
+        _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
+        _logger = Substitute.For<ILogger<GetNewGamesHandler>>();
+        _handler = new GetNewGamesHandler(_dbContext, _logger);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsLatestGamesByCreatedAtDesc()
+    {
+        // Arrange
+        for (int i = 0; i < 15; i++)
+        {
+            _dbContext.SharedGames.Add(new SharedGameEntity
+            {
+                Id = Guid.NewGuid(),
+                Name = $"Game {i}",
+                CreatedAt = DateTime.UtcNow.AddDays(-i),
+                IsDeleted = false
+            });
+        }
+        await _dbContext.SaveChangesAsync();
+
+        var query = new GetNewGamesQuery(Limit: 10);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(10);
+        result.Select(r => r.CreatedAt).Should().BeInDescendingOrder();
+        result.First().Name.Should().Be("Game 0"); // most recent
+    }
+
+    [Fact]
+    public async Task Handle_ExcludesSoftDeletedGames()
+    {
+        _dbContext.SharedGames.Add(new SharedGameEntity { Id = Guid.NewGuid(), Name = "Visible", CreatedAt = DateTime.UtcNow, IsDeleted = false });
+        _dbContext.SharedGames.Add(new SharedGameEntity { Id = Guid.NewGuid(), Name = "Hidden", CreatedAt = DateTime.UtcNow, IsDeleted = true });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _handler.Handle(new GetNewGamesQuery(10), CancellationToken.None);
+
+        result.Should().HaveCount(1);
+        result.Single().Name.Should().Be("Visible");
+    }
+
+    [Fact]
+    public async Task Handle_EmptyCatalog_ReturnsEmptyList()
+    {
+        var result = await _handler.Handle(new GetNewGamesQuery(10), CancellationToken.None);
+        result.Should().BeEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify compile fail**
+
+```bash
+cd apps/api/src/Api && dotnet build
+```
+
+Expected: missing `GetNewGamesQuery`, `NewGameDto`, `GetNewGamesHandler` types.
+
+- [ ] **Step 3: Create Query**
+
+`GetNewGamesQuery.cs`:
+
+```csharp
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetNewGames;
+
+internal sealed record GetNewGamesQuery(int Limit) : IQuery<IReadOnlyList<NewGameDto>>;
+```
+
+- [ ] **Step 4: Create DTO**
+
+`NewGameDto.cs`:
+
+```csharp
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetNewGames;
+
+internal sealed record NewGameDto(
+    Guid Id,
+    string Name,
+    string? ImageUrl,
+    string? Publisher,
+    DateTime CreatedAt,
+    double? RatingAverage
+);
+```
+
+(If `SharedGameEntity` doesn't expose `ImageUrl`/`Publisher`/`RatingAverage`, omit those fields from the DTO. Inspect the entity in Task 0 step 3 output.)
+
+- [ ] **Step 5: Create Handler**
+
+`GetNewGamesHandler.cs`:
+
+```csharp
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetNewGames;
+
+internal sealed class GetNewGamesHandler : IQueryHandler<GetNewGamesQuery, IReadOnlyList<NewGameDto>>
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetNewGamesHandler> _logger;
+
+    public GetNewGamesHandler(MeepleAiDbContext dbContext, ILogger<GetNewGamesHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<IReadOnlyList<NewGameDto>> Handle(GetNewGamesQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        var limit = Math.Clamp(query.Limit, 1, 20);
+
+        return await _dbContext.SharedGames.AsNoTracking()
+            .Where(g => !g.IsDeleted)
+            .OrderByDescending(g => g.CreatedAt)
+            .Take(limit)
+            .Select(g => new NewGameDto(
+                g.Id,
+                g.Name,
+                g.ImageUrl,           // adjust if property doesn't exist
+                g.Publisher,          // adjust if property doesn't exist
+                g.CreatedAt,
+                g.RatingAverage       // adjust if property doesn't exist
+            ))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+}
+```
+
+(If any of `ImageUrl`/`Publisher`/`RatingAverage` is not on `SharedGameEntity`, replace with `null` literal in the DTO constructor and remove from DTO record signature in Step 4.)
+
+- [ ] **Step 6: Run tests, expect pass**
+
+```bash
+cd apps/api/src/Api
+dotnet test --filter "FullyQualifiedName~GetNewGamesHandler" --logger "console;verbosity=normal"
+```
+
+Expected: 3/3 tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/ apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGamesHandlerTests.cs
+git commit -m "feat(discover): #728 GetNewGamesQuery handler
+
+Returns latest non-deleted shared games ordered by createdAt desc,
+clamped to [1, 20]. First sub-query of 5 for the /discover composite.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: G2 sub-query — `GetTopAgentsQuery` (topAgents row)
+
+**Approach decided in Task 0 Step 4.** This task assumes Approach A (AgentSessionEntity proxy). If Approach B (skip in MVP) was chosen, simplify Step 5 to `return Array.Empty<TopAgentDto>()` and skip tests asserting ranking.
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetTopAgents/GetTopAgentsQuery.cs`
+- Create: `…/GetTopAgents/TopAgentDto.cs`
+- Create: `…/GetTopAgents/GetTopAgentsHandler.cs`
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetTopAgentsHandlerTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+[Fact]
+public async Task Handle_ApproachA_RanksByDistinctUserCount()
+{
+    // Arrange: create 3 agents (referenced by AgentId guid). Seed AgentSession rows:
+    //   agentA: 5 distinct users → installCount=5
+    //   agentB: 2 distinct users (1 user has 3 sessions) → installCount=2
+    //   agentC: 0 sessions → installCount=0
+    // Act: query Limit=10
+    // Assert:
+    //   - 3 items returned
+    //   - ordered by installCount desc → agentA, agentB, agentC
+
+    // Concrete seed (adapt field names to Task 0 findings):
+    var agentA = Guid.NewGuid();
+    var agentB = Guid.NewGuid();
+    var agentC = Guid.NewGuid();
+
+    for (int i = 0; i < 5; i++)
+        _dbContext.AgentSessions.Add(new AgentSessionEntity { Id = Guid.NewGuid(), AgentId = agentA, UserId = Guid.NewGuid() /* fill required fields */ });
+
+    var sharedUserB = Guid.NewGuid();
+    _dbContext.AgentSessions.Add(new AgentSessionEntity { Id = Guid.NewGuid(), AgentId = agentB, UserId = sharedUserB });
+    _dbContext.AgentSessions.Add(new AgentSessionEntity { Id = Guid.NewGuid(), AgentId = agentB, UserId = sharedUserB });   // same user
+    _dbContext.AgentSessions.Add(new AgentSessionEntity { Id = Guid.NewGuid(), AgentId = agentB, UserId = Guid.NewGuid() }); // different user
+
+    // agentC has no sessions — must still appear if reachable (depends on impl); for MVP, agents with zero distinct-users may be excluded
+    await _dbContext.SaveChangesAsync();
+
+    var result = await _handler.Handle(new GetTopAgentsQuery(10), CancellationToken.None);
+
+    result.Should().BeInDescendingOrder(r => r.InstallCount);
+    result.First().Id.Should().Be(agentA);
+    result.First().InstallCount.Should().Be(5);
+}
+
+[Fact]
+public async Task Handle_EmptyState_ReturnsEmptyList()
+{
+    var result = await _handler.Handle(new GetTopAgentsQuery(10), CancellationToken.None);
+    result.Should().BeEmpty();
+}
+```
+
+(Adapt `AgentSessionEntity` field names per Task 0 findings. Required fields like `GameId`, `CreatedAt`, etc., must be filled to satisfy EF non-null constraints — copy from a passing seed in another KB test like `GetGameDocumentsHandlerTests` or `RemoveDocumentFromKbCommandHandlerTests`.)
+
+- [ ] **Step 2: Build to verify compile failure**
+
+- [ ] **Step 3: Create Query**
+
+```csharp
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetTopAgents;
+
+internal sealed record GetTopAgentsQuery(int Limit) : IQuery<IReadOnlyList<TopAgentDto>>;
+```
+
+- [ ] **Step 4: Create DTO**
+
+```csharp
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetTopAgents;
+
+internal sealed record TopAgentDto(
+    Guid Id,
+    string Name,
+    string GameName,
+    string AgentType,
+    int InstallCount,
+    DateTime CreatedAt
+);
+```
+
+(`Name`, `GameName`, `AgentType` source: derive from `AgentSessionEntity` if those properties exist on the entity, OR set to `string.Empty` / sensible defaults in MVP. Final mapping decided in Step 5 implementation based on Task 0 inspection.)
+
+- [ ] **Step 5: Create Handler (Approach A)**
+
+```csharp
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetTopAgents;
+
+internal sealed class GetTopAgentsHandler : IQueryHandler<GetTopAgentsQuery, IReadOnlyList<TopAgentDto>>
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetTopAgentsHandler> _logger;
+
+    public GetTopAgentsHandler(MeepleAiDbContext dbContext, ILogger<GetTopAgentsHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<IReadOnlyList<TopAgentDto>> Handle(GetTopAgentsQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        var limit = Math.Clamp(query.Limit, 1, 20);
+
+        // Approach A: aggregate AgentSessionEntity by AgentId; install count = distinct UserId
+        var aggregated = await _dbContext.AgentSessions.AsNoTracking()
+            .GroupBy(s => s.AgentId)
+            .Select(g => new
+            {
+                AgentId = g.Key,
+                InstallCount = g.Select(s => s.UserId).Distinct().Count(),
+                LatestActivity = g.Max(s => s.CreatedAt)
+            })
+            .OrderByDescending(x => x.InstallCount)
+            .ThenByDescending(x => x.LatestActivity)
+            .Take(limit)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // MVP: name/gameName/agentType are not in AgentSessionEntity. Return empty strings or
+        // a follow-up issue can join the proper agent definition entity once it lands.
+        return aggregated.Select(x => new TopAgentDto(
+            Id: x.AgentId,
+            Name: string.Empty,        // TODO: join agent definition when entity exists (out of scope this PR)
+            GameName: string.Empty,
+            AgentType: string.Empty,
+            InstallCount: x.InstallCount,
+            CreatedAt: x.LatestActivity
+        )).ToList();
+    }
+}
+```
+
+(If Task 0 Step 4 chose Approach B, the entire body becomes `return Task.FromResult<IReadOnlyList<TopAgentDto>>(Array.Empty<TopAgentDto>());` and a comment explaining why.)
+
+- [ ] **Step 6: Run tests**
+
+```bash
+dotnet test --filter "FullyQualifiedName~GetTopAgentsHandler" --logger "console;verbosity=normal"
+```
+
+Expected: tests pass with the chosen approach.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetTopAgents/ apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetTopAgentsHandlerTests.cs
+git commit -m "feat(discover): #728 GetTopAgentsQuery handler (Approach A — AgentSession proxy)
+
+Aggregates AgentSessionEntity by AgentId, install count =
+distinct UserId. Name/GameName fields empty in MVP (no proper
+agent definition entity yet). Follow-up issue to join when
+agent BC introduces install model.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: G3 sub-query — `GetRecommendedToolkitsQuery`
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/GetRecommendedToolkitsQuery.cs`
+- Create: `…/GetRecommendedToolkits/RecommendedToolkitDto.cs`
+- Create: `…/GetRecommendedToolkits/GetRecommendedToolkitsHandler.cs`
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkitsHandlerTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+[Fact]
+public async Task Handle_FiltersOutPrivateToolkits()
+{
+    // Seed 3 public + 2 private toolkits
+    for (int i = 0; i < 3; i++)
+        _dbContext.GameToolkits.Add(new GameToolkitEntity { Id = Guid.NewGuid(), Name = $"Public {i}", IsPublic = true, InstallCount = i, CreatedAt = DateTime.UtcNow });
+    for (int i = 0; i < 2; i++)
+        _dbContext.GameToolkits.Add(new GameToolkitEntity { Id = Guid.NewGuid(), Name = $"Private {i}", IsPublic = false, InstallCount = 100, CreatedAt = DateTime.UtcNow });
+    await _dbContext.SaveChangesAsync();
+
+    var result = await _handler.Handle(new GetRecommendedToolkitsQuery(10), CancellationToken.None);
+
+    result.Should().HaveCount(3);
+    result.Select(r => r.Name).Should().NotContain(n => n.StartsWith("Private"));
+}
+
+[Fact]
+public async Task Handle_RanksByInstallCountDesc()
+{
+    _dbContext.GameToolkits.Add(new GameToolkitEntity { Id = Guid.NewGuid(), Name = "Low", IsPublic = true, InstallCount = 1, CreatedAt = DateTime.UtcNow });
+    _dbContext.GameToolkits.Add(new GameToolkitEntity { Id = Guid.NewGuid(), Name = "High", IsPublic = true, InstallCount = 100, CreatedAt = DateTime.UtcNow });
+    await _dbContext.SaveChangesAsync();
+
+    var result = await _handler.Handle(new GetRecommendedToolkitsQuery(10), CancellationToken.None);
+
+    result.Should().HaveCount(2);
+    result.First().Name.Should().Be("High");
+}
+```
+
+(Inspect `GameToolkitEntity` first; `IsPublic` and `InstallCount` may have different names. Adapt.)
+
+- [ ] **Step 2: Build for compile fail**
+
+- [ ] **Step 3: Create Query**
+
+```csharp
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
+
+internal sealed record GetRecommendedToolkitsQuery(int Limit) : IQuery<IReadOnlyList<RecommendedToolkitDto>>;
+```
+
+- [ ] **Step 4: Create DTO**
+
+```csharp
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
+
+internal sealed record RecommendedToolkitDto(
+    Guid Id,
+    string Name,
+    string GameName,
+    string Version,
+    int InstallCount,
+    DateTime CreatedAt
+);
+```
+
+(Adapt fields based on `GameToolkitEntity` shape inspection.)
+
+- [ ] **Step 5: Create Handler**
+
+```csharp
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
+
+internal sealed class GetRecommendedToolkitsHandler : IQueryHandler<GetRecommendedToolkitsQuery, IReadOnlyList<RecommendedToolkitDto>>
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetRecommendedToolkitsHandler> _logger;
+
+    public GetRecommendedToolkitsHandler(MeepleAiDbContext dbContext, ILogger<GetRecommendedToolkitsHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<IReadOnlyList<RecommendedToolkitDto>> Handle(GetRecommendedToolkitsQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        var limit = Math.Clamp(query.Limit, 1, 20);
+
+        return await _dbContext.GameToolkits.AsNoTracking()
+            .Where(t => t.IsPublic)
+            .OrderByDescending(t => t.InstallCount)
+            .ThenByDescending(t => t.CreatedAt)
+            .Take(limit)
+            .Select(t => new RecommendedToolkitDto(
+                t.Id,
+                t.Name,
+                t.GameName ?? string.Empty,    // adapt to actual property name
+                t.Version ?? string.Empty,
+                t.InstallCount,
+                t.CreatedAt
+            ))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+}
+```
+
+- [ ] **Step 6: Run tests, commit**
+
+```bash
+dotnet test --filter "FullyQualifiedName~GetRecommendedToolkitsHandler" --logger "console;verbosity=normal"
+```
+
+Then:
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/ apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkitsHandlerTests.cs
+git commit -m "feat(discover): #728 GetRecommendedToolkitsQuery handler
+
+Public toolkits ordered by install_count desc, ties by created_at.
+MVP simple ranking (no time decay or KB-context awareness).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: G3 sub-query — `GetRecentKbDocumentsQuery`
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocuments/GetRecentKbDocumentsQuery.cs`
+- Create: `…/GetRecentKbDocuments/RecentKbDocDto.cs`
+- Create: `…/GetRecentKbDocuments/GetRecentKbDocumentsHandler.cs`
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocumentsHandlerTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+[Fact]
+public async Task Handle_FiltersOutNonReadyDocs()
+{
+    var ready1 = SeedPdfDoc(state: "Ready", isPublic: true);
+    var embedding = SeedPdfDoc(state: "Embedding", isPublic: true);
+    var failed = SeedPdfDoc(state: "Failed", isPublic: true);
+    await _dbContext.SaveChangesAsync();
+
+    var result = await _handler.Handle(new GetRecentKbDocumentsQuery(10), CancellationToken.None);
+
+    result.Should().HaveCount(1);
+    result.Single().Id.Should().Be(ready1.Id);
+}
+
+[Fact]
+public async Task Handle_FiltersOutPrivateDocs()
+{
+    SeedPdfDoc(state: "Ready", isPublic: false);
+    var publicDoc = SeedPdfDoc(state: "Ready", isPublic: true);
+    await _dbContext.SaveChangesAsync();
+
+    var result = await _handler.Handle(new GetRecentKbDocumentsQuery(10), CancellationToken.None);
+
+    result.Should().HaveCount(1);
+    result.Single().Id.Should().Be(publicDoc.Id);
+}
+
+[Fact]
+public async Task Handle_OrdersByIndexedAtDesc()
+{
+    var olderDoc = SeedPdfDoc(state: "Ready", isPublic: true, indexedAt: DateTime.UtcNow.AddDays(-5));
+    var newerDoc = SeedPdfDoc(state: "Ready", isPublic: true, indexedAt: DateTime.UtcNow.AddDays(-1));
+    await _dbContext.SaveChangesAsync();
+
+    var result = await _handler.Handle(new GetRecentKbDocumentsQuery(10), CancellationToken.None);
+
+    result.First().Id.Should().Be(newerDoc.Id);
+}
+
+private PdfDocumentEntity SeedPdfDoc(string state, bool isPublic, DateTime? indexedAt = null)
+{
+    var doc = new PdfDocumentEntity
+    {
+        Id = Guid.NewGuid(),
+        FileName = "test.pdf",
+        ProcessingState = state,
+        IsPublic = isPublic,
+        UploadedAt = DateTime.UtcNow,
+        Language = "en",
+        DocumentCategory = "Rulebook",
+        UploadedByUserId = Guid.NewGuid(),
+        FilePath = "/tmp/test.pdf"
+    };
+    _dbContext.PdfDocuments.Add(doc);
+
+    var vd = new VectorDocumentEntity
+    {
+        Id = Guid.NewGuid(),
+        PdfDocumentId = doc.Id,
+        GameId = Guid.NewGuid(),
+        ChunkCount = 10,
+        IndexedAt = indexedAt ?? DateTime.UtcNow,
+        IndexingStatus = "Completed",
+        Language = "en"
+    };
+    _dbContext.VectorDocuments.Add(vd);
+    return doc;
+}
+```
+
+- [ ] **Step 2: Build to verify compile fail**
+
+- [ ] **Step 3: Create Query**
+
+```csharp
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetRecentKbDocuments;
+
+internal sealed record GetRecentKbDocumentsQuery(int Limit) : IQuery<IReadOnlyList<RecentKbDocDto>>;
+```
+
+- [ ] **Step 4: Create DTO**
+
+```csharp
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetRecentKbDocuments;
+
+internal sealed record RecentKbDocDto(
+    Guid Id,
+    string Title,
+    string GameName,
+    string DocumentCategory,
+    DateTime IndexedAt,
+    string Language
+);
+```
+
+- [ ] **Step 5: Create Handler**
+
+```csharp
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetRecentKbDocuments;
+
+internal sealed class GetRecentKbDocumentsHandler : IQueryHandler<GetRecentKbDocumentsQuery, IReadOnlyList<RecentKbDocDto>>
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetRecentKbDocumentsHandler> _logger;
+
+    public GetRecentKbDocumentsHandler(MeepleAiDbContext dbContext, ILogger<GetRecentKbDocumentsHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<IReadOnlyList<RecentKbDocDto>> Handle(GetRecentKbDocumentsQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        var limit = Math.Clamp(query.Limit, 1, 20);
+
+        return await (
+            from pdf in _dbContext.PdfDocuments.AsNoTracking()
+            join vd in _dbContext.VectorDocuments.AsNoTracking()
+                on pdf.Id equals vd.PdfDocumentId
+            join game in _dbContext.SharedGames.AsNoTracking()
+                on vd.GameId equals game.Id into gameJoin
+            from game in gameJoin.DefaultIfEmpty()
+            where pdf.IsPublic && pdf.ProcessingState == "Ready" && vd.IndexedAt != null
+            orderby vd.IndexedAt descending
+            select new RecentKbDocDto(
+                pdf.Id,
+                pdf.FileName,
+                game != null ? game.Name : string.Empty,
+                pdf.DocumentCategory,
+                vd.IndexedAt!.Value,
+                pdf.Language
+            )
+        ).Take(limit).ToListAsync(cancellationToken).ConfigureAwait(false);
+    }
+}
+```
+
+- [ ] **Step 6: Run tests, commit**
+
+```bash
+dotnet test --filter "FullyQualifiedName~GetRecentKbDocumentsHandler" --logger "console;verbosity=normal"
+```
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocuments/ apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocumentsHandlerTests.cs
+git commit -m "feat(discover): #728 GetRecentKbDocumentsQuery handler
+
+Public + Ready KB docs ordered by indexedAt desc, joined to
+SharedGame for gameName field. Cross-game aggregation.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: G4 sub-query — `GetTopContributorsQuery`
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/GetTopContributors/GetTopContributorsQuery.cs`
+- Create: `…/GetTopContributors/TopContributorDto.cs`
+- Create: `…/GetTopContributors/GetTopContributorsHandler.cs`
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Queries/GetTopContributorsHandlerTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+[Fact]
+public async Task Handle_RanksByEqualWeightSum()
+{
+    var u1 = Guid.NewGuid();
+    var u2 = Guid.NewGuid();
+    var u3 = Guid.NewGuid();
+    SeedUser(u1, "Alice");
+    SeedUser(u2, "Bob");
+    SeedUser(u3, "Charlie");
+    // u1: 10 faqs, 2 kb, 1 agent → 13
+    // u2: 0 faqs, 8 kb, 5 agent → 13
+    // u3: 5 faqs, 3 kb, 4 agent → 12
+    SeedFaqs(u1, 10);
+    SeedKbUploads(u1, 2);
+    SeedAgentSessions(u1, 1);
+    SeedKbUploads(u2, 8);
+    SeedAgentSessions(u2, 5);
+    SeedFaqs(u3, 5);
+    SeedKbUploads(u3, 3);
+    SeedAgentSessions(u3, 4);
+    await _dbContext.SaveChangesAsync();
+
+    var result = await _handler.Handle(new GetTopContributorsQuery(10), CancellationToken.None);
+
+    result.Should().HaveCount(3);
+    result.First().ContributionCount.Should().Be(13);
+    result.Last().ContributionCount.Should().Be(12);
+}
+
+[Fact]
+public async Task Handle_ExcludesZeroContribution()
+{
+    var u4 = Guid.NewGuid();
+    SeedUser(u4, "NoContributions");
+    await _dbContext.SaveChangesAsync();
+
+    var result = await _handler.Handle(new GetTopContributorsQuery(10), CancellationToken.None);
+
+    result.Should().BeEmpty();
+}
+
+[Fact]
+public async Task Handle_ExcludesSoftDeletedUsers()
+{
+    var u5 = Guid.NewGuid();
+    SeedUser(u5, "Deleted", isDeleted: true);
+    SeedFaqs(u5, 50);
+    await _dbContext.SaveChangesAsync();
+
+    var result = await _handler.Handle(new GetTopContributorsQuery(10), CancellationToken.None);
+
+    result.Should().BeEmpty();
+}
+
+private void SeedUser(Guid id, string name, bool isDeleted = false)
+{
+    _dbContext.Users.Add(new UserEntity
+    {
+        Id = id,
+        DisplayName = name,
+        Email = $"{name}@test.com",
+        IsDeleted = isDeleted
+        // fill required fields per UserEntity shape
+    });
+}
+
+private void SeedFaqs(Guid authorId, int count)
+{
+    for (int i = 0; i < count; i++)
+        _dbContext.GameFaqs.Add(new GameFaqEntity { Id = Guid.NewGuid(), AuthorId = authorId, /* fill */ });
+}
+
+private void SeedKbUploads(Guid uploaderId, int count)
+{
+    for (int i = 0; i < count; i++)
+        _dbContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            UploadedByUserId = uploaderId,
+            IsPublic = true,
+            FileName = "x.pdf",
+            ProcessingState = "Ready",
+            UploadedAt = DateTime.UtcNow,
+            Language = "en",
+            DocumentCategory = "Rulebook",
+            FilePath = "/tmp/x.pdf"
+        });
+}
+
+private void SeedAgentSessions(Guid userId, int distinctAgents)
+{
+    for (int i = 0; i < distinctAgents; i++)
+        _dbContext.AgentSessions.Add(new AgentSessionEntity { Id = Guid.NewGuid(), AgentId = Guid.NewGuid(), UserId = userId /* fill required fields */ });
+}
+```
+
+(`GameFaqEntity.AuthorId`, `UserEntity.IsDeleted`, `AgentSessionEntity.UserId` field names per Task 0 findings.)
+
+- [ ] **Step 2: Build to verify compile fail**
+
+- [ ] **Step 3: Create Query**
+
+```csharp
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Authentication.Application.Queries.GetTopContributors;
+
+internal sealed record GetTopContributorsQuery(int Limit) : IQuery<IReadOnlyList<TopContributorDto>>;
+```
+
+- [ ] **Step 4: Create DTO**
+
+```csharp
+namespace Api.BoundedContexts.Authentication.Application.Queries.GetTopContributors;
+
+internal sealed record TopContributorDto(
+    Guid UserId,
+    string DisplayName,
+    string? AvatarUrl,
+    int ContributionCount,
+    int FaqCount,
+    int KbUploadCount,
+    int AgentCount
+);
+```
+
+- [ ] **Step 5: Create Handler**
+
+```csharp
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.Authentication.Application.Queries.GetTopContributors;
+
+internal sealed class GetTopContributorsHandler : IQueryHandler<GetTopContributorsQuery, IReadOnlyList<TopContributorDto>>
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetTopContributorsHandler> _logger;
+
+    public GetTopContributorsHandler(MeepleAiDbContext dbContext, ILogger<GetTopContributorsHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<IReadOnlyList<TopContributorDto>> Handle(GetTopContributorsQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        var limit = Math.Clamp(query.Limit, 1, 20);
+
+        var aggregated = await (
+            from u in _dbContext.Users.AsNoTracking()
+            where !u.IsDeleted
+            let faqCount = _dbContext.GameFaqs.Count(f => f.AuthorId == u.Id)
+            let kbCount = _dbContext.PdfDocuments.Count(p => p.UploadedByUserId == u.Id && p.IsPublic)
+            let agentCount = _dbContext.AgentSessions.Where(a => a.UserId == u.Id).Select(a => a.AgentId).Distinct().Count()
+            let total = faqCount + kbCount + agentCount
+            where total > 0
+            orderby total descending, u.DisplayName
+            select new TopContributorDto(
+                u.Id,
+                u.DisplayName,
+                u.AvatarUrl,
+                total,
+                faqCount,
+                kbCount,
+                agentCount
+            )
+        ).Take(limit).ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return aggregated;
+    }
+}
+```
+
+- [ ] **Step 6: Run tests, commit**
+
+```bash
+dotnet test --filter "FullyQualifiedName~GetTopContributorsHandler" --logger "console;verbosity=normal"
+```
+
+If tests pass, build the entire solution to verify Task 1's composite DTO compiles now:
+
+```bash
+cd apps/api/src/Api && dotnet build --nologo 2>&1 | tail -3
+```
+
+Expected: clean build (0 errors).
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/GetTopContributors/ apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Queries/GetTopContributorsHandlerTests.cs
+git commit -m "feat(discover): #728 GetTopContributorsQuery handler
+
+Equal-weight sum ranking (faqs + kb_uploads + distinct agent sessions
+per user). Excludes zero-contribution and soft-deleted users.
+Composite DTO now compiles (Task 1 unblocked).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: G1 composer — Task.WhenAll + per-row try-catch + Prometheus counter
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/Discover/Application/Queries/GetDiscoverData/GetDiscoverDataHandler.cs`
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/Discover/Application/Queries/GetDiscoverDataHandlerTests.cs`
+
+- [ ] **Step 1: Write failing tests for composer behavior**
+
+```csharp
+using Api.BoundedContexts.Authentication.Application.Queries.GetTopContributors;
+using Api.BoundedContexts.Discover.Application.Queries.GetDiscoverData;
+using Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetRecentKbDocuments;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetTopAgents;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetNewGames;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Discover.Application.Queries;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Discover")]
+public sealed class GetDiscoverDataHandlerTests
+{
+    private readonly IMediator _mediator;
+    private readonly ILogger<GetDiscoverDataHandler> _logger;
+    private readonly GetDiscoverDataHandler _handler;
+
+    public GetDiscoverDataHandlerTests()
+    {
+        _mediator = Substitute.For<IMediator>();
+        _logger = Substitute.For<ILogger<GetDiscoverDataHandler>>();
+        _handler = new GetDiscoverDataHandler(_mediator, _logger);
+    }
+
+    [Fact]
+    public async Task Handle_AllSubQueriesSucceed_ReturnsFullPayload()
+    {
+        // Arrange
+        var newGames = new[] { new NewGameDto(Guid.NewGuid(), "G1", null, null, DateTime.UtcNow, null) };
+        var topAgents = new[] { new TopAgentDto(Guid.NewGuid(), "", "", "", 5, DateTime.UtcNow) };
+        var toolkits = new[] { new RecommendedToolkitDto(Guid.NewGuid(), "TK", "Game", "1.0", 3, DateTime.UtcNow) };
+        var recentKb = new[] { new RecentKbDocDto(Guid.NewGuid(), "Doc", "Game", "Rulebook", DateTime.UtcNow, "en") };
+        var contributors = new[] { new TopContributorDto(Guid.NewGuid(), "Marco", null, 13, 10, 2, 1) };
+
+        _mediator.Send(Arg.Any<GetNewGamesQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<NewGameDto>>(newGames));
+        _mediator.Send(Arg.Any<GetTopAgentsQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<TopAgentDto>>(topAgents));
+        _mediator.Send(Arg.Any<GetRecommendedToolkitsQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<RecommendedToolkitDto>>(toolkits));
+        _mediator.Send(Arg.Any<GetRecentKbDocumentsQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<RecentKbDocDto>>(recentKb));
+        _mediator.Send(Arg.Any<GetTopContributorsQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<TopContributorDto>>(contributors));
+
+        // Act
+        var result = await _handler.Handle(new GetDiscoverDataQuery(10), CancellationToken.None);
+
+        // Assert
+        result.NewGames.Should().HaveCount(1);
+        result.TopAgents.Should().HaveCount(1);
+        result.RecommendedToolkits.Should().HaveCount(1);
+        result.RecentKb.Should().HaveCount(1);
+        result.TopContributors.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Handle_OneSubQueryFails_PartialSuccessReturnsEmptyForFailedRow()
+    {
+        // Arrange — topAgents throws; others succeed
+        _mediator.Send(Arg.Any<GetNewGamesQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<NewGameDto>>(Array.Empty<NewGameDto>()));
+        _mediator.Send(Arg.Any<GetTopAgentsQuery>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IReadOnlyList<TopAgentDto>>>(_ => throw new InvalidOperationException("simulated DB error"));
+        _mediator.Send(Arg.Any<GetRecommendedToolkitsQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<RecommendedToolkitDto>>(Array.Empty<RecommendedToolkitDto>()));
+        _mediator.Send(Arg.Any<GetRecentKbDocumentsQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<RecentKbDocDto>>(Array.Empty<RecentKbDocDto>()));
+        _mediator.Send(Arg.Any<GetTopContributorsQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<TopContributorDto>>(Array.Empty<TopContributorDto>()));
+
+        // Act
+        var result = await _handler.Handle(new GetDiscoverDataQuery(10), CancellationToken.None);
+
+        // Assert
+        result.TopAgents.Should().BeEmpty(); // failed row returns empty
+        result.NewGames.Should().NotBeNull();
+        result.RecommendedToolkits.Should().NotBeNull();
+        result.RecentKb.Should().NotBeNull();
+        result.TopContributors.Should().NotBeNull();
+
+        // Verify error log emitted
+        _logger.Received().Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<InvalidOperationException>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task Handle_AllSubQueriesFail_ReturnsAllEmptyArrays_NoException()
+    {
+        // Arrange — all 5 throw
+        _mediator.Send(Arg.Any<GetNewGamesQuery>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IReadOnlyList<NewGameDto>>>(_ => throw new Exception("fail"));
+        _mediator.Send(Arg.Any<GetTopAgentsQuery>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IReadOnlyList<TopAgentDto>>>(_ => throw new Exception("fail"));
+        _mediator.Send(Arg.Any<GetRecommendedToolkitsQuery>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IReadOnlyList<RecommendedToolkitDto>>>(_ => throw new Exception("fail"));
+        _mediator.Send(Arg.Any<GetRecentKbDocumentsQuery>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IReadOnlyList<RecentKbDocDto>>>(_ => throw new Exception("fail"));
+        _mediator.Send(Arg.Any<GetTopContributorsQuery>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IReadOnlyList<TopContributorDto>>>(_ => throw new Exception("fail"));
+
+        // Act
+        var result = await _handler.Handle(new GetDiscoverDataQuery(10), CancellationToken.None);
+
+        // Assert — all 5 empty, NO exception bubbles
+        result.NewGames.Should().BeEmpty();
+        result.TopAgents.Should().BeEmpty();
+        result.RecommendedToolkits.Should().BeEmpty();
+        result.RecentKb.Should().BeEmpty();
+        result.TopContributors.Should().BeEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify compile fail (handler signature changed)**
+
+- [ ] **Step 3: Replace skeleton handler with full implementation**
+
+`GetDiscoverDataHandler.cs`:
+
+```csharp
+using Api.BoundedContexts.Authentication.Application.Queries.GetTopContributors;
+using Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetRecentKbDocuments;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetTopAgents;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetNewGames;
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+
+namespace Api.BoundedContexts.Discover.Application.Queries.GetDiscoverData;
+
+internal sealed class GetDiscoverDataHandler : IQueryHandler<GetDiscoverDataQuery, DiscoverDto>
+{
+    private readonly IMediator _mediator;
+    private readonly ILogger<GetDiscoverDataHandler> _logger;
+
+    public GetDiscoverDataHandler(IMediator mediator, ILogger<GetDiscoverDataHandler> logger)
+    {
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<DiscoverDto> Handle(GetDiscoverDataQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var newGamesTask = SafeRun("newGames", () => _mediator.Send(new GetNewGamesQuery(query.Limit), cancellationToken), Array.Empty<NewGameDto>());
+        var topAgentsTask = SafeRun("topAgents", () => _mediator.Send(new GetTopAgentsQuery(query.Limit), cancellationToken), Array.Empty<TopAgentDto>());
+        var toolkitsTask = SafeRun("recommendedToolkits", () => _mediator.Send(new GetRecommendedToolkitsQuery(query.Limit), cancellationToken), Array.Empty<RecommendedToolkitDto>());
+        var recentKbTask = SafeRun("recentKb", () => _mediator.Send(new GetRecentKbDocumentsQuery(query.Limit), cancellationToken), Array.Empty<RecentKbDocDto>());
+        var contributorsTask = SafeRun("topContributors", () => _mediator.Send(new GetTopContributorsQuery(query.Limit), cancellationToken), Array.Empty<TopContributorDto>());
+
+        await Task.WhenAll(newGamesTask, topAgentsTask, toolkitsTask, recentKbTask, contributorsTask).ConfigureAwait(false);
+
+        return new DiscoverDto(
+            NewGames: await newGamesTask.ConfigureAwait(false),
+            TopAgents: await topAgentsTask.ConfigureAwait(false),
+            RecommendedToolkits: await toolkitsTask.ConfigureAwait(false),
+            RecentKb: await recentKbTask.ConfigureAwait(false),
+            TopContributors: await contributorsTask.ConfigureAwait(false)
+        );
+    }
+
+    private async Task<IReadOnlyList<T>> SafeRun<T>(string rowName, Func<Task<IReadOnlyList<T>>> factory, IReadOnlyList<T> fallback)
+    {
+        try
+        {
+            return await factory().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Discover row {RowName} failed", rowName);
+            // TODO: Prometheus counter discover_row_failure_total{row=rowName}.Inc() — wire after metrics infra confirmed
+            return fallback;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run unit tests**
+
+```bash
+cd apps/api/src/Api
+dotnet test --filter "FullyQualifiedName~GetDiscoverDataHandler" --logger "console;verbosity=normal"
+```
+
+Expected: 3/3 tests pass.
+
+- [ ] **Step 5: Run all sub-query tests + composer to ensure no regression**
+
+```bash
+dotnet test --filter "FullyQualifiedName~GetNewGamesHandler|FullyQualifiedName~GetTopAgentsHandler|FullyQualifiedName~GetRecommendedToolkitsHandler|FullyQualifiedName~GetRecentKbDocumentsHandler|FullyQualifiedName~GetTopContributorsHandler|FullyQualifiedName~GetDiscoverDataHandler" --logger "console;verbosity=minimal"
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Discover/Application/Queries/GetDiscoverData/GetDiscoverDataHandler.cs apps/api/tests/Api.Tests/BoundedContexts/Discover/Application/Queries/GetDiscoverDataHandlerTests.cs
+git commit -m "feat(discover): #728 G1 composer with Task.WhenAll + per-row try-catch
+
+Replaces skeleton with full implementation: 5 sub-queries dispatched
+in parallel via SafeRun helper that catches exceptions and returns
+fallback empty array. Structured logging on row failure.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Routing wiring + OpenAPI
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs` (add new map method)
+
+(If `KnowledgeBaseEndpoints.cs` is already large, create a new partial-class file `apps/api/src/Api/Routing/DiscoverEndpoints.cs` mirroring the existing `KnowledgeBaseEndpoints.cs` structure — same `internal static class` pattern.)
+
+- [ ] **Step 1: Add `using` directives**
+
+Append to existing `using` block at top of `KnowledgeBaseEndpoints.cs`:
+
+```csharp
+using Api.BoundedContexts.Discover.Application.Queries.GetDiscoverData;
+```
+
+- [ ] **Step 2: Add `MapDiscoverEndpoints` method**
+
+Add inside `KnowledgeBaseEndpoints` static class:
+
+```csharp
+private static void MapDiscoverEndpoints(RouteGroupBuilder group)
+{
+    // Issue #728: composite discovery dashboard
+    group.MapGet("/discover", HandleGetDiscover)
+        .WithName("GetDiscover")
+        .RequireSession()
+        .WithTags("Discover")
+        .WithSummary("Get composite /discover dashboard data (5 cross-BC rows)")
+        .WithDescription("Returns newGames, topAgents, recommendedToolkits, recentKb, topContributors arrays. Partial-success: a failed sub-query returns empty array (logged); endpoint never returns 500 due to single-row failure.")
+        .Produces<DiscoverDto>()
+        .Produces(StatusCodes.Status400BadRequest)
+        .Produces(StatusCodes.Status401Unauthorized);
+}
+
+private static async Task<IResult> HandleGetDiscover(
+    int? limit,
+    HttpContext httpContext,
+    IMediator mediator,
+    CancellationToken cancellationToken)
+{
+    var limitValue = limit ?? 10;
+
+    if (limitValue < 1 || limitValue > 20)
+    {
+        return Results.BadRequest(new { error = "limit must be between 1 and 20" });
+    }
+
+    var dto = await mediator.Send(new GetDiscoverDataQuery(limitValue), cancellationToken);
+    return Results.Ok(dto);
+}
+```
+
+- [ ] **Step 3: Register the new mapping in `MapKnowledgeBaseEndpoints`**
+
+Add to the chain:
+
+```csharp
+MapDiscoverEndpoints(group);
+```
+
+(Append after existing `MapKbDocumentEndpoints(group);` line.)
+
+- [ ] **Step 4: Build to verify**
+
+```bash
+cd apps/api/src/Api && dotnet build --nologo 2>&1 | tail -3
+```
+
+Expected: clean build.
+
+- [ ] **Step 5: Add integration test**
+
+Create `apps/api/tests/Api.Tests/Integration/DiscoverEndpointIntegrationTests.cs`:
+
+```csharp
+using System.Net;
+using System.Net.Http.Json;
+using Api.BoundedContexts.Discover.Application.Queries.GetDiscoverData;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration;
+
+[Collection("Integration-GroupB")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "Discover")]
+public sealed class DiscoverEndpointIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    public DiscoverEndpointIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"discover_endpoint_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+        }
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    [Fact]
+    public async Task GetDiscover_WhenNotAuthenticated_Returns401()
+    {
+        var response = await _client.GetAsync("/api/v1/discover");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetDiscover_LimitOutOfRange_Returns400()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Get, "/api/v1/discover?limit=50", sessionToken);
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task GetDiscover_HappyPath_ReturnsAll5Arrays()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Get, "/api/v1/discover?limit=10", sessionToken);
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<DiscoverDto>();
+        dto.Should().NotBeNull();
+        // All 5 arrays present (may be empty in fresh DB but not null)
+        dto!.NewGames.Should().NotBeNull();
+        dto.TopAgents.Should().NotBeNull();
+        dto.RecommendedToolkits.Should().NotBeNull();
+        dto.RecentKb.Should().NotBeNull();
+        dto.TopContributors.Should().NotBeNull();
+    }
+}
+```
+
+- [ ] **Step 6: Run integration tests**
+
+```bash
+dotnet test --filter "FullyQualifiedName~DiscoverEndpointIntegrationTests" --logger "console;verbosity=normal"
+```
+
+Expected: 3/3 pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs apps/api/tests/Api.Tests/Integration/DiscoverEndpointIntegrationTests.cs
+git commit -m "feat(discover): #728 GET /api/v1/discover endpoint wired
+
+RequireSession + limit validation [1, 20] + OpenAPI annotations.
+Integration test covers 401 unauth, 400 limit out-of-range, 200 happy-path.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Frontend Zod schemas + client method
+
+**Files:**
+- Create: `apps/web/src/lib/api/schemas/discover.schemas.ts`
+- Create: `apps/web/src/lib/api/clients/discoverClient.ts`
+- Modify: `apps/web/src/lib/api/schemas/index.ts`
+- Modify: `apps/web/src/lib/api/clients/index.ts`
+
+- [ ] **Step 1: Create Zod schemas**
+
+`apps/web/src/lib/api/schemas/discover.schemas.ts`:
+
+```typescript
+import { z } from 'zod';
+
+export const newGameSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  imageUrl: z.string().url().nullable().optional(),
+  publisher: z.string().nullable().optional(),
+  createdAt: z.string().datetime({ offset: true }),
+  ratingAverage: z.number().nullable().optional(),
+});
+export type NewGame = z.infer<typeof newGameSchema>;
+
+export const topAgentSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  gameName: z.string(),
+  agentType: z.string(),
+  installCount: z.number().int().nonnegative(),
+  createdAt: z.string().datetime({ offset: true }),
+});
+export type TopAgent = z.infer<typeof topAgentSchema>;
+
+export const recommendedToolkitSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  gameName: z.string(),
+  version: z.string(),
+  installCount: z.number().int().nonnegative(),
+  createdAt: z.string().datetime({ offset: true }),
+});
+export type RecommendedToolkit = z.infer<typeof recommendedToolkitSchema>;
+
+export const recentKbDocSchema = z.object({
+  id: z.string().uuid(),
+  title: z.string(),
+  gameName: z.string(),
+  documentCategory: z.string(),
+  indexedAt: z.string().datetime({ offset: true }),
+  language: z.string(),
+});
+export type RecentKbDoc = z.infer<typeof recentKbDocSchema>;
+
+export const topContributorSchema = z.object({
+  userId: z.string().uuid(),
+  displayName: z.string(),
+  avatarUrl: z.string().url().nullable().optional(),
+  contributionCount: z.number().int().nonnegative(),
+  faqCount: z.number().int().nonnegative(),
+  kbUploadCount: z.number().int().nonnegative(),
+  agentCount: z.number().int().nonnegative(),
+});
+export type TopContributor = z.infer<typeof topContributorSchema>;
+
+export const discoverSchema = z.object({
+  newGames: z.array(newGameSchema),
+  topAgents: z.array(topAgentSchema),
+  recommendedToolkits: z.array(recommendedToolkitSchema),
+  recentKb: z.array(recentKbDocSchema),
+  topContributors: z.array(topContributorSchema),
+});
+export type Discover = z.infer<typeof discoverSchema>;
+```
+
+- [ ] **Step 2: Re-export from schemas/index.ts**
+
+Append to `apps/web/src/lib/api/schemas/index.ts`:
+
+```typescript
+export * from './discover.schemas';
+```
+
+- [ ] **Step 3: Create discoverClient.ts**
+
+`apps/web/src/lib/api/clients/discoverClient.ts`:
+
+```typescript
+import { httpClient } from '@/lib/api/http-client';
+import { discoverSchema, type Discover } from '@/lib/api/schemas/discover.schemas';
+
+export const discoverClient = {
+  /**
+   * Fetch the composite /discover dashboard payload.
+   * @param limit Items per row (1-20, default 10).
+   */
+  async getDiscover(limit: number = 10): Promise<Discover | null> {
+    return httpClient.get(`/api/v1/discover?limit=${limit}`, discoverSchema);
+  },
+};
+```
+
+(Adapt the `httpClient.get` signature if the actual project pattern differs. Check `knowledgeBaseClient.ts` from issue #730 for canonical pattern: it passes the schema for validation.)
+
+- [ ] **Step 4: Re-export from clients/index.ts**
+
+Append:
+
+```typescript
+export * from './discoverClient';
+```
+
+- [ ] **Step 5: Run frontend typecheck**
+
+```bash
+cd apps/web && pnpm typecheck
+```
+
+Expected: zero errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/lib/api/schemas/discover.schemas.ts apps/web/src/lib/api/schemas/index.ts apps/web/src/lib/api/clients/discoverClient.ts apps/web/src/lib/api/clients/index.ts
+git commit -m "feat(discover): #728 frontend Zod schemas + discoverClient
+
+6 Zod schemas (5 row + composite) mirroring backend DTOs.
+discoverClient.getDiscover(limit) method validates response.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Frontend React Query hook
+
+**Files:**
+- Create: `apps/web/src/hooks/queries/useDiscover.ts`
+- Modify: `apps/web/src/hooks/queries/index.ts`
+
+- [ ] **Step 1: Create useDiscover hook**
+
+`apps/web/src/hooks/queries/useDiscover.ts`:
+
+```typescript
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { discoverClient } from '@/lib/api/clients/discoverClient';
+import type { Discover } from '@/lib/api/schemas/discover.schemas';
+
+export const discoverKeys = {
+  all: ['discover'] as const,
+  byLimit: (limit: number) => ['discover', { limit }] as const,
+} as const;
+
+export function useDiscover(limit: number = 10, enabled: boolean = true) {
+  return useQuery<Discover | null, Error>({
+    queryKey: discoverKeys.byLimit(limit),
+    queryFn: () => discoverClient.getDiscover(limit),
+    enabled,
+    staleTime: 10 * 60_000,  // 10 min — discover rows have varying freshness, this is the conservative lower bound
+    gcTime: 30 * 60_000,
+  });
+}
+```
+
+- [ ] **Step 2: Re-export from hooks/queries/index.ts**
+
+Append:
+
+```typescript
+export * from './useDiscover';
+```
+
+- [ ] **Step 3: Run frontend typecheck + lint**
+
+```bash
+cd apps/web && pnpm typecheck && pnpm lint
+```
+
+Expected: zero errors, no new warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/hooks/queries/useDiscover.ts apps/web/src/hooks/queries/index.ts
+git commit -m "feat(discover): #728 useDiscover React Query hook
+
+10min staleTime (conservative lower bound across 5 row TTLs).
+Single composite hook returns full DiscoverDto for FE Wave 3 child #687.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: PR + close-out
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin feature/issue-728-discover-endpoints
+```
+
+- [ ] **Step 2: Open PR against `main-dev`**
+
+```bash
+gh pr create --base main-dev --title "feat(discover): #728 /discover composite endpoint (Wave 3 prereq)" --body "$(cat <<'EOF'
+## Summary
+
+- Single composite endpoint `GET /api/v1/discover?limit=N` returning 5 cross-BC rows
+- New `Discover` BC owns the composer; 5 sub-queries each in their native BC
+- Partial-success failure semantics (per-row try-catch + structured logging)
+- HybridCache wrapping deferred to follow-up (see spec §8 / Out of Scope)
+- Frontend Zod schemas + `discoverClient.getDiscover()` + `useDiscover` hook
+
+Spec: `docs/superpowers/specs/2026-05-06-discover-endpoints-design.md`
+Plan: `docs/superpowers/plans/2026-05-06-discover-endpoints-plan.md`
+
+## Out of scope (follow-up)
+- HybridCache per-row TTL wrapping
+- Cache invalidation via domain events
+- KB-context aware toolkit ranking (ML)
+- Time-decayed contributor ranking
+- Top agents proper install model (current uses AgentSession proxy)
+
+## Test plan
+- [x] Each handler unit-tested (5 sub-queries + composer)
+- [x] Integration test: 401 unauth, 400 limit out-of-range, 200 happy-path
+- [x] `dotnet build` clean
+- [x] `pnpm typecheck` clean
+- [ ] Manual: hit `/api/v1/discover` via Scalar — verify 5 arrays present
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Comment on issue #687 (FE Wave 3 child) to unblock**
+
+```bash
+gh issue comment 687 --body "Backend prerequisite #728 is in PR \$(gh pr view --json url -q .url). Hook available: \`useDiscover(limit)\` returning composite DTO. Schemas in \`apps/web/src/lib/api/schemas/discover.schemas.ts\`. Phase 0.5 contract for /discover can now be written."
+```
+
+- [ ] **Step 4: Close-out comment on #728**
+
+```bash
+gh issue comment 728 --body "PR opened: \$(gh pr view --json url -q .url)
+
+5 endpoints delivered as a composite:
+- GET /api/v1/discover (composite, 5 rows in single fetch)
+
+Sub-queries (each callable independently for future per-row pages):
+- GetNewGamesQuery (SharedGameCatalog BC)
+- GetTopAgentsQuery (KnowledgeBase BC, AgentSession proxy)
+- GetRecommendedToolkitsQuery (GameToolkit BC)
+- GetRecentKbDocumentsQuery (KnowledgeBase BC)
+- GetTopContributorsQuery (Authentication BC, equal-weight sum)
+
+No DB migration required (uses existing entities).
+
+Closes #728 once PR merges."
+```
+
+---
+
+## Spec coverage note: HybridCache (D7) deferred
+
+Spec D7 proposes per-row HybridCache wrapping (newGames 10min · topAgents 30min · recommendedToolkits 30min · recentKb 5min · topContributors 1h). This plan **defers caching to a follow-up commit/issue** — rationale identical to the deferred HybridCache decision in the #730 plan: caching is non-functional optimization, cold P95 targets are likely achievable with simple indexed SELECTs, and adding cache later is a clean wrap of `mediator.Send(...)` calls in the routing handler.
+
+If post-merge measurements show cold P95 > 400ms for the composite or > spec targets per row, file a follow-up issue and add `IHybridCacheService.GetOrCreateAsync` wraps in `GetDiscoverDataHandler.SafeRun(...)`.
+
+---
+
+## Summary of commits (11 total)
+
+1. `feat(discover): #728 BC scaffolding + composite DTO skeleton`
+2. `feat(discover): #728 GetNewGamesQuery handler`
+3. `feat(discover): #728 GetTopAgentsQuery handler (Approach A — AgentSession proxy)`
+4. `feat(discover): #728 GetRecommendedToolkitsQuery handler`
+5. `feat(discover): #728 GetRecentKbDocumentsQuery handler`
+6. `feat(discover): #728 GetTopContributorsQuery handler`
+7. `feat(discover): #728 G1 composer with Task.WhenAll + per-row try-catch`
+8. `feat(discover): #728 GET /api/v1/discover endpoint wired`
+9. `feat(discover): #728 frontend Zod schemas + discoverClient`
+10. `feat(discover): #728 useDiscover React Query hook`
+11. (PR open, no extra commit; Task 0 has no commit either since it's investigation only)

--- a/docs/superpowers/specs/2026-05-06-discover-endpoints-design.md
+++ b/docs/superpowers/specs/2026-05-06-discover-endpoints-design.md
@@ -1,0 +1,479 @@
+# `/discover` Composite Endpoint — Design
+
+**Issue**: #728 (Backend audit prerequisite for #687 `/discover` Wave 3 v2 migration)
+**Branch**: `feature/issue-728-discover-endpoints` (parent: `main-dev`)
+**Author**: brainstorming session 2026-05-06
+**Status**: Draft → User review pending
+
+---
+
+## 1. Context & Problem Statement
+
+V2 migration Wave 3 child #687 must implement the route `/discover` from mockup `sp4-discover.{html,jsx}`: a discovery dashboard with 7 cross-entity rows. Existing endpoints cover 2 rows (Trending, Eventi vicini); the audit (#681 Wave 3 Step 1) revealed **5 rows missing** backend support:
+
+| # | Row | Source data |
+|---|-----|------------|
+| 1 | **Giochi nuovi** (New games) | `SharedGameCatalog` ordered by `createdAt desc` |
+| 2 | **Agenti più installati** (Top agents) | Aggregate `count(installations) desc` |
+| 3 | **Toolkit consigliati** (Recommended toolkits) | Public toolkits ordered by `installCount desc` |
+| 4 | **KB recenti** (Recent KB docs) | Public KB docs ordered by `lastIngestedAt desc` cross-game |
+| 5 | **Top contributor** | Aggregate users by `count(faqs + kb_uploads + agents)` |
+
+This document specifies the design before implementation begins.
+
+### Key constraint: cross-BC composition
+
+The 5 rows source data from **5 distinct bounded contexts**: SharedGameCatalog, GameManagement (agents), GameToolkit, KnowledgeBase, Authentication (users). The composition layer must orchestrate these without polluting any existing BC with cross-cutting read concerns.
+
+This is the root reason behind decision **D4** (new `Discover` BC) below.
+
+---
+
+## 2. Architectural Decisions
+
+| # | Decision | Choice | Rationale |
+|---|----------|--------|-----------|
+| **D1** | Primary actor | **Mix** of newcomer + returning user + power user — uniform DTO, no per-user personalization in MVP | Discover serves all logged-in users uniformly; personalization is a separate feature scope |
+| **D2** | Ranking algorithm for "Toolkit consigliati" + "Top contributors" | **MVP semplice (count-based)**: `ORDER BY install_count DESC` for toolkits; `ORDER BY (count(faqs) + count(kb_uploads) + count(agents)) DESC` equal-weight sum for contributors | YAGNI — time-decay/weights add complexity without measurable MVP value; refinable when metrics show need |
+| **D3** | Failure semantics | **Partial success (lenient)**: each row try-catch in composer; failure → empty array for that row + structured `ILogger.LogError`. Composite endpoint never returns 500 due to one sub-query failure | Graceful degradation; UX resilient (1 broken row ≠ broken page); errors observable via logs + Prometheus |
+| **D4** | Bounded context location | **Nuovo `Discover` BC** in `BoundedContexts/Discover/`. Composer dispatches 5 MediatR sub-queries (one per BC); each sub-query lives in its native BC; Discover BC owns only orchestration + DTO assembly | Single Responsibility (read-only composition); sub-queries reusable for future per-row pages; isolation prevents BC pollution |
+| **D5** | Endpoint structure | **Single composite endpoint** `GET /api/v1/discover` returning all 5 rows in one response | FE single fetch (no waterfall); coherent with mockup `sp4-discover` page-render-once UX |
+| **D6** | Pagination | **Top-N fixed**: default `limit=10`, max `limit=20` via query param `?limit=N`. No cursor — discover is a browse page, not infinite scroll | Coherent with codebase (small dashboards); avoids over-engineering |
+| **D7** | Caching | **HybridCache per row** with row-specific TTL: newGames 10min · topAgents 30min · recommendedToolkits 30min · recentKb 5min · topContributors 1h. Tags: `discover:newGames`, `discover:topAgents`, etc., for granular invalidation | Different rows have different freshness characteristics (KB ingest is dynamic; contributors changes slowly); per-row cache amortizes load |
+| **D8** | Authorization | `RequireSession()` only; **no admin gating** of fields. All 5 rows are user-facing, no admin-only diagnostic fields like in #730 | Discover serves all users equally; nothing privileged to hide |
+| **D9** | Privacy filtering | All sub-queries filter `IsPublic=true` where applicable + `IsDeleted=false`. User PII (email, full name) never exposed; only `displayName` + optional `avatarUrl` | Standard data-minimization; respect existing privacy boundaries |
+| **D10** | Sub-query independence | Each sub-query is a self-contained `IQuery<T>` + Handler in its native BC, callable independently of the composer | Reusable for future per-row dedicated pages; testable in isolation; composer is thin orchestrator |
+
+---
+
+## 3. SMART User Goals
+
+### G1 — Composite endpoint orchestration with resilient partial success (cross-cutting)
+
+> **As** a logged-in user opening `/discover`,
+> **I want** to receive all 5 new rows in a single HTTP fetch, with graceful degradation if one sub-query fails (other 4 still render),
+> **so that** the discovery page is not blocked by isolated sub-system issues.
+
+**SMART criteria**:
+- **S**: `GET /api/v1/discover` returns `DiscoverDto { newGames, topAgents, recommendedToolkits, recentKb, topContributors }`. Composer dispatches 5 MediatR sub-queries in parallel via `Task.WhenAll`, each wrapped in try-catch; failure → empty array + `_logger.LogError(ex, "Discover row {RowName} failed", ...)`
+- **M**: P95 latency < 400ms (worst single sub-query dominates after parallelism); zero unhandled exceptions; per-row failure rate exposed via Prometheus `discover_row_failure_total{row=...}`
+- **A**: composer in `BoundedContexts/Discover/Application/Queries/GetDiscoverDataHandler.cs`; sub-queries in respective BCs
+- **R**: powers `/discover` mockup `sp4-discover` 5 missing rows; unblocks FE Wave 3 child #687
+- **T**: this PR (~2 days)
+
+**Gherkin scenarios**:
+
+```gherkin
+Feature: Discover composite endpoint resilient orchestration
+
+  Scenario: All 5 queries succeed - full payload
+    Given the user is authenticated as a regular user
+    And the platform has data in all 5 source BCs
+    When the user calls GET /api/v1/discover
+    Then the response is 200 OK in <400ms (P95)
+    And contains 5 non-null arrays: newGames, topAgents, recommendedToolkits, recentKb, topContributors
+    And each array has up to 10 items (default top-N)
+
+  Scenario: One sub-query fails - partial success
+    Given the user is authenticated
+    And the topAgents sub-query throws (simulated DB error)
+    When the user calls GET /api/v1/discover
+    Then the response is 200 OK (NOT 500)
+    And contains topAgents=[] (empty array, not omitted)
+    And the other 4 arrays are populated normally
+    And a structured log entry exists with level=Error, row=topAgents, exception details
+    And the Prometheus metric discover_row_failure_total{row="topAgents"} is incremented by 1
+
+  Scenario: Unauthenticated request
+    Given no session cookie
+    When the request hits GET /api/v1/discover
+    Then the response is 401 Unauthorized (RequireSession middleware)
+
+  Scenario: Custom limit query param
+    When the user calls GET /api/v1/discover?limit=5
+    Then each of the 5 arrays contains at most 5 items
+
+  Scenario: Limit out of range
+    When the user calls GET /api/v1/discover?limit=50
+    Then the response is 400 Bad Request "limit must be between 1 and 20"
+```
+
+---
+
+### G2 — Catalog rows: New games + Top agents
+
+> **As** a logged-in user looking for "what to play",
+> **I want** to see the latest games added to the community catalog AND the AI agents most adopted by the community,
+> **so that** I can explore catalog freshness AND discover popularity-validated agents.
+
+**SMART criteria**:
+- **S**:
+  - `GetNewGamesQuery(int Limit)` in `BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/` → `NewGameDto { id, name, imageUrl?, publisher?, createdAt, ratingAverage? }`. SQL: `ORDER BY created_at DESC LIMIT @limit` on `shared_games` (filter `IsDeleted=false`)
+  - `GetTopAgentsQuery(int Limit)` in `BoundedContexts/GameManagement/Application/Queries/GetTopAgents/` → `TopAgentDto { id, name, gameName, agentType, installCount, createdAt }`. SQL: `LEFT JOIN agent_installations` group-by + `ORDER BY install_count DESC, created_at DESC`
+- **M**: each sub-query P95 < 80ms (cold), <30ms (cached); newGames freshness ≤ 10min stale; topAgents freshness ≤ 30min stale
+- **A**: existing entities (`SharedGameEntity`; for topAgents — `AgentSessionEntity` as install-count proxy, see §5 verification table); HybridCache keys `discover:newGames:{limit}` and `discover:topAgents:{limit}` with tags `gameCatalog` and `agents` for invalidation
+- **R**: powers "Giochi nuovi" + "Agenti più installati" rows
+- **T**: this PR
+
+**Gherkin scenarios**:
+
+```gherkin
+Feature: New games + top agents discovery rows
+
+  Scenario: New games ordering
+    Given 30 shared games exist with createdAt spanning 90 days
+    When GetNewGamesQuery(Limit=10) executes
+    Then the returned array has exactly 10 items
+    And ordered by createdAt descending (newest first)
+    And NO soft-deleted games (IsDeleted=true) are included
+
+  Scenario: Top agents with zero installs handled gracefully
+    Given 5 agents exist, 3 with installations and 2 without
+    When GetTopAgentsQuery(Limit=10) executes
+    Then 5 items returned
+    And the 2 zero-install agents appear at the bottom (installCount=0, ordered by createdAt desc among ties)
+
+  Scenario: Empty catalog state
+    Given no shared games exist (fresh deployment)
+    When GetNewGamesQuery executes
+    Then returns empty array []
+    And does NOT throw
+
+  Scenario: Cache hit
+    Given GetNewGamesQuery(Limit=10) was called 3 minutes ago
+    When the same query fires
+    Then it hits HybridCache (no DB round trip; verifiable via _logger.LogDebug "cache hit")
+```
+
+---
+
+### G3 — Content rows: Recommended toolkits + Recent KB
+
+> **As** a logged-in user wanting to "learn more" about games of interest,
+> **I want** to see AI toolkit recommendations (ranked by install count) AND recently ingested KB documents cross-game,
+> **so that** I can find AI-generated content (toolkit) AND human-curated content (KB) that's fresh.
+
+**SMART criteria**:
+- **S**:
+  - `GetRecommendedToolkitsQuery(int Limit)` in `BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/` → `RecommendedToolkitDto { id, name, gameName, version, installCount, createdAt }`. Filter `IsPublic=true` only. SQL: `ORDER BY install_count DESC, created_at DESC` (MVP simple, see D2)
+  - `GetRecentKbDocumentsQuery(int Limit)` in `BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocuments/` → `RecentKbDocDto { id, title, gameName, documentCategory, indexedAt, language }`. Filter `IsPublic=true` + `processingState='Ready'`. SQL: `ORDER BY indexed_at DESC`
+- **M**: each P95 < 100ms (cold), <40ms (cached); recommendedToolkits freshness ≤ 30min, recentKb freshness ≤ 5min (KB more dynamic)
+- **A**: existing entities (`GameToolkitEntity`, `PdfDocumentEntity` + `VectorDocumentEntity`); HybridCache tags `toolkits` and `kbDocs`
+- **R**: powers "Toolkit consigliati" + "KB recenti" rows
+- **T**: this PR
+
+**Gherkin scenarios**:
+
+```gherkin
+Feature: Recommended toolkits + recent KB documents
+
+  Scenario: Recommended toolkits filter out private
+    Given 20 toolkits exist, 12 IsPublic=true, 8 IsPublic=false
+    When GetRecommendedToolkitsQuery(Limit=10) executes
+    Then returns up to 10 items, ALL with IsPublic=true
+    And NO IsPublic=false toolkit leaks in result
+
+  Scenario: Recent KB filters out non-Ready docs
+    Given 30 KB docs exist: 20 Ready, 5 Embedding, 5 Failed
+    When GetRecentKbDocumentsQuery(Limit=10) executes
+    Then returns up to 10 items, ALL with processingState=Ready
+    And ordered by indexedAt DESC
+
+  Scenario: Recent KB cross-game aggregation
+    Given KB docs span 5 different games (gameA: 5 docs, gameB: 3 docs, gameC: 2 docs, etc.)
+    When GetRecentKbDocumentsQuery(Limit=10) executes
+    Then returned docs may belong to any of the 5 games (no per-game grouping)
+    And ordered purely by indexedAt DESC
+    And gameName field is populated for each item (join PdfDocument → Game)
+```
+
+---
+
+### G4 — Community row: Top contributors
+
+> **As** a logged-in user (especially newcomer) wanting to identify "who are the community protagonists",
+> **I want** to see the top 10 platform contributors ranked by sum of contributions (FAQs, KB uploads, agents created),
+> **so that** I can identify community authorities and follow their work.
+
+**SMART criteria**:
+- **S**: `GetTopContributorsQuery(int Limit)` in `BoundedContexts/Authentication/Application/Queries/GetTopContributors/` → `TopContributorDto { userId, displayName, avatarUrl?, contributionCount, faqCount, kbUploadCount, agentCount }`. LINQ aggregation across 3 tables:
+  ```csharp
+  var query = from u in _dbContext.Users.AsNoTracking()
+              where !u.IsDeleted
+              let faqCount = _dbContext.GameFaqs.Count(f => f.AuthorId == u.Id)
+              let kbCount = _dbContext.PdfDocuments.Count(p => p.UploadedByUserId == u.Id && p.IsPublic)
+              let agentCount = _dbContext.AgentSessions.Where(a => a.CreatedBy == u.Id).Select(a => a.AgentId).Distinct().Count()
+              let total = faqCount + kbCount + agentCount
+              where total > 0  // exclude zero-contribution users
+              orderby total descending, u.DisplayName
+              select new TopContributorDto(u.Id, u.DisplayName, u.AvatarUrl, total, faqCount, kbCount, agentCount);
+  return await query.Take(limit).ToListAsync(cancellationToken);
+  ```
+- **M**: P95 < 200ms (cold), <60ms (cached); cache TTL 1h (top contributors change slowly); MVP equal-weight sum (D2)
+- **A**: existing entities (`UserEntity`, `GameFaqEntity`, `PdfDocumentEntity`, `AgentSessionEntity` proxy for `agentCount`); HybridCache tag `topContributors`. Final entity choices verified in Plan Task 0
+- **R**: powers "Top contributor" row — particularly valuable for newcomer onboarding
+- **T**: this PR
+
+**Gherkin scenarios**:
+
+```gherkin
+Feature: Top contributors community ranking
+
+  Scenario: Equal-weight sum ranking
+    Given 5 users with contributions:
+      | userId | faqs | kbUploads | agents | total |
+      | u1     | 10   | 2         | 1      | 13    |
+      | u2     | 0    | 8         | 5      | 13    |
+      | u3     | 5    | 3         | 4      | 12    |
+      | u4     | 1    | 0         | 0      | 1     |
+      | u5     | 0    | 0         | 0      | 0     |
+    When GetTopContributorsQuery(Limit=10) executes
+    Then 4 items returned (u5 excluded by total > 0 filter)
+    And first two items are u1 and u2 (tie at 13, internal ordering by displayName)
+    And u3 is third (12)
+    And u4 is fourth (1)
+
+  Scenario: Soft-deleted users excluded
+    Given user u6 has 50 contributions but IsDeleted=true
+    When GetTopContributorsQuery executes
+    Then u6 does NOT appear in result
+
+  Scenario: Privacy: avatarUrl null when user has no avatar
+    Given user u1 has displayName="Marco" but no avatarUrl set
+    When the query returns u1
+    Then u1.avatarUrl is null (not empty string, not omitted)
+    And no email/full name fields exposed
+
+  Scenario: Cache invalidation on new contribution
+    Given GetTopContributorsQuery cached 30 minutes ago
+    When a new FAQ is published by a user
+    Then the cache tag "topContributors" is invalidated (via domain event)
+    And next call hits DB fresh
+```
+
+---
+
+## 4. API Contract — Endpoint Specification
+
+### 4.1 `GET /api/v1/discover?limit=N`
+
+**Auth**: `RequireSession()` (any authenticated user)
+**Query params**:
+- `limit` (optional, default `10`, range `[1, 20]`)
+
+**Response 200** (`DiscoverDto`):
+
+```ts
+{
+  newGames: NewGameDto[],
+  topAgents: TopAgentDto[],
+  recommendedToolkits: RecommendedToolkitDto[],
+  recentKb: RecentKbDocDto[],
+  topContributors: TopContributorDto[]
+}
+
+NewGameDto = {
+  id: string (guid),
+  name: string,
+  imageUrl: string?,
+  publisher: string?,
+  createdAt: string (iso8601),
+  ratingAverage: number?
+}
+
+TopAgentDto = {
+  id: string (guid),
+  name: string,
+  gameName: string,
+  agentType: string,
+  installCount: number,
+  createdAt: string (iso8601)
+}
+
+RecommendedToolkitDto = {
+  id: string (guid),
+  name: string,
+  gameName: string,
+  version: string,
+  installCount: number,
+  createdAt: string (iso8601)
+}
+
+RecentKbDocDto = {
+  id: string (guid),
+  title: string,
+  gameName: string,
+  documentCategory: string,
+  indexedAt: string (iso8601),
+  language: string
+}
+
+TopContributorDto = {
+  userId: string (guid),
+  displayName: string,
+  avatarUrl: string?,
+  contributionCount: number,
+  faqCount: number,
+  kbUploadCount: number,
+  agentCount: number
+}
+```
+
+**Errors**:
+- `400 Bad Request` — `limit` out of range
+- `401 Unauthorized` — no session
+- (no `500` due to row failure — partial success per D3)
+
+---
+
+## 5. Data Model Changes
+
+**None required.** All 5 sub-queries use existing entities. **Verified entity inventory** (confirmed via repo grep):
+- `SharedGameEntity` (SharedGameCatalog BC) ✅
+- `GameToolkitEntity` (GameToolkit BC) ✅
+- `PdfDocumentEntity` + `VectorDocumentEntity` (KnowledgeBase BC + DocumentProcessing) ✅
+- `UserEntity` (Authentication BC) ✅
+- `GameFaqEntity` (SharedGameCatalog BC, not standalone `FaqEntity`) ✅
+- `AgentSessionEntity` (KnowledgeBase BC) — **proxy for "agent installs"** since no dedicated `AgentInstallation` entity exists; see assumption below
+
+### ⚠️ Pre-implementation verification (Plan Task 0)
+
+The following entity assumptions need verification before implementing the corresponding sub-query:
+
+| Sub-query | Cited entity | Reality | Mitigation |
+|-----------|--------------|---------|-----------|
+| `GetTopAgentsQuery` (G2) | `AgentEntity` + `AgentInstallationEntity` | **Neither exists** as standalone entity. `AgentSessionEntity` exists (chat sessions) | **Approach A**: aggregate `AgentSessionEntity` distinct `UserId × AgentId` count as install proxy. **Approach B**: skip this row in MVP, defer to follow-up issue once Agent BC introduces a proper definition + install model. Decision in Plan Task 0 after investigation. |
+| `GetTopContributorsQuery` (G4) | `FaqEntity` | **Renamed `GameFaqEntity`** (in SharedGameCatalog BC) | Rename references in handler. Aggregate by `AuthorId` field on `GameFaqEntity` |
+| `GetTopContributorsQuery` (G4) | `AgentEntity` for `agentCount` | Same as G2 | Use `AgentSessionEntity` distinct by `CreatedBy` user, OR skip the agent contribution count if no clean entity exists |
+
+This is a major scope advantage over #730 (which required a 4-column migration), but the agent-install model gap means **the topAgents row may need MVP scope adjustment** during Plan Task 0 (investigation step).
+
+---
+
+## 6. Implementation Strategy
+
+### 6.1 Sequencing (TDD-driven)
+
+1. **Discover BC scaffolding**
+   - Create `apps/api/src/Api/BoundedContexts/Discover/` directory tree (`Application/Queries/GetDiscoverData/`)
+   - Create `DiscoverDto.cs` (composite wrapper)
+   - Create `GetDiscoverDataQuery.cs` and skeleton `GetDiscoverDataHandler.cs` (returns empty DTO initially)
+
+2. **G2 sub-query: GetNewGamesQuery**
+   - `BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/`
+   - Tests + handler + DTO
+   - Wire in composer (replace empty array with `_mediator.Send(new GetNewGamesQuery(limit))`)
+
+3. **G2 sub-query: GetTopAgentsQuery**
+   - `BoundedContexts/GameManagement/Application/Queries/GetTopAgents/`
+   - LEFT JOIN with installations, group-by handling
+   - Tests + handler + DTO
+   - Wire in composer
+
+4. **G3 sub-query: GetRecommendedToolkitsQuery**
+   - `BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/`
+   - Tests + handler + DTO
+   - Wire in composer
+
+5. **G3 sub-query: GetRecentKbDocumentsQuery**
+   - `BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocuments/`
+   - Tests + handler + DTO (similar to existing `GetGameDocumentsQuery` pattern but cross-game)
+   - Wire in composer
+
+6. **G4 sub-query: GetTopContributorsQuery**
+   - `BoundedContexts/Authentication/Application/Queries/GetTopContributors/`
+   - LINQ aggregation across Users + Faqs + PdfDocuments + Agents
+   - Tests + handler + DTO
+   - Wire in composer
+
+7. **G1 composer with Task.WhenAll + try-catch + structured logging**
+   - Implement `GetDiscoverDataHandler.Handle` with parallel dispatch
+   - Add Prometheus counter `discover_row_failure_total`
+   - Unit test with NSubstitute mocks for IMediator (verify each row fail-tolerance)
+
+8. **HybridCache wrapping per row**
+   - Wrap each sub-query call in `IHybridCacheService.GetOrCreateAsync` with per-row TTL + tags
+   - Tag invalidation hooks (deferred — see Out of Scope)
+
+9. **Routing wiring**
+   - Add `MapDiscoverEndpoints` to `KnowledgeBaseEndpoints.cs` OR new `DiscoverEndpoints.cs` partial (decide based on file size)
+   - `RequireSession()`, OpenAPI/Scalar annotations
+
+10. **Frontend Zod schemas + hook**
+    - `apps/web/src/lib/api/schemas/discover.schemas.ts` (6 Zod schemas + composite)
+    - `apps/web/src/lib/api/clients/discoverClient.ts` (1 method `getDiscover`)
+    - `apps/web/src/hooks/queries/useDiscover.ts` (single hook returning composite DTO)
+
+### 6.2 Test strategy
+
+- **Unit tests**: each sub-query handler tested in isolation with `TestDbContextFactory.CreateInMemoryDbContext()` (the pattern established in #730)
+- **Composer test**: NSubstitute mock `IMediator`, simulate each sub-query independently (success/failure combinations)
+- **Integration test** (Testcontainers): single happy-path E2E hitting `/api/v1/discover` with seeded data across 5 BCs
+- Target coverage: 90%+ for new code
+
+### 6.3 Observability
+
+- Structured log per sub-query: `_logger.LogDebug("Discover row {RowName} loaded {Count} items in {Ms}ms", ...)`
+- Prometheus counter: `discover_row_failure_total{row="newGames|topAgents|...|topContributors"}`
+- HybridCache hit/miss metrics already exposed
+
+---
+
+## 7. Risks & Mitigations
+
+| # | Risk | Likelihood | Impact | Mitigation |
+|---|------|-----------|--------|------------|
+| R1 | `Task.WhenAll` parallel dispatch overloads DB on cold cache | Low | Medium | Each sub-query is a single LIMIT 20 query with index hits; max 5 parallel queries per request is well within DB pool capacity |
+| R2 | Top contributors LINQ generates expensive cross-table sub-queries | Medium | Medium | Cache 1h TTL + tag invalidation amortizes. If query > 200ms, refactor to materialized view (follow-up issue) |
+| R3 | DTO contract divergence with parallel migration wave terminal (FE child #687) | Medium | High | Publish Zod schemas early in the same PR; coordinate via PR comment |
+| R4 | Privacy leak: user PII (email, full name) accidentally in TopContributorDto | Low | High | DTO is `internal sealed record` with explicit fields (no entity passthrough); test asserts no email field exists |
+| R5 | Cache stampede on TTL expiry | Low | Medium | HybridCache library handles single-flight semantics by default |
+| R6 | Empty platform state (fresh deploy, no users/games) | Medium | Low | Each sub-query handles empty result gracefully → empty array, not exception |
+| R7 | Tag-based cache invalidation not wired (e.g., new FAQ doesn't invalidate topContributors) | High | Low | Acknowledged in DoD — invalidation is a follow-up. Until then, 1h TTL provides bounded staleness |
+
+---
+
+## 8. Out of Scope (follow-up issues)
+
+| Topic | Tracked as |
+|-------|------------|
+| Cache invalidation hooks (domain events → tag invalidation) | New issue: "Discover cache invalidation via domain events" |
+| KB-context aware toolkit ranking (per-user game context) | Future issue when ML/personalization rollout starts |
+| Time-decayed contributor ranking | Future issue if metrics show stagnant top-list |
+| Per-row dedicated pages (e.g., `/discover/new-games`) | Future Wave (sub-queries already callable independently — D10) |
+| WebSocket / SSE realtime push of discover data | YAGNI for browse use case |
+| Personalization based on user library / preferences | Distinct feature scope (separate epic) |
+| Materialized view for top contributors if query > 200ms | Reactive — only if R2 manifests |
+
+---
+
+## 9. Definition of Done
+
+- [ ] Nuovo `Discover` BC created with `GetDiscoverDataQuery` + DTO + Handler
+- [ ] 5 sub-queries implemented in their respective BCs (SharedGameCatalog, GameManagement, GameToolkit, KnowledgeBase, Authentication)
+- [ ] Unit tests for each sub-query handler (using `TestDbContextFactory.CreateInMemoryDbContext()`)
+- [ ] Composer unit test verifying partial-success semantics (NSubstitute mock IMediator)
+- [ ] Integration test (Testcontainers) covering happy-path 5-row response
+- [ ] HybridCache wrapping with per-row TTL + tags
+- [ ] Endpoint wired in `KnowledgeBaseEndpoints.cs` (or new `DiscoverEndpoints.cs` if file growth warrants split)
+- [ ] OpenAPI/Scalar annotations present (`Produces<DiscoverDto>()`, `WithSummary`, `WithDescription`)
+- [ ] Prometheus counter `discover_row_failure_total` registered
+- [ ] Frontend Zod schemas in `apps/web/src/lib/api/schemas/discover.schemas.ts`
+- [ ] Frontend `discoverClient.getDiscover()` method
+- [ ] Frontend `useDiscover` React Query hook
+- [ ] Coverage ≥ 90% on new code
+- [ ] PR opened against `main-dev` (parent branch)
+- [ ] Close-out comment on #687 with endpoint URL + sample response
+- [ ] Issue #728 closed
+
+---
+
+## 10. References
+
+- Issue #728 — backend audit
+- Issue #687 — Wave 3 child `/discover`
+- Issue #681 — Wave 3 umbrella
+- Migration spec — `docs/superpowers/specs/2026-04-26-v2-design-migration.md` §3.4 (Phase 0.5 contract pattern)
+- Mockup — `admin-mockups/design_files/sp4-discover.{html,jsx}`
+- Stub components — `apps/web/src/components/v2/discover/`
+- Pattern reference (similar issue) — `docs/superpowers/specs/2026-05-06-kb-chunk-endpoints-design.md` (issue #730)


### PR DESCRIPTION
## Summary

- Single composite endpoint `GET /api/v1/discover?limit=N` returning 5 cross-BC discovery rows
- New `Discover` BC owns the composer; 5 sub-queries each in their native BC
- Partial-success failure semantics (per-row try-catch + structured logging via `SafeRun<T>` helper)
- Frontend Zod schemas + `discoverClient.getDiscover()` + `useDiscover` hook

Spec: `docs/superpowers/specs/2026-05-06-discover-endpoints-design.md`
Plan: `docs/superpowers/plans/2026-05-06-discover-endpoints-plan.md`

## Endpoints

| Endpoint | Description |
|----------|-------------|
| `GET /api/v1/discover?limit=N` | Composite dashboard (5 rows in single fetch) |

Sub-queries (callable independently for future per-row pages):
- `GetNewGamesQuery` (SharedGameCatalog BC)
- `GetTopAgentsQuery` (KnowledgeBase BC, AgentSession proxy)
- `GetRecommendedToolkitsQuery` (GameToolkit BC)
- `GetRecentKbDocumentsQuery` (KnowledgeBase BC)
- `GetTopContributorsQuery` (Authentication BC, equal-weight sum)

## Scope adjustments from spec (entity reality verified)

- **Top contributors `faqCount` removed**: `GameFaqEntity` has no user FK; ranking simplified to `kbUploads + distinctAgentSessions`
- **Recommended toolkits `installCount`**: `GameToolkitEntity` has no install tracking; ranked by `createdAt DESC` (latest published) instead, `installCount=0` always in DTO
- **`GameToolkitEntity.IsPublic` → `IsPublished`**
- **`UserEntity.IsDeleted` → `IsSuspended`** filter
- **Top agents** uses `AgentSessionEntity` proxy (no proper agent install model exists)

## Test results

- 27/27 unit tests pass (5 sub-query handlers + composer)
- 3/3 integration tests pass (401 unauth, 400 limit out-of-range, 200 happy-path)
- `dotnet build` clean
- `pnpm typecheck` clean
- `pnpm lint` no new warnings

## Out of scope (follow-up)

- HybridCache per-row TTL wrapping (deferred — measure cold P95 first, see spec §8)
- Top contributors `faqCount` (requires `GameFaqEntity.AuthorId` migration)
- Recommended toolkits `installCount` (requires entity install tracking)
- Top agents proper definition entity join (currently empty Name/GameName/AgentType)
- KB-context aware toolkit ranking
- Time-decayed contributor ranking

🤖 Generated with [Claude Code](https://claude.com/claude-code)