### PR TITLE
fix(discover): resolve Sonar S125 in GetNewGamesQueryHandler (smoke unblock)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/GetNewGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/GetNewGamesQueryHandler.cs
@@ -89,12 +89,13 @@ internal sealed class GetNewGamesQueryHandler
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
+        // YearPublished defaults to 0 for legacy rows seeded without a year; the projection
+        // surfaces null so the FE can render "Year unknown". Image fallback prefers ImageUrl
+        // over ThumbnailUrl when both are present.
         return rows.Select(g => new NewGameDto(
             Id: g.Id,
             Name: g.Title,
             Publisher: string.IsNullOrWhiteSpace(g.Publisher) ? null : g.Publisher,
-            // YearPublished defaults to 0 for legacy rows seeded without a year;
-            // surface as null so the FE can render "Year unknown".
             Year: g.YearPublished > 0 ? g.YearPublished : null,
             ImageUrl: !string.IsNullOrWhiteSpace(g.ImageUrl)
                 ? g.ImageUrl


### PR DESCRIPTION
## Summary

Sblocca nightly smoke E2E (broken da 2026-05-07, tracked #821) — Sonar S125 false-positive su `GetNewGamesQueryHandler.cs:96` rompeva il Release build.

## Root cause

Linee 96-97 erano un commento esplicativo legittimo:
```csharp
// YearPublished defaults to 0 for legacy rows seeded without a year;
// surface as null so the FE can render "Year unknown".
Year: g.YearPublished > 0 ? g.YearPublished : null,
```

Sonar interpretava il pattern `// ...` adiacente a property assignment (`Year: ...`) come codice commentato e bloccava `dotnet publish` in Release.

## Fix

Sposto il commento esplicativo **sopra** il `rows.Select(...)` projection, dove non sta adiacente a alcun property assignment. Stessa informazione, location più sicura per il pattern matcher di Sonar.

```csharp
// YearPublished defaults to 0 for legacy rows seeded without a year; the projection
// surfaces null so the FE can render "Year unknown". Image fallback prefers ImageUrl
// over ThumbnailUrl when both are present.
return rows.Select(g => new NewGameDto(
    Id: g.Id,
    ...
));
```

## Test plan

- [x] `dotnet build -c Release` clean (0 errors, 0 warnings)
- [ ] CI Backend Build + Integration green
- [ ] Nightly smoke verde 2026-05-08 (verifica indirect)

## Refs

- #821 (umbrella RCA smoke streak 2026-05-05/06/07)
- PR #812 (Wave 3 Phase 1 — introduzione del file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)