### PR TITLE
feat(toolkit-ratings): Wave 3 Phase 4b — closeout 14/14 (#805)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitRatings/GetToolkitRatingsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitRatings/GetToolkitRatingsQuery.cs
@@ -1,0 +1,27 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitRatings;
+
+/// <summary>
+/// Query for the toolkit ratings list with 5-star breakdown
+/// (Wave 3 Phase 4b, PR #732 §5.3.3 / Issue #805).
+/// </summary>
+/// <param name="ToolkitId">Target toolkit aggregate id.</param>
+/// <param name="ViewerId">Authenticated viewer id (drives the visibility check).</param>
+/// <param name="Cursor">Opaque pagination cursor (null = first page).</param>
+/// <param name="Limit">Page size. Validator clamps to [1, 50]; default 20.</param>
+/// <remarks>
+/// Powers the SP4 <c>/toolkits/[id]</c> ratings tab. Schema reality v1 carryover
+/// (Gate B): the <c>ToolkitRating</c> entity does not exist yet — handler returns
+/// an empty stub with zeroed breakdown once toolkit existence is verified. The
+/// wire shape is stable so the FE can render today and adopt real data without a
+/// fetch shape change. Returns <c>null</c> when toolkit is not visible to the
+/// viewer (mapped to 404 at the endpoint layer per PR #732 §5.2 security
+/// boundary — non-authors must not learn about drafts/yanked toolkits).
+/// </remarks>
+internal sealed record GetToolkitRatingsQuery(
+    Guid ToolkitId,
+    Guid ViewerId,
+    string? Cursor,
+    int Limit = 20
+) : IQuery<ToolkitRatingsResponse?>;

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitRatings/GetToolkitRatingsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitRatings/GetToolkitRatingsQueryHandler.cs
@@ -1,0 +1,150 @@
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
+using Api.Infrastructure;
+using Api.Services;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitRatings;
+
+/// <summary>
+/// Handler for <see cref="GetToolkitRatingsQuery"/>.
+/// Wave 3 Phase 4b, PR #732 §5.3.3 / Issue #805.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Schema reality v1 carryover (Gate B)</b>: the <c>ToolkitRating</c> entity
+/// does not exist in the current schema. Once the toolkit visibility check
+/// passes the handler returns an empty stub envelope:
+/// <c>items=[]</c>, <c>nextCursor=null</c>, <c>breakdown</c> all zero,
+/// <c>averageStars=0</c>, <c>totalCount=0</c>. Wire shape is stable so the FE
+/// ratings tab can render today and adopt real persistence in Phase 5 without
+/// a fetch shape change.
+/// </para>
+///
+/// <para>
+/// <b>Visibility rule (PR #732 §5.2 security boundary)</b>: mirrors
+/// <c>GetToolkitDetailQueryHandler</c> — non-authors only see published +
+/// approved toolkits. Returning <c>null</c> here surfaces 404 at the endpoint
+/// layer, preventing draft/yanked existence from leaking via the ratings
+/// surface.
+/// </para>
+///
+/// <para>
+/// <b>Cursor</b>: with no persistence yet the cursor is always echoed-or-null;
+/// any non-null input cursor is treated as "page 2 has nothing" → returns
+/// <c>nextCursor=null</c>. The cursor format is intentionally opaque (base64
+/// or token) so Phase 5 can choose its scheme without breaking the wire shape.
+/// </para>
+///
+/// <para>
+/// <b>Cache</b>: 5min HybridCache keyed by <c>toolkits:{toolkitId}:ratings:{cursor}:{limit}</c>
+/// (PR #732 §3.2 caching matrix — short TTL because submissions land in
+/// near-real-time once Phase 5 ships).
+/// </para>
+/// </remarks>
+internal sealed class GetToolkitRatingsQueryHandler
+    : IRequestHandler<GetToolkitRatingsQuery, ToolkitRatingsResponse?>
+{
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
+
+    private static readonly ToolkitRatingsBreakdownDto EmptyBreakdown =
+        new(Star1: 0, Star2: 0, Star3: 0, Star4: 0, Star5: 0);
+
+    private readonly MeepleAiDbContext _context;
+    private readonly IHybridCacheService _cache;
+    private readonly ILogger<GetToolkitRatingsQueryHandler> _logger;
+
+    public GetToolkitRatingsQueryHandler(
+        MeepleAiDbContext context,
+        IHybridCacheService cache,
+        ILogger<GetToolkitRatingsQueryHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<ToolkitRatingsResponse?> Handle(
+        GetToolkitRatingsQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var cursor = request.Cursor ?? "_";
+        var cacheKey = $"toolkits:{request.ToolkitId}:ratings:{cursor}:{request.Limit}";
+
+        var container = await _cache.GetOrCreateAsync(
+            cacheKey,
+            async ct => await ComputeAsync(request, ct).ConfigureAwait(false),
+            tags: [$"toolkit:{request.ToolkitId}", "ratings"],
+            expiration: CacheTtl,
+            ct: cancellationToken).ConfigureAwait(false);
+
+        return container.Response;
+    }
+
+    private async Task<ToolkitRatingsContainer> ComputeAsync(
+        GetToolkitRatingsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var entity = await _context.GameToolkits
+            .AsNoTracking()
+            .Where(t => t.Id == request.ToolkitId)
+            .Select(t => new
+            {
+                t.Id,
+                t.CreatedByUserId,
+                t.IsPublished,
+                t.TemplateStatus
+            })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entity is null)
+        {
+            _logger.LogInformation(
+                "Toolkit {ToolkitId} not found for ratings request (viewer={ViewerId})",
+                request.ToolkitId,
+                request.ViewerId);
+            return new ToolkitRatingsContainer(null);
+        }
+
+        var isOwner = entity.CreatedByUserId == request.ViewerId;
+        var isPublished = entity.IsPublished
+            && (TemplateStatus)entity.TemplateStatus == TemplateStatus.Approved;
+
+        // PR #732 §5.2 security boundary — non-authors must not learn that
+        // a draft/yanked toolkit exists via the ratings surface.
+        if (!isOwner && !isPublished)
+        {
+            _logger.LogInformation(
+                "Toolkit {ToolkitId} hidden from viewer {ViewerId} (isOwner=false, isPublished={IsPublished})",
+                request.ToolkitId,
+                request.ViewerId,
+                isPublished);
+            return new ToolkitRatingsContainer(null);
+        }
+
+        // Schema reality v1 carryover (Gate B): no ToolkitRating entity yet —
+        // return empty stub envelope. Wire shape stable for FE.
+        var response = new ToolkitRatingsResponse(
+            Items: Array.Empty<ToolkitRatingDto>(),
+            NextCursor: null,
+            Breakdown: EmptyBreakdown,
+            AverageStars: 0m,
+            TotalCount: 0);
+
+        _logger.LogInformation(
+            "Returning empty ratings stub for toolkit {ToolkitId} (Gate B v1: ToolkitRating entity missing)",
+            request.ToolkitId);
+
+        return new ToolkitRatingsContainer(response);
+    }
+
+    /// <summary>
+    /// Cache-friendly wrapper so we can store nullable visibility-denied results
+    /// without HybridCache treating <c>null</c> as a cache miss.
+    /// </summary>
+    private sealed record ToolkitRatingsContainer(ToolkitRatingsResponse? Response);
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitRatings/GetToolkitRatingsQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitRatings/GetToolkitRatingsQueryValidator.cs
@@ -1,0 +1,26 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitRatings;
+
+/// <summary>
+/// Validator for <see cref="GetToolkitRatingsQuery"/>.
+/// Wave 3 Phase 4b, PR #732 §5.3.3 / Issue #805.
+/// </summary>
+internal sealed class GetToolkitRatingsQueryValidator
+    : AbstractValidator<GetToolkitRatingsQuery>
+{
+    public GetToolkitRatingsQueryValidator()
+    {
+        RuleFor(x => x.ToolkitId)
+            .NotEqual(Guid.Empty)
+            .WithMessage("ToolkitId is required.");
+
+        RuleFor(x => x.ViewerId)
+            .NotEqual(Guid.Empty)
+            .WithMessage("ViewerId is required.");
+
+        RuleFor(x => x.Limit)
+            .InclusiveBetween(1, 50)
+            .WithMessage("Limit must be between 1 and 50.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitRatings/ToolkitRatingDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitRatings/ToolkitRatingDto.cs
@@ -1,0 +1,45 @@
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitRatings;
+
+/// <summary>
+/// 5-star distribution for the ratings breakdown widget
+/// (Wave 3 Phase 4b, PR #732 §5.3.3 / Issue #805).
+/// </summary>
+/// <remarks>
+/// Schema reality v1 carryover (Gate B): the <c>ToolkitRating</c> entity does
+/// not exist yet — all counts are <c>0</c> until Phase 5 ships persistence.
+/// Wire shape is stable so the FE breakdown bars render today and switch to
+/// real counts without a refetch shape change.
+/// </remarks>
+internal sealed record ToolkitRatingsBreakdownDto(
+    int Star1,
+    int Star2,
+    int Star3,
+    int Star4,
+    int Star5
+);
+
+/// <summary>
+/// Single rating row.
+/// </summary>
+internal sealed record ToolkitRatingDto(
+    Guid Id,
+    string RaterDisplayName,
+    string? RaterAvatarUrl,
+    int Stars,
+    string? Comment,
+    DateTimeOffset CreatedAt
+);
+
+/// <summary>
+/// Cursor-paginated ratings envelope.
+/// Per PR #732 §3.4 empty-state contract: empty list is a 200 with
+/// <c>{ items: [] }</c>, not 404. <c>NextCursor</c> is <c>null</c> when there
+/// are no more pages.
+/// </summary>
+internal sealed record ToolkitRatingsResponse(
+    IReadOnlyList<ToolkitRatingDto> Items,
+    string? NextCursor,
+    ToolkitRatingsBreakdownDto Breakdown,
+    decimal AverageStars,
+    int TotalCount
+);

--- a/apps/api/src/Api/Routing/GameToolkit/ToolkitMarketplaceEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameToolkit/ToolkitMarketplaceEndpoints.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.GameToolkit.Application.Commands.InstallToolkit;
 using Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
 using Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitDetail;
+using Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitRatings;
 using Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitVersions;
 using Api.Extensions;
 using MediatR;
@@ -82,6 +83,50 @@ internal static class ToolkitMarketplaceEndpoints
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound);
 
+        // ── GET /api/v1/toolkits/{toolkitId}/ratings ───────────────────────
+        // Wave 3 Phase 4b (Issue #805 / PR #732 §5.3.3): ratings list with
+        // 5-star breakdown for the SP4 /toolkits/[id] ratings tab. Schema
+        // reality v1 carryover (Gate B): empty stub — ToolkitRating entity
+        // ships in Phase 5.
+        toolkits.MapGet("/{toolkitId:guid}/ratings", HandleGetToolkitRatings)
+            .WithName("GetToolkitRatings")
+            .WithSummary("List toolkit ratings (cursor paginated)")
+            .WithDescription(
+                "Returns ratings sorted by createdAt DESC with 5-star "
+                + "breakdown distribution and averageStars (1-5 with one "
+                + "decimal). Cursor opaque, nextCursor=null when exhausted. "
+                + "Limit clamped 1..50, default 20. 404 when toolkit is "
+                + "missing or hidden from the viewer (PR #732 §5.2 security "
+                + "boundary). Empty-state contract per §3.4: 200 with "
+                + "{ items: [] } rather than 404. Schema reality v1 carryover: "
+                + "ToolkitRating entity not yet shipped — handler returns "
+                + "stub envelope (items=[], breakdown all zero, averageStars=0, "
+                + "totalCount=0) once visibility check passes. Cache: 5min "
+                + "HybridCache. Wave 3 Phase 4b (Issue #805 / PR #732 §5.3.3).")
+            .Produces<ToolkitRatingsResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound);
+
+        // ── POST /api/v1/toolkits/{toolkitId}/ratings ──────────────────────
+        // Wave 3 Phase 4b (Issue #805 / PR #732 §5.3.4): rating submission
+        // STUB — returns 501 Not Implemented because the ToolkitRating
+        // entity + persistence ship in Phase 5. Wire shape (route literal
+        // and method) is reserved so the FE submission flow can call this
+        // surface today and detect the stub via 501.
+        toolkits.MapPost("/{toolkitId:guid}/ratings", HandleSubmitToolkitRating)
+            .WithName("SubmitToolkitRating")
+            .WithSummary("Submit a toolkit rating (Phase 4b stub — 501)")
+            .WithDescription(
+                "Phase 4b stub. Returns 501 Not Implemented with a "
+                + "machine-readable body { error: \"ratings_submission_not_yet_available\", "
+                + "phase: \"4b-stub\" } so the FE can surface a \"coming soon\" "
+                + "affordance without breaking on a 404. Persistence + "
+                + "validation rules (one rating per (userId, toolkitId), "
+                + "hasInstalled gate, viewer != author, edit window 24h) "
+                + "ship in Phase 5. Wave 3 Phase 4b (Issue #805 / PR #732 §5.3.4).")
+            .Produces(StatusCodes.Status501NotImplemented)
+            .Produces(StatusCodes.Status401Unauthorized);
+
         // ── POST /api/v1/toolkits/{toolkitId}/install ──────────────────────
         toolkits.MapPost("/{toolkitId:guid}/install", HandleInstallToolkit)
             .WithName("InstallToolkit")
@@ -155,6 +200,58 @@ internal static class ToolkitMarketplaceEndpoints
         return response is null
             ? Results.NotFound()
             : Results.Ok(response);
+    }
+
+    private static async Task<IResult> HandleGetToolkitRatings(
+        Guid toolkitId,
+        HttpContext httpContext,
+        [FromQuery] string? cursor,
+        [FromQuery] int? limit,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var viewerId = httpContext.User.GetUserId();
+        if (viewerId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
+        // Limit clamping at the endpoint layer (PR #732 §3.3 — UI-friendly
+        // silent clamp rather than 400). Validator on the query enforces the
+        // same range for the CQRS handler.
+        var safeLimit = limit.GetValueOrDefault(20);
+        if (safeLimit < 1) safeLimit = 20;
+        if (safeLimit > 50) safeLimit = 50;
+
+        var query = new GetToolkitRatingsQuery(toolkitId, viewerId, cursor, safeLimit);
+        var response = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
+
+        return response is null
+            ? Results.NotFound()
+            : Results.Ok(response);
+    }
+
+    private static IResult HandleSubmitToolkitRating(
+        Guid toolkitId,
+        HttpContext httpContext)
+    {
+        var viewerId = httpContext.User.GetUserId();
+        if (viewerId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
+        // Phase 4b stub — ToolkitRating entity ships in Phase 5. Body shape
+        // is intentionally minimal and machine-readable so the FE can detect
+        // the stub state without parsing prose error messages.
+        return Results.Json(
+            new
+            {
+                error = "ratings_submission_not_yet_available",
+                phase = "4b-stub",
+                toolkitId
+            },
+            statusCode: StatusCodes.Status501NotImplemented);
     }
 
     private static async Task<IResult> HandleInstallToolkit(

--- a/apps/api/tests/Api.Tests/Integration/Phase4b/ToolkitRatingsEndpointIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Phase4b/ToolkitRatingsEndpointIntegrationTests.cs
@@ -1,0 +1,336 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.Phase4b;
+
+/// <summary>
+/// Integration tests for the toolkit ratings surface
+/// (Wave 3 Phase 4b, PR #732 §5.3.3 + §5.3.4 / Issue #805).
+///
+/// <para>
+/// Schema reality v1 carryover (Gate B): the <c>ToolkitRating</c> entity does
+/// not exist yet. <c>GET /toolkits/{id}/ratings</c> returns an empty stub
+/// envelope once the visibility check passes; <c>POST /toolkits/{id}/ratings</c>
+/// returns 501 Not Implemented with a machine-readable body. Wire shape is
+/// stable so the FE can render today and adopt real persistence in Phase 5.
+/// </para>
+///
+/// <para>
+/// Visibility rule (PR #732 §5.2 security boundary): non-authors must not
+/// learn about drafts/yanked toolkits via the ratings surface — the handler
+/// returns 404 in that case, mirroring the toolkit detail endpoint.
+/// </para>
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameToolkit")]
+[Trait("Wave", "3-Phase-4b")]
+public sealed class ToolkitRatingsEndpointIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    public ToolkitRatingsEndpointIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"toolkit_ratings_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+        }
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        await _factory.DisposeAsync();
+    }
+
+    // ───────────────────────── GET /toolkits/{id}/ratings ─────────────────────
+
+    [Fact]
+    public async Task GetRatings_WithoutAuth_ReturnsUnauthorized()
+    {
+        var response = await _client.GetAsync($"/api/v1/toolkits/{Guid.NewGuid()}/ratings");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetRatings_ForUnknownToolkit_Returns404()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{Guid.NewGuid()}/ratings",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetRatings_OnDraftToolkit_NonOwner_Returns404()
+    {
+        // PR #732 §5.2 security boundary — non-authors must not learn that a
+        // draft toolkit exists via the ratings surface.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var toolkitId = await SeedToolkitAsync(dbContext, authorId, "Hidden Draft",
+            isPublished: false, templateStatus: TemplateStatus.Draft);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkitId}/ratings",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetRatings_OnDraftToolkit_AsOwner_Returns200WithEmptyStub()
+    {
+        // Authors must always see their own toolkits, even drafts.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, authorToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var toolkitId = await SeedToolkitAsync(dbContext, authorId, "My Draft",
+            isPublished: false, templateStatus: TemplateStatus.Draft);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkitId}/ratings",
+            authorToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        AssertEmptyStubShape(await response.Content.ReadFromJsonAsync<JsonElement>());
+    }
+
+    [Fact]
+    public async Task GetRatings_OnPublishedToolkit_Returns200WithEmptyStub()
+    {
+        // PR #732 §3.4 empty-state contract: 200 with { items: [] }, breakdown
+        // all zero, averageStars=0, totalCount=0 (Gate B v1 — no entity yet).
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var toolkitId = await SeedToolkitAsync(dbContext, authorId, "Public Toolkit",
+            isPublished: true, templateStatus: TemplateStatus.Approved);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkitId}/ratings?limit=20",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        AssertEmptyStubShape(await response.Content.ReadFromJsonAsync<JsonElement>());
+    }
+
+    [Fact]
+    public async Task GetRatings_WithCursor_StillReturnsEmptyStub()
+    {
+        // Cursor is opaque in v1 — handler always returns nextCursor=null
+        // until persistence ships in Phase 5.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var toolkitId = await SeedToolkitAsync(dbContext, authorId, "Public",
+            isPublished: true, templateStatus: TemplateStatus.Approved);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkitId}/ratings?cursor=arbitrary-token&limit=10",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        AssertEmptyStubShape(body);
+    }
+
+    [Fact]
+    public async Task GetRatings_LimitClamping_AcceptsOutOfRangeValues()
+    {
+        // Endpoint silent-clamps limit (PR #732 §3.3 UI-friendly behavior).
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var toolkitId = await SeedToolkitAsync(dbContext, authorId, "Public",
+            isPublished: true, templateStatus: TemplateStatus.Approved);
+
+        // limit=0 → clamped to default 20, limit=999 → clamped to 50
+        foreach (var url in new[]
+                 {
+                     $"/api/v1/toolkits/{toolkitId}/ratings?limit=0",
+                     $"/api/v1/toolkits/{toolkitId}/ratings?limit=999",
+                 })
+        {
+            var request = TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Get, url, viewerToken);
+            var response = await _client.SendAsync(request);
+            response.StatusCode.Should().Be(HttpStatusCode.OK, $"limit clamp for {url}");
+        }
+    }
+
+    // ───────────────────────── POST /toolkits/{id}/ratings (stub) ─────────────
+
+    [Fact]
+    public async Task SubmitRating_WithoutAuth_ReturnsUnauthorized()
+    {
+        var response = await _client.PostAsJsonAsync(
+            $"/api/v1/toolkits/{Guid.NewGuid()}/ratings",
+            new { stars = 5, comment = "Great!" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task SubmitRating_Authenticated_Returns501WithStubBody()
+    {
+        // Phase 4b stub — wire shape reserved, FE detects via 501 status +
+        // machine-readable body.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkitId = Guid.NewGuid();
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/toolkits/{toolkitId}/ratings",
+            sessionToken);
+        request.Content = JsonContent.Create(new { stars = 5, comment = "Great!" });
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("error").GetString().Should().Be("ratings_submission_not_yet_available");
+        body.GetProperty("phase").GetString().Should().Be("4b-stub");
+        body.GetProperty("toolkitId").GetGuid().Should().Be(toolkitId);
+    }
+
+    // ───────────────────────── helpers ────────────────────────────────────────
+
+    private static void AssertEmptyStubShape(JsonElement body)
+    {
+        body.GetProperty("items").GetArrayLength().Should().Be(0);
+        body.GetProperty("nextCursor").ValueKind.Should().Be(JsonValueKind.Null);
+        body.GetProperty("totalCount").GetInt32().Should().Be(0);
+        body.GetProperty("averageStars").GetDecimal().Should().Be(0m);
+
+        var breakdown = body.GetProperty("breakdown");
+        breakdown.GetProperty("star1").GetInt32().Should().Be(0);
+        breakdown.GetProperty("star2").GetInt32().Should().Be(0);
+        breakdown.GetProperty("star3").GetInt32().Should().Be(0);
+        breakdown.GetProperty("star4").GetInt32().Should().Be(0);
+        breakdown.GetProperty("star5").GetInt32().Should().Be(0);
+    }
+
+    private static async Task<Guid> SeedToolkitAsync(
+        MeepleAiDbContext dbContext,
+        Guid authorId,
+        string name,
+        bool isPublished,
+        TemplateStatus templateStatus)
+    {
+        // Mirror the Phase 4a seed pattern (raw SQL — bypasses the strict EF
+        // entity which has private setters and required JSON columns).
+        var game = new GameEntity
+        {
+            Id = Guid.NewGuid(),
+            Name = $"Game for {name}",
+            CreatedAt = DateTime.UtcNow,
+        };
+        dbContext.Games.Add(game);
+        await dbContext.SaveChangesAsync();
+
+        var toolkitId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var templateStatusInt = (int)templateStatus;
+        var isTemplate = templateStatus == TemplateStatus.Approved;
+
+        const string sql = """
+            INSERT INTO "GameToolkits" (
+                "Id", "GameId", "PrivateGameId", "Name", "Version",
+                "CreatedByUserId", "IsPublished",
+                "OverridesTurnOrder", "OverridesScoreboard", "OverridesDiceSet",
+                "CreatedAt", "UpdatedAt",
+                "DiceToolsJson", "CardToolsJson", "TimerToolsJson",
+                "CounterToolsJson", "UserDicePresetsJson",
+                "ScoringTemplateJson", "TurnTemplateJson", "StateTemplate",
+                "AgentConfig",
+                "TemplateStatus", "IsTemplate",
+                "ReviewNotes", "ReviewedByUserId", "ReviewedAt",
+                "RowVersion"
+            ) VALUES (
+                {0}, {1}, NULL, {2}, 1,
+                {3}, {4},
+                FALSE, FALSE, FALSE,
+                {5}, {6},
+                NULL, NULL, NULL,
+                NULL, NULL,
+                NULL, NULL, NULL,
+                NULL,
+                {7}, {8},
+                NULL, NULL, NULL,
+                E'\\x01'
+            )
+            """;
+
+        await dbContext.Database.ExecuteSqlRawAsync(
+            sql,
+            toolkitId,
+            game.Id,
+            name,
+            authorId,
+            isPublished,
+            now,
+            now,
+            templateStatusInt,
+            isTemplate);
+
+        return toolkitId;
+    }
+}

--- a/apps/web/src/hooks/queries/__tests__/useToolkitRatings.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useToolkitRatings.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useToolkitRatings unit tests — Wave 3 Phase 4b
+ * (Issue #805 / PR #732 §5.3.3).
+ *
+ * Coverage:
+ *   - Default limit (20) + clamp (1..50)
+ *   - Empty-state contract (Gate B v1 stub: items=[], breakdown all 0)
+ *   - Cursor passed through to URL
+ *   - `enabled: false` and missing toolkitId defer the request
+ *   - Error path surfaces the rejection
+ *   - Schema validates the v1 stub shape
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  TOOLKIT_RATINGS_DEFAULT_LIMIT,
+  TOOLKIT_RATINGS_STALE_TIME_MS,
+  useToolkitRatings,
+} from '../useToolkitRatings';
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: { get: vi.fn() },
+}));
+
+import { apiClient } from '@/lib/api/client';
+
+const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const TOOLKIT_ID = '11111111-1111-1111-1111-111111111111';
+
+const STUB_EMPTY_RESPONSE = {
+  items: [],
+  nextCursor: null,
+  breakdown: { star1: 0, star2: 0, star3: 0, star4: 0, star5: 0 },
+  averageStars: 0,
+  totalCount: 0,
+};
+
+const STUB_WITH_RATINGS = {
+  items: [
+    {
+      id: '22222222-2222-2222-2222-222222222222',
+      raterDisplayName: 'Alice',
+      raterAvatarUrl: null,
+      stars: 5,
+      comment: 'Great toolkit!',
+      createdAt: '2026-05-01T12:00:00Z',
+    },
+  ],
+  nextCursor: 'cursor-page-2',
+  breakdown: { star1: 0, star2: 0, star3: 0, star4: 0, star5: 1 },
+  averageStars: 5,
+  totalCount: 1,
+};
+
+describe('useToolkitRatings', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('exports default limit + stale time constants matching backend cache', () => {
+    expect(TOOLKIT_RATINGS_DEFAULT_LIMIT).toBe(20);
+    expect(TOOLKIT_RATINGS_STALE_TIME_MS).toBe(5 * 60 * 1000);
+  });
+
+  it('fetches with default limit when none is supplied', async () => {
+    mockGet.mockResolvedValueOnce(STUB_EMPTY_RESPONSE);
+
+    const { result } = renderHook(() => useToolkitRatings({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGet).toHaveBeenCalledTimes(1);
+    expect(mockGet.mock.calls[0]![0]).toBe(`/toolkits/${TOOLKIT_ID}/ratings?limit=20`);
+  });
+
+  it('returns the v1 empty stub envelope unchanged', async () => {
+    mockGet.mockResolvedValueOnce(STUB_EMPTY_RESPONSE);
+
+    const { result } = renderHook(() => useToolkitRatings({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(STUB_EMPTY_RESPONSE);
+  });
+
+  it('passes cursor + limit through to the URL', async () => {
+    mockGet.mockResolvedValueOnce(STUB_WITH_RATINGS);
+
+    const { result } = renderHook(
+      () => useToolkitRatings({ toolkitId: TOOLKIT_ID, cursor: 'cursor-page-1', limit: 5 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const url = mockGet.mock.calls[0]![0] as string;
+    expect(url).toContain('limit=5');
+    expect(url).toContain('cursor=cursor-page-1');
+  });
+
+  it('clamps limit values outside [1, 50]', async () => {
+    mockGet.mockResolvedValueOnce(STUB_EMPTY_RESPONSE);
+
+    const { result } = renderHook(() => useToolkitRatings({ toolkitId: TOOLKIT_ID, limit: 999 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGet.mock.calls[0]![0]).toContain('limit=50');
+  });
+
+  it('uses default limit when limit is zero or negative', async () => {
+    mockGet.mockResolvedValueOnce(STUB_EMPTY_RESPONSE);
+
+    const { result } = renderHook(() => useToolkitRatings({ toolkitId: TOOLKIT_ID, limit: 0 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGet.mock.calls[0]![0]).toContain('limit=20');
+  });
+
+  it('does not fire the request when toolkitId is null', () => {
+    renderHook(() => useToolkitRatings({ toolkitId: null }), { wrapper: createWrapper() });
+
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('does not fire the request when enabled is false', () => {
+    renderHook(() => useToolkitRatings({ toolkitId: TOOLKIT_ID, enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a stub envelope when the client returns null (204 safety)', async () => {
+    mockGet.mockResolvedValueOnce(null);
+
+    const { result } = renderHook(() => useToolkitRatings({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(STUB_EMPTY_RESPONSE);
+  });
+
+  it('surfaces upstream errors via the query result', async () => {
+    mockGet.mockRejectedValueOnce(new Error('API failure'));
+
+    const { result } = renderHook(() => useToolkitRatings({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('API failure');
+  });
+});

--- a/apps/web/src/hooks/queries/useToolkitRatings.ts
+++ b/apps/web/src/hooks/queries/useToolkitRatings.ts
@@ -1,0 +1,94 @@
+/**
+ * useToolkitRatings — TanStack Query hook for the SP4 `/toolkits/[id]`
+ * ratings tab (Wave 3 Phase 4b, Issue #805 / PR #732 §5.3.3).
+ *
+ * Backend contract: `GET /api/v1/toolkits/{toolkitId}/ratings?cursor=&limit=20`
+ * returns `{ items, nextCursor, breakdown, averageStars, totalCount }`. Empty
+ * state is a 200 with an empty stub envelope per the PR #732 §3.4 contract.
+ *
+ * Schema reality v1 carryover (Gate B): the `ToolkitRating` entity has not
+ * shipped yet — the backend returns an empty stub once toolkit visibility
+ * passes. The wire shape is stable so the FE can render today and adopt real
+ * persistence in Phase 5 without a fetch shape change.
+ *
+ * Cache: backend caches 5min via HybridCache; FE staleTime mirrors that.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { apiClient } from '@/lib/api/client';
+import {
+  ToolkitRatingsResponseSchema,
+  type ToolkitRatingsResponse,
+} from '@/lib/api/schemas/toolkit-ratings.schemas';
+
+export const TOOLKIT_RATINGS_DEFAULT_LIMIT = 20;
+export const TOOLKIT_RATINGS_STALE_TIME_MS = 5 * 60 * 1000; // 5min, mirrors backend cache
+
+export const toolkitRatingsKeys = {
+  all: ['toolkits', 'ratings'] as const,
+  list: (toolkitId: string, cursor: string | null, limit: number) =>
+    [...toolkitRatingsKeys.all, toolkitId, cursor ?? '_first', limit] as const,
+};
+
+function clampLimit(limit: number): number {
+  if (!Number.isFinite(limit) || limit < 1) return TOOLKIT_RATINGS_DEFAULT_LIMIT;
+  return Math.min(50, Math.floor(limit));
+}
+
+export interface UseToolkitRatingsOptions {
+  readonly toolkitId: string | null | undefined;
+  readonly cursor?: string | null;
+  readonly limit?: number;
+  readonly enabled?: boolean;
+}
+
+/**
+ * Fetch toolkit ratings for the `/toolkits/[id]` ratings tab.
+ *
+ * @example
+ * const { data } = useToolkitRatings({ toolkitId, limit: 20 });
+ * // data?.items — ToolkitRating[] (empty array in v1 stub)
+ * // data?.breakdown.star5 — distribution count (always 0 in v1)
+ * // data?.averageStars — number (0 in v1)
+ */
+export function useToolkitRatings(
+  options: UseToolkitRatingsOptions
+): UseQueryResult<ToolkitRatingsResponse, Error> {
+  const {
+    toolkitId,
+    cursor = null,
+    limit = TOOLKIT_RATINGS_DEFAULT_LIMIT,
+    enabled = true,
+  } = options;
+  const safeLimit = clampLimit(limit);
+
+  return useQuery<ToolkitRatingsResponse, Error>({
+    queryKey: toolkitRatingsKeys.list(toolkitId ?? '_disabled', cursor, safeLimit),
+    queryFn: async () => {
+      if (!toolkitId) {
+        throw new Error('toolkitId is required');
+      }
+      const params = new URLSearchParams();
+      params.set('limit', String(safeLimit));
+      if (cursor) params.set('cursor', cursor);
+      const response = await apiClient.get<ToolkitRatingsResponse>(
+        `/toolkits/${toolkitId}/ratings?${params.toString()}`,
+        ToolkitRatingsResponseSchema
+      );
+      // apiClient returns null on 204; the backend guarantees a body for 200,
+      // so non-null is the happy path. Fall back to an empty stub for safety.
+      return (
+        response ?? {
+          items: [],
+          nextCursor: null,
+          breakdown: { star1: 0, star2: 0, star3: 0, star4: 0, star5: 0 },
+          averageStars: 0,
+          totalCount: 0,
+        }
+      );
+    },
+    enabled: enabled && !!toolkitId,
+    staleTime: TOOLKIT_RATINGS_STALE_TIME_MS,
+  });
+}

--- a/apps/web/src/lib/api/schemas/toolkit-ratings.schemas.ts
+++ b/apps/web/src/lib/api/schemas/toolkit-ratings.schemas.ts
@@ -1,0 +1,54 @@
+/**
+ * Toolkit Ratings Schemas (Wave 3 Phase 4b, Issue #805 / PR #732 §5.3.3)
+ *
+ * Zod schemas for the SP4 `/toolkits/[id]` ratings tab. Backend contract:
+ *   - `GET /api/v1/toolkits/{toolkitId}/ratings?cursor={nullable}&limit=20`
+ *
+ * Response follows the PR #732 §3.4 empty-state contract: shape is always
+ * `{ items, nextCursor, breakdown, averageStars, totalCount }` and an empty
+ * list is a 200 (not 404 / 204).
+ *
+ * Schema reality v1 carryover (Gate B): the `ToolkitRating` entity does not
+ * exist yet. Once toolkit visibility passes, the backend returns:
+ *   - `items: []`
+ *   - `nextCursor: null`
+ *   - `breakdown: { star1..star5: 0 }`
+ *   - `averageStars: 0`
+ *   - `totalCount: 0`
+ * Wire shape is stable so the ratings tab can render today and adopt real
+ * data without a fetch shape change in Phase 5.
+ *
+ * The companion `POST /toolkits/{id}/ratings` returns 501 in Phase 4b — no
+ * FE submission hook ships in this PR; the form can show "coming soon"
+ * affordances without an API call until Phase 5.
+ */
+
+import { z } from 'zod';
+
+export const ToolkitRatingsBreakdownSchema = z.object({
+  star1: z.number().int().nonnegative(),
+  star2: z.number().int().nonnegative(),
+  star3: z.number().int().nonnegative(),
+  star4: z.number().int().nonnegative(),
+  star5: z.number().int().nonnegative(),
+});
+export type ToolkitRatingsBreakdown = z.infer<typeof ToolkitRatingsBreakdownSchema>;
+
+export const ToolkitRatingSchema = z.object({
+  id: z.string().uuid(),
+  raterDisplayName: z.string().min(1),
+  raterAvatarUrl: z.string().nullable(),
+  stars: z.number().int().min(1).max(5),
+  comment: z.string().nullable(),
+  createdAt: z.string(),
+});
+export type ToolkitRating = z.infer<typeof ToolkitRatingSchema>;
+
+export const ToolkitRatingsResponseSchema = z.object({
+  items: z.array(ToolkitRatingSchema),
+  nextCursor: z.string().nullable(),
+  breakdown: ToolkitRatingsBreakdownSchema,
+  averageStars: z.number().nonnegative(),
+  totalCount: z.number().int().nonnegative(),
+});
+export type ToolkitRatingsResponse = z.infer<typeof ToolkitRatingsResponseSchema>;


### PR DESCRIPTION
## Summary

**Closes Wave 3 backend at 14/14 (100%)** — adds the SP4 `/toolkits/[id]` ratings tab surface per PR #732 §5.3.3 + §5.3.4:

- **`GET /api/v1/toolkits/{toolkitId}/ratings?cursor=&limit=20`** — list with 5-star breakdown distribution + `averageStars` + `totalCount` + cursor pagination. 5min HybridCache. Visibility check mirrors `GetToolkitDetail` (404 for non-author when draft/yanked, per PR #732 §5.2 security boundary). Limit silent-clamped 1..50, default 20.
- **`POST /api/v1/toolkits/{toolkitId}/ratings`** — Phase 4b stub. Returns **501 Not Implemented** with machine-readable body `{ error: \"ratings_submission_not_yet_available\", phase: \"4b-stub\", toolkitId }` so the FE form can surface a \"coming soon\" affordance and detect the stub state without parsing prose error messages.

### Schema reality v1 carryover (Gate B)

The `ToolkitRating` entity does not exist yet — the GET handler returns an empty stub envelope (`items=[]`, `breakdown` all zero, `averageStars=0`, `totalCount=0`) once toolkit visibility passes. POST returns 501. Full persistence + edit window + constraints (one rating per `(userId, toolkitId)`, `hasInstalled` gate, viewer ≠ author) ship in Phase 5. Wire shape is stable so the FE ratings tab renders today and adopts real persistence without a fetch shape change.

### Architecture notes

- CQRS strict: `IMediator.Send` only, FluentValidation, internal record DTOs, zero direct service injection.
- Visibility logic mirrors `GetToolkitDetailQueryHandler` exactly (same `IsPublished && TemplateStatus=Approved` gate, same owner override) — single source of truth for the security boundary.
- Cache key `toolkits:{id}:ratings:{cursor}:{limit}` tagged with `toolkit:{id}` so a future Phase 5 invalidation on rating submission can leverage the existing tag-based eviction.
- POST handler is intentionally synchronous (no `IMediator.Send` for the stub) — wiring an empty command + handler would be dead code that complicates Phase 5 review.

### Why no FE submission hook in this PR?

The `useToolkitRatings` GET hook ships now (drives the ratings tab rendering). A submission hook against a 501 stub would be dead code — the form can show \"coming soon\" affordances without an API call. Submission hook lands together with Phase 5 persistence.

## Test plan

- [x] Backend build: ✅ 0 errors / 0 warnings
- [x] Backend integration tests: ✅ **9/9 passed** (Testcontainers Postgres) — 401/404, owner vs non-owner visibility on draft toolkits, empty stub shape on published, cursor pass-through, limit clamp, POST 501 stub body shape
- [x] Frontend unit tests: ✅ **10/10 passed** — hook contract, default + custom limit, clamp, cursor URL encoding, disabled state on null toolkitId, error path, 204 fallback
- [x] Frontend typecheck: ✅ clean
- [x] Frontend lint: ✅ clean
- [ ] CI gates: backend unit + integration + FE build + bundle + a11y

## Wave 3 closeout

After this PR: **14/14 backend endpoints = 100% complete**.

| Phase | Endpoints | PR |
|---|---|---|
| Phase 0 — BGG search | 1 | #811 |
| Phase 1 — /discover quick-wins | 3 | #812 |
| Phase 2 — toolkit marketplace | 3 | #814 |
| Phase 3 — KB chunks (rewrite + bonus search) | 4 | #815 |
| Phase 4a — cross-cutting /discover rails | 2 | #816 |
| **Phase 4b — toolkit ratings (this PR)** | **2** | **this** |

**Phase 5 (deferred, separate scope)**: `ToolkitRating` entity + EF migration + persistence wiring on the existing endpoints. Wire shape preserved by this PR makes the upgrade non-breaking.

Refs #805
Builds on: #811 (BGG), #812 (/discover quick-wins), #814 (toolkit marketplace), #815 (KB chunks), #816 (Phase 4a cross-cutting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)