### PR TITLE
docs(sp6): mockup C/D/E libro game + ripristino vision spec

### DIFF
--- a/admin-mockups/design_files/sp6-libro-game-play-session.html
+++ b/admin-mockups/design_files/sp6-libro-game-play-session.html
@@ -1,0 +1,298 @@
+<!DOCTYPE html>
+<html lang="it" data-theme="light">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SP6 · Libro Game · Play Session — /gamebook/[gameId]/play</title>
+
+  <!-- Schermata: Play Session
+       Route: /gamebook/[gameId]/play
+       Persona: Sara, 32, GM al tavolo, smartphone in mano (single-device GM master)
+       Pattern: Tabbed mobile fullscreen / Split-view desktop (left 380px game-context, right flex content)
+       MVP Phase 1 — SP6 Libro Game (vision §6) -->
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
+
+  <link rel="stylesheet" href="tokens.css" />
+  <link rel="stylesheet" href="components.css" />
+
+  <style>
+    /* Stage layout */
+    .stage {
+      min-height: 100vh;
+      padding: var(--s-7) var(--s-6) var(--s-10);
+      background: var(--bg);
+      color: var(--text);
+    }
+    .stage-wrap { max-width: 1500px; margin: 0 auto; }
+    .stage h1 {
+      font-family: var(--f-display); font-weight: 800;
+      font-size: var(--fs-3xl); margin-bottom: var(--s-2);
+      letter-spacing: -0.02em;
+    }
+    .stage .lead {
+      color: var(--text-sec); font-size: var(--fs-md);
+      max-width: 820px; margin: 0 0 var(--s-7);
+      line-height: var(--lh-body);
+    }
+    .section-label {
+      font-family: var(--f-mono); font-size: var(--fs-xs);
+      color: var(--text-muted); text-transform: uppercase;
+      letter-spacing: 0.08em; margin: var(--s-9) 0 var(--s-4);
+      padding-bottom: var(--s-2); border-bottom: 1px solid var(--border);
+    }
+    .section-label:first-of-type { margin-top: var(--s-7); }
+
+    /* Mobile frame grid */
+    .frames-row {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+      gap: var(--s-7) var(--s-6);
+      align-items: start;
+    }
+    .frame-cell { display: flex; flex-direction: column; gap: var(--s-3); }
+    .frame-meta {
+      font-family: var(--f-mono); font-size: var(--fs-xs);
+      color: var(--text-muted); text-transform: uppercase;
+      letter-spacing: 0.08em; line-height: 1.5;
+    }
+    .frame-meta strong {
+      color: var(--text); font-weight: 700;
+      font-size: var(--fs-sm); display: block; margin-bottom: 2px;
+      letter-spacing: 0.04em;
+    }
+    .frame-meta .gherkin {
+      display: inline-block; padding: 2px 6px; border-radius: var(--r-xs);
+      background: hsl(var(--c-agent) / 0.12); color: hsl(var(--c-agent));
+      font-weight: 700; margin-right: 6px;
+    }
+
+    /* Phone frame override (componenti.css ha .phone già; lo personalizziamo) */
+    .phone-sp6 {
+      width: 380px; height: 780px;
+      border-radius: 48px; border: 10px solid #1a1a1a;
+      background: var(--bg); overflow: hidden; position: relative;
+      box-shadow: 0 28px 60px rgba(0,0,0,.22), 0 0 0 2px #000;
+      display: flex; flex-direction: column;
+    }
+    [data-theme="dark"] .phone-sp6 {
+      border-color: #0a0a0a;
+      box-shadow: 0 28px 60px rgba(0,0,0,.6);
+    }
+    .phone-sbar-sp6 {
+      height: 30px; flex-shrink: 0;
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 4px 22px 0;
+      font-size: 12px; font-weight: 700; font-family: var(--f-display);
+      color: var(--text);
+    }
+    .phone-sbar-sp6 .ind { display: flex; gap: 4px; font-size: 11px; }
+    .phone-screen { flex: 1; display: flex; flex-direction: column; min-height: 0; }
+
+    /* Desktop frame */
+    .desktop-frame {
+      width: 100%;
+      max-width: 1440px;
+      border: 1px solid var(--border);
+      border-radius: var(--r-2xl);
+      overflow: hidden;
+      background: var(--bg);
+      box-shadow: var(--shadow-md);
+    }
+    .desktop-chrome {
+      height: 36px; display: flex; align-items: center; gap: 6px;
+      padding: 0 14px;
+      background: var(--bg-muted);
+      border-bottom: 1px solid var(--border);
+    }
+    .desktop-chrome .dot {
+      width: 12px; height: 12px; border-radius: 50%;
+      background: var(--border-strong);
+    }
+    .desktop-chrome .url {
+      flex: 1; margin-left: 14px;
+      font-family: var(--f-mono); font-size: 11px;
+      color: var(--text-muted);
+      letter-spacing: 0.04em;
+    }
+    .desktop-row { display: flex; flex-direction: column; gap: var(--s-7); }
+
+    /* Theme toggle (multi) */
+    .theme-bar {
+      position: fixed; top: 14px; right: 14px; z-index: 1000;
+      display: flex; gap: 6px;
+    }
+    .theme-bar button {
+      padding: 8px 14px; border-radius: var(--r-pill);
+      background: var(--glass-bg); backdrop-filter: blur(12px);
+      border: 1px solid var(--border); color: var(--text);
+      font-family: var(--f-display); font-size: var(--fs-sm); font-weight: 700;
+      box-shadow: var(--shadow-sm); cursor: pointer;
+    }
+    .theme-bar button.active {
+      background: hsl(var(--c-game) / 0.14);
+      color: hsl(var(--c-game));
+      border-color: hsl(var(--c-game) / 0.3);
+    }
+
+    /* Reduce-motion friendly pulse */
+    @keyframes mai-pulse-session {
+      0%, 100% { transform: scale(1); opacity: 1; }
+      50% { transform: scale(1.18); opacity: 0.6; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .mai-pulse { animation: none !important; }
+      .mai-shimmer { animation: none !important; background: var(--bg-muted) !important; }
+      .mai-typing-dot { animation: none !important; }
+    }
+    @keyframes mai-shimmer-sweep {
+      0% { background-position: -200% 0; }
+      100% { background-position: 200% 0; }
+    }
+    @keyframes mai-spin {
+      to { transform: rotate(360deg); }
+    }
+
+    /* Non-root dark scope — applica i token dark anche a wrapper interni
+       (i token in tokens.css sono :root[data-theme="dark"], serve override locale per #17/18/19) */
+    [data-theme="dark"] {
+      --bg:        #14100a;
+      --bg-card:   #1e1710;
+      --bg-muted:  #241c13;
+      --bg-sunken: #0f0c08;
+      --bg-hover:  rgba(255, 200, 130, 0.05);
+      --text:       #f0e4d2;
+      --text-sec:   #c8b896;
+      --text-muted: #8a7860;
+      --border:       rgba(224, 180, 110, 0.14);
+      --border-light: rgba(224, 180, 110, 0.08);
+      --border-strong: rgba(224, 180, 110, 0.28);
+      --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.3);
+      --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.4);
+      --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.5);
+      --shadow-lg: 0 12px 36px rgba(0, 0, 0, 0.6);
+      --glass-bg: rgba(30, 22, 14, 0.85);
+      --glass-border: rgba(224, 180, 110, 0.14);
+      --c-game:    28 95% 58%;
+      --c-player:  262 75% 70%;
+      --c-session: 235 70% 70%;
+      --c-agent:   38 92% 62%;
+      --c-kb:      174 60% 55%;
+      --c-chat:    218 80% 68%;
+      --c-event:   350 85% 70%;
+      --c-toolkit: 142 60% 58%;
+      --c-tool:    195 75% 62%;
+      color-scheme: dark;
+      background: var(--bg);
+      color: var(--text);
+    }
+    .mai-spinner {
+      animation: mai-spin 0.9s linear infinite;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .mai-spinner { animation: none !important; }
+    }
+    .mai-shimmer {
+      background: linear-gradient(90deg, var(--bg-muted) 0%, var(--bg-sunken) 50%, var(--bg-muted) 100%);
+      background-size: 200% 100%;
+      animation: mai-shimmer-sweep 1.6s ease-in-out infinite;
+    }
+    @keyframes mai-typing {
+      0%, 60%, 100% { transform: translateY(0); opacity: 0.5; }
+      30% { transform: translateY(-4px); opacity: 1; }
+    }
+    .mai-typing-dot {
+      animation: mai-typing 1.2s ease-in-out infinite;
+    }
+
+    /* Hide scrollbars (mobile drawer style) */
+    .mai-noscroll::-webkit-scrollbar { display: none; }
+    .mai-noscroll { scrollbar-width: none; }
+
+    /* Reading-mode body — deviazione esplicita (vision §4.2) */
+    .reading-body {
+      font-family: var(--f-body);
+      font-size: 24px;        /* =18pt assoluto, deviazione vs --fs-lg(17px≈13pt) */
+      line-height: 1.6;
+      max-width: 60ch;
+      color: var(--text);
+    }
+    .reading-body .dialogue {
+      font-style: italic;
+      color: hsl(var(--c-kb) / 0.95);
+    }
+    .reading-body p { margin: 0 0 var(--s-5); }
+    .reading-body p:last-child { margin-bottom: 0; }
+
+    /* Underline tabs */
+    .tab-underline {
+      position: absolute; bottom: 0; height: 2px;
+      background: hsl(var(--e, var(--c-game)));
+      transition: left var(--dur-md) var(--ease-out), width var(--dur-md) var(--ease-out);
+    }
+
+    /* Anti-zoom on phone-shaped containers */
+    .phone-screen, .phone-screen * {
+      -webkit-text-size-adjust: 100%;
+    }
+  </style>
+</head>
+<body>
+  <div class="theme-bar" role="toolbar" aria-label="Tema">
+    <button type="button" data-set-theme="light" class="active">☀ Light</button>
+    <button type="button" data-set-theme="dark">🌙 Dark</button>
+  </div>
+
+  <div class="stage">
+    <div class="stage-wrap">
+      <h1>SP6 · Libro Game — Play Session</h1>
+      <p class="lead">
+        Route <code>/gamebook/[gameId]/play</code>. Pattern <strong>tabbed mobile fullscreen</strong>
+        (Sara con smartphone in mano al tavolo) /
+        <strong>split-view desktop</strong> (left 380px game-context, right flex content).
+        Header sticky + <strong>ConnectionBar 6 pip</strong> (kb 142, chat 8, agent 2,
+        tool 0 <em>isEmpty dashed</em>, player 4, session 1) + 3 tab principali.
+        Tab body adotta <strong>reading-mode 24px (=18pt) esplicito</strong> per accessibilità
+        lettura distante 1.5m al tavolo (vision §4.2). Session Bar pulsing entity=session
+        sostituisce la BottomBar standard mentre la sessione è in corso.
+      </p>
+
+      <div class="section-label">Mobile · 375 × 780 — Tab 💬 Chat regole (G3 — 6 stati)</div>
+      <div id="mount-chat" class="frames-row"></div>
+
+      <div class="section-label">Mobile · 375 × 780 — Tab 📖 Paragrafo (G4 — 6 stati: empty / default / loading / not-found / offline / quota)</div>
+      <div id="mount-paragraph" class="frames-row"></div>
+
+      <div class="section-label">Mobile · 375 × 780 — Tab 🎲 Setup (G2 — 4 stati: default / generated / generating / unclear)</div>
+      <div id="mount-setup" class="frames-row"></div>
+
+      <div class="section-label">Desktop · 1440 — Split-view (left 380 game-context · right flex content)</div>
+      <div id="mount-desktop" class="desktop-row"></div>
+
+      <div class="section-label">Mobile · 375 × 780 — Dark theme proofs (3 stati: chat / paragrafo / setup)</div>
+      <div id="mount-dark" class="frames-row"></div>
+    </div>
+  </div>
+
+  <!-- React + Babel (versioni pinned obbligatorie) -->
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+  <!-- Theme toggle -->
+  <script>
+    document.querySelectorAll('[data-set-theme]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const t = btn.dataset.setTheme;
+        document.documentElement.setAttribute('data-theme', t);
+        document.querySelectorAll('.theme-bar button').forEach(b => b.classList.toggle('active', b === btn));
+      });
+    });
+  </script>
+
+  <!-- Mockup body -->
+  <script type="text/babel" src="sp6-libro-game-play-session.jsx" data-presets="env,react"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp6-libro-game-play-session.jsx
+++ b/admin-mockups/design_files/sp6-libro-game-play-session.jsx
@@ -1,0 +1,1408 @@
+/* SP6 · Libro Game — Play Session
+   Route: /gamebook/[gameId]/play
+   Persona: Sara, 32, GM al tavolo, smartphone in mano (single-device GM master)
+   Pattern: Tabbed mobile fullscreen / Split-view desktop (left 380 game-ctx, right flex)
+   MVP Phase 1 — vision §6
+   Stati Gherkin coperti: G3.1, G3.2, G3.3, G3.4, G3.5 + Tab Chat empty
+                          G4 default, G4.4, G4.6, G4.7
+                          G2 default, G2 generated, G2.3 unclear
+   G4.7 mid-translation-lost = scope mockup D (translation viewer fullscreen),
+   qui copriamo solo G4.7 offline-cached banner */
+
+const { useState, useMemo } = React;
+
+/* ═══════════════════════════════════════════════════════
+   ENTITY HSL HELPER (replica inline — apps/web/src/lib/theme/entity-hsl.ts)
+   ═══════════════════════════════════════════════════════ */
+const ENTITY_HSL = {
+  game:    '25 95% 45%',
+  player:  '262 83% 58%',
+  session: '240 60% 55%',
+  agent:   '38 92% 50%',
+  kb:      '174 60% 40%',
+  chat:    '220 80% 55%',
+  event:   '350 89% 60%',
+  toolkit: '142 70% 45%',
+  tool:    '195 80% 50%',
+};
+const ENTITY_EM = {
+  game: '🎲', player: '👤', session: '🎯', agent: '🤖', kb: '📄',
+  chat: '💬', event: '🎉', toolkit: '🧰', tool: '🔧',
+};
+const entityHsl = (entity, alpha) =>
+  alpha != null ? `hsl(var(--c-${entity}) / ${alpha})` : `hsl(var(--c-${entity}))`;
+
+/* ═══════════════════════════════════════════════════════
+   ENTITY CHIP (sm) — replica produzione
+   ═══════════════════════════════════════════════════════ */
+const EntityChip = ({ entity, children, size = 'sm', icon, dashed }) => {
+  const padding = size === 'sm' ? '3px 8px' : '5px 12px';
+  const fs = size === 'sm' ? 11 : 12;
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: 5,
+      padding, borderRadius: 'var(--r-pill)',
+      background: dashed ? 'transparent' : entityHsl(entity, 0.12),
+      color: entityHsl(entity),
+      border: dashed
+        ? `1.5px dashed ${entityHsl(entity, 0.5)}`
+        : `1px solid ${entityHsl(entity, 0.2)}`,
+      fontFamily: 'var(--f-display)', fontSize: fs, fontWeight: 700,
+      whiteSpace: 'nowrap', lineHeight: 1.2,
+    }}>
+      <span aria-hidden="true" style={{ fontSize: fs + 1 }}>{icon || ENTITY_EM[entity]}</span>
+      {children}
+    </span>
+  );
+};
+
+/* ═══════════════════════════════════════════════════════
+   CONNECTIONBAR (1:1 prod, lezione PR #568/#569/#570)
+   - borderRadius 999 (pill)
+   - bg pieno entityHsl(.1) non-empty / dashed + opacity 0.6 + Plus icon empty
+   - aria-label `${label}: ${count}` non-empty / `${label}` empty
+   - tabular-nums per count
+   ═══════════════════════════════════════════════════════ */
+const ConnectionBar = ({ connections, dense }) => (
+  <div className="mai-noscroll" style={{
+    display: 'flex', alignItems: 'center', gap: 6,
+    overflowX: 'auto', padding: dense ? '4px 0' : '8px 0',
+  }}>
+    {connections.map(c => {
+      const isEmpty = c.isEmpty || c.count === 0;
+      const ariaLabel = isEmpty ? c.label : `${c.label}: ${c.count}`;
+      return (
+        <button
+          key={c.entityType}
+          type="button"
+          aria-label={ariaLabel}
+          style={{
+            display: 'inline-flex', alignItems: 'center', gap: 5,
+            padding: '5px 10px', borderRadius: 999,
+            fontSize: 11, fontWeight: 700, fontFamily: 'var(--f-display)',
+            background: isEmpty ? 'transparent' : entityHsl(c.entityType, 0.1),
+            color: entityHsl(c.entityType),
+            border: isEmpty
+              ? `1.5px dashed ${entityHsl(c.entityType, 0.5)}`
+              : `1px solid ${entityHsl(c.entityType, 0.2)}`,
+            opacity: isEmpty ? 0.6 : 1,
+            cursor: 'pointer', flexShrink: 0, whiteSpace: 'nowrap',
+          }}
+        >
+          <span aria-hidden="true" style={{ fontSize: 12, lineHeight: 1 }}>{ENTITY_EM[c.entityType]}</span>
+          {isEmpty ? (
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <line x1="12" y1="5" x2="12" y2="19"/>
+              <line x1="5" y1="12" x2="19" y2="12"/>
+            </svg>
+          ) : (
+            <span style={{ fontFamily: 'var(--f-mono)', fontVariantNumeric: 'tabular-nums', fontWeight: 700 }}>
+              {c.count}
+            </span>
+          )}
+          <span>{c.label}</span>
+        </button>
+      );
+    })}
+  </div>
+);
+
+const SESSION_CONNECTIONS = [
+  { entityType: 'kb',      count: 142, label: 'pagine',    isEmpty: false },
+  { entityType: 'chat',    count: 8,   label: 'domande',   isEmpty: false },
+  { entityType: 'agent',   count: 2,   label: 'house rules', isEmpty: false },
+  { entityType: 'tool',    count: 0,   label: 'setup',     isEmpty: true  },
+  { entityType: 'player',  count: 4,   label: 'giocatori', isEmpty: false },
+  { entityType: 'session', count: 1,   label: 'sessione',  isEmpty: false },
+];
+
+/* ═══════════════════════════════════════════════════════
+   PHONE FRAME (status bar + screen body)
+   ═══════════════════════════════════════════════════════ */
+const Phone = ({ children }) => (
+  <div className="phone-sp6">
+    <div className="phone-sbar-sp6">
+      <span>21:47</span>
+      <span className="ind"><span>📶</span><span>📡</span><span>78%</span></span>
+    </div>
+    <div className="phone-screen">{children}</div>
+  </div>
+);
+
+/* ═══════════════════════════════════════════════════════
+   SESSION HEADER (sticky)
+   ═══════════════════════════════════════════════════════ */
+const SessionHeader = ({ compact }) => (
+  <div style={{
+    padding: compact ? '10px 14px 8px' : '12px 18px 10px',
+    background: 'var(--bg)',
+    borderBottom: '1px solid var(--border-light)',
+    flexShrink: 0,
+  }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
+      {/* game cover mini */}
+      <div style={{
+        width: 38, height: 46, borderRadius: 'var(--r-sm)',
+        background: `linear-gradient(135deg, ${entityHsl('game', 0.85)}, ${entityHsl('event', 0.7)})`,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        fontSize: 18, flexShrink: 0,
+        boxShadow: 'var(--shadow-xs)',
+      }} aria-hidden="true">🗡️</div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <h1 style={{
+          fontFamily: 'var(--f-display)', fontWeight: 800,
+          fontSize: 18, letterSpacing: '-0.01em', lineHeight: 1.15,
+          color: 'var(--text)', margin: '0 0 2px',
+          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+        }}>Tainted Grail</h1>
+        <div style={{
+          display: 'inline-flex', alignItems: 'center', gap: 5,
+          fontFamily: 'var(--f-mono)', fontSize: 10, fontWeight: 700,
+          color: entityHsl('session'), textTransform: 'uppercase', letterSpacing: '0.06em',
+        }}>
+          <span aria-hidden="true" style={{
+            display: 'inline-block', width: 7, height: 7, borderRadius: '50%',
+            background: entityHsl('session'),
+            animation: 'mai-pulse-session 1.6s ease-in-out infinite',
+          }} className="mai-pulse"/>
+          🎯 In corso · 47 min
+        </div>
+      </div>
+      <button type="button" aria-label="Menu sessione" style={{
+        width: 36, height: 36, borderRadius: 'var(--r-md)',
+        background: 'transparent', border: '1px solid var(--border)',
+        color: 'var(--text-sec)', fontSize: 16, cursor: 'pointer',
+        flexShrink: 0,
+      }}>⋯</button>
+    </div>
+    <ConnectionBar connections={SESSION_CONNECTIONS} dense/>
+  </div>
+);
+
+/* ═══════════════════════════════════════════════════════
+   TABS NAV (animated underline, riuso wave 1)
+   ═══════════════════════════════════════════════════════ */
+const TABS = [
+  { id: 'chat',      em: '💬', label: 'Chat regole', entity: 'chat' },
+  { id: 'paragraph', em: '📖', label: 'Paragrafo',   entity: 'kb' },
+  { id: 'setup',     em: '🎲', label: 'Setup',       entity: 'tool' },
+];
+const TabsNav = ({ active }) => (
+  <div role="tablist" aria-label="Sezioni sessione" style={{
+    display: 'flex', position: 'relative',
+    borderBottom: '1px solid var(--border)',
+    background: 'var(--bg)', flexShrink: 0,
+  }}>
+    {TABS.map((t, i) => {
+      const isActive = t.id === active;
+      return (
+        <button key={t.id} role="tab" aria-selected={isActive}
+          type="button"
+          style={{
+            flex: 1, padding: '11px 6px',
+            background: 'transparent', border: 'none',
+            borderBottom: isActive
+              ? `2px solid ${entityHsl(t.entity)}`
+              : '2px solid transparent',
+            color: isActive ? entityHsl(t.entity) : 'var(--text-sec)',
+            fontFamily: 'var(--f-display)',
+            fontSize: 13, fontWeight: isActive ? 800 : 600,
+            cursor: 'pointer',
+            display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 6,
+            marginBottom: '-1px',
+            transition: 'color var(--dur-sm)',
+          }}>
+          <span aria-hidden="true">{t.em}</span>{t.label}
+        </button>
+      );
+    })}
+  </div>
+);
+
+/* ═══════════════════════════════════════════════════════
+   SESSION BAR (mobile, sostituisce BottomBar)
+   ═══════════════════════════════════════════════════════ */
+const SessionBar = ({ activeTab }) => (
+  <div style={{
+    flexShrink: 0,
+    padding: '10px 14px 14px',
+    borderTop: '1px solid var(--border-light)',
+    background: `linear-gradient(180deg, ${entityHsl('session', 0.06)}, ${entityHsl('session', 0.12)})`,
+    display: 'flex', alignItems: 'center', gap: 6,
+  }}>
+    <span aria-hidden="true" style={{
+      display: 'inline-block', width: 8, height: 8, borderRadius: '50%',
+      background: entityHsl('session'),
+      animation: 'mai-pulse-session 1.6s ease-in-out infinite',
+      marginRight: 4, flexShrink: 0,
+    }} className="mai-pulse"/>
+    {[
+      { id: 'chat',  em: '💬', label: 'Chat',  entity: 'chat' },
+      { id: 'paragraph', em: '📖', label: '§147', entity: 'kb' },
+      { id: 'setup', em: '🎲', label: 'Setup', entity: 'tool' },
+    ].map(b => {
+      const isActive = b.id === activeTab;
+      return (
+        <button key={b.id} type="button" style={{
+          flex: 1, padding: '8px 4px', borderRadius: 'var(--r-md)',
+          background: isActive ? entityHsl(b.entity, 0.14) : 'transparent',
+          border: 'none',
+          color: isActive ? entityHsl(b.entity) : 'var(--text-sec)',
+          fontFamily: 'var(--f-display)', fontSize: 11, fontWeight: 700,
+          display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2,
+          cursor: 'pointer',
+        }}>
+          <span aria-hidden="true" style={{ fontSize: 14 }}>{b.em}</span>
+          {b.label}
+        </button>
+      );
+    })}
+    <button type="button" aria-label="Pausa sessione" style={{
+      width: 40, height: 40, borderRadius: 'var(--r-md)',
+      background: 'transparent', border: '1px solid var(--border)',
+      color: 'var(--text-sec)', fontSize: 14, cursor: 'pointer',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      flexShrink: 0,
+    }}>⏸</button>
+  </div>
+);
+
+/* ═══════════════════════════════════════════════════════
+   CHAT BUBBLES
+   ═══════════════════════════════════════════════════════ */
+const ConfidenceBadge = ({ level }) => {
+  const map = {
+    high: { color: 'toolkit', label: 'Alta', em: '🟢', value: '0.92' },
+    med:  { color: 'agent',   label: 'Media', em: '🟡', value: '0.62' },
+    low:  { color: 'event',   label: 'Bassa', em: '🔴', value: '0.42' },
+  };
+  const c = map[level];
+  return (
+    <span title={`Confidence ${c.value}`} style={{
+      display: 'inline-flex', alignItems: 'center', gap: 4,
+      padding: '2px 7px', borderRadius: 'var(--r-pill)',
+      background: entityHsl(c.color, 0.12),
+      color: entityHsl(c.color),
+      fontFamily: 'var(--f-mono)', fontSize: 10, fontWeight: 700,
+      letterSpacing: '0.04em',
+    }}>
+      <span aria-hidden="true">{c.em}</span>{c.label}
+    </span>
+  );
+};
+
+const UserBubble = ({ children, who = 'Sara' }) => (
+  <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 12 }}>
+    <div style={{ maxWidth: '80%', display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 3 }}>
+      <span style={{
+        fontFamily: 'var(--f-mono)', fontSize: 9, fontWeight: 700,
+        color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.06em',
+      }}>{who}</span>
+      <div style={{
+        background: entityHsl('chat'),
+        color: '#fff',
+        padding: '10px 14px',
+        borderRadius: '14px 14px 4px 14px',
+        fontSize: 14, fontWeight: 500, lineHeight: 1.45,
+      }}>
+        {children}
+      </div>
+    </div>
+  </div>
+);
+
+const AgentBubble = ({ children, footer, confidence, actions, badge }) => (
+  <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, marginBottom: 14 }}>
+    <div style={{
+      width: 28, height: 28, borderRadius: '50%', flexShrink: 0,
+      background: entityHsl('agent', 0.18),
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      fontSize: 14, marginTop: 16,
+    }} aria-hidden="true">🤖</div>
+    <div style={{ flex: 1, minWidth: 0 }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 6, marginBottom: 3,
+      }}>
+        <span style={{
+          fontFamily: 'var(--f-mono)', fontSize: 9, fontWeight: 700,
+          color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.06em',
+        }}>Agente regole</span>
+        {confidence && <ConfidenceBadge level={confidence}/>}
+        {badge}
+      </div>
+      <div style={{
+        background: entityHsl('agent', 0.08),
+        border: `1px solid ${entityHsl('agent', 0.16)}`,
+        padding: '10px 14px',
+        borderRadius: '14px 14px 14px 4px',
+        fontSize: 14, lineHeight: 1.55,
+        color: 'var(--text)',
+      }}>
+        {children}
+        {footer && (
+          <div style={{
+            marginTop: 10, paddingTop: 8,
+            borderTop: `1px solid ${entityHsl('agent', 0.18)}`,
+            display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 6,
+          }}>{footer}</div>
+        )}
+      </div>
+      {actions && (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 6 }}>
+          {actions}
+        </div>
+      )}
+    </div>
+  </div>
+);
+
+const ActionChip = ({ icon, children, primary }) => (
+  <button type="button" style={{
+    display: 'inline-flex', alignItems: 'center', gap: 4,
+    padding: '5px 9px', borderRadius: 'var(--r-pill)',
+    background: primary ? entityHsl('agent', 0.16) : 'var(--bg-card)',
+    border: primary ? `1px solid ${entityHsl('agent', 0.4)}` : '1px solid var(--border)',
+    color: primary ? entityHsl('agent') : 'var(--text-sec)',
+    fontFamily: 'var(--f-display)', fontSize: 11, fontWeight: 700,
+    cursor: 'pointer', whiteSpace: 'nowrap',
+  }}>
+    {icon && <span aria-hidden="true">{icon}</span>}
+    {children}
+  </button>
+);
+
+const ChatInput = ({ placeholder = 'Chiedi qualcosa sulle regole…' }) => (
+  <div style={{
+    flexShrink: 0, padding: '8px 12px',
+    borderTop: '1px solid var(--border-light)',
+    background: 'var(--bg)',
+    display: 'flex', alignItems: 'center', gap: 6,
+  }}>
+    <div style={{
+      flex: 1,
+      padding: '8px 12px',
+      background: 'var(--bg-muted)',
+      borderRadius: 'var(--r-pill)',
+      fontSize: 13, fontFamily: 'var(--f-body)',
+      color: 'var(--text-muted)',
+      display: 'flex', alignItems: 'center', gap: 8,
+    }}>
+      <span style={{ flex: 1 }}>{placeholder}</span>
+      <button type="button" aria-label="Voice input" style={{
+        background: 'transparent', border: 'none', color: 'var(--text-sec)',
+        fontSize: 14, cursor: 'pointer', padding: 0,
+      }}>🎙</button>
+    </div>
+    <button type="button" aria-label="Invia" style={{
+      width: 40, height: 40, borderRadius: '50%',
+      background: entityHsl('chat'), color: '#fff', border: 'none',
+      fontSize: 14, cursor: 'pointer', flexShrink: 0,
+      boxShadow: `0 4px 12px ${entityHsl('chat', 0.4)}`,
+    }}>↑</button>
+  </div>
+);
+
+/* ═══════════════════════════════════════════════════════
+   TAB CHAT — 6 stati
+   ═══════════════════════════════════════════════════════ */
+const ChatBody = ({ children }) => (
+  <div style={{
+    flex: 1, overflowY: 'auto', padding: '14px 14px 8px',
+    background: 'var(--bg)',
+    display: 'flex', flexDirection: 'column',
+  }}>{children}</div>
+);
+
+const ChatStateDefault = () => (
+  <ChatBody>
+    <UserBubble who="Marco">
+      Quanti dadi tira il difensore in combattimento marziale?
+    </UserBubble>
+    <AgentBubble
+      confidence="high"
+      footer={<EntityChip entity="kb" size="sm">p.18 — Combattimento Marziale</EntityChip>}
+      actions={<>
+        <ActionChip icon="👍">Utile</ActionChip>
+        <ActionChip icon="👎">Non chiara</ActionChip>
+        <ActionChip icon="🔁">Rigenera</ActionChip>
+        <ActionChip icon="📋">Copia</ActionChip>
+      </>}>
+      Il difensore tira <strong>2 dadi rossi</strong>: il valore più alto è il successo.
+      Se è in posizione di guardia (token Guard attivo), aggiunge un dado bianco.
+      Vince il duello chi totalizza il valore più alto — pareggio = entrambi feriti.
+    </AgentBubble>
+    <UserBubble>I critici fanno doppio danno?</UserBubble>
+    <AgentBubble
+      confidence="high"
+      footer={<EntityChip entity="kb" size="sm">p.22 — Colpi critici</EntityChip>}>
+      Sì. Quando ottieni un <strong>6 naturale</strong> il danno base viene moltiplicato per 1.5
+      (arrotondato per eccesso). Esempio: 4 danno → 6 danno con critico.
+    </AgentBubble>
+  </ChatBody>
+);
+
+const ChatStateAmbiguity = () => (
+  <ChatBody>
+    <UserBubble>Cosa succede quando si pareggia?</UserBubble>
+    <AgentBubble confidence="med">
+      La tua domanda può riferirsi a <strong>4 contesti diversi</strong> nel manuale.
+      Quale ti interessa?
+      <div style={{
+        marginTop: 10, display: 'flex', flexWrap: 'wrap', gap: 6,
+      }}>
+        <EntityChip entity="kb" size="sm">⚔️ Combattimento</EntityChip>
+        <EntityChip entity="kb" size="sm">⏱️ Iniziativa</EntityChip>
+        <EntityChip entity="kb" size="sm">🗳️ Voto del gruppo</EntityChip>
+        <EntityChip entity="kb" size="sm">🧭 Esplorazione</EntityChip>
+      </div>
+    </AgentBubble>
+  </ChatBody>
+);
+
+const ChatStateLowConfidence = () => (
+  <ChatBody>
+    <UserBubble who="Marco">
+      Se due giocatori muoiono nello stesso turno, chi diventa il leader?
+    </UserBubble>
+    <AgentBubble
+      confidence="low"
+      footer={<EntityChip entity="kb" size="sm">p.34 — Stato del gruppo</EntityChip>}
+      actions={<>
+        <ActionChip icon="📷">Rifotografa pagina</ActionChip>
+        <ActionChip icon="🤝" primary>Definisci house rule</ActionChip>
+        <ActionChip icon="🔍">Cerca su BGG</ActionChip>
+      </>}>
+      <strong>Non sono sicuro</strong> — questa regola non è chiara dal manuale.
+      Il testo a p.34 menziona la successione del leader ma non specifica il caso
+      di morte simultanea. Confidence bassa (0.42).
+    </AgentBubble>
+  </ChatBody>
+);
+
+const ChatStateHouseRule = () => (
+  <ChatBody>
+    <UserBubble>I critici fanno doppio danno o +50%?</UserBubble>
+    <AgentBubble
+      confidence="high"
+      badge={<EntityChip entity="agent" size="sm">House rule attiva</EntityChip>}
+      footer={
+        <span style={{
+          fontSize: 11, color: 'var(--text-muted)',
+          fontFamily: 'var(--f-body)', fontStyle: 'italic',
+          display: 'inline-flex', alignItems: 'center', gap: 4, flexWrap: 'wrap',
+        }}>
+          📖 Regola ufficiale manuale: +50% danno
+          <EntityChip entity="kb" size="sm">p.22</EntityChip>
+          — ma state usando la vostra variante
+        </span>
+      }>
+      Per il vostro gruppo: <strong>doppio danno</strong> sui critici
+      (house rule definita 14 min fa da Sara).
+    </AgentBubble>
+  </ChatBody>
+);
+
+const ChatStateTimeout = () => (
+  <ChatBody>
+    <UserBubble who="Giulia">
+      Come si risolve un test di Resistenza con vantaggio?
+    </UserBubble>
+    <AgentBubble>
+      <div style={{
+        display: 'inline-flex', alignItems: 'center', gap: 8,
+        color: entityHsl('agent'),
+        fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 13,
+      }}>
+        <span style={{ display: 'inline-flex', gap: 3 }}>
+          {[0, 1, 2].map(i => (
+            <span key={i} aria-hidden="true" className="mai-typing-dot"
+              style={{
+                width: 7, height: 7, borderRadius: '50%',
+                background: entityHsl('agent'),
+                display: 'inline-block',
+                animationDelay: `${i * 0.15}s`,
+              }}/>
+          ))}
+        </span>
+        🟡 Sto pensando, ci vuole più del solito…
+      </div>
+      <div style={{
+        marginTop: 8, fontSize: 12, color: 'var(--text-muted)',
+        fontFamily: 'var(--f-mono)',
+      }}>8s · connessione lenta</div>
+    </AgentBubble>
+    <AgentBubble
+      actions={<>
+        <ActionChip icon="📖" primary>Mostrami le pagine sul tema "Resistenza"</ActionChip>
+        <ActionChip icon="🔁">Riprova</ActionChip>
+      </>}>
+      <strong>Connessione lenta</strong> — passa a modalità manuale: ti mostro le pagine
+      che parlano del tema così leggi tu mentre ripristiniamo la connessione.
+    </AgentBubble>
+  </ChatBody>
+);
+
+const ChatStateEmpty = () => (
+  <ChatBody>
+    <div style={{
+      flex: 1, display: 'flex', flexDirection: 'column',
+      alignItems: 'center', justifyContent: 'center',
+      textAlign: 'center', padding: '40px 20px', gap: 14,
+    }}>
+      <div style={{
+        width: 88, height: 88, borderRadius: 'var(--r-2xl)',
+        background: `linear-gradient(135deg, ${entityHsl('chat', 0.18)}, ${entityHsl('agent', 0.16)})`,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        fontSize: 38,
+      }} aria-hidden="true">💬</div>
+      <div>
+        <h3 style={{
+          fontFamily: 'var(--f-display)', fontSize: 18, fontWeight: 800,
+          margin: '0 0 6px', color: 'var(--text)',
+        }}>Prima domanda della sessione</h3>
+        <p style={{
+          fontSize: 13, color: 'var(--text-sec)',
+          margin: 0, lineHeight: 1.5, maxWidth: '28ch',
+        }}>
+          Chiedi qualcosa sulle regole. Ti rispondo citando la pagina del manuale.
+        </p>
+      </div>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, justifyContent: 'center', maxWidth: 280 }}>
+        {['Come funziona il combattimento?', 'Setup per 4 giocatori', 'Cos\'è il Wraithstone?'].map(s => (
+          <button key={s} type="button" style={{
+            padding: '6px 11px', borderRadius: 'var(--r-pill)',
+            background: 'var(--bg-card)', border: '1px solid var(--border)',
+            color: 'var(--text-sec)',
+            fontFamily: 'var(--f-display)', fontSize: 11, fontWeight: 700,
+            cursor: 'pointer',
+          }}>{s}</button>
+        ))}
+      </div>
+    </div>
+  </ChatBody>
+);
+
+/* ═══════════════════════════════════════════════════════
+   TAB PARAGRAFO — 4 stati
+   ═══════════════════════════════════════════════════════ */
+const ParagraphToolbar = ({ active = '147', mode = 'IT' }) => (
+  <div style={{
+    flexShrink: 0, padding: '10px 14px',
+    background: 'var(--bg)',
+    borderBottom: '1px solid var(--border-light)',
+    display: 'flex', alignItems: 'center', gap: 8,
+  }}>
+    <div style={{
+      display: 'inline-flex', alignItems: 'center', gap: 6,
+      padding: '7px 12px', borderRadius: 'var(--r-md)',
+      background: 'var(--bg-muted)',
+      flex: 1, minWidth: 0,
+    }}>
+      <span style={{
+        fontFamily: 'var(--f-mono)', fontSize: 11, fontWeight: 700,
+        color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.06em',
+      }}>Vai al §</span>
+      <span style={{
+        fontFamily: 'var(--f-mono)', fontSize: 18, fontWeight: 700,
+        color: entityHsl('kb'),
+      }}>{active}</span>
+    </div>
+    <div role="tablist" aria-label="Lingua" style={{
+      display: 'inline-flex', padding: 2, borderRadius: 'var(--r-md)',
+      background: 'var(--bg-muted)',
+    }}>
+      {['IT', 'EN'].map(m => (
+        <button key={m} type="button" role="tab" aria-selected={m === mode} style={{
+          padding: '6px 10px', borderRadius: 'var(--r-sm)',
+          background: m === mode ? 'var(--bg-card)' : 'transparent',
+          border: 'none', color: m === mode ? entityHsl('kb') : 'var(--text-sec)',
+          fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 700,
+          cursor: 'pointer',
+          boxShadow: m === mode ? 'var(--shadow-xs)' : 'none',
+        }}>{m}</button>
+      ))}
+    </div>
+  </div>
+);
+
+const ParagraphHeader = ({ num, chapter }) => (
+  <div style={{ marginBottom: 18 }}>
+    <div style={{
+      fontFamily: 'var(--f-display)', fontSize: 14, fontWeight: 600,
+      color: 'var(--text-muted)', marginBottom: 4,
+    }}>{chapter}</div>
+    <div style={{
+      fontFamily: 'var(--f-mono)', fontSize: 36, fontWeight: 700,
+      color: entityHsl('kb'), letterSpacing: '-0.01em', lineHeight: 1,
+    }}>§{num}</div>
+  </div>
+);
+
+const ParagraphStateDefault = () => (
+  <>
+    <ParagraphToolbar active="147" mode="IT"/>
+    <div style={{ flex: 1, overflowY: 'auto', padding: '18px 18px 14px' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 8, marginBottom: 4 }}>
+        <ParagraphHeader num="147" chapter="Capitolo VII — Le brughiere di Avalon"/>
+        <EntityChip entity="kb" size="sm" icon="📦">Cached</EntityChip>
+      </div>
+      <div className="reading-body">
+        <p>
+          La nebbia si dirada e davanti a te si apre la torbiera silenziosa. <strong>Niamh</strong> stringe
+          la <strong>Spada di Avalon</strong> — la lama riflette un bagliore che non viene da nessuna luna.
+        </p>
+        <p className="dialogue">
+          «Senti anche tu? Qualcosa ci osserva da quelle pietre.»
+        </p>
+        <p>
+          Una <strong>Pietra Spettrale</strong> emerge dal fango: la sua superficie è incisa con simboli
+          che bruciano gli occhi se fissati troppo a lungo. Tira un dado di Volontà.
+        </p>
+      </div>
+      <div style={{
+        marginTop: 16, fontSize: 11, color: 'var(--text-muted)',
+        fontStyle: 'italic', fontFamily: 'var(--f-body)',
+      }}>
+        Glossario applicato: Spada di Avalon, Pietra Spettrale, Niamh
+      </div>
+    </div>
+    <div style={{
+      flexShrink: 0, padding: '10px 14px',
+      borderTop: '1px solid var(--border-light)',
+      display: 'flex', gap: 6, alignItems: 'center',
+    }}>
+      <button type="button" style={{
+        padding: '8px 10px', borderRadius: 'var(--r-md)',
+        background: 'transparent', border: '1px solid var(--border)',
+        color: 'var(--text-sec)', fontFamily: 'var(--f-display)',
+        fontSize: 12, fontWeight: 700, cursor: 'pointer',
+      }}>← § prec.</button>
+      <button type="button" style={{
+        flex: 1, padding: '8px 10px', borderRadius: 'var(--r-md)',
+        background: entityHsl('kb', 0.1),
+        border: `1px solid ${entityHsl('kb', 0.3)}`,
+        color: entityHsl('kb'),
+        fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 700,
+        cursor: 'pointer',
+      }}>Letto, vai al prossimo →</button>
+      <button type="button" aria-label="Fullscreen" style={{
+        width: 38, height: 38, borderRadius: 'var(--r-md)',
+        background: 'transparent', border: '1px solid var(--border)',
+        color: 'var(--text-sec)', fontSize: 14, cursor: 'pointer',
+      }}>⛶</button>
+    </div>
+  </>
+);
+
+const ParagraphStateNotFound = () => (
+  <>
+    <ParagraphToolbar active="299" mode="IT"/>
+    <div style={{ flex: 1, overflowY: 'auto', padding: '20px 18px', display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <div style={{
+        display: 'flex', alignItems: 'flex-start', gap: 10,
+        padding: '14px',
+        borderRadius: 'var(--r-lg)',
+        background: entityHsl('event', 0.08),
+        border: `1px solid ${entityHsl('event', 0.24)}`,
+      }}>
+        <span aria-hidden="true" style={{ fontSize: 22, lineHeight: 1, marginTop: 2 }}>🔴</span>
+        <div>
+          <h3 style={{
+            fontFamily: 'var(--f-display)', fontSize: 15, fontWeight: 800,
+            margin: '0 0 4px', color: 'var(--text)',
+          }}>Paragrafo §299 non trovato</h3>
+          <p style={{ margin: 0, fontSize: 13, color: 'var(--text-sec)', lineHeight: 1.5 }}>
+            Non è presente nel manuale indicizzato. Forse hai saltato qualche pagina
+            durante l'acquisizione.
+          </p>
+        </div>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {[
+          { em: '🔍', label: 'Cerca testo simile', sub: 'Mostra paragrafi vicini §290-§300' },
+          { em: '📷', label: 'Rifotografa pagine mancanti', sub: 'Apri photo-upload con pre-filtro' },
+          { em: '⏭️', label: 'Salta paragrafo', sub: 'Vai a §300 (prossimo indicizzato)' },
+        ].map(a => (
+          <button key={a.label} type="button" style={{
+            display: 'flex', alignItems: 'center', gap: 12,
+            padding: '12px 14px', borderRadius: 'var(--r-md)',
+            background: 'var(--bg-card)', border: '1px solid var(--border)',
+            color: 'var(--text)', textAlign: 'left', cursor: 'pointer',
+          }}>
+            <span aria-hidden="true" style={{ fontSize: 22, flexShrink: 0 }}>{a.em}</span>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontFamily: 'var(--f-display)', fontSize: 13, fontWeight: 700 }}>{a.label}</div>
+              <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 2 }}>{a.sub}</div>
+            </div>
+            <span aria-hidden="true" style={{ color: 'var(--text-muted)' }}>›</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  </>
+);
+
+const ParagraphStateOffline = () => (
+  <>
+    <ParagraphToolbar active="147" mode="IT"/>
+    <div style={{
+      flexShrink: 0, padding: '8px 14px',
+      background: entityHsl('agent', 0.12),
+      borderBottom: `1px solid ${entityHsl('agent', 0.24)}`,
+      display: 'flex', alignItems: 'center', gap: 8,
+      fontSize: 12, color: entityHsl('agent'),
+      fontFamily: 'var(--f-display)', fontWeight: 700,
+    }}>
+      <span aria-hidden="true">🟡</span>
+      <span style={{ flex: 1 }}>Connessione persa — paragrafo originale disponibile</span>
+      <button type="button" style={{
+        padding: '4px 9px', borderRadius: 'var(--r-sm)',
+        background: 'var(--bg-card)',
+        border: `1px solid ${entityHsl('agent', 0.4)}`,
+        color: entityHsl('agent'),
+        fontFamily: 'var(--f-display)', fontSize: 11, fontWeight: 700,
+        cursor: 'pointer',
+      }}>Mostra EN</button>
+    </div>
+    <div style={{ flex: 1, overflowY: 'auto', padding: '18px 18px 14px' }}>
+      <ParagraphHeader num="147" chapter="Chapter VII — The moors of Avalon"/>
+      <div className="reading-body" style={{ opacity: 0.85 }}>
+        <p>
+          The mist parts and the silent fen opens before you. <strong>Niamh</strong> grips
+          the <strong>Sword of Avalon</strong> — the blade reflects a glow that comes from no moon.
+        </p>
+        <p className="dialogue">
+          «Do you feel it too? Something watches us from those stones.»
+        </p>
+        <p>
+          A <strong>Wraithstone</strong> rises from the mud, etched with symbols that
+          burn the eye if held too long.
+        </p>
+      </div>
+      <div style={{
+        marginTop: 16, fontSize: 11, color: 'var(--text-muted)',
+        fontStyle: 'italic', fontFamily: 'var(--f-body)',
+      }}>
+        🔄 Auto-retry traduzione fra 8s…
+      </div>
+    </div>
+  </>
+);
+
+const ParagraphStateQuota = () => (
+  <>
+    <ParagraphToolbar active="147" mode="IT"/>
+    <div style={{ flex: 1, overflowY: 'auto', padding: '18px 18px', display: 'flex', flexDirection: 'column', gap: 14 }}>
+      <ParagraphHeader num="147" chapter="Capitolo VII — Le brughiere di Avalon"/>
+      <div style={{
+        padding: 18, borderRadius: 'var(--r-xl)',
+        background: `linear-gradient(135deg, ${entityHsl('event', 0.12)}, ${entityHsl('toolkit', 0.06)})`,
+        border: `1px solid ${entityHsl('event', 0.24)}`,
+        textAlign: 'center',
+      }}>
+        <div aria-hidden="true" style={{ fontSize: 38, marginBottom: 8 }}>💎</div>
+        <h3 style={{
+          fontFamily: 'var(--f-display)', fontSize: 17, fontWeight: 800,
+          margin: '0 0 6px', color: 'var(--text)',
+        }}>Hai esaurito la quota gratuita</h3>
+        <p style={{
+          margin: '0 0 14px', fontSize: 13, color: 'var(--text-sec)', lineHeight: 1.5,
+        }}>
+          50/50 paragrafi tradotti questo mese. Si resetta il 1° giugno (12 giorni).
+        </p>
+        <div style={{
+          width: '100%', height: 6, borderRadius: 'var(--r-pill)',
+          background: 'var(--bg-muted)', overflow: 'hidden',
+          marginBottom: 14,
+        }}>
+          <div style={{
+            width: '100%', height: '100%',
+            background: entityHsl('event', 0.7),
+          }}/>
+        </div>
+        <button type="button" style={{
+          width: '100%', padding: '11px 14px', borderRadius: 'var(--r-md)',
+          background: entityHsl('event'),
+          color: '#fff', border: 'none',
+          fontFamily: 'var(--f-display)', fontSize: 13, fontWeight: 800,
+          cursor: 'pointer',
+          boxShadow: `0 6px 18px ${entityHsl('event', 0.4)}`,
+        }}>💎 Acquista crediti — €5 per 100</button>
+        <button type="button" style={{
+          marginTop: 8, width: '100%', padding: '9px 14px',
+          background: 'transparent', border: '1px solid var(--border)',
+          color: 'var(--text-sec)', borderRadius: 'var(--r-md)',
+          fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 700,
+          cursor: 'pointer',
+        }}>⏸️ Continua senza traduzione</button>
+      </div>
+    </div>
+  </>
+);
+
+/* ─── Skeleton row reusable (rispetta prefers-reduced-motion via .mai-shimmer guard) ─── */
+const SkeletonRow = ({ width = '100%' }) => (
+  <div className="mai-shimmer" style={{
+    height: 18, width, borderRadius: 'var(--r-sm)',
+    background: 'var(--bg-muted)', marginBottom: 10,
+  }}/>
+);
+
+const ParagraphStateEmpty = () => (
+  <>
+    <ParagraphToolbar active="—" mode="IT"/>
+    <div style={{
+      flex: 1, display: 'flex', flexDirection: 'column',
+      alignItems: 'center', justifyContent: 'center',
+      textAlign: 'center', padding: '40px 22px', gap: 14,
+    }}>
+      <div aria-hidden="true" style={{ fontSize: 64, opacity: 0.4, lineHeight: 1 }}>📖</div>
+      <h3 style={{
+        fontFamily: 'var(--f-display)', fontSize: 17, fontWeight: 800,
+        margin: 0, color: 'var(--text)', maxWidth: '24ch', lineHeight: 1.25,
+      }}>Inserisci un numero § o cerca un testo per iniziare</h3>
+      <div style={{ fontSize: 12, color: 'var(--text-muted)', fontFamily: 'var(--f-body)' }}>
+        Esempio: §147 oppure "combattimento marziale"
+      </div>
+    </div>
+    <div style={{
+      flexShrink: 0, padding: '10px 14px',
+      borderTop: '1px solid var(--border-light)',
+      display: 'flex', gap: 6, alignItems: 'center', opacity: 0.4,
+      pointerEvents: 'none',
+    }}>
+      <button type="button" disabled style={{
+        padding: '8px 10px', borderRadius: 'var(--r-md)',
+        background: 'transparent', border: '1px solid var(--border)',
+        color: 'var(--text-sec)', fontFamily: 'var(--f-display)',
+        fontSize: 12, fontWeight: 700,
+      }}>← § prec.</button>
+      <button type="button" disabled style={{
+        flex: 1, padding: '8px 10px', borderRadius: 'var(--r-md)',
+        background: 'transparent', border: '1px solid var(--border)',
+        color: 'var(--text-sec)',
+        fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 700,
+      }}>A− A A+</button>
+      <button type="button" disabled aria-label="Fullscreen" style={{
+        width: 38, height: 38, borderRadius: 'var(--r-md)',
+        background: 'transparent', border: '1px solid var(--border)',
+        color: 'var(--text-sec)', fontSize: 14,
+      }}>⛶</button>
+    </div>
+  </>
+);
+
+const ParagraphStateLoading = () => (
+  <>
+    <ParagraphToolbar active="147" mode="IT"/>
+    <div style={{ flex: 1, overflowY: 'auto', padding: '18px 18px 14px' }}>
+      <ParagraphHeader num="147" chapter="Capitolo VII — Le brughiere di Avalon"/>
+      <div style={{ marginTop: 6 }}>
+        <SkeletonRow width="100%"/>
+        <SkeletonRow width="92%"/>
+        <SkeletonRow width="78%"/>
+      </div>
+    </div>
+    <div style={{
+      flexShrink: 0, padding: '10px 14px',
+      borderTop: '1px solid var(--border-light)',
+      display: 'flex', gap: 6, alignItems: 'center', opacity: 0.4,
+      pointerEvents: 'none',
+    }}>
+      <button type="button" disabled style={{
+        padding: '8px 10px', borderRadius: 'var(--r-md)',
+        background: 'transparent', border: '1px solid var(--border)',
+        color: 'var(--text-sec)', fontFamily: 'var(--f-display)',
+        fontSize: 12, fontWeight: 700,
+      }}>← § prec.</button>
+      <button type="button" disabled style={{
+        flex: 1, padding: '8px 10px', borderRadius: 'var(--r-md)',
+        background: entityHsl('kb', 0.1),
+        border: `1px solid ${entityHsl('kb', 0.3)}`,
+        color: entityHsl('kb'),
+        fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 700,
+      }}>Letto, vai al prossimo →</button>
+    </div>
+  </>
+);
+
+/* ═══════════════════════════════════════════════════════
+   TAB SETUP — 3 stati + 1 generating
+   ═══════════════════════════════════════════════════════ */
+const PlayerPicker = ({ active = 4 }) => (
+  <div style={{
+    display: 'flex', gap: 4, padding: 3,
+    background: 'var(--bg-muted)', borderRadius: 'var(--r-md)',
+  }}>
+    {[2, 3, 4, 5, 6].map(n => (
+      <button key={n} type="button" style={{
+        flex: 1, padding: '8px 0', borderRadius: 'var(--r-sm)',
+        background: n === active ? 'var(--bg-card)' : 'transparent',
+        border: 'none',
+        color: n === active ? entityHsl('tool') : 'var(--text-sec)',
+        fontFamily: 'var(--f-display)', fontSize: 14, fontWeight: 800,
+        cursor: 'pointer',
+        boxShadow: n === active ? 'var(--shadow-xs)' : 'none',
+      }}>{n}</button>
+    ))}
+  </div>
+);
+
+const SetupStateDefault = () => (
+  <div style={{ flex: 1, overflowY: 'auto', padding: '18px 16px', display: 'flex', flexDirection: 'column', gap: 14 }}>
+    <div>
+      <div style={{
+        fontFamily: 'var(--f-mono)', fontSize: 11, fontWeight: 700,
+        color: 'var(--text-muted)', textTransform: 'uppercase',
+        letterSpacing: '0.08em', marginBottom: 8,
+      }}>Quanti giocate stasera?</div>
+      <PlayerPicker active={4}/>
+    </div>
+    <button type="button" style={{
+      padding: '12px 16px', borderRadius: 'var(--r-md)',
+      background: entityHsl('tool'),
+      color: '#fff', border: 'none',
+      fontFamily: 'var(--f-display)', fontSize: 14, fontWeight: 800,
+      cursor: 'pointer',
+      boxShadow: `0 4px 14px ${entityHsl('tool', 0.4)}`,
+    }}>⚙️ Genera guida setup</button>
+    <div style={{
+      flex: 1, display: 'flex', flexDirection: 'column',
+      alignItems: 'center', justifyContent: 'center',
+      textAlign: 'center', padding: '30px 16px', gap: 12,
+    }}>
+      <div style={{
+        width: 80, height: 80, borderRadius: 'var(--r-2xl)',
+        background: `linear-gradient(135deg, ${entityHsl('tool', 0.18)}, ${entityHsl('kb', 0.16)})`,
+        display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 34,
+      }} aria-hidden="true">🎲</div>
+      <p style={{
+        fontSize: 13, color: 'var(--text-sec)', margin: 0,
+        lineHeight: 1.5, maxWidth: '30ch',
+      }}>
+        Premi <strong>Genera guida setup</strong>: ti mostro il paragrafo di setup
+        tradotto per {4} giocatori.
+      </p>
+    </div>
+  </div>
+);
+
+const SetupStateGenerated = () => (
+  <div style={{ flex: 1, overflowY: 'auto', padding: '18px 16px', display: 'flex', flexDirection: 'column', gap: 14 }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <h3 style={{
+        flex: 1, fontFamily: 'var(--f-display)', fontSize: 17, fontWeight: 800,
+        margin: 0, color: 'var(--text)',
+      }}>Setup per 4 giocatori</h3>
+      <EntityChip entity="kb" size="sm">p.4 — Setup base</EntityChip>
+    </div>
+    <div className="reading-body">
+      <p>
+        Disponi al centro del tavolo la <strong>plancia di Avalon</strong>, lato giorno verso l'alto.
+        Mescola separatamente i mazzi <em>Esplorazione</em>, <em>Combattimento</em> e <em>Diplomazia</em>;
+        posizionali nelle aree dedicate.
+      </p>
+      <p>
+        Ogni giocatore sceglie un <strong>Personaggio</strong> e ne prende la <strong>plancia eroe</strong>,
+        i <strong>3 Token Vita</strong> iniziali e la carta abilità di partenza. Per <strong>4 giocatori</strong>:
+        rimuovi le carte evento contrassegnate con il simbolo solo (☉).
+      </p>
+      <p>
+        Posiziona il segnalino <strong>Wyrdness</strong> sullo spazio 7 del tracciato. Il primo giocatore
+        è quello che ha letto un libro più recentemente.
+      </p>
+    </div>
+    <div style={{
+      fontSize: 11, color: 'var(--text-muted)',
+      fontStyle: 'italic', fontFamily: 'var(--f-body)',
+    }}>
+      Glossario applicato: Wyrdness, Token Vita, Plancia eroe
+    </div>
+    <div style={{
+      padding: '8px 12px', borderRadius: 'var(--r-md)',
+      background: entityHsl('tool', 0.1),
+      border: `1px dashed ${entityHsl('tool', 0.4)}`,
+      color: entityHsl('tool'),
+      fontFamily: 'var(--f-display)', fontSize: 11, fontWeight: 700,
+      display: 'inline-flex', alignItems: 'center', gap: 6,
+      alignSelf: 'flex-start',
+    }}>💡 Checklist interattiva con step disponibile in MVP-1</div>
+  </div>
+);
+
+const SetupStateGenerating = () => (
+  <div style={{ flex: 1, overflowY: 'auto', padding: '18px 16px', display: 'flex', flexDirection: 'column', gap: 14, opacity: 0.85 }}>
+    <div style={{ pointerEvents: 'none', opacity: 0.6 }}>
+      <div style={{
+        fontFamily: 'var(--f-mono)', fontSize: 10, fontWeight: 700,
+        color: 'var(--text-muted)', textTransform: 'uppercase',
+        letterSpacing: '0.08em', marginBottom: 8,
+      }}>Quanti giocate stasera?</div>
+      <PlayerPicker active={4}/>
+    </div>
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 10,
+      padding: '12px 14px', borderRadius: 'var(--r-md)',
+      background: entityHsl('tool', 0.1),
+      border: `1px solid ${entityHsl('tool', 0.28)}`,
+      color: entityHsl('tool'),
+      fontFamily: 'var(--f-display)', fontSize: 13, fontWeight: 700,
+    }}>
+      <span aria-hidden="true" className="mai-spinner" style={{
+        width: 16, height: 16, borderRadius: '50%',
+        border: `2px solid ${entityHsl('tool', 0.25)}`,
+        borderTopColor: entityHsl('tool'),
+        display: 'inline-block', flexShrink: 0,
+      }}/>
+      <span>Generazione setup… 12s</span>
+    </div>
+    <div style={{ marginTop: 4 }}>
+      <SkeletonRow width="100%"/>
+      <SkeletonRow width="94%"/>
+      <SkeletonRow width="86%"/>
+      <SkeletonRow width="72%"/>
+    </div>
+  </div>
+);
+
+const SetupStateUnclear = () => (
+  <div style={{ flex: 1, overflowY: 'auto', padding: '18px 16px', display: 'flex', flexDirection: 'column', gap: 14 }}>
+    <PlayerPicker active={4}/>
+    <div style={{
+      padding: 14, borderRadius: 'var(--r-lg)',
+      background: entityHsl('agent', 0.1),
+      border: `1px solid ${entityHsl('agent', 0.28)}`,
+      display: 'flex', gap: 10, alignItems: 'flex-start',
+    }}>
+      <span aria-hidden="true" style={{ fontSize: 22 }}>⚠️</span>
+      <div>
+        <h3 style={{
+          fontFamily: 'var(--f-display)', fontSize: 14, fontWeight: 800,
+          margin: '0 0 4px', color: 'var(--text)',
+        }}>Sezione setup non chiara</h3>
+        <p style={{ margin: 0, fontSize: 12, color: 'var(--text-sec)', lineHeight: 1.5 }}>
+          Non riesco a identificare una sezione setup univoca nel manuale.
+          Confidence 0.38 sull'unica sezione candidata (p.4-6).
+        </p>
+      </div>
+    </div>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {[
+        { em: '✅', label: 'Cerca nel testo generale', sub: 'Mostro p.4-6 senza identificare i passi' },
+        { em: '📷', label: 'Indica tu le pagine setup', sub: 'Selezione manuale dalle 47 pagine indicizzate' },
+        { em: '⏭️', label: 'Salta e inizia direttamente', sub: 'Apri Tab Chat per fare domande live' },
+      ].map(a => (
+        <button key={a.label} type="button" style={{
+          display: 'flex', alignItems: 'center', gap: 12,
+          padding: '12px 14px', borderRadius: 'var(--r-md)',
+          background: 'var(--bg-card)', border: '1px solid var(--border)',
+          color: 'var(--text)', textAlign: 'left', cursor: 'pointer',
+        }}>
+          <span aria-hidden="true" style={{ fontSize: 20, flexShrink: 0 }}>{a.em}</span>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontFamily: 'var(--f-display)', fontSize: 13, fontWeight: 700 }}>{a.label}</div>
+            <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 2 }}>{a.sub}</div>
+          </div>
+        </button>
+      ))}
+    </div>
+  </div>
+);
+
+/* ═══════════════════════════════════════════════════════
+   MOBILE STATES (registry)
+   ═══════════════════════════════════════════════════════ */
+const CHAT_STATES = [
+  { id: 'c1', anchor: 'state-01-chat-default-high-conf', tab: 'chat', label: '01 · Default', gherkin: 'G3.1', desc: 'Q&A con citation kb p.18 + confidence alta + action chips. Bubble user di Marco + Sara.', body: <ChatStateDefault/> },
+  { id: 'c2', anchor: 'state-02-chat-ambiguity', tab: 'chat', label: '02 · Ambiguity', gherkin: 'G3.2', desc: '4 chip kb selezionabili (Combat / Iniziativa / Voto / Esplorazione) per disambig.', body: <ChatStateAmbiguity/> },
+  { id: 'c3', anchor: 'state-03-chat-low-confidence', tab: 'chat', label: '03 · Low-confidence', gherkin: 'G3.3', desc: 'Confidence 🔴 + 3 azioni: rifotografa / house rule (primary) / BGG.', body: <ChatStateLowConfidence/> },
+  { id: 'c4', anchor: 'state-04-chat-house-rule-applied', tab: 'chat', label: '04 · House rule applicata', gherkin: 'G3.4', desc: 'Badge chip agent "House rule attiva" + footnote citation manuale ufficiale.', body: <ChatStateHouseRule/> },
+  { id: 'c5', anchor: 'state-05-chat-timeout', tab: 'chat', label: '05 · Timeout', gherkin: 'G3.5', desc: 'Typing indicator >8s + fallback CTA "Mostrami le pagine sul tema X" manuale.', body: <ChatStateTimeout/> },
+  { id: 'c6', anchor: 'state-06-chat-empty', tab: 'chat', label: '06 · Empty (prima domanda)', gherkin: '—', desc: 'Onboarding session: illustrazione 💬 + 3 suggerimenti tappabili.', body: <ChatStateEmpty/> },
+];
+
+const PARAGRAPH_STATES = [
+  { id: 'p0', anchor: 'state-06bis-paragrafo-empty', tab: 'paragraph', label: '06-bis · Empty', gherkin: '—', desc: 'Simmetrico a #06 chat empty: toolbar visibile, illustrazione 📖, controls disabled. (no Gherkin tag)', body: <ParagraphStateEmpty/> },
+  { id: 'p1', anchor: 'state-07-paragrafo-default', tab: 'paragraph', label: '07 · Default §147', gherkin: 'G4', desc: '§147 Tainted Grail tradotto + glossario applicato + cache indicator + nav prec/next.', body: <ParagraphStateDefault/> },
+  { id: 'p1b', anchor: 'state-07bis-paragrafo-loading', tab: 'paragraph', label: '07-bis · Loading', gherkin: 'G4 loading', desc: 'Header §147 visibile, body 3 righe shimmer (100/92/78%), cache indicator nascosto, footer disabled.', body: <ParagraphStateLoading/> },
+  { id: 'p2', anchor: 'state-08-paragrafo-not-found', tab: 'paragraph', label: '08 · Not found §299', gherkin: 'G4.4', desc: '3 azioni: cerca testo simile / rifotografa pagine / salta paragrafo.', body: <ParagraphStateNotFound/> },
+  { id: 'p3', anchor: 'state-09-paragrafo-offline-cached', tab: 'paragraph', label: '09 · Offline cached', gherkin: 'G4.7', desc: 'Banner amber connessione persa + fallback EN visibile + auto-retry indicator.', body: <ParagraphStateOffline/> },
+  { id: 'p4', anchor: 'state-10-paragrafo-quota-exceeded', tab: 'paragraph', label: '10 · Quota exceeded', gherkin: 'G4.6', desc: 'Block paragrafo + CTA "Acquista crediti €5/100" event color → trigger mockup E.', body: <ParagraphStateQuota/> },
+];
+
+const SETUP_STATES = [
+  { id: 's1', anchor: 'state-11-setup-default', tab: 'setup', label: '11 · Default (4 giocatori)', gherkin: 'G2', desc: 'Player picker 4 attivo + CTA "Genera guida setup" tool color + illustrazione empty.', body: <SetupStateDefault/> },
+  { id: 's2', anchor: 'state-12-setup-generated', tab: 'setup', label: '12 · Generated', gherkin: 'G2', desc: 'Paragrafo setup tradotto reading-mode 24px + citation p.4 + disclaimer "checklist in MVP-1".', body: <SetupStateGenerated/> },
+  { id: 's2b', anchor: 'state-12bis-setup-generating', tab: 'setup', label: '12-bis · Generating', gherkin: 'G2 generating', desc: 'Player picker disabled + CTA sostituito da spinner inline "Generazione setup… 12s" + 4 righe shimmer.', body: <SetupStateGenerating/> },
+  { id: 's3', anchor: 'state-13-setup-unclear', tab: 'setup', label: '13 · Setup unclear', gherkin: 'G2.3', desc: 'Confidence 0.38: 3 opzioni (cerca generale / indica pagine / salta a chat).', body: <SetupStateUnclear/> },
+];
+
+/* ═══════════════════════════════════════════════════════
+   MOBILE SCREEN — Phone wrapper con header + tabs + body + session bar
+   ═══════════════════════════════════════════════════════ */
+const MobileScreen = ({ tab, body }) => (
+  <Phone>
+    <SessionHeader compact/>
+    <TabsNav active={tab}/>
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+      {body}
+    </div>
+    {tab === 'chat' && <ChatInput/>}
+    <SessionBar activeTab={tab}/>
+  </Phone>
+);
+
+const Frame = ({ state }) => (
+  <div className="frame-cell" id={state.anchor}>
+    <MobileScreen tab={state.tab} body={state.body}/>
+    <div className="frame-meta">
+      <strong>{state.label}</strong>
+      {state.gherkin !== '—' && <span className="gherkin">{state.gherkin}</span>}
+      {state.desc}
+    </div>
+  </div>
+);
+
+/* ═══════════════════════════════════════════════════════
+   DESKTOP SPLIT-VIEW
+   ═══════════════════════════════════════════════════════ */
+const DesktopGameContext = () => (
+  <aside style={{
+    width: 360, flexShrink: 0,
+    borderRight: '1px solid var(--border)',
+    background: 'var(--bg-card)',
+    display: 'flex', flexDirection: 'column', gap: 0,
+  }}>
+    {/* Cover */}
+    <div style={{
+      height: 180,
+      background: `linear-gradient(135deg, ${entityHsl('game', 0.85)}, ${entityHsl('event', 0.7)})`,
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      fontSize: 70,
+      position: 'relative',
+    }} aria-hidden="true">
+      🗡️
+      <div style={{
+        position: 'absolute', inset: 0,
+        background: 'linear-gradient(180deg, transparent 50%, rgba(0,0,0,.45) 100%)',
+      }}/>
+    </div>
+    {/* Title block */}
+    <div style={{ padding: '16px 20px 14px', borderBottom: '1px solid var(--border-light)' }}>
+      <h2 style={{
+        fontFamily: 'var(--f-display)', fontSize: 22, fontWeight: 800,
+        letterSpacing: '-0.01em', margin: '0 0 4px', color: 'var(--text)',
+      }}>Tainted Grail</h2>
+      <div style={{
+        fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)',
+        marginBottom: 10,
+      }}>Awaken Realms · 2019 · 1-4 pl · 240 min</div>
+      <div style={{
+        display: 'inline-flex', alignItems: 'center', gap: 6,
+        fontFamily: 'var(--f-mono)', fontSize: 11, fontWeight: 700,
+        color: entityHsl('session'), textTransform: 'uppercase', letterSpacing: '0.06em',
+      }}>
+        <span aria-hidden="true" style={{
+          display: 'inline-block', width: 8, height: 8, borderRadius: '50%',
+          background: entityHsl('session'),
+          animation: 'mai-pulse-session 1.6s ease-in-out infinite',
+        }} className="mai-pulse"/>
+        🎯 Sessione in corso · iniziata 47 min fa
+      </div>
+    </div>
+    {/* Connection bar (vertical context) */}
+    <div style={{ padding: '14px 20px', borderBottom: '1px solid var(--border-light)' }}>
+      <div style={{
+        fontFamily: 'var(--f-mono)', fontSize: 10, fontWeight: 700,
+        color: 'var(--text-muted)', textTransform: 'uppercase',
+        letterSpacing: '0.08em', marginBottom: 8,
+      }}>Connessioni sessione</div>
+      <ConnectionBar connections={SESSION_CONNECTIONS}/>
+    </div>
+    {/* Players at table */}
+    <div style={{ padding: '14px 20px', borderBottom: '1px solid var(--border-light)' }}>
+      <div style={{
+        fontFamily: 'var(--f-mono)', fontSize: 10, fontWeight: 700,
+        color: 'var(--text-muted)', textTransform: 'uppercase',
+        letterSpacing: '0.08em', marginBottom: 8,
+      }}>Giocatori al tavolo</div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {[
+          { name: 'Sara', role: 'GM (tu)', color: 'player' },
+          { name: 'Marco', role: 'Niamh', color: 'player' },
+          { name: 'Giulia', role: 'Beor', color: 'player' },
+          { name: 'Davide', role: 'Maeve', color: 'player' },
+        ].map(p => (
+          <div key={p.name} style={{
+            display: 'flex', alignItems: 'center', gap: 10,
+          }}>
+            <div style={{
+              width: 30, height: 30, borderRadius: '50%',
+              background: entityHsl(p.color, 0.18),
+              color: entityHsl(p.color),
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 800,
+              flexShrink: 0,
+            }}>{p.name[0]}</div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontFamily: 'var(--f-display)', fontSize: 13, fontWeight: 700 }}>{p.name}</div>
+              <div style={{ fontSize: 10, color: 'var(--text-muted)', fontFamily: 'var(--f-mono)' }}>{p.role}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+    {/* House rules */}
+    <div style={{ padding: '14px 20px', flex: 1 }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        marginBottom: 8,
+      }}>
+        <div style={{
+          fontFamily: 'var(--f-mono)', fontSize: 10, fontWeight: 700,
+          color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.08em',
+        }}>House rules attive</div>
+        <button type="button" style={{
+          background: 'transparent', border: 'none',
+          color: entityHsl('agent'),
+          fontFamily: 'var(--f-display)', fontSize: 11, fontWeight: 700, cursor: 'pointer',
+        }}>+ Aggiungi</button>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {[
+          'Critici fanno ×2 danno (no +50%)',
+          'Morte simultanea: chi ha più HP max diventa leader',
+        ].map(r => (
+          <div key={r} style={{
+            padding: '8px 10px', borderRadius: 'var(--r-md)',
+            background: entityHsl('agent', 0.08),
+            border: `1px solid ${entityHsl('agent', 0.18)}`,
+            fontSize: 12, color: 'var(--text)', lineHeight: 1.4,
+            display: 'flex', gap: 6, alignItems: 'flex-start',
+          }}>
+            <span aria-hidden="true">🤝</span>
+            <span style={{ flex: 1 }}>{r}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  </aside>
+);
+
+const DesktopSplit = ({ tab, body, label, gherkin, desc, anchor, theme }) => (
+  <div className="frame-cell" id={anchor} data-theme={theme}>
+    <div className="desktop-frame">
+      <div className="desktop-chrome">
+        <span className="dot" style={{ background: '#ff5f57' }}/>
+        <span className="dot" style={{ background: '#febc2e' }}/>
+        <span className="dot" style={{ background: '#28c840' }}/>
+        <span className="url">meepleai.app/gamebook/gb-tainted-grail/play</span>
+      </div>
+      <div style={{ display: 'flex', height: 720, background: 'var(--bg)' }}>
+        <DesktopGameContext/>
+        <main style={{
+          flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0,
+        }}>
+          <TabsNav active={tab}/>
+          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+            {body}
+          </div>
+          {tab === 'chat' && <ChatInput/>}
+        </main>
+      </div>
+    </div>
+    <div className="frame-meta">
+      <strong>{label}</strong>
+      {gherkin && <span className="gherkin">{gherkin}</span>}
+      {desc}
+    </div>
+  </div>
+);
+
+/* ═══════════════════════════════════════════════════════
+   MOUNT
+   ═══════════════════════════════════════════════════════ */
+const ChatRow = () => (
+  <>{CHAT_STATES.map(s => <Frame key={s.id} state={s}/>)}</>
+);
+const ParagraphRow = () => (
+  <>{PARAGRAPH_STATES.map(s => <Frame key={s.id} state={s}/>)}</>
+);
+const SetupRow = () => (
+  <>{SETUP_STATES.map(s => <Frame key={s.id} state={s}/>)}</>
+);
+const DesktopRow = () => (
+  <>
+    <DesktopSplit
+      anchor="state-14-desktop-split-chat-default"
+      tab="chat"
+      body={<ChatStateDefault/>}
+      label="14 · Desktop · Chat default"
+      gherkin="G3.1"
+      desc="Split-view: left 360px game-context (cover hero + connections + giocatori + house rules), right tab Chat con conversation feed e citation chips."/>
+    <DesktopSplit
+      anchor="state-15-desktop-split-paragrafo-default"
+      tab="paragraph"
+      body={<ParagraphStateDefault/>}
+      label="15 · Desktop · Paragrafo default"
+      gherkin="G4"
+      desc="Tab Paragrafo §147 con reading body 24px (=18pt) max-width 60ch e nav prec/next sticky. Cache indicator visibile."/>
+    <DesktopSplit
+      anchor="state-16-desktop-split-chat-low-confidence"
+      tab="chat"
+      body={<ChatStateLowConfidence/>}
+      label="16 · Desktop · Chat low-confidence"
+      gherkin="G3.3"
+      desc="Stato critico desktop: il drawer F si apre come side panel right 380px sopra questa view (non rappresentato qui — vedi mockup F)."/>
+  </>
+);
+
+ReactDOM.createRoot(document.getElementById('mount-chat')).render(<ChatRow/>);
+ReactDOM.createRoot(document.getElementById('mount-paragraph')).render(<ParagraphRow/>);
+ReactDOM.createRoot(document.getElementById('mount-setup')).render(<SetupRow/>);
+ReactDOM.createRoot(document.getElementById('mount-desktop')).render(<DesktopRow/>);
+
+/* ═══════════════════════════════════════════════════════
+   DARK THEME PROOFS — riusa JSX esistente, wrap data-theme
+   ═══════════════════════════════════════════════════════ */
+const DarkFrame = ({ anchor, label, gherkin, desc, tab, body }) => (
+  <div className="frame-cell" id={anchor}>
+    <div data-theme="dark" style={{ background: 'var(--bg)', borderRadius: 48, padding: 0 }}>
+      <MobileScreen tab={tab} body={body}/>
+    </div>
+    <div className="frame-meta">
+      <strong>{label}</strong>
+      <span className="gherkin">{gherkin}</span>
+      {desc}
+    </div>
+  </div>
+);
+
+const DarkRow = () => (
+  <>
+    <DarkFrame
+      anchor="state-17-chat-default-dark"
+      label="17 · Chat default · DARK"
+      gherkin="G3.1 · dark theme proof"
+      desc="Riuso esatto JSX #01: verifica contrast kb chip + bubble agent + ConnectionPip su bg dark warm neutrals."
+      tab="chat"
+      body={<ChatStateDefault/>}/>
+    <DarkFrame
+      anchor="state-18-paragrafo-default-dark"
+      label="18 · Paragrafo default §147 · DARK"
+      gherkin="G4 · dark theme proof"
+      desc="Riuso esatto JSX #07: reading-body 24px contrast + cache pill kb + footer nav prec/next."
+      tab="paragraph"
+      body={<ParagraphStateDefault/>}/>
+    <DarkFrame
+      anchor="state-19-setup-generated-dark"
+      label="19 · Setup generated · DARK"
+      gherkin="G2 · dark theme proof"
+      desc="Riuso esatto JSX #12: citation kb p.4 + reading-body + disclaimer tool dashed border."
+      tab="setup"
+      body={<SetupStateGenerated/>}/>
+  </>
+);
+
+ReactDOM.createRoot(document.getElementById('mount-dark')).render(<DarkRow/>);

--- a/admin-mockups/design_files/sp6-libro-game-quota-credits.html
+++ b/admin-mockups/design_files/sp6-libro-game-quota-credits.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<!--
+  ===================================================================
+  SP6 Libro Game — Quota Credits Checkout (sp6-libro-game-quota-credits.html)
+  Route: modale centrale + /gamebook/checkout/success
+  Persona: Sara, 32, casual italian gamer / GM al tavolo (mobile-first).
+
+  Gherkin: @G4.6 quota raggiunta + checkout flow.
+
+  Stati implementati (7 V5 + light/dark + mobile/desktop):
+    state-01-step1-quota-raggiunta        — 50/50 fill 100%
+    state-02-step2-pack-picker-starter    — Starter selected default
+    state-03-step3-checkout-form-filled   — form filled
+    state-04-step3-payment-loading        — spinner
+    state-05-step3-payment-failed         — banner red
+    state-06-step4-success                — 🎉 CSS-only + prefers-reduced-motion guard
+    state-07-soft-warning-47-50           — modal/toast SEPARATO dai 4 step
+
+  Deviazione dichiarata: Step 3 form payment è VISUAL ONLY
+    (NON integra real Stripe Elements — brief riga 709). Test card 4242 placeholder.
+
+  Scope-out: stripe-down (riga 681-683), partial-credit-issue (riga 684-685).
+    Descritti nel brief ma NON in stati richiesti riga 695-705.
+
+  StepIndicator riusato dal pattern emerso in mockup B (sp6-libro-game-photo-upload).
+  ===================================================================
+-->
+<html lang="it" data-theme="light">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>SP6 — Quota Credits Checkout · MeepleAI</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet"/>
+
+  <link rel="stylesheet" href="tokens.css"/>
+  <link rel="stylesheet" href="components.css"/>
+
+  <style>
+    body { background: var(--bg); color: var(--text); font-family: var(--f-body); }
+    .canvas {
+      max-width: 1480px; margin: 0 auto;
+      padding: 24px 28px 96px;
+    }
+    .canvas-head {
+      display: flex; align-items: center; justify-content: space-between;
+      gap: 16px; flex-wrap: wrap;
+      padding-bottom: 18px; margin-bottom: 24px;
+      border-bottom: 1px solid var(--border-light);
+    }
+    .canvas-head h1 {
+      font-family: var(--f-display); font-weight: 700;
+      font-size: 22px; color: var(--text); margin: 0;
+    }
+    .canvas-head .meta {
+      font-family: var(--f-mono); font-size: 11px; color: var(--text-muted);
+    }
+    .canvas-head .meta b { color: var(--text-sec); font-weight: 700; }
+    .canvas-controls { display: flex; gap: 14px; align-items: center; flex-wrap: wrap; }
+    .control-group {
+      display: flex; align-items: center; gap: 6px;
+      padding: 4px; border-radius: var(--r-pill);
+      background: var(--bg-card); border: 1px solid var(--border);
+    }
+    .control-group label {
+      font-family: var(--f-mono); font-size: 10px;
+      text-transform: uppercase; letter-spacing: 0.06em;
+      color: var(--text-muted); padding: 0 8px;
+    }
+    .control-group button {
+      padding: 6px 12px; border-radius: var(--r-pill);
+      border: none; background: transparent; color: var(--text-sec);
+      font-family: var(--f-display); font-weight: 600; font-size: 12px;
+      cursor: pointer;
+    }
+    .control-group button.active {
+      background: hsl(var(--c-toolkit)); color: #fff;
+    }
+    .legend {
+      display: flex; flex-wrap: wrap; gap: 8px;
+      margin-bottom: 16px;
+      font-family: var(--f-mono); font-size: 10px; color: var(--text-muted);
+    }
+    .legend .tag {
+      padding: 3px 8px; border-radius: var(--r-sm);
+      background: hsl(var(--c-agent) / .12); color: hsl(var(--c-agent));
+      font-weight: 700;
+    }
+    .legend .scope-out {
+      padding: 3px 8px; border-radius: var(--r-sm);
+      background: hsl(var(--c-event) / .1); color: hsl(var(--c-event));
+      font-weight: 700;
+    }
+  </style>
+</head>
+<body>
+  <div class="canvas" data-screen-label="SP6 Quota Credits — canvas">
+    <div class="canvas-head">
+      <div>
+        <h1>SP6 · Quota Credits Checkout</h1>
+        <div class="meta">
+          /gamebook/checkout · multi-step modal · <b>@G4.6</b> ·
+          7 stati V5 + light/dark + mobile/desktop
+        </div>
+      </div>
+      <div class="canvas-controls">
+        <div class="control-group" role="radiogroup" aria-label="Filtra step">
+          <label>Step</label>
+          <button class="active" data-step="all">Tutti</button>
+          <button data-step="1">1</button>
+          <button data-step="2">2</button>
+          <button data-step="3">3</button>
+          <button data-step="4">4</button>
+          <button data-step="soft">Soft</button>
+        </div>
+        <div class="control-group" role="radiogroup" aria-label="Filtra device">
+          <label>Device</label>
+          <button class="active" data-frame="both">Entrambi</button>
+          <button data-frame="mobile">Mobile</button>
+          <button data-frame="desktop">Desktop</button>
+        </div>
+        <div class="control-group" role="radiogroup" aria-label="Tema">
+          <label>Tema</label>
+          <button class="active" data-theme-set="light">Light</button>
+          <button data-theme-set="dark">Dark</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="legend">
+      <span class="tag">@G4.6</span>
+      <span>StepIndicator riusato da B</span>
+      <span>·</span>
+      <span>Confetti CSS-only + prefers-reduced-motion guard</span>
+      <span>·</span>
+      <span class="scope-out">Scope-out: stripe-down, partial-credit-issue</span>
+    </div>
+
+    <div id="root"></div>
+  </div>
+
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+  <script>
+    // Wire up canvas controls (step / frame / theme)
+    document.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('[data-step]').forEach(btn => {
+        btn.addEventListener('click', () => {
+          document.querySelectorAll('[data-step]').forEach(b => b.classList.remove('active'));
+          btn.classList.add('active');
+          document.dispatchEvent(new CustomEvent('qc-tweak-step', { detail: btn.dataset.step }));
+        });
+      });
+      document.querySelectorAll('[data-frame]').forEach(btn => {
+        btn.addEventListener('click', () => {
+          document.querySelectorAll('[data-frame]').forEach(b => b.classList.remove('active'));
+          btn.classList.add('active');
+          document.dispatchEvent(new CustomEvent('qc-tweak-frame', { detail: btn.dataset.frame }));
+        });
+      });
+      document.querySelectorAll('[data-theme-set]').forEach(btn => {
+        btn.addEventListener('click', () => {
+          document.querySelectorAll('[data-theme-set]').forEach(b => b.classList.remove('active'));
+          btn.classList.add('active');
+          document.documentElement.setAttribute('data-theme', btn.dataset.themeSet);
+        });
+      });
+    });
+  </script>
+
+  <script type="text/babel" src="sp6-libro-game-quota-credits.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp6-libro-game-quota-credits.jsx
+++ b/admin-mockups/design_files/sp6-libro-game-quota-credits.jsx
@@ -1,0 +1,1214 @@
+/* ===================================================================
+   SP6 Libro Game — Quota Credits Checkout (sp6-libro-game-quota-credits.jsx)
+   Route: modale centrale + /gamebook/checkout/success
+   Descrizione: Multi-step modal 4 step + soft warning 47/50 separato.
+   Persona: Sara, 32, casual italian gamer / GM al tavolo (mobile-first).
+
+   Gherkin: @G4.6 quota raggiunta + checkout flow.
+
+   Stati implementati (7 V5 + light/dark + mobile/desktop):
+     state-01-step1-quota-raggiunta        — 50/50 fill 100%
+     state-02-step2-pack-picker-starter    — Starter selected default
+     state-03-step3-checkout-form-filled   — form filled
+     state-04-step3-payment-loading        — spinner
+     state-05-step3-payment-failed         — banner red
+     state-06-step4-success                — 🎉 CSS-only + prefers-reduced-motion guard
+     state-07-soft-warning-47-50           — modal/toast SEPARATO dai 4 step
+
+   Deviazioni:
+     - Step 3 form payment è VISUAL ONLY (non integra real Stripe Elements).
+       Test card 4242 placeholder. Brief riga 709.
+     - Animation 🎉 step 4 = CSS-only + prefers-reduced-motion guard.
+       Brief riga 710 (lezione SP4 wave 2 confetti).
+     - Icon hero 💎 step 1 può usare gradient event→toolkit (warning→solution).
+
+   Scope-out (descritti nel brief MA NON in stati richiesti riga 695-705):
+     - stripe-down (riga 681-683)
+     - partial-credit-issue (riga 684-685)
+
+   StepIndicator: riusato dal pattern emerso in mockup B (sp6-libro-game-photo-upload).
+   =================================================================== */
+
+const { useState, useEffect } = React;
+
+/* ─── entityHsl helper (replica apps/web/src/lib/theme/entity-hsl.ts) ─── */
+const ENTITY_HSL = {
+  game:    '25 95% 45%',
+  player:  '262 83% 58%',
+  session: '240 60% 55%',
+  agent:   '38 92% 50%',
+  kb:      '174 60% 40%',
+  chat:    '220 80% 55%',
+  event:   '350 89% 60%',
+  toolkit: '142 70% 45%',
+  tool:    '195 80% 50%',
+};
+const entityHsl = (entity, alpha) =>
+  alpha != null ? `hsl(${ENTITY_HSL[entity]} / ${alpha})` : `hsl(${ENTITY_HSL[entity]})`;
+
+/* ─── Pack catalog (brief riga 605-610) ─── */
+const PACKS = [
+  { id: 'starter', name: 'Starter', price: 5,  credits: 100,  perPar: '0.05',  badge: 'Più popolare', badgeKind: 'popular' },
+  { id: 'mid',     name: 'Mid',     price: 20, credits: 500,  perPar: '0.04',  badge: null,           badgeKind: null },
+  { id: 'pro',     name: 'Pro',     price: 35, credits: 1000, perPar: '0.035', badge: 'Risparmia 30%', badgeKind: 'save' },
+];
+
+/* ─── StepIndicator riusato da B (NON ridefinire pattern) ─── */
+function StepIndicator({ current }) {
+  const steps = [
+    { n: 1, label: 'Quota',    icon: '💎' },
+    { n: 2, label: 'Pacchetto',icon: '📦' },
+    { n: 3, label: 'Pagamento',icon: '💳' },
+    { n: 4, label: 'Fatto',    icon: '🎉' },
+  ];
+  return (
+    <div className="qc-stepbar" role="list" aria-label="Progresso checkout">
+      <div className="qc-step-list">
+        {steps.map((s, i) => {
+          const done = s.n < current;
+          const active = s.n === current;
+          return (
+            <React.Fragment key={s.n}>
+              <div className={`qc-step ${active ? 'active' : ''} ${done ? 'done' : ''}`} role="listitem">
+                <span
+                  className="qc-step-circle"
+                  style={{
+                    background: done || active ? entityHsl('toolkit') : 'transparent',
+                    color: done || active ? '#fff' : 'var(--text-muted)',
+                    border: `2px solid ${done || active ? entityHsl('toolkit') : 'var(--border)'}`,
+                  }}
+                  aria-current={active ? 'step' : undefined}
+                >
+                  {done ? '✓' : s.n}
+                </span>
+                <span className="qc-step-label" style={{ color: active ? 'var(--text)' : 'var(--text-muted)' }}>
+                  {s.label}
+                </span>
+              </div>
+              {i < steps.length - 1 && (
+                <span className="qc-step-line" style={{
+                  background: s.n < current ? entityHsl('toolkit') : 'var(--border)',
+                }}/>
+              )}
+            </React.Fragment>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/* ─── Modal close X ─── */
+function CloseX({ ariaLabel = 'Chiudi modal' }) {
+  return (
+    <button type="button" className="qc-close" aria-label={ariaLabel}>×</button>
+  );
+}
+
+/* ───────────────────────────────────────────────────────────────
+   STEP 1 — Quota raggiunta (warning hard 50/50)
+   ─────────────────────────────────────────────────────────────── */
+
+function Step1QuotaRaggiunta() {
+  return (
+    <div className="qc-step-content">
+      <div className="qc-hero-icon" aria-hidden="true" style={{
+        background: `radial-gradient(circle at 30% 30%, ${entityHsl('event', 0.25)}, ${entityHsl('toolkit', 0.18)} 70%)`,
+        border: `1px solid ${entityHsl('event', 0.3)}`,
+      }}>
+        <span style={{ fontSize: 48 }}>💎</span>
+      </div>
+
+      <div className="qc-step-header">
+        <h2 className="qc-step-h2">Quota raggiunta</h2>
+        <p className="qc-step-sub">
+          Hai tradotto 50 paragrafi questo mese. La quota gratuita si resetta il 1° giugno.
+        </p>
+      </div>
+
+      <div className="qc-quota-card" style={{
+        background: entityHsl('event', 0.06),
+        borderColor: entityHsl('event', 0.25),
+      }}>
+        <div className="qc-quota-row">
+          <span className="qc-quota-label">Quota mensile</span>
+          <span className="qc-quota-counter" style={{ color: entityHsl('event') }}>
+            <span style={{ fontVariantNumeric: 'tabular-nums' }}>50</span>
+            <span style={{ color: 'var(--text-muted)', fontSize: '60%' }}> / 50</span>
+          </span>
+        </div>
+        <div className="qc-quota-bar" aria-label="Quota 50 su 50 paragrafi">
+          <div className="qc-quota-fill" style={{ width: '100%', background: entityHsl('event', 0.7) }}/>
+        </div>
+        <div className="qc-quota-foot">
+          <span style={{ fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)' }}>
+            Reset tra 12 giorni
+          </span>
+        </div>
+      </div>
+
+      <div className="qc-step-footer qc-cta-stack">
+        <button
+          type="button"
+          className="qc-cta-primary"
+          style={{ background: entityHsl('event') }}
+          aria-label="Acquista 100 crediti per 5 euro"
+        >
+          💎 Acquista 100 crediti (€5)
+        </button>
+        <button type="button" className="qc-cta-outline">
+          ⏸️ Continua senza traduzione
+        </button>
+        <a href="#" className="qc-footer-link">
+          Cosa sono i crediti? →
+        </a>
+      </div>
+    </div>
+  );
+}
+
+/* ───────────────────────────────────────────────────────────────
+   STEP 2 — Pack picker
+   ─────────────────────────────────────────────────────────────── */
+
+function PackCard({ pack, selected }) {
+  return (
+    <label
+      className={`qc-pack-card ${selected ? 'selected' : ''}`}
+      style={{
+        borderColor: selected ? 'var(--border-strong)' : 'var(--border)',
+        background: selected ? entityHsl('toolkit', 0.06) : 'var(--bg-card)',
+        boxShadow: selected ? `0 0 0 3px ${entityHsl('toolkit', 0.15)}` : 'var(--shadow-xs)',
+      }}
+    >
+      <input type="radio" name="pack" defaultChecked={selected} className="qc-pack-radio" aria-label={`Pacchetto ${pack.name}`}/>
+      {pack.badge && (
+        <span
+          className="qc-pack-badge"
+          style={{
+            background: pack.badgeKind === 'popular' ? entityHsl('toolkit') : entityHsl('event'),
+            color: '#fff',
+          }}
+        >
+          {pack.badge}
+        </span>
+      )}
+      <div className="qc-pack-name">{pack.name}</div>
+      <div className="qc-pack-credits" style={{ color: entityHsl('toolkit') }}>
+        <span style={{ fontVariantNumeric: 'tabular-nums' }}>{pack.credits.toLocaleString('it')}</span>
+        <span className="qc-pack-credits-sub">crediti</span>
+      </div>
+      <div className="qc-pack-price">
+        <span style={{ fontVariantNumeric: 'tabular-nums' }}>€{pack.price}</span>
+      </div>
+      <div className="qc-pack-perpar">
+        €{pack.perPar} / paragrafo
+      </div>
+      <div className="qc-pack-radio-visual" style={{
+        borderColor: selected ? entityHsl('toolkit') : 'var(--border)',
+        background: selected ? entityHsl('toolkit') : 'transparent',
+      }}>
+        {selected && <span className="qc-pack-radio-dot"/>}
+      </div>
+    </label>
+  );
+}
+
+function Step2PackPicker({ selectedId = 'starter' }) {
+  const selectedPack = PACKS.find(p => p.id === selectedId);
+  return (
+    <div className="qc-step-content">
+      <div className="qc-step-header">
+        <h2 className="qc-step-h2">Scegli il tuo pacchetto</h2>
+        <p className="qc-step-sub">Più paragrafi = miglior prezzo. I crediti non scadono.</p>
+      </div>
+
+      <div className="qc-pack-grid" role="radiogroup" aria-label="Scelta pacchetto crediti">
+        {PACKS.map(p => (
+          <PackCard key={p.id} pack={p} selected={p.id === selectedId}/>
+        ))}
+      </div>
+
+      <div className="qc-disclaimer">
+        I crediti non scadono. La quota free di 50 paragrafi si resetta automaticamente ogni mese.
+        {' '}
+        <a href="#" style={{ color: entityHsl('toolkit'), textDecoration: 'underline' }}>Privacy & GDPR →</a>
+      </div>
+
+      <div className="qc-step-footer qc-step2-footer">
+        <div className="qc-total-recap">
+          <span className="qc-total-label">Totale</span>
+          <span className="qc-total-value" style={{ fontVariantNumeric: 'tabular-nums' }}>€{selectedPack.price}</span>
+        </div>
+        <button
+          type="button"
+          className="qc-cta-primary"
+          style={{ background: entityHsl('toolkit'), opacity: selectedId ? 1 : 0.5 }}
+          disabled={!selectedId}
+        >
+          Continua →
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ───────────────────────────────────────────────────────────────
+   STEP 3 — Checkout placeholder (Stripe Elements style — VISUAL ONLY)
+   ─────────────────────────────────────────────────────────────── */
+
+function CheckoutForm({ variant = 'filled' }) {
+  // variant: filled | loading | failed
+  const isLoading = variant === 'loading';
+  const isFailed = variant === 'failed';
+
+  return (
+    <div className="qc-step-content">
+      <div className="qc-step-header">
+        <h2 className="qc-step-h2">Pagamento</h2>
+        <p className="qc-step-sub">
+          Pacchetto <strong>Starter</strong> · 100 crediti · <span style={{ fontVariantNumeric: 'tabular-nums' }}>€5,00</span>
+        </p>
+      </div>
+
+      {isFailed && (
+        <div className="qc-banner qc-banner-error" role="alert" style={{
+          background: entityHsl('event', 0.1),
+          borderColor: entityHsl('event', 0.4),
+        }}>
+          <span aria-hidden="true" className="qc-banner-icon" style={{ background: entityHsl('event'), color: '#fff' }}>!</span>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div className="qc-banner-title" style={{ color: entityHsl('event') }}>Pagamento rifiutato</div>
+            <div className="qc-banner-sub">Carta scaduta · prova un altro metodo o riscrivi i dati.</div>
+          </div>
+        </div>
+      )}
+
+      {/* Form payment VISUAL ONLY — non integra real Stripe Elements (brief riga 709) */}
+      <div className="qc-pay-form" aria-label="Modulo pagamento (placeholder visual)">
+        <div className="qc-pay-field">
+          <label className="qc-pay-label">Numero carta</label>
+          <div className="qc-pay-input qc-pay-card-input">
+            <span className="qc-pay-value" style={{ fontFamily: 'var(--f-mono)' }}>
+              •••• •••• •••• 4242
+            </span>
+            <span className="qc-card-brand" aria-hidden="true">VISA</span>
+          </div>
+        </div>
+
+        <div className="qc-pay-row">
+          <div className="qc-pay-field">
+            <label className="qc-pay-label">Scadenza</label>
+            <div className="qc-pay-input">
+              <span className="qc-pay-value" style={{ fontFamily: 'var(--f-mono)' }}>12 / 27</span>
+            </div>
+          </div>
+          <div className="qc-pay-field">
+            <label className="qc-pay-label">CVC</label>
+            <div className="qc-pay-input">
+              <span className="qc-pay-value" style={{ fontFamily: 'var(--f-mono)' }}>•••</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="qc-pay-field">
+          <label className="qc-pay-label">Nome sulla carta</label>
+          <div className="qc-pay-input">
+            <span className="qc-pay-value">Sara Bianchi</span>
+          </div>
+        </div>
+
+        <div className="qc-pay-field">
+          <label className="qc-pay-label">Paese</label>
+          <div className="qc-pay-input qc-pay-select">
+            <span className="qc-pay-value">🇮🇹 Italia</span>
+            <span className="qc-pay-chev" aria-hidden="true">▾</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="qc-recap">
+        <div className="qc-recap-row">
+          <span>100 crediti</span>
+          <span style={{ fontVariantNumeric: 'tabular-nums' }}>€5,00</span>
+        </div>
+        <div className="qc-recap-row qc-recap-muted">
+          <span>IVA inclusa</span>
+          <span style={{ fontVariantNumeric: 'tabular-nums' }}>—</span>
+        </div>
+        <div className="qc-recap-row qc-recap-total">
+          <span>Totale</span>
+          <span style={{ fontVariantNumeric: 'tabular-nums' }}>€5,00</span>
+        </div>
+      </div>
+
+      <div className="qc-trust-row" aria-label="Garanzie sicurezza">
+        <span className="qc-trust-chip">
+          <span aria-hidden="true">🔒</span>
+          <span>SSL secure</span>
+        </span>
+        <span className="qc-trust-chip">
+          <span aria-hidden="true">✓</span>
+          <span>Stripe powered</span>
+        </span>
+        <span className="qc-trust-chip">
+          <span aria-hidden="true">✓</span>
+          <span>Politica rimborso 14gg</span>
+        </span>
+      </div>
+
+      <div className="qc-step-footer qc-cta-stack">
+        <button
+          type="button"
+          className="qc-cta-primary"
+          disabled={isLoading}
+          style={{
+            background: entityHsl('toolkit'),
+            opacity: isLoading ? 0.85 : 1,
+            cursor: isLoading ? 'wait' : 'pointer',
+          }}
+          aria-busy={isLoading || undefined}
+        >
+          {isLoading ? (
+            <>
+              <span className="qc-spinner" aria-hidden="true"/>
+              <span>Elaborazione…</span>
+            </>
+          ) : (
+            <>Paga €5</>
+          )}
+        </button>
+        <a href="#" className="qc-footer-link">← Torna ai pacchetti</a>
+      </div>
+    </div>
+  );
+}
+
+/* ───────────────────────────────────────────────────────────────
+   STEP 4 — Success
+   ─────────────────────────────────────────────────────────────── */
+
+function Step4Success() {
+  return (
+    <div className="qc-step-content qc-success">
+      {/* Confetti CSS-only (rispetta prefers-reduced-motion via @media — vedi <style>) */}
+      <div className="qc-confetti" aria-hidden="true">
+        {Array.from({ length: 14 }).map((_, i) => (
+          <span
+            key={i}
+            className="qc-confetto"
+            style={{
+              left: `${(i * 7.3) % 100}%`,
+              background: [
+                entityHsl('toolkit'),
+                entityHsl('event'),
+                entityHsl('agent'),
+                entityHsl('chat'),
+                entityHsl('game'),
+              ][i % 5],
+              animationDelay: `${(i * 0.13) % 1.4}s`,
+              animationDuration: `${1.6 + (i % 3) * 0.4}s`,
+            }}
+          />
+        ))}
+      </div>
+
+      <div className="qc-success-hero">
+        <div className="qc-success-emoji" aria-hidden="true">🎉</div>
+        <h2 className="qc-success-title">Crediti aggiunti!</h2>
+        <p className="qc-success-sub">100 crediti aggiunti al tuo account. Buon gioco!</p>
+      </div>
+
+      <div className="qc-recap-card" style={{ background: 'var(--bg-card)', borderColor: 'var(--border)' }}>
+        <div className="qc-recap-row">
+          <span>Crediti precedenti</span>
+          <span style={{ fontFamily: 'var(--f-mono)', fontVariantNumeric: 'tabular-nums' }}>0</span>
+        </div>
+        <div className="qc-recap-row" style={{ color: entityHsl('toolkit') }}>
+          <span>Crediti acquistati</span>
+          <span style={{ fontFamily: 'var(--f-mono)', fontVariantNumeric: 'tabular-nums' }}>+100</span>
+        </div>
+        <div className="qc-recap-row qc-recap-total" style={{ color: entityHsl('toolkit') }}>
+          <span>Bilancio crediti</span>
+          <span style={{ fontFamily: 'var(--f-mono)', fontVariantNumeric: 'tabular-nums' }}>100</span>
+        </div>
+        <div className="qc-recap-divider"/>
+        <div className="qc-recap-row qc-recap-muted">
+          <span>Quota free questo mese</span>
+          <span style={{ fontFamily: 'var(--f-mono)', fontVariantNumeric: 'tabular-nums' }}>50 / 50</span>
+        </div>
+        <div className="qc-recap-row qc-recap-muted">
+          <span style={{ fontSize: 11 }}>Si resetta il 1° giugno</span>
+          <span style={{ fontSize: 11 }}>1 paragrafo = 1 credito</span>
+        </div>
+      </div>
+
+      <div className="qc-step-footer qc-cta-stack">
+        <button
+          type="button"
+          className="qc-cta-primary"
+          style={{ background: entityHsl('session') }}
+        >
+          🎯 Torna al gioco →
+        </button>
+        <a href="#" className="qc-footer-link">Vedi ricevuta · email a sara@…</a>
+      </div>
+    </div>
+  );
+}
+
+/* ───────────────────────────────────────────────────────────────
+   SOFT WARNING 47/50 — separato dai 4 step (brief riga 687-693)
+   Toast bottom mobile / modal centro desktop.
+   ─────────────────────────────────────────────────────────────── */
+
+function SoftWarning4750({ desktop }) {
+  if (desktop) {
+    return (
+      <div className="qc-soft-modal" role="dialog" aria-modal="true" aria-labelledby="soft-title">
+        <div className="qc-soft-modal-inner" style={{
+          background: 'var(--bg-card)',
+          borderColor: entityHsl('agent', 0.3),
+        }}>
+          <div className="qc-soft-icon" style={{
+            background: entityHsl('agent', 0.15),
+            color: entityHsl('agent'),
+          }} aria-hidden="true">🟡</div>
+          <div className="qc-soft-body">
+            <h3 id="soft-title" className="qc-soft-title">Quasi alla fine della quota</h3>
+            <p className="qc-soft-sub">Hai usato 47/50 paragrafi gratis questo mese. Restano 3.</p>
+            <div className="qc-soft-actions">
+              <button
+                type="button"
+                className="qc-cta-primary qc-cta-soft"
+                style={{ background: entityHsl('toolkit') }}
+              >
+                Acquista crediti ora
+              </button>
+              <button type="button" className="qc-cta-outline qc-cta-soft">
+                Ok, continua
+              </button>
+            </div>
+          </div>
+          <CloseX ariaLabel="Chiudi avviso"/>
+        </div>
+      </div>
+    );
+  }
+  // Mobile = toast bottom
+  return (
+    <div className="qc-soft-toast" role="status" aria-live="polite" style={{
+      background: 'var(--bg-card)',
+      borderColor: entityHsl('agent', 0.3),
+    }}>
+      <div className="qc-soft-toast-row">
+        <span className="qc-soft-icon-sm" style={{
+          background: entityHsl('agent', 0.15),
+          color: entityHsl('agent'),
+        }} aria-hidden="true">🟡</span>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div className="qc-soft-title" style={{ fontSize: 13 }}>Quasi alla fine della quota</div>
+          <div className="qc-soft-sub" style={{ fontSize: 11 }}>47/50 — restano 3 paragrafi gratis.</div>
+        </div>
+      </div>
+      <div className="qc-soft-actions">
+        <button
+          type="button"
+          className="qc-cta-primary qc-cta-soft"
+          style={{ background: entityHsl('toolkit') }}
+        >
+          Acquista crediti
+        </button>
+        <button type="button" className="qc-cta-outline qc-cta-soft">
+          Ok
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ───────────────────────────────────────────────────────────────
+   Modal shell (4 step lineari + close X)
+   ─────────────────────────────────────────────────────────────── */
+
+function ModalShell({ step, children, desktop }) {
+  return (
+    <div className="qc-modal-overlay">
+      <div
+        className={`qc-modal ${desktop ? 'qc-modal-desktop' : 'qc-modal-mobile'}`}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={`qc-modal-title-${step}`}
+        style={{
+          background: 'var(--bg)',
+          borderColor: 'var(--border)',
+        }}
+      >
+        <div className="qc-modal-head">
+          <StepIndicator current={step}/>
+          <CloseX/>
+        </div>
+        <div className="qc-modal-body" id={`qc-modal-title-${step}`}>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ───────────────────────────────────────────────────────────────
+   State → composed UI
+   ─────────────────────────────────────────────────────────────── */
+
+function StateBody({ stateId, desktop }) {
+  if (stateId === 'state-01-step1-quota-raggiunta') {
+    return <ModalShell step={1} desktop={desktop}><Step1QuotaRaggiunta/></ModalShell>;
+  }
+  if (stateId === 'state-02-step2-pack-picker-starter') {
+    return <ModalShell step={2} desktop={desktop}><Step2PackPicker selectedId="starter"/></ModalShell>;
+  }
+  if (stateId === 'state-03-step3-checkout-form-filled') {
+    return <ModalShell step={3} desktop={desktop}><CheckoutForm variant="filled"/></ModalShell>;
+  }
+  if (stateId === 'state-04-step3-payment-loading') {
+    return <ModalShell step={3} desktop={desktop}><CheckoutForm variant="loading"/></ModalShell>;
+  }
+  if (stateId === 'state-05-step3-payment-failed') {
+    return <ModalShell step={3} desktop={desktop}><CheckoutForm variant="failed"/></ModalShell>;
+  }
+  if (stateId === 'state-06-step4-success') {
+    return <ModalShell step={4} desktop={desktop}><Step4Success/></ModalShell>;
+  }
+  if (stateId === 'state-07-soft-warning-47-50') {
+    return (
+      <div className="qc-soft-stage">
+        <div className="qc-soft-bg" aria-hidden="true">
+          {/* fake page behind toast/modal */}
+          <div className="qc-fake-line" style={{ width: '70%' }}/>
+          <div className="qc-fake-line" style={{ width: '90%' }}/>
+          <div className="qc-fake-line" style={{ width: '60%' }}/>
+          <div className="qc-fake-line" style={{ width: '85%' }}/>
+          <div className="qc-fake-line" style={{ width: '40%' }}/>
+          <div className="qc-fake-line" style={{ width: '78%' }}/>
+        </div>
+        <SoftWarning4750 desktop={desktop}/>
+      </div>
+    );
+  }
+  return null;
+}
+
+/* ───────────────────────────────────────────────────────────────
+   Frames (mobile 375 + desktop 1440)
+   ─────────────────────────────────────────────────────────────── */
+
+function MobileFrame({ stateId, label, gherkin }) {
+  return (
+    <div data-screen-label={`${label} · mobile`}>
+      <div className="qc-frame-caption">
+        📱 Mobile 375 — {label}
+        {gherkin && <span className="gherkin">{gherkin}</span>}
+      </div>
+      <div className="qc-phone" id={`${stateId}-mobile`}>
+        <div className="qc-phone-sbar">
+          <span style={{ fontFamily: 'var(--f-mono)', fontSize: 11 }}>9:41</span>
+          <span style={{ fontSize: 11 }}>▲ ◆ ▶</span>
+        </div>
+        <div className="qc-phone-body">
+          <StateBody stateId={stateId} desktop={false}/>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DesktopFrame({ stateId, label, gherkin }) {
+  return (
+    <div style={{ width: '100%' }} data-screen-label={`${label} · desktop`}>
+      <div className="qc-frame-caption">
+        🖥️ Desktop 1440 — {label}
+        {gherkin && <span className="gherkin">{gherkin}</span>}
+      </div>
+      <div className="qc-desktop" id={`${stateId}-desktop`}>
+        <div className="qc-desktop-bar">
+          <span className="traffic"/><span className="traffic"/><span className="traffic"/>
+          <span className="url">meepleai.app/gamebook/checkout</span>
+        </div>
+        <div className="qc-desktop-body">
+          <StateBody stateId={stateId} desktop={true}/>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ───────────────────────────────────────────────────────────────
+   STATES catalog (7 V5)
+   ─────────────────────────────────────────────────────────────── */
+
+const STATES = [
+  { id: 'state-01-step1-quota-raggiunta',     label: 'Step 1 · Quota raggiunta (50/50)',          group: 1, gherkin: 'G4.6' },
+  { id: 'state-02-step2-pack-picker-starter', label: 'Step 2 · Pack picker (Starter selected)',   group: 2, gherkin: 'G4.6' },
+  { id: 'state-03-step3-checkout-form-filled',label: 'Step 3 · Checkout form filled',             group: 3, gherkin: 'G4.6' },
+  { id: 'state-04-step3-payment-loading',     label: 'Step 3 · Payment loading',                  group: 3, gherkin: 'G4.6' },
+  { id: 'state-05-step3-payment-failed',      label: 'Step 3 · Payment failed (banner red)',      group: 3, gherkin: 'G4.6' },
+  { id: 'state-06-step4-success',             label: 'Step 4 · Success (🎉 reduced-motion guard)',group: 4, gherkin: 'G4.6' },
+  { id: 'state-07-soft-warning-47-50',        label: 'Soft warning 47/50 (separato dai 4 step)',  group: 'soft', gherkin: 'G4.6' },
+];
+
+const GROUP_LABELS = {
+  1: 'STEP 1 · Quota raggiunta',
+  2: 'STEP 2 · Pack picker',
+  3: 'STEP 3 · Checkout',
+  4: 'STEP 4 · Success',
+  soft: 'SOFT WARNING · separato dai 4 step',
+};
+
+function App() {
+  const [stepFilter, setStepFilter] = useState('all');
+  const [frameFilter, setFrameFilter] = useState('both');
+
+  useEffect(() => {
+    const sh = e => setStepFilter(e.detail);
+    const fh = e => setFrameFilter(e.detail);
+    document.addEventListener('qc-tweak-step', sh);
+    document.addEventListener('qc-tweak-frame', fh);
+    return () => {
+      document.removeEventListener('qc-tweak-step', sh);
+      document.removeEventListener('qc-tweak-frame', fh);
+    };
+  }, []);
+
+  const visible = stepFilter === 'all'
+    ? STATES
+    : STATES.filter(s => String(s.group) === String(stepFilter));
+
+  const groups = ['1', '2', '3', '4', 'soft']
+    .map(g => ({ key: g, items: visible.filter(s => String(s.group) === g) }))
+    .filter(g => g.items.length > 0);
+
+  return (
+    <div>
+      {groups.map(g => (
+        <div key={g.key}>
+          <div className="qc-section-label">
+            <span className="step">{GROUP_LABELS[g.key]}</span>
+          </div>
+          {g.items.map(s => (
+            <section key={s.id} id={s.id} style={{ marginBottom: 36 }} data-screen-label={s.label}>
+              <div className="qc-state-grid">
+                {(frameFilter === 'both' || frameFilter === 'mobile') && (
+                  <MobileFrame stateId={s.id} label={s.label} gherkin={s.gherkin}/>
+                )}
+                {(frameFilter === 'both' || frameFilter === 'desktop') && (
+                  <DesktopFrame stateId={s.id} label={s.label} gherkin={s.gherkin}/>
+                )}
+              </div>
+            </section>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ─── Inline scoped styles ─── */
+const qcStyleEl = document.createElement('style');
+qcStyleEl.textContent = `
+  /* Modal overlay + shell */
+  .qc-modal-overlay {
+    position: absolute; inset: 0;
+    background: rgba(0,0,0,.45);
+    backdrop-filter: blur(3px);
+    display: flex; align-items: center; justify-content: center;
+    padding: 12px;
+    z-index: 60;
+  }
+  :root[data-theme="dark"] .qc-modal-overlay { background: rgba(0,0,0,.65); }
+
+  .qc-modal {
+    width: 100%;
+    max-height: calc(100% - 24px);
+    border-radius: var(--r-2xl);
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow-lg);
+    display: flex; flex-direction: column;
+    overflow: hidden;
+  }
+  .qc-modal-mobile { max-width: 100%; }
+  .qc-modal-desktop { max-width: 520px; }
+
+  .qc-modal-head {
+    flex-shrink: 0;
+    display: flex; align-items: center; gap: 8px;
+    padding: 14px 14px 0 14px;
+    position: relative;
+  }
+  .qc-modal-body {
+    flex: 1; min-height: 0;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .qc-close {
+    position: absolute; top: 10px; right: 10px;
+    width: 32px; height: 32px; border-radius: 50%;
+    background: var(--bg-muted); border: 1px solid var(--border);
+    color: var(--text); cursor: pointer; font-size: 18px; line-height: 1;
+    display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+  }
+
+  /* Step indicator */
+  .qc-stepbar { flex: 1; padding: 4px 0; }
+  .qc-step-list { display: flex; align-items: center; gap: 6px; }
+  .qc-step { display: flex; align-items: center; gap: 6px; }
+  .qc-step-circle {
+    width: 22px; height: 22px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    font-family: var(--f-display); font-weight: 700; font-size: 11px;
+    flex-shrink: 0;
+  }
+  .qc-step-label {
+    font-family: var(--f-display); font-weight: 600; font-size: 11px;
+    white-space: nowrap;
+  }
+  .qc-step-line { flex: 1; height: 2px; min-width: 8px; border-radius: var(--r-pill); }
+
+  /* Step content */
+  .qc-step-content {
+    padding: 18px 18px 22px;
+    display: flex; flex-direction: column; gap: 16px;
+  }
+  .qc-step-header { display: flex; flex-direction: column; gap: 4px; }
+  .qc-step-h2 {
+    font-family: var(--f-display); font-weight: 700; font-size: 22px;
+    color: var(--text); margin: 0; line-height: 1.2;
+  }
+  .qc-step-sub { font-size: 13px; color: var(--text-sec); margin: 0; line-height: 1.5; }
+
+  /* Hero icon (step 1) */
+  .qc-hero-icon {
+    width: 96px; height: 96px; border-radius: 28px;
+    margin: 4px auto 0;
+    display: flex; align-items: center; justify-content: center;
+  }
+
+  /* Quota card (step 1) */
+  .qc-quota-card {
+    border: 1px solid; border-radius: var(--r-lg);
+    padding: 14px 16px;
+    display: flex; flex-direction: column; gap: 10px;
+  }
+  .qc-quota-row {
+    display: flex; justify-content: space-between; align-items: flex-end;
+  }
+  .qc-quota-label {
+    font-family: var(--f-mono); font-size: 11px;
+    text-transform: uppercase; letter-spacing: 0.06em;
+    color: var(--text-muted);
+  }
+  .qc-quota-counter {
+    font-family: var(--f-display); font-weight: 800; font-size: 28px;
+    line-height: 1;
+  }
+  .qc-quota-bar {
+    height: 8px; border-radius: var(--r-pill);
+    background: var(--bg-muted); overflow: hidden;
+  }
+  .qc-quota-fill { height: 100%; transition: width var(--dur-md) var(--ease-out); }
+  .qc-quota-foot { display: flex; justify-content: space-between; }
+
+  /* CTA */
+  .qc-step-footer { margin-top: auto; padding-top: 8px; }
+  .qc-cta-stack { display: flex; flex-direction: column; gap: 8px; align-items: stretch; }
+
+  .qc-cta-primary {
+    width: 100%; padding: 14px 18px; border-radius: var(--r-lg);
+    color: #fff; border: none; cursor: pointer;
+    font-family: var(--f-display); font-weight: 700; font-size: 14px;
+    display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+    transition: filter var(--dur-sm) var(--ease-out), transform var(--dur-sm) var(--ease-out);
+  }
+  .qc-cta-primary:hover:not(:disabled) { filter: brightness(1.06); }
+  .qc-cta-primary:active:not(:disabled) { transform: scale(0.98); }
+
+  .qc-cta-outline {
+    width: 100%; padding: 14px 18px; border-radius: var(--r-lg);
+    background: var(--bg-card); border: 1px solid var(--border-strong);
+    color: var(--text); cursor: pointer;
+    font-family: var(--f-display); font-weight: 600; font-size: 14px;
+  }
+  .qc-cta-outline:hover { background: var(--bg-hover); }
+
+  .qc-footer-link {
+    display: inline-block; padding: 6px 4px;
+    color: var(--text-muted); font-size: 12px; text-align: center;
+    text-decoration: none;
+  }
+  .qc-footer-link:hover { color: var(--text-sec); }
+
+  /* Pack picker */
+  .qc-pack-grid {
+    display: flex; flex-direction: column; gap: 10px;
+  }
+  .qc-pack-card {
+    position: relative; padding: 14px 14px 14px 16px;
+    border-radius: var(--r-lg); border: 2px solid;
+    cursor: pointer;
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    grid-template-rows: auto auto auto;
+    grid-template-areas:
+      "name . radio"
+      "credits price radio"
+      "perpar . radio";
+    column-gap: 12px; row-gap: 2px;
+    transition: transform var(--dur-sm) var(--ease-out);
+  }
+  .qc-pack-card:hover { transform: translateY(-1px); }
+  .qc-pack-radio { position: absolute; opacity: 0; pointer-events: none; }
+  .qc-pack-name {
+    grid-area: name;
+    font-family: var(--f-display); font-weight: 700; font-size: 13px;
+    color: var(--text-sec); text-transform: uppercase; letter-spacing: 0.06em;
+  }
+  .qc-pack-credits {
+    grid-area: credits;
+    font-family: var(--f-display); font-weight: 800; font-size: 22px;
+    line-height: 1; display: flex; align-items: baseline; gap: 6px;
+  }
+  .qc-pack-credits-sub {
+    font-family: var(--f-body); font-size: 12px; font-weight: 600;
+    color: var(--text-muted); text-transform: lowercase;
+  }
+  .qc-pack-price {
+    grid-area: price;
+    font-family: var(--f-display); font-weight: 800; font-size: 24px;
+    color: var(--text); line-height: 1;
+  }
+  .qc-pack-perpar {
+    grid-area: perpar;
+    font-family: var(--f-mono); font-size: 11px;
+    color: var(--text-muted);
+  }
+  .qc-pack-radio-visual {
+    grid-area: radio;
+    align-self: center; justify-self: end;
+    width: 22px; height: 22px; border-radius: 50%;
+    border: 2px solid;
+    display: flex; align-items: center; justify-content: center;
+    transition: background var(--dur-sm) var(--ease-out), border-color var(--dur-sm) var(--ease-out);
+  }
+  .qc-pack-radio-dot {
+    width: 8px; height: 8px; border-radius: 50%; background: #fff;
+  }
+  .qc-pack-badge {
+    position: absolute; top: -8px; right: 12px;
+    padding: 3px 8px; border-radius: var(--r-pill);
+    font-family: var(--f-display); font-weight: 700; font-size: 10px;
+    text-transform: uppercase; letter-spacing: 0.04em;
+  }
+
+  .qc-disclaimer {
+    font-size: 11px; color: var(--text-muted); line-height: 1.5;
+    padding: 10px 12px; background: var(--bg-muted);
+    border-radius: var(--r-md);
+  }
+
+  .qc-step2-footer {
+    display: flex; align-items: center; gap: 10px;
+    flex-direction: row;
+  }
+  .qc-total-recap {
+    display: flex; flex-direction: column; align-items: flex-start;
+    flex-shrink: 0;
+  }
+  .qc-total-label {
+    font-family: var(--f-mono); font-size: 10px;
+    text-transform: uppercase; letter-spacing: 0.06em;
+    color: var(--text-muted);
+  }
+  .qc-total-value {
+    font-family: var(--f-display); font-weight: 800; font-size: 22px;
+    color: var(--text); line-height: 1;
+  }
+
+  /* Pay form */
+  .qc-pay-form { display: flex; flex-direction: column; gap: 10px; }
+  .qc-pay-row { display: flex; gap: 10px; }
+  .qc-pay-row .qc-pay-field { flex: 1; }
+  .qc-pay-field { display: flex; flex-direction: column; gap: 4px; }
+  .qc-pay-label {
+    font-family: var(--f-mono); font-size: 10px;
+    text-transform: uppercase; letter-spacing: 0.06em;
+    color: var(--text-muted);
+  }
+  .qc-pay-input {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 12px 14px; border-radius: var(--r-md);
+    background: var(--bg-card); border: 1px solid var(--border);
+    min-height: 44px;
+  }
+  .qc-pay-input:focus-within { outline: 2px solid hsl(var(--c-toolkit)); outline-offset: 1px; }
+  .qc-pay-value { font-family: var(--f-body); font-size: 14px; color: var(--text); }
+  .qc-card-brand {
+    font-family: var(--f-mono); font-weight: 700; font-size: 10px;
+    color: var(--text-muted); letter-spacing: 0.1em;
+  }
+  .qc-pay-select { cursor: pointer; }
+  .qc-pay-chev { color: var(--text-muted); font-size: 10px; }
+
+  /* Recap */
+  .qc-recap {
+    border: 1px solid var(--border); border-radius: var(--r-md);
+    padding: 12px 14px; background: var(--bg-card);
+    display: flex; flex-direction: column; gap: 6px;
+  }
+  .qc-recap-row {
+    display: flex; justify-content: space-between; align-items: center;
+    font-size: 13px; color: var(--text);
+  }
+  .qc-recap-muted { color: var(--text-muted); font-size: 11px; }
+  .qc-recap-total {
+    font-family: var(--f-display); font-weight: 800; font-size: 16px;
+    padding-top: 6px; border-top: 1px solid var(--border-light);
+    margin-top: 4px;
+  }
+  .qc-recap-divider {
+    height: 1px; background: var(--border-light); margin: 4px 0;
+  }
+  .qc-recap-card {
+    border: 1px solid; border-radius: var(--r-lg);
+    padding: 14px 16px;
+    display: flex; flex-direction: column; gap: 6px;
+  }
+
+  /* Trust badges */
+  .qc-trust-row {
+    display: flex; flex-wrap: wrap; gap: 6px; justify-content: center;
+  }
+  .qc-trust-chip {
+    display: inline-flex; align-items: center; gap: 4px;
+    padding: 4px 10px; border-radius: var(--r-pill);
+    background: var(--bg-muted);
+    font-family: var(--f-mono); font-size: 10px;
+    color: var(--text-sec); white-space: nowrap;
+  }
+
+  /* Banner error */
+  .qc-banner {
+    display: flex; align-items: flex-start; gap: 10px;
+    padding: 10px 12px; border-radius: var(--r-md);
+    border: 1px solid;
+  }
+  .qc-banner-icon {
+    width: 22px; height: 22px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    font-family: var(--f-display); font-weight: 800; font-size: 13px;
+    flex-shrink: 0;
+  }
+  .qc-banner-title {
+    font-family: var(--f-display); font-weight: 700; font-size: 13px;
+  }
+  .qc-banner-sub { font-size: 12px; color: var(--text-sec); margin-top: 2px; }
+
+  /* Spinner */
+  .qc-spinner {
+    width: 16px; height: 16px; border-radius: 50%;
+    border: 2px solid rgba(255,255,255,.4);
+    border-top-color: #fff;
+    animation: qcSpin 0.7s linear infinite;
+  }
+  @keyframes qcSpin { to { transform: rotate(360deg); } }
+
+  /* Success */
+  .qc-success {
+    align-items: stretch; text-align: center; gap: 18px;
+    position: relative;
+  }
+  .qc-success-hero {
+    display: flex; flex-direction: column; align-items: center; gap: 6px;
+    padding: 12px 0 4px;
+  }
+  .qc-success-emoji {
+    font-size: 64px; line-height: 1;
+    animation: qcPop 0.6s var(--ease-spring) both;
+  }
+  @keyframes qcPop {
+    0% { transform: scale(0.4) rotate(-12deg); opacity: 0; }
+    60% { transform: scale(1.15) rotate(8deg); opacity: 1; }
+    100% { transform: scale(1) rotate(0deg); opacity: 1; }
+  }
+  .qc-success-title {
+    font-family: var(--f-display); font-weight: 800; font-size: 28px;
+    color: var(--text); margin: 0;
+  }
+  .qc-success-sub {
+    font-size: 13px; color: var(--text-sec); margin: 0;
+  }
+
+  /* Confetti CSS-only — rispetta prefers-reduced-motion (brief riga 710) */
+  .qc-confetti {
+    position: absolute; inset: 0; pointer-events: none;
+    overflow: hidden;
+  }
+  .qc-confetto {
+    position: absolute; top: -10px;
+    width: 7px; height: 12px;
+    border-radius: 2px;
+    animation: qcConfetto 2s ease-in infinite;
+    opacity: 0.85;
+  }
+  @keyframes qcConfetto {
+    0% { transform: translateY(-10px) rotate(0deg); opacity: 0; }
+    20% { opacity: 0.95; }
+    100% { transform: translateY(420px) rotate(540deg); opacity: 0; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .qc-success-emoji { animation: none; }
+    .qc-confetto { animation: none; opacity: 0; }
+    .qc-spinner { animation: none; }
+  }
+
+  /* Soft warning (mobile toast / desktop modal) */
+  .qc-soft-stage {
+    position: relative; height: 100%; min-height: 100%;
+    background: var(--bg);
+    overflow: hidden;
+  }
+  .qc-soft-bg {
+    padding: 32px 18px; display: flex; flex-direction: column; gap: 10px;
+    opacity: 0.4;
+  }
+  .qc-fake-line {
+    height: 10px; border-radius: var(--r-pill);
+    background: var(--bg-muted);
+  }
+  .qc-soft-toast {
+    position: absolute; left: 12px; right: 12px; bottom: 16px;
+    border: 1px solid; border-radius: var(--r-lg);
+    padding: 12px 14px;
+    box-shadow: var(--shadow-md);
+    display: flex; flex-direction: column; gap: 10px;
+  }
+  .qc-soft-toast-row {
+    display: flex; align-items: flex-start; gap: 10px;
+  }
+  .qc-soft-icon-sm {
+    width: 28px; height: 28px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+  }
+  .qc-soft-modal {
+    position: absolute; inset: 0;
+    background: rgba(0,0,0,.4); backdrop-filter: blur(2px);
+    display: flex; align-items: center; justify-content: center;
+    padding: 20px;
+  }
+  .qc-soft-modal-inner {
+    position: relative;
+    width: 100%; max-width: 420px;
+    border: 1px solid; border-radius: var(--r-xl);
+    padding: 22px 22px 18px;
+    display: flex; gap: 14px;
+    box-shadow: var(--shadow-lg);
+  }
+  .qc-soft-icon {
+    width: 44px; height: 44px; border-radius: 12px;
+    display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0; font-size: 20px;
+  }
+  .qc-soft-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 4px; }
+  .qc-soft-title {
+    font-family: var(--f-display); font-weight: 700; font-size: 15px;
+    color: var(--text); margin: 0;
+  }
+  .qc-soft-sub { font-size: 12px; color: var(--text-sec); margin: 0; line-height: 1.5; }
+  .qc-soft-actions {
+    display: flex; gap: 8px; margin-top: 8px;
+  }
+  .qc-cta-soft {
+    flex: 1; padding: 10px 14px; font-size: 12px;
+  }
+
+  /* Frames + canvas chrome */
+  .qc-section-label {
+    font-family: var(--f-mono); font-weight: 700; font-size: 11px;
+    text-transform: uppercase; letter-spacing: 0.08em;
+    color: var(--text-muted);
+    margin: 32px 0 12px;
+    padding-bottom: 6px; border-bottom: 1px solid var(--border-light);
+  }
+  .qc-section-label .step {
+    color: var(--text-sec);
+  }
+  .qc-frame-caption {
+    font-family: var(--f-mono); font-size: 11px;
+    color: var(--text-muted);
+    margin-bottom: 6px;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .qc-frame-caption .gherkin {
+    padding: 2px 6px; border-radius: var(--r-sm);
+    background: hsl(var(--c-agent) / .15); color: hsl(var(--c-agent));
+    font-weight: 700; font-size: 10px;
+  }
+
+  .qc-state-grid {
+    display: grid; grid-template-columns: 375px 1fr; gap: 24px;
+    align-items: start;
+  }
+  @media (max-width: 900px) {
+    .qc-state-grid { grid-template-columns: 1fr; }
+  }
+
+  .qc-phone {
+    width: 375px; height: 720px;
+    border-radius: 36px;
+    background: var(--bg);
+    border: 8px solid #1a1410;
+    overflow: hidden; position: relative;
+    box-shadow: var(--shadow-md);
+    display: flex; flex-direction: column;
+  }
+  .qc-phone-sbar {
+    flex-shrink: 0; height: 28px;
+    display: flex; justify-content: space-between; align-items: center;
+    padding: 0 18px;
+    background: var(--bg);
+    color: var(--text);
+  }
+  .qc-phone-body { flex: 1; min-height: 0; position: relative; overflow: hidden; }
+
+  .qc-desktop {
+    width: 100%; height: 720px;
+    border-radius: var(--r-xl);
+    background: var(--bg);
+    border: 1px solid var(--border);
+    overflow: hidden; position: relative;
+    box-shadow: var(--shadow-md);
+    display: flex; flex-direction: column;
+  }
+  .qc-desktop-bar {
+    flex-shrink: 0;
+    display: flex; align-items: center; gap: 8px;
+    padding: 10px 14px;
+    background: var(--bg-muted);
+    border-bottom: 1px solid var(--border);
+  }
+  .qc-desktop-bar .traffic {
+    width: 10px; height: 10px; border-radius: 50%;
+    background: var(--border-strong);
+  }
+  .qc-desktop-bar .url {
+    margin-left: 14px; padding: 4px 12px; border-radius: var(--r-pill);
+    background: var(--bg); font-family: var(--f-mono); font-size: 11px;
+    color: var(--text-muted);
+  }
+  .qc-desktop-body { flex: 1; min-height: 0; position: relative; overflow: hidden; }
+`;
+document.head.appendChild(qcStyleEl);
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);

--- a/admin-mockups/design_files/sp6-libro-game-translation-viewer.html
+++ b/admin-mockups/design_files/sp6-libro-game-translation-viewer.html
@@ -1,0 +1,603 @@
+<!DOCTYPE html>
+<html lang="it" data-theme="light">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SP6 · Libro Game · Translation Viewer Fullscreen — /gamebook/[id]/play/paragraph/[num]</title>
+
+  <!-- Schermata: Translation Viewer Fullscreen
+       Route: /gamebook/[gameId]/play/paragraph/[num] (fullscreen modal route, NO shell)
+       Persona: Sara, 32, GM al tavolo, lettura distante 1.5m
+       Pattern: Reading-mode minimalista, top bar sticky + body + bottom controls sticky
+       Brief SP6 §D (lines 492-566).
+
+       DEVIAZIONI ESPLICITE (brief riga 519):
+         - Reading body: Nunito 26px (=20pt) ASSOLUTO, NON --fs-xl (20px≈15pt).
+         - line-height: 1.6 esplicito.
+         - max-width: 60ch.
+       Vincolo non-functional vision §4.2 (lettura distante 1.5m).
+
+       Stati 7 (anchor id state-NN-…):
+         01 default-it          (Tainted Grail §147, glossary applied)
+         02 side-by-side        (desktop only, IT|EN 50/50)
+         03 en-replace          (kicker top "Originale")
+         04 loading             (skeleton 5 righe shimmer)
+         05 offline-cached      (G4.7 banner top + auto-retry discreto)
+         06 mid-translation-lost(G4.7 partial + "Sto riprovando…" + CTA "Mostra EN")
+         07 not-found           (G4.4 §299 full empty + 3 azioni)
+       + Theme: light + dark + sepia (sepia = light as-is, NO nuova palette)
+       + Device: mobile + desktop
+
+       Scope-out: ConnectionPip/ConnectionBar (no shell), Quota exceeded (redirect a E).
+  -->
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
+
+  <link rel="stylesheet" href="tokens.css" />
+  <link rel="stylesheet" href="components.css" />
+
+  <style>
+    /* Stage layout (riusato da play-session) */
+    .stage {
+      min-height: 100vh;
+      padding: var(--s-7) var(--s-6) var(--s-10);
+      background: var(--bg);
+      color: var(--text);
+    }
+    .stage-wrap { max-width: 1500px; margin: 0 auto; }
+    .stage h1 {
+      font-family: var(--f-display); font-weight: 800;
+      font-size: var(--fs-3xl); margin-bottom: var(--s-2);
+      letter-spacing: -0.02em;
+    }
+    .stage .lead {
+      color: var(--text-sec); font-size: var(--fs-md);
+      max-width: 880px; margin: 0 0 var(--s-7);
+      line-height: var(--lh-body);
+    }
+    .section-label {
+      font-family: var(--f-mono); font-size: var(--fs-xs);
+      color: var(--text-muted); text-transform: uppercase;
+      letter-spacing: 0.08em; margin: var(--s-9) 0 var(--s-4);
+      padding-bottom: var(--s-2); border-bottom: 1px solid var(--border);
+    }
+    .section-label:first-of-type { margin-top: var(--s-7); }
+
+    .frames-row {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+      gap: var(--s-7) var(--s-6);
+      align-items: start;
+    }
+    .desktop-row { display: flex; flex-direction: column; gap: var(--s-7); }
+
+    .frame-cell { display: flex; flex-direction: column; gap: var(--s-3); }
+    .frame-meta {
+      font-family: var(--f-mono); font-size: var(--fs-xs);
+      color: var(--text-muted); text-transform: uppercase;
+      letter-spacing: 0.08em; line-height: 1.5;
+    }
+    .frame-meta strong {
+      color: var(--text); font-weight: 700;
+      font-size: var(--fs-sm); display: block; margin-bottom: 2px;
+      letter-spacing: 0.04em;
+    }
+    .frame-meta .gherkin {
+      display: inline-block; padding: 2px 6px; border-radius: var(--r-xs);
+      background: hsl(var(--c-agent) / 0.12); color: hsl(var(--c-agent));
+      font-weight: 700; margin-right: 6px;
+    }
+    .frame-meta .anchor {
+      display: inline-block; padding: 2px 6px; border-radius: var(--r-xs);
+      background: var(--bg-muted); color: var(--text-sec);
+      font-weight: 600; margin-right: 6px;
+    }
+
+    /* Phone frame */
+    .phone-sp6 {
+      width: 380px; height: 780px;
+      border-radius: 48px; border: 10px solid #1a1a1a;
+      background: var(--bg); overflow: hidden; position: relative;
+      box-shadow: 0 28px 60px rgba(0,0,0,.22), 0 0 0 2px #000;
+      display: flex; flex-direction: column;
+    }
+    [data-theme="dark"] .phone-sp6,
+    .phone-sp6.t-dark {
+      border-color: #0a0a0a;
+      box-shadow: 0 28px 60px rgba(0,0,0,.6);
+    }
+    .phone-sbar-sp6 {
+      height: 30px; flex-shrink: 0;
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 4px 22px 0;
+      font-size: 12px; font-weight: 700; font-family: var(--f-display);
+      color: var(--text);
+    }
+    .phone-sbar-sp6 .ind { display: flex; gap: 4px; font-size: 11px; }
+    .phone-screen { flex: 1; display: flex; flex-direction: column; min-height: 0; }
+
+    /* Desktop frame */
+    .desktop-frame {
+      width: 100%;
+      max-width: 1440px;
+      border: 1px solid var(--border);
+      border-radius: var(--r-2xl);
+      overflow: hidden;
+      background: var(--bg);
+      box-shadow: var(--shadow-md);
+    }
+    .desktop-chrome {
+      height: 36px; display: flex; align-items: center; gap: 6px;
+      padding: 0 14px;
+      background: var(--bg-muted);
+      border-bottom: 1px solid var(--border);
+    }
+    .desktop-chrome .dot {
+      width: 12px; height: 12px; border-radius: 50%;
+      background: var(--border-strong);
+    }
+    .desktop-chrome .url {
+      flex: 1; margin-left: 14px;
+      font-family: var(--f-mono); font-size: 11px;
+      color: var(--text-muted);
+      letter-spacing: 0.04em;
+    }
+
+    /* Theme bar (light/dark/sepia) */
+    .theme-bar {
+      position: fixed; top: 14px; right: 14px; z-index: 1000;
+      display: flex; gap: 6px;
+    }
+    .theme-bar button {
+      padding: 8px 14px; border-radius: var(--r-pill);
+      background: var(--glass-bg); backdrop-filter: blur(12px);
+      border: 1px solid var(--border); color: var(--text);
+      font-family: var(--f-display); font-size: var(--fs-sm); font-weight: 700;
+      box-shadow: var(--shadow-sm); cursor: pointer;
+    }
+    .theme-bar button.active {
+      background: hsl(var(--c-game) / 0.14);
+      color: hsl(var(--c-game));
+      border-color: hsl(var(--c-game) / 0.3);
+    }
+
+    /* Local theme scope override */
+    [data-theme="dark"] {
+      --bg:        #14100a;
+      --bg-card:   #1e1710;
+      --bg-muted:  #241c13;
+      --bg-sunken: #0f0c08;
+      --bg-hover:  rgba(255, 200, 130, 0.05);
+      --text:       #f0e4d2;
+      --text-sec:   #c8b896;
+      --text-muted: #8a7860;
+      --border:       rgba(224, 180, 110, 0.14);
+      --border-light: rgba(224, 180, 110, 0.08);
+      --border-strong: rgba(224, 180, 110, 0.28);
+      --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.3);
+      --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.4);
+      --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.5);
+      --shadow-lg: 0 12px 36px rgba(0, 0, 0, 0.6);
+      --glass-bg: rgba(30, 22, 14, 0.85);
+      --glass-border: rgba(224, 180, 110, 0.14);
+      --c-game:    28 95% 58%;
+      --c-player:  262 75% 70%;
+      --c-session: 235 70% 70%;
+      --c-agent:   38 92% 62%;
+      --c-kb:      174 60% 55%;
+      --c-chat:    218 80% 68%;
+      --c-event:   350 85% 70%;
+      --c-toolkit: 142 60% 58%;
+      --c-tool:    195 75% 62%;
+      color-scheme: dark;
+      background: var(--bg);
+      color: var(--text);
+    }
+
+    /* prefers-reduced-motion guard (1:1 con C) */
+    @keyframes mai-shimmer-sweep {
+      0% { background-position: -200% 0; }
+      100% { background-position: 200% 0; }
+    }
+    @keyframes mai-spin { to { transform: rotate(360deg); } }
+    @keyframes mai-pulse-soft {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.55; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .mai-shimmer { animation: none !important; background: var(--bg-muted) !important; }
+      .mai-spinner { animation: none !important; }
+      .mai-pulse   { animation: none !important; }
+    }
+    .mai-shimmer {
+      background: linear-gradient(90deg, var(--bg-muted) 0%, var(--bg-sunken) 50%, var(--bg-muted) 100%);
+      background-size: 200% 100%;
+      animation: mai-shimmer-sweep 1.6s ease-in-out infinite;
+    }
+    .mai-spinner { animation: mai-spin 0.9s linear infinite; }
+    .mai-pulse   { animation: mai-pulse-soft 1.6s ease-in-out infinite; }
+
+    /* Hide scrollbars in fullscreen reader */
+    .mai-noscroll::-webkit-scrollbar { display: none; }
+    .mai-noscroll { scrollbar-width: none; }
+
+    /* ───────────────────────────────────────────────────────
+       READING-BODY — DEVIAZIONE ESPLICITA brief riga 519
+       Nunito 26px (=20pt) ASSOLUTO, NON --fs-xl (20px≈15pt).
+       line-height 1.6 esplicito. max-width 60ch.
+       Necessario per lettura distante 1.5m (vision §4.2).
+       ─────────────────────────────────────────────────────── */
+    .reading-body {
+      font-family: var(--f-body);
+      font-size: 26px;       /* DEVIAZIONE token, brief L519 — NON usare --fs-xl */
+      line-height: 1.6;      /* esplicito, NON --lh-body */
+      max-width: 60ch;
+      color: var(--text);
+      margin: 0 auto;
+    }
+    .reading-body[data-fs="sm"] { font-size: 24px; }   /* A− 24px / 18pt */
+    .reading-body[data-fs="md"] { font-size: 26px; }   /* A  26px / 20pt default */
+    .reading-body[data-fs="lg"] { font-size: 32px; }   /* A+ 32px / 24pt lettura distante */
+    .reading-body[data-lh="tight"]   { line-height: 1.4; }
+    .reading-body[data-lh="default"] { line-height: 1.6; }
+    .reading-body[data-lh="loose"]   { line-height: 1.8; }
+
+    .reading-body p { margin: 0 0 var(--s-5); }
+    .reading-body p:last-child { margin-bottom: 0; }
+    .reading-body .dialogue {
+      font-style: italic;
+      color: hsl(var(--c-kb) / 0.95);
+    }
+    .reading-body .glossary-term {
+      border-bottom: 1px dotted hsl(var(--c-kb) / 0.55);
+      cursor: help;
+      color: hsl(var(--c-kb));
+      font-weight: 600;
+    }
+    .reading-body .kicker {
+      font-family: var(--f-mono);
+      font-size: 12px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+      margin-bottom: var(--s-3);
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: var(--r-xs);
+      background: var(--bg-muted);
+    }
+
+    /* Reading-aids: input controls aspect */
+    .seg {
+      display: inline-flex;
+      background: var(--bg-muted);
+      border: 1px solid var(--border);
+      border-radius: var(--r-pill);
+      padding: 3px;
+      gap: 2px;
+    }
+    .seg button {
+      border: 0; background: transparent; color: var(--text-sec);
+      font-family: var(--f-body); font-weight: 700;
+      font-size: 13px;
+      padding: 6px 12px; border-radius: var(--r-pill);
+      cursor: pointer; transition: all var(--dur-sm) var(--ease-out);
+      min-width: 38px;
+    }
+    .seg button.active {
+      background: var(--bg-card);
+      color: var(--text);
+      box-shadow: var(--shadow-xs);
+    }
+
+    /* TopBar minimal sticky */
+    .tv-topbar {
+      flex-shrink: 0;
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 10px 14px;
+      background: var(--glass-bg);
+      backdrop-filter: blur(12px);
+      border-bottom: 1px solid var(--border);
+      position: relative;
+      z-index: 5;
+    }
+    .tv-topbar .icon-btn {
+      width: 36px; height: 36px;
+      display: inline-flex; align-items: center; justify-content: center;
+      background: transparent; border: 1px solid var(--border);
+      border-radius: var(--r-md); color: var(--text-sec);
+      font-size: 16px; cursor: pointer;
+    }
+    .tv-topbar .icon-btn:hover { background: var(--bg-hover); color: var(--text); }
+    .tv-topbar .center {
+      font-family: var(--f-mono);
+      font-size: var(--fs-xl);
+      color: hsl(var(--c-kb));
+      font-weight: 600;
+      letter-spacing: 0.02em;
+    }
+
+    /* Bottom controls sticky */
+    .tv-bottom {
+      flex-shrink: 0;
+      background: var(--glass-bg);
+      backdrop-filter: blur(12px);
+      border-top: 1px solid var(--border);
+      padding: 10px 14px 12px;
+      display: flex; flex-direction: column; gap: 8px;
+    }
+    .tv-bottom .row {
+      display: flex; align-items: center; justify-content: space-between;
+      gap: 8px;
+    }
+    .tv-bottom .row.center { justify-content: center; }
+    .tv-bottom .row.aids { justify-content: space-between; }
+
+    .nav-btn {
+      flex: 1;
+      padding: 10px 12px;
+      border-radius: var(--r-md);
+      border: 1px solid var(--border);
+      background: var(--bg-card);
+      color: var(--text);
+      font-family: var(--f-display);
+      font-weight: 700;
+      font-size: 13px;
+      cursor: pointer;
+      display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+    }
+    .nav-btn.primary {
+      background: hsl(var(--c-kb));
+      color: #fff;
+      border-color: hsl(var(--c-kb));
+    }
+    .nav-btn.ghost { background: transparent; }
+
+    .tts-disabled {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 6px 12px;
+      border: 1px dashed var(--border-strong);
+      border-radius: var(--r-pill);
+      color: var(--text-muted);
+      opacity: 0.55;
+      font-size: 12px;
+      cursor: not-allowed;
+      font-family: var(--f-body);
+      font-weight: 600;
+    }
+    .tts-disabled .v2 {
+      background: hsl(var(--c-agent) / 0.18);
+      color: hsl(var(--c-agent));
+      font-family: var(--f-mono);
+      font-size: 10px;
+      padding: 1px 5px;
+      border-radius: var(--r-xs);
+      font-weight: 700;
+    }
+
+    /* Top banner offline / retry */
+    .tv-banner {
+      display: flex; align-items: center; gap: 8px;
+      padding: 8px 14px;
+      font-size: 12px;
+      font-weight: 600;
+      font-family: var(--f-body);
+      border-bottom: 1px solid var(--border-light);
+    }
+    .tv-banner.warn {
+      background: hsl(var(--c-warning) / 0.14);
+      color: hsl(38 60% 28%);
+    }
+    [data-theme="dark"] .tv-banner.warn { color: hsl(var(--c-warning)); }
+    .tv-banner.danger {
+      background: hsl(var(--c-event) / 0.14);
+      color: hsl(var(--c-event));
+    }
+    .tv-banner .retry-dot {
+      width: 8px; height: 8px; border-radius: 50%;
+      background: currentColor;
+    }
+
+    /* 3-dots drawer */
+    .tv-menu {
+      position: absolute;
+      top: 56px; right: 10px;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--r-lg);
+      box-shadow: var(--shadow-lg);
+      padding: 6px;
+      z-index: 10;
+      width: 230px;
+      display: flex; flex-direction: column; gap: 2px;
+    }
+    .tv-menu button {
+      display: flex; align-items: center; gap: 10px;
+      padding: 10px 10px;
+      background: transparent;
+      border: 0;
+      border-radius: var(--r-sm);
+      color: var(--text);
+      font-family: var(--f-body);
+      font-weight: 600;
+      font-size: 13px;
+      cursor: pointer;
+      text-align: left;
+    }
+    .tv-menu button:hover { background: var(--bg-hover); }
+    .tv-menu button.disabled {
+      color: var(--text-muted); cursor: not-allowed; opacity: 0.7;
+    }
+    .tv-menu button.disabled:hover { background: transparent; }
+    .tv-menu .v2 {
+      margin-left: auto;
+      background: hsl(var(--c-agent) / 0.18);
+      color: hsl(var(--c-agent));
+      font-family: var(--f-mono);
+      font-size: 10px;
+      padding: 1px 5px;
+      border-radius: var(--r-xs);
+      font-weight: 700;
+    }
+
+    /* Side-by-side desktop */
+    .sbs-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: var(--s-7);
+    }
+    .sbs-col .col-label {
+      font-family: var(--f-mono);
+      font-size: 11px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+      margin-bottom: var(--s-3);
+      padding-bottom: var(--s-2);
+      border-bottom: 1px solid var(--border-light);
+    }
+    .sbs-col .col-label.it { color: hsl(var(--c-kb)); }
+    .sbs-col .col-label.en { color: var(--text-sec); }
+
+    /* Body container fullscreen reader */
+    .tv-body {
+      flex: 1;
+      overflow-y: auto;
+      padding: var(--s-7) var(--s-6) var(--s-7);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .tv-body .head {
+      width: 100%;
+      max-width: 60ch;
+      margin: 0 auto var(--s-6);
+      text-align: left;
+    }
+    .tv-body .head .chapter {
+      font-family: var(--f-display);
+      font-size: var(--fs-lg);
+      font-weight: 600;
+      color: var(--text-muted);
+      margin-bottom: 2px;
+    }
+    .tv-body .head .pnum {
+      font-family: var(--f-mono);
+      font-size: var(--fs-3xl);
+      color: hsl(var(--c-kb));
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+
+    /* Skeleton lines */
+    .sk-line {
+      height: 22px;
+      border-radius: var(--r-xs);
+      margin-bottom: 14px;
+    }
+    .sk-line.last { width: 60%; }
+
+    /* Empty / Not-found */
+    .empty {
+      width: 100%; height: 100%;
+      flex: 1;
+      display: flex; flex-direction: column; align-items: center; justify-content: center;
+      text-align: center;
+      padding: var(--s-7);
+      gap: var(--s-3);
+    }
+    .empty .glyph {
+      font-size: 56px;
+      filter: grayscale(0.4);
+      opacity: 0.7;
+    }
+    .empty h2 {
+      font-family: var(--f-display);
+      font-size: var(--fs-xl);
+      font-weight: 700;
+      color: var(--text);
+      margin: 0;
+    }
+    .empty p {
+      color: var(--text-muted);
+      max-width: 32ch;
+      font-size: var(--fs-md);
+      line-height: 1.5;
+      margin: 0;
+    }
+    .empty .actions {
+      display: flex; flex-direction: column; gap: 8px;
+      margin-top: var(--s-4);
+      width: 100%;
+      max-width: 260px;
+    }
+
+    /* Anti-zoom on phone container */
+    .phone-screen, .phone-screen * { -webkit-text-size-adjust: 100%; }
+
+    /* Each screen wrapper id'd for anchor */
+    [id^="state-"] { scroll-margin-top: var(--s-7); }
+  </style>
+</head>
+<body>
+  <div class="theme-bar" role="toolbar" aria-label="Tema">
+    <button type="button" data-set-theme="light" class="active">☀ Light</button>
+    <button type="button" data-set-theme="dark">🌙 Dark</button>
+    <button type="button" data-set-theme="sepia">📜 Sepia</button>
+  </div>
+
+  <div class="stage">
+    <div class="stage-wrap">
+      <h1>SP6 · Libro Game — Translation Viewer Fullscreen</h1>
+      <p class="lead">
+        Route <code>/gamebook/[gameId]/play/paragraph/[num]</code>, fullscreen modal <strong>senza shell</strong>
+        (no MobileBottomBar, no top nav app, no HybridSidebar, no ConnectionPip).
+        Layout: <strong>top bar minimal sticky</strong> (← back · §num mono · 3-dots drawer 4 azioni)
+        + <strong>body reading-mode</strong> (Nunito <strong>26px = 20pt assoluto</strong>, line-height 1.6,
+        max-width 60ch — <em>deviazione esplicita</em> da <code>--fs-xl</code>, brief riga 519,
+        vincolo lettura distante 1.5m vision §4.2)
+        + <strong>bottom controls sticky</strong> (3 row: navigazione paragrafi · reading aids ·
+        TTS placeholder disabled v2). Toggle modes: <strong>IT</strong> (default) /
+        <strong>EN</strong> (kicker "Originale") / <strong>IT + EN side-by-side</strong>
+        (desktop only — su mobile fa stack verticale). Glossary applicato a tre termini
+        (Niamh, Spada di Avalon, Pietra Spettrale, entity=kb).
+        Sepia = light theme as-is, NO nuova palette.
+      </p>
+
+      <div class="section-label">Mobile · 380 × 780 — 7 stati richiesti (anchor <code>state-NN-…</code>)</div>
+      <div id="mount-mobile" class="frames-row"></div>
+
+      <div class="section-label">Desktop · 1440 — Side-by-side IT|EN + Default + Not found</div>
+      <div id="mount-desktop" class="desktop-row"></div>
+
+      <div class="section-label">Mobile · 380 × 780 — Theme proofs (dark + sepia, default IT)</div>
+      <div id="mount-themes" class="frames-row"></div>
+
+      <div class="section-label">Mobile · 380 × 780 — Reading aids variants (font A− / A / A+ · line 1.4 / 1.6 / 1.8)</div>
+      <div id="mount-aids" class="frames-row"></div>
+    </div>
+  </div>
+
+  <!-- React + Babel pinned -->
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+  <!-- Theme toggle (light/dark/sepia — sepia mappa a light per token) -->
+  <script>
+    document.querySelectorAll('[data-set-theme]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const t = btn.dataset.setTheme;
+        // sepia = light per i token (NO nuova palette), brief deviation
+        const themeAttr = (t === 'sepia') ? 'light' : t;
+        document.documentElement.setAttribute('data-theme', themeAttr);
+        document.querySelectorAll('.theme-bar button').forEach(b => b.classList.toggle('active', b === btn));
+      });
+    });
+  </script>
+
+  <script type="text/babel" src="sp6-libro-game-translation-viewer.jsx" data-presets="env,react"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp6-libro-game-translation-viewer.jsx
+++ b/admin-mockups/design_files/sp6-libro-game-translation-viewer.jsx
@@ -1,0 +1,580 @@
+/* SP6 D — Translation Viewer Fullscreen
+   Brief SP6 §D (lines 492-566). 7 stati + theme/device variants.
+
+   Anchor id su ogni screen wrapper (state-NN-…) + Gherkin tag (G4.4 / G4.7).
+   Reading-body: 26px Nunito assoluto, line-height 1.6, max-width 60ch — DEVIAZIONE brief L519.
+   prefers-reduced-motion guard ereditato (mai-shimmer / mai-spinner / mai-pulse).
+*/
+
+const { useState } = React;
+
+/* ────────────────────────── DATA ────────────────────────── */
+
+// Tainted Grail §147 — italian narrative w/ glossary terms (Niamh, Spada di Avalon, Pietra Spettrale)
+const PARAGRAPH_IT = [
+  { type: 'p', frags: [
+    { t: 'La nebbia si solleva lentamente sulle paludi di Cuanacht. ' },
+    { t: 'Niamh', glossary: 'Niamh' },
+    { t: ' ti aspetta sulla riva, le mani strette attorno all’elsa della ' },
+    { t: 'Spada di Avalon', glossary: 'Spada di Avalon' },
+    { t: ', il fiato visibile nell’aria gelida.' },
+  ]},
+  { type: 'd', text: '« Hai trovato la Pietra? » chiede, senza voltarsi.' },
+  { type: 'p', frags: [
+    { t: 'Esiti. La ' },
+    { t: 'Pietra Spettrale', glossary: 'Pietra Spettrale' },
+    { t: ' pulsa appena dentro la tua sacca, fredda come acqua di sorgente. Annuisci, anche se lei non può vederti.' },
+  ]},
+  { type: 'd', text: '« Bene. Allora è il momento di salire al Tor. »' },
+  { type: 'p', frags: [
+    { t: 'Se decidi di seguire Niamh verso il Tor, vai al §148. Se preferisci tornare al villaggio prima del tramonto, vai al §156.' },
+  ]},
+];
+
+// English original (no glossary, no italic dialogues necessary — kept sober)
+const PARAGRAPH_EN = [
+  { type: 'p', text: 'The mist lifts slowly over the marshes of Cuanacht. Niamh waits for you on the shore, hands clenched around the hilt of the Sword of Avalon, her breath visible in the freezing air.' },
+  { type: 'd', text: '“Have you found the Stone?” she asks, without turning.' },
+  { type: 'p', text: 'You hesitate. The Wraith Stone pulses faintly inside your satchel, cold as spring water. You nod, even though she cannot see you.' },
+  { type: 'd', text: '“Good. Then it is time to climb to the Tor.”' },
+  { type: 'p', text: 'If you decide to follow Niamh up to the Tor, go to §148. If you prefer to return to the village before sunset, go to §156.' },
+];
+
+const GLOSSARY = {
+  'Niamh': 'NPC ricorrente · alleata di Avalon. Glossary entry §G-12.',
+  'Spada di Avalon': 'Artefatto leggendario. Glossary entry §G-04.',
+  'Pietra Spettrale': 'Wraith Stone — artefatto chiave atto II. Glossary entry §G-19.',
+};
+
+/* ────────────────────────── PRIMITIVES ────────────────────────── */
+
+function StatusBar() {
+  return (
+    <div className="phone-sbar-sp6">
+      <span>21:47</span>
+      <span className="ind"><span>●●●●</span><span>5G</span><span>87%</span></span>
+    </div>
+  );
+}
+
+function DesktopChrome({ url }) {
+  return (
+    <div className="desktop-chrome">
+      <span className="dot" /><span className="dot" /><span className="dot" />
+      <span className="url">{url}</span>
+    </div>
+  );
+}
+
+function FrameMeta({ anchor, gherkin, label, sub }) {
+  return (
+    <div className="frame-meta">
+      <strong>{label}</strong>
+      {anchor && <span className="anchor">#{anchor}</span>}
+      {gherkin && <span className="gherkin">{gherkin}</span>}
+      {sub && <span>{sub}</span>}
+    </div>
+  );
+}
+
+/* ────────────────────────── TOPBAR ────────────────────────── */
+
+function TopBar({ pnum = '§147', menuOpen, onToggleMenu }) {
+  return (
+    <div className="tv-topbar">
+      <button className="icon-btn" aria-label="Indietro">←</button>
+      <div className="center">{pnum}</div>
+      <button className="icon-btn" aria-label="Altre azioni" onClick={onToggleMenu}>⋯</button>
+      {menuOpen && <ThreeDotsDrawer />}
+    </div>
+  );
+}
+
+function ThreeDotsDrawer() {
+  return (
+    <div className="tv-menu" role="menu">
+      <button role="menuitem"><span>🌐</span><span>Mostra originale (EN)</span></button>
+      <button role="menuitem"><span>📋</span><span>Copia traduzione</span></button>
+      <button role="menuitem" className="disabled" aria-disabled="true">
+        <span>🎙️</span><span>Leggi tu (TTS)</span><span className="v2">v2</span>
+      </button>
+      <button role="menuitem"><span>🐛</span><span>Segnala traduzione errata</span></button>
+    </div>
+  );
+}
+
+/* ────────────────────────── BODY VARIANTS ────────────────────────── */
+
+function ReadingBodyIT({ fs = 'md', lh = 'default', kicker = null, children }) {
+  return (
+    <div className="reading-body" data-fs={fs} data-lh={lh}>
+      {kicker && <div className="kicker">{kicker}</div>}
+      {(children !== undefined) ? children : (
+        PARAGRAPH_IT.map((blk, i) => {
+          if (blk.type === 'd') return <p key={i} className="dialogue">{blk.text}</p>;
+          return (
+            <p key={i}>
+              {blk.frags.map((f, j) =>
+                f.glossary
+                  ? <span key={j} className="glossary-term" title={GLOSSARY[f.glossary]}>{f.t}</span>
+                  : <React.Fragment key={j}>{f.t}</React.Fragment>
+              )}
+            </p>
+          );
+        })
+      )}
+    </div>
+  );
+}
+
+function ReadingBodyEN({ fs = 'md', lh = 'default', kicker = 'Originale', children }) {
+  return (
+    <div className="reading-body" data-fs={fs} data-lh={lh}>
+      {kicker && <div className="kicker">{kicker}</div>}
+      {(children !== undefined) ? children : (
+        PARAGRAPH_EN.map((blk, i) => (
+          blk.type === 'd'
+            ? <p key={i} className="dialogue">{blk.text}</p>
+            : <p key={i}>{blk.text}</p>
+        ))
+      )}
+    </div>
+  );
+}
+
+function BodyHead({ chapter = 'Capitolo 4 — Le Paludi di Cuanacht', pnum = '§147' }) {
+  return (
+    <div className="head">
+      <div className="chapter">{chapter}</div>
+      <div className="pnum">{pnum}</div>
+    </div>
+  );
+}
+
+function SkeletonBody() {
+  // 5 righe shimmer (brief)
+  return (
+    <div className="reading-body" aria-busy="true" aria-live="polite" style={{ width: '100%' }}>
+      <div className="kicker mai-pulse">Sto traducendo…</div>
+      <div className="sk-line mai-shimmer" />
+      <div className="sk-line mai-shimmer" />
+      <div className="sk-line mai-shimmer" />
+      <div className="sk-line mai-shimmer" />
+      <div className="sk-line mai-shimmer last" />
+    </div>
+  );
+}
+
+function PartialBody() {
+  // mid-translation lost (G4.7): solo prime frasi, poi inline retry + CTA EN
+  return (
+    <div className="reading-body" data-fs="md" data-lh="default">
+      <p>
+        La nebbia si solleva lentamente sulle paludi di Cuanacht.{' '}
+        <span className="glossary-term" title={GLOSSARY['Niamh']}>Niamh</span>{' '}
+        ti aspetta sulla riva, le mani strette attorno all’elsa della{' '}
+        <span className="glossary-term" title={GLOSSARY['Spada di Avalon']}>Spada di Avalon</span>…
+      </p>
+      <p style={{
+        display: 'flex', alignItems: 'center', gap: '10px',
+        fontSize: '15px', fontFamily: 'var(--f-body)',
+        color: 'var(--text-muted)', fontStyle: 'italic',
+        padding: '12px 14px',
+        background: 'hsl(var(--c-warning) / 0.10)',
+        borderLeft: '3px solid hsl(var(--c-warning))',
+        borderRadius: 'var(--r-sm)',
+      }}>
+        <span className="mai-spinner" style={{
+          width: 14, height: 14, border: '2px solid currentColor',
+          borderRightColor: 'transparent', borderRadius: '50%', display: 'inline-block',
+        }}/>
+        <span>Sto riprovando… connessione instabile</span>
+      </p>
+      <button style={{
+        marginTop: 0,
+        background: 'transparent',
+        border: '1px solid hsl(var(--c-kb) / 0.5)',
+        color: 'hsl(var(--c-kb))',
+        padding: '10px 14px',
+        borderRadius: 'var(--r-md)',
+        fontFamily: 'var(--f-display)',
+        fontWeight: 700,
+        fontSize: 13,
+        cursor: 'pointer',
+      }}>
+        Mostra EN intanto →
+      </button>
+    </div>
+  );
+}
+
+function NotFoundBody({ pnum = '§299' }) {
+  return (
+    <div className="empty" id={undefined}>
+      <div className="glyph">📕</div>
+      <h2>{pnum} non trovato</h2>
+      <p>Questo paragrafo non esiste in <em>Tainted Grail</em>. Probabilmente è un riferimento errato o un typo.</p>
+      <div className="actions">
+        <button className="nav-btn primary">← Torna al play</button>
+        <button className="nav-btn">📷 Scansiona il libro</button>
+        <button className="nav-btn ghost">🐛 Segnala link errato</button>
+      </div>
+    </div>
+  );
+}
+
+/* ────────────────────────── BOTTOM CONTROLS ────────────────────────── */
+
+function BottomControls({
+  mode = 'IT', onMode = () => {},
+  fs = 'md', onFs = () => {},
+  lh = 'default', onLh = () => {},
+  theme = 'light', onTheme = () => {},
+  navPrev = '§146', navNext = '§148',
+}) {
+  return (
+    <div className="tv-bottom">
+      {/* Row 1 — navigazione paragrafi */}
+      <div className="row">
+        <button className="nav-btn ghost">← {navPrev}</button>
+        <button className="nav-btn primary">Letto, vai a {navNext} →</button>
+      </div>
+
+      {/* Toggle modes IT / EN / IT+EN */}
+      <div className="row center">
+        <div className="seg" role="tablist" aria-label="Modalità lingua">
+          <button className={mode==='IT'?'active':''} onClick={() => onMode('IT')}>IT</button>
+          <button className={mode==='EN'?'active':''} onClick={() => onMode('EN')}>EN</button>
+          <button className={mode==='SBS'?'active':''} onClick={() => onMode('SBS')}>IT + EN</button>
+        </div>
+      </div>
+
+      {/* Row 2 — reading aids: font · line · theme */}
+      <div className="row aids">
+        <div className="seg" aria-label="Dimensione testo">
+          <button className={fs==='sm'?'active':''} onClick={()=>onFs('sm')} title="A− 24px / 18pt">A−</button>
+          <button className={fs==='md'?'active':''} onClick={()=>onFs('md')} title="A 26px / 20pt default">A</button>
+          <button className={fs==='lg'?'active':''} onClick={()=>onFs('lg')} title="A+ 32px / 24pt lettura distante">A+</button>
+        </div>
+        <div className="seg" aria-label="Interlinea">
+          <button className={lh==='tight'?'active':''} onClick={()=>onLh('tight')} title="1.4">≡<sub style={{fontSize:9}}>1.4</sub></button>
+          <button className={lh==='default'?'active':''} onClick={()=>onLh('default')} title="1.6">≡<sub style={{fontSize:9}}>1.6</sub></button>
+          <button className={lh==='loose'?'active':''} onClick={()=>onLh('loose')} title="1.8">≡<sub style={{fontSize:9}}>1.8</sub></button>
+        </div>
+        <div className="seg" aria-label="Tema">
+          <button className={theme==='light'?'active':''} onClick={()=>onTheme('light')} title="Light">☀</button>
+          <button className={theme==='dark'?'active':''} onClick={()=>onTheme('dark')} title="Dark">🌙</button>
+          <button className={theme==='sepia'?'active':''} onClick={()=>onTheme('sepia')} title="Sepia (= light)">📜</button>
+        </div>
+      </div>
+
+      {/* Row 3 — TTS placeholder disabled */}
+      <div className="row center">
+        <span className="tts-disabled" aria-disabled="true" title="Disponibile in v2">
+          🎙️ Leggi tu <span className="v2">v2</span>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/* ────────────────────────── BANNERS ────────────────────────── */
+
+function OfflineBanner() {
+  return (
+    <div className="tv-banner warn" role="status" aria-live="polite">
+      <span>🟡</span>
+      <span>Connessione persa — testo cached</span>
+      <span style={{ flex: 1 }} />
+      <span className="retry-dot mai-pulse" aria-hidden="true" />
+      <span style={{ fontFamily: 'var(--f-mono)', fontSize: 11 }}>auto-retry</span>
+    </div>
+  );
+}
+
+/* ────────────────────────── MOBILE SCREEN ────────────────────────── */
+
+function MobileScreen({
+  state,                           // 'default-it' | 'side-by-side' | 'en-replace' | 'loading' | 'offline-cached' | 'mid-lost' | 'not-found'
+  fs = 'md', lh = 'default',
+  mode = 'IT',                     // for default mostly
+  themeOverride = null,            // 'dark' | 'sepia' (light) — for theme proofs
+  pnum = '§147',
+  showMenu = false,
+}) {
+  const dataTheme = themeOverride === 'dark' ? 'dark' : 'light';
+  const phoneClass = 'phone-sp6' + (themeOverride === 'dark' ? ' t-dark' : '');
+
+  let body = null;
+  let banner = null;
+  let bottomMode = mode;
+
+  if (state === 'default-it') {
+    body = (
+      <div className="tv-body mai-noscroll">
+        <BodyHead pnum={pnum} />
+        <ReadingBodyIT fs={fs} lh={lh} />
+      </div>
+    );
+  } else if (state === 'en-replace') {
+    body = (
+      <div className="tv-body mai-noscroll">
+        <BodyHead pnum={pnum} />
+        <ReadingBodyEN fs={fs} lh={lh} kicker="Originale · EN" />
+      </div>
+    );
+    bottomMode = 'EN';
+  } else if (state === 'side-by-side') {
+    // Su mobile fa stack verticale (brief)
+    body = (
+      <div className="tv-body mai-noscroll">
+        <BodyHead pnum={pnum} />
+        <ReadingBodyIT fs="sm" lh={lh} kicker="Italiano" />
+        <div style={{ height: 1, background: 'var(--border)', width: '60ch', maxWidth: '100%', margin: '20px 0' }} />
+        <ReadingBodyEN fs="sm" lh={lh} kicker="Originale · EN" />
+      </div>
+    );
+    bottomMode = 'SBS';
+  } else if (state === 'loading') {
+    body = (
+      <div className="tv-body mai-noscroll">
+        <BodyHead pnum={pnum} />
+        <SkeletonBody />
+      </div>
+    );
+  } else if (state === 'offline-cached') {
+    banner = <OfflineBanner />;
+    body = (
+      <div className="tv-body mai-noscroll">
+        <BodyHead pnum={pnum} />
+        <ReadingBodyIT fs={fs} lh={lh} kicker="📦 Cached · 2 min fa" />
+      </div>
+    );
+  } else if (state === 'mid-lost') {
+    banner = <OfflineBanner />;
+    body = (
+      <div className="tv-body mai-noscroll">
+        <BodyHead pnum={pnum} />
+        <PartialBody />
+      </div>
+    );
+  } else if (state === 'not-found') {
+    body = <NotFoundBody pnum="§299" />;
+    bottomMode = 'IT';
+  }
+
+  return (
+    <div className={phoneClass} data-theme={dataTheme}>
+      <StatusBar />
+      <div className="phone-screen" style={{ background: 'var(--bg)' }}>
+        <TopBar pnum={state === 'not-found' ? '§299' : pnum} menuOpen={showMenu} onToggleMenu={() => {}} />
+        {banner}
+        {body}
+        {state !== 'not-found' && (
+          <BottomControls
+            mode={bottomMode}
+            fs={fs}
+            lh={lh}
+            theme={themeOverride === 'dark' ? 'dark' : (themeOverride === 'sepia' ? 'sepia' : 'light')}
+            onMode={() => {}}
+            onFs={() => {}}
+            onLh={() => {}}
+            onTheme={() => {}}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ────────────────────────── DESKTOP SCREEN ────────────────────────── */
+
+function DesktopScreen({ variant = 'sbs', themeOverride = null }) {
+  const dataTheme = themeOverride === 'dark' ? 'dark' : 'light';
+
+  let body = null;
+  let bottomMode = 'IT';
+  if (variant === 'sbs') {
+    bottomMode = 'SBS';
+    body = (
+      <div className="tv-body mai-noscroll" style={{ alignItems: 'stretch' }}>
+        <div style={{ width: '100%', maxWidth: 1200, margin: '0 auto' }}>
+          <BodyHead pnum="§147" />
+          <div className="sbs-grid">
+            <div className="sbs-col">
+              <div className="col-label it">Italiano · IT</div>
+              <ReadingBodyIT fs="md" lh="default" />
+            </div>
+            <div className="sbs-col">
+              <div className="col-label en">Originale · EN</div>
+              <ReadingBodyEN fs="md" lh="default" kicker={null} />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  } else if (variant === 'default-it') {
+    body = (
+      <div className="tv-body mai-noscroll">
+        <BodyHead pnum="§147" />
+        <ReadingBodyIT fs="md" lh="default" />
+      </div>
+    );
+  } else if (variant === 'not-found') {
+    body = <NotFoundBody pnum="§299" />;
+  }
+
+  return (
+    <div className="desktop-frame" data-theme={dataTheme}>
+      <DesktopChrome url="meepleai.app/gamebook/tainted-grail/play/paragraph/147" />
+      <div style={{
+        height: 720,
+        display: 'flex', flexDirection: 'column',
+        background: 'var(--bg)',
+        color: 'var(--text)',
+      }}>
+        <TopBar pnum={variant === 'not-found' ? '§299' : '§147'} menuOpen={false} onToggleMenu={() => {}} />
+        {body}
+        {variant !== 'not-found' && (
+          <BottomControls
+            mode={bottomMode}
+            fs="md" lh="default"
+            theme={themeOverride === 'dark' ? 'dark' : 'light'}
+            onMode={()=>{}} onFs={()=>{}} onLh={()=>{}} onTheme={()=>{}}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ────────────────────────── MOUNTS ────────────────────────── */
+
+function MobileSection() {
+  // 7 stati richiesti, ognuno con anchor id state-NN-…
+  const items = [
+    { id: 'state-01-default-it',     label: '01 · Default IT',
+      sub: 'Tainted Grail §147 · glossary: Niamh, Spada di Avalon, Pietra Spettrale',
+      gherkin: '@G4 default',
+      screen: <MobileScreen state="default-it" /> },
+    { id: 'state-02-side-by-side',   label: '02 · Side-by-side IT+EN (mobile = stack)',
+      sub: 'Mobile fa stack verticale · brief riga 525',
+      gherkin: '@G4 sbs',
+      screen: <MobileScreen state="side-by-side" /> },
+    { id: 'state-03-en-replace',     label: '03 · EN replace',
+      sub: 'Kicker top "Originale · EN" · toggle bottom = EN',
+      gherkin: '@G4 en',
+      screen: <MobileScreen state="en-replace" /> },
+    { id: 'state-04-loading',        label: '04 · Loading skeleton',
+      sub: '5 righe shimmer · no full-screen blocking spinner',
+      gherkin: '@G4 loading',
+      screen: <MobileScreen state="loading" /> },
+    { id: 'state-05-offline-cached', label: '05 · Offline cached',
+      sub: 'Banner top + auto-retry discreto · cached 2 min fa',
+      gherkin: '@G4.7 cached',
+      screen: <MobileScreen state="offline-cached" /> },
+    { id: 'state-06-mid-translation-lost', label: '06 · Mid-translation lost',
+      sub: 'Partial: ultime righe + "Sto riprovando…" inline + CTA "Mostra EN"',
+      gherkin: '@G4.7 partial',
+      screen: <MobileScreen state="mid-lost" /> },
+    { id: 'state-07-not-found',      label: '07 · Not found §299',
+      sub: 'Full-screen empty + 3 azioni (Torna play · Scansiona · Segnala)',
+      gherkin: '@G4.4 not-found',
+      screen: <MobileScreen state="not-found" /> },
+  ];
+  return (
+    <>
+      {items.map(it => (
+        <div className="frame-cell" id={it.id} key={it.id}>
+          <FrameMeta anchor={it.id} gherkin={it.gherkin} label={it.label} sub={it.sub} />
+          {it.screen}
+        </div>
+      ))}
+    </>
+  );
+}
+
+function DesktopSection() {
+  const items = [
+    { id: 'state-02-side-by-side-desktop', label: '02d · Side-by-side IT|EN (desktop 2 col 50/50)',
+      gherkin: '@G4 sbs-desktop', sub: 'Glossary applicato a IT (3 termini)', variant: 'sbs' },
+    { id: 'state-01-default-it-desktop', label: '01d · Default IT (desktop)',
+      gherkin: '@G4 default-desktop', sub: 'Reading column 60ch · centered', variant: 'default-it' },
+    { id: 'state-07-not-found-desktop', label: '07d · Not found §299 (desktop)',
+      gherkin: '@G4.4 not-found-desktop', sub: '3 azioni stack centered', variant: 'not-found' },
+  ];
+  return (
+    <>
+      {items.map(it => (
+        <div id={it.id} key={it.id} style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <FrameMeta anchor={it.id} gherkin={it.gherkin} label={it.label} sub={it.sub} />
+          <DesktopScreen variant={it.variant} />
+        </div>
+      ))}
+    </>
+  );
+}
+
+function ThemesSection() {
+  return (
+    <>
+      <div className="frame-cell" id="state-01-default-it-dark">
+        <FrameMeta anchor="state-01-default-it-dark" gherkin="@G4 dark"
+                   label="01·dark — Default IT, dark theme"
+                   sub="Token dark · glossary kb hue shifted lighter" />
+        <MobileScreen state="default-it" themeOverride="dark" />
+      </div>
+      <div className="frame-cell" id="state-01-default-it-sepia">
+        <FrameMeta anchor="state-01-default-it-sepia" gherkin="@G4 sepia"
+                   label="01·sepia — Default IT, sepia theme"
+                   sub="Sepia = light token map (warm sand --bg) — NO nuova palette · brief L566" />
+        <MobileScreen state="default-it" themeOverride="sepia" />
+      </div>
+      <div className="frame-cell" id="state-04-loading-dark">
+        <FrameMeta anchor="state-04-loading-dark" gherkin="@G4 loading-dark"
+                   label="04·dark — Loading skeleton, dark"
+                   sub="5 righe shimmer · prefers-reduced-motion guard" />
+        <MobileScreen state="loading" themeOverride="dark" />
+      </div>
+    </>
+  );
+}
+
+function AidsSection() {
+  return (
+    <>
+      <div className="frame-cell" id="aid-fs-sm">
+        <FrameMeta anchor="aid-fs-sm" gherkin="@aids font" label="A− · 24px (18pt)" sub="Font size step 1 di 3" />
+        <MobileScreen state="default-it" fs="sm" />
+      </div>
+      <div className="frame-cell" id="aid-fs-md">
+        <FrameMeta anchor="aid-fs-md" gherkin="@aids font" label="A · 26px (20pt) default" sub="Brief riga 519 — DEVIAZIONE da --fs-xl documentata in CSS" />
+        <MobileScreen state="default-it" fs="md" />
+      </div>
+      <div className="frame-cell" id="aid-fs-lg">
+        <FrameMeta anchor="aid-fs-lg" gherkin="@aids font" label="A+ · 32px (24pt) lettura distante" sub="Vincolo non-functional vision §4.2" />
+        <MobileScreen state="default-it" fs="lg" />
+      </div>
+      <div className="frame-cell" id="aid-lh-tight">
+        <FrameMeta anchor="aid-lh-tight" gherkin="@aids line" label="≡ 1.4 — tight" sub="Line spacing variant 1 di 3" />
+        <MobileScreen state="default-it" fs="md" lh="tight" />
+      </div>
+      <div className="frame-cell" id="aid-lh-default">
+        <FrameMeta anchor="aid-lh-default" gherkin="@aids line" label="≡ 1.6 — default" sub="Brief riga 521 — esplicito" />
+        <MobileScreen state="default-it" fs="md" lh="default" />
+      </div>
+      <div className="frame-cell" id="aid-lh-loose">
+        <FrameMeta anchor="aid-lh-loose" gherkin="@aids line" label="≡ 1.8 — loose" sub="Line spacing variant 3 di 3" />
+        <MobileScreen state="default-it" fs="md" lh="loose" />
+      </div>
+    </>
+  );
+}
+
+/* ────────────────────────── BOOT ────────────────────────── */
+
+const ReactDOMClient = ReactDOM;
+ReactDOMClient.createRoot(document.getElementById('mount-mobile')).render(<MobileSection />);
+ReactDOMClient.createRoot(document.getElementById('mount-desktop')).render(<DesktopSection />);
+ReactDOMClient.createRoot(document.getElementById('mount-themes')).render(<ThemesSection />);
+ReactDOMClient.createRoot(document.getElementById('mount-aids')).render(<AidsSection />);

--- a/docs/superpowers/specs/2026-05-04-libro-game-assistant-vision.md
+++ b/docs/superpowers/specs/2026-05-04-libro-game-assistant-vision.md
@@ -1,0 +1,967 @@
+---
+title: Libro Game AI Assistant — Vision Document
+status: draft
+type: vision-doc
+date: 2026-05-04
+authors: [DegrassiAaron]
+related-issues: []
+review-cycle: spec-panel + brainstorming + ultrathink-review
+---
+
+# 🎲 Libro Game AI Assistant — Vision Document
+
+> ## ⚠️ DOCUMENT TYPE: VISION, NOT MVP SPEC
+>
+> Questo documento descrive la **vision a 12 mesi** del prodotto AI assistant per gamebook/libro game su MeepleAI. Include scope MVP + roadmap Phase 1.5/v2/v3.
+>
+> **Per implementare**, consultare [§6 MVP Phase 1 Scope](#6-mvp-phase-1--implementation-scope) che è il subset effettivamente buildabile in 4-5 mesi (3 dev fullstack + 1 ML + 1 designer).
+>
+> **Origine**: spec-panel review + brainstorming session + ultrathink critical review (sessione del 2026-05-04 con Aaron).
+
+---
+
+## Indice
+
+- [Executive Summary](#executive-summary)
+- [1. Context & Persona](#1-context--persona)
+- [2. User Goals SMART](#2-user-goals-smart)
+- [3. Gherkin Scenarios](#3-gherkin-scenarios)
+- [4. Non-Functional Requirements](#4-non-functional-requirements)
+- [5. Open Questions, Roadmap, Risk Register](#5-open-questions-roadmap-risk-register)
+- [6. MVP Phase 1 — Implementation Scope](#6-mvp-phase-1--implementation-scope)
+- [7. Decisions Log](#7-decisions-log)
+
+---
+
+## Executive Summary
+
+**Pain risolto**: gruppi casual italofoni che giocano gamebook narrativi (Tainted Grail, ISS Vanguard, Stuffed Fables, etc.) in lingua estera (tipicamente EN) interrompono il flow per tradurre live, cercare regole, gestire setup. La partita "muore alla seconda sessione".
+
+**Soluzione**: companion app smartphone che (a) indicizza il manuale fotografato, (b) traduce on-demand i paragrafi narrativi in italiano da leggere ad alta voce, (c) risponde a domande sulle regole con citazione pagina sorgente, (d) guida lo step-by-step del setup iniziale.
+
+**Differentiation strategica**:
+- *Casual italian gaming community* (first mover sul segmento)
+- *Provider-agnostic LLM platform* (OpenRouter, multi-model)
+- *Trasparenza vs black-box competitor* (Dized, BoardGameArena)
+
+**Status MVP**: Phase 1 scope (4-5 mesi realistic, 3 dev fullstack + 1 ML + 1 designer) definito in §6. Vision completa (12 mesi roadmap) descritta in §1-5.
+
+---
+
+## 1. Context & Persona
+
+### 1.1 Caso d'uso primario
+
+Un gruppo di amici (3-6 persone) si riunisce in salotto per giocare un **libro game/gamebook narrativo** (esempi: *Tainted Grail*, *7th Continent*, *ISS Vanguard*, *Andor Chronicles*, *Stuffed Fables*). Il gioco si articola come storia ramificata: si legge un paragrafo, i giocatori prendono decisioni, si va al paragrafo successivo.
+
+**Asset disponibili al tavolo**:
+- Manuale fisico (cartaceo) **in lingua diversa dall'italiano** — tipicamente EN, occasionalmente DE/FR/ES.
+- Smartphone con camera (un solo device "principale" — il GM).
+- Eventuali smartphone aggiuntivi degli altri giocatori (read-only, opt-in v2+).
+- Connessione WiFi domestica (instabile è la norma).
+
+**Asset NON disponibili**:
+- PDF del manuale.
+- Account/profili dei giocatori (sessione "anonima al tavolo").
+- Dadi, segnalini, fogli personaggio: gestiti fisicamente.
+
+### 1.2 Primary persona
+
+> **"Sara, 32 anni, designer freelance, casual boardgamer"**
+>
+> Compra 3-4 board game all'anno, gioca 1-2 volte al mese con amici e partner. Capisce concetti base ma non vuole "fare il GM". Quando il gioco è in inglese e il gruppo non vuole attendere che lei traduca live ogni paragrafo, la partita rischia di morire alla seconda sessione.
+>
+> *Job-to-be-done emozionale*: «Voglio passare la serata divertendomi con i miei amici, non a fare la traduttrice/lettrice del manuale».
+
+**Persona secondaria** (player al tavolo, non utente diretto): Marco, Giulia, Luca — ascoltatori passivi della traduzione letta da Sara.
+
+**Persona esplicitamente NON-target MVP**: hardcore boardgamer (BGG power-user), famiglie con bambini sotto i 10 anni, developer enterprise.
+
+> ⚠️ **Pain Sara — implicazione MVP**: «la partita rischia di morire alla seconda sessione» implica che save/resume cross-day è critico per risolvere il pain dichiarato. **Phase 1 MVP non include save/resume**, MVP-1 sì (vedi §6.2 trigger esplicito).
+
+### 1.3 Vincoli & decisioni architetturali
+
+| Vincolo | Decisione | Razionale |
+|---------|-----------|-----------|
+| Lingua manuale | LLM single-pass narrative translation (any source language → IT) | Quality bar adeguata a casual senza overhead two-pass |
+| Topologia device | Single-device GM master + multi-device read-only opt-in via QR (v2+) | Casual reality: 1 telefono in mano al GM |
+| Modalità traduzione | On-demand per paragrafo + override "pre-traduci capitolo" user-controlled | Costo controllato, copyright meno esposto |
+| State persistence | Session in-memory + cache locale 24h. Save/resume cross-day deferred MVP-1 | Scope reduction MVP |
+| Pricing | Freemium (50 pag/mese gratis) + consumable credits per power-user | Casual prova gratis |
+| Engine indicizzazione | Riusa MeepleAI esistente: smoldocling-service + embedding-service + RAG | Zero nuova infrastruttura |
+| LLM provider | **OpenRouter** abstraction layer + Anthropic/OpenAI/DeepSeek tiers | Anti-vendor lock-in, cost optimization |
+| Server baseline | **Hetzner CAX31** (16 GB RAM, €14/mese) day 1, NON CAX21 borderline | Production safety, no OOM-killer risk (review issue #4) |
+
+### 1.4 Mapping su Bounded Context MeepleAI esistenti
+
+| Capability | BC riusato | Estensione richiesta |
+|-----------|-----------|---------------------|
+| Foto manuale → testo strutturato | **DocumentProcessing** | Pipeline photo-first (multi-shot, dewarping, page-stitching) |
+| Q&A regole | **KnowledgeBase** (RAG, AI agents) | ✅ Riusabile diretto + filtro `source=phone_camera` |
+| Setup guidato step-by-step | **GameToolbox** (phases templates) | Estensione: derivazione phases da manuale fotografato |
+| Traduzione narrativa | ❌ **Nuovo cross-cutting** | Nuovo `TranslationService` come capability orizzontale (non BC) |
+| House rules / glossario per-gioco | **AgentMemory** | ✅ Riusabile diretto |
+| Multi-device read-only (v2+) | **SessionTracking** | Estensione minore: QR code generation + ephemeral session token |
+
+**Nessun nuovo Bounded Context**. Il caso d'uso libro game è una *configurazione/preset* sopra l'infrastruttura esistente.
+
+### 1.5 Out of scope MVP (Phase 1)
+
+- ❌ Save/resume cross-day → MVP-1 (vedi §6.2 trigger)
+- ❌ State machine narrativa attiva (TTS, voice input, automazione meccaniche)
+- ❌ Multi-device collaborativo full → v3
+- ❌ Modalità famiglia / parental control
+- ❌ Editing post-OCR del testo manuale
+- ❌ Supporto offline completo
+- ❌ User-controlled LLM provider selection (preset, BYOK, transparency UI) → v2 (vedi §4.10)
+- ❌ AI Narrator audio → v2 (vedi §4.9)
+- ❌ Pre-translate chapter background → MVP-1
+- ❌ Setup wizard avanzato → MVP-1 (basta paragrafo setup tradotto in MVP)
+
+---
+
+## 2. User Goals SMART
+
+Quattro user goal coprono le 3 capability core + la pre-condizione tecnica obbligatoria.
+
+### 🎯 G1 — Acquisire manuale fotografandolo
+
+> Sara apre l'app, fotografa le pagine del manuale fisico, e dopo pochi minuti il manuale è interrogabile.
+
+| Criterio SMART | Valore |
+|---------------|--------|
+| **S — Specific** | Convertire foto multiple di pagine manuale in knowledge base interrogabile (testo OCR + embedding vettoriale + metadata pagina/paragrafo) |
+| **M — Measurable** | (a) ≥ 95% delle pagine fotografate sono indicizzate con confidence ≥ 0.7; (b) UI mostra preview confidence per pagina con bandiera per pagine sotto-soglia; (c) **accuracy reale validata su test set golden 5 manuali reali** (review issue #3 — non solo confidence) |
+| **A — Achievable** | Riuso pipeline DocumentProcessing esistente (smoldocling + unstructured) con preprocessor "phone-camera" (dewarping + page detection) + parallel batch processing |
+| **R — Relevant** | Pre-condizione di tutto il resto |
+| **T — Time-bound** | (a) Throughput ≥ 10 pag/min con parallel batch (review issue: serial 8 sec/pag = 6.6 min, OVER budget); (b) Manuale completo (50 pagine) indicizzato in < 5 min totali; (c) UI permette di iniziare a giocare con G2/G3 anche su manuale parzialmente indicizzato |
+
+**Definition of Done**: Sara ha caricato 50 foto del manuale di *Tainted Grail* (in EN). Dopo ≤ 5 min, può chiedere "come funziona il combat?" e ricevere una risposta citante una pagina specifica con confidence ≥ 0.85.
+
+### 🎯 G2 — Ricevere guida step-by-step per setup iniziale
+
+> Sara dice "stiamo per giocare in 4, prepara il tavolo" e ottiene una checklist di passaggi specifici.
+
+| Criterio SMART | Valore |
+|---------------|--------|
+| **S — Specific** | Generare guida ordinata di N step parametrizzata per numero di giocatori, derivata dalle pagine "Setup" del manuale indicizzato |
+| **M — Measurable** | (a) Ogni step ha titolo + componenti necessari + descrizione + checkbox "fatto"; (b) Guida cita ≥ 1 pagina sorgente per ogni step **con citation accuracy ≥ 90% validata** (review issue #2: groundedness hallucination è reale, non solo Q&A); (c) Sara può marcare step come "fatto" |
+| **A — Achievable** | RAG query su KB con filtro tematico "setup" + LLM structuring in formato checklist + traduzione automatica IT |
+| **R — Relevant** | Setup è il momento più frustrante per casual |
+| **T — Time-bound** | Guida generata in ≤ 30 sec dalla richiesta |
+
+**Definition of Done**: Sara apre il gioco mai giocato prima, dice "siamo in 4", ottiene una guida di 6-10 step in italiano con componenti elencati. Marca ogni step "fatto" via tap.
+
+> **Phase 1 MVP scope** (vedi §6): G2 ridotto a "mostra il paragrafo Setup tradotto con citazione". Setup wizard interattivo a checklist deferred MVP-1.
+
+### 🎯 G3 — Risolvere dubbi sulle regole durante il gioco
+
+> A metà partita, Marco chiede "quanti dadi tira il mago?". Sara digita la domanda, ottiene risposta italiana con citazione.
+
+| Criterio SMART | Valore |
+|---------------|--------|
+| **S — Specific** | Q&A in linguaggio naturale (testo) sul manuale indicizzato, con risposta in italiano + citazione pagina sorgente + preview foto pagina |
+| **M — Measurable** | (a) **P95 latenza query → risposta < 5 sec** (rivisto da 3 sec — review issue: Claude Haiku tipica P95 ~4-5 sec end-to-end); (b) confidence score visibile (alta/media/bassa); (c) per confidence bassa: messaggio esplicito "non sono sicuro" + offer "rifotografa pagina / house rule"; (d) **hallucination rate ≤ 3% su test set golden, 0% target su confidence > 0.85** (review issue #8: target definito, non aperto) |
+| **A — Achievable** | Riuso KnowledgeBase BC esistente (RAG + reranker + LLM answer generation) + filtro `language=it` per risposta tradotta |
+| **R — Relevant** | Pain point #1 dichiarato |
+| **T — Time-bound** | P50 < 3 sec, P95 < 5 sec, P99 < 8 sec (timeout con fallback). Risposta deve essere "leggibile in 1 frase" |
+
+**Definition of Done**: Sara fa 20 domande sparse durante una sessione di 4 ore. ≥ 17/20 risposte sono giudicate "utili" da Sara. ≥ 18/20 risposte arrivano in < 5 sec. Le 2-3 "non lo so" hanno azionable suggestion.
+
+### 🎯 G4 — Leggere ad alta voce paragrafi narrativi tradotti
+
+> Sara dice "ora paragrafo §147". L'app traduce e mostra il testo italiano. Sara legge ad alta voce.
+
+| Criterio SMART | Valore |
+|---------------|--------|
+| **S — Specific** | Identificare paragrafo specifico nel manuale (per numero §, capitolo, o snippet testo), tradurre in italiano preservando tono narrativo, mostrare in formato leggibile a voce alta |
+| **M — Measurable** | (a) Latenza traduzione on-demand < 5 sec per paragrafo medio (200-400 parole); (b) modalità "pre-traduci capitolo" disponibile (deferred MVP-1); (c) cache traduzione per la sessione (free), persist 24h locale; (d) UI mostra testo con font ≥ 18pt; (e) **fallback per manuali NON paragrafo-numerati**: ricerca per snippet testo (review issue: Andor è chapter-based, non tutti i gamebook hanno § numbering) |
+| **A — Achievable** | LLM single-pass con prompt: source language + tono dedotto + glossario per-gioco + costraint "preserva paragrafazione e dialoghi" |
+| **R — Relevant** | Pain point #1 acuto. Senza questo, casual non può giocare gamebook in lingua estera. |
+| **T — Time-bound** | (a) On-demand: P95 < 5 sec; (b) tap "prossimo §" → testo visibile in < 1 sec se cached, < 5 sec se non cached |
+
+**Definition of Done**: Sara gioca 1 sessione di 4 ore traducendo 30 paragrafi narrativi. ≥ 28/30 traduzioni sono giudicate "lette senza esitare". Costo per Sara: ≤ 30 credits (~€1.50) o entro la free tier mensile.
+
+### 📊 Goal coverage matrix
+
+| Goal | Capability MeepleAI BC | Pricing tier | Latenza target |
+|------|------------------------|--------------|----------------|
+| G1 — Acquisire manuale | DocumentProcessing (estensione photo-first) | Free | 5 min/manuale 50 pag |
+| G2 — Setup guidato | GameToolbox + KnowledgeBase | Free | 30 sec generation |
+| G3 — Q&A regole | KnowledgeBase (riuso diretto) | Free | < 5 sec P95 |
+| G4 — Traduzione narrativa | Nuovo TranslationService cross-cutting | Freemium 50pag/mese + credits | < 5 sec on-demand |
+
+---
+
+## 3. Gherkin Scenarios
+
+Per ogni user goal, scenari nel formato Adzic specification-by-example.
+
+Convenzione tag: `@happy` percorso principale, `@edge` casi limite plausibili, `@error` failure mode.
+
+### G1 — Acquisire manuale
+
+#### G1.1 — Upload manuale completo @happy
+```gherkin
+Given Sara è loggata in MeepleAI con un account free
+And ha aperto la tab "Nuovo libro game"
+And ha selezionato "Tainted Grail" dal catalogo SharedGameCatalog
+When fotografa 50 pagine del manuale (lingua sorgente: EN)
+And tappa "Inizia indicizzazione"
+Then l'app mostra una progress bar con counter "X/50 pagine indicizzate"
+And ogni pagina mostra preview + confidence badge entro 8 sec dall'upload
+And il manuale completo è interrogabile entro 5 minuti totali (parallel batch processing)
+And Sara può iniziare ad usare G2/G3/G4 anche su manuale parzialmente indicizzato
+```
+
+#### G1.2 — Foto sfocata o angolata @edge
+```gherkin
+Given Sara sta fotografando il manuale in salotto con luce bassa
+When carica una foto con confidence OCR < 0.5
+Then l'app marca quella pagina con badge giallo "qualità bassa"
+And mostra un'azione "📸 Rifotografa" sulla card della pagina
+And nei risultati Q&A successivi quella pagina è retrocessa nel ranking
+And se Sara chiede una regola che dipende da quella pagina, l'app risponde "Non sono sicuro — la pagina X è poco leggibile, vuoi rifotografarla?"
+```
+
+#### G1.3 — Pagine duplicate o mancanti @edge
+```gherkin
+Given Sara ha caricato 50 foto ma 3 sono duplicate della stessa pagina
+And ha saltato per errore le pagine 12-13
+When l'indicizzazione completa
+Then l'app rileva duplicati via similarity score > 0.95 e mostra "3 pagine sembrano duplicate, vuoi mantenerle tutte?"
+And l'app rileva gap nella numerazione e mostra "Sembrano mancare le pagine 12-13, vuoi aggiungerle?"
+And Sara può ignorare entrambi i warning e procedere
+```
+
+#### G1.4 — Connessione interrotta durante upload @error
+```gherkin
+Given Sara ha caricato 30 delle 50 foto
+And il WiFi domestico cade per 2 minuti
+When la connessione torna
+Then l'app riprende automaticamente l'upload delle restanti 20 foto
+And nessuna foto già uploaded viene ri-uploadata
+And Sara non perde alcun progresso
+```
+
+#### G1.5 — Manuale di gioco non in SharedGameCatalog @edge (NEW from review)
+```gherkin
+Given Sara fotografa un manuale di un gioco non presente nel SharedGameCatalog
+When tappa "Inizia indicizzazione"
+Then l'app chiede "Non riconosco questo gioco. Vuoi:"
+   | Azione                          | Effetto                                                  |
+   | 🆕 Crea nuovo gioco             | Nome + editore + anno → aggiunto al catalogo             |
+   | 🔍 Cerca su BoardGameGeek       | API call BGG per autodetect e prefill                    |
+   | 📖 Indicizza solo per me        | Manuale privato, non condiviso al catalogo               |
+And l'indicizzazione procede dopo conferma
+```
+
+#### G1.6 — Manuale in lingua non-Latin script @error (NEW from review)
+```gherkin
+Given Sara fotografa un manuale di un gamebook giapponese (CJK script)
+When carica le foto
+Then l'app rileva script non supportato dall'OCR pipeline corrente
+And risponde "Il manuale è in giapponese — al momento supportiamo solo Latin script (EN/IT/DE/FR/ES/PT/NL)."
+And offre alternative: [📅 Notifica quando supportato, 🔗 Suggerisci feature, ⏭️ Procedi solo con immagini (no OCR)]
+```
+
+### G2 — Setup guidato
+
+#### G2.1 — Setup primo capitolo per gruppo di 4 @happy
+```gherkin
+Given Sara ha indicizzato il manuale di "Tainted Grail"
+When apre la tab "Setup partita"
+And imposta "numero giocatori = 4"
+And tappa "Genera guida setup"
+Then in ≤ 30 sec l'app mostra una checklist di 8 step in italiano:
+   | # | Step                                                   | Componenti               |
+   | 1 | Posiziona il tabellone Avalon al centro                | Tabellone                |
+   | 2 | Distribuisci 1 segnalino salute per giocatore          | Segnalini salute (4)     |
+   | 3 | Ogni giocatore sceglie un personaggio                  | Card personaggio (8)     |
+   | 4 | Ogni giocatore prende 5 carte azione                   | Mazzo azioni             |
+   | 5 | Posiziona il segnalino narrativo sul Menhir 1          | Segnalino + tabellone    |
+   | 6 | Mescola il mazzo Esplorazione                          | Mazzo Esplorazione       |
+   | 7 | Posiziona 3 carte Evento scoperte                      | Mazzo Eventi             |
+   | 8 | Leggi il paragrafo §1 per iniziare                     | Manuale                  |
+And ogni step ha checkbox "fatto" + link "📖 fonte: pag. 4" con accuracy citation ≥ 90%
+And quando Sara marca tutti gli 8 step come fatti, l'app suggerisce "Pronti? Tap qui per leggere §1"
+```
+
+#### G2.2 — Setup variabile per numero di giocatori @edge
+```gherkin
+Given il manuale di "Stuffed Fables" specifica setup diverso per 2/3/4 player
+When Sara imposta "numero giocatori = 3"
+Then la guida mostra solo le componenti per 3 player
+And ogni step che varia per player count menziona esplicitamente la variante usata
+And se il numero giocatori è fuori range supportato, l'app avverte "Il manuale supporta 2-4 giocatori — vuoi procedere comunque?"
+```
+
+#### G2.3 — Manuale senza sezione "setup" chiara @error
+```gherkin
+Given il manuale ha le istruzioni setup sparse in più capitoli
+When Sara tappa "Genera guida setup"
+Then l'app risponde "Non riesco a identificare una sezione setup chiara. Vuoi che cerchi le istruzioni nel testo generale?"
+And offre 3 opzioni: [✅ Cerca nel testo, 📷 Indica tu le pagine setup, ⏭️ Salta e inizia direttamente]
+```
+
+### G3 — Q&A regole
+
+#### G3.1 — Domanda chiara su regola ben documentata @happy
+```gherkin
+Given la partita di "Tainted Grail" è in corso
+And il manuale è completamente indicizzato con confidence media > 0.85
+When Marco chiede "quanti dadi tira il guerriero per attaccare con una spada a due mani?"
+And Sara digita la domanda nell'app
+Then l'app risponde in < 5 sec:
+   "Il guerriero tira 3 dadi quando attacca con armi a due mani, +1 dado se ha 'Forza Bruta' attiva."
+And mostra una citazione: "📖 Manuale, p.18 — Combattimento Marziale"
+And mostra preview thumbnail della pagina sorgente
+And confidence badge: 🟢 Alta
+```
+
+#### G3.2 — Domanda ambigua @edge
+```gherkin
+Given Sara chiede "cosa succede quando si pareggia?"
+When l'app interpreta la domanda
+Then l'app rileva ambiguità (può essere combat, iniziativa, voto, esplorazione)
+And risponde "La tua domanda può riferirsi a 4 contesti diversi:"
+And mostra 4 opzioni cliccabili
+And Sara tappa "Combattimento" → ottiene risposta dettagliata + citazione
+```
+
+#### G3.3 — Domanda su regola non chiara @edge
+```gherkin
+Given Sara chiede "se due giocatori muoiono nello stesso turno, chi diventa il leader?"
+And il manuale non copre esplicitamente questo caso
+When l'app processa la query
+Then risponde "Non sono sicuro — questa regola non è chiara dal manuale di Tainted Grail."
+And confidence badge: 🟡 Bassa
+And offre 3 azioni:
+   | Azione                   | Effetto                                                     |
+   | 📷 Rifotografa pagina     | Apre camera per ri-OCR di pagine specifiche                |
+   | 🤝 Definisci house rule   | Salva la decisione del gruppo per le query future          |
+   | 🔍 Cerca su BoardGameGeek | Apre query esterna (link BGG forum)                        |
+And se Sara sceglie house rule e digita la decisione, AgentMemory salva la regola per la sessione
+```
+
+#### G3.4 — House rule trump manuale @edge (NEW from review)
+```gherkin
+Given Sara ha definito una house rule "i critici fanno doppio danno" che contraddice il manuale
+When Marco chiede "quanto danno fa un colpo critico?"
+Then l'app risponde "Per il vostro gruppo: doppio danno (house rule definita 14 min fa)."
+And include footnote: "📖 Regola ufficiale manuale: +50% danno (p.22) — ma state usando la vostra variante"
+And confidence badge: 🟢 Alta (house rule esplicita)
+```
+
+#### G3.5 — Latenza eccede target @error
+```gherkin
+Given la connessione internet è degradata
+When Sara fa una domanda
+And la risposta non arriva entro 8 sec (P99 timeout)
+Then l'app mostra "⏳ Sto pensando, ci vuole più del solito..."
+And dopo 15 sec aggiuntivi, se ancora niente, mostra "Connessione lenta — riprova o passa a modalità manuale"
+And offre azione "📖 Mostrami le pagine sul tema X" (fallback ai risultati di ricerca grezza senza LLM generation)
+```
+
+### G4 — Traduzione narrativa
+
+#### G4.1 — Lettura paragrafo richiesto dal GM @happy
+```gherkin
+Given Sara ha indicizzato un manuale EN
+And la partita è in corso
+When Sara digita "vai al §147"
+Then l'app cerca il paragrafo §147 nel manuale
+And in < 5 sec mostra il testo tradotto in italiano formattato per lettura ad alta voce:
+   - Font 20pt, line height 1.5, larghezza max 60ch
+   - Dialoghi evidenziati in corsivo
+And il testo originale EN è disponibile in toggle "🌐 Mostra originale"
+And la traduzione viene cached per la sessione (no re-cost)
+```
+
+#### G4.2 — Pre-traduzione capitolo @happy (deferred MVP-1)
+```gherkin
+Given Sara è in setup pre-partita
+When Sara tappa "📚 Pre-traduci Capitolo 1"
+And conferma il prompt "Pre-traduzione di 50 paragrafi consumerà ~30 credits"
+Then l'app inizia traduzione background dei 50 paragrafi
+And mostra progress "12/50 paragrafi tradotti" sopra la UI di gioco
+And quando Sara apre §X durante la partita, il testo è già pronto (latenza < 1 sec)
+```
+
+#### G4.3 — Paragrafo con riferimenti tecnici @edge
+```gherkin
+Given il manuale contiene oggetti "Sword of Avalon", "Wraithstone", personaggi "Niamh"
+And il glossario per-gioco ha mappato:
+   | EN              | IT                |
+   | Sword of Avalon | Spada di Avalon   |
+   | Wraithstone     | Pietra Spettrale  |
+   | Niamh           | Niamh (invariato) |
+When Sara apre §147 che contiene "Niamh raises the Sword of Avalon and the Wraithstone glows."
+Then la traduzione output è "Niamh solleva la Spada di Avalon e la Pietra Spettrale brilla."
+And il glossario è applicato consistentemente in tutti i paragrafi della stessa sessione
+```
+
+#### G4.4 — Paragrafo non trovato @error
+```gherkin
+Given Sara digita "vai al §299" ma il manuale ha solo paragrafi fino a §250
+When l'app cerca §299
+Then risponde "Paragrafo §299 non trovato nel manuale indicizzato."
+And offre 3 azioni:
+   | Azione                          | Effetto                                            |
+   | 🔍 Cerca testo simile           | Mostra paragrafi con numerazione vicina (§290-§300) |
+   | 📷 Rifotografa pagine mancanti  | Apre camera per ri-OCR pagine non indicizzate      |
+   | ⏭️ Salta paragrafo              | Marca come "letto" e lascia gestione manuale       |
+```
+
+#### G4.5 — Manuale chapter-based (no §) @edge (NEW from review)
+```gherkin
+Given Sara ha indicizzato un manuale chapter-based (es. "Andor Chronicles")
+When Sara cerca "il prossimo segmento"
+Then l'app mostra l'indice dei capitoli disponibili
+And consente di cercare via snippet testo: "L'eroe entra nella foresta oscura"
+And ritorna il segmento più simile via semantic search con confidence ≥ 0.75
+And se confidence < 0.75: "Non sono sicuro di quale segmento intendi — vuoi navigare manualmente?"
+```
+
+#### G4.6 — Quota mensile esaurita @error
+```gherkin
+Given Sara è in piano free (50 pag/mese di traduzione)
+And ha già consumato 49/50 pagine questo mese
+When Sara apre il 51° paragrafo
+Then l'app mostra modale: "Hai esaurito la tua quota gratuita di traduzioni questo mese."
+And offre 2 azioni (semplificate Phase 1 — review issue #5):
+   | Azione                              | Effetto                                            |
+   | 💎 Acquista 100 credits (€5)        | Sblocca 100 traduzioni aggiuntive                  |
+   | ⏸️ Continua senza traduzione        | Mostra solo testo originale, gruppo traduce manualmente |
+And la quota free si resetta automaticamente il 1° del mese successivo
+```
+
+#### G4.7 — WiFi cade durante traduzione @error (NEW from review)
+```gherkin
+Given Sara sta leggendo §147 ad alta voce al gruppo
+And richiede §148
+When la connessione cade prima che la traduzione arrivi
+Then l'app mostra l'ultima frase tradotta visibile (non hard error)
+And status indicator discreto: "🟡 Sto riprovando..."
+And dopo 10 sec senza riconnessione: "Connessione persa — paragrafo originale disponibile" + bottone "Mostra EN"
+And alla riconnessione, traduzione completa appare automatically
+And UI non mai blocca completamente o mostra modal full-screen (review issue #4.3)
+```
+
+### 📊 Scenario coverage matrix
+
+| Goal | @happy | @edge | @error | Totale |
+|------|--------|-------|--------|--------|
+| G1 — Acquisire manuale | 1 | 3 | 2 | 6 |
+| G2 — Setup guidato | 1 | 1 | 1 | 3 |
+| G3 — Q&A regole | 1 | 3 | 1 | 5 |
+| G4 — Traduzione narrativa | 2 | 2 | 3 | 7 |
+| **Totale** | **5** | **9** | **7** | **21** |
+
+---
+
+## 4. Non-Functional Requirements
+
+### 4.1 ⚡ Performance
+
+| Aspetto | Target | Misurazione |
+|---------|--------|-------------|
+| Q&A regole — P50 | < 3 sec | Telemetry `query_to_first_token` |
+| Q&A regole — P95 | **< 5 sec** (rivisto da 3 sec) | Telemetry stesso |
+| Q&A regole — P99 | < 8 sec (timeout con fallback) | Telemetry + alerting |
+| Traduzione on-demand — P95 | < 5 sec per paragrafo medio | Telemetry `translation_request_to_complete` |
+| Setup guidato generation | < 30 sec end-to-end | Telemetry `setup_request_to_render` |
+| OCR throughput | **≥ 10 pag/min batch parallel** (rivisto da 8 sec/pag seriale) | Telemetry `pages_indexed_per_minute` |
+| Manuale completo (50 pag.) | < 5 min totali | Job tracking |
+| Concurrent users per session | 4 telefoni simultanei senza degradazione | Load test pre-release |
+
+### 4.2 ♿ Accessibilità
+
+| Requisito | Target |
+|-----------|--------|
+| Touch target minimi | ≥ 48×48 dp |
+| Font size testo narrativo | ≥ 18pt default, ≥ 24pt opzionale "lettura distante" |
+| Contrasto testo | WCAG AA (≥ 4.5:1) |
+| Voice input | Voice-to-text per Q&A (riuso device-native, low expectation in salotto rumoroso — vedi R-14) |
+| Screen always-on | Durante sessione attiva, opzione "tieni schermo acceso" abilitata di default |
+| Reduced motion | Rispetta `prefers-reduced-motion` |
+| Localizzazione UI | Italiano per MVP. Stringhe estratte i18n-ready |
+| TTS audio narrator | **Roadmap v2** — vedi §4.9 (eliminata duplicazione review issue) |
+
+### 4.3 🌐 Offline & resilienza
+
+| Scenario | Behavior atteso |
+|----------|----------------|
+| WiFi cade durante upload manuale | Resume automatico, no perdita progresso |
+| WiFi cade durante Q&A | Mostra errore graceful + offer retry, no crash |
+| **WiFi cade durante traduzione mid-flow** | **Last frase visibile + status indicator discreto + auto-retry, no hard error modal** (review issue) |
+| App killed dal SO durante OCR background | Job server-side continua, push notification a completion |
+| Batteria smartphone < 10% | UI mostra warning discreto |
+| Server LLM rate limited / down | Circuit breaker → degrade graceful |
+| Foto esistente già indicizzata da altro user | Riusa indice via SharedGameCatalog hash → costo 0 |
+
+### 4.4 🔒 Privacy & sicurezza
+
+| Aspetto | Decisione |
+|---------|-----------|
+| Manuale caricato | Storato lato server. Visibile solo a Sara. Cancellabile via "Elimina manuale" |
+| Foto pagine | Compresse + dewarped + storate. Cancellabili da Sara |
+| Conformità GDPR | Right to deletion implementato. Data export su richiesta. Privacy policy chiara |
+| Copyright manuale | **PREREQUISITE pre-launch** — legal review obbligatoria (vedi §5.1 PR-1, ex OQ-1) |
+| Glossario per-gioco | Locale + sincronizzato per session |
+| House rules | Salvate in AgentMemory |
+| Auth multi-device opt-in (v2+) | QR code → token ephemeral **8 ore** (rivisto da 4 — sessioni gamebook 5-6h tipiche, review issue) |
+| Dati telemetria | Anonimizzati. Opt-out disponibile. Niente tracking di contenuto traduzioni |
+
+### 4.5 📱 Compatibilità device
+
+| Aspetto | Supporto MVP |
+|---------|--------------|
+| iOS | ≥ 16 (Safari + PWA) |
+| Android | ≥ 12 (Chrome + PWA) |
+| Form factor | Smartphone portrait + landscape. Tablet roadmap. |
+| Camera | Risoluzione minima 8MP. Warning su < 5MP |
+| Connessione | WiFi/4G/5G. Bandwidth minima 1 Mbps |
+| Storage locale | < 200 MB cache per sessione attiva. Auto-purge 24h |
+
+### 4.6 💰 Cost analysis (consolidato — review issue #4.6)
+
+**Target unitari** (post OpenRouter + DeepSeek tier):
+
+| Operazione | Model preferito | Cost/op | Volume/utente attivo/mese | Cost utente/mese |
+|-----------|-----------------|---------|--------------------------|------------------|
+| Q&A regola (high-confidence) | DeepSeek-V3 via OpenRouter | €0.003 | 60 query | €0.18 |
+| Q&A regola (high-stakes) | Claude Haiku 4.5 | €0.015 | 10 query | €0.15 |
+| Traduzione paragrafo | Claude Sonnet 4.5 | €0.025 | 90 pag (3 sess × 30 pag) | €2.25 |
+| Setup guide generation | Claude Haiku | €0.020 | 3/mese | €0.06 |
+| **TOTALE LLM utente attivo/mese** | | | | **~€2.64** |
+
+**Cost per active user (full picture)** — vedi §4.11 per breakdown infrastruttura:
+
+| Scenario | Infra fissa/utente | LLM | Storage | **Total** |
+|----------|-------------------|-----|---------|-----------|
+| 50 utenti (CAX31) | €0.40 | €2.64 | €0.05 | **€3.09** |
+| 200 utenti (CAX31) | €0.10 | €2.64 | €0.04 | **€2.78** |
+| 1000 utenti (cluster) | €0.10 | €2.64 | €0.03 | **€2.77** |
+
+**Revenue assumption** (rivisto conservative — review issue):
+
+- **Phase 1 MVP** (2-tier solo Free + Credits):
+  - Free tier: 70% utenti, €0 revenue
+  - Credits avg buyer: 30% utenti × €5/100 credits ≈ €1.50/utente/mese
+  - **Revenue avg/utente Phase 1 MVP: €1.50**
+- **Post-v2** (con Premium subscription attivata):
+  - Free tier: 60% utenti, €0 revenue
+  - Credits avg buyer: 30% utenti × €5/100 credits ≈ €1.50/utente/mese
+  - Premium subscription: 10% utenti × €8/mese = €0.80/utente/mese
+  - **Revenue avg/utente post-v2: €2.30** (rivisto da €3.50 ottimistico)
+
+**Break-even MVP Phase 1**: ~600 utenti attivi (LLM cost €2.64 vs revenue €1.50 → cross con scale).
+**Break-even post-v2**: ~250 utenti attivi.
+
+> ⚠️ **Implicazione strategica**: MVP Phase 1 è **loss-making fino a ~600 utenti**. Pricing-to-cost gap sanato dall'attivazione tier Premium in v2. Considerare aumento Credits price (€5 → €7) se scale lenta.
+
+### 4.7 🧪 Testabilità
+
+| Livello | Strategia | Owner | Effort |
+|---------|-----------|-------|--------|
+| Unit | State helpers (setup checklist, glossary application, cache lookup) | Backend dev | 1 week |
+| Integration | OCR pipeline foto → KB indexed (Testcontainers) | Backend dev | 1 week |
+| E2E | "Sessione salotto" full journey | Playwright dev | 2 weeks |
+| Visual | Manuali reali fotografati in condizioni domestiche. Dataset golden 5 manuali. | QA | 1 week |
+| Usability | 5 sessioni reali con gruppi target | UX researcher | 2 weeks |
+| Chaos | Spegni WiFi, kill app, batteria 5%, server LLM 503 | Manuale + scripted | 1 week |
+| **LLM evaluation** | **Test set 100 query Q&A + 50 paragrafi traduzione golden** | **ML engineer + IT native speaker (gamebook expertise)** | **2 weeks dedicati** (review issue #10 — owner + budget esplicito) |
+
+### 4.8 🌍 Internazionalizzazione (i18n) & localizzazione (l10n)
+
+#### Architectural readiness (MVP must-have)
+
+| Aspetto | Decisione MVP | Razionale |
+|---------|--------------|-----------|
+| Stringhe UI | Tutte estratte in file resource (`it.json`) | Aggiunta lingua = nuovo file, no code change |
+| Locale formatting | `Intl.DateTimeFormat`, `Intl.NumberFormat` | Nessuna formattazione manuale |
+| Encoding | UTF-8 ovunque | Supporto immediato |
+| Pluralizzazione | ICU MessageFormat | Plurali corretti |
+| Date input parsing | Formato locale-aware | Evita ambiguità |
+
+#### Lingue supportate per dimensione
+
+| Dimensione | MVP | Roadmap v1 | Roadmap v2+ |
+|-----------|-----|------------|-------------|
+| **UI lingua app** | IT | + EN | + DE, FR, ES, PT |
+| **Lingua sorgente manuale** (OCR) | EN, IT (latin script) | + DE, FR, ES, PT, NL | + JP, ZH (CJK pipeline) |
+| **Lingua target traduzione** | IT | + EN, DE, FR, ES | + qualsiasi LLM-supported |
+| **Glossario per-gioco** | IT/EN bilingual MVP | Multi-lingue parallel | + auto-suggest da BGG |
+
+> ❌ **RTL support DEFERRED v3+** (review issue #4.8 — gamebook market dominato latin script, over-engineering per MVP).
+
+### 4.9 🎙️ AI Narrator audio (roadmap v2 — non MVP)
+
+> **Scope roadmap**: l'app legge ad alta voce con voce sintetica narrativa (TTS), eliminando la duplicazione con §4.2 — questa è feature di prodotto, non solo accessibility.
+
+#### Use case roadmap
+
+> Sara apre §147. Tap "🎙️ Leggi tu" → l'app riproduce audio narrativo in italiano. Sara e gli amici ascoltano insieme.
+
+#### Modalità di consumo
+
+| Modalità | Descrizione | Quando preferita |
+|----------|-------------|------------------|
+| **Solo testo** (MVP) | Mostra traduzione, GM legge | Default casual |
+| **Testo + audio toggle** (v2) | Mostra testo + bottone "🎙️ Leggi" | Sara sceglie paragrafo per paragrafo |
+| **Audio-only immersivo** (v2.5) | Schermo si oscura, solo audio | Sessioni atmosferiche |
+| **Dual-track (audio + sottotitoli)** (v3) | Audio + testo evidenziato in sync | Accessibilità |
+
+#### Architettura tecnica
+
+| Aspetto | Decisione roadmap |
+|---------|-------------------|
+| Engine TTS cloud | ElevenLabs (quality top), OpenAI TTS (bilanciato), Google Cloud TTS, Azure Neural TTS |
+| **Engine TTS self-hostable** | **Coqui TTS / Piper / Bark** — required per coerenza con Privacy strict preset (review issue #4.9) |
+| Voice selection | Catalogo curato di 4-6 voci italiane |
+| Tono adattivo | Prompt LLM pre-TTS analizza paragrafo → suggerisce parametri |
+| Streaming | Audio generato in streaming. Latency target: primo audio < 3 sec |
+| Cache | Audio cached per la sessione. Persist 24h locale |
+| Storage | Audio NON storato server-side. Solo cache CDN edge-region |
+
+#### Trigger di prioritizzazione
+
+- ≥ 30% utenti MVP richiedono TTS in feedback survey
+- Costo medio sessione testo < €1.50 (margine sufficiente)
+- Almeno 1 competitor lancia feature simile
+
+### 4.10 🎛️ User-controlled LLM provider selection (roadmap v2)
+
+> **NON in MVP Phase 1** (review issue #6: over-engineering per casual primary). Default Auto invisibile in MVP. Preset selector + BYOK + transparency UI introdotti in v2.
+
+#### Tre modalità di selezione (v2)
+
+| Mode | Audience | UX |
+|------|----------|-----|
+| **🤖 Auto (default)** | Casual primary | Sistema sceglie best provider per ogni task via OpenRouter routing |
+| **🎚️ Preset (intermediate)** | Power-user, privacy-conscious | 4-5 preset curati |
+| **🔧 Custom (advanced)** | Developer, B2B, enterprise | Per ogni task scegli provider+modello |
+
+#### Preset curati (v2)
+
+| Preset | Optimization | Provider mix | Quality bar |
+|--------|--------------|--------------|-------------|
+| **🌱 Risparmio** | Cost-first | DeepSeek-V3 / Llama 3.1 self-hosted | "Buono" |
+| **⚖️ Bilanciato** (default) | Cost+quality | OpenRouter routing dinamico | "Eccellente" |
+| **💎 Premium** | Quality-first | Claude Sonnet 4.5 / GPT-4o | "Top" |
+| **🇪🇺 Privacy EU-only** | Data sovereignty | Mistral Large + self-hosted | "Buono" |
+| **🔒 Privacy strict** | Zero data retention | Self-hosted Llama 3.1 70B | "Discreto" |
+
+#### BYOK (v2.5)
+
+| Aspetto | Valore |
+|---------|--------|
+| Audience | Enterprise, dev, hobbyist |
+| Pricing | "BYOK Pro" subscription €3/mese |
+| Sicurezza | Key cifrata at-rest (AES-256) |
+
+### 4.11 🖥️ Infrastructure cost analysis (Hetzner CAX31 baseline)
+
+> **Decisione architetturale** (review issue #4): **CAX31 day 1**, NON CAX21 borderline. €14/mese fisso evita OOM-killer in produzione.
+
+#### Server reference
+
+**Hetzner CAX31** (Cloud ARM-based):
+- 8 vCPU Ampere Altra ARM
+- 16 GB RAM
+- 160 GB NVMe SSD
+- 20 TB traffic incluso
+- **€11.49/mese** + IVA (€14.02 IVA inc.)
+
+#### Capacity assessment
+
+| Componente | RAM stimata | CAX31 fit |
+|-----------|-------------|-----------|
+| API .NET 9 | 400-600 MB | ✅ |
+| PostgreSQL 16 + pgvector | 1.5-2 GB | ✅ |
+| Redis | 200-400 MB | ✅ |
+| Next.js 16 (SSR) | 500-800 MB | ✅ |
+| embedding-service Python | 800 MB-1.5 GB | ✅ |
+| reranker-service Python | 600 MB-1 GB | ✅ |
+| smoldocling-service Python (OCR) | 1.5-2 GB | ✅ |
+| unstructured-service Python | 500 MB-800 MB | ✅ |
+| Monitoring | 300-500 MB | ✅ |
+| **TOTALE picco** | **6.4-9.0 GB** | **✅ Comfortable su 16 GB** |
+
+#### Cost breakdown infrastruttura mensile
+
+| Voce | MVP (CAX31) | Growth (CAX31 + Box) | Scale (cluster) |
+|------|-------------|----------------------|-----------------|
+| Hetzner server | €14.02 | €14.02 | €42 (3× CAX31) |
+| Storage Box 1 TB | – | €4.65 | €4.65 |
+| Domain + DNS | €1.00 | €1.00 | €1.00 |
+| Cloudflare | €0 (free) | €0 | €20 (Pro) |
+| TLS / Monitoring | €0 | €0 | €29 |
+| **TOTALE INFRA FISSA** | **€15.02/mese** | **€19.67/mese** | **€96.65/mese** |
+
+#### Self-hosted LLM roadmap (5000+ MAU trigger)
+
+> ⚠️ **Review issue ROI math**: il saving reale è ~€150-300/mese (Q&A bulk solo), NON €700/mese stimato originale. Translation Sonnet rimane cloud per quality bar.
+
+**Setup**: Hetzner Dedicated GEX44 (RTX 4000 Ada 20GB) — €184/mese.
+**Use case**: Q&A bulk routing (DeepSeek replacement self-hosted), embedding self-hosted.
+**Break-even**: 5000 MAU con €900/mese cloud Q&A → €184 self-hosted = €700 saving lordo. Quality match Llama 3.1 70B vs DeepSeek validation richiesta.
+
+#### Disaster recovery
+
+| Scenario | Recovery strategy | Cost |
+|----------|-------------------|------|
+| CAX31 down | Restore da Storage Box su nuovo CAX31 | RTO ~2h, €0 incremental |
+| Region down | Hot standby Helsinki | +€14/mese standby, RTO 15 min |
+| Data loss | Daily backup su Storage Box, weekly su Cloudflare R2 | +€2/mese |
+| **DR add-on totale** | | **+€16/mese per RTO 15 min** |
+
+---
+
+## 5. Open Questions, Roadmap, Risk Register
+
+### 5.1 ❓ Open Questions & Prerequisites
+
+#### 🚨 Prerequisites (BLOCKERS pre-launch)
+
+| # | Item | Owner | Deadline |
+|---|------|-------|----------|
+| **PR-1** | **Copyright stance — Legal review** (ex-OQ-1, promosso da open question — review issue #2) | Legal advisor da identificare (owner: Aaron) | Pre-MVP launch (entro mese 4 di sprint) |
+| **PR-2** | **OCR validation su 5 manuali gamebook reali** (test layout artistici — review issue #3 + R-13) | ML engineer | Pre-Phase 1 sprint start (2 settimane) |
+| **PR-3** | **Test set golden creation** (100 Q&A + 50 paragrafi narrativi) | ML engineer + IT native speaker | Pre-MVP launch (4 settimane lead time) |
+
+#### Decisioni differite (rinviabili)
+
+| # | Question | Owner | Trigger per riapertura |
+|---|----------|-------|------------------------|
+| OQ-2 | Edition lock: come distinguiamo 1st vs 2nd edition? | Product | Quando un utente reporta "regole sbagliate" |
+| OQ-3 | Hallucination rate target → **DEFINITO**: ≤ 3% golden, 0% target su confidence > 0.85 (review issue #8) | – | – |
+| OQ-4 | Glossario auto-bootstrap (NER vs manual curation) | Product + ML | Dopo G1 implementato — A/B test 5 giochi |
+| OQ-5 | Multi-tenant glossario: condivisione cross-utente? | Product + Privacy | Quando SharedGameCatalog dedup è in produzione |
+| OQ-6 | Pricing localization: elasticità casual italiano vs internazionale? | Pricing team | Pre-launch in nuovi mercati |
+| OQ-7 | Save/resume MVP-1 trigger esplicito (review issue #7) | Product | Misurare retention post-MVP — se < 40% sessioni hanno follow-up entro 7 giorni |
+| OQ-8 | Validation MOS DeepSeek su traduzione narrativa italiana | ML | Pre-attivazione DeepSeek tier in production |
+| OQ-9 | OpenRouter vs direct API overhead | Backend | Primo trimestre post-launch |
+| OQ-10 | BYOK launch timing — v2 o v2.5? | Product | Dopo validation power-user adopters |
+| OQ-11 | EU-only preset infra cost (self-hosted Llama capacity) | DevOps | Pre-v2 launch |
+| OQ-12 | Cost transparency UI granularità (A/B test) | Product + Design | Pre-v2 launch |
+| OQ-13 | Multi-device QR session lifecycle (review issue #1.3 critical) | Product + Backend | Pre-v2 implementation |
+
+### 5.2 🗺️ Roadmap
+
+#### Phase 0 — Foundation (esistente)
+> Stato corrente MeepleAI: BC funzionanti, pipeline PDF + RAG operativa, frontend Next.js v2 in migration.
+
+#### Phase 1 — MVP libro game (vedi §6 per scope dettagliato)
+
+**Effort realistic**: **4-5 mesi, 3 dev fullstack + 1 ML + 1 designer** (review issue #9 — riallineato da 2-3 mesi sottostimato).
+
+#### Phase 1.5 — Polish & retention (post-MVP, 1-2 mesi)
+
+| Feature | Trigger | Priorità |
+|---------|---------|----------|
+| **Save/resume base** (paragrafo + glossario + house rules) | Sara's pain top priority — esplicita non opzionale (review issue #7) | **Alta MVP+1** |
+| Setup wizard interattivo (G2 full) | Se MVP usa solo "show setup paragraph" e completion rate < 60% | Alta |
+| UI lingua EN | 30%+ utenti registrati hanno locale non-IT | Alta se trigger |
+| Pre-translate chapter background (G4.2) | Se utenti chiedono ripetutamente | Media |
+| Multi-device QR opt-in (read-only) | Se 30%+ sessioni hanno > 4 player al tavolo | Media |
+| Voice-to-text Q&A | Se Q&A typing < 5/sessione media | Bassa (R-14 risk) |
+
+#### Phase 2 — Differentiation (3-4 mesi)
+
+- Two-pass translation quality (Premium tier moat)
+- AI Narrator audio (§4.9)
+- LLM provider control: preset selector + transparency UI (§4.10)
+- Glossario auto-bootstrap via NER
+
+#### Phase 2.5 — Power-user
+
+- BYOK (Bring Your Own API Key) + "BYOK Pro" subscription
+- Custom per-task LLM mode
+
+#### Phase 3 — Expansion (3+ mesi)
+
+- Lingue UI: DE, FR, ES, PT
+- Lingue source: JP/ZH (CJK pipeline)
+- AI Narrator multilingue + voice cloning
+- Multi-device collaborativo full (sync real-time)
+- Modalità famiglia con parental control
+- Tablet-optimized UI
+
+### 5.3 🛡️ Risk register
+
+| Risk | Probabilità | Impatto | Mitigazione |
+|------|-------------|---------|-------------|
+| **R-1**: LLM pricing raddoppia | 🟡 Media | 🟡 Medio (declassato grazie a OpenRouter) | Multi-provider abstraction. Pricing rivisto trimestrale |
+| **R-2**: OCR quality bassa | 🔴 Alta | 🟡 Medio | Test set 20 manuali. Smoldocling fallback unstructured. UI confidence + manual override |
+| **R-3**: Copyright takedown | 🟡 Media | 🔴 Alto | **PR-1 legal review pre-launch**. TOS robusto. Reactive takedown process |
+| **R-4**: Competitor giant entry (Asmodee, Dized funded) | 🟡 Media | 🔴 Alto | Moat = casual italian + traduzione narrativa quality. Differentiation roadmap (AI Narrator) v2 |
+| **R-5**: LLM hallucination su regole critiche | 🟡 Media | 🔴 Alto | Confidence threshold ≥ 0.8. Test set golden 100 Q&A. Telemetry user-flagged. Human review loop |
+| **R-6**: Casual non vuole installare app | 🟡 Media | 🟡 Medio | PWA prioritized. Web-first dev priority |
+| **R-7**: Stagionalità board game | 🟢 Bassa | 🟡 Medio | Pricing freemium + credits assorbe variabilità |
+| **R-8**: Glossario errato propaga errori | 🟡 Media | 🟡 Medio | Glossario per-sessione esposto in UI. Auto-flag inconsistencies |
+| **R-9**: WiFi domestico instabile | 🔴 Alta | 🟡 Medio | Cache aggressiva. Pre-translate option. Graceful degradation (G4.7 scenario) |
+| **R-10**: GDPR non-compliance su foto manuali | 🟢 Bassa | 🔴 Alto | Right to deletion. Privacy policy. Annual GDPR audit |
+| **R-11**: DeepSeek GDPR (data trasferimento extra-UE) | 🟡 Media | 🟡 Medio | Restringere uso a task non-PII (NER glossario). Disclosure TOS |
+| **R-12**: OpenRouter SPOF | 🟢 Bassa | 🟡 Medio | Direct API fallback configurato per provider critici |
+| **R-13** (NEW): **OCR fallisce su layout artistici gamebook** (Tainted Grail, ISS Vanguard) | 🔴 **Alta** | 🔴 **Alto** | **PR-2 validation upfront**. Manual override UI. Curated OCR per gioco premium |
+| **R-14** (NEW): **Voice-to-text in salotto rumoroso fallisce** | 🔴 Alta | 🟢 Bassa (feature roadmap, non MVP critica) | Aspettativa user lowered. Type-first UI primario |
+| **R-15** (NEW): **Test set golden creation è collo di bottiglia ML eval** | 🔴 Alta | 🟡 Medio | **PR-3 owner + 4 settimane lead time**. Procurement IT native speaker con gamebook expertise |
+
+### 5.4 🏆 Competitive moat (Porter)
+
+| Competitor | Loro strength | Nostra differentiation |
+|-----------|---------------|------------------------|
+| **BoardGameArena** | Catalogo enorme di giochi *digitalizzati* | Loro: digital-only. Noi: companion del fisico |
+| **Tabletopia** | Tabletop digitale 3D | Stesso: digital-only |
+| **Dized** | Tutorial board game ufficiali pre-prodotti | Loro: slow per gioco, no traduzione. Noi: AI generative + traduzione |
+| **BGG forum** | Community Q&A umana | Loro: high quality ma async. Noi: instant + traduzione + cited |
+| **Google Translate / DeepL** | Traduzione generic | Loro: zero context gaming. Noi: glossario + tono narrativo + manuale OCR'd |
+| **Manuali italiani ufficiali** | Traduzione ufficiale | Loro: solo top-seller (10%). Noi: long-tail (90%) |
+
+**Sustainable moats**:
+1. Casual italian gaming community (first-mover)
+2. House rules database — network effect (con tensione vs Privacy strict preset, vedi OQ-5)
+3. Glossario per-gioco crowdsourced
+4. Integration multi-capability (OCR + RAG + traduzione + setup)
+5. Provider-agnostic platform (OpenRouter)
+6. Trust transparency (reputational moat EU-aware market)
+
+---
+
+## 6. MVP Phase 1 — Implementation Scope
+
+> ## 🎯 Questo è il subset effettivamente buildabile in 4-5 mesi
+>
+> Drastic scope cut dalla vision per evitare scope creep severo (review issue #1). Effort estimate realistic — vedi §6.4 per breakdown per componente.
+
+### 6.1 ✅ What's IN — Phase 1
+
+| Feature | Scope ridotto |
+|---------|---------------|
+| **G1 Acquire manuale** | Photo-first ingestion. Quality bar realistic: confidence visibile, manual override per pagine fail. **PR-2 validation OCR su 5 manuali pre-sprint start.** |
+| **G3 Q&A regole** | On-demand, latency P95 < 5 sec, hallucination ≤ 3% golden. House rule capability G3.4 inclusa. |
+| **G4 Translation on-demand single paragraph** | Cache 24h locale + sessione. **NO pre-translate chapter** (deferred MVP-1). Fallback chapter-based G4.5 incluso. Graceful WiFi loss G4.7. |
+| **LLM mode** | **Default Auto invisible**. OpenRouter routing internal. **NO preset, NO BYOK, NO transparency UI** (deferred v2). |
+| **Pricing** | **2 tier solamente: Free 50 pag/mese + Credits €5/100 pag**. NO subscription premium, NO BYOK Pro (deferred v2). |
+| **Topology** | **Single-device only**. NO multi-device QR opt-in (deferred MVP-1). |
+| **Infrastructure** | **CAX31 day 1** (€14/mese). Cloud-managed Python services optional se carico cresce. NO borderline RAM gamble. |
+| **i18n architecture** | Stringhe estratte i18n-ready, ma UI lingua solo IT. NO selector lingua (deferred MVP-1). |
+| **Test plan** | Unit + Integration + E2E + LLM evaluation con test set golden 100 Q&A + 50 trad. |
+
+### 6.2 ❌ What's OUT — Phase 1 (con deferral target)
+
+| Feature | Deferred to | Trigger |
+|---------|-------------|---------|
+| **Save/resume cross-day** | **MVP-1** (Phase 1.5) | **Esplicito high-priority** — risolve persona Sara pain |
+| G2 Setup wizard interattivo | MVP-1 | Se MVP "show setup paragraph" completion < 60% |
+| G4.2 Pre-translate chapter | MVP-1 | Richiesta utenti |
+| Multi-device QR opt-in | MVP-1 | 30%+ sessioni > 4 player |
+| UI lingua EN | MVP-1 | 30%+ utenti locale non-IT |
+| AI Narrator audio | v2 | 30%+ utenti chiedono TTS |
+| Two-pass translation | v2 | Premium tier validation |
+| LLM preset selector + transparency | v2 | Power-user segment validation |
+| BYOK | v2.5 | Dev/enterprise inbound |
+| Multi-device collaborative full | v3 | Market validation |
+| Source language CJK | v3 | Mercato JP/ZH |
+| RTL support | v3+ | Mercato Arabic/Hebrew |
+| Modalità famiglia / parental | v3 | Famiglia segment validation |
+
+### 6.3 📋 Acceptance criteria Phase 1
+
+MVP è "shippable" quando:
+
+1. ✅ 5 sessioni reali end-to-end completate con gruppi target (gamebook in EN tradotto)
+2. ✅ ≥ 70% utenti completano almeno 1 sessione di 2h+
+3. ✅ Costo medio sessione ≤ €3.00 (target consolidato §4.6)
+4. ✅ Hallucination rate Q&A ≤ 3% su test set golden (PR-3)
+5. ✅ OCR validation su 5 manuali gamebook reali ≥ 85% pages confidence accettabile (PR-2)
+6. ✅ Legal review copyright completata + TOS aggiornato (PR-1)
+7. ✅ Latenza P95 Q&A < 5 sec, traduzione < 5 sec
+8. ✅ Pricing engine 2-tier funzionante con cap free 50 pag/mese
+
+### 6.4 ⏱️ Realistic effort estimate
+
+| Componente | Effort | Owner |
+|-----------|--------|-------|
+| Photo-first ingestion (dewarping + page detect + multi-shot stitching) | 4-6 weeks | 1 ML engineer dedicated |
+| Translation service (cache + glossary + OpenRouter integration) | 3-4 weeks | 1 backend dev |
+| Q&A flow with confidence + citations + house rule | 3 weeks | 1 fullstack |
+| 5+ UI screens + onboarding | 4-6 weeks | 1 designer + 1 fullstack |
+| LLM evaluation infra + golden test set creation | **2 weeks dedicated** + IT native speaker | 1 ML + contractor |
+| Pricing engine + Free tier counter | 1-2 weeks | 1 fullstack |
+| Legal review + TOS update | 2-3 weeks | Legal advisor |
+| OCR validation on real manuals | 2 weeks | 1 ML |
+| Integration testing + chaos engineering | 2 weeks | 1 QA |
+| **TOTALE realistic** | **4-5 mesi** | **3 fullstack + 1 ML + 1 designer + legal advisor part-time** |
+
+> ⚠️ **NON 2-3 mesi 4 persone come stimato originalmente** (review issue #9).
+
+### 6.5 🚦 Pre-launch prerequisites checklist
+
+Prima di pubblicare MVP:
+
+- [ ] **PR-1**: Legal review copyright + TOS aggiornato + privacy policy GDPR-compliant
+- [ ] **PR-2**: OCR validated su ≥ 5 manuali gamebook reali (Tainted Grail, ISS Vanguard, Stuffed Fables, Andor, 7th Continent)
+- [ ] **PR-3**: Test set golden 100 Q&A + 50 paragrafi narrativi italiani con expert validation
+- [ ] **CAX31 deployment** + monitoring + alerting + backup automated
+- [ ] **Pricing engine tested** end-to-end (Free counter + Credits checkout + Stripe/payment integration)
+- [ ] **Hallucination rate ≤ 3%** validato su test set golden in CI gate
+- [ ] **5 sessioni usability testing** completate, feedback incorporato
+- [ ] **Disaster recovery drill** eseguito (restore da backup in < 2h)
+
+---
+
+## 7. Decisions Log
+
+Decisioni prese durante la sessione di brainstorming 2026-05-04, in ordine cronologico.
+
+| # | Decisione | Razionale |
+|---|-----------|-----------|
+| D-01 | Job-to-be-done: companion passivo + per libro game traduzione narrativa | Sara cita esplicitamente "manuale non in italiano" come pain primario non considerato nelle 3 user story originali |
+| D-02 | Modalità traduzione: on-demand default + override "pre-traduci capitolo" user-controlled | Costo controllato, flessibilità per power-user senza forzare decisioni a casual |
+| D-03 | Topologia device: single-device GM + multi-device read-only opt-in via QR | Casual reality, progressive enhancement per nerd entusiasta |
+| D-04 | Save/resume **OUT MVP, IN MVP-1** | Scope reduction per shipping velocity, ma promosso esplicitamente in Phase 1.5 (review issue) |
+| D-05 | Customer focus: casual gruppo (B) | Mercato espandibile, pain acuto, non hardcore vocal minority |
+| D-06 | Pricing MVP: Freemium 50 pag/mese + Credits €5/100 pag (2 tier solamente) | Riduzione da 4 tier originali per evitare confusione casual (review issue #5) |
+| D-07 | Quality bar traduzione: LLM single-pass narrative MVP, two-pass premium roadmap | Sweet spot quality/cost per casual, premium come differentiation v2 |
+| D-08 | LLM provider: OpenRouter abstraction + Anthropic primary + DeepSeek tier per cost | Anti-vendor lock-in, cost optimization, multi-tier per use case |
+| D-09 | User-controlled LLM provider selection: **OUT MVP, v2** | Over-engineering per casual primary (review issue #6) |
+| D-10 | Infrastructure: **CAX31 day 1**, NON CAX21 borderline | Production safety, no OOM-killer risk (review issue #4) |
+| D-11 | Documento type: **Vision Doc, NOT MVP spec** | Scope creep severo durante brainstorming → riposizionamento honest (review path B) |
+| D-12 | OQ-1 Copyright promosso a **PR-1 Prerequisite** | Blocker pre-launch, non rinviabile (review issue #2) |
+| D-13 | OQ-3 Hallucination rate **DEFINITO**: ≤ 3% golden, 0% target su confidence > 0.85 | Eliminata open question rinviabile, target operationale (review issue #8) |
+| D-14 | Test set golden creation: 4 settimane lead time + IT native speaker + ML engineer (PR-3) | Owner + budget esplicito (review issue #10) |
+| D-15 | OCR validation 5 manuali gamebook reali pre-sprint start (PR-2) | R-13 mitigation upfront, evita scoperta late di layout artistici problematici (review issue #3) |
+| D-16 | Roadmap effort: **4-5 mesi** 3 fullstack + 1 ML + 1 designer | Riallineato da 2-3 mesi sottostimato (review issue #9) |
+| D-17 | RTL support **OUT v3+** | Over-engineering MVP, gamebook market dominato latin script |
+| D-18 | TTS self-hostable engine identificato (Coqui/Piper/Bark) per coerenza Privacy strict preset | Eliminata inconsistenza §4.9 vs §4.10 (review issue) |
+| D-19 | Multi-device token expiry: **8 ore** (rivisto da 4) | Sessioni gamebook tipiche 5-6h, 4h causava expiry mid-session (review issue) |
+| D-20 | Q&A latency P95: **5 sec** (rivisto da 3 sec) | Realistic LLM Haiku end-to-end performance (review issue) |
+
+---
+
+## Appendix A — Riferimenti
+
+- **MeepleAI CLAUDE.md**: `D:\Repositories\meepleai-monorepo-frontend\CLAUDE.md`
+- **Sessione brainstorming**: chat session 2026-05-04
+- **Spec-panel review iniziale**: stesso session, output del comando `/sc:spec-panel`
+- **Ultrathink review**: stesso session, response a path B selection
+- **BC esistenti riferiti**: DocumentProcessing, KnowledgeBase, GameToolbox, AgentMemory, SessionTracking, SharedGameCatalog
+
+## Appendix B — Glossario domain
+
+| Termine | Definizione |
+|---------|-------------|
+| **Gamebook / libro game** | Board game con narrativa ramificata letta a paragrafi numerati (Tainted Grail, ISS Vanguard, etc.) |
+| **GM (Game Master)** | Giocatore al tavolo che conduce la sessione, legge i paragrafi, gestisce regole. In contesto MeepleAI è il primary user dell'app. |
+| **Paragrafo §** | Unità narrativa identificata da numero (es. §147) nel manuale gamebook |
+| **House rule** | Variante di regola decisa dal gruppo che differisce dal manuale ufficiale |
+| **OCR confidence** | Score 0-1 sicurezza del modello OCR sulla riconoscibilità testo. Confidence ≠ accuracy. |
+| **MOS (Mean Opinion Score)** | Metrica 1-5 quality TTS / traduzione, valutata da human raters |
+| **BYOK (Bring Your Own Key)** | Pattern in cui utente fornisce propria API key per LLM provider, bypassando billing platform |
+
+---
+
+**Fine Vision Document.**


### PR DESCRIPTION
## Summary

- Mockup hifi Claude Design per SP6 Libro Game (gamebook AI assistant MVP Phase 1): **C** play-session, **D** translation-viewer, **E** quota-credits checkout — totale 4233 righe di mockup
- Ripristino `docs/superpowers/specs/2026-05-04-libro-game-assistant-vision.md` (967 righe) eliminato per errore in PR #791 (docs reorg Phase 2), ancora referenziato come knowledge file allegato nelle sessioni Claude Design SP6

## Mockup overview

| Id | File | Stati | Gherkin |
|----|------|-------|---------|
| C | sp6-libro-game-play-session.{html,jsx} | 22 | G3.1-G3.5 + G4/G4.4/G4.6/G4.7 + G2/G2.3 |
| D | sp6-libro-game-translation-viewer.{html,jsx} | 14 | G4/G4.4/G4.7 |
| E | sp6-libro-game-quota-credits.{html,jsx} | 7 V5 | @G4.6 |

Pattern applicati su tutti C/D/E:
- Anchor id `state-NN-...` su tutti i wrapper (review meeting via URL fragment)
- Numerazione Gherkin brief 1:1 (no SC-XX inventati)
- `prefers-reduced-motion` guard su tutte le animazioni
- Dark theme tokens scope `[data-theme="dark"]` per wrapper non-root
- Verifiche pre-mockup 6/6 prima del go (anti-drift)

## Scope

- Solo asset mockup statici sotto `admin-mockups/design_files/` — **nessuna modifica codice runtime**
- Nessun impatto su `apps/api`, `apps/web`, `infra/`
- Mockup F (`sp6-libro-game-house-rule`) ancora pending, sarà PR separato

## Test plan

- [ ] Verificare apertura HTML in browser (canvas con tutti gli stati visibili)
- [ ] Aprire JSX nelle sezioni `apps/web/src/components/v2/` per riferimento implementazione futura
- [ ] Confermare path file vision restored sotto `docs/superpowers/specs/` (valutare se spostare sotto `docs/for-developers/specs/` post-PR #791 reorg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)