### PR TITLE
fix(deploy-staging): P1 pipeline trustworthy — CF Access bypass + trigger semplificato + runbook

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -743,13 +743,19 @@ jobs:
           sparse-checkout-cone-mode: true
 
       - name: Deep Health Check
+        env:
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           echo "🔍 Running deep health checks..."
 
-          # Wait for API with structured health response
+          # CF Access bypass headers reused for all curls in this step
+          CF_HEADERS=(-H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}")
+
+          # Wait for API with structured health response (CF Access bypass)
           HEALTH=""
           for i in {1..30}; do
-            HEALTH=$(curl -sf https://api.meepleai.app/health 2>/dev/null || true)
+            HEALTH=$(curl -sf "${CF_HEADERS[@]}" https://api.meepleai.app/health 2>/dev/null || true)
             if [ -n "$HEALTH" ]; then
               echo "📋 Health response received"
               break
@@ -786,8 +792,14 @@ jobs:
           echo "✅ All critical services healthy"
 
       - name: Web Health Check
+        env:
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
-          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://meepleai.app)
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+            -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+            https://meepleai.app)
           if [ "$HTTP_STATUS" != "200" ]; then
             echo "❌ Web returned status $HTTP_STATUS"
             exit 1
@@ -795,6 +807,9 @@ jobs:
           echo "✅ Web healthy (HTTP $HTTP_STATUS)"
 
       - name: Smoke Tests
+        env:
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           echo "🧪 Running staging smoke tests..."
           FAIL=0
@@ -803,7 +818,10 @@ jobs:
           smoke_test() {
             local name="$1" url="$2" expect="$3"
             local status
-            status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$url" 2>/dev/null || echo "000")
+            status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+              -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+              -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+              "$url" 2>/dev/null || echo "000")
             if echo "$expect" | grep -q "$status"; then
               echo "  ✅ $name: HTTP $status"
               RESULTS="${RESULTS}| $name | $status | ✅ |\n"
@@ -822,7 +840,10 @@ jobs:
 
           # Health endpoint JSON validation
           echo "  Validating health response structure..."
-          HEALTH_JSON=$(curl -sf --max-time 10 https://meepleai.app/health 2>/dev/null || true)
+          HEALTH_JSON=$(curl -sf --max-time 10 \
+            -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+            -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+            https://meepleai.app/health 2>/dev/null || true)
           if [ -n "$HEALTH_JSON" ] && echo "$HEALTH_JSON" | jq -e '.status' > /dev/null 2>&1; then
             echo "  ✅ Health JSON: valid structure"
           else
@@ -830,7 +851,10 @@ jobs:
           fi
 
           # Response time check
-          RT=$(curl -sf -o /dev/null -w "%{time_total}" --max-time 10 https://meepleai.app 2>/dev/null || echo "9.999")
+          RT=$(curl -sf -o /dev/null -w "%{time_total}" --max-time 10 \
+            -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+            -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+            https://meepleai.app 2>/dev/null || echo "9.999")
           echo "  📊 Response time: ${RT}s"
 
           # Write summary to job output

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -23,9 +23,7 @@ name: Deploy to Staging
 # was removed in favor of workflow_run. To rollback, restore the push block
 # and revert the env-var routing.
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
+  push:
     branches: [main-staging]
   workflow_dispatch:
     inputs:
@@ -65,41 +63,28 @@ env:
   WEB_IMAGE: ghcr.io/${{ github.repository }}/web
   ENVIRONMENT: staging
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  # Spec R2 — Deploy SHA/branch routing
-  # Under workflow_run trigger, github.sha and github.ref point to the
-  # default branch, NOT the commit that triggered CI. Use the workflow_run
-  # context to recover the actual deploy SHA, with a fallback to github.sha
-  # for workflow_dispatch and any future trigger that doesn't expose
-  # workflow_run context. Every checkout `ref:` and every shell reference
-  # to the deploy SHA must use these env vars instead of github.sha.
-  DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
-  DEPLOY_BRANCH: ${{ github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
+  # Deploy SHA/branch routing
+  # Under push trigger, github.sha is the actual commit pushed to main-staging.
+  # Under workflow_dispatch, github.sha is HEAD of the ref input.
+  # workflow_run path retained as defensive fallback (currently unused but
+  # cheap). Every checkout `ref:` should route through these.
+  DEPLOY_SHA: ${{ github.sha }}
+  DEPLOY_BRANCH: ${{ github.ref_name }}
 
 jobs:
-  # Spec R2 — Deploy quality gate
-  # All deployment jobs depend on this gate. The gate passes only if:
-  #   - The workflow was triggered manually (workflow_dispatch escape hatch), OR
-  #   - The workflow was triggered by a successful CI run on main-staging
-  #
-  # When ci.yml on main-staging fails, this gate stays in `skipped` state
-  # and no downstream jobs run. The result: zero deploy attempts on red CI.
+  # CI Quality Gate
+  # Trigger now is push to main-staging or workflow_dispatch — both are
+  # explicit operator-controlled actions. The gate confirms inputs for
+  # observability but always passes (no skip path). Future CI policy
+  # hardening (out of scope P1) may re-introduce a CI Success branch
+  # protection check or workflow_run trigger if desired.
   gate:
     name: CI Quality Gate
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch'
-      || (
-        github.event_name == 'workflow_run'
-        && github.event.workflow_run.conclusion == 'success'
-        && github.event.workflow_run.head_branch == 'main-staging'
-      )
     steps:
       - name: Confirm gate inputs
         run: |
           echo "Trigger:           ${{ github.event_name }}"
-          echo "Source CI status:  ${{ github.event.workflow_run.conclusion || 'n/a (manual)' }}"
-          echo "Source CI branch:  ${{ github.event.workflow_run.head_branch || 'n/a (manual)' }}"
-          echo "Source CI run id:  ${{ github.event.workflow_run.id || 'n/a (manual)' }}"
           echo "Deploy SHA:        ${{ env.DEPLOY_SHA }}"
           echo "Deploy branch:     ${{ env.DEPLOY_BRANCH }}"
           echo "Gate passed - proceeding with deployment pipeline"

--- a/docs/for-developers/operations/deploy-staging-runbook.md
+++ b/docs/for-developers/operations/deploy-staging-runbook.md
@@ -1,0 +1,149 @@
+# Deploy to Staging — Runbook
+
+> Ultima revisione: 2026-05-07 (P1 fix — pipeline trustworthy minimal viable)
+
+## Modello deploy
+
+Il workflow `.github/workflows/deploy-staging.yml` deploya `https://meepleai.app` (staging che funge da unico ambiente pubblico al momento — produzione `meepleai.com` non provisionata).
+
+**Trigger**:
+
+- `push: branches: [main-staging]` — modello canonico: merge da `main-dev → main-staging` via release PR triggera deploy
+- `workflow_dispatch` — escape hatch manuale (emergency / retry / hotfix)
+
+**Pipeline jobs** (in ordine):
+
+1. `gate` — CI Quality Gate (sempre passa post-P1; observability-only)
+2. `notify-start` — Slack notification
+3. `detect-changes` — paths-filter su API / Web / infra
+4. `pre-deploy-check` — backend build + frontend build verification
+5. `build` — Docker images push to GHCR (ARM64)
+6. `migrate-db` — idempotent SQL migration via dotnet ef + pre-migration backup
+7. `snapshot-baseline` — read previous DEPLOYMENT.json performance metrics
+8. `deploy` — SSH-based blue-green deploy
+9. `validate` — Deep Health Check + Web Health Check + Smoke Tests + K6 smoke + perf regression
+10. `e2e-staging` — Playwright smoke spec
+11. `notify-end` — Slack completion
+
+## Promote main-dev → main-staging
+
+```bash
+# 1. Verify CI is green on main-dev (manual check)
+gh pr checks <latest-merged-pr-number>
+
+# 2. Create release PR
+git checkout main-staging
+git pull --ff-only origin main-staging
+git checkout -b release/main-dev-YYYY-MM-DD
+git merge --no-ff origin/main-dev -m "chore(release): merge main-dev into main-staging"
+git push -u origin release/main-dev-YYYY-MM-DD
+
+# 3. Create + merge PR
+gh pr create --base main-staging --head release/main-dev-YYYY-MM-DD \
+  --title "chore(release): main-dev → main-staging" \
+  --body "Promote latest main-dev for staging deployment"
+gh pr merge <PR_NUM> --merge --delete-branch
+
+# 4. Watch deploy
+gh run watch $(gh run list --workflow "Deploy to Staging" --limit 1 --json databaseId --jq '.[0].databaseId')
+```
+
+## Smoke testing meepleai.app dietro CF Access
+
+`meepleai.app` è dietro Cloudflare Access. Curl pubblici ricevono `HTTP/1.1 302 Found` redirect a login.
+
+**Per smoke locale o ad-hoc**:
+
+Il service token è salvato in `infra/secrets/cf-access.secret` (gitignored). Template documentale a `infra/secrets/cf-access.secret.example`.
+
+```bash
+# Carica credentials da file gitignored
+set -a; source infra/secrets/cf-access.secret; set +a
+
+# Smoke health
+curl -sf -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+        -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+        https://meepleai.app/health | jq
+
+# Smoke API endpoint
+curl -sf -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+        -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+        "https://meepleai.app/api/v1/discover/recent-games?pageSize=1" | jq
+
+# Cleanup env vars
+unset CF_ACCESS_CLIENT_ID CF_ACCESS_CLIENT_SECRET
+```
+
+**Per CI runner**: i secrets `CF_ACCESS_CLIENT_ID` e `CF_ACCESS_CLIENT_SECRET` sono iniettati nei step `validate` job di `deploy-staging.yml` via `env:` block. Non serve azione manuale.
+
+**Storage del token**: il token è salvato in CF Zero Trust dashboard. Rotazione raccomandata annuale. Per emettere nuovo token:
+
+1. CF dashboard → Access → Service Auth → Create Service Token (TTL ≥ 1 anno)
+2. Aggiungi nuovo token alla policy "Service auth for staging smoke" già attaccata all'application meepleai.app
+3. Aggiorna `infra/secrets/cf-access.secret` con nuovi valori
+4. Re-popola GitHub secrets:
+   ```bash
+   set -a; source infra/secrets/cf-access.secret; set +a
+   printf '%s' "$CF_ACCESS_CLIENT_ID"    | gh secret set CF_ACCESS_CLIENT_ID
+   printf '%s' "$CF_ACCESS_CLIENT_SECRET" | gh secret set CF_ACCESS_CLIENT_SECRET
+   unset CF_ACCESS_CLIENT_ID CF_ACCESS_CLIENT_SECRET
+   ```
+5. Verifica deploy success al prossimo run, poi revoca il token vecchio in CF dashboard
+
+## Distinguere skip vacuo da real success run
+
+Pre-P1, deploy-staging.yml mostrava `conclusion=success` su run dove TUTTI i job critici erano skippati (gate condition `workflow_run.head_branch=='main-staging'` non soddisfatta da CI completion su main-dev). Solo `notify-end` (senza `needs: gate`) eseguiva.
+
+**Per verificare un run è realmente eseguito**:
+
+```bash
+gh run view <RUN_ID> --json jobs | \
+  jq '[.jobs[] | select(.name | test("Build Images|Database Migration|Deploy to Staging|Post-deploy Validation")) | {name: .name, conclusion: .conclusion}]'
+```
+
+Expected per run reale: 4 entries con `conclusion="success"` (no `"skipped"`).
+Expected per run vacuo (pre-P1): tutti `"skipped"` con run-level conclusion=success → BUG.
+
+Post-P1 il trigger è `push: [main-staging]` quindi non si verificano più run vacui.
+
+## Rollback procedure
+
+`deploy-staging.yml` non ha auto-rollback. Manual rollback richiede:
+
+```bash
+# 1. Identifica merge commit responsabile
+git checkout main-staging
+git pull --ff-only origin main-staging
+git log -1 --pretty='%H' --merges
+
+# 2. Crea revert PR
+git checkout -b revert/staging-deploy-YYYY-MM-DD
+git revert -m 1 <MERGE_SHA> --no-edit
+git push -u origin revert/staging-deploy-YYYY-MM-DD
+gh pr create --base main-staging --head revert/staging-deploy-YYYY-MM-DD \
+  --title "revert: staging deploy <MERGE_SHA>" \
+  --body "Rollback. Cause: <DESCRIBE_FAILURE>"
+
+# 3. Merge → triggera nuovo deploy con codice precedente
+gh pr merge <REVERT_PR_NUM> --merge --delete-branch
+gh run watch $(gh run list --workflow "Deploy to Staging" --limit 1 --json databaseId --jq '.[0].databaseId')
+```
+
+## Observability
+
+- Slack: notifiche via `notify-start` + `notify-end` jobs (channel configurato in repo secrets `SLACK_GITNOTIFY_WEBHOOK_URL` + `SLACK_CRITICAL_WEBHOOK_URL`)
+- Run history: `gh run list --workflow "Deploy to Staging" --limit 20`
+- DEPLOYMENT.json on staging server: `/opt/meepleai/repo/infra/DEPLOYMENT.json` — contiene version + commit + perf baseline ultimo deploy success
+
+## Known limitations (P1 minimal)
+
+- Trigger `push: [main-staging]` accetta qualsiasi push, anche con CI rosso. Affidamento al disciplinare merge process: chi mergia main-dev → main-staging deve aver verificato CI green pre-merge.
+- Smoke test K6 + perf regression sono `continue-on-error: true` — non bloccanti.
+- Auto-rollback assente — richiede manual revert PR.
+
+Future hardening (out of scope P1):
+
+- Reintroduzione branch protection rule che richiede CI Success su main-staging
+- Auto-rollback workflow su validate failure
+- RUM Web Vitals per p75 reali post-deploy
+- CF Access bypass per `/health` endpoint (consentirebbe smoke pubblico senza service token, trade-off security)

--- a/docs/superpowers/plans/2026-05-07-a1-promote-main-dev-staging.md
+++ b/docs/superpowers/plans/2026-05-07-a1-promote-main-dev-staging.md
@@ -1,0 +1,505 @@
+# A1 — Promote main-dev → main-staging (visibilità v2 su meepleai.app) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Sincronizzare `main-staging` con `main-dev` (6 commit Wave 3 backend) e verificare che le 16+ rotte v2 siano effettivamente raggiungibili e funzionanti su `https://meepleai.app`. Goal A1 dello SMART set 2026-05-07.
+
+**Architecture:** `meepleai.app` è **staging**, deploy-staging.yml fires automaticamente via `workflow_run` quando CI su `main-staging` passa. Il lavoro è una release PR `main-dev → main-staging` + verifica end-to-end del risultato del deploy automatico. **NESSUN cambiamento a workflow o codice applicativo**.
+
+**Scope chiarification — fuori scope:**
+- Riabilitazione `deploy-production.yml.disabled` (= production a `meepleai.com`) — separato in goal futuro
+- Token redesign A11y (#807 / #808 freeze) — è goal A2
+- Implementazione rotte v2 ancora pending (`/discover`, `/game-nights`, `/kb/[id]`, `/toolkits/[id]`) — sbloccate solo post #807 Fase 2
+
+**Tech Stack:** GitHub CLI (`gh`), git, GitHub Actions (deploy-staging.yml), curl per smoke.
+
+---
+
+## File Structure
+
+Nessun file di codice applicativo modificato. L'unico artefatto creato è la PR di release.
+
+- **Crea (transitorio)**: branch `release/main-dev-to-main-staging-2026-05-07`
+- **Crea (transitorio)**: PR di release `main-dev → main-staging`
+- **Modifica**: nessun file repo (la PR contiene solo merge commit dei 6 commit di Wave 3 backend)
+- **Verifica**: deploy-staging.yml run + `https://meepleai.app/health` + 3 rotte v2 random sample
+
+---
+
+## Task 1: Pre-flight verification
+
+**Files:**
+- Lettura: stato `origin/main-dev` vs `origin/main-staging`
+
+- [ ] **Step 1: Verifica fetch fresco e count divergenza**
+
+Run:
+```bash
+git fetch origin main-dev main-staging --prune
+git log origin/main-staging..origin/main-dev --oneline
+```
+
+Expected:
+```
+b787ed460 fix(discover): resolve Sonar S125 false-positive in GetNewGamesQueryHandler (#823)
+91bfb8951 feat(toolkit-ratings): Wave 3 Phase 4b — ratings endpoints (#805) (#819)
+f6a0bc70a feat(discover): Wave 3 Phase 4a — 2 cross-cutting endpoints (#805) (#816)
+38f35eaf7 feat(kb-chunks): Wave 3 Phase 3 — full spec-conformant rewrite (#805) (#815)
+8cfd5fee8 feat(toolkit-marketplace): Wave 3 Phase 2 — 3 marketplace endpoints (#805) (#814)
+2d8f0bdbc feat(discover): Wave 3 Phase 1 — 3 quick-win endpoints (#805) (#812)
+```
+
+Se la divergenza eccede 6 commit O include commit non-backend (es. cambi `apps/web/**`), STOP e ri-valuta scope con utente prima di procedere.
+
+- [ ] **Step 2: Verifica CI verde su `main-dev` HEAD**
+
+Run:
+```bash
+gh run list --branch main-dev --limit 5 --workflow CI --json conclusion,headSha,createdAt,url
+```
+
+Expected: top entry ha `"conclusion": "success"` e `"headSha"` inizia con `b787ed460`.
+
+Se top run è `failure` o `in_progress`, STOP. Non promuovere a staging finché CI non è verde.
+
+- [ ] **Step 3: Verifica staging attualmente sano (baseline pre-deploy)**
+
+Run:
+```bash
+curl -sf https://meepleai.app/health | jq -r '.status' || echo "STAGING UNHEALTHY"
+```
+
+Expected output: `Healthy` (o codice di stato 200 con qualsiasi struttura JSON valida).
+
+Se `STAGING UNHEALTHY` o curl fallisce → investiga prima di procedere (potenziale stato pre-rotto).
+
+- [ ] **Step 4: Snapshot baseline rotte v2 attualmente live**
+
+Run:
+```bash
+for route in / /games /agents /library /sessions /discover /gamebook; do
+  status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "https://meepleai.app${route}")
+  echo "  ${route} → ${status}"
+done
+```
+
+Expected: tutte le rotte ritornano 200, 301, 302 (login redirect), o 401 (unauth) — **NESSUN 5xx**.
+
+Salva l'output in commento PR successivo per confronto post-deploy.
+
+---
+
+## Task 2: Crea release PR main-dev → main-staging
+
+**Files:**
+- Crea (transitorio): branch e PR su GitHub
+
+- [ ] **Step 1: Verifica working tree pulito**
+
+Run:
+```bash
+git status --porcelain
+```
+
+Expected: output vuoto. Se non vuoto, stash o committa modifiche locali prima di procedere.
+
+- [ ] **Step 2: Aggiorna `main-staging` locale dal remote**
+
+Run:
+```bash
+git checkout main-staging
+git pull --ff-only origin main-staging
+```
+
+Expected: `Already up to date.` oppure fast-forward pulito.
+
+Se non fast-forward, STOP — divergenza inaspettata su `main-staging`.
+
+- [ ] **Step 3: Crea branch di release**
+
+Run:
+```bash
+git checkout -b release/main-dev-to-main-staging-2026-05-07
+git merge --no-ff origin/main-dev -m "chore(release): merge main-dev into main-staging
+
+Promotes 6 commits (Wave 3 backend Phase 0-4):
+- BGG search public exposure (#811)
+- /discover Phase 1+4a quick-wins (#812, #816)
+- toolkit marketplace Phase 2 (#814)
+- KB chunks Phase 3 rewrite (#815)
+- toolkit ratings Phase 4b (#819)
+- Sonar S125 fix (#823)
+
+Refs A1 SMART goal docs/superpowers/specs/2026-05-07-v2-meepleai-deploy-goals.md"
+```
+
+Expected: merge commit creato senza conflitti. Se conflitti, STOP — non risolverli a mano in questo branch.
+
+- [ ] **Step 4: Push branch**
+
+Run:
+```bash
+git push -u origin release/main-dev-to-main-staging-2026-05-07
+```
+
+Expected: push successful, link PR suggerito.
+
+- [ ] **Step 5: Crea PR target main-staging**
+
+Run:
+```bash
+gh pr create \
+  --base main-staging \
+  --head release/main-dev-to-main-staging-2026-05-07 \
+  --title "chore(release): main-dev → main-staging — Wave 3 backend Phase 0-4 (6 commits)" \
+  --body "$(cat <<'EOF'
+## Scope
+
+Release PR per A1 SMART goal: visibilità v2 su `meepleai.app`.
+
+Promuove **6 commit backend-only** da `main-dev` a `main-staging`:
+
+| SHA | Titolo | Issue |
+|-----|--------|-------|
+| `b787ed460` | fix(discover): Sonar S125 false-positive | #823 |
+| `91bfb8951` | feat(toolkit-ratings): Wave 3 Phase 4b ratings | #805 / #819 |
+| `f6a0bc70a` | feat(discover): Wave 3 Phase 4a cross-cutting | #805 / #816 |
+| `38f35eaf7` | feat(kb-chunks): Wave 3 Phase 3 spec rewrite | #805 / #815 |
+| `8cfd5fee8` | feat(toolkit-marketplace): Wave 3 Phase 2 | #805 / #814 |
+| `2d8f0bdbc` | feat(discover): Wave 3 Phase 1 quick-wins | #805 / #812 |
+
+## Out of scope
+
+- Frontend: nessun cambio a `apps/web/**`
+- Production deploy (meepleai.com): A1 termina al deploy staging
+- A11y token redesign: vedi A2 / #807
+
+## Verifica post-merge
+
+CI su `main-staging` deve passare → `deploy-staging.yml` parte automatico via `workflow_run` → smoke su `https://meepleai.app/health`.
+
+Refs:
+- Goal SMART: `docs/superpowers/specs/2026-05-07-v2-meepleai-deploy-goals.md`
+- Plan: `docs/superpowers/plans/2026-05-07-a1-promote-main-dev-staging.md`
+EOF
+)"
+```
+
+Expected: PR URL stampato, es. `https://github.com/meepleAi-app/meepleai-monorepo/pull/<N>`. Annota il numero PR per i task successivi (sostituisci `<PR_NUM>` ovunque).
+
+- [ ] **Step 6: Posta snapshot baseline come PR comment**
+
+Run (sostituisci `<PR_NUM>` con il numero PR):
+```bash
+gh pr comment <PR_NUM> --body "$(cat <<'EOF'
+## Baseline pre-deploy snapshot
+
+Output di `curl -s -o /dev/null -w "%{http_code}"` per rotte v2 critical-path catturato pre-merge:
+
+\`\`\`
+  / → <STATUS>
+  /games → <STATUS>
+  /agents → <STATUS>
+  /library → <STATUS>
+  /sessions → <STATUS>
+  /discover → <STATUS>
+  /gamebook → <STATUS>
+\`\`\`
+
+Codici accettabili: 200/301/302/401. Qualsiasi 5xx invalida la baseline.
+EOF
+)"
+```
+
+Sostituisci i `<STATUS>` con i valori effettivi catturati in Task 1 Step 4 prima di postare.
+
+---
+
+## Task 3: Attendi CI verde su PR e mergia
+
+**Files:** nessuno locale.
+
+- [ ] **Step 1: Polling CI status su PR (background)**
+
+Run (sostituisci `<PR_NUM>`):
+```bash
+gh pr checks <PR_NUM> --watch
+```
+
+Expected: tutti i check passano (esce con exit 0). Tempo atteso: 15-30 minuti per CI completa.
+
+Se check fallisce, STOP — leggi log del check fallito (`gh run view <run-id> --log-failed`) prima di decidere se è flake retry-able o blocker reale.
+
+- [ ] **Step 2: Verifica mergeability stato finale**
+
+Run (sostituisci `<PR_NUM>`):
+```bash
+gh pr view <PR_NUM> --json mergeable,mergeStateStatus,statusCheckRollup
+```
+
+Expected: `"mergeable": "MERGEABLE"` AND `"mergeStateStatus": "CLEAN"`.
+
+Se `BLOCKED` o `BEHIND`, STOP — investiga.
+
+- [ ] **Step 3: Mergia PR (squash NON desiderato — usa merge commit per release)**
+
+Run (sostituisci `<PR_NUM>`):
+```bash
+gh pr merge <PR_NUM> --merge --delete-branch
+```
+
+Expected: `✓ Merged pull request #<N>` + `✓ Deleted branch release/...`.
+
+**RAZIONALE merge commit (no squash)**: una release PR conserva la cronologia atomica dei 6 commit Wave 3 backend; `git log main-staging` deve continuare a mostrare i commit originali per traceability per-feature.
+
+- [ ] **Step 4: Pull `main-staging` aggiornato e verifica**
+
+Run:
+```bash
+git checkout main-staging
+git pull --ff-only origin main-staging
+git log -1 --pretty='%H %s'
+```
+
+Expected: HEAD è il merge commit appena creato; `git log` mostra `b787ed460` raggiungibile da `main-staging`.
+
+---
+
+## Task 4: Verifica deploy-staging.yml fires automaticamente
+
+**Files:** nessuno.
+
+- [ ] **Step 1: Localizza CI run su main-staging post-merge**
+
+Run:
+```bash
+sleep 30  # let GitHub register the push
+gh run list --branch main-staging --limit 3 --workflow CI --json status,conclusion,headSha,createdAt,databaseId
+```
+
+Expected: top entry `"status": "in_progress"` o `"queued"` con `headSha` corrispondente al merge commit.
+
+- [ ] **Step 2: Watch CI su main-staging fino a green**
+
+Run (sostituisci `<RUN_ID>` con `databaseId` da step precedente):
+```bash
+gh run watch <RUN_ID>
+```
+
+Expected: `✓ <run name>` quando completa con success.
+
+Se fallisce, **NON**provare hotfix — apri issue `[A1 fail] CI red on main-staging post-merge` e investiga separatamente. La auto-rollback su staging non esiste; il deploy semplicemente non parte.
+
+- [ ] **Step 3: Verifica deploy-staging.yml triggered via workflow_run**
+
+Run:
+```bash
+sleep 60  # workflow_run lag
+gh run list --branch main-staging --limit 3 --workflow "Deploy to Staging" --json status,conclusion,headSha,createdAt,databaseId
+```
+
+Expected: top entry esiste con `"status": "in_progress"` o `"queued"` e stesso `headSha` del CI run.
+
+Se nessun run "Deploy to Staging" appare entro 2 minuti dal CI green, STOP — leggi `deploy-staging.yml` riga 89-95 (gate condition workflow_run); possibile mismatch su `head_branch` o `conclusion`.
+
+- [ ] **Step 4: Watch deploy completo**
+
+Run (sostituisci `<DEPLOY_RUN_ID>`):
+```bash
+gh run watch <DEPLOY_RUN_ID>
+```
+
+Expected: completion success. Tempo atteso: 20-40 minuti (build + migrate-db + deploy + validate + e2e-staging).
+
+Se job `validate` o `e2e-staging` falliscono → STOP — staging potenzialmente in stato degradato. Vedi Task 6 rollback.
+
+---
+
+## Task 5: Smoke test post-deploy contro meepleai.app
+
+**Files:** nessuno modificato. Solo verifica.
+
+- [ ] **Step 1: API health structured response**
+
+Run:
+```bash
+curl -sf https://meepleai.app/health | jq '{status, checks: [.checks[] | {name, status}]}'
+```
+
+Expected:
+```json
+{
+  "status": "Healthy",
+  "checks": [
+    {"name": "postgres", "status": "Healthy"},
+    {"name": "redis", "status": "Healthy"},
+    ...
+  ]
+}
+```
+
+Se `status != "Healthy"` o postgres/redis non Healthy → escalate.
+
+- [ ] **Step 2: Verifica DEPLOYMENT.json riflette nuovo SHA**
+
+Run (richiede SSH key staging — se non disponibile, skippa e usa `gh run view`):
+```bash
+gh run view <DEPLOY_RUN_ID> --log | grep -A2 "Version recorded"
+```
+
+Expected: log contiene `Version recorded: staging-2026<...>-<SHA::7>` dove `<SHA::7>` corrisponde a `b787ed4` o al merge commit.
+
+- [ ] **Step 3: Smoke test rotte v2 vs baseline**
+
+Run:
+```bash
+echo "Post-deploy snapshot:"
+for route in / /games /agents /library /sessions /discover /gamebook; do
+  status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "https://meepleai.app${route}")
+  echo "  ${route} → ${status}"
+done
+```
+
+Expected: stessa serie di codici 200/301/302/401 della baseline (Task 1 Step 4). **NESSUN 5xx** o cambio inaspettato (es. da 200 a 404 ⇒ regressione).
+
+- [ ] **Step 4: Smoke test endpoint Wave 3 backend nuovi (verifica core scope)**
+
+Run:
+```bash
+echo "Wave 3 backend endpoint smoke:"
+curl -s -o /dev/null -w "  /api/v1/discover/recent-games → %{http_code}\n" \
+  --max-time 10 "https://meepleai.app/api/v1/discover/recent-games?pageSize=1"
+curl -s -o /dev/null -w "  /api/v1/discover/popular-agents → %{http_code}\n" \
+  --max-time 10 "https://meepleai.app/api/v1/discover/popular-agents?pageSize=1"
+curl -s -o /dev/null -w "  /api/v1/toolkit-marketplace → %{http_code}\n" \
+  --max-time 10 "https://meepleai.app/api/v1/toolkit-marketplace?pageSize=1"
+```
+
+Expected: tutti 200 o 401 (auth required). **NON 404** — un 404 significa che gli endpoint Wave 3 NON sono live e il deploy non ha funzionato per i nuovi commit.
+
+- [ ] **Step 5: Browser visual check (manuale)**
+
+Apri https://meepleai.app in browser, autentica con credenziali test, e verifica:
+
+1. `/library` renderizza `LibraryHubV2` (cerca `data-slot="v2-*"` in DevTools, oppure cerca classe `library-hybrid-grid`)
+2. `/games?tab=library` renderizza v2 (`GamesLibraryView`)
+3. `/sessions` renderizza v2 (cards con OutcomeBadge visibile)
+4. `/gamebook` mostra hero + grid (componenti SP6 Phase B)
+
+Screenshot delle 4 rotte allegati come PR comment chiusura.
+
+- [ ] **Step 6: Posta closure comment su PR**
+
+Run (sostituisci `<PR_NUM>` con il PR di release già mergiato):
+```bash
+gh pr comment <PR_NUM> --body "$(cat <<'EOF'
+## ✅ A1 SMART goal verified — meepleai.app live
+
+### Deploy summary
+
+- CI on main-staging: ✅
+- Deploy-Staging workflow: ✅
+- API /health: Healthy
+- Postgres + Redis: Healthy
+- 7 frontend routes smoke: <PASTE Task 5 Step 3 OUTPUT>
+- 3 Wave 3 backend endpoint smoke: <PASTE Task 5 Step 4 OUTPUT>
+- Visual check (4 rotte v2): <PASTE LINK SCREENSHOTS>
+
+### Acceptance criteria status (vs SMART goal A1)
+
+- [x] 16+ rotte v2 raggiungibili pubblicamente su meepleai.app
+- [x] Smoke E2E green
+- [x] No 5xx su rotte critical path
+- [x] Wave 3 backend endpoints rispondono
+
+A1 chiusa. Prossimo: A2 (#807 token redesign) per lift freeze e abilitare Wave 3 frontend.
+EOF
+)"
+```
+
+---
+
+## Task 6: Rollback procedure (eseguire SOLO se Task 4 o Task 5 falliscono)
+
+**Files:** nessuno locale. Operazioni remote tramite `gh` e GitHub UI.
+
+> **NB**: deploy-staging.yml NON ha auto-rollback. Manual rollback è git revert + nuova promote.
+
+- [ ] **Step 1: Identifica merge commit da revertire**
+
+Run:
+```bash
+git checkout main-staging
+git pull --ff-only origin main-staging
+git log -1 --pretty='%H' --merges
+```
+
+Expected: SHA del merge commit appena creato.
+
+- [ ] **Step 2: Crea revert PR**
+
+Run:
+```bash
+git checkout -b revert/main-dev-promotion-2026-05-07
+git revert -m 1 <MERGE_COMMIT_SHA> --no-edit
+git push -u origin revert/main-dev-promotion-2026-05-07
+gh pr create \
+  --base main-staging \
+  --head revert/main-dev-promotion-2026-05-07 \
+  --title "revert: main-dev → main-staging promotion (A1 rollback)" \
+  --body "Rollback A1 deploy. Cause: <DESCRIVI FALLIMENTO>. Refs PR <PR_NUM>."
+```
+
+- [ ] **Step 3: Mergia revert PR + monitora redeploy**
+
+Run (sostituisci):
+```bash
+gh pr checks <REVERT_PR_NUM> --watch
+gh pr merge <REVERT_PR_NUM> --merge --delete-branch
+gh run list --branch main-staging --limit 1 --workflow "Deploy to Staging"
+```
+
+Expected: nuovo deploy parte automatico, restora staging allo stato pre-A1.
+
+- [ ] **Step 4: Verifica staging restaurato**
+
+Run:
+```bash
+curl -sf https://meepleai.app/health | jq -r '.status'
+```
+
+Expected: `Healthy`.
+
+---
+
+## Definition of Done — A1 chiusa
+
+- [ ] PR release `main-dev → main-staging` mergiata in main-staging
+- [ ] CI su main-staging post-merge: success
+- [ ] deploy-staging.yml run: success (build + migrate-db + deploy + validate + e2e-staging tutti green)
+- [ ] `https://meepleai.app/health` ritorna `{"status": "Healthy"}` con postgres + redis Healthy
+- [ ] Smoke test 7 rotte v2 frontend: nessun 5xx, codici stessi della baseline
+- [ ] Smoke test 3 endpoint Wave 3 backend nuovi: 200 o 401 (mai 404)
+- [ ] Visual check manuale 4 rotte v2 (library / games / sessions / gamebook): componenti v2 presenti nel DOM
+- [ ] Closure comment postato su PR di release
+
+**Tempo stimato totale**: 1-2 ore di wall-clock (di cui ~45-60 min CI + ~30 min deploy + ~15 min smoke). Lavoro attivo umano: ~20-30 minuti spread on touchpoint.
+
+---
+
+## Self-review checklist (skill enforcement)
+
+- ✅ **Spec coverage**: ogni acceptance criteria del SMART goal A1 è coperto da un Task con verifica concreta
+- ✅ **No placeholder**: ogni step ha comando esatto + expected output (eccezione: `<PR_NUM>`, `<RUN_ID>`, `<SHA>` che sono variabili runtime)
+- ✅ **Type consistency**: nomi workflow/branch consistenti — `deploy-staging.yml`, `main-staging`, `release/main-dev-to-main-staging-2026-05-07`
+- ✅ **Scope check**: focused su solo A1 (staging promotion); produzione e A2/B*/freeze esplicitamente fuori scope
+- ✅ **Rollback path**: Task 6 documentato esplicitamente con trigger condition
+
+## Riferimenti
+
+- Goal SMART: `docs/superpowers/specs/2026-05-07-v2-meepleai-deploy-goals.md` (TBD — comporlo se richiesto)
+- Workflow staging: `.github/workflows/deploy-staging.yml`
+- Workflow production (disabled): `.github/workflows/deploy-production.yml.disabled`
+- v2 migration matrix: `docs/for-developers/frontend/v2-migration-matrix.md`
+- Freeze policy: GitHub issue #808
+- A11y audit: GitHub issue #807

--- a/docs/superpowers/plans/2026-05-07-p1-pipeline-staging-trustworthy.md
+++ b/docs/superpowers/plans/2026-05-07-p1-pipeline-staging-trustworthy.md
@@ -1,0 +1,920 @@
+# P1 — Pipeline staging trustworthy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rendere `deploy-staging.yml` end-to-end fidato: trigger fires consistentemente, tutti job critici eseguono (no vacuum success da gate skip), smoke test job verifica HTTP 200 reale dietro CF Access. Goal P1 dello SMART set 2026-05-07.
+
+**Architecture:** Tre fix indipendenti su `.github/workflows/deploy-staging.yml`: (1) trigger semplificato a `push: [main-staging]` (rimuove workflow_run + gate complessità); (2) smoke test passa header CF Access service token via secret per bypass 302; (3) runbook documenta il modello "promote PR main-dev → main-staging quando ready to deploy" + come usare il bypass. Verifica via 3 deploy consecutivi success-no-skip.
+
+**Tech Stack:** GitHub Actions (workflow YAML), Bash (smoke test functions), curl con CF-Access-Client-Id/Secret headers, Markdown runbook.
+
+---
+
+## Diagnosi pre-plan (osservata 2026-05-07)
+
+Stato attuale verificato:
+
+```
+event=workflow_run, headBranch=main-dev, conclusion=success → tutti i 9 job CRITICI in stato "skipped", solo notify-end gira (= vacuum success)
+event=workflow_dispatch, headBranch=main-staging, conclusion=failure → tutti job girano fino a Post-deploy Validation che FALLISCE (smoke test riceve 302 da CF Access invece di 200)
+```
+
+Root causes:
+1. **Trigger `workflow_run` + gate `head_branch=='main-staging'` non si parlano**: GitHub fires workflow_run su main-dev ma gate skippa, lasciando `notify-end` (senza `needs: gate`) come unico job → "success" vacuamente
+2. **Smoke test `curl -sf https://meepleai.app/health` riceve 302** da Cloudflare Access redirect invece del 200 atteso → `validate` job fail
+3. **CF Access service token non disponibile** ai GitHub Actions runner (secrets `CF_ACCESS_CLIENT_ID`/`CF_ACCESS_CLIENT_SECRET` non esistono nei repo/env secrets di GitHub — verificato via `gh secret list`)
+
+Fix scope: 1 file YAML modificato (`deploy-staging.yml`) + 1 markdown runbook nuovo + 2 GitHub secrets aggiunti dall'utente owner.
+
+---
+
+## File Structure
+
+- **Modify**: `.github/workflows/deploy-staging.yml` (~10-15 righe modificate, suddivise in 2 commit logici: trigger fix + smoke fix)
+- **Create**: `docs/for-developers/operations/deploy-staging-runbook.md` (~150 righe nuovo doc)
+- **Modify (out-of-tree, manual via GitHub UI)**: GitHub repository secrets — aggiungere `CF_ACCESS_CLIENT_ID` + `CF_ACCESS_CLIENT_SECRET`
+
+Nessun file applicativo (`apps/api/**`, `apps/web/**`) modificato.
+
+---
+
+## Task 1: CF Access service token discovery + GitHub secrets setup
+
+**Files:**
+- Read: Cloudflare Zero Trust dashboard (esterno al repo)
+- Modify: GitHub repository secrets (manual via UI o `gh secret set`)
+- No code/file commits in repo
+
+> **Razionale**: il servizio Cloudflare Access wrappa `meepleai.app/*`. Il GitHub Actions runner ha bisogno di credenziali di service-token per bypass HTTP 302. User indica che "abbiamo già lavorato sui token di accesso" — Task 1 è appurare DOVE sono e renderli disponibili al runner.
+
+- [ ] **Step 1: Owner verifica esistenza service token Cloudflare Access**
+
+Apri https://one.dash.cloudflare.com → Access → Service Auth → Service Tokens.
+
+Cerca un token già emesso per `meepleai.app` con scope che include `/health` o `/*` (lista tutti).
+
+Output atteso: almeno un token esistente con CLIENT_ID + CLIENT_SECRET. Se NON esiste, crea uno nuovo nominato `github-actions-staging-smoke` con TTL ≥ 1 anno.
+
+- [ ] **Step 2: Verifica policy CF Access permette il service token**
+
+Dashboard CF → Access → Applications → seleziona l'app coprente `meepleai.app` → Policies.
+
+Conferma esiste policy "Service Auth" che include il service token. Se non esiste, crea con: action=Allow, include=Service Auth + nome token sopra.
+
+Test from local:
+```bash
+curl -H "CF-Access-Client-Id: <CLIENT_ID>.access" \
+     -H "CF-Access-Client-Secret: <CLIENT_SECRET>" \
+     -sf -o /dev/null -w "%{http_code}\n" \
+     https://meepleai.app/health
+```
+
+Expected: `200` (non 302).
+
+Se 302 ancora → policy non abbinata correttamente, ferma e correggi policy in CF dashboard.
+
+- [ ] **Step 3: Aggiungi service token come GitHub repository secrets**
+
+Run (sostituisci `<CLIENT_ID>` e `<CLIENT_SECRET>` con valori reali, mai committarli):
+```bash
+gh secret set CF_ACCESS_CLIENT_ID --body "<CLIENT_ID>.access"
+gh secret set CF_ACCESS_CLIENT_SECRET --body "<CLIENT_SECRET>"
+```
+
+Verify:
+```bash
+gh secret list --json name | jq -r '.[] | select(.name | test("CF_ACCESS")) | .name'
+```
+
+Expected: 2 righe `CF_ACCESS_CLIENT_ID` e `CF_ACCESS_CLIENT_SECRET`.
+
+- [ ] **Step 4: Commit "preparazione" doc nel repo**
+
+Crea file segnaposto che traccia il setup avvenuto:
+```bash
+echo "# CF Access secrets setup — Task 1 P1 (2026-05-07)
+- CF_ACCESS_CLIENT_ID added to GitHub repo secrets
+- CF_ACCESS_CLIENT_SECRET added to GitHub repo secrets
+- Service token configured in CF Zero Trust for meepleai.app /* with policy 'Service Auth'
+" > /tmp/cf-access-setup-note.md
+```
+
+NB: Non committare il /tmp file. Questa è solo una traccia per Task 4 runbook.
+
+---
+
+## Task 2: Smoke test usa CF Access bypass headers
+
+**Files:**
+- Modify: `.github/workflows/deploy-staging.yml`:797-833 (job `validate`, sezione "Smoke Tests")
+- Modify: `.github/workflows/deploy-staging.yml`:745-786 (job `validate`, sezione "Deep Health Check")
+
+> **Razionale**: tutti i `curl` contro `https://meepleai.app/*` nel job `validate` ricevono 302 da CF Access. Aggiungiamo CF Access service token headers a ogni curl, passando i secrets via env.
+
+- [ ] **Step 1: Controlla baseline corrente del job `validate`**
+
+Run:
+```bash
+sed -n '745,855p' .github/workflows/deploy-staging.yml
+```
+
+Verifica che esistano:
+- "Deep Health Check" step con `HEALTH=$(curl -sf https://api.meepleai.app/health ...)`
+- "Web Health Check" step con `curl ... https://meepleai.app`
+- "Smoke Tests" step con funzione `smoke_test()` che fa curl
+
+- [ ] **Step 2: Modifica step "Deep Health Check" — passa CF Access headers**
+
+Edit `.github/workflows/deploy-staging.yml`. Trova la riga ~745 con step `name: Deep Health Check` e modifica come segue:
+
+Sostituisci:
+```yaml
+      - name: Deep Health Check
+        run: |
+          echo "🔍 Running deep health checks..."
+
+          # Wait for API with structured health response
+          HEALTH=""
+          for i in {1..30}; do
+            HEALTH=$(curl -sf https://api.meepleai.app/health 2>/dev/null || true)
+            if [ -n "$HEALTH" ]; then
+```
+
+Con:
+```yaml
+      - name: Deep Health Check
+        env:
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: |
+          echo "🔍 Running deep health checks..."
+
+          # CF Access bypass headers reused for all curls in this step
+          CF_HEADERS=(-H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}")
+
+          # Wait for API with structured health response (CF Access bypass)
+          HEALTH=""
+          for i in {1..30}; do
+            HEALTH=$(curl -sf "${CF_HEADERS[@]}" https://api.meepleai.app/health 2>/dev/null || true)
+            if [ -n "$HEALTH" ]; then
+```
+
+- [ ] **Step 3: Modifica step "Web Health Check" — passa CF Access headers**
+
+Sostituisci:
+```yaml
+      - name: Web Health Check
+        run: |
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://meepleai.app)
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "❌ Web returned status $HTTP_STATUS"
+            exit 1
+          fi
+          echo "✅ Web healthy (HTTP $HTTP_STATUS)"
+```
+
+Con:
+```yaml
+      - name: Web Health Check
+        env:
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: |
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+            -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+            https://meepleai.app)
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "❌ Web returned status $HTTP_STATUS"
+            exit 1
+          fi
+          echo "✅ Web healthy (HTTP $HTTP_STATUS)"
+```
+
+- [ ] **Step 4: Modifica step "Smoke Tests" — funzione smoke_test riceve CF headers**
+
+Sostituisci:
+```yaml
+      - name: Smoke Tests
+        run: |
+          echo "🧪 Running staging smoke tests..."
+          FAIL=0
+          RESULTS=""
+
+          smoke_test() {
+            local name="$1" url="$2" expect="$3"
+            local status
+            status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$url" 2>/dev/null || echo "000")
+```
+
+Con:
+```yaml
+      - name: Smoke Tests
+        env:
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: |
+          echo "🧪 Running staging smoke tests..."
+          FAIL=0
+          RESULTS=""
+
+          smoke_test() {
+            local name="$1" url="$2" expect="$3"
+            local status
+            status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+              -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+              -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+              "$url" 2>/dev/null || echo "000")
+```
+
+E nello stesso step più sotto, modifica anche la chiamata `HEALTH_JSON=$(curl ...)`:
+
+Sostituisci:
+```bash
+          HEALTH_JSON=$(curl -sf --max-time 10 https://meepleai.app/health 2>/dev/null || true)
+```
+
+Con:
+```bash
+          HEALTH_JSON=$(curl -sf --max-time 10 \
+            -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+            -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+            https://meepleai.app/health 2>/dev/null || true)
+```
+
+E ancora la response time check:
+Sostituisci:
+```bash
+          RT=$(curl -sf -o /dev/null -w "%{time_total}" --max-time 10 https://meepleai.app 2>/dev/null || echo "9.999")
+```
+
+Con:
+```bash
+          RT=$(curl -sf -o /dev/null -w "%{time_total}" --max-time 10 \
+            -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+            -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+            https://meepleai.app 2>/dev/null || echo "9.999")
+```
+
+- [ ] **Step 5: Verifica YAML lint del workflow**
+
+Run:
+```bash
+gh workflow view deploy-staging.yml --yaml > /tmp/deploy-staging-current.yml 2>&1
+# Local YAML syntax check (using actionlint if available, else python yaml)
+python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-staging.yml'))" && echo "YAML OK"
+```
+
+Expected: `YAML OK`. Se errore, leggi il messaggio (probabilmente indentazione `env:` block) e correggi.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+git add .github/workflows/deploy-staging.yml
+git commit -m "fix(deploy-staging): pass CF Access service token headers to all smoke curls
+
+Smoke test job validate failed because curl received 302 from Cloudflare
+Access redirect instead of 200. Add CF-Access-Client-Id and
+CF-Access-Client-Secret headers to:
+- Deep Health Check step
+- Web Health Check step
+- Smoke Tests step (smoke_test function + HEALTH_JSON + RT timer)
+
+Secrets CF_ACCESS_CLIENT_ID and CF_ACCESS_CLIENT_SECRET must be populated
+in repo secrets per Task 1 of P1 plan.
+
+Refs docs/superpowers/specs/2026-05-07-v2-meepleai-deploy-goals.md (Goal P1)
+Refs docs/superpowers/plans/2026-05-07-p1-pipeline-staging-trustworthy.md"
+```
+
+---
+
+## Task 3: Trigger semplificato a `push: [main-staging]`
+
+**Files:**
+- Modify: `.github/workflows/deploy-staging.yml`:25-49 (top-level `on:` block)
+- Modify: `.github/workflows/deploy-staging.yml`:78-105 (job `gate` — possibilmente eliminato)
+
+> **Razionale**: rimuovere workflow_run + gate accoppiato. Trigger diventa: push a `main-staging` (manuale via release PR) OPPURE workflow_dispatch (escape hatch). Il modello "deploy quando merge a main-staging" è esplicito e deterministico. Future CI policy hardening (out of scope P1) può ripristinare un gate strutturato.
+
+- [ ] **Step 1: Sostituisci il blocco `on:` (righe 25-49 attuali)**
+
+Edit `.github/workflows/deploy-staging.yml`. Trova:
+```yaml
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main-staging]
+  workflow_dispatch:
+    inputs:
+      skip_tests:
+        description: 'Skip tests (emergency deploy only)'
+        required: false
+        default: 'false'
+        type: boolean
+      force_full_deploy:
+        description: 'Force rebuild and deploy of both API and Web'
+        required: false
+        default: 'false'
+        type: boolean
+      perf_regression_mode:
+        description: 'Performance regression behavior (warn|fail)'
+        required: false
+        default: 'warn'
+        type: choice
+        options:
+          - warn
+          - fail
+```
+
+Sostituisci con:
+```yaml
+on:
+  push:
+    branches: [main-staging]
+  workflow_dispatch:
+    inputs:
+      skip_tests:
+        description: 'Skip tests (emergency deploy only)'
+        required: false
+        default: 'false'
+        type: boolean
+      force_full_deploy:
+        description: 'Force rebuild and deploy of both API and Web'
+        required: false
+        default: 'false'
+        type: boolean
+      perf_regression_mode:
+        description: 'Performance regression behavior (warn|fail)'
+        required: false
+        default: 'warn'
+        type: choice
+        options:
+          - warn
+          - fail
+```
+
+- [ ] **Step 2: Aggiorna env DEPLOY_SHA / DEPLOY_BRANCH (righe 67-77)**
+
+Trova:
+```yaml
+  # Spec R2 — Deploy SHA/branch routing
+  # Under workflow_run trigger, github.sha and github.ref point to the
+  # default branch, NOT the commit that triggered CI. Use the workflow_run
+  # context to recover the actual deploy SHA, with a fallback to github.sha
+  # for workflow_dispatch and any future trigger that doesn't expose
+  # workflow_run context. Every checkout `ref:` and every shell reference
+  # to the deploy SHA must use these env vars instead of github.sha.
+  DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+  DEPLOY_BRANCH: ${{ github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
+```
+
+Sostituisci con:
+```yaml
+  # Deploy SHA/branch routing
+  # Under push trigger, github.sha is the actual commit pushed.
+  # Under workflow_dispatch, github.sha is HEAD of the ref input.
+  # workflow_run path retained as defensive fallback (currently unused but
+  # cheap). Every checkout `ref:` should route through these.
+  DEPLOY_SHA: ${{ github.sha }}
+  DEPLOY_BRANCH: ${{ github.ref_name }}
+```
+
+- [ ] **Step 3: Sostituisci il job `gate` con un placeholder no-op (per minimizzare blast radius del cambio)**
+
+Trova:
+```yaml
+  # Spec R2 — Deploy quality gate
+  # All deployment jobs depend on this gate. The gate passes only if:
+  #   - The workflow was triggered manually (workflow_dispatch escape hatch), OR
+  #   - The workflow was triggered by a successful CI run on main-staging
+  #
+  # When ci.yml on main-staging fails, this gate stays in `skipped` state
+  # and no downstream jobs run. The result: zero deploy attempts on red CI.
+  gate:
+    name: CI Quality Gate
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch'
+      || (
+        github.event_name == 'workflow_run'
+        && github.event.workflow_run.conclusion == 'success'
+        && github.event.workflow_run.head_branch == 'main-staging'
+      )
+    steps:
+      - name: Confirm gate inputs
+        run: |
+          echo "Trigger:           ${{ github.event_name }}"
+          echo "Source CI status:  ${{ github.event.workflow_run.conclusion || 'n/a (manual)' }}"
+          echo "Source CI branch:  ${{ github.event.workflow_run.head_branch || 'n/a (manual)' }}"
+          echo "Source CI run id:  ${{ github.event.workflow_run.id || 'n/a (manual)' }}"
+          echo "Deploy SHA:        ${{ env.DEPLOY_SHA }}"
+          echo "Deploy branch:     ${{ env.DEPLOY_BRANCH }}"
+          echo "Gate passed - proceeding with deployment pipeline"
+```
+
+Sostituisci con:
+```yaml
+  # CI Quality Gate
+  # Trigger now is push to main-staging or workflow_dispatch — both are
+  # explicit operator-controlled actions. The gate confirms inputs for
+  # observability but always passes (no skip path). Future CI policy
+  # hardening (out of scope P1) may re-introduce a CI Success branch
+  # protection check or workflow_run trigger if desired.
+  gate:
+    name: CI Quality Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm gate inputs
+        run: |
+          echo "Trigger:           ${{ github.event_name }}"
+          echo "Deploy SHA:        ${{ env.DEPLOY_SHA }}"
+          echo "Deploy branch:     ${{ env.DEPLOY_BRANCH }}"
+          echo "Gate passed - proceeding with deployment pipeline"
+```
+
+- [ ] **Step 4: Verifica YAML lint dopo edit**
+
+Run:
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-staging.yml'))" && echo "YAML OK"
+```
+
+Expected: `YAML OK`.
+
+- [ ] **Step 5: Verifica visivamente che jobs downstream `needs: gate` ancora funzionano**
+
+Run:
+```bash
+grep -n "needs.*gate" .github/workflows/deploy-staging.yml
+```
+
+Expected: alcune righe `needs: gate` o `needs: [gate, ...]`. Confermati ancora referenziati. Il gate ora passa SEMPRE quindi non bloccherà i downstream jobs.
+
+- [ ] **Step 6: Commit Task 3**
+
+```bash
+git add .github/workflows/deploy-staging.yml
+git commit -m "fix(deploy-staging): trigger su push:main-staging, rimuove workflow_run + gate skip vacuo
+
+Sostituisce 'workflow_run from CI on main-staging' con 'push to main-staging'.
+Risolve il problema dove workflow_run firava ma il gate head_branch=='main-staging'
+skippava tutti i job lasciando notify-end come solo job ad eseguire (vacuum success).
+
+Modello deploy ora: merge a main-staging → push trigger → tutti job eseguono.
+workflow_dispatch resta come escape hatch.
+
+Future CI policy hardening (out of scope P1) può re-introdurre un gate
+strutturato basato su branch protection o workflow_run con filter affidabile.
+
+Refs docs/superpowers/plans/2026-05-07-p1-pipeline-staging-trustworthy.md (Task 3)"
+```
+
+---
+
+## Task 4: Runbook deploy-staging
+
+**Files:**
+- Create: `docs/for-developers/operations/deploy-staging-runbook.md`
+
+> **Razionale**: nuovo developer/operator deve sapere (1) come funziona il pipeline post-fix, (2) come usare CF Access service token per smoke locale, (3) come distinguere skip vacuo da real run.
+
+- [ ] **Step 1: Crea il runbook con sezioni essenziali**
+
+Crea il file:
+```bash
+mkdir -p docs/for-developers/operations
+cat > docs/for-developers/operations/deploy-staging-runbook.md << 'RUNBOOK_EOF'
+# Deploy to Staging — Runbook
+
+> Ultima revisione: 2026-05-07 (P1 fix — pipeline trustworthy minimal viable)
+
+## Modello deploy
+
+Il workflow `.github/workflows/deploy-staging.yml` deploya `https://meepleai.app` (staging che funge da unico ambiente pubblico al momento — produzione `meepleai.com` non provisionata).
+
+**Trigger**:
+- `push: branches: [main-staging]` — modello canonico: merge da `main-dev → main-staging` via release PR triggera deploy
+- `workflow_dispatch` — escape hatch manuale (emergency / retry / hotfix)
+
+**Pipeline jobs** (in ordine):
+1. `gate` — CI Quality Gate (sempre passa post-P1; observability-only)
+2. `notify-start` — Slack notification
+3. `detect-changes` — paths-filter su API / Web / infra
+4. `pre-deploy-check` — backend build + frontend build verification
+5. `build` — Docker images push to GHCR (ARM64)
+6. `migrate-db` — idempotent SQL migration via dotnet ef + pre-migration backup
+7. `snapshot-baseline` — read previous DEPLOYMENT.json performance metrics
+8. `deploy` — SSH-based blue-green deploy
+9. `validate` — Deep Health Check + Web Health Check + Smoke Tests + K6 smoke + perf regression
+10. `e2e-staging` — Playwright smoke spec
+11. `notify-end` — Slack completion
+
+## Promote main-dev → main-staging
+
+```bash
+# 1. Verify CI is green on main-dev (manual check)
+gh pr checks <latest-merged-pr-number>
+
+# 2. Create release PR
+git checkout main-staging
+git pull --ff-only origin main-staging
+git checkout -b release/main-dev-YYYY-MM-DD
+git merge --no-ff origin/main-dev -m "chore(release): merge main-dev into main-staging"
+git push -u origin release/main-dev-YYYY-MM-DD
+
+# 3. Create + merge PR
+gh pr create --base main-staging --head release/main-dev-YYYY-MM-DD \
+  --title "chore(release): main-dev → main-staging" \
+  --body "Promote latest main-dev for staging deployment"
+gh pr merge <PR_NUM> --merge --delete-branch
+
+# 4. Watch deploy
+gh run watch $(gh run list --workflow "Deploy to Staging" --limit 1 --json databaseId --jq '.[0].databaseId')
+```
+
+## Smoke testing meepleai.app dietro CF Access
+
+`meepleai.app` è dietro Cloudflare Access. Curl pubblici ricevono `HTTP/1.1 302 Found` redirect a login.
+
+**Per smoke locale o ad-hoc**:
+
+```bash
+# Recupera service token da CF Zero Trust dashboard:
+# https://one.dash.cloudflare.com → Access → Service Auth → Service Tokens
+# Token GitHub Actions: github-actions-staging-smoke
+export CF_ACCESS_CLIENT_ID="<id>.access"
+export CF_ACCESS_CLIENT_SECRET="<secret>"
+
+# Smoke health
+curl -sf -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+        -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+        https://meepleai.app/health | jq
+
+# Smoke API endpoint
+curl -sf -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+        -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+        "https://meepleai.app/api/v1/discover/recent-games?pageSize=1" | jq
+```
+
+**Per CI runner**: i secrets `CF_ACCESS_CLIENT_ID` e `CF_ACCESS_CLIENT_SECRET` sono iniettati nei step `validate` job di `deploy-staging.yml` via `env:` block. Non serve azione manuale.
+
+**Storage del token**: il token è salvato in CF Zero Trust dashboard. Rotazione raccomandata annuale. Per emettere nuovo token:
+1. CF dashboard → Access → Service Auth → Create Service Token
+2. Aggiorna repo secrets: `gh secret set CF_ACCESS_CLIENT_ID --body "<new>.access"`, `gh secret set CF_ACCESS_CLIENT_SECRET --body "<new>"`
+3. Disabilita il token vecchio dopo verifica next deploy success
+
+## Distinguere skip vacuo da real success run
+
+Pre-P1, deploy-staging.yml mostrava `conclusion=success` su run dove TUTTI i job critici erano skippati (gate condition non soddisfatta). Solo `notify-end` (senza `needs: gate`) eseguiva.
+
+**Per verificare un run è realmente eseguito**:
+```bash
+gh run view <RUN_ID> --json jobs | \
+  jq '[.jobs[] | select(.name=="Deploy to Staging" or .name=="Build Images" or .name=="Database Migration") | .conclusion]'
+```
+
+Expected per run reale: `["success", "success", "success"]` (no `"skipped"`).
+Expected per run vacuo (pre-P1): `["skipped", "skipped", "skipped"]` con run-level conclusion=success → BUG.
+
+Post-P1 il gate passa sempre (observability-only), quindi questo problema non si ripresenta.
+
+## Rollback procedure
+
+`deploy-staging.yml` non ha auto-rollback. Manual rollback richiede:
+
+```bash
+# 1. Identifica merge commit responsabile
+git checkout main-staging
+git log -1 --pretty='%H' --merges
+
+# 2. Crea revert PR
+git checkout -b revert/staging-deploy-YYYY-MM-DD
+git revert -m 1 <MERGE_SHA> --no-edit
+git push -u origin revert/staging-deploy-YYYY-MM-DD
+gh pr create --base main-staging --head revert/staging-deploy-YYYY-MM-DD \
+  --title "revert: staging deploy <MERGE_SHA>" \
+  --body "Rollback. Cause: <DESCRIBE_FAILURE>"
+
+# 3. Merge → triggera nuovo deploy con codice precedente
+gh pr merge <REVERT_PR_NUM> --merge --delete-branch
+gh run watch $(gh run list --workflow "Deploy to Staging" --limit 1 --json databaseId --jq '.[0].databaseId')
+```
+
+## Observability
+
+- Slack: `#deploy-notifications` (via `notify-start` + `notify-end` jobs)
+- Run history: `gh run list --workflow "Deploy to Staging" --limit 20`
+- DEPLOYMENT.json on staging server: `/opt/meepleai/repo/infra/DEPLOYMENT.json` — contiene version + commit + perf baseline ultimo deploy success
+
+## Known limitations (P1 minimal)
+
+- Trigger `push: [main-staging]` accetta qualsiasi push, anche con CI rosso. Affidamento al disciplinare merge process: chi mergia main-dev → main-staging deve aver verificato CI green pre-merge.
+- Smoke test K6 + perf regression `continue-on-error: true` — non bloccanti.
+- Auto-rollback assente — richiede manual revert PR.
+
+Future hardening (out of scope P1):
+- Reintroduzione branch protection rule che richiede CI Success su main-staging
+- Auto-rollback workflow su validate failure
+- RUM Web Vitals per p75 reali post-deploy
+RUNBOOK_EOF
+```
+
+- [ ] **Step 2: Verifica markdown valido**
+
+Run:
+```bash
+ls -lh docs/for-developers/operations/deploy-staging-runbook.md
+head -5 docs/for-developers/operations/deploy-staging-runbook.md
+```
+
+Expected: file esiste, ~150 linee, primi 5 righe mostrano titolo + revisione.
+
+- [ ] **Step 3: Commit Task 4**
+
+```bash
+git add docs/for-developers/operations/deploy-staging-runbook.md
+git commit -m "docs(deploy-staging): add runbook for trusted pipeline (P1)
+
+Documenta:
+- Modello deploy post-P1 (push main-staging → trigger automatico)
+- Procedura promote main-dev → main-staging via release PR
+- Smoke testing meepleai.app dietro CF Access (service token usage)
+- Come distinguere skip vacuo (pre-P1) da real success run
+- Rollback manuale procedure
+- Known limitations P1 minimal + future hardening notes
+
+Refs docs/superpowers/plans/2026-05-07-p1-pipeline-staging-trustworthy.md (Task 4)"
+```
+
+---
+
+## Task 5: Apri PR e attendi prima deploy reale
+
+**Files:** nessuno modificato locale.
+
+> **Razionale**: tutti i fix sono ora committati su un branch feature. Apriamo PR target main-dev (perché Task 2+3 modificano il workflow file e devono essere validati via CI), poi merge a main-dev, e da lì owner può fare release PR main-dev → main-staging (che triggera il primo deploy POST-fix).
+
+- [ ] **Step 1: Determina parent branch e crea feature branch se non già su uno**
+
+Run:
+```bash
+git status
+git branch --show-current
+```
+
+Se HEAD è già su `feature/p1-pipeline-staging-trustworthy` o simile (creato durante Task 2-4), skippa al Step 2.
+
+Se HEAD è su `main-dev` con i commit Task 2-4 sopra, sposta su feature branch:
+```bash
+git log --oneline -5  # verifica i 3 commit di P1 sono in cima
+LAST_PRE_P1=$(git log --oneline | sed -n '4p' | awk '{print $1}')
+git checkout -b feature/p1-pipeline-staging-trustworthy
+git checkout main-dev
+git reset --hard $LAST_PRE_P1
+git checkout feature/p1-pipeline-staging-trustworthy
+```
+
+(NB: questo script serve solo se accidentalmente i commit erano stati fatti direttamente su main-dev. Best practice: lavora su feature branch da Task 2.)
+
+- [ ] **Step 2: Push feature branch**
+
+Run:
+```bash
+git push -u origin feature/p1-pipeline-staging-trustworthy
+```
+
+Expected: `Branch 'feature/p1-pipeline-staging-trustworthy' set up to track remote ...`.
+
+- [ ] **Step 3: Crea PR target main-dev**
+
+Run:
+```bash
+gh pr create \
+  --base main-dev \
+  --head feature/p1-pipeline-staging-trustworthy \
+  --title "fix(deploy-staging): P1 pipeline trustworthy — CF Access bypass + trigger semplificato + runbook" \
+  --body "$(cat <<'EOF'
+## P1 Implementation
+
+Implementa Goal P1 dello SMART set: deploy-staging.yml end-to-end fidato.
+
+## Diagnosi pre-fix
+- workflow_run + gate `head_branch=='main-staging'` skippava 9/10 job → vacuum success
+- Smoke test riceveva 302 da CF Access invece di 200
+
+## Fix
+- **Task 2**: CF Access service token headers su Deep Health Check + Web Health Check + Smoke Tests step
+- **Task 3**: Trigger semplificato a `push: [main-staging]` + workflow_dispatch (rimosso workflow_run + gate skip)
+- **Task 4**: Runbook `docs/for-developers/operations/deploy-staging-runbook.md`
+
+## Pre-req merge
+Repo secrets devono esistere (verificati in Task 1):
+- ✅ \`CF_ACCESS_CLIENT_ID\`
+- ✅ \`CF_ACCESS_CLIENT_SECRET\`
+
+## Acceptance
+Post-merge a main-dev → owner crea release PR main-dev → main-staging → trigger \`push: main-staging\` → primo deploy POST-fix gira tutti i job. Verifica Task 6.
+
+Refs spec: \`docs/superpowers/specs/2026-05-07-v2-meepleai-deploy-goals.md\`
+Refs plan: \`docs/superpowers/plans/2026-05-07-p1-pipeline-staging-trustworthy.md\`
+EOF
+)"
+```
+
+Annota PR_NUM stampato per i passaggi successivi.
+
+- [ ] **Step 4: Watch CI checks su PR**
+
+Run (sostituisci `<PR_NUM>`):
+```bash
+gh pr checks <PR_NUM> --watch
+```
+
+Expected: tutti i check passano. Se YAML lint fail o altro, fix sul branch e push (Task 2-3 step 5 dovrebbe averlo prevenuto).
+
+- [ ] **Step 5: Verifica mergeability**
+
+Run:
+```bash
+gh pr view <PR_NUM> --json mergeable,mergeStateStatus
+```
+
+Expected: `MERGEABLE` + `CLEAN`.
+
+- [ ] **Step 6: Mergia a main-dev**
+
+Run:
+```bash
+gh pr merge <PR_NUM> --squash --delete-branch
+```
+
+Squash perché è una "feature" P1 conceptualmente atomic (anche se 3 commit logici).
+
+---
+
+## Task 6: Acceptance verification — 3 deploy consecutivi success no-skip
+
+**Files:** nessuno modificato.
+
+> **Razionale**: SMART criterion P1 richiede 3 deploy consecutivi con conclusion=success E nessun job critico in stato skipped. Eseguiamo 3 trigger (mix di push reali main-dev → main-staging release PR + workflow_dispatch ammessi come surrogato) e ispezioniamo job results.
+
+- [ ] **Step 1: Trigger deploy #1 — release PR main-dev → main-staging**
+
+Run:
+```bash
+git checkout main-staging
+git pull --ff-only origin main-staging
+git checkout -b release/p1-acceptance-deploy-1-2026-05-07
+git merge --no-ff origin/main-dev -m "chore(release): P1 acceptance deploy #1 — main-dev → main-staging"
+git push -u origin release/p1-acceptance-deploy-1-2026-05-07
+gh pr create --base main-staging --head release/p1-acceptance-deploy-1-2026-05-07 \
+  --title "chore(release): P1 acceptance deploy #1" \
+  --body "First post-P1 deploy verification. Refs P1 plan Task 6 step 1."
+gh pr checks --watch  # attendi CI verde su release PR (su main-dev side)
+gh pr merge --merge --delete-branch
+```
+
+- [ ] **Step 2: Watch deploy #1 fino a completion**
+
+Run:
+```bash
+sleep 30
+RUN_ID=$(gh run list --workflow "Deploy to Staging" --limit 1 --branch main-staging --json databaseId --jq '.[0].databaseId')
+echo "Watching run $RUN_ID"
+gh run watch $RUN_ID
+```
+
+Expected: completa con conclusion=success in ~30-40 minuti.
+
+- [ ] **Step 3: Verifica deploy #1 NO skipped critical jobs**
+
+Run:
+```bash
+gh run view $RUN_ID --json jobs | \
+  jq '[.jobs[] | select(.name | test("Build Images|Database Migration|Deploy to Staging|Post-deploy Validation")) | {name, conclusion}]'
+```
+
+Expected output (4 entries, tutti conclusion="success"):
+```json
+[
+  {"name": "Build Images", "conclusion": "success"},
+  {"name": "Database Migration", "conclusion": "success"},
+  {"name": "Deploy to Staging", "conclusion": "success"},
+  {"name": "Post-deploy Validation", "conclusion": "success"}
+]
+```
+
+Se qualche conclusion="skipped", P1 acceptance fallisce — investiga (gate ancora skippante? trigger non firato?).
+
+Se qualche conclusion="failure" su Post-deploy Validation, smoke test ancora fail — verifica secrets popolati e curl headers corretti.
+
+- [ ] **Step 4: Trigger deploy #2 — workflow_dispatch (surrogato manuale)**
+
+Run:
+```bash
+gh workflow run "Deploy to Staging" --ref main-staging
+sleep 30
+RUN_ID2=$(gh run list --workflow "Deploy to Staging" --limit 1 --branch main-staging --json databaseId --jq '.[0].databaseId')
+echo "Watching run $RUN_ID2"
+gh run watch $RUN_ID2
+```
+
+Expected: completion success entro ~30 min. Detect-changes potrebbe forzare full deploy via workflow_dispatch input default.
+
+- [ ] **Step 5: Verifica deploy #2 NO skipped critical jobs**
+
+Run (sostituisci $RUN_ID2):
+```bash
+gh run view $RUN_ID2 --json jobs | \
+  jq '[.jobs[] | select(.name | test("Build Images|Database Migration|Deploy to Staging|Post-deploy Validation")) | {name, conclusion}]'
+```
+
+Expected: 4 entries tutti success.
+
+- [ ] **Step 6: Trigger deploy #3 — workflow_dispatch ripetuto**
+
+Run:
+```bash
+gh workflow run "Deploy to Staging" --ref main-staging
+sleep 30
+RUN_ID3=$(gh run list --workflow "Deploy to Staging" --limit 1 --branch main-staging --json databaseId --jq '.[0].databaseId')
+echo "Watching run $RUN_ID3"
+gh run watch $RUN_ID3
+```
+
+- [ ] **Step 7: Verifica deploy #3 e finale**
+
+Run (sostituisci $RUN_ID3):
+```bash
+gh run view $RUN_ID3 --json jobs | \
+  jq '[.jobs[] | select(.name | test("Build Images|Database Migration|Deploy to Staging|Post-deploy Validation")) | {name, conclusion}]'
+```
+
+Expected: 4 entries tutti success.
+
+- [ ] **Step 8: Smoke test post-deploy con CF Access (verifica indipendente)**
+
+Run (sostituisci `<CLIENT_ID>` `<SECRET>` con i valori GitHub secrets):
+```bash
+curl -sf -H "CF-Access-Client-Id: <CLIENT_ID>" \
+         -H "CF-Access-Client-Secret: <SECRET>" \
+         https://meepleai.app/health | jq -r '.status'
+```
+
+Expected: `Healthy`.
+
+- [ ] **Step 9: Posta closure comment su PR P1**
+
+Run (sostituisci `<P1_PR_NUM>` = il PR aperto in Task 5):
+```bash
+gh pr comment <P1_PR_NUM> --body "$(cat <<EOF
+## ✅ P1 acceptance verification — 3 deploy consecutivi green
+
+| Deploy | Run ID | Trigger | Build Images | DB Migration | Deploy | Validate |
+|--------|--------|---------|--------------|--------------|--------|----------|
+| #1 | $RUN_ID | release PR push:main-staging | success | success | success | success |
+| #2 | $RUN_ID2 | workflow_dispatch | success | success | success | success |
+| #3 | $RUN_ID3 | workflow_dispatch | success | success | success | success |
+
+Smoke independent: \`curl https://meepleai.app/health\` con CF Access headers ritorna \`{"status": "Healthy"}\`.
+
+P1 SMART Goal acceptance:
+- [x] 3 consecutive Deploy to Staging runs con conclusion=success
+- [x] Nessun job critico (Build/Migration/Deploy/Validate) in stato skipped
+- [x] Smoke test verifica HTTP 200 reale (non 302)
+- [x] Runbook \`docs/for-developers/operations/deploy-staging-runbook.md\` esistente
+
+P1 chiusa. Prossimo: P2 (deploy v2 + #807 token redesign + #808 freeze lift).
+EOF
+)"
+```
+
+---
+
+## Definition of Done — P1 chiusa
+
+- [ ] Repo secrets `CF_ACCESS_CLIENT_ID` + `CF_ACCESS_CLIENT_SECRET` popolati e funzionanti (Task 1)
+- [ ] `.github/workflows/deploy-staging.yml` modificato: smoke test usa CF Access headers (Task 2) + trigger semplificato push:main-staging (Task 3)
+- [ ] `docs/for-developers/operations/deploy-staging-runbook.md` creato e committato (Task 4)
+- [ ] PR P1 mergiata a main-dev (Task 5)
+- [ ] 3 deploy consecutivi su main-staging completano success con NESSUN job critico skipped (Task 6)
+- [ ] Smoke test indipendente con CF Access headers ritorna `{"status": "Healthy"}`
+
+**Tempo stimato totale**: 1 settimana wall-clock owner-paced. Active work ~4-6 ore (Task 1-5) + ~2 ore observation (Task 6 wait + verify).
+
+---
+
+## Self-review checklist
+
+- ✅ **Spec coverage**: ogni Gherkin scenario di P1 (deploy fires + smoke real 200 + 3 consecutive + runbook) è implementato da una Task con verifica concreta
+- ✅ **No placeholder**: ogni step ha comando esatto + expected output. Variabili runtime (`<PR_NUM>`, `<CLIENT_ID>`, `$RUN_ID`) sono chiaramente marcate come sostituibili
+- ✅ **Type consistency**: nomi consistenti — `CF_ACCESS_CLIENT_ID`/`CF_ACCESS_CLIENT_SECRET` ovunque, branch naming `feature/p1-...` e `release/p1-acceptance-deploy-N-...`
+- ✅ **Scope check**: focused su solo P1 (pipeline trustworthy minimal). #807 / #808 / Wave 3 frontend / production stand-up esplicitamente fuori scope (richiamati out-of-scope nello spec sopra)
+
+## Riferimenti
+
+- Spec parent: `docs/superpowers/specs/2026-05-07-v2-meepleai-deploy-goals.md`
+- Workflow modificato: `.github/workflows/deploy-staging.yml`
+- Plan A1 invalidato (storico): `docs/superpowers/plans/2026-05-07-a1-promote-main-dev-staging.md`

--- a/docs/superpowers/specs/2026-05-07-v2-meepleai-deploy-goals.md
+++ b/docs/superpowers/specs/2026-05-07-v2-meepleai-deploy-goals.md
@@ -1,0 +1,220 @@
+# MeepleAI v2 deploy goals — design (process-focused redesign)
+
+> **Date**: 2026-05-07
+> **Owner**: @DegrassiAaron (single dev / decision authority)
+> **Supersedes**: `docs/superpowers/plans/2026-05-07-a1-promote-main-dev-staging.md` (plan basato su assunzioni invalidate)
+> **Companion plan**: TBD — questo design viene tradotto in implementation plan via `superpowers:writing-plans` skill
+
+## Context
+
+### Goal di sessione
+
+Definire goal SMART trackable per portare la nuova UI v2 (Wave A/B/C/D + SP6, ~16 rotte già `done` su `main-dev`) a essere visibile e funzionale su `https://meepleai.app` (staging che funge da unico ambiente pubblico), con qualità accettabile su accessibility e performance.
+
+### Findings dalla sessione di discovery (2026-05-07)
+
+Iterazione precedente di brainstorming aveva prodotto 5 goal outcome-focused (A1, A2, B1, B2, B3) che assumevano:
+
+- pipeline `deploy-staging.yml` automatica e affidabile
+- produzione separata su `meepleai.com`
+- baseline performance pre-Wave-A misurabile
+- smoke verificabile esternamente via `curl https://meepleai.app/health`
+
+Investigation diretta ha invalidato tutte e quattro le assunzioni:
+
+1. **Pipeline staging in stato ambiguo**: `deploy-staging.yml` gate (riga 89-95) richiede `head_branch=main-staging` ma run "success" recenti mostrano `head_branch=main-dev` → gate skippato silentemente, success vacuo. Deploy reali eseguiti manualmente via `workflow_dispatch` (alcuni recenti FAIL: `c9e997c77`, `38c08d693`).
+2. **CI policy permissiva**: PR mergiate con `CI Success = FAILURE` via `--admin` override (es. #819, #823 nel set Wave 3). Promote automatico porterebbe red su main-staging.
+3. **Cloudflare Access wrappa `meepleai.app/*` incluso `/health`**: smoke esterni ritornano 302 (redirect login). Service token CF Access esistente (lavoro precedente). GitHub IP whitelist non confermato.
+4. **`meepleai.com` (produzione) inesistente**: no record DNS, no server provisionato. Goal di "production deploy" out-of-scope finché stand-up infrastructure non viene affrontato come progetto separato.
+5. **Nessuna baseline performance pre-Wave-A**: codice mai rilasciato in produzione, quindi "no regression vs legacy" è ill-definito.
+
+### Decisioni di scoping
+
+- **Approccio**: `β` da brainstorm — process focus + outcome semplificato (3 macro-goal invece di 5)
+- **EAA 2026-06-01**: IGNORE — non più hard deadline; goal owner-paced
+- **Produzione `meepleai.com`**: out of scope per questo design; eventuale stand-up tracked separatamente
+- **P1 scope**: minimal viable — solo quanto serve per sbloccare P2
+
+## Goal P1 — Pipeline staging trustworthy (minimal viable)
+
+| SMART | Detail |
+|---|---|
+| **S**pecific | `deploy-staging.yml` esegue end-to-end su trigger deterministico (push a `main-staging` post-merge release PR da `main-dev`, o `workflow_dispatch` come escape hatch): build/migrate/deploy/validate completano success reale (no jobs vacuamente skippati); smoke test job verifica HTTP 200 reale (non 302 da CF Access redirect) usando service token; runbook documenta strategia smoke + promote model |
+| **M**easurable | 3 deploy "Deploy to Staging" consecutivi (push reali a main-staging O `gh workflow run` manuali surrogati) con conclusion=success E nessun job critico (Build Images, Database Migration, Deploy to Staging, Post-deploy Validation) in stato `skipped`; job `validate.smoke_tests` ritorna HTTP 200 da `/health`; documento `docs/for-developers/operations/deploy-staging-runbook.md` esiste e include sezione CF Access bypass + promote PR procedure |
+| **A**chievable | Solo workflow YAML edits + 1 doc + uso service token già disponibile. Nessun infra provisioning. Single dev fattibile in ~1 settimana |
+| **R**elevant | Pre-requisito atomico per P2: deploy a `meepleai.app` non può essere "trusted" senza pipeline trusted |
+| **T**ime-bound | **~1 settimana** owner-paced |
+
+### Gherkin scenarios
+
+```gherkin
+Feature: deploy-staging.yml fires reliably on main-dev push
+
+  Scenario: Promote main-dev → main-staging triggers automatic staging deploy end-to-end
+    Given un release PR "main-dev → main-staging" viene mergiato (push a main-staging)
+    When GitHub Actions trigger "push: branches: [main-staging]" del workflow "Deploy to Staging" fires
+    Then il job "CI Quality Gate" passa (observability-only, sempre success)
+    And i job [build, migrate-db, snapshot-baseline, deploy, validate, e2e-staging] eseguono effettivamente (status≠skipped)
+    And la conclusion finale del run "Deploy to Staging" è "success"
+    And la latenza totale push-to-deploy è ≤ 60 minuti
+
+  Scenario: Smoke test job verifica HTTP 200 reale dietro Cloudflare Access
+    Given deploy-staging.yml job "validate" è in esecuzione
+    And i secrets CF_ACCESS_CLIENT_ID + CF_ACCESS_CLIENT_SECRET sono popolati nel repo
+    When eseguo "smoke_test API Health" contro https://meepleai.app/health con CF Access service token headers
+    Then il response status è 200 (non 302 da Cloudflare Access redirect)
+    And il body JSON contiene {"status": "Healthy"}
+
+  Scenario: Tre deploy consecutivi registrati green (manuali accettati come surrogato)
+    Given P1 è in fase di acceptance verification
+    When ispeziono "gh run list --workflow 'Deploy to Staging' --limit 3 --json conclusion,event,headBranch"
+    Then i 3 entry più recenti hanno tutti event in [push, workflow_dispatch] AND conclusion=success
+    And nessuno dei 3 ha "skipped" come stato finale di alcun job critico (Build Images, Database Migration, Deploy to Staging, Post-deploy Validation)
+    And tutti e 3 referenziano commit reali su main-staging
+
+  Scenario: Runbook documenta strategia smoke test + promote model
+    Given un nuovo developer/operator vuole verificare salute staging post-deploy
+    When apre "docs/for-developers/operations/deploy-staging-runbook.md"
+    Then trova sezione "Smoke testing meepleai.app dietro CF Access"
+    And documenta: come usare service token esistente, come interpretare 200 vs 302
+    And trova sezione "Promote main-dev → main-staging"
+    And documenta: procedura release PR + watch deploy completion
+    And documenta: rollback manuale via revert PR
+```
+
+## Goal P2 — v2 visibile + accessibile su meepleai.app (consolida A1+A2+B1+B2)
+
+| SMART | Detail |
+|---|---|
+| **S**pecific | 16+ rotte v2 (Wave A/B/C/D + SP6) live su `meepleai.app`; codice legacy lungo critical-path Alpha rimosso/corretto in favore dei v2 component; 0 axe-core color-contrast violations sulle rotte v2; keyboard nav funzionante (verifica automated via axe + role check); #807 Fase 1 (audit) + Fase 2 (token redesign AA) deployati nello **stesso PR** atomico; #808 freeze policy lifted |
+| **M**easurable | Critical-path Alpha 9-step (login → /library → /games?tab=library → /games/[id] → /agents → /agents/[id] → /sessions → /sessions/[id] → /gamebook) renderizza componenti v2 nel DOM (`data-slot` v2-* presente) senza fallback legacy; `pnpm test:e2e:a11y` ritorna 0 violations su tutte le rotte v2; A11y E2E job CI con `continue-on-error: false`; #807 e #808 issue closed |
+| **A**chievable | Dipende da P1. #807 audit + token redesign è il lavoro più sostanzioso (~2-3 settimane single dev). Cleanup legacy critical-path è scope addizionale rispetto al goal originale |
+| **R**elevant | Output user-visible primario — è "la nuova UI" promessa; sblocca anche Wave 3 frontend pending tramite freeze lift |
+| **T**ime-bound | **~3-4 settimane** dopo P1 (owner-paced, no EAA pressure) |
+
+### Gherkin scenarios
+
+```gherkin
+Feature: v2 routes deployed AND accessible on meepleai.app
+
+  Scenario: Critical-path Alpha user vede 16+ rotte v2 live, no fallback legacy
+    Given P1 è done (pipeline trustworthy) e ultimo deploy main-dev è success
+    And sono utente Alpha autenticato su meepleai.app (post CF Access + login app)
+    When percorro: /login → /library → /games?tab=library → /games/[id] → /agents → /agents/[id] → /sessions → /sessions/[id] → /gamebook
+    Then ogni rotta renderizza componenti v2 (DOM contiene "data-slot" che inizia con "v2-" oppure markup da components/v2/**)
+    And nessuna rotta cade in fallback legacy (data-slot v1-* assente) — eventuali deviazioni sono tracked come issue + documentate
+    And la console browser non mostra errori critici (severity=error)
+
+  Scenario: axe-core 0 color-contrast violations su tutte le 16 rotte v2
+    Given P1 è done e il workflow "Frontend - A11y E2E" gira contro meepleai.app post-deploy
+    When eseguo "pnpm test:e2e:a11y" su staging (o equivalente CI job)
+    Then il report axe-core ritorna 0 violations di rule "color-contrast"
+    And tutti i testi normali hanno ratio computato ≥ 4.5:1 (WCAG 2.1 AA SC 1.4.3)
+    And il job CI "Frontend - A11y E2E" è impostato a continue-on-error=false (blocking)
+    And nessuna PR successiva può passare merge gate con violazioni nuove
+
+  Scenario: #807 token redesign + visual baseline regen + freeze lift atomic in same PR
+    Given audit token ha catalogato N violazioni (#807 Fase 1)
+    When committo Fase 1 (catalogo audit CSV) + Fase 2 (token redesign AA in tailwind.config + tokens.css) + visual baselines rigenerati nello STESSO PR
+    Then "pnpm test:e2e:a11y" passa su tutte le rotte v2 senza .exclude(...) workaround
+    And visual baseline rigenerati committati senza diff inattesi (>0.5%) sui componenti già done
+    And #807 issue closed con summary che include catalogo audit + diff token
+    And #808 freeze policy issue closed con commento "lift criteria met"
+    And v2-migration-matrix permette nuovi pending row pickable
+
+  Scenario: Keyboard navigation funzionante su drawer + dialog v2 (automated check)
+    Given sono su https://meepleai.app/sessions/[id]/live (E2E test scenario)
+    And il test driver simula solo keyboard input (no mouse)
+    When premo Tab finché focus arriva su trigger button "Apri menu"
+    And premo Enter
+    Then drawer si apre AND focus si sposta su primo elemento focusabile interno
+    And premendo Escape drawer si chiude AND focus torna al trigger button
+    And axe-core verifica role="dialog" + aria-modal="true" + aria-labelledby presenti
+```
+
+## Goal P3 — Performance v2 meets absolute Web Vitals "Good" thresholds
+
+> **Re-framing rispetto al draft originale (B3)**: il goal originale era "no regression vs legacy baseline". Senza baseline (mai rilasciato in produzione) il confronto è ill-definito. Il goal viene re-framed con **threshold assoluti** Web Vitals "Good" + first-deploy v2 come baseline per future PR.
+
+| SMART | Detail |
+|---|---|
+| **S**pecific | Aggiornare `apps/web/lighthouserc.json` + `lighthouserc.mobile.json` per coprire critical-path Alpha (5 rotte sample); tutte le rotte rispettano threshold assoluti Web Vitals "Good" (LCP ≤ 2.5s, CLS ≤ 0.1, TBT ≤ 200ms); bundle aggregato JS first-load ≤ 20 MB; first-deploy v2 produce baseline JSON committato per future regression detection |
+| **M**easurable | Lighthouse CI run post-P2 ottiene Performance ≥ 90 su 5 rotte [/library, /games, /agents, /sessions, /gamebook] in entrambi profili desktop + mobile; `Frontend - Bundle Size` job verifica ≤ 20 MB JS first-load aggregato e nessun chunk > 500 KB gzipped; file `docs/for-developers/frontend/perf-baselines/baseline-v2-<DATE>.json` committato; il job Bundle Size è blocking (no continue-on-error) post-baseline establishment |
+| **A**chievable | Tooling già esistente (Lighthouse CI workflow + lighthouserc + Bundle Size CI). Solo URL list update + budget assertion + baseline file commit. ~2-3 giorni single dev |
+| **R**elevant | Impedisce regressioni perf future + stabilisce contract observable per rotte v2 |
+| **T**ime-bound | **~1 settimana** post-P2 |
+
+### Gherkin scenarios
+
+```gherkin
+Feature: Performance v2 meets absolute Web Vitals "Good" thresholds
+
+  Scenario: Lighthouse CI URL list aggiornato al critical-path Alpha
+    Given P2 è completato e Lighthouse CI gira su PR via "test-performance.yml"
+    When ispeziono "apps/web/lighthouserc.json" + "apps/web/lighthouserc.mobile.json"
+    Then la lista URL include le 5 rotte critical-path Alpha [/library, /games, /agents, /sessions, /gamebook]
+    And rimuove URL legacy non più rilevanti per v2 (es. /editor se obsoleto)
+    And il file è committato come parte del PR P3
+
+  Scenario: Tutte le rotte Alpha rispettano Web Vitals "Good" thresholds (absolute)
+    Given Lighthouse CI run su 5 rotte critical-path Alpha post-build localhost (artefatto = stesso bundle deployato)
+    When ispeziono il report dell'ultimo run su PR
+    Then ogni rotta ottiene LCP ≤ 2.5s ("Good")
+    And ogni rotta ottiene CLS ≤ 0.1 ("Good")
+    And ogni rotta ottiene TBT ≤ 200ms ("Good" — surrogato di FID per Lighthouse synthetic)
+    And score Performance ≥ 90 su ogni rotta
+    And nessun threshold richiede confronto con baseline storico (assoluto)
+
+  Scenario: Bundle aggregato sotto budget hard 20 MB
+    Given il job CI "Frontend - Bundle Size" gira su main-dev post-P2
+    When ispeziono il report bundle-size dell'ultimo run
+    Then bundle JS first-load aggregato ≤ 20 MB
+    And nessun chunk individuale eccede 500 KB gzipped
+    And il job è blocking (continue-on-error=false) per future PR
+
+  Scenario: First-deploy v2 produce baseline che future PR confrontano
+    Given P3 acceptance run completa con tutti threshold rispettati
+    When committo il report Lighthouse + bundle-size come "baseline-v2-2026-XX-XX.json"
+    Then il file è salvato in "docs/for-developers/frontend/perf-baselines/"
+    And future PR che peggiorano metriche di > 10% vs questa baseline triggherano warning su PR comment
+    And la baseline è ri-aggiornata solo via PR esplicita (no auto-update silente)
+```
+
+## Dependency graph
+
+```
+P1 (~1 settimana)
+  ↓ blocking
+P2 (~3-4 settimane)
+  ↓ blocking
+P3 (~1 settimana)
+
+Total owner-paced: ~5-6 settimane
+```
+
+P1 deve essere `done` prima che P2 cleanup deploy abbia senso (deploy va eseguito da pipeline trustworthy, non da workflow_dispatch manuali ad hoc). P2 deve essere `done` prima che P3 misuri perf su rotte v2 effettivamente live.
+
+## Out of scope (esplicitamente)
+
+- **Production stand-up** (`meepleai.com` DNS + server + secrets bootstrap) — progetto separato, requires brainstorm dedicato + plan infrastruttura
+- **Real User Monitoring** (RUM) per Web Vitals reali p75 da utenti — non disponibile, P3 usa Lighthouse synthetic come surrogato
+- **Wave 3 frontend rotte rimanenti** (`/discover`, `/game-nights`, `/kb/[id]`, `/toolkits/[id]`) — sbloccate da P2 (#808 lift) ma non parte di questo set di goal; tracked in v2-migration-matrix
+- **SP5 admin batch** + **SP3 public secondary** — fuori scope
+- **CI policy hardening** (no più `--admin` merge con CI Success rosso) — out of scope P1 minimal; potenziale follow-up se P1 done expone necessity
+
+## Riferimenti
+
+- v2 migration matrix: `docs/for-developers/frontend/v2-migration-matrix.md`
+- Plan A1 (invalidato): `docs/superpowers/plans/2026-05-07-a1-promote-main-dev-staging.md`
+- Workflow staging: `.github/workflows/deploy-staging.yml`
+- Workflow performance: `.github/workflows/test-performance.yml`
+- Lighthouse config: `apps/web/lighthouserc.json` + `lighthouserc.mobile.json`
+- Issue #807 — A11y design system audit
+- Issue #808 — Freeze SP6 v2 expansion (policy)
+
+## Self-review checklist
+
+- ✅ **Placeholder scan**: nessun TBD/TODO non risolto. "TBD" appare solo nel header come riferimento al companion plan da generare via writing-plans
+- ✅ **Internal consistency**: dipendenze P1→P2→P3 coerenti tra sezioni; threshold assoluti P3 non confliggono con altri goal; baseline storage path consistente in P3
+- ✅ **Scope check**: 3 macro-goal, ognuno SMART discreto, owner-paced timeline, decomposizione adeguata per single dev
+- ✅ **Ambiguity check**: critical-path 9-step esplicito; threshold Web Vitals "Good" valori esatti; bundle 20 MB esplicito; "atomic same PR" per #807 redesign chiarito

--- a/infra/secrets/cf-access.secret.example
+++ b/infra/secrets/cf-access.secret.example
@@ -1,0 +1,29 @@
+# Cloudflare Access service token for GitHub Actions staging smoke tests
+# Source: https://one.dash.cloudflare.com -> Access -> Service credentials -> Service Tokens
+# Policy: "Service auth for staging smoke" (attached to meepleai.app application)
+# Used by: .github/workflows/deploy-staging.yml job "validate" (Deep Health Check, Web Health Check, Smoke Tests)
+#
+# Setup procedure:
+#   1. cp infra/secrets/cf-access.secret.example infra/secrets/cf-access.secret
+#   2. Edit infra/secrets/cf-access.secret with real values from CF Zero Trust dashboard
+#   3. Populate GitHub repo secrets:
+#        set -a; source infra/secrets/cf-access.secret; set +a
+#        gh secret set CF_ACCESS_CLIENT_ID    --body "$CF_ACCESS_CLIENT_ID"
+#        gh secret set CF_ACCESS_CLIENT_SECRET --body "$CF_ACCESS_CLIENT_SECRET"
+#        unset CF_ACCESS_CLIENT_ID CF_ACCESS_CLIENT_SECRET
+#   4. Verify smoke locally:
+#        set -a; source infra/secrets/cf-access.secret; set +a
+#        curl -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
+#             -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
+#             -sf -o /dev/null -w "%{http_code}\n" https://meepleai.app/health
+#        unset CF_ACCESS_CLIENT_ID CF_ACCESS_CLIENT_SECRET
+#      Expected: 200
+#
+# Rotation: Recommended yearly. Procedure:
+#   1. CF dashboard -> create new service token + apply existing "Service auth for staging smoke" policy
+#   2. Update infra/secrets/cf-access.secret with new values
+#   3. Re-run gh secret set commands above
+#   4. Verify deploy success on next run, then revoke old token in CF dashboard
+
+CF_ACCESS_CLIENT_ID=<token-id>.access
+CF_ACCESS_CLIENT_SECRET=<token-secret>


### PR DESCRIPTION
## P1 Implementation

Implementa Goal P1 dello SMART set: deploy-staging.yml end-to-end fidato.

## Diagnosi pre-fix
- workflow_run + gate `head_branch=='main-staging'` skippava 9/10 job → vacuum success
- Smoke test riceveva 302 da CF Access invece di 200

## Fix
- **Task 2** (`c24bf553a`): CF Access service token headers su Deep Health Check + Web Health Check + Smoke Tests step
- **Task 3** (`cf9fe7519`): Trigger semplificato a `push: [main-staging]` + workflow_dispatch (rimosso workflow_run + gate skip)
- **Task 4** (`97f2f1c65`): Runbook `docs/for-developers/operations/deploy-staging-runbook.md` + template `infra/secrets/cf-access.secret.example`

## Pre-req merge

Repo secrets verificati popolati:
- ✅ `CF_ACCESS_CLIENT_ID`
- ✅ `CF_ACCESS_CLIENT_SECRET`

Smoke locale verificato: `curl https://meepleai.app/health` con headers ritorna `HTTP=200` + body `{"status":"healthy"}`.

## Acceptance

Post-merge a main-dev → owner crea release PR main-dev → main-staging → trigger \`push: main-staging\` → primo deploy POST-fix gira tutti i job critici (no skip vacuo). Verifica Task 6 del plan.

## Refs

- Spec: \`docs/superpowers/specs/2026-05-07-v2-meepleai-deploy-goals.md\`
- Plan: \`docs/superpowers/plans/2026-05-07-p1-pipeline-staging-trustworthy.md\`