### PR TITLE
feat(discover): Wave 3 Phase 4a — 2 cross-cutting endpoints (#805)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetTopUserContributors/GetTopUserContributorsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetTopUserContributors/GetTopUserContributorsQuery.cs
@@ -1,0 +1,19 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Administration.Application.Queries.GetTopUserContributors;
+
+/// <summary>
+/// Query for the SP4 /discover "Top contributors" rail
+/// (Wave 3 Phase 4a, PR #732 §4.3.6 / Issue #805).
+/// </summary>
+/// <param name="Limit">Number of contributors to return. Validator clamps to [1, 50]; default 10.</param>
+/// <remarks>
+/// Distinct surface from the existing public
+/// <c>/shared-games/top-contributors</c> leaderboard
+/// (<see cref="SharedGameCatalog.Application.Queries.GetTopContributors.GetTopContributorsQuery"/>),
+/// which scores by <c>sessions + wins * 2</c>. This query aggregates
+/// <em>contribution sources</em> (FAQs authored, KB documents uploaded,
+/// AI agents created) to surface community editors rather than active players.
+/// </remarks>
+internal sealed record GetTopUserContributorsQuery(int Limit = 10)
+    : IQuery<TopUserContributorsResponse>;

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetTopUserContributors/GetTopUserContributorsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetTopUserContributors/GetTopUserContributorsQueryHandler.cs
@@ -1,0 +1,184 @@
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.Administration.Application.Queries.GetTopUserContributors;
+
+/// <summary>
+/// Handler for <see cref="GetTopUserContributorsQuery"/>.
+/// Wave 3 Phase 4a, PR #732 §4.3.6 / Issue #805.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>V1 strategy (Fowler §4.3.6 spec)</b>: cross-BC SQL aggregation at request
+/// time + 1h cache. V2 (deferred): background job + materialized view
+/// (<c>top_contributors_daily</c> table) — out of scope for this issue.
+/// </para>
+///
+/// <para>
+/// <b>Schema reality v1 carryover (Gate B audit results)</b>:
+/// <list type="bullet">
+///   <item><c>PdfDocumentEntity.UploadedByUserId</c> ✅ exists — KB uploads count
+///         is real.</item>
+///   <item><c>GameFaqEntity</c> ❌ no creator FK column — FAQs count stubbed
+///         to <c>0</c>. Documented in DTO XML doc.</item>
+///   <item><c>AgentDefinition</c> ❌ no <c>OwnerUserId</c> / <c>CreatedByUserId</c>
+///         column — agents-created count stubbed to <c>0</c>. Documented in DTO XML doc.</item>
+/// </list>
+/// In v1 the effective <c>ContributionCount</c> therefore equals
+/// <c>KbUploadsCount</c>. The wire shape is stable so the FE rail can render
+/// today and adopt the real metrics without a re-fetch shape change.
+/// </para>
+///
+/// <para>
+/// <b>Privacy guards</b>: skip suspended accounts, require <c>Status == "Active"</c>,
+/// and require non-null <c>DisplayName</c> (mirrors the existing
+/// <c>GetTopContributorsQueryHandler</c> in <c>SharedGameCatalog</c>). Email-derived
+/// identifiers must not leak on a public discover surface.
+/// </para>
+///
+/// <para>
+/// <b>Cross-BC read</b>: this handler reads <c>PdfDocuments</c>
+/// (DocumentProcessing) and <c>Users</c> (Authentication) directly via
+/// <see cref="MeepleAiDbContext"/>. Acceptable as a read-only projection — no
+/// command crosses BC boundaries.
+/// </para>
+///
+/// <para>
+/// <b>Cache</b>: 1h HybridCache keyed by <c>discover:topUserContributors</c>
+/// (PR #732 §3.2 caching matrix — daily batch refresh slot for V2 migration).
+/// </para>
+/// </remarks>
+internal sealed class GetTopUserContributorsQueryHandler
+    : IRequestHandler<GetTopUserContributorsQuery, TopUserContributorsResponse>
+{
+    private const string CacheKey = "discover:topUserContributors";
+    private const int MaxCacheLimit = 50;
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(1);
+
+    private readonly MeepleAiDbContext _context;
+    private readonly IHybridCacheService _cache;
+    private readonly ILogger<GetTopUserContributorsQueryHandler> _logger;
+
+    public GetTopUserContributorsQueryHandler(
+        MeepleAiDbContext context,
+        IHybridCacheService cache,
+        ILogger<GetTopUserContributorsQueryHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<TopUserContributorsResponse> Handle(
+        GetTopUserContributorsQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var allContributors = await _cache.GetOrCreateAsync(
+            CacheKey,
+            async ct => await ComputeContributorsAsync(MaxCacheLimit, ct).ConfigureAwait(false),
+            tags: ["users", "discover", "topUserContributors"],
+            expiration: CacheTtl,
+            ct: cancellationToken).ConfigureAwait(false);
+
+        var trimmed = allContributors.Items
+            .Take(request.Limit)
+            .ToList();
+
+        _logger.LogInformation(
+            "Returning {Count} top user contributors (limit={Limit}) from cache/compute",
+            trimmed.Count,
+            request.Limit);
+
+        return new TopUserContributorsResponse(trimmed);
+    }
+
+    private async Task<TopUserContributorsResponse> ComputeContributorsAsync(
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        // Step 1: aggregate KB uploads per user (the only real signal in v1).
+        // PdfDocuments use DocumentProcessing BC; cross-BC read is acceptable
+        // as a read-only projection per §4.3.6 V1 strategy.
+        var uploadCounts = await _context.PdfDocuments
+            .AsNoTracking()
+            .Where(p => p.UploadedByUserId != Guid.Empty)
+            .GroupBy(p => p.UploadedByUserId)
+            .Select(g => new { UserId = g.Key, Count = g.Count() })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (uploadCounts.Count == 0)
+        {
+            _logger.LogInformation("No PDF uploads found — top-contributors empty.");
+            return new TopUserContributorsResponse(Array.Empty<TopUserContributorDto>());
+        }
+
+        // Step 2: rank by ContributionCount (= KbUploadsCount in v1) DESC.
+        // Tie-break: UserId ASC for deterministic pagination.
+        // Over-fetch buffer (limit * 2 + 10) to compensate for users filtered
+        // out by privacy guards in step 3.
+        var overFetch = Math.Max(limit * 2, limit + 10);
+        var ranked = uploadCounts
+            .Select(u => new
+            {
+                u.UserId,
+                FaqsCount = 0,            // Schema reality v1 carryover (Gate B)
+                KbUploadsCount = u.Count,
+                AgentsCreatedCount = 0,    // Schema reality v1 carryover (Gate B)
+                ContributionCount = u.Count
+            })
+            .OrderByDescending(x => x.ContributionCount)
+            .ThenBy(x => x.UserId)
+            .Take(overFetch)
+            .ToList();
+
+        // Step 3: fetch user profile details and apply privacy guards.
+        // Privacy guards: skip suspended, require Active status, require
+        // non-null DisplayName (mirror SharedGameCatalog GetTopContributors
+        // pattern for consistency on public surfaces).
+        var candidateIds = ranked.Select(r => r.UserId).ToList();
+        var users = await _context.Set<UserEntity>()
+            .AsNoTracking()
+            .Where(u => candidateIds.Contains(u.Id)
+                     && !u.IsSuspended
+                     && u.Status == "Active"
+                     && u.DisplayName != null)
+            .Select(u => new { u.Id, u.DisplayName, u.AvatarUrl })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var userMap = users.ToDictionary(u => u.Id);
+
+        // Step 4: build DTOs in rank order, drop users filtered out by privacy guards.
+        var items = ranked
+            .Where(r => userMap.ContainsKey(r.UserId))
+            .Take(limit)
+            .Select(r =>
+            {
+                var u = userMap[r.UserId];
+                return new TopUserContributorDto(
+                    Id: r.UserId,
+                    DisplayName: u.DisplayName!, // guarded non-null in step 3
+                    AvatarUrl: u.AvatarUrl,
+                    ContributionCount: r.ContributionCount,
+                    Breakdown: new TopUserContributorBreakdownDto(
+                        FaqsCount: r.FaqsCount,
+                        KbUploadsCount: r.KbUploadsCount,
+                        AgentsCreatedCount: r.AgentsCreatedCount));
+            })
+            .ToList();
+
+        _logger.LogInformation(
+            "Computed {Count} top contributors from {UploadUsers} upload aggregates (Gate B v1: only KB uploads count).",
+            items.Count,
+            uploadCounts.Count);
+
+        return new TopUserContributorsResponse(items);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetTopUserContributors/GetTopUserContributorsQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetTopUserContributors/GetTopUserContributorsQueryValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.Administration.Application.Queries.GetTopUserContributors;
+
+/// <summary>
+/// Validator for <see cref="GetTopUserContributorsQuery"/>.
+/// Wave 3 Phase 4a, PR #732 §4.3.6 / Issue #805.
+/// </summary>
+internal sealed class GetTopUserContributorsQueryValidator
+    : AbstractValidator<GetTopUserContributorsQuery>
+{
+    public GetTopUserContributorsQueryValidator()
+    {
+        RuleFor(x => x.Limit)
+            .InclusiveBetween(1, 50)
+            .WithMessage("Limit must be between 1 and 50.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetTopUserContributors/TopUserContributorDto.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetTopUserContributors/TopUserContributorDto.cs
@@ -1,0 +1,52 @@
+namespace Api.BoundedContexts.Administration.Application.Queries.GetTopUserContributors;
+
+/// <summary>
+/// Per-source breakdown of contribution counts for a single contributor.
+/// Wave 3 Phase 4a, PR #732 §4.3.6 / Issue #805.
+/// </summary>
+internal sealed record TopUserContributorBreakdownDto(
+    int FaqsCount,
+    int KbUploadsCount,
+    int AgentsCreatedCount
+);
+
+/// <summary>
+/// Single contributor row for the SP4 /discover "Top contributors" rail
+/// (Wave 3 Phase 4a, PR #732 §4.3.6 / Issue #805).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Distinct from the existing <see
+/// cref="SharedGameCatalog.Application.DTOs.TopContributorDto"/> (sessions/wins
+/// score for the public /shared-games sidebar). This surface aggregates
+/// <em>contribution sources</em> (FAQs authored, KB documents uploaded,
+/// AI agents created) for the discover route.
+/// </para>
+///
+/// <para>
+/// Schema reality v1 carryover (Gate B):
+/// <list type="bullet">
+///   <item><c>AgentsCreatedCount</c> is always <c>0</c> in v1 because
+///         <c>AgentDefinition</c> aggregates do not track a
+///         <c>CreatedByUserId</c> / <c>OwnerUserId</c> column. The wire shape
+///         is stable so the rail can render today and adopt the real metric
+///         when ownership tracking lands.</item>
+///   <item><c>GameFaqEntity</c> tracks <c>CreatedAt</c> but not a creator FK
+///         column in v1 — falls back to <c>0</c> for the same reason.</item>
+/// </list>
+/// </para>
+/// </remarks>
+internal sealed record TopUserContributorDto(
+    Guid Id,
+    string DisplayName,
+    string? AvatarUrl,
+    int ContributionCount,
+    TopUserContributorBreakdownDto Breakdown
+);
+
+/// <summary>
+/// Stable response envelope for the top-contributors endpoint.
+/// </summary>
+internal sealed record TopUserContributorsResponse(
+    IReadOnlyList<TopUserContributorDto> Items
+);

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/GetRecommendedToolkitsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/GetRecommendedToolkitsQuery.cs
@@ -1,0 +1,18 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
+
+/// <summary>
+/// Query for the recommended toolkits surface
+/// (Wave 3 Phase 4a, PR #732 §4.3.4 / Issue #805).
+/// </summary>
+/// <param name="Limit">Number of toolkits to return. Validator clamps to [1, 50]; default 10.</param>
+/// <remarks>
+/// Per PR #732 §5.1 (Newman BC decomposition), this query lives in the
+/// <c>GameToolkit</c> BC because the marketplace surface extends the existing
+/// toolkit aggregate rather than introducing a new <c>MarketplaceBC</c>.
+/// Visibility filter: only published toolkits
+/// (<c>IsPublished == true &amp;&amp; TemplateStatus == Approved</c>).
+/// </remarks>
+internal sealed record GetRecommendedToolkitsQuery(int Limit = 10)
+    : IQuery<RecommendedToolkitsResponse>;

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/GetRecommendedToolkitsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/GetRecommendedToolkitsQueryHandler.cs
@@ -1,0 +1,163 @@
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
+
+/// <summary>
+/// Handler for <see cref="GetRecommendedToolkitsQuery"/>.
+/// Wave 3 Phase 4a, PR #732 §4.3.4 / Issue #805.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Recommendation algorithm (Nygard §4.3.4 spec)</b>:
+/// <c>(ratingAverage * log(ratingCount + 1)) DESC, installCount DESC tiebreak,
+/// createdAt DESC final tiebreak</c>. The Bayesian-style score balances rating
+/// quality against rating volume so a single 5-star toolkit doesn't outrank a
+/// 4.5-star toolkit with hundreds of ratings.
+/// </para>
+///
+/// <para>
+/// <b>Schema reality v1 carryover (Gate B)</b>: there is no <c>ToolkitRating</c>
+/// or <c>ToolkitInstallation</c> entity in the current schema, so all three
+/// inputs to the score formula are 0/null in v1. The effective sort therefore
+/// collapses to <c>createdAt DESC</c> — recent published toolkits surface first.
+/// The wire shape is stable so the FE rail can render today and adopt the real
+/// signals without a re-fetch shape change.
+/// </para>
+///
+/// <para>
+/// <b>Visibility filter</b>: only published toolkits surface
+/// (<c>IsPublished == true &amp;&amp; TemplateStatus == Approved</c>). Drafts,
+/// pending review, rejected, and yanked toolkits are excluded — non-authors
+/// must not see them on a public discover surface (mirrors the security
+/// boundary in <c>GetToolkitDetailQueryHandler</c>).
+/// </para>
+///
+/// <para>
+/// <b>Cache</b>: 30min HybridCache keyed by <c>discover:recommendedToolkits</c>
+/// (PR #732 §3.2 caching matrix). Bulk-fetches author display names for the
+/// trimmed slice (no N+1) using <c>UserEntity</c> lookup.
+/// </para>
+/// </remarks>
+internal sealed class GetRecommendedToolkitsQueryHandler
+    : IRequestHandler<GetRecommendedToolkitsQuery, RecommendedToolkitsResponse>
+{
+    private const string CacheKey = "discover:recommendedToolkits";
+    private const int MaxCacheLimit = 50;
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(30);
+
+    private readonly MeepleAiDbContext _context;
+    private readonly IHybridCacheService _cache;
+    private readonly ILogger<GetRecommendedToolkitsQueryHandler> _logger;
+
+    public GetRecommendedToolkitsQueryHandler(
+        MeepleAiDbContext context,
+        IHybridCacheService cache,
+        ILogger<GetRecommendedToolkitsQueryHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<RecommendedToolkitsResponse> Handle(
+        GetRecommendedToolkitsQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var allRecommended = await _cache.GetOrCreateAsync(
+            CacheKey,
+            async ct => await ComputeRecommendedAsync(MaxCacheLimit, ct).ConfigureAwait(false),
+            tags: ["toolkits", "discover", "recommendedToolkits"],
+            expiration: CacheTtl,
+            ct: cancellationToken).ConfigureAwait(false);
+
+        var trimmed = allRecommended.Items
+            .Take(request.Limit)
+            .ToList();
+
+        _logger.LogInformation(
+            "Returning {Count} recommended toolkits (limit={Limit}) from cache/compute",
+            trimmed.Count,
+            request.Limit);
+
+        return new RecommendedToolkitsResponse(trimmed);
+    }
+
+    private async Task<RecommendedToolkitsResponse> ComputeRecommendedAsync(
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        // Visibility filter (PR #732 §5.2 security boundary): only show published
+        // + approved toolkits on the public discover surface.
+        var approvedStatus = (int)TemplateStatus.Approved;
+
+        // Schema reality v1 carryover (Gate B): rating/install/cover columns do
+        // not exist on GameToolkitEntity, so we sort by CreatedAt DESC as the
+        // effective fallback. The wire shape declares the full Bayesian score
+        // formula so the sort upgrade is non-breaking.
+        var rows = await _context.GameToolkits
+            .AsNoTracking()
+            .Where(t => t.IsPublished && t.TemplateStatus == approvedStatus)
+            .OrderByDescending(t => t.CreatedAt)
+            .Take(limit)
+            .Select(t => new
+            {
+                t.Id,
+                t.Name,
+                t.CreatedByUserId,
+                t.CreatedAt
+            })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (rows.Count == 0)
+        {
+            return new RecommendedToolkitsResponse(Array.Empty<RecommendedToolkitDto>());
+        }
+
+        // Bulk-fetch author display names for the slice (no N+1).
+        var authorIds = rows.Select(r => r.CreatedByUserId).Distinct().ToList();
+        var authors = await _context.Set<UserEntity>()
+            .AsNoTracking()
+            .Where(u => authorIds.Contains(u.Id))
+            .Select(u => new { u.Id, u.DisplayName, u.Email })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var authorMap = authors.ToDictionary(a => a.Id);
+
+        var items = rows.Select(r =>
+        {
+            string authorName;
+            if (authorMap.TryGetValue(r.CreatedByUserId, out var author))
+            {
+                authorName = !string.IsNullOrWhiteSpace(author.DisplayName)
+                    ? author.DisplayName!
+                    : (string.IsNullOrWhiteSpace(author.Email) ? "Unknown author" : author.Email);
+            }
+            else
+            {
+                // Defensive: author row was deleted (account removal).
+                authorName = "Unknown author";
+            }
+
+            return new RecommendedToolkitDto(
+                Id: r.Id,
+                Name: r.Name,
+                AuthorName: authorName,
+                InstallCount: 0,
+                RatingAverage: null,
+                RatingCount: 0,
+                CoverImageUrl: null);
+        }).ToList();
+
+        return new RecommendedToolkitsResponse(items);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/GetRecommendedToolkitsQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/GetRecommendedToolkitsQueryValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
+
+/// <summary>
+/// Validator for <see cref="GetRecommendedToolkitsQuery"/>.
+/// Wave 3 Phase 4a, PR #732 §4.3.4 / Issue #805.
+/// </summary>
+internal sealed class GetRecommendedToolkitsQueryValidator
+    : AbstractValidator<GetRecommendedToolkitsQuery>
+{
+    public GetRecommendedToolkitsQueryValidator()
+    {
+        RuleFor(x => x.Limit)
+            .InclusiveBetween(1, 50)
+            .WithMessage("Limit must be between 1 and 50.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/RecommendedToolkitDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/RecommendedToolkitDto.cs
@@ -1,0 +1,43 @@
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
+
+/// <summary>
+/// Lightweight DTO for the SP4 /discover route's "Recommended toolkits" rail
+/// (Wave 3 Phase 4a, PR #732 §4.3.4 / Issue #805).
+/// </summary>
+/// <remarks>
+/// Powers the FE <c>useDiscoverRecommendedToolkits</c> hook (Wave 3 Step 3b).
+///
+/// <para>
+/// Schema reality v1 carryover (Gate B) — flagged in field comments:
+/// <list type="bullet">
+///   <item><see cref="InstallCount"/>: no <c>ToolkitInstallation</c> entity yet → always 0.</item>
+///   <item><see cref="RatingAverage"/>: no <c>ToolkitRating</c> entity yet → always null.</item>
+///   <item><see cref="RatingCount"/>: same as <see cref="RatingAverage"/> → always 0.</item>
+///   <item><see cref="CoverImageUrl"/>: no cover image column on
+///     <c>GameToolkitEntity</c> in v1 → always null.</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// Recommendation algorithm (per Nygard §4.3.4 spec):
+/// <c>(ratingAverage * log(ratingCount + 1)) DESC, installCount DESC tiebreak,
+/// createdAt DESC final tiebreak</c>. With all P22 stubs at 0/null, the effective
+/// sort collapses to <c>createdAt DESC</c> in v1.
+/// </para>
+/// </remarks>
+internal sealed record RecommendedToolkitDto(
+    Guid Id,
+    string Name,
+    string AuthorName,
+    int InstallCount,
+    decimal? RatingAverage,
+    int RatingCount,
+    string? CoverImageUrl
+);
+
+/// <summary>
+/// Stable response envelope for the recommended-toolkits endpoint.
+/// </summary>
+internal sealed record RecommendedToolkitsResponse(
+    IReadOnlyList<RecommendedToolkitDto> Items
+);

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -10,6 +10,7 @@ using Api.Middleware;
 using Api.Models;
 using Api.Observability;
 using Api.Routing;
+using Api.Routing.AdministrationDiscover;
 using Api.Routing.GameManagement;
 using Api.Routing.GameToolkit;
 using Api.BoundedContexts.GameManagement.Routing; // Issue #4273
@@ -710,6 +711,9 @@ v1Api.MapAiEndpoints();
 v1Api.MapAgentsEndpoints(); // Issue #641 (Wave B.2 hotfix): user-facing agent listing
 v1Api.MapAgentTypologiesEndpoints(); // Issue #649: user-facing typology dropdown
 v1Api.MapRulebookAnalysisEndpoints(); // ISSUE-2402: Rulebook analysis service
+
+// Discover surface (cross-BC aggregation)
+TopUserContributorsEndpoints.Map(v1Api); // Wave 3 Phase 4a (#805): /users/top-contributors
 
 // User Library
 v1Api.MapUserLibraryEndpoints();       // User game library

--- a/apps/api/src/Api/Routing/Administration/TopUserContributorsEndpoints.cs
+++ b/apps/api/src/Api/Routing/Administration/TopUserContributorsEndpoints.cs
@@ -1,0 +1,59 @@
+using Api.BoundedContexts.Administration.Application.Queries.GetTopUserContributors;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Routing.AdministrationDiscover;
+
+/// <summary>
+/// Public discover-surface endpoint that aggregates user contribution sources
+/// (Wave 3 Phase 4a, PR #732 §4.3.6 / Issue #805).
+/// </summary>
+/// <remarks>
+/// Distinct surface from <c>/api/v1/shared-games/top-contributors</c>
+/// (sessions/wins score for the public /shared-games sidebar) — this endpoint
+/// powers the SP4 /discover route's "Top contributors" rail with a
+/// per-source breakdown (FAQs authored, KB documents uploaded, AI agents
+/// created).
+/// </remarks>
+internal static class TopUserContributorsEndpoints
+{
+    public static void Map(RouteGroupBuilder group)
+    {
+        group.MapGet("/users/top-contributors", HandleGetTopUserContributors)
+            .RequireAuthorization()
+            .WithName("GetTopUserContributors")
+            .WithTags("Discover")
+            .WithSummary("Get the top user contributors")
+            .WithDescription(
+                "Returns top users ranked by aggregate contribution count "
+                + "(FAQs authored + KB documents uploaded + AI agents created), "
+                + "with a per-source breakdown. Limit clamped 1..50, default 10. "
+                + "Schema reality v1 carryover (Gate B): only the KB uploads "
+                + "metric is real; FAQs + AgentsCreated are stubbed to 0 until "
+                + "creator FK columns land. Privacy guards: skips suspended + "
+                + "non-Active accounts and users without a DisplayName. Cache: "
+                + "1h HybridCache (V2 deferred: materialized view daily refresh). "
+                + "Powers the SP4 /discover \"Top contributors\" rail. "
+                + "Wave 3 Phase 4a (Issue #805 / PR #732 §4.3.6).")
+            .Produces<TopUserContributorsResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized);
+    }
+
+    private static async Task<IResult> HandleGetTopUserContributors(
+        [FromQuery] int? limit,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        // Limit clamping at the endpoint layer (PR #732 §3.3 — UI-friendly
+        // silent clamp rather than 400). Validator on the query enforces the
+        // same range for the CQRS handler.
+        var safeLimit = limit.GetValueOrDefault(10);
+        if (safeLimit < 1) safeLimit = 10;
+        if (safeLimit > 50) safeLimit = 50;
+
+        var query = new GetTopUserContributorsQuery(safeLimit);
+        var response = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
+
+        return Results.Ok(response);
+    }
+}

--- a/apps/api/src/Api/Routing/GameToolkit/ToolkitMarketplaceEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameToolkit/ToolkitMarketplaceEndpoints.cs
@@ -1,8 +1,10 @@
 using Api.BoundedContexts.GameToolkit.Application.Commands.InstallToolkit;
+using Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
 using Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitDetail;
 using Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitVersions;
 using Api.Extensions;
 using MediatR;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Routing.GameToolkit;
 
@@ -34,6 +36,25 @@ internal static class ToolkitMarketplaceEndpoints
         var toolkits = group.MapGroup("/toolkits")
             .WithTags("ToolkitMarketplace")
             .RequireAuthorization();
+
+        // ── GET /api/v1/toolkits/recommended ────────────────────────────────
+        // Wave 3 Phase 4a (Issue #805 / PR #732 §4.3.4): SP4 /discover rail
+        // "Recommended toolkits". Static route registered BEFORE /{toolkitId:guid}
+        // so the /recommended literal does not get parsed as a Guid route value.
+        toolkits.MapGet("/recommended", HandleGetRecommendedToolkits)
+            .WithName("GetRecommendedToolkits")
+            .WithSummary("Get recommended marketplace toolkits")
+            .WithDescription(
+                "Returns published toolkits sorted by Bayesian score "
+                + "(ratingAverage * log(ratingCount + 1) DESC, installCount DESC "
+                + "tiebreak, createdAt DESC final tiebreak). Limit clamped 1..50, "
+                + "default 10. Schema reality v1 carryover: rating + install "
+                + "metrics are 0/null until the ToolkitRating + ToolkitInstallation "
+                + "entities ship — effective sort collapses to createdAt DESC. "
+                + "Cache: 30min HybridCache. Powers the SP4 /discover \"Recommended "
+                + "toolkits\" rail. Wave 3 Phase 4a (Issue #805 / PR #732 §4.3.4).")
+            .Produces<RecommendedToolkitsResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized);
 
         // ── GET /api/v1/toolkits/{toolkitId} ────────────────────────────────
         toolkits.MapGet("/{toolkitId:guid}", HandleGetToolkitDetail)
@@ -96,6 +117,24 @@ internal static class ToolkitMarketplaceEndpoints
         return response is null
             ? Results.NotFound()
             : Results.Ok(response);
+    }
+
+    private static async Task<IResult> HandleGetRecommendedToolkits(
+        [FromQuery] int? limit,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        // Limit clamping at the endpoint layer (PR #732 §3.3 — UI-friendly
+        // silent clamp rather than 400). Validator on the query enforces the
+        // same range for the CQRS handler.
+        var safeLimit = limit.GetValueOrDefault(10);
+        if (safeLimit < 1) safeLimit = 10;
+        if (safeLimit > 50) safeLimit = 50;
+
+        var query = new GetRecommendedToolkitsQuery(safeLimit);
+        var response = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
+
+        return Results.Ok(response);
     }
 
     private static async Task<IResult> HandleGetToolkitVersions(

--- a/apps/api/tests/Api.Tests/Integration/Phase4a/RecommendedToolkitsEndpointIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Phase4a/RecommendedToolkitsEndpointIntegrationTests.cs
@@ -1,0 +1,327 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.Phase4a;
+
+/// <summary>
+/// Integration tests for <c>GET /api/v1/toolkits/recommended</c>
+/// (Wave 3 Phase 4a, PR #732 §4.3.4 / Issue #805).
+///
+/// <para>
+/// Powers the SP4 /discover route's "Recommended toolkits" rail. Sort:
+/// rating-weighted Bayesian score with createdAt DESC fallback (effective
+/// in v1 because rating/install entities are deferred to Phase 4b).
+/// </para>
+///
+/// <para>
+/// Visibility: only published + approved toolkits surface. Drafts, pending,
+/// and rejected are filtered out (PR #732 §5.2 security boundary).
+/// </para>
+///
+/// <para>
+/// Empty-state contract per PR #732 §3.4: 200 with <c>{ items: [] }</c>
+/// rather than 404 / 204.
+/// </para>
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameToolkit")]
+[Trait("Wave", "3-Phase-4a")]
+public sealed class RecommendedToolkitsEndpointIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    public RecommendedToolkitsEndpointIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"recommended_toolkits_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+        }
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        await _factory.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task RecommendedToolkits_WithoutAuth_ReturnsUnauthorized()
+    {
+        var response = await _client.GetAsync("/api/v1/toolkits/recommended?limit=10");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task RecommendedToolkits_WithEmptyCatalog_Returns200WithEmptyItems()
+    {
+        // PR #732 §3.4 — empty state is 200 with { items: [] }, not 404.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/toolkits/recommended?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RecommendedToolkits_OnlyReturnsPublishedAndApproved()
+    {
+        // Drafts, pending, rejected, and yanked must NOT surface on the public
+        // discover rail (PR #732 §5.2 security boundary).
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        // Approved + published → SHOULD surface.
+        await SeedToolkitAsync(dbContext, authorId, "Approved+Published",
+            isPublished: true, templateStatus: TemplateStatus.Approved,
+            createdAt: DateTime.UtcNow.AddDays(-1));
+        // Draft → must NOT surface.
+        await SeedToolkitAsync(dbContext, authorId, "Hidden Draft",
+            isPublished: false, templateStatus: TemplateStatus.Draft,
+            createdAt: DateTime.UtcNow.AddHours(-1));
+        // Approved but unpublished → must NOT surface (combined gate).
+        await SeedToolkitAsync(dbContext, authorId, "Approved Unpublished",
+            isPublished: false, templateStatus: TemplateStatus.Approved,
+            createdAt: DateTime.UtcNow.AddHours(-2));
+        // Published but pending → must NOT surface.
+        await SeedToolkitAsync(dbContext, authorId, "Pending Published",
+            isPublished: true, templateStatus: TemplateStatus.PendingReview,
+            createdAt: DateTime.UtcNow.AddHours(-3));
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/toolkits/recommended?limit=10",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items");
+        items.GetArrayLength().Should().Be(1);
+        items[0].GetProperty("name").GetString().Should().Be("Approved+Published");
+    }
+
+    [Fact]
+    public async Task RecommendedToolkits_SortedByCreatedAtDescendingV1Fallback()
+    {
+        // Schema reality v1 (Gate B): rating + install metrics are 0/null,
+        // so the Bayesian score collapses to createdAt DESC.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        await SeedToolkitAsync(dbContext, authorId, "Oldest", true, TemplateStatus.Approved,
+            createdAt: DateTime.UtcNow.AddDays(-30));
+        await SeedToolkitAsync(dbContext, authorId, "Middle", true, TemplateStatus.Approved,
+            createdAt: DateTime.UtcNow.AddDays(-7));
+        await SeedToolkitAsync(dbContext, authorId, "Newest", true, TemplateStatus.Approved,
+            createdAt: DateTime.UtcNow.AddDays(-1));
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/toolkits/recommended?limit=10",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items");
+        items.GetArrayLength().Should().Be(3);
+        items[0].GetProperty("name").GetString().Should().Be("Newest");
+        items[1].GetProperty("name").GetString().Should().Be("Middle");
+        items[2].GetProperty("name").GetString().Should().Be("Oldest");
+    }
+
+    [Fact]
+    public async Task RecommendedToolkits_DtoExposesV1StubFields()
+    {
+        // Schema reality v1 (Gate B): installCount=0, ratingAverage=null,
+        // ratingCount=0, coverImageUrl=null.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        await SeedToolkitAsync(dbContext, authorId, "Wingspan Toolkit", true,
+            TemplateStatus.Approved, createdAt: DateTime.UtcNow.AddHours(-1));
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/toolkits/recommended?limit=10",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var item = body.GetProperty("items")[0];
+        item.GetProperty("id").GetString().Should().NotBeNullOrEmpty();
+        item.GetProperty("name").GetString().Should().Be("Wingspan Toolkit");
+        // Author name resolved from UserEntity (DisplayName fallback to email "Test User").
+        item.GetProperty("authorName").GetString().Should().NotBeNullOrEmpty();
+        item.GetProperty("installCount").GetInt32().Should().Be(0);
+        item.GetProperty("ratingAverage").ValueKind.Should().Be(JsonValueKind.Null);
+        item.GetProperty("ratingCount").GetInt32().Should().Be(0);
+        item.GetProperty("coverImageUrl").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task RecommendedToolkits_RespectsLimitParameter()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        for (var i = 0; i < 5; i++)
+        {
+            await SeedToolkitAsync(dbContext, authorId, $"Toolkit {i}",
+                true, TemplateStatus.Approved,
+                createdAt: DateTime.UtcNow.AddMinutes(-i));
+        }
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/toolkits/recommended?limit=2",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task RecommendedToolkits_ClampsExcessiveLimitTo50()
+    {
+        // PR #732 §3.3: silent UI-friendly clamp rather than 400.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        await SeedToolkitAsync(dbContext, authorId, "Solo", true, TemplateStatus.Approved,
+            createdAt: DateTime.UtcNow);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/toolkits/recommended?limit=200",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Only 1 toolkit exists, but the request wouldn't 400 with limit=200.
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(1);
+    }
+
+    /// <summary>
+    /// Seeds an authored GameToolkit with explicit createdAt. Mirrors the raw
+    /// SQL pattern from <c>ToolkitMarketplaceEndpointsIntegrationTests</c> —
+    /// the row-version + JSONB columns require a raw INSERT to bypass EF's
+    /// store-generated stripping of <c>RowVersion</c>.
+    /// </summary>
+    private static async Task SeedToolkitAsync(
+        MeepleAiDbContext dbContext,
+        Guid authorId,
+        string name,
+        bool isPublished,
+        TemplateStatus templateStatus,
+        DateTime createdAt)
+    {
+        // GameToolkitEntity.GameId references the "games" table (GameEntity).
+        var game = new GameEntity
+        {
+            Id = Guid.NewGuid(),
+            Name = $"Game for {name}",
+            CreatedAt = DateTime.UtcNow,
+        };
+        dbContext.Games.Add(game);
+        await dbContext.SaveChangesAsync();
+
+        var toolkitId = Guid.NewGuid();
+        var updatedAt = createdAt;
+        var templateStatusInt = (int)templateStatus;
+        var isTemplate = templateStatus == TemplateStatus.Approved;
+
+        const string sql = """
+            INSERT INTO "GameToolkits" (
+                "Id", "GameId", "PrivateGameId", "Name", "Version",
+                "CreatedByUserId", "IsPublished",
+                "OverridesTurnOrder", "OverridesScoreboard", "OverridesDiceSet",
+                "CreatedAt", "UpdatedAt",
+                "DiceToolsJson", "CardToolsJson", "TimerToolsJson",
+                "CounterToolsJson", "UserDicePresetsJson",
+                "ScoringTemplateJson", "TurnTemplateJson", "StateTemplate",
+                "AgentConfig",
+                "TemplateStatus", "IsTemplate",
+                "ReviewNotes", "ReviewedByUserId", "ReviewedAt",
+                "RowVersion"
+            ) VALUES (
+                {0}, {1}, NULL, {2}, 1,
+                {3}, {4},
+                FALSE, FALSE, FALSE,
+                {5}, {6},
+                NULL, NULL, NULL,
+                NULL, NULL,
+                NULL, NULL, NULL,
+                NULL,
+                {7}, {8},
+                NULL, NULL, NULL,
+                E'\\x01'
+            )
+            """;
+
+        await dbContext.Database.ExecuteSqlRawAsync(
+            sql,
+            toolkitId,
+            game.Id,
+            name,
+            authorId,
+            isPublished,
+            createdAt,
+            updatedAt,
+            templateStatusInt,
+            isTemplate);
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/Phase4a/TopUserContributorsEndpointIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Phase4a/TopUserContributorsEndpointIntegrationTests.cs
@@ -1,0 +1,353 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.Phase4a;
+
+/// <summary>
+/// Integration tests for <c>GET /api/v1/users/top-contributors</c>
+/// (Wave 3 Phase 4a, PR #732 §4.3.6 / Issue #805).
+///
+/// <para>
+/// Powers the SP4 /discover route's "Top contributors" rail. Distinct from
+/// the existing <c>/api/v1/shared-games/top-contributors</c> leaderboard
+/// (sessions/wins) — this surface aggregates contribution sources (FAQs,
+/// KB uploads, AI agents created) for community editors.
+/// </para>
+///
+/// <para>
+/// Schema reality v1 (Gate B audit): only <c>UploadedByUserId</c> on
+/// <c>PdfDocumentEntity</c> exists. <c>GameFaqEntity</c> + <c>AgentDefinition</c>
+/// have no creator FK in v1, so <c>FaqsCount</c> and <c>AgentsCreatedCount</c>
+/// are stubbed to 0. <c>ContributionCount</c> therefore equals
+/// <c>KbUploadsCount</c> in v1.
+/// </para>
+///
+/// <para>
+/// Privacy guards: skip suspended accounts, require <c>Status == "Active"</c>,
+/// require non-null <c>DisplayName</c>.
+/// </para>
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "Administration")]
+[Trait("Wave", "3-Phase-4a")]
+public sealed class TopUserContributorsEndpointIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    public TopUserContributorsEndpointIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"top_user_contributors_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+        }
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        await _factory.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task TopContributors_WithoutAuth_ReturnsUnauthorized()
+    {
+        var response = await _client.GetAsync("/api/v1/users/top-contributors?limit=10");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task TopContributors_WithEmptyData_Returns200WithEmptyItems()
+    {
+        // PR #732 §3.4 — empty state is 200 with { items: [] }, not 404.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/users/top-contributors?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task TopContributors_RanksUsersByKbUploadsDescending()
+    {
+        // V1: only KB uploads count toward ContributionCount. Sort: count DESC,
+        // then UserId ASC tiebreak.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        // Seed three contributors with explicit display names + upload counts.
+        var alice = await SeedActiveUserAsync(dbContext, "Alice");
+        var bob = await SeedActiveUserAsync(dbContext, "Bob");
+        var carol = await SeedActiveUserAsync(dbContext, "Carol");
+
+        await SeedPdfUploadsAsync(dbContext, alice, count: 1);
+        await SeedPdfUploadsAsync(dbContext, bob, count: 5);
+        await SeedPdfUploadsAsync(dbContext, carol, count: 3);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/users/top-contributors?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items");
+        items.GetArrayLength().Should().Be(3);
+        items[0].GetProperty("displayName").GetString().Should().Be("Bob");
+        items[0].GetProperty("contributionCount").GetInt32().Should().Be(5);
+        items[1].GetProperty("displayName").GetString().Should().Be("Carol");
+        items[1].GetProperty("contributionCount").GetInt32().Should().Be(3);
+        items[2].GetProperty("displayName").GetString().Should().Be("Alice");
+        items[2].GetProperty("contributionCount").GetInt32().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task TopContributors_BreakdownStubsFaqsAndAgentsToZeroV1()
+    {
+        // Schema reality v1 (Gate B): FaqsCount + AgentsCreatedCount stubbed
+        // to 0 because GameFaqEntity + AgentDefinition lack creator FK columns.
+        // Only KbUploadsCount is real.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var alice = await SeedActiveUserAsync(dbContext, "Alice");
+        await SeedPdfUploadsAsync(dbContext, alice, count: 4);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/users/top-contributors?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var item = body.GetProperty("items")[0];
+        var breakdown = item.GetProperty("breakdown");
+        breakdown.GetProperty("faqsCount").GetInt32().Should().Be(0);
+        breakdown.GetProperty("kbUploadsCount").GetInt32().Should().Be(4);
+        breakdown.GetProperty("agentsCreatedCount").GetInt32().Should().Be(0);
+        // ContributionCount = sum of breakdown sources (in v1: KbUploadsCount only).
+        item.GetProperty("contributionCount").GetInt32().Should().Be(4);
+    }
+
+    [Fact]
+    public async Task TopContributors_ExcludesSuspendedUsers()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var alice = await SeedActiveUserAsync(dbContext, "Alice");
+        var bob = await SeedSuspendedUserAsync(dbContext, "Bob");
+        await SeedPdfUploadsAsync(dbContext, alice, count: 1);
+        await SeedPdfUploadsAsync(dbContext, bob, count: 10); // would dominate if not filtered
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/users/top-contributors?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items");
+        items.GetArrayLength().Should().Be(1);
+        items[0].GetProperty("displayName").GetString().Should().Be("Alice");
+    }
+
+    [Fact]
+    public async Task TopContributors_ExcludesUsersWithNullDisplayName()
+    {
+        // Privacy guard: avoid surfacing email-derived identifiers.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var alice = await SeedActiveUserAsync(dbContext, "Alice");
+        var bob = await SeedActiveUserAsync(dbContext, displayName: null);
+        await SeedPdfUploadsAsync(dbContext, alice, count: 1);
+        await SeedPdfUploadsAsync(dbContext, bob, count: 10);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/users/top-contributors?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items");
+        items.GetArrayLength().Should().Be(1);
+        items[0].GetProperty("displayName").GetString().Should().Be("Alice");
+    }
+
+    [Fact]
+    public async Task TopContributors_RespectsLimitParameter()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        for (var i = 0; i < 5; i++)
+        {
+            var u = await SeedActiveUserAsync(dbContext, $"User-{i}");
+            await SeedPdfUploadsAsync(dbContext, u, count: i + 1);
+        }
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/users/top-contributors?limit=2",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task TopContributors_DtoExposesExpectedFieldShape()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var alice = await SeedActiveUserAsync(dbContext, "Alice", avatarUrl: "https://example.com/alice.png");
+        await SeedPdfUploadsAsync(dbContext, alice, count: 2);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/users/top-contributors?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var item = body.GetProperty("items")[0];
+        item.GetProperty("id").GetGuid().Should().Be(alice);
+        item.GetProperty("displayName").GetString().Should().Be("Alice");
+        item.GetProperty("avatarUrl").GetString().Should().Be("https://example.com/alice.png");
+        item.GetProperty("contributionCount").GetInt32().Should().Be(2);
+        item.GetProperty("breakdown").ValueKind.Should().Be(JsonValueKind.Object);
+    }
+
+    /// <summary>
+    /// Seeds an active <see cref="UserEntity"/> with the given display name.
+    /// </summary>
+    private static async Task<Guid> SeedActiveUserAsync(
+        MeepleAiDbContext dbContext,
+        string? displayName,
+        string? avatarUrl = null)
+    {
+        var id = Guid.NewGuid();
+        dbContext.Set<UserEntity>().Add(new UserEntity
+        {
+            Id = id,
+            Email = $"user-{id:N}@test.com",
+            DisplayName = displayName,
+            PasswordHash = null,
+            Role = "user",
+            Tier = "free",
+            EmailVerified = true,
+            CreatedAt = DateTime.UtcNow,
+            Status = "Active",
+            IsSuspended = false,
+            AvatarUrl = avatarUrl,
+        });
+        await dbContext.SaveChangesAsync();
+        dbContext.ChangeTracker.Clear();
+        return id;
+    }
+
+    private static async Task<Guid> SeedSuspendedUserAsync(
+        MeepleAiDbContext dbContext,
+        string? displayName)
+    {
+        var id = Guid.NewGuid();
+        dbContext.Set<UserEntity>().Add(new UserEntity
+        {
+            Id = id,
+            Email = $"suspended-{id:N}@test.com",
+            DisplayName = displayName,
+            PasswordHash = null,
+            Role = "user",
+            Tier = "free",
+            EmailVerified = true,
+            CreatedAt = DateTime.UtcNow,
+            Status = "Active",   // Privacy guard fires on IsSuspended; Active+IsSuspended drops them.
+            IsSuspended = true,
+            SuspendedAt = DateTime.UtcNow.AddDays(-1),
+        });
+        await dbContext.SaveChangesAsync();
+        dbContext.ChangeTracker.Clear();
+        return id;
+    }
+
+    private static async Task SeedPdfUploadsAsync(
+        MeepleAiDbContext dbContext,
+        Guid userId,
+        int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            var id = Guid.NewGuid();
+            dbContext.PdfDocuments.Add(new PdfDocumentEntity
+            {
+                Id = id,
+                FileName = $"doc-{i}.pdf",
+                FilePath = $"/uploads/{id}.pdf",
+                FileSizeBytes = 1024,
+                UploadedByUserId = userId,
+                UploadedAt = DateTime.UtcNow.AddMinutes(-i),
+                ProcessingState = "Ready",
+                Language = "en",
+                IsActiveForRag = true
+            });
+        }
+        await dbContext.SaveChangesAsync();
+        dbContext.ChangeTracker.Clear();
+    }
+}

--- a/apps/web/src/hooks/queries/__tests__/useDiscoverRecommendedToolkits.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useDiscoverRecommendedToolkits.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useDiscoverRecommendedToolkits unit tests — Wave 3 Phase 4a
+ * (Issue #805 / PR #732 §4.3.4).
+ *
+ * Coverage:
+ *   - Default limit (10) + clamp (1..50)
+ *   - Empty-state contract (200 with { items: [] } → [] from hook)
+ *   - Schema validates Gate-B-aware DTO (installCount: 0, ratingAverage: null)
+ *   - `enabled: false` defers the request
+ *   - Error path surfaces the rejection
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  DISCOVER_RECOMMENDED_TOOLKITS_DEFAULT_LIMIT,
+  DISCOVER_RECOMMENDED_TOOLKITS_STALE_TIME_MS,
+  useDiscoverRecommendedToolkits,
+} from '../useDiscoverRecommendedToolkits';
+
+// Mocks
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/lib/api/client';
+
+const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const SAMPLE_RECOMMENDED = {
+  items: [
+    {
+      id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      name: 'Catan Strategy Toolkit',
+      authorName: 'Alice',
+      // Gate B v1: backend always returns 0 / null until rating + install entities ship.
+      installCount: 0,
+      ratingAverage: null,
+      ratingCount: 0,
+      coverImageUrl: null,
+    },
+    {
+      id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      name: 'Wingspan Helper',
+      authorName: 'Bob',
+      installCount: 0,
+      ratingAverage: null,
+      ratingCount: 0,
+      coverImageUrl: null,
+    },
+  ],
+};
+
+describe('useDiscoverRecommendedToolkits — constants', () => {
+  it('exports a default limit of 10', () => {
+    expect(DISCOVER_RECOMMENDED_TOOLKITS_DEFAULT_LIMIT).toBe(10);
+  });
+
+  it('exports a 30min staleTime to mirror the backend HybridCache TTL', () => {
+    expect(DISCOVER_RECOMMENDED_TOOLKITS_STALE_TIME_MS).toBe(30 * 60 * 1000);
+  });
+});
+
+describe('useDiscoverRecommendedToolkits — limit handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(SAMPLE_RECOMMENDED);
+  });
+
+  it('uses default limit=10 when no option is passed', async () => {
+    const { result } = renderHook(() => useDiscoverRecommendedToolkits(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith('/toolkits/recommended?limit=10', expect.anything());
+  });
+
+  it('clamps an oversize limit to 50', async () => {
+    const { result } = renderHook(() => useDiscoverRecommendedToolkits({ limit: 200 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith('/toolkits/recommended?limit=50', expect.anything());
+  });
+
+  it('clamps a sub-1 limit to default 10', async () => {
+    const { result } = renderHook(() => useDiscoverRecommendedToolkits({ limit: 0 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith('/toolkits/recommended?limit=10', expect.anything());
+  });
+});
+
+describe('useDiscoverRecommendedToolkits — query result', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the items array on success', async () => {
+    mockGet.mockResolvedValue(SAMPLE_RECOMMENDED);
+
+    const { result } = renderHook(() => useDiscoverRecommendedToolkits(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(SAMPLE_RECOMMENDED.items);
+    // Gate B sanity: all items have installCount=0 and ratingAverage=null in v1.
+    expect(result.current.data!.every(t => t.installCount === 0)).toBe(true);
+    expect(result.current.data!.every(t => t.ratingAverage === null)).toBe(true);
+  });
+
+  it('returns an empty array on the empty-state envelope', async () => {
+    mockGet.mockResolvedValue({ items: [] });
+
+    const { result } = renderHook(() => useDiscoverRecommendedToolkits(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('does not fire when enabled is false', () => {
+    renderHook(() => useDiscoverRecommendedToolkits({ enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('exposes error state when the API rejects', async () => {
+    mockGet.mockRejectedValue(new Error('Toolkits service unavailable'));
+
+    const { result } = renderHook(() => useDiscoverRecommendedToolkits(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Toolkits service unavailable');
+  });
+});

--- a/apps/web/src/hooks/queries/__tests__/useDiscoverTopContributors.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useDiscoverTopContributors.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useDiscoverTopContributors unit tests — Wave 3 Phase 4a
+ * (Issue #805 / PR #732 §4.3.6).
+ *
+ * Coverage:
+ *   - Default limit (10) + clamp (1..50)
+ *   - Empty-state contract (200 with { items: [] } → [] from hook)
+ *   - Schema validates Gate-B-aware breakdown (faqsCount: 0,
+ *     agentsCreatedCount: 0; only kbUploadsCount carries a real signal)
+ *   - `enabled: false` defers the request
+ *   - Error path surfaces the rejection
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  DISCOVER_TOP_CONTRIBUTORS_DEFAULT_LIMIT,
+  DISCOVER_TOP_CONTRIBUTORS_STALE_TIME_MS,
+  useDiscoverTopContributors,
+} from '../useDiscoverTopContributors';
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/lib/api/client';
+
+const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const SAMPLE_TOP_CONTRIBUTORS = {
+  items: [
+    {
+      id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      displayName: 'Alice',
+      avatarUrl: 'https://example.com/alice.png',
+      contributionCount: 7,
+      breakdown: {
+        // Gate B v1: backend stubs faqsCount + agentsCreatedCount to 0.
+        faqsCount: 0,
+        kbUploadsCount: 7,
+        agentsCreatedCount: 0,
+      },
+    },
+    {
+      id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      displayName: 'Bob',
+      avatarUrl: null,
+      contributionCount: 3,
+      breakdown: {
+        faqsCount: 0,
+        kbUploadsCount: 3,
+        agentsCreatedCount: 0,
+      },
+    },
+  ],
+};
+
+describe('useDiscoverTopContributors — constants', () => {
+  it('exports a default limit of 10', () => {
+    expect(DISCOVER_TOP_CONTRIBUTORS_DEFAULT_LIMIT).toBe(10);
+  });
+
+  it('exports a 1h staleTime to mirror the backend HybridCache TTL', () => {
+    expect(DISCOVER_TOP_CONTRIBUTORS_STALE_TIME_MS).toBe(60 * 60 * 1000);
+  });
+});
+
+describe('useDiscoverTopContributors — limit handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(SAMPLE_TOP_CONTRIBUTORS);
+  });
+
+  it('uses default limit=10 when no option is passed', async () => {
+    const { result } = renderHook(() => useDiscoverTopContributors(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith('/users/top-contributors?limit=10', expect.anything());
+  });
+
+  it('clamps an oversize limit to 50', async () => {
+    const { result } = renderHook(() => useDiscoverTopContributors({ limit: 999 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith('/users/top-contributors?limit=50', expect.anything());
+  });
+
+  it('clamps a sub-1 limit to default 10', async () => {
+    const { result } = renderHook(() => useDiscoverTopContributors({ limit: -5 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith('/users/top-contributors?limit=10', expect.anything());
+  });
+});
+
+describe('useDiscoverTopContributors — query result', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the items array on success', async () => {
+    mockGet.mockResolvedValue(SAMPLE_TOP_CONTRIBUTORS);
+
+    const { result } = renderHook(() => useDiscoverTopContributors(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(SAMPLE_TOP_CONTRIBUTORS.items);
+    // Gate B sanity: faqsCount and agentsCreatedCount are 0 in v1.
+    expect(result.current.data!.every(u => u.breakdown.faqsCount === 0)).toBe(true);
+    expect(result.current.data!.every(u => u.breakdown.agentsCreatedCount === 0)).toBe(true);
+    // contributionCount equals kbUploadsCount in v1.
+    expect(
+      result.current.data!.every(u => u.contributionCount === u.breakdown.kbUploadsCount)
+    ).toBe(true);
+  });
+
+  it('returns an empty array on the empty-state envelope', async () => {
+    mockGet.mockResolvedValue({ items: [] });
+
+    const { result } = renderHook(() => useDiscoverTopContributors(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('does not fire when enabled is false', () => {
+    renderHook(() => useDiscoverTopContributors({ enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('exposes error state when the API rejects', async () => {
+    mockGet.mockRejectedValue(new Error('Contributors service unavailable'));
+
+    const { result } = renderHook(() => useDiscoverTopContributors(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Contributors service unavailable');
+  });
+});

--- a/apps/web/src/hooks/queries/useDiscoverRecommendedToolkits.ts
+++ b/apps/web/src/hooks/queries/useDiscoverRecommendedToolkits.ts
@@ -1,0 +1,69 @@
+/**
+ * useDiscoverRecommendedToolkits — TanStack Query hook for the /discover route's
+ * "Recommended toolkits" rail (Wave 3 Phase 4a, Issue #805 / PR #732 §4.3.4).
+ *
+ * Backend contract: `GET /api/v1/toolkits/recommended?limit={n}` returns
+ * `{ items: RecommendedToolkit[] }`. Empty state is a 200 with `{ items: [] }`
+ * per the PR #732 §3.4 empty-state contract.
+ *
+ * Schema reality v1 carryovers (Gate B): `installCount: 0`, `ratingAverage: null`,
+ * `ratingCount: 0`, `coverImageUrl: null` until the rating + install entities ship
+ * in Phase 4b. The wire shape is stable — the rail can adopt the real metrics
+ * without a fetch shape change.
+ *
+ * Cache: backend caches 30min via HybridCache; FE staleTime mirrors that.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { apiClient } from '@/lib/api/client';
+import {
+  RecommendedToolkitsResponseSchema,
+  type RecommendedToolkit,
+  type RecommendedToolkitsResponse,
+} from '@/lib/api/schemas/discover-cross-cutting.schemas';
+
+export const DISCOVER_RECOMMENDED_TOOLKITS_DEFAULT_LIMIT = 10;
+export const DISCOVER_RECOMMENDED_TOOLKITS_STALE_TIME_MS = 30 * 60 * 1000; // 30min, mirrors backend cache
+
+export const discoverRecommendedToolkitsKeys = {
+  all: ['discover', 'recommendedToolkits'] as const,
+  list: (limit: number) => [...discoverRecommendedToolkitsKeys.all, limit] as const,
+};
+
+function clampLimit(limit: number): number {
+  if (!Number.isFinite(limit) || limit < 1) return DISCOVER_RECOMMENDED_TOOLKITS_DEFAULT_LIMIT;
+  return Math.min(50, Math.floor(limit));
+}
+
+export interface UseDiscoverRecommendedToolkitsOptions {
+  readonly limit?: number;
+  readonly enabled?: boolean;
+}
+
+/**
+ * Fetch the recommended toolkits for the /discover "Recommended toolkits" rail.
+ *
+ * @example
+ * const { data, isLoading } = useDiscoverRecommendedToolkits({ limit: 8 });
+ * // data — RecommendedToolkit[] (empty array on empty state)
+ */
+export function useDiscoverRecommendedToolkits(
+  options: UseDiscoverRecommendedToolkitsOptions = {}
+): UseQueryResult<RecommendedToolkit[], Error> {
+  const { limit = DISCOVER_RECOMMENDED_TOOLKITS_DEFAULT_LIMIT, enabled = true } = options;
+  const safeLimit = clampLimit(limit);
+
+  return useQuery<RecommendedToolkit[], Error>({
+    queryKey: discoverRecommendedToolkitsKeys.list(safeLimit),
+    queryFn: async () => {
+      const response = await apiClient.get<RecommendedToolkitsResponse>(
+        `/toolkits/recommended?limit=${safeLimit}`,
+        RecommendedToolkitsResponseSchema
+      );
+      return response?.items ?? [];
+    },
+    enabled,
+    staleTime: DISCOVER_RECOMMENDED_TOOLKITS_STALE_TIME_MS,
+  });
+}

--- a/apps/web/src/hooks/queries/useDiscoverTopContributors.ts
+++ b/apps/web/src/hooks/queries/useDiscoverTopContributors.ts
@@ -1,0 +1,75 @@
+/**
+ * useDiscoverTopContributors — TanStack Query hook for the /discover route's
+ * "Top contributors" rail (Wave 3 Phase 4a, Issue #805 / PR #732 §4.3.6).
+ *
+ * Backend contract: `GET /api/v1/users/top-contributors?limit={n}` returns
+ * `{ items: TopUserContributor[] }`. Empty state is a 200 with `{ items: [] }`
+ * per the PR #732 §3.4 empty-state contract.
+ *
+ * Distinct from the existing /api/v1/shared-games/top-contributors endpoint
+ * (which scores by sessions + wins for the public /shared-games sidebar).
+ * This surface aggregates contribution sources (FAQs authored, KB documents
+ * uploaded, AI agents created) for the SP4 /discover community editors rail.
+ *
+ * Schema reality v1 carryovers (Gate B): `breakdown.faqsCount` and
+ * `breakdown.agentsCreatedCount` are stubbed to 0 (no creator FK columns on
+ * GameFaqEntity / AgentDefinition). Only `breakdown.kbUploadsCount` carries
+ * a real signal in v1, and `contributionCount` therefore equals
+ * `breakdown.kbUploadsCount`.
+ *
+ * Cache: backend caches 1h via HybridCache; FE staleTime mirrors that.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { apiClient } from '@/lib/api/client';
+import {
+  TopUserContributorsResponseSchema,
+  type TopUserContributor,
+  type TopUserContributorsResponse,
+} from '@/lib/api/schemas/discover-cross-cutting.schemas';
+
+export const DISCOVER_TOP_CONTRIBUTORS_DEFAULT_LIMIT = 10;
+export const DISCOVER_TOP_CONTRIBUTORS_STALE_TIME_MS = 60 * 60 * 1000; // 1h, mirrors backend cache
+
+export const discoverTopContributorsKeys = {
+  all: ['discover', 'topContributors'] as const,
+  list: (limit: number) => [...discoverTopContributorsKeys.all, limit] as const,
+};
+
+function clampLimit(limit: number): number {
+  if (!Number.isFinite(limit) || limit < 1) return DISCOVER_TOP_CONTRIBUTORS_DEFAULT_LIMIT;
+  return Math.min(50, Math.floor(limit));
+}
+
+export interface UseDiscoverTopContributorsOptions {
+  readonly limit?: number;
+  readonly enabled?: boolean;
+}
+
+/**
+ * Fetch the top user contributors for the /discover "Top contributors" rail.
+ *
+ * @example
+ * const { data, isLoading } = useDiscoverTopContributors({ limit: 5 });
+ * // data — TopUserContributor[] (empty array on empty state)
+ */
+export function useDiscoverTopContributors(
+  options: UseDiscoverTopContributorsOptions = {}
+): UseQueryResult<TopUserContributor[], Error> {
+  const { limit = DISCOVER_TOP_CONTRIBUTORS_DEFAULT_LIMIT, enabled = true } = options;
+  const safeLimit = clampLimit(limit);
+
+  return useQuery<TopUserContributor[], Error>({
+    queryKey: discoverTopContributorsKeys.list(safeLimit),
+    queryFn: async () => {
+      const response = await apiClient.get<TopUserContributorsResponse>(
+        `/users/top-contributors?limit=${safeLimit}`,
+        TopUserContributorsResponseSchema
+      );
+      return response?.items ?? [];
+    },
+    enabled,
+    staleTime: DISCOVER_TOP_CONTRIBUTORS_STALE_TIME_MS,
+  });
+}

--- a/apps/web/src/lib/api/schemas/discover-cross-cutting.schemas.ts
+++ b/apps/web/src/lib/api/schemas/discover-cross-cutting.schemas.ts
@@ -1,0 +1,70 @@
+/**
+ * /discover Cross-Cutting Schemas (Wave 3 Phase 4a, Issue #805 / PR #732 §4.3)
+ *
+ * Zod schemas for the SP4 /discover route's Phase 4a rails. Backend contract:
+ *   - §4.3.4 — GET /api/v1/toolkits/recommended       (RecommendedToolkit)
+ *   - §4.3.6 — GET /api/v1/users/top-contributors      (TopUserContributor)
+ *
+ * Both follow the PR #732 §3.4 empty-state contract: response shape is
+ * `{ items: [...] }` and an empty list is a 200 (not 404 / 204).
+ *
+ * Schema reality v1 carryovers (Gate B) — backend stubs documented inline:
+ *   - RecommendedToolkit.installCount: 0 (no ToolkitInstallation entity)
+ *   - RecommendedToolkit.ratingAverage: null (no ToolkitRating entity)
+ *   - RecommendedToolkit.ratingCount: 0 (same)
+ *   - RecommendedToolkit.coverImageUrl: null (no cover column)
+ *   - TopUserContributor.breakdown.faqsCount: 0 (no FAQ creator FK)
+ *   - TopUserContributor.breakdown.agentsCreatedCount: 0 (no agent owner FK)
+ *
+ * In v1 only `breakdown.kbUploadsCount` carries a real signal, and
+ * `contributionCount` therefore equals `kbUploadsCount`.
+ */
+
+import { z } from 'zod';
+
+// ========== /api/v1/toolkits/recommended (PR #732 §4.3.4) ==========
+
+export const RecommendedToolkitSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1),
+  authorName: z.string().min(1),
+  // Gate B v1: backend always returns 0 until ToolkitInstallation lands.
+  installCount: z.number().int().nonnegative(),
+  // Gate B v1: backend always returns null until ToolkitRating lands.
+  ratingAverage: z.number().nullable(),
+  ratingCount: z.number().int().nonnegative(),
+  // Gate B v1: backend always returns null until a cover-image column lands.
+  coverImageUrl: z.string().nullable(),
+});
+export type RecommendedToolkit = z.infer<typeof RecommendedToolkitSchema>;
+
+export const RecommendedToolkitsResponseSchema = z.object({
+  items: z.array(RecommendedToolkitSchema),
+});
+export type RecommendedToolkitsResponse = z.infer<typeof RecommendedToolkitsResponseSchema>;
+
+// ========== /api/v1/users/top-contributors (PR #732 §4.3.6) ==========
+
+export const TopUserContributorBreakdownSchema = z.object({
+  // Gate B v1: GameFaqEntity has no creator FK column → always 0.
+  faqsCount: z.number().int().nonnegative(),
+  // Real signal in v1 — derived from PdfDocumentEntity.UploadedByUserId.
+  kbUploadsCount: z.number().int().nonnegative(),
+  // Gate B v1: AgentDefinition has no owner FK column → always 0.
+  agentsCreatedCount: z.number().int().nonnegative(),
+});
+export type TopUserContributorBreakdown = z.infer<typeof TopUserContributorBreakdownSchema>;
+
+export const TopUserContributorSchema = z.object({
+  id: z.string().uuid(),
+  displayName: z.string().min(1),
+  avatarUrl: z.string().nullable(),
+  contributionCount: z.number().int().nonnegative(),
+  breakdown: TopUserContributorBreakdownSchema,
+});
+export type TopUserContributor = z.infer<typeof TopUserContributorSchema>;
+
+export const TopUserContributorsResponseSchema = z.object({
+  items: z.array(TopUserContributorSchema),
+});
+export type TopUserContributorsResponse = z.infer<typeof TopUserContributorsResponseSchema>;


### PR DESCRIPTION
## Summary

Adds the SP4 `/discover` route's **Phase 4a "cross-cutting" rails** per PR #732 §4.3.4 + §4.3.6:

- **`GET /api/v1/toolkits/recommended`** (GameToolkit BC) — Bayesian-style score `ratingAverage * log(ratingCount+1) DESC`, `installCount DESC` tiebreak, `createdAt DESC` final tiebreak. Visibility: `IsPublished && TemplateStatus=Approved` only. 30min HybridCache. Limit clamped 1..50, default 10.
- **`GET /api/v1/users/top-contributors`** (Administration BC, distinct from existing `/shared-games/top-contributors` sessions/wins surface) — aggregates contribution sources (FAQs authored + KB uploads + AI agents created) with per-source breakdown. Privacy guards: skip suspended, require `Status=Active` + non-null `DisplayName`. 1h HybridCache. Limit clamped 1..50, default 10.

### Schema reality v1 carryover (Gate B)

Only KB uploads (`PdfDocument.UploadedByUserId`) and toolkit `CreatedAt` are real signals in v1. FAQ + agent creator FKs and `Toolkit{Rating,Installation}` entities ship in Phase 4b — wire shape is stable so the FE rails render today and adopt the real metrics without a fetch shape change.

| Field | v1 status | Surfaces in |
|---|---|---|
| `RecommendedToolkit.installCount` | `0` (no `ToolkitInstallation`) | Phase 4b |
| `RecommendedToolkit.ratingAverage` | `null` (no `ToolkitRating`) | Phase 4b |
| `RecommendedToolkit.ratingCount` | `0` | Phase 4b |
| `RecommendedToolkit.coverImageUrl` | `null` (no cover column) | Future schema |
| `TopUserContributor.breakdown.faqsCount` | `0` (no FAQ creator FK) | Phase 4b |
| `TopUserContributor.breakdown.kbUploadsCount` | **real** | — |
| `TopUserContributor.breakdown.agentsCreatedCount` | `0` (no agent owner FK) | Phase 4b |

### Architecture notes

- CQRS strict: `IMediator.Send` only, FluentValidation, internal record DTOs, zero direct service injection in endpoints.
- BC ownership per PR #732 §5.1 (Newman): toolkits surface extends `GameToolkit` (no new MarketplaceBC); contributors surface lives in `Administration` (cross-BC read-only projection acceptable per §4.3.6 V1 strategy).
- Static `/recommended` route registered **before** `/{toolkitId:guid}` to prevent literal being parsed as Guid.

## Test plan

- [x] Backend build: ✅ 0 errors / 0 warnings
- [x] Backend integration tests: ✅ **15/15 passed** (Testcontainers Postgres) — empty/200 contract, limit clamp, privacy guards, sort tiebreakers, visibility filters, schema-stub stability
- [x] Frontend unit tests: ✅ **18/18 passed** — hook contract, limit clamping, schema validation, error/loading/empty states
- [x] Frontend typecheck: ✅ clean
- [x] Frontend lint: ✅ 0 errors (only pre-existing warnings unrelated to this PR)
- [ ] CI gates: backend unit + integration + FE build + bundle + a11y

## Wave 3 progress

After this PR: **12/14 backend endpoints = 86% complete**. Remaining Phase 4 (deferred): 2 endpoints.

Refs #805
Builds on: #811 (BGG), #812 (/discover quick-wins), #814 (toolkit marketplace), #815 (KB chunks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)