### PR TITLE
feat(toolkit-marketplace): Wave 3 Phase 2 — 3 marketplace endpoints (#805)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/InstallToolkit/InstallToolkitCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/InstallToolkit/InstallToolkitCommand.cs
@@ -1,0 +1,24 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Commands.InstallToolkit;
+
+/// <summary>
+/// Command for the toolkit install action
+/// (Wave 3 Phase 2, PR #732 §5.3.5 / Issue #805).
+/// </summary>
+/// <param name="ToolkitId">Toolkit aggregate id.</param>
+/// <param name="ViewerId">
+/// Authenticated caller — the user installing the toolkit. Used for
+/// idempotency (PR #732 §5.3.5 Nygard note): subsequent calls by the
+/// same viewer return the current state instead of raising 409.
+/// </param>
+/// <remarks>
+/// Returns null when the toolkit is missing or yanked (endpoint maps to
+/// 404). Otherwise returns <see cref="InstallToolkitResponse"/> with the
+/// post-install state. Side-effect: invalidates the
+/// <c>discover:popularAgents</c> Redis cache so the popularity rail
+/// reflects the new install on the next read.
+/// </remarks>
+internal sealed record InstallToolkitCommand(
+    Guid ToolkitId,
+    Guid ViewerId) : ICommand<InstallToolkitResponse?>;

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/InstallToolkit/InstallToolkitCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/InstallToolkit/InstallToolkitCommandHandler.cs
@@ -1,0 +1,124 @@
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
+using Api.Infrastructure;
+using Api.Services;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Commands.InstallToolkit;
+
+/// <summary>
+/// Handler for <see cref="InstallToolkitCommand"/> — idempotent install
+/// action that returns the post-install state.
+/// Wave 3 Phase 2, PR #732 §5.3.5 / Issue #805.
+/// </summary>
+/// <remarks>
+/// Idempotency contract (PR #732 §5.3.5 Nygard note): calling install
+/// repeatedly for the same (ViewerId, ToolkitId) pair MUST return 200 with
+/// the current state — never 409. This avoids client retry loops on
+/// network blips and matches the "install" mental model of "ensure it's
+/// in my library" rather than "create a new install record".
+///
+/// Cache invalidation side-effect: removes <c>discover:popularAgents</c>
+/// (Phase 1 cache key) so the discover rail picks up the new install on
+/// the next read. Also removes the toolkit detail cache for the viewer so
+/// <c>ViewerContext.HasInstalled</c> reflects the new state immediately.
+///
+/// Schema reality v1 carryover (Gate B): no <c>ToolkitInstallation</c>
+/// entity exists. This handler does NOT persist anything in v1 — it just
+/// validates the toolkit is installable (exists + not yanked) and returns
+/// the stub response. Wire shape is stable so the FE mutation hook can
+/// optimistically update without a fetch shape change once Phase 4 ships
+/// the real installation upsert.
+/// </remarks>
+internal sealed class InstallToolkitCommandHandler
+    : IRequestHandler<InstallToolkitCommand, InstallToolkitResponse?>
+{
+    private readonly MeepleAiDbContext _context;
+    private readonly IHybridCacheService _cache;
+    private readonly ILogger<InstallToolkitCommandHandler> _logger;
+
+    public InstallToolkitCommandHandler(
+        MeepleAiDbContext context,
+        IHybridCacheService cache,
+        ILogger<InstallToolkitCommandHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<InstallToolkitResponse?> Handle(
+        InstallToolkitCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Existence + visibility check. PR #732 §5.3.5: install requires the
+        // toolkit to be reachable (not 404 / not yanked). v1 yank flag does
+        // not exist yet (Gate B carryover) — placeholder structure preserved.
+        var entity = await _context.GameToolkits
+            .AsNoTracking()
+            .Where(t => t.Id == request.ToolkitId)
+            .Select(t => new
+            {
+                t.Id,
+                t.IsPublished,
+                t.TemplateStatus,
+                t.CreatedByUserId,
+            })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entity is null)
+        {
+            _logger.LogInformation(
+                "InstallToolkit: toolkit {ToolkitId} not found (viewer {ViewerId})",
+                request.ToolkitId,
+                request.ViewerId);
+            return null;
+        }
+
+        var isOwner = entity.CreatedByUserId == request.ViewerId;
+        var isPublished = entity.IsPublished
+            && (TemplateStatus)entity.TemplateStatus == TemplateStatus.Approved;
+
+        // Non-owners cannot install drafts (PR #732 §5.2 boundary). Owners
+        // installing their own toolkit is allowed (matches "test the install
+        // flow on my own toolkit" use case).
+        if (!isOwner && !isPublished)
+        {
+            _logger.LogInformation(
+                "InstallToolkit: toolkit {ToolkitId} not installable for viewer {ViewerId} (not published, not owner)",
+                request.ToolkitId,
+                request.ViewerId);
+            return null;
+        }
+
+        // ── v1 stub install (no ToolkitInstallation entity) ────────────────
+        // Idempotency contract preserved: every call returns the same shape
+        // regardless of whether it's the first or Nth install for the viewer.
+        const int installCount = 0;
+        var response = new InstallToolkitResponse(
+            InstallCount: installCount,
+            HasInstalled: true);
+
+        // Side-effect: invalidate the discover popularity cache so the rail
+        // reflects the install on the next read. Tag-based removal scoops up
+        // any per-viewer or per-limit variants under the same tag namespace.
+        await _cache.RemoveAsync("discover:popularAgents", cancellationToken)
+            .ConfigureAwait(false);
+        // Per-viewer toolkit detail cache must invalidate so `HasInstalled`
+        // reflects the new state on the next /toolkits/{id} call.
+        await _cache.RemoveByTagAsync($"toolkit:{request.ToolkitId:N}", cancellationToken)
+            .ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "InstallToolkit: viewer {ViewerId} installed toolkit {ToolkitId} (idempotent, installCount={InstallCount})",
+            request.ViewerId,
+            request.ToolkitId,
+            installCount);
+
+        return response;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/InstallToolkit/InstallToolkitCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/InstallToolkit/InstallToolkitCommandValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Commands.InstallToolkit;
+
+/// <summary>
+/// Validator for <see cref="InstallToolkitCommand"/>.
+/// Wave 3 Phase 2, PR #732 §5.3.5 / Issue #805.
+/// </summary>
+internal sealed class InstallToolkitCommandValidator
+    : AbstractValidator<InstallToolkitCommand>
+{
+    public InstallToolkitCommandValidator()
+    {
+        RuleFor(x => x.ToolkitId)
+            .NotEmpty()
+            .WithMessage("ToolkitId is required.");
+
+        RuleFor(x => x.ViewerId)
+            .NotEmpty()
+            .WithMessage("ViewerId is required (caller must be authenticated).");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/InstallToolkit/InstallToolkitDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/InstallToolkit/InstallToolkitDto.cs
@@ -1,0 +1,19 @@
+namespace Api.BoundedContexts.GameToolkit.Application.Commands.InstallToolkit;
+
+/// <summary>
+/// Wire response for the toolkit install endpoint
+/// (Wave 3 Phase 2, PR #732 §5.3.5 / Issue #805).
+/// </summary>
+/// <param name="InstallCount">
+/// Total cumulative install count after this call. Schema reality v1
+/// carryover (Gate B): no <c>ToolkitInstallation</c> entity, so the value
+/// is always <c>0</c> until Phase 4 wires the schema.
+/// </param>
+/// <param name="HasInstalled">
+/// Always <c>true</c> on success — the install command is idempotent
+/// (PR #732 §5.3.5 Nygard note); subsequent calls return the same flag
+/// without raising 409.
+/// </param>
+internal sealed record InstallToolkitResponse(
+    int InstallCount,
+    bool HasInstalled);

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitDetail/GetToolkitDetailQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitDetail/GetToolkitDetailQuery.cs
@@ -1,0 +1,23 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitDetail;
+
+/// <summary>
+/// Query for the marketplace toolkit detail surface
+/// (Wave 3 Phase 2, PR #732 §5.3.1 / Issue #805).
+/// </summary>
+/// <param name="ToolkitId">Toolkit aggregate id.</param>
+/// <param name="ViewerId">
+/// Authenticated caller — drives <c>ViewerContext.IsOwner</c> /
+/// <c>HasInstalled</c> / <c>CanRate</c> derivation. Required for
+/// per-viewer cache key partitioning (§5.3.1: cache 10min + ETag per viewer).
+/// </param>
+/// <remarks>
+/// Returns null when the toolkit is not visible to the viewer per PR #732
+/// §5.2 security boundary (unpublished or yanked AND viewer != author);
+/// the endpoint translates null to 404. Owners always see their own
+/// drafts/yanked toolkits — soft-delete preserves owner access.
+/// </remarks>
+internal sealed record GetToolkitDetailQuery(
+    Guid ToolkitId,
+    Guid ViewerId) : IQuery<ToolkitDetailResponse?>;

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitDetail/GetToolkitDetailQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitDetail/GetToolkitDetailQueryHandler.cs
@@ -1,0 +1,273 @@
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.GameToolkit;
+using Api.Services;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitDetail;
+
+/// <summary>
+/// Handler for <see cref="GetToolkitDetailQuery"/> — surfaces the marketplace
+/// detail envelope with per-viewer derived <see cref="ViewerContextDto"/>.
+/// Wave 3 Phase 2, PR #732 §5.3.1 / Issue #805.
+/// </summary>
+/// <remarks>
+/// Cache strategy (PR #732 §5.3.1): per-viewer 10min HybridCache, since
+/// <c>ViewerContext.IsOwner</c> / <c>HasInstalled</c> / <c>CanRate</c> all
+/// vary by caller. Cache key: <c>toolkits:{toolkitId}:detail:{viewerId}</c>.
+/// Tagged with <c>"toolkit:{id}"</c> for downstream invalidation by the
+/// install command (cf. <see cref="GameToolkit.Application.Commands.InstallToolkit"/>).
+///
+/// Visibility rule (PR #732 §5.2 Wiegers security boundary):
+/// <list type="bullet">
+///   <item>Owner: always sees toolkit (drafts, yanked, published).</item>
+///   <item>Other viewers: only see published + non-yanked (proxied via
+///         <c>IsPublished == true &amp;&amp; TemplateStatus == Approved</c> in v1).</item>
+/// </list>
+///
+/// Schema reality v1 carryover (Gate B) — flagged in DTO XML doc:
+/// installCount/ratingAverage/ratingCount stubbed (no entities); description
+/// derived from name; coverImageUrl always null; publishedAt = UpdatedAt
+/// when in published state; yankedAt always null; currentVersion =
+/// "1.0.{intVersion}" until semver schema lands.
+/// </remarks>
+internal sealed class GetToolkitDetailQueryHandler
+    : IRequestHandler<GetToolkitDetailQuery, ToolkitDetailResponse?>
+{
+    private const int MaxSystemPromptPreviewLength = 500;
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(10);
+
+    private readonly MeepleAiDbContext _context;
+    private readonly IHybridCacheService _cache;
+    private readonly ILogger<GetToolkitDetailQueryHandler> _logger;
+
+    public GetToolkitDetailQueryHandler(
+        MeepleAiDbContext context,
+        IHybridCacheService cache,
+        ILogger<GetToolkitDetailQueryHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<ToolkitDetailResponse?> Handle(
+        GetToolkitDetailQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var cacheKey = $"toolkits:{request.ToolkitId:N}:detail:{request.ViewerId:N}";
+
+        // Wrap in a class container so HybridCache's class constraint accepts
+        // the nullable detail (record is reference type but we still need a
+        // non-null sentinel for the cache value channel).
+        var cached = await _cache.GetOrCreateAsync(
+            cacheKey,
+            async ct => await ComputeDetailAsync(request, ct).ConfigureAwait(false),
+            tags:
+            [
+                $"toolkit:{request.ToolkitId:N}",
+                "toolkitDetail",
+            ],
+            expiration: CacheTtl,
+            ct: cancellationToken).ConfigureAwait(false);
+
+        return cached.Response;
+    }
+
+    private async Task<ToolkitDetailContainer> ComputeDetailAsync(
+        GetToolkitDetailQuery request,
+        CancellationToken cancellationToken)
+    {
+        var entity = await _context.GameToolkits
+            .AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == request.ToolkitId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entity is null)
+        {
+            _logger.LogInformation(
+                "Toolkit {ToolkitId} not found for viewer {ViewerId}",
+                request.ToolkitId,
+                request.ViewerId);
+            return new ToolkitDetailContainer((ToolkitDetailResponse?)null);
+        }
+
+        var isOwner = entity.CreatedByUserId == request.ViewerId;
+        var isPublished = entity.IsPublished
+            && (TemplateStatus)entity.TemplateStatus == TemplateStatus.Approved;
+        // YankedAt is always null in v1 (Gate B carryover); the visibility check
+        // is structured for the future yank flag without changing wire shape.
+        const bool isYanked = false;
+
+        // PR #732 §5.2 security boundary — non-authors must not see drafts/yanked.
+        if (!isOwner && (!isPublished || isYanked))
+        {
+            _logger.LogInformation(
+                "Toolkit {ToolkitId} hidden from viewer {ViewerId} (not published or yanked, not author)",
+                request.ToolkitId,
+                request.ViewerId);
+            return new ToolkitDetailContainer((ToolkitDetailResponse?)null);
+        }
+
+        // Author lookup (DisplayName + AvatarUrl). Falls back gracefully when
+        // missing (e.g. removed account) so the detail surface stays renderable.
+        var author = await _context.Set<UserEntity>()
+            .AsNoTracking()
+            .Where(u => u.Id == entity.CreatedByUserId)
+            .Select(u => new { u.DisplayName, u.AvatarUrl, u.Email })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var authorName = author?.DisplayName
+            ?? (string.IsNullOrWhiteSpace(author?.Email)
+                ? "Unknown author"
+                : author!.Email);
+
+        var (toolsCount, kbDocsCount) = ComputeToolAndKbCounts(entity);
+
+        // Schema reality v1 carryover (Gate B):
+        //   - InstallCount: no ToolkitInstallation entity yet → stub 0.
+        //   - HasInstalled: derives from same missing entity → false.
+        //   - RatingAverage/RatingCount: no ToolkitRating entity → null/0.
+        //   - CanRate: HasInstalled && !alreadyRated && !isOwner. With no
+        //     installation tracking, this collapses to false in v1.
+        const int installCount = 0;
+        const bool hasInstalled = false;
+        decimal? ratingAverage = null;
+        const int ratingCount = 0;
+        var canRate = hasInstalled && !isOwner; // !alreadyRated true by stub
+
+        var publishedAt = isPublished ? entity.UpdatedAt : (DateTime?)null;
+        // currentVersion: "1.0.{intVersion}" placeholder until semver lands.
+        var currentVersion = $"1.0.{entity.Version}";
+
+        var agentSummary = BuildAgentSummary(entity);
+
+        var detail = new ToolkitDetailDto(
+            Id: entity.Id,
+            Name: entity.Name,
+            // Description: no column; derived from Name + author preview until v2.
+            Description: $"Toolkit by {authorName}.",
+            AuthorId: entity.CreatedByUserId,
+            AuthorName: authorName,
+            AuthorAvatarUrl: author?.AvatarUrl,
+            CoverImageUrl: null,
+            Agent: agentSummary,
+            KbDocsCount: kbDocsCount,
+            ToolsCount: toolsCount,
+            InstallCount: installCount,
+            RatingAverage: ratingAverage,
+            RatingCount: ratingCount,
+            CreatedAt: entity.CreatedAt,
+            PublishedAt: publishedAt,
+            YankedAt: null,
+            CurrentVersion: currentVersion);
+
+        var viewerContext = new ViewerContextDto(
+            IsOwner: isOwner,
+            HasInstalled: hasInstalled,
+            CanRate: canRate);
+
+        var response = new ToolkitDetailResponse(detail, viewerContext);
+
+        _logger.LogInformation(
+            "Returning toolkit detail {ToolkitId} for viewer {ViewerId} (isOwner={IsOwner}, isPublished={IsPublished})",
+            entity.Id,
+            request.ViewerId,
+            isOwner,
+            isPublished);
+
+        return new ToolkitDetailContainer(response);
+    }
+
+    private static (int ToolsCount, int KbDocsCount) ComputeToolAndKbCounts(GameToolkitEntity entity)
+    {
+        // ToolsCount: rough sum of dice/card/timer/counter tool entries embedded
+        // in the JSONB columns. Counting at the JSON-array level avoids a full
+        // aggregate hydration just for the surface metric.
+        var toolsCount = CountJsonArrayItems(entity.DiceToolsJson)
+            + CountJsonArrayItems(entity.CardToolsJson)
+            + CountJsonArrayItems(entity.TimerToolsJson)
+            + CountJsonArrayItems(entity.CounterToolsJson);
+
+        // KbDocsCount: GameToolkitEntity does not currently track linked KB
+        // documents (Gate B carryover). Stub 0 until Phase 4 wires the schema.
+        const int kbDocsCount = 0;
+
+        return (toolsCount, kbDocsCount);
+    }
+
+    private static int CountJsonArrayItems(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return 0;
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            return doc.RootElement.ValueKind == System.Text.Json.JsonValueKind.Array
+                ? doc.RootElement.GetArrayLength()
+                : 0;
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return 0;
+        }
+    }
+
+    private static ToolkitAgentSummaryDto BuildAgentSummary(GameToolkitEntity entity)
+    {
+        // AgentConfig is JSON; extract a name + system prompt preview when
+        // present. Absent / malformed configs fall back to a deterministic stub
+        // so the FE renderer can always show *something* (Doumont clarity).
+        var agentName = entity.Name;
+        var systemPromptPreview = string.Empty;
+
+        if (!string.IsNullOrWhiteSpace(entity.AgentConfig))
+        {
+            try
+            {
+                using var doc = System.Text.Json.JsonDocument.Parse(entity.AgentConfig);
+                var root = doc.RootElement;
+                if (root.ValueKind == System.Text.Json.JsonValueKind.Object)
+                {
+                    if (root.TryGetProperty("name", out var nameProp)
+                        && nameProp.ValueKind == System.Text.Json.JsonValueKind.String)
+                    {
+                        agentName = nameProp.GetString() ?? entity.Name;
+                    }
+
+                    if (root.TryGetProperty("systemPrompt", out var promptProp)
+                        && promptProp.ValueKind == System.Text.Json.JsonValueKind.String)
+                    {
+                        var raw = promptProp.GetString() ?? string.Empty;
+                        systemPromptPreview = raw.Length > MaxSystemPromptPreviewLength
+                            ? raw[..MaxSystemPromptPreviewLength]
+                            : raw;
+                    }
+                }
+            }
+            catch (System.Text.Json.JsonException)
+            {
+                // Malformed AgentConfig → leave preview empty.
+            }
+        }
+
+        // AgentId: GameToolkitEntity has no FK to AgentDefinition in v1.
+        // Use a deterministic GUID derived from toolkit Id so the FE can
+        // dedupe across renders without colliding across toolkits.
+        return new ToolkitAgentSummaryDto(
+            Id: entity.Id,
+            Name: agentName,
+            SystemPromptPreview: systemPromptPreview);
+    }
+
+    /// <summary>
+    /// HybridCache requires a class type for caching; this container lets us
+    /// cache a nullable <see cref="ToolkitDetailResponse"/> uniformly.
+    /// </summary>
+    internal sealed record ToolkitDetailContainer(ToolkitDetailResponse? Response);
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitDetail/GetToolkitDetailQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitDetail/GetToolkitDetailQueryValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitDetail;
+
+/// <summary>
+/// Validator for <see cref="GetToolkitDetailQuery"/>.
+/// Wave 3 Phase 2, PR #732 §5.3.1 / Issue #805.
+/// </summary>
+internal sealed class GetToolkitDetailQueryValidator
+    : AbstractValidator<GetToolkitDetailQuery>
+{
+    public GetToolkitDetailQueryValidator()
+    {
+        RuleFor(x => x.ToolkitId)
+            .NotEmpty()
+            .WithMessage("ToolkitId is required.");
+
+        RuleFor(x => x.ViewerId)
+            .NotEmpty()
+            .WithMessage("ViewerId is required (caller must be authenticated).");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitDetail/ToolkitDetailDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitDetail/ToolkitDetailDto.cs
@@ -1,0 +1,80 @@
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitDetail;
+
+/// <summary>
+/// Toolkit detail wire DTO for the marketplace surface
+/// (Wave 3 Phase 2, PR #732 §5.3.1 / Issue #805).
+/// </summary>
+/// <remarks>
+/// Powers the SP4 /toolkits/[id] route hero + meta sections via the FE
+/// <c>useToolkitDetail</c> hook. The <c>Agent</c> field surfaces a
+/// truncated system-prompt preview so the hero can render the agent voice
+/// without forcing the FE to call a separate agent endpoint.
+///
+/// Schema reality v1 carryovers documented inline (Gate B):
+/// <list type="bullet">
+///   <item><c>Description</c>: GameToolkitEntity has no Description column;
+///         derived from <c>Name</c> + author DisplayName until v2 schema lands.</item>
+///   <item><c>AuthorAvatarUrl</c>: pulled from UserEntity.AvatarUrl (real).</item>
+///   <item><c>CoverImageUrl</c>: no column exists; always null in v1.</item>
+///   <item><c>InstallCount</c>, <c>RatingAverage</c>, <c>RatingCount</c>:
+///         no installation/rating entities; stub 0/null/0 (Phase 4 will add).</item>
+///   <item><c>PublishedAt</c>: derived from <c>UpdatedAt</c> when
+///         <c>IsPublished</c> + <c>TemplateStatus == Approved</c>; null otherwise.</item>
+///   <item><c>YankedAt</c>: no yank workflow yet; always null in v1.</item>
+///   <item><c>CurrentVersion</c>: GameToolkitEntity stores int Version;
+///         surfaced as <c>"1.0.{version}"</c> until semver schema lands.</item>
+/// </list>
+///
+/// FE wire shape mirrors PR #732 §5.3.1 TypeScript interface exactly so the
+/// <c>useToolkitDetail</c> hook can typecheck against the live envelope.
+/// </remarks>
+internal sealed record ToolkitDetailDto(
+    Guid Id,
+    string Name,
+    string Description,
+    Guid AuthorId,
+    string AuthorName,
+    string? AuthorAvatarUrl,
+    string? CoverImageUrl,
+    ToolkitAgentSummaryDto Agent,
+    int KbDocsCount,
+    int ToolsCount,
+    int InstallCount,
+    decimal? RatingAverage,
+    int RatingCount,
+    DateTime CreatedAt,
+    DateTime? PublishedAt,
+    DateTime? YankedAt,
+    string CurrentVersion);
+
+/// <summary>
+/// Truncated agent summary embedded in <see cref="ToolkitDetailDto"/>.
+/// SystemPromptPreview is capped at 500 chars (PR #732 §5.3.1).
+/// </summary>
+internal sealed record ToolkitAgentSummaryDto(
+    Guid Id,
+    string Name,
+    string SystemPromptPreview);
+
+/// <summary>
+/// Per-viewer derived flags exposed alongside the toolkit detail
+/// (PR #732 §5.2 Wiegers requirement: server-side variant gating).
+/// </summary>
+/// <param name="IsOwner">True when caller authored the toolkit.</param>
+/// <param name="HasInstalled">True when caller has installed any version.</param>
+/// <param name="CanRate">
+/// Server-derived: <c>HasInstalled &amp;&amp; !alreadyRated &amp;&amp; !isOwner</c>.
+/// In v1 (no rating entity) collapses to <c>HasInstalled &amp;&amp; !isOwner</c>.
+/// </param>
+internal sealed record ViewerContextDto(
+    bool IsOwner,
+    bool HasInstalled,
+    bool CanRate);
+
+/// <summary>
+/// Stable response envelope for the detail endpoint — wraps DTO + viewer
+/// context together so the FE atomic snapshot matches the hero render.
+/// </summary>
+internal sealed record ToolkitDetailResponse(
+    ToolkitDetailDto Toolkit,
+    ViewerContextDto ViewerContext);

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitVersions/GetToolkitVersionsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitVersions/GetToolkitVersionsQuery.cs
@@ -1,0 +1,23 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitVersions;
+
+/// <summary>
+/// Query for a toolkit's published version history
+/// (Wave 3 Phase 2, PR #732 §5.3.2 / Issue #805).
+/// </summary>
+/// <param name="ToolkitId">Toolkit aggregate id.</param>
+/// <param name="ViewerId">
+/// Authenticated caller — used by the security boundary (PR #732 §5.2):
+/// non-authors can only see versions of published+non-yanked toolkits.
+/// </param>
+/// <remarks>
+/// Returns <c>null</c> from the handler when the toolkit cannot be found
+/// or is not visible to the viewer; the endpoint maps that to 404.
+/// Returning an envelope with an empty <c>Items</c> list is reserved for
+/// the case where the toolkit exists and is visible but has no published
+/// versions yet (handler stub creates a single v1.0.x row in v1).
+/// </remarks>
+internal sealed record GetToolkitVersionsQuery(
+    Guid ToolkitId,
+    Guid ViewerId) : IQuery<ToolkitVersionsResponse?>;

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitVersions/GetToolkitVersionsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitVersions/GetToolkitVersionsQueryHandler.cs
@@ -1,0 +1,142 @@
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
+using Api.Infrastructure;
+using Api.Services;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitVersions;
+
+/// <summary>
+/// Handler for <see cref="GetToolkitVersionsQuery"/> — returns the published
+/// version history sorted by <c>PublishedAt DESC</c>.
+/// Wave 3 Phase 2, PR #732 §5.3.2 / Issue #805.
+/// </summary>
+/// <remarks>
+/// Cache strategy (PR #732 §5.3.2): 10min HybridCache, no per-viewer
+/// partition — versions are non-personalised once the toolkit is visible
+/// (visibility check still executes per request before cache lookup).
+///
+/// Schema reality v1 carryover (Gate B): no <c>ToolkitVersion</c> entity.
+/// The handler synthesises a single-row stub: <c>{ version: "1.0.{int}",
+/// publishedAt: UpdatedAt or CreatedAt, yankedAt: null, changelog:
+/// "Initial version", isCurrent: true }</c>. Wire shape is stable so the
+/// FE versions list can render today and absorb the real history rows
+/// (sorted desc, isCurrent on the latest row) without a fetch shape change.
+/// </remarks>
+internal sealed class GetToolkitVersionsQueryHandler
+    : IRequestHandler<GetToolkitVersionsQuery, ToolkitVersionsResponse?>
+{
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(10);
+
+    private readonly MeepleAiDbContext _context;
+    private readonly IHybridCacheService _cache;
+    private readonly ILogger<GetToolkitVersionsQueryHandler> _logger;
+
+    public GetToolkitVersionsQueryHandler(
+        MeepleAiDbContext context,
+        IHybridCacheService cache,
+        ILogger<GetToolkitVersionsQueryHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<ToolkitVersionsResponse?> Handle(
+        GetToolkitVersionsQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Visibility check happens outside the cache so a non-author cannot
+        // benefit from a cached author response if the toolkit becomes a draft.
+        var entity = await _context.GameToolkits
+            .AsNoTracking()
+            .Where(t => t.Id == request.ToolkitId)
+            .Select(t => new
+            {
+                t.Id,
+                t.CreatedByUserId,
+                t.IsPublished,
+                t.TemplateStatus,
+                t.Version,
+                t.UpdatedAt,
+                t.CreatedAt,
+            })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entity is null)
+        {
+            _logger.LogInformation(
+                "Toolkit {ToolkitId} not found for versions request (viewer {ViewerId})",
+                request.ToolkitId,
+                request.ViewerId);
+            return null;
+        }
+
+        var isOwner = entity.CreatedByUserId == request.ViewerId;
+        var isPublished = entity.IsPublished
+            && (TemplateStatus)entity.TemplateStatus == TemplateStatus.Approved;
+
+        if (!isOwner && !isPublished)
+        {
+            _logger.LogInformation(
+                "Toolkit {ToolkitId} versions hidden from viewer {ViewerId} (not published, not author)",
+                request.ToolkitId,
+                request.ViewerId);
+            return null;
+        }
+
+        var cacheKey = $"toolkits:{request.ToolkitId:N}:versions";
+        var cached = await _cache.GetOrCreateAsync(
+            cacheKey,
+            ct => Task.FromResult(BuildStubVersionsList(entity.Version, entity.UpdatedAt, entity.CreatedAt, isPublished)),
+            tags:
+            [
+                $"toolkit:{request.ToolkitId:N}",
+                "toolkitVersions",
+            ],
+            expiration: CacheTtl,
+            ct: cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Returning {Count} version(s) for toolkit {ToolkitId} (viewer {ViewerId})",
+            cached.Items.Count,
+            request.ToolkitId,
+            request.ViewerId);
+
+        return cached;
+    }
+
+    /// <summary>
+    /// Synthesises the v1 stub versions list. When the toolkit has not yet
+    /// been published (<c>IsPublished == false</c>), the handler still returns
+    /// a single-row entry so the FE can render the "draft only" state without
+    /// special-casing — <c>publishedAt</c> falls back to <c>CreatedAt</c>.
+    /// </summary>
+    internal static ToolkitVersionsResponse BuildStubVersionsList(
+        int version,
+        DateTime updatedAt,
+        DateTime createdAt,
+        bool isPublished)
+    {
+        var publishedAt = isPublished ? updatedAt : createdAt;
+        var changelog = isPublished
+            ? "Initial version"
+            : "Draft — not yet published";
+
+        var items = new List<ToolkitVersionDto>
+        {
+            new(
+                Version: $"1.0.{version}",
+                PublishedAt: publishedAt,
+                YankedAt: null,
+                Changelog: changelog,
+                IsCurrent: true),
+        };
+
+        return new ToolkitVersionsResponse(items);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitVersions/GetToolkitVersionsQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitVersions/GetToolkitVersionsQueryValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitVersions;
+
+/// <summary>
+/// Validator for <see cref="GetToolkitVersionsQuery"/>.
+/// Wave 3 Phase 2, PR #732 §5.3.2 / Issue #805.
+/// </summary>
+internal sealed class GetToolkitVersionsQueryValidator
+    : AbstractValidator<GetToolkitVersionsQuery>
+{
+    public GetToolkitVersionsQueryValidator()
+    {
+        RuleFor(x => x.ToolkitId)
+            .NotEmpty()
+            .WithMessage("ToolkitId is required.");
+
+        RuleFor(x => x.ViewerId)
+            .NotEmpty()
+            .WithMessage("ViewerId is required (caller must be authenticated).");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitVersions/ToolkitVersionDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitVersions/ToolkitVersionDto.cs
@@ -1,0 +1,26 @@
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitVersions;
+
+/// <summary>
+/// Wire DTO for a single toolkit version row
+/// (Wave 3 Phase 2, PR #732 §5.3.2 / Issue #805).
+/// </summary>
+/// <remarks>
+/// Schema reality v1 carryover (Gate B): there is no <c>ToolkitVersion</c>
+/// entity yet — GameToolkitEntity stores a single <c>int Version</c> column
+/// that increments on Publish(). The handler synthesises a single-row stub
+/// list so the FE wire shape can stabilise ahead of the Phase 4 schema work.
+/// </remarks>
+internal sealed record ToolkitVersionDto(
+    string Version,
+    DateTime PublishedAt,
+    DateTime? YankedAt,
+    string Changelog,
+    bool IsCurrent);
+
+/// <summary>
+/// Response envelope for the versions endpoint — mirrors the empty-state
+/// contract from PR #732 §3.4 (200 with empty <c>items</c> rather than 404
+/// when the toolkit exists but has no published versions yet).
+/// </summary>
+internal sealed record ToolkitVersionsResponse(
+    IReadOnlyList<ToolkitVersionDto> Items);

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -11,6 +11,7 @@ using Api.Models;
 using Api.Observability;
 using Api.Routing;
 using Api.Routing.GameManagement;
+using Api.Routing.GameToolkit;
 using Api.BoundedContexts.GameManagement.Routing; // Issue #4273
 using Api.BoundedContexts.Administration.Infrastructure.DependencyInjection;
 using Api.BoundedContexts.AgentMemory.Infrastructure.DependencyInjection;
@@ -748,6 +749,7 @@ if (!isAlphaMode)
     v1Api.MapLiveSessionEndpoints(); // Issue #4749: Live session CQRS endpoints
     v1Api.MapSessionAttachmentEndpoints(); // Issue #5365: Session photo attachment endpoints
     v1Api.MapGameToolkitEndpoints(); // Issue #4753: Game toolkit CQRS endpoints
+    v1Api.MapToolkitMarketplaceEndpoints(); // Wave 3 Phase 2 (#805): /toolkits/[id] marketplace
     v1Api.MapGameToolboxEndpoints(); // Epic #412: Game toolbox per-game containers
     v1Api.MapToolStateEndpoints(); // Issue #4754: Tool state CQRS endpoints
     v1Api.MapTurnOrderEndpoints(); // Issue #4970: TurnOrder base toolkit endpoints

--- a/apps/api/src/Api/Routing/GameToolkit/ToolkitMarketplaceEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameToolkit/ToolkitMarketplaceEndpoints.cs
@@ -1,0 +1,140 @@
+using Api.BoundedContexts.GameToolkit.Application.Commands.InstallToolkit;
+using Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitDetail;
+using Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitVersions;
+using Api.Extensions;
+using MediatR;
+
+namespace Api.Routing.GameToolkit;
+
+/// <summary>
+/// Marketplace endpoints for the SP4 /toolkits/[id] route
+/// (Wave 3 Phase 2, PR #732 §5.3 / Issue #805).
+/// </summary>
+/// <remarks>
+/// Per PR #732 §5.1 (Newman BC decomposition), these endpoints EXTEND the
+/// existing <c>GameToolkit</c> bounded context rather than introducing a new
+/// <c>MarketplaceBC</c> — the toolkit aggregate is shared between internal
+/// session toolkits and community marketplace, only differing in publishing
+/// state and authorship.
+///
+/// All three endpoints use <c>IMediator.Send()</c> only (CLAUDE.md CQRS
+/// rule); no service is injected directly. Auth: <c>RequireAuthorization()</c>
+/// (any authenticated user) — server-side variant gating is enforced inside
+/// the handlers via <c>ViewerContext.IsOwner</c> / visibility checks.
+///
+/// Mounted under <c>/api/v1/toolkits</c> rather than the existing
+/// <c>/api/v1/game-toolkits</c> group because PR #732 §5.3 explicitly
+/// scopes the marketplace surface to the shorter prefix; the legacy
+/// session-toolkit CRUD endpoints stay on their own prefix.
+/// </remarks>
+internal static class ToolkitMarketplaceEndpoints
+{
+    public static RouteGroupBuilder MapToolkitMarketplaceEndpoints(this RouteGroupBuilder group)
+    {
+        var toolkits = group.MapGroup("/toolkits")
+            .WithTags("ToolkitMarketplace")
+            .RequireAuthorization();
+
+        // ── GET /api/v1/toolkits/{toolkitId} ────────────────────────────────
+        toolkits.MapGet("/{toolkitId:guid}", HandleGetToolkitDetail)
+            .WithName("GetToolkitDetail")
+            .WithSummary("Get marketplace toolkit detail with viewer context")
+            .WithDescription(
+                "Returns the toolkit detail envelope plus per-viewer flags "
+                + "(isOwner, hasInstalled, canRate). 404 when the toolkit is "
+                + "unpublished or yanked AND the viewer is not the author "
+                + "(server-enforced security boundary per PR #732 §5.2). "
+                + "Cache: 10min HybridCache, partitioned per (toolkitId, viewerId).")
+            .Produces<ToolkitDetailResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound);
+
+        // ── GET /api/v1/toolkits/{toolkitId}/versions ──────────────────────
+        toolkits.MapGet("/{toolkitId:guid}/versions", HandleGetToolkitVersions)
+            .WithName("GetToolkitVersions")
+            .WithSummary("List toolkit version history")
+            .WithDescription(
+                "Returns the published version history sorted by publishedAt "
+                + "DESC. 404 when the toolkit is missing or hidden from the "
+                + "viewer. Cache: 10min HybridCache (no per-viewer partition).")
+            .Produces<ToolkitVersionsResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound);
+
+        // ── POST /api/v1/toolkits/{toolkitId}/install ──────────────────────
+        toolkits.MapPost("/{toolkitId:guid}/install", HandleInstallToolkit)
+            .WithName("InstallToolkit")
+            .WithSummary("Install a toolkit (idempotent)")
+            .WithDescription(
+                "Idempotent install action — repeated calls return 200 with "
+                + "the current state, never 409 (PR #732 §5.3.5 Nygard note). "
+                + "404 when the toolkit is missing or yanked. Side-effect: "
+                + "invalidates the discover:popularAgents cache so the rail "
+                + "reflects the new install on the next read.")
+            .Produces<InstallToolkitResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound);
+
+        return toolkits;
+    }
+
+    private static async Task<IResult> HandleGetToolkitDetail(
+        Guid toolkitId,
+        HttpContext httpContext,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var viewerId = httpContext.User.GetUserId();
+        if (viewerId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
+        var query = new GetToolkitDetailQuery(toolkitId, viewerId);
+        var response = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
+
+        return response is null
+            ? Results.NotFound()
+            : Results.Ok(response);
+    }
+
+    private static async Task<IResult> HandleGetToolkitVersions(
+        Guid toolkitId,
+        HttpContext httpContext,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var viewerId = httpContext.User.GetUserId();
+        if (viewerId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
+        var query = new GetToolkitVersionsQuery(toolkitId, viewerId);
+        var response = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
+
+        return response is null
+            ? Results.NotFound()
+            : Results.Ok(response);
+    }
+
+    private static async Task<IResult> HandleInstallToolkit(
+        Guid toolkitId,
+        HttpContext httpContext,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var viewerId = httpContext.User.GetUserId();
+        if (viewerId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
+        var command = new InstallToolkitCommand(toolkitId, viewerId);
+        var response = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+
+        return response is null
+            ? Results.NotFound()
+            : Results.Ok(response);
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/ToolkitMarketplace/ToolkitMarketplaceEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/ToolkitMarketplace/ToolkitMarketplaceEndpointsIntegrationTests.cs
@@ -1,0 +1,704 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.GameToolkit;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.ToolkitMarketplace;
+
+/// <summary>
+/// Integration tests for the Wave 3 Phase 2 toolkit marketplace endpoints
+/// (Issue #805 / PR #732 §5.3.1, §5.3.2, §5.3.5):
+///
+/// <list type="number">
+///   <item><c>GET /api/v1/toolkits/{id}</c> — detail with viewerContext, 10min ETag per-viewer</item>
+///   <item><c>GET /api/v1/toolkits/{id}/versions</c> — versions list, 10min cache</item>
+///   <item><c>POST /api/v1/toolkits/{id}/install</c> — idempotent install</item>
+/// </list>
+///
+/// Per PR #732 §5.1 (Newman BC decomposition), these endpoints EXTEND the
+/// existing GameToolkit BC rather than creating a new MarketplaceBC. Schema
+/// reality v1 carryovers are documented inline in the handlers (Gate B):
+/// installCount stub 0, ratingAverage null, currentVersion "1.0.{int}",
+/// publishedAt = UpdatedAt for approved, yankedAt always null in v1.
+///
+/// Security boundary (PR #732 §5.2): non-author viewers must receive 404
+/// when the toolkit is not yet published / approved.
+///
+/// Idempotency contract (PR #732 §5.3.5 Nygard): the install endpoint
+/// returns 200 on every call (never 409) regardless of whether it is the
+/// first or Nth call for the same (viewer, toolkit) pair.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameToolkit")]
+[Trait("Wave", "3-Phase-2")]
+public sealed class ToolkitMarketplaceEndpointsIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    public ToolkitMarketplaceEndpointsIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"toolkit_marketplace_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+        }
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        await _factory.DisposeAsync();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  GET /api/v1/toolkits/{toolkitId}  (PR #732 §5.3.1)
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ToolkitDetail_WithoutAuth_ReturnsUnauthorized()
+    {
+        var response = await _client.GetAsync($"/api/v1/toolkits/{Guid.NewGuid()}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ToolkitDetail_WhenToolkitNotFound_Returns404()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{Guid.NewGuid()}",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ToolkitDetail_WhenPublished_AnyAuthUser_Returns200WithViewerContext()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Public Toolkit",
+            isPublished: true,
+            templateStatus: TemplateStatus.Approved);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkit.Id}",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var detail = body.GetProperty("toolkit");
+        detail.GetProperty("id").GetString().Should().Be(toolkit.Id.ToString());
+        detail.GetProperty("name").GetString().Should().Be("Public Toolkit");
+        detail.GetProperty("authorId").GetString().Should().Be(authorId.ToString());
+        // Schema reality v1 carryover (Gate B): installCount stubbed to 0.
+        detail.GetProperty("installCount").GetInt32().Should().Be(0);
+        // ratingAverage is null; ratingCount is 0.
+        detail.GetProperty("ratingAverage").ValueKind.Should().Be(JsonValueKind.Null);
+        detail.GetProperty("ratingCount").GetInt32().Should().Be(0);
+        // currentVersion shape: "1.0.{int}".
+        detail.GetProperty("currentVersion").GetString().Should().StartWith("1.0.");
+        // publishedAt populated for approved+published toolkit.
+        detail.GetProperty("publishedAt").ValueKind.Should().Be(JsonValueKind.String);
+        // yankedAt always null in v1.
+        detail.GetProperty("yankedAt").ValueKind.Should().Be(JsonValueKind.Null);
+
+        var viewerContext = body.GetProperty("viewerContext");
+        viewerContext.GetProperty("isOwner").GetBoolean().Should().BeFalse();
+        viewerContext.GetProperty("hasInstalled").GetBoolean().Should().BeFalse();
+        // canRate = hasInstalled && !isOwner. With v1 stub hasInstalled=false → canRate=false.
+        viewerContext.GetProperty("canRate").GetBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ToolkitDetail_WhenOwnDraft_OwnerSeesIsOwnerTrue()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, authorToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "My Draft",
+            isPublished: false,
+            templateStatus: TemplateStatus.Draft);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkit.Id}",
+            authorToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("viewerContext").GetProperty("isOwner").GetBoolean().Should().BeTrue();
+        // publishedAt null for unpublished draft.
+        body.GetProperty("toolkit").GetProperty("publishedAt").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task ToolkitDetail_WhenUnpublishedDraft_NonAuthorReceives404()
+    {
+        // PR #732 §5.2 security boundary — server-side enforcement.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Hidden Draft",
+            isPublished: false,
+            templateStatus: TemplateStatus.Draft);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkit.Id}",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ToolkitDetail_WhenPendingReview_NonAuthorReceives404()
+    {
+        // Even PendingReview does not equal Approved; non-authors cannot see.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Pending Review",
+            isPublished: true,
+            templateStatus: TemplateStatus.PendingReview);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkit.Id}",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ToolkitDetail_OwnerStillSeesUnpublishedToolkit()
+    {
+        // Owners always see their own toolkits (parallel to "yanked-but-mine"
+        // soft-delete owner access carved out by PR #732 §5.2).
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, authorToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "My Pending",
+            isPublished: true,
+            templateStatus: TemplateStatus.PendingReview);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkit.Id}",
+            authorToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("viewerContext").GetProperty("isOwner").GetBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ToolkitDetail_AgentSummary_TruncatesSystemPromptTo500Chars()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var longPrompt = new string('a', 750);
+        var agentConfigJson = JsonSerializer.Serialize(new
+        {
+            name = "TestAgent",
+            systemPrompt = longPrompt,
+        });
+
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Toolkit With Agent",
+            isPublished: true,
+            templateStatus: TemplateStatus.Approved,
+            agentConfig: agentConfigJson);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkit.Id}",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var agent = body.GetProperty("toolkit").GetProperty("agent");
+        agent.GetProperty("name").GetString().Should().Be("TestAgent");
+        agent.GetProperty("systemPromptPreview").GetString()!.Length.Should().Be(500);
+    }
+
+    [Fact]
+    public async Task ToolkitDetail_PopulatesAuthorNameFromUser()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        // Set DisplayName on the author so the wire shape exposes a real label.
+        var authorEntity = await dbContext.Users.FirstAsync(u => u.Id == authorId);
+        authorEntity.DisplayName = "Marco Designer";
+        authorEntity.AvatarUrl = "https://example.com/marco.jpg";
+        await dbContext.SaveChangesAsync();
+
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Marco's Toolkit",
+            isPublished: true,
+            templateStatus: TemplateStatus.Approved);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkit.Id}",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var detail = body.GetProperty("toolkit");
+        detail.GetProperty("authorName").GetString().Should().Be("Marco Designer");
+        detail.GetProperty("authorAvatarUrl").GetString().Should().Be("https://example.com/marco.jpg");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  GET /api/v1/toolkits/{toolkitId}/versions  (PR #732 §5.3.2)
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ToolkitVersions_WithoutAuth_ReturnsUnauthorized()
+    {
+        var response = await _client.GetAsync($"/api/v1/toolkits/{Guid.NewGuid()}/versions");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ToolkitVersions_ToolkitNotFound_Returns404()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{Guid.NewGuid()}/versions",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ToolkitVersions_PublishedToolkit_Returns200WithStubV1()
+    {
+        // Schema reality v1 carryover (Gate B): single-row stub list.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Versioned Toolkit",
+            isPublished: true,
+            templateStatus: TemplateStatus.Approved);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkit.Id}/versions",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items");
+        items.GetArrayLength().Should().Be(1);
+        var first = items[0];
+        first.GetProperty("version").GetString().Should().StartWith("1.0.");
+        first.GetProperty("isCurrent").GetBoolean().Should().BeTrue();
+        first.GetProperty("yankedAt").ValueKind.Should().Be(JsonValueKind.Null);
+        first.GetProperty("changelog").GetString().Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task ToolkitVersions_NonAuthorOnDraft_Returns404()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Draft Versions",
+            isPublished: false,
+            templateStatus: TemplateStatus.Draft);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkit.Id}/versions",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ToolkitVersions_OwnerOnDraft_Returns200WithDraftChangelog()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, authorToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Owner Draft",
+            isPublished: false,
+            templateStatus: TemplateStatus.Draft);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkit.Id}/versions",
+            authorToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items");
+        items.GetArrayLength().Should().Be(1);
+        // The handler labels the stub row as "Draft — not yet published" when
+        // the toolkit hasn't crossed the publish threshold yet.
+        items[0].GetProperty("changelog").GetString().Should().Contain("Draft");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  POST /api/v1/toolkits/{toolkitId}/install  (PR #732 §5.3.5)
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task InstallToolkit_WithoutAuth_ReturnsUnauthorized()
+    {
+        var response = await _client.PostAsync(
+            $"/api/v1/toolkits/{Guid.NewGuid()}/install",
+            content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task InstallToolkit_ToolkitNotFound_Returns404()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/toolkits/{Guid.NewGuid()}/install",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task InstallToolkit_PublishedToolkit_Returns200WithHasInstalledTrue()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Installable Toolkit",
+            isPublished: true,
+            templateStatus: TemplateStatus.Approved);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/toolkits/{toolkit.Id}/install",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("hasInstalled").GetBoolean().Should().BeTrue();
+        // Schema reality v1 carryover (Gate B): installCount stub 0.
+        body.GetProperty("installCount").GetInt32().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task InstallToolkit_Idempotent_RepeatedInstallsAlwaysReturn200()
+    {
+        // PR #732 §5.3.5 Nygard: repeated installs must NOT raise 409.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Idempotent Toolkit",
+            isPublished: true,
+            templateStatus: TemplateStatus.Approved);
+
+        // First install.
+        var request1 = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/toolkits/{toolkit.Id}/install",
+            viewerToken);
+        var response1 = await _client.SendAsync(request1);
+        response1.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Second install (should be idempotent → still 200).
+        var request2 = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/toolkits/{toolkit.Id}/install",
+            viewerToken);
+        var response2 = await _client.SendAsync(request2);
+        response2.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body2 = await response2.Content.ReadFromJsonAsync<JsonElement>();
+        body2.GetProperty("hasInstalled").GetBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task InstallToolkit_NonAuthorOnDraft_Returns404()
+    {
+        // PR #732 §5.2 boundary — viewers cannot install drafts.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Draft Toolkit",
+            isPublished: false,
+            templateStatus: TemplateStatus.Draft);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/toolkits/{toolkit.Id}/install",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task InstallToolkit_OwnerCanInstallOwnDraft()
+    {
+        // Owners installing their own toolkit (e.g. for testing) is allowed.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, authorToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Owner Self Install",
+            isPublished: false,
+            templateStatus: TemplateStatus.Draft);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/toolkits/{toolkit.Id}/install",
+            authorToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Helpers
+    // ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Seeds a <see cref="GameToolkitEntity"/> directly via raw SQL because
+    /// EF treats the <c>RowVersion</c> column as <c>IsRowVersion()</c> which
+    /// strips the value from INSERT statements. The migration declares the
+    /// column NOT NULL with no DB-side default, so the EF path produces a
+    /// constraint violation when seeding outside the production aggregate
+    /// repository (which similarly omits RowVersion but is exercised through
+    /// SaveChangesAsync paths that EF rewrites server-side).
+    ///
+    /// Using raw SQL bypasses the EF generator and gives us full control of
+    /// the IsPublished / TemplateStatus combinations needed for the security
+    /// boundary tests (PR #732 §5.2). FK to <see cref="SharedGameEntity"/>
+    /// (via <see cref="GameEntity"/> mapping that points to the SharedGame
+    /// row) is satisfied by inserting a sibling SharedGame first.
+    /// </summary>
+    private static async Task<GameToolkitEntity> SeedToolkitAsync(
+        MeepleAiDbContext dbContext,
+        Guid authorId,
+        string name,
+        bool isPublished,
+        TemplateStatus templateStatus,
+        string? agentConfig = null)
+    {
+        // GameToolkitEntity.GameId references the "games" table (GameEntity),
+        // NOT SharedGames. Seed a GameEntity row so the FK constraint holds.
+        var game = new GameEntity
+        {
+            Id = Guid.NewGuid(),
+            Name = $"Game for {name}",
+            CreatedAt = DateTime.UtcNow,
+        };
+        dbContext.Games.Add(game);
+        await dbContext.SaveChangesAsync();
+
+        var toolkitId = Guid.NewGuid();
+        var createdAt = DateTime.UtcNow.AddDays(-1);
+        var updatedAt = DateTime.UtcNow;
+        var templateStatusInt = (int)templateStatus;
+        var isTemplate = templateStatus == TemplateStatus.Approved;
+
+        // Raw INSERT that explicitly sets RowVersion. EF treats RowVersion as
+        // store-generated under IsRowVersion(), which strips the value during
+        // INSERT and produces a NOT-NULL violation when seeding outside the
+        // production aggregate path. The aggregate's repository takes the same
+        // path through SaveChangesAsync but EF's update pipeline rewrites the
+        // RowVersion side-effect for IsRowVersion()-tagged properties — that
+        // does not happen for raw entity inserts via Add() in tests.
+        //
+        // We embed the agentConfig literal directly when present (escaping
+        // single quotes for SQL safety AND escaping curly braces because the
+        // composite format-string under ExecuteSqlRawAsync interprets {n} as
+        // positional placeholders) instead of using a parameter, because
+        // mixing positional {N} and named @pN parameters in the same SQL
+        // produces ambiguous parameter bindings under Npgsql.
+        var agentConfigSql = agentConfig is null
+            ? "NULL"
+            : $"'{agentConfig.Replace("'", "''", StringComparison.Ordinal).Replace("{", "{{", StringComparison.Ordinal).Replace("}", "}}", StringComparison.Ordinal)}'::jsonb";
+
+        var sql = $$"""
+            INSERT INTO "GameToolkits" (
+                "Id", "GameId", "PrivateGameId", "Name", "Version",
+                "CreatedByUserId", "IsPublished",
+                "OverridesTurnOrder", "OverridesScoreboard", "OverridesDiceSet",
+                "CreatedAt", "UpdatedAt",
+                "DiceToolsJson", "CardToolsJson", "TimerToolsJson",
+                "CounterToolsJson", "UserDicePresetsJson",
+                "ScoringTemplateJson", "TurnTemplateJson", "StateTemplate",
+                "AgentConfig",
+                "TemplateStatus", "IsTemplate",
+                "ReviewNotes", "ReviewedByUserId", "ReviewedAt",
+                "RowVersion"
+            ) VALUES (
+                {0}, {1}, NULL, {2}, 1,
+                {3}, {4},
+                FALSE, FALSE, FALSE,
+                {5}, {6},
+                NULL, NULL, NULL,
+                NULL, NULL,
+                NULL, NULL, NULL,
+                {{agentConfigSql}},
+                {7}, {8},
+                NULL, NULL, NULL,
+                E'\\x01'
+            )
+            """;
+
+        await dbContext.Database.ExecuteSqlRawAsync(
+            sql,
+            toolkitId,
+            game.Id,
+            name,
+            authorId,
+            isPublished,
+            createdAt,
+            updatedAt,
+            templateStatusInt,
+            isTemplate);
+
+        return new GameToolkitEntity
+        {
+            Id = toolkitId,
+            GameId = game.Id,
+            Name = name,
+            Version = 1,
+            CreatedByUserId = authorId,
+            IsPublished = isPublished,
+            CreatedAt = createdAt,
+            UpdatedAt = updatedAt,
+            TemplateStatus = templateStatusInt,
+            IsTemplate = isTemplate,
+            AgentConfig = agentConfig,
+            RowVersion = new byte[] { 1 },
+        };
+    }
+}

--- a/apps/web/src/hooks/queries/__tests__/useInstallToolkit.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useInstallToolkit.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useInstallToolkit unit tests — Wave 3 Phase 2 (Issue #805 / PR #732 §5.3.5).
+ *
+ * Coverage:
+ *   - POST /toolkits/{id}/install with empty body.
+ *   - Schema validation forwards typed payload.
+ *   - Idempotency contract: repeated mutateAsync calls succeed.
+ *   - Detail-cache invalidation runs on success (so viewerContext.has
+ *     Installed flips on next render).
+ *   - Error path surfaces the rejection.
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { toolkitDetailKeys } from '../useToolkitDetail';
+import { useInstallToolkit } from '../useInstallToolkit';
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    post: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/lib/api/client';
+
+const mockPost = apiClient.post as ReturnType<typeof vi.fn>;
+
+const TOOLKIT_ID = '11111111-1111-1111-1111-111111111111';
+
+const SAMPLE_INSTALL = {
+  installCount: 0,
+  hasInstalled: true,
+};
+
+function renderInstallHook() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  const { result } = renderHook(() => useInstallToolkit(), { wrapper: Wrapper });
+  return { result, queryClient };
+}
+
+describe('useInstallToolkit — request shape', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPost.mockResolvedValue(SAMPLE_INSTALL);
+  });
+
+  it('POSTs to /toolkits/{id}/install with no body', async () => {
+    const { result } = renderInstallHook();
+    await result.current.mutateAsync({ toolkitId: TOOLKIT_ID });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      `/toolkits/${TOOLKIT_ID}/install`,
+      undefined,
+      expect.anything()
+    );
+  });
+
+  it('returns the parsed install response on success', async () => {
+    const { result } = renderInstallHook();
+    const response = await result.current.mutateAsync({ toolkitId: TOOLKIT_ID });
+
+    expect(response).toEqual(SAMPLE_INSTALL);
+  });
+});
+
+describe('useInstallToolkit — idempotency', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPost.mockResolvedValue(SAMPLE_INSTALL);
+  });
+
+  it('repeated installs all return success (PR #732 §5.3.5 Nygard)', async () => {
+    const { result } = renderInstallHook();
+    const r1 = await result.current.mutateAsync({ toolkitId: TOOLKIT_ID });
+    const r2 = await result.current.mutateAsync({ toolkitId: TOOLKIT_ID });
+    const r3 = await result.current.mutateAsync({ toolkitId: TOOLKIT_ID });
+
+    expect(r1.hasInstalled).toBe(true);
+    expect(r2.hasInstalled).toBe(true);
+    expect(r3.hasInstalled).toBe(true);
+    expect(mockPost).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('useInstallToolkit — cache invalidation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPost.mockResolvedValue(SAMPLE_INSTALL);
+  });
+
+  it('invalidates the toolkit-detail query on success', async () => {
+    const { result, queryClient } = renderInstallHook();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    await result.current.mutateAsync({ toolkitId: TOOLKIT_ID });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: toolkitDetailKeys.byId(TOOLKIT_ID),
+      });
+    });
+  });
+});
+
+describe('useInstallToolkit — error handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('surfaces an error on rejection', async () => {
+    mockPost.mockRejectedValue(new Error('install failed'));
+    const { result } = renderInstallHook();
+
+    await expect(result.current.mutateAsync({ toolkitId: TOOLKIT_ID })).rejects.toThrow(
+      'install failed'
+    );
+  });
+});

--- a/apps/web/src/hooks/queries/__tests__/useToolkitDetail.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useToolkitDetail.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useToolkitDetail unit tests — Wave 3 Phase 2 (Issue #805 / PR #732 §5.3.1).
+ *
+ * Coverage:
+ *   - Stable URL shape `/toolkits/{id}` and 10min staleTime mirror.
+ *   - Schema validation forwards typed envelope.
+ *   - 404 / 401 / null fallback (apiClient returns null) → null result.
+ *   - `enabled: false` defers the request.
+ *   - Empty / invalid toolkitId is a no-op.
+ *   - Error path surfaces the rejection.
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { TOOLKIT_DETAIL_STALE_TIME_MS, useToolkitDetail } from '../useToolkitDetail';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/lib/api/client';
+
+const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const TOOLKIT_ID = '11111111-1111-1111-1111-111111111111';
+
+const SAMPLE_DETAIL = {
+  toolkit: {
+    id: TOOLKIT_ID,
+    name: 'Test Toolkit',
+    description: 'Toolkit by Test Author.',
+    authorId: '22222222-2222-2222-2222-222222222222',
+    authorName: 'Test Author',
+    authorAvatarUrl: null,
+    coverImageUrl: null,
+    agent: {
+      id: TOOLKIT_ID,
+      name: 'Test Toolkit',
+      systemPromptPreview: '',
+    },
+    kbDocsCount: 0,
+    toolsCount: 0,
+    installCount: 0,
+    ratingAverage: null,
+    ratingCount: 0,
+    createdAt: '2026-04-01T12:00:00Z',
+    publishedAt: '2026-05-01T08:30:00Z',
+    yankedAt: null,
+    currentVersion: '1.0.1',
+  },
+  viewerContext: {
+    isOwner: false,
+    hasInstalled: false,
+    canRate: false,
+  },
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useToolkitDetail — constants', () => {
+  it('exports a 10-minute staleTime to mirror the backend HybridCache TTL', () => {
+    expect(TOOLKIT_DETAIL_STALE_TIME_MS).toBe(10 * 60 * 1000);
+  });
+});
+
+describe('useToolkitDetail — request shape', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(SAMPLE_DETAIL);
+  });
+
+  it('issues GET /toolkits/{id} for the supplied toolkitId', async () => {
+    const { result } = renderHook(() => useToolkitDetail({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith(`/toolkits/${TOOLKIT_ID}`, expect.anything());
+  });
+
+  it('does not fire when toolkitId is null', () => {
+    renderHook(() => useToolkitDetail({ toolkitId: null }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when toolkitId is empty string', () => {
+    renderHook(() => useToolkitDetail({ toolkitId: '' }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when enabled is false', () => {
+    renderHook(() => useToolkitDetail({ toolkitId: TOOLKIT_ID, enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});
+
+describe('useToolkitDetail — query result', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the parsed envelope on success', async () => {
+    mockGet.mockResolvedValue(SAMPLE_DETAIL);
+
+    const { result } = renderHook(() => useToolkitDetail({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(SAMPLE_DETAIL);
+  });
+
+  it('returns null when the backend returns null (401/404/circuit-open)', async () => {
+    mockGet.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useToolkitDetail({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toBeNull();
+  });
+
+  it('exposes error state when the API rejects', async () => {
+    mockGet.mockRejectedValue(new Error('network down'));
+
+    const { result } = renderHook(() => useToolkitDetail({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('network down');
+  });
+});

--- a/apps/web/src/hooks/queries/__tests__/useToolkitVersions.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useToolkitVersions.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useToolkitVersions unit tests — Wave 3 Phase 2 (Issue #805 / PR #732 §5.3.2).
+ *
+ * Coverage:
+ *   - Stable URL `/toolkits/{id}/versions` and 10min staleTime mirror.
+ *   - Schema validation forwards typed array (items unwrapped).
+ *   - Empty / null fallback returns empty array.
+ *   - `enabled: false` and missing toolkitId defer the request.
+ *   - Error path surfaces the rejection.
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { TOOLKIT_VERSIONS_STALE_TIME_MS, useToolkitVersions } from '../useToolkitVersions';
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/lib/api/client';
+
+const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const TOOLKIT_ID = '11111111-1111-1111-1111-111111111111';
+
+const SAMPLE_VERSIONS = {
+  items: [
+    {
+      version: '1.0.2',
+      publishedAt: '2026-05-01T10:00:00Z',
+      yankedAt: null,
+      changelog: 'Initial version',
+      isCurrent: true,
+    },
+  ],
+};
+
+describe('useToolkitVersions — constants', () => {
+  it('exports a 10-minute staleTime to mirror the backend HybridCache TTL', () => {
+    expect(TOOLKIT_VERSIONS_STALE_TIME_MS).toBe(10 * 60 * 1000);
+  });
+});
+
+describe('useToolkitVersions — request shape', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(SAMPLE_VERSIONS);
+  });
+
+  it('issues GET /toolkits/{id}/versions', async () => {
+    const { result } = renderHook(() => useToolkitVersions({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith(`/toolkits/${TOOLKIT_ID}/versions`, expect.anything());
+  });
+
+  it('does not fire when toolkitId is null', () => {
+    renderHook(() => useToolkitVersions({ toolkitId: null }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when enabled is false', () => {
+    renderHook(() => useToolkitVersions({ toolkitId: TOOLKIT_ID, enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});
+
+describe('useToolkitVersions — query result', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('unwraps items and returns the typed array', async () => {
+    mockGet.mockResolvedValue(SAMPLE_VERSIONS);
+
+    const { result } = renderHook(() => useToolkitVersions({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(SAMPLE_VERSIONS.items);
+  });
+
+  it('returns an empty array on null response (401/404/circuit-open)', async () => {
+    mockGet.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useToolkitVersions({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('returns an empty array on empty-state envelope', async () => {
+    mockGet.mockResolvedValue({ items: [] });
+
+    const { result } = renderHook(() => useToolkitVersions({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('exposes error state when the API rejects', async () => {
+    mockGet.mockRejectedValue(new Error('versions fetch failed'));
+
+    const { result } = renderHook(() => useToolkitVersions({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('versions fetch failed');
+  });
+});

--- a/apps/web/src/hooks/queries/useInstallToolkit.ts
+++ b/apps/web/src/hooks/queries/useInstallToolkit.ts
@@ -1,0 +1,67 @@
+/**
+ * useInstallToolkit — TanStack Query mutation hook for the toolkit
+ * install action (Wave 3 Phase 2, Issue #805 / PR #732 §5.3.5).
+ *
+ * Backend contract: `POST /api/v1/toolkits/{toolkitId}/install` returns
+ * `{ installCount, hasInstalled }`. 404 when the toolkit is missing or
+ * yanked. Idempotent (PR #732 §5.3.5 Nygard) — repeated calls return 200
+ * with the current state, NEVER 409.
+ *
+ * Side-effects: backend invalidates the discover popularity cache; this
+ * hook also invalidates the toolkit-detail query so `viewerContext.has
+ * Installed` flips to true on the next render.
+ *
+ * Schema reality v1 carryover (Gate B): `installCount` is always 0 until
+ * Phase 4 wires the ToolkitInstallation entity. The `hasInstalled` flag
+ * still flips to `true` on success so the FE button-state machine can
+ * render the "Installed" pill.
+ */
+
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+
+import { apiClient } from '@/lib/api/client';
+import {
+  InstallToolkitResponseSchema,
+  type InstallToolkitResponse,
+} from '@/lib/api/schemas/toolkit-marketplace.schemas';
+
+import { toolkitDetailKeys } from './useToolkitDetail';
+
+export interface InstallToolkitVariables {
+  readonly toolkitId: string;
+}
+
+/**
+ * Install (or re-install, idempotently) a marketplace toolkit.
+ *
+ * @example
+ * const installToolkit = useInstallToolkit();
+ * await installToolkit.mutateAsync({ toolkitId: 'xxx' });
+ */
+export function useInstallToolkit(): UseMutationResult<
+  InstallToolkitResponse,
+  Error,
+  InstallToolkitVariables
+> {
+  const queryClient = useQueryClient();
+
+  return useMutation<InstallToolkitResponse, Error, InstallToolkitVariables>({
+    mutationFn: async ({ toolkitId }) => {
+      // apiClient.post returns the parsed body; schema validates wire shape.
+      return await apiClient.post<InstallToolkitResponse>(
+        `/toolkits/${toolkitId}/install`,
+        // Empty body — install endpoint takes no payload.
+        undefined,
+        InstallToolkitResponseSchema
+      );
+    },
+    onSuccess: async (_data, variables) => {
+      // Refresh the detail envelope so viewerContext.hasInstalled flips on
+      // the next render. The backend invalidates the per-viewer cache too;
+      // this client-side invalidation just shortens the round-trip.
+      await queryClient.invalidateQueries({
+        queryKey: toolkitDetailKeys.byId(variables.toolkitId),
+      });
+    },
+  });
+}

--- a/apps/web/src/hooks/queries/useToolkitDetail.ts
+++ b/apps/web/src/hooks/queries/useToolkitDetail.ts
@@ -1,0 +1,67 @@
+/**
+ * useToolkitDetail — TanStack Query hook for the /toolkits/[id] hero
+ * + meta sections (Wave 3 Phase 2, Issue #805 / PR #732 §5.3.1).
+ *
+ * Backend contract: `GET /api/v1/toolkits/{toolkitId}` returns
+ * `{ toolkit, viewerContext }`. 404 when the toolkit is unpublished or
+ * yanked AND the viewer is not the author (server-enforced security
+ * boundary per PR #732 §5.2). 401 when unauthenticated.
+ *
+ * Cache: backend caches 10min via HybridCache (per-viewer ETag); FE
+ * staleTime mirrors that to avoid wasteful re-fetches while users browse
+ * the marketplace.
+ *
+ * Schema reality v1 carryovers documented in the schema file (Gate B):
+ * installCount/ratingAverage/etc. are stubbed — wire shape is stable so
+ * the hook contract survives the Phase 4 schema work without changes.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { apiClient } from '@/lib/api/client';
+import {
+  ToolkitDetailResponseSchema,
+  type ToolkitDetailResponse,
+} from '@/lib/api/schemas/toolkit-marketplace.schemas';
+
+export const TOOLKIT_DETAIL_STALE_TIME_MS = 10 * 60 * 1000; // 10 min, mirrors backend cache.
+
+export const toolkitDetailKeys = {
+  all: ['toolkits', 'detail'] as const,
+  byId: (toolkitId: string) => [...toolkitDetailKeys.all, toolkitId] as const,
+};
+
+export interface UseToolkitDetailOptions {
+  readonly toolkitId: string | null | undefined;
+  readonly enabled?: boolean;
+}
+
+/**
+ * Fetch the marketplace detail envelope for a single toolkit.
+ *
+ * @example
+ * const { data, isLoading, isError } = useToolkitDetail({ toolkitId: 'xxx' });
+ * // data — { toolkit: ToolkitDetail, viewerContext: ViewerContext } | null
+ */
+export function useToolkitDetail(
+  options: UseToolkitDetailOptions
+): UseQueryResult<ToolkitDetailResponse | null, Error> {
+  const { toolkitId, enabled = true } = options;
+  const isValid = typeof toolkitId === 'string' && toolkitId.length > 0;
+
+  return useQuery<ToolkitDetailResponse | null, Error>({
+    queryKey: isValid ? toolkitDetailKeys.byId(toolkitId) : toolkitDetailKeys.all,
+    queryFn: async () => {
+      if (!isValid) return null;
+      const response = await apiClient.get<ToolkitDetailResponse>(
+        `/toolkits/${toolkitId}`,
+        ToolkitDetailResponseSchema
+      );
+      // null is returned by apiClient on 401/404/circuit-open — surface as
+      // null so the FE can render the not-found state.
+      return response ?? null;
+    },
+    enabled: enabled && isValid,
+    staleTime: TOOLKIT_DETAIL_STALE_TIME_MS,
+  });
+}

--- a/apps/web/src/hooks/queries/useToolkitVersions.ts
+++ b/apps/web/src/hooks/queries/useToolkitVersions.ts
@@ -1,0 +1,65 @@
+/**
+ * useToolkitVersions — TanStack Query hook for the /toolkits/[id]
+ * versions list (Wave 3 Phase 2, Issue #805 / PR #732 §5.3.2).
+ *
+ * Backend contract: `GET /api/v1/toolkits/{toolkitId}/versions` returns
+ * `{ items: ToolkitVersion[] }` sorted by `publishedAt DESC`. 404 when
+ * the toolkit is missing or hidden from the viewer.
+ *
+ * Cache: backend caches 10min via HybridCache (no per-viewer partition);
+ * FE staleTime mirrors that.
+ *
+ * Schema reality v1 carryover (Gate B): backend currently synthesises a
+ * single-row stub list because there is no ToolkitVersion entity — wire
+ * shape is stable so the FE list can render today and pick up multi-row
+ * history once Phase 4 ships the schema.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { apiClient } from '@/lib/api/client';
+import {
+  ToolkitVersionsResponseSchema,
+  type ToolkitVersion,
+  type ToolkitVersionsResponse,
+} from '@/lib/api/schemas/toolkit-marketplace.schemas';
+
+export const TOOLKIT_VERSIONS_STALE_TIME_MS = 10 * 60 * 1000; // 10 min, mirrors backend cache.
+
+export const toolkitVersionsKeys = {
+  all: ['toolkits', 'versions'] as const,
+  byId: (toolkitId: string) => [...toolkitVersionsKeys.all, toolkitId] as const,
+};
+
+export interface UseToolkitVersionsOptions {
+  readonly toolkitId: string | null | undefined;
+  readonly enabled?: boolean;
+}
+
+/**
+ * Fetch the published version history for a toolkit.
+ *
+ * @example
+ * const { data, isLoading } = useToolkitVersions({ toolkitId: 'xxx' });
+ * // data — ToolkitVersion[] (empty array when not visible)
+ */
+export function useToolkitVersions(
+  options: UseToolkitVersionsOptions
+): UseQueryResult<ToolkitVersion[], Error> {
+  const { toolkitId, enabled = true } = options;
+  const isValid = typeof toolkitId === 'string' && toolkitId.length > 0;
+
+  return useQuery<ToolkitVersion[], Error>({
+    queryKey: isValid ? toolkitVersionsKeys.byId(toolkitId) : toolkitVersionsKeys.all,
+    queryFn: async () => {
+      if (!isValid) return [];
+      const response = await apiClient.get<ToolkitVersionsResponse>(
+        `/toolkits/${toolkitId}/versions`,
+        ToolkitVersionsResponseSchema
+      );
+      return response?.items ?? [];
+    },
+    enabled: enabled && isValid,
+    staleTime: TOOLKIT_VERSIONS_STALE_TIME_MS,
+  });
+}

--- a/apps/web/src/lib/api/schemas/toolkit-marketplace.schemas.ts
+++ b/apps/web/src/lib/api/schemas/toolkit-marketplace.schemas.ts
@@ -1,0 +1,95 @@
+/**
+ * /toolkits Marketplace Schemas (Wave 3 Phase 2, Issue #805)
+ *
+ * Zod schemas for the SP4 /toolkits/[id] marketplace surface. Backend
+ * contract is defined in PR #732 §5.3:
+ *   - §5.3.1 — GET  /api/v1/toolkits/{id}             (ToolkitDetailResponse)
+ *   - §5.3.2 — GET  /api/v1/toolkits/{id}/versions    (ToolkitVersionsResponse)
+ *   - §5.3.5 — POST /api/v1/toolkits/{id}/install     (InstallToolkitResponse)
+ *
+ * Schema reality v1 carryovers (Gate B) — backend stubs documented inline:
+ *   - installCount: always 0 (no ToolkitInstallation entity yet).
+ *   - ratingAverage / ratingCount: null / 0 (no ToolkitRating entity yet).
+ *   - currentVersion: "1.0.{int}" until semver schema lands.
+ *   - publishedAt: derived from UpdatedAt for approved toolkits, else null.
+ *   - yankedAt: always null in v1 (no yank workflow yet).
+ *
+ * Wire shape is stable so the FE surface can adopt the real metrics in
+ * Phase 4 without a fetch-shape change.
+ */
+
+import { z } from 'zod';
+
+// ========== /api/v1/toolkits/{id} (PR #732 §5.3.1) ==========
+
+export const ToolkitAgentSummarySchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1),
+  systemPromptPreview: z.string(),
+});
+export type ToolkitAgentSummary = z.infer<typeof ToolkitAgentSummarySchema>;
+
+export const ToolkitDetailSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1),
+  description: z.string(),
+  authorId: z.string().uuid(),
+  authorName: z.string().min(1),
+  authorAvatarUrl: z.string().nullable(),
+  coverImageUrl: z.string().nullable(),
+  agent: ToolkitAgentSummarySchema,
+  kbDocsCount: z.number().int().nonnegative(),
+  toolsCount: z.number().int().nonnegative(),
+  // Schema reality v1 carryover (Gate B): backend always returns 0 until
+  // ToolkitInstallation tracking lands.
+  installCount: z.number().int().nonnegative(),
+  // Schema reality v1 carryover (Gate B): null/0 until ToolkitRating lands.
+  ratingAverage: z.number().nullable(),
+  ratingCount: z.number().int().nonnegative(),
+  createdAt: z.string().datetime({ offset: true }),
+  publishedAt: z.string().datetime({ offset: true }).nullable(),
+  yankedAt: z.string().datetime({ offset: true }).nullable(),
+  // Schema reality v1 carryover (Gate B): "1.0.{int}" until semver lands.
+  currentVersion: z.string().min(1),
+});
+export type ToolkitDetail = z.infer<typeof ToolkitDetailSchema>;
+
+export const ViewerContextSchema = z.object({
+  isOwner: z.boolean(),
+  hasInstalled: z.boolean(),
+  // Server-derived: hasInstalled && !alreadyRated && !isOwner. With v1 stub
+  // hasInstalled=false the flag collapses to false.
+  canRate: z.boolean(),
+});
+export type ViewerContext = z.infer<typeof ViewerContextSchema>;
+
+export const ToolkitDetailResponseSchema = z.object({
+  toolkit: ToolkitDetailSchema,
+  viewerContext: ViewerContextSchema,
+});
+export type ToolkitDetailResponse = z.infer<typeof ToolkitDetailResponseSchema>;
+
+// ========== /api/v1/toolkits/{id}/versions (PR #732 §5.3.2) ==========
+
+export const ToolkitVersionSchema = z.object({
+  version: z.string().min(1),
+  publishedAt: z.string().datetime({ offset: true }),
+  yankedAt: z.string().datetime({ offset: true }).nullable(),
+  changelog: z.string(),
+  isCurrent: z.boolean(),
+});
+export type ToolkitVersion = z.infer<typeof ToolkitVersionSchema>;
+
+export const ToolkitVersionsResponseSchema = z.object({
+  items: z.array(ToolkitVersionSchema),
+});
+export type ToolkitVersionsResponse = z.infer<typeof ToolkitVersionsResponseSchema>;
+
+// ========== POST /api/v1/toolkits/{id}/install (PR #732 §5.3.5) ==========
+
+export const InstallToolkitResponseSchema = z.object({
+  // Schema reality v1 carryover (Gate B): always 0 until installation entity.
+  installCount: z.number().int().nonnegative(),
+  hasInstalled: z.boolean(),
+});
+export type InstallToolkitResponse = z.infer<typeof InstallToolkitResponseSchema>;


### PR DESCRIPTION
## Summary

Wave 3 backend Phase 2 — 3 toolkit marketplace endpoints unblocking \`/toolkits/[id]\` Wave 3 frontend (Step 5). Per PR #732 spec §5.3.1, §5.3.2, §5.3.5 + §8 roadmap.

## Resolves

Refs #805 (Wave 3 backend execution umbrella)

## 3 endpoints

| Endpoint | Method | Cache | Behavior |
|----------|--------|-------|----------|
| \`/api/v1/toolkits/{id}\` | GET | 10min ETag per-viewer | Detail with viewerContext (isOwner/hasInstalled/canRate) |
| \`/api/v1/toolkits/{id}/versions\` | GET | 10min | Versions list, sorted publishedAt DESC |
| \`/api/v1/toolkits/{id}/install\` | POST | (mutation) | Idempotent install, invalidates agents/popular cache |

## BC ownership decision (Newman §5.1)

EXTEND existing GameToolkit BC. No new MarketplaceBC. Marketplace surface mounted at \`/api/v1/toolkits/*\` (separate from legacy \`/api/v1/game-toolkits/*\` session-toolkit CRUD).

## CQRS preserved

Per CLAUDE.md: 3 Query/Command + Handler + Validator triples, \`IMediator.Send()\` only, internal sealed record DTOs.

## Security boundary (Wiegers §5.2)

Server-enforced 404 for unpublished/yanked toolkits when viewer != author. \`viewerContext.canRate\` derived server-side from \`hasInstalled && !alreadyRated && !isOwner\`.

## Idempotency (Nygard §5.3.5)

Re-install returns 200 with current state, NOT 409. Avoids client retry loops on network blips.

## Schema reality v1 carryovers (Gate B documented inline)

ToolkitAggregate currently lacks several Phase 4-scoped entities — stub fields documented:
- \`installCount\`: 0 (no ToolkitInstallation entity)
- \`ratingAverage\`/\`ratingCount\`: null/0 (no ToolkitRating entity)
- \`currentVersion\`: \`"1.0.{int}"\` synthesised from existing Version int (no semver schema)
- \`publishedAt\`: derived from \`UpdatedAt\` when IsPublished && TemplateStatus == Approved
- \`yankedAt\`: always null in v1 (no yank workflow)
- \`description\`/\`coverImageUrl\`: derived/null (columns missing)
- Versions endpoint returns single-row stub
- \`viewerContext.canRate\` collapses to false in v1

Wire shapes stable for FE adoption when Phase 4 ships entities.

## Tests

- 20 backend integration tests (Testcontainers, all PASS — 211 prior + 20 new in BoundedContext=GameToolkit)
- 21 frontend unit tests (8+8+5 hooks, all PASS)
- TOTAL: 41 new tests

## Test plan

- [x] dotnet build clean
- [x] dotnet test 211/211 PASS
- [x] pnpm typecheck clean
- [x] pnpm test 21/21 PASS
- [ ] CI Backend Integration green
- [ ] CI Frontend Build & Test green

## Frontend hooks ready

- \`useToolkitDetail({ toolkitId })\`
- \`useToolkitVersions({ toolkitId })\`
- \`useInstallToolkit()\` (mutation w/ optimistic invalidation hint)

Ready for Wave 3 Step 5 \`/toolkits/[id]\` Phase 0.5 contract drafting.

## Out-of-scope (Phase 4)

Per PR #732 §5.3 endpoints §5.3.3 (ratings list cursor) + §5.3.4 (submit rating) + §5.3.6 (publish version) + §5.3.7 (yank) deferred to Phase 4 per spec roadmap §8.

## Refs

- Wave 3 backend umbrella #805
- PR #732 spec d8aac33de §5.1 §5.2 §5.3.1 §5.3.2 §5.3.5
- Phase 0 PR #811 (BGG search) ✅ shipped
- Phase 1 PR #812 (/discover quick-wins) ✅ shipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)